### PR TITLE
fix: respect prompt version when fetching prompts via CLI

### DIFF
--- a/typescript-sdk/__tests__/e2e/prompts/handlers.ts
+++ b/typescript-sdk/__tests__/e2e/prompts/handlers.ts
@@ -7,9 +7,12 @@ export const http = createOpenApiHttp<paths>({
 });
 
 export const handles = [
-  http.get("/api/prompts/{id}", ({ params, response }) => {
+  http.get("/api/prompts/{id}", ({ params, request, response }) => {
+    const url = new URL(request.url);
+    const versionParam = url.searchParams.get("version");
     const prompt = promptResponseFactory.build({
       id: params.id,
+      ...(versionParam && { version: parseInt(versionParam, 10) }),
     });
     return response(200).json(prompt);
   }),

--- a/typescript-sdk/src/cli/commands/add.ts
+++ b/typescript-sdk/src/cli/commands/add.ts
@@ -98,7 +98,7 @@ export const addCommand = async (
 
     try {
       // Fetch the prompt from the API
-      const prompt = await promptsApiService.get(name);
+      const prompt = await promptsApiService.get(name, { version });
 
       if (!prompt) {
         spinner.fail();

--- a/typescript-sdk/src/cli/commands/sync.ts
+++ b/typescript-sdk/src/cli/commands/sync.ts
@@ -124,7 +124,7 @@ export const syncCommand = async (): Promise<void> => {
           const lockEntry = lock.prompts[name];
 
           // Fetch the prompt from the API to check current version
-          const prompt = await promptsApiService.get(name);
+          const prompt = await promptsApiService.get(name, { version: versionSpec });
 
           if (prompt) {
             // Check if we need to update (new version or not materialized)

--- a/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts.integration.test.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts.integration.test.ts
@@ -26,8 +26,13 @@ const http = createOpenApiHttp<paths>({
 });
 
 const handlers = [
-  http.get("/api/prompts/{id}", ({ params, response }) => {
-    const prompt = promptResponseFactory.build({ id: params.id });
+  http.get("/api/prompts/{id}", ({ params, request, response }) => {
+    const url = new URL(request.url);
+    const versionParam = url.searchParams.get("version");
+    const prompt = promptResponseFactory.build({
+      id: params.id,
+      ...(versionParam && { version: parseInt(versionParam, 10) }),
+    });
     return response(200).json(prompt);
   }),
   http.post("/api/prompts", async ({ request, response }) => {

--- a/typescript-sdk/src/client-sdk/services/prompts/prompts-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/prompts-api.service.ts
@@ -95,12 +95,17 @@ export class PromptsApiService {
    * @throws {PromptsApiError} If the API call fails.
    */
   get = async (id: string, options?: { version?: string }): Promise<PromptResponse> => {
+    // Parse version to number, skip for "latest" or invalid values
+    const versionNumber = options?.version && options.version !== "latest"
+      ? parseInt(options.version, 10)
+      : undefined;
+
     const { data, error } = await this.apiClient.GET(
       "/api/prompts/{id}",
       {
         params: { path: { id } },
         query: {
-          version: options?.version,
+          version: Number.isNaN(versionNumber) ? undefined : versionNumber,
         },
       },
     );


### PR DESCRIPTION
## Summary

This PR fixes how the TypeScript SDK and CLI handle prompt versions.

The `add` and `sync` commands now pass the selected version through to the prompts API, and the `PromptsApiService` converts string version inputs into a numeric `version` query parameter. The E2E handlers and integration tests were updated to correctly parse and return the `version` field from the query string.

## Context

Previously, the CLI commands did not consistently propagate the prompt version when fetching prompts. This meant:

- `add` could ignore a provided version flag and effectively always fetch the latest version.
- `sync` could ignore the version stored in the lock file.
- The SDK could send a string value like `"latest"` directly as the `version` query parameter.

This change makes version handling explicit and predictable.

## Changes

- **CLI**
  - `add`: call `promptsApiService.get(name, { version })` so `add` respects the version flag.
  - `sync`: call `promptsApiService.get(name, { version: versionSpec })` so `sync` respects the lock file version.

- **Prompts API service**
  - Parse `options.version` to a number when it is present and not `"latest"`.
  - Only send `query.version` for valid numeric values; omit it for `"latest"` or invalid values.

- **Tests / E2E**
  - `GET /api/prompts/{id}` handlers in E2E and integration tests now:
    - Accept `request`.
    - Parse `version` from the request URL.
    - Pass the parsed numeric version into `promptResponseFactory.build` when present.

## Testing

- [ ] `pnpm test` (or the relevant TypeScript SDK test task)
- [ ] Run prompts-related integration tests
- [ ] Run prompts E2E tests
