### PR TITLE
fix: remove knn from index settings for opensearch, it's not needed and breaks lite version without knn plugin

### DIFF
--- a/langwatch/src/tasks/elasticMigrate.ts
+++ b/langwatch/src/tasks/elasticMigrate.ts
@@ -151,12 +151,6 @@ const createIndexes = async (lastMigration: string, client: ElasticClient) => {
       number_of_replicas: 0,
     };
 
-    if (process.env.IS_OPENSEARCH === "true") {
-      settings.index = {
-        knn: true,
-      };
-    }
-
     await client.indices.create({
       index: TRACE_INDEX.base,
       settings: settings,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the OpenSearch-specific k-nearest neighbors (knn) configuration from index creation settings. This does not affect general functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->