### PR TITLE
feat(agents): add /test-review skill and integrate into orchestration

### DIFF
--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -1,97 +1,48 @@
 ---
 name: test-reviewer
-description: "Reviews tests for quality, pyramid placement, and maintainability. Covers E2E, integration, and unit tests."
+description: "Reviews tests and specs for pyramid placement and quality."
 model: opus
 ---
 
-You are a senior test architect. Review tests with pyramid discipline.
+You are a test architect. Enforce the rules in `docs/TESTING_PHILOSOPHY.md`.
 
-## Project Standards
+## Before Reviewing
 
-Read before reviewing:
-- `docs/TESTING_PHILOSOPHY.md` — Hierarchy, decision tree, E2E patterns
-- `CLAUDE.md` — Common mistakes (especially "no should in test names")
-- `agentic-e2e-tests/README.md` — E2E workflow context (if reviewing Playwright tests)
+Read these files - they are the source of truth:
+- `docs/TESTING_PHILOSOPHY.md` — All rules live here
+- `CLAUDE.md` — Common mistakes
 
-## E2E Philosophy (Project-Specific)
+## Project-Specific Exceptions
 
-This project follows specific E2E conventions:
+These are intentional patterns, not issues:
 - **No test-only APIs** — We don't create APIs just for test seeding
-- **Workflow tests are intentional** — User flows (create → edit → delete) are tested as single workflows because that's how users actually use the feature
-- **UI-based setup is acceptable** — Creating data through UI in tests is fine when no API exists
-
-Do NOT flag these as issues. Focus on whether tests follow these patterns correctly.
-
-## Primary Focus Areas
-
-### 1. Naming (Critical)
-- Test names: action-based, concise, no "should" prefix
-- File names: match the feature being tested
-- Step functions: clear Given/When/Then intent, not vague or overly permissive
-
-Bad: `"Scenario Execution - view simulations page loads"`
-Good: `"displays simulations page after navigation"`
-
-Bad: `thenISeeEmptyStateOrScenarioList` (tests two things)
-Good: `thenISeeEmptyState` or `thenISeeScenarioList`
-
-### 2. Structure & Organization
-- Consistent use of `test.describe` blocks
-- Related tests grouped logically
-- Test file placement matches directory conventions
-- Setup/teardown patterns consistent across files
-
-### 3. Pyramid Placement (Critical)
-Flag tests that should be downgraded:
-- **Smoke tests masquerading as E2E** — "page loads", "element visible" tests
-- **Navigation-only tests** — Just verify routing works, no user behavior
-- **API-only tests in E2E suite** — Pure HTTP calls belong in integration tests
-- **Component render tests** — Verifying form fields exist could be unit tests
-
-E2E tests should verify **meaningful user workflows**, not just that pages render.
-
-### 4. Hierarchy & Coverage
-- Tests should map to feature specs in `specs/`
-- Missing coverage should be flagged or specs should have `@skip` tags
-- Duplicate coverage across levels wastes resources
-
-### 5. Locator Quality
-- User-facing: `getByRole`, `getByLabel`, `getByText`
-- Avoid: CSS selectors, test IDs (unless necessary), implementation details
-
-### 6. Flakiness Vectors
-- `waitForTimeout` — Replace with web-first assertions
-- `networkidle` — Problematic with SPAs
-- Race conditions, timing assumptions
+- **Workflow tests** — User flows (create → edit → delete) as single tests
+- **UI-based setup** — Creating data through UI when no API exists
 
 ## Output Format
 
 ```
 ## Summary
-[One paragraph assessment focusing on design, not just implementation]
-
-## Naming Issues
-[Specific examples with file:line and suggested renames]
-
-## Structure Issues
-[Organization problems, inconsistent patterns]
+[One paragraph assessment]
 
 ## Pyramid Violations
-[Tests at wrong level with reasoning and recommended level]
+[Tests at wrong level - include file:line, current tag, recommended tag, reason from decision tree]
+
+## Naming Issues
+[Tests using "should" or unclear names - include file:line and fix]
 
 ## What's Working Well
 [Patterns to maintain]
 
 ## Recommendations
-1) Must fix — Blocking issues
-2) Should fix — Important improvements
-3) Consider — Nice-to-haves
+1) Must fix — Blocking
+2) Should fix — Important
+3) Consider — Nice-to-have
 ```
 
-## Decision Hierarchy
+## Valid Tags
 
