### PR TITLE
fix: update BullMQ job ID deduplication for multi-target and repeated runs

### DIFF
--- a/langwatch/src/server/api/routers/scenarios/__tests__/simulation-runner.router.unit.test.ts
+++ b/langwatch/src/server/api/routers/scenarios/__tests__/simulation-runner.router.unit.test.ts
@@ -270,6 +270,7 @@ describe("simulationRunnerRouter.run", () => {
           target: { type: "prompt", referenceId: "prompt_123" },
           setId: expectedSetId,
           batchRunId: "batch_test_123",
+          index: 0,
         });
       });
 
@@ -300,6 +301,7 @@ describe("simulationRunnerRouter.run", () => {
           target: { type: "prompt", referenceId: "prompt_123" },
           setId: "production-tests",
           batchRunId: "batch_test_123",
+          index: 0,
         });
       });
 

--- a/langwatch/src/server/api/routers/scenarios/simulation-runner.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/simulation-runner.router.ts
@@ -99,6 +99,7 @@ export const simulationRunnerRouter = createTRPCRouter({
         target: input.target,
         setId,
         batchRunId,
+        index: 0,
       });
 
       logger.info({ jobId: job.id, batchRunId }, "Scenario scheduled");

--- a/langwatch/src/server/scenarios/scenario.queue.jobId.ts
+++ b/langwatch/src/server/scenarios/scenario.queue.jobId.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure function for building scenario job IDs.
+ *
+ * Extracted from scenario.queue.ts to enable unit testing without
+ * triggering module-level side effects (Redis/DB connections).
+ *
+ * The job ID must be unique per (project, scenario, target, batch, index)
+ * to prevent BullMQ from silently deduplicating jobs when the same scenario
+ * runs against multiple targets or with repeats in the same batch.
+ *
+ * @see https://github.com/langwatch/langwatch/issues/1396
+ * @see specs/scenarios/scenario-job-id-uniqueness.feature
+ */
+
+/** Parameters needed to build a unique scenario job ID. */
+export interface BuildScenarioJobIdParams {
+  projectId: string;
+  scenarioId: string;
+  targetReferenceId: string;
+  batchRunId: string;
+  /** Zero-based index distinguishing repeated runs within the same batch+target. */
+  index: number;
+}
+
+/**
+ * Build a deterministic, unique job ID for a scenario execution.
+ *
+ * Formula: `scenario_${projectId}_${scenarioId}_${targetReferenceId}_${batchRunId}_${index}`
+ *
+ * @param params - All dimensions needed for uniqueness
+ * @returns A string suitable for use as a BullMQ job ID
+ */
+export function buildScenarioJobId({
+  projectId,
+  scenarioId,
+  targetReferenceId,
+  batchRunId,
+  index,
+}: BuildScenarioJobIdParams): string {
+  return `scenario_${projectId}_${scenarioId}_${targetReferenceId}_${batchRunId}_${index}`;
+}

--- a/specs/scenarios/scenario-job-id-uniqueness.feature
+++ b/specs/scenarios/scenario-job-id-uniqueness.feature
@@ -1,0 +1,50 @@
+Feature: Scenario Job ID Uniqueness
+  As the scenario scheduling system
+  I need unique job IDs for each distinct execution
+  So that BullMQ does not silently deduplicate jobs in multi-target or repeated runs
+
+  # Context: scheduleScenarioRun() generates job IDs used by BullMQ for deduplication.
+  # The current formula `scenario_${projectId}_${scenarioId}_${batchRunId}` omits
+  # the target and repeat index, causing jobs to collide when the same scenario
+  # runs against multiple targets or with repeats in the same batch.
+  #
+  # Fix: include target referenceId and a unique index in the job ID.
+
+  # ============================================================================
+  # Multi-Target: distinct jobs per target
+  # ============================================================================
+
+  @unit
+  Scenario: Scheduling same scenario against two different targets produces distinct job IDs
+    Given scenario "Refund Flow" in project "proj_1" with batch "batch_1"
+    When the scenario is scheduled against target "prompt_A"
+    And the scenario is scheduled against target "prompt_B"
+    Then the two jobs have different IDs
+
+  @unit
+  Scenario: Job ID includes target reference ID
+    Given scenario "Refund Flow" in project "proj_1" with batch "batch_1"
+    When the scenario is scheduled against target "prompt_A"
+    Then the job ID contains "prompt_A"
+
+  # ============================================================================
+  # Repeated Runs: distinct jobs per repeat
+  # ============================================================================
+
+  @unit
+  Scenario: Scheduling same scenario three times in one batch produces three distinct job IDs
+    Given scenario "Refund Flow" in project "proj_1" with batch "batch_1" and target "prompt_A"
+    When the scenario is scheduled 3 times
+    Then all 3 jobs have different IDs
+
+  # ============================================================================
+  # Combined: multi-target with repeats
+  # ============================================================================
+
+  @unit
+  Scenario: Running scenario against two targets with repeat=2 produces four distinct jobs
+    Given scenario "Refund Flow" exists in project "proj_1"
+    And targets "prompt_A" and "prompt_B" are configured
+    When the scenario is scheduled against both targets with 2 repeats each
+    Then 4 jobs are created
+    And all 4 jobs have unique IDs


### PR DESCRIPTION
## Summary
- Expands scenario job ID formula to include target `referenceId` and repeat `index`
- Extracts `buildScenarioJobId()` as a pure, testable function
- Prevents BullMQ from silently deduplicating jobs in multi-target or repeated-run batches

Closes #1396

## Changes
| File | Change |
|------|--------|
| `scenario.queue.jobId.ts` | New pure function for job ID generation |
| `scenario.queue.ts` | Uses `buildScenarioJobId`, signature accepts `index` |
| `simulation-runner.router.ts` | Passes `index: 0` for single-run calls |
| `simulation-runner.unit.test.ts` | Rewritten to test real function, 10 tests |
| `simulation-runner.router.unit.test.ts` | Updated assertions for `index: 0` |
| `scenario-job-id-uniqueness.feature` | BDD spec with 4 unit scenarios |

## Test plan
- [x] Two different targets produce distinct job IDs
- [x] Job ID contains target reference ID
- [x] Three repeats produce three distinct job IDs
- [x] Two targets x 2 repeats = 4 unique job IDs
- [x] All 23 tests passing (10 unit + 13 router)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1396