### PR TITLE
feat: add support for otel /metrics endpoint for genai metrics

### DIFF
--- a/langwatch/package-lock.json
+++ b/langwatch/package-lock.json
@@ -93,6 +93,7 @@
         "express-prom-bundle": "^8.0.0",
         "fast-deep-equal": "^3.1.3",
         "fetch-h2": "^3.0.2",
+        "flat": "^6.0.1",
         "framer-motion": "^10.16.4",
         "handlebars": "^4.7.8",
         "hono": "^4.7.5",
@@ -11127,6 +11128,15 @@
         "json2tsv": "bin/json2dsv",
         "tsv2csv": "bin/dsv2dsv",
         "tsv2json": "bin/dsv2json"
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/@copilotkit/runtime/node_modules/node-fetch": {
@@ -26606,12 +26616,15 @@
       "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA=="
     },
     "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-6.0.1.tgz",
+      "integrity": "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==",
       "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/flat-cache": {

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -113,6 +113,7 @@
     "express-prom-bundle": "^8.0.0",
     "fast-deep-equal": "^3.1.3",
     "fetch-h2": "^3.0.2",
+    "flat": "^6.0.1",
     "framer-motion": "^10.16.4",
     "handlebars": "^4.7.8",
     "hono": "^4.7.5",

--- a/langwatch/src/app/api/otel/v1/metrics/route.ts
+++ b/langwatch/src/app/api/otel/v1/metrics/route.ts
@@ -1,90 +1,181 @@
 import { type IExportMetricsServiceRequest } from "@opentelemetry/otlp-transformer";
 import * as root from "@opentelemetry/otlp-transformer/build/src/generated/root";
 import * as Sentry from "@sentry/nextjs";
+import crypto from "node:crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { prisma } from "../../../../../server/db";
 import { createLogger } from "../../../../../utils/logger";
+import { openTelemetryMetricsRequestToTracesForCollection } from "~/server/tracer/otel.metrics";
+import {
+  fetchExistingMD5s,
+  scheduleTraceCollectionWithFallback,
+} from "~/server/background/workers/collectorWorker";
 import { withAppRouterLogger } from "../../../../../middleware/app-router-logger";
+import { getLangWatchTracer } from "langwatch";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 
+const tracer = getLangWatchTracer("langwatch.otel.metrics");
 const logger = createLogger("langwatch:otel:v1:metrics");
 
 const metricsRequestType = (root as any).opentelemetry.proto.collector.metrics
   .v1.ExportMetricsServiceRequest;
 
 async function handleMetricsRequest(req: NextRequest) {
-  const body = await req.arrayBuffer();
+  return await tracer.withActiveSpan(
+    "[POST] /api/otel/v1/metrics",
+    { kind: SpanKind.SERVER },
+    async (span) => {
+      const xAuthToken = req.headers.get("x-auth-token");
+      const authHeader = req.headers.get("authorization");
+      const contentType = req.headers.get("content-type");
 
-  const xAuthToken = req.headers.get("x-auth-token");
-  const authHeader = req.headers.get("authorization");
-  const contentType = req.headers.get("content-type");
+      const authToken =
+        xAuthToken ??
+        (authHeader?.toLowerCase().startsWith("bearer ")
+          ? authHeader.slice(7)
+          : null);
 
-  const authToken =
-    xAuthToken ??
-    (authHeader?.toLowerCase().startsWith("bearer ")
-      ? authHeader.slice(7)
-      : null);
+      if (!authToken) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: "No auth token provided.",
+        });
 
-  if (!authToken) {
-    return NextResponse.json(
-      {
-        message:
-          "Authentication token is required. Use X-Auth-Token header or Authorization: Bearer token.",
-      },
-      { status: 401 }
-    );
-  }
+        return NextResponse.json(
+          {
+            message:
+              "Authentication token is required. Use X-Auth-Token header or Authorization: Bearer token.",
+          },
+          { status: 401 }
+        );
+      }
 
-  const project = await prisma.project.findUnique({
-    where: { apiKey: authToken },
-    include: {
-      team: true,
-    },
-  });
-
-  if (!project) {
-    return NextResponse.json(
-      { message: "Invalid auth token." },
-      { status: 401 }
-    );
-  }
-
-  let metricsRequest: IExportMetricsServiceRequest;
-  try {
-    if (contentType === "application/json") {
-      metricsRequest = JSON.parse(Buffer.from(body).toString("utf-8"));
-    } else {
-      metricsRequest = metricsRequestType.decode(new Uint8Array(body));
-    }
-  } catch (error) {
-    try {
-      const json = JSON.parse(Buffer.from(body).toString("utf-8"));
-      metricsRequest = metricsRequestType.decode(
-        new Uint8Array(metricsRequestType.encode(json).finish())
-      );
-    } catch (jsonError) {
-      logger.error(
-        {
-          error: jsonError,
-          metricsRequest: Buffer.from(body).toString("base64"),
-        },
-        "error parsing metrics"
-      );
-      Sentry.captureException(error, {
-        extra: {
-          projectId: project.id,
-          metricsRequest: Buffer.from(body).toString("base64"),
-          jsonError,
+      const project = await prisma.project.findUnique({
+        where: { apiKey: authToken },
+        include: {
+          team: true,
         },
       });
 
-      return NextResponse.json(
-        { error: "Failed to parse metrics" },
-        { status: 400 }
-      );
-    }
-  }
+      if (!project) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: "Invalid auth token.",
+        });
 
-  return NextResponse.json({ message: "Not implemented" }, { status: 501 });
+        return NextResponse.json(
+          { message: "Invalid auth token." },
+          { status: 401 }
+        );
+      }
+
+      span.setAttribute("langwatch.project.id", project.id);
+
+      const body = await req.arrayBuffer();
+      let metricsRequest: IExportMetricsServiceRequest;
+      try {
+        if (contentType === "application/json") {
+          metricsRequest = JSON.parse(Buffer.from(body).toString("utf-8"));
+        } else {
+          metricsRequest = metricsRequestType.decode(new Uint8Array(body));
+        }
+      } catch (error) {
+        try {
+          const json = JSON.parse(Buffer.from(body).toString("utf-8"));
+          metricsRequest = metricsRequestType.decode(
+            new Uint8Array(metricsRequestType.encode(json).finish())
+          );
+        } catch (jsonError) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: "Failed to parse metrics",
+          });
+          span.recordException(
+            jsonError instanceof Error
+              ? jsonError
+              : new Error(String(jsonError))
+          );
+
+          logger.error(
+            {
+              error: jsonError,
+              metricsRequest: Buffer.from(body).toString("base64"),
+            },
+            "error parsing metrics"
+          );
+
+          Sentry.captureException(error, {
+            extra: {
+              projectId: project.id,
+              metricsRequest: Buffer.from(body).toString("base64"),
+              jsonError,
+            },
+          });
+
+          return NextResponse.json(
+            { error: "Failed to parse metrics" },
+            { status: 400 }
+          );
+        }
+      }
+
+      const tracesGeneratedFromMetrics =
+        await openTelemetryMetricsRequestToTracesForCollection(metricsRequest);
+
+      const promises = await tracer.withActiveSpan(
+        "check which traces have already been collected",
+        { kind: SpanKind.INTERNAL },
+        async () => {
+          const promises: Promise<void>[] = [];
+          for (const traceForCollection of tracesGeneratedFromMetrics) {
+            const paramsMD5 = crypto
+              .createHash("md5")
+              .update(JSON.stringify({ ...traceForCollection }))
+              .digest("hex");
+            const existingTrace = await fetchExistingMD5s(
+              traceForCollection.traceId,
+              project.id
+            );
+            if (existingTrace?.indexing_md5s?.includes(paramsMD5)) {
+              continue;
+            }
+
+            logger.info(
+              { traceId: traceForCollection.traceId },
+              "collecting traces from metrics"
+            );
+
+            promises.push(
+              scheduleTraceCollectionWithFallback({
+                ...traceForCollection,
+                projectId: project.id,
+                existingTrace,
+                paramsMD5,
+                expectedOutput: void 0,
+                evaluations: void 0,
+                collectedAt: Date.now(),
+              })
+            );
+          }
+          return promises;
+        }
+      );
+
+      if (promises.length === 0) {
+        return NextResponse.json({ message: "No changes" });
+      }
+
+      await tracer.withActiveSpan(
+        "push pending traces to collector queue",
+        { kind: SpanKind.PRODUCER },
+        async () => {
+          await Promise.all(promises);
+        }
+      );
+
+      return NextResponse.json({ message: "OK" }, { status: 200 });
+    }
+  );
 }
 
 // Export the handler wrapped with logging middleware

