### PR TITLE
Use bash shell for start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM node:20-alpine
-RUN apk --no-cache add curl python3 make gcc g++ openssl
+RUN apk --no-cache add curl python3 make gcc g++ openssl bash
 WORKDIR /app
 COPY langwatch/package.json langwatch/package-lock.json ./langwatch/
 RUN npm --prefix=langwatch ci
 COPY langwatch ./langwatch
 RUN npm --prefix=langwatch run build
 EXPOSE 5560
+
+# Set bash as the default shell
+SHELL ["/bin/bash", "-c"]
 
 CMD npm --prefix=langwatch start

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,11 @@
 FROM node:20-alpine
-RUN apk --no-cache add curl python3 make gcc g++ openssl
+RUN apk --no-cache add curl python3 make gcc g++ openssl bash
 WORKDIR /app
 COPY langwatch/package.json langwatch/package-lock.json ./langwatch/
 RUN npm --prefix=langwatch ci
 COPY langwatch ./langwatch
 CMD npm --prefix=langwatch run dev
 EXPOSE 5560
+
+# Set bash as the default shell
+SHELL ["/bin/bash", "-c"]

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eo pipefail
 


### PR DESCRIPTION
Adding the bash shell to the docker images and use bash shell in start.sh script. Fixes #84 