### PR TITLE
feat: encrypt model provider API keys at rest

### DIFF
--- a/charts/langwatch/templates/app/secrets.yaml
+++ b/charts/langwatch/templates/app/secrets.yaml
@@ -21,7 +21,7 @@ data:
   {{- if .Values.app.credentialsEncryptionKey.value }}
   credentialsEncryptionKey: {{ .Values.app.credentialsEncryptionKey.value | b64enc | quote }}
   {{- else }}
-  credentialsEncryptionKey: {{ randAlphaNum 32 | b64enc | quote }}
+  credentialsEncryptionKey: {{ randAlphaNum 64 | sha256sum | b64enc | quote }}
   {{- end }}
   {{- if .Values.app.cronApiKey.value }}
   cronApiKey: {{ .Values.app.cronApiKey.value | b64enc | quote }}

--- a/langwatch/specs/model-providers/encrypt-custom-keys.feature
+++ b/langwatch/specs/model-providers/encrypt-custom-keys.feature
@@ -1,0 +1,43 @@
+Feature: Encrypt model provider API keys at rest
+  As a platform operator
+  I want model provider API keys encrypted in the database
+  So that a database breach does not expose customer credentials
+
+  Background:
+    Given a project with CREDENTIALS_SECRET configured
+    And the encryption utility uses AES-256-GCM
+
+  Scenario: New model provider keys are encrypted on save
+    When a user saves a model provider with an API key
+    Then the customKeys column contains an encrypted string
+    And the encrypted string is not valid JSON
+    And the encrypted string contains three colon-separated segments
+
+  Scenario: Encrypted keys are decrypted on read
+    Given a model provider with encrypted customKeys in the database
+    When the repository reads the model provider
+    Then the returned customKeys is a decrypted JSON object
+    And the original key values are preserved
+
+  Scenario: Null customKeys are handled gracefully
+    When a model provider is saved without customKeys
+    Then the customKeys column remains null
+    And reading the model provider returns null customKeys
+
+  Scenario: Migration encrypts existing plaintext keys
+    Given model providers with plaintext customKeys in the database
+    When the encryption migration task runs
+    Then all plaintext customKeys are encrypted
+    And the migration logs the number of updated rows
+
+  Scenario: Migration is idempotent
+    Given model providers with already-encrypted customKeys
+    When the encryption migration task runs again
+    Then the already-encrypted rows are skipped
+    And the data remains valid after decryption
+
+  Scenario: All database access goes through the repository
+    Given the modelProvider router and service
+    Then no code outside the repository calls prisma.modelProvider directly
+    And deletes use repository.delete or repository.deleteByProvider
+    And reads use repository.findAll or repository.findByProvider

--- a/langwatch/src/server/api/routers/providerValidation.ts
+++ b/langwatch/src/server/api/routers/providerValidation.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { providerDefaultBaseUrls } from "../../../features/onboarding/regions/model-providers/registry";
 import { MASKED_KEY_PLACEHOLDER } from "../../../utils/constants";
+import { ModelProviderRepository } from "../../modelProviders/modelProvider.repository";
 import { modelProviders } from "../../modelProviders/registry";
 
 /** Validation result returned by all validation functions */
