### PR TITLE
Feature add annotation queue trigger

### DIFF
--- a/langwatch/prisma/migrations/20250306101103_add_enum_add_to_annotation_queue/migration.sql
+++ b/langwatch/prisma/migrations/20250306101103_add_enum_add_to_annotation_queue/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "TriggerAction" ADD VALUE 'ADD_TO_ANNOTATION_QUEUE';

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -370,6 +370,7 @@ model BatchEvaluation {
 enum TriggerAction {
     SEND_EMAIL
     ADD_TO_DATASET
+    ADD_TO_ANNOTATION_QUEUE
     SEND_SLACK_MESSAGE
 }
 

--- a/langwatch/src/components/AddTriggerDrawer.tsx
+++ b/langwatch/src/components/AddTriggerDrawer.tsx
@@ -38,11 +38,12 @@ import type {
   MappingState,
   TRACE_EXPANSIONS,
 } from "./datasets/DatasetMapping";
-
+import { AddParticipants } from "~/components/traces/AddParticipants";
 import { DatasetMappingPreview } from "./datasets/DatasetMappingPreview";
 import { DatasetSelector } from "./datasets/DatasetSelector";
 
 import { CheckSquare } from "react-feather";
+import { AddAnnotationQueueDrawer } from "./AddAnnotationQueueDrawer";
 
 export function TriggerDrawer() {
   const { project, organization, team } = useOrganizationTeamProject();
@@ -66,9 +67,13 @@ export function TriggerDrawer() {
     { enabled: typeof teamSlug === "string" && !!organization?.id }
   );
 
-  const { closeDrawer } = useDrawer();
+  const [annotators, setAnnotators] = useState<{ id: string; name: string }[]>(
+    []
+  );
 
+  const { closeDrawer } = useDrawer();
   const { filterParams } = useFilterParams();
+  const queueDrawerOpen = useDisclosure();
 
   const [localStorageDatasetId, setLocalStorageDatasetId] =
     useLocalStorage<string>("selectedDatasetId", "");
@@ -89,7 +94,6 @@ export function TriggerDrawer() {
     formState: { errors },
     reset,
     setValue,
-    control,
   } = useForm<FormValues>({
     defaultValues: {
       name: "",
@@ -158,6 +162,7 @@ export function TriggerDrawer() {
     members?: string[];
     slackWebhook?: string;
     datasetId?: string;
+    annotators?: { id: string; name: string }[];
     datasetMapping?:
       | {
           mapping: Mapping;
@@ -172,6 +177,7 @@ export function TriggerDrawer() {
       slackWebhook: "",
       datasetId: datasetId,
       datasetMapping: datasetTriggerMapping,
+      annotators: annotators,
     };
     if (data.action === TriggerAction.SEND_EMAIL) {
       actionParams = {
@@ -180,6 +186,10 @@ export function TriggerDrawer() {
     } else if (data.action === TriggerAction.SEND_SLACK_MESSAGE) {
       actionParams = {
         slackWebhook: data.slackWebhook ?? "",
+      };
+    } else if (data.action === TriggerAction.ADD_TO_ANNOTATION_QUEUE) {
+      actionParams = {
+        annotators: annotators,
       };
     } else if (data.action === TriggerAction.ADD_TO_DATASET) {
       actionParams = {
@@ -408,24 +418,6 @@ export function TriggerDrawer() {
 
                   <VStack align="start">
                     <Radio
-                      value={TriggerAction.ADD_TO_DATASET}
-                      colorPalette="blue"
-                      alignItems="start"
-                      gap={3}
-                      paddingTop={2}
-                      {...register("action")}
-                    >
-                      <VStack align="start" marginTop={-1}>
-                        <Text fontWeight="500">Add to Dataset</Text>
-                        <Text fontSize="13px" fontWeight="normal">
-                          Add entries to the dataset, this allows you to keep
-                          track of the results of your triggers.
-                        </Text>
-                      </VStack>
-                    </Radio>
-                  </VStack>
-                  <VStack align="start">
-                    <Radio
                       value={TriggerAction.ADD_TO_ANNOTATION_QUEUE}
                       colorPalette="blue"
                       alignItems="start"
@@ -442,9 +434,38 @@ export function TriggerDrawer() {
                       </VStack>
                     </Radio>
                   </VStack>
+                  {currentAction === TriggerAction.ADD_TO_ANNOTATION_QUEUE && (
+                    <Box>
+                      <AddParticipants
+                        annotators={annotators}
+                        setAnnotators={setAnnotators}
+                        queueDrawerOpen={queueDrawerOpen}
+                        isTrigger={true}
+                      />
+                    </Box>
+                  )}
+                  <VStack align="start">
+                    <Radio
+                      value={TriggerAction.ADD_TO_DATASET}
+                      colorPalette="blue"
+                      alignItems="start"
+                      gap={3}
+                      paddingTop={2}
+                      {...register("action")}
+                    >
+                      <VStack align="start" marginTop={-1}>
+                        <Text fontWeight="500">Add to Dataset</Text>
+                        <Text fontSize="13px" fontWeight="normal">
+                          Add entries to the dataset, this allows you to keep
+                          track of the results of your triggers.
+                        </Text>
+                      </VStack>
+                    </Radio>
+                  </VStack>
                 </Stack>
               </RadioGroup>
             </HorizontalFormControl>
+
             {currentAction === TriggerAction.ADD_TO_DATASET && (
               <>
                 <DatasetSelector
@@ -498,6 +519,11 @@ export function TriggerDrawer() {
         open={editDataset.open}
         onClose={editDataset.onClose}
         onSuccess={onCreateDatasetSuccess}
+      />
+      <AddAnnotationQueueDrawer
+        open={queueDrawerOpen.open}
+        onClose={queueDrawerOpen.onClose}
+        onOverlayClick={queueDrawerOpen.onClose}
       />
     </Drawer.Root>
   );

--- a/langwatch/src/components/AddTriggerDrawer.tsx
+++ b/langwatch/src/components/AddTriggerDrawer.tsx
@@ -424,6 +424,24 @@ export function TriggerDrawer() {
                       </VStack>
                     </Radio>
                   </VStack>
+                  <VStack align="start">
+                    <Radio
+                      value={TriggerAction.ADD_TO_ANNOTATION_QUEUE}
+                      colorPalette="blue"
+                      alignItems="start"
+                      gap={3}
+                      paddingTop={2}
+                      {...register("action")}
+                    >
+                      <VStack align="start" marginTop={-1}>
+                        <Text fontWeight="500">Add to Annotation Queue</Text>
+                        <Text fontSize="13px" fontWeight="normal">
+                          Add entries to the annotation queue, this allows you
+                          to keep track of the results of your triggers.
+                        </Text>
+                      </VStack>
+                    </Radio>
+                  </VStack>
                 </Stack>
               </RadioGroup>
             </HorizontalFormControl>

--- a/langwatch/src/components/traces/TraceDetails.tsx
+++ b/langwatch/src/components/traces/TraceDetails.tsx
@@ -45,8 +45,7 @@ export function TraceDetails(props: {
   showMessages?: boolean;
   onToggleView?: () => void;
 }) {
-  const { project, hasTeamPermission, organization } =
-    useOrganizationTeamProject();
+  const { project, hasTeamPermission } = useOrganizationTeamProject();
   const [threadId, setThreadId] = useState<string | undefined>(undefined);
   const router = useRouter();
 
@@ -66,35 +65,6 @@ export function TraceDetails(props: {
       refetchOnWindowFocus: false,
     }
   );
-
-  const annotationQueues = api.annotation.getQueues.useQuery(
-    { projectId: project?.id ?? "" },
-    {
-      enabled: !!project,
-    }
-  );
-
-  const users =
-    api.organization.getOrganizationWithMembersAndTheirTeams.useQuery(
-      {
-        organizationId: organization?.id ?? "",
-      },
-      {
-        enabled: !!organization,
-      }
-    );
-
-  const userOptions = users.data?.members.map((member) => ({
-    label: member.user.name ?? "",
-    value: `user-${member.user.id}`,
-  }));
-
-  const queueOptions = annotationQueues.data?.map((queue) => ({
-    label: queue.name ?? "",
-    value: `queue-${queue.id}`,
-  }));
-
-  const options = [...(userOptions ?? []), ...(queueOptions ?? [])];
 
   useEffect(() => {
     if (evaluations.data) {
@@ -199,9 +169,9 @@ export function TraceDetails(props: {
     );
   };
 
-  const [annotators, setAnnotators] = useState<
-    { id: string; name: string | null }[]
-  >([]);
+  const [annotators, setAnnotators] = useState<{ id: string; name: string }[]>(
+    []
+  );
 
   useEffect(() => {
     if (trace.data?.metadata.thread_id) {
@@ -257,7 +227,6 @@ export function TraceDetails(props: {
             <HStack>
               {hasTeamPermission(TeamRoleGroup.ANNOTATIONS_MANAGE) && (
                 <Button
-
                   variant="outline"
                   onClick={() => {
                     commentState.setCommentState({
@@ -283,9 +252,7 @@ export function TraceDetails(props: {
                     open={open}
                   >
                     <Popover.Trigger asChild>
-                      <Button variant="outline">
-                        Annotation Queue
-                      </Button>
+                      <Button variant="outline">Annotation Queue</Button>
                     </Popover.Trigger>
                     <Popover.Content
                       display={queueDrawerOpen.open ? "none" : "block"}
@@ -294,7 +261,6 @@ export function TraceDetails(props: {
                       <Popover.CloseTrigger />
                       <Popover.Body>
                         <AddParticipants
-                          options={options}
                           annotators={annotators}
                           setAnnotators={setAnnotators}
                           queueDrawerOpen={queueDrawerOpen}
@@ -308,7 +274,6 @@ export function TraceDetails(props: {
               )}
               {hasTeamPermission(TeamRoleGroup.DATASETS_MANAGE) && (
                 <Button
-
                   type="submit"
                   variant="outline"
                   minWidth="fit-content"

--- a/langwatch/src/pages/[project]/triggers.tsx
+++ b/langwatch/src/pages/[project]/triggers.tsx
@@ -149,6 +149,8 @@ export default function Members() {
         return "Email";
       case "ADD_TO_DATASET":
         return "Add to dataset";
+      case "ADD_TO_ANNOTATION_QUEUE":
+        return "Add to annotation queue";
     }
   };
 
@@ -288,7 +290,7 @@ export default function Members() {
       <FilterContainer fontSize="sm">
         <FilterLabel>Evaluations</FilterLabel>
         <FilterValue>
-          {checks.map((check, index) => check?.name).join(", ")}
+          {checks.map((check) => check?.name).join(", ")}
         </FilterValue>
       </FilterContainer>
     );

--- a/langwatch/src/pages/api/cron/triggers.ts
+++ b/langwatch/src/pages/api/cron/triggers.ts
@@ -5,7 +5,7 @@ import { getAllTracesForProject } from "~/server/api/routers/traces";
 import { sendTriggerEmail } from "~/server/mailer/triggerEmail";
 import { sendSlackWebhook } from "~/server/triggers/sendSlackWebhook";
 import { prisma } from "../../../server/db";
-
+import { createOrUpdateQueueItems } from "~/server/api/routers/annotation";
 import { type Trace } from "~/server/tracer/types";
 
 import {
@@ -31,6 +31,8 @@ interface ActionParams {
     expansions: Set<keyof typeof TRACE_EXPANSIONS>;
   };
   datasetId: string;
+  annotators?: { id: string; name: string }[];
+  createdByUserId?: string;
 }
 
 interface TriggerData {
@@ -188,6 +190,26 @@ const getTracesForAlert = async (trigger: Trigger, projects: Project[]) => {
           },
         });
       }
+    } else if (action === TriggerAction.ADD_TO_ANNOTATION_QUEUE) {
+      try {
+        const trigger = await prisma.trigger.findUnique({
+          where: { id: triggerId, projectId: input.projectId },
+        });
+
+        const actionParamsRaw =
+          trigger?.actionParams as unknown as ActionParams;
+        const { annotators, createdByUserId } = actionParamsRaw;
+
+        await createQueueItems(triggerData, annotators!, createdByUserId);
+      } catch (error) {
+        Sentry.captureException(error, {
+          extra: {
+            triggerId,
+            projectId: input.projectId,
+            action: TriggerAction.ADD_TO_ANNOTATION_QUEUE,
+          },
+        });
+      }
     } else if (action === TriggerAction.ADD_TO_DATASET) {
       try {
         const trigger = await prisma.trigger.findUnique({
@@ -327,4 +349,22 @@ export const getLatestUpdatedAt = (traces: TraceGroups) => {
     .sort((a: number, b: number) => b - a);
 
   return updatedTimes[0];
+};
+
+const createQueueItems = async (
+  triggerData: TriggerData[],
+  annotators: { id: string; name: string }[],
+  createdByUserId?: string
+) => {
+  await Promise.all(
+    triggerData.map((data) =>
+      createOrUpdateQueueItems({
+        traceId: data.traceId,
+        projectId: data.projectId,
+        annotators: annotators.map((annotator) => annotator.id),
+        userId: createdByUserId ?? "",
+        prisma: prisma,
+      })
+    )
+  );
 };

--- a/langwatch/src/pages/api/cron/triggers.ts
+++ b/langwatch/src/pages/api/cron/triggers.ts
@@ -200,7 +200,7 @@ const getTracesForAlert = async (trigger: Trigger, projects: Project[]) => {
           trigger?.actionParams as unknown as ActionParams;
         const { annotators, createdByUserId } = actionParamsRaw;
 
-        await createQueueItems(triggerData, annotators!, createdByUserId);
+        await createQueueItems(triggerData, annotators ?? [], createdByUserId);
       } catch (error) {
         Sentry.captureException(error, {
           extra: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an "Add to Annotation Queue" option in trigger creation, allowing users to assign annotators for managing annotations.
  
- **Enhancements**
  - Streamlined the trigger setup interface for clearer participant selection.
  - Improved backend processing for annotation queue actions with enhanced validation and error handling.
  - Added support for tracking the user who created the trigger action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->