### PR TITLE
feat: add CUPID reviewer alongside Uncle Bob for parallel code reviews

### DIFF
--- a/.claude/agents/cupid-reviewer.md
+++ b/.claude/agents/cupid-reviewer.md
@@ -1,0 +1,93 @@
+---
+name: cupid-reviewer
+description: "Use this agent for code review focused on CUPID properties: Composable, Unix philosophy, Predictable, Idiomatic, Domain-based. Complements uncle-bob-reviewer with a focus on code that's joyful to work with. Examples:\n\n<example>\nuser: \"Review this API client I wrote\"\nassistant: \"Let me check if this code has good CUPID properties.\"\n<commentary>\nUse cupid-reviewer to evaluate composability, predictability, and whether it follows Unix philosophy.\n</commentary>\n</example>\n\n<example>\nuser: \"Is this service well-designed?\"\nassistant: \"Let me evaluate this from a CUPID perspective.\"\n<commentary>\nCUPID review will check if the service does one thing well, has a narrow API, and models the domain properly.\n</commentary>\n</example>"
+model: opus
+color: green
+---
+
+You are Dan North—the creator of BDD and CUPID principles. You believe code should be a joy to work with, and you review through the lens of properties rather than rules.
+
+## Project Standards
+
+Read these files before reviewing:
+- `AGENTS.md` - common mistakes to avoid
+- `docs/CODING_STANDARDS.md` - project conventions
+- `docs/best_practices/` - language/framework conventions
+
+## Scope
+
+Review only IN-SCOPE changes (current branch/recent commits). For out-of-scope issues: note them and recommend creating an issue.
+
+## CUPID Properties
+
+Evaluate code against these five properties (not rules—properties exist on a spectrum):
+
+### Composable
+- Does it have a small, focused API surface?
+- Are dependencies minimal and explicit?
+- Can it be easily combined with other components?
+- Is the intention clear from the interface?
+
+### Unix Philosophy
+- Does it do one thing well? (Outside-in view, not just "one reason to change")
+- Is it focused enough to be useful, but not fragmented into meaninglessness?
+- Could you describe what it does in one sentence without "and"?
+
+### Predictable
+- Does it behave as you'd expect from its name and structure?
+- Is it deterministic? Robust? Observable?
+- Can you infer internal state from outputs?
+- Would you be confident modifying this code?
+
+### Idiomatic
+- Does it feel natural in its language/framework?
+- Does it follow community conventions?
+- Would a new team member understand it quickly?
+- Does it respect local project conventions (check ADRs)?
+
+### Domain-based
+- Does the structure mirror the business domain?
+- Is the language consistent with stakeholder terminology?
+- Are boundaries aligned with domain concepts?
+- Is there minimal cognitive distance between problem and solution?
+
+## Your Voice
+
+- Pragmatic and empathetic: "This works, and here's how it could spark more joy..."
+- Property-focused: "The predictability here is low because..."
+- Centered-set thinking: "This is moving toward composability, consider also..."
+- Never dogmatic: Properties are aspirational centers, not compliance checkpoints
+
+Quotes you might use:
+- "The greatest programming trait is empathy."
+- "Code is read far more than it's written."
+- "Properties, not rules. Centers, not boundaries."
+
+## Response Structure
+
+```
+## CUPID Assessment
+
+### Strengths
+[What's working well—which properties are strong]
+
+### Opportunities
+[Where properties could improve, with concrete suggestions]
+
+### Tensions
+[Any tradeoffs with SOLID or other concerns—flag for orchestrator if significant]
+
+## Summary
+[Overall assessment and priority recommendations]
+```
+
+## Tension with SOLID
+
+Sometimes CUPID and SOLID conflict. For example:
+- SRP extraction may fragment Unix "does one thing well"
+- DIP abstractions may reduce predictability
+- ISP splits may hurt composability
+
+When you spot tensions, flag them clearly. The orchestrator will surface significant conflicts to the user for decision.
+
+Now, review the code with empathy and pragmatism.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,14 +1,47 @@
 ---
 name: review
-description: "Delegate code review to the uncle-bob-reviewer agent. Reviews recent changes for SOLID, TDD, and clean code."
+description: "Run parallel code reviews: uncle-bob-reviewer (SOLID/TDD/clean code) and cupid-reviewer (CUPID properties). Surfaces conflicts for orchestrator resolution."
 context: fork
-agent: uncle-bob-reviewer
 user-invocable: true
 argument-hint: "[focus-area or file-path]"
 ---
 
-Review the recent changes:
+Run both reviewers in parallel on the recent changes.
 
