### PR TITLE
feat: add AI-readable trace mapping to dataset mapping dropdowns

### DIFF
--- a/langwatch/src/components/evaluations/wizard/hooks/evaluation-wizard-store/useEvaluationWizardStore.ts
+++ b/langwatch/src/components/evaluations/wizard/hooks/evaluation-wizard-store/useEvaluationWizardStore.ts
@@ -105,7 +105,7 @@ export const workbenchStateSchema = z.object({
     .object({
       mapping: z.record(
         z.object({
-          source: z.enum(["", "thread_id", "traces"]),
+          source: z.enum(["", "thread_id", "traces", "formatted_traces"]),
           selectedFields: z.array(z.string()).optional(),
         }),
       ),

--- a/langwatch/src/server/tracer/tracesMapping.ts
+++ b/langwatch/src/server/tracer/tracesMapping.ts
@@ -685,7 +685,7 @@ export type ThreadMappingState = {
   mapping: Record<
     string,
     {
-      source: keyof typeof THREAD_MAPPINGS | "";
+      source: AllThreadMappingSources | "";
       selectedFields?: string[];
     }
   >;
@@ -758,7 +758,7 @@ export const mapTraceToDatasetEntry = (
   mapping: Record<
     string,
     {
-      source: keyof typeof TRACE_MAPPINGS | "";
+      source: string;
       key?: string;
       subkey?: string;
       selectedFields?: string[];
@@ -784,7 +784,7 @@ export const mapTraceToDatasetEntry = (
         ([column, { source, key, subkey, selectedFields }]) => {
           const source_ =
             source && source in TRACE_MAPPINGS
-              ? TRACE_MAPPINGS[source]
+              ? TRACE_MAPPINGS[source as keyof typeof TRACE_MAPPINGS]
               : undefined;
 
           let value = source_?.mapping(trace, key!, subkey!, {
@@ -920,7 +920,7 @@ const THREAD_TRACES_CHILDREN = [
  * Human-readable labels for trace mapping sources.
  * Keys not listed here will use their key name as the label.
  */
-const TRACE_MAPPING_LABELS: Record<string, string | undefined> = {
+export const TRACE_MAPPING_LABELS: Record<string, string | undefined> = {
   formatted_trace: "Full Trace (AI-Readable)",
 };
 
@@ -928,7 +928,7 @@ const TRACE_MAPPING_LABELS: Record<string, string | undefined> = {
  * Human-readable labels for thread mapping sources.
  * Keys not listed here will use their key name as the label.
  */
-const THREAD_MAPPING_LABELS: Record<string, string | undefined> = {
+export const THREAD_MAPPING_LABELS: Record<string, string | undefined> = {
   formatted_traces: "Full Thread (AI-Readable)",
 };
 


### PR DESCRIPTION
## Summary

- Adds "Full Trace (AI-Readable)" and "Full Thread (AI-Readable)" options to the dataset mapping dropdowns in the "Add to Dataset" drawer
- Creates a new `traces.getFormattedSpansDigest` tRPC endpoint that fetches traces and formats their spans using `formatSpansDigest` from `@langwatch/scenario` server-side
- When a user selects an AI-readable source, the client fetches the formatted digest from the server and overrides the mapped column value in the preview

## Details

Since `@langwatch/scenario` has Node.js-only dependencies (`fs/promises`, `crypto`, `process`), the formatting cannot run client-side. The solution uses a batched tRPC query that:
1. Fetches traces with spans by IDs
2. Formats each trace's spans using `formatSpansDigest`
3. Returns a `Record<traceId, formattedDigest>` map

The client components (`TracesMapping.tsx` and `ThreadMapping.tsx`) conditionally enable this query only when a server-only source is selected, then override the relevant columns in the dataset entry building step.

## Test plan
- [x] Select "Full Trace (AI-Readable)" in trace-level dataset mapping dropdown and verify the preview shows formatted span digest
- [x] Select "Full Thread (AI-Readable)" in thread-level dataset mapping dropdown and verify the preview shows concatenated formatted digests for all traces in the thread
- [x] Verify other mapping sources continue to work as before
- [x] Verify typecheck passes (`pnpm typecheck`)