### PR TITLE
fix: disable server-side rendering

### DIFF
--- a/langwatch/src/pages/[project]/chat/[workflow].tsx
+++ b/langwatch/src/pages/[project]/chat/[workflow].tsx
@@ -45,7 +45,7 @@ function ChatContent() {
   }
 
   if (!publishedWorkflow.data) {
-    return <Box p={8}>Workflow não encontrado.</Box>;
+    return <Box p={8}>Workflow not found.</Box>;
   }
 
   return (

--- a/langwatch/src/pages/[project]/chat/[workflow].tsx
+++ b/langwatch/src/pages/[project]/chat/[workflow].tsx
@@ -1,14 +1,26 @@
+import dynamic from "next/dynamic";
 import { Box, Card as ChakraCard } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import { FullLogo } from "../../../components/icons/FullLogo";
 import { useOrganizationTeamProject } from "../../../hooks/useOrganizationTeamProject";
-import { ChatBox } from "../../../optimization_studio/components/ChatWindow";
 import { api } from "../../../utils/api";
 import { type Edge, type Node } from "@xyflow/react";
 import { type Workflow } from "../../../optimization_studio/types/dsl";
 import { LoadingScreen } from "../../../components/LoadingScreen";
+import { useEffect, useState } from "react";
 
-export default function ChatPage() {
+const ChatBox = dynamic(
+  () =>
+    import("../../../optimization_studio/components/ChatWindow").then(
+      (mod) => mod.ChatBox
+    ),
+  {
+    ssr: false,
+    loading: () => <LoadingScreen />,
+  }
+);
+
+function ChatContent() {
   const router = useRouter();
   const { project } = useOrganizationTeamProject();
   const workflowId = router.query.workflow as string;
@@ -19,16 +31,21 @@ export default function ChatPage() {
       projectId: project?.id ?? "",
     },
     {
-      enabled: !!project?.id,
+      enabled: !!project?.id && !!workflowId,
     }
   );
 
-  if (publishedWorkflow.isLoading) {
+  const [isClient, setIsClient] = useState(false);
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  if (!isClient || !router.isReady || publishedWorkflow.isLoading) {
     return <LoadingScreen />;
   }
 
   if (!publishedWorkflow.data) {
-    return;
+    return <Box p={8}>Workflow não encontrado.</Box>;
   }
 
   return (
@@ -52,4 +69,12 @@ export default function ChatPage() {
       </Box>
     </Box>
   );
+}
+
+const ClientOnlyChatContent = dynamic(() => Promise.resolve(ChatContent), {
+  ssr: false,
+});
+
+export default function ChatPage() {
+  return <ClientOnlyChatContent />;
 }


### PR DESCRIPTION
[Prerender Error with Next.js](https://nextjs.org/docs/messages/prerender-error#5-disable-server-side-rendering-for-components-using-browser-apis)

Error at docker build:
```
#12 128.0    Checking validity of types ...
#12 174.8    Collecting page data ...
#12 180.4 ReferenceError: Cannot access 'w' before initialization
#12 180.4     at Object.ue (.next/server/chunks/9980.js:215:6240)
#12 180.4     at <unknown> (.next/server/chunks/9980.js:223:46652)
#12 180.4 
#12 180.4 > Build error occurred
#12 180.4 [Error: Failed to collect page data for /[project]/chat/[workflow]] {
#12 180.4   type: 'Error'
#12 180.4 }
#12 ERROR: process "/bin/sh -c npm --prefix=langwatch run build" did not complete successfully: exit code: 1
------
 > [8/8] RUN npm --prefix=langwatch run build:
128.0    Checking validity of types ...
174.8    Collecting page data ...
180.4 ReferenceError: Cannot access 'w' before initialization
180.4     at Object.ue (.next/server/chunks/9980.js:215:6240)
180.4     at <unknown> (.next/server/chunks/9980.js:223:46652)
180.4 
180.4 > Build error occurred
180.4 [Error: Failed to collect page data for /[project]/chat/[workflow]] {
180.4   type: 'Error'
180.4 }
------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved chat page performance and reliability by ensuring all content is rendered only on the client side.
  - Enhanced loading experience with a visible loading screen while chat components are loading.
  - Added a clear message when a workflow is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->