### PR TITLE
Disable trace sharing for project admins

### DIFF
--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -200,6 +200,7 @@ model Project {
     piiRedactionLevel        PIIRedactionLevel                   @default(ESSENTIAL)
     capturedInputVisibility  ProjectSensitiveDataVisibilityLevel @default(VISIBLE_TO_ALL)
     capturedOutputVisibility ProjectSensitiveDataVisibilityLevel @default(VISIBLE_TO_ALL)
+    traceSharingDisabled     Boolean                             @default(false)
     triggers                 Trigger[]
     experiments              Experiment[]
     annotations              Annotation[]

--- a/langwatch/src/components/traces/ShareButton.tsx
+++ b/langwatch/src/components/traces/ShareButton.tsx
@@ -39,6 +39,7 @@ export function ShareButton({
     onClose();
   }, [disableClose, onClose]);
 
+  // Hide share button if user doesn't have permission and trace isn't already shared
   if (!hasSharePermission && !shareState.data?.id) {
     return null;
   }
@@ -148,6 +149,13 @@ export function ShareButton({
                   )}
                 </HStack>
               </>
+            ) : project.traceSharingDisabled ? (
+              <VStack align="start" gap={3}>
+                <Text>Trace sharing has been disabled for this project by an admin.</Text>
+                <Text fontSize="sm" color="gray.600">
+                  Contact your project admin to enable trace sharing if needed.
+                </Text>
+              </VStack>
             ) : (
               <>
                 <Text>Are you sure you want to share this trace publicly?</Text>

--- a/langwatch/src/pages/settings.tsx
+++ b/langwatch/src/pages/settings.tsx
@@ -11,6 +11,7 @@ import {
   Alert,
   Badge,
 } from "@chakra-ui/react";
+import { Switch } from "~/components/ui/switch";
 import { PIIRedactionLevel, ProjectSensitiveDataVisibilityLevel, type Project } from "@prisma/client";
 import isEqual from "lodash-es/isEqual";
 import { useState } from "react";
@@ -301,6 +302,7 @@ type ProjectFormData = {
   piiRedactionLevel: PIIRedactionLevel;
   capturedInputVisibility: ProjectSensitiveDataVisibilityLevel;
   capturedOutputVisibility: ProjectSensitiveDataVisibilityLevel;
+  traceSharingDisabled: boolean;
 };
 
 function ProjectSettingsForm({ project }: { project: Project }) {
@@ -378,6 +380,7 @@ function ProjectSettingsForm({ project }: { project: Project }) {
     redirectToOnboarding: false,
   });
   const userIsAdmin = hasTeamPermission(TeamRoleGroup.PROJECT_CHANGE_CAPTURED_DATA_VISIBILITY);
+  const userCanChangeTraceSharing = hasTeamPermission(TeamRoleGroup.PROJECT_CHANGE_TRACE_SHARING);
 
   const defaultValues = {
     name: project.name,
@@ -391,6 +394,7 @@ function ProjectSettingsForm({ project }: { project: Project }) {
     piiRedactionLevel: project.piiRedactionLevel,
     capturedInputVisibility: project.capturedInputVisibility,
     capturedOutputVisibility: project.capturedOutputVisibility,
+    traceSharingDisabled: project.traceSharingDisabled,
   };
   const [previousValues, setPreviousValues] =
     useState<ProjectFormData>(defaultValues);
@@ -421,6 +425,7 @@ function ProjectSettingsForm({ project }: { project: Project }) {
         // Only admins can change the visibility settings, this is enforced in the backend
         capturedInputVisibility: userIsAdmin ? data.capturedInputVisibility : void 0,
         capturedOutputVisibility: userIsAdmin ? data.capturedOutputVisibility : void 0,
+        traceSharingDisabled: userCanChangeTraceSharing ? data.traceSharingDisabled : void 0,
       },
       {
         onSuccess: () => {
@@ -651,6 +656,38 @@ function ProjectSettingsForm({ project }: { project: Project }) {
                       ))}
                     </Select.Content>
                   </Select.Root>
+                )}
+              />
+            </HorizontalFormControl>
+
+            <HorizontalFormControl
+              label="Disable Trace Sharing"
+              helper={
+                <VStack align="start" gap={1}>
+                  <Text>Prevent users from sharing traces publicly for this project</Text>
+                  {!userCanChangeTraceSharing && (
+                    <Badge colorPalette="blue" variant="surface" size={"xs"}>
+                      <Tooltip content="Contact your admin to change this setting">
+                        <HStack>
+                          <Lock size={10} />
+                          <Text>Admin only</Text>
+                        </HStack>
+                      </Tooltip>
+                    </Badge>
+                  )}
+                </VStack>
+              }
+            >
+              <Controller
+                control={control}
+                name="traceSharingDisabled"
+                render={({ field }) => (
+                  <Switch
+                    {...field}
+                    checked={field.value}
+                    onCheckedChange={(e) => field.onChange(e.checked)}
+                    disabled={!userCanChangeTraceSharing}
+                  />
                 )}
               />
             </HorizontalFormControl>

--- a/langwatch/src/server/api/permission.ts
+++ b/langwatch/src/server/api/permission.ts
@@ -53,6 +53,7 @@ export const teamRolePermissionMapping = {
   TEAM_MEMBERS_MANAGE: [TeamUserRole.ADMIN],
   TEAM_CREATE_NEW_PROJECTS: [TeamUserRole.ADMIN],
   PROJECT_CHANGE_CAPTURED_DATA_VISIBILITY: [TeamUserRole.ADMIN],
+  PROJECT_CHANGE_TRACE_SHARING: [TeamUserRole.ADMIN],
   SCENARIOS_VIEW: [
     TeamUserRole.ADMIN,
     TeamUserRole.MEMBER,

--- a/python-sdk/src/langwatch/telemetry/tracing.py
+++ b/python-sdk/src/langwatch/telemetry/tracing.py
@@ -286,6 +286,10 @@ class LangWatchTrace:
                 headers={"X-Auth-Token": get_api_key()},
                 timeout=15,
             )
+            if response.status_code == 403:
+                error_data = response.json()
+                if "Trace sharing has been disabled" in error_data.get("message", ""):
+                    raise ValueError("Trace sharing has been disabled for this project by an admin")
             response.raise_for_status()
             path = response.json()["path"]
             return f"{endpoint}{path}"


### PR DESCRIPTION
Enable project admins to disable public trace sharing for a project.

---
<a href="https://cursor.com/background-agent?bcId=bc-63157f09-72bc-40f9-9f81-95d694eab8a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63157f09-72bc-40f9-9f81-95d694eab8a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

