### PR TITLE
docs: improve Claude Code agent configuration and BDD workflow

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -158,7 +158,7 @@ The orchestrator reads only feature files and planning docs, not source code.
 ```
 ORCHESTRATOR (main thread)
 │
-├── /plan  ──────► PLAN AGENT
+├── /plan  ──────► (self-contained skill)
 │                  - Feature file creation
 │                  - Acceptance criteria
 │

--- a/.claude/agents/repo-sherpa.md
+++ b/.claude/agents/repo-sherpa.md
@@ -39,3 +39,81 @@ Read `docs/adr/` (Architecture Decision Records) to explain decisions:
 - Match existing patterns and conventions when making changes
 - Be concise - don't dump information unless asked
 - Acknowledge uncertainty and offer to investigate
+
+## Quick Reference Map
+
+### Root Files
+| File | Purpose |
+|------|---------|
+| `CLAUDE.md` | Main entry point, references AGENTS.md |
+| `AGENTS.md` | Commands, structure, common mistakes - primary developer reference |
+| `README.md` | Public-facing project overview |
+| `Makefile` | Dev environment commands (make dev, make dev-full) |
+
+### .claude/ Structure
+```
+.claude/
+├── README.md           # Orchestration system documentation
+├── agents/             # Agent definitions (personas)
+│   ├── README.md       # How agents work
+│   ├── coder.md        # TDD implementation agent
+│   ├── repo-sherpa.md  # This file - meta-layer ownership
+│   └── uncle-bob-reviewer.md  # SOLID/clean code reviewer
+├── skills/             # Entry points that invoke agents
+│   ├── README.md       # How skills work
+│   ├── code/           # /code → coder agent
+│   ├── review/         # /review → uncle-bob-reviewer
+│   ├── sherpa/         # /sherpa → repo-sherpa
+│   ├── plan/           # /plan → creates feature files
+│   ├── orchestrate/    # /orchestrate → manages plan/code/review loop
+│   └── implement/      # /implement #123 → fetches issue, invokes orchestrate
+└── commands/           # Simple slash commands (no forks)
+    ├── README.md       # Commands vs Skills
+    ├── onboard.md      # /onboard - orientation + review
+    ├── refocus.md      # /refocus - realign with BDD
+    ├── pr-review.md    # /pr-review - address PR comments
+    └── worktree.md     # /worktree - create git worktree
+```
+
+### docs/ Structure
+```
+docs/
+├── README.md              # Documentation index
+├── CODING_STANDARDS.md    # Clean code, SOLID principles
+├── TESTING_PHILOSOPHY.md  # Test hierarchy, BDD workflow
+├── adr/                   # Architecture Decision Records
+│   ├── 001-rbac.md        # Org → Team → Project hierarchy
+│   ├── 002-event-sourcing.md  # Traces/evaluations storage
+│   ├── 003-logging.md     # Structured logging
+│   └── 004-docker-dev-environment.md  # Make targets
+├── best_practices/        # Language/framework conventions
+│   ├── typescript.md
+│   ├── react.md
+│   ├── git.md
+│   └── repository-service.md
+└── design/                # UI design system
+```
+
+### specs/ Structure
+- `specs/README.md` - BDD guidance and test level decisions
+- `specs/<area>/<feature>.feature` - Feature files (requirements source of truth)
+- ~70 feature files organized by domain area
+
+### Key Workflows
+
+**Implementing a feature:**
+1. `/implement #123` - Start from GitHub issue
+2. Orchestrator checks for feature file → `/plan` if missing
+3. `/code` implements with TDD
+4. `/review` for quality gate
+5. Loop until complete
+
+**Updating meta-layer:**
+1. `/sherpa` with the change request
+2. Sherpa investigates current state
+3. Updates agents/skills/docs in alignment
+4. Updates this reference section if structure changes
+
+**Commands vs Skills:**
+- Commands (`.claude/commands/`) - Simple instructions, same thread
+- Skills (`.claude/skills/`) - Can fork context and invoke agents

--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -19,12 +19,13 @@ Simple slash commands that provide instructions to Claude without spawning agent
 | Command | Purpose |
 |---------|---------|
 | `/onboard` | Orientation via sherpa + code review |
+| `/refocus` | Compact context and realign with BDD workflow |
 | `/pr-review` | Address PR comments from Code Rabbit/reviewers |
 | `/worktree` | Create git worktree with proper setup |
-| `/review` | Invoke uncle-bob-reviewer (legacy, prefer skill) |
-| `/sherpa` | Invoke repo-sherpa (legacy, prefer skill) |
+| `/review` | Quick review invocation (same thread) |
+| `/sherpa` | Quick sherpa invocation (same thread) |
 
-Note: `/review` and `/sherpa` commands exist for backward compatibility. The skills (`skills/review/`, `skills/sherpa/`) are preferred as they use `context: fork` for proper isolation.
+Note: `/review` and `/sherpa` commands run in the same thread. The skills (`skills/review/`, `skills/sherpa/`) use `context: fork` for isolated agent runs - prefer skills when you need clean separation or are delegating from an orchestrator.
 
 ## Writing Commands
 

