### PR TITLE
feat: add helm charts

### DIFF
--- a/.github/workflows/release-helm-charts.yml
+++ b/.github/workflows/release-helm-charts.yml
@@ -1,0 +1,38 @@
+name: Release Helm Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/**"
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/langwatch/.helmignore
+++ b/charts/langwatch/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/langwatch/Chart.yaml
+++ b/charts/langwatch/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: langwatch
+description: Helm chart for LangWatch application
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -1,0 +1,19 @@
+## Installation
+
+When installing this chart, the following values must be provided:
+
+- `app.env.NEXTAUTH_SECRET`: A random string used to hash tokens, sign cookies and generate cryptographic keys. If not provided, authentication will fail.
+- `app.env.API_TOKEN_JWT_SECRET`: A random string to store provided API tokens.
+- `app.env.BASE_HOST`: The base URL of the application.
+- `app.env.NEXTAUTH_URL`: The URL of the authentication service.
+
+Example:
+
+```bash
+export NEXTAUTH_SECRET=$(openssl rand -base64 32)
+export API_TOKEN_JWT_SECRET=$(openssl rand -base64 32)
+export BASE_HOST="http://localhost:5560" # or yourdomain.com
+export NEXTAUTH_URL="http://localhost:5560" # or yourdomain.com
+
+helm install langwatch ./langwatch --set app.env.NEXTAUTH_SECRET=$NEXTAUTH_SECRET --set app.env.API_TOKEN_JWT_SECRET=$API_TOKEN_JWT_SECRET --set app.env.BASE_HOST=$BASE_HOST --set app.env.NEXTAUTH_URL=$NEXTAUTH_URL
+```

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/* Generate common labels */}}
+{{- define "langwatch.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: langwatch
+{{- end }}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-app
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "langwatch.labels" . | nindent 4 }}
+  {{- if .Values.global.monitoring.enabled }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.app.service.port }}"
+  {{- end }}
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-app
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-app
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "langwatch.labels" . | nindent 8 }}
+    spec:
+      # Pod security context
+      securityContext:
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
+      # Node selection
+      {{- with .Values.global.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-app
+          securityContext:
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.images.app.repository }}:{{ .Values.images.app.tag }}"
+          imagePullPolicy: {{ .Values.images.app.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.service.port }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.app.env }}
+            - name: {{ $key }}
+              value: {{ tpl $value $ | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -22,7 +22,6 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Release.Name }}-app
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- include "langwatch.labels" . | nindent 8 }}
     spec:
       # Pod security context
       securityContext:
@@ -57,3 +56,9 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}

