### PR TITLE
fix: csv upload with reserved column name

### DIFF
--- a/langwatch/src/components/datasets/UploadCSVModal.tsx
+++ b/langwatch/src/components/datasets/UploadCSVModal.tsx
@@ -169,14 +169,19 @@ export function UploadCSVForm({
     const { data, acceptedFile } = results;
 
     // Check for reserved column names and rename them
-    const columns: DatasetColumns = (data[0] ?? []).map((col: string) => {
-      const safeColumnName = getSafeColumnName(col);
+    const originalColumnNames = data[0] ?? [];
+    const existingNames = new Set<string>();
+    const columns: DatasetColumns = originalColumnNames.map((col: string) => {
+      const safeColumnName = getSafeColumnName(col, existingNames);
+
+      // Add the safe name to the set to prevent future collisions
+      existingNames.add(safeColumnName);
 
       // If this column name was changed, show a warning to the user
       if (safeColumnName !== col) {
         toaster.create({
           title: "Column Renamed",
-          description: `Column "${col}" is reserved and has been renamed to "${safeColumnName}"`,
+          description: `Column "${col}" is reserved or conflicts with existing columns and has been renamed to "${safeColumnName}"`,
           type: "warning",
           meta: {
             closable: true,

--- a/langwatch/src/components/datasets/utils/__tests__/reservedColumns.test.ts
+++ b/langwatch/src/components/datasets/utils/__tests__/reservedColumns.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  isReservedColumnName,
+  getSafeColumnName,
+  RESERVED_COLUMN_NAMES,
+} from "../reservedColumns";
+
+/**
+ * Tests for reserved column names utilities
+ * Single Responsibility: Ensure reserved column validation and safe name generation works correctly
+ */
+describe("reservedColumns utilities", () => {
+  describe("isReservedColumnName", () => {
+    it("should identify reserved column names case-insensitively", () => {
+      expect(isReservedColumnName("id")).toBe(true);
+      expect(isReservedColumnName("ID")).toBe(true);
+      expect(isReservedColumnName("Id")).toBe(true);
+      expect(isReservedColumnName("selected")).toBe(true);
+      expect(isReservedColumnName("SELECTED")).toBe(true);
+      expect(isReservedColumnName("Selected")).toBe(true);
+    });
+
+    it("should not identify non-reserved column names", () => {
+      expect(isReservedColumnName("name")).toBe(false);
+      expect(isReservedColumnName("email")).toBe(false);
+      expect(isReservedColumnName("user_id")).toBe(false);
+      expect(isReservedColumnName("")).toBe(false);
+    });
+  });
+
+  describe("getSafeColumnName", () => {
+    it("should append '_' to reserved names", () => {
+      expect(getSafeColumnName("id")).toBe("id_");
+      expect(getSafeColumnName("ID")).toBe("ID_");
+      expect(getSafeColumnName("selected")).toBe("selected_");
+      expect(getSafeColumnName("SELECTED")).toBe("SELECTED_");
+    });
+
+    it("should return non-reserved names unchanged", () => {
+      expect(getSafeColumnName("name")).toBe("name");
+      expect(getSafeColumnName("email")).toBe("email");
+      expect(getSafeColumnName("user_id")).toBe("user_id");
+      expect(getSafeColumnName("")).toBe("");
+    });
+  });
+
+  describe("RESERVED_COLUMN_NAMES", () => {
+    it("should contain expected reserved column names", () => {
+      expect(RESERVED_COLUMN_NAMES).toContain("id");
+      expect(RESERVED_COLUMN_NAMES).toContain("selected");
+    });
+
+    it("should be a readonly array", () => {
+      // This test ensures the type is properly set as readonly
+      const names: readonly string[] = RESERVED_COLUMN_NAMES;
+      expect(Array.isArray(names)).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/components/datasets/utils/reservedColumns.ts
+++ b/langwatch/src/components/datasets/utils/reservedColumns.ts
@@ -17,8 +17,39 @@ export function isReservedColumnName(columnName: string): boolean {
 }
 
 /**
- * Generates a safe column name by appending "_" to reserved names
+ * Generates a safe column name that avoids reserved names and collisions with existing names
+ * @param columnName - The original column name to make safe
+ * @param existingNames - Set of existing column names to avoid collisions with
+ * @returns A unique column name that is not reserved and doesn't collide with existing names
  */
-export function getSafeColumnName(columnName: string): string {
-  return isReservedColumnName(columnName) ? `${columnName}_` : columnName;
+export function getSafeColumnName(
+  columnName: string,
+  existingNames: Set<string>
+): string {
+  // If the name is not reserved and doesn't exist, return as-is
+  if (!isReservedColumnName(columnName) && !existingNames.has(columnName)) {
+    return columnName;
+  }
+
+  // Generate a unique name by trying different suffixes
+  let candidate = columnName;
+  let suffix = "_";
+  let counter = 0;
+
+  while (isReservedColumnName(candidate) || existingNames.has(candidate)) {
+    if (counter === 0) {
+      candidate = `${columnName}${suffix}`;
+    } else {
+      candidate = `${columnName}_${counter}`;
+    }
+    counter++;
+
+    // Safety check to prevent infinite loops (should never happen in practice)
+    if (counter > 1000) {
+      candidate = `${columnName}_${Date.now()}`;
+      break;
+    }
+  }
+
+  return candidate;
 }

--- a/langwatch/src/components/datasets/utils/reservedColumns.ts
+++ b/langwatch/src/components/datasets/utils/reservedColumns.ts
@@ -1,0 +1,24 @@
+/**
+ * Reserved column names that cannot be used in datasets because they conflict
+ * with system-generated fields or UI functionality.
+ *
+ * Single Responsibility: Centralize the definition of reserved column names to ensure consistency across dataset operations.
+ */
+export const RESERVED_COLUMN_NAMES = [
+  "id", // Used as the primary key for dataset records
+  "selected", // Used for row selection in the dataset grid UI
+] as const;
+
+/**
+ * Checks if a column name is reserved
+ */
+export function isReservedColumnName(columnName: string): boolean {
+  return RESERVED_COLUMN_NAMES.includes(columnName.toLowerCase() as any);
+}
+
+/**
+ * Generates a safe column name by appending "_" to reserved names
+ */
+export function getSafeColumnName(columnName: string): string {
+  return isReservedColumnName(columnName) ? `${columnName}_` : columnName;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CSV uploads now automatically rename reserved headers (e.g., "id", "selected") to safe, unique alternatives and show a "Column Renamed" warning toast.
  - Renamed headers are immediately reflected in the column list during upload.

- Improvements
  - Upload flow avoids header name collisions by ensuring unique column names.
  - Upload handler now supports asynchronous processing to accommodate longer-running work.

- Tests
  - Added unit tests for reserved-header detection and safe renaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->