### PR TITLE
feat: add trace usage to dashboard and usage page

### DIFF
--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   VStack,
   Progress,
+  Link,
   type StackProps,
 } from "@chakra-ui/react";
 import { type Organization, type Project, type Team } from "@prisma/client";
@@ -45,7 +46,6 @@ import { ProjectTechStackIcon } from "./TechStack";
 import { ChecklistIcon } from "./icons/Checklist";
 import { useColorRawValue } from "./ui/color-mode";
 import { InputGroup } from "./ui/input-group";
-import { Link } from "./ui/link";
 import { Menu } from "./ui/menu";
 import { Popover } from "./ui/popover";
 import { Tooltip } from "./ui/tooltip";
@@ -513,25 +513,27 @@ export const DashboardLayout = ({
               width="full"
             >
               <HStack>
-                <Link href="/settings/usage" width="150px" cursor="pointer">
-                  <Progress.Label fontSize="xs">
-                    <HStack gap={1}>
-                      Trace Usage
-                      <Tooltip
-                        content={`You have used ${usage.data?.currentMonthMessagesCount.toLocaleString()} out of ${usage.data?.activePlan.maxMessagesPerMonth.toLocaleString()} this month.`}
-                      >
-                        <Info size="12" />
-                      </Tooltip>
-                    </HStack>
-                  </Progress.Label>
-                  <Progress.Track
-                    flex="1"
-                    borderRadius="full"
-                    border="1px solid"
-                    borderColor="#eee"
+                <Link href="/settings/usage" width="150px">
+                  <Tooltip
+                    content={`You have used ${usage.data?.currentMonthMessagesCount.toLocaleString()} traces out of ${usage.data?.activePlan.maxMessagesPerMonth.toLocaleString()} this month.`}
                   >
-                    <Progress.Range />
-                  </Progress.Track>
+                    <HStack width="full" cursor="pointer">
+                      <Progress.Label fontSize="xs">
+                        <HStack gap={1} cursor="pointer">
+                          Usage
+                          <Info size="12" />
+                        </HStack>
+                      </Progress.Label>
+                      <Progress.Track
+                        flex="1"
+                        borderRadius="full"
+                        border="1px solid"
+                        borderColor="#eee"
+                      >
+                        <Progress.Range />
+                      </Progress.Track>
+                    </HStack>
+                  </Tooltip>
                 </Link>
               </HStack>
             </Progress.Root>

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -10,6 +10,7 @@ import {
   Spacer,
   Text,
   VStack,
+  Progress,
   type StackProps,
 } from "@chakra-ui/react";
 import { type Organization, type Project, type Team } from "@prisma/client";
@@ -19,7 +20,14 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import numeral from "numeral";
 import React, { useMemo, useState } from "react";
-import { ChevronDown, ChevronRight, Lock, Plus, Search } from "react-feather";
+import {
+  ChevronDown,
+  ChevronRight,
+  Lock,
+  Plus,
+  Search,
+  Info,
+} from "react-feather";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
 import { usePublicEnv } from "../hooks/usePublicEnv";
 import { useRequiredSession } from "../hooks/useRequiredSession";
@@ -492,9 +500,43 @@ export const DashboardLayout = ({
               </InputGroup>
             </form>
           )}
-          <HStack gap={6} flex={1}>
+
+          <HStack gap={2} flex={1}>
             <Spacer />
-            <HStack gap={4}>
+
+            <Progress.Root
+              defaultValue={0}
+              max={usage.data?.activePlan.maxMessagesPerMonth}
+              value={usage.data?.currentMonthMessagesCount}
+              maxW="150px"
+              colorPalette="orange"
+              width="full"
+            >
+              <HStack>
+                <Link href="/settings/usage" width="150px" cursor="pointer">
+                  <Progress.Label fontSize="xs">
+                    <HStack gap={1}>
+                      Trace Usage
+                      <Tooltip
+                        content={`You have used ${usage.data?.currentMonthMessagesCount.toLocaleString()} out of ${usage.data?.activePlan.maxMessagesPerMonth.toLocaleString()} this month.`}
+                      >
+                        <Info size="12" />
+                      </Tooltip>
+                    </HStack>
+                  </Progress.Label>
+                  <Progress.Track
+                    flex="1"
+                    borderRadius="full"
+                    border="1px solid"
+                    borderColor="#eee"
+                  >
+                    <Progress.Range />
+                  </Progress.Track>
+                </Link>
+              </HStack>
+            </Progress.Root>
+
+            <HStack>
               {integrationsLeft ? (
                 <Popover.Root positioning={{ placement: "bottom-end" }}>
                   <Popover.Trigger asChild>
@@ -524,7 +566,7 @@ export const DashboardLayout = ({
                   </Popover.Content>
                 </Popover.Root>
               ) : (
-                <Box width={["auto", "auto", "auto", "55px"]} />
+                <Spacer />
               )}
               <Menu.Root>
                 <Menu.Trigger asChild>

--- a/langwatch/src/pages/settings/usage.tsx
+++ b/langwatch/src/pages/settings/usage.tsx
@@ -96,7 +96,7 @@ export default function Usage() {
               <Text>
                 You have used{" "}
                 <b>{usage.data?.currentMonthMessagesCount.toLocaleString()}</b>{" "}
-                out of{" "}
+                traces out of{" "}
                 <b>
                   {usage.data?.activePlan.maxMessagesPerMonth.toLocaleString()}
                 </b>{" "}

--- a/langwatch/src/pages/settings/usage.tsx
+++ b/langwatch/src/pages/settings/usage.tsx
@@ -1,8 +1,10 @@
 import {
   Alert,
+  Button,
   Card,
   HStack,
   Heading,
+  Progress,
   Spacer,
   Table,
   Text,
@@ -40,6 +42,15 @@ export default function Usage() {
     {}
   );
 
+  const usage = api.limits.getUsage.useQuery(
+    { organizationId: organization?.id ?? "" },
+    {
+      enabled: !!organization,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    }
+  );
+
   return (
     <SettingsLayout>
       <VStack
@@ -66,13 +77,41 @@ export default function Usage() {
               paddingX={4}
               align="start"
             >
+              <Heading size="md" as="h2">
+                Trace Usage
+              </Heading>
+              <Progress.Root
+                defaultValue={0}
+                max={usage.data?.activePlan.maxMessagesPerMonth}
+                value={usage.data?.currentMonthMessagesCount}
+                maxW="sm"
+                colorPalette="orange"
+                width="full"
+              >
+                <Progress.Label fontSize="xs"></Progress.Label>
+                <Progress.Track flex="1">
+                  <Progress.Range />
+                </Progress.Track>
+              </Progress.Root>
+              <Text>
+                You have used{" "}
+                <b>{usage.data?.currentMonthMessagesCount.toLocaleString()}</b>{" "}
+                out of{" "}
+                <b>
+                  {usage.data?.activePlan.maxMessagesPerMonth.toLocaleString()}
+                </b>{" "}
+                traces this month.
+              </Text>
+              <Button asChild marginBottom={2}>
+                <Link href="/settings/subscription">Change plan</Link>
+              </Button>
               {activePlan.data && (
                 <>
                   <Heading size="md" as="h2">
                     Active Plan
                   </Heading>
                   <Text paddingBottom={4}>
-                    You are on the {activePlan.data.name} plan
+                    You are on the <b>{activePlan.data.name}</b> plan
                     {activePlan.data.free && ", no payment is required"}
                   </Text>
                 </>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a progress bar in the dashboard header to visually display current month's message usage relative to your plan limit, with tooltip details and a link to usage settings.
  * Introduced a "Trace Usage" section on the usage settings page, featuring a progress bar and a summary of message usage versus plan limits.
  * Added a button on the usage page to easily access subscription settings for plan changes.

* **Style**
  * Improved layout spacing and alignment in the dashboard header and usage settings page.
  * Enhanced formatting of plan names and usage numbers for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->