### PR TITLE
fix: local setup readme guide was wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Get up and running in under 30 seconds. The example below uses Docker, but if yo
 
 ```bash
 git clone https://github.com/langwatch/langwatch.git
-cp langwatch/.env.example langwatch/.env
 docker compose up -d --wait --build
 open http://localhost:5560
 ```


### PR DESCRIPTION
Fixes https://github.com/langwatch/langwatch/issues/365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated local setup instructions in the README by removing the step to copy the example environment file. Docker-based setup instructions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->