### PR TITLE
fix(python-sdk): add httpx.ReadTimeout to transient error skip list

### DIFF
--- a/python-sdk/tests/test_examples.py
+++ b/python-sdk/tests/test_examples.py
@@ -197,6 +197,7 @@ async def test_example(example_file: str):
                         "Connection error",
                         "Timeout",
                         "Request timed out",
+                        "read operation timed out",
                     ]
                 ):
                     pytest.skip(


### PR DESCRIPTION
See: https://github.com/langwatch/langwatch/actions/runs/19895711566/job/57028195329

# Related Issue

- Resolve #909