### PR TITLE
fix(ci): add pnpm-lock.yaml for agentic-e2e-tests

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -96,7 +96,9 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
-          cache-dependency-path: "langwatch/pnpm-lock.yaml"
+          cache-dependency-path: |
+            langwatch/pnpm-lock.yaml
+            agentic-e2e-tests/pnpm-lock.yaml
 
       - name: Install app dependencies
         working-directory: langwatch

--- a/agentic-e2e-tests/pnpm-lock.yaml
+++ b/agentic-e2e-tests/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.58.0
+
+packages:
+
+  '@playwright/test@1.58.0':
+    resolution: {integrity: sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.58.0:
+    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.0:
+    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.58.0':
+    dependencies:
+      playwright: 1.58.0
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.58.0: {}
+
+  playwright@1.58.0:
+    dependencies:
+      playwright-core: 1.58.0
+    optionalDependencies:
+      fsevents: 2.3.2


### PR DESCRIPTION
The e2e-ci workflow was failing because agentic-e2e-tests directory had no pnpm-lock.yaml file, causing `pnpm install --frozen-lockfile` to fail in CI environments.

- Add pnpm-lock.yaml to agentic-e2e-tests
- Update cache-dependency-path to include both lockfiles