### PR TITLE
fix: span fix to allow all types

### DIFF
--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -150,22 +150,22 @@ export const TracesMapping = ({
   );
   const mapping = traceMappingState.mapping;
 
-  const availableExpansions = useMemo(
-    () =>
-      new Set(
-        Object.values(mapping)
-          .map((mapping) => {
-            const source = mapping.source && TRACE_MAPPINGS[mapping.source];
-            if (source && "expandable_by" in source && source.expandable_by) {
-              return source.expandable_by;
-            }
-            return;
-          })
-          .filter(Boolean)
-          .map((x) => x!)
-      ),
-    [mapping]
-  );
+  const availableExpansions = useMemo(() => {
+    const result = new Set(
+      Object.values(mapping)
+        .map((mapping) => {
+          const source = mapping.source && TRACE_MAPPINGS[mapping.source];
+          if (source && "expandable_by" in source && source.expandable_by) {
+            return source.expandable_by;
+          }
+          return;
+        })
+        .filter(Boolean)
+        .map((x) => x!)
+    );
+
+    return result;
+  }, [mapping]);
   const expansions = useMemo(
     () =>
       new Set(

--- a/langwatch/src/server/tracer/tracesMapping.ts
+++ b/langwatch/src/server/tracer/tracesMapping.ts
@@ -101,7 +101,7 @@ export const TRACE_MAPPINGS = {
       }
       return filteredSpans.map((span) => span[subkey as keyof DatasetSpan]);
     },
-    expandable_by: "spans.llm.span_id",
+    expandable_by: "spans.all.span_id",
   },
   "spans.llm.input": {
     mapping: (trace: TraceWithAnnotations) =>
@@ -359,6 +359,16 @@ export const TRACE_EXPANSIONS = {
     label: "LLM span",
     expansion: (trace: TraceWithAnnotations) => {
       const spans = trace.spans?.filter((span) => span.type === "llm") ?? [];
+      return spans.map((span) => ({
+        ...trace,
+        spans: [span],
+      }));
+    },
+  },
+  "spans.all.span_id": {
+    label: "all spans",
+    expansion: (trace: TraceWithAnnotations) => {
+      const spans = trace.spans ?? [];
       return spans.map((span) => ({
         ...trace,
         spans: [span],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - Enable per-span exploration across all trace spans, not limited to LLM spans. Users can now expand a trace to view individual spans for deeper analysis.
* Refactor
  - Optimized internal logic for computing available expansions in the traces mapping component; no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->