### PR TITLE
fix(ui): add overflow scrolling to ExpandedTextDialog for large content

### DIFF
--- a/langwatch/src/components/HoverableBigText.tsx
+++ b/langwatch/src/components/HoverableBigText.tsx
@@ -41,7 +41,7 @@ export function ExpandedTextDialog({
           </HStack>
         </Dialog.Header>
         <Dialog.CloseTrigger />
-        <Dialog.Body paddingY={6} paddingX={8}>
+        <Dialog.Body paddingY={6} paddingX={8} overflow="auto" maxHeight="calc(100vh - 200px)">
           {open && textExpanded && isFormatted ? (
             isJson(textExpanded) ? (
               <RenderInputOutput value={textExpanded} showTools={"copy-only"} />

--- a/langwatch/src/components/__tests__/ExpandedTextDialog.integration.test.tsx
+++ b/langwatch/src/components/__tests__/ExpandedTextDialog.integration.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { ExpandedTextDialog } from "../HoverableBigText";
+
+vi.mock("@microlink/react-json-view", () => ({
+  __esModule: true,
+  default: ({ src }: { src: object }) => (
+    <pre data-testid="react-json-view">{JSON.stringify(src, null, 2)}</pre>
+  ),
+}));
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: (loader: () => Promise<{ default: unknown }>) => {
+    let Component: React.ComponentType<Record<string, unknown>> | null = null;
+    const promise = loader();
+    promise.then((mod) => {
+      Component = mod.default as React.ComponentType<Record<string, unknown>>;
+    });
+    return function DynamicComponent(props: Record<string, unknown>) {
+      if (Component) return <Component {...props} />;
+      return <div />;
+    };
+  },
+}));
+
+const DIALOG_BODY_SELECTOR = ".chakra-dialog__body";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderDialog({
+  text,
+  open = true,
+}: {
+  text: string;
+  open?: boolean;
+}) {
+  return render(
+    <ExpandedTextDialog
+      open={open}
+      onOpenChange={() => {}}
+      textExpanded={text}
+    />,
+    { wrapper: Wrapper },
+  );
+}
+
+function findDialogBody(baseElement: HTMLElement) {
+  return baseElement.querySelector(DIALOG_BODY_SELECTOR);
+}
+
+const LARGE_JSON = JSON.stringify(
+  Object.fromEntries(
+    Array.from({ length: 200 }, (_, i) => [
+      `key${i}`,
+      `value${i} - ${"x".repeat(100)}`,
+    ]),
+  ),
+);
+
+const SMALL_JSON = JSON.stringify({ hello: "world" });
+
+const LARGE_PLAIN_TEXT = "Line of text\n".repeat(500);
+
+const LARGE_MARKDOWN = Array.from(
+  { length: 200 },
+  (_, i) => `## Heading ${i}\n\nParagraph content here.\n`,
+).join("\n");
+
+describe("<ExpandedTextDialog/>", () => {
+  describe("when content exceeds the dialog viewport height", () => {
+    it("makes large JSON content accessible within the dialog body", () => {
+      const { baseElement } = renderDialog({ text: LARGE_JSON });
+
+      const dialogBody = findDialogBody(baseElement);
+      expect(dialogBody).toBeTruthy();
+
+      const style = window.getComputedStyle(dialogBody as Element);
+      expect(style.overflow).toBe("auto");
+      expect(style.maxHeight).toBeTruthy();
+    });
+
+    it("makes large plain text accessible within the dialog body", () => {
+      const { baseElement } = renderDialog({ text: LARGE_PLAIN_TEXT });
+
+      const dialogBody = findDialogBody(baseElement);
+      expect(dialogBody).toBeTruthy();
+
+      const style = window.getComputedStyle(dialogBody as Element);
+      expect(style.overflow).toBe("auto");
+    });
+
+    it("makes large Markdown content accessible within the dialog body", () => {
+      const { baseElement } = renderDialog({ text: LARGE_MARKDOWN });
+
+      const dialogBody = findDialogBody(baseElement);
+      expect(dialogBody).toBeTruthy();
+
+      const style = window.getComputedStyle(dialogBody as Element);
+      expect(style.overflow).toBe("auto");
+    });
+  });
+
+  describe("when content fits within the dialog viewport", () => {
+    it("does not force scrolling for small content", () => {
+      const { baseElement } = renderDialog({ text: SMALL_JSON });
+
+      const dialogBody = findDialogBody(baseElement);
+      expect(dialogBody).toBeTruthy();
+
+      // overflow: auto only shows scrollbars when content overflows,
+      // so small content will not scroll even with overflow: auto set
+      const style = window.getComputedStyle(dialogBody as Element);
+      expect(style.overflow).toBe("auto");
+    });
+  });
+
+  describe("when JSON content is displayed with formatted mode enabled", () => {
+    it("renders the copy button within the dialog", () => {
+      const { baseElement } = renderDialog({
+        text: JSON.stringify({ nested: { key: "value" } }),
+      });
+
+      // The RenderInputOutput component renders a copy button
+      const copyButton = baseElement.querySelector("button svg");
+      expect(copyButton).toBeTruthy();
+    });
+  });
+
+  describe("when toggling the formatted switch off", () => {
+    it("keeps the dialog body scrollable after toggling", () => {
+      const { baseElement } = render(
+        <ExpandedTextDialog
+          open={true}
+          onOpenChange={() => {}}
+          textExpanded={LARGE_JSON}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      // Toggle the formatted switch off
+      const switchInput = baseElement.querySelector("input[type='checkbox']");
+      expect(switchInput).toBeTruthy();
+      fireEvent.click(switchInput as Element);
+
+      const dialogBody = findDialogBody(baseElement);
+      expect(dialogBody).toBeTruthy();
+
+      const style = window.getComputedStyle(dialogBody as Element);
+      expect(style.overflow).toBe("auto");
+    });
+  });
+});

--- a/specs/components/hoverable-big-text-overflow.feature
+++ b/specs/components/hoverable-big-text-overflow.feature
@@ -1,0 +1,47 @@
+Feature: Expanded text dialog handles overflow for large content
+  As a user viewing trace metadata or other large content
+  I want the expanded dialog to scroll when content exceeds the viewport
+  So that I can browse the full content without it breaking the layout
+
+  Background:
+    Given the ExpandedTextDialog is rendered
+
+  # ============================================================================
+  # Dialog body overflow handling
+  # ============================================================================
+
+  @integration
+  Scenario Outline: Full content is accessible when it exceeds the dialog viewport
+    Given a large <content_type> that exceeds the dialog viewport height
+    When the ExpandedTextDialog opens with formatted mode <mode>
+    Then all content is accessible within the dialog
+
+    Examples:
+      | content_type  | mode     |
+      | JSON object   | enabled  |
+      | plain text    | disabled |
+      | Markdown text | enabled  |
+
+  @integration
+  Scenario: Small content does not trigger unnecessary scrolling
+    Given a small JSON object that fits within the dialog viewport height
+    When the ExpandedTextDialog opens with formatted mode enabled
+    Then all content is visible without scrolling
+
+  # ============================================================================
+  # Content rendering remains correct with overflow fix
+  # ============================================================================
+
+  @integration
+  Scenario: JSON content renders with interactive viewer and copy button
+    Given a JSON object with nested keys and values
+    When the ExpandedTextDialog opens with formatted mode enabled
+    Then the JSON is rendered using the interactive JSON viewer
+    And the copy button is visible
+    And all JSON keys and values are accessible within the dialog
+
+  @integration
+  Scenario: Scrollability persists after toggling formatted mode
+    Given a large JSON object displayed in the ExpandedTextDialog
+    When I toggle the "Formatted" switch off
+    Then all content is accessible within the dialog


### PR DESCRIPTION
## Summary

- Adds `overflow="auto"` and `maxHeight="calc(100vh - 200px)"` to `Dialog.Body` in `ExpandedTextDialog` so large JSON/text/Markdown content scrolls instead of overflowing the layout
- Adds integration tests covering overflow behavior for JSON, plain text, Markdown, small content, copy button, and formatted mode toggling
- Adds BDD feature spec in `specs/components/hoverable-big-text-overflow.feature`

Closes #1015

## Test plan

- [ ] Open a trace with large JSON metadata and verify the expanded dialog scrolls
- [ ] Open a trace with small metadata and verify no unnecessary scrollbar appears
- [ ] Toggle "Formatted" switch and verify scrolling still works
- [ ] Run `pnpm test:unit langwatch/src/components/__tests__/ExpandedTextDialog.integration.test.tsx` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1015