### PR TITLE
fix(traces): check plan before bypassing trace limits for self-hosted

### DIFF
--- a/langwatch/src/pages/settings/license.tsx
+++ b/langwatch/src/pages/settings/license.tsx
@@ -16,12 +16,12 @@ export default function License() {
         <HStack width="full">
           <Heading>License</Heading>
           <Spacer />
-          <PageLayout.HeaderButton
+          {/* <PageLayout.HeaderButton
             onClick={() => setIsGeneratorOpen(true)}
           >
             <Plus size={20} />
             New License
-          </PageLayout.HeaderButton>
+          </PageLayout.HeaderButton> */}
         </HStack>
         <Text color="fg.muted">
           Manage your LangWatch license for self-hosted deployments. A valid

--- a/langwatch/src/server/traces/trace-usage.service.ts
+++ b/langwatch/src/server/traces/trace-usage.service.ts
@@ -1,4 +1,5 @@
 import type { QueryDslBoolQuery } from "@elastic/elasticsearch/lib/api/types";
+import { FREE_PLAN } from "../../../ee/licensing/constants";
 import type { PrismaClient } from "@prisma/client";
 import { env } from "~/env.mjs";
 import { dependencies } from "~/injection/dependencies.server";
@@ -55,11 +56,6 @@ export class TraceUsageService {
     maxMessagesPerMonth?: number;
     planName?: string;
   }> {
-    // Self-hosted = unlimited traces
-    if (!env.IS_SAAS) {
-      return { exceeded: false };
-    }
-
     const organizationId =
       await this.organizationRepository.getOrganizationIdByTeamId(teamId);
     if (!organizationId) {
@@ -70,6 +66,11 @@ export class TraceUsageService {
       this.getCurrentMonthCount({ organizationId }),
       this.subscriptionHandler.getActivePlan(organizationId),
     ]);
+
+    // Self-hosted = unlimited traces
+    if (!env.IS_SAAS && plan === FREE_PLAN) {
+      return { exceeded: false };
+    }
 
     if (count >= plan.maxMessagesPerMonth) {
       return {


### PR DESCRIPTION
## Summary
- Fix trace limit check to properly validate plans on self-hosted instances
- Only bypass trace limits when using FREE_PLAN on self-hosted (not for licensed plans)
- Load .env at config time for stress tests
- Hide unused "New License" button in license settings

## Test plan
- [ ] Verify self-hosted with FREE_PLAN bypasses trace limits
- [ ] Verify self-hosted with licensed plan enforces trace limits
- [ ] Verify SaaS behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)