### PR TITLE
fix: save dashboard return url 

### DIFF
--- a/langwatch/src/components/analytics/reports/DraggableGraphCard.tsx
+++ b/langwatch/src/components/analytics/reports/DraggableGraphCard.tsx
@@ -28,6 +28,7 @@ interface GraphData {
 interface DraggableGraphCardProps {
   graph: GraphData;
   projectSlug: string;
+  dashboardId?: string;
   onDelete: () => void;
   onSizeChange: (size: SizeOption) => void;
   isDeleting: boolean;
@@ -36,6 +37,7 @@ interface DraggableGraphCardProps {
 export function DraggableGraphCard({
   graph,
   projectSlug,
+  dashboardId,
   onDelete,
   onSizeChange,
   isDeleting,
@@ -75,6 +77,7 @@ export function DraggableGraphCard({
             name={graph.name}
             graph={graph.graph}
             projectSlug={projectSlug}
+            dashboardId={dashboardId}
             colSpan={graph.colSpan}
             rowSpan={graph.rowSpan}
             filters={graph.filters}

--- a/langwatch/src/components/analytics/reports/GraphCardHeader.tsx
+++ b/langwatch/src/components/analytics/reports/GraphCardHeader.tsx
@@ -20,6 +20,7 @@ interface GraphCardHeaderProps {
   name: string;
   graph: unknown;
   projectSlug: string;
+  dashboardId?: string;
   colSpan: number;
   rowSpan: number;
   filters: unknown;
@@ -41,6 +42,7 @@ export function GraphCardHeader({
   name,
   graph,
   projectSlug,
+  dashboardId,
   colSpan,
   rowSpan,
   filters,
@@ -174,6 +176,7 @@ export function GraphCardHeader({
       <GraphCardMenu
         graphId={graphId}
         projectSlug={projectSlug}
+        dashboardId={dashboardId}
         colSpan={colSpan}
         rowSpan={rowSpan}
         onSizeChange={onSizeChange}

--- a/langwatch/src/components/analytics/reports/GraphCardMenu.tsx
+++ b/langwatch/src/components/analytics/reports/GraphCardMenu.tsx
@@ -27,6 +27,7 @@ const getCurrentSize = (colSpan: number, rowSpan: number): SizeOption => {
 interface GraphCardMenuProps {
   graphId: string;
   projectSlug: string;
+  dashboardId?: string;
   colSpan: number;
   rowSpan: number;
   onSizeChange: (size: SizeOption) => void;
@@ -37,6 +38,7 @@ interface GraphCardMenuProps {
 export function GraphCardMenu({
   graphId,
   projectSlug,
+  dashboardId,
   colSpan,
   rowSpan,
   onSizeChange,
@@ -45,6 +47,8 @@ export function GraphCardMenu({
 }: GraphCardMenuProps) {
   const router = useRouter();
   const currentSize = getCurrentSize(colSpan, rowSpan);
+
+  const editUrl = `/${projectSlug}/analytics/custom/${graphId}${dashboardId ? `?dashboard=${dashboardId}` : ""}`;
 
   return (
     <Menu.Root>
@@ -57,7 +61,7 @@ export function GraphCardMenu({
         <Menu.Item
           value="edit"
           onClick={() => {
-            void router.push(`/${projectSlug}/analytics/custom/${graphId}`);
+            void router.push(editUrl);
           }}
         >
           <Edit /> Edit Graph

--- a/langwatch/src/components/analytics/reports/ReportGrid.tsx
+++ b/langwatch/src/components/analytics/reports/ReportGrid.tsx
@@ -22,6 +22,7 @@ import {
 interface ReportGridProps {
   graphs: GraphData[];
   projectSlug: string;
+  dashboardId?: string;
   onGraphDelete: (graphId: string) => void;
   onGraphSizeChange: (graphId: string, size: SizeOption) => void;
   onGraphsReorder: (layouts: GridLayout[]) => void;
@@ -31,6 +32,7 @@ interface ReportGridProps {
 export function ReportGrid({
   graphs,
   projectSlug,
+  dashboardId,
   onGraphDelete,
   onGraphSizeChange,
   onGraphsReorder,
@@ -93,6 +95,7 @@ export function ReportGrid({
               key={graph.id}
               graph={graph}
               projectSlug={projectSlug}
+              dashboardId={dashboardId}
               onDelete={() => onGraphDelete(graph.id)}
               onSizeChange={(size) => onGraphSizeChange(graph.id, size)}
               isDeleting={deletingGraphId === graph.id}

--- a/langwatch/src/pages/[project]/analytics/reports.tsx
+++ b/langwatch/src/pages/[project]/analytics/reports.tsx
@@ -232,6 +232,7 @@ function ReportsContent() {
             <ReportGrid
               graphs={graphs}
               projectSlug={project?.slug ?? ""}
+              dashboardId={activeDashboardId ?? undefined}
               onGraphDelete={handleGraphDelete}
               onGraphSizeChange={handleGraphSizeChange}
               onGraphsReorder={handleGraphsReorder}


### PR DESCRIPTION
## Return to dashboard after saving/editing custom graph

### Problem
When editing a custom graph from a dashboard (e.g. `?dashboard=nCEzbZbmTSOfLKMYw3f08`), saving or cancelling sent the user to the generic reports route (`/analytics/reports`) instead of back to that dashboard.

### Cause
The custom graph page already used `router.query.dashboard` to build the redirect URL after save/cancel. The "Add chart" flow passed `?dashboard=...` in the URL, but the "Edit Graph" action in the card menu navigated to `/analytics/custom/[id]` without the dashboard query param, so the redirect had no dashboard id.

### Solution
- Thread optional `dashboardId` from the reports page through: `ReportGrid` → `DraggableGraphCard` → `GraphCardHeader` → `GraphCardMenu`.
- In `GraphCardMenu`, when opening the edit page, append `?dashboard=${dashboardId}` when a dashboard id is present.
- No changes to the custom graph page; it already reads `dashboard` from the URL and uses it for the back redirect.

### Files changed
- `src/pages/[project]/analytics/reports.tsx` – pass `dashboardId` to `ReportGrid`
- `src/components/analytics/reports/ReportGrid.tsx` – accept and forward `dashboardId`
- `src/components/analytics/reports/DraggableGraphCard.tsx` – accept and forward `dashboardId`
- `src/components/analytics/reports/GraphCardHeader.tsx` – accept and forward `dashboardId`
- `src/components/analytics/reports/GraphCardMenu.tsx` – accept `dashboardId` and include it in the edit URL