### PR TITLE
feat(license): add purchase license link to license activation page

### DIFF
--- a/langwatch/src/components/license/NoLicenseCard.tsx
+++ b/langwatch/src/components/license/NoLicenseCard.tsx
@@ -233,13 +233,12 @@ export function NoLicenseCard({
             </Button>
             <Tooltip content="After purchase, your license will be generated and delivered to your email.">
               <Button asChild variant="outline" size="sm">
-                <a
+                <Link
                   href="https://buy.stripe.com/dRm3cwaIDgXs6yK6sX0480f"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  isExternal
                 >
                   Purchase license
-                </a>
+                </Link>
               </Button>
             </Tooltip>
             <Link


### PR DESCRIPTION
## Summary
- Adds a "Purchase license" link pointing to Stripe payment page on the license activation screen
- Placed between the "Activate License" button and the existing "Contact sales" link

<img width="1247" height="564" alt="image" src="https://github.com/user-attachments/assets/7e18ef58-18a4-4118-bfd4-b53564425f74" />


<img width="1264" height="641" alt="image" src="https://github.com/user-attachments/assets/91938f30-7ce1-4d24-935a-c6d78e2b300b" />


## Test plan
- [ ] Navigate to Settings > License without an active license
- [ ] Verify the "Purchase license" link is visible and opens the Stripe payment page in a new tab
- [ ] Verify the "Contact sales" link still works as expected