### PR TITLE
feat(skills): check for existing feature files before creating new ones

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -28,8 +28,10 @@ Work should be tied to a GitHub issue. If requirements are unclear:
 
 Before specifying new functionality, search for existing patterns and systems in the codebase. Extend what exists rather than building from scratch.
 
+**Same for feature files**: Check `specs/features/` for related files first. Amend existing features instead of creating duplicates.
+
 ## Output Location
-Write to `specs/features/<feature-name>.feature`
+Write to `specs/features/<feature-name>.feature` (or amend an existing file if one covers this area).
 
 ## What Makes a Good Feature File
 


### PR DESCRIPTION
## Summary

Updates `/plan` and `/orchestrate` skills to check for existing feature files before creating new ones.

## Problem

Every new issue was creating a new feature file, even when it should just amend or revise an existing one. This led to duplicate/fragmented specs.

## Solution

- **`/plan` skill**: Now requires checking `specs/features/` for related files first. Must amend existing if related feature exists.
- **`/orchestrate` skill**: Plan step now explicitly says to search for related features and amend rather than duplicate.

## Changes

| File | Change |
|------|--------|
| `.claude/skills/plan/SKILL.md` | Added "Check for Existing Feature Files" section |
| `.claude/skills/orchestrate/SKILL.md` | Updated Plan step to search/amend |

## Testing

Workflow change - validated by reading the skills.

---
*Ready for review* 🦞