### PR TITLE
feat: re-apply frontend feature flags

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -32,7 +32,17 @@ Then explore relevant code to understand existing patterns.
 4. Run `pnpm typecheck` after changes
 5. Run relevant tests after changes
 
-### 4. Self-Verify Before Returning
+### 4. Update Documentation
+
+Before returning, check if documentation needs updating:
+- **ADRs**: If implementing a new architectural pattern, check `docs/adr/` for existing ADRs or create one
+- **JSDoc**: Add/update JSDoc for new public APIs, classes, and exported functions
+- **README**: If feature affects usage, update README
+- **CLAUDE.md/AGENTS.md**: If introducing new patterns or common mistakes
+
+Documentation that contradicts implementation is worse than no documentation.
+
+### 5. Self-Verify Before Returning
 
 **Tests must pass before you return.** If tests fail, fix them.
 
@@ -44,7 +54,7 @@ Check EACH acceptance criterion:
 
 If ANY criterion is not met or tests are failing, fix it before returning.
 
-### 5. Return Summary
+### 6. Return Summary
 
 ```
 ## Implemented
@@ -52,6 +62,10 @@ If ANY criterion is not met or tests are failing, fix it before returning.
 
 ## Tests
 - What tests added/modified
+
+## Documentation
+- ADRs created/updated: [list or "N/A"]
+- JSDoc added: [list key classes/functions]
 
 ## Verification
 [x] Criterion 1 - test_name
@@ -72,3 +86,6 @@ Ready for review / Blocked on [X]
 - Returning with failing tests
 - Assuming "it should work" without verification
 - Not reporting pivots/discoveries
+- Implementing new patterns without updating/creating ADRs
+- Leaving public APIs undocumented
+- Creating ADRs that don't match implementation

--- a/.claude/agents/uncle-bob-reviewer.md
+++ b/.claude/agents/uncle-bob-reviewer.md
@@ -50,7 +50,16 @@ Demand evidence of test-first development:
 - **Duplication**: The root of all evil in software. DRY without mercy.
 - **Complexity**: Cyclomatic complexity should be low. Nested conditionals are a code smell.
 
-### 4. TypeScript-Specific Standards
+### 4. Documentation Alignment Check
+Documentation that contradicts implementation is worse than no documentation:
+- **ADRs**: Check `docs/adr/` for relevant ADRs. Does implementation match documented decisions?
+- **JSDoc/Typedocs**: Are public APIs documented? Do docs match actual behavior?
+- **README**: If feature affects usage, is README updated?
+- **CLAUDE.md/AGENTS.md**: If new patterns introduced, are they documented?
+
+"Working software over comprehensive documentation—but documentation that lies actively harms the next engineer."
+
+### 5. TypeScript-Specific Standards
 - Prefer interfaces over classes for type definitions
 - Enforce strict typing—`any` is surrender
 - Favor pure functions over stateful methods
@@ -71,6 +80,12 @@ For every review, structure your response as:
 
 ### 2. [Next violation...]
 ...
+
+## Documentation Status
+- [ ] ADRs match implementation
+- [ ] Public APIs have JSDoc
+- [ ] README updated (if applicable)
+- [List any documentation issues found]
 
 ## The Path Forward
 [Summary of refactoring priority and craftsmanship guidance]
@@ -97,6 +112,9 @@ For every review, structure your response as:
 - The word 'Manager', 'Processor', or 'Handler' in a class name (usually indicates SRP violation)
 - `any` types in TypeScript
 - Mutable shared state
+- ADRs that contradict implementation
+- Missing documentation for public APIs
+- Stale or outdated docs (check file dates against code changes)
 
 ## Your Mission
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ prompts/**
 .chainlit
 
 # Claude Code personal settings
-.claude/settings.local.json
+**/.claude/settings.local.json
 
 # Playwright E2E tests
 agentic-e2e-tests/test-results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ specs/               # BDD feature specs
 | Code before tests | Outside-In TDD: spec → test → code |
 | Tests after TODO list | BDD specs come first |
 | Shared types in `types.ts` | Colocate unless truly shared |
-| Duplicating Zod + TS types | Zod only, use `infer` |
+| Duplicating Zod + TS types | When you need both validation AND types, use Zod only with `infer`. For internal constants (no external input), `as const` is sufficient |
 | Skipping test run after edits | Always run tests after any code change to catch regressions immediately |
 | Writing tests in the incorrect order | Outside-In TDD: examples drive E2E tests => then integration tests => then unit tests |
 | Defining BDD specs on the end of the TODO list | BDD specs should come before any other tasks to guide them, not the other way around |

--- a/docs/TESTING_PHILOSOPHY.md
+++ b/docs/TESTING_PHILOSOPHY.md
@@ -15,6 +15,39 @@ Use present tense, active voice. Describe expected behavior directly.
 | `it("should sign up a user")` | `it("signs up a user")` |
 | `it("should redirect guests")` | `it("redirects guest users")` |
 
+### Describe Block Naming
+
+Use MDN-style naming for the unit under test:
+
+| Type | Format | Example |
+|------|--------|---------|
+| Function | `name()` | `describe("transformData()", ...)` |
+| Class | `Name` | `describe("Analytics", ...)` |
+| Component | `<Name/>` | `describe("<DatePicker/>", ...)` |
+| Hook | `useName()` | `describe("useFeatureFlag()", ...)` |
+
+### Nested Describe for Context
+
+Use nested `describe` blocks to group tests by context/condition. The outer `describe` names the unit under test, inner `describe` blocks specify the "when" condition, and `it` blocks describe the behavior.
+
+```typescript
+describe("useFeatureFlag()", () => {
+  describe("when flag is enabled", () => {
+    it("returns true", () => {
+      // ...
+    });
+  });
+
+  describe("when query is loading", () => {
+    it("returns false", () => {
+      // ...
+    });
+  });
+});
+```
+
+See [bettertests.js.org](https://bettertests.js.org/) for more patterns.
+
 ### Single Expectation Per Test
 
 Isolating assertions makes failures immediately clear. When multiple behaviors need testing, create separate tests.

--- a/docs/adr/005-feature-flags.md
+++ b/docs/adr/005-feature-flags.md
@@ -1,0 +1,193 @@
+# ADR-005: Feature Flags via tRPC and PostHog
+
+**Date:** 2026-01-29
+
+**Status:** Accepted
+
+## Context
+
+We need feature flags to control UI features, enable gradual rollouts, and provide kill switches for the LangWatch platform. The system must support flexible targeting at multiple levels:
+
+- **User-level**: Flags for specific users (beta testers, internal team)
+- **Project-level**: Flags for specific projects
+- **Organization-level**: Flags for entire organizations
+
+Previous approaches using email-based checks (e.g., `email?.endsWith("@langwatch.ai")`) were inflexible. We needed a solution that:
+
+- Integrates with our existing PostHog setup
+- Provides fast kill switch response (sub-5-second propagation)
+- Works reliably even when PostHog is unavailable
+- Supports local development without PostHog
+
+## Decision
+
+We implement feature flags using a tRPC endpoint backed by PostHog with a hybrid Redis/memory caching layer.
+
+### Architecture Flow
+
+```
+Component
+    |
+    v
+useFeatureFlag (React Query, 5s staleTime)
+    |
+    v
+tRPC endpoint: featureFlag.isEnabled
+    |
+    v
+FeatureFlagService (env override check)
+    |
+    v
+FeatureFlagServicePostHog
+    |
+    v
+StaleWhileRevalidateCache (Redis -> Memory fallback)
+    |
+    v
+PostHog API (on cache miss)
+```
+
+### Key Components
+
+1. **`useFeatureFlag` hook**: React hook that calls tRPC with React Query caching.
+
+2. **`featureFlag.isEnabled` tRPC endpoint**: Protected endpoint that checks flags server-side. Only flags in `FRONTEND_FEATURE_FLAGS` can be queried.
+
+3. **`FeatureFlagService`**: Main service that checks env overrides first, then delegates to PostHog or memory service.
+
+4. **`FeatureFlagServicePostHog`**: PostHog integration with hybrid caching.
+
+5. **`StaleWhileRevalidateCache`**: Redis-first cache with in-memory fallback.
+
+### Targeting via personProperties
+
+Flags target users, projects, or organizations using PostHog `personProperties`:
+
+```typescript
+await featureFlagService.isEnabled(
+  "release_ui_simulations_menu_enabled",
+  userId,
+  false,
+  {
+    projectId: "proj_123",
+    organizationId: "org_456",
+  }
+);
+```
+
+PostHog receives these as `personProperties.project_id` and `personProperties.organization_id` for release condition evaluation.
+
+### Caching Strategy
+
+A 5-second TTL (`FEATURE_FLAG_CACHE_TTL_MS`) is used at two levels:
+
+1. **Server-side**: `StaleWhileRevalidateCache` with Redis (shared) + memory (per-instance)
+2. **Client-side**: React Query `staleTime`
+
+Cache key format: `{flagKey}:{distinctId}:{projectId}:{organizationId}`
+
+### Flag Naming Convention
+
+Pattern: `{type}_{area}_{feature}_{descriptor}`
+
+| Type | Purpose |
+|------|---------|
+| `release` | New feature rollout |
+| `experiment` | A/B test |
+| `permission` | Access control |
+| `ops` | Operational/kill switch |
+
+| Area | System part |
+|------|-------------|
+| `ui` | Frontend/UI features |
+| `api` | API endpoints |
+| `es` | Event sourcing |
+| `worker` | Background workers |
+
+Examples:
+- `release_ui_simulations_menu_enabled` - UI feature rollout
+- `ops_worker_trace_processing_killswitch` - Kill switch for workers
+
+### Environment Overrides
+
+Flags can be force-enabled/disabled via environment variables:
+- `RELEASE_UI_SIMULATIONS_MENU_ENABLED=1` - Force enable
+- `RELEASE_UI_SIMULATIONS_MENU_ENABLED=0` - Force disable
+
+Env overrides take precedence over PostHog.
+
+### Adding New Flags
+
+1. Create the flag in PostHog with release conditions
+2. Add the flag key to `FRONTEND_FEATURE_FLAGS` array
+3. Use `useFeatureFlag("your_flag_key")` in components
+
+```typescript
+// In frontendFeatureFlags.ts
+export const FRONTEND_FEATURE_FLAGS = [
+  "release_ui_simulations_menu_enabled",
+  "your_new_flag_here",
+] as const;
+
+// In your component
+const { enabled, isLoading } = useFeatureFlag("your_new_flag_here", {
+  projectId: project.id, // Optional targeting
+});
+```
+
+## Rationale / Trade-offs
+
+**Why tRPC instead of session-based:**
+- Flags can be refreshed without re-authentication
+- Supports dynamic targeting (project/org can change without logout)
+- Cleaner separation of concerns
+- React Query provides built-in loading states and caching
+
+**Why 5-second TTL:**
+- Fast enough for kill switches (changes propagate in <5s)
+- Low enough API overhead (one call per 5s per unique key)
+- Good balance between freshness and performance
+
+**Why Redis + memory hybrid:**
+- Redis provides cross-instance cache sharing
+- Memory fallback ensures resilience when Redis is down
+- Zero configuration for local development (memory-only)
+
+**Trade-offs accepted:**
+- Slight delay (up to 5s) for flag changes to propagate
+- Additional network call on cache miss
+- React Query bundle size (already used elsewhere)
+
+## Consequences
+
+**Positive:**
+- Flexible targeting at user/project/org level via PostHog
+- Fast kill switch response (5s max)
+- Resilient to PostHog/Redis outages
+- Type-safe flag names with `FrontendFeatureFlag` type
+- Local development works without PostHog (env overrides or memory fallback)
+
+**Negative:**
+- Extra network round-trip on first load (mitigated by caching)
+- Two caching layers to reason about (React Query + server cache)
+
+**Neutral:**
+- PostHog is required for production flag evaluation
+- New flags require code changes (adding to `FRONTEND_FEATURE_FLAGS`)
+
+## Default Value Strategy
+
+The `isEnabled` method accepts a `defaultValue` parameter:
+
+| Default | Use case |
+|---------|----------|
+| `false` (fail-closed) | New features, experimental UI, paid features |
+| `true` (fail-open) | Kill switches that disable functionality when enabled |
+
+The tRPC endpoint uses `defaultValue = false` (fail-closed), meaning new UI features stay hidden if PostHog fails.
+
+## References
+
+- PostHog feature flags: https://posthog.com/docs/feature-flags
+- tRPC: https://trpc.io/
+- React Query: https://tanstack.com/query

--- a/langwatch/src/components/MainMenu.tsx
+++ b/langwatch/src/components/MainMenu.tsx
@@ -1,8 +1,8 @@
 import { Box, Text, VStack } from "@chakra-ui/react";
 import type { Project } from "@prisma/client";
 import { useRouter } from "next/router";
-import { useSession } from "next-auth/react";
 import React, { useState } from "react";
+import { useFeatureFlag } from "../hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
 import { OrganizationRoleGroup } from "../server/api/permission";
 import { api } from "../utils/api";
@@ -27,8 +27,7 @@ export const MainMenu = React.memo(function MainMenu({
   isCompact = false,
 }: MainMenuProps) {
   const router = useRouter();
-  const { data: session } = useSession();
-  const { project, hasOrganizationPermission, isPublicRoute } =
+  const { project, hasOrganizationPermission, isPublicRoute, organization } =
     useOrganizationTeamProject();
   const [isHovered, setIsHovered] = useState(false);
 
@@ -37,9 +36,10 @@ export const MainMenu = React.memo(function MainMenu({
     { enabled: !!project?.id },
   );
 
-  // Feature flag: show collapsible navigation for @langwatch.ai users
-  const showScenariosOnThePlatform =
-    session?.user?.email?.endsWith("@langwatch.ai");
+  const { enabled: showScenariosOnThePlatform } = useFeatureFlag(
+    "release_ui_simulations_menu_enabled",
+    { projectId: project?.id, organizationId: organization?.id },
+  );
 
   // In compact mode, show expanded view on hover
   const showExpanded = !isCompact || isHovered;

--- a/langwatch/src/hooks/__tests__/useFeatureFlag.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useFeatureFlag.unit.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { FEATURE_FLAG_CACHE_TTL_MS } from "../../server/featureFlag/constants";
+import { useFeatureFlag } from "../useFeatureFlag";
+
+vi.mock("../../utils/api", () => ({
+  api: {
+    featureFlag: {
+      isEnabled: {
+        useQuery: vi.fn(),
+      },
+    },
+  },
+}));
+
+import { api } from "../../utils/api";
+
+const mockUseQuery = vi.mocked(api.featureFlag.isEnabled.useQuery);
+
+describe("useFeatureFlag()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when query is loading", () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      } as any);
+    });
+
+    it("returns isLoading true", () => {
+      const { result } = renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled"),
+      );
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("returns enabled false", () => {
+      const { result } = renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled"),
+      );
+
+      expect(result.current.enabled).toBe(false);
+    });
+  });
+
+  describe("when flag is disabled", () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: { enabled: false },
+        isLoading: false,
+      } as any);
+    });
+
+    it("returns enabled false", () => {
+      const { result } = renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled"),
+      );
+
+      expect(result.current.enabled).toBe(false);
+    });
+
+    it("returns isLoading false", () => {
+      const { result } = renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled"),
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("when flag is enabled", () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: { enabled: true },
+        isLoading: false,
+      } as any);
+    });
+
+    it("returns enabled true", () => {
+      const { result } = renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled"),
+      );
+
+      expect(result.current.enabled).toBe(true);
+    });
+
+    it("returns isLoading false", () => {
+      const { result } = renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled"),
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("when options are provided", () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: { enabled: false },
+        isLoading: false,
+      } as any);
+    });
+
+    it("passes projectId and organizationId to query", () => {
+      renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled", {
+          projectId: "proj-123",
+          organizationId: "org-456",
+        }),
+      );
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        {
+          flag: "release_ui_simulations_menu_enabled",
+          projectId: "proj-123",
+          organizationId: "org-456",
+        },
+        {
+          staleTime: FEATURE_FLAG_CACHE_TTL_MS,
+          refetchOnWindowFocus: false,
+          enabled: true,
+        },
+      );
+    });
+  });
+
+  describe("when options are not provided", () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: { enabled: false },
+        isLoading: false,
+      } as any);
+    });
+
+    it("passes undefined for optional params", () => {
+      renderHook(() => useFeatureFlag("release_ui_simulations_menu_enabled"));
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        {
+          flag: "release_ui_simulations_menu_enabled",
+          projectId: undefined,
+          organizationId: undefined,
+        },
+        {
+          staleTime: FEATURE_FLAG_CACHE_TTL_MS,
+          refetchOnWindowFocus: false,
+          enabled: true,
+        },
+      );
+    });
+  });
+
+  describe("when enabled option is false", () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      } as any);
+    });
+
+    it("disables the query", () => {
+      renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled", {
+          projectId: undefined,
+          enabled: false,
+        }),
+      );
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+    });
+
+    it("returns enabled false", () => {
+      const { result } = renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled", {
+          enabled: false,
+        }),
+      );
+
+      expect(result.current.enabled).toBe(false);
+    });
+
+    it("returns isLoading false", () => {
+      const { result } = renderHook(() =>
+        useFeatureFlag("release_ui_simulations_menu_enabled", {
+          enabled: false,
+        }),
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/hooks/useFeatureFlag.ts
+++ b/langwatch/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,82 @@
+import { FEATURE_FLAG_CACHE_TTL_MS } from "../server/featureFlag/constants";
+import type { FrontendFeatureFlag } from "../server/featureFlag/frontendFeatureFlags";
+import { api } from "../utils/api";
+
+interface UseFeatureFlagOptions {
+  projectId?: string;
+  organizationId?: string;
+  /**
+   * Set to false to disable the query (e.g., while waiting for projectId).
+   * Defaults to true.
+   */
+  enabled?: boolean;
+}
+
+interface UseFeatureFlagResult {
+  /** Whether the feature flag is enabled. Returns false while loading. */
+  enabled: boolean;
+  /** Whether the flag check is in progress. */
+  isLoading: boolean;
+}
+
+/**
+ * React hook to check if a feature flag is enabled for the current user.
+ *
+ * Makes a tRPC call to check the flag server-side with PostHog, with optional
+ * project/organization context for targeted feature rollouts.
+ *
+ * ## Usage
+ *
+ * ```tsx
+ * // Basic usage - user-level flag
+ * const { enabled } = useFeatureFlag("release_ui_simulations_menu_enabled");
+ *
+ * // Project-level targeting
+ * const { enabled } = useFeatureFlag("release_ui_simulations_menu_enabled", {
+ *   projectId: project.id,
+ * });
+ *
+ * // Conditional fetching (e.g., wait for project to load)
+ * const { enabled } = useFeatureFlag("release_ui_simulations_menu_enabled", {
+ *   projectId: project?.id,
+ *   enabled: !!project,
+ * });
+ * ```
+ *
+ * ## Caching
+ *
+ * Results are cached both server-side (Redis/memory) and client-side (React Query)
+ * with a 5-second TTL. This ensures fast kill switch response while minimizing
+ * API calls.
+ *
+ * @param flag - The feature flag key (must be in FRONTEND_FEATURE_FLAGS)
+ * @param options - Optional targeting and query configuration
+ * @returns Object with `enabled` (boolean) and `isLoading` (boolean)
+ *
+ * @see docs/adr/005-feature-flags.md for architecture decisions
+ * @see FRONTEND_FEATURE_FLAGS for available flags
+ */
+export function useFeatureFlag(
+  flag: FrontendFeatureFlag,
+  options?: UseFeatureFlagOptions,
+): UseFeatureFlagResult {
+  const queryEnabled = options?.enabled ?? true;
+
+  const { data, isLoading } = api.featureFlag.isEnabled.useQuery(
+    {
+      flag,
+      projectId: options?.projectId,
+      organizationId: options?.organizationId,
+    },
+    {
+      staleTime: FEATURE_FLAG_CACHE_TTL_MS,
+      refetchOnWindowFocus: false,
+      enabled: queryEnabled,
+    },
+  );
+
+  return {
+    enabled: data?.enabled ?? false,
+    isLoading: queryEnabled ? isLoading : false,
+  };
+}

--- a/langwatch/src/server/api/permission.ts
+++ b/langwatch/src/server/api/permission.ts
@@ -280,25 +280,94 @@ export const backendHasOrganizationPermission = async (
   );
 };
 
-export const skipPermissionCheck = ({
-  ctx,
-  next,
-  input,
-}: PermissionMiddlewareParams<object>) => {
-  ctx.permissionChecked = true;
+const SENSITIVE_KEYS = ["organizationId", "teamId", "projectId"] as const;
+type SensitiveKey = (typeof SENSITIVE_KEYS)[number];
+type SkipPermissionCheckOptions = { allow?: Partial<Record<SensitiveKey, string>> };
 
-  const SENSITIVE_KEYS = ["organizationId", "teamId", "projectId"];
+function isMiddlewareParams(value: unknown): value is PermissionMiddlewareParams<object> {
+  return typeof value === "object" && value !== null && "ctx" in value;
+}
 
-  for (const key of SENSITIVE_KEYS) {
-    if (key in input) {
-      throw new Error(
-        `${key} is not allowed to be used without permission check`,
-      );
+/**
+ * Permission middleware for endpoints that need authentication but not resource-level access.
+ *
+ * Use this when:
+ * - User must be logged in (via `protectedProcedure`)
+ * - No project/team/org-scoped data is accessed
+ * - Examples: user preferences, feature flags, global settings
+ *
+ * By default, blocks `projectId`, `organizationId`, and `teamId` in the input
+ * to prevent accidental resource access without permission checks.
+ *
+ * @param options.allow - Map of keys to reasons explaining why they're allowed
+ *
+ * @example
+ * ```typescript
+ * // Auth-only endpoint (no resource IDs)
+ * myEndpoint: protectedProcedure
+ *   .input(z.object({ userId: z.string() }))
+ *   .use(skipPermissionCheck)
+ *   .query(...)
+ *
+ * // Allow projectId for targeting (not permission)
+ * featureFlag: protectedProcedure
+ *   .input(z.object({ flag: z.string(), projectId: z.string().optional() }))
+ *   .use(skipPermissionCheck({
+ *     allow: {
+ *       projectId: "for PostHog targeting, not resource access",
+ *       organizationId: "for PostHog targeting, not resource access",
+ *     },
+ *   }))
+ *   .query(...)
+ *
+ * // Will throw - use checkUserPermissionForProject instead
+ * badEndpoint: protectedProcedure
+ *   .input(z.object({ projectId: z.string() }))
+ *   .use(skipPermissionCheck)  // Error: projectId not allowed
+ *   .query(...)
+ * ```
+ */
+export function skipPermissionCheck(
+  options?: SkipPermissionCheckOptions,
+): (params: PermissionMiddlewareParams<object>) => ReturnType<typeof params.next>;
+export function skipPermissionCheck(
+  params: PermissionMiddlewareParams<object>,
+): ReturnType<typeof params.next>;
+export function skipPermissionCheck(
+  paramsOrOptions?: PermissionMiddlewareParams<object> | SkipPermissionCheckOptions,
+) {
+  // Called directly as middleware (backward compat)
+  if (isMiddlewareParams(paramsOrOptions)) {
+    const { ctx, next, input } = paramsOrOptions;
+    ctx.permissionChecked = true;
+
+    for (const key of SENSITIVE_KEYS) {
+      if (key in input) {
+        throw new Error(
+          `${key} is not allowed to be used without permission check`,
+        );
+      }
     }
+
+    return next();
   }
 
-  return next();
-};
+  // Called with options: return middleware function
+  const allowedKeys = Object.keys(paramsOrOptions?.allow ?? {});
+  return ({ ctx, next, input }: PermissionMiddlewareParams<object>) => {
+    ctx.permissionChecked = true;
+
+    for (const key of SENSITIVE_KEYS) {
+      if (key in input && !allowedKeys.includes(key)) {
+        throw new Error(
+          `${key} is not allowed to be used without permission check`,
+        );
+      }
+    }
+
+    return next();
+  };
+}
 
 export const skipPermissionCheckProjectCreation = ({
   ctx,

--- a/langwatch/src/server/api/root.ts
+++ b/langwatch/src/server/api/root.ts
@@ -12,6 +12,7 @@ import { dashboardsRouter } from "./routers/dashboards";
 import { datasetRouter } from "./routers/dataset";
 import { datasetRecordRouter } from "./routers/datasetRecord";
 import { evaluationsRouter } from "./routers/evaluations";
+import { featureFlagRouter } from "./routers/featureFlag";
 import { evaluatorsRouter } from "./routers/evaluators";
 import { licenseRouter } from "./routers/license";
 import { licenseEnforcementRouter } from "./routers/licenseEnforcement";
@@ -71,6 +72,7 @@ export const appRouter = createTRPCRouter({
   limits: limitsRouter,
   trigger: triggerRouter,
   experiments: experimentsRouter,
+  featureFlag: featureFlagRouter,
   annotation: annotationRouter,
   modelProvider: modelProviderRouter,
   llmModelCost: llmModelCostsRouter,

--- a/langwatch/src/server/api/routers/featureFlag.ts
+++ b/langwatch/src/server/api/routers/featureFlag.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { createLogger } from "~/utils/logger";
+import { featureFlagService } from "../../featureFlag";
+import { FRONTEND_FEATURE_FLAGS } from "../../featureFlag/frontendFeatureFlags";
+import { skipPermissionCheck } from "../permission";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+const logger = createLogger("langwatch:feature-flag-router");
+
+const frontendFeatureFlagSchema = z.enum([
+  ...FRONTEND_FEATURE_FLAGS,
+] as [string, ...string[]]);
+
+/**
+ * tRPC router for feature flag checks.
+ *
+ * Uses PostHog for flag evaluation with optional project/organization targeting.
+ * Results are cached server-side (5s TTL) and client-side (React Query).
+ *
+ * @see docs/adr/005-feature-flags.md for architecture decisions
+ */
+export const featureFlagRouter = createTRPCRouter({
+  /**
+   * Check if a feature flag is enabled for the current user.
+   *
+   * @param flag - The feature flag key (must be in FRONTEND_FEATURE_FLAGS)
+   * @param projectId - Optional project ID for project-level targeting
+   * @param organizationId - Optional organization ID for org-level targeting
+   * @returns { enabled: boolean }
+   */
+  isEnabled: protectedProcedure
+    .input(
+      z.object({
+        flag: frontendFeatureFlagSchema,
+        projectId: z.string().optional(),
+        organizationId: z.string().optional(),
+      }),
+    )
+    .use(skipPermissionCheck({
+      allow: {
+        projectId: "for PostHog targeting, not resource access",
+        organizationId: "for PostHog targeting, not resource access",
+      },
+    }))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      logger.debug(
+        { userId, flag: input.flag, projectId: input.projectId, organizationId: input.organizationId },
+        "Feature flag check requested",
+      );
+
+      const enabled = await featureFlagService.isEnabled(
+        input.flag,
+        userId,
+        false,
+        {
+          projectId: input.projectId,
+          organizationId: input.organizationId,
+        },
+      );
+
+      logger.debug(
+        { userId, flag: input.flag, enabled },
+        "Feature flag check result",
+      );
+
+      return { enabled };
+    }),
+});

--- a/langwatch/src/server/featureFlag/__tests__/envOverride.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/envOverride.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { checkFlagEnvOverride } from "../envOverride";
+
+describe("checkFlagEnvOverride()", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("when env var is set to 1", () => {
+    it("returns true", () => {
+      process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED = "1";
+      expect(checkFlagEnvOverride("release_ui_simulations_menu_enabled")).toBe(true);
+    });
+  });
+
+  describe("when env var is set to 0", () => {
+    it("returns false", () => {
+      process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED = "0";
+      expect(checkFlagEnvOverride("release_ui_simulations_menu_enabled")).toBe(false);
+    });
+  });
+
+  describe("when env var is not set", () => {
+    it("returns undefined", () => {
+      delete process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED;
+      expect(checkFlagEnvOverride("release_ui_simulations_menu_enabled")).toBeUndefined();
+    });
+  });
+
+  describe("when env var has invalid value", () => {
+    it("returns undefined for 'true'", () => {
+      process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED = "true";
+      expect(checkFlagEnvOverride("release_ui_simulations_menu_enabled")).toBeUndefined();
+    });
+
+    it("returns undefined for 'false'", () => {
+      process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED = "false";
+      expect(checkFlagEnvOverride("release_ui_simulations_menu_enabled")).toBeUndefined();
+    });
+
+    it("returns undefined for empty string", () => {
+      process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED = "";
+      expect(checkFlagEnvOverride("release_ui_simulations_menu_enabled")).toBeUndefined();
+    });
+  });
+
+  describe("when flag name has dashes", () => {
+    it("converts to underscores and uppercases", () => {
+      process.env.MY_FEATURE_FLAG = "1";
+      expect(checkFlagEnvOverride("my-feature-flag")).toBe(true);
+    });
+  });
+
+  describe("when flag name has mixed case and multiple dashes", () => {
+    it("normalizes correctly", () => {
+      process.env.ES_TRACE_PROCESSING_COMMAND_RECORDSPAN_KILLSWITCH = "0";
+      expect(
+        checkFlagEnvOverride("es-trace_processing-command-recordSpan-killSwitch"),
+      ).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/featureFlag/__tests__/featureFlag.service.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/featureFlag.service.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FeatureFlagService } from "../featureFlag.service";
+
+vi.mock("../featureFlagService.posthog", () => ({
+  FeatureFlagServicePostHog: {
+    create: () => ({
+      isEnabled: vi.fn().mockResolvedValue(false),
+    }),
+  },
+}));
+
+vi.mock("../featureFlagService.memory", () => ({
+  FeatureFlagServiceMemory: {
+    create: () => ({
+      isEnabled: vi.fn().mockResolvedValue(false),
+    }),
+  },
+}));
+
+describe("FeatureFlagService", () => {
+  describe("isEnabled()", () => {
+    let service: FeatureFlagService;
+
+    beforeEach(() => {
+      service = FeatureFlagService.create();
+    });
+
+    describe("when no env override is set", () => {
+      const originalEnvValue = process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED;
+
+      beforeEach(() => {
+        delete process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED;
+      });
+
+      afterEach(() => {
+        if (originalEnvValue === undefined) {
+          delete process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED;
+        } else {
+          process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED = originalEnvValue;
+        }
+      });
+
+      it("delegates to underlying service", async () => {
+        const mockService = { isEnabled: vi.fn().mockResolvedValue(true) };
+        vi.spyOn(service as any, "service", "get").mockReturnValue(mockService);
+
+        const result = await service.isEnabled("some-flag", "user-1", false);
+
+        expect(result).toBe(true);
+        expect(mockService.isEnabled).toHaveBeenCalledWith(
+          "some-flag",
+          "user-1",
+          false,
+          undefined,
+        );
+      });
+
+      it("passes projectId to underlying service", async () => {
+        const mockService = { isEnabled: vi.fn().mockResolvedValue(true) };
+        vi.spyOn(service as any, "service", "get").mockReturnValue(mockService);
+
+        const options = { projectId: "proj-123" };
+        await service.isEnabled("some-flag", "user-1", true, options);
+
+        expect(mockService.isEnabled).toHaveBeenCalledWith(
+          "some-flag",
+          "user-1",
+          true,
+          options,
+        );
+      });
+
+      it("passes organizationId to underlying service", async () => {
+        const mockService = { isEnabled: vi.fn().mockResolvedValue(true) };
+        vi.spyOn(service as any, "service", "get").mockReturnValue(mockService);
+
+        const options = { organizationId: "org-456" };
+        await service.isEnabled("some-flag", "user-1", false, options);
+
+        expect(mockService.isEnabled).toHaveBeenCalledWith(
+          "some-flag",
+          "user-1",
+          false,
+          options,
+        );
+      });
+    });
+
+    describe("when env override is set", () => {
+      const originalEnv = process.env;
+
+      beforeEach(() => {
+        process.env = { ...originalEnv };
+      });
+
+      afterEach(() => {
+        process.env = originalEnv;
+      });
+
+      describe("when env var is 1", () => {
+        it("returns true regardless of default", async () => {
+          process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED = "1";
+          const service = FeatureFlagService.create();
+
+          const result = await service.isEnabled(
+            "release_ui_simulations_menu_enabled",
+            "user-123",
+            false,
+          );
+
+          expect(result).toBe(true);
+        });
+      });
+
+      describe("when env var is 0", () => {
+        it("returns false regardless of default", async () => {
+          process.env.RELEASE_UI_SIMULATIONS_MENU_ENABLED = "0";
+          const service = FeatureFlagService.create();
+
+          const result = await service.isEnabled(
+            "release_ui_simulations_menu_enabled",
+            "user-123",
+            true,
+          );
+
+          expect(result).toBe(false);
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/featureFlag/constants.ts
+++ b/langwatch/src/server/featureFlag/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Feature flag configuration constants.
+ *
+ * @see docs/adr/005-feature-flags.md for architecture decisions
+ */
+
+/**
+ * Cache TTL for feature flags in milliseconds.
+ *
+ * This value is used for:
+ * - Server-side Redis/memory cache (StaleWhileRevalidateCache)
+ * - Client-side React Query staleTime (useFeatureFlag)
+ *
+ * A 5-second TTL provides fast kill switch response while minimizing
+ * PostHog API calls. Changes to flags propagate within 5 seconds.
+ */
+export const FEATURE_FLAG_CACHE_TTL_MS = 5_000;

--- a/langwatch/src/server/featureFlag/envOverride.ts
+++ b/langwatch/src/server/featureFlag/envOverride.ts
@@ -1,0 +1,14 @@
+/**
+ * Check if a flag is overridden by environment variable.
+ * Format: FLAG_NAME=1 (enabled) or FLAG_NAME=0 (disabled)
+ * Flag name is uppercased with dashes replaced by underscores.
+ * Example: release_ui_simulations_menu_enabled -> RELEASE_UI_SIMULATIONS_MENU_ENABLED=1
+ */
+export function checkFlagEnvOverride(flagKey: string): boolean | undefined {
+  const envKey = flagKey.toUpperCase().replace(/-/g, "_");
+  const envValue = process.env[envKey];
+
+  if (envValue === "1") return true;
+  if (envValue === "0") return false;
+  return undefined;
+}

--- a/langwatch/src/server/featureFlag/featureFlag.service.ts
+++ b/langwatch/src/server/featureFlag/featureFlag.service.ts
@@ -1,20 +1,53 @@
-import { getLangWatchTracer } from "langwatch";
 import { env } from "~/env.mjs";
 import { createLogger } from "~/utils/logger";
+import { checkFlagEnvOverride } from "./envOverride";
 import { FeatureFlagServiceMemory } from "./featureFlagService.memory";
 import { FeatureFlagServicePostHog } from "./featureFlagService.posthog";
-import type { FeatureFlagServiceInterface } from "./types";
+import type {
+  FeatureFlagOptions,
+  FeatureFlagServiceInterface,
+} from "./types";
 
 /**
- * Feature flag service that automatically chooses between PostHog and memory
- * based on environment configuration.
+ * Main feature flag service with automatic backend selection and env overrides.
+ *
+ * This is the primary entry point for feature flag evaluation. It automatically
+ * selects the appropriate backend (PostHog or memory) based on environment
+ * configuration and supports environment variable overrides for local development.
+ *
+ * ## Backend Selection
+ *
+ * - **PostHog** (production): Used when `POSTHOG_KEY` env var is set
+ * - **Memory** (development): Fallback when PostHog is not configured
+ *
+ * ## Environment Overrides
+ *
+ * Flags can be force-enabled/disabled via environment variables:
+ * - `FLAG_NAME=1` - Force enable (e.g., `RELEASE_UI_SIMULATIONS_MENU_ENABLED=1`)
+ * - `FLAG_NAME=0` - Force disable
+ *
+ * Env overrides take precedence over PostHog evaluation.
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * // Use the singleton instance
+ * import { featureFlagService } from "./featureFlag";
+ *
+ * const enabled = await featureFlagService.isEnabled(
+ *   "release_ui_simulations_menu_enabled",
+ *   userId,
+ *   false, // defaultValue
+ *   { projectId, organizationId }
+ * );
+ * ```
+ *
+ * @see docs/adr/005-feature-flags.md for architecture decisions
+ * @see FeatureFlagServicePostHog for PostHog implementation details
  */
 export class FeatureFlagService implements FeatureFlagServiceInterface {
   private readonly service: FeatureFlagServiceInterface;
   private readonly logger = createLogger("langwatch:feature-flag-service");
-  private readonly _tracer = getLangWatchTracer(
-    "langwatch.feature-flag-service",
-  );
 
   constructor() {
     this.service = this.createService();
@@ -29,13 +62,22 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
 
   /**
    * Check if a feature flag is enabled for a given user or tenant/project.
+   * Environment overrides take precedence over PostHog/memory service.
    */
   async isEnabled(
     flagKey: string,
     distinctId: string,
     defaultValue = true,
+    options?: FeatureFlagOptions,
   ): Promise<boolean> {
-    return this.service.isEnabled(flagKey, distinctId, defaultValue);
+    const envOverride = checkFlagEnvOverride(flagKey);
+    if (envOverride !== undefined) {
+      this.logger.debug({ flagKey, distinctId, envOverride }, "Flag resolved via env override");
+      return envOverride;
+    }
+    const result = await this.service.isEnabled(flagKey, distinctId, defaultValue, options);
+    this.logger.debug({ flagKey, distinctId, enabled: result, projectId: options?.projectId, organizationId: options?.organizationId }, "Flag checked");
+    return result;
   }
 
   /**
@@ -44,11 +86,11 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
   private createService(): FeatureFlagServiceInterface {
     // Use PostHog if the environment variable is set
     if (env.POSTHOG_KEY) {
-      this.logger.debug("Using PostHog feature flag service");
+      this.logger.info("Using PostHog feature flag service");
       return FeatureFlagServicePostHog.create();
     }
 
-    this.logger.debug("Using memory feature flag service");
+    this.logger.warn("POSTHOG_KEY not set, using memory feature flag service. All flags will return defaults. Set POSTHOG_KEY or use env overrides (e.g. RELEASE_UI_SIMULATIONS_MENU_ENABLED=1).");
     return FeatureFlagServiceMemory.create();
   }
 

--- a/langwatch/src/server/featureFlag/featureFlagService.memory.ts
+++ b/langwatch/src/server/featureFlag/featureFlagService.memory.ts
@@ -1,6 +1,9 @@
 import { getLangWatchTracer } from "langwatch";
 import { createLogger } from "~/utils/logger";
-import type { FeatureFlagServiceInterface } from "./types";
+import type {
+  FeatureFlagOptions,
+  FeatureFlagServiceInterface,
+} from "./types";
 
 /**
  * In-memory feature flag service with default values.
@@ -29,11 +32,13 @@ export class FeatureFlagServiceMemory implements FeatureFlagServiceInterface {
 
   /**
    * Check if a feature flag is enabled.
+   * Note: options parameter is accepted for interface compatibility but ignored.
    */
   async isEnabled(
     flagKey: string,
     distinctId: string,
     defaultValue = true,
+    _options?: FeatureFlagOptions,
   ): Promise<boolean> {
     return await this.tracer.withActiveSpan(
       "FeatureFlagServiceMemory.isEnabled",

--- a/langwatch/src/server/featureFlag/featureFlagService.posthog.ts
+++ b/langwatch/src/server/featureFlag/featureFlagService.posthog.ts
@@ -1,11 +1,37 @@
 import { getLangWatchTracer } from "langwatch";
 import { createLogger } from "~/utils/logger";
 import { getPostHogInstance } from "../posthog";
+import { FEATURE_FLAG_CACHE_TTL_MS } from "./constants";
 import { StaleWhileRevalidateCache } from "./staleWhileRevalidateCache.redis";
-import type { FeatureFlagServiceInterface } from "./types";
+import type {
+  FeatureFlagOptions,
+  FeatureFlagServiceInterface,
+} from "./types";
 
 /**
  * PostHog-based feature flag service with hybrid Redis/in-memory caching.
+ *
+ * This service evaluates feature flags via PostHog's API with a hybrid caching
+ * strategy that uses Redis when available, falling back to in-memory cache.
+ *
+ * ## Architecture
+ *
+ * The service follows a stale-while-revalidate pattern:
+ * 1. Check Redis cache first (shared across instances)
+ * 2. Fall back to in-memory cache (per-instance)
+ * 3. On cache miss, call PostHog API and cache result
+ *
+ * ## Targeting
+ *
+ * Flags can target users, projects, or organizations via personProperties:
+ * - `distinctId` - The user ID (required)
+ * - `projectId` - Optional project ID for project-level targeting
+ * - `organizationId` - Optional organization ID for org-level targeting
+ *
+ * Configure targeting rules in PostHog release conditions.
+ *
+ * @see docs/adr/005-feature-flags.md for architecture decisions
+ * @see FEATURE_FLAG_CACHE_TTL_MS for cache TTL configuration
  */
 export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
   private readonly posthog: ReturnType<typeof getPostHogInstance>;
@@ -16,10 +42,9 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
     "langwatch.posthog-feature-flag-service",
   );
 
-  // Stale-while-revalidate cache: 5 min stale threshold, 30 sec refresh threshold
   private readonly cache = new StaleWhileRevalidateCache(
-    1 * 60 * 1000,
-    1 * 30 * 1000,
+    FEATURE_FLAG_CACHE_TTL_MS,
+    FEATURE_FLAG_CACHE_TTL_MS,
   );
 
   constructor() {
@@ -40,6 +65,7 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
     flagKey: string,
     distinctId: string,
     defaultValue = true,
+    options?: FeatureFlagOptions,
   ): Promise<boolean> {
     return await this.tracer.withActiveSpan(
       "FeatureFlagServicePostHog.isEnabled",
@@ -48,6 +74,9 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
           "feature.flag.key": flagKey,
           "feature.flag.distinct_id": distinctId,
           "feature.flag.default": defaultValue,
+          "feature.flag.project_id": options?.projectId ?? "",
+          "feature.flag.organization_id": options?.organizationId ?? "",
+          "tenant.id": options?.projectId ?? "",
           "cache.redis_available": this.cache.isRedisAvailable(),
         },
       },
@@ -57,7 +86,9 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
           return defaultValue;
         }
 
-        const cacheKey = `${flagKey}:${distinctId}`;
+        const projectId = options?.projectId;
+        const orgId = options?.organizationId;
+        const cacheKey = `${flagKey}:${distinctId}:${projectId ?? ""}:${orgId ?? ""}`;
 
         // Check hybrid cache first
         const cachedResult = await this.cache.get(cacheKey);
@@ -72,13 +103,34 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
         }
 
         try {
-          // Fetch from PostHog
+          // Build personProperties only with defined values
+          const personProperties: Record<string, string> = {};
+          if (projectId) {
+            personProperties.project_id = projectId;
+          }
+          if (orgId) {
+            personProperties.organization_id = orgId;
+          }
+
+          const posthogOptions = {
+            disableGeoip: true,
+            personProperties,
+          };
+
+          this.logger.debug(
+            { flagKey, distinctId, posthogOptions },
+            "Checking PostHog feature flag",
+          );
+
           const isEnabled = await this.posthog.isFeatureEnabled(
             flagKey,
             distinctId,
-            {
-              disableGeoip: true,
-            },
+            posthogOptions,
+          );
+
+          this.logger.debug(
+            { flagKey, distinctId, isEnabled, posthogOptions },
+            "PostHog feature flag result",
           );
 
           const result = isEnabled ?? defaultValue;

--- a/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
@@ -1,0 +1,59 @@
+/**
+ * Feature flags exposed to the frontend via tRPC.
+ *
+ * This constant defines which flags can be checked from the frontend using
+ * the `useFeatureFlag` hook. Only flags listed here can be queried via the
+ * `featureFlag.isEnabled` tRPC endpoint.
+ *
+ * ## Naming Convention
+ *
+ * Pattern: `{type}_{area}_{feature}_{descriptor}`
+ *
+ * ### Type (what kind of flag):
+ * - `release` - new feature rollout
+ * - `experiment` - A/B test
+ * - `permission` - access control
+ * - `ops` - operational/kill switch
+ *
+ * ### Area (part of the system):
+ * - `ui` - frontend/UI features
+ * - `api` - API endpoints
+ * - `es` - event sourcing
+ * - `worker` - background workers
+ *
+ * ### Feature: the feature area (e.g., `simulations`, `prompts`, `traces`)
+ *
+ * ### Descriptor: specific target + state (e.g., `menu_enabled`, `endpoint_access`)
+ *
+ * ## Examples
+ * - `release_ui_simulations_menu_enabled` - UI feature rollout
+ * - `permission_api_prompts_v2_access` - API access control
+ * - `ops_es_trace_processing_killswitch` - operational kill switch
+ * - `experiment_ui_dashboard_new_layout` - A/B experiment
+ *
+ * ## Optional Suffixes
+ * - `_temp` - temporary flag, clean up after rollout
+ * - `_perma` - permanent flag, long-lived
+ *
+ * ## Targeting
+ *
+ * Flags can target users, projects, or organizations via PostHog personProperties.
+ * Configure targeting in PostHog release conditions, not in the flag name.
+ * Pass `projectId` or `organizationId` to `useFeatureFlag` for targeted evaluation.
+ *
+ * ## Adding New Flags
+ *
+ * 1. Create the flag in PostHog with your desired release conditions
+ * 2. Add the flag key to this array
+ * 3. Use `useFeatureFlag("your_flag_key")` in components
+ *
+ * @see docs/adr/005-feature-flags.md for architecture decisions
+ * @see useFeatureFlag for frontend usage
+ */
+export const FRONTEND_FEATURE_FLAGS = ["release_ui_simulations_menu_enabled"] as const;
+
+/**
+ * Type representing a valid frontend feature flag key.
+ * Use this type for type-safe flag references.
+ */
+export type FrontendFeatureFlag = (typeof FRONTEND_FEATURE_FLAGS)[number];

--- a/langwatch/src/server/featureFlag/index.ts
+++ b/langwatch/src/server/featureFlag/index.ts
@@ -1,4 +1,11 @@
 export { FeatureFlagService, featureFlagService } from "./featureFlag.service";
 export { FeatureFlagServiceMemory } from "./featureFlagService.memory";
 export { FeatureFlagServicePostHog } from "./featureFlagService.posthog";
-export type { FeatureFlagServiceInterface } from "./types";
+export type {
+  FeatureFlagOptions,
+  FeatureFlagServiceInterface,
+} from "./types";
+export {
+  FRONTEND_FEATURE_FLAGS,
+  type FrontendFeatureFlag,
+} from "./frontendFeatureFlags";

--- a/langwatch/src/server/featureFlag/staleWhileRevalidateCache.redis.ts
+++ b/langwatch/src/server/featureFlag/staleWhileRevalidateCache.redis.ts
@@ -8,8 +8,31 @@ interface CacheEntry {
 }
 
 /**
- * Hybrid cache with stale-while-revalidate pattern.
- * Always returns cached data immediately, but refreshes in background when stale, rapido.
+ * Hybrid Redis/in-memory cache with stale-while-revalidate pattern.
+ *
+ * This cache provides fast, resilient caching for feature flags with automatic
+ * fallback from Redis to in-memory storage when Redis is unavailable.
+ *
+ * ## Cache Strategy
+ *
+ * 1. **Redis first**: When available, uses Redis for cross-instance cache sharing
+ * 2. **Memory fallback**: Falls back to in-memory TtlCache when Redis is down
+ * 3. **Stale-while-revalidate**: Returns cached data immediately, refreshes in background
+ *
+ * ## Key Structure
+ *
+ * Redis keys are prefixed with `feature_flag:` followed by a composite key:
+ * `{flagKey}:{distinctId}:{projectId}:{organizationId}`
+ *
+ * ## TTL Configuration
+ *
+ * The cache uses a 5-second TTL (see `FEATURE_FLAG_CACHE_TTL_MS`) which provides:
+ * - Fast kill switch response (changes propagate within 5 seconds)
+ * - Reduced PostHog API calls (one call per 5 seconds per unique key)
+ * - Resilience to PostHog outages (serves cached values while down)
+ *
+ * @see docs/adr/005-feature-flags.md for architecture decisions
+ * @see FEATURE_FLAG_CACHE_TTL_MS for TTL configuration
  */
 export class StaleWhileRevalidateCache {
   private readonly staleThresholdMs: number; // How long before considering data stale
@@ -23,8 +46,8 @@ export class StaleWhileRevalidateCache {
     this.staleThresholdMs = staleThresholdMs;
     this.refreshThresholdMs = refreshThresholdMs;
 
-    // Keep entries in memory much longer than stale threshold for background refresh
-    this.memoryCache = new TtlCache<CacheEntry>(staleThresholdMs * 10);
+    // Memory cache TTL matches stale threshold
+    this.memoryCache = new TtlCache<CacheEntry>(staleThresholdMs);
   }
 
   async get(key: string): Promise<CacheEntry | undefined> {
@@ -34,6 +57,7 @@ export class StaleWhileRevalidateCache {
         const result = await redisConnection.get(`${this.prefix}${key}`);
         if (result !== null) {
           const entry: CacheEntry = JSON.parse(result);
+          // Redis TTL handles expiration, so if it exists it's valid
           return entry;
         }
       } catch (_error) {
@@ -42,7 +66,13 @@ export class StaleWhileRevalidateCache {
     }
 
     // Fall back to memory cache
-    return this.memoryCache.get(key);
+    const entry = this.memoryCache.get(key);
+    // Check if memory cache entry is stale
+    if (entry && this.isStale(entry)) {
+      this.memoryCache.delete(key);
+      return undefined;
+    }
+    return entry;
   }
 
   async set(key: string, value: boolean): Promise<void> {
@@ -54,10 +84,11 @@ export class StaleWhileRevalidateCache {
     // Try Redis first if available
     if (redisConnection && !isBuildOrNoRedis) {
       try {
-        // Store for much longer than stale threshold (24 hours for Redis)
+        // Store for stale threshold (convert ms to seconds)
+        const ttlSeconds = Math.ceil(this.staleThresholdMs / 1000);
         await redisConnection.setex(
           `${this.prefix}${key}`,
-          24 * 60 * 60, // 24 hours
+          ttlSeconds,
           JSON.stringify(entry),
         );
       } catch (_error) {

--- a/langwatch/src/server/featureFlag/types.ts
+++ b/langwatch/src/server/featureFlag/types.ts
@@ -1,4 +1,12 @@
 /**
+ * Options for feature flag evaluation.
+ */
+export interface FeatureFlagOptions {
+  projectId?: string;
+  organizationId?: string;
+}
+
+/**
  * Common interface for feature flag services.
  */
 export interface FeatureFlagServiceInterface {
@@ -9,5 +17,6 @@ export interface FeatureFlagServiceInterface {
     flagKey: string,
     distinctId: string,
     defaultValue?: boolean,
+    options?: FeatureFlagOptions,
   ): Promise<boolean>;
 }


### PR DESCRIPTION
## Summary

Re-applies the frontend feature flags changes from #1218 which were reverted in #1254.

This PR reverts the revert to restore:
- tRPC `featureFlag.isEnabled` endpoint for on-demand flag checks
- `useFeatureFlag` hook with React Query caching
- Environment variable overrides for local development
- PostHog integration with personProperties for targeting
- ADR-005 documenting the architecture

## Previous Issue

The original PR was reverted due to admin panel redirect issues. The root cause was identified as related to the dependency injection setup where the client-side injection didn't have `/admin` registered, causing it to fall through to the home page.

## Changes

This is a revert of commit 3deb8203b (the revert commit), which restores all 23 files from the original feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)