### PR TITLE
Add monitor graph as a new type of graph to be rendered on the new evaluations v2 page for real time monitoring

### DIFF
--- a/langwatch/src/components/analytics/CustomGraph.tsx
+++ b/langwatch/src/components/analytics/CustomGraph.tsx
@@ -5,6 +5,9 @@ import {
   Spinner,
   Flex,
   type SystemStyleObject,
+  Text,
+  VStack,
+  Skeleton,
 } from "@chakra-ui/react";
 import type { TRPCClientErrorLike } from "@trpc/client";
 import type { UseTRPCQueryResult } from "@trpc/react-query/shared";
@@ -71,13 +74,15 @@ export type CustomGraphInput = {
     | "scatter"
     | "pie"
     | "donnut"
-    | "summary";
+    | "summary"
+    | "monitor_graph";
   series: Series[];
   groupBy?: z.infer<typeof timeseriesSeriesInput>["groupBy"];
   includePrevious: boolean;
   timeScale: "full" | number;
   connected?: boolean;
   height?: number;
+  disabled?: boolean;
 };
 
 export const summaryGraphTypes: CustomGraphInput["graphType"][] = [
@@ -99,16 +104,19 @@ const GraphComponentMap: Partial<{
   area: [AreaChart, Area],
   stacked_area: [AreaChart, Area],
   scatter: [ScatterChart, Scatter],
+  monitor_graph: [AreaChart, Area],
 };
 
 export function CustomGraph({
   input,
   titleProps,
   hideGroupLabel = false,
+  size = "md",
 }: {
   input: CustomGraphInput;
   titleProps?: SystemStyleObject;
   hideGroupLabel?: boolean;
+  size?: "sm" | "md";
 }) {
   const publicEnv = usePublicEnv();
 
@@ -127,7 +135,7 @@ export function CustomGraph({
       input={input}
       titleProps={titleProps}
       hideGroupLabel={hideGroupLabel}
-      enabled={!!publicEnv.data}
+      load={!!publicEnv.data}
     />
   );
 }
@@ -137,7 +145,8 @@ const CustomGraph_ = React.memo(
     input,
     titleProps,
     hideGroupLabel = false,
-    enabled = true,
+    load = true,
+    size,
   }: {
     input: CustomGraphInput;
     titleProps?: {
@@ -146,7 +155,8 @@ const CustomGraph_ = React.memo(
       fontWeight?: SystemStyleObject["fontWeight"];
     };
     hideGroupLabel?: boolean;
-    enabled?: boolean;
+    load?: boolean;
+    size?: "sm" | "md";
   }) {
     const height_ = input.height ?? 300;
     const { filterParams, queryOpts } = useFilterParams();
@@ -161,7 +171,7 @@ const CustomGraph_ = React.memo(
           ? input.timeScale
           : parseInt(input.timeScale.toString(), 10),
       },
-      { ...queryOpts, enabled: queryOpts.enabled && enabled }
+      { ...queryOpts, enabled: queryOpts.enabled && load }
     );
 
     const currentAndPreviousData = shapeDataForGraph(input, timeseries);
@@ -177,7 +187,14 @@ const CustomGraph_ = React.memo(
     const currentAndPreviousDataFilled =
       input.graphType === "scatter"
         ? currentAndPreviousData
-        : fillEmptyData(currentAndPreviousData, expectedKeys);
+        : fillEmptyData(
+            currentAndPreviousData,
+            expectedKeys,
+            input.graphType === "monitor_graph" &&
+              input.series[0]?.metric.includes("pass_rate")
+              ? 1
+              : 0
+          );
     const keysToValues = Object.fromEntries(
       expectedKeys.map((key) => [
         key,
@@ -256,7 +273,8 @@ const CustomGraph_ = React.memo(
           "without error": positive,
         };
 
-        return getColor(colorSet, colorMap[groupKey] ?? neutral);
+        const color = getColor(colorSet, colorMap[groupKey] ?? neutral);
+        return color;
       }
 
       return getColor(colorSet, index);
@@ -516,6 +534,26 @@ const CustomGraph_ = React.memo(
             </Bar>
           </BarChart>
         </ResponsiveContainer>
+      );
+    }
+
+    if (input.graphType === "monitor_graph") {
+      return container(
+        <MonitorGraph
+          input={input}
+          seriesByKey={seriesByKey}
+          currentAndPreviousData={currentAndPreviousData}
+          currentAndPreviousDataFilled={currentAndPreviousDataFilled}
+          sortedKeys={sortedKeys}
+          nameForSeries={nameForSeries}
+          getColor={getColor}
+          size={size}
+          filterParams={filterParams}
+          height_={height_}
+          formatWith={formatWith}
+          yAxisValueFormat={yAxisValueFormat}
+          formatDate={formatDate}
+        />
       );
     }
 
@@ -818,24 +856,223 @@ const flattenGroupData = (
 
 const fillEmptyData = (
   data: ReturnType<typeof shapeDataForGraph>,
-  expectedKeys: string[]
+  expectedKeys: string[],
+  fillWith = 0
 ) => {
   if (!data) return data;
   const filledData = data.map((entry) => {
     const filledEntry = { ...entry };
     expectedKeys.forEach((key) => {
       if (filledEntry[key] === null || filledEntry[key] === undefined) {
-        filledEntry[key] = 0;
+        filledEntry[key] = fillWith;
       }
       const previousKey = `previous>${key}`;
       if (
         filledEntry[previousKey] === null ||
         filledEntry[previousKey] === undefined
       ) {
-        filledEntry[previousKey] = 0;
+        filledEntry[previousKey] = fillWith;
       }
     });
     return filledEntry;
   });
   return filledData;
 };
+
+function MonitorGraph({
+  input,
+  seriesByKey,
+  sortedKeys,
+  currentAndPreviousData,
+  currentAndPreviousDataFilled,
+  nameForSeries,
+  getColor,
+  size,
+  filterParams,
+  height_,
+  formatWith,
+  yAxisValueFormat,
+  formatDate,
+}: {
+  input: CustomGraphInput;
+  seriesByKey: Record<string, Series>;
+  currentAndPreviousData: ReturnType<typeof shapeDataForGraph>;
+  currentAndPreviousDataFilled: ReturnType<typeof shapeDataForGraph>;
+  sortedKeys: string[];
+  nameForSeries: (aggKey: string) => string;
+  getColor: (
+    colorSet: RotatingColorSet,
+    index: number,
+    opacity: number
+  ) => string;
+  size?: "sm" | "md";
+  filterParams: ReturnType<typeof useFilterParams>["filterParams"];
+  height_: number;
+  formatWith: (
+    format: string | ((value: number) => string) | undefined,
+    value: number
+  ) => string | ((value: number) => string);
+  yAxisValueFormat: string | ((value: number) => string) | undefined;
+  formatDate: (date: string) => string;
+}) {
+  const firstKey = Object.keys(seriesByKey)[0] ?? "";
+  const name = nameForSeries(firstKey);
+  const isPassRate = firstKey.includes("pass_rate");
+  const allValues = isPassRate
+    ? currentAndPreviousDataFilled?.map((entry) => entry[firstKey]!).filter(x => x !== undefined && x !== null)
+    : currentAndPreviousData?.map((entry) => entry[firstKey]!).filter(x => x !== undefined && x !== null);
+  const total =
+    allValues?.reduce((acc, curr) => {
+      return acc + curr;
+    }, 0) ?? 0;
+  const average = total / (allValues?.length ?? 1);
+  const hasLoaded = currentAndPreviousDataFilled?.length !== undefined;
+  const gray400 = useColorRawValue("gray.400");
+
+  // TODO: allow user to define the thresholds instead of hardcoded amounts
+  const colorSet: RotatingColorSet = input.disabled
+    ? "grayTones"
+    : average > 0.8 || !hasLoaded
+    ? "greenTones"
+    : average < 0.4
+    ? "redTones"
+    : "orangeTones";
+
+  const maxValue = isPassRate
+    ? 1
+    : Math.max(...(allValues && allValues.length > 0 ? allValues : [1]));
+
+  return (
+    <Box
+      width="full"
+      height="full"
+      position="relative"
+      border="1px solid"
+      borderColor={getColor(colorSet, 0, -200)}
+      backgroundColor={getColor(colorSet, 0, -400)}
+      borderRadius="lg"
+      padding={2}
+    >
+      <VStack
+        position="absolute"
+        bottom={size === "md" ? 8 : 0}
+        left={size === "md" ? 20 : 0}
+        zIndex={1}
+        padding={8}
+        gap={2}
+        align="start"
+        color={getColor(colorSet, 0, 300)}
+      >
+        <Text fontSize="sm" fontWeight="medium" paddingBottom={1}>
+          {name}
+          {input.disabled && " (disabled)"}
+        </Text>
+        <HStack gap={2}>
+          <Text fontSize="2xl" fontWeight="bold">
+            {hasLoaded ? (
+              numeral(average).format(isPassRate ? "0%" : "0.[00]")
+            ) : (
+              <Skeleton
+                width="56px"
+                height="36px"
+                backgroundColor={getColor(colorSet, 0, -100)}
+              />
+            )}
+          </Text>
+          <Text fontSize="xs">
+            {isPassRate ? "Pass Rate" : "Average Score"}
+          </Text>
+        </HStack>
+        <Text fontSize="xs">
+          {filterParams.startDate &&
+            filterParams.endDate &&
+            (() => {
+              const now = new Date().getTime();
+              const daysDiff = Math.abs(
+                Math.ceil((now - filterParams.endDate) / (1000 * 60 * 60 * 24))
+              );
+              const periodDays = Math.ceil(
+                (filterParams.endDate - filterParams.startDate) /
+                  (1000 * 60 * 60 * 24)
+              );
+
+              // If end date is within one day of today, show "Last X days"
+              if (daysDiff <= 1) {
+                return `Last ${periodDays} days`;
+              }
+              // Otherwise show date range
+              else {
+                return `${format(
+                  new Date(filterParams.startDate),
+                  "MMM d"
+                )} - ${format(new Date(filterParams.endDate), "MMM d, yyyy")}`;
+              }
+            })()}
+        </Text>
+      </VStack>
+      <ResponsiveContainer
+        key={currentAndPreviousDataFilled ? input.graphId : "loading"}
+        height={height_}
+      >
+        <AreaChart
+          data={currentAndPreviousDataFilled}
+          margin={
+            size === "md"
+              ? {
+                  top: 10,
+                  left: formatWith(yAxisValueFormat, maxValue).length * 6 - 5,
+                  right: 24,
+                }
+              : {}
+          }
+        >
+          {size === "md" && (
+            <>
+              <XAxis
+                type="category"
+                dataKey="date"
+                name="Date"
+                tickFormatter={formatDate}
+                tickLine={false}
+                axisLine={false}
+                tick={{ fill: gray400 }}
+              />
+              <YAxis
+                type="number"
+                axisLine={false}
+                tickLine={false}
+                tickCount={4}
+                tickMargin={20}
+                domain={[0, maxValue]}
+                tick={{ fill: gray400 }}
+                tickFormatter={(value) => {
+                  if (typeof yAxisValueFormat === "function") {
+                    return yAxisValueFormat(value);
+                  }
+                  return numeral(value).format(yAxisValueFormat);
+                }}
+              />
+            </>
+          )}
+          {(sortedKeys ?? []).map((aggKey, index) => (
+            <Area
+              key={aggKey}
+              type="monotone"
+              dataKey={aggKey}
+              stroke={getColor(colorSet, index, -300)}
+              stackId={
+                ["stacked_bar", "stacked_area"].includes(input.graphType)
+                  ? "same"
+                  : undefined
+              }
+              fill={getColor(colorSet, index, -300)}
+              strokeWidth={2.5}
+              dot={false}
+              name={nameForSeries(aggKey)}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}

--- a/langwatch/src/components/evaluations/MonitorsSection.tsx
+++ b/langwatch/src/components/evaluations/MonitorsSection.tsx
@@ -1,40 +1,31 @@
-import { useState } from "react";
 import {
+  Badge,
   Box,
-  Button,
   Card,
   HStack,
   Heading,
-  Text,
-  VStack,
-  Badge,
   IconButton,
   SimpleGrid,
+  Text,
 } from "@chakra-ui/react";
+import type { Check } from "@prisma/client";
+import { useState } from "react";
 import { ChevronDown, ChevronUp, MoreHorizontal } from "react-feather";
-import { AreaChart, Area, ResponsiveContainer } from "recharts";
-import { getStatusColor, getStatusIcon, getChartColor } from "./utils";
 import { Menu } from "../../components/ui/menu";
-
-type Monitor = {
-  id: string;
-  name: string;
-  type: string;
-  metric: string;
-  value: number;
-  status: "error" | "warning" | "healthy";
-  lastUpdated: string;
-  history: { time: string; value: number }[];
-};
+import { CustomGraph } from "../analytics/CustomGraph";
+import { getEvaluatorDefinitions } from "../../server/evaluations/getEvaluator";
 
 type MonitorsSectionProps = {
   title: string;
-  description: string;
-  monitors: Monitor[];
+  evaluations: Check[];
   onEditMonitor: (monitorId: string) => void;
 };
 
-export const MonitorsSection = ({ title, description, monitors, onEditMonitor }: MonitorsSectionProps) => {
+export const MonitorsSection = ({
+  title,
+  evaluations,
+  onEditMonitor,
+}: MonitorsSectionProps) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   return (
@@ -44,7 +35,7 @@ export const MonitorsSection = ({ title, description, monitors, onEditMonitor }:
           <HStack gap={2}>
             <Heading size="md">{title}</Heading>
             <Badge variant="outline" px={2} py={1}>
-              {monitors.length} Active
+              {evaluations.length} Active
             </Badge>
           </HStack>
           <IconButton
@@ -59,89 +50,62 @@ export const MonitorsSection = ({ title, description, monitors, onEditMonitor }:
 
         {!isCollapsed && (
           <>
-            <Text color="gray.600" mb={4}>
-              {description}
-            </Text>
-
             <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={4}>
-              {monitors.map((monitor) => {
-                const statusColor = getStatusColor(monitor.status, monitor.value);
-                const statusIcon = getStatusIcon(monitor.status, monitor.value);
-                const chartColor = getChartColor(monitor.status, monitor.value);
+              {evaluations.map((evaluation) => {
+                const evaluatorDefinition = getEvaluatorDefinitions(
+                  evaluation.checkType
+                );
+                // TODO: handle custom evaluators
 
                 return (
-                  <Card.Root
-                    key={monitor.id}
-                    position="relative"
-                    overflow="hidden"
-                    bg={statusColor.bg}
-                    color={statusColor.color}
-                    borderColor={statusColor.borderColor}
-                    borderWidth="1px"
-                    _hover={{ shadow: "sm" }}
-                    height="full"
-                  >
-                    <Card.Body>
-                      {/* Background Chart */}
-                      <Box position="absolute" inset={0} opacity={0.15} pointerEvents="none">
-                        <ResponsiveContainer width="100%" height="100%">
-                          <AreaChart data={monitor.history}>
-                            <defs>
-                              <linearGradient id={`color-${monitor.id}`} x1="0" y1="0" x2="0" y2="1">
-                                <stop offset="0%" stopColor={chartColor} stopOpacity={0.8} />
-                                <stop offset="100%" stopColor={chartColor} stopOpacity={0.2} />
-                              </linearGradient>
-                            </defs>
-                            <Area
-                              type="monotone"
-                              dataKey="value"
-                              stroke={chartColor}
-                              fill={`url(#color-${monitor.id})`}
-                            />
-                          </AreaChart>
-                        </ResponsiveContainer>
-                      </Box>
-
-                      <VStack align="start" gap={2} position="relative" zIndex={1} height="full">
-                        <HStack width="full" justify="space-between">
-                          <Text fontWeight="medium" fontSize="sm">
-                            {monitor.name}
-                          </Text>
-                          <HStack gap={2}>
-                            <Box>{statusIcon}</Box>
-                            <Menu.Root>
-                              <Menu.Trigger asChild>
-                                <IconButton
-                                  variant="ghost"
-                                  size="sm"
-                                  aria-label="More options"
-                                >
-                                  <MoreHorizontal size={16} />
-                                </IconButton>
-                              </Menu.Trigger>
-                              <Menu.Content>
-                                <Menu.Item value="edit" onClick={() => onEditMonitor(monitor.id)}>
-                                  Edit
-                                </Menu.Item>
-                              </Menu.Content>
-                            </Menu.Root>
-                          </HStack>
-                        </HStack>
-
-                        <VStack align="start" gap={1} mt="auto">
-                          <HStack>
-                            <Text fontSize="2xl" fontWeight="bold" mr={1}>
-                              {(monitor.value * 100).toFixed(0)}%
-                            </Text>
-                            <Text fontSize="xs">{monitor.metric}</Text>
-                          </HStack>
-                          <Text fontSize="xs" opacity={0.7}>
-                            Updated {monitor.lastUpdated}
-                          </Text>
-                        </VStack>
-                      </VStack>
-                    </Card.Body>
-                  </Card.Root>
+                  <Box key={evaluation.id} position="relative">
+                    <Menu.Root>
+                      <Menu.Trigger
+                        asChild
+                        position="absolute"
+                        top={4}
+                        right={4}
+                        zIndex={2}
+                      >
+                        <IconButton
+                          variant="ghost"
+                          size="sm"
+                          aria-label="More options"
+                        >
+                          <MoreHorizontal size={16} />
+                        </IconButton>
+                      </Menu.Trigger>
+                      <Menu.Content>
+                        <Menu.Item
+                          value="edit"
+                          onClick={() => onEditMonitor(evaluation.id)}
+                        >
+                          Edit
+                        </Menu.Item>
+                      </Menu.Content>
+                    </Menu.Root>
+                    <CustomGraph
+                      input={{
+                        graphId: evaluation.id,
+                        graphType: "monitor_graph",
+                        series: [
+                          {
+                            aggregation: "avg",
+                            colorSet: "tealTones",
+                            key: evaluation.id,
+                            metric: evaluatorDefinition?.isGuardrail
+                              ? "evaluations.evaluation_pass_rate"
+                              : "evaluations.evaluation_score",
+                            name: evaluation.name,
+                          },
+                        ],
+                        includePrevious: false,
+                        timeScale: 1,
+                        height: 140,
+                        disabled: !evaluation.enabled,
+                      }}
+                    />
+                  </Box>
                 );
               })}
             </SimpleGrid>

--- a/langwatch/src/components/evaluations/wizard/steps/evaluations/EvaluatorSettingsAccordion.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/evaluations/EvaluatorSettingsAccordion.tsx
@@ -90,7 +90,6 @@ export const EvaluatorSettingsAccordion = () => {
 
   useEffect(() => {
     form.watch(() => {
-      console.log(form.getValues());
       void form.handleSubmit(onSubmit)();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/langwatch/src/hooks/useGetRotatingColorForCharts.tsx
+++ b/langwatch/src/hooks/useGetRotatingColorForCharts.tsx
@@ -2,12 +2,17 @@ import { rotatingColors, type RotatingColorSet } from "../utils/rotatingColors";
 import { getRawColorValue } from "../components/ui/color-mode";
 
 export const useGetRotatingColorForCharts = () => {
-  return (set: RotatingColorSet, index: number) => {
+  return (set: RotatingColorSet, index: number, adjustment = 0) => {
     const [name, number] =
       rotatingColors[set]![index % rotatingColors[set]!.length]!.color.split(
         "."
       );
 
-    return getRawColorValue(`${name}.${number}`);
+    return getRawColorValue(
+      `${name}.${Math.max(
+        Math.min(parseInt(number ?? "0") + adjustment, 900),
+        50
+      )}`
+    );
   };
 };

--- a/langwatch/src/pages/[project]/analytics/custom/index.tsx
+++ b/langwatch/src/pages/[project]/analytics/custom/index.tsx
@@ -16,7 +16,7 @@ import {
   Textarea,
   VStack,
   createListCollection,
-  useDisclosure
+  useDisclosure,
 } from "@chakra-ui/react";
 
 import {
@@ -36,7 +36,7 @@ import {
   PieChart,
   Trash,
   TrendingUp,
-  Triangle
+  Triangle,
 } from "react-feather";
 import {
   Controller,
@@ -99,6 +99,7 @@ import {
   camelCaseToTitleCase,
   uppercaseFirstLetterLowerCaseRest,
 } from "../../../../utils/stringCasing";
+import { LuChartArea } from "react-icons/lu";
 
 export interface CustomGraphFormData {
   title?: string;
@@ -199,6 +200,11 @@ const chartOptions: Required<CustomGraphFormData>["graphType"][] = [
     label: "Donut Chart",
     value: "donnut",
     icon: <PieChart />,
+  },
+  {
+    label: "Monitor Graph",
+    value: "monitor_graph",
+    icon: <LuChartArea />,
   },
 ];
 

--- a/langwatch/src/pages/[project]/evaluations_v2.tsx
+++ b/langwatch/src/pages/[project]/evaluations_v2.tsx
@@ -47,51 +47,6 @@ export default function EvaluationsV2() {
     void router.push(`/${project.slug}/evaluations/${monitorId}/edit`);
   };
 
-  // Transform checks data into monitor format
-  const guardrails =
-    checks.data
-      ?.filter((check) => check.executionMode === "AS_GUARDRAIL")
-      .map((check) => ({
-        id: check.id,
-        name: check.name,
-        type: "boolean",
-        metric: "Pass Rate",
-        value: 0.95, // TODO: Get real value from metrics
-        status: "healthy" as const,
-        lastUpdated: "2 min ago", // TODO: Get real timestamp
-        history: [
-          { time: "1", value: 0.92 },
-          { time: "2", value: 0.95 },
-          { time: "3", value: 0.97 },
-          { time: "4", value: 0.96 },
-          { time: "5", value: 0.95 },
-          { time: "6", value: 0.99 },
-          { time: "7", value: 0.95 },
-        ],
-      })) ?? [];
-
-  const monitors =
-    checks.data
-      ?.filter((check) => check.executionMode !== "AS_GUARDRAIL")
-      .map((check) => ({
-        id: check.id,
-        name: check.name,
-        type: "boolean",
-        metric: "Pass Rate",
-        value: 0.87, // TODO: Get real value from metrics
-        status: "healthy" as const,
-        lastUpdated: "5 min ago", // TODO: Get real timestamp
-        history: [
-          { time: "1", value: 0.82 },
-          { time: "2", value: 0.84 },
-          { time: "3", value: 0.81 },
-          { time: "4", value: 0.85 },
-          { time: "5", value: 0.86 },
-          { time: "6", value: 0.87 },
-          { time: "7", value: 0.87 },
-        ],
-      })) ?? [];
-
   return (
     <DashboardLayout>
       <Container maxWidth="1200" padding={6}>
@@ -138,16 +93,8 @@ export default function EvaluationsV2() {
           ) : (
             <>
               <MonitorsSection
-                title="Active Guardrails"
-                description="Real-time evaluation systems that block or flag messages"
-                monitors={guardrails}
-                onEditMonitor={handleEditMonitor}
-              />
-
-              <MonitorsSection
                 title="Active Monitors"
-                description="Post-execution evaluation systems that analyze results"
-                monitors={monitors}
+                evaluations={checks.data}
                 onEditMonitor={handleEditMonitor}
               />
 

--- a/langwatch/src/server/analytics/registry.ts
+++ b/langwatch/src/server/analytics/registry.ts
@@ -606,7 +606,7 @@ export const analyticsMetrics = {
       },
       aggregation: (aggregation, key) => {
         return {
-          [`evaluation_score_${aggregation}_${key}`]: {
+          [`evaluation_pass_rate_${aggregation}_${key}`]: {
             nested: {
               path: "evaluations",
             },
@@ -644,7 +644,7 @@ export const analyticsMetrics = {
         };
       },
       extractionPath: (aggregation: AggregationTypes, key) => {
-        return `evaluation_score_${aggregation}_${key}>child>child`;
+        return `evaluation_pass_rate_${aggregation}_${key}>child>child`;
       },
       quickwitSupport: false,
     },

--- a/langwatch/src/utils/rotatingColors.ts
+++ b/langwatch/src/utils/rotatingColors.ts
@@ -83,6 +83,7 @@ export const rotatingColors = {
   cyanTones: tones("cyan"),
   pinkTones: tones("pink"),
   grayTones: tones("gray"),
+  redTones: tones("red"),
 } satisfies Record<string, { background: string; color: string }[]>;
 
 const colorMap: Record<string, { background: string; color: string }> = {};


### PR DESCRIPTION
The way I added this new graph together with all others on CustomGraph is a bit messy, but bear with me, we might review all our analytics section later on

<img width="1495" alt="Screenshot 2025-03-28 at 14 12 13" src="https://github.com/user-attachments/assets/3bb53433-4ab7-40b3-861a-b8f31bdf6a40" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "monitor_graph" visualization option with a dedicated display component.
  - Added a new analytics metric for evaluation pass rate.

- **Refactor**
  - Transitioned the evaluations display from a monitor-centric to an evaluation-centric view.
  - Simplified data handling and layout for clearer visualization.
  - Updated the dynamic color selection mechanism to offer enhanced flexibility.
  - Removed unnecessary debugging output for cleaner operation.

- **Chores**
  - Expanded available color tones by adding new red tones for improved styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->