### PR TITLE
Include SDK metadata in traces

### DIFF
--- a/langwatch/src/pages/api/collector.ts
+++ b/langwatch/src/pages/api/collector.ts
@@ -131,6 +131,8 @@ export default async function handler(
     thread_id: threadId,
     user_id: userId,
     customer_id: customerId,
+    sdk_version: sdkVersion,
+    sdk_language: sdkLanguage,
     labels,
   } = params.metadata ?? {};
 
@@ -302,6 +304,8 @@ export default async function handler(
       user_id: nullToUndefined(userId), // Optional: This will be undefined if not sent
       customer_id: nullToUndefined(customerId),
       labels: nullToUndefined(labels),
+      sdk_version: nullToUndefined(sdkVersion),
+      sdk_language: nullToUndefined(sdkLanguage),
     },
     timestamps: {
       started_at: Math.min(...spans.map((span) => span.timestamps.started_at)),

--- a/langwatch/src/server/tracer/types.ts
+++ b/langwatch/src/server/tracer/types.ts
@@ -295,6 +295,8 @@ export type TraceCheck = {
     thread_id?: string;
     user_id?: string;
     customer_id?: string;
+    sdk_version?: string;
+    sdk_language?: string;
     labels?: string[];
     topics?: string[];
   };
@@ -314,6 +316,8 @@ export type CollectorRESTParams = {
     customer_id?: string | null | undefined;
     labels?: string[] | null | undefined;
     experiments?: Experiment[] | null | undefined;
+    sdk_version?: string | null | undefined;
+    sdk_language?: string | null | undefined;
   };
 };
 
@@ -334,6 +338,8 @@ export type Event = {
     customer_id?: string;
     labels?: string[];
     topics?: string[];
+    sdk_version?: string | null | undefined;
+    sdk_language?: string | null | undefined;
   };
   timestamps: { started_at: number; inserted_at: number; updated_at: number };
 };

--- a/langwatch/src/server/tracer/types.ts
+++ b/langwatch/src/server/tracer/types.ts
@@ -247,6 +247,8 @@ export type Trace = {
     labels?: string[];
     topic_id?: string;
     subtopic_id?: string;
+    sdk_version?: string;
+    sdk_language?: string;
   };
   timestamps: { started_at: number; inserted_at: number; updated_at: number };
   input: TraceInput;

--- a/langwatch/src/tasks/elasticIndexCreate.ts
+++ b/langwatch/src/tasks/elasticIndexCreate.ts
@@ -55,6 +55,8 @@ const traceMapping: ElasticSearchMappingFrom<ElasticSearchTrace> = {
       labels: { type: "keyword" },
       topic_id: { type: "keyword" },
       subtopic_id: { type: "keyword" },
+      sdk_version: { type: "keyword" },
+      sdk_language: { type: "keyword" },
     },
   },
   timestamps: {
@@ -228,6 +230,8 @@ const traceChecksMapping: ElasticSearchMappingFrom<TraceCheck> = {
       customer_id: { type: "keyword" },
       labels: { type: "keyword" },
       topics: { type: "keyword" },
+      sdk_version: { type: "keyword" },
+      sdk_language: { type: "keyword" },
     },
   },
 };
@@ -267,6 +271,8 @@ const eventsMapping: ElasticSearchMappingFrom<ElasticSearchEvent> = {
       customer_id: { type: "keyword" },
       labels: { type: "keyword" },
       topics: { type: "keyword" },
+      sdk_version: { type: "keyword" },
+      sdk_language: { type: "keyword" },
     },
   },
 };

--- a/python-sdk/langwatch/tracer.py
+++ b/python-sdk/langwatch/tracer.py
@@ -1,4 +1,4 @@
-import importlib
+from importlib.metadata import version
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
 import time
@@ -55,8 +55,8 @@ T = TypeVar("T", bound=Callable[..., Any])
 def get_version():
     """Retrieves the version of the current library."""
     try:
