### PR TITLE
Fix OpenSearch Compatibility in Development Environment

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -7,6 +7,7 @@ services:
       DISABLE_PII_REDACTION: true
       DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
       ELASTICSEARCH_NODE_URL: http://opensearch:9200
+      IS_OPENSEARCH: true
       REDIS_URL: redis://redis:6379
       LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
       LANGEVALS_ENDPOINT: http://langevals:5562


### PR DESCRIPTION
**Summary**

This PR resolves an issue preventing the Docker development environment from running due to an incompatibility with OpenSearch. The error occurred because the client expected an Elasticsearch server but encountered an unsupported product.

**Changes**
	•	Added IS_OPENSEARCH: true to compose.dev.yml to explicitly configure compatibility with OpenSearch.

**Context**

Without this variable, the application failed to execute with the following error:

```
ProductNotSupportedError: The client noticed that the server is not Elasticsearch and we do not support this unknown product.
``` 

This change ensures the development environment runs smoothly by properly identifying the OpenSearch server in the development environment.

**Testing**
	•	Verified that the Docker development environment starts without errors after adding the variable.
	•	Confirmed OpenSearch compatibility with the client.
