### PR TITLE
refactor: derive response_format from outputs, eliminate duality

### DIFF
--- a/langwatch/src/prompts/schemas/field-schemas.ts
+++ b/langwatch/src/prompts/schemas/field-schemas.ts
@@ -112,6 +112,28 @@ export const modelNameSchema = z.string();
 export const schemaVersionSchema = z.nativeEnum(SchemaVersion);
 
 /**
+ * Derives response_format from the outputs array.
+ * This is the single source of truth: if an output has type "json_schema",
+ * we construct the OpenAI-compatible response_format from it.
+ */
+export function deriveResponseFormatFromOutputs(
+  outputs: z.infer<typeof outputsSchema>[],
+): z.infer<typeof responseFormatSchema> | undefined {
+  const jsonSchemaOutput = outputs.find(
+    (o) => o.type === "json_schema" && o.json_schema,
+  );
+  if (!jsonSchemaOutput?.json_schema) return undefined;
+
+  return {
+    type: "json_schema",
+    json_schema: {
+      name: jsonSchemaOutput.identifier,
+      schema: jsonSchemaOutput.json_schema,
+    },
+  };
+}
+
+/**
  * Extended runtime input schema including a value for execution time.
  * Single Responsibility: Add value-carrying variant of inputs for runtime usage.
  */

--- a/langwatch/src/prompts/utils/llmPromptConfigUtils.ts
+++ b/langwatch/src/prompts/utils/llmPromptConfigUtils.ts
@@ -537,7 +537,6 @@ export function formValuesToTriggerSaveVersionParams(
     verbosity: llm.verbosity,
     promptingTechnique: formValues.version.configData.promptingTechnique,
     demonstrations: formValues.version.configData.demonstrations,
-    responseFormat: formValues.version.configData.responseFormat,
   };
 }
 

--- a/langwatch/src/server/api/routers/prompts/prompts.trpc-router.ts
+++ b/langwatch/src/server/api/routers/prompts/prompts.trpc-router.ts
@@ -505,7 +505,6 @@ export const promptsRouter = createTRPCRouter({
         verbosity: sourcePrompt.verbosity ?? undefined,
         promptingTechnique: sourcePrompt.promptingTechnique ?? undefined,
         demonstrations: sourcePrompt.demonstrations ?? undefined,
-        responseFormat: sourcePrompt.responseFormat ?? undefined,
       });
 
       // Set the copiedFromPromptId to track the source
@@ -660,9 +659,6 @@ export const promptsRouter = createTRPCRouter({
             promptingTechnique: sourcePrompt.promptingTechnique,
           }),
           demonstrations: sourcePrompt.demonstrations,
-          ...(sourcePrompt.responseFormat != null && {
-            responseFormat: sourcePrompt.responseFormat,
-          }),
           authorId,
         },
       });

--- a/langwatch/src/server/prompt-config/__tests__/transformToDbFormat.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/transformToDbFormat.test.ts
@@ -39,7 +39,12 @@ describe("transformToDbFormat", () => {
       const mapping = buildCamelToSnakeMapping();
 
       expect(mapping.promptingTechnique).toBe("prompting_technique");
-      expect(mapping.responseFormat).toBe("response_format");
+    });
+
+    it("does not include responseFormat (derived from outputs)", () => {
+      const mapping = buildCamelToSnakeMapping();
+
+      expect(mapping.responseFormat).toBeUndefined();
     });
   });
 
@@ -60,11 +65,11 @@ describe("transformToDbFormat", () => {
       expect(result).not.toHaveProperty("promptingTechnique");
     });
 
-    it("converts responseFormat to response_format when defined", () => {
+    it("strips responseFormat and response_format (derived from outputs)", () => {
       const input = { ...BASE_CONFIG, responseFormat: { type: "json" } };
       const result = transformCamelToSnake(input);
 
-      expect(result.response_format).toEqual({ type: "json" });
+      expect(result).not.toHaveProperty("response_format");
       expect(result).not.toHaveProperty("responseFormat");
     });
 

--- a/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-version-schema.ts
@@ -63,6 +63,8 @@ const configSchemaV1_0 = z.object({
     verbosity: z.string().optional(),
     demonstrations: nodeDatasetSchema.optional(),
     prompting_technique: promptingTechniqueSchema.optional(),
+    // Deprecated: response_format is now derived from outputs at read time.
+    // Kept optional for backward compat reading old data, but never written for new data.
     response_format: responseFormatSchema.optional(),
   }),
 });

--- a/langwatch/src/server/prompt-config/transformToDbFormat.ts
+++ b/langwatch/src/server/prompt-config/transformToDbFormat.ts
@@ -24,7 +24,6 @@ const CAMEL_TO_SNAKE_MAPPING: Record<string, string> = {
   repetitionPenalty: "repetition_penalty",
   // Prompt-specific parameters
   promptingTechnique: "prompting_technique",
-  responseFormat: "response_format",
 };
 
 /**
@@ -59,6 +58,10 @@ export function transformCamelToSnake(
 
   // 'reasoning' passes through unchanged - it's the canonical field
   // Provider-specific mapping happens at runtime boundary (reasoningBoundary.ts)
+
+  // response_format is derived from outputs at read time, never stored directly
+  delete result.responseFormat;
+  delete result.response_format;
 
   return result;
 }

--- a/typescript-sdk/src/cli/commands/push.ts
+++ b/typescript-sdk/src/cli/commands/push.ts
@@ -127,17 +127,7 @@ export const pushPrompts = async ({
           max_tokens: localConfig.modelParameters?.max_tokens,
           inputs: [{ identifier: "input", type: "str" }],
           outputs,
-          ...(responseFormat
-            ? {
-                response_format: {
-                  type: "json_schema" as const,
-                  json_schema: {
-                    name: responseFormat.name ?? "output",
-                    schema: responseFormat.schema ?? {},
-                  },
-                },
-              }
-            : {}),
+          // response_format is derived from outputs on the server side
         };
 
         const syncResult = await promptsApiService.sync({


### PR DESCRIPTION
## Summary
- `response_format` was stored separately alongside `outputs` in the DB, creating two sources of truth that could drift and cause bugs
- Now `responseFormat` is always **derived from `outputs`** at read time via `deriveResponseFormatFromOutputs()`
- `transformToDbFormat` strips `responseFormat` so it's never written to DB
- CLI push only sends `outputs` (with `json_schema` type) — no more `response_format` in sync payload
- API response still returns `responseFormat` for backward compat (computed, not stored)
- DSPy and Python SDK unaffected (DSPy already derives from outputs, Python SDK reads from API)

## Changes
- **field-schemas.ts**: Added `deriveResponseFormatFromOutputs()` helper
- **prompt.service.ts**: Uses derive function in read path, removed from write paths
- **transformToDbFormat.ts**: Strips `responseFormat`/`response_format` from DB writes
- **prompts.trpc-router.ts**: Removed `responseFormat` from create/copy/push calls
- **llmPromptConfigUtils.ts**: Removed `responseFormat` from form save path
- **push.ts** (CLI): Removed `response_format` from sync configData
- Tests updated across all changed files

## Test plan
- [x] All server prompt tests pass (58 tests)
- [x] CLI push unit tests pass (5 tests)
- [ ] Manual test: create prompt with structured outputs via UI, verify it works
- [ ] Manual test: push YAML prompt with response_format via CLI, verify outputs appear on platform
- [ ] Manual test: copy prompt, verify structured outputs preserved