### PR TITLE
Evals wizard require api keys

### DIFF
--- a/langwatch/src/components/evaluations/wizard/EvaluationWizard.tsx
+++ b/langwatch/src/components/evaluations/wizard/EvaluationWizard.tsx
@@ -8,6 +8,7 @@ import {
   Spinner,
   VStack,
 } from "@chakra-ui/react";
+import { ReactFlowProvider } from "@xyflow/react";
 import { useRouter } from "next/router";
 import { memo, useEffect, useRef, useState } from "react";
 import {
@@ -22,21 +23,20 @@ import {
   useEvaluationWizardStore,
 } from "~/components/evaluations/wizard/hooks/evaluation-wizard-store/useEvaluationWizardStore";
 import { useOrganizationTeamProject } from "../../../hooks/useOrganizationTeamProject";
+import { api } from "../../../utils/api";
 import { LogoIcon } from "../../icons/LogoIcon";
 import { Dialog } from "../../ui/dialog";
 import { Steps } from "../../ui/steps";
+import { toaster } from "../../ui/toaster";
 import { Tooltip } from "../../ui/tooltip";
 import { WizardWorkspace } from "./WizardWorkspace";
+import { RunEvaluationButton } from "./components/RunTrialEvaluationButton";
 import { useStepCompletedValue } from "./hooks/useStepCompletedValue";
 import { DatasetStep } from "./steps/DatasetStep";
 import { EvaluationStep } from "./steps/EvaluationStep";
 import { ExecutionStep } from "./steps/ExecutionStep";
 import { ResultsStep } from "./steps/ResultsStep";
 import { TaskStep } from "./steps/TaskStep";
-import { api } from "../../../utils/api";
-import { toaster } from "../../ui/toaster";
-import { ReactFlowProvider } from "@xyflow/react";
-import { RunTrialButton } from "./components/RunTrialEvaluationButton";
 
 export function EvaluationWizard({ isLoading }: { isLoading: boolean }) {
   const router = useRouter();
@@ -398,7 +398,11 @@ const WizardSidebar = memo(function WizardSidebar({
                   Show Code
                 </Button>
               )}
-            {step === "results" && task !== "real_time" && <RunTrialButton />}
+            {step === "results" && task !== "real_time" && (
+              <RunEvaluationButton colorPalette="green">
+                Run Evaluation
+              </RunEvaluationButton>
+            )}
           </HStack>
         </>
       )}

--- a/langwatch/src/components/evaluations/wizard/components/RunTrialEvaluationButton.tsx
+++ b/langwatch/src/components/evaluations/wizard/components/RunTrialEvaluationButton.tsx
@@ -1,23 +1,19 @@
-import { Button } from "@chakra-ui/react";
-import { LuCirclePlay } from "react-icons/lu";
+import { Button, type ButtonProps } from "@chakra-ui/react";
 import { useRunEvalution } from "../hooks/useRunEvalution";
 import { useStepCompletedValue } from "../hooks/useStepCompletedValue";
+import { LuCirclePlay } from "react-icons/lu";
 
 /**
- * This is a stateless button
+ * This is a stateful component is used to run a trial evaluation.
+ * @returns A button to run a trial evaluation.
  */
-function RunTrialButtonUI({
-  runEvaluation,
-  isLoading,
-  trialDisabled,
-}: {
-  runEvaluation: () => void;
-  isLoading: boolean;
-  trialDisabled: boolean;
-}) {
+export function RunEvaluationButton({ children, ...props }: ButtonProps) {
+  const { runEvaluation, isLoading } = useRunEvalution();
+  const stepCompletedValue = useStepCompletedValue();
+  const trialDisabled = !stepCompletedValue("all");
+
   return (
     <Button
-      colorPalette="blue"
       _icon={{
         minWidth: "18px",
         minHeight: "18px",
@@ -25,27 +21,10 @@ function RunTrialButtonUI({
       onClick={runEvaluation}
       loading={isLoading}
       disabled={trialDisabled}
+      {...props}
     >
       <LuCirclePlay />
-      Run Trial Evaluation
+      {children}
     </Button>
-  );
-}
-
-/**
- * This is a stateful component is used to run a trial evaluation.
- * @returns A button to run a trial evaluation.
- */
-export function RunTrialButton() {
-  const { runEvaluation, isLoading } = useRunEvalution();
-  const stepCompletedValue = useStepCompletedValue();
-  const trialDisabled = !stepCompletedValue("all");
-
-  return (
-    <RunTrialButtonUI
-      runEvaluation={runEvaluation}
-      isLoading={isLoading}
-      trialDisabled={trialDisabled}
-    />
   );
 }

--- a/langwatch/src/components/evaluations/wizard/components/RunTrialEvaluationButton.tsx
+++ b/langwatch/src/components/evaluations/wizard/components/RunTrialEvaluationButton.tsx
@@ -2,29 +2,53 @@ import { Button, type ButtonProps } from "@chakra-ui/react";
 import { useRunEvalution } from "../hooks/useRunEvalution";
 import { useStepCompletedValue } from "../hooks/useStepCompletedValue";
 import { LuCirclePlay } from "react-icons/lu";
+import { useEvaluationWizardStore } from "../hooks/evaluation-wizard-store/useEvaluationWizardStore";
+import { useShallow } from "zustand/react/shallow";
+import { useModelProviderKeys } from "../../../../optimization_studio/hooks/useModelProviderKeys";
+import { Tooltip } from "../../../ui/tooltip";
 
 /**
  * This is a stateful component is used to run a trial evaluation.
  * @returns A button to run a trial evaluation.
  */
 export function RunEvaluationButton({ children, ...props }: ButtonProps) {
+  const { getDSL } = useEvaluationWizardStore(
+    useShallow((state) => ({
+      getDSL: state.getDSL,
+    }))
+  );
   const { runEvaluation, isLoading } = useRunEvalution();
+
   const stepCompletedValue = useStepCompletedValue();
-  const trialDisabled = !stepCompletedValue("all");
+  const { hasProvidersWithoutCustomKeys } = useModelProviderKeys({
+    workflow: getDSL(),
+  });
+  const trialDisabled = !stepCompletedValue("all")
+    ? "Complete all the previous steps to run the evaluation"
+    : hasProvidersWithoutCustomKeys
+    ? "Add your API keys to run the evaluation"
+    : undefined;
 
   return (
-    <Button
-      _icon={{
-        minWidth: "18px",
-        minHeight: "18px",
+    <Tooltip
+      content={trialDisabled}
+      positioning={{
+        placement: "top",
       }}
-      onClick={runEvaluation}
-      loading={isLoading}
-      disabled={trialDisabled}
-      {...props}
     >
-      <LuCirclePlay />
-      {children}
-    </Button>
+      <Button
+        _icon={{
+          minWidth: "18px",
+          minHeight: "18px",
+        }}
+        onClick={runEvaluation}
+        loading={isLoading}
+        disabled={!!trialDisabled}
+        {...props}
+      >
+        <LuCirclePlay />
+        {children}
+      </Button>
+    </Tooltip>
   );
 }

--- a/langwatch/src/components/evaluations/wizard/hooks/usePostEvent.ts
+++ b/langwatch/src/components/evaluations/wizard/hooks/usePostEvent.ts
@@ -69,7 +69,13 @@ export const usePostEvent = () => {
           });
 
           if (!response.ok) {
-            throw new Error(`Failed to post message: ${response.statusText}`);
+            let responseJson: { error: string };
+            try {
+              responseJson = await response.json();
+            } catch (error) {
+              throw new Error(response.statusText);
+            }
+            throw new Error(responseJson.error);
           }
 
           // Process the SSE stream

--- a/langwatch/src/components/evaluations/wizard/steps/ResultsStep.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/ResultsStep.tsx
@@ -18,15 +18,22 @@ import { FullWidthFormControl } from "../../../FullWidthFormControl";
 import { Tooltip } from "../../../ui/tooltip";
 import { RunEvaluationButton } from "../components/RunTrialEvaluationButton";
 import { useStepCompletedValue } from "../hooks/useStepCompletedValue";
+import { useModelProviderKeys } from "../../../../optimization_studio/hooks/useModelProviderKeys";
+import { AddModelProviderKey } from "../../../../optimization_studio/components/AddModelProviderKey";
 
 export function ResultsStep() {
-  const { name, wizardState, setWizardState } = useEvaluationWizardStore(
-    ({ wizardState, setWizardState }) => ({
+  const { name, wizardState, setWizardState, getDSL } =
+    useEvaluationWizardStore(({ wizardState, setWizardState, getDSL }) => ({
       name: wizardState.name,
       wizardState,
       setWizardState,
-    })
-  );
+      getDSL,
+    }));
+
+  const { hasProvidersWithoutCustomKeys, nodeProvidersWithoutCustomKeys } =
+    useModelProviderKeys({
+      workflow: getDSL(),
+    });
 
   const form = useForm<{
     name: string;
@@ -84,6 +91,12 @@ export function ResultsStep() {
           />
           <StepStatus name="Evaluation" step="evaluation" />
         </VStack>
+        {hasProvidersWithoutCustomKeys && (
+          <AddModelProviderKey
+            runWhat="run evaluations"
+            nodeProvidersWithoutCustomKeys={nodeProvidersWithoutCustomKeys}
+          />
+        )}
         {wizardState.executionMethod?.startsWith("realtime") && (
           <Alert.Root colorPalette="blue">
             <Alert.Content>

--- a/langwatch/src/components/evaluations/wizard/steps/ResultsStep.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/ResultsStep.tsx
@@ -7,18 +7,17 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
-import { LuCircleAlert, LuCircleCheck, LuCirclePlay } from "react-icons/lu";
+import { LuCircleAlert, LuCircleCheck } from "react-icons/lu";
 import {
   useEvaluationWizardStore,
   type Step,
 } from "~/components/evaluations/wizard/hooks/evaluation-wizard-store/useEvaluationWizardStore";
 import { FullWidthFormControl } from "../../../FullWidthFormControl";
-import { useRunEvalution } from "../hooks/useRunEvalution";
-import { useStepCompletedValue } from "../hooks/useStepCompletedValue";
 import { Tooltip } from "../../../ui/tooltip";
-import { useEffect } from "react";
-import { RunTrialButton } from "../components/RunTrialEvaluationButton";
+import { RunEvaluationButton } from "../components/RunTrialEvaluationButton";
+import { useStepCompletedValue } from "../hooks/useStepCompletedValue";
 
 export function ResultsStep() {
   const { name, wizardState, setWizardState } = useEvaluationWizardStore(
@@ -102,7 +101,9 @@ export function ResultsStep() {
                       placement: "top",
                     }}
                   >
-                    <RunTrialButton />
+                    <RunEvaluationButton colorPalette="blue">
+                      Run Trial Evaluation
+                    </RunEvaluationButton>
                   </Tooltip>
                 </VStack>
               </Alert.Description>

--- a/langwatch/src/optimization_studio/components/Evaluate.tsx
+++ b/langwatch/src/optimization_studio/components/Evaluate.tsx
@@ -1,16 +1,15 @@
 import {
   Button,
+  createListCollection,
   HStack,
   Skeleton,
   Spacer,
   Text,
   useDisclosure,
-  VStack,
-  createListCollection,
-  Portal,
+  VStack
 } from "@chakra-ui/react";
-import { Select } from "../../components/ui/select";
 import { Dialog } from "../../components/ui/dialog";
+import { Select } from "../../components/ui/select";
 import { Tooltip } from "../../components/ui/tooltip";
 
 import type { Node } from "@xyflow/react";
@@ -20,22 +19,21 @@ import {
   Controller,
   useForm,
   type ControllerRenderProps,
-  type UseControllerProps,
-  type UseFormReturn,
+  type UseFormReturn
 } from "react-hook-form";
 import { SmallLabel } from "../../components/SmallLabel";
+import { toaster } from "../../components/ui/toaster";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
+import { trackEvent } from "../../utils/tracking";
 import { useEvaluationExecution } from "../hooks/useEvaluationExecution";
 import { useGetDatasetData } from "../hooks/useGetDatasetData";
 import { useModelProviderKeys } from "../hooks/useModelProviderKeys";
 import { useWorkflowStore } from "../hooks/useWorkflowStore";
 import type { Entry } from "../types/dsl";
+import { trainTestSplit } from "../utils/datasetUtils";
 import { AddModelProviderKey } from "./AddModelProviderKey";
 import { useVersionState, VersionToBeUsed } from "./History";
-import { trainTestSplit } from "../utils/datasetUtils";
-import { trackEvent } from "../../utils/tracking";
-import { toaster } from "../../components/ui/toaster";
 
 export function Evaluate() {
   const { open, onToggle, onClose, setOpen } = useDisclosure();
@@ -98,8 +96,6 @@ export function EvaluateModalContent({
   onClose: () => void;
 }) {
   const { project } = useOrganizationTeamProject();
-  const { hasProvidersWithoutCustomKeys, nodeProvidersWithoutCustomKeys } =
-    useModelProviderKeys();
   const {
     workflowId,
     getWorkflow,
@@ -121,6 +117,11 @@ export function EvaluateModalContent({
       setOpenResultsPanelRequest: setOpenResultsPanelRequest,
     })
   );
+
+  const { hasProvidersWithoutCustomKeys, nodeProvidersWithoutCustomKeys } =
+    useModelProviderKeys({
+      workflow: getWorkflow(),
+    });
 
   const entryNode = getWorkflow().nodes.find(
     (node) => node.type === "entry"

--- a/langwatch/src/optimization_studio/components/Optimize.tsx
+++ b/langwatch/src/optimization_studio/components/Optimize.tsx
@@ -291,11 +291,13 @@ export function OptimizeModalContent({
   );
 
   const { hasProvidersWithoutCustomKeys, nodeProvidersWithoutCustomKeys } =
-    useModelProviderKeys(
-      "llm" in optimizer.params && "llm" in params
-        ? [params.llm ?? default_llm]
-        : undefined
-    );
+    useModelProviderKeys({
+      workflow: getWorkflow(),
+      extra_llms:
+        "llm" in optimizer.params && "llm" in params
+          ? [params.llm ?? default_llm]
+          : undefined,
+    });
 
   const isRunning = optimizationState?.status === "running";
 

--- a/langwatch/src/optimization_studio/components/Publish.tsx
+++ b/langwatch/src/optimization_studio/components/Publish.tsx
@@ -368,14 +368,17 @@ function PublishModalContent({
   const { project } = useOrganizationTeamProject();
   const router = useRouter();
 
-  const { hasProvidersWithoutCustomKeys, nodeProvidersWithoutCustomKeys } =
-    useModelProviderKeys();
   const { workflowId, getWorkflow } = useWorkflowStore(
     ({ workflow_id: workflowId, getWorkflow }) => ({
       workflowId,
       getWorkflow,
     })
   );
+
+  const { hasProvidersWithoutCustomKeys, nodeProvidersWithoutCustomKeys } =
+    useModelProviderKeys({
+      workflow: getWorkflow(),
+    });
 
   const form = useForm<{
     version: string;

--- a/langwatch/src/optimization_studio/hooks/useModelProviderKeys.tsx
+++ b/langwatch/src/optimization_studio/hooks/useModelProviderKeys.tsx
@@ -1,16 +1,15 @@
-import { useWorkflowStore } from "../hooks/useWorkflowStore";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 
-import type { Component, Field, LLMConfig, Signature } from "../types/dsl";
+import type { Component, LLMConfig, Signature, Workflow } from "../types/dsl";
 
-export const useModelProviderKeys = (extra_llms?: LLMConfig[]) => {
+export const useModelProviderKeys = ({
+  workflow,
+  extra_llms,
+}: {
+  workflow: Workflow;
+  extra_llms?: LLMConfig[];
+}) => {
   const { modelProviders } = useOrganizationTeamProject();
-  const { getWorkflow, nodes } = useWorkflowStore((state) => ({
-    getWorkflow: state.getWorkflow,
-    nodes: state.nodes,
-  }));
-
-  const workflow = getWorkflow();
 
   const modelProvidersWithoutCustomKeys = Object.values(
     modelProviders ?? {}
@@ -18,7 +17,7 @@ export const useModelProviderKeys = (extra_llms?: LLMConfig[]) => {
 
   const defaultModelProvider = workflow.default_llm.model.split("/")[0];
 
-  const nodesWithLLMParameter = nodes.filter(
+  const nodesWithLLMParameter = workflow.nodes.filter(
     (node) => node.data.parameters?.find((p) => p.type === "llm")
   );
 


### PR DESCRIPTION
Disables evaluation and display custom llm alert if api keys are not set up before running evaluation

<img width="1512" alt="Screenshot 2025-04-16 at 19 03 36" src="https://github.com/user-attachments/assets/c60d026e-b23f-4d46-8027-2652f2c415b5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Evaluation wizard now prompts users to add missing model provider API keys before running evaluations.
  - Enhanced button tooltips provide specific reasons when evaluation actions are disabled.

- **Improvements**
  - Improved error messages for failed evaluation event submissions, offering clearer feedback.
  - Evaluation and trial buttons feature updated labels, color palettes, and dynamic states.
  - Workflow state is now explicitly passed to model provider key checks for more accurate validation.

- **Bug Fixes**
  - Added robust error handling to prevent unhandled errors during dataset loading in workflow event APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->