### PR TITLE
docs: add detailed markdown documentation for LangWatch eval notebook

### DIFF
--- a/mcp-server/tests/evaluations.ipynb
+++ b/mcp-server/tests/evaluations.ipynb
@@ -2,10 +2,36 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "966f5e12",
+   "metadata": {},
+   "source": [
+    "# LangWatch Evaluation Notebook\n",
+    "\n",
+    "This notebook demonstrates how to evaluate LangWatch integration capabilities using a simple coding agent. It shows the process of:\n",
+    "1. Setting up LangWatch\n",
+    "2. Preparing test data\n",
+    "3. Creating a simple coding agent that adds LangWatch instrumentation to code\n",
+    "4. Evaluating the agent's performance using LangWatch's evaluation framework\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "LangWatch is an open-source LLMOps platform that helps monitor, evaluate, and improve LLM applications. This notebook shows how to use LangWatch to evaluate a simple coding agent that adds LangWatch instrumentation to existing code. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f272607b",
    "metadata": {},
    "source": [
     "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d9b0e1f",
+   "metadata": {},
+   "source": [
+    "This section initializes LangWatch by logging in. You'll need to have a LangWatch account and API key set up."
    ]
   },
   {
@@ -34,6 +60,18 @@
    "metadata": {},
    "source": [
     "## Prepare the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e93d137f",
+   "metadata": {},
+   "source": [
+    "This section loads test cases from fixture files. Each test case consists of:\n",
+    "- An input Python file (without LangWatch instrumentation)\n",
+    "- An expected output file (with proper LangWatch instrumentation)\n",
+    "\n",
+    "The code reads these files, formats them as Python code blocks, and creates a pandas DataFrame with columns for test_case, input, and expected output. The test cases include various frameworks like DSPy and LangChain with different configurations."
    ]
   },
   {
@@ -169,6 +207,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c056f992",
+   "metadata": {},
+   "source": [
+    "This section sets up the Model Context Protocol (MCP) client to communicate with the LangWatch documentation server. MCP allows the agent to access LangWatch documentation to learn how to properly instrument code.\n",
+    "\n",
+    "The code:\n",
+    "1. Builds the MCP server if needed\n",
+    "2. Creates a function to call MCP tools\n",
+    "3. Fetches the LangWatch documentation index"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "4627964c",
@@ -214,6 +265,24 @@
    "metadata": {},
    "source": [
     "## Setup simple agent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87fdcb63",
+   "metadata": {},
+   "source": [
+    "This section creates a simple coding agent that:\n",
+    "1. Takes input code without LangWatch instrumentation\n",
+    "2. Uses Claude Sonnet 4 to identify relevant documentation links\n",
+    "3. Fetches those documentation pages\n",
+    "4. Uses Claude again to implement LangWatch in the code based on the documentation\n",
+    "5. Returns the instrumented code\n",
+    "\n",
+    "Key components:\n",
+    "- `LinksToFetch`: A Pydantic model to parse the LLM's output\n",
+    "- First LLM call: Identifies relevant documentation links\n",
+    "- Second LLM call: Implements LangWatch based on documentation and input code"
    ]
   },
   {
@@ -380,6 +449,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f896e880",
+   "metadata": {},
+   "source": [
+    "This section creates a function to compare the agent's output with the expected output using a diff. The diff shows:\n",
+    "- Lines added (prefixed with +)\n",
+    "- Lines removed (prefixed with -)\n",
+    "- Unchanged lines\n",
+    "\n",
+    "It also counts the number of changed lines, which serves as a simple metric for how different the agent's implementation is from the expected implementation."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 53,
    "id": "fad6bd5d",
@@ -466,6 +548,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "984f2268",
+   "metadata": {},
+   "source": [
+    "This section runs the evaluation process:\n",
+    "1. Initializes a LangWatch evaluation experiment\n",
+    "2. For each test case:\n",
+    "   - Runs the agent on the input code\n",
+    "   - Computes the diff between the agent's output and expected output\n",
+    "   - Uses LangWatch's evaluation framework to judge if the implementation is correct\n",
+    "   - Logs the diff and line change count as metrics\n",
+    "\n",
+    "The evaluation results are available in the LangWatch dashboard, where you can analyze:\n",
+    "- Success rate across test cases\n",
+    "- Common patterns in failures\n",
+    "- Detailed diffs for each test case\n",
+    "\n",
+    "This approach allows for systematic evaluation of the agent's ability to correctly\n",
+    "implement LangWatch instrumentation across different frameworks and configurations."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 51,
    "id": "404bd4b9",
@@ -528,6 +632,18 @@
     "        )\n",
     "\n",
     "    evaluation.submit(evaluate, index, row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8989c710",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how to use LangWatch to evaluate a code instrumentation agent. Key takeaways:\n",
+    "1. LangWatch can be used to trace and evaluate LLM-powered coding assistants\n",
+    "2. The evaluation framework allows for systematic testing across multiple examples\n",
+    "3. Metrics like diff line count and LLM judgement provide quantitative measures of performance\n",
+    "4. Results are tracked in the LangWatch dashboard for analysis"
    ]
   }
  ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an end-to-end evaluation workflow that integrates with MCP to fetch official docs and powers an automated code-instrumenting agent, with results accessible via a monitoring URL.

- Tests
  - Introduced an evaluation loop that runs test cases, compares outputs with a unified diff metric and line-change count, and captures LLM-based judgments for accuracy tracking.

- Documentation
  - Documented the agent workflow, including doc discovery, application steps, and evaluation process, plus a summary of outcomes and observability guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->