### PR TITLE
fix(billing): make plan limits as pricing-model-aware for orgs

### DIFF
--- a/langwatch/ee/billing/__tests__/planProvider.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planProvider.unit.test.ts
@@ -1,5 +1,6 @@
+import type { PrismaClient } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { PLAN_LIMITS } from "../planLimits";
+import { PLAN_LIMITS, getFreePlanLimits } from "../planLimits";
 import { PlanTypes, SubscriptionStatus } from "../planTypes";
 
 vi.mock("../../../src/env.mjs", () => ({
@@ -18,13 +19,63 @@ import { createSaaSPlanProvider } from "../planProvider";
 
 const mockEnv = env as { IS_SAAS: boolean | undefined; ADMIN_EMAILS: string | undefined };
 
-const createMockDb = (findFirstResult: unknown = null) => {
+const createMockDb = ({
+  findFirstResult = null,
+  orgFindUniqueResult = undefined,
+}: {
+  findFirstResult?: unknown;
+  orgFindUniqueResult?: unknown;
+} = {}) => {
   return {
     subscription: {
       findFirst: vi.fn().mockResolvedValue(findFirstResult),
     },
-  } as any;
+    organization: {
+      findUnique: vi.fn().mockResolvedValue(orgFindUniqueResult),
+    },
+  } as unknown as PrismaClient;
 };
+
+describe("getFreePlanLimits", () => {
+  describe("when pricing model is TIERED", () => {
+    it("returns 1,000 messages per month", () => {
+      const plan = getFreePlanLimits("TIERED");
+      expect(plan.maxMessagesPerMonth).toBe(1_000);
+    });
+  });
+
+  describe("when pricing model is SEAT_EVENT", () => {
+    it("returns 50,000 messages per month", () => {
+      const plan = getFreePlanLimits("SEAT_EVENT");
+      expect(plan.maxMessagesPerMonth).toBe(50_000);
+    });
+  });
+
+  describe("when pricing model is null", () => {
+    it("returns 1,000 messages per month", () => {
+      const plan = getFreePlanLimits(null);
+      expect(plan.maxMessagesPerMonth).toBe(1_000);
+    });
+  });
+
+  describe("when pricing model is undefined", () => {
+    it("returns 1,000 messages per month", () => {
+      const plan = getFreePlanLimits(undefined);
+      expect(plan.maxMessagesPerMonth).toBe(1_000);
+    });
+  });
+
+  it("preserves all other FREE plan properties", () => {
+    const plan = getFreePlanLimits("SEAT_EVENT");
+    const baseFree = PLAN_LIMITS[PlanTypes.FREE];
+
+    expect(plan.type).toBe(PlanTypes.FREE);
+    expect(plan.name).toBe("Free");
+    expect(plan.free).toBe(true);
+    expect(plan.maxMembers).toBe(baseFree.maxMembers);
+    expect(plan.maxProjects).toBe(baseFree.maxProjects);
+  });
+});
 
 describe("createSaaSPlanProvider", () => {
   beforeEach(() => {
@@ -52,12 +103,51 @@ describe("createSaaSPlanProvider", () => {
 
     describe("when no subscription exists", () => {
       it("returns FREE limits", async () => {
-        const db = createMockDb(null);
+        const db = createMockDb();
         const provider = createSaaSPlanProvider(db);
         const plan = await provider.getActivePlan("org_1");
 
         expect(plan.type).toBe(PlanTypes.FREE);
         expect(plan.maxMembers).toBe(PLAN_LIMITS[PlanTypes.FREE].maxMembers);
+      });
+
+      describe("when organization has SEAT_EVENT pricing model", () => {
+        it("returns FREE with 50,000 messages per month", async () => {
+          const db = createMockDb({
+            orgFindUniqueResult: { pricingModel: "SEAT_EVENT" },
+          });
+          const provider = createSaaSPlanProvider(db);
+          const plan = await provider.getActivePlan("org_1");
+
+          expect(plan.type).toBe(PlanTypes.FREE);
+          expect(plan.maxMessagesPerMonth).toBe(50_000);
+        });
+      });
+
+      describe("when organization has TIERED pricing model", () => {
+        it("returns FREE with 1,000 messages per month", async () => {
+          const db = createMockDb({
+            orgFindUniqueResult: { pricingModel: "TIERED" },
+          });
+          const provider = createSaaSPlanProvider(db);
+          const plan = await provider.getActivePlan("org_1");
+
+          expect(plan.type).toBe(PlanTypes.FREE);
+          expect(plan.maxMessagesPerMonth).toBe(1_000);
+        });
+      });
+
+      describe("when organization is not found", () => {
+        it("returns FREE with 1,000 messages per month", async () => {
+          const db = createMockDb({
+            orgFindUniqueResult: null,
+          });
+          const provider = createSaaSPlanProvider(db);
+          const plan = await provider.getActivePlan("org_1");
+
+          expect(plan.type).toBe(PlanTypes.FREE);
+          expect(plan.maxMessagesPerMonth).toBe(1_000);
+        });
       });
     });
 
@@ -72,13 +162,36 @@ describe("createSaaSPlanProvider", () => {
           evaluationsCredit: null,
         };
 
-        const db = createMockDb(subscription);
+        const db = createMockDb({ findFirstResult: subscription });
         const provider = createSaaSPlanProvider(db);
         const plan = await provider.getActivePlan("org_1");
 
         expect(plan.type).toBe(PlanTypes.LAUNCH);
         expect(plan.maxMembers).toBe(10);
         expect(plan.maxProjects).toBe(PLAN_LIMITS[PlanTypes.LAUNCH].maxProjects);
+      });
+
+      describe("when valid subscription exists for SEAT_EVENT org", () => {
+        it("does not query the organization table", async () => {
+          const subscription = {
+            plan: PlanTypes.LAUNCH,
+            status: SubscriptionStatus.ACTIVE,
+            maxMembers: null,
+            maxProjects: null,
+            maxMessagesPerMonth: null,
+            evaluationsCredit: null,
+          };
+
+          const db = createMockDb({
+            findFirstResult: subscription,
+            orgFindUniqueResult: { pricingModel: "SEAT_EVENT" },
+          });
+          const provider = createSaaSPlanProvider(db);
+          const plan = await provider.getActivePlan("org_1");
+
+          expect(plan.type).toBe(PlanTypes.LAUNCH);
+          expect(db.organization.findUnique).not.toHaveBeenCalled();
+        });
       });
     });
 
@@ -93,7 +206,7 @@ describe("createSaaSPlanProvider", () => {
           evaluationsCredit: 0,
         };
 
-        const db = createMockDb(subscription);
+        const db = createMockDb({ findFirstResult: subscription });
         const provider = createSaaSPlanProvider(db);
         const plan = await provider.getActivePlan("org_1");
 
@@ -115,11 +228,58 @@ describe("createSaaSPlanProvider", () => {
           evaluationsCredit: null,
         };
 
-        const db = createMockDb(subscription);
+        const db = createMockDb({ findFirstResult: subscription });
         const provider = createSaaSPlanProvider(db);
         const plan = await provider.getActivePlan("org_1");
 
         expect(plan.type).toBe(PlanTypes.FREE);
+      });
+
+      describe("when SEAT_EVENT org has unknown plan key", () => {
+        it("returns FREE with 50,000 messages per month", async () => {
+          const subscription = {
+            plan: "NONEXISTENT_PLAN",
+            status: SubscriptionStatus.ACTIVE,
+            maxMembers: null,
+            maxProjects: null,
+            maxMessagesPerMonth: null,
+            evaluationsCredit: null,
+          };
+
+          const db = createMockDb({
+            findFirstResult: subscription,
+            orgFindUniqueResult: { pricingModel: "SEAT_EVENT" },
+          });
+          const provider = createSaaSPlanProvider(db);
+          const plan = await provider.getActivePlan("org_1");
+
+          expect(plan.type).toBe(PlanTypes.FREE);
+          expect(plan.maxMessagesPerMonth).toBe(50_000);
+        });
+      });
+
+      describe("when SEAT_EVENT org has unknown plan key with custom limits", () => {
+        it("preserves subscription custom limits over free plan limits", async () => {
+          const subscription = {
+            plan: "NONEXISTENT_PLAN",
+            status: SubscriptionStatus.ACTIVE,
+            maxMembers: 15,
+            maxProjects: null,
+            maxMessagesPerMonth: null,
+            evaluationsCredit: null,
+          };
+
+          const db = createMockDb({
+            findFirstResult: subscription,
+            orgFindUniqueResult: { pricingModel: "SEAT_EVENT" },
+          });
+          const provider = createSaaSPlanProvider(db);
+          const plan = await provider.getActivePlan("org_1");
+
+          expect(plan.type).toBe(PlanTypes.FREE);
+          expect(plan.maxMessagesPerMonth).toBe(50_000);
+          expect(plan.maxMembers).toBe(15);
+        });
       });
     });
   });

--- a/specs/features/pricing-model-aware-free-plan.feature
+++ b/specs/features/pricing-model-aware-free-plan.feature
@@ -1,0 +1,55 @@
+Feature: Pricing-model-aware FREE plan limits
+  As a SaaS platform operator
+  I want the FREE plan to respect the organization's pricing model
+  So that SEAT_EVENT organizations get appropriate event limits on the free tier
+
+  Background:
+    Given the platform is running in SaaS mode
+
+  @integration
+  Scenario: TIERED organization on FREE plan gets 1,000 traces per month
+    Given an organization with the TIERED pricing model
+    And no active subscription exists
+    When the plan provider resolves the active plan
+    Then the plan is FREE with 1,000 messages per month
+
+  @integration
+  Scenario: SEAT_EVENT organization on FREE plan gets 50,000 events per month
+    Given an organization with the SEAT_EVENT pricing model
+    And no active subscription exists
+    When the plan provider resolves the active plan
+    Then the plan is FREE with 50,000 messages per month
+
+  @integration
+  Scenario: Organization not found falls back to default FREE limits
+    Given the organization does not exist in the database
+    And no active subscription exists
+    When the plan provider resolves the active plan
+    Then the plan is FREE with 1,000 messages per month
+
+  @integration
+  Scenario: SEAT_EVENT organization with unknown subscription plan key
+    Given an organization with the SEAT_EVENT pricing model
+    And an active subscription with an unrecognized plan key
+    When the plan provider resolves the active plan
+    Then the plan is FREE with 50,000 messages per month
+    And subscription custom limits override the base free limits
+
+  @integration
+  Scenario: Valid subscription returns its own plan regardless of pricing model
+    Given an organization with the SEAT_EVENT pricing model
+    And an active subscription on the LAUNCH plan
+    When the plan provider resolves the active plan
+    Then the plan is LAUNCH with standard LAUNCH limits
+
+  @unit
+  Scenario Outline: FREE plan limits vary by pricing model
+    When resolving free plan limits for <pricingModel>
+    Then the limit is <maxMessagesPerMonth> messages per month
+
+    Examples:
+      | pricingModel | maxMessagesPerMonth |
+      | TIERED       | 1,000               |
+      | SEAT_EVENT   | 50,000              |
+      | null         | 1,000               |
+      | undefined    | 1,000               |


### PR DESCRIPTION
## Summary

- SEAT_EVENT organizations on the FREE tier now get 50,000 events/month
- Added `getFreePlanLimits(pricingModel)` helper with exhaustive switch for compile-time safety
- Organization's `pricingModel` is only queried on the FREE fallback path (not on every call) to avoid adding latency to the hot ingestion path
- No changes to licensing, subscription handler, usage services, or usage UI

## Test plan

- [x] `pnpm test:unit ee/billing/__tests__/planProvider.unit.test.ts` — 19 tests passing
- [x] `pnpm typecheck` — clean
- [ ] Verify SEAT_EVENT org on FREE tier sees 50,000 limit in usage page
- [ ] Verify TIERED org on FREE tier still sees 1,000 limit