### PR TITLE
Add logfire parsing otel

### DIFF
--- a/langwatch/src/server/tracer/opentelemetry.ts
+++ b/langwatch/src/server/tracer/opentelemetry.ts
@@ -422,6 +422,14 @@ const addOpenTelemetrySpanAsSpan = (
     };
   }
 
+  // logfire
+  if (!input && attributesMap.raw_input) {
+    input = {
+      type: "chat_messages",
+      value: attributesMap.raw_input as any,
+    };
+  }
+
   // Output
   if (
     attributesMap.llm?.output_messages &&
@@ -527,6 +535,21 @@ const addOpenTelemetrySpanAsSpan = (
           };
   }
   delete attributesMap.output;
+
+  // logfire
+  if (!output) {
+    const genAIChoice = (attributesMap?.events as unknown as any[])?.find(
+      (event) => event?.["event.name"] === "gen_ai.choice"
+    );
+    if (genAIChoice?.message) {
+      output = {
+        type: "chat_messages",
+        value: [
+          genAIChoice.message
+        ],
+      };
+    }
+  }
 
   // Metadata
   if (attributesMap.user?.id) {


### PR DESCRIPTION
As many other providers, logfire's opentelemetry maps genai input/outputs to a different key, which we map back here too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced telemetry monitoring for chat interactions.
  - Now captures both user chat inputs and AI-generated message events, leading to more comprehensive and accurate logging of chat data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->