### PR TITLE
fix: strands agents choice events now support json and non-json content fields

### DIFF
--- a/langwatch/src/server/tracer/otel.traces.test.ts
+++ b/langwatch/src/server/tracer/otel.traces.test.ts
@@ -1641,10 +1641,11 @@ describe("opentelemetry traces receiver", () => {
       type: "chat_messages",
       value: [
         {
-          role: "choice",
           content: [{ text: "Hello!" }],
           id: "choice-1",
           finish_reason: "stop",
+          role: void 0,
+          tool_result: void 0,
         },
       ],
     });

--- a/langwatch/src/server/tracer/otel.traces.test.ts
+++ b/langwatch/src/server/tracer/otel.traces.test.ts
@@ -1606,7 +1606,7 @@ describe("opentelemetry traces receiver", () => {
                       attributes: [
                         { key: "message", value: { stringValue: '[{"text": "Hello!"}]' } },
                         { key: "id", value: { stringValue: "choice-1" } },
-                        { key: "finish_reason", value: { stringValue: "stop" } },
+                        { key: "finish_reason", value: { stringValue: "end_turn" } },
                       ],
                     },
                   ],
@@ -1641,10 +1641,10 @@ describe("opentelemetry traces receiver", () => {
       type: "chat_messages",
       value: [
         {
+          role: "assistant",
           content: [{ text: "Hello!" }],
           id: "choice-1",
-          finish_reason: "stop",
-          role: void 0,
+          finish_reason: "end_turn",
           tool_result: void 0,
         },
       ],

--- a/langwatch/src/server/tracer/span-event-processing/strands-agents.test.ts
+++ b/langwatch/src/server/tracer/span-event-processing/strands-agents.test.ts
@@ -150,7 +150,7 @@ describe("extractStrandsAgentsInputOutput", () => {
           attributes: [
             { key: "message", value: { stringValue: '{"bar":99}' } },
             { key: "id", value: { stringValue: "choice-1" } },
-            { key: "finish_reason", value: { stringValue: "stop" } },
+            { key: "finish_reason", value: { stringValue: "end_turn" } },
           ],
         },
       ] as unknown as IEvent[],
@@ -176,10 +176,11 @@ describe("extractStrandsAgentsInputOutput", () => {
         type: "chat_messages",
         value: [
           {
-            role: "choice",
+            role: "assistant",
             content: { bar: 99 },
             id: "choice-1",
-            finish_reason: "stop",
+            finish_reason: "end_turn",
+            tool_result: void 0,
           },
         ],
       },
@@ -188,5 +189,85 @@ describe("extractStrandsAgentsInputOutput", () => {
 
   it("returns null if no events", () => {
     expect(extractStrandsAgentsInputOutput({})).toBeNull();
+  });
+
+  it("parses content/message as JSON or string for input and output", () => {
+    const span: DeepPartial<ISpan> = {
+      events: [
+        // content is a valid JSON string (should parse to object)
+        {
+          name: "gen_ai.user.message",
+          attributes: [
+            { key: "role", value: { stringValue: "user" } },
+            { key: "content", value: { stringValue: '{"foo":123}' } },
+            { key: "id", value: { stringValue: "msg-1" } },
+          ],
+        },
+        // content is a plain string (should remain string)
+        {
+          name: "gen_ai.tool.message",
+          attributes: [
+            { key: "role", value: { stringValue: "tool" } },
+            { key: "content", value: { stringValue: "plain string" } },
+            { key: "id", value: { stringValue: "tool-1" } },
+          ],
+        },
+        // message is a valid JSON string (should parse to object)
+        {
+          name: "gen_ai.choice",
+          attributes: [
+            { key: "message", value: { stringValue: '{"bar":456}' } },
+            { key: "id", value: { stringValue: "choice-1" } },
+            { key: "finish_reason", value: { stringValue: "end_turn" } },
+          ],
+        },
+        // message is a plain string (should remain string)
+        {
+          name: "gen_ai.choice",
+          attributes: [
+            { key: "message", value: { stringValue: "just a string" } },
+            { key: "id", value: { stringValue: "choice-2" } },
+            { key: "finish_reason", value: { stringValue: "end_turn" } },
+          ],
+        },
+      ] as unknown as IEvent[],
+    };
+    const result = extractStrandsAgentsInputOutput(span);
+    expect(result).toEqual({
+      input: {
+        type: "chat_messages",
+        value: [
+          {
+            role: "user",
+            content: { foo: 123 },
+            id: "msg-1",
+          },
+          {
+            role: "tool",
+            content: "plain string",
+            id: "tool-1",
+          },
+        ],
+      },
+      output: {
+        type: "chat_messages",
+        value: [
+          {
+            role: "assistant",
+            content: { bar: 456 },
+            id: "choice-1",
+            finish_reason: "end_turn",
+            tool_result: void 0,
+          },
+          {
+            role: "assistant",
+            content: "just a string",
+            id: "choice-2",
+            finish_reason: "end_turn",
+            tool_result: void 0,
+          },
+        ],
+      },
+    });
   });
 });

--- a/langwatch/src/server/tracer/span-event-processing/strands-agents.test.ts
+++ b/langwatch/src/server/tracer/span-event-processing/strands-agents.test.ts
@@ -270,4 +270,62 @@ describe("extractStrandsAgentsInputOutput", () => {
       },
     });
   });
