### PR TITLE
fix: trace details loading 15-30s due to unnecessary annotation queries

### DIFF
--- a/langwatch/src/components/AddAnnotationQueueDrawer.tsx
+++ b/langwatch/src/components/AddAnnotationQueueDrawer.tsx
@@ -44,7 +44,7 @@ export const AddAnnotationQueueDrawer = ({
       projectId: project?.id ?? "",
     },
     {
-      enabled: !!project && !!queueId,
+      enabled: !!project && !!queueId && open,
     },
   );
 
@@ -64,7 +64,7 @@ export const AddAnnotationQueueDrawer = ({
       projectId: project?.id ?? "",
     },
     {
-      enabled: !!project,
+      enabled: !!project && open,
     },
   );
 
@@ -81,7 +81,7 @@ export const AddAnnotationQueueDrawer = ({
         organizationId: organization?.id ?? "",
       },
       {
-        enabled: !!organization,
+        enabled: !!organization && open,
       },
     );
   const {

--- a/langwatch/src/components/traces/TraceDetails.tsx
+++ b/langwatch/src/components/traces/TraceDetails.tsx
@@ -122,19 +122,19 @@ export function TraceDetails(props: {
       setTimeout(() => {
         void router.replace(
           "?" +
-            qs.stringify(
-              {
-                ...Object.fromEntries(
-                  Object.entries(router.query).filter(
-                    ([key]) => !key.startsWith("drawer.selectedTab"),
-                  ),
+          qs.stringify(
+            {
+              ...Object.fromEntries(
+                Object.entries(router.query).filter(
+                  ([key]) => !key.startsWith("drawer.selectedTab"),
                 ),
-                drawer: {
-                  selectedTab: tab,
-                },
+              ),
+              drawer: {
+                selectedTab: tab,
               },
-              { allowDots: true },
-            ),
+            },
+            { allowDots: true },
+          ),
         );
       }, 100);
     },
@@ -273,13 +273,15 @@ export function TraceDetails(props: {
                       <Popover.Arrow />
                       <Popover.CloseTrigger />
                       <Popover.Body>
-                        <AddParticipants
-                          annotators={annotators}
-                          setAnnotators={setAnnotators}
-                          queueDrawerOpen={queueDrawerOpen}
-                          sendToQueue={sendToQueue}
-                          isLoading={queueItem.isLoading}
-                        />
+                        {open && (
+                          <AddParticipants
+                            annotators={annotators}
+                            setAnnotators={setAnnotators}
+                            queueDrawerOpen={queueDrawerOpen}
+                            sendToQueue={sendToQueue}
+                            isLoading={queueItem.isLoading}
+                          />
+                        )}
                       </Popover.Body>
                     </Popover.Content>
                   </Popover.Root>
@@ -426,11 +428,13 @@ export function TraceDetails(props: {
         </Tabs.Content>
       </Tabs.Root>
 
-      <AddAnnotationQueueDrawer
-        open={queueDrawerOpen.open}
-        onClose={queueDrawerOpen.onClose}
-        onOverlayClick={queueDrawerOpen.onClose}
-      />
+      {queueDrawerOpen.open && (
+        <AddAnnotationQueueDrawer
+          open={queueDrawerOpen.open}
+          onClose={queueDrawerOpen.onClose}
+          onOverlayClick={queueDrawerOpen.onClose}
+        />
+      )}
     </VStack>
   );
 }


### PR DESCRIPTION
## Summary
- Defer rendering of `AddParticipants` and `AddAnnotationQueueDrawer` until the user actually interacts with the annotation queue UI, preventing their heavy queries from firing on every trace detail open
- Slim down the `getQueues` endpoint from a multi-table join with trace/span enrichment to a simple `SELECT id, name` — the only fields its sole consumer uses
- Gate all queries in `AddAnnotationQueueDrawer` on the existing `open` prop so they don't fire while the drawer is closed

## Problem
Opening any trace detail triggered a batched tRPC call (`annotation.getQueues` + `organization.getOrganizationWithMembersAndTheirTeams`) that took 15-30 seconds. These queries powered the "Annotation Queue" popover and drawer, which most users never interact with on a given trace.

`getQueues` was the worst offender — it fetched all annotation queues with all their items, then enriched every item with full traces (including spans) and annotations. All of that was discarded by the frontend, which only read `queue.id` and `queue.name` for a dropdown.

## Changes
- **`TraceDetails.tsx`**: Conditionally render `AddParticipants` only when popover is open; conditionally render `AddAnnotationQueueDrawer` only when its drawer is open
- **`annotation.ts` `getQueues`**: Replaced the heavyweight query (nested includes + `enrichQueueItemsWithTracesAndAnnotations`) with a minimal `select: { id, name }` query
- **`AddAnnotationQueueDrawer.tsx`**: Added `open` to the `enabled` flag on all three queries (`getQueueBySlugOrId`, `getAllActive`, `getOrganizationWithMembersAndTheirTeams`)
