### PR TITLE
chore: fix responsiveness of organization screens

### DIFF
--- a/langwatch/src/pages/onboarding/[team]/select.tsx
+++ b/langwatch/src/pages/onboarding/[team]/select.tsx
@@ -142,7 +142,7 @@ export default function ProjectOnboardingSelect() {
           <FormControl>
             <RadioGroup value={""}>
               <Box>
-                <HStack width="full" height="100%" alignItems="start">
+                <HStack width="full" height="100%" alignItems="start" wrap="wrap" >
                   {Object.entries(projectTypes).map(([value, details]) => {
                     return (
                       <Box

--- a/langwatch/src/pages/onboarding/organization.tsx
+++ b/langwatch/src/pages/onboarding/organization.tsx
@@ -328,7 +328,7 @@ export default function OrganizationOnboarding() {
                     value={selectedValueUsage || ""}
                     onChange={(value) => setValue("usage", value)}
                   >
-                    <HStack width="full">
+                    <HStack width="full" wrap="wrap">
                       {Object.entries(options).map(([value, icon]) => (
                         <CustomRadio
                           key={value}


### PR DESCRIPTION
Description:

- Fixed the `/organization` screen while onboarding
- Fixed the `/select` screen after creating an organization

**Before:**

<img width="186" alt="image" src="https://github.com/user-attachments/assets/7decf24c-e8c0-411a-a321-d32d8b21930b" />

<img width="187" alt="image" src="https://github.com/user-attachments/assets/14bc6d65-f921-4115-93c1-bb301a016df2" />


**After:**

<img width="186" alt="image" src="https://github.com/user-attachments/assets/cdf256ac-604a-4070-a79f-59b8c482e0be" />

<img width="183" alt="image" src="https://github.com/user-attachments/assets/455b0d43-2736-4a17-af6e-44cc5af105f5" />
