### PR TITLE
fix: remove padding for scenario library page

### DIFF
--- a/langwatch/src/pages/[project]/simulations/scenarios/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/scenarios/index.tsx
@@ -169,7 +169,7 @@ function ScenarioLibraryPage() {
         </HStack>
       </PageLayout.Header>
 
-      <PageLayout.Container>
+      <PageLayout.Container padding={0}>
         {isLoading && (
           <VStack gap={4} align="center" py={8}>
             <Spinner borderWidth="3px" animationDuration="0.8s" />


### PR DESCRIPTION
## Before

<img width="1511" height="799" alt="Screenshot 2026-02-21 at 12 17 15" src="https://github.com/user-attachments/assets/6dee894f-827b-45d5-9c00-2abe7b2876d7" />

## After

<img width="1512" height="680" alt="image" src="https://github.com/user-attachments/assets/4cd0a068-8f08-478e-afbf-d94ecbfa8210" />