-When uncertain whether to flag something:
-
-1. **Is this a meaningful user workflow?** — If no, consider demotion
-2. **Does the name clearly describe the behavior?** — If no, flag naming issue
-3. **Is this at the lowest sufficient level?** — Smoke/navigation → integration, render checks → unit
+Only these three:
+- `@e2e`
+- `@integration`
+- `@unit`

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -47,24 +47,33 @@ Be aware of context size. When context grows large, ask the user if they'd like 
 - Read the feature file to understand acceptance criteria
 - Create tasks for each acceptance criterion
 
-### 2. Implement
+### 2. Test Review (Required)
+- Invoke `/test-review` on the feature file
+- Validates pyramid placement before any implementation begins
+- Checks that `@e2e`, `@integration`, `@unit` tags are appropriate
+- If violations found:
+  - Update the feature file to fix tag placement
+  - Re-run `/test-review` to confirm fixes
+- If approved → proceed to Implement
+
+### 3. Implement
 - Mark task as `in_progress`
 - Invoke `/code` with the feature file path and requirements
 - Coder agent implements with TDD and returns a summary
 - Mark task as `completed` when done
 
-### 3. Verify
+### 4. Verify
 - Check the coder's summary against acceptance criteria
 - If incomplete → invoke `/code` again with specific feedback
 - Max 3 iterations, then escalate to user
 
-### 4. Review (Required)
+### 5. Review (Required)
 - Mark review task as `in_progress`
 - Invoke `/review` to run quality gate
 - If issues found → invoke `/code` with reviewer feedback
 - If approved → mark task as `completed`
 
-### 5. E2E Verification (Conditional)
+### 6. E2E Verification (Conditional)
 - Check if feature file has `@e2e` tagged scenarios
 - If yes:
   - Mark e2e task as `in_progress`
@@ -78,7 +87,7 @@ Be aware of context size. When context grows large, ask the user if they'd like 
   - If all pass → mark task as `completed`
 - If no `@e2e` scenarios → skip to Complete
 
-### 6. Complete
+### 7. Complete
 - Verify all tasks are completed
 - Report summary to user (include E2E test status if applicable)
 
@@ -86,6 +95,7 @@ Be aware of context size. When context grows large, ask the user if they'd like 
 
 You delegate, you don't implement:
 - `/plan` creates feature files
+- `/test-review` validates pyramid placement before implementation
 - `/code` writes code and runs tests
 - `/review` checks quality
 - `/e2e` generates and verifies E2E tests

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,25 +1,26 @@
 ---
 name: review
-description: "Run parallel code reviews: uncle-bob-reviewer (SOLID/TDD/clean code) and cupid-reviewer (CUPID properties). Surfaces conflicts for orchestrator resolution."
+description: "Run parallel code reviews: uncle-bob-reviewer (SOLID/TDD), cupid-reviewer (CUPID properties), and test-reviewer (pyramid placement). Surfaces conflicts for orchestrator resolution."
 context: fork
 user-invocable: true
 argument-hint: "[focus-area or file-path]"
 ---
 
-Run both reviewers in parallel on the recent changes.
+Run all three reviewers in parallel on the recent changes.
 
 ## Step 1: Parallel Reviews
 
-Spawn BOTH agents simultaneously using the Task tool in a single message:
+Spawn ALL agents simultaneously using the Task tool in a single message:
 
 1. **uncle-bob-reviewer**: SOLID scan, TDD interrogation, clean code inspection
 2. **cupid-reviewer**: CUPID properties assessment (Composable, Unix, Predictable, Idiomatic, Domain-based)
+3. **test-reviewer**: Test pyramid placement, spec validation, naming conventions, flakiness vectors
 
 Focus area: $ARGUMENTS
 
 ## Step 2: Synthesize Results
 
-After both complete, synthesize:
+After all complete, synthesize:
 
 ```
 ## Review Summary
@@ -30,17 +31,20 @@ After both complete, synthesize:
 ### Dan North (CUPID)
 [Key findings]
 
+### Test Architect (Pyramid/Quality)
+[Key findings on test placement, naming, and quality]
+
 ### Conflicts Requiring Decision
-[Any tensions between SOLID and CUPID recommendations—these need user input]
+[Any tensions between reviewers—these need user input]
 
 ### Agreed Improvements
-[Recommendations both reviewers support]
+[Recommendations all reviewers support]
 ```
 
 ## Step 3: Surface Conflicts
 
-If reviewers disagree on approach (e.g., "extract this class" vs "keep it unified"):
-- Clearly state both positions
+If reviewers disagree on approach (e.g., "extract this class" vs "keep it unified", or "this is E2E" vs "this is integration"):
+- Clearly state all positions
 - Explain the tradeoff
 - Mark as **NEEDS USER DECISION** for the orchestrator to surface
 

