### PR TITLE
Fix bug

### DIFF
--- a/langwatch/src/injection/components/ManagedModelProviderAlert.tsx
+++ b/langwatch/src/injection/components/ManagedModelProviderAlert.tsx
@@ -1,0 +1,34 @@
+/**
+ * Reference implementation for Managed Model Provider Alert Component
+ * 
+ * BUG FIX #0913: Grammar correction
+ * Changed "is managed" to "are managed" because "credentials" is plural
+ * 
+ * This component should be used in the saas-src managed model provider component
+ * to display the correct alert message when model provider credentials are managed
+ * by LangWatch.
+ */
+
+import { Alert } from "@chakra-ui/react";
+import type React from "react";
+import type { MaybeStoredModelProvider } from "../../server/modelProviders/registry";
+
+interface ManagedModelProviderAlertProps {
+  provider: MaybeStoredModelProvider;
+}
+
+export const ManagedModelProviderAlert: React.FC<
+  ManagedModelProviderAlertProps
+> = ({ provider }) => {
+  const providerName = provider.provider;
+
+  return (
+    <Alert.Root status="info" variant="subtle">
+      <Alert.Indicator />
+      <Alert.Content>
+        The {providerName} provider credentials are managed by LangWatch for
+        your organization.
+      </Alert.Content>
+    </Alert.Root>
+  );
+};

--- a/langwatch/src/injection/components/README.md
+++ b/langwatch/src/injection/components/README.md
@@ -1,0 +1,31 @@
+# Managed Model Provider Components
+
+This directory contains reference implementations for components used in the SaaS version of LangWatch via dependency injection.
+
+## Bug Fix #0913
+
+**Issue**: Grammar error in managed model provider credentials alert message
+
+**Error**: "The bedrock provider credentials **is** managed by LangWatch for your organization."
+
+**Fix**: Changed to "The bedrock provider credentials **are** managed by LangWatch for your organization."
+
+### Implementation Details
+
+The managed model provider component is injected via the dependency injection system defined in:
+- `next.config.mjs` (lines 119-122): Aliases `@injected-dependencies.client` to `injection.client.ts`
+- `src/injection/injection.client.ts`: Exports the `Dependencies` interface
+- The actual SaaS implementation should be in the `saas-src` directory (not in OSS repo)
+
+### Files to Update in SaaS Repository
+
+The managed model provider component that needs to be fixed is likely located at:
+- `saas-src/injection/components/ManagedModelProvider.tsx` (or similar path)
+
+The component should:
+1. Check if `provider.customKeys.MANAGED` is set
+2. Display an Alert with the **corrected** message: "The {provider} provider credentials **are** managed by LangWatch for your organization."
+
+### Reference Implementation
+
+See `ManagedModelProviderAlert.tsx` in this directory for a complete reference implementation with the correct grammar.


### PR DESCRIPTION
Create reference files to fix a grammar error in the managed model provider credentials alert message.

The original alert message incorrectly used "is" with the plural noun "credentials" ("The bedrock provider credentials **is** managed..."). This PR provides a reference implementation and documentation for the corrected message ("The bedrock provider credentials **are** managed..."), as the affected component is part of a private SaaS repository.

---
[Slack Thread](https://langwatch.slack.com/archives/C06JEE9RMPE/p1765361994824119?thread_ts=1765361994.824119&cid=C06JEE9RMPE)

<a href="https://cursor.com/background-agent?bcId=bc-c99040e8-d30b-4337-9a83-f68d6c69bf4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c99040e8-d30b-4337-9a83-f68d6c69bf4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

