### PR TITLE
Add less Filter options, 100 should be enough, remove spans from get …

### DIFF
--- a/langwatch/src/server/api/routers/traces.ts
+++ b/langwatch/src/server/api/routers/traces.ts
@@ -475,7 +475,8 @@ export const getAllTracesForProject = async ({
           "input.embeddings.embeddings",
           "output.embeddings",
           "output.embeddings.embeddings",
-          ...(downloadMode ? ["spans"] : []),
+          "spans",
+          ...(downloadMode ? [] : []),
         ],
       },
       ...(downloadMode && includeContexts
@@ -632,12 +633,6 @@ export const getAllTracesForProject = async ({
     )[0];
 
     let contexts: RAGChunk[] = [];
-    for (const span of spans ?? []) {
-      if ("contexts" in span && Array.isArray(span.contexts)) {
-        contexts = [...contexts, ...span.contexts];
-      }
-    }
-
     return {
       ...trace,
       lastGuardrail: lastFailedGuardrailResult,

--- a/langwatch/src/server/filters/registry.ts
+++ b/langwatch/src/server/filters/registry.ts
@@ -35,7 +35,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
             child: {
               terms: {
                 field: "metadata.topic_id",
-                size: 10_000,
+                size: 100,
                 order: { _key: "asc" },
               },
             },
@@ -78,7 +78,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
             child: {
               terms: {
                 field: "metadata.subtopic_id",
-                size: 10_000,
+                size: 100,
                 order: { _key: "asc" },
               },
             },
@@ -164,7 +164,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
             child: {
               terms: {
                 field: "metadata.thread_id",
-                size: 10_000,
+                size: 100,
                 order: { _key: "asc" },
               },
             },
@@ -207,7 +207,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
             child: {
               terms: {
                 field: "metadata.customer_id",
-                size: 10_000,
+                size: 100,
                 order: { _key: "asc" },
               },
             },
@@ -266,7 +266,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
                       },
                     }
                   : { field: "metadata.labels" }),
-                size: 10_000,
+                size: 100,
                 order: { _key: "asc" },
               },
             },


### PR DESCRIPTION
…all traces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance and reliability by always excluding "spans" from trace data and no longer extracting contexts from spans.
  - Reduced the number of filter options shown for certain metadata fields to ensure faster and more stable results when filtering traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->