### PR TITLE
feat(cli): add --version command

### DIFF
--- a/typescript-sdk/src/cli/index.ts
+++ b/typescript-sdk/src/cli/index.ts
@@ -7,6 +7,8 @@ config();
 import { Command } from "commander";
 import { parsePromptSpec } from "./types";
 
+declare const __CLI_VERSION__: string;
+
 // Import commands with proper async handling
 const addCommand = async (name: string, options: { version?: string; localFile?: string }): Promise<void> => {
   const { addCommand: addCommandImpl } = await import("./commands/add.js");
@@ -48,6 +50,7 @@ const program = new Command();
 program
   .name("langwatch")
   .description("LangWatch CLI - The npm of prompts")
+  .version(__CLI_VERSION__, "-v, --version", "Display the current version")
   .configureHelp({
     showGlobalOptions: true,
   })

--- a/typescript-sdk/tsup.config.ts
+++ b/typescript-sdk/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsup";
+import packageJson from "./package.json";
 
 export default defineConfig([
   {
@@ -14,5 +15,8 @@ export default defineConfig([
     format: ["cjs", "esm"],
     dts: true,
     sourcemap: true,
+    define: {
+      __CLI_VERSION__: JSON.stringify(packageJson.version),
+    },
   },
 ]);


### PR DESCRIPTION
the computer expected the --version command to be there, but the computer couldn't find it:

<img width="1131" height="584" alt="Screenshot 2025-12-02 at 15 43 45" src="https://github.com/user-attachments/assets/cf9ccfea-0c34-4d14-81ba-80a202b18705" />
