### PR TITLE
fix: import on workers do not work with aliases due to a tsx issue

### DIFF
--- a/langwatch/src/server/background/workers/collector/evaluations.ts
+++ b/langwatch/src/server/background/workers/collector/evaluations.ts
@@ -1,6 +1,6 @@
 import { EvaluationExecutionMode } from "@prisma/client";
 import crypto from "crypto";
-import { slugify } from "~/utils/slugify";
+import { slugify } from "../../../../utils/slugify";
 import type { EvaluatorTypes } from "../../../../server/evaluations/evaluators.generated";
 import {
   evaluatePreconditions,


### PR DESCRIPTION
Use use `tsx` to startup the workers, and this looks like a #wontfix issue on their side:

https://github.com/privatenumber/tsx/issues/96

For now I'm just changing back to `../` relative path, but moving forward we can try ditching tsx and going with a quick esbuild instead for the workers