### PR TITLE
fix: api snipper dialog header

### DIFF
--- a/langwatch/src/components/GenerateApiSnippetDialog.tsx
+++ b/langwatch/src/components/GenerateApiSnippetDialog.tsx
@@ -49,7 +49,7 @@ export function GenerateApiSnippetDialog({
   const [selectedTarget, setSelectedTarget] =
     useState<Target>("python_python3");
   const [selectedSnippet, setSelectedSnippet] = useState<Snippet | undefined>(
-    snippets[0]
+    snippets[0],
   );
 
   const handleOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -60,7 +60,7 @@ export function GenerateApiSnippetDialog({
   useEffect(() => {
     if (!selectedTarget) return;
     const snippet = snippets.find(
-      (snippet) => snippet.target === selectedTarget
+      (snippet) => snippet.target === selectedTarget,
     );
     if (snippet) {
       setSelectedSnippet(snippet);
@@ -85,39 +85,21 @@ export function GenerateApiSnippetDialog({
         <Dialog.Content>
           <Dialog.CloseTrigger />
           <Dialog.Header width="100%" marginTop={4}>
-            <HStack justifyContent="space-between" width="100%">
-              <Dialog.Title>{title ?? "API Usage"}</Dialog.Title>
+            <HStack
+              justifyContent="space-between"
+              width="100%"
+              alignItems="flex-start"
+            >
+              <VStack alignItems="flex-start" gap={2}>
+                <Dialog.Title>{title ?? "API Usage"}</Dialog.Title>
+                <Dialog.Description>{description}</Dialog.Description>
+              </VStack>
               <LanguageMenu
                 selectedTarget={selectedTarget}
                 setSelectedTarget={setSelectedTarget}
                 targets={targets}
               />
             </HStack>
-            <Dialog.Description>
-              <VStack alignItems="flex-start" gap={2}>
-                {description}
-                <HStack>
-                  <Text
-                    fontSize="sm"
-                    color="green.500"
-                    backgroundColor="gray.100"
-                    paddingX={2}
-                    paddingY={1}
-                    borderRadius={5}
-                  >
-                    {selectedSnippet.method}
-                  </Text>
-                  <Text
-                    fontSize="sm"
-                    color="gray.500"
-                    fontWeight="bold"
-                    fontFamily="monospace"
-                  >
-                    {selectedSnippet.path}
-                  </Text>
-                </HStack>
-              </VStack>
-            </Dialog.Description>
           </Dialog.Header>
           <Dialog.Body>
             <RenderCode

--- a/langwatch/src/prompt-configs/components/GeneratePromptApiSnippetDialog.tsx
+++ b/langwatch/src/prompt-configs/components/GeneratePromptApiSnippetDialog.tsx
@@ -39,15 +39,12 @@ export function GeneratePromptApiSnippetDialog({
 
   const description = (
     <VStack alignItems="flex-start" gap={3} marginBottom={4}>
-      <Text>
-        Use the following API code snippets to interact with the prompt.
-      </Text>
       <Link
         href="https://docs.langwatch.ai/api-reference/prompts/get-prompt"
         isExternal
         color="blue.500"
         _hover={{ textDecoration: "underline" }}
-        fontSize="sm"
+        fontSize="xs"
       >
         📖 View API documentation
       </Link>


### PR DESCRIPTION
The layout here was crowded and messed up. This fixes it.

<img width="819" height="274" alt="Screenshot 2025-11-03 at 12 30 08" src="https://github.com/user-attachments/assets/5efc5186-895f-4fd2-a4c0-acfc3c926139" />