--- a/.claude/commands/refocus.md
+++ b/.claude/commands/refocus.md
@@ -1,0 +1,31 @@
+# Refocus
+
+Stop and realign with BDD workflow before continuing.
+
+## Immediate Actions
+
+1. **Compact context** - Run `/compact` to clear noise and focus on essentials
+
+2. **Review relevant specs** - Find and read feature files in `specs/` related to current work:
+   - List subdirectories: `ls specs/`
+   - Read relevant `.feature` files - these ARE the requirements
+   - If no feature file exists for your current task, that is a problem - create one first
+
+3. **Review best practices**:
+   - `AGENTS.md` - common mistakes table
+   - `docs/TESTING_PHILOSOPHY.md` - workflow and test hierarchy
+   - `specs/README.md` - BDD guidance
+
+4. **Rebuild the todo list** - Replace the current todo list with:
+   - A "Review feature file for [area]" task (in_progress)
+   - Specific implementation tasks derived from the feature scenarios
+   - A final task: "Refocus check - verify alignment with spec before completing"
+
+5. **State your plan** - Before writing any code, explicitly state:
+   - Which feature file(s) you are implementing
+   - Which scenario(s) you are working on
+   - What test level (E2E/integration/unit) comes first
+
+## Why This Exists
+
+Agents repeatedly implement code without checking existing specs. This wastes time and creates work that diverges from requirements. The specs are not suggestions - they are the source of truth.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -10,10 +10,17 @@ These skills use `context: fork` to spawn agents in isolated contexts:
 
 | Skill | Agent | Purpose |
 |-------|-------|---------|
-| `/plan` | Plan (built-in) | Create feature file with acceptance criteria |
 | `/code` | coder | Implement with TDD, self-verification |
 | `/review` | uncle-bob-reviewer | SOLID/Clean Code review |
 | `/sherpa` | repo-sherpa | Documentation, DX, meta-layer |
+
+### Self-Contained Skills
+
+These skills use `context: fork` but contain their own instructions:
+
+| Skill | Purpose |
+|-------|---------|
+| `/plan` | Create feature file with acceptance criteria |
 
 ### Orchestration Skills (Opt-In)
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -9,6 +9,24 @@ argument-hint: "[requirements or feature description]"
 
 You are the **orchestrator**. You hold requirements, delegate to agents, and verify outcomes. You do not read or write code directly.
 
+## First: Create a Task Checklist
+
+Before delegating any work, create a task list using **TaskCreate** to map out the flow:
+
+1. Break down the requirements into discrete tasks
+2. Each task should map to an acceptance criterion
+3. Use tasks to track progress through the plan → code → review loop
+
+Example:
+```
+TaskCreate: "Create feature file for user auth"
+TaskCreate: "Implement login endpoint"
+TaskCreate: "Implement logout endpoint"
+TaskCreate: "Review implementation"
+```
+
+Update task status as you progress (`in_progress` when starting, `completed` when done).
+
 ## Source of Work
 
 All work should be tied to a GitHub issue. If you don't have issue context:
@@ -27,10 +45,13 @@ Be aware of context size. When context grows large, ask the user if they'd like 
 - Check if a feature file exists in `specs/features/`
 - If not, invoke `/plan` to create one first
 - Read the feature file to understand acceptance criteria
+- Create tasks for each acceptance criterion
 
 ### 2. Implement
+- Mark task as `in_progress`
 - Invoke `/code` with the feature file path and requirements
 - Coder agent implements with TDD and returns a summary
+- Mark task as `completed` when done
 
 ### 3. Verify
 - Check the coder's summary against acceptance criteria
@@ -38,11 +59,13 @@ Be aware of context size. When context grows large, ask the user if they'd like 
 - Max 3 iterations, then escalate to user
 
 ### 4. Review (Required)
+- Mark review task as `in_progress`
 - Invoke `/review` to run quality gate
 - If issues found → invoke `/code` with reviewer feedback
-- If approved → complete
+- If approved → mark task as `completed`
 
 ### 5. Complete
+- Verify all tasks are completed
 - Report summary to user
 
 ## Boundaries

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -2,12 +2,20 @@
 name: plan
 description: "Create a feature file with acceptance criteria before implementation. Use when no specs/features/*.feature file exists for the work."
 context: fork
-agent: Plan
 user-invocable: true
 argument-hint: "[feature description or issue summary]"
 ---
 
 Create a BDD feature file for: $ARGUMENTS
+
+## First: Read the Spec Guidelines
+
+**Before writing any feature file, read `specs/README.md`** to understand:
+- What makes a good feature file
+- How to achieve non-overlapping test coverage
+- The distinction between @e2e, @integration, and @unit scenarios
+
+Also reference `docs/TESTING_PHILOSOPHY.md` for the test hierarchy and decision tree.
 
 ## Requirements Source
 
