### PR TITLE
chore: require user approval on feature file before implementation

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -47,7 +47,18 @@ Be aware of context size. When context grows large, ask the user if they'd like 
 - Read the feature file to understand acceptance criteria
 - Create tasks for each acceptance criterion
 
-### 2. Test Review (Required)
+### 2. User Approval (Required)
+- **STOP and show the feature file to the user**
+- Present the acceptance criteria and scenarios clearly
+- Ask explicitly: "Please review the feature file. Do you approve this plan?"
+- **Do NOT proceed until user explicitly approves**
+- If user requests changes:
+  - Update the feature file accordingly
+  - Show the updated version
+  - Ask for approval again
+- Only after explicit approval → proceed to Test Review
+
+### 3. Test Review (Required)
 - Invoke `/test-review` on the feature file
 - Validates pyramid placement before any implementation begins
 - Checks that `@e2e`, `@integration`, `@unit` tags are appropriate
@@ -56,24 +67,24 @@ Be aware of context size. When context grows large, ask the user if they'd like 
   - Re-run `/test-review` to confirm fixes
 - If approved → proceed to Implement
 
-### 3. Implement
+### 4. Implement
 - Mark task as `in_progress`
 - Invoke `/code` with the feature file path and requirements
 - Coder agent implements with TDD and returns a summary
 - Mark task as `completed` when done
 
-### 4. Verify
+### 5. Verify
 - Check the coder's summary against acceptance criteria
 - If incomplete → invoke `/code` again with specific feedback
 - Max 3 iterations, then escalate to user
 
-### 5. Review (Required)
+### 6. Review (Required)
 - Mark review task as `in_progress`
 - Invoke `/review` to run quality gate
 - If issues found → invoke `/code` with reviewer feedback
 - If approved → mark task as `completed`
 
-### 6. E2E Verification (Conditional)
+### 7. E2E Verification (Conditional)
 - Check if feature file has `@e2e` tagged scenarios
 - If yes:
   - Mark e2e task as `in_progress`
@@ -87,7 +98,7 @@ Be aware of context size. When context grows large, ask the user if they'd like 
   - If all pass → mark task as `completed`
 - If no `@e2e` scenarios → skip to Complete
 
-### 7. Self-Check (Required)
+### 8. Self-Check (Required)
 
 Before completing, verify you didn't make mistakes:
 
@@ -112,7 +123,7 @@ If ANY check fails:
 
 This self-check exists because it's easy to rationalize skipping work. Don't.
 
-### 8. Complete
+### 9. Complete
 - Verify all tasks are completed
 - Verify self-check passed
 - Report summary to user (include E2E test status if applicable)


### PR DESCRIPTION
## Summary
- Adds step 2 "User Approval" to the orchestration flow
- Requires explicit user sign-off on the feature file before proceeding
- Prevents wasted effort from implementing based on incorrect requirements

## Changes
- Updated `.claude/skills/orchestrate/SKILL.md` to add user approval gate between Plan and Test Review steps
- Renumbered subsequent steps (3-9)

## Why
Without this gate, the orchestrator could proceed to implement features based on a feature file that doesn't match what the user actually wanted, wasting time and effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)