### PR TITLE
fix(agents): restore simplified test-reviewer.md

### DIFF
--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -16,94 +16,28 @@ Read these files - they are the source of truth:
 
 These are intentional patterns, not issues:
 - **No test-only APIs** — We don't create APIs just for test seeding
-- **Workflow tests are intentional** — User flows (create → edit → delete) are tested as single workflows because that's how users actually use the feature
-- **UI-based setup is acceptable** — Creating data through UI in tests is fine when no API exists
-
-Do NOT flag these as issues. Focus on whether tests follow these patterns correctly.
-
-## Primary Focus Areas
-
-### 1. Naming (Critical)
-- Test names: action-based, concise, no "should" prefix
-- File names: match the feature being tested
-- Step functions: clear Given/When/Then intent, not vague or overly permissive
-
-Bad: `"Scenario Execution - view simulations page loads"`
-Good: `"displays simulations page after navigation"`
-
-Bad: `thenISeeEmptyStateOrScenarioList` (tests two things)
-Good: `thenISeeEmptyState` or `thenISeeScenarioList`
-
-### 2. Structure & Organization
-- **BDD-style nesting**: Tests must use `describe("given X")` and `describe("when Y")` blocks, not flat structures with Given/When/Then only in comments
-- Related tests share setup via `beforeEach` in the appropriate `given` block
-- Test file placement matches directory conventions
-- Setup/teardown patterns consistent across files
-
-Bad (flat with comments):
-```typescript
-it("returns error when project not found", () => {
-  // Given: project doesn't exist
-  // When: execute
-  // Then: error
-});
-```
-
-Good (nested describes):
-```typescript
-describe("given project does not exist", () => {
-  beforeEach(() => { /* setup */ });
-  describe("when executing", () => {
-    it("returns error with project not found message", () => { });
-  });
-});
-```
-
-### 3. Pyramid Placement (Critical)
-Flag tests that should be downgraded:
-- **Smoke tests masquerading as E2E** — "page loads", "element visible" tests
-- **Navigation-only tests** — Just verify routing works, no user behavior
-- **API-only tests in E2E suite** — Pure HTTP calls belong in integration tests
-- **Component render tests** — Verifying form fields exist could be unit tests
-
-E2E tests should verify **meaningful user workflows**, not just that pages render.
-
-### 4. Hierarchy & Coverage
-- Tests should map to feature specs in `specs/`
-- Missing coverage should be flagged or specs should have `@skip` tags
-- Duplicate coverage across levels wastes resources
-
-### 5. Locator Quality
-- User-facing: `getByRole`, `getByLabel`, `getByText`
-- Avoid: CSS selectors, test IDs (unless necessary), implementation details
-
-### 6. Flakiness Vectors
-- `waitForTimeout` — Replace with web-first assertions
-- `networkidle` — Problematic with SPAs
-- Race conditions, timing assumptions
+- **Workflow tests** — User flows (create → edit → delete) as single tests
+- **UI-based setup** — Creating data through UI when no API exists
 
 ## Output Format
 
 ```
 ## Summary
-[One paragraph assessment focusing on design, not just implementation]
-
-## Naming Issues
-[Specific examples with file:line and suggested renames]
-
-## Structure Issues
-[Organization problems, missing Given/When describe blocks, flat test structures]
+[One paragraph assessment]
 
 ## Pyramid Violations
 [Tests at wrong level - include file:line, current tag, recommended tag, reason from decision tree]
+
+## Naming Issues
+[Tests using "should" or unclear names - include file:line and fix]
 
 ## What's Working Well
 [Patterns to maintain]
 
 ## Recommendations
-1) Must fix — Blocking issues (includes missing BDD structure)
-2) Should fix — Important improvements
-3) Consider — Nice-to-haves
+1) Must fix — Blocking
+2) Should fix — Important
+3) Consider — Nice-to-have
 ```
 
 ## Valid Tags


### PR DESCRIPTION
## Summary

Restores the simplified test-reviewer.md that was accidentally expanded during the PR #1134 rebase conflict resolution.

## What happened

During the rebase of #1134, there was a conflict in `.claude/agents/test-reviewer.md`. I incorrectly kept the longer version instead of the simplified version from PR #1297.

## Changes

- Removes detailed "Primary Focus Areas" sections (naming, structure, pyramid, locator quality, flakiness)
- Keeps only the essentials: exceptions, output format, valid tags
- Restores the concise version (~50 lines vs ~115 lines)

The detailed guidance lives in `docs/TESTING_PHILOSOPHY.md` which the agent reads before reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)