### PR TITLE
fix(evaluations-v3): display Code Agent outputs with custom field names

### DIFF
--- a/langwatch/src/server/evaluations-v3/execution/__tests__/resultMapper.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/resultMapper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { StudioServerEvent } from "~/optimization_studio/types/events";
 import {
+  extractTargetOutput,
   isEvaluatorNode,
   mapErrorEvent,
   mapEvaluatorResult,
@@ -42,6 +43,44 @@ describe("resultMapper", () => {
 
     it("returns true for evaluator nodes", () => {
       expect(isEvaluatorNode("target-1.eval-1")).toBe(true);
+    });
+  });
+
+  describe("extractTargetOutput", () => {
+    it("returns undefined for undefined outputs", () => {
+      expect(extractTargetOutput(undefined)).toBeUndefined();
+    });
+
+    it("returns undefined for empty outputs object", () => {
+      expect(extractTargetOutput({})).toBeUndefined();
+    });
+
+    it("returns output field when present (backward compatible)", () => {
+      expect(extractTargetOutput({ output: "hello world" })).toBe("hello world");
+    });
+
+    it("returns output field even when other fields present", () => {
+      expect(extractTargetOutput({ output: "main", extra: "ignored" })).toBe(
+        "main",
+      );
+    });
+
+    it("returns single custom field value unwrapped", () => {
+      expect(extractTargetOutput({ result: "my title" })).toBe("my title");
+    });
+
+    it("returns full object for multiple custom fields", () => {
+      const outputs = { result: "title", reason: "because it fits" };
+      expect(extractTargetOutput(outputs)).toEqual(outputs);
+    });
+
+    it("handles nested object in output field", () => {
+      const nested = { result: "title", reason: "because" };
+      expect(extractTargetOutput({ output: nested })).toEqual(nested);
+    });
+
+    it("handles null output value", () => {
+      expect(extractTargetOutput({ output: null })).toBeNull();
     });
   });
 

--- a/langwatch/src/server/evaluations-v3/execution/workflowBuilder.ts
+++ b/langwatch/src/server/evaluations-v3/execution/workflowBuilder.ts
@@ -219,28 +219,43 @@ const buildTargetNode = (
   } else {
     // Agent target - dispatch based on agent type
     if (loadedData.agent) {
-      // Check if it's an HTTP agent
-      if (loadedData.agent.type === "http") {
-        return {
-          targetNode: buildHttpNodeFromAgent(
+      switch (loadedData.agent.type) {
+        case "http":
+          return {
+            targetNode: buildHttpNodeFromAgent(
+              targetNodeId,
+              loadedData.agent,
+              targetConfig,
+              cell,
+            ),
             targetNodeId,
-            loadedData.agent,
-            targetConfig,
-            cell,
-          ),
-          targetNodeId,
-        };
+          };
+        case "signature":
+          return {
+            targetNode: buildSignatureNodeFromAgent(
+              targetNodeId,
+              loadedData.agent,
+              targetConfig,
+              cell,
+            ),
+            targetNodeId,
+          };
+        case "code":
+        case "workflow":
+          return {
+            targetNode: buildCodeNodeFromAgent(
+              targetNodeId,
+              loadedData.agent,
+              targetConfig,
+              cell,
+            ),
+            targetNodeId,
+          };
+        default: {
+          const _exhaustive: never = loadedData.agent.type;
+          throw new Error(`Unknown agent type: ${_exhaustive}`);
+        }
       }
-      // Default to code node for other agent types (code, signature, workflow)
-      return {
-        targetNode: buildCodeNodeFromAgent(
-          targetNodeId,
-          loadedData.agent,
-          targetConfig,
-          cell,
-        ),
-        targetNodeId,
-      };
     } else {
       throw new Error(`Agent target ${targetConfig.id} has no loaded agent`);
     }
@@ -394,7 +409,117 @@ export const buildSignatureNodeFromLocalConfig = (
 };
 
 /**
- * Builds a code node from a TypedAgent (database agent).
+ * Builds a signature node from a TypedAgent with type "signature".
+ *
+ * Signature agents store config in SignatureComponentConfig format:
+ * - llm: top-level or in parameters array
+ * - prompt: top-level or as "instructions" in parameters
+ * - messages: top-level or in parameters array
+ */
+export const buildSignatureNodeFromAgent = (
+  nodeId: string,
+  agent: TypedAgent,
+  targetConfig: TargetConfig,
+  cell: ExecutionCell,
+): Node<Signature> => {
+  const config = agent.config;
+
+  // Get inputs with value mappings applied
+  const inputs = (config.inputs ?? []).map((input) => ({
+    identifier: input.identifier,
+    type: input.type as Field["type"],
+    value: getInputValue(input.identifier, targetConfig, cell),
+  }));
+
+  const outputs = (config.outputs ?? []).map((output) => ({
+    identifier: output.identifier,
+    type: output.type as Field["type"],
+  }));
+
+  // Build parameters array, normalizing from top-level fields or existing parameters
+  const parameters = buildSignatureNodeParameters(config);
+
+  return {
+    id: nodeId,
+    type: "signature",
+    position: { x: 200, y: 0 },
+    data: {
+      name: agent.name,
+      inputs,
+      outputs,
+      parameters,
+    } as LlmPromptConfigComponent,
+  };
+};
+
+/**
+ * Builds parameters array for signature node from agent config.
+ *
+ * Signature-type agents can store config in two formats:
+ * 1. Top-level fields (llm, prompt, messages) - agent drawer format
+ * 2. Parameters array with llm/instructions/messages entries - workflow node format
+ *
+ * This function normalizes both formats into the parameters array
+ * so that addEnvs() can process them consistently.
+ */
+const buildSignatureNodeParameters = (
+  config: TypedAgent["config"],
+): Field[] => {
+  const baseParams = config.parameters ?? [];
+
+  // Start with existing parameters (may already have llm, instructions, messages)
+  const resultParams: Field[] = [...baseParams];
+
+  // Check if llm exists in parameters
+  const hasLlmInParams = resultParams.some(
+    (p) => p.identifier === "llm" && p.type === "llm",
+  );
+
+  // Add top-level llm if not in parameters
+  if (!hasLlmInParams && "llm" in config && config.llm) {
+    resultParams.unshift({
+      identifier: "llm",
+      type: "llm",
+      value: config.llm,
+    });
+  }
+
+  // Check if instructions exists in parameters
+  const hasInstructionsInParams = resultParams.some(
+    (p) => p.identifier === "instructions" && p.type === "str",
+  );
+
+  // Add top-level prompt as instructions if not in parameters
+  if (!hasInstructionsInParams && "prompt" in config && config.prompt) {
+    resultParams.push({
+      identifier: "instructions",
+      type: "str",
+      value: config.prompt,
+    });
+  }
+
+  // Check if messages exists in parameters
+  const hasMessagesInParams = resultParams.some(
+    (p) => p.identifier === "messages" && p.type === "chat_messages",
+  );
+
+  // Add top-level messages if not in parameters
+  if (!hasMessagesInParams && "messages" in config && config.messages) {
+    resultParams.push({
+      identifier: "messages",
+      type: "chat_messages",
+      value: config.messages,
+    });
+  }
+
+  return resultParams;
+};
+
+/**
+ * Builds a code node from a TypedAgent with type "code" or "workflow".
+ *
+ * Code agents contain Python code with DSPy modules that handle their own LLM calls.
+ * Parameters are passed directly - no LLM config normalization needed.
  */
 export const buildCodeNodeFromAgent = (
   nodeId: string,


### PR DESCRIPTION
## Summary

- Fix Code Agent outputs not displaying when using custom field names (e.g., `{result, reason}` instead of `{output: ...}`)
- Fix signature-type agents being incorrectly built as code nodes

## Problem

Code Agents returning custom output fields were not visible in the workbench because:
1. The result mapper hardcoded `outputs?.output`, ignoring other field names
2. Signature-type agents were being built as `code` nodes, which the NLP parser doesn't process for LLM configs

## Solution

### 1. Result Mapper Fix (`resultMapper.ts`)

Added `extractTargetOutput()` function with OCP-compliant strategy:
- If `outputs.output` exists → return it (backward compatible)
- If outputs has exactly one key → return that value (single custom field)
- Otherwise → return full outputs object (multiple fields like `{result, reason}`)

### 2. Workflow Builder Fix (`workflowBuilder.ts`)

- Added `buildSignatureNodeFromAgent()` for proper signature node creation
- Updated dispatcher to route agent types correctly:
  - `signature` → `buildSignatureNodeFromAgent`
  - `http` → `buildHttpNodeFromAgent`
  - `code`, `workflow` → `buildCodeNodeFromAgent`

## Test plan

- [x] All existing tests pass (3,775 tests)
- [x] Added 8 new tests for `extractTargetOutput` edge cases
- [x] Added tests for `buildSignatureNodeFromAgent`
- [x] TypeScript type check passes
- [ ] Manual test: Code Agent with custom outputs displays correctly