### PR TITLE
fix: dspy optimization studio fixes for template adapter

### DIFF
--- a/langwatch/src/prompt-configs/hooks/usePromptConfigForm.ts
+++ b/langwatch/src/prompt-configs/hooks/usePromptConfigForm.ts
@@ -71,14 +71,20 @@ export const usePromptConfigForm = ({
     const newColumns = inputsAndOutputsToDemostrationColumns(inputs, outputs);
     const currentColumns =
       formData.version?.configData.demonstrations?.inline?.columnTypes ?? [];
+    const currentRecords =
+      formData.version?.configData.demonstrations?.inline?.records ?? {};
 
     if (!isEqual(newColumns, currentColumns)) {
       methods.setValue(
         "version.configData.demonstrations.inline.columnTypes",
         newColumns
       );
+      methods.setValue(
+        "version.configData.demonstrations.inline.records",
+        currentRecords
+      );
     }
-  }, [formData]);
+  }, [formData, methods]);
 
   // Provides forward sync of parent component to form values
   useEffect(() => {

--- a/langwatch/src/utils/sse/fetchSSE.ts
+++ b/langwatch/src/utils/sse/fetchSSE.ts
@@ -41,7 +41,7 @@ export async function fetchSSE<T>({
   onEvent,
   shouldStopProcessing,
   timeout = 10_000,
-  chunkTimeout = 240_000,
+  chunkTimeout = 480_000,
   headers = {},
   onError,
 }: FetchSSEOptions<T>): Promise<void> {

--- a/langwatch_nlp/langwatch_nlp/studio/dspy/langwatch_workflow_module.py
+++ b/langwatch_nlp/langwatch_nlp/studio/dspy/langwatch_workflow_module.py
@@ -21,6 +21,7 @@ T = TypeVar("T", bound=dspy.Module)
 class LangWatchWorkflowModule(ReportingModule):
     cost: float = 0
     duration: int = 0
+    prevent_crashes: bool = False
 
     def __init__(self, run_evaluations: bool = False, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -35,8 +36,9 @@ class LangWatchWorkflowModule(ReportingModule):
             delattr(module, "__forward_before_autoparsing__")
             delattr(module, "__forward_before_reporting__")
             delattr(module, "__forward_before_metadata__")
+            delattr(module, "__forward_before_prevent_crashes__")
 
-        module = self.with_reporting(with_autoparsing(module), node_id)
+        module = self.with_crash_prevention(self.with_reporting(with_autoparsing(module), node_id))
         module.__forward_before_metadata__ = module.forward  # type: ignore
 
         def forward_with_metadata(instance_self, *args, **kwargs):
@@ -98,21 +100,23 @@ class LangWatchWorkflowModule(ReportingModule):
 
         return results
 
-    def prevent_crashes(self):
-        if hasattr(self, "__forward_before_prevent_crashes__"):
-            self.forward = self.__forward_before_prevent_crashes__
-            delattr(self, "__forward_before_prevent_crashes__")
-
-        self.__forward_before_prevent_crashes__ = self.forward
+    def with_crash_prevention(self, module: type[T]) -> type[T]:
+        # If already patched, repatch so new config can be picked up
+        if hasattr(module, "__forward_before_crash_prevention__"):
+            module.forward = module.__forward_before_crash_prevention__  # type: ignore
+        module.__forward_before_prevent_crashes__ = module.forward  # type: ignore
 
         def prevent_crashes_forward(*args, **kwargs):
             try:
-                return self.__forward_before_prevent_crashes__(*args, **kwargs)
+                return module.__forward_before_prevent_crashes__(*args, **kwargs)  # type: ignore
             except Exception as e:
+                if not getattr(module, "prevent_crashes", False):
+                    raise e
                 return PredictionWithEvaluationAndMetadata(
                     duration=self.duration,
                     cost=self.cost,
                     error=e,
                 )
 
-        self.forward = prevent_crashes_forward
+        module.forward = prevent_crashes_forward  # type: ignore
+        return module

--- a/langwatch_nlp/langwatch_nlp/studio/dspy/template_adapter.py
+++ b/langwatch_nlp/langwatch_nlp/studio/dspy/template_adapter.py
@@ -30,6 +30,9 @@ class TemplateAdapter(dspy.JSONAdapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
+        if getattr(signature, "_messages", None) is None:
+            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+
         # If the signature has only one output field and it's a string, we can use the text only completion
         if self._use_text_only_completion(signature, inputs):
             return ChatAdapter.__call__(self, lm, lm_kwargs, signature, demos, inputs)  # type: ignore
@@ -51,6 +54,9 @@ class TemplateAdapter(dspy.JSONAdapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
+        if getattr(signature, "_messages", None) is None:
+            return super().format(signature, demos, inputs)
+
         inputs_copy = dict(inputs)
 
         # If the signature and inputs have conversation history, we need to format the conversation history and
@@ -114,6 +120,9 @@ class TemplateAdapter(dspy.JSONAdapter):
         return template_fmt.format_map(SafeDict(str_inputs))  # type: ignore
 
     def parse(self, signature, completion):
+        if getattr(signature, "_messages", None) is None:
+            return super().parse(signature, completion)
+
         if len(signature.output_fields) == 0:
             return {}
 
@@ -132,18 +141,9 @@ class TemplateAdapter(dspy.JSONAdapter):
     def format_demos(
         self, signature: Type[Signature], demos: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Format the few-shot examples.
+        if getattr(signature, "_messages", None) is None:
+            return super().format_demos(signature, demos)
 
-        This method formats the few-shot examples as multiturn messages.
-
-        Args:
-            signature: The DSPy signature for which to format the few-shot examples.
-            demos: A list of few-shot examples, each element is a dictionary with keys of the input and output fields of
-                the signature.
-
-        Returns:
-            A list of multiturn messages.
-        """
         _messages = getattr(signature, "_messages", Field(default=[])).default
         complete_demos = []
         incomplete_demos = []
@@ -215,6 +215,11 @@ class TemplateAdapter(dspy.JSONAdapter):
         outputs: dict[str, Any],
         missing_field_message=None,
     ) -> str:
+        if getattr(signature, "_messages", None) is None:
+            return super().format_assistant_message_content(
+                signature, outputs, missing_field_message
+            )
+
         if self._use_text_only_completion(signature, outputs):
             first_key = list(signature.output_fields.keys())[0]
             if first_key in outputs:

--- a/langwatch_nlp/langwatch_nlp/studio/execute/execute_evaluation.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/execute_evaluation.py
@@ -56,7 +56,8 @@ async def execute_evaluation(
             do_not_trace=True,
         ) as (Module, _):
             module = Module(run_evaluations=True)
-            module.prevent_crashes()
+            module.prevent_crashes = True
+
             langwatch.setup(workflow.api_key)
 
             entry_node = cast(

--- a/langwatch_nlp/langwatch_nlp/studio/execute/execute_flow.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/execute_flow.py
@@ -27,6 +27,7 @@ from langwatch_nlp.studio.utils import (
     ClientReadableValueError,
     SerializableWithPydanticAndPredictEncoder,
     disable_dsp_caching,
+    normalize_to_variable_name,
     optional_langwatch_trace,
     transpose_inline_dataset_to_object_list,
     get_dataset_entry_selection,
@@ -106,7 +107,7 @@ async def execute_flow(
 
             try:
                 input_keys = [input.identifier for input in module_inputs]
-                inputs_ = {k: v for k, v in entries[0].items() if k in input_keys}
+                inputs_ = {k: v for k, v in entries[0].items() if normalize_to_variable_name(k) in input_keys}
                 result = await dspy.asyncify(module.forward)(**inputs_)  # type: ignore
 
             except Exception as e:

--- a/langwatch_nlp/langwatch_nlp/studio/execute/execute_optimization.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/execute_optimization.py
@@ -81,7 +81,7 @@ async def execute_optimization(
             do_not_trace=True,
         ) as (Module, _):
             module = Module(run_evaluations=True)
-            module.prevent_crashes()
+            module.prevent_crashes = True
 
             entry_node = cast(
                 EntryNode,

--- a/python-sdk/src/langwatch/telemetry/tracing.py
+++ b/python-sdk/src/langwatch/telemetry/tracing.py
@@ -267,9 +267,10 @@ class LangWatchTrace:
         self,
     ):
         ensure_setup()
-        import langwatch.dspy
+        # Making sure it doesn't get mixed up with langwatch.dspy from `import langwatch`
+        from langwatch.dspy.__init__ import DSPyTracer
 
-        langwatch.dspy.DSPyTracer(trace=self)
+        DSPyTracer(trace=self)
 
     def share(self) -> str:
         """Share this trace and get a shareable URL."""


### PR DESCRIPTION
- fix: demonstrations being set without records key was preventing it from being saved and executed
- fix: fix template adapter not being used during optimizations due to with_functions signature recreation
- fix: crash prevention preventing demos from being used during optimization
- fix: fix template adapter being mistakenly used by the instructions generators and other inner dspy programs of the optimizers that generate instructions
- fix: getting example from dataset with Capital Case columns when running the flow
- fix: weird dynamic imports we do causing issues on autotrack sometimes
- fix: demonstrations being set without records key was preventing it from being saved and executed
- fix: fix template adapter not being used during optimizations due to with_functions signature recreation
- fix: crash prevention preventing demos from being used during optimization
- fix: fix template adapter being mistakenly used by the instructions generators and other inner dspy programs of the optimizers that generate instructions
- fix: getting example from dataset with Capital Case columns when running the flow
- fix: weird dynamic imports we do causing issues on autotrack sometimes
- fix: demonstrations formatting when using template adapter