### PR TITLE
feat: click to prompt filter new page LWH-1091

### DIFF
--- a/langwatch/src/components/MetadataTag.tsx
+++ b/langwatch/src/components/MetadataTag.tsx
@@ -32,10 +32,12 @@ export const MetadataTag = ({
   label,
   value,
   copyable,
+  onClick,
 }: {
   label: string;
   value: string;
   copyable?: boolean;
+  onClick?: () => void;
 }) => {
   const { project } = useOrganizationTeamProject();
   const { isCopied, copyToClipboard } = useCopyToClipboard();
@@ -64,7 +66,13 @@ export const MetadataTag = ({
   };
 
   return (
-    <HStack gap={0} fontSize="smaller" margin={0}>
+    <HStack
+      gap={0}
+      fontSize="smaller"
+      margin={0}
+      onClick={onClick}
+      cursor={onClick ? "pointer" : "default"}
+    >
       <Text
         borderWidth={1}
         borderColor="gray.200"

--- a/langwatch/src/components/traces/Summary.tsx
+++ b/langwatch/src/components/traces/Summary.tsx
@@ -2,13 +2,15 @@ import { Alert, Box, HStack, Skeleton, VStack } from "@chakra-ui/react";
 import numeral from "numeral";
 import React, { type PropsWithChildren } from "react";
 import { HelpCircle } from "react-feather";
-import { getTotalTokensDisplay } from "~/utils/getTotalTokensDisplay";
+
 import { useTraceDetailsState } from "../../hooks/useTraceDetailsState";
 import type { Trace } from "../../server/tracer/types";
 import { formatMilliseconds } from "../../utils/formatMilliseconds";
 import { isNotFound } from "../../utils/trpcError";
 import { MetadataTag } from "../MetadataTag";
 import { Tooltip } from "../ui/tooltip";
+
+import { getTotalTokensDisplay } from "~/utils/getTotalTokensDisplay";
 
 const SummaryItem = ({
   label,
@@ -104,6 +106,28 @@ const TraceSummaryValues = React.forwardRef<HTMLDivElement, { trace: Trace }>(
 
     const shouldShowCost = hasTraceCost() || hasSpanCosts();
 
+    /**
+     * Handle metadata tag click.
+     * Note: This is a quick hack to open the current page in a new tab with the prompt_id filter applied
+     * since the double update of the query params has race conditions and we can't use the current hooks.
+     *
+     * TODO: Create a more robust/seemless way to open the current page in a new tab with the prompt_id filter applied,
+     * probably that will work for all of the metadata tags.
+     *
+     * @param key - The key of the metadata tag.
+     * @param value - The value of the metadata tag.
+     */
+    const handleMetadataTagClick = async (key: string, value: string) => {
+      if (key === "prompt_ids") {
+        // Open current page in new tab with prompt_id filter applied
+        const baseUrl = window.location.origin + window.location.pathname;
+        const newUrl = new URL(baseUrl);
+        newUrl.searchParams.set("prompt_id", value);
+        // Open in new tab
+        window.open(newUrl.toString(), "_blank");
+      }
+    };
+
     return (
       <>
         <HStack
@@ -189,6 +213,9 @@ const TraceSummaryValues = React.forwardRef<HTMLDivElement, { trace: Trace }>(
                   key={i}
                   label={key}
                   value={renderValue as string}
+                  onClick={() =>
+                    void handleMetadataTagClick(key, renderValue as string)
+                  }
                 />
               )
             );


### PR DESCRIPTION
### ✨ Feature: Clickable Metadata Tag for Prompt Filtering

- **Makes metadata tags clickable** in the trace summary UI.
- When clicking a tag with key **prompt_ids**, a **new tab opens** with the current page filtered by the selected prompt ID.
- **Improves navigation and usability** for users analyzing traces by prompt.

---

#### Implementation Notes

- This is a **quick hack** to open the current page in a new tab with the **prompt_id filter** applied.
- **Reason:** Double updating query params causes race conditions; current hooks can't be used.
- **TODO:** Build a **more robust/seamless solution** that works for all metadata tags, not just prompt_id.

---

**Files changed:**  
- `MetadataTag.tsx`  
- `traces/Summary.tsx`

[_Closes LWH-1091._](https://www.notion.so/langwatchdata/Click-on-prompt-id-tag-in-trace-and-go-to-url-with-query-for-filtering-2415e165d482807e930cdfdccc8a456d?source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata tags in trace summaries are now clickable when relevant, allowing users to open filtered views in a new browser tab by clicking on certain tags.
  * The cursor style updates to indicate interactivity when a metadata tag is clickable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->