### PR TITLE
feat: make Simulations a collapsible nav item with Scenarios and Runs

### DIFF
--- a/langwatch/src/components/MainMenu.tsx
+++ b/langwatch/src/components/MainMenu.tsx
@@ -8,6 +8,7 @@ import { api } from "../utils/api";
 import { featureIcons } from "../utils/featureIcons";
 import { projectRoutes } from "../utils/routes";
 import { useTableView } from "./messages/HeaderButtons";
+import { CollapsibleMenuGroup } from "./sidebar/CollapsibleMenuGroup";
 import { SideMenuLink } from "./sidebar/SideMenuLink";
 import { SupportMenu } from "./sidebar/SupportMenu";
 import { UsageIndicator } from "./sidebar/UsageIndicator";
@@ -96,13 +97,37 @@ export const MainMenu = React.memo(function MainMenu({
               isActive={router.pathname.includes("/messages")}
               showLabel={showExpanded}
             />
-            <PageMenuLink
-              path={projectRoutes.simulations.path}
+            <CollapsibleMenuGroup
               icon={featureIcons.simulations.icon}
               label={projectRoutes.simulations.title}
               project={project}
-              isActive={router.pathname.includes("/simulations")}
               showLabel={showExpanded}
+              children={[
+                {
+                  icon: featureIcons.scenarios.icon,
+                  label: projectRoutes.scenarios.title,
+                  href: project
+                    ? projectRoutes.scenarios.path.replace(
+                        "[project]",
+                        project.slug
+                      )
+                    : "/auth/signin",
+                  isActive: router.pathname.includes("/simulations/scenarios"),
+                },
+                {
+                  icon: featureIcons.simulation_runs.icon,
+                  label: projectRoutes.simulation_runs.title,
+                  href: project
+                    ? projectRoutes.simulation_runs.path.replace(
+                        "[project]",
+                        project.slug
+                      )
+                    : "/auth/signin",
+                  isActive:
+                    router.pathname.includes("/simulations") &&
+                    !router.pathname.includes("/simulations/scenarios"),
+                },
+              ]}
             />
             <PageMenuLink
               path={projectRoutes.evaluations.path}

--- a/langwatch/src/components/sidebar/CollapsibleMenuGroup.tsx
+++ b/langwatch/src/components/sidebar/CollapsibleMenuGroup.tsx
@@ -1,0 +1,196 @@
+import {
+  Box,
+  Collapsible,
+  HStack,
+  Spacer,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import type { Project } from "@prisma/client";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type React from "react";
+import { useState } from "react";
+import { trackEvent } from "../../utils/tracking";
+import { useColorRawValue } from "../ui/color-mode";
+import { Link } from "../ui/link";
+import { ICON_SIZE, MENU_ITEM_HEIGHT } from "./SideMenuLink";
+
+export type CollapsibleMenuChild = {
+  icon: React.ComponentType<{ size?: string | number; color?: string }>;
+  label: string;
+  href: string;
+  isActive: boolean;
+};
+
+export type CollapsibleMenuGroupProps = {
+  icon: React.ComponentType<{ size?: string | number; color?: string }>;
+  label: string;
+  children: CollapsibleMenuChild[];
+  project?: Project;
+  showLabel?: boolean;
+  defaultExpanded?: boolean;
+};
+
+export const CollapsibleMenuGroup = ({
+  icon: Icon,
+  label,
+  children,
+  project,
+  showLabel = true,
+  defaultExpanded = false,
+}: CollapsibleMenuGroupProps) => {
+  const gray600 = useColorRawValue("gray.600");
+  const isAnyChildActive = children.some((child) => child.isActive);
+  const [isExpanded, setIsExpanded] = useState(
+    defaultExpanded || isAnyChildActive,
+  );
+
+  const handleToggle = (details: { open: boolean }) => {
+    setIsExpanded(details.open);
+    trackEvent("side_menu_toggle", {
+      project_id: project?.id,
+      menu_item: label,
+      expanded: details.open,
+    });
+  };
+
+  return (
+    <VStack width="full" gap={0} align="start">
+      <Collapsible.Root
+        open={isExpanded && showLabel}
+        onOpenChange={handleToggle}
+      >
+        {/* Parent item - toggle button */}
+        <Collapsible.Trigger asChild>
+          <Box
+            as="button"
+            width="full"
+            cursor="pointer"
+            aria-label={`${isExpanded ? "Collapse" : "Expand"} ${label}`}
+          >
+            <HStack
+              width="full"
+              height={MENU_ITEM_HEIGHT}
+              gap={3}
+              paddingX={3}
+              borderRadius="lg"
+              backgroundColor={isAnyChildActive ? "gray.200" : "transparent"}
+              _hover={{
+                backgroundColor: "gray.200",
+              }}
+              transition="background-color 0.15s ease-in-out"
+            >
+              <Box
+                flexShrink={0}
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                width={`${ICON_SIZE}px`}
+                height={`${ICON_SIZE}px`}
+              >
+                <Icon size={ICON_SIZE} color={gray600} />
+              </Box>
+              {showLabel && (
+                <>
+                  <Text
+                    fontSize="14px"
+                    fontWeight="normal"
+                    color="gray.700"
+                    whiteSpace="nowrap"
+                  >
+                    {label}
+                  </Text>
+                  <Spacer />
+                  {isExpanded ? (
+                    <ChevronDown size={14} color={gray600} />
+                  ) : (
+                    <ChevronRight size={14} color={gray600} />
+                  )}
+                </>
+              )}
+            </HStack>
+          </Box>
+        </Collapsible.Trigger>
+
+        {/* Child items */}
+        <Collapsible.Content>
+          <VStack width="full" gap={0.5} align="start" paddingLeft={4}>
+            {children.map((child) => (
+              <CollapsibleMenuChildItem
+                key={child.href}
+                {...child}
+                project={project}
+                showLabel={showLabel}
+              />
+            ))}
+          </VStack>
+        </Collapsible.Content>
+      </Collapsible.Root>
+    </VStack>
+  );
+};
+
+type CollapsibleMenuChildItemProps = CollapsibleMenuChild & {
+  project?: Project;
+  showLabel?: boolean;
+};
+
+const CollapsibleMenuChildItem = ({
+  icon: Icon,
+  label,
+  href,
+  isActive,
+  project,
+  showLabel = true,
+}: CollapsibleMenuChildItemProps) => {
+  const gray600 = useColorRawValue("gray.600");
+
+  return (
+    <Link
+      variant="plain"
+      width="full"
+      href={href}
+      aria-label={label}
+      onClick={() => {
+        trackEvent("side_menu_click", {
+          project_id: project?.id,
+          menu_item: label,
+        });
+      }}
+    >
+      <HStack
+        width="full"
+        height={MENU_ITEM_HEIGHT}
+        gap={3}
+        paddingX={3}
+        borderRadius="lg"
+        backgroundColor={isActive ? "gray.200" : "transparent"}
+        _hover={{
+          backgroundColor: "gray.200",
+        }}
+        transition="background-color 0.15s ease-in-out"
+      >
+        <Box
+          flexShrink={0}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          width={`${ICON_SIZE}px`}
+          height={`${ICON_SIZE}px`}
+        >
+          <Icon size={ICON_SIZE} color={gray600} />
+        </Box>
+        {showLabel && (
+          <Text
+            fontSize="14px"
+            fontWeight="normal"
+            color="gray.700"
+            whiteSpace="nowrap"
+          >
+            {label}
+          </Text>
+        )}
+      </HStack>
+    </Link>
+  );
+};

--- a/langwatch/src/utils/featureIcons.ts
+++ b/langwatch/src/utils/featureIcons.ts
@@ -5,15 +5,17 @@
 import {
   BookText,
   CheckSquare,
+  FileText,
   Home,
   ListTree,
+  type LucideIcon,
   Pencil,
   Play,
+  PlayCircle,
   Settings,
   Table,
   TrendingUp,
   Workflow,
-  type LucideIcon,
 } from "lucide-react";
 
 export type FeatureKey =
@@ -21,6 +23,8 @@ export type FeatureKey =
   | "analytics"
   | "traces"
   | "simulations"
+  | "scenarios"
+  | "simulation_runs"
   | "evaluations"
   | "workflows"
   | "prompts"
@@ -58,6 +62,16 @@ export const featureIcons: Record<FeatureKey, FeatureConfig> = {
     icon: Play,
     color: "pink.500",
     label: "Simulations",
+  },
+  scenarios: {
+    icon: FileText,
+    color: "pink.500",
+    label: "Scenarios",
+  },
+  simulation_runs: {
+    icon: PlayCircle,
+    color: "pink.500",
+    label: "Runs",
   },
   evaluations: {
     icon: CheckSquare,

--- a/langwatch/src/utils/routes.ts
+++ b/langwatch/src/utils/routes.ts
@@ -112,6 +112,16 @@ export const projectRoutes = {
     path: "/[project]/simulations",
     title: "Simulations",
   },
+  simulation_runs: {
+    path: "/[project]/simulations",
+    title: "Runs",
+    parent: "simulations",
+  },
+  scenarios: {
+    path: "/[project]/simulations/scenarios",
+    title: "Scenarios",
+    parent: "simulations",
+  },
   simulations_batch: {
     path: "/[project]/simulations/[scenarioSetId]/[batchRunId]",
     title: "Simulations",


### PR DESCRIPTION
# BLOCKED -- Waiting for release

<img width="176" height="395" alt="Screenshot 2026-01-13 at 11 00 47" src="https://github.com/user-attachments/assets/86710129-0015-44d8-b4ed-579563e1a9e1" />


## Summary

- Add `CollapsibleMenuGroup` component for expandable navigation items in the sidebar
- Update routes to include `scenarios` and `simulation_runs` as child routes of `simulations`
- Add feature icons for the new navigation sub-items
- Replace flat "Simulations" menu item with a collapsible group containing:
  - **Scenarios** → `/simulations/scenarios` (Scenario Library)
  - **Runs** → `/simulations` (Simulation Sets/Runs)

## Test plan

- [ ] Verify the Simulations menu item expands/collapses on click
- [ ] Verify clicking "Scenarios" navigates to `/simulations/scenarios`
- [ ] Verify clicking "Runs" navigates to `/simulations`
- [ ] Verify correct active state highlighting for child items
- [ ] Verify the menu works correctly in both compact and expanded sidebar modes
- [ ] Verify the collapsible menu auto-expands when a child route is active

Closes #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1076