### PR TITLE
feat: show error stack when present

### DIFF
--- a/langwatch/src/components/simulations/simulation-console/ErrorDetails.tsx
+++ b/langwatch/src/components/simulations/simulation-console/ErrorDetails.tsx
@@ -1,0 +1,89 @@
+import { Box, Text, VStack, Code } from "@chakra-ui/react";
+
+import { CONSOLE_COLORS } from "./constants";
+
+interface ParsedError {
+  name?: string;
+  message?: string;
+  stack?: string;
+}
+
+/**
+ * Parses error string and returns structured error object
+ * Single Responsibility: Safely parses error JSON or handles plain strings
+ */
+function parseError(errorString?: string): ParsedError | null {
+  if (!errorString) return null;
+
+  // Check if it looks like JSON (starts with { and ends with })
+  if (errorString.trim().startsWith("{") && errorString.trim().endsWith("}")) {
+    try {
+      return JSON.parse(errorString);
+    } catch {
+      // If JSON parsing fails, return the raw string as message
+      return { message: errorString };
+    }
+  }
+
+  // If it's not JSON, treat as plain string message
+  return { message: errorString };
+}
+
+interface ErrorDetailsProps {
+  error: string;
+}
+
+/**
+ * Error details component
+ * Single Responsibility: Displays structured error information in console format
+ */
+export function ErrorDetails({ error }: ErrorDetailsProps) {
+  const parsedError = parseError(error);
+
+  if (!parsedError) return null;
+
+  return (
+    <Box>
+      <Text color={CONSOLE_COLORS.failureColor} fontWeight="semibold" mb={1}>
+        Error Details:
+      </Text>
+      <VStack align="start" gap={1} pl={2}>
+        {parsedError.name && (
+          <Text color={CONSOLE_COLORS.failureColor} fontSize="sm">
+            <Text as="span" color="white">
+              Type:
+            </Text>{" "}
+            {parsedError.name}
+          </Text>
+        )}
+        {parsedError.message && (
+          <Text color={CONSOLE_COLORS.failureColor} fontSize="sm">
+            <Text as="span" color="white">
+              Message:
+            </Text>{" "}
+            {parsedError.message}
+          </Text>
+        )}
+        {parsedError.stack && (
+          <Box>
+            <Text color="white" fontSize="sm" mb={1}>
+              Stack Trace:
+            </Text>
+            <Code
+              colorScheme="red"
+              bg="transparent"
+              color={CONSOLE_COLORS.failureColor}
+              fontSize="xs"
+              whiteSpace="pre-wrap"
+              display="block"
+              width="100%"
+              pl={2}
+            >
+              {parsedError.stack}
+            </Code>
+          </Box>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/langwatch/src/components/simulations/simulation-console/SimulationConsole.tsx
+++ b/langwatch/src/components/simulations/simulation-console/SimulationConsole.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { ConsoleHeader } from "./ConsoleHeader";
 import { CONSOLE_COLORS } from "./constants";
 import { CriteriaDetails } from "./CriteriaDetails";
+import { ErrorDetails } from "./ErrorDetails";
 import { MetricsSummary } from "./MetricsSummary";
 import { StatusDisplay } from "./StatusDisplay";
 
@@ -63,7 +64,14 @@ export function SimulationConsole({
             </HStack>
           )}
 
-          {!isPending && <CriteriaDetails results={results} />}
+          {!isPending && !Boolean(results?.error) && (
+            <CriteriaDetails results={results} />
+          )}
+
+          {/* Error Details */}
+          {!isPending && results?.error && (
+            <ErrorDetails error={results.error} />
+          )}
         </VStack>
       </Code>
     </Box>


### PR DESCRIPTION
We want to errors to be clearer and easier to debug on the UI for the user experience.

<img width="720" height="495" alt="image" src="https://github.com/user-attachments/assets/bcf44f6d-24f3-4c65-998b-a7ab09196d9e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new error details panel in the simulation console to display structured error information when a simulation fails.
  * Error messages now appear with clear labels and formatting, making it easier to understand issues during simulation runs.

* **Enhancements**
  * The simulation console now conditionally shows either simulation results or error details, improving clarity for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->