### PR TITLE
fix(traces): check IS_SAAS before DB calls in checkLimit

### DIFF
--- a/langwatch/src/server/traces/trace-usage.service.ts
+++ b/langwatch/src/server/traces/trace-usage.service.ts
@@ -1,5 +1,4 @@
 import type { QueryDslBoolQuery } from "@elastic/elasticsearch/lib/api/types";
-import { FREE_PLAN } from "../../../ee/licensing/constants";
 import type { PrismaClient } from "@prisma/client";
 import { env } from "~/env.mjs";
 import { dependencies } from "~/injection/dependencies.server";
@@ -56,6 +55,11 @@ export class TraceUsageService {
     maxMessagesPerMonth?: number;
     planName?: string;
   }> {
+    // Self-hosted = unlimited traces, skip all limit checks
+    if (!env.IS_SAAS) {
+      return { exceeded: false };
+    }
+
     const organizationId =
       await this.organizationRepository.getOrganizationIdByTeamId(teamId);
     if (!organizationId) {
@@ -66,11 +70,6 @@ export class TraceUsageService {
       this.getCurrentMonthCount({ organizationId }),
       this.subscriptionHandler.getActivePlan(organizationId),
     ]);
-
-    // Self-hosted = unlimited traces
-    if (!env.IS_SAAS && plan === FREE_PLAN) {
-      return { exceeded: false };
-    }
 
     if (count >= plan.maxMessagesPerMonth) {
       return {


### PR DESCRIPTION
## Summary
- Move the `IS_SAAS` check to the beginning of `checkLimit` method to ensure self-hosted deployments skip all limit-checking logic

## Problem
The test `TraceUsageService > checkLimit > when self-hosted (IS_SAAS=false) > returns exceeded: false without checking limits` was failing on CI because:
- The original code called `getOrganizationIdByTeamId` BEFORE checking `IS_SAAS`
- The test expected no DB calls when `IS_SAAS=false`

## Solution
- Move the `IS_SAAS` check to the very beginning of `checkLimit()`
- Return `{ exceeded: false }` immediately for self-hosted deployments
- Remove the now-redundant later check `if (!env.IS_SAAS && plan === FREE_PLAN)`
- Remove the unused `FREE_PLAN` import

## Test plan
- [x] All 9 tests in `trace-usage.service.test.ts` pass
- [x] Typecheck passes

Fixes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1249