### PR TITLE
fix: copy SDK package files into Docker image for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ COPY langwatch/vendor ./langwatch/vendor
 # https://stackoverflow.com/questions/70154568/pnpm-equivalent-command-for-npm-ci
 RUN cd langwatch && CI=true pnpm install --frozen-lockfile
 COPY langevals/ts-integration/evaluators.generated.ts ./langevals/ts-integration/evaluators.generated.ts
+# SDK package files needed by generate-sdk-versions.sh during build
+COPY typescript-sdk/package.json ./typescript-sdk/package.json
+COPY python-sdk/pyproject.toml ./python-sdk/pyproject.toml
 COPY langwatch ./langwatch
 RUN cd langwatch && pnpm run build
 EXPOSE 5560


### PR DESCRIPTION
## Summary
- `generate-sdk-versions.sh` (added in #1746) needs `typescript-sdk/package.json` and `python-sdk/pyproject.toml` to generate `sdk-versions.json` at build time
- These files were never copied into the Docker image, causing the `pnpm run build` step to fail
- Adds two `COPY` lines before the build step

Fixes the failing Docker build: https://github.com/langwatch/langwatch/actions/runs/22232461971/job/64315538053

🤖 Generated with [Claude Code](https://claude.com/claude-code)