### PR TITLE
feat(dev): add Docker Compose dev environment with profiles

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,0 +1,314 @@
+# Development compose with profiles
+#
+# Setup:
+#   cp langwatch/.env.example langwatch/.env        # Add your keys
+#   cp langwatch_nlp/.env.example langwatch_nlp/.env  # Add OPENAI_API_KEY for NLP
+#
+# Usage:
+#   docker compose -f compose.dev.yml up                     # minimal: postgres + redis + app
+#   docker compose -f compose.dev.yml --profile search up    # + opensearch
+#   docker compose -f compose.dev.yml --profile nlp up       # + NLP + langevals
+#   docker compose -f compose.dev.yml --profile scenarios up # + scenario worker + bullboard + NLP (no opensearch)
+#   docker compose -f compose.dev.yml --profile test up      # + AI test server
+#   docker compose -f compose.dev.yml --profile full up      # everything
+#
+# Per-worktree ports (create .env.dev in your worktree):
+#   APP_PORT=5560
+#   BULLBOARD_PORT=3000
+#   AI_SERVER_PORT=3456
+#
+# Resource limits:
+#   minimal (dev):     ~4.3GB (postgres 256 + redis 64 + app 4096)
+#   scenarios:         ~5.6GB (+ workers 512 + scenario 512 + nlp 256 + bullboard 128 + ai-server 128)
+#   full:              ~6.6GB (+ opensearch 512 + langevals 256)
+#
+# Stop everything:
+#   docker compose -f compose.dev.yml --profile full down
+
+services:
+  # =============================================================================
+  # INFRASTRUCTURE (always started)
+  # =============================================================================
+
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: mydb
+      POSTGRES_USER: prisma
+      POSTGRES_PASSWORD: prisma
+    # No host port - accessed via docker network as "postgres:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U prisma -d mydb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+
+  redis:
+    image: redis:alpine
+    # No host port - accessed via docker network as "redis:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 64m
+          cpus: "0.25"
+
+  opensearch:
+    image: langwatch/opensearch-lite:latest
+    profiles: [search, full] # Not needed for scenarios-only work
+    environment:
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms256m -Xmx256m"
+      - "cluster.routing.allocation.disk.threshold_enabled=false"
+      - "bootstrap.memory_lock=false"
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=dev-password-not-for-prod
+      - "node.store.allow_mmap=false"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    # No host port - accessed via docker network as "opensearch:9200"
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200 || exit 1"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 40s
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "1.0"
+
+  # =============================================================================
+  # INIT (installs dependencies once for Linux, all containers share)
+  # =============================================================================
+
+  init:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./langwatch:/app
+      - app_modules:/app/node_modules
+    command: >
+      sh -c "
+        corepack enable &&
+        if [ ! -f node_modules/.modules.yaml ]; then
+          echo 'Installing dependencies for Linux...' &&
+          pnpm install &&
+          pnpm prisma generate
+        else
+          echo 'Dependencies already installed'
+        fi
+      "
+    environment:
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+
+  # =============================================================================
+  # APP (mounted for hot reload)
+  # =============================================================================
+
+  app:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./langwatch:/app
+      - app_modules:/app/node_modules
+    command: sh -c "corepack enable && pnpm run start:prepare:db && pnpm run start:app"
+    ports:
+      - "${APP_PORT:-5560}:5560"
+    environment:
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+      NODE_ENV: development
+      DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
+      # ELASTICSEARCH_NODE_URL comes from .env (shared dev elastic or local opensearch)
+      REDIS_URL: redis://redis:6379
+      LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
+      LANGEVALS_ENDPOINT: http://langevals:5562
+    env_file:
+      - langwatch/.env
+    depends_on:
+      init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    tty: true
+    stdin_open: true
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+          cpus: "2.0"
+
+  # =============================================================================
+  # WORKERS (profile: workers)
+  # =============================================================================
+
+  workers:
+    image: node:20
+    working_dir: /app
+    profiles: [workers, scenarios, full]
+    volumes:
+      - ./langwatch:/app
+      - app_modules:/app/node_modules
+    command: sh -c "corepack enable && pnpm tsx --watch --tsconfig tsconfig.workers.json src/workers.ts"
+    environment:
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+      NODE_ENV: development
+      DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
+      # ELASTICSEARCH_NODE_URL comes from .env
+      REDIS_URL: redis://redis:6379
+      LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
+      LANGEVALS_ENDPOINT: http://langevals:5562
+    env_file:
+      - langwatch/.env
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+
+  scenario-worker:
+    image: node:20
+    working_dir: /app
+    profiles: [scenarios, full]
+    volumes:
+      - ./langwatch:/app
+      - app_modules:/app/node_modules
+    command: sh -c "corepack enable && pnpm tsx --watch --tsconfig tsconfig.workers.json src/scenario-worker.ts"
+    environment:
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+      NODE_ENV: development
+      DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
+      # ELASTICSEARCH_NODE_URL comes from .env
+      REDIS_URL: redis://redis:6379
+      LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
+      LANGEVALS_ENDPOINT: http://langevals:5562
+    env_file:
+      - langwatch/.env
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+
+  # =============================================================================
+  # NLP SERVICE (profile: nlp)
+  # =============================================================================
+
+  langwatch_nlp:
+    image: langwatch/langwatch_nlp:latest
+    profiles: [nlp, scenarios, full]
+    env_file:
+      - langwatch_nlp/.env
+    # No host port - accessed via docker network as "langwatch_nlp:5561"
+    environment:
+      LANGWATCH_ENDPOINT: http://app:5560
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+
+  langevals:
+    image: langwatch/langevals:latest
+    profiles: [nlp, full]
+    # No host port - accessed via docker network as "langevals:5562"
+    environment:
+      DISABLE_EVALUATORS_PRELOAD: "true"
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+
+  # =============================================================================
+  # DEBUG TOOLS (profile: debug)
+  # =============================================================================
+
+  bullboard:
+    image: node:20
+    working_dir: /app
+    profiles: [debug, scenarios, full]
+    volumes:
+      - ./langwatch:/app
+      - app_modules:/app/node_modules
+    command: sh -c "corepack enable && pnpm bullboard"
+    ports:
+      - "${BULLBOARD_PORT:-6380}:6380"
+    environment:
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+      REDIS_URL: redis://redis:6379
+    env_file:
+      - langwatch/.env
+    depends_on:
+      init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+          cpus: "0.25"
+
+  # =============================================================================
+  # TEST TOOLS (profile: test)
+  # =============================================================================
+
+  ai-server:
+    image: node:20
+    working_dir: /app
+    profiles: [test, scenarios, full]
+    volumes:
+      - ./langwatch:/app
+      - app_modules:/app/node_modules
+    command: sh -c "corepack enable && pnpm tsx scripts/ai-server.ts"
+    ports:
+      - "${AI_SERVER_PORT:-3456}:3456"
+    environment:
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+    env_file:
+      - langwatch/.env
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+          cpus: "0.25"
+
+volumes:
+  db-data:
+  redis-data:
+  opensearch-data:
+  app_modules:

