### PR TITLE
docs(scenarios): add production testing guide and verification script

### DIFF
--- a/langwatch/docs/testing-scenarios-production.md
+++ b/langwatch/docs/testing-scenarios-production.md
@@ -1,0 +1,184 @@
+# Testing Scenarios in Production-Like Environments
+
+This guide covers how to test the scenario execution system before deploying to production.
+
+## Quick Start
+
+### Option 1: Docker Dev Environment (Recommended)
+
+The fastest way to test scenarios with the full stack:
+
+```bash
+# From langwatch/ directory
+make dev-scenarios
+```
+
+This starts:
+- PostgreSQL + Redis
+- Next.js app (port 5560)
+- Workers (includes scenario processor)
+- Bull Board (port 3000) - queue visualization
+- AI Server (port 3456)
+
+Then:
+1. Open http://localhost:5560
+2. Create/select a project
+3. Go to Scenarios
+4. Run a scenario against a prompt or HTTP agent
+
+### Option 2: Production Docker Build
+
+To test the exact Docker image that will be deployed:
+
+```bash
+# From langwatch-saas/ directory
+docker build -t langwatch-test .
+
+# Run with required env vars
+docker run -it --rm \
+  -e DATABASE_URL="postgresql://..." \
+  -e REDIS_URL="redis://..." \
+  -e NEXTAUTH_SECRET="test-secret" \
+  -e NEXTAUTH_URL="http://localhost:5560" \
+  -p 5560:5560 \
+  langwatch-test
+```
+
+## Architecture Overview
+
+Scenario execution flow:
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   API Router    │────▶│  BullMQ Queue   │────▶│ Scenario Worker │
+│ (schedules job) │     │ (scenarios/exec)│     │ (processes job) │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                                                         │
+                                                         ▼
+                                               ┌─────────────────┐
+                                               │  Child Process  │
+                                               │ (isolated OTEL) │
+                                               └─────────────────┘
+```
+
+Key components:
+- `simulation-runner.router.ts` - API endpoint that schedules scenario jobs
+- `scenario.queue.ts` - BullMQ queue for scenario execution
+- `scenario.processor.ts` - Worker that processes jobs and spawns child processes
+- `scenario-child-process.ts` - Isolated process with its own OTEL context
+
+## Debugging
+
+### View Queue Status
+
+Bull Board UI: http://localhost:3000
+
+Shows:
+- Pending jobs
+- Active jobs
+- Completed/failed jobs
+- Job logs
+
+### Check Worker Logs
+
+```bash
+# Docker dev environment
+docker logs -f langwatch-workers-1
+
+# Or filter for scenario logs
+docker logs langwatch-workers-1 2>&1 | grep -i scenario
+```
+
+### Common Issues
+
+#### ERR_MODULE_NOT_FOUND when spawning child process
+
+**Symptom:** Jobs fail with module resolution errors
+
+**Cause:** Path resolution issue in Docker where `process.cwd()` differs from source location
+
+**Fix:** PR #1306 - uses `__dirname` for reliable path resolution
+
+#### Jobs stuck in "waiting" state
+
+**Check:**
+1. Workers are running: `docker ps | grep workers`
+2. Redis connection: Worker logs should show "connected to Redis"
+3. Queue name matches: Should be `simulations/scenarios/executions`
+
+#### Child process crashes silently
+
+**Check job logs in Bull Board** - the worker captures child stderr
+
+**Common causes:**
+- Missing environment variables (check `buildChildProcessEnv` whitelist)
+- Dependencies not resolved (check `cwd` is set to package root)
+
+## Environment Variables
+
+Required for scenario execution:
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `REDIS_URL` | Redis connection for BullMQ |
+| `BASE_HOST` | LangWatch endpoint for trace collection |
+
+Optional:
+
+| Variable | Description |
+|----------|-------------|
+| `PINO_LOG_LEVEL` | Log verbosity (debug, info, warn, error) |
+| `WORKER_METRICS_PORT` | Prometheus metrics port (default: 9090) |
+
+## Verifying Scenario Execution
+
+### 1. Create a Test Scenario
+
+```typescript
+// Via API or UI
+const scenario = {
+  name: "Test Greeting",
+  situation: "User asks for a greeting",
+  criteria: "Agent responds with a friendly greeting"
+};
+```
+
+### 2. Run Against a Target
+
+Targets can be:
+- **Prompt config**: Tests a prompt template with LLM
+- **HTTP agent**: Tests an external API endpoint
+
+### 3. Check Results
+
+1. **UI**: Scenario results page shows pass/fail with reasoning
+2. **Traces**: LangWatch captures full execution trace
+3. **Bull Board**: Job status and logs
+
+## Rollback Plan
+
+If scenarios fail in production after deploy:
+
+### Option A: Quick Fix - Bypass Queue
+
+PR #1310 provides a fallback that runs scenarios directly without the queue/worker infrastructure:
+
+```bash
+git checkout fix/scenarios-bypass-queue
+# Deploy this branch
+```
+
+### Option B: Revert OTEL Changes
+
+PR #1309 fully reverts the OTEL isolation feature:
+
+```bash
+git checkout revert/otel-trace-isolation
+# Deploy this branch
+```
+
+## Related Documentation
+
+- [ADR-004: Docker Dev Environment](./adr/004-docker-dev-environment.md)
+- [Testing Philosophy](./TESTING_PHILOSOPHY.md)

--- a/langwatch/scripts/test-scenarios.sh
+++ b/langwatch/scripts/test-scenarios.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Quick test script to verify scenario execution is working
+# Usage: ./scripts/test-scenarios.sh
+
+set -e
+
+echo "=== Scenario Execution Test ==="
+echo ""
+
+# Check if workers are running
+echo "1. Checking workers..."
+if docker ps | grep -q "langwatch-workers"; then
+    echo "   ✓ Workers container is running"
+else
+    echo "   ✗ Workers container not found"
+    echo "   Run: make dev-scenarios"
+    exit 1
+fi
+
+# Check Redis container
+echo ""
+echo "2. Checking Redis..."
+if docker ps | grep -q "langwatch-redis"; then
+    REDIS_STATUS=$(docker ps --filter "name=langwatch-redis" --format "{{.Status}}")
+    if echo "$REDIS_STATUS" | grep -q "healthy"; then
+        echo "   ✓ Redis is healthy"
+    else
+        echo "   ✓ Redis is running ($REDIS_STATUS)"
+    fi
+else
+    echo "   ✗ Redis container not found"
+    exit 1
+fi
+
+# Check for scenario processor initialization
+echo ""
+echo "3. Checking scenario processor..."
+if docker logs langwatch-workers-1 2>&1 | grep -iq "scenario\|simulations"; then
+    echo "   ✓ Scenario processor found in logs"
+else
+    echo "   ? No scenario logs found (may be normal if no scenarios run yet)"
+fi
+
+# Check Bull Board
+echo ""
+echo "4. Checking Bull Board..."
+BULLBOARD_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 2>/dev/null || echo "failed")
+if [ "$BULLBOARD_STATUS" = "200" ] || [ "$BULLBOARD_STATUS" = "302" ]; then
+    echo "   ✓ Bull Board is accessible at http://localhost:3000"
+else
+    echo "   ? Bull Board not accessible (status: $BULLBOARD_STATUS)"
+fi
+
+# Check app
+echo ""
+echo "5. Checking app..."
+APP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5560 2>/dev/null || echo "failed")
+if [ "$APP_STATUS" = "200" ] || [ "$APP_STATUS" = "302" ]; then
+    echo "   ✓ App is accessible at http://localhost:5560"
+else
+    echo "   ? App may still be starting (status: $APP_STATUS)"
+    echo "   Wait a moment and check http://localhost:5560"
+fi
+
+echo ""
+echo "=== Checks Complete ==="
+echo ""
+echo "To test scenario execution:"
+echo "1. Open http://localhost:5560"
+echo "2. Create or select a project"
+echo "3. Go to Scenarios"
+echo "4. Create a scenario and run it"
+echo "5. Check Bull Board at http://localhost:3000 for job status"
+echo ""
+echo "To check worker logs:"
+echo "  docker logs -f langwatch-workers-1"
+echo ""


### PR DESCRIPTION
## Summary

Adds documentation and tooling to make it easy to test scenario execution before deploying to production.

## Changes

### `docs/testing-scenarios-production.md`
- Quick start guide for testing scenarios locally
- Architecture overview of the scenario execution flow
- Debugging tips for common issues
- Environment variables reference
- Rollback plan with links to PRs #1309 and #1310

### `scripts/test-scenarios.sh`
- Quick verification script that checks:
  - Workers container running
  - Redis healthy
  - Scenario processor initialized
  - Bull Board accessible
  - App accessible
- Provides clear next steps for manual testing

## Usage

```bash
# Run the verification script
./langwatch/scripts/test-scenarios.sh

# Or just start the dev environment with scenarios
make dev-scenarios
```

🤖 Generated with [Claude Code](https://claude.ai/code)