### PR TITLE
fix: support air-gapped Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/goose
 
 WORKDIR /app
+
+# Skip Prisma checksum verification for air-gapped builds
+ENV PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1
+
 COPY langwatch/package.json langwatch/pnpm-lock.yaml langwatch/pnpm-workspace.yaml ./langwatch/
 COPY langwatch/vendor ./langwatch/vendor
 # https://stackoverflow.com/questions/70154568/pnpm-equivalent-command-for-npm-ci


### PR DESCRIPTION
## Summary

- Add `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` to Dockerfile
- Enables building/running the Docker image in air-gapped environments

## Context

Prisma tries to fetch SHA256 checksums from `binaries.prisma.sh` during `pnpm install` (engine download) and `prisma generate`. This fails in air-gapped environments. The env var skips checksum verification.

Set early in the Dockerfile before `pnpm install` since that's when Prisma downloads engines.

## Test plan

- [ ] Build Docker image in an environment without access to `binaries.prisma.sh`
- [ ] Verify the image builds and runs correctly

Closes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1241