### PR TITLE
[LWH-686] Feature: Show full trace button

### DIFF
--- a/langwatch/src/components/executable-panel/ExecutionOutputPanel.tsx
+++ b/langwatch/src/components/executable-panel/ExecutionOutputPanel.tsx
@@ -18,7 +18,7 @@ import type { ExecutionState } from "~/optimization_studio/types/dsl";
 
 interface OutputPanelProps {
   executionState?: ExecutionState;
-  isTracingEnabled: boolean;
+  isTracingEnabled?: boolean;
   nodeType?: string;
 }
 
@@ -28,7 +28,7 @@ interface OutputPanelProps {
  */
 export const ExecutionOutputPanel = ({
   executionState,
-  isTracingEnabled,
+  isTracingEnabled = false,
   nodeType,
 }: OutputPanelProps) => {
   const [isWaitingLong] = useDebounceValue(

--- a/langwatch/src/prompt-configs/PromptConfigPanel.tsx
+++ b/langwatch/src/prompt-configs/PromptConfigPanel.tsx
@@ -25,6 +25,8 @@ import {
   PANEL_ANIMATION_DURATION,
 } from "~/components/executable-panel/InputOutputExecutablePanel";
 import { useExecutePrompt } from "./hooks/useInvokePrompt";
+import { InputOutputExecutablePanel } from "~/components/executable-panel/InputOutputExecutablePanel";
+import { useInvokePrompt } from "./hooks/useInvokePrompt";
 import { ExecutionOutputPanel } from "~/components/executable-panel/ExecutionOutputPanel";
 import { useDebouncedCallback } from "use-debounce";
 
@@ -58,7 +60,7 @@ export const PromptConfigPanel = forwardRef(function PromptConfigPanel(
     mutate: invokeLLM,
     isLoading: isExecuting,
     data: promptExecutionResult,
-  } = useExecutePrompt();
+  } = useInvokePrompt();
 
   // Fetch the LLM configuration
   const { data: llmConfig, isLoading: isLoadingConfig } =

--- a/langwatch/src/prompt-configs/PromptConfigPanel.tsx
+++ b/langwatch/src/prompt-configs/PromptConfigPanel.tsx
@@ -24,8 +24,6 @@ import {
   InputOutputExecutablePanel,
   PANEL_ANIMATION_DURATION,
 } from "~/components/executable-panel/InputOutputExecutablePanel";
-import { useExecutePrompt } from "./hooks/useInvokePrompt";
-import { InputOutputExecutablePanel } from "~/components/executable-panel/InputOutputExecutablePanel";
 import { useInvokePrompt } from "./hooks/useInvokePrompt";
 import { ExecutionOutputPanel } from "~/components/executable-panel/ExecutionOutputPanel";
 import { useDebouncedCallback } from "use-debounce";
@@ -172,12 +170,12 @@ export const PromptConfigPanel = forwardRef(function PromptConfigPanel(
 
       <InputOutputExecutablePanel.RightDrawer>
         <ExecutionOutputPanel
+          isTracingEnabled={true}
           executionState={
             isExecuting
               ? { status: "running" }
               : promptExecutionResult?.executionState
           }
-          isTracingEnabled={false}
         />
       </InputOutputExecutablePanel.RightDrawer>
     </InputOutputExecutablePanel>

--- a/langwatch/src/prompt-configs/hooks/useInvokePrompt.ts
+++ b/langwatch/src/prompt-configs/hooks/useInvokePrompt.ts
@@ -12,7 +12,7 @@ const logger = createLogger("useInvokePrompt");
  * This hook wraps the invokeLLM utility function in a mutation,
  * providing loading states, error handling, and cache management.
  */
-export function useExecutePrompt() {
+export function useInvokePrompt() {
   return useMutation<
     PromptExecutionResult,
     Error,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tracing is now enabled by default in the execution output panel when accessed from the prompt configuration panel.

- **Refactor**
  - Updated naming of the prompt execution hook for improved clarity and consistency.
  - The tracing option in the execution output panel is now optional and defaults to disabled unless explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->