### PR TITLE
fix: dataset mapping after selecting again

### DIFF
--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -180,13 +180,6 @@ export const TracesMapping = ({
   const isInitializedRef = React.useRef(false);
 
   useEffect(() => {
-    if (
-      isInitializedRef.current &&
-      Object.keys(traceMappingState.mapping).length > 0
-    ) {
-      return;
-    }
-
     const traceMappingStateWithDefaults = {
       mapping: Object.fromEntries(
         targetFields.map((name) => [
@@ -277,7 +270,7 @@ export const TracesMapping = ({
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(targetFields), dsl?.sourceOptions]);
+  }, [JSON.stringify(targetFields), dsl?.sourceOptions, currentMapping]);
 
   useEffect(() => {
     let index = 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures trace mapping defaults refresh when the mapping state changes, addressing cases where updates were not applied after the initial load.
  * Improves consistency of mapping initialization across renders, reducing stale or incomplete mappings.

* **Improvements**
  * More responsive re-initialization of trace mappings when underlying configuration changes, leading to more reliable default field selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->