### PR TITLE
fix: change default pricing model from SEAT_EVENT to TIERED

### DIFF
--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -290,7 +290,7 @@ export const organizationRouter = createTRPCRouter({
               slug: orgSlug,
               phoneNumber: input.phoneNumber,
               signupData: input.signUpData,
-              pricingModel: PricingModel.SEAT_EVENT,
+              pricingModel: PricingModel.TIERED,
             },
           });
 


### PR DESCRIPTION
## Summary
- Changes default pricing model for new organizations from `SEAT_EVENT` to `TIERED` in the `createAndAssign` mutation.

## Test plan
- [ ] Verify new organization creation uses `TIERED` pricing model
- [ ] Confirm existing organizations are not affected