### PR TITLE
feat(billing): add subscription override support for all plan limit fields

### DIFF
--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -5,6 +5,7 @@ vi.mock("../notifications/notificationHandlers", () => ({
 }));
 
 import { notifySubscriptionEvent } from "../notifications/notificationHandlers";
+import { NUMERIC_OVERRIDE_FIELDS } from "../planProvider";
 import { SubscriptionStatus } from "../planTypes";
 import { createWebhookService } from "../services/webhookService";
 
@@ -194,7 +195,7 @@ describe("webhookService", () => {
     });
 
     describe("when subscription exists", () => {
-      it("cancels and nullifies limits", async () => {
+      it("cancels and nullifies all override fields", async () => {
         db.subscription.findUnique.mockResolvedValue({
           id: "sub_db_1",
         });
@@ -204,15 +205,16 @@ describe("webhookService", () => {
           stripeSubscriptionId: "sub_stripe_1",
         });
 
+        const expectedNulledFields = Object.fromEntries(
+          NUMERIC_OVERRIDE_FIELDS.map((f) => [f, null]),
+        );
+
         expect(db.subscription.update).toHaveBeenCalledWith({
           where: { id: "sub_db_1" },
           data: {
             status: SubscriptionStatus.CANCELLED,
             endDate: expect.any(Date),
-            maxMembers: null,
-            maxMessagesPerMonth: null,
-            maxProjects: null,
-            evaluationsCredit: null,
+            ...expectedNulledFields,
           },
         });
       });

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -2,6 +2,7 @@ import { Currency, type PrismaClient } from "@prisma/client";
 import type Stripe from "stripe";
 import { createLogger } from "../../../src/utils/logger";
 import { notifySubscriptionEvent } from "../notifications/notificationHandlers";
+import { NUMERIC_OVERRIDE_FIELDS } from "../planProvider";
 import { PlanTypes, SubscriptionStatus } from "../planTypes";
 import type { calculateQuantityForPrice, prices } from "./subscriptionItemCalculator";
 import { isGrowthEventsPrice, isGrowthSeatEventPlan, isGrowthSeatPrice } from "../utils/growthSeatEvent";
@@ -175,10 +176,7 @@ export const createWebhookService = ({
   const cancellationData = () => ({
     status: SubscriptionStatus.CANCELLED,
     endDate: new Date(),
-    maxMembers: null,
-    maxMessagesPerMonth: null,
-    maxProjects: null,
-    evaluationsCredit: null,
+    ...Object.fromEntries(NUMERIC_OVERRIDE_FIELDS.map((f) => [f, null])),
   });
 
   return {

--- a/langwatch/prisma/migrations/20260227120000_add_subscription_limit_overrides/migration.sql
+++ b/langwatch/prisma/migrations/20260227120000_add_subscription_limit_overrides/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "Subscription" ADD COLUMN     "maxMembersLite" INTEGER,
+ADD COLUMN     "maxTeams" INTEGER,
+ADD COLUMN     "maxPrompts" INTEGER,
+ADD COLUMN     "maxEvaluators" INTEGER,
+ADD COLUMN     "maxScenarios" INTEGER,
+ADD COLUMN     "maxAgents" INTEGER,
+ADD COLUMN     "maxExperiments" INTEGER,
+ADD COLUMN     "maxOnlineEvaluations" INTEGER,
+ADD COLUMN     "maxDatasets" INTEGER,
+ADD COLUMN     "maxDashboards" INTEGER,
+ADD COLUMN     "maxCustomGraphs" INTEGER,
+ADD COLUMN     "maxAutomations" INTEGER;

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -1093,6 +1093,18 @@ model Subscription {
     evaluationsCredit     Int?
     maxWorkflows          Int?
     maxRetentionDays      Int?
+    maxMembersLite        Int?
+    maxTeams              Int?
+    maxPrompts            Int?
+    maxEvaluators         Int?
+    maxScenarios          Int?
+    maxAgents             Int?
+    maxExperiments        Int?
+    maxOnlineEvaluations  Int?
+    maxDatasets           Int?
+    maxDashboards         Int?
+    maxCustomGraphs       Int?
+    maxAutomations        Int?
 
     organization Organization @relation(fields: [organizationId], references: [id])
     invoices     Invoice[]

--- a/specs/licensing/subscription-limit-overrides.feature
+++ b/specs/licensing/subscription-limit-overrides.feature
@@ -1,0 +1,171 @@
+@unit
+Feature: Subscription Limit Overrides
+  As a LangWatch Cloud operator
+  I want per-subscription overrides to take precedence over plan defaults
+  So that I can customize limits for individual organizations without creating new plans
+
+  Background:
+    Given a SaaS organization with an active subscription on a known plan
+
+  # ============================================================================
+  # Existing Overrides Still Work
+  # ============================================================================
+
+  Scenario: Subscription with a member override uses that value
+    Given the subscription overrides member capacity to 20
+    When the plan is resolved for the organization
+    Then the plan allows 20 members
+
+  Scenario: Subscription with a project override uses that value
+    Given the subscription overrides project capacity to 50
+    When the plan is resolved for the organization
+    Then the plan allows 50 projects
+
+  Scenario: Subscription with a monthly message override uses that value
+    Given the subscription overrides monthly message capacity to 500000
+    When the plan is resolved for the organization
+    Then the plan allows 500000 messages per month
+
+  Scenario: Subscription with an evaluations credit override uses that value
+    Given the subscription overrides evaluations credit to 100
+    When the plan is resolved for the organization
+    Then the plan allows 100 evaluations credits
+
+  # ============================================================================
+  # Bug Fix: maxWorkflows Override Is Applied
+  # ============================================================================
+
+  Scenario: Subscription with a workflow override uses that value
+    Given the subscription overrides workflow capacity to 25
+    When the plan is resolved for the organization
+    Then the plan allows 25 workflows
+
+  # ============================================================================
+  # New Numeric Overrides Are Applied
+  # ============================================================================
+
+  Scenario: Subscription with a lite-member override uses that value
+    Given the subscription overrides lite-member capacity to 15
+    When the plan is resolved for the organization
+    Then the plan allows 15 lite members
+
+  Scenario: Subscription with a team override uses that value
+    Given the subscription overrides team capacity to 10
+    When the plan is resolved for the organization
+    Then the plan allows 10 teams
+
+  Scenario: Subscription with a prompt override uses that value
+    Given the subscription overrides prompt capacity to 30
+    When the plan is resolved for the organization
+    Then the plan allows 30 prompts
+
+  Scenario: Subscription with an evaluator override uses that value
+    Given the subscription overrides evaluator capacity to 40
+    When the plan is resolved for the organization
+    Then the plan allows 40 evaluators
+
+  Scenario: Subscription with a scenario override uses that value
+    Given the subscription overrides scenario capacity to 20
+    When the plan is resolved for the organization
+    Then the plan allows 20 scenarios
+
+  Scenario: Subscription with an agent override uses that value
+    Given the subscription overrides agent capacity to 12
+    When the plan is resolved for the organization
+    Then the plan allows 12 agents
+
+  Scenario: Subscription with an experiment override uses that value
+    Given the subscription overrides experiment capacity to 50
+    When the plan is resolved for the organization
+    Then the plan allows 50 experiments
+
+  Scenario: Subscription with an online-evaluation override uses that value
+    Given the subscription overrides online-evaluation capacity to 18
+    When the plan is resolved for the organization
+    Then the plan allows 18 online evaluations
+
+  Scenario: Subscription with a dataset override uses that value
+    Given the subscription overrides dataset capacity to 25
+    When the plan is resolved for the organization
+    Then the plan allows 25 datasets
+
+  Scenario: Subscription with a dashboard override uses that value
+    Given the subscription overrides dashboard capacity to 8
+    When the plan is resolved for the organization
+    Then the plan allows 8 dashboards
+
+  Scenario: Subscription with a custom-graph override uses that value
+    Given the subscription overrides custom-graph capacity to 15
+    When the plan is resolved for the organization
+    Then the plan allows 15 custom graphs
+
+  Scenario: Subscription with an automation override uses that value
+    Given the subscription overrides automation capacity to 22
+    When the plan is resolved for the organization
+    Then the plan allows 22 automations
+
+  # ============================================================================
+  # Null Overrides Fall Back to Plan Defaults
+  # ============================================================================
+
+  Scenario: Null override fields use the plan default values
+    Given the subscription has no overrides set
+    When the plan is resolved for the organization
+    Then all limits match the base plan defaults
+
+  Scenario: Only non-null overrides replace plan defaults
+    Given the subscription overrides member capacity to 20
+    And all other override fields are null
+    When the plan is resolved for the organization
+    Then the plan allows 20 members
+    And all other limits match the base plan defaults
+
+  # ============================================================================
+  # Zero Values Are Preserved
+  # ============================================================================
+
+  Scenario: Zero override for lite members is applied as zero
+    Given the subscription overrides lite-member capacity to 0
+    When the plan is resolved for the organization
+    Then the plan allows 0 lite members
+
+  Scenario: Zero override for workflows is applied as zero
+    Given the subscription overrides workflow capacity to 0
+    When the plan is resolved for the organization
+    Then the plan allows 0 workflows
+
+  # ============================================================================
+  # Multiple Overrides Combine
+  # ============================================================================
+
+  Scenario: Several overrides are applied together
+    Given the subscription overrides member capacity to 20
+    And the subscription overrides workflow capacity to 50
+    And the subscription overrides prompt capacity to 30
+    And the subscription overrides monthly message capacity to 200000
+    When the plan is resolved for the organization
+    Then the plan allows 20 members
+    And the plan allows 50 workflows
+    And the plan allows 30 prompts
+    And the plan allows 200000 messages per month
+    And all non-overridden limits match the base plan defaults
+
+  # ============================================================================
+  # Unknown Plan Key Falls Back to Free With Overrides
+  # ============================================================================
+
+  Scenario: Override on subscription with unknown plan applies over free defaults
+    Given the subscription plan key is not recognized
+    And the subscription overrides workflow capacity to 50
+    When the plan is resolved for the organization
+    Then the plan type is FREE
+    And the plan allows 50 workflows
+
+  # ============================================================================
+  # Cancellation Clears All Override Fields
+  # ============================================================================
+
+  Scenario: Cancelled subscription nullifies all override fields
+    Given the subscription had overrides for multiple limits
+    When the subscription is cancelled
+    Then all override fields are cleared


### PR DESCRIPTION
## Summary

- Add 12 nullable `Int?` override columns to `Subscription` model for all `PlanInfo` limit fields that were previously missing (`maxMembersLite`, `maxTeams`, `maxPrompts`, `maxEvaluators`, `maxScenarios`, `maxAgents`, `maxExperiments`, `maxOnlineEvaluations`, `maxDatasets`, `maxDashboards`, `maxCustomGraphs`, `maxAutomations`)
- Replace 4 hardcoded if-statements in `planProvider` with a type-safe data-driven loop over all 17 numeric override fields, fixing the `maxWorkflows` override bug (column existed but was never applied)
- Update `cancellationData()` in webhook service to null all 17 override fields via shared `NUMERIC_OVERRIDE_FIELDS` array

## Test plan

- [x] `pnpm test:unit ee/billing/__tests__/planProvider.unit.test.ts` — 34 tests pass (new override fields, maxWorkflows fix, zero-value preservation, unknown plan fallback)
- [x] `pnpm test:unit ee/billing/__tests__/webhookService.unit.test.ts` — 12 tests pass (cancellation nullifies all 17 fields)
- [x] `pnpm typecheck` — no type errors (intersection type catches mismatches between PlanInfo and Subscription)
- [x] Prisma migration applies cleanly