### PR TITLE
fix: inner box scenario overflow

### DIFF
--- a/langwatch/src/components/simulations/SimulationZoomGrid.tsx
+++ b/langwatch/src/components/simulations/SimulationZoomGrid.tsx
@@ -164,6 +164,11 @@ function GridComponent({ scenarioRunIds }: GridProps) {
             height="400px"
             cursor="pointer"
             onClick={() => handleExpandToggle(scenarioRunId)}
+            overflow="auto"
+            style={{
+              minWidth: 0,
+              minHeight: 0,
+            }}
           >
             <SimulationChatViewer scenarioRunId={scenarioRunId} />
           </Box>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Simulation Zoom grid cards from expanding beyond their intended height by enabling internal scrolling for lengthy content.
  * Ensured consistent 400px card height, reducing layout shifts and overflow issues.
  * Improved usability on smaller screens by keeping content contained within each card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->