### PR TITLE
feat: expose feature flags to frontend via session

### DIFF
--- a/langwatch/src/components/MainMenu.tsx
+++ b/langwatch/src/components/MainMenu.tsx
@@ -37,9 +37,9 @@ export const MainMenu = React.memo(function MainMenu({
     { enabled: !!project?.id },
   );
 
-  // Feature flag: show collapsible navigation for @langwatch.ai users
+  // Feature flag: show collapsible navigation for users with SCENARIOS feature
   const showScenariosOnThePlatform =
-    session?.user?.email?.endsWith("@langwatch.ai");
+    session?.user?.enabledFeatures?.includes("SCENARIOS");
 
   // In compact mode, show expanded view on hover
   const showExpanded = !isCompact || isHovered;

--- a/langwatch/src/server/featureFlag/__tests__/featureFlag.service.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/featureFlag.service.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { FeatureFlagService } from "../featureFlag.service";
+import { FeatureFlagServiceMemory } from "../featureFlagService.memory";
+
+// Mock the environment to use memory service
+vi.mock("~/env.mjs", () => ({
+  env: {
+    POSTHOG_KEY: undefined,
+  },
+}));
+
+// Mock langwatch tracer
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: async (
+      _name: string,
+      _options: unknown,
+      fn: (span: { setAttribute: () => void }) => Promise<unknown>,
+    ) => fn({ setAttribute: () => {} }),
+  }),
+}));
+
+// Mock logger
+vi.mock("~/utils/logger", () => ({
+  createLogger: () => ({
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+describe("FeatureFlagService.getEnabledFlags", () => {
+  describe("FeatureFlagServiceMemory", () => {
+    let memoryService: FeatureFlagServiceMemory;
+
+    beforeEach(() => {
+      memoryService = new FeatureFlagServiceMemory();
+    });
+
+    it("returns only enabled flags from the provided list", async () => {
+      // Arrange: set up some flags
+      memoryService.setFlag("FLAG_A", true);
+      memoryService.setFlag("FLAG_B", false);
+      memoryService.setFlag("FLAG_C", true);
+
+      // Act
+      const result = await memoryService.getEnabledFlags(
+        ["FLAG_A", "FLAG_B", "FLAG_C"],
+        "user-123",
+      );
+
+      // Assert
+      expect(result).toEqual(["FLAG_A", "FLAG_C"]);
+    });
+
+    it("returns empty array when flagKeys is empty", async () => {
+      // Arrange
+      memoryService.setFlag("FLAG_A", true);
+
+      // Act
+      const result = await memoryService.getEnabledFlags([], "user-123");
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when no flags are enabled", async () => {
+      // Arrange: all flags disabled
+      memoryService.setFlag("FLAG_A", false);
+      memoryService.setFlag("FLAG_B", false);
+
+      // Act
+      const result = await memoryService.getEnabledFlags(
+        ["FLAG_A", "FLAG_B"],
+        "user-123",
+      );
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+
+    it("returns flags that default to true when not explicitly set", async () => {
+      // Arrange: FLAG_UNKNOWN is not set, should default to true
+      // Act
+      const result = await memoryService.getEnabledFlags(
+        ["FLAG_UNKNOWN"],
+        "user-123",
+      );
+
+      // Assert: default is true
+      expect(result).toEqual(["FLAG_UNKNOWN"]);
+    });
+  });
+
+  describe("FeatureFlagService (delegating)", () => {
+    it("delegates getEnabledFlags to underlying service", async () => {
+      // Arrange
+      const service = FeatureFlagService.create();
+      const memoryService = service.getService() as FeatureFlagServiceMemory;
+      memoryService.setFlag("FEATURE_X", true);
+      memoryService.setFlag("FEATURE_Y", false);
+
+      // Act
+      const result = await service.getEnabledFlags(
+        ["FEATURE_X", "FEATURE_Y"],
+        "user-456",
+      );
+
+      // Assert
+      expect(result).toEqual(["FEATURE_X"]);
+    });
+  });
+});

--- a/langwatch/src/server/featureFlag/featureFlag.service.ts
+++ b/langwatch/src/server/featureFlag/featureFlag.service.ts
@@ -39,6 +39,16 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
   }
 
   /**
+   * Get all enabled flags from a list of flag keys for a given user or tenant/project.
+   */
+  async getEnabledFlags(
+    flagKeys: string[],
+    distinctId: string,
+  ): Promise<string[]> {
+    return this.service.getEnabledFlags(flagKeys, distinctId);
+  }
+
+  /**
    * Create the appropriate service based on environment.
    */
   private createService(): FeatureFlagServiceInterface {

--- a/langwatch/src/server/featureFlag/index.ts
+++ b/langwatch/src/server/featureFlag/index.ts
@@ -2,3 +2,8 @@ export { FeatureFlagService, featureFlagService } from "./featureFlag.service";
 export { FeatureFlagServiceMemory } from "./featureFlagService.memory";
 export { FeatureFlagServicePostHog } from "./featureFlagService.posthog";
 export type { FeatureFlagServiceInterface } from "./types";
+
+/**
+ * Feature flags that are exposed to the frontend via session.
+ */
+export const FRONTEND_FEATURE_FLAGS = ["SCENARIOS"] as const;

--- a/langwatch/src/server/featureFlag/types.ts
+++ b/langwatch/src/server/featureFlag/types.ts
@@ -10,4 +10,10 @@ export interface FeatureFlagServiceInterface {
     distinctId: string,
     defaultValue?: boolean,
   ): Promise<boolean>;
+
+  /**
+   * Get all enabled flags from a list of flag keys for a given user or tenant/project.
+   * Returns an array of flag keys that are enabled.
+   */
+  getEnabledFlags(flagKeys: string[], distinctId: string): Promise<string[]>;
 }


### PR DESCRIPTION
## Summary

Expose the existing `FeatureFlagService` to the frontend by adding enabled feature flags to the user session.

**Changes:**
- Add `getEnabledFlags(flagKeys, distinctId)` method to FeatureFlagServiceInterface
- Implement in both PostHog and Memory services
- Add `FRONTEND_FEATURE_FLAGS` constant defining which flags to expose
- Update session callback to fetch and include `enabledFeatures`
- Refactor MainMenu.tsx to use `session.user.enabledFeatures` instead of email domain check

## Usage

Configure feature flags in PostHog dashboard, then check in frontend:

```typescript
const { data: session } = useSession();
if (session?.user.enabledFeatures?.includes("SCENARIOS")) {
  // show feature
}
```

To add more frontend flags, add them to `FRONTEND_FEATURE_FLAGS` in `src/server/featureFlag/index.ts`.

## Test plan

- [x] Unit tests for `getEnabledFlags` (5 tests passing)
- [x] TypeScript compiles
- [x] MainMenu.tsx refactored

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)