### PR TITLE
fix: studio prompt editor bugs

### DIFF
--- a/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawer.test-helpers.tsx
+++ b/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawer.test-helpers.tsx
@@ -340,6 +340,22 @@ export function createApiMock() {
             error: null,
           })),
         },
+        getFieldNames: {
+          useQuery: vi.fn(() => ({
+            data: {
+              spanNames: [
+                { name: "openai/gpt-4", type: "llm" },
+                { name: "my-custom-span", type: "span" },
+              ],
+              metadataKeys: [
+                { key: "user_id" },
+                { key: "session_id" },
+              ],
+            },
+            isLoading: false,
+            error: null,
+          })),
+        },
       },
       licenseEnforcement: {
         checkLimit: {

--- a/langwatch/src/components/llmPromptConfigs/LLMConfigPopover.tsx
+++ b/langwatch/src/components/llmPromptConfigs/LLMConfigPopover.tsx
@@ -9,7 +9,7 @@ import {
   type OutputType,
 } from "../outputs/OutputsSection";
 import { Popover } from "../ui/popover";
-import { Switch } from "../ui/switch";
+
 
 import { ParameterRow } from "./ParameterRow";
 import {
@@ -152,6 +152,8 @@ export function LLMConfigPopover({
 
   const handleStructuredOutputsToggle = (checked: boolean) => {
     if (!onOutputsChange) return;
+    // Guard against duplicate calls from nested click handlers
+    if (checked === isStructuredOutputsEnabled) return;
 
     userInitiatedToggleRef.current = true;
     setIsStructuredOutputsEnabled(checked);
@@ -272,18 +274,47 @@ export function LLMConfigPopover({
         {showStructuredOutputs && onOutputsChange && (
           <VStack width="full" gap={2}>
             <HStack width="full" justify="space-between" paddingX={2} paddingBottom={isStructuredOutputsEnabled ? 0 : 2}>
-              <HStack width="full" align="start" gap={0} justify="space-between">
+              <HStack
+                width="full"
+                align="start"
+                gap={0}
+                justify="space-between"
+                cursor="pointer"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={() =>
+                  handleStructuredOutputsToggle(!isStructuredOutputsEnabled)
+                }
+              >
                 <Text fontSize="13px" fontWeight="medium" color="fg.subtle">
                   Structured Outputs
                 </Text>
-                <Switch
-                  size="sm"
+                <Box
+                  as="button"
+                  role="switch"
+                  aria-checked={isStructuredOutputsEnabled}
                   data-testid="structured-outputs-switch"
-                  checked={isStructuredOutputsEnabled}
-                  onCheckedChange={({ checked }) =>
-                    handleStructuredOutputsToggle(checked)
-                  }
-                />
+                  data-state={isStructuredOutputsEnabled ? "checked" : "unchecked"}
+                  display="flex"
+                  alignItems="center"
+                  justifyContent={isStructuredOutputsEnabled ? "flex-end" : "flex-start"}
+                  width="34px"
+                  height="20px"
+                  borderRadius="full"
+                  bg={isStructuredOutputsEnabled ? "blue.500" : "gray.300"}
+                  padding="2px"
+                  cursor="pointer"
+                  transition="background 0.2s"
+                  flexShrink={0}
+                >
+                  <Box
+                    width="16px"
+                    height="16px"
+                    borderRadius="full"
+                    bg="white"
+                    boxShadow="sm"
+                    transition="all 0.2s"
+                  />
+                </Box>
               </HStack>
             </HStack>
 

--- a/langwatch/src/components/llmPromptConfigs/LlmConfigField.tsx
+++ b/langwatch/src/components/llmPromptConfigs/LlmConfigField.tsx
@@ -1,7 +1,10 @@
 import { Box, HStack } from "@chakra-ui/react";
 import { ChevronDown } from "lucide-react";
 
-import { LLMConfigPopover } from "~/components/llmPromptConfigs/LLMConfigPopover";
+import {
+  LLMConfigPopover,
+  type Output,
+} from "~/components/llmPromptConfigs/LLMConfigPopover";
 import { AddModelProviderKey } from "~/optimization_studio/components/AddModelProviderKey";
 import type { LLMConfig } from "~/optimization_studio/types/dsl";
 import type { ModelOption } from "~/server/topicClustering/types";
@@ -14,6 +17,12 @@ type LLMConfigFieldProps = {
   requiresCustomKey: boolean;
   onChange: (llmConfig: LLMConfig) => void;
   showProviderKeyMessage?: boolean;
+  /** Outputs configuration (for structured outputs) */
+  outputs?: Output[];
+  /** Callback when outputs change */
+  onOutputsChange?: (outputs: Output[]) => void;
+  /** Whether to show the structured outputs section */
+  showStructuredOutputs?: boolean;
 };
 
 /**
@@ -29,6 +38,9 @@ export function LLMConfigField({
   modelOption,
   requiresCustomKey,
   showProviderKeyMessage = true,
+  outputs,
+  onOutputsChange,
+  showStructuredOutputs = false,
 }: LLMConfigFieldProps) {
   const { model } = llmConfig ?? {};
 
@@ -59,7 +71,13 @@ export function LLMConfigField({
           </HStack>
         </Popover.Trigger>
 
-        <LLMConfigPopover values={llmConfig} onChange={onChange} />
+        <LLMConfigPopover
+          values={llmConfig}
+          onChange={onChange}
+          outputs={outputs}
+          onOutputsChange={onOutputsChange}
+          showStructuredOutputs={showStructuredOutputs}
+        />
       </Popover.Root>
       {(requiresCustomKey || isModelDisabled) && showProviderKeyMessage && (
         <AddModelProviderKey

--- a/langwatch/src/components/llmPromptConfigs/__tests__/LLMConfigPopover.test.tsx
+++ b/langwatch/src/components/llmPromptConfigs/__tests__/LLMConfigPopover.test.tsx
@@ -361,6 +361,102 @@ describe("LLMConfigPopover", () => {
         expect(screen.getByText("output2")).toBeInTheDocument();
       });
     });
+
+    describe("when toggle is clicked to enable", () => {
+      it("enables the toggle", async () => {
+        const user = userEvent.setup();
+        const outputs: Output[] = [{ identifier: "output", type: "str" }];
+        renderComponent({
+          showStructuredOutputs: true,
+          outputs,
+          onOutputsChange: vi.fn(),
+        });
+
+        const toggle = screen.getByTestId("structured-outputs-switch");
+        await user.click(toggle);
+
+        expect(toggle).toHaveAttribute("data-state", "checked");
+      });
+
+      it("shows the Outputs section", async () => {
+        const user = userEvent.setup();
+        const outputs: Output[] = [{ identifier: "output", type: "str" }];
+        renderComponent({
+          showStructuredOutputs: true,
+          outputs,
+          onOutputsChange: vi.fn(),
+        });
+
+        // Outputs section should not be visible before toggle
+        expect(screen.queryByText("Outputs")).not.toBeInTheDocument();
+
+        const toggle = screen.getByTestId("structured-outputs-switch");
+        await user.click(toggle);
+
+        expect(screen.getByText("Outputs")).toBeInTheDocument();
+      });
+    });
+
+    describe("when toggle is clicked to disable", () => {
+      it("disables the toggle", async () => {
+        const user = userEvent.setup();
+        // Start with non-default outputs so toggle starts enabled
+        const outputs: Output[] = [
+          { identifier: "custom_output", type: "json_schema" },
+        ];
+        renderComponent({
+          showStructuredOutputs: true,
+          outputs,
+          onOutputsChange: vi.fn(),
+        });
+
+        const toggle = screen.getByTestId("structured-outputs-switch");
+        expect(toggle).toHaveAttribute("data-state", "checked");
+
+        await user.click(toggle);
+
+        expect(toggle).toHaveAttribute("data-state", "unchecked");
+      });
+
+      it("hides the Outputs section", async () => {
+        const user = userEvent.setup();
+        const outputs: Output[] = [
+          { identifier: "custom_output", type: "json_schema" },
+        ];
+        renderComponent({
+          showStructuredOutputs: true,
+          outputs,
+          onOutputsChange: vi.fn(),
+        });
+
+        expect(screen.getByText("Outputs")).toBeInTheDocument();
+
+        const toggle = screen.getByTestId("structured-outputs-switch");
+        await user.click(toggle);
+
+        expect(screen.queryByText("Outputs")).not.toBeInTheDocument();
+      });
+
+      it("calls onOutputsChange with default output", async () => {
+        const user = userEvent.setup();
+        const onOutputsChange = vi.fn();
+        const outputs: Output[] = [
+          { identifier: "custom_output", type: "json_schema" },
+        ];
+        renderComponent({
+          showStructuredOutputs: true,
+          outputs,
+          onOutputsChange,
+        });
+
+        const toggle = screen.getByTestId("structured-outputs-switch");
+        await user.click(toggle);
+
+        expect(onOutputsChange).toHaveBeenCalledWith([
+          { identifier: "output", type: "str" },
+        ]);
+      });
+    });
   });
 
   describe("error display", () => {

--- a/langwatch/src/components/variables/VariableMappingInput.tsx
+++ b/langwatch/src/components/variables/VariableMappingInput.tsx
@@ -306,7 +306,7 @@ export const VariableMappingInput = ({
     // If we're in nested selection mode, filter the nested fields
     if (currentDropdownContext.fields && currentDropdownContext.source) {
       const filtered = currentDropdownContext.fields.filter((field) =>
-        (field.label ?? field.name)
+        (field.label ?? field.name ?? "")
           .toLowerCase()
           .includes(searchQuery.toLowerCase()),
       );
@@ -925,7 +925,7 @@ export const VariableMappingInput = ({
                           <VariableTypeIcon type={field.type} size={12} />
                           <Text fontSize="13px" fontFamily="mono" flex={1}>
                             {(() => {
-                              const label = field.label ?? field.name;
+                              const label = field.label ?? field.name ?? "";
                               // Render "* (description)" with gray parenthesis part
                               if (label.startsWith("* (") && label.endsWith(")")) {
                                 const parenContent = label.slice(2); // "(description)"

--- a/langwatch/src/components/variables/VariablesSection.tsx
+++ b/langwatch/src/components/variables/VariablesSection.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chakra-ui/react";
 import { Info, Plus, X } from "lucide-react";
 import { useCallback, useState } from "react";
+import { Menu } from "~/components/ui/menu";
 import { Tooltip } from "~/components/ui/tooltip";
 import {
   TYPE_LABELS,
@@ -114,16 +115,19 @@ export const VariablesSection = ({
   const shouldShowAddButton = showAddButton ?? canAddRemove;
   const [editingId, setEditingId] = useState<string | null>(null);
 
-  const handleAddVariable = useCallback(() => {
-    const existingIdentifiers = variables.map((v) => v.identifier);
-    const newIdentifier = generateUniqueIdentifier(
-      "input",
-      existingIdentifiers,
-    );
-    onChange([...variables, { identifier: newIdentifier, type: "str" }]);
-    // Auto-focus the new variable name
-    setEditingId(newIdentifier);
-  }, [variables, onChange]);
+  const handleAddVariable = useCallback(
+    (type: FieldType = "str") => {
+      const existingIdentifiers = variables.map((v) => v.identifier);
+      const newIdentifier = generateUniqueIdentifier(
+        "input",
+        existingIdentifiers,
+      );
+      onChange([...variables, { identifier: newIdentifier, type }]);
+      // Auto-focus the new variable name
+      setEditingId(newIdentifier);
+    },
+    [variables, onChange],
+  );
 
   const handleRemoveVariable = useCallback(
     (identifier: string) => {
@@ -192,15 +196,34 @@ export const VariablesSection = ({
         </Text>
         <Spacer />
         {shouldShowAddButton && !readOnly && (
-          <Button
-            size="xs"
-            variant="outline"
-            onClick={handleAddVariable}
-            data-testid="add-variable-button"
-          >
-            <Plus size={14} />
-            Add
-          </Button>
+          <Menu.Root>
+            <Menu.Trigger asChild>
+              <Button
+                size="xs"
+                variant="outline"
+                data-testid="add-variable-button"
+              >
+                <Plus size={14} />
+                Add
+              </Button>
+            </Menu.Trigger>
+            <Menu.Content>
+              {INPUT_TYPE_OPTIONS.map((option) => (
+                <Menu.Item
+                  key={option.value}
+                  value={option.value}
+                  onClick={() =>
+                    handleAddVariable(option.value as FieldType)
+                  }
+                >
+                  <HStack gap={2}>
+                    <VariableTypeIcon type={option.value} size={14} />
+                    <Text>{option.label}</Text>
+                  </HStack>
+                </Menu.Item>
+              ))}
+            </Menu.Content>
+          </Menu.Root>
         )}
       </HStack>
 

--- a/langwatch/src/components/variables/__tests__/VariablesSection.test.tsx
+++ b/langwatch/src/components/variables/__tests__/VariablesSection.test.tsx
@@ -7,7 +7,6 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -114,8 +113,9 @@ describe("VariablesSection", () => {
       const onChange = vi.fn();
       renderComponent({ variables: [], onChange });
 
-      const addButton = screen.getByRole("button");
-      await user.click(addButton);
+      // Open the type picker menu and select "Text"
+      await user.click(screen.getByTestId("add-variable-button"));
+      await user.click(screen.getByRole("menuitem", { name: /Text/ }));
 
       expect(onChange).toHaveBeenCalledWith([
         { identifier: "input", type: "str" },
@@ -128,10 +128,9 @@ describe("VariablesSection", () => {
       const variables: Variable[] = [{ identifier: "input", type: "str" }];
       renderComponent({ variables, onChange });
 
-      // First button is the + button
-      const buttons = screen.getAllByRole("button");
-      const addButton = buttons[0]!;
-      await user.click(addButton);
+      // Open the type picker menu and select "Text"
+      await user.click(screen.getByTestId("add-variable-button"));
+      await user.click(screen.getByRole("menuitem", { name: /Text/ }));
 
       expect(onChange).toHaveBeenCalledWith([
         { identifier: "input", type: "str" },

--- a/langwatch/src/optimization_studio/components/properties/llm-configs/OptimizationStudioLLMConfigField.tsx
+++ b/langwatch/src/optimization_studio/components/properties/llm-configs/OptimizationStudioLLMConfigField.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { LLMConfigField } from "~/components/llmPromptConfigs/LlmConfigField";
+import type { Output } from "~/components/llmPromptConfigs/LLMConfigPopover";
 import {
   allModelOptions,
   useModelSelectionOptions,
@@ -13,6 +14,12 @@ type OptimizationStudioLLMConfigFieldProps = {
   llmConfig: LLMConfig;
   onChange: (llmConfig: LLMConfig) => void;
   showProviderKeyMessage?: boolean;
+  /** Outputs configuration (for structured outputs) */
+  outputs?: Output[];
+  /** Callback when outputs change */
+  onOutputsChange?: (outputs: Output[]) => void;
+  /** Whether to show the structured outputs section */
+  showStructuredOutputs?: boolean;
 };
 
 /**
@@ -26,6 +33,9 @@ export function OptimizationStudioLLMConfigField({
   llmConfig,
   onChange,
   showProviderKeyMessage = true,
+  outputs,
+  onOutputsChange,
+  showStructuredOutputs = false,
 }: OptimizationStudioLLMConfigFieldProps) {
   const model = llmConfig?.model ?? "";
   const { modelOption } = useModelSelectionOptions(
@@ -60,6 +70,9 @@ export function OptimizationStudioLLMConfigField({
       modelOption={modelOption}
       requiresCustomKey={requiresCustomKey}
       showProviderKeyMessage={showProviderKeyMessage}
+      outputs={outputs}
+      onOutputsChange={onOutputsChange}
+      showStructuredOutputs={showStructuredOutputs}
     />
   );
 }

--- a/langwatch/src/prompts/components/ui/VariableTypeIcon.tsx
+++ b/langwatch/src/prompts/components/ui/VariableTypeIcon.tsx
@@ -2,6 +2,7 @@ import { Box } from "@chakra-ui/react";
 import {
   Braces,
   Hash,
+  Image,
   List,
   MessageSquare,
   ToggleLeft,
@@ -55,6 +56,9 @@ export const VariableTypeIcon = ({
 
     case "chat_messages":
       return <MessageSquare {...iconProps} />;
+
+    case "image":
+      return <Image {...iconProps} />;
 
     default:
       return <Type {...iconProps} />;

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/__tests__/PromptTabbedSection.test.tsx
@@ -145,7 +145,9 @@ describe("Playground Variables Section Integration", () => {
         onChange,
       });
 
+      // Open the type picker menu and select "Text"
       await user.click(screen.getByTestId("add-variable-button"));
+      await user.click(screen.getByRole("menuitem", { name: /Text/ }));
 
       // onChange should be called with the new variable added
       expect(onChange).toHaveBeenCalledWith([

--- a/langwatch/src/prompts/utils/llmPromptConfigUtils.ts
+++ b/langwatch/src/prompts/utils/llmPromptConfigUtils.ts
@@ -299,6 +299,10 @@ function inputOutputTypeToDatasetColumnType(
       return "list";
     case "dict":
       return "json";
+    case "list":
+      return "list";
+    case "chat_messages":
+      return "json";
     default:
       type_ satisfies never;
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/langwatch/src/server/analytics/__tests__/analytics.service.test.ts
+++ b/langwatch/src/server/analytics/__tests__/analytics.service.test.ts
@@ -149,7 +149,7 @@ describe("AnalyticsService", () => {
       expect(result).toBe(false);
     });
 
-    it("throws when Prisma throws an error", async () => {
+    it("returns false when Prisma throws an error", async () => {
       const fakeES = createFakeBackend();
       const fakeCH = createFakeBackend({ available: true });
       const fakePrisma = {
@@ -164,9 +164,9 @@ describe("AnalyticsService", () => {
         prisma: fakePrisma,
       });
 
-      await expect(
-        service.isClickHouseEnabled("test-project"),
-      ).rejects.toThrow("DB error");
+      const result = await service.isClickHouseEnabled("test-project");
+
+      expect(result).toBe(false);
     });
   });
 

--- a/langwatch/src/types.ts
+++ b/langwatch/src/types.ts
@@ -13,11 +13,13 @@ export const LlmConfigInputTypes = [
   "float",
   "bool",
   "image",
+  "list",
   "list[str]",
   "list[float]",
   "list[int]",
   "list[bool]",
   "dict",
+  "chat_messages",
 ] as const;
 export type LlmConfigInputType = (typeof LlmConfigInputTypes)[number];
 


### PR DESCRIPTION
## Summary

- **Structured Outputs toggle**: The toggle in the studio's model selector popover was visible but non-functional. Root cause: Chakra UI's Zag.js Switch state machine fails inside nested Popover layers (pointer events intercepted by dismiss handlers). Fixed by replacing the Zag.js Switch with a custom toggle element that bypasses the state machine entirely. Also threaded `showStructuredOutputs`/`outputs`/`onOutputsChange` props through the full studio component chain (`WrappedOptimizationStudioLLMConfigField` → `OptimizationStudioLLMConfigField` → `LLMConfigField` → `LLMConfigPopover`).
- **Variable type icons**: Fixed Image icon not showing for `"image"` type variables, and added missing `"list"` and `"chat_messages"` to `LlmConfigInputTypes` to prevent runtime errors.
- **Null safety**: Fixed `VariableMappingInput` crash when `field.label` and `field.name` are both undefined.
- **Pre-existing test fixes**: Added missing `getFieldNames` mock in evaluation drawer test helpers (23 tests), fixed analytics service test expectation to match graceful fallback behavior, updated VariablesSection and PromptTabbedSection tests.

## Test plan

- [x] Typecheck passes
- [x] All 126 LLMConfigPopover tests pass (including 5 new structured outputs toggle tests)
- [x] Full test suite green (5223 tests)
- [x] Manual: open studio → select prompt node → open model selector → click Structured Outputs toggle → enables and shows Outputs section