--- a/.claude/skills/test-review/SKILL.md
+++ b/.claude/skills/test-review/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: test-review
+description: "Review specs and tests for pyramid placement and quality."
+context: fork
+agent: test-reviewer
+user-invocable: true
+argument-hint: "<path>"
+---
+
+# Test Review
+
+Review feature files or test files for pyramid placement and quality.
+
+## Usage
+
+```
+/test-review <path>
+```
+
+Examples:
+```
+/test-review specs/scenarios/my-feature.feature
+/test-review langwatch/src/__tests__/
+```
+
+## Focus Area
+
+$ARGUMENTS

--- a/docs/TESTING_PHILOSOPHY.md
+++ b/docs/TESTING_PHILOSOPHY.md
@@ -105,19 +105,52 @@ See `specs/README.md` for detailed BDD guidance.
 
 ## Decision Tree
 
+Apply in order. Stop at first match.
+
 ```text
-Is this a happy path demonstrating SDK usage?
-  -> E2E (wrap an example)
+Is this testing UI elements exist? (form fields, buttons, layout)
+  -> @integration
 
-Does it test orchestration between internal modules or external API behavior?
-  -> Integration (mock external boundaries)
+Is this testing navigation/routing only?
+  -> @integration
 
-Is it pure logic or a single class in isolation?
-  -> Unit (mock collaborators)
+Is this testing error handling or edge cases?
+  -> @integration (mock boundaries)
 
-Is it a regression from production?
-  -> Add test at the LOWEST sufficient level (unit > integration > e2e)
+Is this a complete user workflow with observable outcome?
+  -> @e2e (user intent + multiple steps + result + business value)
+
+Is this pure logic in isolation?
+  -> @unit
+
+Is this a regression from production?
+  -> Add at LOWEST sufficient level (unit > integration > e2e)
 ```
+
+### Examples
+
+**Valid @e2e** - Complete workflow:
+```gherkin
+@e2e
+Scenario: User creates and publishes a scenario
+  Given I am logged in
+  When I create a new scenario
+  And I fill in the required fields
+  And I save the scenario
+  Then I see a success message
+  And the scenario appears in my list after refresh
+```
+
+**Invalid @e2e** - Should be @integration:
+```gherkin
+@e2e  # WRONG: just testing UI exists
+Scenario: Create form has required fields
+  Given I am on the create page
+  Then I see a name field
+  And I see a submit button
+```
+
+Use `/test-review` to validate pyramid placement.
 
 ## Scenario Design
 


### PR DESCRIPTION
## Summary

- Add `/test-review` skill for manual invocation of test-reviewer agent
- Enhance test-reviewer agent with feature file review capabilities and decision tree
- Integrate test-review into orchestration workflow (runs after `/plan`, before `/code`)
- Add test-reviewer to `/review` skill (runs in parallel with uncle-bob + cupid)
- Add spec review decision tree to `docs/TESTING_PHILOSOPHY.md`

## Problem

Currently there is no way to review tests or BDD specs for proper pyramid placement before implementation begins. This leads to issues like:
- Feature files with `@e2e` tags on granular UI checks that should be component tests
- Scenarios testing "modal has title" or "button is visible" marked as E2E
- No validation that specs follow the testing philosophy before code is written

## Solution

### New Skill: `/test-review <path>`

```bash
/test-review specs/scenarios/ai-create-modal.feature
/test-review src/components/scenarios/__tests__/
```

### Enhanced Orchestration Flow

```
PLAN → TEST-REVIEW → IMPLEMENT → VERIFY → REVIEW → E2E → COMPLETE
```

### Decision Tree for Feature Files

```
Is this scenario testing that UI elements exist?
  → Component/integration test, remove @e2e

Is this scenario testing navigation/routing only?
  → Integration test, remove @e2e

Is this scenario a complete user workflow with observable outcome?
  → Appropriate for @e2e

Is this testing error handling or edge cases?
  → Integration test (mock boundaries)
```

## Test plan

- [ ] Invoke `/test-review specs/orchestration/test-review-skill.feature` and verify it provides feedback
- [ ] Invoke `/review` and verify test-reviewer runs in parallel with uncle-bob and cupid
- [ ] Run `/orchestrate` on a new feature and verify test-review step executes after plan

Closes #1295

🤖 Generated with [Claude Code](https://claude.ai/code)

# Related Issue

- Resolve #1295