### PR TITLE
fix(settings): prevent redirect loop on settings pages without active project

### DIFF
--- a/langwatch/src/components/SettingsLayout.tsx
+++ b/langwatch/src/components/SettingsLayout.tsx
@@ -11,7 +11,9 @@ export default function SettingsLayout({
   children,
   isSubscription,
 }: PropsWithChildren<{ isSubscription?: boolean }>) {
-  const { project } = useOrganizationTeamProject();
+  const { project } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+  });
   const publicEnv = usePublicEnv();
   const isSaaS = publicEnv.data?.IS_SAAS ?? false;
   const { isEnterprise } = useActivePlan();


### PR DESCRIPTION
## Summary
- SettingsLayout called `useOrganizationTeamProject()` with default `redirectToOnboarding: true`, causing users whose current organization had no visible projects to be redirected back to the dashboard from any settings page (including `/settings/license`)
- Pass `redirectToOnboarding: false` since settings pages are org-level and don't require an active project context

## Context
A self-hosted user reported being unable to reach the license settings page — clicking Settings redirected them back to the dashboard in a loop.

## Test plan
- [ ] User with org that has no projects can access all `/settings/*` pages without being redirected
- [ ] Normal users with projects can still access settings pages as before
- [ ] Onboarding redirect still works on project-level pages (e.g. `/[project]/messages`)