### PR TITLE
fix: support air-gapped Docker deployments

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,7 @@ services:
       LANGEVALS_ENDPOINT: http://langevals:5562
       INSTALL_METHOD: docker
       NODE_ENV: production
+      PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING: 1
     env_file:
       - langwatch/.env
     pull_policy: always


### PR DESCRIPTION
## Summary

- Add `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` to compose.yml app service
- Enables deployments in air-gapped/corporate environments without internet access

## Context

Prisma tries to fetch SHA256 checksums from `binaries.prisma.sh` at runtime, which fails in air-gapped environments. Since the engines are already installed during Docker build, this env var skips the unnecessary runtime verification.

## Test plan

- [ ] Deploy using compose.yml in an environment without access to `binaries.prisma.sh`
- [ ] Verify Prisma operations work correctly

Closes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1239