### PR TITLE
fix: readme was from an early draft of the typescript sdk

### DIFF
--- a/typescript-sdk/README.md
+++ b/typescript-sdk/README.md
@@ -168,63 +168,6 @@ span.end();
   });
   ```
 
----
-
-## API Reference
-
-### Setup
-- `setupLangWatch(options?)` → Initialize LangWatch (from `langwatch/node` or `langwatch/browser`)
-
-### Observability
-- `getLangWatchTracer(name, version?)` → `LangWatchTracer`
-- `LangWatchTracer` methods: `.startSpan()`, `.startActiveSpan()`, `.withActiveSpan()`
-- `LangWatchSpan` methods:
-  - `.setType()`, `.setInput()`, `.setOutput()`, `.setInputString()`, `.setOutputString()`
-  - `.recordEvaluation()`, `.setRequestModel()`, `.setResponseModel()`
-  - `.setRAGContexts()`, `.setRAGContext()`, `.setMetrics()`, `.setSelectedPrompt()`
-  - `.addGenAISystemMessageEvent()`, `.addGenAIUserMessageEvent()`, `.addGenAIAssistantMessageEvent()`, `.addGenAIToolMessageEvent()`, `.addGenAIChoiceEvent()`
-
-### Prompt
-- `getPrompt(promptId, variables?)` → fetches and formats a prompt (creates a span automatically)
-- `getPromptVersion(promptId, versionId, variables?)` → fetches specific prompt version
-
-### Evaluation
-- `runEvaluation(details)` → runs an evaluation and returns result (creates a span automatically)
-- `recordEvaluation(details, attributes?)` → records a custom evaluation span (creates a span automatically)
-
-### LangChain Integration
-- `LangWatchCallbackHandler` → LangChain callback handler for automatic instrumentation
-
-### Exporters & Processors
-- `LangWatchExporter` → Custom OpenTelemetry exporter
-- `FilterableBatchSpanProcessor` → Span processor with filtering capabilities
-
----
-
-## Types
-
-### Core Types
-- `LangWatchSpan` → Extended OpenTelemetry span with LangWatch methods
-- `LangWatchTracer` → Extended OpenTelemetry tracer with LangWatch methods
-- `SpanType` → Union of supported span types (`"llm"`, `"chain"`, `"tool"`, `"agent"`, etc.)
-
-### Evaluation Types
-- `EvaluationDetails` → Configuration for running evaluations
-- `SingleEvaluationResult` → Result from evaluation runs
-- `RecordedEvaluationDetails` → Configuration for recording custom evaluations
-
-### Prompt Types
-- `Prompt` → Prompt object with compilation capabilities
-- `CompiledPrompt` → Compiled prompt with variables interpolated
-- `TemplateVariables` → Variables for prompt compilation
-
-### RAG & Metrics Types
-- `LangWatchSpanRAGContext` → RAG context structure
-- `LangWatchSpanMetrics` → Metrics structure (tokens, cost)
-- `LangWatchSpanGenAI*EventBody` → GenAI message event structures
-
----
-
 ## Advanced
 
 ### Custom OpenTelemetry Integration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced setupLangWatch with setupObservability across Node and browser examples.
  * Updated Node/browser setup to import observability entry points and use LANGWATCH_API_KEY from environment.
  * Migrated initial examples, tips, and public API narrative to the new observability-based wording.
  * Removed/condensed outdated public API reference sections to reflect the consolidated entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->