### PR TITLE
Truncate llm call response

### DIFF
--- a/langwatch/src/pages/api/dspy/log_steps.ts
+++ b/langwatch/src/pages/api/dspy/log_steps.ts
@@ -197,10 +197,10 @@ const processDSPyStep = async (project: Project, param: DSPyStepRESTParams) => {
         if (llmCall.response?.output) {
           delete llmCall.response.choices;
         }
-        totalSize += JSON.stringify(llmCall).length;
 
         if (llmCall.response) {
           llmCall.response = safeTruncate(llmCall.response);
+          totalSize = JSON.stringify(llmCall).length;
 
           if (totalSize >= 256_000) {
             llmCall.response.output = "[truncated]";

--- a/langwatch/src/pages/api/dspy/log_steps.ts
+++ b/langwatch/src/pages/api/dspy/log_steps.ts
@@ -32,6 +32,7 @@ import {
   type MaybeStoredLLMModelCost,
 } from "../../../server/modelProviders/llmModelCost";
 import { getPayloadSizeHistogram } from "../../../server/metrics";
+import { safeTruncate } from "../../../utils/truncate";
 
 export const debug = getDebugger("langwatch:dspy_log_steps");
 
@@ -197,10 +198,16 @@ const processDSPyStep = async (project: Project, param: DSPyStepRESTParams) => {
           delete llmCall.response.choices;
         }
         totalSize += JSON.stringify(llmCall).length;
-        if (totalSize >= 256_000 && llmCall.response) {
-          llmCall.response.output = "[truncated]";
-          llmCall.response.messages = [];
+
+        if (llmCall.response) {
+          llmCall.response = safeTruncate(llmCall.response);
+
+          if (totalSize >= 256_000) {
+            llmCall.response.output = "[truncated]";
+            llmCall.response.messages = [];
+          }
         }
+
         return llmCall;
       }),
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved handling of lengthy responses to ensure that overly large outputs are automatically shortened. This update enhances the overall reliability and consistency of response displays, ensuring a smoother experience even when data exceeds predefined limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->