### PR TITLE
Add default model

### DIFF
--- a/langwatch/prisma/migrations/20250413070227_add_default_model/migration.sql
+++ b/langwatch/prisma/migrations/20250413070227_add_default_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "defaultModel" TEXT;

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -190,6 +190,7 @@ model Project {
     experiments          Experiment[]
     annotations          Annotation[]
     modelProviders       ModelProvider[]
+    defaultModel         String?
     topicClusteringModel String?
     embeddingsModel      String?
     TriggerSent          TriggerSent[]

--- a/langwatch/src/components/checks/DynamicZodForm.tsx
+++ b/langwatch/src/components/checks/DynamicZodForm.tsx
@@ -32,6 +32,8 @@ import { SmallLabel } from "../SmallLabel";
 import { Tooltip } from "../ui/tooltip";
 import { Switch } from "../ui/switch";
 import type { CheckConfigFormData } from "./CheckConfigForm";
+import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+import { DEFAULT_EMBEDDINGS_MODEL, DEFAULT_MODEL } from "../../utils/constants";
 
 const DynamicZodForm = ({
   schema,
@@ -51,6 +53,7 @@ const DynamicZodForm = ({
   skipFields?: string[];
 }) => {
   const { control, register } = useFormContext();
+  const { project } = useOrganizationTeamProject();
 
   const renderField = <T extends EvaluatorTypes>(
     fieldSchema: ZodType,
@@ -58,9 +61,17 @@ const DynamicZodForm = ({
     evaluator: EvaluatorDefinition<T> | undefined
   ): React.JSX.Element | null => {
     const fullPath = prefix ? `${prefix}.${fieldName}` : fieldName;
-    const defaultValue =
+    let defaultValue =
       evaluator?.settings?.[fieldName as keyof Evaluators[T]["settings"]]
         ?.default;
+
+    if (fieldName === "model") {
+      defaultValue = (project?.defaultModel ?? DEFAULT_MODEL) as any;
+    }
+    if (fieldName === "embeddings_model") {
+      defaultValue = (project?.embeddingsModel ??
+        DEFAULT_EMBEDDINGS_MODEL) as any;
+    }
 
     const fieldSchema_ =
       fieldSchema instanceof z.ZodOptional ? fieldSchema.unwrap() : fieldSchema;

--- a/langwatch/src/components/evaluations/wizard/EvaluationWizard.tsx
+++ b/langwatch/src/components/evaluations/wizard/EvaluationWizard.tsx
@@ -126,6 +126,7 @@ const WizardSidebar = memo(function WizardSidebar({
     executionMethod,
     isAutosaving,
     experimentId,
+    evaluatorNode,
   } = useEvaluationWizardStore(
     useShallow((state) => {
       return {
@@ -137,6 +138,7 @@ const WizardSidebar = memo(function WizardSidebar({
         executionMethod: state.wizardState.executionMethod,
         isAutosaving: state.isAutosaving,
         experimentId: state.experimentId,
+        evaluatorNode: state.getFirstEvaluatorNode(),
       };
     })
   );
@@ -192,10 +194,13 @@ const WizardSidebar = memo(function WizardSidebar({
   const saveAsMonitor = api.experiments.saveAsMonitor.useMutation();
   const router = useRouter();
 
-  // When step changes, if it's execution or evaluation,
-  // Update the view to show the workflow tab
+  // When state changes, update the view to show the tab user
+  // should be paying attention to at the moment
   useEffect(() => {
-    if (step === "execution" || step === "evaluation") {
+    if (step === "execution" && executionMethod) {
+      setWizardState({ workspaceTab: "workflow" });
+    }
+    if (step === "evaluation" && evaluatorNode) {
       setWizardState({ workspaceTab: "workflow" });
     }
     if (step === "dataset") {
@@ -204,7 +209,7 @@ const WizardSidebar = memo(function WizardSidebar({
     if (step === "results") {
       setWizardState({ workspaceTab: "results" });
     }
-  }, [step, setWizardState]);
+  }, [step, setWizardState, executionMethod, evaluatorNode]);
 
   return (
     <VStack

--- a/langwatch/src/components/evaluations/wizard/hooks/evaluation-wizard-store/slices/executorSlice.ts
+++ b/langwatch/src/components/evaluations/wizard/hooks/evaluation-wizard-store/slices/executorSlice.ts
@@ -25,8 +25,10 @@ export interface ExecutorSlice {
    */
   upsertExecutorNodeByType: ({
     type,
+    project,
   }: {
     type: "signature" | "code";
+    project?: { defaultModel?: string | null };
   }) => NodeId;
 }
 
@@ -39,10 +41,13 @@ export const createExecutorSlice: StateCreator<
   [],
   ExecutorSlice
 > = (_set, get) => {
-  const createNodeByType = (type: "signature" | "code") => {
+  const createNodeByType = (
+    type: "signature" | "code",
+    project?: { defaultModel?: string | null }
+  ) => {
     switch (type) {
       case "signature":
-        return get().createNewLlmSignatureNode();
+        return get().createNewLlmSignatureNode({ project });
       case "code":
         return get().createNewCodeExecutionNode();
       default:
@@ -58,10 +63,9 @@ export const createExecutorSlice: StateCreator<
         (node) => node.type && EXECUTOR_NODE_TYPES.includes(node.type)
       );
     },
-    upsertExecutorNodeByType: ({ type }: { type: "signature" | "code" }) => {
+    upsertExecutorNodeByType: ({ type, project }) => {
       const existingExecutorNode = get().getFirstExecutorNode();
-      const node = createNodeByType(type);
-      console.log({ existingExecutorNode, node });
+      const node = createNodeByType(type, project);
 
       if (!existingExecutorNode) {
         switch (type) {

--- a/langwatch/src/components/evaluations/wizard/hooks/evaluation-wizard-store/slices/factories/llm-signature-node.factory.ts
+++ b/langwatch/src/components/evaluations/wizard/hooks/evaluation-wizard-store/slices/factories/llm-signature-node.factory.ts
@@ -1,13 +1,12 @@
 import type { Signature } from "~/optimization_studio/types/dsl";
 import type { NodeWithOptionalPosition } from "../types";
+import { DEFAULT_MODEL } from "../../../../../../../utils/constants";
 
 type LlmSignatureNode = NodeWithOptionalPosition<Signature>;
 
-const DEFAULT_LLM_CONFIG = {
-  model: "openai/gpt-4o-mini",
-};
-
-const DEFAULT_SIGNATURE_NODE_PROPERTIES: LlmSignatureNode = {
+const DEFAULT_SIGNATURE_NODE_PROPERTIES = (
+  model: string
+): LlmSignatureNode => ({
   type: "signature",
   id: "signature_node",
   deletable: false,
@@ -18,7 +17,9 @@ const DEFAULT_SIGNATURE_NODE_PROPERTIES: LlmSignatureNode = {
       {
         identifier: "llm",
         type: "llm" as const,
-        value: DEFAULT_LLM_CONFIG,
+        value: {
+          model,
+        },
       },
       {
         identifier: "prompting_technique",
@@ -49,15 +50,20 @@ const DEFAULT_SIGNATURE_NODE_PROPERTIES: LlmSignatureNode = {
       },
     ],
   },
-};
+});
 
 /**
  * Simple factory for creating LLM Signature Nodes
  */
 export class LlmSignatureNodeFactory {
-  static build(overrides?: Partial<LlmSignatureNode>): LlmSignatureNode {
+  static build(
+    overrides?: Partial<LlmSignatureNode>,
+    project?: { defaultModel?: string | null }
+  ): LlmSignatureNode {
     return {
-      ...DEFAULT_SIGNATURE_NODE_PROPERTIES,
+      ...DEFAULT_SIGNATURE_NODE_PROPERTIES(
+        project?.defaultModel ?? DEFAULT_MODEL
+      ),
       ...overrides,
     };
   }

--- a/langwatch/src/components/evaluations/wizard/hooks/evaluation-wizard-store/slices/llmSignatureNodeSlice.ts
+++ b/langwatch/src/components/evaluations/wizard/hooks/evaluation-wizard-store/slices/llmSignatureNodeSlice.ts
@@ -12,7 +12,11 @@ import { buildEntryToTargetEdges } from "./utils/edge.util";
 import { calculateNextPosition } from "./utils/node.util";
 
 export interface LlmSignatureNodeSlice {
-  createNewLlmSignatureNode: () => Node<Signature>;
+  createNewLlmSignatureNode: ({
+    project,
+  }: {
+    project?: { defaultModel?: string | null };
+  }) => Node<Signature>;
   addNewSignatureNodeToWorkflow: () => string;
   updateSignatureNodeLLMConfigValue: (
     nodeId: string,
@@ -30,15 +34,18 @@ export const createLlmSignatureNodeSlice: StateCreator<
     get().getNodesByType("entry")[0] as Node<Entry> | undefined;
 
   return {
-    createNewLlmSignatureNode: (): Node<Signature> => {
+    createNewLlmSignatureNode: ({ project }): Node<Signature> => {
       const entryNode = getEntryNode();
       const position = entryNode
         ? calculateNextPosition(entryNode.position)
         : { x: 0, y: 0 };
       return get().createNewNode(
-        LlmSignatureNodeFactory.build({
-          position,
-        })
+        LlmSignatureNodeFactory.build(
+          {
+            position,
+          },
+          project
+        )
       );
     },
 

--- a/langwatch/src/components/evaluations/wizard/hooks/usePostEvent.ts
+++ b/langwatch/src/components/evaluations/wizard/hooks/usePostEvent.ts
@@ -134,7 +134,7 @@ export const usePostEvent = () => {
         }
       })();
     },
-    [project]
+    [handleServerMessage, handleTimeout, project]
   );
 
   return { postEvent, isLoading };

--- a/langwatch/src/components/evaluations/wizard/steps/DatasetStep.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/DatasetStep.tsx
@@ -80,9 +80,9 @@ export function DatasetStep() {
     columnTypes: DatasetColumns
   ) => {
     setDatasetId(datasetId, columnTypes);
-    setWizardState({
-      step: "execution",
-    });
+    setTimeout(() => {
+      focusElementById("js-next-step-button");
+    }, 2000);
   };
 
   return (

--- a/langwatch/src/components/evaluations/wizard/steps/ResultsStep.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/ResultsStep.tsx
@@ -141,7 +141,9 @@ function StepStatus({
       justifyContent="start"
       _icon={{
         color: value ? "green.400" : "yellow.500",
+        minWidth: "20px",
         maxWidth: "20px",
+        minHeight: "20px",
         maxHeight: "20px",
         width: "20px",
         height: "20px",
@@ -154,7 +156,7 @@ function StepStatus({
           <Text fontWeight="medium" fontSize="14px">
             {name}
           </Text>
-          <Text fontSize="13px" fontWeight="normal">
+          <Text fontSize="13px" fontWeight="normal" lineClamp={1}>
             {value ?? `No ${action} selected`}
           </Text>
         </VStack>

--- a/langwatch/src/components/evaluations/wizard/steps/TaskStep.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/TaskStep.tsx
@@ -13,10 +13,9 @@ export function TaskStep() {
   const { wizardState, setWizardState, setDSL } = useEvaluationWizardStore();
 
   const handleTaskSelection = (task: State["wizardState"]["task"]) => {
-    if (task === wizardState.task) {
-      return;
-    } else {
+    if (task !== wizardState.task) {
       // Reset the workflow
+      // TODO: delete the executor node only
       setDSL({
         nodes: [],
         edges: [],

--- a/langwatch/src/components/evaluations/wizard/steps/evaluations/EvaluatorSettingsAccordion.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/evaluations/EvaluatorSettingsAccordion.tsx
@@ -9,8 +9,10 @@ import { getEvaluatorDefaultSettings } from "../../../../../server/evaluations/g
 import DynamicZodForm from "../../../../checks/DynamicZodForm";
 import type { Field } from "../../../../../optimization_studio/types/dsl";
 import { StepAccordion } from "../../components/StepAccordion";
+import { useOrganizationTeamProject } from "../../../../../hooks/useOrganizationTeamProject";
 
 export const EvaluatorSettingsAccordion = () => {
+  const { project } = useOrganizationTeamProject();
   const { wizardState, getFirstEvaluatorNode, setFirstEvaluator } =
     useEvaluationWizardStore();
 
@@ -41,7 +43,10 @@ export const EvaluatorSettingsAccordion = () => {
     Object.keys(settingsFromParameters).length > 0
       ? (settingsFromParameters as any)
       : evaluatorType
-      ? getEvaluatorDefaultSettings(AVAILABLE_EVALUATORS[evaluatorType])
+      ? getEvaluatorDefaultSettings(
+          AVAILABLE_EVALUATORS[evaluatorType],
+          project
+        )
       : undefined;
 
   const form = useForm<{

--- a/langwatch/src/components/evaluations/wizard/steps/execution/offline-exectution/ExecutionMethodSelectionStepAccordion.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/execution/offline-exectution/ExecutionMethodSelectionStepAccordion.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../hooks/evaluation-wizard-store/useEvaluationWizardStore";
 import { useAnimatedFocusElementById } from "../../../../../../hooks/useAnimatedFocusElementById";
 import { useUpdateNodeInternals } from "@xyflow/react";
+import { useOrganizationTeamProject } from "../../../../../../hooks/useOrganizationTeamProject";
 
 export const EXECUTION_METHOD_SELECTOR_STEP_ACCORDION_VALUE =
   "execution-method-selector";
@@ -26,6 +27,7 @@ export function ExecutionMethodSelectionStepAccordion({
 }: {
   onSelect: (executionMethod: OfflineExecutionMethod) => void;
 }) {
+  const { project } = useOrganizationTeamProject();
   const updateNodeInternals = useUpdateNodeInternals();
   const { executionMethod, upsertExecutorNodeByType, setWizardState } =
     useEvaluationWizardStore(
@@ -79,7 +81,7 @@ export function ExecutionMethodSelectionStepAccordion({
           description="Run a prompt via any LLM model to evaluate"
           icon={<LuMessageSquareCode />}
           onClick={() => {
-            const nodeId = upsertExecutorNodeByType({ type: "signature" });
+            const nodeId = upsertExecutorNodeByType({ type: "signature", project });
             updateNodeInternals(nodeId);
             handleOptionClick("offline_prompt");
           }}
@@ -89,7 +91,10 @@ export function ExecutionMethodSelectionStepAccordion({
           description="Run code"
           icon={<LuCode />}
           onClick={() => {
-            const nodeId = upsertExecutorNodeByType({ type: "code" });
+            const nodeId = upsertExecutorNodeByType({
+              type: "code",
+              project,
+            });
             updateNodeInternals(nodeId);
             handleOptionClick("offline_code_execution");
           }}

--- a/langwatch/src/optimization_studio/components/properties/EvaluatorPropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/EvaluatorPropertiesPanel.tsx
@@ -4,18 +4,17 @@ import { BasePropertiesPanel } from "./BasePropertiesPanel";
 import { z } from "zod";
 import { FormProvider, useForm } from "react-hook-form";
 import DynamicZodForm from "../../../components/checks/DynamicZodForm";
-import {
-  AVAILABLE_EVALUATORS,
-  type Evaluators,
-} from "../../../server/evaluations/evaluators.generated";
+import { AVAILABLE_EVALUATORS } from "../../../server/evaluations/evaluators.generated";
 import { evaluatorsSchema } from "../../../server/evaluations/evaluators.zod.generated";
 import { VStack } from "@chakra-ui/react";
 import { useCallback, useEffect } from "react";
 import { getEvaluatorDefaultSettings } from "../../../server/evaluations/getEvaluator";
 import { useWorkflowStore } from "../../hooks/useWorkflowStore";
 import { useDebouncedCallback } from "use-debounce";
+import { useOrganizationTeamProject } from "../../../hooks/useOrganizationTeamProject";
 
 export function EvaluatorPropertiesPanel({ node }: { node: Node<Evaluator> }) {
+  const { project } = useOrganizationTeamProject();
   const { setNode } = useWorkflowStore(({ setNode }) => ({ setNode }));
 
   const settingsFromParameters = Object.fromEntries(
@@ -34,15 +33,14 @@ export function EvaluatorPropertiesPanel({ node }: { node: Node<Evaluator> }) {
 
   const schema =
     evaluator && evaluator in AVAILABLE_EVALUATORS
-      ? evaluatorsSchema.shape[evaluator as keyof Evaluators].shape.settings
+      ? evaluatorsSchema.shape[evaluator].shape.settings
       : undefined;
 
   useEffect(() => {
     if (!evaluator || !(evaluator in AVAILABLE_EVALUATORS)) return;
     if (node.data.parameters) return;
 
-    const evaluatorDefinition =
-      AVAILABLE_EVALUATORS[evaluator as keyof Evaluators];
+    const evaluatorDefinition = AVAILABLE_EVALUATORS[evaluator];
 
     const setDefaultSettings = (
       defaultValues: Record<string, any>,
@@ -65,7 +63,7 @@ export function EvaluatorPropertiesPanel({ node }: { node: Node<Evaluator> }) {
     };
 
     setDefaultSettings(
-      getEvaluatorDefaultSettings(evaluatorDefinition),
+      getEvaluatorDefaultSettings(evaluatorDefinition, project),
       "settings"
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -118,7 +116,7 @@ export function EvaluatorPropertiesPanel({ node }: { node: Node<Evaluator> }) {
           <VStack width="full" gap={3}>
             <DynamicZodForm
               schema={schema}
-              evaluatorType={evaluator as keyof Evaluators}
+              evaluatorType={evaluator}
               prefix="settings"
               errors={form.formState.errors.settings}
               variant="studio"

--- a/langwatch/src/optimization_studio/components/workflow/NewWorkflowForm.tsx
+++ b/langwatch/src/optimization_studio/components/workflow/NewWorkflowForm.tsx
@@ -17,6 +17,7 @@ import { EmojiPickerModal } from "../properties/modals/EmojiPickerModal";
 import { trackEvent } from "../../../utils/tracking";
 import { toaster } from "../../../components/ui/toaster";
 import { Dialog } from "../../../components/ui/dialog";
+import { DEFAULT_MODEL } from "../../../utils/constants";
 
 type FormData = {
   name: string;
@@ -59,6 +60,10 @@ export const NewWorkflowForm = ({
         name: data.name,
         description: data.description,
         icon: data.icon ?? "🧩",
+        default_llm: {
+          ...template.default_llm,
+          model: project?.defaultModel ?? DEFAULT_MODEL,
+        },
       };
       const createdWorkflow = await createWorkflowMutation.mutateAsync(
         {

--- a/langwatch/src/optimization_studio/templates/blank.ts
+++ b/langwatch/src/optimization_studio/templates/blank.ts
@@ -37,7 +37,7 @@ export const blankTemplate: Workflow = {
   default_llm: {
     model: "openai/gpt-4o-mini",
     temperature: 0,
-    max_tokens: 2048,
+    max_tokens: 8192,
   },
   enable_tracing: true,
   nodes: [

--- a/langwatch/src/optimization_studio/templates/simple_rag.ts
+++ b/langwatch/src/optimization_studio/templates/simple_rag.ts
@@ -11,7 +11,7 @@ export const simpleRagTemplate: Workflow = {
   default_llm: {
     model: "openai/gpt-4o-mini",
     temperature: 0,
-    max_tokens: 2048,
+    max_tokens: 8192,
   },
   enable_tracing: true,
   nodes: [

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -44,6 +44,7 @@ import { toaster } from "../../components/ui/toaster";
 import {
   DEFAULT_EMBEDDINGS_MODEL,
   DEFAULT_TOPIC_CLUSTERING_MODEL,
+  DEFAULT_MODEL,
 } from "../../utils/constants";
 
 export default function ModelsPage() {
@@ -110,6 +111,7 @@ export default function ModelsPage() {
             </VStack>
           </Card.Body>
         </Card.Root>
+        <DefaultModel />
         <TopicClusteringModel />
         <EmbeddingsModel />
       </VStack>
@@ -376,6 +378,7 @@ function ModelProviderForm({
               </Field.Root>
               <Field.Root>
                 <Checkbox
+                  // eslint-disable-next-line @typescript-eslint/no-misused-promises
                   onChange={onUseCustomKeysChange}
                   checked={isUseCustomKeys}
                   flexShrink={0}
@@ -502,6 +505,79 @@ function ModelProviderForm({
   );
 }
 
+type DefaultModelForm = {
+  defaultModel: string;
+};
+
+function DefaultModel() {
+  const { project } = useOrganizationTeamProject();
+  const updateDefaultModel = api.project.updateDefaultModel.useMutation();
+
+  const { register, handleSubmit, control } = useForm<DefaultModelForm>({
+    defaultValues: {
+      defaultModel: project?.defaultModel ?? DEFAULT_MODEL,
+    },
+  });
+
+  const defaultModelField = register("defaultModel");
+
+  const onUpdateSubmit = useCallback(
+    async (data: DefaultModelForm) => {
+      await updateDefaultModel.mutateAsync({
+        projectId: project?.id ?? "",
+        defaultModel: data.defaultModel,
+      });
+      toaster.create({
+        title: "Default Model Updated",
+        type: "success",
+        duration: 3000,
+        meta: {
+          closable: true,
+        },
+      });
+    },
+    [updateDefaultModel, project?.id]
+  );
+
+  return (
+    <>
+      <HStack width="full" marginTop={6}>
+        <Heading size="md" as="h2">
+          Default Model
+        </Heading>
+        <Spacer />
+        {updateDefaultModel.isLoading && <Spinner />}
+      </HStack>
+      <Text>
+        Select the default model to be used for general tasks within LangWatch.
+      </Text>
+      <Card.Root width="full">
+        <Card.Body width="full">
+          <HorizontalFormControl label="Default Model" helper="">
+            <Controller
+              name={defaultModelField.name}
+              control={control}
+              render={({ field }) => (
+                <ModelSelector
+                  model={field.value}
+                  options={modelSelectorOptions
+                    .filter((option) => option.mode === "chat")
+                    .map((option) => option.value)}
+                  onChange={(model) => {
+                    field.onChange(model);
+                    void handleSubmit(onUpdateSubmit)();
+                  }}
+                  mode="chat"
+                />
+              )}
+            />
+          </HorizontalFormControl>
+        </Card.Body>
+      </Card.Root>
+    </>
+  );
+}
+
 type TopicClusteringModelForm = {
   topicClusteringModel: string;
 };
@@ -532,6 +608,14 @@ function TopicClusteringModel() {
         projectId: project?.id ?? "",
         topicClusteringModel: data.topicClusteringModel,
       });
+      toaster.create({
+        title: "Topic Clustering Model Updated",
+        type: "success",
+        duration: 3000,
+        meta: {
+          closable: true,
+        },
+      });
     },
     [updateTopicClusteringModel, project?.id]
   );
@@ -559,7 +643,6 @@ function TopicClusteringModel() {
                 <ModelSelector
                   model={field.value}
                   options={allowedTopicClusteringModels}
-                  // eslint-disable-next-line @typescript-eslint/no-misused-promises
                   onChange={(model) => {
                     field.onChange(model);
                     void handleSubmit(onUpdateSubmit)();
@@ -593,6 +676,14 @@ function EmbeddingsModel() {
         projectId: project?.id ?? "",
         embeddingsModel: data.embeddingsModel,
       });
+      toaster.create({
+        title: "Embeddings Model Updated",
+        type: "success",
+        duration: 3000,
+        meta: {
+          closable: true,
+        },
+      });
     },
     [updateEmbeddingsModel, project?.id]
   );
@@ -621,7 +712,6 @@ function EmbeddingsModel() {
                   options={modelSelectorOptions
                     .filter((option) => option.mode === "embedding")
                     .map((option) => option.value)}
-                  // eslint-disable-next-line @typescript-eslint/no-misused-promises
                   onChange={(model) => {
                     field.onChange(model);
                     void handleSubmit(onUpdateSubmit)();

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -111,9 +111,27 @@ export default function ModelsPage() {
             </VStack>
           </Card.Body>
         </Card.Root>
-        <DefaultModel />
-        <TopicClusteringModel />
-        <EmbeddingsModel />
+
+        <VStack width="full" align="start" gap={6}>
+          <VStack gap={2} marginTop={2} align="start" width="full">
+            <Heading size="md" as="h2">
+              Default Models
+            </Heading>
+            <Text>
+              Configure the default models used on workflows, evaluations and
+              other LangWatch features.
+            </Text>
+          </VStack>
+          <Card.Root width="full">
+            <Card.Body width="full">
+              <VStack gap={0} width="full" align="stretch">
+                <DefaultModel />
+                <TopicClusteringModel />
+                <EmbeddingsModel />
+              </VStack>
+            </Card.Body>
+          </Card.Root>
+        </VStack>
       </VStack>
     </SettingsLayout>
   );
@@ -269,7 +287,6 @@ function ModelProviderForm({
       await refetch();
     },
     [
-      enabledField,
       updateMutation,
       provider.id,
       provider.provider,
@@ -319,14 +336,7 @@ function ModelProviderForm({
         )
       );
     },
-    [
-      useCustomKeysField,
-      setValue,
-      provider,
-      deleteMutation,
-      project?.id,
-      refetch,
-    ]
+    [setValue, provider, deleteMutation, project?.id, refetch]
   );
 
   const providerKeys =
@@ -540,41 +550,33 @@ function DefaultModel() {
   );
 
   return (
-    <>
-      <HStack width="full" marginTop={6}>
-        <Heading size="md" as="h2">
-          Default Model
-        </Heading>
-        <Spacer />
-        {updateDefaultModel.isLoading && <Spinner />}
-      </HStack>
-      <Text>
-        Select the default model to be used for general tasks within LangWatch.
-      </Text>
-      <Card.Root width="full">
-        <Card.Body width="full">
-          <HorizontalFormControl label="Default Model" helper="">
-            <Controller
-              name={defaultModelField.name}
-              control={control}
-              render={({ field }) => (
-                <ModelSelector
-                  model={field.value}
-                  options={modelSelectorOptions
-                    .filter((option) => option.mode === "chat")
-                    .map((option) => option.value)}
-                  onChange={(model) => {
-                    field.onChange(model);
-                    void handleSubmit(onUpdateSubmit)();
-                  }}
-                  mode="chat"
-                />
-              )}
+    <HorizontalFormControl
+      label="Default Model"
+      helper="For general tasks within LangWatch"
+      paddingY={4}
+      borderBottomWidth="1px"
+    >
+      <HStack>
+        <Controller
+          name={defaultModelField.name}
+          control={control}
+          render={({ field }) => (
+            <ModelSelector
+              model={field.value}
+              options={modelSelectorOptions
+                .filter((option) => option.mode === "chat")
+                .map((option) => option.value)}
+              onChange={(model) => {
+                field.onChange(model);
+                void handleSubmit(onUpdateSubmit)();
+              }}
+              mode="chat"
             />
-          </HorizontalFormControl>
-        </Card.Body>
-      </Card.Root>
-    </>
+          )}
+        />
+        {updateDefaultModel.isLoading && <Spinner size="sm" marginRight={2} />}
+      </HStack>
+    </HorizontalFormControl>
   );
 }
 
@@ -621,40 +623,33 @@ function TopicClusteringModel() {
   );
 
   return (
-    <>
-      <HStack width="full" marginTop={6}>
-        <Heading size="md" as="h2">
-          Topic Clustering Model
-        </Heading>
-        <Spacer />
-        {updateTopicClusteringModel.isLoading && <Spinner />}
-      </HStack>
-      <Text>
-        Select which model will be used to generate the topic names based on the
-        messages
-      </Text>
-      <Card.Root width="full">
-        <Card.Body width="full">
-          <HorizontalFormControl label="Topic Clustering Model" helper="">
-            <Controller
-              name={topicClusteringModelField.name}
-              control={control}
-              render={({ field }) => (
-                <ModelSelector
-                  model={field.value}
-                  options={allowedTopicClusteringModels}
-                  onChange={(model) => {
-                    field.onChange(model);
-                    void handleSubmit(onUpdateSubmit)();
-                  }}
-                  mode="chat"
-                />
-              )}
+    <HorizontalFormControl
+      label="Topic Clustering Model"
+      helper="For generating topic names"
+      paddingY={4}
+      borderBottomWidth="1px"
+    >
+      <HStack>
+        <Controller
+          name={topicClusteringModelField.name}
+          control={control}
+          render={({ field }) => (
+            <ModelSelector
+              model={field.value}
+              options={allowedTopicClusteringModels}
+              onChange={(model) => {
+                field.onChange(model);
+                void handleSubmit(onUpdateSubmit)();
+              }}
+              mode="chat"
             />
-          </HorizontalFormControl>
-        </Card.Body>
-      </Card.Root>
-    </>
+          )}
+        />
+        {updateTopicClusteringModel.isLoading && (
+          <Spinner size="sm" marginRight={2} />
+        )}
+      </HStack>
+    </HorizontalFormControl>
   );
 }
 
@@ -689,40 +684,33 @@ function EmbeddingsModel() {
   );
 
   return (
-    <>
-      <HStack width="full" marginTop={6}>
-        <Heading size="md" as="h2">
-          Embeddings Model
-        </Heading>
-        <Spacer />
-        {updateEmbeddingsModel.isLoading && <Spinner />}
-      </HStack>
-      <Text>
-        Select which model will be used to generate embeddings for the messages
-      </Text>
-      <Card.Root width="full">
-        <Card.Body width="full">
-          <HorizontalFormControl label="Embeddings Model" helper="">
-            <Controller
-              name={embeddingsModelField.name}
-              control={control}
-              render={({ field }) => (
-                <ModelSelector
-                  model={field.value}
-                  options={modelSelectorOptions
-                    .filter((option) => option.mode === "embedding")
-                    .map((option) => option.value)}
-                  onChange={(model) => {
-                    field.onChange(model);
-                    void handleSubmit(onUpdateSubmit)();
-                  }}
-                  mode="embedding"
-                />
-              )}
+    <HorizontalFormControl
+      label="Embeddings Model"
+      helper="For embeddings to be used in topic clustering and evaluations"
+      paddingY={4}
+    >
+      <HStack>
+        <Controller
+          name={embeddingsModelField.name}
+          control={control}
+          render={({ field }) => (
+            <ModelSelector
+              model={field.value}
+              options={modelSelectorOptions
+                .filter((option) => option.mode === "embedding")
+                .map((option) => option.value)}
+              onChange={(model) => {
+                field.onChange(model);
+                void handleSubmit(onUpdateSubmit)();
+              }}
+              mode="embedding"
             />
-          </HorizontalFormControl>
-        </Card.Body>
-      </Card.Root>
-    </>
+          )}
+        />
+        {updateEmbeddingsModel.isLoading && (
+          <Spinner size="sm" marginRight={2} />
+        )}
+      </HStack>
+    </HorizontalFormControl>
   );
 }

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -1,9 +1,5 @@
 import type { QueryDslBoolQuery } from "@elastic/elasticsearch/lib/api/types";
-import {
-  EvaluationExecutionMode,
-  ExperimentType,
-  type Monitor,
-} from "@prisma/client";
+import { EvaluationExecutionMode, ExperimentType } from "@prisma/client";
 import type { JsonValue } from "@prisma/client/runtime/library";
 import { TRPCError } from "@trpc/server";
 import type { Node } from "@xyflow/react";

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -357,6 +357,36 @@ export const projectRouter = createTRPCRouter({
 
       return { success: true, projectSlug: updatedProject.slug };
     }),
+  updateDefaultModel: protectedProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        defaultModel: z.string(),
+      })
+    )
+    .use(checkUserPermissionForProject(TeamRoleGroup.SETUP_PROJECT))
+    .mutation(async ({ input, ctx }) => {
+      const prisma = ctx.prisma;
+      const project = await prisma.project.findUnique({
+        where: { id: input.projectId },
+      });
+
+      if (!project) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Project not found",
+        });
+      }
+
+      const updatedProject = await prisma.project.update({
+        where: { id: input.projectId },
+        data: {
+          defaultModel: input.defaultModel,
+        },
+      });
+
+      return { success: true, projectSlug: updatedProject.slug };
+    }),
 });
 
 const generateApiKey = (): string => {

--- a/langwatch/src/server/evaluations/getEvaluator.ts
+++ b/langwatch/src/server/evaluations/getEvaluator.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_EMBEDDINGS_MODEL, DEFAULT_MODEL } from "../../utils/constants";
 import {
   AVAILABLE_EVALUATORS,
   type EvaluatorDefinition,
@@ -13,10 +14,17 @@ export const getEvaluatorDefinitions = (evaluator: string) => {
 };
 
 export const getEvaluatorDefaultSettings = <T extends EvaluatorTypes>(
-  evaluator: EvaluatorDefinition<T>
+  evaluator: EvaluatorDefinition<T>,
+  project?: { defaultModel?: string | null; embeddingsModel?: string | null }
 ) => {
   return Object.fromEntries(
     Object.entries(evaluator.settings).map(([key, setting]) => {
+      if (key === "model") {
+        return [key, project?.defaultModel ?? DEFAULT_MODEL];
+      }
+      if (key === "embeddings_model") {
+        return [key, project?.embeddingsModel ?? DEFAULT_EMBEDDINGS_MODEL];
+      }
       return [key, (setting as any).default];
     })
   ) as Evaluators[T]["settings"];

--- a/langwatch/src/utils/constants.ts
+++ b/langwatch/src/utils/constants.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_MODEL = "openai/gpt-4o-mini";
+
 export const DEFAULT_EMBEDDINGS_MODEL = "openai/text-embedding-3-small";
 
 export const OPENAI_EMBEDDING_DIMENSION = 1536;


### PR DESCRIPTION
We now allow the user to chose the default model to be used all around LangWatch:

<img width="972" alt="image" src="https://github.com/user-attachments/assets/cafe8291-b6b9-466a-8356-f449bcd1df54" />

This model will be used now for any new LLM Signature nodes and Evaluators users create on the studio or the wizard:

<img width="1072" alt="Screenshot 2025-04-13 at 11 27 22" src="https://github.com/user-attachments/assets/3bbc0cb2-becf-46ec-b976-80744bd87dbe" />

But also, more specially, this allows us to use the default model for many small helper features going forward, like generating the version commit message automatically, while users keep full control of where is their data going to

