### PR TITLE
fix: add workflow to publish legacy python sdk

### DIFF
--- a/.github/workflows/python-legacy-publish.yml
+++ b/.github/workflows/python-legacy-publish.yml
@@ -1,0 +1,44 @@
+name: Publish Python SDK to PyPI
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-pypi:
+    if: startsWith(github.event.release.tag_name, 'python-sdk-') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          cd python-sdk-legacy
+          make install
+          uv pip install build
+
+      - name: Build package
+        run: |
+          cd python-sdk-legacy
+          uv run python -m build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          packages_dir: python-sdk-legacy/dist/
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new automated workflow to publish the Python SDK to PyPI when a release is published or triggered manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->