--- a/langwatch/src/server/tracer/otel.metrics.test.ts
+++ b/langwatch/src/server/tracer/otel.metrics.test.ts
@@ -1,0 +1,614 @@
+import type { IExportMetricsServiceRequest } from "@opentelemetry/otlp-transformer";
+import { assert, describe, expect, it } from "vitest";
+import { z, type ZodError } from "zod";
+import { fromZodError } from "zod-validation-error";
+import type { DeepPartial } from "../../utils/types";
+import { openTelemetryMetricsRequestToTracesForCollection } from "./otel.metrics";
+import { spanSchema } from "./types.generated";
+
+const timeToFirstTokenMetricsRequest: DeepPartial<IExportMetricsServiceRequest> =
+  {
+    resourceMetrics: [
+      {
+        resource: {
+          attributes: [
+            {
+              key: "telemetry.sdk.language",
+              value: {
+                stringValue: "python",
+              },
+            },
+            {
+              key: "telemetry.sdk.name",
+              value: {
+                stringValue: "opentelemetry",
+              },
+            },
+            {
+              key: "telemetry.sdk.version",
+              value: {
+                stringValue: "1.36.0",
+              },
+            },
+            {
+              key: "service.name",
+              value: {
+                stringValue: "my-agent",
+              },
+            },
+          ],
+        },
+        scopeMetrics: [
+          {
+            scope: {
+              name: "gen_ai.server",
+            },
+            metrics: [
+              {
+                name: "gen_ai.server.time_to_first_token",
+                description:
+                  "Time to generate first token for successful responses",
+                unit: "s",
+                histogram: {
+                  dataPoints: [
+                    {
+                      startTimeUnixNano: "1759757017682048000",
+                      timeUnixNano: "1759757033052292000",
+                      count: 1,
+                      sum: 2.7979350090026855,
+                      bucketCounts: [
+                        0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      ],
+                      explicitBounds: [
+                        0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500,
+                        5000, 7500, 10000,
+                      ],
+                      exemplars: [
+                        {
+                          timeUnixNano: "1759757017681929000",
+                          asDouble: 2.7979350090026855,
+                          spanId: "I9f0+HNXuqs=",
+                          traceId: "lW9EqTIEUX6EAJ8GxleP8w==",
+                        },
+                      ],
+                      attributes: [
+                        {
+                          key: "model",
+                          value: {
+                            stringValue: "gpt-5",
+                          },
+                        },
+                        {
+                          key: "request.status",
+                          value: {
+                            stringValue: "success",
+                          },
+                        },
+                      ],
+                      min: 2.7979350090026855,
+                      max: 2.7979350090026855,
+                    },
+                  ],
+                  aggregationTemporality: 1,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+const multipleExemplarsRequest: DeepPartial<IExportMetricsServiceRequest> = {
+  resourceMetrics: [
+    {
+      resource: {
+        attributes: [
+          {
+            key: "service.name",
+            value: {
+              stringValue: "test-service",
+            },
+          },
+        ],
+      },
+      scopeMetrics: [
+        {
+          scope: {
+            name: "gen_ai.server",
+          },
+          metrics: [
+            {
+              name: "gen_ai.server.time_to_first_token",
+              unit: "s",
+              histogram: {
+                dataPoints: [
+                  {
+                    timeUnixNano: "1759757033052292000",
+                    exemplars: [
+                      {
+                        timeUnixNano: "1759757017681929000",
+                        asDouble: 1.5,
+                        spanId: "c3BhbjExMTExMTExMTE=",
+                        traceId: "dHJhY2UxMTExMTExMTE=",
+                      },
+                      {
+                        timeUnixNano: "1759757020000000000",
+                        asDouble: 2.3,
+                        spanId: "c3BhbjIyMjIyMjIyMjI=",
+                        traceId: "dHJhY2UxMTExMTExMTE=",
+                      },
+                    ],
+                    attributes: [],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const gaugeMetricsRequest: DeepPartial<IExportMetricsServiceRequest> = {
+  resourceMetrics: [
+    {
+      resource: {
+        attributes: [
+          {
+            key: "service.name",
+            value: {
+              stringValue: "gauge-service",
+            },
+          },
+        ],
+      },
+      scopeMetrics: [
+        {
+          scope: {
+            name: "gen_ai.server",
+          },
+          metrics: [
+            {
+              name: "gen_ai.server.active_requests",
+              unit: "count",
+              gauge: {
+                dataPoints: [
+                  {
+                    timeUnixNano: "1759757033052292000",
+                    asInt: 5,
+                    exemplars: [
+                      {
+                        timeUnixNano: "1759757017681929000",
+                        asInt: 5,
+                        spanId: "Z2F1Z2VzcGFuaWQxMg==",
+                        traceId: "Z2F1Z2V0cmFjZWlkMQ==",
+                      },
+                    ],
+                    attributes: [
+                      {
+                        key: "endpoint",
+                        value: {
+                          stringValue: "/api/chat",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const sumMetricsRequest: DeepPartial<IExportMetricsServiceRequest> = {
+  resourceMetrics: [
+    {
+      resource: {
+        attributes: [
+          {
+            key: "service.name",
+            value: {
+              stringValue: "sum-service",
+            },
+          },
+        ],
+      },
+      scopeMetrics: [
+        {
+          scope: {
+            name: "gen_ai.server",
+          },
+          metrics: [
+            {
+              name: "gen_ai.server.request.duration",
+              unit: "s",
+              sum: {
+                dataPoints: [
+                  {
+                    timeUnixNano: "1759757033052292000",
+                    asDouble: 12.5,
+                    exemplars: [
+                      {
+                        timeUnixNano: "1759757017681929000",
+                        asDouble: 12.5,
+                        spanId: "c3Vtc3BhbmlkMTIzNDU=",
+                        traceId: "c3VtdHJhY2VpZDEyMzQ=",
+                      },
+                    ],
+                    attributes: [
+                      {
+                        key: "model",
+                        value: {
+                          stringValue: "gpt-4",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const emptyMetricsRequest: DeepPartial<IExportMetricsServiceRequest> = {
+  resourceMetrics: [],
+};
+
+const noExemplarsRequest: DeepPartial<IExportMetricsServiceRequest> = {
+  resourceMetrics: [
+    {
+      resource: {
+        attributes: [],
+      },
+      scopeMetrics: [
+        {
+          scope: {
+            name: "gen_ai.server",
+          },
+          metrics: [
+            {
+              name: "gen_ai.server.time_to_first_token",
+              unit: "s",
+              histogram: {
+                dataPoints: [
+                  {
+                    timeUnixNano: "1759757033052292000",
+                    count: 10,
+                    sum: 25.5,
+                    // No exemplars
+                    attributes: [],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const missingIdsRequest: DeepPartial<IExportMetricsServiceRequest> = {
+  resourceMetrics: [
+    {
+      resource: {
+        attributes: [],
+      },
+      scopeMetrics: [
+        {
+          scope: {
+            name: "gen_ai.server",
+          },
+          metrics: [
+            {
+              name: "gen_ai.server.time_to_first_token",
+              unit: "s",
+              histogram: {
+                dataPoints: [
+                  {
+                    timeUnixNano: "1759757033052292000",
+                    exemplars: [
+                      {
+                        timeUnixNano: "1759757017681929000",
+                        asDouble: 1.5,
+                        // Missing spanId and traceId
+                      },
+                    ],
+                    attributes: [],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const multipleDifferentTracesRequest: DeepPartial<IExportMetricsServiceRequest> =
+  {
+    resourceMetrics: [
+      {
+        resource: {
+          attributes: [],
+        },
+        scopeMetrics: [
+          {
+            scope: {
+              name: "gen_ai.server",
+            },
+            metrics: [
+              {
+                name: "gen_ai.server.time_to_first_token",
+                unit: "s",
+                histogram: {
+                  dataPoints: [
+                    {
+                      timeUnixNano: "1759757033052292000",
+                      exemplars: [
+                        {
+                          timeUnixNano: "1759757017681929000",
+                          asDouble: 1.5,
+                          spanId: "c3BhbjExMTExMTExMTE=",
+                          traceId: "dHJhY2VhYWFhYWFhYWE=",
+                        },
+                        {
+                          timeUnixNano: "1759757020000000000",
+                          asDouble: 2.3,
+                          spanId: "c3BhbjIyMjIyMjIyMjI=",
+                          traceId: "dHJhY2ViYmJiYmJiYmI=",
+                        },
+                      ],
+                      attributes: [],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+describe("opentelemetry metrics receiver", () => {
+  it("receives time_to_first_token metric and maps to span timestamps", async () => {
+    const traces = await openTelemetryMetricsRequestToTracesForCollection(
+      timeToFirstTokenMetricsRequest
+    );
+
+    expect(traces).toHaveLength(1);
+
+    const trace = traces[0];
+
+    try {
+      z.array(spanSchema).parse(trace!.spans);
+    } catch (error) {
+      const validationError = fromZodError(error as ZodError);
+      console.log("trace", JSON.stringify(trace, undefined, 2));
+      console.log("validationError", validationError);
+      assert.fail(validationError.message);
+    }
+
+    const expectedTraceId = "956f44a93204517e84009f06c6578ff3";
+    const expectedSpanId = "23d7f4f87357baab"; // Decoded from "I9f0+HNXuqs="
+
+    expect(trace?.traceId).toEqual(expectedTraceId);
+    expect(trace?.spans).toHaveLength(1);
+    expect(trace?.spans[0]?.span_id).toEqual(expectedSpanId);
+    expect(trace?.spans[0]?.trace_id).toEqual(expectedTraceId);
+    expect(trace?.spans[0]?.type).toEqual("llm");
+    expect(trace?.spans[0]?.timestamps?.first_token_at).toEqual(1759757017682);
+    expect(
+      trace?.spans[0]?.params?.metrics?.["gen_ai.server.time_to_first_token"]
+    ).toEqual({
+      model: "gpt-5",
+      request: {
+        status: "success",
+      },
+      value: 2.7979350090026855,
+      unit: "s",
+      timestamp: 1759757017682,
+    });
+  });
+
+  it("handles multiple exemplars in the same trace", async () => {
+    const traces = await openTelemetryMetricsRequestToTracesForCollection(
+      multipleExemplarsRequest
+    );
+
+    expect(traces).toHaveLength(1);
+
+    const trace = traces[0];
+    if (!trace) {
+      assert.fail("No trace found");
+    }
+
+    try {
+      z.array(spanSchema).parse(trace.spans);
+    } catch (error) {
+      const validationError = fromZodError(error as ZodError);
+      console.log("trace", JSON.stringify(trace, undefined, 2));
+      console.log("validationError", validationError);
+      assert.fail(validationError.message);
+    }
+
+    expect(trace.spans).toHaveLength(2);
+
+    // "c3BhbjExMTExMTExMTE=" -> "span1111111111" -> hex: 7370616e31313131313131313131
+    const span1 = trace.spans.find(
+      (s) => s.span_id === "7370616e31313131313131313131"
+    );
+    expect(span1).toBeDefined();
+    expect(span1?.timestamps?.first_token_at).toEqual(1759757017682); // Rounded from 1759757017681.929
+
+    // "c3BhbjIyMjIyMjIyMjI=" -> "span2222222222" -> hex: 7370616e32323232323232323232
+    const span2 = trace.spans.find(
+      (s) => s.span_id === "7370616e32323232323232323232"
+    );
+    expect(span2).toBeDefined();
+    expect(span2?.timestamps?.first_token_at).toEqual(1759757020000);
+  });
+
+  it("handles multiple traces from different exemplars", async () => {
+    const traces = await openTelemetryMetricsRequestToTracesForCollection(
+      multipleDifferentTracesRequest
+    );
+
+    expect(traces).toHaveLength(2);
+
+    try {
+      for (const trace of traces) {
+        z.array(spanSchema).parse(trace.spans);
+      }
+    } catch (error) {
+      const validationError = fromZodError(error as ZodError);
+      console.log("traces", JSON.stringify(traces, undefined, 2));
+      console.log("validationError", validationError);
+      assert.fail(validationError.message);
+    }
+
+    // "dHJhY2VhYWFhYWFhYWE=" -> "traceaaaaaaaaa" -> hex: 7472616365616161616161616161
+    const trace1 = traces.find(
+      (t) => t.traceId === "7472616365616161616161616161"
+    );
+    expect(trace1).toBeDefined();
+    expect(trace1?.spans).toHaveLength(1);
+
+    // "dHJhY2ViYmJiYmJiYmI=" -> "tracebbbbbbbbb" -> hex: 7472616365626262626262626262
+    const trace2 = traces.find(
+      (t) => t.traceId === "7472616365626262626262626262"
+    );
+    expect(trace2).toBeDefined();
+    expect(trace2?.spans).toHaveLength(1);
+  });
+
+  it("handles gauge metrics with exemplars", async () => {
+    const traces =
+      await openTelemetryMetricsRequestToTracesForCollection(
+        gaugeMetricsRequest
+      );
+
+    expect(traces).toHaveLength(1);
+
+    const trace = traces[0];
+    if (!trace) {
+      assert.fail("No trace found");
+    }
+
+    try {
+      z.array(spanSchema).parse(trace.spans);
+    } catch (error) {
+      const validationError = fromZodError(error as ZodError);
+      console.log("trace", JSON.stringify(trace, undefined, 2));
+      console.log("validationError", validationError);
+      assert.fail(validationError.message);
+    }
+
+    expect(trace.spans).toHaveLength(1);
+    const span = trace.spans[0];
+    expect(span?.params?.metrics).toBeDefined();
+    // Check that the metric was stored
+    const metrics = span?.params?.metrics;
+    expect(metrics?.["gen_ai.server.active_requests"]).toBeDefined();
+    expect(metrics?.["gen_ai.server.active_requests"]?.endpoint).toEqual(
+      "/api/chat"
+    );
+    expect(metrics?.["gen_ai.server.active_requests"]?.value).toEqual(5);
+    expect(metrics?.["gen_ai.server.active_requests"]?.unit).toEqual("count");
+  });
+
+  it("handles sum metrics with exemplars", async () => {
+    const traces =
+      await openTelemetryMetricsRequestToTracesForCollection(sumMetricsRequest);
+
+    expect(traces).toHaveLength(1);
+
+    const trace = traces[0];
+    if (!trace) {
+      assert.fail("No trace found");
+    }
+
+    try {
+      z.array(spanSchema).parse(trace.spans);
+    } catch (error) {
+      const validationError = fromZodError(error as ZodError);
+      console.log("trace", JSON.stringify(trace, undefined, 2));
+      console.log("validationError", validationError);
+      assert.fail(validationError.message);
+    }
+
+    expect(trace.spans).toHaveLength(1);
+    const span = trace.spans[0];
+    expect(span?.params?.metrics).toBeDefined();
+    const metrics = span?.params?.metrics;
+    expect(metrics?.["gen_ai.server.request.duration"]).toBeDefined();
+    expect(metrics?.["gen_ai.server.request.duration"]?.model).toEqual("gpt-4");
+    expect(metrics?.["gen_ai.server.request.duration"]?.value).toEqual(12.5);
+    expect(metrics?.["gen_ai.server.request.duration"]?.unit).toEqual("s");
+  });
+
+  it("handles empty metrics request", async () => {
+    const traces =
+      await openTelemetryMetricsRequestToTracesForCollection(
+        emptyMetricsRequest
+      );
+
+    expect(traces).toHaveLength(0);
+  });
+
+  it("handles metrics without exemplars", async () => {
+    const traces =
+      await openTelemetryMetricsRequestToTracesForCollection(
+        noExemplarsRequest
+      );
+
+    expect(traces).toHaveLength(0);
+  });
+
+  it("handles exemplars with missing trace or span IDs", async () => {
+    const traces =
+      await openTelemetryMetricsRequestToTracesForCollection(missingIdsRequest);
+
+    expect(traces).toHaveLength(0);
+  });
+
+  it("validates all spans against schema", async () => {
+    const allTestRequests = [
+      timeToFirstTokenMetricsRequest,
+      multipleExemplarsRequest,
+      gaugeMetricsRequest,
+      sumMetricsRequest,
+      multipleDifferentTracesRequest,
+    ];
+
+    for (const request of allTestRequests) {
+      const traces =
+        await openTelemetryMetricsRequestToTracesForCollection(request);
+
+      for (const trace of traces) {
+        try {
+          z.array(spanSchema).parse(trace.spans);
+        } catch (error) {
+          const validationError = fromZodError(error as ZodError);
+          console.log("Failed request:", JSON.stringify(request, undefined, 2));
+          console.log("trace", JSON.stringify(trace, undefined, 2));
+          console.log("validationError", validationError);
+          assert.fail(
+            `Schema validation failed for trace ${trace.traceId}: ${validationError.message}`
+          );
+        }
+      }
+    }
+  });
+});

--- a/langwatch/src/server/tracer/otel.metrics.test.ts
+++ b/langwatch/src/server/tracer/otel.metrics.test.ts
@@ -410,7 +410,7 @@ describe("opentelemetry metrics receiver", () => {
     expect(trace?.spans[0]?.type).toEqual("llm");
     expect(trace?.spans[0]?.timestamps?.first_token_at).toEqual(1759757017682);
     expect(
-      trace?.spans[0]?.params?.metrics?.["gen_ai.server.time_to_first_token"]
+      trace?.spans[0]?.params?.metrics?.gen_ai?.server?.time_to_first_token
     ).toEqual({
       model: "gpt-5",
       request: {
@@ -520,12 +520,12 @@ describe("opentelemetry metrics receiver", () => {
     expect(span?.params?.metrics).toBeDefined();
     // Check that the metric was stored
     const metrics = span?.params?.metrics;
-    expect(metrics?.["gen_ai.server.active_requests"]).toBeDefined();
-    expect(metrics?.["gen_ai.server.active_requests"]?.endpoint).toEqual(
+    expect(metrics?.gen_ai?.server?.active_requests).toBeDefined();
+    expect(metrics?.gen_ai?.server?.active_requests?.endpoint).toEqual(
       "/api/chat"
     );
-    expect(metrics?.["gen_ai.server.active_requests"]?.value).toEqual(5);
-    expect(metrics?.["gen_ai.server.active_requests"]?.unit).toEqual("count");
+    expect(metrics?.gen_ai?.server?.active_requests?.value).toEqual(5);
+    expect(metrics?.gen_ai?.server?.active_requests?.unit).toEqual("count");
   });
 
   it("handles sum metrics with exemplars", async () => {
@@ -552,10 +552,10 @@ describe("opentelemetry metrics receiver", () => {
     const span = trace.spans[0];
     expect(span?.params?.metrics).toBeDefined();
     const metrics = span?.params?.metrics;
-    expect(metrics?.["gen_ai.server.request.duration"]).toBeDefined();
-    expect(metrics?.["gen_ai.server.request.duration"]?.model).toEqual("gpt-4");
-    expect(metrics?.["gen_ai.server.request.duration"]?.value).toEqual(12.5);
-    expect(metrics?.["gen_ai.server.request.duration"]?.unit).toEqual("s");
+    expect(metrics?.gen_ai?.server?.request?.duration).toBeDefined();
+    expect(metrics?.gen_ai?.server?.request?.duration?.model).toEqual("gpt-4");
+    expect(metrics?.gen_ai?.server?.request?.duration?.value).toEqual(12.5);
+    expect(metrics?.gen_ai?.server?.request?.duration?.unit).toEqual("s");
   });
 
   it("handles empty metrics request", async () => {

--- a/langwatch/src/server/tracer/otel.metrics.ts
+++ b/langwatch/src/server/tracer/otel.metrics.ts
@@ -310,7 +310,6 @@ export const openTelemetryMetricsRequestToTracesForCollection = async (
         }
 
         const result = Object.values(traceMap);
-        console.log("traceMap", JSON.stringify(traceMap, undefined, 2));
         span.setAttribute("processed.traces.count", result.length);
         return result;
       } catch (error) {

--- a/langwatch/src/server/tracer/otel.metrics.ts
+++ b/langwatch/src/server/tracer/otel.metrics.ts
@@ -5,7 +5,7 @@ import {
   otelAttributesToNestedAttributes,
   type TraceForCollection,
 } from "./otel.traces";
-import { decodeBase64OpenTelemetryId, convertFromUnixNano } from "./utils";
+import { decodeBase64OpenTelemetryId, convertFromUnixNano, setNestedProperty } from "./utils";
 import { getLangWatchTracer } from "langwatch";
 import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 
@@ -136,17 +136,19 @@ export const openTelemetryMetricsRequestToTracesForCollection = async (
                         existingSpan.params.metrics = {};
                       }
 
-                      const metricKey = metric.name ?? "unknown";
-                      (existingSpan.params.metrics as Record<string, any>)[
-                        metricKey
-                      ] = {
-                        ...otelAttributesToNestedAttributes(
-                          dataPoint.attributes
-                        ),
-                        value: exemplar.asDouble ?? exemplar.asInt,
-                        unit: metric.unit,
-                        timestamp: exemplarTime,
-                      };
+                      const metricName = metric.name ?? "unknown";
+                      setNestedProperty(
+                        existingSpan.params.metrics as Record<string, any>,
+                        metricName,
+                        {
+                          ...otelAttributesToNestedAttributes(
+                            dataPoint.attributes
+                          ),
+                          value: exemplar.asDouble ?? exemplar.asInt,
+                          unit: metric.unit,
+                          timestamp: exemplarTime,
+                        }
+                      );
                     }
                   }
                 }
@@ -214,17 +216,19 @@ export const openTelemetryMetricsRequestToTracesForCollection = async (
                       existingSpan.params.metrics = {};
                     }
 
-                    const metricKey = metric.name ?? "unknown";
-                    (existingSpan.params.metrics as Record<string, any>)[
-                      metricKey
-                    ] = {
-                      ...(dataPoint.attributes
-                        ? otelAttributesToNestedAttributes(dataPoint.attributes)
-                        : {}),
-                      value: exemplar.asDouble ?? exemplar.asInt,
-                      unit: metric.unit,
-                      timestamp: exemplarTime,
-                    };
+                    const metricName = metric.name ?? "unknown";
+                    setNestedProperty(
+                      existingSpan.params.metrics as Record<string, any>,
+                      metricName,
+                      {
+                        ...(dataPoint.attributes
+                          ? otelAttributesToNestedAttributes(dataPoint.attributes)
+                          : {}),
+                        value: exemplar.asDouble ?? exemplar.asInt,
+                        unit: metric.unit,
+                        timestamp: exemplarTime,
+                      }
+                    );
                   }
                 }
               }
@@ -291,17 +295,19 @@ export const openTelemetryMetricsRequestToTracesForCollection = async (
                       existingSpan.params.metrics = {};
                     }
 
-                    const metricKey = metric.name ?? "unknown";
-                    (existingSpan.params.metrics as Record<string, any>)[
-                      metricKey
-                    ] = {
-                      ...(dataPoint.attributes
-                        ? otelAttributesToNestedAttributes(dataPoint.attributes)
-                        : {}),
-                      value: exemplar.asDouble ?? exemplar.asInt,
-                      unit: metric.unit,
-                      timestamp: exemplarTime,
-                    };
+                    const metricName = metric.name ?? "unknown";
+                    setNestedProperty(
+                      existingSpan.params.metrics as Record<string, any>,
+                      metricName,
+                      {
+                        ...(dataPoint.attributes
+                          ? otelAttributesToNestedAttributes(dataPoint.attributes)
+                          : {}),
+                        value: exemplar.asDouble ?? exemplar.asInt,
+                        unit: metric.unit,
+                        timestamp: exemplarTime,
+                      }
+                    );
                   }
                 }
               }

--- a/langwatch/src/server/tracer/otel.metrics.ts
+++ b/langwatch/src/server/tracer/otel.metrics.ts
@@ -1,0 +1,339 @@
+import type { DeepPartial } from "~/utils/types";
+import type { IExportMetricsServiceRequest } from "@opentelemetry/otlp-transformer";
+import { createLogger } from "~/utils/logger";
+import {
+  otelAttributesToNestedAttributes,
+  type TraceForCollection,
+} from "./otel.traces";
+import { decodeBase64OpenTelemetryId, convertFromUnixNano } from "./utils";
+import { getLangWatchTracer } from "langwatch";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+
+const logger = createLogger("langwatch.tracer.otel.metrics");
+const tracer = getLangWatchTracer("langwatch.tracer.otel.metrics");
+
+// Supported GenAI metrics we want to extract
+const GENAI_METRICS = {
+  TIME_TO_FIRST_TOKEN: "gen_ai.server.time_to_first_token",
+  REQUEST_DURATION: "gen_ai.server.request.duration",
+  TIME_PER_OUTPUT_TOKEN: "gen_ai.server.time_per_output_token",
+} as const;
+
+export const openTelemetryMetricsRequestToTracesForCollection = async (
+  otelMetrics: DeepPartial<IExportMetricsServiceRequest>
+): Promise<TraceForCollection[]> => {
+  console.log("otelMetrics", JSON.stringify(otelMetrics, undefined, 2));
+  return await tracer.withActiveSpan(
+    "openTelemetryMetricsRequestToTracesForCollection",
+    { kind: SpanKind.INTERNAL },
+    async (span) => {
+      try {
+        if (!otelMetrics.resourceMetrics) {
+          span.setAttribute("resourceMetrics.count", 0);
+          return [];
+        }
+
+        span.setAttribute(
+          "resourceMetrics.count",
+          otelMetrics.resourceMetrics.length
+        );
+
+        const traceMap: Record<string, TraceForCollection> = {};
+
+        for (const resourceMetric of otelMetrics.resourceMetrics) {
+          if (!resourceMetric?.scopeMetrics) {
+            continue;
+          }
+
+          for (const scopeMetric of resourceMetric.scopeMetrics) {
+            if (!scopeMetric?.metrics) {
+              continue;
+            }
+
+            for (const metric of scopeMetric.metrics) {
+              if (!metric) {
+                continue;
+              }
+
+              // Process histogram metrics
+              if (metric.histogram?.dataPoints) {
+                for (const dataPoint of metric.histogram.dataPoints) {
+                  if (!dataPoint?.exemplars) {
+                    continue;
+                  }
+
+                  for (const exemplar of dataPoint.exemplars) {
+                    if (!exemplar) {
+                      continue;
+                    }
+
+                    const traceId = decodeBase64OpenTelemetryId(exemplar.traceId);
+                    const spanId = decodeBase64OpenTelemetryId(exemplar.spanId);
+
+                    if (!traceId || !spanId) {
+                      logger.info(
+                        "received metric exemplar with no span or trace id, rejecting"
+                      );
+                      continue;
+                    }
+
+                    let trace = traceMap[traceId];
+                    if (!trace) {
+                      trace = {
+                        traceId,
+                        spans: [],
+                        evaluations: [],
+                        reservedTraceMetadata: {},
+                        customMetadata: {},
+                      } satisfies TraceForCollection;
+                      traceMap[traceId] = trace;
+                    }
+
+                    let existingSpan = trace.spans.find(
+                      (span) => span.span_id === spanId
+                    );
+
+                    const exemplarTime = convertFromUnixNano(
+                      exemplar.timeUnixNano
+                    );
+
+                    if (!existingSpan) {
+                      existingSpan = {
+                        span_id: spanId,
+                        trace_id: traceId,
+                        type: "llm",
+                        params: {},
+                        timestamps: {
+                          ignore_timestamps_on_write: true,
+                          started_at: exemplarTime,
+                          finished_at: exemplarTime,
+                        },
+                      };
+                      trace.spans.push(existingSpan);
+                    }
+
+                    // Map specific GenAI metrics to span fields
+                    if (metric.name === GENAI_METRICS.TIME_TO_FIRST_TOKEN) {
+                      const firstTokenMs = convertSecondsToMilliseconds(
+                        exemplar.asDouble ?? exemplar.asInt
+                      );
+
+                      if (firstTokenMs !== null) {
+                        // Set first_token_at based on the exemplar time
+                        existingSpan.timestamps.first_token_at = exemplarTime;
+                      }
+                    }
+
+                    // Store all metric attributes generically in params
+                    if (
+                      dataPoint.attributes &&
+                      dataPoint.attributes.length > 0
+                    ) {
+                      if (!existingSpan.params) {
+                        existingSpan.params = {};
+                      }
+                      if (!existingSpan.params.metrics) {
+                        existingSpan.params.metrics = {};
+                      }
+
+                      const metricKey = metric.name ?? "unknown";
+                      (existingSpan.params.metrics as Record<string, any>)[
+                        metricKey
+                      ] = {
+                        ...otelAttributesToNestedAttributes(
+                          dataPoint.attributes
+                        ),
+                        value: exemplar.asDouble ?? exemplar.asInt,
+                        unit: metric.unit,
+                        timestamp: exemplarTime,
+                      };
+                    }
+                  }
+                }
+              }
+
+              // Process gauge metrics
+              if (metric.gauge?.dataPoints) {
+                for (const dataPoint of metric.gauge.dataPoints) {
+                  if (!dataPoint?.exemplars) {
+                    continue;
+                  }
+
+                  for (const exemplar of dataPoint.exemplars) {
+                    if (!exemplar) {
+                      continue;
+                    }
+
+                    const traceId = decodeBase64OpenTelemetryId(exemplar.traceId);
+                    const spanId = decodeBase64OpenTelemetryId(exemplar.spanId);
+
+                    if (!traceId || !spanId) {
+                      continue;
+                    }
+
+                    let trace = traceMap[traceId];
+                    if (!trace) {
+                      trace = {
+                        traceId,
+                        spans: [],
+                        evaluations: [],
+                        reservedTraceMetadata: {},
+                        customMetadata: {},
+                      } satisfies TraceForCollection;
+                      traceMap[traceId] = trace;
+                    }
+
+                    const exemplarTime = convertFromUnixNano(
+                      exemplar.timeUnixNano
+                    );
+
+                    let existingSpan = trace.spans.find(
+                      (span) => span.span_id === spanId
+                    );
+
+                    if (!existingSpan) {
+                      existingSpan = {
+                        span_id: spanId,
+                        trace_id: traceId,
+                        type: "llm",
+                        params: {},
+                        timestamps: {
+                          ignore_timestamps_on_write: true,
+                          started_at: exemplarTime,
+                          finished_at: exemplarTime,
+                        },
+                      };
+                      trace.spans.push(existingSpan);
+                    }
+
+                    // Store gauge metrics in params
+                    if (!existingSpan.params) {
+                      existingSpan.params = {};
+                    }
+                    if (!existingSpan.params.metrics) {
+                      existingSpan.params.metrics = {};
+                    }
+
+                    const metricKey = metric.name ?? "unknown";
+                    (existingSpan.params.metrics as Record<string, any>)[
+                      metricKey
+                    ] = {
+                      ...(dataPoint.attributes
+                        ? otelAttributesToNestedAttributes(dataPoint.attributes)
+                        : {}),
+                      value: exemplar.asDouble ?? exemplar.asInt,
+                      unit: metric.unit,
+                      timestamp: exemplarTime,
+                    };
+                  }
+                }
+              }
+
+              // Process sum metrics
+              if (metric.sum?.dataPoints) {
+                for (const dataPoint of metric.sum.dataPoints) {
+                  if (!dataPoint?.exemplars) {
+                    continue;
+                  }
+
+                  for (const exemplar of dataPoint.exemplars) {
+                    if (!exemplar) {
+                      continue;
+                    }
+
+                    const traceId = decodeBase64OpenTelemetryId(exemplar.traceId);
+                    const spanId = decodeBase64OpenTelemetryId(exemplar.spanId);
+
+                    if (!traceId || !spanId) {
+                      continue;
+                    }
+
+                    let trace = traceMap[traceId];
+                    if (!trace) {
+                      trace = {
+                        traceId,
+                        spans: [],
+                        evaluations: [],
+                        reservedTraceMetadata: {},
+                        customMetadata: {},
+                      } satisfies TraceForCollection;
+                      traceMap[traceId] = trace;
+                    }
+
+                    const exemplarTime = convertFromUnixNano(
+                      exemplar.timeUnixNano
+                    );
+
+                    let existingSpan = trace.spans.find(
+                      (span) => span.span_id === spanId
+                    );
+
+                    if (!existingSpan) {
+                      existingSpan = {
+                        span_id: spanId,
+                        trace_id: traceId,
+                        type: "llm",
+                        params: {},
+                        timestamps: {
+                          ignore_timestamps_on_write: true,
+                          started_at: exemplarTime,
+                          finished_at: exemplarTime,
+                        },
+                      };
+                      trace.spans.push(existingSpan);
+                    }
+
+                    // Store sum metrics in params
+                    if (!existingSpan.params) {
+                      existingSpan.params = {};
+                    }
+                    if (!existingSpan.params.metrics) {
+                      existingSpan.params.metrics = {};
+                    }
+
+                    const metricKey = metric.name ?? "unknown";
+                    (existingSpan.params.metrics as Record<string, any>)[
+                      metricKey
+                    ] = {
+                      ...(dataPoint.attributes
+                        ? otelAttributesToNestedAttributes(dataPoint.attributes)
+                        : {}),
+                      value: exemplar.asDouble ?? exemplar.asInt,
+                      unit: metric.unit,
+                      timestamp: exemplarTime,
+                    };
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        const result = Object.values(traceMap);
+        console.log("traceMap", JSON.stringify(traceMap, undefined, 2));
+        span.setAttribute("processed.traces.count", result.length);
+        return result;
+      } catch (error) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+        span.recordException(
+          error instanceof Error ? error : new Error(String(error))
+        );
+        throw error;
+      }
+    }
+  );
+};
+
+const convertSecondsToMilliseconds = (seconds: unknown): number | null => {
+  if (typeof seconds === "number") {
+    return Math.round(seconds * 1000);
+  }
+  if (typeof seconds === "string") {
+    const parsed = parseFloat(seconds);
+    return !isNaN(parsed) ? Math.round(parsed * 1000) : null;
+  }
+  return null;
+};

--- a/langwatch/src/server/tracer/utils.ts
+++ b/langwatch/src/server/tracer/utils.ts
@@ -185,3 +185,23 @@ export const convertFromUnixNano = (timeUnixNano: unknown): number => {
   // Convert nanoseconds to milliseconds
   return Math.round(unixNano / 1000000);
 };
+
+export const setNestedProperty = (
+  obj: Record<string, any>,
+  path: string,
+  value: any
+): void => {
+  const keys = path.split(".");
+  let current = obj;
+
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]!;
+    if (!(key in current) || typeof current[key] !== "object") {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+
+  const lastKey = keys[keys.length - 1]!;
+  current[lastKey] = value;
+};

--- a/python-sdk/examples/openai_bot_otel_metrics.py
+++ b/python-sdk/examples/openai_bot_otel_metrics.py
@@ -1,0 +1,89 @@
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+import chainlit as cl
+from openai import OpenAI
+import langwatch
+
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
+import time
+
+client = OpenAI()
+
+exporter = OTLPMetricExporter(
+    endpoint=f"{os.environ.get('LANGWATCH_ENDPOINT', 'https://app.langwatch.ai')}/api/otel/v1/metrics",
+    headers={"Authorization": "Bearer " + os.environ["LANGWATCH_API_KEY"]},
+)
+
+
+reader = PeriodicExportingMetricReader(exporter)
+provider = MeterProvider(
+    resource=Resource.create({"service.name": "my-agent"}), metric_readers=[reader]
+)
+metrics.set_meter_provider(provider)
+meter = metrics.get_meter("gen_ai.server")
+
+# Create the histogram
+time_to_first_token_hist = meter.create_histogram(
+    name="gen_ai.server.time_to_first_token",
+    unit="s",
+    description="Time to generate first token for successful responses",
+)
+
+
+@langwatch.trace(type="llm")
+async def do_call_llm(content: str, msg):
+    start_time = time.time()
+    completion = client.chat.completions.create(
+        model="gpt-5",
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a helpful assistant that only reply in short tweet-like responses, using lots of emojis.",
+            },
+            {"role": "user", "content": content},
+        ],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    first_token_time = None
+    full_response = ""
+    for part in completion:
+        if len(part.choices) == 0:
+            continue
+        if token := part.choices[0].delta.content or "":
+            if first_token_time is None:
+                first_token_time = time.time()
+                record_first_token_latency((time.time() - start_time) * 1000)
+            await msg.stream_token(token)
+            full_response += token
+
+    langwatch.get_current_trace().update(output=full_response)
+
+
+@cl.on_message
+@langwatch.trace()
+async def main(message: cl.Message):
+    msg = cl.Message(
+        content="",
+    )
+
+    await do_call_llm(message.content, msg)
+
+    await msg.update()
+
+
+def record_first_token_latency(milliseconds: float):
+    seconds = milliseconds / 1000.0
+    print(f"Record first token latency: {seconds} seconds")
+    time_to_first_token_hist.record(
+        seconds, attributes={"model": "gpt-5", "request.status": "success"}
+    )

--- a/python-sdk/src/langwatch/__version__.py
+++ b/python-sdk/src/langwatch/__version__.py
@@ -1,3 +1,3 @@
 """Version information for LangWatch."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -2861,7 +2861,7 @@ wheels = [
 
 [[package]]
 name = "langwatch"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
OTEL GenAI metrics are in `development` stage, however they are the most likely way forward for capturing things like time to first token, check out the reference:

https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiservertime_to_first_token

This PR adds the otel /metrics endpoint, which along with /logs, makes us future ready and fully compliant with otel [genai spec](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)

It works by automatically associating the incoming metric with the span id, both computing the default langwatch-standard time to first token, and putting the raw otel metric under the span params:

<img width="720" height="670" alt="image" src="https://github.com/user-attachments/assets/2ad2059a-ab29-4dde-abf3-eb72880a657a" />
