### PR TITLE
feat(scenarios): display friendly name for internal scenario sets

### DIFF
--- a/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
+++ b/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
@@ -119,7 +119,7 @@ test.describe("Scenario Execution", () => {
     );
 
     // Verify we're NOT in the legacy "default" fallback set
-    // Note: "local-scenarios" (PLATFORM_SET_ID) is valid - that's the platform default
+    // Internal on-platform sets use getOnPlatformSetId() from internal-set-id.ts
     expect(page.url()).not.toContain("/default/");
   });
 

--- a/langwatch/src/components/simulations/SimulationLayout.tsx
+++ b/langwatch/src/components/simulations/SimulationLayout.tsx
@@ -8,6 +8,10 @@ import {
 } from "@chakra-ui/react";
 import { LuPanelLeftClose, LuPanelLeftOpen } from "react-icons/lu";
 import { useSimulationRouter } from "~/hooks/simulations";
+import {
+  isOnPlatformSet,
+  ON_PLATFORM_DISPLAY_NAME,
+} from "~/server/scenarios/internal-set-id";
 import { DashboardLayout } from "../DashboardLayout";
 import { SetRunHistorySidebar } from "./set-run-history-sidebar";
 
@@ -60,6 +64,10 @@ const Header = ({
   onHistorySidebarOpenChange: (open: boolean) => void;
 }) => {
   const { scenarioSetId } = useSimulationRouter();
+  const displayName =
+    scenarioSetId && isOnPlatformSet(scenarioSetId)
+      ? ON_PLATFORM_DISPLAY_NAME
+      : scenarioSetId ?? "unknown";
   return (
     <Box w="full" p={4} borderBottom="1px" bg="bg.surface" borderColor="border">
       <HStack>
@@ -80,7 +88,7 @@ const Header = ({
             <Text fontSize={"xs"} color={"fg.muted"} as="span">
               Scenario Set ID:
             </Text>{" "}
-            <code>{scenarioSetId ?? "unknown"}</code>
+            <code>{displayName}</code>
           </Text>
         </Flex>
       </HStack>

--- a/langwatch/src/components/simulations/__tests__/SimulationLayout.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/SimulationLayout.integration.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for SimulationLayout component.
+ *
+ * Tests the UI treatment for internal vs user-created sets in the header.
+ *
+ * @see specs/scenarios/internal-scenario-namespace.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the useSimulationRouter hook
+const mockUseSimulationRouter = vi.fn();
+vi.mock("~/hooks/simulations", () => ({
+  useSimulationRouter: () => mockUseSimulationRouter(),
+}));
+
+// Mock DashboardLayout to simplify testing
+vi.mock("../../DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dashboard-layout">{children}</div>
+  ),
+}));
+
+// Mock SetRunHistorySidebar to simplify testing
+vi.mock("../set-run-history-sidebar", () => ({
+  SetRunHistorySidebar: () => <div data-testid="sidebar" />,
+}));
+
+// Import after mocks are set up
+import { SimulationLayout } from "../SimulationLayout";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("<SimulationLayout/>", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe("given an internal set ID in the URL", () => {
+    const internalSetId = "__internal__proj_abc123__on-platform-scenarios";
+
+    describe("when the header displays the scenario set", () => {
+      it('shows "On-Platform Scenarios" instead of the internal namespace ID', () => {
+        mockUseSimulationRouter.mockReturnValue({
+          scenarioSetId: internalSetId,
+        });
+
+        render(
+          <SimulationLayout>
+            <div>content</div>
+          </SimulationLayout>,
+          { wrapper: Wrapper }
+        );
+
+        expect(screen.getByText("On-Platform Scenarios")).toBeInTheDocument();
+        expect(screen.queryByText(internalSetId)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given a user-created set ID in the URL", () => {
+    const userSetId = "my-custom-set";
+
+    describe("when the header displays the scenario set", () => {
+      it("shows the raw set ID", () => {
+        mockUseSimulationRouter.mockReturnValue({
+          scenarioSetId: userSetId,
+        });
+
+        render(
+          <SimulationLayout>
+            <div>content</div>
+          </SimulationLayout>,
+          { wrapper: Wrapper }
+        );
+
+        expect(screen.getByText(userSetId)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given no set ID in the URL", () => {
+    describe("when the header displays the scenario set", () => {
+      it('shows "unknown" as fallback', () => {
+        mockUseSimulationRouter.mockReturnValue({
+          scenarioSetId: undefined,
+        });
+
+        render(
+          <SimulationLayout>
+            <div>content</div>
+          </SimulationLayout>,
+          { wrapper: Wrapper }
+        );
+
+        expect(screen.getByText("unknown")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/simulations/set-run-history-sidebar/SetRunHistorySidebarComponent.tsx
+++ b/langwatch/src/components/simulations/set-run-history-sidebar/SetRunHistorySidebarComponent.tsx
@@ -13,6 +13,10 @@ import {
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { ChevronLeft, ChevronRight } from "react-feather";
+import {
+  isOnPlatformSet,
+  ON_PLATFORM_DISPLAY_NAME,
+} from "~/server/scenarios/internal-set-id";
 import { useColorModeValue } from "../../ui/color-mode";
 import { RunAccordionItem } from "./RunAccordionItem";
 import type { useSetRunHistorySidebarController } from "./useSetRunHistorySidebarController";
@@ -23,6 +27,10 @@ export const SetRunHistorySidebarComponent = (
 ) => {
   const [openIndex, setOpenIndex] = useState<string[]>(["0"]);
   const { runs, onRunClick, isLoading, scenarioSetId, pagination } = props;
+  const displayName =
+    scenarioSetId && isOnPlatformSet(scenarioSetId)
+      ? ON_PLATFORM_DISPLAY_NAME
+      : scenarioSetId ?? "unknown";
 
   return (
     <Box
@@ -77,7 +85,7 @@ export const SetRunHistorySidebarComponent = (
               <EmptyState.Title>This set is all alone</EmptyState.Title>
               <EmptyState.Description>
                 You haven&apos;t run any simulations yet for the set
-                <code>{scenarioSetId ?? "unknown"}</code>
+                <code>{displayName}</code>
               </EmptyState.Description>
             </VStack>
           </EmptyState.Content>

--- a/langwatch/src/components/simulations/set-run-history-sidebar/__tests__/SetRunHistorySidebarComponent.integration.test.tsx
+++ b/langwatch/src/components/simulations/set-run-history-sidebar/__tests__/SetRunHistorySidebarComponent.integration.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for SetRunHistorySidebarComponent.
+ *
+ * Tests the empty state message for internal vs user-created sets.
+ *
+ * @see specs/scenarios/internal-scenario-namespace.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SetRunHistorySidebarComponent } from "../SetRunHistorySidebarComponent";
+import type { useSetRunHistorySidebarController } from "../useSetRunHistorySidebarController";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function createMockProps(
+  overrides: Partial<ReturnType<typeof useSetRunHistorySidebarController>> = {}
+): ReturnType<typeof useSetRunHistorySidebarController> {
+  return {
+    runs: [],
+    onRunClick: vi.fn(),
+    isLoading: false,
+    scenarioSetId: "test-set",
+    error: null,
+    pagination: {
+      page: 1,
+      limit: 8,
+      totalPages: 1,
+      totalCount: 0,
+      hasPrevPage: false,
+      hasNextPage: false,
+      onPageChange: vi.fn(),
+      onPrevPage: vi.fn(),
+      onNextPage: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+describe("<SetRunHistorySidebarComponent/>", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given an internal set ID with no runs", () => {
+    const internalSetId = "__internal__proj_abc123__on-platform-scenarios";
+
+    describe("when the empty state is displayed", () => {
+      it('shows "On-Platform Scenarios" in the message', () => {
+        const props = createMockProps({
+          scenarioSetId: internalSetId,
+          runs: [],
+          isLoading: false,
+        });
+
+        render(<SetRunHistorySidebarComponent {...props} />, {
+          wrapper: Wrapper,
+        });
+
+        expect(screen.getByText("On-Platform Scenarios")).toBeInTheDocument();
+        expect(screen.queryByText(internalSetId)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given a user-created set ID with no runs", () => {
+    const userSetId = "production-tests";
+
+    describe("when the empty state is displayed", () => {
+      it("shows the raw set ID in the message", () => {
+        const props = createMockProps({
+          scenarioSetId: userSetId,
+          runs: [],
+          isLoading: false,
+        });
+
+        render(<SetRunHistorySidebarComponent {...props} />, {
+          wrapper: Wrapper,
+        });
+
+        expect(screen.getByText(userSetId)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given no set ID with no runs", () => {
+    describe("when the empty state is displayed", () => {
+      it('shows "unknown" as fallback', () => {
+        const props = createMockProps({
+          scenarioSetId: undefined,
+          runs: [],
+          isLoading: false,
+        });
+
+        render(<SetRunHistorySidebarComponent {...props} />, {
+          wrapper: Wrapper,
+        });
+
+        expect(screen.getByText("unknown")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/scenario.constants.ts
+++ b/langwatch/src/server/scenarios/scenario.constants.ts
@@ -35,13 +35,3 @@ export const CHILD_PROCESS = {
   /** Timeout for scenario child process execution (ms) */
   TIMEOUT_MS: 5 * 60 * 1000, // 5 minutes
 } as const;
-
-/**
- * @deprecated Use getOnPlatformSetId() from internal-set-id.ts instead.
- * This constant is kept for backward compatibility only.
- * @see internal-set-id.ts
- */
-export const SCENARIO_DEFAULTS = {
-  /** @deprecated Use getOnPlatformSetId(projectId) instead */
-  PLATFORM_SET_ID: "local-scenarios",
-} as const;

--- a/langwatch/src/server/scenarios/simulation-runner.service.ts
+++ b/langwatch/src/server/scenarios/simulation-runner.service.ts
@@ -11,9 +11,6 @@ import { HttpAgentAdapter } from "./adapters/http-agent.adapter";
 import { PromptConfigAdapter } from "./adapters/prompt-config.adapter";
 import { ScenarioService } from "./scenario.service";
 
-/** Default scenario set for local/quick runs */
-const _DEFAULT_SIMULATION_SET_ID = "local-scenarios";
-
 /** Generates a unique batch run ID for grouping scenario executions */
 export function generateBatchRunId(): string {
   return `scenariobatch_${nanoid()}`;

--- a/specs/scenarios/internal-scenario-namespace.feature
+++ b/specs/scenarios/internal-scenario-namespace.feature
@@ -1,0 +1,53 @@
+Feature: Internal Scenario Set Namespace Display
+  As a LangWatch user
+  I want internal scenario set IDs to display as friendly names
+  So that I see "On-Platform Scenarios" instead of technical namespace IDs
+
+  Background:
+    The on-platform scenario runner uses an internal namespace pattern:
+    `__internal__${projectId}__on-platform-scenarios`
+
+    This technical ID should never be displayed to users. Instead,
+    the UI should show "On-Platform Scenarios" wherever the set ID appears.
+
+  # ============================================================================
+  # Display Name Transformation
+  # ============================================================================
+
+  @integration
+  Scenario: Simulation layout header shows friendly name for internal sets
+    Given I am viewing a simulation run in an on-platform scenario set
+    When the page header displays the scenario set
+    Then I see "On-Platform Scenarios" instead of the internal namespace ID
+
+  @integration
+  Scenario: Simulation layout header shows raw ID for user-created sets
+    Given I am viewing a simulation run in set "my-custom-set"
+    When the page header displays the scenario set
+    Then I see "my-custom-set" as the set identifier
+
+  @integration
+  Scenario: Empty state message shows friendly name for internal sets
+    Given I am viewing an on-platform scenario set with no runs
+    When the empty state message is displayed
+    Then I see "On-Platform Scenarios" in the message
+
+  @integration
+  Scenario: Empty state message shows raw ID for user-created sets
+    Given I am viewing set "production-tests" with no runs
+    When the empty state message is displayed
+    Then I see "production-tests" in the message
+
+  # ============================================================================
+  # Cleanup: Deprecated Constants
+  # ============================================================================
+
+  @integration
+  Scenario: Legacy PLATFORM_SET_ID constant is removed
+    When inspecting scenario.constants.ts
+    Then no "PLATFORM_SET_ID" constant with value "local-scenarios" exists
+
+  @integration
+  Scenario: All scenario set references use getOnPlatformSetId
+    When inspecting scenario-related modules
+    Then all internal set ID references use getOnPlatformSetId() from internal-set-id.ts


### PR DESCRIPTION

<img width="962" height="548" alt="Screenshot 2026-02-04 at 19 12 06" src="https://github.com/user-attachments/assets/d1512276-2bed-4f6f-8d97-eba07c3ca12f" />


## Summary
- Display "On-Platform Scenarios" instead of raw internal namespace ID in UI
- Remove deprecated `PLATFORM_SET_ID` constant and unused variables
- Add integration tests for display name transformation

## Changes
| File | Change |
|------|--------|
| `SimulationLayout.tsx` | Shows friendly name for internal sets in header |
| `SetRunHistorySidebarComponent.tsx` | Shows friendly name in empty state message |
| `scenario.constants.ts` | Removed deprecated `SCENARIO_DEFAULTS.PLATFORM_SET_ID` |
| `simulation-runner.service.ts` | Removed unused `_DEFAULT_SIMULATION_SET_ID` |
| `scenario-execution.spec.ts` | Updated comment referencing `local-scenarios` |

## Test plan
- [x] `SimulationLayout.integration.test.tsx` - 3 tests passing
- [x] `SetRunHistorySidebarComponent.integration.test.tsx` - 3 tests passing
- [x] Typecheck passes
- [x] No remaining `local-scenarios` references in production code

Closes #1349

🤖 Generated with [Claude Code](https://claude.ai/code)

# Related Issue

- Resolve #1349