### PR TITLE
fix: handle NaN/Infinity in JSON serialization for batch evaluation payloads

### DIFF
--- a/langwatch/src/pages/api/evaluations/batch/log_results.ts
+++ b/langwatch/src/pages/api/evaluations/batch/log_results.ts
@@ -68,6 +68,10 @@ export default async function handler(
     req.headers["content-type"] !== "application/json" ||
     typeof req.body !== "object"
   ) {
+    logger.warn(
+      { contentType: req.headers["content-type"], bodyType: typeof req.body },
+      "log_results request body is not json",
+    );
     return res.status(400).json({ message: "Invalid body, expecting json" });
   }
 
@@ -101,6 +105,10 @@ export default async function handler(
   }
 
   if (!params.experiment_id && !params.experiment_slug) {
+    logger.warn(
+      { runId: params.run_id },
+      "log_results missing experiment_id and experiment_slug",
+    );
     return res.status(400).json({
       error: "Either experiment_id or experiment_slug is required",
     });


### PR DESCRIPTION
## Summary

Fixes #1557

- **Root cause**: pandas DataFrames represent `None` as `float('nan')`. Python's `json.dumps` outputs bare `NaN` tokens which are invalid per RFC 8259. This caused the server to reject payloads with `400 Invalid body, expecting json` when users had missing values in their dataset.
- **SDK fix**: Added `_sanitize_nan()` to recursively replace `NaN`/`Infinity` with `None` before JSON serialization. Overrides `encode()`, `iterencode()`, and `default()` in `SerializableWithStringFallback` to cover all `json.dumps`/`json.dump` code paths. Sets `allow_nan=False` as a safety net.
- **Server logging**: Added `logger.warn` to two previously silent 400 paths in `log_results.ts` (invalid JSON body, missing experiment identifiers) for better Grafana observability.

## Test plan

- [x] 17 new unit tests covering `_sanitize_nan` helper and encoder NaN handling (direct values, nested dicts/lists, Pydantic models, sets, `json.dump` file path)
- [x] Full SDK test suite passes (161 tests)
- [x] Verified fix against production — DataFrame with NaN values now returns 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1557