### PR TITLE
feat: add GitHub issue templates with project autolinking

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,28 @@
+---
+name: 🐛 Bug Report
+about: Report a bug or unexpected behavior
+title: "[BUG] "
+labels: ["bug"]
+projects: ["5"]
+assignees: ""
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+**Expected behavior**
+A clear description of what you expected to happen.
+
+**Environment**
+- Component: [langwatch/langwatch_nlp/langwatch_mcp_server/langwatch_sdk_python/langwatch_sdk_typescript/langwatch_sdk_go]
+- Version: [e.g. v1.2.3]
+- Browser/OS: [if applicable]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,26 @@
+---
+name: 🔧 Chore
+about: Maintenance tasks, refactoring, or technical debt
+title: "[CHORE] "
+labels: ["chore"]
+projects: ["5"]
+assignees: ""
+---
+
+**Description**
+What maintenance task or technical work needs to be done?
+
+**Context**
+Why is this task needed? Any background or related issues?
+
+**Scope**
+What components or areas does this affect?
+- [ ] Dependencies
+- [ ] Build/CI
+- [ ] Documentation
+- [ ] Code quality
+- [ ] Infrastructure
+- [ ] Other: __________
+
+**Additional context**
+Any specific requirements or constraints?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://docs.langwatch.ai
+    about: Check our docs for help
+  - name: 💬 Discord Community
+    url: https://discord.gg/langwatch
+    about: Join our community for discussions

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: ✨ Feature Request
+about: Suggest a new feature or enhancement
+title: "[FEATURE] "
+labels: ["enhancement"]
+projects: ["5"]
+assignees: ""
+---
+
+**Problem**
+What problem does this feature solve? Why is it needed?
+
+**Proposed solution**
+Describe the solution you'd like to see.
+
+**Alternatives considered**
+Any alternative solutions or features you've considered?
+
+**Additional context**
+Any other context or screenshots about the feature request.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: ❓ Question
+about: Ask a question about LangWatch
+title: "[QUESTION] "
+labels: ["question"]
+projects: ["5"]
+assignees: ""
+---
+
+**Question**
+What would you like to know?
+
+**Context**
+Provide any relevant context or background information.
+
+**What have you tried?**
+Describe any troubleshooting or research you've already done.

--- a/.github/workflows/issue-link.yml
+++ b/.github/workflows/issue-link.yml
@@ -1,0 +1,21 @@
+name: 'Issue Links'
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  issue-links:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: tkt-actions/add-issue-links@v1.9.1
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          branch-prefix: 'issue'
+          link-style: 'comment'
+          position: 'body'
+          header: '# Related Issue'
+          resolve: true
+          assign-pr-creator-to-issue: 'true' 


### PR DESCRIPTION
- Add bug report, feature request, question, and chore templates
- Configure automatic project linking to project
- Include contact links for docs and Discord community
- Disable blank issues to enforce template usage

Resolves #828 