@@ -19,29 +27,61 @@ Work should be tied to a GitHub issue. If requirements are unclear:
 ## Output Location
 Write to `specs/features/<feature-name>.feature`
 
+## What Makes a Good Feature File
+
+### Feature Complete
+- Captures ALL acceptance criteria from the issue
+- Describes ALL user-visible behaviors
+- No gaps - if it's not in the feature file, it's not in scope
+- This file IS the specification of work to be done
+
+### Non-Overlapping Test Coverage
+
+Each scenario must be tagged with exactly ONE of:
+
+| Tag | What It Tests | Mocking |
+|-----|---------------|---------|
+| `@e2e` | Happy paths, full system flow | None |
+| `@integration` | Edge cases, error handling, module boundaries | External services only |
+| `@unit` | Pure logic, branches, single function | Collaborators |
+
+**Critical**: Don't duplicate coverage across levels. If E2E covers the happy path, integration tests edge cases, unit tests logic branches.
+
 ## Feature File Format
+
 ```gherkin
 Feature: <Feature Name>
   As a <role>
   I want <goal>
   So that <benefit>
 
-  @unit
-  Scenario: <unit test scenario>
+  # Happy path - full system
+  @e2e
+  Scenario: User successfully completes main flow
     Given <precondition>
     When <action>
     Then <expected result>
 
+  # Edge cases and error handling
   @integration
-  Scenario: <integration test scenario>
-    ...
+  Scenario: Handles invalid input gracefully
+    Given <precondition>
+    When <invalid action>
+    Then <error handling>
+
+  # Pure logic branches
+  @unit
+  Scenario: Validates input format
+    Given <input state>
+    When <validation runs>
+    Then <specific validation result>
 ```
 
 ## Guidelines
-- Extract clear acceptance criteria from the GitHub issue
-- Tag scenarios with @unit, @integration, or @e2e
+
+- One invariant per scenario (test one thing)
+- Scenarios should be independent
 - Focus on behavior, not implementation
-- Keep scenarios independent and atomic
-- If requirements are ambiguous, ask for clarification before writing
+- Ask for clarification if requirements are ambiguous
 
 Return the file path when complete.

--- a/docs/TESTING_PHILOSOPHY.md
+++ b/docs/TESTING_PHILOSOPHY.md
@@ -63,6 +63,8 @@ const user = { id: "1", role: "guest" }
 
 ## Workflow
 
+See `specs/README.md` for detailed BDD guidance.
+
 1. **Spec first**: Write a `.feature` file in `specs/`. Use tags: `@e2e`, `@integration`, `@unit` only.
 2. **Challenge**: LLM/reviewer challenges missing edge cases before implementation.
 3. **Examples drive E2E**: Working examples in `examples/` are wrapped by E2E tests.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,43 @@
+# Specs
+
+BDD feature files describing user-facing behavior.
+
+## Before Implementing
+
+1. Check if a feature file already exists for your area
+2. Read the scenarios - they ARE the requirements
+3. If no feature file exists, create one first
+
+## What Makes a Good Feature File
+
+A feature file should be a **complete specification** of the work:
+
+### Feature Complete
+- All acceptance criteria from the issue are captured as scenarios
+- All user-visible behaviors are described
+- No gaps - if it's not in the feature file, it's not in scope
+
+### Non-Overlapping Test Coverage
+Each test level has a distinct purpose (see `docs/TESTING_PHILOSOPHY.md`):
+
+| Tag | Purpose | What It Tests |
+|-----|---------|---------------|
+| `@e2e` | Happy paths via real examples | Full system, no mocks |
+| `@integration` | Edge cases, error handling | Module boundaries, external services mocked |
+| `@unit` | Pure logic, branches | Single function/class, collaborators mocked |
+
+**Avoid overlap**: If an E2E test covers the happy path, don't duplicate it in integration. Integration tests edge cases. Unit tests logic branches.
+
+### Scenario Design
+- One invariant per scenario
+- Scenarios should be independent
+- Focus on behavior, not implementation
+- "When I run a scenario, traces appear" not "spawn child process with env vars"
+
+## What Goes Here
+
+- Observable behavior, not implementation details
+- User stories, not technical architecture
+- Complete coverage plan with appropriate test levels
+
+See `docs/TESTING_PHILOSOPHY.md` for detailed testing workflow and decision tree.


### PR DESCRIPTION
## Summary
- Add `/refocus` command to realign with BDD workflow when lost
- Update orchestration skill to create task checklists using TaskCreate
- Expand repo-sherpa with quick reference map
- Update `/plan` skill to reference specs/README.md
- Add `specs/README.md` with BDD guidance
- Clean up AGENTS.md with common mistakes table
- Add cross-reference to specs/README.md in TESTING_PHILOSOPHY.md

## Test plan
- [ ] Run `/refocus` and verify it provides BDD realignment steps
- [ ] Run `/plan` and verify it reads specs/README.md first
- [ ] Verify AGENTS.md has clear guidance for spec-first development

Closes #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)