### PR TITLE
feat: skip hostname/TLS validation in scenario runner for on-prem

### DIFF
--- a/langwatch/src/utils/ssrfProtection.unit.test.ts
+++ b/langwatch/src/utils/ssrfProtection.unit.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import dns from "dns/promises";
+import { Agent, fetch as undiciFetch } from "undici";
+import {
+  createSSRFValidator,
+  createSSRFSafeFetchConfig,
+  fetchWithResolvedIp,
+  type SSRFDevelopmentBypassResult,
+  type SSRFResolvedResult,
+} from "./ssrfProtection";
+
+vi.mock("dns/promises", () => ({
+  default: {
+    resolve: vi.fn(),
+  },
+}));
+
+vi.mock("undici", async () => {
+  const actual = await vi.importActual("undici");
+  return {
+    ...actual,
+    fetch: vi.fn(),
+  };
+});
+
+const mockedFetch = vi.mocked(undiciFetch);
+
+const mockedDnsResolve = vi.mocked(dns.resolve);
+
+function stubDnsResolve(ipv4: string[], ipv6: string[] = []) {
+  mockedDnsResolve.mockImplementation((hostname: string, type: string) => {
+    if (type === "A") return Promise.resolve(ipv4);
+    if (type === "AAAA") return Promise.resolve(ipv6);
+    return Promise.resolve([]);
+  });
+}
+
+describe("createSSRFValidator()", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("when isSaaS is false", () => {
+    const validate = createSSRFValidator({
+      isDevelopment: false,
+      allowedDevHosts: [],
+      isSaaS: false,
+    });
+
+    it("allows a private hostname", async () => {
+      stubDnsResolve(["192.168.1.100"]);
+
+      const result = await validate("https://my-internal-agent:8443/chat");
+      expect(result.hostname).toBe("my-internal-agent");
+    });
+
+    it("allows a private IP literal like 10.0.0.5", async () => {
+      const result = await validate("https://10.0.0.5:8443/chat");
+      expect(result).toMatchObject({
+        type: "resolved",
+        resolvedIp: "10.0.0.5",
+      });
+    });
+
+    it("blocks cloud metadata endpoints", async () => {
+      await expect(
+        validate("http://169.254.169.254/latest/meta-data/")
+      ).rejects.toThrow(
+        "Access to cloud metadata endpoints is not allowed for security reasons"
+      );
+    });
+
+    it("blocks cloud provider internal domains", async () => {
+      stubDnsResolve(["52.94.76.1"]);
+
+      await expect(
+        validate("https://s3.amazonaws.com/my-bucket")
+      ).rejects.toThrow(
+        "Access to cloud provider internal domains is not allowed for security reasons"
+      );
+    });
+  });
+
+  describe("when isSaaS is true", () => {
+    const validate = createSSRFValidator({
+      isDevelopment: false,
+      allowedDevHosts: [],
+      isSaaS: true,
+    });
+
+    it("blocks a private hostname", async () => {
+      stubDnsResolve(["192.168.1.100"]);
+
+      await expect(
+        validate("https://my-internal-agent:8443/chat")
+      ).rejects.toThrow(
+        /not allowed for security reasons/
+      );
+    });
+
+    it("blocks a private IP literal like 10.0.0.5", async () => {
+      await expect(
+        validate("https://10.0.0.5:8443/chat")
+      ).rejects.toThrow(
+        "Access to private or localhost IP addresses is not allowed for security reasons"
+      );
+    });
+
+    it("blocks cloud metadata endpoints", async () => {
+      await expect(
+        validate("http://169.254.169.254/latest/meta-data/")
+      ).rejects.toThrow(
+        "Access to cloud metadata endpoints is not allowed for security reasons"
+      );
+    });
+
+    it("blocks cloud provider internal domains", async () => {
+      stubDnsResolve(["52.94.76.1"]);
+
+      await expect(
+        validate("https://s3.amazonaws.com/my-bucket")
+      ).rejects.toThrow(
+        "Access to cloud provider internal domains is not allowed for security reasons"
+      );
+    });
+  });
+});
+
+describe("createSSRFSafeFetchConfig()", () => {
+  describe("when isSaaS is false", () => {
+    it("disables TLS certificate validation", () => {
+      const config = createSSRFSafeFetchConfig({ isSaaS: false });
+      expect(config.rejectUnauthorized).toBe(false);
+    });
+  });
+
+  describe("when isSaaS is true", () => {
+    it("enables TLS certificate validation", () => {
+      const config = createSSRFSafeFetchConfig({ isSaaS: true });
+      expect(config.rejectUnauthorized).toBe(true);
+    });
+  });
+});
+
+describe("fetchWithResolvedIp()", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("when resolvedIp is null (development-bypass)", () => {
+    const devBypassResult: SSRFDevelopmentBypassResult = {
+      type: "development-bypass",
+      reason: "dns-failed",
+      originalUrl: "http://my-service:3000/api",
+      hostname: "my-service",
+      port: 3000,
+      protocol: "http:",
+      path: "/api",
+    };
+
+    it("creates a non-pinning Agent with the provided TLS config", async () => {
+      const fakeResponse = { status: 200, headers: new Headers() };
+      mockedFetch.mockResolvedValue(fakeResponse as never);
+
+      await fetchWithResolvedIp(devBypassResult, undefined, {
+        rejectUnauthorized: false,
+      });
+
+      expect(mockedFetch).toHaveBeenCalledOnce();
+      const callArgs = mockedFetch.mock.calls[0]!;
+      const options = callArgs[1] as Record<string, unknown>;
+      expect(options.dispatcher).toBeInstanceOf(Agent);
+    });
+
+    it("uses injected TLS config instead of module default", async () => {
+      const fakeResponse = { status: 200, headers: new Headers() };
+      mockedFetch.mockResolvedValue(fakeResponse as never);
+
+      // Passing rejectUnauthorized: false (on-prem mode)
+      await fetchWithResolvedIp(devBypassResult, undefined, {
+        rejectUnauthorized: false,
+      });
+
+      expect(mockedFetch).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("when resolvedIp is present", () => {
+    const resolvedResult: SSRFResolvedResult = {
+      type: "resolved",
+      resolvedIp: "93.184.216.34",
+      originalUrl: "https://example.com/api",
+      hostname: "example.com",
+      port: 443,
+      protocol: "https:",
+      path: "/api",
+    };
+
+    it("creates an IP-pinning Agent with injected TLS config", async () => {
+      const fakeResponse = { status: 200, headers: new Headers() };
+      mockedFetch.mockResolvedValue(fakeResponse as never);
+
+      await fetchWithResolvedIp(resolvedResult, undefined, {
+        rejectUnauthorized: true,
+      });
+
+      expect(mockedFetch).toHaveBeenCalledOnce();
+      const callArgs = mockedFetch.mock.calls[0]!;
+      const options = callArgs[1] as Record<string, unknown>;
+      expect(options.dispatcher).toBeInstanceOf(Agent);
+    });
+  });
+});

--- a/specs/features/scenarios/on-prem-hostname-validation.feature
+++ b/specs/features/scenarios/on-prem-hostname-validation.feature
@@ -1,0 +1,67 @@
+Feature: On-prem hostname validation bypass for scenario runner
+  As an on-prem operator
+  I want scenarios to reach internal hostnames and self-signed HTTPS services
+  So that I can run evaluations against agents hosted on my private network
+
+  # --- Private hostname validation depends on IS_SAAS ---
+  @unit
+  Scenario: Scenario runner reaches a private hostname when IS_SAAS is false
+    Given IS_SAAS is false
+    When the scenario runner validates a URL with a private hostname
+    Then the validation passes
+
+  @unit
+  Scenario: Scenario runner blocks a private hostname when IS_SAAS is true
+    Given IS_SAAS is true
+    When the scenario runner validates a URL with a private hostname
+    Then the validation fails with an SSRF error
+
+  # --- Self-signed TLS behavior depends on IS_SAAS ---
+  @unit
+  Scenario: Scenario runner allows self-signed certificates when IS_SAAS is false
+    Given IS_SAAS is false
+    When the scenario runner builds a fetch request
+    Then TLS certificate validation is disabled
+
+  @unit
+  Scenario: Scenario runner enforces TLS certificates when IS_SAAS is true
+    Given IS_SAAS is true
+    When the scenario runner builds a fetch request
+    Then TLS certificate validation is enabled
+
+  # --- Cloud metadata always blocked, even on-prem ---
+  @unit
+  Scenario Outline: Cloud metadata endpoints are blocked even when IS_SAAS is <saas_value>
+    Given IS_SAAS is <saas_value>
+    When the scenario runner validates a cloud metadata endpoint
+    Then the validation fails with a metadata security error
+
+    Examples:
+      | saas_value |
+      | true       |
+      | false      |
+
+  # --- Cloud internal domains always blocked ---
+  @unit
+  Scenario Outline: Cloud provider internal domains are blocked even when IS_SAAS is <saas_value>
+    Given IS_SAAS is <saas_value>
+    When the scenario runner validates a cloud provider internal domain
+    Then the validation fails with a cloud domain security error
+
+    Examples:
+      | saas_value |
+      | true       |
+      | false      |
+
+  # --- Private IP literals ---
+  @unit
+  Scenario: Private IP literals are allowed when IS_SAAS is false
+    Given IS_SAAS is false
+    When the scenario runner validates a private IP literal like 10.0.0.5
+    Then the validation passes
+
+  @unit
+  Scenario: Private IP literals are blocked when IS_SAAS is true
+    Given IS_SAAS is true
+    When the scenario runner validates a private IP literal like 10.0.0.5
+    Then the validation fails with an SSRF error


### PR DESCRIPTION
## Summary
- On-prem deployments (`IS_SAAS=false`) can now run scenarios against internal hostnames and self-signed TLS certificates
- Cloud metadata endpoints remain blocked in all environments for security
- Uses the existing `env` module as single source of truth for `IS_SAAS`

## Changes
- Added `isSaaS` to `SSRFConfig` interface in `ssrfProtection.ts`
- When `isSaaS=false`: skip private IP/hostname checks, disable TLS cert validation (`rejectUnauthorized: false`)
- Cloud metadata endpoints and cloud provider domains are always blocked regardless of `isSaaS`
- Made TLS config injectable for testability
- 13 new unit tests, 66 existing tests updated and passing

## Test plan
- [x] Private hostname validation passes when `IS_SAAS=false`
- [x] Private hostname validation blocked when `IS_SAAS=true`
- [x] Self-signed TLS allowed when `IS_SAAS=false`
- [x] Self-signed TLS rejected when `IS_SAAS=true`
- [x] Cloud metadata always blocked (both `IS_SAAS` values)
- [x] Cloud provider domains always blocked (both `IS_SAAS` values)
- [x] Private IP literals allowed/blocked correctly per `IS_SAAS`
- [x] All 79 tests passing

Closes #1818

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1818