### PR TITLE
chore(event-sourcing): add non-sequential event handler mode to fix slow span ingestion

### DIFF
--- a/langwatch/src/server/event-sourcing/library/eventHandler.types.ts
+++ b/langwatch/src/server/event-sourcing/library/eventHandler.types.ts
@@ -55,6 +55,20 @@ export interface EventHandlerOptions<
    * When the feature flag is true, the handler is disabled.
    */
   killSwitch?: KillSwitchOptions;
+
+  /**
+   * Whether this handler requires sequential, ordered processing with checkpointing.
+   * Defaults to `true`.
+   *
+   * When `true`: Events are processed through BatchEventProcessor with distributed
+   * locking, sequence numbers, ordering validation, and per-event checkpoints.
+   *
+   * When `false`: Events are processed directly from the queue payload without
+   * locking, checkpoints, or ordering. Each queue job calls handler.handle(event)
+   * independently. Use for handlers where idempotency is guaranteed externally
+   * (e.g., ClickHouse primary key deduplication) and event ordering doesn't matter.
+   */
+  sequential?: boolean;
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -30,6 +30,7 @@ export const traceProcessingPipelineDefinition =
     })
     .withEventHandler("spanStorage", SpanStorageEventHandler, {
       eventTypes: [SPAN_RECEIVED_EVENT_TYPE],
+      sequential: false,
     })
     // .withEventHandler("observabilityPush", ObservabilityPushEventHandler, {
     //   eventTypes: [SPAN_RECEIVED_EVENT_TYPE],


### PR DESCRIPTION
Traces with many spans (e.g. 13,000) were taking 30+ minutes due to per-event checkpoint overhead, lock contention, and sequential processing. Non-sequential handlers bypass BatchEventProcessor entirely — no lock, no checkpoints, no sequence numbers — and process events directly. This is safe for span storage where ClickHouse PK deduplication guarantees idempotency and ordering doesn't matter.