### PR TITLE
feat: allow admins to turn off trace sharing per project

### DIFF
--- a/langwatch/prisma/migrations/20250831172829_add_trace_sharing_enabled/migration.sql
+++ b/langwatch/prisma/migrations/20250831172829_add_trace_sharing_enabled/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "traceSharingEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -200,6 +200,7 @@ model Project {
     piiRedactionLevel        PIIRedactionLevel                   @default(ESSENTIAL)
     capturedInputVisibility  ProjectSensitiveDataVisibilityLevel @default(VISIBLE_TO_ALL)
     capturedOutputVisibility ProjectSensitiveDataVisibilityLevel @default(VISIBLE_TO_ALL)
+    traceSharingEnabled      Boolean                             @default(true)
     triggers                 Trigger[]
     experiments              Experiment[]
     annotations              Annotation[]

--- a/langwatch/src/factories/project.factory.ts
+++ b/langwatch/src/factories/project.factory.ts
@@ -22,6 +22,7 @@ export const projectFactory = Factory.define<Project>(({ sequence }) => ({
   piiRedactionLevel: PIIRedactionLevel.ESSENTIAL,
   capturedInputVisibility: ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
   capturedOutputVisibility: ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+  traceSharingEnabled: true,
   defaultModel: null,
   topicClusteringModel: null,
   embeddingsModel: null,

--- a/langwatch/src/pages/settings.tsx
+++ b/langwatch/src/pages/settings.tsx
@@ -36,6 +36,7 @@ import { HStack, VStack } from "@chakra-ui/react";
 import { toaster } from "../components/ui/toaster";
 import { Select } from "../components/ui/select";
 import { Tooltip } from "~/components/ui/tooltip";
+import { Switch } from "../components/ui/switch";
 import { Lock } from "react-feather";
 
 type OrganizationFormData = {
@@ -301,6 +302,7 @@ type ProjectFormData = {
   piiRedactionLevel: PIIRedactionLevel;
   capturedInputVisibility: ProjectSensitiveDataVisibilityLevel;
   capturedOutputVisibility: ProjectSensitiveDataVisibilityLevel;
+  traceSharingEnabled: boolean;
 };
 
 function ProjectSettingsForm({ project }: { project: Project }) {
@@ -391,6 +393,7 @@ function ProjectSettingsForm({ project }: { project: Project }) {
     piiRedactionLevel: project.piiRedactionLevel,
     capturedInputVisibility: project.capturedInputVisibility,
     capturedOutputVisibility: project.capturedOutputVisibility,
+    traceSharingEnabled: project.traceSharingEnabled,
   };
   const [previousValues, setPreviousValues] =
     useState<ProjectFormData>(defaultValues);
@@ -421,6 +424,7 @@ function ProjectSettingsForm({ project }: { project: Project }) {
         // Only admins can change the visibility settings, this is enforced in the backend
         capturedInputVisibility: userIsAdmin ? data.capturedInputVisibility : void 0,
         capturedOutputVisibility: userIsAdmin ? data.capturedOutputVisibility : void 0,
+        traceSharingEnabled: userIsAdmin ? data.traceSharingEnabled : void 0,
       },
       {
         onSuccess: () => {
@@ -651,6 +655,38 @@ function ProjectSettingsForm({ project }: { project: Project }) {
                       ))}
                     </Select.Content>
                   </Select.Root>
+                )}
+              />
+            </HorizontalFormControl>
+
+            <HorizontalFormControl
+              label="Trace Sharing"
+              helper={
+                <VStack align="start" gap={1}>
+                  <Text>Allow users to share traces with public links</Text>
+                  {!userIsAdmin && (
+                    <Badge colorPalette="blue" variant="surface" size={"xs"}>
+                      <Tooltip content="Contact your admin to change this setting">
+                        <HStack>
+                          <Lock size={10} />
+                          <Text>Admin only</Text>
+                        </HStack>
+                      </Tooltip>
+                    </Badge>
+                  )}
+                </VStack>
+              }
+              invalid={!!formState.errors.traceSharingEnabled}
+            >
+              <Controller
+                control={control}
+                name="traceSharingEnabled"
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onChange={(e) => field.onChange(e.target.checked)}
+                    disabled={!userIsAdmin}
+                  />
                 )}
               />
             </HorizontalFormControl>

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -28,6 +28,7 @@ import {
 } from "@prisma/client";
 import { encrypt } from "~/utils/encryption";
 import type { Session } from "next-auth";
+import { revokeAllTraceShares } from "./share";
 
 export const projectRouter = createTRPCRouter({
   publicGetById: publicProcedure
@@ -318,6 +319,14 @@ export const projectRouter = createTRPCRouter({
           s3Bucket: input.s3Bucket,
         },
       });
+
+      // If trace sharing was disabled, revoke all existing trace shares
+      if (
+        input.traceSharingEnabled === false &&
+        project.traceSharingEnabled === true
+      ) {
+        await revokeAllTraceShares(input.projectId);
+      }
 
       return { success: true, projectSlug: updatedProject.slug };
     }),

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -245,6 +245,7 @@ export const projectRouter = createTRPCRouter({
           capturedOutputVisibility: z
             .enum(["REDACTED_TO_ALL", "VISIBLE_TO_ADMIN", "VISIBLE_TO_ALL"])
             .optional(),
+          traceSharingEnabled: z.boolean().optional(),
           userLinkTemplate: z.string().optional(),
           s3Endpoint: z.string().optional(),
           s3AccessKeyId: z.string().optional(),
@@ -305,6 +306,8 @@ export const projectRouter = createTRPCRouter({
             input.capturedInputVisibility ?? project.capturedInputVisibility,
           capturedOutputVisibility:
             input.capturedOutputVisibility ?? project.capturedOutputVisibility,
+          traceSharingEnabled:
+            input.traceSharingEnabled ?? project.traceSharingEnabled,
           s3Endpoint: input.s3Endpoint ? encrypt(input.s3Endpoint) : null,
           s3AccessKeyId: input.s3AccessKeyId
             ? encrypt(input.s3AccessKeyId)
@@ -494,12 +497,14 @@ async function checkCapturedDataVisibilityPermission({
     projectId: string;
     capturedInputVisibility?: string;
     capturedOutputVisibility?: string;
+    traceSharingEnabled?: boolean;
   };
   next: () => Promise<any>;
 }) {
   if (
     (input.capturedInputVisibility !== void 0 ||
-      input.capturedOutputVisibility !== void 0) &&
+      input.capturedOutputVisibility !== void 0 ||
+      input.traceSharingEnabled !== void 0) &&
     !(await backendHasTeamProjectPermission(
       ctx,
       { projectId: input.projectId },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Trace Sharing setting in Project settings (toggle), admin-only and enabled by default.
* Improvements
  * Sharing a trace now respects the project’s setting: attempts are blocked with a clear error when disabled.
  * Updating Trace Sharing requires the appropriate visibility permission; non-admins cannot modify this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->