### PR TITLE
feat: standardize search fields with shared SearchInput component

### DIFF
--- a/langwatch/src/components/suites/ScenarioPicker.tsx
+++ b/langwatch/src/components/suites/ScenarioPicker.tsx
@@ -10,12 +10,12 @@ import {
   Box,
   Button,
   HStack,
-  Input,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { Plus } from "lucide-react";
 import { Checkbox } from "../ui/checkbox";
+import { SearchInput } from "../ui/SearchInput";
 
 interface Scenario {
   id: string;
@@ -75,7 +75,7 @@ export function ScenarioPicker({
       width="full"
     >
       <Box paddingX={3} paddingY={2}>
-        <Input
+        <SearchInput
           size="sm"
           placeholder="Search scenarios..."
           value={searchQuery}

--- a/langwatch/src/components/suites/SuiteSidebar.tsx
+++ b/langwatch/src/components/suites/SuiteSidebar.tsx
@@ -2,11 +2,12 @@
  * Suite sidebar with search, new suite button, all runs link, and suite list.
  */
 
-import { Box, HStack, Input, Separator, Text, VStack } from "@chakra-ui/react";
+import { Box, HStack, Separator, Text, VStack } from "@chakra-ui/react";
 import type { SimulationSuite } from "@prisma/client";
 import { FolderOpen, List, Play, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
+import { SearchInput } from "../ui/SearchInput";
 
 export type SuiteRunSummary = {
   passedCount: number;
@@ -52,7 +53,7 @@ export function SuiteSidebar({
       gap={0}
     >
       <Box paddingX={3} paddingTop={3} paddingBottom={2}>
-        <Input
+        <SearchInput
           size="sm"
           placeholder="Search..."
           value={searchQuery}

--- a/langwatch/src/components/suites/TargetPicker.tsx
+++ b/langwatch/src/components/suites/TargetPicker.tsx
@@ -5,10 +5,11 @@
  * "Add New Agent" and "Add New Prompt" action rows, and a count footer.
  */
 
-import { Box, HStack, Input, Text, VStack } from "@chakra-ui/react";
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
 import { Plus } from "lucide-react";
 import type { SuiteTarget } from "~/server/suites/types";
 import { Checkbox } from "../ui/checkbox";
+import { SearchInput } from "../ui/SearchInput";
 
 interface AvailableTarget {
   name: string;
@@ -59,7 +60,7 @@ export function TargetPicker({
       width="full"
     >
       <Box paddingX={3} paddingY={2}>
-        <Input
+        <SearchInput
           size="sm"
           placeholder="Search targets..."
           value={searchQuery}

--- a/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
@@ -176,6 +176,18 @@ describe("<SuiteSidebar/>", () => {
       });
     });
 
+    describe("when looking at the search field", () => {
+      it("displays a search icon inside the input", () => {
+        render(<SuiteSidebar {...defaultProps} suites={suites} />, {
+          wrapper: Wrapper,
+        });
+
+        expect(
+          screen.getByRole("img", { name: "Search" }),
+        ).toBeInTheDocument();
+      });
+    });
+
     describe("when typing 'billing' in the search box", () => {
       it("filters to only show Billing Edge", async () => {
         const user = userEvent.setup();

--- a/langwatch/src/components/ui/SearchInput.tsx
+++ b/langwatch/src/components/ui/SearchInput.tsx
@@ -1,0 +1,28 @@
+/**
+ * Search input with a leading search icon.
+ *
+ * Wraps the existing InputGroup with a Search icon in the start element.
+ * Renders with `role="searchbox"` for accessibility and testability.
+ */
+
+import type { InputProps } from "@chakra-ui/react";
+import { Input } from "@chakra-ui/react";
+import { Search } from "lucide-react";
+import * as React from "react";
+import { InputGroup } from "./input-group";
+
+export const SearchInput = React.forwardRef<HTMLInputElement, InputProps>(
+  function SearchInput(props, ref) {
+    return (
+      <InputGroup
+        startElement={
+          <span>
+            <Search size={14} aria-label="Search" role="img" />
+          </span>
+        }
+      >
+        <Input ref={ref} role="searchbox" {...props} />
+      </InputGroup>
+    );
+  },
+);

--- a/langwatch/src/components/ui/__tests__/SearchInput.integration.test.tsx
+++ b/langwatch/src/components/ui/__tests__/SearchInput.integration.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for SearchInput component.
+ *
+ * @see specs/components/search-input.feature - "SearchInput renders with a search icon and placeholder"
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SearchInput } from "../SearchInput";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("<SearchInput/>", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when mounted with a placeholder", () => {
+    beforeEach(() => {
+      render(<SearchInput placeholder="Search suites..." />, {
+        wrapper: Wrapper,
+      });
+    });
+
+    it("renders a search icon inside the input", () => {
+      expect(
+        screen.getByRole("img", { name: "Search" }),
+      ).toBeInTheDocument();
+    });
+
+    it("displays the placeholder text", () => {
+      expect(
+        screen.getByPlaceholderText("Search suites..."),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the input with searchbox role", () => {
+      expect(screen.getByRole("searchbox")).toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/components/ui/__tests__/SearchInput.unit.test.tsx
+++ b/langwatch/src/components/ui/__tests__/SearchInput.unit.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Unit tests for SearchInput component.
+ *
+ * @see specs/components/search-input.feature - "SearchInput forwards typed text"
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SearchInput } from "../SearchInput";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("<SearchInput/>", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("when typing text into the input", () => {
+    it("forwards the value to the onChange callback", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<SearchInput onChange={onChange} />, { wrapper: Wrapper });
+
+      const input = screen.getByRole("searchbox");
+      await user.type(input, "billing");
+
+      expect(onChange).toHaveBeenCalled();
+      const lastCallEvent = onChange.mock.calls.at(-1)?.[0] as React.ChangeEvent<HTMLInputElement>;
+      expect(lastCallEvent.target.value).toBe("billing");
+    });
+  });
+});

--- a/specs/components/search-input.feature
+++ b/specs/components/search-input.feature
@@ -1,0 +1,41 @@
+Feature: Standardized search input with search icon
+  As a user navigating lists and pickers
+  I want search fields to display a search icon
+  So that I can quickly identify where to type a search query
+
+  Background:
+    Given the application renders a search input field
+
+  # Shared SearchInput component behavior
+  @unit
+  Scenario: SearchInput forwards typed text to the onChange handler
+    When I type "billing" into the SearchInput
+    Then the onChange callback receives "billing"
+
+  @integration
+  Scenario: SearchInput renders with a search icon and placeholder
+    When the SearchInput component mounts with placeholder "Search suites..."
+    Then a search icon is visible inside the input
+    And the placeholder "Search suites..." is visible
+
+  # Suite sidebar uses the shared SearchInput
+  @integration
+  Scenario: Suite sidebar filters suites with search icon visible
+    Given the suites sidebar is rendered with suites "Billing" and "Onboarding"
+    When I look at the search field in the sidebar
+    Then a search icon is visible inside the input
+    When I type "billing" into the sidebar search field
+    Then only "Billing" appears in the suite list
+
+  # Other search fields adopt the shared component
+  @integration
+  Scenario: Scenario picker search field displays a search icon
+    Given the scenario picker is rendered
+    When I look at the search field
+    Then a search icon is visible inside the input
+
+  @integration
+  Scenario: Target picker search field displays a search icon
+    Given the target picker is rendered
+    When I look at the search field
+    Then a search icon is visible inside the input


### PR DESCRIPTION
## Summary
- Extracted a reusable `SearchInput` component (`src/components/ui/SearchInput.tsx`) with a leading search icon from `lucide-react`, `forwardRef` support, and `role="searchbox"` for accessibility
- Adopted `SearchInput` in suite sidebar, scenario picker, and target picker — replacing bare `<Input>` elements
- Added unit and integration tests (20 tests passing)

Closes #1672

## Test plan
- [x] `SearchInput` renders search icon and forwards `onChange` (unit test)
- [x] `SearchInput` renders with placeholder and `role="searchbox"` (integration tests)
- [x] Suite sidebar displays search icon and still filters correctly (integration test)
- [x] Scenario picker and target picker adopt shared component (existing tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1672