### PR TITLE
Standardize page layout

### DIFF
--- a/langwatch/src/components/ui/layouts/PageLayout.tsx
+++ b/langwatch/src/components/ui/layouts/PageLayout.tsx
@@ -1,0 +1,89 @@
+import {
+  Container as ChakraContainer,
+  HStack,
+  Heading as ChakraHeading,
+  Card,
+  Button,
+} from "@chakra-ui/react";
+import type {
+  ContainerProps as ChakraContainerProps,
+  StackProps as ChakraStackProps,
+  HeadingProps as ChakraHeadingProps,
+  ButtonProps as ChakraButtonProps,
+  CardRootProps,
+} from "@chakra-ui/react";
+import { type PropsWithChildren } from "react";
+
+// Container component
+interface ContainerProps extends ChakraContainerProps {
+  sidebarWidth?: number;
+}
+
+function Container({
+  children,
+  sidebarWidth = 200,
+  ...props
+}: PropsWithChildren<ContainerProps>) {
+  return (
+    <ChakraContainer
+      maxW={`calc(100vw - ${sidebarWidth}px)`}
+      padding={6}
+      marginTop={8}
+      {...props}
+    >
+      {children}
+    </ChakraContainer>
+  );
+}
+
+// Header component
+interface HeaderProps extends ChakraStackProps {}
+
+function Header({ children, ...props }: PropsWithChildren<HeaderProps>) {
+  return (
+    <HStack width="full" align="top" gap={6} paddingBottom={6} {...props}>
+      {children}
+    </HStack>
+  );
+}
+
+interface HeadingProps extends ChakraHeadingProps {}
+
+function Heading({ children, ...props }: PropsWithChildren<HeadingProps>) {
+  return (
+    <ChakraHeading as="h1" size="lg" paddingTop={1} {...props}>
+      {children}
+    </ChakraHeading>
+  );
+}
+
+// Content component
+function Content({ children, ...props }: PropsWithChildren<CardRootProps>) {
+  return (
+    <Card.Root {...props}>
+      <Card.Body>{children}</Card.Body>
+    </Card.Root>
+  );
+}
+
+interface HeaderButtonProps extends ChakraButtonProps {}
+
+function HeaderButton({
+  children,
+  ...props
+}: PropsWithChildren<HeaderButtonProps>) {
+  return (
+    <Button colorPalette="blue" minWidth="fit-content" {...props}>
+      {children}
+    </Button>
+  );
+}
+
+// Export as a namespace
+export const PageLayout = {
+  Container,
+  Header,
+  Content,
+  Heading,
+  HeaderButton,
+};

--- a/langwatch/src/pages/[project]/datasets.tsx
+++ b/langwatch/src/pages/[project]/datasets.tsx
@@ -33,6 +33,7 @@ import { NoDataInfoBlock } from "~/components/NoDataInfoBlock";
 import { Link } from "../../components/ui/link";
 import { Menu } from "../../components/ui/menu";
 import { toaster } from "../../components/ui/toaster";
