### PR TITLE
fix(config): disable HSTS and upgrade-insecure-requests in development

### DIFF
--- a/langwatch/next.config.mjs
+++ b/langwatch/next.config.mjs
@@ -9,7 +9,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const aliasPath =
   process.env.DEPENDENCY_INJECTION_DIR ?? path.join("src", "injection");
 
-const isProduction = process.env.NODE_ENV === "production";
+const isProduction =
+  process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test";
 
 const cspHeader = `
     default-src 'self';


### PR DESCRIPTION
## Summary

- Conditionally enable HSTS header only in production to prevent Safari from caching the policy during local development
- Conditionally include `upgrade-insecure-requests` CSP directive only in production

## Problem

Safari aggressively caches HSTS policies and provides no easy way to clear them (unlike Chrome's `chrome://net-internals/#hsts`). When developing locally on `http://localhost`, this can cause persistent redirect issues.

## Solution

Added `isProduction` check based on `NODE_ENV` to conditionally apply:
- `Strict-Transport-Security` header
- `upgrade-insecure-requests` CSP directive

## Test Plan

- [ ] Run dev server (`npm run dev`) and verify no HSTS header in response
- [ ] Run production build (`NODE_ENV=production npm start`) and verify HSTS header is present