### PR TITLE
feat: increase OTEL collector body size limit to 10MB

### DIFF
--- a/langwatch/src/app/api/otel/v1/logs/route.ts
+++ b/langwatch/src/app/api/otel/v1/logs/route.ts
@@ -24,7 +24,7 @@ const logRequestType = (root as any).opentelemetry.proto.collector.logs.v1
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "1mb",
+      sizeLimit: "10mb",
     },
   },
 };

--- a/langwatch/src/app/api/otel/v1/metrics/route.ts
+++ b/langwatch/src/app/api/otel/v1/metrics/route.ts
@@ -24,7 +24,7 @@ const metricsRequestType = (root as any).opentelemetry.proto.collector.metrics
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "1mb",
+      sizeLimit: "10mb",
     },
   },
 };

--- a/langwatch/src/app/api/otel/v1/traces/route.ts
+++ b/langwatch/src/app/api/otel/v1/traces/route.ts
@@ -28,7 +28,7 @@ const traceRequestType = (root as any).opentelemetry.proto.collector.trace.v1
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "1mb",
+      sizeLimit: "10mb",
     },
   },
 };

--- a/langwatch/src/pages/api/collector.ts
+++ b/langwatch/src/pages/api/collector.ts
@@ -34,7 +34,7 @@ const logger = createLogger("langwatch.collector");
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "1mb",
+      sizeLimit: "10mb",
     },
   },
 };


### PR DESCRIPTION
## Summary
Increases the OTEL collector body size limit from 1MB to 10MB to handle large trace payloads from OpenClaw with `captureContent: true`.

### Problem
OpenClaw traces were being silently dropped when they exceeded 1MB. With `captureContent: true`, the config schema gets embedded in every span, causing trace payloads to grow to 2-5MB for multi-step agent turns.

### Fix
Increased `bodyParser.sizeLimit` from `"1mb"` to `"10mb"` on:
- `/app/api/otel/v1/traces/route.ts` - OTEL traces endpoint
- `/app/api/otel/v1/logs/route.ts` - OTEL logs endpoint
- `/app/api/otel/v1/metrics/route.ts` - OTEL metrics endpoint
- `/pages/api/collector.ts` - Legacy REST collector endpoint

## Test plan
- [x] Send OpenClaw trace with `captureContent: true` (payload >1MB) → verify it arrives in LangWatch