### PR TITLE
Refactor Startup Scripts for Better Windows Compatibility

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -6,7 +6,7 @@
     "build": "npm run start:prepare:files && npm run build:websocket && BUILD_TIME=1 next build --no-lint && rm -rf .next/cache",
     "build:websocket": "esbuild src/optimization_studio/server/socketServer.ts --bundle --platform=node --outfile=build-websocket/socketServer.js --packages=external --alias:@injected-dependencies.server=src/injection/injection.server.ts",
     "lint": "next lint",
-    "dev": "npm run start:prepare:files && npm run build:websocket && NODE_ENV=development npm run start",
+    "dev": "./scripts/dev-start.sh",
     "start": "./scripts/start.sh",
     "start:app": "tsx src/server.ts",
     "start:quickwit": "cd quickwit && ./quickwit run",

--- a/langwatch/scripts/dev-start.sh
+++ b/langwatch/scripts/dev-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [ "$OS" = "Windows_NT" ]; then
+  echo "Windows detected"
+  npm run start:prepare:files && npm run build:websocket && set NODE_ENV=development && npm run start
+else
+  npm run start:prepare:files && npm run build:websocket && NODE_ENV=development npm run start
+fi

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -7,6 +7,21 @@ if [ -z "$NODE_ENV" ]; then
   RUNTIME_ENV="$RUNTIME_ENV NODE_ENV=production"
 fi
 
+#If on Windows, prefix the RUNTIME_ENV with && set
+if [ "$OS" = "Windows_NT" ]; then
+  RUNTIME_ENV_TEMP=""
+  first=1
+  for VAR in $RUNTIME_ENV; do
+    if [ $first -eq 1 ]; then
+      RUNTIME_ENV_TEMP="set \"$VAR\""
+      first=0
+    else
+      RUNTIME_ENV_TEMP="$RUNTIME_ENV_TEMP && set \"$VAR\""
+    fi
+  done
+  RUNTIME_ENV="$RUNTIME_ENV_TEMP"
+fi
+
 START_APP_COMMAND="npm run start:app"
 
 START_WORKERS_COMMAND=""
@@ -35,18 +50,23 @@ if [ "$NODE_ENV" = "development" ]; then
 fi
 
 
+SEPARATOR=" "
+if [ "$OS" = "Windows_NT" ]; then 
+  SEPARATOR=" && "
+fi
+
 COMMANDS=()
 if [ -n "$START_APP_COMMAND" ]; then
-  COMMANDS+=("\"$RUNTIME_ENV $START_APP_COMMAND\"")
+  COMMANDS+=("\"$RUNTIME_ENV${SEPARATOR}$START_APP_COMMAND\"")
 fi
 if [ -n "$START_WORKERS_COMMAND" ]; then
-  COMMANDS+=("\"$RUNTIME_ENV $START_WORKERS_COMMAND\"")
+  COMMANDS+=("\"$RUNTIME_ENV${SEPARATOR}$START_WORKERS_COMMAND\"")
 fi
 if [ -n "$START_QUICKWIT_COMMAND" ]; then
-  COMMANDS+=("\"$RUNTIME_ENV $START_QUICKWIT_COMMAND\"")
+  COMMANDS+=("\"$RUNTIME_ENV${SEPARATOR}$START_QUICKWIT_COMMAND\"")
 fi
 if [ -n "$WATCH_WEBSOCKET_COMMAND" ]; then
-  COMMANDS+=("\"$RUNTIME_ENV $WATCH_WEBSOCKET_COMMAND\"")
+  COMMANDS+=("\"$RUNTIME_ENV${SEPARATOR}$WATCH_WEBSOCKET_COMMAND\"")
 fi
 
 concurrently --restart-tries -1 "${COMMANDS[@]}"


### PR DESCRIPTION
This Pull Request refactors the startup scripts to improve compatibility with Windows.

🔧 Changes made:
1 - langwatch/package.json
 - Modified the development command to use the dev-start.sh script instead of
 calling npm start directly.
 - Avoids adding an extra command to the package.json scripts section.

2 - langwatch/scripts/dev-start.sh
 - Added a new script file.
 - Automatically detects the operating system and adjusts the command syntax accordingly.
 - Sets environment variables and executes the appropriate build and start commands.

3 - langwatch/scripts/start.sh
 - Updated to better handle environment variables on Windows.
 - Ensures a more robust and environment-independent execution.

These changes improve the development workflow, particularly on Windows, by handling system-specific command execution automatically while keeping package.json scripts clean and minimal.