### PR TITLE
feat: prompt ids first class filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ langwatch_server/
 
 # vscode
 .vscode/
+
+# Misc
+.local

--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -12,6 +12,7 @@ import {
   VStack,
   useDisclosure,
 } from "@chakra-ui/react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { TRPCClientErrorLike } from "@trpc/client";
 import type { UseTRPCQueryResult } from "@trpc/react-query/shared";
 import type { inferRouterOutputs } from "@trpc/server";
@@ -20,22 +21,23 @@ import numeral from "numeral";
 import React, { useEffect, useMemo } from "react";
 import { ChevronDown, Search, X } from "react-feather";
 import { useDebounceValue } from "usehooks-ts";
-import { useDrawer } from "~/components/CurrentDrawer";
-import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+
 import { useFilterParams, type FilterParam } from "../../hooks/useFilterParams";
 import { TeamRoleGroup } from "../../server/api/permission";
 import type { AppRouter } from "../../server/api/root";
 import { availableFilters } from "../../server/filters/registry";
 import type { FilterDefinition, FilterField } from "../../server/filters/types";
 import { api } from "../../utils/api";
-import { Popover } from "../ui/popover";
+import { OverflownTextWithTooltip } from "../OverflownText";
 import { Checkbox } from "../ui/checkbox";
-import { Tooltip } from "../ui/tooltip";
 import { useColorRawValue } from "../ui/color-mode";
 import { InputGroup } from "../ui/input-group";
+import { Popover } from "../ui/popover";
 import { Slider } from "../ui/slider";
-import { useVirtualizer } from "@tanstack/react-virtual";
-import { OverflownTextWithTooltip } from "../OverflownText";
+import { Tooltip } from "../ui/tooltip";
+
+import { useDrawer } from "~/components/CurrentDrawer";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 
 export function FieldsFilters() {
   const { nonEmptyFilters } = useFilterParams();
@@ -45,6 +47,7 @@ export function FieldsFilters() {
   const isEditMode = isDrawerOpen("editTriggerFilter");
 
   const filterKeys: FilterField[] = [
+    "metadata.prompt_ids",
     "spans.model",
     "metadata.labels",
     "evaluations.passed",

--- a/langwatch/src/components/traces/TraceDetails.tsx
+++ b/langwatch/src/components/traces/TraceDetails.tsx
@@ -12,22 +12,20 @@ import { useRouter } from "next/router";
 import qs from "qs";
 import { useCallback, useEffect, useState } from "react";
 import { Maximize2, Minimize2 } from "react-feather";
+
+import { useAnnotationCommentStore } from "../../hooks/useAnnotationCommentStore";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { useTraceDetailsState } from "../../hooks/useTraceDetailsState";
 import { TeamRoleGroup } from "../../server/api/permission";
 import { api } from "../../utils/api";
+import { AddAnnotationQueueDrawer } from "../AddAnnotationQueueDrawer";
 import { useDrawer } from "../CurrentDrawer";
 import { Conversation } from "../messages/Conversation";
+import { Drawer } from "../ui/drawer";
 import { Link } from "../ui/link";
 import { Popover } from "../ui/popover";
 import { toaster } from "../ui/toaster";
-import { ShareButton } from "./ShareButton";
-import { SpanTree } from "./SpanTree";
-import { TraceSummary } from "./Summary";
 
-import { useAnnotationCommentStore } from "../../hooks/useAnnotationCommentStore";
-import { AddAnnotationQueueDrawer } from "../AddAnnotationQueueDrawer";
-import { Drawer } from "../ui/drawer";
 import { AddParticipants } from "./AddParticipants";
 import {
   Blocked,
@@ -36,6 +34,9 @@ import {
   Guardrails,
 } from "./Evaluations";
 import { Events } from "./Events";
+import { ShareButton } from "./ShareButton";
+import { SpanTree } from "./SpanTree";
+import { TraceSummary } from "./Summary";
 
 export function TraceDetails(props: {
   traceId: string;

--- a/langwatch/src/server/filters/registry.ts
+++ b/langwatch/src/server/filters/registry.ts
@@ -2,11 +2,13 @@ import type {
   QueryDslBoolQuery,
   QueryDslQueryContainer,
 } from "@elastic/elasticsearch/lib/api/types";
+
 import {
   AVAILABLE_EVALUATORS,
   type EvaluatorTypes,
 } from "../../server/evaluations/evaluators.generated";
 import { reservedTraceMetadataSchema } from "../tracer/types.generated";
+
 import type { FilterDefinition, FilterField } from "./types";
 
 export const availableFilters: { [K in FilterField]: FilterDefinition } = {
@@ -477,9 +479,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
         return (
           result.unique_values?.buckets?.map((bucket: any) => ({
             field: bucket.key ? "true" : "false",
-            label: bucket.key
-              ? "Traces with error"
-              : "Traces without error",
+            label: bucket.key ? "Traces with error" : "Traces without error",
             count: bucket.doc_count,
           })) ?? []
         );

--- a/langwatch/src/server/filters/registry.ts
+++ b/langwatch/src/server/filters/registry.ts
@@ -1429,6 +1429,49 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
       },
     },
   },
+  "metadata.prompt_ids": {
+    name: "Prompt ID",
+    urlKey: "prompt_id",
+    query: (values: string[]) => ({
+      terms: { "metadata.prompt_ids": values },
+    }),
+    listMatch: {
+      aggregation: (query: string | undefined) => ({
+        unique_values: {
+          filter: query
+            ? {
+                prefix: {
+                  "metadata.prompt_ids": {
+                    value: query,
+                    case_insensitive: true,
+                  },
+                },
+              }
+            : {
+                match_all: {},
+              },
+          aggs: {
+            child: {
+              terms: {
+                field: "metadata.prompt_ids",
+                size: 10_000,
+                order: { _key: "asc" },
+              },
+            },
+          },
+        },
+      }),
+      extract: (result: Record<string, any>) => {
+        return (
+          result.unique_values?.child?.buckets?.map((bucket: any) => ({
+            field: bucket.key,
+            label: bucket.key,
+            count: bucket.doc_count,
+          })) ?? []
+        );
+      },
+    },
+  },
 };
 
 const metadataKey = (key: string | undefined) => {

--- a/langwatch/src/server/filters/types.ts
+++ b/langwatch/src/server/filters/types.ts
@@ -13,6 +13,7 @@ export const filterFieldsEnum = z.enum([
   "metadata.labels",
   "metadata.key",
   "metadata.value",
+  "metadata.prompt_ids",
   "traces.error",
   "spans.type",
   "spans.model",


### PR DESCRIPTION
Allows for quick filtering of prompt_id on the metadata

Notion ticket: https://www.notion.so/langwatchdata/Filter-for-prompt-ids-as-a-first-class-citizen-22c5e165d48280bea677dcb8e75cba74?v=1d75e165d48280098ae5000c9553ed1d&source=copy_link

<img width="1210" height="345" alt="Screenshot 2025-07-29 at 16 32 46" src="https://github.com/user-attachments/assets/290f8cb0-f3ff-49c4-87de-c1dc34493e3a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering by "Prompt ID" in the available filters, allowing users to filter results using prompt identifiers.

* **Refactor**
  * Improved organization and grouping of import statements in several components for better maintainability.

* **Chores**
  * Updated ignored files configuration to include `.local` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->