### PR TITLE
Fix studio experiments not loading

### DIFF
--- a/langwatch/.eslintrc.cjs
+++ b/langwatch/.eslintrc.cjs
@@ -65,6 +65,11 @@ const config = {
             message:
               "Component must be imported from 'components/ui' instead of '@chakra-ui/react'.",
           },
+          {
+            name: "slugify",
+            importNames: ["default"],
+            message: "Use 'utils/slugify' instead of 'slugify' directly.",
+          },
         ],
       },
     ],

--- a/langwatch/src/components/AddAnnotationQueueDrawer.tsx
+++ b/langwatch/src/components/AddAnnotationQueueDrawer.tsx
@@ -14,7 +14,7 @@ import { Select as MultiSelect, chakraComponents } from "chakra-react-select";
 import { useState } from "react";
 import { Plus } from "react-feather";
 import { useForm } from "react-hook-form";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 import { Drawer } from "../components/ui/drawer";

--- a/langwatch/src/components/AddOrEditDatasetDrawer.tsx
+++ b/langwatch/src/components/AddOrEditDatasetDrawer.tsx
@@ -13,7 +13,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { Trash2 } from "react-feather";
 import { useFieldArray, useForm, type FieldErrors } from "react-hook-form";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 import { Drawer } from "../components/ui/drawer";
 import { toaster } from "../components/ui/toaster";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";

--- a/langwatch/src/components/checks/CheckConfigForm.tsx
+++ b/langwatch/src/components/checks/CheckConfigForm.tsx
@@ -22,7 +22,7 @@ import {
   useFieldArray,
   useForm,
 } from "react-hook-form";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 import { z } from "zod";
 import { useAvailableEvaluators } from "../../hooks/useAvailableEvaluators";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";

--- a/langwatch/src/optimization_studio/components/ResultsPanel.tsx
+++ b/langwatch/src/optimization_studio/components/ResultsPanel.tsx
@@ -36,7 +36,6 @@ import {
 import { toaster } from "../../components/ui/toaster";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import type { AppliedOptimization } from "../../server/experiments/types";
-import { experimentSlugify } from "../../server/experiments/utils";
 import { api } from "../../utils/api";
 import { useEvaluationExecution } from "../hooks/useEvaluationExecution";
 import { useOptimizationExecution } from "../hooks/useOptimizationExecution";
@@ -44,6 +43,7 @@ import { useWorkflowStore } from "../hooks/useWorkflowStore";
 import type { Field, Signature, Workflow } from "../types/dsl";
 import { simpleRecordListToNodeDataset } from "../utils/datasetUtils";
 import { OptimizationProgressBar } from "./ProgressToast";
+import { slugify } from "../../utils/slugify";
 
 export function ResultsPanel({
   isCollapsed,
@@ -153,9 +153,7 @@ export function EvaluationResults({
     {
       projectId: project?.id ?? "",
       experimentId: experimentId,
-      experimentSlug: experimentId
-        ? undefined
-        : experimentSlugify(workflowId ?? ""),
+      experimentSlug: experimentId ? undefined : slugify(workflowId ?? ""),
     },
     {
       enabled: !!project && !!workflowId,
@@ -311,7 +309,7 @@ export function OptimizationResults() {
   const experiment = api.experiments.getExperimentBySlugOrId.useQuery(
     {
       projectId: project?.id ?? "",
-      experimentSlug: experimentSlugify(`${workflowId ?? ""}-optimizations`),
+      experimentSlug: slugify(`${workflowId ?? ""}-optimizations`),
     },
     {
       enabled: !!project && !!workflowId,

--- a/langwatch/src/pages/api/experiment/init.ts
+++ b/langwatch/src/pages/api/experiment/init.ts
@@ -12,7 +12,7 @@ import {
 import * as Sentry from "@sentry/nextjs";
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { experimentSlugify } from "../../../server/experiments/utils";
+import { slugify } from "../../../utils/slugify";
 
 export const debug = getDebugger("langwatch:dspy:init");
 
@@ -118,7 +118,7 @@ export const findOrCreateExperiment = async ({
 
   let slug_ = null;
   if (experiment_slug) {
-    slug_ = experimentSlugify(experiment_slug);
+    slug_ = slugify(experiment_slug);
     experiment = await prisma.experiment.findUnique({
       where: { projectId_slug: { projectId: project.id, slug: slug_ } },
     });

--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -4,7 +4,7 @@ import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import { PublicShareResourceTypes } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 import {
   TeamRoleGroup,
   checkPermissionOrPubliclyShared,

--- a/langwatch/src/server/api/routers/monitors.ts
+++ b/langwatch/src/server/api/routers/monitors.ts
@@ -1,7 +1,7 @@
 import { ZodError, z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { TeamRoleGroup, checkUserPermissionForProject } from "../permission";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 import { TRPCError } from "@trpc/server";
 import { checkPreconditionsSchema } from "../../evaluations/types.generated";
 import { nanoid } from "nanoid";

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -10,7 +10,7 @@ import {
 } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { sendInviteEmail } from "../../mailer/inviteEmail";

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 import { z } from "zod";
 import {
   createTRPCRouter,

--- a/langwatch/src/server/api/routers/team.ts
+++ b/langwatch/src/server/api/routers/team.ts
@@ -10,7 +10,7 @@ import {
   TeamRoleGroup,
 } from "../permission";
 import { nanoid } from "nanoid";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 
 export const teamRouter = createTRPCRouter({
   getBySlug: protectedProcedure

--- a/langwatch/src/server/background/workers/collector/evaluations.ts
+++ b/langwatch/src/server/background/workers/collector/evaluations.ts
@@ -1,6 +1,6 @@
 import { EvaluationExecutionMode } from "@prisma/client";
 import crypto from "crypto";
-import slugify from "slugify";
+import { slugify } from "~/utils/slugify";
 import type { EvaluatorTypes } from "../../../../server/evaluations/evaluators.generated";
 import {
   evaluatePreconditions,

--- a/langwatch/src/server/experiments/utils.ts
+++ b/langwatch/src/server/experiments/utils.ts
@@ -1,9 +1,0 @@
-import slugify from "slugify";
-
-export const experimentSlugify = (name: string) => {
-  return slugify(name.replace(/[:\?&_]/g, "-"), {
-    lower: true,
-    strict: true,
-    replacement: "-",
-  });
-};

--- a/langwatch/src/utils/slugify.ts
+++ b/langwatch/src/utils/slugify.ts
@@ -6,11 +6,12 @@ export const slugify = (
   options: Parameters<typeof originalSlugify>[1] = {}
 ) => {
   return originalSlugify(
-    str.replaceAll("_", "-"),
+    str.replaceAll(/[:\?&_]/g, "-"),
     typeof options === "object"
       ? {
           lower: true,
           strict: true,
+          replacement: "-",
           ...options,
         }
       : options

--- a/langwatch/src/utils/slugify.ts
+++ b/langwatch/src/utils/slugify.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import originalSlugify from "slugify";
 
 // TODO: use only that for the whole project and prevent the package from being imported elsewhere


### PR DESCRIPTION
This was caused due to a mismatch in different "slugiffications" import. I have now changed the whole codebase to use our same slugifyier everywhere

- [x] Fix experiments on the studio not loading due to slugify mismatch
- [x] Prevent the original slugify from being imported, always use our utils one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all references to the slugify function to use a unified local utility, ensuring consistent slug formatting across the app.
  - Removed the redundant experiment-specific slugify utility.
- **Style**
  - Expanded character replacement in slug generation for improved URL consistency.
- **Chores**
  - Enhanced linting rules to enforce correct import paths for slugify usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->