### PR TITLE
fix(contact): update contact link from mail to HubSpot link

### DIFF
--- a/langwatch/src/components/license/NoLicenseCard.tsx
+++ b/langwatch/src/components/license/NoLicenseCard.tsx
@@ -13,6 +13,7 @@ import { Link } from "~/components/ui/link";
 import { Radio, RadioGroup } from "~/components/ui/radio";
 import { Tooltip } from "~/components/ui/tooltip";
 import { formatFileSize } from "./licenseStatusUtils";
+import { CONTACT_SALES_URL } from "../plans/constants";
 
 type ActivationMethod = "file" | "key";
 
@@ -242,7 +243,7 @@ export function NoLicenseCard({
               </Button>
             </Tooltip>
             <Link
-              href="mailto:sales@langwatch.ai"
+              href={CONTACT_SALES_URL}
               isExternal
               color="blue.fg"
               fontSize="sm"

--- a/langwatch/src/components/plans/constants.ts
+++ b/langwatch/src/components/plans/constants.ts
@@ -1,2 +1,2 @@
 export const CONTACT_SALES_URL =
-  "https://meetings-eu1.hubspot.com/pedro-silva2/langwatch-enterprise";
+  "https://meetings-eu1.hubspot.com/manouk-draisma?uuid=3c29cf0c-03e5-4a53-81fd-94abb0b66cfd";


### PR DESCRIPTION
## Summary
- Update the contact sales URL in `constants.ts` to point to the new HubSpot meeting link
- Replace hardcoded `mailto:sales@langwatch.ai` in `NoLicenseCard` with the shared `CONTACT_SALES_URL` constant

## Test plan
- [ ] Verify the "Contact Sales" link in the NoLicenseCard redirects to the correct HubSpot meeting page
- [ ] Verify other usages of `CONTACT_SALES_URL` still work correctly