### PR TITLE
feat(licensing): add usageUnit to license schema and generation

### DIFF
--- a/langwatch/ee/licensing/__tests__/defaults.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/defaults.unit.test.ts
@@ -44,6 +44,60 @@ describe("resolvePlanDefaults", () => {
     expect(resolved.maxScenarios).toBe(DEFAULT_LIMIT);
     expect(resolved.maxAgents).toBe(DEFAULT_LIMIT);
     expect(resolved.maxOnlineEvaluations).toBe(DEFAULT_LIMIT);
+    expect(resolved.usageUnit).toBe("traces");
+  });
+
+  it("defaults usageUnit to traces when not provided", () => {
+    const plan: LicensePlanLimits = {
+      type: "PRO",
+      name: "Pro",
+      maxMembers: 10,
+      maxProjects: 20,
+      maxMessagesPerMonth: 100_000,
+      evaluationsCredit: 500,
+      maxWorkflows: 50,
+      canPublish: true,
+    };
+
+    const resolved = resolvePlanDefaults(plan);
+
+    expect(resolved.usageUnit).toBe("traces");
+  });
+
+  it("preserves explicit usageUnit events value", () => {
+    const plan: LicensePlanLimits = {
+      type: "ENTERPRISE",
+      name: "Enterprise",
+      maxMembers: 100,
+      maxProjects: 50,
+      maxMessagesPerMonth: 1_000_000,
+      evaluationsCredit: 10_000,
+      maxWorkflows: 200,
+      canPublish: true,
+      usageUnit: "events",
+    };
+
+    const resolved = resolvePlanDefaults(plan);
+
+    expect(resolved.usageUnit).toBe("events");
+  });
+
+  it("normalizes unknown usageUnit values to traces", () => {
+    const plan: LicensePlanLimits = {
+      type: "ENTERPRISE",
+      name: "Enterprise",
+      maxMembers: 100,
+      maxProjects: 50,
+      maxMessagesPerMonth: 1_000_000,
+      evaluationsCredit: 10_000,
+      maxWorkflows: 200,
+      canPublish: true,
+      usageUnit: "spans",
+    };
+
+    const resolved = resolvePlanDefaults(plan);
+
+    expect(resolved.usageUnit).toBe("traces");
   });
 
   it("preserves explicitly set optional fields", () => {
@@ -139,6 +193,7 @@ describe("resolvePlanDefaults", () => {
       maxCustomGraphs: resolved.maxCustomGraphs,
       maxAutomations: resolved.maxAutomations,
       canPublish: resolved.canPublish,
+      usageUnit: resolved.usageUnit,
     };
 
     expect(allFields).toEqual(resolved);

--- a/langwatch/ee/licensing/__tests__/planMapping.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/planMapping.unit.test.ts
@@ -152,6 +152,39 @@ describe("mapToPlanInfo", () => {
     expect(result.maxMembersLite).toBe(DEFAULT_MEMBERS_LITE);
   });
 
+  it("maps usageUnit from license data", () => {
+    const licenseData = createLicenseData({ usageUnit: "events" });
+
+    const result = mapToPlanInfo(licenseData);
+
+    expect(result.usageUnit).toBe("events");
+  });
+
+  it("defaults usageUnit to traces for legacy licenses", () => {
+    const oldLicenseData: LicenseData = {
+      licenseId: "lic-old-002",
+      version: 1,
+      organizationName: "Legacy Org",
+      email: "legacy@example.com",
+      issuedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+      plan: {
+        type: "PRO",
+        name: "Pro",
+        maxMembers: 10,
+        maxProjects: 99,
+        maxMessagesPerMonth: 100_000,
+        evaluationsCredit: 100,
+        maxWorkflows: 50,
+        canPublish: true,
+      },
+    };
+
+    const result = mapToPlanInfo(oldLicenseData);
+
+    expect(result.usageUnit).toBe("traces");
+  });
+
   it("uses DEFAULT_LIMIT which is JSON-serializable", () => {
     // Ensure DEFAULT_LIMIT can be serialized (not Infinity)
     const serialized = JSON.stringify({ limit: DEFAULT_LIMIT });

--- a/langwatch/ee/licensing/__tests__/planTemplates.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/planTemplates.unit.test.ts
@@ -50,6 +50,10 @@ describe("PRO_TEMPLATE", () => {
   it("has canPublish true", () => {
     expect(PRO_TEMPLATE.canPublish).toBe(true);
   });
+
+  it("has usageUnit of traces", () => {
+    expect(PRO_TEMPLATE.usageUnit).toBe("traces");
+  });
 });
 
 describe("ENTERPRISE_TEMPLATE", () => {
@@ -99,6 +103,10 @@ describe("ENTERPRISE_TEMPLATE", () => {
 
   it("has canPublish true", () => {
     expect(ENTERPRISE_TEMPLATE.canPublish).toBe(true);
+  });
+
+  it("has usageUnit of traces", () => {
+    expect(ENTERPRISE_TEMPLATE.usageUnit).toBe("traces");
   });
 });
 

--- a/langwatch/ee/licensing/constants.ts
+++ b/langwatch/ee/licensing/constants.ts
@@ -119,6 +119,7 @@ export const UNLIMITED_PLAN: PlanInfo = {
   maxCustomGraphs: Number.MAX_SAFE_INTEGER,
   maxAutomations: Number.MAX_SAFE_INTEGER,
   canPublish: true,
+  usageUnit: "traces",
   prices: {
     USD: 0,
     EUR: 0,
@@ -155,6 +156,7 @@ export const FREE_PLAN: PlanInfo = {
   maxCustomGraphs: FREE_TIER_LIMITS.CUSTOM_GRAPHS,
   maxAutomations: FREE_TIER_LIMITS.AUTOMATIONS,
   canPublish: false,
+  usageUnit: "traces",
   prices: {
     USD: 0,
     EUR: 0,

--- a/langwatch/ee/licensing/defaults.ts
+++ b/langwatch/ee/licensing/defaults.ts
@@ -1,6 +1,8 @@
 import { DEFAULT_LIMIT, DEFAULT_MEMBERS_LITE } from "./constants";
 import type { LicensePlanLimits } from "./types";
 
+const KNOWN_USAGE_UNITS = ["traces", "events"] as const;
+
 /**
  * ResolvedPlanLimits has all optional fields made required after defaults are applied.
  * This provides compile-time safety that all limits have defined values.
@@ -16,6 +18,7 @@ export type ResolvedPlanLimits = Required<LicensePlanLimits>;
  * - maxPrompts: DEFAULT_LIMIT (Number.MAX_SAFE_INTEGER - effectively unlimited)
  * - maxEvaluators: DEFAULT_LIMIT (effectively unlimited)
  * - maxScenarios: DEFAULT_LIMIT (effectively unlimited)
+ * - usageUnit: "traces"
  *
  * @param plan - License plan limits with optional fields
  * @returns Plan limits with all fields guaranteed to have values
@@ -45,5 +48,8 @@ export function resolvePlanDefaults(plan: LicensePlanLimits): ResolvedPlanLimits
     maxDashboards: plan.maxDashboards ?? DEFAULT_LIMIT,
     maxCustomGraphs: plan.maxCustomGraphs ?? DEFAULT_LIMIT,
     maxAutomations: plan.maxAutomations ?? DEFAULT_LIMIT,
+    usageUnit: KNOWN_USAGE_UNITS.includes(plan.usageUnit as any)
+      ? plan.usageUnit!
+      : "traces",
   };
 }

--- a/langwatch/ee/licensing/planInfo.ts
+++ b/langwatch/ee/licensing/planInfo.ts
@@ -30,6 +30,7 @@ export type PlanInfo = {
   maxCustomGraphs: number;
   maxAutomations: number;
   canPublish: boolean;
+  usageUnit?: string;
   userPrice?: {
     USD: number;
     EUR: number;

--- a/langwatch/ee/licensing/planMapping.ts
+++ b/langwatch/ee/licensing/planMapping.ts
@@ -28,6 +28,7 @@ export function mapToPlanInfo(licenseData: LicenseData): PlanInfo {
     maxCustomGraphs: resolved.maxCustomGraphs,
     maxAutomations: resolved.maxAutomations,
     canPublish: resolved.canPublish,
+    usageUnit: resolved.usageUnit,
     prices: {
       USD: 0,
       EUR: 0,

--- a/langwatch/ee/licensing/planTemplates.ts
+++ b/langwatch/ee/licensing/planTemplates.ts
@@ -25,6 +25,7 @@ export const PRO_TEMPLATE: LicensePlanLimits = {
   maxCustomGraphs: 50,
   maxAutomations: 50,
   canPublish: true,
+  usageUnit: "traces",
 };
 
 /**
@@ -52,6 +53,7 @@ export const ENTERPRISE_TEMPLATE: LicensePlanLimits = {
   maxCustomGraphs: 1000,
   maxAutomations: 1000,
   canPublish: true,
+  usageUnit: "traces",
 };
 
 /**

--- a/langwatch/ee/licensing/types.ts
+++ b/langwatch/ee/licensing/types.ts
@@ -25,6 +25,9 @@ export const LicensePlanLimitsSchema = z.object({
   maxCustomGraphs: z.number().optional(),
   maxAutomations: z.number().optional(),
   canPublish: z.boolean(),
+  // Usage counting mode - optional for backward compatibility with existing signed licenses
+  // Uses z.string() (not z.enum) for forward compatibility: future values won't break old deployments
+  usageUnit: z.string().optional(),
 });
 
 export type LicensePlanLimits = z.infer<typeof LicensePlanLimitsSchema>;

--- a/langwatch/src/components/license/__tests__/planFormDefaults.unit.test.ts
+++ b/langwatch/src/components/license/__tests__/planFormDefaults.unit.test.ts
@@ -22,6 +22,7 @@ describe("planFormDefaults", () => {
         maxScenarios: PRO_TEMPLATE.maxScenarios,
         maxAgents: PRO_TEMPLATE.maxAgents,
         canPublish: PRO_TEMPLATE.canPublish,
+        usageUnit: PRO_TEMPLATE.usageUnit,
       });
     });
 
@@ -40,6 +41,7 @@ describe("planFormDefaults", () => {
         maxScenarios: ENTERPRISE_TEMPLATE.maxScenarios,
         maxAgents: ENTERPRISE_TEMPLATE.maxAgents,
         canPublish: ENTERPRISE_TEMPLATE.canPublish,
+        usageUnit: ENTERPRISE_TEMPLATE.usageUnit,
       });
     });
 
@@ -66,6 +68,11 @@ describe("planFormDefaults", () => {
       expect(proDefaults.maxEvaluators).toBe(PRO_TEMPLATE.maxEvaluators);
       expect(proDefaults.maxScenarios).toBe(PRO_TEMPLATE.maxScenarios);
       expect(proDefaults.maxAgents).toBe(PRO_TEMPLATE.maxAgents);
+    });
+
+    it("includes usageUnit in PRO and ENTERPRISE defaults", () => {
+      expect(PLAN_DEFAULTS.PRO.usageUnit).toBe("traces");
+      expect(PLAN_DEFAULTS.ENTERPRISE.usageUnit).toBe("traces");
     });
 
     it("ENTERPRISE defaults match ENTERPRISE_TEMPLATE values without fallbacks", () => {

--- a/langwatch/src/components/license/planFormDefaults.ts
+++ b/langwatch/src/components/license/planFormDefaults.ts
@@ -17,6 +17,7 @@ export interface PlanFormDefaults {
   maxScenarios?: number;
   maxAgents?: number;
   canPublish?: boolean;
+  usageUnit?: "traces" | "events";
 }
 
 /**
@@ -36,6 +37,7 @@ export const PLAN_DEFAULTS: Record<PlanType, PlanFormDefaults> = {
     maxScenarios: PRO_TEMPLATE.maxScenarios,
     maxAgents: PRO_TEMPLATE.maxAgents,
     canPublish: PRO_TEMPLATE.canPublish,
+    usageUnit: PRO_TEMPLATE.usageUnit as "traces" | "events",
   },
   ENTERPRISE: {
     maxMembers: ENTERPRISE_TEMPLATE.maxMembers,
@@ -49,6 +51,7 @@ export const PLAN_DEFAULTS: Record<PlanType, PlanFormDefaults> = {
     maxScenarios: ENTERPRISE_TEMPLATE.maxScenarios,
     maxAgents: ENTERPRISE_TEMPLATE.maxAgents,
     canPublish: ENTERPRISE_TEMPLATE.canPublish,
+    usageUnit: ENTERPRISE_TEMPLATE.usageUnit as "traces" | "events",
   },
   CUSTOM: {},
 };

--- a/langwatch/src/server/api/routers/__tests__/license.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/license.integration.test.ts
@@ -364,6 +364,7 @@ describe("License Router Integration", () => {
         maxAgents: 50,
         maxExperiments: 50,
         canPublish: true,
+        usageUnit: "traces" as const,
       },
     });
 
@@ -442,6 +443,7 @@ describe("License Router Integration", () => {
           maxAgents: ENTERPRISE_TEMPLATE.maxAgents ?? 1000,
           maxExperiments: ENTERPRISE_TEMPLATE.maxExperiments ?? 1000,
           canPublish: true,
+          usageUnit: "traces" as const,
         },
       });
 
@@ -487,6 +489,25 @@ describe("License Router Integration", () => {
           },
         })
       ).rejects.toThrow();
+    });
+
+    it("includes usageUnit in generated license", async () => {
+      const result = await adminCaller.license.generate(getValidInput());
+
+      const parsedLicense = parseLicenseKey(result.licenseKey);
+      expect(parsedLicense?.data.plan.usageUnit).toBe("traces");
+    });
+
+    it("generates license with events usageUnit", async () => {
+      const input = {
+        ...getValidInput(),
+        plan: { ...getValidInput().plan, usageUnit: "events" as const },
+      };
+
+      const result = await adminCaller.license.generate(input);
+
+      const parsedLicense = parseLicenseKey(result.licenseKey);
+      expect(parsedLicense?.data.plan.usageUnit).toBe("events");
     });
 
     it("throws UNAUTHORIZED when member tries to generate", async () => {

--- a/langwatch/src/server/api/routers/license.ts
+++ b/langwatch/src/server/api/routers/license.ts
@@ -26,6 +26,7 @@ const planLimitsSchema = z.object({
   maxAgents: z.number().int().positive("Plan limits must be positive numbers"),
   maxExperiments: z.number().int().positive("Plan limits must be positive numbers"),
   canPublish: z.boolean(),
+  usageUnit: z.enum(["traces", "events"]),
 });
 
 /** Schema for license generation input */
@@ -174,6 +175,7 @@ export const licenseRouter = createTRPCRouter({
           maxAgents: plan.maxAgents,
           maxExperiments: plan.maxExperiments,
           canPublish: plan.canPublish,
+          usageUnit: plan.usageUnit,
         },
       };
 


### PR DESCRIPTION
## Summary

- Adds an optional `usageUnit` field to the license schema so self-hosted customers can control whether usage is counted as **traces** or **events** (traces + evaluations + experiments)
- Uses `z.string().optional()` in the license schema for forward compatibility (future values won't break old deployments), with `z.enum()` constraint only in the generation form
- Normalizes unknown values to `"traces"` in `resolvePlanDefaults()` and defaults missing values to `"traces"` for backward compat with existing licenses
- Adds Usage Unit dropdown to the license generator form

## Test plan

- [x] `pnpm test:unit ee/licensing` — 99 tests pass (defaults, mapping, templates, backward compat)
- [x] `pnpm test:unit src/components/license` — 48 tests pass (form defaults)
- [ ] `pnpm test:integration src/server/api/routers/__tests__/license` — validates end-to-end generation with both values (requires Prisma client)
- [x] Legacy licenses without `usageUnit` resolve to `"traces"` via `resolvePlanDefaults()`
- [x] Unknown future values (e.g. `"spans"`) parse successfully but normalize to `"traces"`