@@ -208,11 +209,9 @@ export async function validateKeyWithCustomUrl(
   const apiKeyField = providerDef.apiKey;
   const endpointField = providerDef.endpointKey;
 
-  // Try to get stored API key from DB
-  const storedProvider = await prisma.modelProvider.findFirst({
-    where: { projectId, provider },
-    select: { customKeys: true },
-  });
+  // Try to get stored API key from DB (decrypted by repository)
+  const repository = new ModelProviderRepository(prisma);
+  const storedProvider = await repository.findByProvider(provider, projectId);
 
   const storedKeys = storedProvider?.customKeys as Record<
     string,

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.integration.test.ts
@@ -1,0 +1,236 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for ModelProviderRepository encryption.
+ * Tests real database operations with real AES-256-GCM encryption.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getTestUser } from "../../../utils/testUtils";
+import { prisma } from "../../db";
+import { ModelProviderRepository } from "../modelProvider.repository";
+import { generate } from "@langwatch/ksuid";
+import { KSUID_RESOURCES } from "../../../utils/constants";
+import main from "../../../tasks/migrateModelProviderKeys";
+
+const projectId = "test-project-id";
+
+describe("ModelProviderRepository Integration", () => {
+  const repository = new ModelProviderRepository(prisma);
+  const createdProviderIds: string[] = [];
+
+  beforeAll(async () => {
+    await getTestUser();
+
+    // Ensure CREDENTIALS_SECRET is set for encryption
+    if (!process.env.CREDENTIALS_SECRET) {
+      process.env.CREDENTIALS_SECRET =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    }
+  });
+
+  afterAll(async () => {
+    if (createdProviderIds.length > 0) {
+      await prisma.modelProvider.deleteMany({
+        where: { id: { in: createdProviderIds }, projectId },
+      });
+    }
+  });
+
+  describe("given a model provider with customKeys", () => {
+    describe("when saved and read back through the repository", () => {
+      it("encrypts on save and decrypts on read preserving original values", async () => {
+        const created = await repository.create({
+          projectId,
+          provider: "openai",
+          enabled: true,
+          customKeys: { OPENAI_API_KEY: "sk-test-key-123" },
+        });
+        createdProviderIds.push(created.id);
+
+        // Read back through repository (decrypts)
+        const found = await repository.findById(created.id, projectId);
+
+        expect(found).not.toBeNull();
+        expect(
+          (found!.customKeys as Record<string, unknown>).OPENAI_API_KEY
+        ).toBe("sk-test-key-123");
+
+        // Read raw from prisma to verify DB value is encrypted
+        const rawRow = await prisma.modelProvider.findFirst({
+          where: { id: created.id, projectId },
+          select: { customKeys: true },
+        });
+
+        expect(typeof rawRow!.customKeys).toBe("string");
+
+        const rawString = rawRow!.customKeys as string;
+        const parts = rawString.split(":");
+        expect(parts).toHaveLength(3); // iv:encrypted:authTag
+      });
+    });
+  });
+
+  describe("given a model provider with plaintext customKeys in the database (pre-migration)", () => {
+    describe("when read through the repository", () => {
+      it("returns decrypted keys without error (backward compatibility)", async () => {
+        const id = generate(KSUID_RESOURCES.MODEL_PROVIDER).toString();
+        createdProviderIds.push(id);
+
+        // Insert directly via prisma (bypassing repository) with plaintext JSON
+        await prisma.modelProvider.create({
+          data: {
+            id,
+            projectId,
+            provider: "azure",
+            enabled: true,
+            customKeys: { OPENAI_API_KEY: "sk-legacy-key" },
+          },
+        });
+
+        // Read through repository
+        const found = await repository.findByProvider("azure", projectId);
+
+        expect(found).not.toBeNull();
+        expect(
+          (found!.customKeys as Record<string, unknown>).OPENAI_API_KEY
+        ).toBe("sk-legacy-key");
+      });
+    });
+  });
+
+  describe("given a model provider without customKeys", () => {
+    describe("when saved and read back", () => {
+      it("preserves null customKeys", async () => {
+        const created = await repository.create({
+          projectId,
+          provider: "google",
+          enabled: true,
+        });
+        createdProviderIds.push(created.id);
+
+        const found = await repository.findById(created.id, projectId);
+
+        expect(found).not.toBeNull();
+        expect(found!.customKeys).toBeNull();
+      });
+    });
+  });
+
+  describe("given model providers with mixed encrypted and plaintext keys", () => {
+    const migrationIds: string[] = [];
+
+    describe("when the migration task runs", () => {
+      it("encrypts only the plaintext rows", async () => {
+        // 1. Insert plaintext row directly via prisma
+        const plaintextId = generate(
+          KSUID_RESOURCES.MODEL_PROVIDER
+        ).toString();
+        migrationIds.push(plaintextId);
+        createdProviderIds.push(plaintextId);
+
+        await prisma.modelProvider.create({
+          data: {
+            id: plaintextId,
+            projectId,
+            provider: "cohere",
+            enabled: true,
+            customKeys: { COHERE_API_KEY: "sk-plain" },
+          },
+        });
+
+        // 2. Insert null row directly via prisma
+        const nullId = generate(KSUID_RESOURCES.MODEL_PROVIDER).toString();
+        migrationIds.push(nullId);
+        createdProviderIds.push(nullId);
+
+        await prisma.modelProvider.create({
+          data: {
+            id: nullId,
+            projectId,
+            provider: "mistral",
+            enabled: true,
+            customKeys: undefined,
+          },
+        });
+
+        // 3. Save one through repository (will be encrypted)
+        const encryptedRow = await repository.create({
+          projectId,
+          provider: "anthropic",
+          enabled: true,
+          customKeys: { ANTHROPIC_API_KEY: "sk-ant-already" },
+        });
+        migrationIds.push(encryptedRow.id);
+        createdProviderIds.push(encryptedRow.id);
+
+        // Run migration
+        await main();
+
+        // Read all through repository
+        const plaintextProvider = await repository.findById(
+          plaintextId,
+          projectId
+        );
+        const nullProvider = await repository.findById(nullId, projectId);
+        const encryptedProvider = await repository.findById(
+          encryptedRow.id,
+          projectId
+        );
+
+        // Verify plaintext was migrated correctly
+        expect(
+          (plaintextProvider!.customKeys as Record<string, unknown>)
+            .COHERE_API_KEY
+        ).toBe("sk-plain");
+
+        // Verify null stayed null
+        expect(nullProvider!.customKeys).toBeNull();
+
+        // Verify already-encrypted stayed correct
+        expect(
+          (encryptedProvider!.customKeys as Record<string, unknown>)
+            .ANTHROPIC_API_KEY
+        ).toBe("sk-ant-already");
+
+        // Verify raw DB: non-null customKeys are now encrypted strings
+        for (const id of migrationIds) {
+          const raw = await prisma.modelProvider.findFirst({
+            where: { id, projectId },
+            select: { customKeys: true },
+          });
+
+          if (raw!.customKeys !== null) {
+            expect(typeof raw!.customKeys).toBe("string");
+            expect((raw!.customKeys as string).split(":")).toHaveLength(3);
+          }
+        }
+      });
+    });
+
+    describe("given already-migrated providers", () => {
+      describe("when migration runs again", () => {
+        it("is idempotent -- skips encrypted rows and data remains valid", async () => {
+          // Run migration again (same data from previous test)
+          await main();
+
+          // Read through repository -- values still correct
+          for (const id of migrationIds) {
+            const provider = await repository.findById(id, projectId);
+            expect(provider).not.toBeNull();
+
+            if (provider!.customKeys !== null) {
+              const keys = provider!.customKeys as Record<string, unknown>;
+              // At least one key should have a string value
+              const values = Object.values(keys);
+              expect(values.length).toBeGreaterThan(0);
+              for (const value of values) {
+                expect(typeof value).toBe("string");
+                expect((value as string).startsWith("sk-")).toBe(true);
+              }
+            }
+          }
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the encryption module before importing the repository
+vi.mock("../../../utils/encryption", () => ({
+  encrypt: vi.fn((text: string) => `mock-iv:mock-encrypted-${text}:mock-tag`),
+  decrypt: vi.fn((encrypted: string) => {
+    const match = encrypted.match(/^mock-iv:mock-encrypted-(.+):mock-tag$/);
+    if (!match) throw new Error("Invalid encrypted string format");
+    return match[1]!;
+  }),
+}));
+
+import type { ModelProvider, PrismaClient } from "@prisma/client";
+import { ModelProviderRepository } from "../modelProvider.repository";
+import { encrypt, decrypt } from "../../../utils/encryption";
+
+function createMockPrisma() {
+  return {
+    modelProvider: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  } as unknown as PrismaClient;
+}
+
+function createModelProvider(
+  overrides: Partial<ModelProvider> = {},
+): ModelProvider {
+  return {
+    id: "mp_test123",
+    projectId: "proj_test",
+    provider: "openai",
+    enabled: true,
+    customKeys: null,
+    customModels: null,
+    customEmbeddingsModels: null,
+    deploymentMapping: null,
+    extraHeaders: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("ModelProviderRepository", () => {
+  let prisma: ReturnType<typeof createMockPrisma>;
+  let repository: ModelProviderRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma = createMockPrisma();
+    repository = new ModelProviderRepository(prisma);
+  });
+
+  describe("encryptCustomKeys", () => {
+    describe("when given a Record of keys", () => {
+      it("produces an encrypted string", () => {
+        const keys = { OPENAI_API_KEY: "sk-secret123" };
+        const result = (repository as any).encryptCustomKeys(keys);
+
+        expect(typeof result).toBe("string");
+        expect(encrypt).toHaveBeenCalledWith(JSON.stringify(keys));
+      });
+
+      it("calls encrypt with the JSON-serialized keys", () => {
+        const keys = { OPENAI_API_KEY: "sk-secret123" };
+        (repository as any).encryptCustomKeys(keys);
+
+        expect(encrypt).toHaveBeenCalledWith(JSON.stringify(keys));
+      });
+
+      it("produces a value that is not valid JSON for an object", () => {
+        const keys = { OPENAI_API_KEY: "sk-secret123" };
+        const result = (repository as any).encryptCustomKeys(keys);
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(result);
+        } catch {
+          parsed = undefined;
+        }
+        // The encrypted string should not parse to an object
+        expect(typeof parsed).not.toBe("object");
+      });
+    });
+
+    describe("when given null", () => {
+      it("returns null", () => {
+        const result = (repository as any).encryptCustomKeys(null);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when given undefined", () => {
+      it("returns undefined", () => {
+        const result = (repository as any).encryptCustomKeys(undefined);
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe("decryptCustomKeys", () => {
+    describe("when given an encrypted string", () => {
+      it("round-trips correctly with encryptCustomKeys", () => {
+        const original = { OPENAI_API_KEY: "sk-secret123", BASE_URL: "https://api.openai.com" };
+        const encrypted = (repository as any).encryptCustomKeys(original);
+        const decrypted = (repository as any).decryptCustomKeys(encrypted);
+
+        expect(decrypted).toEqual(original);
+      });
+    });
+
+    describe("when given a plaintext object (migration compatibility)", () => {
+      it("returns the object as-is", () => {
+        const plaintext = { OPENAI_API_KEY: "sk-secret123" };
+        const result = (repository as any).decryptCustomKeys(plaintext);
+
+        expect(result).toEqual(plaintext);
+        expect(decrypt).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when given null", () => {
+      it("returns null", () => {
+        const result = (repository as any).decryptCustomKeys(null);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when given undefined", () => {
+      it("returns null", () => {
+        const result = (repository as any).decryptCustomKeys(undefined);
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("findById()", () => {
+    describe("when provider exists", () => {
+      it("decrypts customKeys before returning", async () => {
+        const encrypted = (repository as any).encryptCustomKeys({
+          OPENAI_API_KEY: "sk-secret",
+        });
+        const stored = createModelProvider({ customKeys: encrypted });
+        (prisma.modelProvider.findFirst as any).mockResolvedValue(stored);
+
+        const result = await repository.findById("mp_test123", "proj_test");
+
+        expect(result).not.toBeNull();
+        expect(result!.customKeys).toEqual({ OPENAI_API_KEY: "sk-secret" });
+      });
+
+      it("uses findFirst instead of findUnique", async () => {
+        (prisma.modelProvider.findFirst as any).mockResolvedValue(
+          createModelProvider(),
+        );
+
+        await repository.findById("mp_test123", "proj_test");
+
+        expect(prisma.modelProvider.findFirst).toHaveBeenCalledWith({
+          where: { id: "mp_test123", projectId: "proj_test" },
+        });
+      });
+    });
+
+    describe("when provider has null customKeys", () => {
+      it("returns null customKeys", async () => {
+        const stored = createModelProvider({ customKeys: null });
+        (prisma.modelProvider.findFirst as any).mockResolvedValue(stored);
+
+        const result = await repository.findById("mp_test123", "proj_test");
+
+        expect(result!.customKeys).toBeNull();
+      });
+    });
+
+    describe("when provider not found", () => {
+      it("returns null", async () => {
+        (prisma.modelProvider.findFirst as any).mockResolvedValue(null);
+
+        const result = await repository.findById("mp_test123", "proj_test");
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("findByProvider()", () => {
+    describe("when provider exists with encrypted keys", () => {
+      it("decrypts customKeys before returning", async () => {
+        const encrypted = (repository as any).encryptCustomKeys({
+          ANTHROPIC_API_KEY: "sk-ant-secret",
+        });
+        const stored = createModelProvider({
+          provider: "anthropic",
+          customKeys: encrypted,
+        });
+        (prisma.modelProvider.findFirst as any).mockResolvedValue(stored);
+
+        const result = await repository.findByProvider(
+          "anthropic",
+          "proj_test",
+        );
+
+        expect(result!.customKeys).toEqual({
+          ANTHROPIC_API_KEY: "sk-ant-secret",
+        });
+      });
+    });
+  });
+
+  describe("findAll()", () => {
+    describe("when multiple providers exist", () => {
+      it("decrypts customKeys for each provider", async () => {
+        const encrypted1 = (repository as any).encryptCustomKeys({
+          OPENAI_API_KEY: "sk-openai",
+        });
+        const encrypted2 = (repository as any).encryptCustomKeys({
+          ANTHROPIC_API_KEY: "sk-anthropic",
+        });
+
+        const stored = [
+          createModelProvider({
+            id: "mp_1",
+            provider: "openai",
+            customKeys: encrypted1,
+          }),
+          createModelProvider({
+            id: "mp_2",
+            provider: "anthropic",
+            customKeys: encrypted2,
+          }),
+          createModelProvider({
+            id: "mp_3",
+            provider: "google",
+            customKeys: null,
+          }),
+        ];
+        (prisma.modelProvider.findMany as any).mockResolvedValue(stored);
+
+        const results = await repository.findAll("proj_test");
+
+        expect(results[0]!.customKeys).toEqual({ OPENAI_API_KEY: "sk-openai" });
+        expect(results[1]!.customKeys).toEqual({
+          ANTHROPIC_API_KEY: "sk-anthropic",
+        });
+        expect(results[2]!.customKeys).toBeNull();
+      });
+    });
+  });
+
+  describe("create()", () => {
+    describe("when customKeys are provided", () => {
+      it("encrypts customKeys before storing", async () => {
+        const keys = { OPENAI_API_KEY: "sk-secret" };
+        (prisma.modelProvider.create as any).mockResolvedValue(
+          createModelProvider({ customKeys: "encrypted" }),
+        );
+
+        await repository.create({
+          projectId: "proj_test",
+          provider: "openai",
+          enabled: true,
+          customKeys: keys,
+        });
+
+        const createCall = (prisma.modelProvider.create as any).mock.calls[0][0];
+        const storedCustomKeys = createCall.data.customKeys;
+
+        // The stored value must be an encrypted string, not the original object
+        expect(typeof storedCustomKeys).toBe("string");
+        expect(storedCustomKeys).toContain(":");
+      });
+    });
+
+    describe("when customKeys are null", () => {
+      it("stores null without encryption", async () => {
+        (prisma.modelProvider.create as any).mockResolvedValue(
+          createModelProvider(),
+        );
+
+        await repository.create({
+          projectId: "proj_test",
+          provider: "openai",
+          enabled: true,
+          customKeys: null,
+        });
+
+        const createCall = (prisma.modelProvider.create as any).mock.calls[0][0];
+        // null or undefined should pass through
+        expect(createCall.data.customKeys).toBeUndefined();
+      });
+    });
+  });
+
+  describe("update()", () => {
+    describe("when customKeys are provided", () => {
+      it("encrypts customKeys before storing", async () => {
+        const keys = { OPENAI_API_KEY: "sk-new-secret" };
+        (prisma.modelProvider.update as any).mockResolvedValue(
+          createModelProvider({ customKeys: "encrypted" }),
+        );
+
+        await repository.update("mp_test123", "proj_test", {
+          customKeys: keys,
+        });
+
+        const updateCall = (prisma.modelProvider.update as any).mock.calls[0][0];
+        const storedCustomKeys = updateCall.data.customKeys;
+
+        expect(typeof storedCustomKeys).toBe("string");
+        expect(storedCustomKeys).toContain(":");
+      });
+    });
+
+    describe("when customKeys are not provided", () => {
+      it("does not include customKeys in update", async () => {
+        (prisma.modelProvider.update as any).mockResolvedValue(
+          createModelProvider(),
+        );
+
+        await repository.update("mp_test123", "proj_test", {
+          enabled: false,
+        });
+
+        const updateCall = (prisma.modelProvider.update as any).mock.calls[0][0];
+        expect(updateCall.data.customKeys).toBeUndefined();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/modelProviders/modelProvider.repository.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.repository.ts
@@ -1,11 +1,15 @@
 import type { ModelProvider, Prisma, PrismaClient } from "@prisma/client";
 import { generate } from "@langwatch/ksuid";
 import { KSUID_RESOURCES } from "../../utils/constants";
+import { encrypt, decrypt } from "../../utils/encryption";
 import type { CustomModelsInput } from "./customModel.schema";
 
 /**
  * Repository for ModelProvider data access.
  * Single Responsibility: Database operations for model providers.
+ *
+ * Encrypts customKeys (API credentials) before writing to the database
+ * and decrypts them after reading, using AES-256-GCM encryption.
  */
 export class ModelProviderRepository {
   constructor(private readonly prisma: PrismaClient) {}
@@ -16,9 +20,10 @@ export class ModelProviderRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<ModelProvider | null> {
     const client = tx ?? this.prisma;
-    return client.modelProvider.findUnique({
+    const result = await client.modelProvider.findFirst({
       where: { id, projectId },
     });
+    return result ? this.withDecryptedKeys(result) : null;
   }
 
   async findByProvider(
@@ -27,9 +32,10 @@ export class ModelProviderRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<ModelProvider | null> {
     const client = tx ?? this.prisma;
-    return client.modelProvider.findFirst({
+    const result = await client.modelProvider.findFirst({
       where: { provider, projectId },
     });
+    return result ? this.withDecryptedKeys(result) : null;
   }
 
   async findAll(
@@ -37,9 +43,10 @@ export class ModelProviderRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<ModelProvider[]> {
     const client = tx ?? this.prisma;
-    return client.modelProvider.findMany({
+    const results = await client.modelProvider.findMany({
       where: { projectId },
     });
+    return results.map((result) => this.withDecryptedKeys(result));
   }
 
   async create(
@@ -55,15 +62,14 @@ export class ModelProviderRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<ModelProvider> {
     const client = tx ?? this.prisma;
+    const encryptedKeys = this.encryptCustomKeys(data.customKeys ?? undefined);
     return client.modelProvider.create({
       data: {
         id: generate(KSUID_RESOURCES.MODEL_PROVIDER).toString(),
         projectId: data.projectId,
         provider: data.provider,
         enabled: data.enabled,
-        customKeys: (data.customKeys ?? undefined) as
-          | Prisma.InputJsonValue
-          | undefined,
+        customKeys: encryptedKeys as Prisma.InputJsonValue | undefined,
         customModels: data.customModels as Prisma.InputJsonValue | undefined,
         customEmbeddingsModels: data.customEmbeddingsModels as
           | Prisma.InputJsonValue
@@ -86,11 +92,12 @@ export class ModelProviderRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<ModelProvider> {
     const client = tx ?? this.prisma;
+    const encryptedKeys = this.encryptCustomKeys(data.customKeys);
     return client.modelProvider.update({
       where: { id, projectId },
       data: {
         ...data,
-        customKeys: data.customKeys as Prisma.InputJsonValue | undefined,
+        customKeys: encryptedKeys as Prisma.InputJsonValue | undefined,
         customModels: data.customModels as Prisma.InputJsonValue | undefined,
         customEmbeddingsModels: data.customEmbeddingsModels as
           | Prisma.InputJsonValue
@@ -119,5 +126,60 @@ export class ModelProviderRepository {
     return client.modelProvider.deleteMany({
       where: { provider, projectId },
     });
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // Private encryption helpers
+  // ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Encrypts customKeys before storing in the database.
+   * Serializes the object to JSON, then encrypts the JSON string.
+   *
+   * @returns Encrypted string, or null/undefined if input is null/undefined.
+   */
+  private encryptCustomKeys(
+    customKeys: Record<string, unknown> | null | undefined,
+  ): string | null | undefined {
+    if (customKeys === null) return null;
+    if (customKeys === undefined) return undefined;
+    return encrypt(JSON.stringify(customKeys));
+  }
+
+  /**
+   * Decrypts customKeys after reading from the database.
+   * Handles the migration transition where some rows may still have plaintext JSON objects.
+   *
+   * @returns Decrypted object, or null if input is null/undefined.
+   */
+  private decryptCustomKeys(
+    customKeys: unknown,
+  ): Record<string, unknown> | null {
+    if (customKeys === null || customKeys === undefined) return null;
+
+    // Plaintext object (migration compatibility): return as-is
+    if (typeof customKeys === "object") {
+      return customKeys as Record<string, unknown>;
+    }
+
+    // Encrypted string: decrypt and parse
+    if (typeof customKeys === "string") {
+      const decrypted = decrypt(customKeys);
+      return JSON.parse(decrypted) as Record<string, unknown>;
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns a copy of the ModelProvider with decrypted customKeys.
+   */
+  private withDecryptedKeys(provider: ModelProvider): ModelProvider {
+    return {
+      ...provider,
+      customKeys: this.decryptCustomKeys(provider.customKeys) as
+        | Prisma.JsonValue
+        | null,
+    };
   }
 }

--- a/langwatch/src/tasks/__tests__/migrateModelProviderKeys.unit.test.ts
+++ b/langwatch/src/tasks/__tests__/migrateModelProviderKeys.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { migrateModelProviderKeysRow } from "../migrateModelProviderKeys";
+
+vi.mock("../../utils/encryption", () => ({
+  encrypt: vi.fn((text: string) => `encrypted:${text}`),
+}));
+
+describe("migrateModelProviderKeysRow", () => {
+  describe("given a row with plaintext object customKeys", () => {
+    describe("when migrating", () => {
+      it("returns the encrypted string", () => {
+        const row = {
+          id: "provider-1",
+          projectId: "project-1",
+          customKeys: { apiKey: "sk-123", orgId: "org-456" },
+        };
+
+        const result = migrateModelProviderKeysRow({ row });
+
+        expect(result).toBe(
+          `encrypted:${JSON.stringify({ apiKey: "sk-123", orgId: "org-456" })}`
+        );
+      });
+    });
+  });
+
+  describe("given a row with already-encrypted string customKeys", () => {
+    describe("when migrating", () => {
+      it("returns null to indicate no migration needed", () => {
+        const row = {
+          id: "provider-2",
+          projectId: "project-1",
+          customKeys: "abc123:def456:ghi789",
+        };
+
+        const result = migrateModelProviderKeysRow({ row });
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("given a row with null customKeys", () => {
+    describe("when migrating", () => {
+      it("returns null to indicate no migration needed", () => {
+        const row = {
+          id: "provider-3",
+          projectId: "project-1",
+          customKeys: null,
+        };
+
+        const result = migrateModelProviderKeysRow({ row });
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("given a row with undefined customKeys", () => {
+    describe("when migrating", () => {
+      it("returns null to indicate no migration needed", () => {
+        const row = {
+          id: "provider-4",
+          projectId: "project-1",
+          customKeys: undefined,
+        };
+
+        const result = migrateModelProviderKeysRow({ row });
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/tasks/migrateModelProviderKeys.ts
+++ b/langwatch/src/tasks/migrateModelProviderKeys.ts
@@ -1,0 +1,115 @@
+/**
+ * Data migration: Encrypt existing plaintext customKeys in the ModelProvider table.
+ *
+ * Background:
+ * - ModelProvider.customKeys was stored as a plain JSON object (unencrypted)
+ * - The new system encrypts keys at rest using AES-256-GCM
+ * - After encryption, the JSON column stores a JSON string (the ciphertext)
+ * - Prisma reads a JSON string value back as `typeof string`, while a
+ *   JSON object value comes back as `typeof object`
+ *
+ * This script is idempotent: if data is already encrypted (string type), it is skipped.
+ *
+ * Usage:
+ *   pnpm task migrateModelProviderKeys
+ */
+
+import { prisma } from "../server/db";
+import { encrypt } from "../utils/encryption";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Minimal row shape needed by the migration logic */
+interface ModelProviderRow {
+  id: string;
+  projectId: string;
+  customKeys: unknown;
+}
+
+// ============================================================================
+// Pure migration logic (no DB dependency)
+// ============================================================================
+
+/**
+ * Determine whether a customKeys value is already encrypted.
+ *
+ * After encryption, the JSON column contains a JSON string (ciphertext),
+ * which Prisma deserializes as a `string`. Before encryption, it contains
+ * a JSON object, which Prisma deserializes as an `object`.
+ */
+function isAlreadyEncrypted(customKeys: unknown): boolean {
+  if (typeof customKeys === "string") return true;
+  return false;
+}
+
+/**
+ * Migrate a single ModelProvider row's customKeys.
+ *
+ * Pure function: takes a row, returns the encrypted value or null if
+ * no migration is needed (already encrypted, null, or undefined).
+ */
+export function migrateModelProviderKeysRow({
+  row,
+}: {
+  row: ModelProviderRow;
+}): string | null {
+  // Null/undefined: nothing to migrate
+  if (row.customKeys == null) return null;
+
+  // Already encrypted: skip
+  if (isAlreadyEncrypted(row.customKeys)) return null;
+
+  // Plaintext JSON object: serialize and encrypt
+  const serialized = JSON.stringify(row.customKeys);
+  return encrypt(serialized);
+}
+
+// ============================================================================
+// Task entry point (called by pnpm task migrateModelProviderKeys)
+// ============================================================================
+
+export default async function main() {
+  console.log("Starting model provider keys encryption migration...");
+
+  const projects = await prisma.project.findMany({
+    select: { id: true },
+  });
+
+  console.log(`Found ${projects.length} projects to process.`);
+
+  let updatedCount = 0;
+  let skippedCount = 0;
+
+  for (const project of projects) {
+    const rows = await prisma.modelProvider.findMany({
+      where: { projectId: project.id },
+      select: {
+        id: true,
+        projectId: true,
+        customKeys: true,
+      },
+    });
+
+    for (const row of rows) {
+      const encryptedKeys = migrateModelProviderKeysRow({ row });
+
+      if (encryptedKeys === null) {
+        skippedCount++;
+        continue;
+      }
+
+      await prisma.modelProvider.update({
+        where: { id: row.id, projectId: row.projectId },
+        data: { customKeys: encryptedKeys },
+      });
+      updatedCount++;
+      console.log(`  Encrypted keys for provider ${row.id}`);
+    }
+  }
+
+  console.log(
+    `Migration complete. Updated: ${updatedCount}, Skipped: ${skippedCount}`
+  );
+}


### PR DESCRIPTION
## Summary

- **Encrypt customKeys at rest** using AES-256-GCM (same encryption as ProjectSecret) via `CREDENTIALS_SECRET` env var
- **All DB access routes through ModelProviderRepository** — eliminates direct `prisma.modelProvider.*` calls from router, service, and validation code
- **Backward compatible**: plaintext JSON rows from before migration are detected (typeof object) and returned as-is without breaking
- **Migration task**: `pnpm task migrateModelProviderKeys` encrypts all existing plaintext keys (idempotent — safe to run multiple times)
- **Helm chart fix**: autogen `credentialsEncryptionKey` now produces a valid 32-byte hex key (`sha256sum`) instead of alphanumeric that would crash at runtime

## Changed files

| File | Change |
|------|--------|
| `modelProvider.repository.ts` | Encrypt on write, decrypt on read, detect plaintext for backward compat |
| `modelProviders.ts` (router) | Delegate to service instead of direct Prisma access |
| `providerValidation.ts` | Use repository for key lookup (gets decrypted keys) |
| `modelProvider.service.ts` | Use repository.create/update instead of tx.modelProvider directly |
| `migrateModelProviderKeys.ts` | One-time migration task |
| `charts/.../secrets.yaml` | Fix autogen to produce valid hex key |
| `encrypt-custom-keys.feature` | BDD spec |
| 3 test files | 19 unit + 4 migration + 5 integration (real DB, no mocks) |

## Test plan

- [x] 19 unit tests for repository encryption helpers
- [x] 4 unit tests for migration pure function
- [x] 5 integration tests with real DB (no mocks):
  - [x] Encrypt/decrypt round-trip
  - [x] Backward compat: plaintext JSON in DB reads correctly
  - [x] Null customKeys preserved
  - [x] Migration encrypts only plaintext rows
  - [x] Migration is idempotent
- [ ] Manual: save a model provider with API key → check DB column is encrypted string
- [ ] Manual: run `pnpm task migrateModelProviderKeys` on existing data