### PR TITLE
fix: import getApp directly to avoid circular dependency

### DIFF
--- a/langwatch/src/server/api/routers/plan.ts
+++ b/langwatch/src/server/api/routers/plan.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { getApp } from "~/server/app-layer";
+import { getApp } from "~/server/app-layer/app";
 import { checkOrganizationPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -15,7 +15,7 @@ import {
   protectedProcedure,
   publicProcedure,
 } from "~/server/api/trpc";
-import { getApp } from "~/server/app-layer";
+import { getApp } from "~/server/app-layer/app";
 import { encrypt } from "~/utils/encryption";
 import { slugify } from "~/utils/slugify";
 import { auditLog } from "../../auditLog";

--- a/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { on } from "node:events";
 import { z } from "zod";
-import { getApp } from "~/server/app-layer";
+import { getApp } from "~/server/app-layer/app";
 import { SimulationService } from "~/server/simulations/simulation.service";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { createLogger } from "~/utils/logger/server";

--- a/langwatch/src/server/api/routers/team.ts
+++ b/langwatch/src/server/api/routers/team.ts
@@ -2,7 +2,7 @@ import { TeamUserRole } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { getApp } from "~/server/app-layer";
+import { getApp } from "~/server/app-layer/app";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { slugify } from "~/utils/slugify";
 import { checkOrganizationPermission, checkTeamPermission } from "../rbac";

--- a/langwatch/src/server/api/routers/traces.ts
+++ b/langwatch/src/server/api/routers/traces.ts
@@ -8,7 +8,7 @@ import {
   protectedProcedure,
   publicProcedure,
 } from "~/server/api/trpc";
-import { getApp } from "~/server/app-layer";
+import { getApp } from "~/server/app-layer/app";
 import { formatSpansDigest } from "~/server/tracer/spanToReadableSpan";
 import { TraceService } from "~/server/traces/trace.service";
 import { createLogger } from "~/utils/logger/server";


### PR DESCRIPTION
## Summary

- Fixes `ReferenceError: Cannot access 'f' before initialization` at `createTRPCRouter` caused by circular dependency introduced in #1867
- Changed `getApp` imports from barrel `~/server/app-layer` to direct `~/server/app-layer/app` in 5 router files, matching the pattern already used by `organization.ts` and `evaluations.ts`

**Root cause:** The barrel import triggers turbopack to load the full `presets.ts` → `ee/billing/index.ts` → `ee/billing/subscriptionRouter.ts` chain, which imports `createTRPCRouter` from `trpc.ts` before it has finished initializing.

## Test plan

- [ ] Verify the app starts without the `ReferenceError` in CI
- [ ] Verify tRPC routes for plan, project, team, traces, and scenarios still work