### PR TITLE
fix: pre-fetch tiktoken models during build

### DIFF
--- a/langwatch/src/server/background/workers/collector/cost.ts
+++ b/langwatch/src/server/background/workers/collector/cost.ts
@@ -10,6 +10,7 @@ import {
 import * as Sentry from "@sentry/nextjs";
 import NodeFetchCache, { FileSystemCache } from "node-fetch-cache";
 import { createLogger } from "../../../../utils/logger";
+import { isBuildOrNoRedis } from "../../../redis";
 
 const logger = createLogger("langwatch:workers:collector:cost");
 
@@ -61,6 +62,7 @@ const initTikToken = async (
   }
 
   if (!cachedModel[tokenizer]) {
+    logger.info(`loading tiktoken model ${tokenizer}`);
     loadingModel.add(tokenizer);
     const registryInfo = (registry as any)[tokenizer];
     const fetch = NodeFetchCache.create({
@@ -173,3 +175,7 @@ export const prewarmTiktokenModels = async () => {
   await initTikToken("gpt-4");
   await initTikToken("gpt-4o");
 };
+
+if (isBuildOrNoRedis) {
+  prewarmTiktokenModels();
+}

--- a/langwatch/src/server/redis.ts
+++ b/langwatch/src/server/redis.ts
@@ -5,7 +5,7 @@ import { PHASE_PRODUCTION_BUILD } from "next/constants";
 
 const logger = createLogger("langwatch:redis");
 
-const isBuild =
+export const isBuildOrNoRedis =
   process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD ||
   !!process.env.BUILD_TIME ||
   (!env.REDIS_URL && !env.REDIS_CLUSTER_ENDPOINTS);
@@ -21,7 +21,7 @@ function parseClusterEndpoints(endpointsStr: string) {
 
 export let connection: IORedis | Cluster | undefined;
 
-if (!isBuild) {
+if (!isBuildOrNoRedis) {
   if (useCluster) {
     const clusterEndpoints = parseClusterEndpoints(
       env.REDIS_CLUSTER_ENDPOINTS ?? ""


### PR DESCRIPTION
Preload tiktoken models if during build so models can be fetched during docker build process instead of runtime for when behind proxys, or if redis is not available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved internal handling for model prewarming and Redis detection to enhance reliability during builds and when Redis is unavailable.
  - Added logging for better visibility when tokenization models are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->