### PR TITLE
rename file after cache bust

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -18,7 +18,7 @@
     "elastic:index:create": "npm run task -- elasticIndexCreate",
     "types:zod:generate": "ts-to-zod src/server/tracer/types.ts src/server/tracer/types.generated.ts && ts-to-zod src/trace_checks/types.ts src/trace_checks/types.generated.ts && ts-to-zod src/trace_checks/evaluators.generated.ts src/trace_checks/evaluators.zod.generated.ts",
     "copy:integration": "cp -R ../docs/docs/integration-guides src/components/",
-    "copy:langevals-types": "cd src/trace_checks && curl -O \"https://raw.githubusercontent.com/langwatch/langevals/main/ts-integration/evaluators.generated.ts?$(date +%s)\""
+    "copy:langevals-types": "cd src/trace_checks && curl -L \"https://raw.githubusercontent.com/langwatch/langevals/main/ts-integration/evaluators.generated.ts?$(date +%s)\" -o evaluators.generated.ts"
   },
   "dependencies": {
     "@azure/openai": "^1.0.0-beta.10",


### PR DESCRIPTION
timestamp used for cache busting will be persisted in the filename which will lead to failures in the builds.

we rename file to its originals explicitly.