### PR TITLE
Add new record if not found

### DIFF
--- a/langwatch/src/server/api/routers/datasetRecord.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.ts
@@ -283,18 +283,24 @@ const updateDatasetRecord = async ({
       (record: any) => record.id === recordId
     );
     if (recordIndex === -1) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "Record not found",
-      });
+      // Create a new record
+      const newRecord = {
+        id: recordId,
+        entry: updatedRecord,
+        datasetId,
+        projectId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      records.push(newRecord);
+    } else {
+      // Update the record
+      records[recordIndex] = {
+        ...records[recordIndex],
+        entry: updatedRecord,
+        updatedAt: new Date().toISOString(),
+      };
     }
-
-    // Update the record
-    records[recordIndex] = {
-      ...records[recordIndex],
-      entry: updatedRecord,
-      updatedAt: new Date().toISOString(),
-    };
 
     // Save back to S3
     await storageService.putObject(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of updates for S3-backed datasets so that if a record does not exist, it is now created instead of causing an error. Existing records are still updated as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->