### PR TITLE
feat: add release-please to mcp-server

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -8,11 +8,11 @@
       "include-component-in-tag": true,
       "tag-separator": "@",
       "changelog-sections": [
-        {"type": "feat", "section": "Features"},
-        {"type": "fix", "section": "Bug Fixes"},
-        {"type": "chore", "section": "Miscellaneous", "hidden": false},
-        {"type": "docs", "section": "Documentation", "hidden": false},
-        {"type": "refactor", "section": "Code Refactoring", "hidden": false}
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "chore", "section": "Miscellaneous", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": false }
       ],
       "extra-files": [
         {
@@ -30,11 +30,33 @@
       "include-component-in-tag": true,
       "tag-separator": "@",
       "changelog-sections": [
-        {"type": "feat", "section": "Features"},
-        {"type": "fix", "section": "Bug Fixes"},
-        {"type": "chore", "section": "Miscellaneous", "hidden": false},
-        {"type": "docs", "section": "Documentation", "hidden": false},
-        {"type": "refactor", "section": "Code Refactoring", "hidden": false}
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "chore", "section": "Miscellaneous", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": false }
+      ]
+    },
+    "mcp-server": {
+      "release-type": "node",
+      "package-name": "@langwatch/mcp-server",
+      "prerelease": true,
+      "component": "mcp-server",
+      "include-component-in-tag": true,
+      "tag-separator": "@",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "chore", "section": "Miscellaneous", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": false }
+      ],
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "package.json",
+          "jsonpath": "$.version"
+        }
       ]
     }
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Enabled automated prerelease publishing and changelog generation for the new mcp-server package.
  * Improved release tagging to include the component name for clearer package identification.
  * Ensured versioning is sourced consistently from the package metadata for reliable releases.
  * Standardized changelog sections (Features, Bug Fixes, Documentation, Refactors, Miscellaneous) across packages for consistency.
  * Minor formatting cleanups in release configuration with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->