+
+  it("assigns 'assistant' role to choice when role is missing and finish_reason is 'end_turn'", () => {
+    const span: DeepPartial<ISpan> = {
+      events: [
+        {
+          name: "gen_ai.choice",
+          attributes: [
+            { key: "message", value: { stringValue: '"response"' } },
+            { key: "id", value: { stringValue: "choice-1" } },
+            { key: "finish_reason", value: { stringValue: "end_turn" } },
+            // No 'role' attribute
+          ],
+        },
+        {
+          name: "gen_ai.choice",
+          attributes: [
+            { key: "message", value: { stringValue: '"response2"' } },
+            { key: "id", value: { stringValue: "choice-2" } },
+            { key: "finish_reason", value: { stringValue: "not_end_turn" } },
+            // No 'role' attribute
+          ],
+        },
+        {
+          name: "gen_ai.choice",
+          attributes: [
+            { key: "message", value: { stringValue: '"response3"' } },
+            { key: "id", value: { stringValue: "choice-3" } },
+            { key: "finish_reason", value: { stringValue: "end_turn" } },
+            { key: "role", value: { stringValue: "customrole" } },
+          ],
+        },
+      ] as unknown as IEvent[],
+    };
+    const result = extractStrandsAgentsInputOutput(span);
+    expect(result?.output?.value).toEqual([
+      {
+        role: "assistant",
+        content: "response",
+        id: "choice-1",
+        finish_reason: "end_turn",
+        tool_result: void 0,
+      },
+      {
+        role: void 0,
+        content: "response2",
+        id: "choice-2",
+        finish_reason: "not_end_turn",
+        tool_result: void 0,
+      },
+      {
+        role: "customrole",
+        content: "response3",
+        id: "choice-3",
+        finish_reason: "end_turn",
+        tool_result: void 0,
+      },
+    ]);
+  });
 });

--- a/langwatch/src/server/tracer/span-event-processing/strands-agents.ts
+++ b/langwatch/src/server/tracer/span-event-processing/strands-agents.ts
@@ -74,7 +74,7 @@ export function extractStrandsAgentsInputOutput(otelSpan: DeepPartial<ISpan>): {
 
         outputChoices.push({
           // Use the role, but fallback to "assistant" if we're at the end of a turn.
-          role: role ?? finishReason === "end_turn" ? "assistant" : void 0,
+          role: role !== void 0 ? role : (finishReason === "end_turn" ? "assistant" : void 0),
           content: jsonOrString(event.attributes.find(a => a?.key === "message")?.value?.stringValue),
           id: event.attributes.find(a => a?.key === "id")?.value?.stringValue,
           finish_reason: event.attributes.find(a => a?.key === "finish_reason")?.value?.stringValue,

--- a/langwatch/src/server/tracer/span-event-processing/strands-agents.ts
+++ b/langwatch/src/server/tracer/span-event-processing/strands-agents.ts
@@ -27,12 +27,13 @@ export function isStrandsAgentsInstrumentation(
   span: DeepPartial<ISpan> | undefined,
 ): boolean {
   // The ordering here is specific, don't change it for aesthetic reasons please.
+  if (scope?.name === "strands.telemetry.tracer") return true;
+  if (scope?.name === "opentelemetry.instrumentation.strands") return true;
   if (scope?.name === "strands-agents") return true;
   if (attrStrVal(scope?.attributes, "gen_ai.system") === "strands-agents") return true;
   if (attrStrVal(scope?.attributes, "system.name") === "strands-agents") return true;
   if (attrStrVal(span?.attributes, "gen_ai.agent.name") === "Strands Agents") return true;
   if (attrStrVal(span?.attributes, "service.name") === "strands-agents") return true; 
-  if (scope?.name === "opentelemetry.instrumentation.strands") return true;
   if (span?.name?.includes(" Strands Agents")) return true;
 
   return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of message roles and finish reasons in trace outputs, ensuring more accurate representation of assistant responses.
  * Enhanced parsing of tool results and message content for better trace event processing.

* **Refactor**
  * Unified JSON parsing logic for trace event attributes, providing more permissive and consistent handling of input and output data.
  * Updated instrumentation detection to support additional scope names for broader compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->