### PR TITLE
chore: add prometheus metric to track event loop lag

### DIFF
--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -15,7 +15,7 @@ register.removeSingleMetric("event_loop_lag_milliseconds");
 const eventLoopLag = new Histogram({
   name: "event_loop_lag_milliseconds",
   help: "Event loop lag in milliseconds",
-  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.2, 0.5, 1, 2],
+  buckets: [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000]
 });
 setInterval(() => {
   const start = performance.now();

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter, Histogram, register, collectDefaultMetrics } from "prom-client";
+import { Counter, Histogram, register } from "prom-client";
 import { performance } from 'node:perf_hooks';
 
 type Endpoint =
@@ -10,7 +10,7 @@ type Endpoint =
   | "topic_clustering_batch"
   | "topic_clustering_incremental";
 
-// Histogram for event loop lap
+// Histogram for event loop lag
 register.removeSingleMetric("event_loop_lag_milliseconds");
 const eventLoopLag = new Histogram({
   name: "event_loop_lag_milliseconds",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced monitoring of event loop lag, providing real-time metrics on server performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->