### PR TITLE
chore: handle the UseSVE issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ docker compose up -d --wait --build
 open http://localhost:5560
 ```
 
+#### ARM (aarch64) note
+
+- The default Compose config targets amd64 and no longer sets SVE-related JVM flags.
+- On ARM (aarch64), include the ARM override to disable SVE in the JVM:
+
+```bash
+# On amd64 (no special flag)
+docker compose up
+
+# On aarch64 (ARM), include the override
+docker compose -f compose.yml -f docker-compose.arm64.override.yml up
+```
+
+The override file `docker-compose.arm64.override.yml` lives at the repo root (next to `compose.yml`) and only adds `_JAVA_OPTIONS=-XX:UseSVE=0` for the `opensearch` service.
+
 You'll be launched right into our onboarding flow. Welcome aboard 🫡.
 
 ### Self-hosted ⚓️

--- a/compose.yml
+++ b/compose.yml
@@ -83,7 +83,7 @@ services:
     environment:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
-      - "_JAVA_OPTIONS=-XX:UseSVE=0"
+      # - "_JAVA_OPTIONS=-XX:UseSVE=0" # Uncomment for arm64, or override this file with: docker-compose.arm64.override.yml
       # Performance settings
       - "OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m -XX:+UseG1GC -XX:-UseSerialGC -XX:G1ReservePercent=25 -XX:+AlwaysPreTouch -XX:InitiatingHeapOccupancyPercent=30"
       - "cluster.routing.allocation.disk.threshold_enabled=false"

--- a/docker-compose.arm64.override.yml
+++ b/docker-compose.arm64.override.yml
@@ -1,0 +1,6 @@
+services:
+  opensearch:
+    environment:
+      - "_JAVA_OPTIONS=-XX:UseSVE=0"
+
+


### PR DESCRIPTION
**PR Description**

- **Removes** `_JAVA_OPTIONS=-XX:UseSVE=0` from the default `compose.yml` to fix OpenSearch startup on **amd64**.
- **Adds** `docker-compose.arm64.override.yml` for ARM (aarch64) users, which sets the SVE JVM flag only when needed.
- **Updates** `README.md` with clear instructions for running on both amd64 and ARM.

**Fixes**: OpenSearch failing to start on amd64 due to unrecognized JVM option.  
**ARM users:** Now use the override file for SVE handling.

Addresses: https://github.com/langwatch/langwatch/pull/536