### PR TITLE
fix: disallow non-named params to avoid confusing users

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langwatch"
-version = "0.2.13" # remember to also update it in src/langwatch/__version__.py
+version = "0.2.14" # remember to also update it in src/langwatch/__version__.py
 description = "LangWatch Python SDK, for monitoring your LLMs"
 authors = [{ name = "Langwatch Engineers", email = "engineering@langwatch.ai" }]
 requires-python = ">=3.10,<3.14"

--- a/python-sdk/src/langwatch/__version__.py
+++ b/python-sdk/src/langwatch/__version__.py
@@ -1,3 +1,3 @@
 """Version information for LangWatch."""
 
-__version__ = "0.2.13"
+__version__ = "0.2.14"

--- a/python-sdk/src/langwatch/telemetry/span.py
+++ b/python-sdk/src/langwatch/telemetry/span.py
@@ -79,6 +79,7 @@ class LangWatchSpan:
 
     def __init__(
         self,
+        *,
         trace: Optional["LangWatchTrace"] = None,
         span_id: Optional[Union[str, UUID]] = None,
         parent: Optional[Union[OtelSpan, "LangWatchSpan"]] = None,
@@ -339,6 +340,7 @@ class LangWatchSpan:
 
     def update(
         self,
+        *,
         span_id: Optional[Union[str, UUID]] = None,
         name: Optional[str] = None,
         type: Optional[SpanTypes] = None,

--- a/python-sdk/src/langwatch/telemetry/tracing.py
+++ b/python-sdk/src/langwatch/telemetry/tracing.py
@@ -71,6 +71,7 @@ class LangWatchTrace:
 
     def __init__(
         self,
+        *,
         trace_id: Optional[Union[str, UUID]] = None,
         metadata: Optional[TraceMetadata] = None,
         expected_output: Optional[str] = None,
@@ -306,6 +307,7 @@ class LangWatchTrace:
 
     def update(
         self,
+        *,
         trace_id: Optional[Union[str, UUID]] = None,
         metadata: Optional[TraceMetadata] = None,
         expected_output: Optional[str] = None,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Enforced keyword-only parameters across tracing and span-related APIs to promote explicit usage. Calls that previously passed these arguments positionally may need updates. No behavioral changes.

- Chores
  - Bumped Python SDK version to 0.2.14 for distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->