### PR TITLE
fix: skip flow opens blank editor instead of creating Untitled scenario

### DIFF
--- a/langwatch/src/components/scenarios/__tests__/ScenarioCreateModal.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioCreateModal.test.tsx
@@ -93,14 +93,6 @@ vi.mock("~/hooks/useModelProvidersSettings", () => ({
   }),
 }));
 
-// Mock toaster
-const mockToasterCreate = vi.fn();
-vi.mock("../../ui/toaster", () => ({
-  toaster: {
-    create: (args: unknown) => mockToasterCreate(args),
-  },
-}));
-
 // Mock fetch for AI generation API
 const mockGeneratedScenario = {
   name: "Generated Scenario",
@@ -128,7 +120,6 @@ describe("<ScenarioCreateModal/>", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockToasterCreate.mockClear();
     // Reset to having providers by default
     mockHasEnabledProviders = true;
 
@@ -300,8 +291,9 @@ describe("<ScenarioCreateModal/>", () => {
 
   describe("when user clicks Skip", () => {
     it("opens drawer with empty initial data without creating a DB record", async () => {
+      const onClose = vi.fn();
       render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        <ScenarioCreateModal open={true} onClose={onClose} />,
         { wrapper: Wrapper }
       );
 
@@ -343,7 +335,6 @@ describe("<ScenarioCreateModal/>", () => {
   describe("when no model providers are configured", () => {
     beforeEach(() => {
       vi.clearAllMocks();
-      mockToasterCreate.mockClear();
       // Set to no providers
       mockHasEnabledProviders = false;
     });


### PR DESCRIPTION
## Summary
- When clicking "I'll write it myself" in the scenario create modal, open the blank editor drawer directly instead of creating a scenario pre-named "Untitled"
- Remove `DEFAULT_SCENARIO_NAME` constant and the fallback that silently replaced empty AI-generated names
- The editor drawer already supports blank/new mode with name validation (`min(1)`)

Closes #1768

## Test plan
- [x] Unit tests updated — skip flow verifies drawer opens without creating a scenario
- [ ] Manual: click "New Scenario" → "I'll write it myself" → editor opens with blank name field
- [ ] Manual: try saving without a name → validation error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1768