### PR TITLE
fix: rename scenario Delete to Archive in UI

### DIFF
--- a/langwatch/src/components/scenarios/BatchActionBar.tsx
+++ b/langwatch/src/components/scenarios/BatchActionBar.tsx
@@ -1,5 +1,5 @@
 import { Button, HStack, Text } from "@chakra-ui/react";
-import { Trash2 } from "lucide-react";
+import { Archive } from "lucide-react";
 
 /**
  * Action bar that appears when one or more table rows are selected.
@@ -29,11 +29,11 @@ export function BatchActionBar({
       <Button
         size="sm"
         variant="outline"
-        colorPalette="red"
+        colorPalette="orange"
         onClick={onArchive}
       >
-        <Trash2 size={14} />
-        Delete
+        <Archive size={14} />
+        Archive
       </Button>
     </HStack>
   );

--- a/langwatch/src/components/scenarios/ScenarioArchiveDialog.tsx
+++ b/langwatch/src/components/scenarios/ScenarioArchiveDialog.tsx
@@ -11,6 +11,7 @@ type ScenarioToArchive = {
  *
  * - Single scenario: shows "Archive scenario?" with the scenario name.
  * - Multiple scenarios: shows "Archive N scenarios?" with a list of names.
+ * - Uses orange (warning) color rather than red (danger) since archiving is reversible.
  *
  * Note: All interactive elements use stopPropagation() to prevent event bubbling,
  * since this dialog may be rendered inside clickable parent elements.
@@ -30,8 +31,8 @@ export function ScenarioArchiveDialog({
 }) {
   const isBatch = scenarios.length > 1;
   const title = isBatch
-    ? `Delete ${scenarios.length} scenarios?`
-    : "Delete scenario?";
+    ? `Archive ${scenarios.length} scenarios?`
+    : "Archive scenario?";
 
   return (
     <Dialog.Root open={open} onOpenChange={onClose} placement="center">
@@ -62,7 +63,7 @@ export function ScenarioArchiveDialog({
               )
             )}
             <Text color="fg.muted" fontSize="sm">
-              This action cannot be undone.
+              Archived scenarios will no longer appear in the library.
             </Text>
           </VStack>
         </Dialog.Body>
@@ -79,14 +80,14 @@ export function ScenarioArchiveDialog({
             Cancel
           </Button>
           <Button
-            colorPalette="red"
+            colorPalette="orange"
             onClick={(e) => {
               e.stopPropagation();
               onConfirm();
             }}
             disabled={isLoading}
           >
-            {isLoading ? <Spinner size="sm" /> : "Delete"}
+            {isLoading ? <Spinner size="sm" /> : "Archive"}
           </Button>
         </Dialog.Footer>
       </Dialog.Content>

--- a/langwatch/src/components/scenarios/ScenarioTable.tsx
+++ b/langwatch/src/components/scenarios/ScenarioTable.tsx
@@ -12,7 +12,7 @@ import {
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { ChevronDown, ChevronUp, MoreVertical, Trash2 } from "lucide-react";
+import { Archive, ChevronDown, ChevronUp, MoreVertical } from "lucide-react";
 import { useMemo, useState } from "react";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
 import { Checkbox } from "../ui/checkbox";
@@ -129,14 +129,14 @@ export function ScenarioTable({
             <Menu.Content portalled={false}>
               <Menu.Item
                 value="archive"
-                color="red.500"
+                color="orange.500"
                 onClick={(e) => {
                   e.stopPropagation();
                   onArchive(row.original);
                 }}
               >
-                <Trash2 size={14} />
-                Delete
+                <Archive size={14} />
+                Archive
               </Menu.Item>
             </Menu.Content>
           </Menu.Root>

--- a/langwatch/src/components/scenarios/__tests__/ScenarioTable.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioTable.integration.test.tsx
@@ -7,7 +7,7 @@
  * - Select all checkbox toggles all visible rows
  * - Select all with active filter only selects visible rows
  * - Deselecting all rows hides the batch action bar
- * - Row action menu contains archive option
+ * - Row action menu contains Archive option
  * - Single archive confirmation modal shows scenario name
  * - Cancel single archive dismisses modal without archiving
  * - Batch archive confirmation modal lists all selected scenarios
@@ -176,7 +176,7 @@ describe("<ScenarioTable/>", () => {
   // --------------------------------------------------------------------------
 
   describe("when row action menu is opened", () => {
-    it("contains a Delete option", async () => {
+    it("contains an Archive option", async () => {
       const user = userEvent.setup();
       renderTable();
 
@@ -184,11 +184,11 @@ describe("<ScenarioTable/>", () => {
       await user.click(actionButton);
 
       await waitFor(() => {
-        expect(screen.getByText("Delete")).toBeInTheDocument();
+        expect(screen.getByText("Archive")).toBeInTheDocument();
       });
     });
 
-    it("calls onArchive with the scenario when Delete is clicked", async () => {
+    it("calls onArchive with the scenario when Archive is clicked", async () => {
       const user = userEvent.setup();
       const onArchive = vi.fn();
       renderTable({ onArchive });
@@ -197,10 +197,10 @@ describe("<ScenarioTable/>", () => {
       await user.click(actionButton);
 
       await waitFor(() => {
-        expect(screen.getByText("Delete")).toBeInTheDocument();
+        expect(screen.getByText("Archive")).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText("Delete"));
+      await user.click(screen.getByText("Archive"));
       expect(onArchive).toHaveBeenCalledWith(
         expect.objectContaining({
           id: "scen_4",
@@ -258,15 +258,15 @@ describe("<BatchActionBar/>", () => {
       expect(screen.getByText("3 selected")).toBeInTheDocument();
     });
 
-    it("displays a Delete button", () => {
+    it("displays an Archive button", () => {
       render(<BatchActionBar selectedCount={2} onArchive={vi.fn()} />, {
         wrapper: Wrapper,
       });
 
-      expect(screen.getByText("Delete")).toBeInTheDocument();
+      expect(screen.getByText("Archive")).toBeInTheDocument();
     });
 
-    it("calls onArchive when Delete button is clicked", async () => {
+    it("calls onArchive when Archive button is clicked", async () => {
       const user = userEvent.setup();
       const onArchive = vi.fn();
 
@@ -274,7 +274,7 @@ describe("<BatchActionBar/>", () => {
         wrapper: Wrapper,
       });
 
-      await user.click(screen.getByText("Delete"));
+      await user.click(screen.getByText("Archive"));
       expect(onArchive).toHaveBeenCalledTimes(1);
     });
   });
@@ -309,7 +309,7 @@ describe("<ScenarioArchiveDialog/>", () => {
   describe("when archiving a single scenario", () => {
     const singleScenario = [{ id: "scen_4", name: "Angry double-charge refund" }];
 
-    it("displays 'Delete scenario?' as the title", async () => {
+    it("displays 'Archive scenario?' as the title", async () => {
       render(
         <ScenarioArchiveDialog
           open={true}
@@ -321,7 +321,7 @@ describe("<ScenarioArchiveDialog/>", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Delete scenario?")).toBeInTheDocument();
+        expect(screen.getByText("Archive scenario?")).toBeInTheDocument();
       });
     });
 
@@ -354,12 +354,12 @@ describe("<ScenarioArchiveDialog/>", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("This action cannot be undone."),
+          screen.getByText("Archived scenarios will no longer appear in the library."),
         ).toBeInTheDocument();
       });
     });
 
-    it("has Cancel and Delete buttons", async () => {
+    it("has Cancel and Archive buttons", async () => {
       render(
         <ScenarioArchiveDialog
           open={true}
@@ -372,7 +372,7 @@ describe("<ScenarioArchiveDialog/>", () => {
 
       await waitFor(() => {
         expect(screen.getByText("Cancel")).toBeInTheDocument();
-        expect(screen.getByText("Delete")).toBeInTheDocument();
+        expect(screen.getByText("Archive")).toBeInTheDocument();
       });
     });
 
@@ -398,7 +398,7 @@ describe("<ScenarioArchiveDialog/>", () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onConfirm when Delete is clicked", async () => {
+    it("calls onConfirm when Archive is clicked", async () => {
       const user = userEvent.setup();
       const onConfirm = vi.fn();
 
@@ -413,10 +413,10 @@ describe("<ScenarioArchiveDialog/>", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Delete")).toBeInTheDocument();
+        expect(screen.getByText("Archive")).toBeInTheDocument();
       });
 
-      await user.click(screen.getByRole("button", { name: "Delete" }));
+      await user.click(screen.getByRole("button", { name: "Archive" }));
 
       expect(onConfirm).toHaveBeenCalledTimes(1);
     });
@@ -450,7 +450,7 @@ describe("<ScenarioArchiveDialog/>", () => {
       { id: "scen_3", name: "Failed booking escalation" },
     ];
 
-    it("displays 'Delete 2 scenarios?' as the title", async () => {
+    it("displays 'Archive 2 scenarios?' as the title", async () => {
       render(
         <ScenarioArchiveDialog
           open={true}
@@ -462,7 +462,7 @@ describe("<ScenarioArchiveDialog/>", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Delete 2 scenarios?")).toBeInTheDocument();
+        expect(screen.getByText("Archive 2 scenarios?")).toBeInTheDocument();
       });
     });
 
@@ -496,12 +496,12 @@ describe("<ScenarioArchiveDialog/>", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("This action cannot be undone."),
+          screen.getByText("Archived scenarios will no longer appear in the library."),
         ).toBeInTheDocument();
       });
     });
 
-    it("has Cancel and Delete buttons", async () => {
+    it("has Cancel and Archive buttons", async () => {
       render(
         <ScenarioArchiveDialog
           open={true}
@@ -514,7 +514,7 @@ describe("<ScenarioArchiveDialog/>", () => {
 
       await waitFor(() => {
         expect(screen.getByText("Cancel")).toBeInTheDocument();
-        expect(screen.getByText("Delete")).toBeInTheDocument();
+        expect(screen.getByText("Archive")).toBeInTheDocument();
       });
     });
 
@@ -555,7 +555,7 @@ describe("<ScenarioArchiveDialog/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.queryByText("Delete scenario?")).not.toBeInTheDocument();
+      expect(screen.queryByText("Archive scenario?")).not.toBeInTheDocument();
     });
   });
 });

--- a/langwatch/src/pages/[project]/simulations/scenarios/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/scenarios/index.tsx
@@ -72,7 +72,7 @@ function ScenarioLibraryPage() {
     onSuccess: (result) => {
       if (result.failed.length > 0) {
         toaster.create({
-          title: "Some scenarios couldn't be deleted",
+          title: "Some scenarios couldn't be archived",
           description: `${result.failed.length} failed. Please retry.`,
           type: "error",
           meta: { closable: true },

--- a/specs/scenarios/scenario-deletion.feature
+++ b/specs/scenarios/scenario-deletion.feature
@@ -18,24 +18,24 @@ Feature: Scenario Archiving
   # ============================================================================
 
   @e2e
-  Scenario: Delete a single scenario via row action menu
+  Scenario: Archive a single scenario via row action menu
     When I am on the scenarios list page
     And I open the row action menu for "Angry double-charge refund"
-    And I click "Delete"
-    Then I see a confirmation modal asking to delete "Angry double-charge refund"
-    When I confirm the deletion
+    And I click "Archive"
+    Then I see a confirmation modal asking to archive "Angry double-charge refund"
+    When I confirm the archive
     Then "Angry double-charge refund" no longer appears in the scenarios list
     And the remaining 4 scenarios are still visible
 
   @e2e
-  Scenario: Batch delete multiple selected scenarios
+  Scenario: Batch archive multiple selected scenarios
     When I am on the scenarios list page
     And I select the checkbox for "Cross-doc synthesis question"
     And I select the checkbox for "Failed booking escalation"
     Then I see a batch action bar showing "2 selected"
-    When I click the "Delete" button in the batch action bar
+    When I click the "Archive" button in the batch action bar
     Then I see a confirmation modal listing both scenarios
-    When I confirm the deletion
+    When I confirm the archive
     Then neither scenario appears in the scenarios list
     And the remaining 3 scenarios are still visible
 
@@ -71,26 +71,26 @@ Feature: Scenario Archiving
   # ============================================================================
 
   @integration
-  Scenario: Row action menu contains delete option
+  Scenario: Row action menu contains archive option
     When I am on the scenarios list page
     And I open the row action menu for "Angry double-charge refund"
-    Then I see a "Delete" option in the menu
+    Then I see an "Archive" option in the menu
 
   @integration
-  Scenario: Single delete confirmation modal shows scenario name
+  Scenario: Single archive confirmation modal shows scenario name
     When I am on the scenarios list page
     And I open the row action menu for "Angry double-charge refund"
-    And I click "Delete"
-    Then I see a confirmation modal with title "Delete scenario?"
+    And I click "Archive"
+    Then I see a confirmation modal with title "Archive scenario?"
     And the modal displays the scenario name "Angry double-charge refund"
-    And the modal shows "This action cannot be undone."
-    And the modal has "Cancel" and "Delete" buttons
+    And the modal shows "Archived scenarios will no longer appear in the library."
+    And the modal has "Cancel" and "Archive" buttons
 
   @integration
-  Scenario: Cancel single delete dismisses modal without deleting
+  Scenario: Cancel single archive dismisses modal without archiving
     When I am on the scenarios list page
     And I open the row action menu for "Angry double-charge refund"
-    And I click "Delete"
+    And I click "Archive"
     And I click "Cancel" in the confirmation modal
     Then the modal closes
     And "Angry double-charge refund" still appears in the scenarios list
@@ -100,20 +100,20 @@ Feature: Scenario Archiving
   # ============================================================================
 
   @integration
-  Scenario: Batch delete confirmation modal lists all selected scenarios
+  Scenario: Batch archive confirmation modal lists all selected scenarios
     When I am on the scenarios list page
     And I select 2 scenarios
-    And I click the "Delete" button in the batch action bar
-    Then I see a confirmation modal with title "Delete 2 scenarios?"
+    And I click the "Archive" button in the batch action bar
+    Then I see a confirmation modal with title "Archive 2 scenarios?"
     And the modal lists each selected scenario by name
-    And the modal shows "This action cannot be undone."
-    And the modal has "Cancel" and "Delete" buttons
+    And the modal shows "Archived scenarios will no longer appear in the library."
+    And the modal has "Cancel" and "Archive" buttons
 
   @integration
-  Scenario: Cancel batch delete dismisses modal and preserves selection
+  Scenario: Cancel batch archive dismisses modal and preserves selection
     When I am on the scenarios list page
     And I select 2 scenarios
-    And I click the "Delete" button in the batch action bar
+    And I click the "Archive" button in the batch action bar
     And I click "Cancel" in the confirmation modal
     Then the modal closes
     And the 2 scenarios remain selected


### PR DESCRIPTION
## Summary

- Renames all user-facing "Delete" labels to "Archive" in the scenario UI to accurately reflect the soft-delete (archiving) behavior
- Swaps `Trash2` icon for `Archive` icon (lucide-react) in row action menu and batch action bar
- Changes color palette from `red` (danger) to `orange` (warning) since archiving is less destructive
- Updates warning text from "This action cannot be undone." to "Archived scenarios will no longer appear in the library."
- Updates error toast from "couldn't be deleted" to "couldn't be archived"
- Updates all integration test assertions and BDD feature specs to match

## Test plan

- [ ] Verify "Archive" label appears in row action menu instead of "Delete"
- [ ] Verify "Archive" button appears in batch action bar instead of "Delete"
- [ ] Verify confirmation dialog says "Archive scenario?" / "Archive N scenarios?"
- [ ] Verify orange color scheme on archive buttons
- [ ] Verify Archive icon (box) instead of Trash icon
- [ ] Run integration tests: `pnpm test:unit src/components/scenarios/__tests__/ScenarioTable.integration.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1403