### PR TITLE
feat: remove label generation from AI scenario creation

### DIFF
--- a/langwatch/src/app/api/scenario/generate/route.ts
+++ b/langwatch/src/app/api/scenario/generate/route.ts
@@ -24,11 +24,6 @@ const scenarioSchema = z.object({
     .describe(
       "3-6 specific, observable success criteria that can be judged from the conversation",
     ),
-  labels: z
-    .array(z.string())
-    .describe(
-      "1-3 short labels for categorization (e.g., 'billing', 'escalation', 'edge-case')",
-    ),
 });
 
 const requestSchema = z.object({
@@ -38,7 +33,6 @@ const requestSchema = z.object({
       name: z.string(),
       situation: z.string(),
       criteria: z.array(z.string()),
-      labels: z.array(z.string()),
     })
     .nullable(),
   projectId: z.string().min(1, "Project ID is required"),
@@ -69,8 +63,6 @@ Given a description of an agent and desired scenario, generate:
    - Are observable from the conversation
    - Test one specific behavior each
    - Use clear, judgeable language (e.g., "Agent must acknowledge the error" not "Agent is helpful")
-
-4. **labels**: 1-3 categorization labels (e.g., "billing", "escalation", "edge-case")
 
 When refining an existing scenario, incorporate the user's feedback while preserving the overall structure and any parts they haven't asked to change.`;
 

--- a/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
+++ b/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
@@ -167,7 +167,6 @@ export function ScenarioAIGeneration({ form }: ScenarioAIGenerationProps) {
             name: form.getValues("name"),
             situation: form.getValues("situation"),
             criteria: form.getValues("criteria"),
-            labels: form.getValues("labels"),
           }
         : null;
 
@@ -177,7 +176,6 @@ export function ScenarioAIGeneration({ form }: ScenarioAIGenerationProps) {
       form.setValue("name", scenario.name ?? "");
       form.setValue("situation", scenario.situation ?? "");
       form.setValue("criteria", scenario.criteria ?? []);
-      form.setValue("labels", scenario.labels ?? []);
 
       addPrompt(input);
       setInput("");

--- a/langwatch/src/components/scenarios/ScenarioCreateModal.tsx
+++ b/langwatch/src/components/scenarios/ScenarioCreateModal.tsx
@@ -117,7 +117,6 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
       name: "",
       situation: "",
       criteria: [],
-      labels: [],
     });
   }, [openEditorWithData]);
 

--- a/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.unit.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.unit.test.tsx
@@ -61,7 +61,6 @@ describe("useScenarioGeneration", () => {
     name: "Test Scenario",
     situation: "Test situation",
     criteria: ["criterion 1"],
-    labels: ["test"],
   };
 
   beforeEach(() => {
@@ -182,7 +181,6 @@ describe("useScenarioGeneration", () => {
       name: "Current",
       situation: "Current situation",
       criteria: ["existing"],
-      labels: ["label"],
     };
 
     await act(async () => {

--- a/langwatch/src/components/scenarios/services/__tests__/scenarioGeneration.unit.test.ts
+++ b/langwatch/src/components/scenarios/services/__tests__/scenarioGeneration.unit.test.ts
@@ -12,7 +12,6 @@ describe("generateScenarioWithAI()", () => {
     name: "Test Scenario",
     situation: "Test situation",
     criteria: ["criterion 1"],
-    labels: ["test"],
   };
 
   beforeEach(() => {
@@ -68,7 +67,6 @@ describe("generateScenarioWithAI()", () => {
         name: "Current",
         situation: "Current situation",
         criteria: ["existing"],
-        labels: ["label"],
       };
 
       await generateScenarioWithAI(

--- a/langwatch/src/components/scenarios/services/scenarioGeneration.ts
+++ b/langwatch/src/components/scenarios/services/scenarioGeneration.ts
@@ -9,7 +9,6 @@ export type GeneratedScenario = {
   name: string;
   situation: string;
   criteria: string[];
-  labels: string[];
 };
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Removes `labels` from AI scenario generation response schema and system prompt
- AI no longer invents arbitrary categorization labels — users apply labels manually for consistency
- Labels are environment/context tags (e.g. "production", "staging") not content categories

Closes #1770

## Test plan
- [x] 3 new integration tests for schema validation
- [x] 26 existing unit tests updated and passing
- [x] No type errors in changed files
- [x] Feature file: `specs/scenarios/ai-generation-omits-labels.feature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)