### PR TITLE
chore: Python version constraint to allow 3.13

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -3,7 +3,7 @@ name = "langwatch"
 version = "0.2.11" # remember to also update it in src/langwatch/__version__.py
 description = "LangWatch Python SDK, for monitoring your LLMs"
 authors = [{ name = "Langwatch Engineers", email = "engineering@langwatch.ai" }]
-requires-python = ">=3.10,<=3.13"
+requires-python = ">=3.10,<3.14"
 license = { text = "MIT" }
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
Hi, currently when using Python 3.13, a very old version of the SDK will be installed if Python 3.13 is used.

I cloned the repo and modified the build to allow 3.13, and it builds & runs tests absolutely fine with 3.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Python 3.13 in the Python SDK — you can now install and run the SDK on Python 3.10–3.13.
  * Expanded interpreter compatibility improves flexibility for users on the latest Python release without requiring code changes.
  * Note: Versions above 3.13 are not supported at this time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->