### PR TITLE
Max width selector

### DIFF
--- a/langwatch/src/components/filters/TopicsSelector.tsx
+++ b/langwatch/src/components/filters/TopicsSelector.tsx
@@ -172,6 +172,7 @@ export function TopicsSelector({ showTitle = true }: { showTitle?: boolean }) {
                         lineClamp={1}
                         wordBreak="break-all"
                         fontSize="15px"
+                        maxWidth="300px"
                       >
                         {topic.name}
                       </OverflownTextWithTooltip>
@@ -210,6 +211,7 @@ export function TopicsSelector({ showTitle = true }: { showTitle?: boolean }) {
                             <OverflownTextWithTooltip
                               lineClamp={1}
                               wordBreak="break-all"
+                              maxWidth="300px"
                             >
                               {subtopic.name}
                             </OverflownTextWithTooltip>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Limited the maximum width of topic and subtopic name containers to 300 pixels in the topics selector, which may affect text wrapping or truncation display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->