--- a/docs/adr/004-docker-dev-environment.md
+++ b/docs/adr/004-docker-dev-environment.md
@@ -1,0 +1,99 @@
+# ADR-004: Docker Compose Development Environment
+
+**Date:** 2026-01-23
+
+**Status:** Accepted
+
+## Context
+
+Local development required running multiple services (postgres, redis, opensearch, NLP, workers, app) manually in separate terminals. Different developers need different service combinations:
+- Frontend work: just app + postgres + redis
+- Scenario development: + workers + scenario-worker + bullboard + ai-server
+- Full stack: everything
+
+Additionally, macOS developers face platform mismatch issues: native Node modules (esbuild, Prisma) compiled for macOS don't work in Linux containers.
+
+## Decision
+
+We use Docker Compose with **profiles** for selective service startup, and an **init container** for cross-platform dependency installation.
+
+### Profiles
+
+| Profile | Services | Use Case |
+|---------|----------|----------|
+| (none) | postgres, redis, app | Minimal frontend dev |
+| search | + opensearch | Trace/search features |
+| nlp | + langwatch_nlp, langevals | Evaluations |
+| scenarios | + workers, scenario-worker, bullboard, ai-server, nlp | Scenario development |
+| full | Everything | Full integration |
+
+### Init Container Pattern
+
+```yaml
+init:
+  image: node:20
+  command: sh -c "pnpm install && pnpm prisma generate"
+  volumes:
+    - ./langwatch:/app
+    - app_modules:/app/node_modules  # Named volume
+
+app:
+  volumes:
+    - ./langwatch:/app
+    - app_modules:/app/node_modules  # Same volume
+  depends_on:
+    init:
+      condition: service_completed_successfully
+```
+
+The init container installs Linux-native dependencies into a named volume. All other containers share this volume, avoiding platform mismatch.
+
+### Networking
+
+Internal services (postgres, redis, opensearch, nlp, langevals) have no host port exposure. They communicate via Docker network hostnames (`postgres:5432`, `redis:6379`). Only app, bullboard, and ai-server expose ports for browser access.
+
+### Environment Variables
+
+`ELASTICSEARCH_NODE_URL` comes from `.env`, not hardcoded in compose. This allows developers to use shared dev Elasticsearch instead of local opensearch when the search profile isn't needed.
+
+### Resource Limits
+
+- **App:** 4GB memory, 2 CPUs (turbopack is hungry)
+- **Infra services:** Smaller limits (256MB-512MB) to prevent runaway
+
+No limit means a misbehaving container can starve the whole system. Too tight means OOM kills (exit code 137).
+
+## Rationale
+
+**Why profiles over multiple compose files?**
+Profiles keep everything in one file, easier to maintain. `--profile scenarios` is clearer than `-f compose.yml -f compose.scenarios.yml`.
+
+**Why init container over host install?**
+macOS binaries don't work in Linux containers. We tried `.npmrc` supportedArchitectures but it was unreliable. Init container guarantees correct platform binaries.
+
+**Why node:20 over node:20-slim?**
+Slim lacks build tools (python, gcc) for native modules and OpenSSL for Prisma. The ~200MB size difference is negligible for dev.
+
+**Why custom server over next dev?**
+The app uses `tsx src/server.ts` which wraps Next.js with metrics, proper upgrade handling, and other customizations. Plain `next dev` doesn't include these.
+
+## Consequences
+
+**Commands:**
+```bash
+make dev              # Minimal
+make dev-scenarios    # Scenario work
+make dev-full         # Everything
+make quickstart       # Interactive chooser
+make down             # Stop all
+```
+
+**Key files:**
+- `compose.dev.yml` - Docker Compose configuration
+- `scripts/dev.sh` - Interactive profile chooser
+- `Makefile` - Convenience targets
+
+**Trade-offs accepted:**
+- First startup slower (init container installs deps)
+- Requires Docker Desktop with sufficient memory allocation
+- Host node_modules still needed for IDE tooling (separate from container's)

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Interactive development environment launcher
+set -e
+
+COMPOSE="docker compose -f compose.dev.yml"
+LAST_CHOICE_FILE="/tmp/.langwatch-dev-last-choice"
+
+# Check for required .env files
+check_env_files() {
+  local missing=0
+  if [ ! -f "langwatch/.env" ]; then
+    echo "WARNING: langwatch/.env not found"
+    echo "  → cp langwatch/.env.example langwatch/.env"
+    missing=1
+  fi
+  if [ ! -f "langwatch_nlp/.env" ]; then
+    echo "WARNING: langwatch_nlp/.env not found (needed for nlp/scenarios profiles)"
+    echo "  → cp langwatch_nlp/.env.example langwatch_nlp/.env"
+    missing=1
+  fi
+  if [ $missing -eq 1 ]; then
+    echo ""
+    read -p "Continue anyway? [y/N]: " confirm
+    [[ ! $confirm =~ ^[Yy]$ ]] && exit 1
+  fi
+}
+
+# Run prep steps on host (curl available, prisma generate needs node_modules)
+ensure_prepared() {
+  check_env_files
+  cd langwatch
+  # Host needs its own node_modules for prep (separate from container's Linux deps)
+  if [ ! -d node_modules ]; then
+    echo "Installing host dependencies (for prep)..."
+    pnpm install
+  fi
+  # Prepare files (prisma generate, curl download, etc)
+  echo "Preparing files..."
+  pnpm run start:prepare:files 2>/dev/null || true
+  cd ..
+}
+
+# Find a free port starting from base
+find_free_port() {
+  local port=$1
+  while lsof -i :$port >/dev/null 2>&1; do
+    port=$((port + 1))
+  done
+  echo $port
+}
+
+# Auto-detect free ports
+export APP_PORT=$(find_free_port 5560)
+export BULLBOARD_PORT=$(find_free_port 3000)
+export AI_SERVER_PORT=$(find_free_port 3456)
+
+# Load last choice if exists
+LAST=""
+if [ -f "$LAST_CHOICE_FILE" ]; then
+  LAST=$(cat "$LAST_CHOICE_FILE")
+fi
+
+echo ""
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║              LangWatch Development Environment             ║"
+echo "╠════════════════════════════════════════════════════════════╣"
+echo "║  Ports: app=$APP_PORT  bullboard=$BULLBOARD_PORT  ai-server=$AI_SERVER_PORT"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo ""
+PROFILE_NAMES=("" "dev" "dev-search" "dev-nlp" "dev-scenarios" "dev-test" "dev-full")
+
+echo "Select a profile:"
+echo ""
+echo "  1) dev           - Minimal (postgres, redis, app)"
+echo "  2) dev-search    - + opensearch (for traces/search)"
+echo "  3) dev-nlp       - + NLP + langevals (for evaluations)"
+echo "  4) dev-scenarios - + scenario worker + bullboard + NLP"
+echo "  5) dev-test      - + AI test server"
+echo "  6) dev-full      - Everything"
+echo ""
+echo "  r) rebuild       - Rebuild (removes node_modules, restarts)"
+echo "  d) down          - Stop all services"
+echo "  l) logs          - Tail logs"
+echo "  p) ps            - Show running services"
+echo "  c) clean         - Stop and remove all data"
+echo "  q) quit"
+echo ""
+
+if [ -n "$LAST" ]; then
+  echo "Or just hit enter to use previous (${PROFILE_NAMES[$LAST]})"
+  echo ""
+fi
+read -p "Choice: " choice
+[ -z "$choice" ] && [ -n "$LAST" ] && choice="$LAST"
+
+case $choice in
+  1)
+    echo "$choice" > "$LAST_CHOICE_FILE"
+    ensure_prepared
+    echo "Starting: postgres + redis + app..."
+    $COMPOSE up
+    ;;
+  2)
+    echo "$choice" > "$LAST_CHOICE_FILE"
+    ensure_prepared
+    echo "Starting: + opensearch..."
+    $COMPOSE --profile search up
+    ;;
+  3)
+    echo "$choice" > "$LAST_CHOICE_FILE"
+    ensure_prepared
+    echo "Starting: + nlp + langevals..."
+    $COMPOSE --profile nlp up
+    ;;
+  4)
+    echo "$choice" > "$LAST_CHOICE_FILE"
+    ensure_prepared
+    echo "Starting: scenarios (+ workers + bullboard + nlp)..."
+    $COMPOSE --profile scenarios up
+    ;;
+  5)
+    echo "$choice" > "$LAST_CHOICE_FILE"
+    ensure_prepared
+    echo "Starting: + ai-server..."
+    $COMPOSE --profile test up
+    ;;
+  6)
+    echo "$choice" > "$LAST_CHOICE_FILE"
+    ensure_prepared
+    echo "Starting: full stack..."
+    $COMPOSE --profile full up
+    ;;
+  r|R)
+    echo "Rebuilding (removes container node_modules)..."
+    $COMPOSE --profile full down
+    docker volume rm "${PWD##*/}_app_modules" 2>/dev/null || true
+    # Re-run with last profile
+    if [ -n "$LAST" ]; then
+      echo "Restarting with last profile..."
+      exec "$0"
+    else
+      echo "Done. Run quickstart again to start."
+    fi
+    ;;
+  d|D)
+    echo "Stopping all services..."
+    $COMPOSE --profile full down
+    ;;
+  l|L)
+    echo "Tailing logs..."
+    $COMPOSE --profile full logs -f
+    ;;
+  p|P)
+    $COMPOSE --profile full ps
+    ;;
+  c|C)
+    read -p "This will delete all data. Are you sure? [y/N]: " confirm
+    if [[ $confirm =~ ^[Yy]$ ]]; then
+      echo "Stopping and removing volumes..."
+      $COMPOSE --profile full down -v
+      echo "Done. Next start will be fresh."
+    else
+      echo "Cancelled."
+    fi
+    ;;
+  q|Q)
+    echo "Bye!"
+    exit 0
+    ;;
+  *)
+    echo "Invalid choice"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add `compose.dev.yml` with profiles for selective service startup
- Add interactive launcher script (`scripts/dev.sh`)
- Add Makefile targets: `make dev`, `make dev-scenarios`, `make dev-full`, etc.
- Add ADR documenting design decisions (ADR-004)

## Profiles

| Profile | Services | Use Case |
|---------|----------|----------|
| (none) | postgres, redis, app | Minimal frontend dev |
| search | + opensearch | Trace/search features |
| nlp | + langwatch_nlp, langevals | Evaluations |
| scenarios | + workers, scenario-worker, bullboard, ai-server, nlp | Scenario development |
| full | Everything | Full integration |

## Test plan
- [ ] Run `make quickstart` and verify interactive menu works
- [ ] Run `make dev` and verify app starts on port 5560
- [ ] Run `make dev-scenarios` and verify all scenario services start
- [ ] Run `make down` and verify all services stop

Closes #1183

🤖 Generated with [Claude Code](https://claude.com/claude-code)