### PR TITLE
fix(model-providers): save API key when switching from env vars to custom

### DIFF
--- a/langwatch/src/hooks/useModelProviderForm.ts
+++ b/langwatch/src/hooks/useModelProviderForm.ts
@@ -14,6 +14,7 @@ import {
   getDisplayKeysForProvider,
   getEffectiveDefaults,
   getSchemaShape,
+  hasUserEnteredNewApiKey,
   hasUserModifiedNonApiKeyFields,
   isProviderDefaultModel,
 } from "../utils/modelProviderHelpers";
@@ -448,13 +449,17 @@ export function useModelProviderForm(
 
       // Determine what customKeys to send:
       // - Not using env vars: send all customKeys
-      // - Using env vars with non-API-key changes: send filtered keys (without masked API keys)
+      // - Using env vars with new API key or non-API-key changes: send the keys
       // - Using env vars without changes: send undefined (don't update)
       let customKeysToSend: Record<string, unknown> | undefined;
+      const userEnteredNewKey = hasUserEnteredNewApiKey(customKeys);
       if (!isUsingEnvVars) {
         customKeysToSend = { ...customKeys };
-      } else if (hasNonApiKeyChanges) {
-        customKeysToSend = filterMaskedApiKeys(customKeys);
+      } else if (userEnteredNewKey || hasNonApiKeyChanges) {
+        // User entered a new key or modified non-API-key fields - send the keys
+        customKeysToSend = userEnteredNewKey
+          ? { ...customKeys }
+          : filterMaskedApiKeys(customKeys);
       } else {
         customKeysToSend = undefined;
       }


### PR DESCRIPTION
## Summary
Bug fix for `useModelProviderForm` - when a user has env vars configured but enters a new API key, the key should be saved.

## Problem
When `isUsingEnvVars` was true and a user entered a new API key, the form would filter out the key thinking it was a masked placeholder (`***...***`).

## Solution
Add `hasUserEnteredNewApiKey()` check to detect when user has actually typed a new key (not just the masked placeholder), and send it to the server in that case.

## Test plan
- [ ] Configure a model provider using env vars
- [ ] Enter a new API key in the custom keys field
- [ ] Save - verify the new key is persisted
- [ ] Reload - verify the provider now uses the custom key

Closes #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)