### PR TITLE
feat(license): add contact sales link to license activation page

### DIFF
--- a/langwatch/src/components/license/NoLicenseCard.tsx
+++ b/langwatch/src/components/license/NoLicenseCard.tsx
@@ -9,6 +9,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { Upload, X } from "lucide-react";
+import { Link } from "~/components/ui/link";
 import { Radio, RadioGroup } from "~/components/ui/radio";
 import { formatFileSize } from "./licenseStatusUtils";
 
@@ -216,16 +217,27 @@ export function NoLicenseCard({
             </Field.Root>
           )}
 
-          <Button
-            colorPalette="blue"
-            variant="solid"
-            size="sm"
-            onClick={handleActivate}
-            loading={isActivating}
-            disabled={isActivateDisabled}
-          >
-            Activate License
-          </Button>
+          <HStack gap={3}>
+            <Button
+              colorPalette="blue"
+              variant="solid"
+              size="sm"
+              onClick={handleActivate}
+              loading={isActivating}
+              disabled={isActivateDisabled}
+            >
+              Activate License
+            </Button>
+            <Link
+              href="mailto:sales@langwatch.ai"
+              isExternal
+              color="blue.fg"
+              fontSize="sm"
+              _hover={{ textDecoration: "underline" }}
+            >
+              Contact sales
+            </Link>
+          </HStack>
         </VStack>
       </VStack>
     </Box>


### PR DESCRIPTION
## Summary
- Adds a "Contact sales" mailto link (`sales@langwatch.ai`) next to the "Activate License" button on the license settings page
- Uses the project's existing `Link` component with `isExternal` and Chakra v3 semantic color token (`blue.fg`)

<img width="987" height="479" alt="image" src="https://github.com/user-attachments/assets/b0f88f1b-5045-4c67-b4e9-a4ab1fc6396c" />


## Test plan
- [x] Verify "Contact sales" link appears next to "Activate License" button
- [x] Verify clicking opens default email client with `sales@langwatch.ai`
- [x] Verify link underlines on hover