### PR TITLE
Fix autoconversion for running evaluations with contexts which was causing 422 in prod

### DIFF
--- a/langwatch/src/server/background/workers/evaluationsWorker.ts
+++ b/langwatch/src/server/background/workers/evaluationsWorker.ts
@@ -306,10 +306,10 @@ export const runEvaluation = async ({
             {
               input: tryAndConvertTo(data.data.input, "string"),
               output: tryAndConvertTo(data.data.output, "string"),
-              contexts: tryAndConvertTo(data.data.contexts, "array"),
+              contexts: tryAndConvertTo(data.data.contexts, "string[]"),
               expected_contexts: tryAndConvertTo(
                 data.data.expected_contexts,
-                "array"
+                "string[]"
               ),
               expected_output: tryAndConvertTo(
                 data.data.expected_output,

--- a/langwatch/src/server/tracer/tracesMapping.ts
+++ b/langwatch/src/server/tracer/tracesMapping.ts
@@ -493,10 +493,17 @@ export const tryAndConvertTo = <T extends keyof StringTypeToType>(
     return undefined;
   }
   if (type === "string") {
-    return value.toString();
+    return (
+      typeof value === "string" ? value : JSON.stringify(value)
+    ) as StringTypeToType[T];
   }
   if (type === "number") {
     return Number(value) as StringTypeToType[T];
+  }
+  if (Array.isArray(value) && type === "string[]") {
+    return value.map((v) =>
+      tryAndConvertTo(v, "string")
+    ) as unknown as StringTypeToType[T];
   }
   if (
     typeof value === "string" &&
@@ -508,15 +515,22 @@ export const tryAndConvertTo = <T extends keyof StringTypeToType>(
         return parsed as unknown as StringTypeToType[T];
       }
       if (Array.isArray(parsed)) {
+        if (type === "string[]") {
+          return parsed.map((v) =>
+            tryAndConvertTo(v, "string")
+          ) as unknown as StringTypeToType[T];
+        }
         return parsed as unknown as StringTypeToType[T];
       }
       throw new Error("Failed to parse to a valid type, falling back");
     } catch (e) {
       if (type === "string[]") {
-        return [value.toString()] as unknown as StringTypeToType[T];
+        return [
+          tryAndConvertTo(value, "string"),
+        ] as unknown as StringTypeToType[T];
       }
       if (type === "array") {
-        return [value.toString()] as unknown as StringTypeToType[T];
+        return [value] as unknown as StringTypeToType[T];
       }
       if (type === "object") {
         return { _json: value } as unknown as StringTypeToType[T];


### PR DESCRIPTION
Fixes this issue when running evaluators like Ragas Response Context Precision:

<img width="575" alt="image" src="https://github.com/user-attachments/assets/13ac73e0-8e82-4fdc-9f6c-ddd4b31fb63b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced internal data processing to ensure that evaluation inputs are consistently handled as arrays of strings.
	- Improved conversion routines for various input types, resulting in more robust error handling and reliable data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->