### PR TITLE
Remove Object.freeze and add a late update example showing how you can modify spans after being sent to send again

### DIFF
--- a/typescript-sdk/example/app/late-update/page.tsx
+++ b/typescript-sdk/example/app/late-update/page.tsx
@@ -1,0 +1,27 @@
+import { nanoid } from '@/lib/utils'
+import { Chat } from '@/components/chat'
+import { auth } from '@/auth'
+import { Session } from '@/lib/types'
+import { getMissingKeys } from '@/app/actions'
+import { LateUpdateTracing } from '../../lib/chat/late-update'
+
+export const metadata = {
+  title: 'Late Update Tracing Example'
+}
+
+export default async function IndexPage() {
+  const id = nanoid()
+  const session = (await auth()) as Session
+  const missingKeys = await getMissingKeys()
+
+  return (
+    <>
+      <div className="text-center w-full absolute pt-1">
+        Late Update Tracing Example
+      </div>
+      <LateUpdateTracing initialAIState={{ chatId: id, messages: [] }}>
+        <Chat id={id} session={session} missingKeys={missingKeys} />
+      </LateUpdateTracing>
+    </>
+  )
+}

--- a/typescript-sdk/example/components/header.tsx
+++ b/typescript-sdk/example/components/header.tsx
@@ -93,6 +93,10 @@ export function Header() {
         <Button variant="plain" asChild className="-ml-2">
           <Link href="/manual">Manual Tracing</Link>
         </Button>
+        <IconSeparator className="size-6 text-muted-foreground/50" />
+        <Button variant="plain" asChild className="-ml-2">
+          <Link href="/late-update">Late Update Tracing</Link>
+        </Button>
       </div>
       <div className="flex items-center justify-end space-x-2">
         <a

--- a/typescript-sdk/example/lib/chat/late-update.tsx
+++ b/typescript-sdk/example/lib/chat/late-update.tsx
@@ -1,0 +1,208 @@
+import 'server-only'
+
+import { openai } from '@ai-sdk/openai'
+import {
+  createAI,
+  createStreamableValue,
+  getAIState,
+  getMutableAIState,
+  streamUI
+} from 'ai/rsc'
+
+import { BotMessage } from '@/components/stocks'
+
+import { saveChat } from '@/app/actions'
+import { auth } from '@/auth'
+import { SpinnerMessage, UserMessage } from '@/components/stocks/message'
+import { Chat, Message } from '@/lib/types'
+import { nanoid } from '@/lib/utils'
+import { LangWatch, convertFromVercelAIMessages } from 'langwatch'
+
+async function submitUserMessage(content: string) {
+  'use server'
+
+  const langwatch = new LangWatch()
+  langwatch.on('error', e => {
+    console.log('Error from LangWatch:', e)
+  })
+
+  const trace = langwatch.getTrace()
+
+  const aiState = getMutableAIState<typeof LateUpdateTracing>()
+
+  aiState.update({
+    ...aiState.get(),
+    messages: [
+      ...aiState.get().messages,
+      {
+        id: nanoid(),
+        role: 'user',
+        content
+      }
+    ]
+  })
+
+  const system = "You are a helpful assistant."
+
+  const span = trace.startLLMSpan({
+    model: 'gpt-4o-mini',
+    input: {
+      type: 'chat_messages',
+      value: [
+        {
+          role: 'system',
+          content: system
+        },
+        ...convertFromVercelAIMessages(aiState.get().messages)
+      ]
+    }
+  })
+
+  const onFinish = (output: Message[]) => {
+    aiState.done({
+      ...aiState.get(),
+      messages: [...aiState.get().messages, ...output]
+    })
+
+    span.end({
+      output: {
+        type: 'chat_messages',
+        value: convertFromVercelAIMessages(output)
+      }
+    })
+
+    setTimeout(() => {
+      span.end({
+        params: {
+          late_update_at: (new Date()).toISOString()
+        }
+      })
+    }, 5000);
+  }
+
+  let textStream: undefined | ReturnType<typeof createStreamableValue<string>>
+  let textNode: undefined | React.ReactNode
+
+  const result = await streamUI({
+    model: openai('gpt-4o-mini'),
+    initial: <SpinnerMessage />,
+    system,
+    messages: [
+      ...aiState.get().messages.map((message: any) => ({
+        role: message.role,
+        content: message.content,
+        name: message.name
+      }))
+    ],
+    text: ({ content, done, delta }) => {
+      if (!textStream) {
+        textStream = createStreamableValue('')
+        textNode = <BotMessage content={textStream.value} />
+      }
+
+      if (done) {
+        textStream.done()
+
+        onFinish([
+          {
+            id: nanoid(),
+            role: 'assistant',
+            content
+          }
+        ])
+      } else {
+        textStream.update(delta)
+      }
+
+      return textNode
+    }
+  })
+
+  return {
+    id: nanoid(),
+    display: result.value
+  }
+}
+
+export type AIState = {
+  chatId: string
+  messages: Message[]
+}
+
+export type UIState = {
+  id: string
+  display: React.ReactNode
+}[]
+
+export const LateUpdateTracing = createAI<AIState, UIState>({
+  actions: {
+    submitUserMessage
+  },
+  initialUIState: [],
+  initialAIState: { chatId: nanoid(), messages: [] },
+  onGetUIState: async () => {
+    'use server'
+
+    const session = await auth()
+
+    if (session && session.user) {
+      const aiState = getAIState()
+
+      if (aiState) {
+        // @ts-ignore
+        const uiState = getUIStateFromAIState(aiState)
+        return uiState
+      }
+    } else {
+      return
+    }
+  },
+  onSetAIState: async ({ state }) => {
+    'use server'
+
+    const session = await auth()
+
+    if (session && session.user) {
+      const { chatId, messages } = state
+
+      const createdAt = new Date()
+      const userId = session.user.id as string
+      const path = `/chat/${chatId}`
+
+      const firstMessageContent = messages[0].content as string
+      const title = firstMessageContent.substring(0, 100)
+
+      const chat: Chat = {
+        id: chatId,
+        title,
+        userId,
+        createdAt,
+        messages,
+        path
+      }
+
+      await saveChat(chat)
+    } else {
+      return
+    }
+  }
+})
+
+export const getUIStateFromAIState = (aiState: Chat) => {
+  return aiState.messages
+    .filter(message => message.role !== 'system')
+    .map((message, index) => ({
+      id: `${aiState.chatId}-${index}`,
+      display:
+        message.role === 'tool' ? (
+          message.content.map(tool => {
+            return `Tool used: ${tool.toolName}`
+          })
+        ) : message.role === 'user' ? (
+          <UserMessage>{message.content as string}</UserMessage>
+        ) : message.role === 'assistant' &&
+          typeof message.content === 'string' ? (
+          <BotMessage content={message.content} />
+        ) : null
+    }))
+}

--- a/typescript-sdk/package-lock.json
+++ b/typescript-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langwatch",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langwatch",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@langchain/core": "^0.2.7",

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langwatch",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/typescript-sdk/src/index.ts
+++ b/typescript-sdk/src/index.ts
@@ -520,8 +520,6 @@ export class LangWatchSpan implements PendingBaseSpan {
       this.update(params);
     }
 
-    Object.freeze(this);
-
     try {
       const finalSpan = spanSchema.parse(
         camelToSnakeCaseNested({


### PR DESCRIPTION
This is useful in some use cases where user wants to send in the span earlier, but still want to attach additional metadata after a long running process later on