### PR TITLE
fix: disable sorting on topics, metadata, events

### DIFF
--- a/langwatch/src/components/messages/MessagesTable.tsx
+++ b/langwatch/src/components/messages/MessagesTable.tsx
@@ -649,7 +649,7 @@ export function MessagesTable({
     },
     events: {
       name: "Events",
-      sortable: true,
+      sortable: false,
       render: (trace, index) => (
         <Table.Cell key={index}>{trace.events?.length}</Table.Cell>
       ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Disabled sorting for the "Metadata," "Topic," "Subtopic," and "Events" columns in the messages table.
  * Improved performance of table updates after sending items to the queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->