### PR TITLE
fix: increase HTTP agent default timeout to 5 minutes

### DIFF
--- a/langwatch_nlp/langwatch_nlp/studio/execute/http_node.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/http_node.py
@@ -245,8 +245,8 @@ async def execute_http_node(
     # Build headers
     headers = build_headers(config)
 
-    # Configure timeout (default 30 seconds)
-    timeout_seconds = (config.timeout_ms / 1000) if config.timeout_ms else 30.0
+    # Configure timeout (default 5 minutes for slow RAG agents)
+    timeout_seconds = (config.timeout_ms / 1000) if config.timeout_ms else 300.0
 
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:


### PR DESCRIPTION
## Summary
Increase default HTTP agent timeout from 30 seconds to 5 minutes (300s).

## Problem
HTTP agents with slow backends (e.g. RAG lookups) were timing out before they could respond. A customer reported this issue where their agent works for quick queries but times out for RAG-heavy requests.

## Solution
- Changed default timeout from 30s to 300s (5 minutes)
- Timeout remains configurable via `timeoutMs` for users who need different values

## Files Changed
- `langwatch_nlp/langwatch_nlp/studio/execute/http_node.py` - Updated default timeout constant