### PR TITLE
feat: add inline prompt creation drawer to scenario editor

### DIFF
--- a/langwatch/src/components/scenarios/PromptSelector.tsx
+++ b/langwatch/src/components/scenarios/PromptSelector.tsx
@@ -1,10 +1,13 @@
 import {
+  Box,
   Button,
   createListCollection,
+  HStack,
   Portal,
+  Text,
   useListbox,
 } from "@chakra-ui/react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Plus } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { Listbox } from "../ui/listbox";
 import { Popover } from "../ui/popover";
@@ -13,13 +16,18 @@ import { useAllPromptsForProject } from "../../prompts/hooks/useAllPromptsForPro
 interface PromptSelectorProps {
   value: string | null;
   onChange: (value: string | null) => void;
+  onCreatePrompt?: () => void;
 }
 
 /**
  * Dropdown selector for prompts from the library.
  * Uses Listbox with Popover pattern per Chakra recommendations.
  */
-export function PromptSelector({ value, onChange }: PromptSelectorProps) {
+export function PromptSelector({
+  value,
+  onChange,
+  onCreatePrompt,
+}: PromptSelectorProps) {
   const { data: prompts } = useAllPromptsForProject();
   const [inputValue, setInputValue] = useState("");
   const [open, setOpen] = useState(false);
@@ -52,6 +60,12 @@ export function PromptSelector({ value, onChange }: PromptSelectorProps) {
   });
 
   const selectedItem = listbox.selectedItems[0];
+
+  const handleCreatePrompt = () => {
+    setOpen(false);
+    setInputValue("");
+    onCreatePrompt?.();
+  };
 
   return (
     <Popover.Root
@@ -92,6 +106,20 @@ export function PromptSelector({ value, onChange }: PromptSelectorProps) {
               ))}
             </Listbox.Content>
           </Listbox.RootProvider>
+          {/* Add New Prompt */}
+          <Box borderTopWidth="1px" borderColor="gray.200">
+            <HStack
+              paddingX={3}
+              paddingY={2}
+              cursor="pointer"
+              _hover={{ bg: "gray.100" }}
+              color="blue.500"
+              onClick={handleCreatePrompt}
+            >
+              <Plus size={14} />
+              <Text fontSize="sm">Add New Prompt</Text>
+            </HStack>
+          </Box>
         </Popover.Content>
       </Portal>
     </Popover.Root>

--- a/langwatch/src/components/scenarios/QuickTestBar.tsx
+++ b/langwatch/src/components/scenarios/QuickTestBar.tsx
@@ -8,6 +8,7 @@ interface QuickTestBarProps {
   onTargetTypeChange: (type: TargetType) => void;
   selectedTargetId: string | null;
   onTargetIdChange: (value: string | null) => void;
+  onCreatePrompt?: () => void;
 }
 
 /**
@@ -19,6 +20,7 @@ export function QuickTestBar({
   onTargetTypeChange,
   selectedTargetId,
   onTargetIdChange,
+  onCreatePrompt,
 }: QuickTestBarProps) {
   return (
     <HStack gap={4}>
@@ -33,7 +35,11 @@ export function QuickTestBar({
       <HStack gap={2}>
         <TargetTypeSelector value={targetType} onChange={onTargetTypeChange} />
         {targetType === "prompt" ? (
-          <PromptSelector value={selectedTargetId} onChange={onTargetIdChange} />
+          <PromptSelector
+            value={selectedTargetId}
+            onChange={onTargetIdChange}
+            onCreatePrompt={onCreatePrompt}
+          />
         ) : (
           <HttpAgentSelector
             value={selectedTargetId}

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -13,6 +13,7 @@ import type { UseFormReturn } from "react-hook-form";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { useDrawer, useDrawerParams } from "../../hooks/useDrawer";
 import { api } from "../../utils/api";
+import { PromptEditorDrawer } from "../prompts/PromptEditorDrawer";
 import { Drawer } from "../ui/drawer";
 import { toaster } from "../ui/toaster";
 import { pollForScenarioRun } from "../../utils/pollForScenarioRun";
@@ -40,6 +41,7 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
   const formRef = useRef<UseFormReturn<ScenarioFormData> | null>(null);
   const [targetType, setTargetType] = useState<TargetType>("prompt");
   const [selectedTargetId, setSelectedTargetId] = useState<string | null>(null);
+  const [promptDrawerOpen, setPromptDrawerOpen] = useState(false);
   const runMutation = api.scenarios.run.useMutation();
   const scenarioId = params.scenarioId;
   const isOpen = props.open !== false && props.open !== undefined;
@@ -209,6 +211,7 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
             }}
             selectedTargetId={selectedTargetId}
             onTargetIdChange={setSelectedTargetId}
+            onCreatePrompt={() => setPromptDrawerOpen(true)}
           />
           <HStack gap={2}>
             <Button
@@ -231,6 +234,17 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
           </HStack>
         </Drawer.Footer>
       </Drawer.Content>
+
+      {/* Prompt Creation Drawer */}
+      <PromptEditorDrawer
+        open={promptDrawerOpen}
+        onClose={() => setPromptDrawerOpen(false)}
+        onSave={(prompt) => {
+          // Auto-select the newly created prompt
+          setSelectedTargetId(prompt.id);
+          setPromptDrawerOpen(false);
+        }}
+      />
     </Drawer.Root>
   );
 }


### PR DESCRIPTION
## Summary
- Add "Add New Prompt" button to PromptSelector dropdown
- Wire up existing PromptEditorDrawer in ScenarioFormDrawer  
- Auto-select newly created prompt after save

## Motivation
When creating a scenario, users currently have to navigate away to create prompts. This matches the existing HTTP agent creation pattern where users can create agents inline via a drawer.

## Test plan
- [ ] Open scenario editor
- [ ] Click "Select prompt" dropdown
- [ ] Click "Add New Prompt" button
- [ ] Verify PromptEditorDrawer opens
- [ ] Create a new prompt and save
- [ ] Verify prompt is auto-selected in dropdown

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)