### PR TITLE
fix: add to dataset would stay loading if trace was not in a thread

### DIFF
--- a/langwatch/src/components/traces/TraceDetails.tsx
+++ b/langwatch/src/components/traces/TraceDetails.tsx
@@ -179,6 +179,7 @@ export function TraceDetails(props: {
     );
   };
 
+  const hasThread = Boolean(threadId);
   const threadTraces = api.traces.getTracesByThreadId.useQuery(
     {
       projectId: project?.id ?? "",
@@ -186,7 +187,7 @@ export function TraceDetails(props: {
       traceId: props.traceId,
     },
     {
-      enabled: !!project && !!threadId,
+      enabled: !!project && hasThread,
     }
   );
 
@@ -295,7 +296,7 @@ export function TraceDetails(props: {
               )}
               {hasTeamPermission(TeamRoleGroup.DATASETS_MANAGE) && (
                 <>
-                  {threadTraces.data && threadTraces.data.length > 0 ? (
+                  {hasThread && threadTraces.data && threadTraces.data.length > 0 ? (
                     <Menu.Root>
                       <Menu.Trigger asChild>
                         <Button variant="outline" size="sm">
@@ -335,7 +336,7 @@ export function TraceDetails(props: {
                       type="submit"
                       variant="outline"
                       minWidth="fit-content"
-                      loading={threadTraces.isLoading}
+                      loading={hasThread && threadTraces.isLoading}
                       onClick={() => {
                         openDrawer("addDatasetRecord", {
                           traceId: props.traceId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - “Add to Dataset” now appears only when a conversation thread exists, avoiding misleading options on single traces.
  - Loading indicator for this action shows only when relevant, reducing unnecessary spinners and UI flicker.
  - Prevents background loading when no thread is present, improving responsiveness and accuracy of availability.
  - Overall, availability and state of the “Add to Dataset” action better reflect actual data conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->