### PR TITLE
fix: skip integration tests when external services are unreachable

### DIFF
--- a/langwatch/src/server/evaluations-v3/execution/__tests__/httpAgentExecution.integration.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/httpAgentExecution.integration.test.ts
@@ -12,6 +12,7 @@
 import type { Project } from "@prisma/client";
 import { nanoid } from "nanoid";
 import { beforeAll, describe, expect, it } from "vitest";
+import { isServiceReachable } from "~/utils/testUtils";
 import { studioBackendPostEvent } from "~/app/api/workflows/post_event/post-event";
 import type { TargetConfig, HttpConfig } from "~/evaluations-v3/types";
 import { addEnvs } from "~/optimization_studio/server/addEnvs";
@@ -35,15 +36,15 @@ import type { ExecutionCell } from "../types";
  * and it falls through to the code node case which fails.
  */
 
-describe.skipIf(process.env.CI)("HTTP Agent Execution Integration", () => {
+const httpNlpUrl = process.env.LANGWATCH_NLP_SERVICE;
+const httpNlpReachable = httpNlpUrl
+  ? await isServiceReachable(httpNlpUrl)
+  : false;
+
+describe.skipIf(!httpNlpReachable)("HTTP Agent Execution Integration", () => {
   let project: Project;
 
   beforeAll(async () => {
-    const nlpServiceUrl = process.env.LANGWATCH_NLP_SERVICE;
-    if (!nlpServiceUrl) {
-      console.warn("LANGWATCH_NLP_SERVICE not set, tests may fail");
-    }
-
     project = await getTestProject("http-agent-execution");
   });
 

--- a/langwatch/src/server/evaluations-v3/execution/__tests__/orchestrator.integration.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/orchestrator.integration.test.ts
@@ -12,7 +12,7 @@ import {
   createInitialUIState,
 } from "~/evaluations-v3/types";
 import type { VersionedPrompt } from "~/server/prompt-config/prompt.service";
-import { getTestProject } from "~/utils/testUtils";
+import { getTestProject, isServiceReachable } from "~/utils/testUtils";
 import { abortManager } from "../abortManager";
 import { type OrchestratorInput, runOrchestrator } from "../orchestrator";
 import type { EvaluationV3Event, ExecutionScope } from "../types";
@@ -21,14 +21,16 @@ import type { EvaluationV3Event, ExecutionScope } from "../types";
  * Integration tests for the orchestrator against langwatch_nlp.
  * Requires:
  * - LANGWATCH_NLP_SERVICE running on localhost:5561
+ * - LANGEVALS_ENDPOINT running on localhost:5562 (for evaluator tests)
  * - OPENAI_API_KEY in environment
  * - Redis available (for abort flags)
  * - Database available for test project
  */
-// Skip when NLP service isn't available (CI or prisma-integration tests)
-const hasNlpService = !!process.env.LANGWATCH_NLP_SERVICE;
+// Skip when NLP service isn't reachable
+const nlpUrl = process.env.LANGWATCH_NLP_SERVICE;
+const nlpReachable = nlpUrl ? await isServiceReachable(nlpUrl) : false;
 
-describe.skipIf(!hasNlpService)("Orchestrator Integration", () => {
+describe.skipIf(!nlpReachable)("Orchestrator Integration", () => {
   let project: Project;
 
   beforeAll(async () => {

--- a/langwatch/src/server/evaluations-v3/execution/__tests__/workflowExecution.integration.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/workflowExecution.integration.test.ts
@@ -10,7 +10,7 @@ import type {
 import { addEnvs } from "~/optimization_studio/server/addEnvs";
 import { loadDatasets } from "~/optimization_studio/server/loadDatasets";
 import type { StudioServerEvent } from "~/optimization_studio/types/events";
-import { getTestProject } from "~/utils/testUtils";
+import { getTestProject, isServiceReachable } from "~/utils/testUtils";
 import type { ExecutionCell } from "../types";
 import { buildCellWorkflow } from "../workflowBuilder";
 
@@ -21,25 +21,16 @@ import { buildCellWorkflow } from "../workflowBuilder";
  * - OPENAI_API_KEY in environment
  * - Database available for test project
  */
-// Skip when NLP service isn't available (CI or prisma-integration tests)
-const hasNlpService = !!process.env.LANGWATCH_NLP_SERVICE;
+// Skip when NLP service isn't reachable
+const wfNlpUrl = process.env.LANGWATCH_NLP_SERVICE;
+const wfNlpReachable = wfNlpUrl
+  ? await isServiceReachable(wfNlpUrl)
+  : false;
 
-describe.skipIf(!hasNlpService)("WorkflowExecution Integration", () => {
+describe.skipIf(!wfNlpReachable)("WorkflowExecution Integration", () => {
   let project: Project;
 
   beforeAll(async () => {
-    // Check if NLP service is available
-    const nlpServiceUrl = process.env.LANGWATCH_NLP_SERVICE;
-    if (!nlpServiceUrl) {
-      console.warn("LANGWATCH_NLP_SERVICE not set, tests may fail");
-    }
-
-    // Check for OpenAI key
-    if (!process.env.OPENAI_API_KEY) {
-      console.warn("OPENAI_API_KEY not set, tests may fail");
-    }
-
-    // Get or create test project
     project = await getTestProject("workflow-execution");
   });
 

--- a/langwatch/src/utils/testUtils.ts
+++ b/langwatch/src/utils/testUtils.ts
@@ -195,6 +195,22 @@ export const waitForResult = async <T>(
  * @param param0 - The request method, headers, and body.
  * @returns A mock request and response.
  */
+/**
+ * Checks if a service is reachable by making a HEAD/GET request.
+ * Useful for conditionally skipping integration tests that need external services.
+ */
+export async function isServiceReachable(url: string): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    await fetch(url, { method: "GET", signal: controller.signal });
+    clearTimeout(timeout);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export const createNextApiMocks = ({
   method,
   headers,


### PR DESCRIPTION
## Summary
- Adds `isServiceReachable()` helper to `testUtils.ts` that performs an actual HTTP connectivity check with a 2s timeout
- Updates 5 integration test files to use runtime reachability checks instead of just checking if env vars are set
- Prevents false failures when `.env` defines service URLs (NLP, LangEvals, dev server) but services aren't running

## Test plan
- [x] Full integration suite passes — evaluation tests properly skip when services are unavailable
- [x] Tests run and pass when services (LangEvals, NLP) are actually available