### PR TITLE
fix: worktree script nesting guard and .env copy

### DIFF
--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -144,9 +144,11 @@ main() {
   if [ -n "$issue_url" ]; then
     echo "  Issue:  ${issue_url}"
   fi
+
+  # Open a new shell in the worktree directory
   echo ""
-  echo "To start working:"
-  echo "  cd ${abs_dir}"
+  echo "Opening shell in worktree..."
+  cd "$abs_dir" && exec "$SHELL"
 }
 
 # Only run main when executed directly (not sourced)


### PR DESCRIPTION
## Summary
- Adds a guard to prevent running `scripts/worktree.sh` from inside a worktree (which would nest worktrees)
- Copies `.env` files from `langwatch/` and `langwatch_nlp/` subdirectories, not just the repo root
- Auto-`cd`s into the new worktree directory after creation

Supersedes the `fix/worktree-env-and-nesting-guard` branch.

Closes #1691

## Test plan
- [ ] Run `scripts/worktree.sh` from main repo — should create worktree and cd into it
- [ ] Run `scripts/worktree.sh` from inside a worktree — should error with nesting guard
- [ ] Verify `.env` files are copied from root, `langwatch/`, and `langwatch_nlp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1691