### PR TITLE
fix(helm): workers workingDir, langevals security, opensearch singleNode, init container image

### DIFF
--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             runAsNonRoot: true
         {{- if .Values.opensearch.chartManaged }}
         - name: wait-for-opensearch
-          image: curlimages/curl:latest
+          image: "{{ .Values.cronjobs.image.repository }}:{{ .Values.cronjobs.image.tag }}"
           command: ['sh', '-c']
           args:
             - |

--- a/charts/langwatch/templates/langevals/deployment.yaml
+++ b/charts/langwatch/templates/langevals/deployment.yaml
@@ -87,6 +87,10 @@ spec:
 
           # Environment variables for the LangEvals service
           env:
+            # uv defaults to /.cache/uv but containers run as non-root (user 1000),
+            # which lacks permission to create directories under /. /tmp is always writable.
+            - name: UV_CACHE_DIR
+              value: /tmp/.cache/uv
             {{- with .Values.langevals.extraEnvs}}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -70,7 +70,7 @@ spec:
         {{- end }}
         {{- if .Values.opensearch.chartManaged }}
         - name: wait-for-opensearch
-          image: curlimages/curl:latest
+          image: "{{ .Values.cronjobs.image.repository }}:{{ .Values.cronjobs.image.tag }}"
           command: ['sh', '-c']
           args:
             - |
@@ -93,6 +93,7 @@ spec:
           imagePullPolicy: "{{ .Values.images.app.pullPolicy }}"
           command: ['pnpm']
           args: ['run', 'start:workers']
+          workingDir: /app/langwatch
           env:
             - name: NODE_ENV
               value: {{ .Values.app.nodeEnv | default .Values.global.env | default "production" }}

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -796,7 +796,10 @@ langevals:
   # Container security context (capabilities, readOnlyRootFilesystem, etc.)
   # See: https://kubespec.dev/v1/Pod#spec.containers.securityContext
   ## @param langevals.containerSecurityContext [object] Container security context overrides.
-  containerSecurityContext: {}
+  # readOnlyRootFilesystem must be false: langevals runs `uv sync` at startup
+  # which writes package files into /usr/src/app/.venv inside the container.
+  containerSecurityContext:
+    readOnlyRootFilesystem: false
   # PodDisruptionBudget pass-through (spec fields)
   # See: https://kubespec.dev/kubernetes/policy/v1/PodDisruptionBudget
   ## @param langevals.podDisruptionBudget [object] PodDisruptionBudget spec overrides.
@@ -1376,13 +1379,16 @@ opensearch:
       discovery.type: single-node
       plugins.security.disabled: true
 
+  # Set to true for single-node deployments. Prevents the opensearch sub-chart
+  # from injecting the cluster.initial_master_nodes env var, which conflicts
+  # with discovery.type: single-node and can prevent the node from starting.
+  singleNode: true
+
   # Additional environment variables
   # See: https://kubespec.dev/v1/Pod#spec.containers.env
   ## @extra opensearch.extraEnvs Additional environment variables.
   ## @skip opensearch.extraEnvs Skip documenting example environment variable item.
-  extraEnvs:
-    - name: cluster.initial_master_nodes
-      value: "" # force empty so the setting is gone
+  extraEnvs: []
 
   # Persistent storage configuration
   # See: https://kubespec.dev/v1/PersistentVolumeClaim


### PR DESCRIPTION
## Summary

Four runtime failures discovered when deploying with a hardened security context (`readOnlyRootFilesystem: true`, `runAsUser: 1000`) or a registry that requires fully-qualified image names.

### 1. workers: `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND`

The workers deployment overrides `ENTRYPOINT` with `command: ['pnpm']`, bypassing the image's startup script which does `cd /app/langwatch`. pnpm then runs from the image `WORKDIR` (`/app`) where no `package.json` exists.

**Fix:** add `workingDir: /app/langwatch` to the workers container spec.

### 2. langevals: crashes on startup under `readOnlyRootFilesystem: true`

langevals runs `uv sync` at startup, writing package files into `/usr/src/app/.venv` — this fails with a read-only root filesystem. Additionally, uv's default cache dir (`/.cache/uv`) is not writable by non-root user 1000 even with a writable rootfs (root owns `/`).

**Fix:** default `containerSecurityContext.readOnlyRootFilesystem` to `false` for langevals, and hardcode `UV_CACHE_DIR=/tmp/.cache/uv` in the template (`/tmp` is always writable).

### 3. opensearch: `cluster.initial_master_nodes` conflicts with single-node mode

The chart forces `cluster.initial_master_nodes=` via `extraEnvs` as a workaround, but the opensearch sub-chart natively supports `singleNode: true` which suppresses this env var cleanly. The empty-string env var approach can still cause issues in some OpenSearch versions.

**Fix:** replace `extraEnvs` hack with `singleNode: true`.

### 4. `wait-for-opensearch` init container: hardcoded unqualified image

Both `app` and `workers` templates hardcode `curlimages/curl:latest` for the `wait-for-opensearch` init container. Clusters that require fully-qualified image names (`docker.io/...`) or use a private registry mirror will fail to pull this image with no override available.

**Fix:** use `cronjobs.image.repository`/`tag` (already the same curl image and already user-configurable) so a single values override covers all three occurrences.

## Test plan

- [ ] Deploy with `global.containerSecurityContext.readOnlyRootFilesystem: true` — workers and langevals should start cleanly
- [ ] Verify `langwatch-workers` pod reaches `Running` state (previously crashed with `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND`)
- [ ] Verify `langwatch-langevals` pod reaches `Running` state (previously crashed on `uv sync` / `/.cache/uv` write)
- [ ] Deploy with a registry mirror by setting `cronjobs.image.repository` — confirm init containers use the overridden image
- [ ] Verify opensearch starts cleanly with `discovery.type: single-node` and no `cluster.initial_master_nodes` conflict
