### PR TITLE
fix: use local monorepo path for evaluators types in SDK publish

### DIFF
--- a/typescript-sdk/copy-types.sh
+++ b/typescript-sdk/copy-types.sh
@@ -13,9 +13,7 @@ else
 fi
 ts-to-zod src/internal/generated/types/evaluations.ts src/internal/generated/types/evaluations.generated.ts
 
-cd src/internal/generated/types/
-curl -L "https://raw.githubusercontent.com/langwatch/langevals/main/ts-integration/evaluators.generated.ts?$(date +%s)" -o evaluators.generated.ts
-cd -
+cp ../langevals/ts-integration/evaluators.generated.ts src/internal/generated/types/evaluators.generated.ts
 ts-to-zod src/internal/generated/types/evaluators.generated.ts src/internal/generated/types/evaluators.zod.generated.ts
 
 # Fix z.record(z.never()) to z.record(z.string(), z.never())


### PR DESCRIPTION
## Summary
- The `langevals` repo was deprecated and moved into the monorepo (#1591), but `typescript-sdk/copy-types.sh` still `curl`ed from the now-404 GitHub URL
- This broke the `sdk-javascript-cd` workflow: https://github.com/langwatch/langwatch/actions/runs/22059449649/job/63735700217
- Fix: replace `curl` with a local `cp` from `../langevals/ts-integration/`, consistent with how other types are already copied in the script

## Test plan
- [ ] Re-run the `sdk-javascript-cd` workflow after merge to verify the publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)