### PR TITLE
fix: change default org pricing model to SEAT_EVENT

### DIFF
--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -290,7 +290,7 @@ export const organizationRouter = createTRPCRouter({
               slug: orgSlug,
               phoneNumber: input.phoneNumber,
               signupData: input.signUpData,
-              pricingModel: PricingModel.TIERED,
+              pricingModel: PricingModel.SEAT_EVENT,
             },
           });
 


### PR DESCRIPTION
## Summary
- Changes the default pricing model for new organizations created during onboarding from `TIERED` to `SEAT_EVENT`

## Test plan
- [ ] Verify new organizations created via onboarding are assigned `SEAT_EVENT` pricing model
- [ ] Verify existing organizations are unaffected