### PR TITLE
feat: prefix platform MCP tools with `platform_` and add disambiguation notes

### DIFF
--- a/mcp-server/src/__tests__/integration.integration.test.ts
+++ b/mcp-server/src/__tests__/integration.integration.test.ts
@@ -222,7 +222,7 @@ describe("MCP tools integration", () => {
     });
   });
 
-  describe("list_prompts", () => {
+  describe("platform_list_prompts", () => {
     it("returns formatted prompt list from mock server", async () => {
       const { handleListPrompts } = await import("../tools/list-prompts.js");
       const result = await handleListPrompts();
@@ -232,7 +232,7 @@ describe("MCP tools integration", () => {
     });
   });
 
-  describe("get_prompt", () => {
+  describe("platform_get_prompt", () => {
     it("returns formatted prompt details from mock server", async () => {
       const { handleGetPrompt } = await import("../tools/get-prompt.js");
       const result = await handleGetPrompt({ idOrHandle: "greeting-bot" });
@@ -243,7 +243,7 @@ describe("MCP tools integration", () => {
     });
   });
 
-  describe("create_prompt", () => {
+  describe("platform_create_prompt", () => {
     it("returns success message from mock server", async () => {
       const { handleCreatePrompt } = await import(
         "../tools/create-prompt.js"
@@ -259,7 +259,7 @@ describe("MCP tools integration", () => {
     });
   });
 
-  describe("update_prompt", () => {
+  describe("platform_update_prompt", () => {
     it("returns success message for in-place update from mock server", async () => {
       const { handleUpdatePrompt } = await import(
         "../tools/update-prompt.js"

--- a/mcp-server/src/__tests__/scenario-tools.integration.test.ts
+++ b/mcp-server/src/__tests__/scenario-tools.integration.test.ts
@@ -165,7 +165,7 @@ describe("MCP scenario tools integration", () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 
-  describe("list_scenarios", () => {
+  describe("platform_list_scenarios", () => {
     describe("when the API returns scenarios", () => {
       it("returns a non-empty result", async () => {
         const { handleListScenarios } = await import(
@@ -187,7 +187,7 @@ describe("MCP scenario tools integration", () => {
     });
   });
 
-  describe("get_scenario", () => {
+  describe("platform_get_scenario", () => {
     describe("when the scenario exists", () => {
       it("returns a non-empty result", async () => {
         const { handleGetScenario } = await import(
@@ -210,7 +210,7 @@ describe("MCP scenario tools integration", () => {
     });
   });
 
-  describe("create_scenario", () => {
+  describe("platform_create_scenario", () => {
     describe("when valid data is provided", () => {
       it("returns confirmation with new scenario ID", async () => {
         const { handleCreateScenario } = await import(
@@ -241,7 +241,7 @@ describe("MCP scenario tools integration", () => {
     });
   });
 
-  describe("update_scenario", () => {
+  describe("platform_update_scenario", () => {
     describe("when the scenario exists", () => {
       it("returns a non-empty result", async () => {
         const { handleUpdateScenario } = await import(
@@ -270,7 +270,7 @@ describe("MCP scenario tools integration", () => {
     });
   });
 
-  describe("archive_scenario", () => {
+  describe("platform_archive_scenario", () => {
     describe("when the scenario exists", () => {
       it("returns confirmation that scenario was archived", async () => {
         const { handleArchiveScenario } = await import(

--- a/mcp-server/src/__tests__/scenario-tools.unit.test.ts
+++ b/mcp-server/src/__tests__/scenario-tools.unit.test.ts
@@ -96,8 +96,8 @@ describe("handleListScenarios()", () => {
       expect(result).toContain("No scenarios found");
     });
 
-    it("includes a tip to use create_scenario", () => {
-      expect(result).toContain("create_scenario");
+    it("includes a tip to use platform_create_scenario", () => {
+      expect(result).toContain("platform_create_scenario");
     });
   });
 

--- a/mcp-server/src/__tests__/tools.unit.test.ts
+++ b/mcp-server/src/__tests__/tools.unit.test.ts
@@ -488,14 +488,14 @@ describe("handleListPrompts()", () => {
     });
   });
 
-  it("includes usage tip about get_prompt", async () => {
+  it("includes usage tip about platform_get_prompt", async () => {
     mockListPrompts.mockResolvedValue([
       { handle: "test", name: "Test", latestVersionNumber: 1 },
     ]);
 
     const result = await handleListPrompts();
 
-    expect(result).toContain("get_prompt");
+    expect(result).toContain("platform_get_prompt");
   });
 });
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -225,43 +225,20 @@ server.tool(
   }
 );
 
-server.tool(
-  "list_prompts",
-  "List all prompts configured in the LangWatch project.",
-  {},
-  async () => {
-    const { requireApiKey } = await import("./config.js");
-    requireApiKey();
-    const { handleListPrompts } = await import("./tools/list-prompts.js");
-    return {
-      content: [{ type: "text", text: await handleListPrompts() }],
-    };
-  }
-);
+// --- Platform Prompt Tools (require API key) ---
+// These tools manage prompts on the LangWatch platform via API.
+// For code-based prompt management, see `fetch_langwatch_docs` for the CLI/SDK approach.
 
 server.tool(
-  "get_prompt",
-  "Get a specific prompt by ID or handle, including messages, model config, and version history.",
-  {
-    idOrHandle: z.string().describe("Prompt ID or handle"),
-    version: z
-      .number()
-      .optional()
-      .describe("Specific version number (default: latest)"),
-  },
-  async (params) => {
-    const { requireApiKey } = await import("./config.js");
-    requireApiKey();
-    const { handleGetPrompt } = await import("./tools/get-prompt.js");
-    return {
-      content: [{ type: "text", text: await handleGetPrompt(params) }],
-    };
-  }
-);
+  "platform_create_prompt",
+  `Create a new prompt on the LangWatch platform.
 
-server.tool(
-  "create_prompt",
-  "Create a new prompt in the LangWatch project.",
+NOTE: Prompts can be managed two ways. Determine which approach the user needs:
+
+1. Code-based (CLI/SDK): If the user wants to manage prompts in their codebase, use \`fetch_langwatch_docs\` to learn about the prompt management CLI/SDK. This lets them version-control prompts and pull them into code.
+
+2. Platform-based (LangWatch UI): If the user wants to manage prompts directly on the LangWatch platform, use the \`platform_\` MCP tools (\`platform_create_prompt\`, \`platform_update_prompt\`, etc.).
+`,
   {
     name: z.string().describe("Prompt name"),
     handle: z
@@ -297,8 +274,42 @@ server.tool(
 );
 
 server.tool(
-  "update_prompt",
-  "Update an existing prompt or create a new version.",
+  "platform_list_prompts",
+  "List all prompts configured on the LangWatch platform.",
+  {},
+  async () => {
+    const { requireApiKey } = await import("./config.js");
+    requireApiKey();
+    const { handleListPrompts } = await import("./tools/list-prompts.js");
+    return {
+      content: [{ type: "text", text: await handleListPrompts() }],
+    };
+  }
+);
+
+server.tool(
+  "platform_get_prompt",
+  "Get a specific prompt from the LangWatch platform by ID or handle, including messages, model config, and version history.",
+  {
+    idOrHandle: z.string().describe("Prompt ID or handle"),
+    version: z
+      .number()
+      .optional()
+      .describe("Specific version number (default: latest)"),
+  },
+  async (params) => {
+    const { requireApiKey } = await import("./config.js");
+    requireApiKey();
+    const { handleGetPrompt } = await import("./tools/get-prompt.js");
+    return {
+      content: [{ type: "text", text: await handleGetPrompt(params) }],
+    };
+  }
+);
+
+server.tool(
+  "platform_update_prompt",
+  "Update an existing prompt on the LangWatch platform or create a new version.",
   {
     idOrHandle: z.string().describe("Prompt ID or handle to update"),
     messages: z
@@ -333,64 +344,20 @@ server.tool(
   }
 );
 
-// --- Scenario Tools (require API key) ---
+// --- Platform Scenario Tools (require API key) ---
+// These tools manage scenarios on the LangWatch platform via API.
+// For code-based scenario testing, see `fetch_scenario_docs` for the SDK approach.
 
 server.tool(
-  "list_scenarios",
-  `List all scenarios in the LangWatch project. Returns AI-readable digest by default.
+  "platform_create_scenario",
+  `Create a new scenario on the LangWatch platform. Call discover_schema({ category: 'scenarios' }) first to learn how to write effective situations and criteria.
 
-  *Important Note*: There are two ways of creating scenarios
+NOTE: Scenarios can be created two ways. Determine which approach the user needs:
 
-  - Via Code: When you are in a codebase, helping users test their agents, most likely what they want is
-    to create scenarios is to use the Scenario Python and TypeScript libraries, so you can run the tests and
-    iterate locally. Use the \`fetch_scenario_docs\` tool to learn more.
+1. Code-based (local testing): If the user has a codebase with an AI agent they want to test, use \`fetch_scenario_docs\` to learn about the Scenario Python/TypeScript SDK. This lets them run tests locally and iterate in code.
 
-  - Via LangWatch UI: When the user is using you more as an assistant to create, update and run scenarios on
-    LangWatch platform, this is when you should use the MCP tools like this and the ones below instead.
-  `,
-  {
-    format: z
-      .enum(["digest", "json"])
-      .optional()
-      .describe(
-        "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)"
-      ),
-  },
-  async (params) => {
-    const { requireApiKey } = await import("./config.js");
-    requireApiKey();
-    const { handleListScenarios } = await import("./tools/list-scenarios.js");
-    return {
-      content: [{ type: "text", text: await handleListScenarios(params) }],
-    };
-  }
-);
-
-server.tool(
-  "get_scenario",
-  "Get full details of a scenario by ID, including situation, criteria, and labels.",
-  {
-    scenarioId: z.string().describe("The scenario ID to retrieve"),
-    format: z
-      .enum(["digest", "json"])
-      .optional()
-      .describe(
-        "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)"
-      ),
-  },
-  async (params) => {
-    const { requireApiKey } = await import("./config.js");
-    requireApiKey();
-    const { handleGetScenario } = await import("./tools/get-scenario.js");
-    return {
-      content: [{ type: "text", text: await handleGetScenario(params) }],
-    };
-  }
-);
-
-server.tool(
-  "create_scenario",
-  "Create a new scenario in the LangWatch project. Call discover_schema({ category: 'scenarios' }) first to learn how to write effective situations and criteria.",
+2. Platform-based (LangWatch UI): If the user wants to manage scenarios directly on the LangWatch platform, use the \`platform_\` MCP tools (\`platform_create_scenario\`, \`platform_update_scenario\`, etc.).
+`,
   {
     name: z.string().describe("Scenario name"),
     situation: z
@@ -418,8 +385,51 @@ server.tool(
 );
 
 server.tool(
-  "update_scenario",
-  "Update an existing scenario.",
+  "platform_list_scenarios",
+  "List all scenarios on the LangWatch platform. Returns AI-readable digest by default.",
+  {
+    format: z
+      .enum(["digest", "json"])
+      .optional()
+      .describe(
+        "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)"
+      ),
+  },
+  async (params) => {
+    const { requireApiKey } = await import("./config.js");
+    requireApiKey();
+    const { handleListScenarios } = await import("./tools/list-scenarios.js");
+    return {
+      content: [{ type: "text", text: await handleListScenarios(params) }],
+    };
+  }
+);
+
+server.tool(
+  "platform_get_scenario",
+  "Get full details of a scenario on the LangWatch platform by ID, including situation, criteria, and labels.",
+  {
+    scenarioId: z.string().describe("The scenario ID to retrieve"),
+    format: z
+      .enum(["digest", "json"])
+      .optional()
+      .describe(
+        "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)"
+      ),
+  },
+  async (params) => {
+    const { requireApiKey } = await import("./config.js");
+    requireApiKey();
+    const { handleGetScenario } = await import("./tools/get-scenario.js");
+    return {
+      content: [{ type: "text", text: await handleGetScenario(params) }],
+    };
+  }
+);
+
+server.tool(
+  "platform_update_scenario",
+  "Update an existing scenario on the LangWatch platform.",
   {
     scenarioId: z.string().describe("The scenario ID to update"),
     name: z.string().optional().describe("Updated scenario name"),
@@ -446,8 +456,8 @@ server.tool(
 );
 
 server.tool(
-  "archive_scenario",
-  "Archive (soft-delete) a scenario.",
+  "platform_archive_scenario",
+  "Archive (soft-delete) a scenario on the LangWatch platform.",
   {
     scenarioId: z.string().describe("The scenario ID to archive"),
   },

--- a/mcp-server/src/tools/archive-scenario.ts
+++ b/mcp-server/src/tools/archive-scenario.ts
@@ -1,7 +1,7 @@
 import { archiveScenario as apiArchiveScenario } from "../langwatch-api-scenarios.js";
 
 /**
- * Handles the archive_scenario MCP tool invocation.
+ * Handles the platform_archive_scenario MCP tool invocation.
  *
  * Archives (soft-deletes) a scenario and returns confirmation.
  */

--- a/mcp-server/src/tools/create-prompt.ts
+++ b/mcp-server/src/tools/create-prompt.ts
@@ -1,7 +1,7 @@
 import { createPrompt as apiCreatePrompt } from "../langwatch-api.js";
 
 /**
- * Handles the create_prompt MCP tool invocation.
+ * Handles the platform_create_prompt MCP tool invocation.
  *
  * Creates a new prompt in the LangWatch project and returns a
  * confirmation with the created prompt's details.

--- a/mcp-server/src/tools/create-scenario.ts
+++ b/mcp-server/src/tools/create-scenario.ts
@@ -1,7 +1,7 @@
 import { createScenario as apiCreateScenario } from "../langwatch-api-scenarios.js";
 
 /**
- * Handles the create_scenario MCP tool invocation.
+ * Handles the platform_create_scenario MCP tool invocation.
  *
  * Creates a new scenario in the LangWatch project and returns a
  * confirmation with the created scenario's details.

--- a/mcp-server/src/tools/get-prompt.ts
+++ b/mcp-server/src/tools/get-prompt.ts
@@ -1,7 +1,7 @@
 import { getPrompt as apiGetPrompt } from "../langwatch-api.js";
 
 /**
- * Handles the get_prompt MCP tool invocation.
+ * Handles the platform_get_prompt MCP tool invocation.
  *
  * Retrieves a specific prompt by ID or handle and formats it as
  * AI-readable markdown, including messages, model config, and version history.

--- a/mcp-server/src/tools/list-prompts.ts
+++ b/mcp-server/src/tools/list-prompts.ts
@@ -1,7 +1,7 @@
 import { listPrompts as apiListPrompts } from "../langwatch-api.js";
 
 /**
- * Handles the list_prompts MCP tool invocation.
+ * Handles the platform_list_prompts MCP tool invocation.
  *
  * Lists all prompts in the LangWatch project, formatted as an
  * AI-readable markdown table.
@@ -28,7 +28,7 @@ export async function handleListPrompts(): Promise<string> {
   }
 
   lines.push(
-    "\n> Use `get_prompt` with the handle or ID to see full prompt details."
+    "\n> Use `platform_get_prompt` with the handle or ID to see full prompt details."
   );
 
   return lines.join("\n");

--- a/mcp-server/src/tools/list-scenarios.ts
+++ b/mcp-server/src/tools/list-scenarios.ts
@@ -1,7 +1,7 @@
 import { listScenarios as apiListScenarios } from "../langwatch-api-scenarios.js";
 
 /**
- * Handles the list_scenarios MCP tool invocation.
+ * Handles the platform_list_scenarios MCP tool invocation.
  *
  * Lists all scenarios in the LangWatch project, formatted as an
  * AI-readable digest or raw JSON.
@@ -16,7 +16,7 @@ export async function handleListScenarios(params: {
   }
 
   if (!Array.isArray(scenarios) || scenarios.length === 0) {
-    return "No scenarios found in this project.\n\n> Tip: Use `create_scenario` to create your first scenario.";
+    return "No scenarios found in this project.\n\n> Tip: Use `platform_create_scenario` to create your first scenario.";
   }
 
   const lines: string[] = [];
@@ -40,7 +40,7 @@ export async function handleListScenarios(params: {
   }
 
   lines.push(
-    "> Use `get_scenario` with the ID to see full scenario details.",
+    "> Use `platform_get_scenario` with the ID to see full scenario details.",
   );
 
   return lines.join("\n");

--- a/mcp-server/src/tools/update-prompt.ts
+++ b/mcp-server/src/tools/update-prompt.ts
@@ -5,7 +5,7 @@ import {
 import type { PromptMutationResponse } from "../langwatch-api.js";
 
 /**
- * Handles the update_prompt MCP tool invocation.
+ * Handles the platform_update_prompt MCP tool invocation.
  *
  * Updates an existing prompt or creates a new version, depending on the
  * `createVersion` flag. Returns a confirmation with the updated details.

--- a/mcp-server/src/tools/update-scenario.ts
+++ b/mcp-server/src/tools/update-scenario.ts
@@ -1,7 +1,7 @@
 import { updateScenario as apiUpdateScenario } from "../langwatch-api-scenarios.js";
 
 /**
- * Handles the update_scenario MCP tool invocation.
+ * Handles the platform_update_scenario MCP tool invocation.
  *
  * Updates an existing scenario and returns a confirmation
  * with the updated details.


### PR DESCRIPTION
## Summary

When an AI agent has all MCP tools loaded, it can confuse platform API tools (e.g. `create_scenario`) with the code-based SDK approach (`fetch_scenario_docs`). This PR fixes that by:

- **Prefixing all prompt and scenario CRUD tools with `platform_`** — e.g. `create_scenario` → `platform_create_scenario`, `get_prompt` → `platform_get_prompt`. The tool name is the strongest signal an agent reads, so this makes the distinction clear at a glance.
- **Reordering `platform_create_*` tools to appear first** in their groups, since creation is the most likely entry point where agents go wrong.
- **Adding disambiguation notes** on `platform_create_scenario` and `platform_create_prompt` explaining both approaches (code-based SDK vs platform UI), so agents can route correctly.
- **Updating handler output** (e.g. "Use `platform_get_prompt`...") and all test references to match.

### Tools renamed

| Before | After |
|--------|-------|
| `list_prompts` | `platform_list_prompts` |
| `get_prompt` | `platform_get_prompt` |
| `create_prompt` | `platform_create_prompt` |
| `update_prompt` | `platform_update_prompt` |
| `list_scenarios` | `platform_list_scenarios` |
| `get_scenario` | `platform_get_scenario` |
| `create_scenario` | `platform_create_scenario` |
| `update_scenario` | `platform_update_scenario` |
| `archive_scenario` | `platform_archive_scenario` |

Unchanged tools: `fetch_langwatch_docs`, `fetch_scenario_docs`, `discover_schema`, `search_traces`, `get_trace`, `get_analytics` — these have no local/platform ambiguity.

## Test plan

- [x] All unit and integration tests pass (137/137, only pre-existing `scenario-openai` e2e failure unrelated)
- [ ] Verify MCP client picks up new tool names correctly