### PR TITLE
fix(prompts-api): derive output schema from storage to prevent drift

### DIFF
--- a/langwatch/src/app/api/prompts/[[...route]]/schemas/__tests__/schema-compatibility.test.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/schemas/__tests__/schema-compatibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+
+import { getLatestConfigVersionSchema } from "~/server/prompt-config/repositories/llm-config-version-schema";
+import { apiResponsePromptWithVersionDataSchema } from "../outputs";
+
+describe("Schema compatibility", () => {
+  describe("when storage schema allows defaults", () => {
+    it("output schema accepts storage schema defaults", () => {
+      const storageSchema = getLatestConfigVersionSchema();
+
+      const storageData = storageSchema.parse({
+        id: "version_123",
+        projectId: "project_123",
+        configId: "config_123",
+        schemaVersion: "1.0",
+        commitMessage: "initial",
+        version: 1,
+        createdAt: new Date(),
+        configData: {
+          prompt: "",
+          model: "gpt-4",
+          outputs: [{ identifier: "out", type: "str" }],
+        },
+      });
+
+      const apiResponse = {
+        id: "config_123",
+        handle: "test",
+        scope: "PROJECT" as const,
+        name: "Test",
+        updatedAt: new Date(),
+        projectId: storageData.projectId,
+        organizationId: "org_123",
+        versionId: storageData.id,
+        version: storageData.version,
+        createdAt: storageData.createdAt,
+        commitMessage: storageData.commitMessage,
+        authorId: null,
+        ...storageData.configData,
+      };
+
+      expect(() =>
+        apiResponsePromptWithVersionDataSchema.parse(apiResponse)
+      ).not.toThrow();
+    });
+  });
+});

--- a/langwatch/src/app/api/prompts/[[...route]]/schemas/outputs.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/schemas/outputs.ts
@@ -1,14 +1,9 @@
 import { PromptScope } from "@prisma/client";
 import { z } from "zod";
 
-import { nodeDatasetSchema } from "~/optimization_studio/types/dsl";
-import {
-  inputsSchema,
-  messageSchema,
-  outputsSchema,
-  promptingTechniqueSchema,
-  responseFormatSchema,
-} from "~/prompts/schemas";
+import { getLatestConfigVersionSchema } from "~/server/prompt-config/repositories/llm-config-version-schema";
+
+const configDataSchema = getLatestConfigVersionSchema().shape.configData;
 
 /**
  * Base schema for API Response (only llm config)
@@ -25,7 +20,7 @@ const apiResponsePromptSchemaBase = z.object({
 
 /**
  * Schema for version output responses
- * Extends the input schema with metadata about the created version
+ * Derives configData fields from storage schema to prevent drift
  */
 const apiResponseVersionOutputSchema = z.object({
   configId: z.string(),
@@ -35,16 +30,17 @@ const apiResponseVersionOutputSchema = z.object({
   version: z.number(),
   createdAt: z.date(),
   commitMessage: z.string().optional().nullable(),
-  prompt: z.string(),
-  messages: z.array(messageSchema).default([]),
-  inputs: z.array(inputsSchema).min(1, "At least one input is required"),
-  outputs: z.array(outputsSchema).min(1, "At least one output is required"),
-  model: z.string().min(1, "Model identifier cannot be empty"),
-  temperature: z.number().optional(),
-  maxTokens: z.number().optional(),
-  demonstrations: nodeDatasetSchema.optional(),
-  promptingTechnique: promptingTechniqueSchema.optional(),
-  responseFormat: responseFormatSchema.optional(),
+  // Derived from storage schema
+  prompt: configDataSchema.shape.prompt,
+  messages: configDataSchema.shape.messages,
+  inputs: configDataSchema.shape.inputs,
+  outputs: configDataSchema.shape.outputs,
+  model: configDataSchema.shape.model,
+  temperature: configDataSchema.shape.temperature,
+  maxTokens: configDataSchema.shape.max_tokens,
+  demonstrations: configDataSchema.shape.demonstrations,
+  promptingTechnique: configDataSchema.shape.prompting_technique,
+  responseFormat: configDataSchema.shape.response_format,
 });
 
 /**


### PR DESCRIPTION
- Output schema now derives configData fields from getLatestConfigVersionSchema()
- Fixes 500 errors when prompts have empty inputs (allowed by storage, rejected by output)
- Adds schema compatibility test to prevent future drift

# Related Issue

- Resolve #947