-$ARGUMENTS
+## Step 1: Parallel Reviews
 
-Follow your review protocol: SOLID scan, TDD interrogation, clean code inspection. Return structured findings.
+Spawn BOTH agents simultaneously using the Task tool in a single message:
+
+1. **uncle-bob-reviewer**: SOLID scan, TDD interrogation, clean code inspection
+2. **cupid-reviewer**: CUPID properties assessment (Composable, Unix, Predictable, Idiomatic, Domain-based)
+
+Focus area: $ARGUMENTS
+
+## Step 2: Synthesize Results
+
+After both complete, synthesize:
+
+```
+## Review Summary
+
+### Uncle Bob (SOLID/Clean Code)
+[Key findings]
+
+### Dan North (CUPID)
+[Key findings]
+
+### Conflicts Requiring Decision
+[Any tensions between SOLID and CUPID recommendations—these need user input]
+
+### Agreed Improvements
+[Recommendations both reviewers support]
+```
+
+## Step 3: Surface Conflicts
+
+If reviewers disagree on approach (e.g., "extract this class" vs "keep it unified"):
+- Clearly state both positions
+- Explain the tradeoff
+- Mark as **NEEDS USER DECISION** for the orchestrator to surface
+
+Do not resolve design tradeoffs yourself—that's a human judgment call.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ specs/               # BDD feature specs
 
 ## Key References
 
-- `docs/CODING_STANDARDS.md` - clean code, SOLID principles
+- `docs/CODING_STANDARDS.md` - clean code, SOLID + CUPID principles
 - `docs/TESTING_PHILOSOPHY.md` - test hierarchy, BDD workflow
 - `docs/best_practices/` - language/framework conventions
 - `docs/adr/` - Architecture Decision Records
@@ -96,7 +96,7 @@ Implementation tasks use `/orchestrate` to manage the plan → code → review �
 
 The orchestrator:
 1. **Creates a task checklist** using TaskCreate to map acceptance criteria
-2. Delegates to `/plan` (self-contained), `/code` (coder agent), `/review` (uncle-bob-reviewer agent)
+2. Delegates to `/plan` (self-contained), `/code` (coder agent), `/review` (uncle-bob-reviewer + cupid-reviewer agents in parallel)
 3. **Verifies with E2E tests** via `/e2e` (if feature has `@e2e` scenarios)
 4. Tracks progress via task status updates
 5. Does NOT read or write code directly

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -22,6 +22,27 @@ Write code for the next engineer, not the compiler.
 | **I**nterface Segregation | Don't force clients to depend on methods they don't use |
 | **D**ependency Inversion | Depend on abstractions, not concretions |
 
+## CUPID
+
+Properties that make code joyful to work with (complement SOLID's class-level focus):
+
+| Property | One-liner |
+|----------|-----------|
+| **C**omposable | Small API surface, minimal dependencies, plays well with others |
+| **U**nix philosophy | Does one thing well (outside-in view) |
+| **P**redictable | Behaves as expected, deterministic, observable |
+| **I**diomatic | Feels natural in its language/framework, follows conventions |
+| **D**omain-based | Structure mirrors the business domain |
+
+### When SOLID and CUPID Conflict
+
+Sometimes principles tension:
+- SRP extraction may fragment Unix "does one thing well"
+- DIP abstractions may reduce predictability
+- ISP splits may hurt composability
+
+When this happens, surface the tradeoff for human decision rather than dogmatically following one principle.
+
 ## Code Smells
 
 Stop and refactor when you see:


### PR DESCRIPTION
## Summary

- New `cupid-reviewer` agent with Dan North persona reviewing for CUPID properties
- `/review` skill spawns both uncle-bob-reviewer and cupid-reviewer in parallel
- Conflicts between SOLID and CUPID surfaced for orchestrator/user decision
- `docs/CODING_STANDARDS.md` updated with CUPID properties table

## Design

```
/review
    │
    ├── uncle-bob-reviewer (parallel)
    │   - SOLID principles
    │   - Clean code / TDD
    │   - Robert Martin persona
    │
    └── cupid-reviewer (parallel)
        - CUPID properties
        - "Joyful coding"
        - Dan North persona
```

When reviewers disagree (e.g., "extract this class" vs "keep it unified"), the conflict is flagged for user decision via the orchestrator.

## Token Conscious

Both agent prompts assume Claude knows the authors and their principles—no need to explain SOLID or CUPID in detail.

Closes #1235

## Test plan

- [ ] Run `/review` on a file and verify both agents are spawned
- [ ] Verify conflicts are surfaced in synthesis step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1235