### PR TITLE
New menu design

### DIFF
--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -32,7 +32,7 @@ import { CurrentDrawer } from "./CurrentDrawer";
 import { HoverableBigText } from "./HoverableBigText";
 import { IntegrationChecks, useIntegrationChecks } from "./IntegrationChecks";
 import { LoadingScreen } from "./LoadingScreen";
-import { MainMenu } from "./MainMenu";
+import { MainMenu, MENU_WIDTH } from "./MainMenu";
 import { ProjectTechStackIcon } from "./TechStack";
 import { ChecklistIcon } from "./icons/Checklist";
 import { useColorRawValue } from "./ui/color-mode";
@@ -302,7 +302,6 @@ export const DashboardLayout = ({
 
   const user = session?.user;
   const currentRoute = findCurrentRoute(router.pathname);
-  const menuWidth = 88;
 
   return (
     <HStack
@@ -320,10 +319,10 @@ export const DashboardLayout = ({
             : ""}
         </title>
       </Head>
-      <MainMenu menuWidth={menuWidth} />
+      <MainMenu />
       <VStack
-        width={`calc(100vw - ${menuWidth}px)`}
-        maxWidth={`calc(100vw - ${menuWidth}px)`}
+        width={`calc(100vw - ${MENU_WIDTH})`}
+        maxWidth={`calc(100vw - ${MENU_WIDTH})`}
         gap={0}
         background="gray.100"
         {...props}

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -302,7 +302,7 @@ export const DashboardLayout = ({
 
   const user = session?.user;
   const currentRoute = findCurrentRoute(router.pathname);
-  const menuWidth = 73;
+  const menuWidth = 88;
 
   return (
     <HStack

--- a/langwatch/src/components/MainMenu.tsx
+++ b/langwatch/src/components/MainMenu.tsx
@@ -1,7 +1,7 @@
 import {
   Badge,
   Box,
-  Button,
+  Center,
   HStack,
   Spacer,
   Text,
@@ -14,18 +14,15 @@ import {
   Bell,
   BookOpen,
   CheckSquare,
-  ChevronLeft,
-  ChevronRight,
   Edit,
   GitHub,
+  Layers,
   MessageSquare,
   Settings,
   Shield,
   Table,
   TrendingUp,
-  Layers,
 } from "react-feather";
-import { useLocalStorage } from "usehooks-ts";
 import { useAnnotationQueues } from "../hooks/useAnnotationQueues";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
 import { OrganizationRoleGroup } from "../server/api/permission";
@@ -43,11 +40,6 @@ import { Tooltip } from "./ui/tooltip";
 
 export const MainMenu = React.memo(
   function MainMenu({ menuWidth }: { menuWidth: number }) {
-    const [isExpanded, setIsExpanded] = useLocalStorage(
-      "main-menu-expanded",
-      false
-    );
-
     const { project, hasOrganizationPermission, isPublicRoute } =
       useOrganizationTeamProject();
     const { assignedQueueItems, memberAccessibleQueueItems } =
@@ -66,8 +58,8 @@ export const MainMenu = React.memo(
         borderRightColor="gray.300"
         background="white"
         transition="all 0.2s ease-in-out"
-        width={isExpanded ? "200px" : menuWidth + "px"}
-        minWidth={isExpanded ? "200px" : menuWidth + "px"}
+        width={menuWidth + "px"}
+        minWidth={menuWidth + "px"}
         overflowX="hidden"
         height="100vh"
         position="sticky"
@@ -76,54 +68,15 @@ export const MainMenu = React.memo(
         <VStack
           paddingX={0}
           paddingTop={4}
-          paddingBottom={3}
-          gap={6}
+          paddingBottom={0}
+          gap={4}
           height="100vh"
           align="start"
-          width={isExpanded ? "200px" : "full"}
+          width="full"
         >
-          <Box width="full" paddingX="6px">
-            <Button
-              asChild
-              className="group"
-              variant="plain"
-              onClick={() => setIsExpanded(!isExpanded)}
-              width="full"
-              minWidth="0"
-              padding={2}
-              paddingRight={isExpanded ? "6px" : "2px"}
-              size="lg"
-              _icon={{
-                width: "auto",
-                height: "auto",
-                maxWidth: "none",
-                maxHeight: "none",
-              }}
-              backgroundColor="white"
-              _hover={{
-                backgroundColor: isExpanded ? undefined : "gray.50",
-              }}
-            >
-              <HStack fontSize="32px" fontWeight="bold" gap={0}>
-                <LogoIcon width={25} height={34} />
-                <Spacer />
-                <Box
-                  padding={isExpanded ? 2 : 0}
-                  borderRadius="md"
-                  backgroundColor="white"
-                  _groupHover={{
-                    backgroundColor: isExpanded ? "gray.50" : undefined,
-                  }}
-                >
-                  {isExpanded ? (
-                    <ChevronLeft size={16} />
-                  ) : (
-                    <ChevronRight size={16} />
-                  )}
-                </Box>
-              </HStack>
-            </Button>
-          </Box>
+          <Center width="full" paddingX="6px">
+            <LogoIcon width={25} height={34} />
+          </Center>
 
           <VStack width="full" height="full" gap={0} align="start">
             <PageMenuLink
@@ -131,22 +84,19 @@ export const MainMenu = React.memo(
               icon={TrendingUp}
               label={projectRoutes.home.title}
               project={project}
-              isExpanded={isExpanded}
             />
             <PageMenuLink
               path={projectRoutes.messages.path}
               icon={MessageSquare}
               label={projectRoutes.messages.title}
               project={project}
-              isExpanded={isExpanded}
             />
 
             <PageMenuLink
               path={projectRoutes.evaluations.path}
-              icon={Shield}
+              icon={CheckSquare}
               label={projectRoutes.evaluations.title}
               project={project}
-              isExpanded={isExpanded}
             />
 
             <PageMenuLink
@@ -154,23 +104,20 @@ export const MainMenu = React.memo(
               icon={PuzzleIcon}
               label={projectRoutes.workflows.title}
               project={project}
-              isExpanded={isExpanded}
             />
 
-            <PageMenuLink
+            {/* <PageMenuLink
               path={projectRoutes.promptConfigs.path}
               icon={Layers} // Use an appropriate icon
               label={projectRoutes.promptConfigs.title}
               project={project}
-              isExpanded={isExpanded}
-            />
+            /> */}
 
             <PageMenuLink
               path={projectRoutes.datasets.path}
               icon={Table}
               label={projectRoutes.datasets.title}
               project={project}
-              isExpanded={isExpanded}
             />
             <PageMenuLink
               path={projectRoutes.annotations.path}
@@ -178,32 +125,9 @@ export const MainMenu = React.memo(
               label={projectRoutes.annotations.title}
               project={project}
               badgeNumber={totalQueueItems}
-              isExpanded={isExpanded}
               iconStyle={{ marginLeft: "1px" }}
             />
 
-            <PageMenuLink
-              path={projectRoutes.experiments.path}
-              icon={CheckSquare}
-              label={projectRoutes.experiments.title}
-              project={project}
-              isExpanded={isExpanded}
-            />
-
-            <PageMenuLink
-              path={projectRoutes.triggers.path}
-              icon={Bell}
-              label={projectRoutes.triggers.title}
-              project={project}
-              isExpanded={isExpanded}
-            />
-
-            {/*<SideMenuLink
-              path={projectRoutes.prompts.path}
-              icon={Database}
-              label={projectRoutes.prompts.title}
-              project={project}
-            /> */}
             {(!!hasOrganizationPermission(
               OrganizationRoleGroup.ORGANIZATION_VIEW
             ) ||
@@ -213,52 +137,11 @@ export const MainMenu = React.memo(
                 icon={Settings}
                 label={projectRoutes.settings.title}
                 project={project}
-                isExpanded={isExpanded}
               />
             )}
 
             <Spacer />
-            <SideMenuLink
-              size="sm"
-              href="https://docs.langwatch.ai"
-              icon={
-                <IconWrapper width="18px" height="18px" marginLeft="1px">
-                  <BookOpen />
-                </IconWrapper>
-              }
-              label="Documentation"
-              isActive={false}
-              project={project}
-              isExpanded={isExpanded}
-            />
 
-            <SideMenuLink
-              size="sm"
-              href="https://github.com/langwatch/langwatch"
-              icon={
-                <IconWrapper width="18px" height="18px">
-                  <GitHub />
-                </IconWrapper>
-              }
-              label="GitHub"
-              isActive={false}
-              project={project}
-              isExpanded={isExpanded}
-            />
-
-            <SideMenuLink
-              size="sm"
-              href="https://discord.gg/kT4PhDS2gH"
-              icon={
-                <IconWrapper width="18px" height="18px">
-                  <DiscordOutlineIcon />
-                </IconWrapper>
-              }
-              label="Community"
-              isActive={false}
-              project={project}
-              isExpanded={isExpanded}
-            />
             {(window as any)?.$crisp && project && (
               <SideMenuLink
                 size="sm"
@@ -303,9 +186,48 @@ export const MainMenu = React.memo(
                 label="Live Help"
                 isActive={false}
                 project={project}
-                isExpanded={isExpanded}
               />
             )}
+            <HStack width="full" gap={0} paddingX={2} paddingTop={2}>
+              <SideMenuLink
+                size="sm"
+                href="https://docs.langwatch.ai"
+                icon={
+                  <IconWrapper width="14px" height="14px" marginLeft="1px">
+                    <BookOpen />
+                  </IconWrapper>
+                }
+                label="Documentation"
+                isActive={false}
+                project={project}
+              />
+
+              <SideMenuLink
+                size="sm"
+                href="https://github.com/langwatch/langwatch"
+                icon={
+                  <IconWrapper width="14px" height="14px">
+                    <GitHub />
+                  </IconWrapper>
+                }
+                label="GitHub"
+                isActive={false}
+                project={project}
+              />
+
+              <SideMenuLink
+                size="sm"
+                href="https://discord.gg/kT4PhDS2gH"
+                icon={
+                  <IconWrapper width="14px" height="14px">
+                    <DiscordOutlineIcon />
+                  </IconWrapper>
+                }
+                label="Community"
+                isActive={false}
+                project={project}
+              />
+            </HStack>
           </VStack>
         </VStack>
       </Box>
@@ -322,7 +244,6 @@ const PageMenuLink = ({
   path,
   project,
   badgeNumber,
-  isExpanded,
   iconStyle,
 }: {
   icon: React.ComponentType<{ size?: string | number; color?: string }>;
@@ -330,7 +251,6 @@ const PageMenuLink = ({
   path: string;
   project?: Project;
   badgeNumber?: number;
-  isExpanded?: boolean;
   iconStyle?: React.CSSProperties;
 }) => {
   const router = useRouter();
@@ -372,7 +292,6 @@ const PageMenuLink = ({
       }
       isActive={isActive}
       badgeNumber={badgeNumber}
-      isExpanded={isExpanded}
       iconStyle={iconStyle}
     />
   );
@@ -386,7 +305,6 @@ const SideMenuLink = ({
   project,
   isActive,
   badgeNumber,
-  isExpanded,
   onClick,
   iconStyle,
 }: {
@@ -399,7 +317,6 @@ const SideMenuLink = ({
   project?: Project;
   isActive: boolean;
   badgeNumber?: number;
-  isExpanded?: boolean;
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   iconStyle?: React.CSSProperties;
 }) => {
@@ -436,14 +353,16 @@ const SideMenuLink = ({
   return (
     <Tooltip
       content={label}
-      positioning={{ placement: "right" }}
-      disabled={isExpanded}
+      positioning={{
+        placement: "top",
+      }}
+      disabled={size !== "sm"}
+      openDelay={0}
     >
       <Link
-        role="group"
         variant="plain"
         width="full"
-        paddingX={6}
+        paddingX={size === "sm" ? 0 : 4}
         paddingY={size === "sm" ? 2 : 3}
         href={href}
         aria-label={label}
@@ -454,13 +373,12 @@ const SideMenuLink = ({
           });
           onClick?.(e);
         }}
-        fontSize={size === "sm" ? 13 : 14}
+        fontSize={size === "sm" ? 10 : 11}
         _hover={{
           backgroundColor: "gray.50",
         }}
-        cursor="pointer"
       >
-        <HStack align="center" gap={4} minHeight="21px">
+        <VStack width="full" align="center" gap={1} minHeight="21px">
           <VStack align="start" position="relative">
             {iconNode}
 
@@ -470,12 +388,11 @@ const SideMenuLink = ({
               </Box>
             )}
           </VStack>
-          {isExpanded && (
-            <Text color={isActive ? "orange.600" : "gray.900"} marginTop="-1px">
-              {label}
-            </Text>
+          {/* {isHovered && ( */}
+          {size === "md" && (
+            <Text color={isActive ? "orange.600" : "gray.600"}>{label}</Text>
           )}
-        </HStack>
+        </VStack>
       </Link>
     </Tooltip>
   );

--- a/langwatch/src/components/MainMenu.tsx
+++ b/langwatch/src/components/MainMenu.tsx
@@ -11,15 +11,12 @@ import type { Project } from "@prisma/client";
 import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 import {
-  Bell,
   BookOpen,
   CheckSquare,
   Edit,
   GitHub,
-  Layers,
   MessageSquare,
   Settings,
-  Shield,
   Table,
   TrendingUp,
 } from "react-feather";
@@ -38,205 +35,201 @@ import { useColorRawValue } from "./ui/color-mode";
 import { Link } from "./ui/link";
 import { Tooltip } from "./ui/tooltip";
 
-export const MainMenu = React.memo(
-  function MainMenu({ menuWidth }: { menuWidth: number }) {
-    const { project, hasOrganizationPermission, isPublicRoute } =
-      useOrganizationTeamProject();
-    const { assignedQueueItems, memberAccessibleQueueItems } =
-      useAnnotationQueues();
-    const totalQueueItems = useMemo(
-      () =>
-        (assignedQueueItems?.filter((item) => !item.doneAt)?.length ?? 0) +
-        (memberAccessibleQueueItems?.filter((item) => !item.doneAt)?.length ??
-          0),
-      [assignedQueueItems, memberAccessibleQueueItems]
-    );
+export const MENU_WIDTH = "88px";
 
-    return (
-      <Box
-        borderRightWidth="1px"
-        borderRightColor="gray.300"
-        background="white"
-        transition="all 0.2s ease-in-out"
-        width={menuWidth + "px"}
-        minWidth={menuWidth + "px"}
-        overflowX="hidden"
+export const MainMenu = React.memo(function MainMenu() {
+  const { project, hasOrganizationPermission, isPublicRoute } =
+    useOrganizationTeamProject();
+  const { assignedQueueItems, memberAccessibleQueueItems } =
+    useAnnotationQueues();
+  const totalQueueItems = useMemo(
+    () =>
+      (assignedQueueItems?.filter((item) => !item.doneAt)?.length ?? 0) +
+      (memberAccessibleQueueItems?.filter((item) => !item.doneAt)?.length ?? 0),
+    [assignedQueueItems, memberAccessibleQueueItems]
+  );
+
+  return (
+    <Box
+      borderRightWidth="1px"
+      borderRightColor="gray.300"
+      background="white"
+      transition="all 0.2s ease-in-out"
+      width={MENU_WIDTH}
+      minWidth={MENU_WIDTH}
+      overflowX="hidden"
+      height="100vh"
+      position="sticky"
+      top={0}
+    >
+      <VStack
+        paddingX={0}
+        paddingTop={4}
+        paddingBottom={0}
+        gap={4}
         height="100vh"
-        position="sticky"
-        top={0}
+        align="start"
+        width="full"
       >
-        <VStack
-          paddingX={0}
-          paddingTop={4}
-          paddingBottom={0}
-          gap={4}
-          height="100vh"
-          align="start"
-          width="full"
-        >
-          <Center width="full" paddingX="6px">
-            <LogoIcon width={25} height={34} />
-          </Center>
+        <Center width="full" paddingX="6px">
+          <LogoIcon width={25} height={34} />
+        </Center>
 
-          <VStack width="full" height="full" gap={0} align="start">
-            <PageMenuLink
-              path={projectRoutes.home.path}
-              icon={TrendingUp}
-              label={projectRoutes.home.title}
-              project={project}
-            />
-            <PageMenuLink
-              path={projectRoutes.messages.path}
-              icon={MessageSquare}
-              label={projectRoutes.messages.title}
-              project={project}
-            />
+        <VStack width="full" height="full" gap={0} align="start">
+          <PageMenuLink
+            path={projectRoutes.home.path}
+            icon={TrendingUp}
+            label={projectRoutes.home.title}
+            project={project}
+          />
+          <PageMenuLink
+            path={projectRoutes.messages.path}
+            icon={MessageSquare}
+            label={projectRoutes.messages.title}
+            project={project}
+          />
 
-            <PageMenuLink
-              path={projectRoutes.evaluations.path}
-              icon={CheckSquare}
-              label={projectRoutes.evaluations.title}
-              project={project}
-            />
+          <PageMenuLink
+            path={projectRoutes.evaluations.path}
+            icon={CheckSquare}
+            label={projectRoutes.evaluations.title}
+            project={project}
+          />
 
-            <PageMenuLink
-              path={projectRoutes.workflows.path}
-              icon={PuzzleIcon}
-              label={projectRoutes.workflows.title}
-              project={project}
-            />
+          <PageMenuLink
+            path={projectRoutes.workflows.path}
+            icon={PuzzleIcon}
+            label={projectRoutes.workflows.title}
+            project={project}
+          />
 
-            {/* <PageMenuLink
+          {/* <PageMenuLink
               path={projectRoutes.promptConfigs.path}
               icon={Layers} // Use an appropriate icon
               label={projectRoutes.promptConfigs.title}
               project={project}
             /> */}
 
+          <PageMenuLink
+            path={projectRoutes.datasets.path}
+            icon={Table}
+            label={projectRoutes.datasets.title}
+            project={project}
+          />
+          <PageMenuLink
+            path={projectRoutes.annotations.path}
+            icon={Edit}
+            label={projectRoutes.annotations.title}
+            project={project}
+            badgeNumber={totalQueueItems}
+            iconStyle={{ marginLeft: "1px" }}
+          />
+
+          {(!!hasOrganizationPermission(
+            OrganizationRoleGroup.ORGANIZATION_VIEW
+          ) ||
+            isPublicRoute) && (
             <PageMenuLink
-              path={projectRoutes.datasets.path}
-              icon={Table}
-              label={projectRoutes.datasets.title}
+              path={projectRoutes.settings.path}
+              icon={Settings}
+              label={projectRoutes.settings.title}
               project={project}
             />
-            <PageMenuLink
-              path={projectRoutes.annotations.path}
-              icon={Edit}
-              label={projectRoutes.annotations.title}
-              project={project}
-              badgeNumber={totalQueueItems}
-              iconStyle={{ marginLeft: "1px" }}
-            />
+          )}
 
-            {(!!hasOrganizationPermission(
-              OrganizationRoleGroup.ORGANIZATION_VIEW
-            ) ||
-              isPublicRoute) && (
-              <PageMenuLink
-                path={projectRoutes.settings.path}
-                icon={Settings}
-                label={projectRoutes.settings.title}
-                project={project}
-              />
-            )}
+          <Spacer />
 
-            <Spacer />
-
-            {(window as any)?.$crisp && project && (
-              <SideMenuLink
-                size="sm"
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  (window as any)?.$crisp.push(["do", "chat:show"]);
-                  (window as any)?.$crisp.push(["do", "chat:toggle"]);
-                }}
-                icon={
+          {(window as any)?.$crisp && project && (
+            <SideMenuLink
+              size="sm"
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                (window as any)?.$crisp.push(["do", "chat:show"]);
+                (window as any)?.$crisp.push(["do", "chat:toggle"]);
+              }}
+              icon={
+                <Box
+                  position="relative"
+                  color="white"
+                  padding={2}
+                  marginX={-2}
+                  borderRadius="full"
+                  minWidth={0}
+                  minHeight={0}
+                  backgroundColor="blue.500"
+                  transition="all 0.2s ease-in-out"
+                  _groupHover={{
+                    transform: "scale(1.2)",
+                  }}
+                  _active={{
+                    color: "white",
+                  }}
+                >
+                  <ChatBalloonIcon width={20} height={20} />
                   <Box
-                    position="relative"
-                    color="white"
-                    padding={2}
-                    marginX={-2}
+                    position="absolute"
+                    bottom="0px"
+                    right="0px"
+                    width="10px"
+                    height="10px"
                     borderRadius="full"
-                    minWidth={0}
-                    minHeight={0}
-                    backgroundColor="blue.500"
-                    transition="all 0.2s ease-in-out"
-                    _groupHover={{
-                      transform: "scale(1.2)",
-                    }}
-                    _active={{
-                      color: "white",
-                    }}
-                  >
-                    <ChatBalloonIcon width={20} height={20} />
-                    <Box
-                      position="absolute"
-                      bottom="0px"
-                      right="0px"
-                      width="10px"
-                      height="10px"
-                      borderRadius="full"
-                      backgroundColor="green.500"
-                      border="1px solid"
-                      borderColor="white"
-                    />
-                  </Box>
-                }
-                label="Live Help"
-                isActive={false}
-                project={project}
-              />
-            )}
-            <HStack width="full" gap={0} paddingX={2} paddingTop={2}>
-              <SideMenuLink
-                size="sm"
-                href="https://docs.langwatch.ai"
-                icon={
-                  <IconWrapper width="14px" height="14px" marginLeft="1px">
-                    <BookOpen />
-                  </IconWrapper>
-                }
-                label="Documentation"
-                isActive={false}
-                project={project}
-              />
+                    backgroundColor="green.500"
+                    border="1px solid"
+                    borderColor="white"
+                  />
+                </Box>
+              }
+              label="Live Help"
+              isActive={false}
+              project={project}
+            />
+          )}
+          <HStack width="full" gap={0} paddingX={2} paddingTop={2}>
+            <SideMenuLink
+              size="sm"
+              href="https://docs.langwatch.ai"
+              icon={
+                <IconWrapper width="14px" height="14px" marginLeft="1px">
+                  <BookOpen />
+                </IconWrapper>
+              }
+              label="Documentation"
+              isActive={false}
+              project={project}
+            />
 
-              <SideMenuLink
-                size="sm"
-                href="https://github.com/langwatch/langwatch"
-                icon={
-                  <IconWrapper width="14px" height="14px">
-                    <GitHub />
-                  </IconWrapper>
-                }
-                label="GitHub"
-                isActive={false}
-                project={project}
-              />
+            <SideMenuLink
+              size="sm"
+              href="https://github.com/langwatch/langwatch"
+              icon={
+                <IconWrapper width="14px" height="14px">
+                  <GitHub />
+                </IconWrapper>
+              }
+              label="GitHub"
+              isActive={false}
+              project={project}
+            />
 
-              <SideMenuLink
-                size="sm"
-                href="https://discord.gg/kT4PhDS2gH"
-                icon={
-                  <IconWrapper width="14px" height="14px">
-                    <DiscordOutlineIcon />
-                  </IconWrapper>
-                }
-                label="Community"
-                isActive={false}
-                project={project}
-              />
-            </HStack>
-          </VStack>
+            <SideMenuLink
+              size="sm"
+              href="https://discord.gg/kT4PhDS2gH"
+              icon={
+                <IconWrapper width="14px" height="14px">
+                  <DiscordOutlineIcon />
+                </IconWrapper>
+              }
+              label="Community"
+              isActive={false}
+              project={project}
+            />
+          </HStack>
         </VStack>
-      </Box>
-    );
-  },
-  (prevProps, nextProps) => {
-    return prevProps.menuWidth === nextProps.menuWidth;
-  }
-);
+      </VStack>
+    </Box>
+  );
+});
 
 const PageMenuLink = ({
   icon,
@@ -362,8 +355,8 @@ const SideMenuLink = ({
       <Link
         variant="plain"
         width="full"
-        paddingX={size === "sm" ? 0 : 4}
-        paddingY={size === "sm" ? 2 : 3}
+        paddingX={4}
+        paddingY={3}
         href={href}
         aria-label={label}
         onClick={(e) => {
@@ -373,10 +366,15 @@ const SideMenuLink = ({
           });
           onClick?.(e);
         }}
-        fontSize={size === "sm" ? 10 : 11}
+        fontSize={11}
         _hover={{
           backgroundColor: "gray.50",
         }}
+        {...(size === "sm" && {
+          paddingX: 0,
+          paddingY: 2,
+          fontSize: 10,
+        })}
       >
         <VStack width="full" align="center" gap={1} minHeight="21px">
           <VStack align="start" position="relative">
@@ -388,7 +386,6 @@ const SideMenuLink = ({
               </Box>
             )}
           </VStack>
-          {/* {isHovered && ( */}
           {size === "md" && (
             <Text color={isActive ? "orange.600" : "gray.600"}>{label}</Text>
           )}

--- a/langwatch/src/components/SettingsLayout.tsx
+++ b/langwatch/src/components/SettingsLayout.tsx
@@ -29,10 +29,10 @@ export default function SettingsLayout({
           <MenuLink href={`/${project?.slug}/setup`}>Setup</MenuLink>
           <MenuLink href="/settings/model-providers">Model Providers</MenuLink>
           <MenuLink href="/settings/model-costs">Model Costs</MenuLink>
+          <MenuLink href={`/${project?.slug}/triggers`}>Triggers</MenuLink>
           <MenuLink href="/settings/projects">Projects</MenuLink>
           <MenuLink href="/settings/teams">Teams</MenuLink>
           <MenuLink href="/settings/members">Members</MenuLink>
-          <MenuLink href={`/${project?.slug}/triggers`}>Triggers</MenuLink>
           <MenuLink href="/settings/annotation-scores">
             Annotation Scores
           </MenuLink>

--- a/langwatch/src/components/messages/MessagesTable.tsx
+++ b/langwatch/src/components/messages/MessagesTable.tsx
@@ -1011,14 +1011,9 @@ export function MessagesTable() {
     }
   };
 
-  const [isExpanded] = useLocalStorage("main-menu-expanded", false);
-
   return (
     <>
-      <Container
-        maxWidth={isExpanded ? "calc(100vw - 200px)" : "calc(100vw - 50px)"}
-        padding={6}
-      >
+      <Container maxWidth="calc(100vw - 50px)" padding={6}>
         <HStack width="full" align="top" paddingBottom={6}>
           <HStack align="center" gap={6}>
             <Heading as="h1" size="lg" paddingTop={1}>
@@ -1141,13 +1136,7 @@ export function MessagesTable() {
                 <Card.Body
                   padding={0}
                   maxWidth={
-                    showFilters && isExpanded
-                      ? "calc(100vw - 580px)"
-                      : showFilters
-                      ? "calc(100vw - 450px)"
-                      : isExpanded
-                      ? "calc(100vw - 260px)"
-                      : "calc(100vw - 130px)"
+                    showFilters ? "calc(100vw - 450px)" : "calc(100vw - 130px)"
                   }
                 >
                   {downloadProgress > 0 && (

--- a/langwatch/src/pages/[project]/evaluations_v2.tsx
+++ b/langwatch/src/pages/[project]/evaluations_v2.tsx
@@ -121,7 +121,7 @@ export default function EvaluationsV2() {
 
   return (
     <DashboardLayout>
-      <Container maxWidth="1200" padding={6}>
+      <Container maxW={"calc(min(1440px, 100vw - 200px))"} padding={6}>
         <VStack width="fill" gap={4} align="stretch">
           <HStack paddingTop={4}>
             <VStack align="start" gap={1}>

--- a/langwatch/src/pages/[project]/triggers.tsx
+++ b/langwatch/src/pages/[project]/triggers.tsx
@@ -29,10 +29,8 @@ import { useDrawer } from "~/components/CurrentDrawer";
 import { HoverableBigText } from "~/components/HoverableBigText";
 import { NoDataInfoBlock } from "~/components/NoDataInfoBlock";
 import { SmallLabel } from "~/components/SmallLabel";
-import {
-  DashboardLayout,
-  ProjectSelector,
-} from "../../components/DashboardLayout";
+import { ProjectSelector } from "../../components/DashboardLayout";
+import SettingsLayout from "../../components/SettingsLayout";
 import { Drawer } from "../../components/ui/drawer";
 import { Link } from "../../components/ui/link";
 import { Menu } from "../../components/ui/menu";
@@ -297,7 +295,7 @@ export default function Members() {
   };
 
   return (
-    <DashboardLayout>
+    <SettingsLayout>
       <Container maxW={"calc(100vw - 200px)"} padding={6} marginTop={8}>
         <HStack width="full" align="top" gap={6} paddingBottom={6}>
           <Heading size="lg" as="h1">
@@ -505,7 +503,7 @@ export default function Members() {
           </Drawer.Body>
         </Drawer.Content>
       </Drawer.Root>
-    </DashboardLayout>
+    </SettingsLayout>
   );
 }
 

--- a/langwatch/src/utils/routes.ts
+++ b/langwatch/src/utils/routes.ts
@@ -16,7 +16,7 @@ export const projectRoutes = {
     title: "Analytics",
   },
   evaluations: {
-    path: "/[project]/evaluations",
+    path: "/[project]/evaluations_v2",
     title: "Evaluations",
   },
   evaluations_new_choose: {


### PR DESCRIPTION
Most users are confused by navigation on LangWatch, it takes a while to get used to which icon is what. We tried to solve previously by having an expandable menu, but if we leave it expanded by default it takes too much of the screen, if we leave it closed people don't open it, and if we expand on hover then it's extremely annoying

So instead we are now writing the menu label right under the icons, this makes the screen more busy, but extremely more navigable, the UX is much better

However it does mean we need to clean up a little bit to not look _too_ busy. This was already the plan anyway, specially by merging experiments and evaluations on a single screen with the evaluation wizard now. This is pretty much the summary of changes:

- Merged evaluations and experiments pages into one with the new evaluations wizard
- Removed triggers from the main menu, into the settings page
- Hide prompts for now briefly, until further improvements
- Reduce the icons size of the socials at the bottom and put them horizontally

## Before

<img width="1511" alt="Screenshot 2025-04-16 at 21 01 06" src="https://github.com/user-attachments/assets/c154ecc8-a2e6-42cd-905c-496cbe1d7c5d" />

## After

<img width="1512" alt="Screenshot 2025-04-16 at 20 56 14" src="https://github.com/user-attachments/assets/ef844f8b-3b08-4f52-8dfa-cd96f0d45b84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved menu layout with a fixed-width vertical sidebar and simplified navigation.
  - Enhanced responsiveness for evaluation pages with dynamic container widths.

- **Bug Fixes**
  - Removed duplicate "Triggers" link in the settings sidebar.

- **Refactor**
  - Simplified menu logic by removing expandable/collapsible sidebar functionality.
  - Streamlined layout calculations by eliminating conditional width logic based on menu expansion.
  - Updated navigation routes for evaluations to use the latest version.

- **Chores**
  - Switched triggers page layout to use the settings layout for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->