### PR TITLE
Add ascii tree of spans to the trace for helping LLMs understanding the span tree when reading the api with MCP

### DIFF
--- a/langwatch/src/pages/api/trace/[id].ts
+++ b/langwatch/src/pages/api/trace/[id].ts
@@ -30,7 +30,7 @@ const buildTree = (spans: Span[]): Record<string, SpanWithChildren> => {
 };
 
 // Generate ASCII tree representation
-const generateAsciiTree = (spans: Span[]): string => {
+export const generateAsciiTree = (spans: Span[]): string => {
   const tree = buildTree(spans);
 
   // Find root spans (spans without parents or with parents not in the spans list)

--- a/langwatch/src/pages/api/trace/[id].ts
+++ b/langwatch/src/pages/api/trace/[id].ts
@@ -7,6 +7,79 @@ import {
   getSpansForTraceIds,
 } from "~/server/api/routers/traces";
 import { elasticSearchEvaluationsToEvaluations } from "../../../server/tracer/utils";
+import type { Span } from "../../../server/tracer/types";
+
+type SpanWithChildren = Span & { children: SpanWithChildren[] };
+
+// Build a tree structure from spans
+const buildTree = (spans: Span[]): Record<string, SpanWithChildren> => {
+  const lookup: Record<string, SpanWithChildren> = {};
+
+  spans.forEach((span) => {
+    lookup[span.span_id] = { ...span, children: [] };
+  });
+
+  spans.forEach((span) => {
+    const lookupSpan = lookup[span.span_id];
+    if (span.parent_id && lookup[span.parent_id] && lookupSpan) {
+      lookup[span.parent_id]?.children.push?.(lookupSpan);
+    }
+  });
+
+  return lookup;
+};
+
+// Generate ASCII tree representation
+const generateAsciiTree = (spans: Span[]): string => {
+  const tree = buildTree(spans);
+
+  // Find root spans (spans without parents or with parents not in the spans list)
+  const spansById = spans.reduce(
+    (acc, span) => {
+      acc[span.span_id] = span;
+      return acc;
+    },
+    {} as Record<string, Span>
+  );
+
+  const rootSpans = spans.filter(
+    (s) => !s.parent_id || !spansById[s.parent_id]
+  );
+
+  let result = ".\n";
+
+  // Recursively build the tree
+  const buildAsciiTree = (
+    span: SpanWithChildren,
+    prefix: string,
+    isLast: boolean
+  ): void => {
+    // Add current span to result
+    const connector = isLast ? "└── " : "├── ";
+    const displayName = `${span.type || "unknown"}${
+      span.name ? `: ${span.name}` : ""
+    }${span.type === "llm" && "model" in span ? ` (${span.model})` : ""}`;
+    result += `${prefix}${connector}${displayName}\n`;
+
+    // Prepare prefix for children
+    const childPrefix = prefix + (isLast ? "    " : "│   ");
+
+    // Add children
+    span.children.forEach((child, index) => {
+      buildAsciiTree(child, childPrefix, index === span.children.length - 1);
+    });
+  };
+
+  // Process each root span
+  rootSpans.forEach((rootSpan, index) => {
+    const span = tree[rootSpan.span_id];
+    if (span) {
+      buildAsciiTree(span, "", index === rootSpans.length - 1);
+    }
+  });
+
+  return result;
+};
 
 export default async function handler(
   req: NextApiRequest,
@@ -42,6 +115,9 @@ export default async function handler(
     await getSpansForTraceIds(project?.id, [traceId])
   ).flat();
 
+  // Generate ASCII tree representation
+  const asciiTree = generateAsciiTree(spans);
+
   const evaluations = await getEvaluationsMultiple({
     projectId: project?.id,
     traceIds: [traceId],
@@ -52,7 +128,10 @@ export default async function handler(
     }
   );
 
-  return res
-    .status(200)
-    .json({ ...traceDetails, spans, evaluations: evaluations_ });
+  return res.status(200).json({
+    ...traceDetails,
+    spans,
+    evaluations: evaluations_,
+    asciiTree,
+  });
 }

--- a/langwatch/src/pages/api/trace/search.ts
+++ b/langwatch/src/pages/api/trace/search.ts
@@ -8,7 +8,7 @@ import {
 import { fromZodError, type ZodError } from "zod-validation-error";
 import { z } from "zod";
 import { generateAsciiTree } from "./[id]";
-import type { LLMModeTrace, Trace } from "../../../server/tracer/types";
+import type { LLMModeTrace, Span, Trace } from "../../../server/tracer/types";
 import { formatTimeAgo } from "../../../utils/formatTimeAgo";
 
 export const config = {
@@ -86,7 +86,7 @@ export default async function handler(
           : params.endDate,
       pageSize,
     },
-    downloadMode: params.llmMode ? false : true,
+    downloadMode: !params.llmMode,
     scrollId: params.scrollId ?? undefined,
   });
   let traces: (Trace | LLMModeTrace)[] = results.groups.flat();
@@ -97,7 +97,10 @@ export default async function handler(
       spans: undefined,
       indexing_md5s: undefined,
       evaluations: undefined,
-      asciiTree: generateAsciiTree((trace as any).spans),
+      asciiTree:
+        "spans" in trace && Array.isArray(trace.spans as Span[])
+          ? generateAsciiTree(trace.spans as Span[])
+          : "",
       timestamps: {
         started_at:
           formatTimeAgo(new Date(trace.timestamps?.started_at).getTime()) ?? "",

--- a/langwatch/src/server/tracer/types.ts
+++ b/langwatch/src/server/tracer/types.ts
@@ -305,14 +305,14 @@ export type Trace = {
 
 export type LLMModeTrace = Omit<
   Trace,
-  "spans" | "evaluations" | "timestamps"
+  "timestamps" | "indexing_md5s"
 > & {
   timestamps: {
     started_at: string;
     inserted_at: string;
     updated_at: string;
   };
-  asciiTree: string;
+  ascii_tree: string;
 };
 
 // TODO: kill this after previous todo is done

--- a/langwatch/src/server/tracer/types.ts
+++ b/langwatch/src/server/tracer/types.ts
@@ -303,6 +303,18 @@ export type Trace = {
   // TODO: add spans here too
 };
 
+export type LLMModeTrace = Omit<
+  Trace,
+  "spans" | "evaluations" | "timestamps"
+> & {
+  timestamps: {
+    started_at: string;
+    inserted_at: string;
+    updated_at: string;
+  };
+  asciiTree: string;
+};
+
 // TODO: kill this after previous todo is done
 export type TraceWithSpans = Trace & { spans: Span[] };
 

--- a/typescript-sdk/package-lock.json
+++ b/typescript-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langwatch",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langwatch",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@langchain/core": "^0.2.7",

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langwatch",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/typescript-sdk/src/index.ts
+++ b/typescript-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'eventemitter3';
+import EventEmitter from "eventemitter3";
 import { nanoid } from "nanoid";
 import { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
@@ -21,6 +21,7 @@ import {
   spanSchema,
 } from "./server/types/tracer.generated";
 import {
+  type Trace,
   type BaseSpan,
   type ChatMessage,
   type ChatRichContent,
@@ -32,6 +33,7 @@ import {
   type RAGSpan,
   type RESTEvaluation,
   type SpanInputOutput,
+  type LLMModeTrace,
 } from "./types";
 import { camelToSnakeCaseNested, type Strict } from "./typeUtils";
 import {
@@ -42,6 +44,7 @@ import {
 import { LangWatchExporter } from "./LangWatchExporter";
 
 export type {
+  Trace,
   BaseSpan,
   ChatMessage as ChatMessage,
   ChatRichContent,
@@ -52,6 +55,7 @@ export type {
   PendingRAGSpan,
   RAGSpan,
   SpanInputOutput,
+  LLMModeTrace,
 };
 
 export {

--- a/typescript-sdk/src/types.ts
+++ b/typescript-sdk/src/types.ts
@@ -8,9 +8,14 @@ import {
   type RAGSpan as ServerRAGSpan,
   type SpanInputOutput as ServerSpanInputOutput,
   type TypedValueChatMessages,
-  type Trace,
+  type Trace as ServerTrace,
   type RESTEvaluation as ServerRESTEvaluation,
+  type LLMModeTrace as ServerLLMModeTrace,
 } from "./server/types/tracer";
+
+export type Trace = ServerTrace;
+
+export type LLMModeTrace = ServerLLMModeTrace;
 
 export type Metadata = SnakeToCamelCaseNested<Trace["metadata"]>;
 

--- a/typescript-sdk/src/utils.ts
+++ b/typescript-sdk/src/utils.ts
@@ -62,6 +62,9 @@ export function convertFromVercelAIMessages(
                       },
                     };
                   }
+                  default: {
+                    return part as any;
+                  }
                 }
               })
             : content,

--- a/typescript-sdk/ts-to-zod.config.js
+++ b/typescript-sdk/ts-to-zod.config.js
@@ -18,5 +18,7 @@ module.exports = {
       "EvaluationRESTResult",
       "Json",
       "Literal",
+      "DatasetSpan",
+      "LLMModeTrace",
     ].includes(name),
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an ASCII tree representation of trace spans in the JSON response, enhancing visualization of hierarchical relationships.
  - Added a new optional parameter `llmMode` that modifies the response structure, including a `asciiTree` and formatted timestamps when enabled.
  - Expanded type definitions with new types `LLMModeTrace` and updated `Trace` for clearer naming conventions.

- **Bug Fixes**
  - Enhanced robustness of the `convertFromVercelAIMessages` function to handle unexpected part types without errors.

- **Chores**
  - Updated package version from "0.1.5" to "0.1.6".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->