### PR TITLE
fix: display scenario runs with errors when MESSAGE_SNAPSHOT is missing

### DIFF
--- a/langwatch/src/app/api/scenario-events/[[...route]]/scenario-event.service.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/scenario-event.service.ts
@@ -63,16 +63,12 @@ export class ScenarioEventService {
       return null;
     }
 
-    // Get latest message snapshot event using dedicated repository method
+    // Get latest message snapshot event using dedicated repository method (optional)
     const latestMessageEvent =
       await this.eventRepository.getLatestMessageSnapshotEventByScenarioRunId({
         projectId,
         scenarioRunId,
       });
-
-    if (!latestMessageEvent) {
-      return null;
-    }
 
     // Get latest run finished event using dedicated repository method
     const latestRunFinishedEvent =
@@ -82,13 +78,13 @@ export class ScenarioEventService {
       });
 
     return {
-      scenarioId: latestMessageEvent.scenarioId,
-      batchRunId: latestMessageEvent.batchRunId,
-      scenarioRunId: latestMessageEvent.scenarioRunId,
+      scenarioId: runStartedEvent.scenarioId,
+      batchRunId: runStartedEvent.batchRunId,
+      scenarioRunId: runStartedEvent.scenarioRunId,
       status: latestRunFinishedEvent?.status ?? ScenarioRunStatus.IN_PROGRESS,
       results: latestRunFinishedEvent?.results ?? null,
-      messages: latestMessageEvent.messages ?? [],
-      timestamp: latestMessageEvent.timestamp ?? 0,
+      messages: latestMessageEvent?.messages ?? [],
+      timestamp: latestMessageEvent?.timestamp ?? runStartedEvent.timestamp,
       name: runStartedEvent?.metadata?.name ?? null,
       description: runStartedEvent?.metadata?.description ?? null,
       durationInMs:
@@ -380,18 +376,18 @@ export class ScenarioEventService {
       const runFinishedEvent = runFinishedEvents.get(scenarioRunId);
 
       // Skip if we don't have the required events
-      if (!runStartedEvent || !messageEvent) {
+      if (!runStartedEvent) {
         continue;
       }
 
       runs.push({
-        scenarioId: messageEvent.scenarioId,
-        batchRunId: messageEvent.batchRunId,
-        scenarioRunId: messageEvent.scenarioRunId,
+        scenarioId: runStartedEvent.scenarioId,
+        batchRunId: runStartedEvent.batchRunId,
+        scenarioRunId: runStartedEvent.scenarioRunId,
         status: runFinishedEvent?.status ?? ScenarioRunStatus.IN_PROGRESS,
         results: runFinishedEvent?.results ?? null,
-        messages: messageEvent.messages ?? [],
-        timestamp: messageEvent.timestamp ?? 0,
+        messages: messageEvent?.messages ?? [],
+        timestamp: messageEvent?.timestamp ?? 0,
         name: runStartedEvent?.metadata?.name ?? null,
         description: runStartedEvent?.metadata?.description ?? null,
         durationInMs:


### PR DESCRIPTION
Scenario runs that fail before sending MESSAGE_SNAPSHOT events were not displayed on the frontend. This change makes MESSAGE_SNAPSHOT optional in both getScenarioRunData and getScenarioRunDataBatch, requiring only RUN_STARTED to display a run.

- Remove null return when latestMessageEvent is missing
- Use runStartedEvent for required fields (scenarioId, batchRunId, etc.)
- Fallback to empty messages array when no snapshot exists
- Fallback timestamp to runStartedEvent.timestamp

Closes #984

# Related Issue

- Resolve #984