### PR TITLE
temp: reduce max bodyparser size

### DIFF
--- a/langwatch/src/pages/api/collector.ts
+++ b/langwatch/src/pages/api/collector.ts
@@ -35,7 +35,7 @@ const logger = createLogger("langwatch:collector");
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "10mb",
+      sizeLimit: "1mb",
     },
   },
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the maximum allowed size for incoming API request bodies from 10MB to 1MB on the collector endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->