### PR TITLE
fix: worktree script warns when .env files are missing

### DIFF
--- a/specs/features/devtools/worktree-creation.feature
+++ b/specs/features/devtools/worktree-creation.feature
@@ -80,10 +80,13 @@ Feature: Streamlined worktree creation
     Then all .env* files are copied to the new worktree
 
   @integration
-  Scenario: Succeeds when no .env files exist
+  Scenario: Warns when .env files are missing from main checkout
     Given no .env files exist in the current working tree
+    And .env.example files exist in langwatch/ and langwatch_nlp/
     When I run the worktree script with argument "add-dark-mode"
     Then the worktree is created successfully
+    And a warning is printed for each missing .env file
+    And the warning suggests copying from .env.example
 
   @integration
   Scenario: Exits when worktree directory already exists


### PR DESCRIPTION
## Summary

- The worktree script .env copy loop silently skipped missing files, leaving new worktrees without required configuration
- Now warns when .env is missing from the main checkout and suggests copying from .env.example
- Updated the feature spec to cover the warning behavior

## Test plan

- [ ] Run scripts/worktree.sh without langwatch/.env in main checkout — verify warning is printed
- [ ] Run scripts/worktree.sh with all .env files present — verify no warnings

Generated with [Claude Code](https://claude.com/claude-code)