+import { PageLayout } from "~/components/ui/layouts/PageLayout";
 
 export default function Datasets() {
   const addEditDatasetDrawer = useDisclosure();
@@ -135,154 +136,148 @@ export default function Datasets() {
 
   return (
     <DashboardLayout>
-      <Container maxW={"calc(100vw - 200px)"} padding={6} marginTop={8}>
-        <HStack width="full" align="top" gap={6}>
-          <Heading as={"h1"} size="lg" paddingBottom={6} paddingTop={1}>
-            Datasets and Evaluations
-          </Heading>
+      <PageLayout.Container
+        maxW={"calc(100vw - 200px)"}
+        padding={6}
+        marginTop={8}
+      >
+        <PageLayout.Header>
+          <PageLayout.Heading>Datasets and Evaluations</PageLayout.Heading>
           <Spacer />
-          <Button
-            colorPalette="blue"
+          <PageLayout.HeaderButton
             onClick={() => {
               openDrawer("batchEvaluation", {
                 selectDataset: true,
               });
             }}
-            minWidth="fit-content"
           >
             <Play height={16} /> Batch Evaluation
-          </Button>
-          <Button
-            colorPalette="blue"
-            onClick={() => uploadCSVModal.onOpen()}
-            minWidth="fit-content"
-          >
+          </PageLayout.HeaderButton>
+          <PageLayout.HeaderButton onClick={() => uploadCSVModal.onOpen()}>
             <Upload height={17} width={17} strokeWidth={2.5} /> Upload or Create
             Dataset
-          </Button>
-        </HStack>
-        <Card.Root>
-          <Card.Body>
-            {datasets.data && datasets.data.length == 0 ? (
-              <NoDataInfoBlock
-                title="No datasets yet"
-                description="Upload or create datasets on your messages to do further analysis or to train your own models."
-                docsInfo={
-                  <Text>
-                    To learn more about datasets, please visit our{" "}
-                    <Link
-                      color="orange.400"
-                      href="https://docs.langwatch.ai/features/datasets"
-                      isExternal
-                    >
-                      documentation
-                    </Link>
-                    .
-                  </Text>
-                }
-                icon={<TableIcon />}
-              />
-            ) : (
-              <Table.Root variant="line">
-                <Table.Header>
-                  <Table.Row>
-                    <Table.ColumnHeader>Name</Table.ColumnHeader>
-                    <Table.ColumnHeader>Columns</Table.ColumnHeader>
-                    <Table.ColumnHeader>Entries</Table.ColumnHeader>
-                    <Table.ColumnHeader width={240}>
-                      Last Update
-                    </Table.ColumnHeader>
-                    <Table.ColumnHeader width={20}></Table.ColumnHeader>
-                  </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  {datasets.isLoading
-                    ? Array.from({ length: 3 }).map((_, i) => (
-                        <Table.Row key={i}>
-                          {Array.from({ length: 4 }).map((_, i) => (
-                            <Table.Cell key={i}>
-                              <Skeleton height="20px" />
-                            </Table.Cell>
-                          ))}
-                        </Table.Row>
-                      ))
-                    : datasets.data
-                    ? datasets.data?.map((dataset) => (
-                        <Table.Row
-                          cursor="pointer"
-                          onClick={() => goToDataset(dataset.id)}
-                          key={dataset.id}
-                        >
-                          <Table.Cell>{dataset.name}</Table.Cell>
-                          <Table.Cell maxWidth="250px">
-                            <HStack wrap="wrap">
-                              {(
-                                (dataset.columnTypes as DatasetColumns) ?? []
-                              ).map(({ name }) => (
-                                <Badge size="sm" key={name}>
-                                  {name}
-                                </Badge>
-                              ))}
-                            </HStack>
+          </PageLayout.HeaderButton>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          {datasets.data && datasets.data.length == 0 ? (
+            <NoDataInfoBlock
+              title="No datasets yet"
+              description="Upload or create datasets on your messages to do further analysis or to train your own models."
+              docsInfo={
+                <Text>
+                  To learn more about datasets, please visit our{" "}
+                  <Link
+                    color="orange.400"
+                    href="https://docs.langwatch.ai/features/datasets"
+                    isExternal
+                  >
+                    documentation
+                  </Link>
+                  .
+                </Text>
+              }
+              icon={<TableIcon />}
+            />
+          ) : (
+            <Table.Root variant="line">
+              <Table.Header>
+                <Table.Row>
+                  <Table.ColumnHeader>Name</Table.ColumnHeader>
+                  <Table.ColumnHeader>Columns</Table.ColumnHeader>
+                  <Table.ColumnHeader>Entries</Table.ColumnHeader>
+                  <Table.ColumnHeader width={240}>
+                    Last Update
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader width={20}></Table.ColumnHeader>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {datasets.isLoading
+                  ? Array.from({ length: 3 }).map((_, i) => (
+                      <Table.Row key={i}>
+                        {Array.from({ length: 4 }).map((_, i) => (
+                          <Table.Cell key={i}>
+                            <Skeleton height="20px" />
                           </Table.Cell>
-                          <Table.Cell>
-                            {dataset.useS3
-                              ? dataset.s3RecordCount ?? 0
-                              : dataset._count.datasetRecords ?? 0}
-                          </Table.Cell>
-                          <Table.Cell>
-                            {new Date(dataset.createdAt).toLocaleString()}
-                          </Table.Cell>
-                          <Table.Cell>
-                            <Menu.Root>
-                              <Menu.Trigger asChild>
-                                <Button
-                                  variant={"ghost"}
-                                  onClick={(event) => {
-                                    event.stopPropagation();
-                                  }}
-                                >
-                                  <MoreVertical />
-                                </Button>
-                              </Menu.Trigger>
-                              <Menu.Content>
-                                <Menu.Item
-                                  value="edit"
-                                  onClick={(event) => {
-                                    event.stopPropagation();
-                                    setEditDataset({
-                                      datasetId: dataset.id,
-                                      name: dataset.name,
-                                      columnTypes:
-                                        dataset.columnTypes as DatasetColumns,
-                                    });
-                                    addEditDatasetDrawer.onOpen();
-                                  }}
-                                >
-                                  <Edit size={16} /> Edit dataset
-                                </Menu.Item>
-                                <Menu.Item
-                                  value="delete"
-                                  color="red.600"
-                                  onClick={(event) => {
-                                    event.stopPropagation();
-                                    deleteDataset(dataset.id, dataset.name);
-                                  }}
-                                >
-                                  <Trash2 size={16} /> Delete dataset
-                                </Menu.Item>
-                              </Menu.Content>
-                            </Menu.Root>
-                          </Table.Cell>
-                        </Table.Row>
-                      ))
-                    : null}
-                </Table.Body>
-              </Table.Root>
-            )}
-          </Card.Body>
-        </Card.Root>
-      </Container>
+                        ))}
+                      </Table.Row>
+                    ))
+                  : datasets.data
+                  ? datasets.data?.map((dataset) => (
+                      <Table.Row
+                        cursor="pointer"
+                        onClick={() => goToDataset(dataset.id)}
+                        key={dataset.id}
+                      >
+                        <Table.Cell>{dataset.name}</Table.Cell>
+                        <Table.Cell maxWidth="250px">
+                          <HStack wrap="wrap">
+                            {(
+                              (dataset.columnTypes as DatasetColumns) ?? []
+                            ).map(({ name }) => (
+                              <Badge size="sm" key={name}>
+                                {name}
+                              </Badge>
+                            ))}
+                          </HStack>
+                        </Table.Cell>
+                        <Table.Cell>
+                          {dataset.useS3
+                            ? dataset.s3RecordCount ?? 0
+                            : dataset._count.datasetRecords ?? 0}
+                        </Table.Cell>
+                        <Table.Cell>
+                          {new Date(dataset.createdAt).toLocaleString()}
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Menu.Root>
+                            <Menu.Trigger asChild>
+                              <Button
+                                variant={"ghost"}
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                }}
+                              >
+                                <MoreVertical />
+                              </Button>
+                            </Menu.Trigger>
+                            <Menu.Content>
+                              <Menu.Item
+                                value="edit"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  setEditDataset({
+                                    datasetId: dataset.id,
+                                    name: dataset.name,
+                                    columnTypes:
+                                      dataset.columnTypes as DatasetColumns,
+                                  });
+                                  addEditDatasetDrawer.onOpen();
+                                }}
+                              >
+                                <Edit size={16} /> Edit dataset
+                              </Menu.Item>
+                              <Menu.Item
+                                value="delete"
+                                color="red.600"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  deleteDataset(dataset.id, dataset.name);
+                                }}
+                              >
+                                <Trash2 size={16} /> Delete dataset
+                              </Menu.Item>
+                            </Menu.Content>
+                          </Menu.Root>
+                        </Table.Cell>
+                      </Table.Row>
+                    ))
+                  : null}
+              </Table.Body>
+            </Table.Root>
+          )}
+        </PageLayout.Content>
+      </PageLayout.Container>
       <AddOrEditDatasetDrawer
         open={addEditDatasetDrawer.open}
         onClose={() => {

--- a/langwatch/src/pages/[project]/prompt-configs.tsx
+++ b/langwatch/src/pages/[project]/prompt-configs.tsx
@@ -5,6 +5,8 @@ import {
   Heading,
   VStack,
   Flex,
+  Card,
+  Spacer,
 } from "@chakra-ui/react";
 import { type LlmPromptConfig } from "@prisma/client";
 import { useState, useMemo } from "react";
@@ -20,6 +22,7 @@ import {
   PromptConfigTable,
 } from "~/prompt-configs/PromptConfigTable";
 import { api } from "~/utils/api";
+import { PageLayout } from "~/components/ui/layouts/PageLayout";
 
 export default function PromptConfigsPage() {
   const utils = api.useContext();
@@ -152,28 +155,28 @@ export default function PromptConfigsPage() {
         width="100%"
         position="relative"
       >
-        <Container padding={6} height="full" width="full">
-          <VStack align="start" width="full">
-            {/* Header with title and "Create New" button */}
-            <HStack width="full" justifyContent="space-between">
-              <Heading as="h1" size="lg">
-                Prompts
-              </Heading>
-              <Button
-                colorPalette="blue"
-                minWidth="fit-content"
-                onClick={() => void handleCreateButtonClick()}
-              >
-                <Plus height={16} /> Create New
-              </Button>
-            </HStack>
+        <PageLayout.Container
+          maxW={"calc(100vw - 200px)"}
+          padding={6}
+          marginTop={8}
+        >
+          <PageLayout.Header>
+            <PageLayout.Heading>Prompts</PageLayout.Heading>
+            <Spacer />
+            <PageLayout.HeaderButton
+              onClick={() => void handleCreateButtonClick()}
+            >
+              <Plus height={16} /> Create New
+            </PageLayout.HeaderButton>
+          </PageLayout.Header>
+          <PageLayout.Content>
             <PromptConfigTable
               configs={promptConfigs ?? []}
               isLoading={false}
               onRowClick={(config) => setSelectedConfigId(config.id)}
               columns={defaultColumns}
             />
-          </VStack>
+          </PageLayout.Content>
 
           <DeleteConfirmationDialog
             title="Are you really sure?"
@@ -184,7 +187,7 @@ export default function PromptConfigsPage() {
               void confirmDeleteConfig();
             }}
           />
-        </Container>
+        </PageLayout.Container>
         <PromptConfigPanel
           isOpen={!!selectedConfigId}
           onClose={closePanel}

--- a/langwatch/src/pages/[project]/prompts.tsx
+++ b/langwatch/src/pages/[project]/prompts.tsx
@@ -1,13 +1,4 @@
-import {
-  Button,
-  Container,
-  HStack,
-  Heading,
-  VStack,
-  Flex,
-  Card,
-  Spacer,
-} from "@chakra-ui/react";
+import { Flex, Spacer } from "@chakra-ui/react";
 import { type LlmPromptConfig } from "@prisma/client";
 import { useState, useMemo } from "react";
 import { Plus } from "react-feather";

--- a/langwatch/src/prompt-configs/PromptConfigTable.tsx
+++ b/langwatch/src/prompt-configs/PromptConfigTable.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Table, Text } from "@chakra-ui/react";
+import { Box, Button, Card, Table, Text } from "@chakra-ui/react";
 import { Trash } from "react-feather";
 import type { LlmPromptConfig } from "@prisma/client";
 import { type ReactNode } from "react";


### PR DESCRIPTION
Standardizes page layout and renames page to Prompts"


Ticket: https://www.notion.so/langwatchdata/0542037d491d48d09f17825efdc48219?v=1d75e165d48280098ae5000c9553ed1d&p=1e55e165d48280d4b56cd54adfe61e71&pm=s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified PageLayout component with customizable subcomponents for consistent page structure and styling.

- **Refactor**
  - Updated the Datasets and Prompts pages to use the new PageLayout components, improving layout consistency and maintainability.
  - Adjusted imports to support the updated layout structure.

No changes to core logic or user interactions; all updates are visual and structural.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->