### PR TITLE
fix: remove double pushing to hubspot

### DIFF
--- a/langwatch/src/server/api/routers/onboarding.ts
+++ b/langwatch/src/server/api/routers/onboarding.ts
@@ -58,7 +58,6 @@ export const onboardingRouter = createTRPCRouter({
         const orgResult = await orgRouter.createAndAssign({
           orgName: input.orgName,
           phoneNumber: input.phoneNumber,
-          signUpData: input.signUpData,
         });
         if (!orgResult.success) {
           throw new TRPCError({

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -21,7 +21,6 @@ import {
   checkUserPermissionForTeam,
   skipPermissionCheck,
 } from "../permission";
-import { dependencies } from "../../../injection/dependencies.server";
 import * as Sentry from "@sentry/nextjs";
 import { env } from "~/env.mjs";
 
@@ -75,23 +74,6 @@ export const organizationRouter = createTRPCRouter({
       z.object({
         orgName: z.string().optional(),
         phoneNumber: z.string().optional(),
-        signUpData: z
-          .object({
-            usage: z.string().optional().nullable(),
-            solution: z.string().optional().nullable(),
-            terms: z.boolean().optional(),
-            companyType: z.string().optional().nullable(),
-            companySize: z.string().optional().nullable(),
-            projectType: z.string().optional().nullable(),
-            howDidYouHearAboutUs: z.string().optional().nullable(),
-            otherCompanyType: z.string().optional().nullable(),
-            otherProjectType: z.string().optional().nullable(),
-            otherHowDidYouHearAboutUs: z.string().optional().nullable(),
-            yourRole: z.string().optional().nullable(),
-            featureUsage: z.string().optional().nullable(),
-            utmCampaign: z.string().optional().nullable(),
-          })
-          .optional(),
       })
     )
     .use(skipPermissionCheck)
@@ -158,14 +140,6 @@ export const organizationRouter = createTRPCRouter({
 
         return { organization, team };
       });
-
-      if (dependencies.postRegistrationCallback) {
-        try {
-          await dependencies.postRegistrationCallback(ctx.session.user, input);
-        } catch (err) {
-          Sentry.captureException(err);
-        }
-      }
 
       return {
         success: true,


### PR DESCRIPTION
This is done inside the new `onboarding` router, so we can remove onboarding logic from the organization domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the organization registration process by removing optional input fields related to sign-up data.
	- Eliminated post-registration processing steps, resulting in a simpler, more efficient workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->