### PR TITLE
fix: add auth pages to publicRoutes to prevent infinite redirect loop

### DIFF
--- a/langwatch/src/hooks/useRequiredSession.ts
+++ b/langwatch/src/hooks/useRequiredSession.ts
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { signIn, useSession } from "next-auth/react";
 
-export const publicRoutes = ["/share/[id]"];
+export const publicRoutes = ["/share/[id]", "/auth/signin", "/auth/signup", "/auth/error"];
 
 export const useRequiredSession = (
   { required = true }: { required?: boolean } = { required: true },


### PR DESCRIPTION
## Summary
- Auth pages (`/auth/signin`, `/auth/signup`, `/auth/error`) were not in `publicRoutes`, causing an infinite redirect loop when unauthenticated users visited the sign-in page
- Root cause: `CommandBarProvider`  wraps every page in `_app.tsx` and calls `useOrganizationTeamProject` → `useRequiredSession`, which redirects unauthenticated users to `/auth/signin` — even when already on that page
- Fix: add auth routes to the `publicRoutes` array so `useRequiredSession` skips the redirect on those pages

## Test plan
- [x] Visit `/auth/signin` while unauthenticated — should render without redirect loop
- [ ] Visit `/auth/signup` while unauthenticated — should render without redirect loop
- [ ] Visit a protected page while unauthenticated — should still redirect to sign-in
- [ ] Sign in flow completes successfully and redirects to the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)