--- a/charts/langwatch/templates/app/service.yaml
+++ b/charts/langwatch/templates/app/service.yaml
@@ -1,0 +1,18 @@
+# Service for the main LangWatch application
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-app
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.app.service.type }}
+  ports:
+    - port: {{ .Values.app.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-app
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/langwatch/templates/langevals/deployment.yaml
+++ b/charts/langwatch/templates/langevals/deployment.yaml
@@ -18,8 +18,13 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-langevals
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      # Pod security context
+      securityContext:
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-langevals
+          securityContext:
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
           image: "{{ .Values.images.langevals.repository }}:{{ .Values.images.langevals.tag }}"
           imagePullPolicy: {{ .Values.images.langevals.pullPolicy }}
           ports:
@@ -34,3 +39,9 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.langevals.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}

--- a/charts/langwatch/templates/langevals/deployment.yaml
+++ b/charts/langwatch/templates/langevals/deployment.yaml
@@ -1,0 +1,36 @@
+# Deployment for the LangWatch Evaluations service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-langevals
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-langevals
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.langevals.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-langevals
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-langevals
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-langevals
+          image: "{{ .Values.images.langevals.repository }}:{{ .Values.images.langevals.tag }}"
+          imagePullPolicy: {{ .Values.images.langevals.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.langevals.service.port }}
+              protocol: TCP
+          # Environment variables for the evaluations service
+          env:
+            {{- range $key, $value := .Values.langevals.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.langevals.resources | nindent 12 }}

--- a/charts/langwatch/templates/langevals/service.yaml
+++ b/charts/langwatch/templates/langevals/service.yaml
@@ -1,0 +1,18 @@
+# Service for the LangWatch Evaluations component
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-langevals
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-langevals
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.langevals.service.type }}
+  ports:
+    - port: {{ .Values.langevals.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-langevals
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/langwatch/templates/langwatch_nlp/deployment.yaml
+++ b/charts/langwatch/templates/langwatch_nlp/deployment.yaml
@@ -18,8 +18,13 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-langwatch-nlp
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      # Pod security context
+      securityContext:
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-langwatch-nlp
+          securityContext:
+            {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
           image: "{{ .Values.images.langwatch_nlp.repository }}:{{ .Values.images.langwatch_nlp.tag }}"
           imagePullPolicy: {{ .Values.images.langwatch_nlp.pullPolicy }}
           ports:
@@ -34,3 +39,13 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.langwatch_nlp.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp
+            - name: log-dir
+              mountPath: /var/log
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}
+        - name: log-dir
+          emptyDir: {}

--- a/charts/langwatch/templates/langwatch_nlp/deployment.yaml
+++ b/charts/langwatch/templates/langwatch_nlp/deployment.yaml
@@ -1,0 +1,36 @@
+# Deployment for the LangWatch NLP service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-langwatch-nlp
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-langwatch-nlp
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.langwatch_nlp.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-langwatch-nlp
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-langwatch-nlp
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-langwatch-nlp
+          image: "{{ .Values.images.langwatch_nlp.repository }}:{{ .Values.images.langwatch_nlp.tag }}"
+          imagePullPolicy: {{ .Values.images.langwatch_nlp.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.langwatch_nlp.service.port }}
+              protocol: TCP
+          # Environment variables for the NLP service
+          env:
+            {{- range $key, $value := .Values.langwatch_nlp.env }}
+            - name: {{ $key }}
+              value: {{ tpl $value $ | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.langwatch_nlp.resources | nindent 12 }}

--- a/charts/langwatch/templates/langwatch_nlp/service.yaml
+++ b/charts/langwatch/templates/langwatch_nlp/service.yaml
@@ -1,0 +1,18 @@
+# Service for the LangWatch NLP component
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-langwatch-nlp
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-langwatch-nlp
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.langwatch_nlp.service.type }}
+  ports:
+    - port: {{ .Values.langwatch_nlp.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-langwatch-nlp
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/langwatch/templates/opensearch/service.yaml
+++ b/charts/langwatch/templates/opensearch/service.yaml
@@ -1,0 +1,20 @@
+# Service for OpenSearch
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-opensearch
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-opensearch
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.opensearch.service.type }}
+  ports:
+    {{- range .Values.opensearch.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .name }}
+      protocol: TCP
+      name: {{ .name }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-opensearch
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/langwatch/templates/opensearch/statefulset.yaml
+++ b/charts/langwatch/templates/opensearch/statefulset.yaml
@@ -63,16 +63,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 30
             failureThreshold: 3
-      # Set ulimits for the container
-      initContainers:
-        - name: init-sysctl
-          image: busybox
-          command:
-            - sysctl
-            - -w
-            - vm.max_map_count=262144
-          securityContext:
-            privileged: true
       # Pod security context
       securityContext:
         fsGroup: 1000

--- a/charts/langwatch/templates/opensearch/statefulset.yaml
+++ b/charts/langwatch/templates/opensearch/statefulset.yaml
@@ -1,0 +1,93 @@
+# StatefulSet for OpenSearch
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-opensearch
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-opensearch
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  serviceName: {{ .Release.Name }}-opensearch
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-opensearch
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-opensearch
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-opensearch
+          image: "{{ .Values.images.opensearch.repository }}:{{ .Values.images.opensearch.tag }}"
+          imagePullPolicy: {{ .Values.images.opensearch.pullPolicy }}
+          ports:
+            {{- range .Values.opensearch.service.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: TCP
+            {{- end }}
+          # Environment variables for OpenSearch
+          env:
+            {{- range $key, $value := .Values.opensearch.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.opensearch.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/opensearch/data
+          # Security context settings for OpenSearch
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+          # Health check for OpenSearch
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ index .Values.opensearch.service.ports 0 "port" }}
+            initialDelaySeconds: 90
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ index .Values.opensearch.service.ports 0 "port" }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 3
+      # Set ulimits for the container
+      initContainers:
+        - name: init-sysctl
+          image: busybox
+          command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          securityContext:
+            privileged: true
+      # Pod security context
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+  # Persistent volume claim for OpenSearch data
+  {{- if .Values.opensearch.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.opensearch.persistence.storageClass }}
+        storageClassName: {{ .Values.opensearch.persistence.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.opensearch.persistence.size }}
+  {{- end }}

--- a/charts/langwatch/templates/postgres/service.yaml
+++ b/charts/langwatch/templates/postgres/service.yaml
@@ -1,0 +1,18 @@
+# Service for PostgreSQL database
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-postgres
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.postgres.service.type }}
+  ports:
+    - port: {{ .Values.postgres.service.port }}
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/langwatch/templates/postgres/statefulset.yaml
+++ b/charts/langwatch/templates/postgres/statefulset.yaml
@@ -1,0 +1,75 @@
+# StatefulSet for PostgreSQL database
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-postgres
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  serviceName: {{ .Release.Name }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-postgres
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-postgres
+          image: "{{ .Values.images.postgres.repository }}:{{ .Values.images.postgres.tag }}"
+          imagePullPolicy: {{ .Values.images.postgres.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgres.service.port }}
+              protocol: TCP
+          # Environment variables for PostgreSQL
+          env:
+            {{- range $key, $value := .Values.postgres.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          # Health checks for PostgreSQL
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready -U {{ .Values.postgres.env.POSTGRES_USER }} -d {{ .Values.postgres.env.POSTGRES_DB }}
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready -U {{ .Values.postgres.env.POSTGRES_USER }} -d {{ .Values.postgres.env.POSTGRES_DB }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+  # Persistent volume claim for PostgreSQL data
+  {{- if .Values.postgres.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.postgres.persistence.storageClass }}
+        storageClassName: {{ .Values.postgres.persistence.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size }}
+  {{- end }}

--- a/charts/langwatch/templates/redis/service.yaml
+++ b/charts/langwatch/templates/redis/service.yaml
@@ -1,0 +1,12 @@
+# Service for Redis
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.redis.service.type }}
+  ports:
+    - port

--- a/charts/langwatch/templates/redis/service.yaml
+++ b/charts/langwatch/templates/redis/service.yaml
@@ -9,4 +9,10 @@ metadata:
 spec:
   type: {{ .Values.redis.service.type }}
   ports:
-    - port
+    - port: {{ .Values.redis.service.port }}
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -1,0 +1,67 @@
+# StatefulSet for Redis
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-redis
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  serviceName: {{ .Release.Name }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-redis
+          image: "{{ .Values.images.redis.repository }}:{{ .Values.images.redis.tag }}"
+          imagePullPolicy: {{ .Values.images.redis.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.redis.service.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          # Health checks for Redis
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+  # Persistent volume claim for Redis data
+  {{- if .Values.redis.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.redis.persistence.storageClass }}
+        storageClassName: {{ .Values.redis.persistence.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size }}
+  {{- end }}

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -57,10 +57,10 @@ app:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1024Mi
   env:
     SKIP_ENV_VALIDATION: "true"
     DISABLE_PII_REDACTION: "true"
@@ -70,6 +70,13 @@ app:
     REDIS_URL: "redis://{{ .Release.Name }}-redis:6379"
     LANGWATCH_NLP_SERVICE: "http://{{ .Release.Name }}-langwatch-nlp:5561"
     LANGEVALS_ENDPOINT: "http://{{ .Release.Name }}-langevals:5562"
+    # User provided environment variables
+    BASE_HOST: "http://localhost:5560"
+    NEXTAUTH_URL: "http://localhost:5560"
+    NEXTAUTH_SECRET: ""  # Users must provide this values
+    API_TOKEN_JWT_SECRET: ""  # Users must provide this values
+    # SENDGRID_API_KEY: ""  # Optional
+
 
 langwatch_nlp:
   replicaCount: 1
@@ -85,6 +92,8 @@ langwatch_nlp:
       memory: 512Mi
   env:
     LANGWATCH_ENDPOINT: "http://{{ .Release.Name }}-app:5560"
+    # For when running on minikube on Mac OS
+    # STUDIO_RUNTIME: "async"
 
 langevals:
   replicaCount: 1
@@ -93,13 +102,11 @@ langevals:
     port: 5562
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
       cpu: 500m
-      memory: 512Mi
-  env:
-    DISABLE_EVALUATORS_PRELOAD: "true"
+      memory: 4096Mi
+    limits:
+      cpu: 1000m
+      memory: 6144Mi
 
 postgres:
   service:

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1,0 +1,196 @@
+# Global configuration
+global:
+  env: production
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+  scheduling:
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  monitoring:
+    enabled: false
+    prometheusAnnotations: true
+
+
+# Image configurations
+images:
+  app:
+    repository: langwatch/langwatch
+    tag: latest
+    pullPolicy: Always
+  langwatch_nlp:
+    repository: langwatch/langwatch_nlp
+    tag: latest
+    pullPolicy: Always
+  langevals:
+    repository: langwatch/langevals
+    tag: latest
+    pullPolicy: Always
+  postgres:
+    repository: postgres
+    tag: "16"
+    pullPolicy: IfNotPresent
+  redis:
+    repository: redis
+    tag: alpine
+    pullPolicy: IfNotPresent
+  opensearch:
+    repository: opensearchproject/opensearch
+    tag: 2.17.1
+    pullPolicy: IfNotPresent
+
+
+# Service configurations
+app:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 5560
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  env:
+    SKIP_ENV_VALIDATION: "true"
+    DISABLE_PII_REDACTION: "true"
+    DATABASE_URL: "postgresql://prisma:prisma@{{ .Release.Name }}-postgres:5432/mydb?schema=mydb"
+    ELASTICSEARCH_NODE_URL: "http://{{ .Release.Name }}-opensearch:9200"
+    IS_OPENSEARCH: "true"
+    REDIS_URL: "redis://{{ .Release.Name }}-redis:6379"
+    LANGWATCH_NLP_SERVICE: "http://{{ .Release.Name }}-langwatch-nlp:5561"
+    LANGEVALS_ENDPOINT: "http://{{ .Release.Name }}-langevals:5562"
+
+langwatch_nlp:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 5561
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  env:
+    LANGWATCH_ENDPOINT: "http://{{ .Release.Name }}-app:5560"
+
+langevals:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 5562
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  env:
+    DISABLE_EVALUATORS_PRELOAD: "true"
+
+postgres:
+  service:
+    type: ClusterIP
+    port: 5432
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  env:
+    POSTGRES_DB: mydb
+    POSTGRES_USER: prisma
+    POSTGRES_PASSWORD: prisma
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+
+redis:
+  service:
+    type: ClusterIP
+    port: 6379
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+
+opensearch:
+  service:
+    type: ClusterIP
+    ports:
+      - name: http
+        port: 9200
+      - name: transport
+        port: 9600
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  env:
+    discovery.type: single-node
+    DISABLE_SECURITY_PLUGIN: "true"
+    _JAVA_OPTIONS: "-XX:UseSVE=0"
+    plugins.anomaly_detection.enabled: "false"
+    plugins.flow_framework.enabled: "false"
+    plugins.security_analytics.ioc_finding_enabled: "false"
+    plugins.sql.enabled: "false"
+    plugins.rollup.enabled: "false"
+    OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m -XX:+UseG1GC -XX:-UseSerialGC -XX:G1ReservePercent=25 -XX:+AlwaysPreTouch -XX:InitiatingHeapOccupancyPercent=30"
+    cluster.routing.allocation.disk.threshold_enabled: "false"
+    bootstrap.memory_lock: "false"
+    cluster.routing.allocation.disk.watermark.low: "95%"
+    cluster.routing.allocation.disk.watermark.high: "96%"
+    cluster.routing.allocation.disk.watermark.flood_stage: "97%"
+    cluster.info.update.interval: "1m"
+    OPENSEARCH_INITIAL_ADMIN_PASSWORD: "Some-random-password-which-is-greater-than-16-chars-long~"
+    node.store.allow_mmap: "false"
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+  ulimits:
+    memlock:
+      soft: -1
+      hard: -1
+    nofile:
+      soft: 65536
+      hard: 65536
+
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []

--- a/compose.yml
+++ b/compose.yml
@@ -35,6 +35,8 @@ services:
     pull_policy: always
     environment:
       - LANGWATCH_ENDPOINT=http://app:5560
+      # For when running on Mac OS
+      # - STUDIO_RUNTIME=async
 
   langevals:
     image: langwatch/langevals:latest


### PR DESCRIPTION
This one adds a Helm chart for deploying LangWatch and its dependencies on Kubernetes. The chart provides a standardized way to deploy the entire LangWatch stack including the main application, NLP service, evaluations service, and required infrastructure components (PostgreSQL, Redis, and OpenSearch).

### [Features]
- Complete Helm chart structure following best practices
- Service-based organization within templates directory
- Configurable resource settings for all components
- Persistent storage for stateful services
- Health checks and readiness probes
- Support for custom environment variables


### [How to use]
Add the repository (once repository is set up)
```
helm repo add langwatch https://langwatch.github.io/charts
```

Update repositories
```
helm repo update
```

Install LangWatch
```
helm install langwatch langwatch/langwatch
```

### [Future Improvements]
- Add support for advanced Kubernetes features (HPA, PDB, NetworkPolicies)
- Improve security context settings
- Add node affinity and scheduling options
- Add monitoring and metrics integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a comprehensive deployment package for the LangWatch application with configurable setups.
	- Enabled flexible, scalable deployments for multiple components including the main application, NLP, evaluations, search functionalities, database services, and caching.
	- Added centralized settings for resource management, monitoring, persistence, and dynamic environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->