### PR TITLE
fix(scenarios): bypass queue and run scenarios directly

### DIFF
--- a/langwatch/src/server/scenarios/simulation-runner.service.ts
+++ b/langwatch/src/server/scenarios/simulation-runner.service.ts
@@ -1,0 +1,193 @@
+/**
+ * Direct scenario execution service.
+ *
+ * Runs scenarios directly in the main process without queue/worker infrastructure.
+ * This is a simpler approach that trades OTEL trace isolation for reliability.
+ */
+
+import ScenarioRunner, { type AgentAdapter } from "@langwatch/scenario";
+import type { PrismaClient } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { env } from "~/env.mjs";
+import { DEFAULT_MODEL } from "~/utils/constants";
+import { createLogger } from "~/utils/logger";
+import type { SimulationTarget } from "../api/routers/scenarios";
+import { getVercelAIModel } from "../modelProviders/utils";
+import { PromptService } from "../prompt-config/prompt.service";
+import { HttpAgentAdapter } from "./adapters/http-agent.adapter";
+import { PromptConfigAdapter } from "./adapters/prompt-config.adapter";
+import { ScenarioService } from "./scenario.service";
+
+/** Default scenario set for on-platform runs */
+const PLATFORM_SET_ID = "on-platform";
+
+/** Generates a unique batch run ID for grouping scenario executions */
+export function generateBatchRunId(): string {
+  return `scenariobatch_${nanoid()}`;
+}
+
+const logger = createLogger("SimulationRunnerService");
+
+interface ExecuteParams {
+  projectId: string;
+  scenarioId: string;
+  target: SimulationTarget;
+  setId: string;
+  batchRunId: string;
+}
+
+/**
+ * Service for running scenarios against targets directly.
+ */
+export class SimulationRunnerService {
+  private readonly scenarioService: ScenarioService;
+  private readonly promptService: PromptService;
+
+  constructor(private readonly prisma: PrismaClient) {
+    this.scenarioService = ScenarioService.create(prisma);
+    this.promptService = new PromptService(prisma);
+  }
+
+  /**
+   * Execute a scenario against a target.
+   * Fire and forget - returns immediately, execution happens async.
+   */
+  async execute(params: ExecuteParams): Promise<void> {
+    const { projectId, scenarioId, target, setId, batchRunId } = params;
+
+    try {
+      // 1. Fetch scenario
+      const scenario = await this.scenarioService.getById({
+        projectId,
+        id: scenarioId,
+      });
+
+      if (!scenario) {
+        logger.error({ scenarioId, projectId }, "Scenario not found");
+        return;
+      }
+
+      // 2. Fetch project config
+      const project = await this.prisma.project.findUnique({
+        where: { id: projectId },
+        select: { apiKey: true, defaultModel: true },
+      });
+
+      if (!project?.apiKey) {
+        throw new Error(`Project ${projectId} not found or has no API key`);
+      }
+
+      // 3. Get project's default model for simulator and judge agents
+      const defaultModel = project.defaultModel ?? DEFAULT_MODEL;
+      const simulatorModel = await getVercelAIModel(projectId, defaultModel);
+      const judgeModel = await getVercelAIModel(projectId, defaultModel);
+
+      // 4. Resolve target to adapter
+      logger.debug(
+        { targetType: target.type, referenceId: target.referenceId, projectId },
+        "Resolving target to adapter",
+      );
+      const adapter = this.resolveAdapter(target, projectId);
+      logger.debug(
+        { adapterName: adapter.name, adapterRole: adapter.role },
+        "Adapter resolved",
+      );
+
+      // 5. Validate batchRunId
+      if (!batchRunId || typeof batchRunId !== "string") {
+        logger.error(
+          { batchRunId, type: typeof batchRunId },
+          "Invalid batchRunId",
+        );
+        throw new Error(`Invalid batchRunId: ${batchRunId}`);
+      }
+
+      logger.info(
+        {
+          scenarioId,
+          setId,
+          batchRunId,
+          targetType: target.type,
+          model: defaultModel,
+        },
+        "Starting scenario execution",
+      );
+
+      // Run in headless mode on server (don't open browser tabs)
+      process.env.SCENARIO_HEADLESS = "true";
+
+      const result = await ScenarioRunner.run(
+        {
+          id: scenarioId,
+          name: scenario.name,
+          description: scenario.situation,
+          setId,
+          agents: [
+            adapter,
+            ScenarioRunner.userSimulatorAgent({ model: simulatorModel }),
+            ScenarioRunner.judgeAgent({
+              model: judgeModel,
+              criteria: scenario.criteria,
+            }),
+          ],
+          verbose: true,
+        },
+        {
+          batchRunId,
+          langwatch: {
+            endpoint: this.getLangWatchEndpoint(),
+            apiKey: project.apiKey,
+          },
+        },
+      );
+
+      logger.info(
+        {
+          scenarioId,
+          setId,
+          runId: result.runId,
+          success: result.success,
+          reasoning: result.reasoning,
+        },
+        "Scenario execution completed",
+      );
+    } catch (error) {
+      logger.error(
+        { error, scenarioId, projectId, setId },
+        "Scenario execution failed",
+      );
+    }
+  }
+
+  private getLangWatchEndpoint(): string {
+    return env.BASE_HOST ?? "https://app.langwatch.ai";
+  }
+
+  private resolveAdapter(
+    target: SimulationTarget,
+    projectId: string,
+  ): AgentAdapter {
+    switch (target.type) {
+      case "prompt":
+        return new PromptConfigAdapter(
+          target.referenceId,
+          this.promptService,
+          projectId,
+        );
+      case "http":
+        return HttpAgentAdapter.create({
+          agentId: target.referenceId,
+          projectId,
+          prisma: this.prisma,
+        });
+      default: {
+        const _exhaustive: never = target.type;
+        throw new Error(`Unknown target type: ${_exhaustive}`);
+      }
+    }
+  }
+
+  static create(prisma: PrismaClient): SimulationRunnerService {
+    return new SimulationRunnerService(prisma);
+  }
+}


### PR DESCRIPTION
## Summary

Run scenarios directly in the main process instead of scheduling to the BullMQ queue and spawning child processes. This is a **temporary fix** to unblock the team while OTEL isolation issues are resolved.

## Changes

- Add `SimulationRunnerService` for direct scenario execution (same pattern as before #1134)
- Update router to use service directly instead of `scheduleScenarioRun`
- Remove dependency on queue/processor infrastructure for scenario runs

## What this does NOT change

- The queue infrastructure (scenario.queue.ts, scenario.processor.ts) remains in place
- The worker still starts the scenario processor (it just won't receive jobs)
- All other OTEL-related code remains

## Trade-offs

| Before (queue) | After (direct) |
|----------------|----------------|
| OTEL trace isolation per scenario | Traces may mix with server traces |
| Child process crashes don't affect server | Errors in scenarios affect server process |
| Requires workers running | Works without workers |
| Complex debugging | Simple debugging |

## Testing

- [ ] Run a scenario against a prompt target
- [ ] Run a scenario against an HTTP agent target
- [ ] Verify results appear in the UI

🤖 Generated with [Claude Code](https://claude.ai/code)