### PR TITLE
fix: failing python tests

### DIFF
--- a/python-sdk/tests/telemetry/test_context.py
+++ b/python-sdk/tests/telemetry/test_context.py
@@ -55,9 +55,7 @@ class TestContext(unittest.TestCase):
         mock_warn: MagicMock,
     ):
         mock_trace_instance = MagicMock(spec=LangWatchTrace)
-        mock_lw_trace_constructor.return_value.__enter__.return_value = (
-            mock_trace_instance
-        )
+        mock_lw_trace_constructor.return_value = mock_trace_instance
 
         trace = telemetry_context.get_current_trace(start_if_none=True)
 
@@ -67,7 +65,8 @@ class TestContext(unittest.TestCase):
             "No trace in context when calling langwatch.get_current_trace(), perhaps you forgot to use @langwatch.trace()?",
         )
         mock_lw_trace_constructor.assert_called_once()
-        mock_lw_trace_constructor.return_value.__enter__.assert_called_once()
+        mock_trace_instance.__enter__.assert_called_once()
+        mock_trace_instance.__exit__.assert_called_once_with(None, None, None)
 
     @patch("langwatch.telemetry.context.warnings.warn")
     @patch("langwatch.telemetry.context.ensure_setup")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of telemetry span selection when an existing LangWatch span is present.
  * Reduced false warnings related to context mismatches during span reset.
  * Enhanced error handling when setting and resetting telemetry context to avoid unnecessary noise.

* **Tests**
  * Updated tests to align with revised trace context management, validating enter/exit behavior on the trace instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->