### PR TITLE
fix: include langevals generated types in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 .pytest_cache
 .venv
 *.generated.*
+!langevals/ts-integration/evaluators.generated.ts
 .DS_Store
 .github
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY langwatch/package.json langwatch/pnpm-lock.yaml langwatch/pnpm-workspace.ya
 COPY langwatch/vendor ./langwatch/vendor
 # https://stackoverflow.com/questions/70154568/pnpm-equivalent-command-for-npm-ci
 RUN cd langwatch && CI=true pnpm install --frozen-lockfile
+COPY langevals/ts-integration/evaluators.generated.ts ./langevals/ts-integration/evaluators.generated.ts
 COPY langwatch ./langwatch
 RUN cd langwatch && pnpm run build
 EXPOSE 5560


### PR DESCRIPTION
## Summary
- The `build-and-push-amd64` CI job fails because `pnpm run build` calls `copy:langevals-types`, which copies `../langevals/ts-integration/evaluators.generated.ts` — a file never included in the Docker image
- Added `COPY` for the langevals generated types file in the Dockerfile
- Added a `.dockerignore` exception so `*.generated.*` doesn't exclude this specific file

## Test plan
- [ ] Verify `build-and-push-amd64` CI job passes on this PR

Generated with [Claude Code](https://claude.com/claude-code)