### PR TITLE
fix: include pre-suite scenario runs in All Runs panel

### DIFF
--- a/specs/features/suites/all-runs-panel.feature
+++ b/specs/features/suites/all-runs-panel.feature
@@ -1,0 +1,26 @@
+Feature: All Runs panel shows all scenario runs
+  As a user viewing the Suites page
+  I want the All Runs panel to show all scenario runs for my project
+  So that I can see historical runs regardless of when they were created
+
+  Background:
+    Given a project with scenario runs
+
+  @integration
+  Scenario: Pre-suite scenario runs appear in All Runs
+    Given scenario runs exist with scenarioSetId "default"
+    When I fetch all suite run data
+    Then the pre-suite runs are included in the results
+
+  @integration
+  Scenario: Suite-created runs still appear in All Runs
+    Given scenario runs exist with a suite-pattern scenarioSetId
+    When I fetch all suite run data
+    Then the suite runs are included in the results
+
+  @integration
+  Scenario: All run types appear together
+    Given scenario runs exist with scenarioSetId "default"
+    And scenario runs exist with a suite-pattern scenarioSetId
+    When I fetch all suite run data
+    Then both pre-suite and suite runs are included in the results


### PR DESCRIPTION
## Summary
- Remove the restrictive `__internal__*__suite` wildcard filter from `getBatchRunIdsForAllSuites` so pre-suite runs (`scenarioSetId="default"`) appear in the All Runs panel
- Make `setFilter` optional in `queryBatchRunIds` — suite-specific queries still pass their filter, but All Runs no longer excludes non-suite runs
- Remove the `trackScenarioSetIds && !scenarioSetId` guard that skipped runs without a scenarioSetId

## Test plan
- [ ] Integration tests added for pre-suite runs appearing in All Runs
- [ ] Integration test for mixed suite + pre-suite runs
- [ ] Existing suite-only test still passes
- [ ] Typecheck passes with no new errors

Closes #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1663