-        return importlib.metadata.version("langwatch")
-    except importlib.metadata.PackageNotFoundError:
+        return version("langwatch")
+    except Exception:
         return "unknown"
 
 

--- a/python-sdk/langwatch/tracer.py
+++ b/python-sdk/langwatch/tracer.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
 import time
@@ -49,6 +50,14 @@ except ImportError:
     pass
 
 T = TypeVar("T", bound=Callable[..., Any])
+
+
+def get_version():
+    """Retrieves the version of the current library."""
+    try:
+        return importlib.metadata.version("langwatch")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
 
 
 class ContextSpan:
@@ -448,7 +457,8 @@ class ContextTrace:
     ):
         self.spans: Dict[str, Span] = {}
         self.trace_id = trace_id or f"trace_{nanoid.generate()}"
-        self.metadata = metadata
+        self.metadata = metadata or {}
+        self.metadata.update({"sdk_version": get_version(), "sdk_language": "python"})
         self.span = cast(
             Type[ContextSpan], lambda **kwargs: ContextSpan(trace=self, **kwargs)
         )

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langwatch",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/typescript-sdk/src/index.test.ts
+++ b/typescript-sdk/src/index.test.ts
@@ -11,6 +11,7 @@ import {
 import { openai } from "@ai-sdk/openai";
 import { generateText, type CoreMessage } from "ai";
 import "dotenv/config";
+import { version } from "../package.json";
 
 describe("LangWatch tracer", () => {
   let mockFetch: SpyInstanceFn;
@@ -65,6 +66,8 @@ describe("LangWatch tracer", () => {
       threadId: "123",
       userId: "456",
       labels: ["foo", "bar"],
+      sdkLanguage: "typescript",
+      sdkVersion: version,
     });
     expect(span.timestamps.startedAt).toBeDefined();
     expect(span.timestamps.finishedAt).toBeDefined();
@@ -133,6 +136,8 @@ describe("LangWatch tracer", () => {
       thread_id: "123",
       user_id: "456",
       labels: ["foo", "bar"],
+      sdk_language: "typescript",
+      sdk_version: version,
     });
     expect(requestBody.spans.length).toBe(3);
   });

--- a/typescript-sdk/src/index.ts
+++ b/typescript-sdk/src/index.ts
@@ -30,6 +30,7 @@ import {
   convertFromVercelAIMessages,
 } from "./utils";
 import { LangWatchCallbackHandler } from "./langchain";
+import { version } from "../package.json";
 
 export type {
   BaseSpan,
@@ -158,8 +159,8 @@ export class LangWatchTrace {
     this.traceId = traceId;
     this.metadata = {
       ...metadata,
-      sdk_version: require("../../package.json").version,
-      sdk_language: "typescript",
+      sdkVersion: version,
+      sdkLanguage: "typescript",
     };
   }
 

--- a/typescript-sdk/src/index.ts
+++ b/typescript-sdk/src/index.ts
@@ -24,7 +24,11 @@ import {
   type RAGSpan,
   type SpanInputOutput,
 } from "./types";
-import { autoconvertTypedValues, captureError, convertFromVercelAIMessages } from "./utils";
+import {
+  autoconvertTypedValues,
+  captureError,
+  convertFromVercelAIMessages,
+} from "./utils";
 import { LangWatchCallbackHandler } from "./langchain";
 
 export type {
@@ -152,7 +156,11 @@ export class LangWatchTrace {
   }) {
     this.client = client;
     this.traceId = traceId;
-    this.metadata = metadata;
+    this.metadata = {
+      ...metadata,
+      sdk_version: require("../../package.json").version,
+      sdk_language: "typescript",
+    };
   }
 
   update({ metadata }: { metadata: Metadata }) {


### PR DESCRIPTION
Extended the traces logging to include SDK metadata for typescript (tested) and python (not tested yet).

<img width="1396" alt="Screenshot 2024-07-09 at 10 48 39" src="https://github.com/langwatch/langwatch/assets/102327502/a9cb94b6-8694-4e16-8829-68da1221c053">
