### PR TITLE
feat: add prompt metadata tags to traces view

### DIFF
--- a/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts
+++ b/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts
@@ -100,11 +100,10 @@ export class PromptStudioAdapter implements CopilotServiceAdapter {
         messagesHistory,
       });
 
-      // Build execute_flow event (inputs must be an array)
+      // Build execute_component event
       const rawEvent: StudioClientEvent = {
         type: "execute_component",
         payload: {
-          enable_tracing: true,
           trace_id: traceId,
           workflow,
           node_id: nodeId,
@@ -112,8 +111,13 @@ export class PromptStudioAdapter implements CopilotServiceAdapter {
             ...variables,
             messages: messagesHistory,
           },
+          metadata: {
+            prompt_id: formValues.configId,
+            prompt_version_id: formValues.versionMetadata?.versionId,
+            prompt_handle: formValues.handle,
+          },
         },
-      } as StudioClientEvent;
+      };
 
       // Enrich with envs and datasets to match server route behavior
       preparedEvent = await loadDatasets(

--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -83,6 +83,7 @@ export function FieldsFilters({
 }) {
   const filterKeys: FilterField[] = [
     "metadata.prompt_ids",
+    "metadata.prompt_version_ids",
     "spans.model",
     "metadata.labels",
     "evaluations.passed",

--- a/langwatch/src/optimization_studio/types/events.ts
+++ b/langwatch/src/optimization_studio/types/events.ts
@@ -11,6 +11,7 @@ export const studioClientEventSchema = z.discriminatedUnion("type", [
       workflow: workflowJsonSchema,
       node_id: z.string(),
       inputs: z.record(z.string(), z.any()),
+      metadata: z.record(z.string(), z.any()).optional(),
     }),
   }),
   z.object({

--- a/langwatch/src/server/filters/registry.ts
+++ b/langwatch/src/server/filters/registry.ts
@@ -410,7 +410,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
                         ? {
                             script: {
                               source: `if (${nullChecks}) { return params._source.${metadataKey(
-                                key
+                                key,
                               )}; } else { return null; }`,
                             },
                           }
@@ -745,7 +745,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
             })
             .filter(
               (option: any) =>
-                option?.label !== undefined && option?.label !== null
+                option?.label !== undefined && option?.label !== null,
             ) ?? []
         );
       },
@@ -772,7 +772,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
               {
                 terms: {
                   "evaluations.passed": values.map(
-                    (value) => value === "true" || value === "1"
+                    (value) => value === "true" || value === "1",
                   ),
                 },
               },
@@ -957,7 +957,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
         return (
           result.unique_values?.child?.child?.buckets
             ?.filter(
-              (bucket: any) => !["succeeded", "failed"].includes(bucket.key)
+              (bucket: any) => !["succeeded", "failed"].includes(bucket.key),
             )
             .map((bucket: any) => ({
               field: bucket.key,
@@ -1032,7 +1032,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
         return (
           result.unique_values?.child?.child?.buckets
             ?.filter(
-              (bucket: any) => !["succeeded", "failed"].includes(bucket.key)
+              (bucket: any) => !["succeeded", "failed"].includes(bucket.key),
             )
             .map((bucket: any) => ({
               field: bucket.key,
@@ -1178,7 +1178,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
               field: bucket.key,
               label: bucket.key,
               count: bucket.doc_count,
-            })
+            }),
           ) ?? []
         );
       },
@@ -1269,14 +1269,14 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
         return [
           {
             field: Math.ceil(
-              result.unique_values?.child?.child?.child?.child?.min
+              result.unique_values?.child?.child?.child?.child?.min,
             ).toString(),
             label: "min",
             count: 0,
           },
           {
             field: Math.ceil(
-              result.unique_values?.child?.child?.child?.child?.max
+              result.unique_values?.child?.child?.child?.child?.max,
             ).toString(),
             label: "max",
             count: 0,
@@ -1356,7 +1356,7 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
               field: bucket.key,
               label: bucket.key,
               count: bucket.doc_count,
-            })
+            }),
           ) ?? []
         );
       },
@@ -1471,9 +1471,51 @@ export const availableFilters: { [K in FilterField]: FilterDefinition } = {
         );
       },
     },
+    "metadata.prompt_version_ids": {
+      name: "Prompt Version ID",
+      urlKey: "prompt_version_id",
+      query: (values: string[]) => ({
+        terms: { "metadata.prompt_version_ids": values },
+      }),
+      listMatch: {
+        aggregation: (query: string | undefined) => ({
+          unique_values: {
+            filter: query
+              ? {
+                  prefix: {
+                    "metadata.prompt_version_ids": {
+                      value: query,
+                      case_insensitive: true,
+                    },
+                  },
+                }
+              : {
+                  match_all: {},
+                },
+            aggs: {
+              child: {
+                terms: {
+                  field: "metadata.prompt_version_ids",
+                  size: 10_000,
+                  order: { _key: "asc" },
+                },
+              },
+            },
+          },
+        }),
+        extract: (result: Record<string, any>) => {
+          return (
+            result.unique_values?.child?.buckets?.map((bucket: any) => ({
+              field: bucket.key,
+              label: bucket.key,
+              count: bucket.doc_count,
+            })) ?? []
+          );
+        },
+      },
+    },
   },
 };
-
 const metadataKey = (key: string | undefined) => {
   const reservedKeys = Object.keys(reservedTraceMetadataSchema.shape);
   if (key && reservedKeys.includes(key)) {

--- a/langwatch/src/server/filters/types.ts
+++ b/langwatch/src/server/filters/types.ts
@@ -14,6 +14,7 @@ export const filterFieldsEnum = z.enum([
   "metadata.key",
   "metadata.value",
   "metadata.prompt_ids",
+  "metadata.prompt_version_ids",
   "traces.error",
   "spans.type",
   "spans.model",
@@ -38,7 +39,7 @@ export type FilterDefinition = {
   query: (
     values: string[],
     key: string | undefined,
-    subkey: string | undefined
+    subkey: string | undefined,
   ) => QueryDslQueryContainer;
   single?: boolean;
   type?: "numeric";
@@ -52,10 +53,10 @@ export type FilterDefinition = {
     aggregation: (
       query: string | undefined,
       key: string | undefined,
-      subkey: string | undefined
+      subkey: string | undefined,
     ) => Record<string, AggregationsAggregationContainer>;
     extract: (
-      result: Record<string, any>
+      result: Record<string, any>,
     ) => { field: string; label: string; count: number }[];
   };
 };


### PR DESCRIPTION
- Extend execute_component event schema to accept metadata
- Attach prompt id/version/handle to traces via service adapter
- Add clickable prompt metadata badges in traces table
- Implement filtering by clicking prompt/version tags
- Add prompt_version_ids filter to registry and UI

Users can now easily navigate from prompts to filtered traces and vice versa.

# Related Issue

- Resolve #843