### PR TITLE
fix(ci): start background workers in SDK e2e tests

### DIFF
--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Start LangWatch server
         working-directory: langwatch
         run: |
-          pnpm run start &
+          START_WORKERS=true pnpm run start &
           # Wait for server to be ready (check Next.js is responding)
           timeout 60 bash -c 'until curl -f http://localhost:5560 2>/dev/null | grep -q "LangWatch\|<!DOCTYPE"; do sleep 2; done'
           echo "✅ LangWatch server is ready"


### PR DESCRIPTION
## Summary
- Add `START_WORKERS=true` to the LangWatch server start command in the JS SDK e2e CI job
- Since PR #1134 decoupled workers from the web server, traces were enqueued to BullMQ but never processed, causing 26/78 tests to timeout

Closes #1581

## Test plan
- [ ] Verify SDK e2e tests pass (observability tests no longer timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1581