### PR TITLE
fix(subscription): correct legacy paid plan detection logic

### DIFF
--- a/langwatch/src/components/subscription/SubscriptionPage.tsx
+++ b/langwatch/src/components/subscription/SubscriptionPage.tsx
@@ -143,7 +143,7 @@ export function SubscriptionPage() {
   const isDeveloperPlan = plan?.free ?? true;
   const isTieredPricingModel = organization?.pricingModel === PricingModel.TIERED;
   const isEnterprisePlan = plan?.type === "ENTERPRISE";
-  const isTieredLegacyPaidPlan = isTieredPricingModel && isDeveloperPlan && !isEnterprisePlan;
+  const isTieredLegacyPaidPlan = isTieredPricingModel && !isDeveloperPlan && !isEnterprisePlan;
 
   useEffect(() => {
     if (isTieredLegacyPaidPlan && plan && isAnnualTieredPlan(plan.type)) {


### PR DESCRIPTION
## Summary
- Fixes `isTieredLegacyPaidPlan` condition which was incorrectly using `isDeveloperPlan` instead of `!isDeveloperPlan`
- This caused the condition to match free/developer plans instead of actual legacy paid plans, preventing those users from upgrading their subscription

## Test plan
- [ ] Verify legacy paid plan users see the correct upgrade flow on the subscription page
- [ ] Verify developer (free) plan users are not incorrectly treated as legacy paid plan users