### PR TITLE
feat: convert scenario BatchActionBar to floating bottom bar

### DIFF
--- a/langwatch/src/components/scenarios/BatchActionBar.tsx
+++ b/langwatch/src/components/scenarios/BatchActionBar.tsx
@@ -1,10 +1,6 @@
-import { Button, HStack, Text } from "@chakra-ui/react";
+import { Box, Button, HStack, Text } from "@chakra-ui/react";
 import { Archive } from "lucide-react";
 
-/**
- * Action bar that appears when one or more table rows are selected.
- * Shows the number of selected items and provides bulk actions.
- */
 export function BatchActionBar({
   selectedCount,
   onArchive,
@@ -15,26 +11,34 @@ export function BatchActionBar({
   if (selectedCount === 0) return null;
 
   return (
-    <HStack
-      bg="bg.muted"
-      px={4}
-      py={2}
+    <Box
+      position="fixed"
+      bottom={10}
+      left="50%"
+      transform="translateX(-50%)"
+      backgroundColor="#ffffff"
+      border="1px solid #ccc"
+      boxShadow="0 0 15px rgba(0, 0, 0, 0.2)"
       borderRadius="md"
-      justify="space-between"
+      padding="8px"
+      paddingX="16px"
+      zIndex={1000}
       data-testid="batch-action-bar"
     >
-      <Text fontSize="sm" fontWeight="medium">
-        {selectedCount} selected
-      </Text>
-      <Button
-        size="sm"
-        variant="outline"
-        colorPalette="orange"
-        onClick={onArchive}
-      >
-        <Archive size={14} />
-        Archive
-      </Button>
-    </HStack>
+      <HStack gap={3}>
+        <Text whiteSpace="nowrap" fontSize="sm" fontWeight="medium">
+          {selectedCount} selected
+        </Text>
+        <Button
+          size="sm"
+          variant="outline"
+          colorPalette="orange"
+          onClick={onArchive}
+        >
+          <Archive size={14} />
+          Archive
+        </Button>
+      </HStack>
+    </Box>
   );
 }

--- a/langwatch/src/components/scenarios/__tests__/ScenarioTable.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioTable.integration.test.tsx
@@ -279,6 +279,24 @@ describe("<BatchActionBar/>", () => {
     });
   });
 
+  describe("when selection count changes", () => {
+    it("updates the displayed count", () => {
+      const onArchive = vi.fn();
+      const { rerender } = render(
+        <BatchActionBar selectedCount={2} onArchive={onArchive} />,
+        { wrapper: Wrapper },
+      );
+      expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+      rerender(
+        <ChakraProvider value={defaultSystem}>
+          <BatchActionBar selectedCount={3} onArchive={onArchive} />
+        </ChakraProvider>,
+      );
+      expect(screen.getByText("3 selected")).toBeInTheDocument();
+    });
+  });
+
   describe("when selection transitions from 1 to 0", () => {
     it("hides the batch action bar", () => {
       const { rerender } = render(

--- a/specs/scenarios/scenario-bulk-actions.feature
+++ b/specs/scenarios/scenario-bulk-actions.feature
@@ -1,0 +1,62 @@
+Feature: Scenario Bulk Actions
+  As a LangWatch user
+  I want a floating action bar when I select multiple scenarios
+  So that I can perform bulk operations efficiently
+
+  Background:
+    Given I am logged into project "my-project"
+    And scenarios exist in the project:
+      | name            | labels      |
+      | Refund Flow     | ["support"] |
+      | Billing Check   | ["billing"] |
+      | Greeting Prompt | ["general"] |
+
+  # ============================================================================
+  # Floating Bar Visibility
+  # ============================================================================
+
+  @integration
+  Scenario: Floating bar appears when scenarios are selected
+    Given I am on the scenarios list page
+    When I select "Refund Flow" and "Billing Check"
+    Then I see a floating action bar at the bottom of the page
+    And the bar shows "2 selected"
+
+  @integration
+  Scenario: Floating bar disappears when selection is cleared
+    Given I am on the scenarios list page
+    And I have selected "Refund Flow"
+    When I deselect "Refund Flow"
+    Then I do not see the floating action bar
+
+  @integration
+  Scenario: Floating bar updates count when selection changes
+    Given I am on the scenarios list page
+    And I have selected "Refund Flow" and "Billing Check"
+    When I also select "Greeting Prompt"
+    Then the bar shows "3 selected"
+
+  # ============================================================================
+  # Floating Bar Layout (matches traces pattern)
+  # ============================================================================
+
+  @e2e
+  Scenario: Floating bar stays fixed during scroll
+    Given I am on the scenarios list page
+    And the scenario list is long enough to scroll
+    When I select "Refund Flow"
+    And I scroll down the scenario list
+    Then the floating action bar remains visible
+
+  # ============================================================================
+  # Bulk Actions
+  # ============================================================================
+
+  @e2e
+  Scenario: Archive selected scenarios via floating bar
+    Given I am on the scenarios list page
+    And I select "Refund Flow" and "Billing Check"
+    When I click "Archive" on the floating action bar
+    And I confirm the archive
+    Then "Refund Flow" and "Billing Check" are no longer in the list
+    And the floating action bar disappears


### PR DESCRIPTION
## Summary
- Converts the inline `BatchActionBar` to a fixed-position floating bar at the bottom center of the viewport, matching the traces bulk action pattern
- Preserves the existing Archive action with the same selection infrastructure
- Adds integration test for count update on rerender

Closes #1766

## Deferred to follow-up
- "Create new suite from selected" action (discussed in issue)
- Extract shared `FloatingActionBar` component to reduce duplication with `MessagesTable`

## Test plan
- [x] 25 integration tests passing for `ScenarioTable`
- [x] Floating bar appears/disappears based on selection count
- [x] Count updates correctly when selection changes
- [x] Archive action works from floating bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1766