### PR TITLE
feat: show sdk for python snippet with docs link

### DIFF
--- a/langwatch/src/components/GenerateApiSnippetDialog.tsx
+++ b/langwatch/src/components/GenerateApiSnippetDialog.tsx
@@ -1,12 +1,15 @@
 import { Button, HStack, Text, VStack } from "@chakra-ui/react";
+import { useDisclosure } from "@chakra-ui/react";
+import type { PrismLanguage } from "@react-email/components";
+import { ChevronDownIcon, CheckIcon } from "lucide-react";
+import React, { useEffect, useState, createContext, useContext } from "react";
+
+import type { Snippet, Target } from "../prompt-configs/types";
+
+import { RenderCode } from "./code/RenderCode";
 import { Dialog } from "./ui/dialog";
 import { Menu } from "./ui/menu";
-import { useDisclosure } from "@chakra-ui/react";
-import React, { useEffect, useState, createContext, useContext } from "react";
-import { ChevronDownIcon, CheckIcon } from "lucide-react";
-import { RenderCode } from "./code/RenderCode";
-import type { Snippet, Target } from "../prompt-configs/types";
-import type { PrismLanguage } from "@react-email/components";
+
 import { uppercaseFirstLetter } from "~/utils/stringCasing";
 
 // Add context for dialog state
@@ -21,7 +24,7 @@ interface GenerateApiSnippetProps {
   snippets: Snippet[];
   targets: Target[];
   title?: string;
-  description?: string;
+  description?: React.ReactNode;
   children?: React.ReactNode;
 }
 
@@ -91,7 +94,7 @@ export function GenerateApiSnippetDialog({
             </HStack>
             <Dialog.Description>
               <VStack alignItems="flex-start" gap={2}>
-                {description && description}
+                {description}
                 <HStack>
                   <Text
                     fontSize="sm"
@@ -182,7 +185,7 @@ const LanguageMenu = React.memo(function LanguageMenu({
           <Menu.Item
             key={target}
             value={target}
-            onClick={() => setSelectedTarget(target as Target)}
+            onClick={() => setSelectedTarget(target)}
           >
             {formatTarget(target)}
             {selectedTarget === target && <CheckIcon />}

--- a/langwatch/src/prompt-configs/components/GeneratePromptApiSnippetDialog.tsx
+++ b/langwatch/src/prompt-configs/components/GeneratePromptApiSnippetDialog.tsx
@@ -1,6 +1,10 @@
+import { Text, VStack } from "@chakra-ui/react";
 import React from "react";
-import { GenerateApiSnippetDialog } from "~/components/GenerateApiSnippetDialog";
+
 import { getGetPromptSnippets } from "../utils/snippets/getGetPromptSnippets";
+
+import { GenerateApiSnippetDialog } from "~/components/GenerateApiSnippetDialog";
+import { Link } from "~/components/ui/link";
 
 interface GeneratePromptApiSnippetButtonProps {
   configId?: string;
@@ -13,6 +17,9 @@ interface GeneratePromptApiSnippetButtonProps {
  *
  * Renders an icon-only button that, when clicked, opens a modal (Dialog)
  * for displaying API code snippets for prompt usage.
+ *
+ * Single Responsibility: This component specifically handles prompt API snippet generation
+ * and documentation display for the Get Prompt endpoint.
  */
 export function GeneratePromptApiSnippetDialog({
   configId,
@@ -30,12 +37,29 @@ export function GeneratePromptApiSnippetDialog({
     return children;
   }
 
+  const description = (
+    <VStack alignItems="flex-start" gap={3} marginBottom={4}>
+      <Text>
+        Use the following API code snippets to interact with the prompt.
+      </Text>
+      <Link
+        href="https://docs.langwatch.ai/api-reference/prompts/get-prompt"
+        isExternal
+        color="blue.500"
+        _hover={{ textDecoration: "underline" }}
+        fontSize="sm"
+      >
+        📖 View API documentation
+      </Link>
+    </VStack>
+  );
+
   return (
     <GenerateApiSnippetDialog
       snippets={snippets}
       targets={targets}
       title="Get Prompt by ID"
-      description="Use the following API code snippets to interact with the prompt."
+      description={description}
     >
       {children}
     </GenerateApiSnippetDialog>

--- a/langwatch/src/prompt-configs/utils/snippets/getGetPromptSnippets.ts
+++ b/langwatch/src/prompt-configs/utils/snippets/getGetPromptSnippets.ts
@@ -26,19 +26,44 @@ curl --request GET \\
     },
     {
       content: `
-import httpx
+import asyncio
+import langwatch.prompt
 
-url = "https://app.langwatch.ai/api/prompts/${promptId}"
+# Setup LangWatch (ensure LANGWATCH_API_KEY is set in environment)
+langwatch.setup(api_key="${apiKey}")
 
-headers = {"X-Auth-Token": "${apiKey}"}
+# Synchronous example
+prompt = langwatch.prompt.get_prompt("${promptId}")
 
-with httpx.Client() as client:
-    response = client.get(url, headers=headers)
+# Access prompt properties
+print(f"Prompt Name: {prompt.name}")
+print(f"Model: {prompt.model}")
+print(f"Version: {prompt.version_number}")
 
-print(response.text)
+# Format messages with variables (example)
+messages = prompt.format_messages(
+    user_name="John Doe",
+    input="Hello world"
+)
+print(f"Formatted messages: {messages}")
+
+# Asynchronous example
+async def get_prompt_async_example():
+    prompt = await langwatch.prompt.async_get_prompt("${promptId}")
+    
+    # Same functionality as sync version
+    print(f"Async - Prompt Name: {prompt.name}")
+    messages = prompt.format_messages(
+        user_name="Jane Doe",
+        input="Hello async world"
+    )
+    print(f"Async - Formatted messages: {messages}")
+
+# Run the async function
+asyncio.run(get_prompt_async_example())
 `,
       target: "python_python3",
-      title: "Get Prompts (Python httpx)",
+      title: "Get Prompts (Python SDK)",
       path: "/api/prompts/{id}",
       method: "GET",
     },


### PR DESCRIPTION
<img width="747" height="793" alt="Screenshot 2025-07-22 at 16 15 38" src="https://github.com/user-attachments/assets/f995313c-ad6b-45e9-9f69-5055d042f2b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced API snippet dialog descriptions to support richer content, including formatted text and external links for improved clarity and interactivity.

* **Improvements**
  * Updated the Python code sample for retrieving prompts to use the LangWatch Python SDK, providing clearer and more practical usage examples.
  * Improved organization and clarity of component imports and prop types for better consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->