### PR TITLE
ci: replace describe.skip with test.fixme for flaky e2e tests

### DIFF
--- a/agentic-e2e-tests/tests/evaluations-v3/http-agent-cell-rerun.spec.ts
+++ b/agentic-e2e-tests/tests/evaluations-v3/http-agent-cell-rerun.spec.ts
@@ -30,8 +30,9 @@ import {
  * I want to re-execute individual cells
  * So that I can test modifications without re-running the entire evaluation
  */
-// Skipped: flaky — Lambda warmup failures in CI cause timeouts (#1802)
-test.describe.skip("Single Cell Re-execution", () => {
+test.describe("Single Cell Re-execution", () => {
+  // fixme(#1811): flaky — Lambda warmup failures in CI cause timeouts
+  test.fixme();
   /**
    * Scenario: Single cell re-execution for HTTP agent
    * Source: http-agent-support.feature lines 233-238

--- a/agentic-e2e-tests/tests/evaluations-v3/http-agent-full-evaluation.spec.ts
+++ b/agentic-e2e-tests/tests/evaluations-v3/http-agent-full-evaluation.spec.ts
@@ -26,8 +26,9 @@ import {
  * I want to use HTTP agents as targets in Evaluations V3
  * So that I can evaluate external APIs that expose my agent via HTTP endpoints
  */
-// Skipped: flaky — Lambda warmup failures in CI cause timeouts (#1802)
-test.describe.skip("Full Evaluation Run with HTTP Agent Target", () => {
+test.describe("Full Evaluation Run with HTTP Agent Target", () => {
+  // fixme(#1811): flaky — Lambda warmup failures in CI cause timeouts
+  test.fixme();
   /**
    * Scenario: Full evaluation run with HTTP agent target
    * Source: http-agent-support.feature lines 222-231

--- a/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
@@ -16,8 +16,9 @@ import {
  *
  * Scenario: Admin approves an invitation request (lines 27-33)
  */
-// Skipped: flaky — fails consistently in CI environment (#1802)
-test.describe.skip("Invitation Approval - Admin Approves Request", () => {
+test.describe("Invitation Approval - Admin Approves Request", () => {
+  // fixme(#1811): flaky — fails consistently in CI environment
+  test.fixme();
   /**
    * Scenario: Admin approves an invitation request
    * Source: update-pending-invitation.feature lines 27-33

--- a/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
@@ -16,8 +16,9 @@ import {
  *
  * Scenario: Admin creates an immediate invite (lines 19-24)
  */
-// Skipped: flaky — fails consistently in CI environment (#1802)
-test.describe.skip("Invitation Approval - Admin Creates Immediate Invite", () => {
+test.describe("Invitation Approval - Admin Creates Immediate Invite", () => {
+  // fixme(#1811): flaky — fails consistently in CI environment
+  test.fixme();
   /**
    * Scenario: Admin creates an immediate invite
    * Source: update-pending-invitation.feature lines 19-24

--- a/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
@@ -16,8 +16,9 @@ import {
  *
  * Scenario: Admin rejects an invitation request (lines 36-42)
  */
-// Skipped: flaky — fails consistently in CI environment (#1802)
-test.describe.skip("Invitation Approval - Admin Rejects Request", () => {
+test.describe("Invitation Approval - Admin Rejects Request", () => {
+  // fixme(#1811): flaky — fails consistently in CI environment
+  test.fixme();
   /**
    * Scenario: Admin rejects an invitation request
    * Source: update-pending-invitation.feature lines 36-42

--- a/agentic-e2e-tests/tests/scenarios/scenario-editor.spec.ts
+++ b/agentic-e2e-tests/tests/scenarios/scenario-editor.spec.ts
@@ -24,8 +24,9 @@ import {
  * I want to create and edit scenario specifications
  * So that I can define behavioral test cases for my agents
  */
-// Skipped: flaky — timeouts in CI environment (#1802)
-test.describe.skip("Scenario Editor", () => {
+test.describe("Scenario Editor", () => {
+  // fixme(#1811): flaky — timeouts in CI environment
+  test.fixme();
   // Background: Given I am logged into project
   test.beforeEach(async ({ page }) => {
     await givenIAmLoggedIntoProject(page);

--- a/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
+++ b/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
@@ -25,8 +25,7 @@ import {
  *
  * Note: These tests require NLP service to be running for execution.
  */
-// Skipped: flaky — timeouts in CI environment (#1802)
-test.describe.skip("Scenario Execution", () => {
+test.describe("Scenario Execution", () => {
   test.beforeEach(async ({ page }) => {
     await givenIAmLoggedIntoProject(page);
   });
@@ -55,7 +54,8 @@ test.describe.skip("Scenario Execution", () => {
    * Workflow test: creates scenario, runs it, and verifies results appear.
    * Requires NLP service to be running.
    */
-  test("executes scenario and displays run results", async ({ page }) => {
+  // fixme(#1811): flaky — toBeVisible fails consistently in CI
+  test.fixme("executes scenario and displays run results", async ({ page }) => {
     // Create a scenario first
     await givenIAmOnTheScenariosListPage(page);
     await whenIClickNewScenario(page);


### PR DESCRIPTION
## Summary

- Replaces `describe.skip` (from #1802) with `test.fixme()` which signals these need fixing, not just skipping
- Restores 3 passing tests in scenario-execution.spec.ts that were over-skipped by the blanket describe.skip

Closes #1811

## Changes

| File | Before | After |
|------|--------|-------|
| evaluations-v3/http-agent-cell-rerun.spec.ts | describe.skip | test.fixme() |
| evaluations-v3/http-agent-full-evaluation.spec.ts | describe.skip | test.fixme() |
| members/admin-approves-invitation.spec.ts | describe.skip | test.fixme() |
| members/admin-creates-immediate-invite.spec.ts | describe.skip | test.fixme() |
| members/admin-rejects-invitation.spec.ts | describe.skip | test.fixme() |
| scenarios/scenario-editor.spec.ts | describe.skip | test.fixme() |
| scenarios/scenario-execution.spec.ts | describe.skip (all 4) | test.fixme on 1, 3 passing tests restored |

## Test plan

- [ ] Verify e2e CI passes (fixme tests show as fixme not failed)
- [ ] Verify the 3 restored scenario-execution tests still pass


# Related Issue

- Resolve #1811