### PR TITLE
feat(python-sdk): add prompts_path configuration to setup()

### DIFF
--- a/python-sdk/src/langwatch/client.py
+++ b/python-sdk/src/langwatch/client.py
@@ -50,6 +50,7 @@ class Client(LangWatchClientProtocol):
     _registered_instrumentors: ClassVar[
         dict[opentelemetry.trace.TracerProvider, set[BaseInstrumentor]]
     ] = {}
+    _prompts_path: ClassVar[Optional[str]] = None
 
     # Regular attributes for protocol compatibility
     base_attributes: BaseAttributes
@@ -69,6 +70,7 @@ class Client(LangWatchClientProtocol):
         span_exclude_rules: Optional[List[SpanProcessingExcludeRule]] = None,
         ignore_global_tracer_provider_override_warning: Optional[bool] = None,
         skip_open_telemetry_setup: Optional[bool] = None,
+        prompts_path: Optional[str] = None,
     ) -> "Client":
         """Ensure only one instance of Client exists (singleton pattern)."""
         if cls._instance is None:
@@ -88,6 +90,7 @@ class Client(LangWatchClientProtocol):
         span_exclude_rules: Optional[List[SpanProcessingExcludeRule]] = None,
         ignore_global_tracer_provider_override_warning: Optional[bool] = None,
         skip_open_telemetry_setup: Optional[bool] = None,
