### PR TITLE
chore: update python sdk to support Python 3.13

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langwatch"
-version = "0.2.11" # remember to also update it in src/langwatch/__version__.py
+version = "0.2.12" # remember to also update it in src/langwatch/__version__.py
 description = "LangWatch Python SDK, for monitoring your LLMs"
 authors = [{ name = "Langwatch Engineers", email = "engineering@langwatch.ai" }]
 requires-python = ">=3.10,<3.14"

--- a/python-sdk/src/langwatch/__version__.py
+++ b/python-sdk/src/langwatch/__version__.py
@@ -1,3 +1,3 @@
 """Version information for LangWatch."""
 
-__version__ = "0.2.11"
+__version__ = "0.2.12"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped SDK release to 0.2.12.
  * Expanded official Python support to include Python 3.13 (runtime range now >=3.10,<3.14).
  * Updated package classifiers to reflect Python 3.13 support for better discoverability.
  * No changes to runtime behavior, APIs, or dependencies; existing environments remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->