### PR TITLE
[LWH-675] Redact spans for anything in the outputs that match anything on the inputs and vice-versa

### DIFF
--- a/langwatch/src/components/ui/RedactedField.tsx
+++ b/langwatch/src/components/ui/RedactedField.tsx
@@ -36,4 +36,4 @@ export const RedactedField: React.FC<RedactedFieldProps> = ({ field, children, l
   }
 
   return <>{children}</>;
-}; 
+};

--- a/langwatch/src/server/elasticsearch/transformers.test.ts
+++ b/langwatch/src/server/elasticsearch/transformers.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { transformElasticSearchTraceToTrace } from "./transformers";
+import type { ElasticSearchTrace } from "../tracer/types";
+import type { Protections } from "./protections";
+
+describe("transformElasticSearchTraceToTrace", () => {
+  it("redacts input values in output when canSeeCapturedInput is false", () => {
+    const now = Date.now();
+    const trace: ElasticSearchTrace = {
+      trace_id: "trace1",
+      project_id: "proj1",
+      metadata: {},
+      timestamps: { started_at: now, inserted_at: now, updated_at: now },
+      input: {
+        value: JSON.stringify({ somekey: "secret" }),
+      },
+      output: {
+        value: JSON.stringify({ somekey: "secret", another: "visible" }),
+      },
+      metrics: { total_cost: 1 },
+      spans: [
+        {
+          span_id: "span1",
+          trace_id: "trace1",
+          project_id: "proj1",
+          type: "span",
+          name: "span1",
+          input: {
+            type: "json",
+            value: JSON.stringify({ somekey: "secret" }),
+          },
+          output: {
+            type: "json",
+            value: JSON.stringify({ somekey: "secret", spanonly: "spanvalue" }),
+          },
+          timestamps: {
+            started_at: now,
+            finished_at: now,
+            inserted_at: now,
+            updated_at: now,
+          },
+          metrics: { cost: 1 },
+        },
+        {
+          span_id: "span2",
+          trace_id: "trace1",
+          project_id: "proj1",
+          type: "span",
+          name: "span2",
+          input: {
+            type: "json",
+            value: JSON.stringify({ somekey: "secret" }),
+          },
+          output: {
+            type: "json",
+            value: JSON.stringify({ another: "visible" }),
+          },
+          timestamps: {
+            started_at: now,
+            finished_at: now,
+            inserted_at: now,
+            updated_at: now,
+          },
+          metrics: { cost: 2 },
+        },
+      ],
+    };
+
+    const protections: Protections = {
+      canSeeCapturedInput: false,
+      canSeeCapturedOutput: true,
+      canSeeCosts: true,
+    };
+
+    const result = transformElasticSearchTraceToTrace(trace, protections);
+
+    // Top-level input should be undefined
+    expect(result.input).toBeUndefined();
+    // Output should redact keys that were present in input
+    expect(result.output).toEqual({
+      value: { somekey: "[REDACTED]", another: "visible" },
+    });
+
+    // Spans: input should be [REDACTED], output should redact keys present in input
+    expect(result.spans).toBeDefined();
+    if (result.spans) {
+      expect(result.spans[0]?.input).toEqual({ type: 'text', value: '[REDACTED]' });
+      expect(result.spans[0]?.output).toEqual({
+        type: 'json',
+        value: { somekey: '[REDACTED]', spanonly: 'spanvalue' },
+      });
+      expect(result.spans[1]?.input).toEqual({ type: 'text', value: '[REDACTED]' });
+      expect(result.spans[1]?.output).toEqual({
+        type: 'json',
+        value: { another: 'visible' },
+      });
+    }
+  });
+});


### PR DESCRIPTION
But while still keeping the structure in place, this is how it looks now:

![image](https://github.com/user-attachments/assets/3f2cc5af-51c9-45c6-9a79-4311e5c88524)

This takes each value and nested values from the inputs if inputs are blocked, and use that to filter out outputs. Pretty heristic-y, but seems very solid looking at a variety of messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced privacy controls for trace and span data with both full and partial redaction of sensitive information based on user permissions.
- **Bug Fixes**
	- Improved parsing of data fields for redaction by supporting Python-like JSON formats.
- **Style**
	- Minor formatting adjustment in the user interface component.
- **Tests**
	- Added comprehensive tests to verify redaction behavior for various input formats and user permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->