+        prompts_path: Optional[str] = None,
     ):
         """
         Initialize the LangWatch tracing client.
@@ -140,6 +143,8 @@ class Client(LangWatchClientProtocol):
                 )
             if skip_open_telemetry_setup is not None:
                 Client._skip_open_telemetry_setup = skip_open_telemetry_setup
+            if prompts_path is not None:
+                Client._prompts_path = prompts_path
             if base_attributes is not None:
                 Client._base_attributes = base_attributes
                 # Ensure required SDK attributes remain present after reconfiguration
@@ -215,6 +220,9 @@ class Client(LangWatchClientProtocol):
         if skip_open_telemetry_setup is not None:
             Client._skip_open_telemetry_setup = skip_open_telemetry_setup
 
+        if prompts_path is not None:
+            Client._prompts_path = prompts_path
+
         if base_attributes is not None:
             Client._base_attributes = base_attributes
         elif not Client._base_attributes:
@@ -284,6 +292,7 @@ class Client(LangWatchClientProtocol):
         span_exclude_rules: Optional[List[SpanProcessingExcludeRule]] = None,
         ignore_global_tracer_provider_override_warning: Optional[bool] = None,
         skip_open_telemetry_setup: Optional[bool] = None,
+        prompts_path: Optional[str] = None,
     ) -> "Client":
         """Create or get the singleton instance of the LangWatch client. Internal use only."""
         if cls._instance is None:
@@ -299,6 +308,7 @@ class Client(LangWatchClientProtocol):
                 span_exclude_rules=span_exclude_rules,
                 ignore_global_tracer_provider_override_warning=ignore_global_tracer_provider_override_warning,
                 skip_open_telemetry_setup=skip_open_telemetry_setup,
+                prompts_path=prompts_path,
             )
         return cls._instance
 
@@ -327,6 +337,7 @@ class Client(LangWatchClientProtocol):
         cls._skip_open_telemetry_setup = False
         cls._tracer_provider = None
         cls._rest_api_client = None
+        cls._prompts_path = None
         cls._registered_instrumentors.clear()
 
     @classmethod
@@ -415,6 +426,11 @@ class Client(LangWatchClientProtocol):
     def skip_open_telemetry_setup(self) -> bool:
         """Get whether OpenTelemetry setup is skipped."""
         return Client._skip_open_telemetry_setup
+
+    @property
+    def prompts_path(self) -> Optional[str]:
+        """Get the base path for local prompt files."""
+        return Client._prompts_path
 
     @disable_sending.setter
     def disable_sending(self, value: bool) -> None:

--- a/python-sdk/src/langwatch/prompts/local_loader.py
+++ b/python-sdk/src/langwatch/prompts/local_loader.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 class LocalPromptLoader:
     """Loads prompts from local files in CLI format."""
 
+    _warned_no_prompts_path: bool = False
+
     def __init__(self, base_path: Optional[Path] = None):
         """Initialize with base path (defaults to current working directory at load time)."""
         self._base_path = base_path
@@ -43,6 +45,16 @@ class LocalPromptLoader:
             # Check if prompts.json exists
             prompts_json_path = self.base_path / "prompts.json"
             if not prompts_json_path.exists():
+                # Warn once if no prompts_path was configured and prompts.json doesn't exist
+                if self._base_path is None and not LocalPromptLoader._warned_no_prompts_path:
+                    LocalPromptLoader._warned_no_prompts_path = True
+                    warnings.warn(
+                        f"No prompts.json found at {prompts_json_path}. "
+                        f"If you have local prompt files, configure the path with "
+                        f"langwatch.setup(prompts_path='/path/to/prompts') or ensure "
+                        f"prompts.json is in the current working directory.",
+                        UserWarning,
+                    )
                 logger.debug(
                     f"No prompts.json found at {prompts_json_path}, falling back to API"
                 )

--- a/python-sdk/src/langwatch/prompts/prompt_facade.py
+++ b/python-sdk/src/langwatch/prompts/prompt_facade.py
@@ -8,6 +8,7 @@ or when API is unavailable.
 
 Follows the facade pattern to coordinate between LocalPromptLoader and PromptApiService.
 """
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 import time
 from langwatch.generated.langwatch_rest_api_client.client import (
@@ -35,10 +36,16 @@ class PromptsFacade:
     work even when offline or when API is unavailable.
     """
 
-    def __init__(self, rest_api_client: LangWatchRestApiClient):
+    def __init__(
+        self,
+        rest_api_client: LangWatchRestApiClient,
+        prompts_path: Optional[str] = None,
+    ):
         """Initialize the prompt service facade with dependencies."""
         self._api_service = PromptApiService(rest_api_client)
-        self._local_loader = LocalPromptLoader()
+        self._local_loader = LocalPromptLoader(
+            base_path=Path(prompts_path) if prompts_path else None
+        )
         self._cache: Dict[str, Dict[str, Any]] = {}
 
     @classmethod
@@ -50,7 +57,7 @@ class PromptsFacade:
             raise RuntimeError(
                 "LangWatch client has not been initialized. Call setup() first."
             )
-        return cls(instance.rest_api_client)
+        return cls(instance.rest_api_client, prompts_path=instance.prompts_path)
 
     def get(
         self,

--- a/python-sdk/src/langwatch/types.py
+++ b/python-sdk/src/langwatch/types.py
@@ -89,6 +89,11 @@ class LangWatchClientProtocol(Protocol):
         """Get whether OpenTelemetry setup is skipped."""
         ...
 
+    @property
+    def prompts_path(self) -> Optional[str]:
+        """Get the base path for local prompt files."""
+        ...
+
     # Regular attributes (not properties)
     base_attributes: BaseAttributes
     tracer_provider: Optional[TracerProvider]

--- a/python-sdk/src/langwatch/utils/initialization.py
+++ b/python-sdk/src/langwatch/utils/initialization.py
@@ -41,6 +41,7 @@ def setup(
     span_exclude_rules: Optional[List[SpanProcessingExcludeRule]] = None,
     debug: Optional[bool] = None,
     skip_open_telemetry_setup: Optional[bool] = None,
+    prompts_path: Optional[str] = None,
 ) -> Client:
     """
     Initialize the LangWatch client.
@@ -54,6 +55,7 @@ def setup(
         span_exclude_rules: Optional. A list of rules that will be applied to spans processed by the exporter.
         debug: Whether to enable debug logging for the LangWatch client.
         skip_open_telemetry_setup: Whether to skip setting up the OpenTelemetry tracer provider. If this is skipped, instrumentors will be added to the global tracer provider.
+        prompts_path: The base path for local prompt files. If not set, defaults to the current working directory.
     Returns:
         The LangWatch client.
     """
@@ -87,6 +89,7 @@ def setup(
         span_exclude_rules=span_exclude_rules,
         ignore_global_tracer_provider_override_warning=changed_api_key,
         skip_open_telemetry_setup=skip_open_telemetry_setup,
+        prompts_path=prompts_path,
     )
 
     if debug:

--- a/python-sdk/tests/prompts/test_prompts_path_config.py
+++ b/python-sdk/tests/prompts/test_prompts_path_config.py
@@ -1,0 +1,139 @@
+"""
+Tests for prompts_path configuration flowing through setup() to LocalPromptLoader.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import langwatch
+from langwatch.client import Client
+
+
+def test_setup_prompts_path_flows_to_local_loader(clean_langwatch):
+    """
+    GIVEN langwatch.setup() is called with prompts_path parameter
+    WHEN langwatch.prompts.get() is called
+    THEN the LocalPromptLoader uses the configured path
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create prompts.json
+        config = {"prompts": {"test-prompt": "file:prompts/test-prompt.prompt.yaml"}}
+        (temp_path / "prompts.json").write_text(json.dumps(config))
+
+        # Create prompts-lock.json
+        lock = {
+            "prompts": {
+                "test-prompt": {
+                    "version": 1,
+                    "versionId": "v1",
+                    "materialized": "prompts/test-prompt.prompt.yaml",
+                }
+            }
+        }
+        (temp_path / "prompts-lock.json").write_text(json.dumps(lock))
+
+        # Create the prompt file
+        prompts_dir = temp_path / "prompts"
+        prompts_dir.mkdir()
+        prompt_content = """model: openai/gpt-4
+messages:
+  - role: system
+    content: Test prompt from custom path
+"""
+        (prompts_dir / "test-prompt.prompt.yaml").write_text(prompt_content)
+
+        # Setup langwatch with prompts_path
+        langwatch.setup(
+            api_key="test-api-key",
+            prompts_path=str(temp_path),
+        )
+
+        # Block HTTP requests to ensure we're using local files
+        with patch("httpx.Client.request") as mock_request:
+            mock_request.side_effect = Exception("HTTP should not be called")
+
+            result = langwatch.prompts.get("test-prompt")
+
+            assert result is not None
+            assert result.model == "openai/gpt-4"
+            assert result.messages[0]["content"] == "Test prompt from custom path"
+            mock_request.assert_not_called()
+
+
+def test_setup_prompts_path_stored_in_client():
+    """
+    GIVEN langwatch.setup() is called with prompts_path parameter
+    WHEN the client is retrieved
+    THEN the prompts_path is accessible on the client
+    """
+    # Reset client for clean test
+    Client._reset_instance()
+
+    try:
+        langwatch.setup(
+            api_key="test-api-key",
+            prompts_path="/custom/prompts/path",
+        )
+
+        from langwatch.state import get_instance
+
+        client = get_instance()
+        assert client is not None
+        assert client.prompts_path == "/custom/prompts/path"
+    finally:
+        Client._reset_instance()
+
+
+def test_setup_without_prompts_path_defaults_to_none():
+    """
+    GIVEN langwatch.setup() is called without prompts_path parameter
+    WHEN the client is retrieved
+    THEN prompts_path is None (will use cwd at runtime)
+    """
+    # Reset client for clean test
+    Client._reset_instance()
+
+    try:
+        langwatch.setup(api_key="test-api-key")
+
+        from langwatch.state import get_instance
+
+        client = get_instance()
+        assert client is not None
+        assert client.prompts_path is None
+    finally:
+        Client._reset_instance()
+
+
+def test_prompts_path_update_on_second_setup():
+    """
+    GIVEN langwatch.setup() was called without prompts_path
+    WHEN langwatch.setup() is called again with prompts_path
+    THEN the prompts_path is updated
+    """
+    # Reset client for clean test
+    Client._reset_instance()
+
+    try:
+        # First setup without prompts_path
+        langwatch.setup(api_key="test-api-key")
+
+        from langwatch.state import get_instance
+
+        client = get_instance()
+        assert client.prompts_path is None
+
+        # Second setup with prompts_path
+        langwatch.setup(
+            api_key="test-api-key",
+            prompts_path="/updated/path",
+        )
+
+        assert client.prompts_path == "/updated/path"
+    finally:
+        Client._reset_instance()


### PR DESCRIPTION
Add ability to configure the base path for local prompt files via `langwatch.setup(prompts_path="/path/to/prompts")`. This fixes inconsistent behavior when the working directory differs from where prompt files are located.

Changes:
- Add prompts_path parameter to `langwatch.setup()`
- Flow prompts_path through Client -> PromptsFacade -> LocalPromptLoader
- Add warning when prompts_path not configured and prompts.json not found
- Warning only shown once per session to avoid noise