### PR TITLE
Fix multiple type issues due to pending workflow dsl schema

### DIFF
--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -47,7 +47,7 @@ const DATASET_INFERRED_MAPPINGS_BY_NAME_TRANSPOSED = Object.entries(
 ).reduce(
   (acc, [key, value]) => {
     if (acc[value]) {
-      acc[value].push(key);
+      acc[value]!.push(key);
     } else {
       acc[value] = [key];
     }

--- a/langwatch/src/optimization_studio/server/addEnvs.ts
+++ b/langwatch/src/optimization_studio/server/addEnvs.ts
@@ -4,7 +4,7 @@ import {
 } from "../../server/api/routers/modelProviders";
 import { prisma } from "../../server/db";
 import type { MaybeStoredModelProvider } from "../../server/modelProviders/registry";
-import type { LLMConfig, ServerWorkflow } from "../types/dsl";
+import type { LLMConfig, ServerWorkflow, Workflow } from "../types/dsl";
 import type { StudioClientEvent } from "../types/events";
 import crypto from "crypto";
 
@@ -50,10 +50,10 @@ export const addEnvs = async (
   };
 
   const workflow: ServerWorkflow = {
-    ...event.payload.workflow,
+    ...(event.payload.workflow as Workflow),
     workflow_id,
     api_key: apiKey,
-    nodes: event.payload.workflow.nodes.map((node) => {
+    nodes: (event.payload.workflow.nodes as Workflow["nodes"]).map((node) => {
       const parameters = node.data.parameters?.map((p) => {
         if (p.type === "llm") {
           return {

--- a/langwatch/src/optimization_studio/server/loadDatasets.ts
+++ b/langwatch/src/optimization_studio/server/loadDatasets.ts
@@ -97,7 +97,7 @@ export const loadDatasets = async (
   );
 
   const workflow: Workflow = {
-    ...event.payload.workflow,
+    ...(event.payload.workflow as Workflow),
     nodes,
   };
 

--- a/langwatch/src/optimization_studio/types/dsl.ts
+++ b/langwatch/src/optimization_studio/types/dsl.ts
@@ -144,6 +144,7 @@ type Flow = {
   edges: Edge[];
 };
 
+// TODO: make this a complete replacement for Workflow below
 export const workflowJsonSchema = z
   .object({
     workflow_id: z.string().optional(),
@@ -158,6 +159,7 @@ export const workflowJsonSchema = z
         "Version must be in the format 'number.number' (e.g. 1.0)"
       ),
     nodes: z.array(z.any()),
+    default_llm: llmConfigSchema,
   })
   .passthrough();
 

--- a/langwatch/src/optimization_studio/types/events.ts
+++ b/langwatch/src/optimization_studio/types/events.ts
@@ -26,7 +26,7 @@ export const studioClientEventSchema = z.discriminatedUnion("type", [
       trace_id: z.string(),
       workflow: workflowJsonSchema,
       until_node_id: z.string().optional(),
-      inputs: z.record(z.string()).optional(),
+      inputs: z.array(z.record(z.string())).optional(),
       manual_execution_mode: z.boolean().optional(),
     }),
   }),

--- a/langwatch/src/server/tracer/types.ts
+++ b/langwatch/src/server/tracer/types.ts
@@ -426,12 +426,12 @@ export type DatasetSpan =
   | (Omit<
       BaseSpan,
       "project_id" | "trace_id" | "id" | "timestamps" | "metrics" | "params"
-    > & { params: Record<string, any>; model?: string })
+    > & { params: Record<string, any>; model?: string | null })
   | (Omit<
       LLMSpan,
       "project_id" | "trace_id" | "id" | "timestamps" | "metrics" | "params"
-    > & { params: Record<string, any>; model?: string })
+    > & { params: Record<string, any>; model?: string | null })
   | (Omit<
       RAGSpan,
       "project_id" | "trace_id" | "id" | "timestamps" | "metrics" | "params"
-    > & { params: Record<string, any>; model?: string });
+    > & { params: Record<string, any>; model?: string | null });


### PR DESCRIPTION
I broke typechecking in quite a few places with #178, sorry for that, this PR is to unblock the pipeline, once workflowJsonSchema is done the other places will force me to remove the current typecasting as well (it will throw a "typecasting is not needed"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration option for specifying a default language model in workflow definitions.
	- Updated event handling now supports multiple input records for executing flows.
- **Refactor**
	- Enhanced internal reliability by enforcing stricter type checks and null safety, reducing potential runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->