### PR TITLE
fix: update Azure API version to 2024-06-01 for tool_choice support

### DIFF
--- a/langwatch_nlp/langwatch_nlp/main.py
+++ b/langwatch_nlp/langwatch_nlp/main.py
@@ -29,7 +29,7 @@ import litellm.proxy.proxy_server as litellm_proxy_server
 
 from litellm.router import Router
 
-os.environ["AZURE_API_VERSION"] = "2024-02-01"
+os.environ["AZURE_API_VERSION"] = "2024-06-01"
 if "DATABASE_URL" in os.environ:
     # we need to delete this otherwise if this is present the proxy server tries to set up a db
     del os.environ["DATABASE_URL"]


### PR DESCRIPTION
## Summary

Updates the Azure OpenAI API version from `2024-02-01` to `2024-06-01` in the LangWatch NLP proxy.

## Problem

The JudgeAgent in `@langwatch/scenario` uses `tool_choice: "required"`, which requires Azure API version `2024-06-01` or later. Scenario runs using Azure models (e.g., `azure/gpt-5.1`) were failing with:

```
litellm.BadRequestError: AzureException - tool_choice value as required is enabled only for api versions 2024-06-01 and later
```

## Fix

One-line change in `langwatch_nlp/langwatch_nlp/main.py`:

```diff
-os.environ["AZURE_API_VERSION"] = "2024-02-01"
+os.environ["AZURE_API_VERSION"] = "2024-06-01"
```

## Testing

- [ ] Verify scenario runs with Azure models work correctly

Fixes #1546