### PR TITLE
fix(scenarios): use __dirname for reliable child process path resolution

### DIFF
--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -242,9 +242,12 @@ async function spawnScenarioChildProcess(
     });
 
     // tsx is available since the worker runs via tsx
+    // Use __dirname to resolve cwd reliably - go up from src/server/scenarios to package root
+    const packageRoot = path.resolve(__dirname, "../../..");
     const child: ChildProcess = spawn("pnpm", ["exec", "tsx", childPath], {
       env: childEnv,
       stdio: ["pipe", "pipe", "pipe"],
+      cwd: packageRoot,
     });
 
     let stderr = "";


### PR DESCRIPTION
## Summary

- Fixes ERR_MODULE_NOT_FOUND error when spawning scenario child process in Docker
- `process.cwd()` returns `/app` but source files are at `/app/langwatch/src/...`
- Changed to use `__dirname` which resolves relative to the module file itself
- Follows the same pattern as `goose.ts` for migrations directory resolution

## Test plan

- [ ] Deploy to staging and run a scenario execution
- [ ] Verify child process spawns correctly without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)