### PR TITLE
fix(test): assert cursor resets when period changes

### DIFF
--- a/langwatch/src/components/suites/__tests__/AllRunsPanel.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/AllRunsPanel.integration.test.tsx
@@ -208,6 +208,7 @@ describe("<AllRunsPanel/>", () => {
       expect(lastCall![0]).toMatchObject({
         startDate: period2.startDate.getTime(),
         endDate: period2.endDate.getTime(),
+        cursor: undefined,
       });
     });
   });


### PR DESCRIPTION
## Summary
- Adds missing `cursor: undefined` assertion to the "resets pagination when re-rendered with a new period" test in `AllRunsPanel.integration.test.tsx`
- The test previously verified `startDate`/`endDate` updated but never checked that the pagination cursor was actually reset

Closes #1833

## Test plan
- [x] All 6 existing tests in `AllRunsPanel.integration.test.tsx` pass
- [x] New assertion validates `cursor: undefined` in the query args after period change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1833