### PR TITLE
chore: update sve flag references

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,16 @@ docker compose up -d --wait --build
 open http://localhost:5560
 ```
 
-#### ARM (aarch64) note
+You'll be launched right into our onboarding flow. Welcome aboard 🫡.
 
-- The default Compose config targets amd64 and no longer sets SVE-related JVM flags.
-- On ARM (aarch64), include the ARM override to disable SVE in the JVM:
+### Note: 🍎 Mac M4 Compatibility
+
+If you're running on a Mac with M4 processor, you may need to uncomment the Java options line in the `compose.yml` file to disable SVE (Scalable Vector Extension) for OpenSearch:
 
 ```bash
-# On amd64 (no special flag)
-docker compose up
-
-# On aarch64 (ARM), include the override
-docker compose -f compose.yml -f docker-compose.arm64.override.yml up
+# Uncomment the next line if running on Mac M4 processors to disable SVE
+# - "_JAVA_OPTIONS=-XX:UseSVE=0"
 ```
-
-The override file `docker-compose.arm64.override.yml` lives at the repo root (next to `compose.yml`) and only adds `_JAVA_OPTIONS=-XX:UseSVE=0` for the `opensearch` service.
-
-You'll be launched right into our onboarding flow. Welcome aboard 🫡.
 
 ### Self-hosted ⚓️
 

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -147,3 +147,12 @@ metadata:
     prometheus.io/port: "5560" # For main app
     prometheus.io/path: "/metrics" # For workers with custom paths
 ```
+
+## 🍎 Mac M4 Compatibility
+
+If you're running on a Mac with M4 processor, you may need to uncomment the Java options line in the `values.yaml` file to disable SVE (Scalable Vector Extension) for OpenSearch:
+
+```bash
+# Uncomment the next line if running on Mac M4 processors to disable SVE
+# - "_JAVA_OPTIONS=-XX:UseSVE=0"
+```

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -187,7 +187,8 @@ opensearch:
   env:
     discovery.type: single-node
     DISABLE_SECURITY_PLUGIN: "true"
-    # _JAVA_OPTIONS: "-XX:UseSVE=0"
+    # Uncomment the next line if running on Mac M4 processors to disable SVE
+    # - "_JAVA_OPTIONS=-XX:UseSVE=0"
     OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m -XX:+UseG1GC -XX:-UseSerialGC -XX:G1ReservePercent=25 -XX:+AlwaysPreTouch -XX:InitiatingHeapOccupancyPercent=30"
     cluster.routing.allocation.disk.threshold_enabled: "false"
     bootstrap.memory_lock: "false"

--- a/compose.yml
+++ b/compose.yml
@@ -83,7 +83,8 @@ services:
     environment:
       - discovery.type=single-node
       - DISABLE_SECURITY_PLUGIN=true
-      # - "_JAVA_OPTIONS=-XX:UseSVE=0" # Uncomment for arm64, or override this file with: docker-compose.arm64.override.yml
+      # Uncomment the next line if running on Mac M4 processors to disable SVE
+      # - "_JAVA_OPTIONS=-XX:UseSVE=0"
       # Performance settings
       - "OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m -XX:+UseG1GC -XX:-UseSerialGC -XX:G1ReservePercent=25 -XX:+AlwaysPreTouch -XX:InitiatingHeapOccupancyPercent=30"
       - "cluster.routing.allocation.disk.threshold_enabled=false"

--- a/docker-compose.arm64.override.yml
+++ b/docker-compose.arm64.override.yml
@@ -1,6 +1,0 @@
-services:
-  opensearch:
-    environment:
-      - "_JAVA_OPTIONS=-XX:UseSVE=0"
-
-


### PR DESCRIPTION
This seems to be a problem only on M4 macs.