### PR TITLE
fix: prompting technique and end node change

### DIFF
--- a/langwatch/src/optimization_studio/components/properties/WorkflowPropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/WorkflowPropertiesPanel.tsx
@@ -57,7 +57,7 @@ export const WorkflowPropertiesPanel = () => {
     ) {
       updateNode(workflow.workflow_type);
     }
-  }, [workflow.workflow_type]);
+  }, [workflow.workflow_type, isEvaluator]);
 
   const updateNode = (workflowType: WorkflowTypes) => {
     if (!endNode) return;

--- a/langwatch/src/optimization_studio/components/properties/WorkflowPropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/WorkflowPropertiesPanel.tsx
@@ -51,7 +51,10 @@ export const WorkflowPropertiesPanel = () => {
   };
 
   useEffect(() => {
-    if (workflow.workflow_type) {
+    if (
+      workflow.workflow_type &&
+      workflow.workflow_type !== (isEvaluator ? "evaluator" : "workflow")
+    ) {
       updateNode(workflow.workflow_type);
     }
   }, [workflow.workflow_type]);

--- a/langwatch/src/optimization_studio/components/properties/llm-configs/SignaturePropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/llm-configs/SignaturePropertiesPanel.tsx
@@ -416,6 +416,9 @@ export function SignaturePropertiesPanel({
               max_tokens: llm?.max_tokens ?? currentConfigData.max_tokens,
               demonstrations:
                 rest?.demonstrations ?? currentConfigData.demonstrations,
+              prompting_technique:
+                rest?.prompting_technique ??
+                currentConfigData.prompting_technique,
             } as LatestConfigVersionSchema["configData"],
             "Save from legacy node"
           );

--- a/langwatch/src/prompt-configs/hooks/usePromptConfigForm.ts
+++ b/langwatch/src/prompt-configs/hooks/usePromptConfigForm.ts
@@ -30,6 +30,8 @@ const formSchema = promptConfigSchema.extend({
       }),
       demonstrations:
         latestConfigVersionSchema.shape.configData.shape.demonstrations,
+      prompting_technique:
+        latestConfigVersionSchema.shape.configData.shape.prompting_technique,
     }),
   }),
 });

--- a/langwatch/src/prompt-configs/llmPromptConfigUtils.ts
+++ b/langwatch/src/prompt-configs/llmPromptConfigUtils.ts
@@ -101,9 +101,7 @@ export function promptConfigFormValuesToOptimizationStudioNodeData(
       {
         identifier: "prompting_technique",
         type: "prompting_technique",
-        value: {
-          ref: formValues.version?.configData?.prompting_technique,
-        },
+        value: formValues.version?.configData?.prompting_technique,
       },
     ],
   };

--- a/langwatch/src/prompt-configs/llmPromptConfigUtils.ts
+++ b/langwatch/src/prompt-configs/llmPromptConfigUtils.ts
@@ -59,6 +59,11 @@ export function llmConfigToOptimizationStudioNodeData(
         type: "chat_messages",
         value: version.configData.messages ?? [],
       },
+      {
+        identifier: "prompting_technique",
+        type: "prompting_technique",
+        value: version.configData.prompting_technique,
+      },
     ],
   };
 }
@@ -92,6 +97,13 @@ export function promptConfigFormValuesToOptimizationStudioNodeData(
         identifier: "messages",
         type: "chat_messages",
         value: formValues.version?.configData?.messages ?? [],
+      },
+      {
+        identifier: "prompting_technique",
+        type: "prompting_technique",
+        value: {
+          ref: formValues.version?.configData?.prompting_technique,
+        },
       },
     ],
   };
@@ -130,6 +142,8 @@ export function safeOptimizationStudioNodeDataToPromptConfigFormInitialValues(
               }
             )?.rows ?? [],
         },
+        prompting_technique: parametersMap.prompting_technique
+          ?.value as PromptConfigFormValues["version"]["configData"]["prompting_technique"],
       },
     },
   };

--- a/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
@@ -95,6 +95,11 @@ const configSchemaV1_0 = z.object({
     temperature: z.number().optional(),
     max_tokens: z.number().optional(),
     demonstrations: demonstrationsSchema,
+    prompting_technique: z
+      .object({
+        ref: z.string().optional(),
+      })
+      .optional(),
   }),
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a "prompting technique" in prompt and LLM configuration forms.
  - The "prompting technique" field is now included and preserved when creating or migrating LLM configuration versions.

- **Bug Fixes**
  - Improved efficiency in workflow property updates to avoid redundant operations when the workflow type matches the current state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->