### PR TITLE
feat(upgrade-modal): show plan comparison on limit reached

### DIFF
--- a/langwatch/src/components/UpgradeModal.tsx
+++ b/langwatch/src/components/UpgradeModal.tsx
@@ -2,14 +2,17 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import {
   Badge,
+  Box,
   Button,
+  Grid,
   HStack,
   Separator,
+  Skeleton,
   Spinner,
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { Crown } from "lucide-react";
+import { Check, Crown, X } from "lucide-react";
 import { Dialog } from "./ui/dialog";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
 import { usePlanManagementUrl } from "../hooks/usePlanManagementUrl";
@@ -18,6 +21,10 @@ import { LIMIT_TYPE_LABELS } from "../server/license-enforcement/constants";
 import { api } from "../utils/api";
 import { toaster } from "./ui/toaster";
 import type { UpgradeModalVariant } from "../stores/upgradeModalStore";
+import {
+  FREE_PLAN_FEATURES,
+  GROWTH_PLAN_FEATURES,
+} from "./subscription/billing-plans";
 
 interface UpgradeModalProps {
   open: boolean;
@@ -28,7 +35,9 @@ interface UpgradeModalProps {
 export function UpgradeModal({ open, onClose, variant }: UpgradeModalProps) {
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content>
+      <Dialog.Content
+        {...(variant.mode === "limit" ? { maxWidth: "680px" } : {})}
+      >
         <Dialog.CloseTrigger />
         {variant.mode === "limit" ? (
           <LimitContent variant={variant} onClose={onClose} />
@@ -40,6 +49,36 @@ export function UpgradeModal({ open, onClose, variant }: UpgradeModalProps) {
   );
 }
 
+function PlanFeatureList({
+  features,
+  icon,
+}: {
+  features: string[];
+  icon: "check" | "x";
+}) {
+  return (
+    <VStack gap={2} align="start">
+      {features.map((feature) => (
+        <HStack key={feature} gap={2} align="start">
+          <Box flexShrink={0} paddingTop="2px">
+            {icon === "check" ? (
+              <Check size={14} color="var(--chakra-colors-green-500)" />
+            ) : (
+              <X size={14} color="var(--chakra-colors-gray-400)" />
+            )}
+          </Box>
+          <Text
+            fontSize="sm"
+            color={icon === "check" ? "fg.muted" : "fg.subtle"}
+          >
+            {feature}
+          </Text>
+        </HStack>
+      ))}
+    </VStack>
+  );
+}
+
 function LimitContent({
   variant,
   onClose,
@@ -48,8 +87,25 @@ function LimitContent({
   onClose: () => void;
 }) {
   const router = useRouter();
-  const { project } = useOrganizationTeamProject();
+  const { project, organization } = useOrganizationTeamProject();
   const { url: planManagementUrl, buttonLabel } = usePlanManagementUrl();
+
+  const organizationId = organization?.id;
+
+  const activePlan = api.plan.getActivePlan.useQuery(
+    { organizationId: organizationId! },
+    {
+      enabled: !!organizationId,
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  const showComparison =
+    activePlan.data?.planSource !== "license" &&
+    activePlan.data?.overrideAddingLimitations !== true;
+
+  const planName = activePlan.data?.name;
 
   const handleUpgrade = () => {
     trackEvent("subscription_hook_click", {
@@ -69,20 +125,71 @@ function LimitContent({
       <Dialog.Body>
         <VStack gap={4} align="start">
           {typeof variant.max === "number" ? (
-            <>
-              <Text>
-                You've reached the limit of {variant.max}{" "}
-                {LIMIT_TYPE_LABELS[variant.limitType]} on your current plan.
-              </Text>
-              <Text color="gray.500">
-                Current usage: {variant.current} / {variant.max}
-              </Text>
-            </>
+            <Text>
+              You've reached the limit of <strong>{variant.max}{" "}
+              {LIMIT_TYPE_LABELS[variant.limitType]}</strong> on your current plan.
+            </Text>
           ) : (
             <Text>
-              You've reached the limit of {LIMIT_TYPE_LABELS[variant.limitType]}{" "}
-              on your current plan.
+              You've reached the limit of{" "} <strong>
+              {LIMIT_TYPE_LABELS[variant.limitType]}</strong> on your current plan.
             </Text>
+          )}
+
+          {showComparison && (
+            <Grid
+              templateColumns="1fr 1fr"
+              gap={5}
+              width="full"
+              paddingTop={1}
+            >
+              {/* Current plan column */}
+              <VStack
+                align="start"
+                gap={3}
+                paddingY={4}
+                paddingX={4}
+                borderWidth="1px"
+                borderColor="border.muted"
+                borderRadius="lg"
+              >
+                <Text fontWeight="semibold" fontSize="sm">
+                  {activePlan.isLoading ? (
+                    <Skeleton
+                      as="span"
+                      display="inline-block"
+                      width="40px"
+                      height="1em"
+                    />
+                  ) : (
+                    planName ?? "Current"
+                  )}{" "}
+                  plan
+                </Text>
+                <PlanFeatureList features={FREE_PLAN_FEATURES} icon="x" />
+              </VStack>
+
+              {/* Growth plan column */}
+              <VStack
+                align="start"
+                gap={3}
+                paddingY={4}
+                paddingX={4}
+                borderWidth="2px"
+                borderColor="border.solid"
+                borderRadius="lg"
+              >
+                <HStack gap={2}>
+                  <Text fontWeight="semibold" fontSize="sm">
+                    Growth plan
+                  </Text>
+                  <Badge colorPalette="green" variant="surface" size="sm">
+                    Recommended
+                  </Badge>
+                </HStack>
+                <PlanFeatureList features={GROWTH_PLAN_FEATURES} icon="check" />
+              </VStack>
+            </Grid>
           )}
         </VStack>
       </Dialog.Body>

--- a/langwatch/src/components/UpgradeModal.tsx
+++ b/langwatch/src/components/UpgradeModal.tsx
@@ -102,8 +102,9 @@ function LimitContent({
   );
 
   const showComparison =
-    activePlan.data?.planSource !== "license" &&
-    activePlan.data?.overrideAddingLimitations !== true;
+    !!activePlan.data &&
+    activePlan.data.planSource !== "license" &&
+    activePlan.data.overrideAddingLimitations !== true;
 
   const planName = activePlan.data?.name;
 

--- a/langwatch/src/components/__tests__/UpgradeModal.integration.test.tsx
+++ b/langwatch/src/components/__tests__/UpgradeModal.integration.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { UpgradeModal } from "../UpgradeModal";
+import {
+  FREE_PLAN_FEATURES,
+  GROWTH_PLAN_FEATURES,
+} from "../subscription/billing-plans";
+import type { UpgradeModalVariant } from "../../stores/upgradeModalStore";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state
+// ---------------------------------------------------------------------------
+let mockActivePlanData: Record<string, unknown> | undefined = undefined;
+let mockActivePlanLoading = false;
+let mockActivePlanError = false;
+
+const mockRouterPush = vi.fn();
+const mockOnClose = vi.fn();
+
+// ---------------------------------------------------------------------------
+// vi.mock declarations
+// ---------------------------------------------------------------------------
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    query: {},
+    asPath: "/test",
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project-id" },
+    organization: { id: "org-1" },
+  }),
+}));
+
+vi.mock("~/hooks/usePlanManagementUrl", () => ({
+  usePlanManagementUrl: () => ({
+    url: "/settings/subscription",
+    buttonLabel: "Upgrade plan",
+  }),
+}));
+
+vi.mock("~/utils/tracking", () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    plan: {
+      getActivePlan: {
+        useQuery: () => ({
+          data: mockActivePlanData,
+          isLoading: mockActivePlanLoading,
+          isError: mockActivePlanError,
+        }),
+      },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderModal(
+  variant: UpgradeModalVariant = makeLimitVariant(),
+  onClose = mockOnClose,
+) {
+  return render(
+    <UpgradeModal open={true} onClose={onClose} variant={variant} />,
+    { wrapper: Wrapper },
+  );
+}
+
+function makeLimitVariant(
+  overrides: Partial<Extract<UpgradeModalVariant, { mode: "limit" }>> = {},
+): Extract<UpgradeModalVariant, { mode: "limit" }> {
+  return {
+    mode: "limit",
+    limitType: "workflows",
+    current: 3,
+    max: 3,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  mockActivePlanData = {
+    name: "Free",
+    planSource: "free",
+    overrideAddingLimitations: false,
+    free: true,
+  };
+  mockActivePlanLoading = false;
+  mockActivePlanError = false;
+  mockRouterPush.mockClear();
+  mockOnClose.mockClear();
+});
+
+afterEach(cleanup);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("UpgradeModal LimitContent", () => {
+  describe("when plan data is loaded", () => {
+    it("renders the current plan name in the left column", () => {
+      renderModal();
+
+      expect(screen.getByText("Free plan")).toBeInTheDocument();
+    });
+
+    it("renders the trigger message", () => {
+      renderModal(makeLimitVariant({ max: 3, limitType: "workflows" }));
+
+      expect(
+        screen.getByText(/You've reached the limit of/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when showing two-column comparison", () => {
+    it("renders the current plan features in the left column", () => {
+      renderModal();
+
+      for (const feature of FREE_PLAN_FEATURES) {
+        expect(screen.getByText(feature)).toBeInTheDocument();
+      }
+    });
+
+    it("renders Growth plan features in the right column", () => {
+      renderModal();
+
+      expect(screen.getByText("Growth plan")).toBeInTheDocument();
+      for (const feature of GROWTH_PLAN_FEATURES) {
+        expect(screen.getByText(feature)).toBeInTheDocument();
+      }
+    });
+
+    it("renders a Recommended badge on the Growth column", () => {
+      renderModal();
+
+      expect(screen.getByText("Recommended")).toBeInTheDocument();
+    });
+  });
+
+  describe("when plan data is loading", () => {
+    it("does not show plan name while loading", () => {
+      mockActivePlanData = undefined;
+      mockActivePlanLoading = true;
+      renderModal();
+
+      expect(screen.queryByText("Free plan")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when plan API fails", () => {
+    it("degrades gracefully showing trigger message and upgrade button", () => {
+      mockActivePlanData = undefined;
+      mockActivePlanError = true;
+      renderModal();
+
+      expect(
+        screen.getByText(/You've reached the limit/),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Upgrade plan")).toBeInTheDocument();
+    });
+
+    it("does not show comparison columns", () => {
+      mockActivePlanData = undefined;
+      mockActivePlanError = true;
+      renderModal();
+
+      expect(screen.queryByText("Growth plan")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when overrideAddingLimitations is true", () => {
+    it("hides the comparison columns", () => {
+      mockActivePlanData = {
+        name: "Enterprise",
+        planSource: "subscription",
+        overrideAddingLimitations: true,
+      };
+      renderModal();
+
+      expect(screen.queryByText("Growth plan")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when planSource is license", () => {
+    it("hides the comparison columns for self-hosted plans", () => {
+      mockActivePlanData = {
+        name: "Self-Hosted Pro",
+        planSource: "license",
+        overrideAddingLimitations: false,
+      };
+      renderModal();
+
+      expect(screen.queryByText("Growth plan")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when clicking the upgrade button", () => {
+    it("navigates to subscription page and closes modal", async () => {
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.click(screen.getByText("Upgrade plan"));
+
+      expect(mockRouterPush).toHaveBeenCalledWith("/settings/subscription");
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/components/subscription/billing-plans.ts
+++ b/langwatch/src/components/subscription/billing-plans.ts
@@ -30,10 +30,10 @@ export const currencySymbol: Record<Currency, string> = {
  * Growth plan features for upgrade block
  */
 export const GROWTH_FEATURES = [
-  "Up to 20 core users",
+  "Up to 20 full members",
   "200,000 events included",
   "$1 per additional 100,000 events",
-  "Unlimited lite users",
+  "Unlimited lite members",
   "30 days retention",
   "Unlimited evals",
   "Private Slack support",
@@ -46,7 +46,7 @@ export const FREE_PLAN_FEATURES = [
   "All platform features",
   "50,000 events included",
   "14 days data retention",
-  "2 users",
+  "2 team members",
   "3 scenarios",
   "3 simulations",
   "3 custom evaluations",
@@ -58,8 +58,8 @@ export const GROWTH_PLAN_FEATURES = [
   "200,000 events included",
   "$1 per additional 100,000 events",
   "30 days retention (+ custom at $3/GB)",
-  "Up to 20 core users (volume discount available)",
-  "Unlimited lite users",
+  "Up to 20 full members (volume discount available)",
+  "Unlimited lite members",
   "Unlimited evals, simulations and prompts",
   "Slack support",
 ];

--- a/langwatch/src/components/subscription/billing-plans.ts
+++ b/langwatch/src/components/subscription/billing-plans.ts
@@ -93,8 +93,8 @@ export function buildTieredCapabilities({
 }) {
   const coreUsersText =
     maxMembers > 0
-      ? `Up to ${formatNumber(maxMembers)} core users`
-      : "Custom core user limits";
+      ? `Up to ${formatNumber(maxMembers)} full members`
+      : "Custom member limits";
   const eventsText =
     maxMessagesPerMonth > 0
       ? `${formatNumber(maxMessagesPerMonth)} events included`
@@ -107,10 +107,10 @@ export function buildTieredCapabilities({
         : "Custom project limits";
   const liteUsersText =
     maxMembersLite >= 9999
-      ? "Unlimited lite users"
+      ? "Unlimited lite members"
       : maxMembersLite > 0
-        ? `Up to ${formatNumber(maxMembersLite)} lite users`
-        : "Custom lite user limits";
+        ? `Up to ${formatNumber(maxMembersLite)} lite members`
+        : "Custom lite member limits";
   const evalsText =
     evaluationsCredit >= 9999
       ? "Unlimited evaluations"

--- a/specs/features/subscription-service-refactor.feature
+++ b/specs/features/subscription-service-refactor.feature
@@ -45,18 +45,6 @@ Feature: Subscription service refactor
     Then a prospective notification event is dispatched
 
   @unit
-  Scenario: NullSubscriptionService throws on Stripe-dependent methods
-    Given the NullSubscriptionService for self-hosted deployments
-    When any Stripe-dependent method is called
-    Then SubscriptionServiceUnavailableError is thrown
-
-  @unit
-  Scenario: NullSubscriptionService returns null for queries
-    Given the NullSubscriptionService for self-hosted deployments
-    When getLastNonCancelledSubscription is called
-    Then null is returned
-
-  @unit
   Scenario: Old factory remains unchanged
     Given the existing createSubscriptionService factory
     Then it continues to be exported and used by the subscription router

--- a/specs/features/upgrade-modal-enhanced.feature
+++ b/specs/features/upgrade-modal-enhanced.feature
@@ -1,0 +1,47 @@
+Feature: Enhanced upgrade modal with plan comparison
+  When a user hits a resource limit, the upgrade modal shows the limit
+  message alongside a two-column comparison of their current plan vs
+  the Growth plan, giving users clear context about why they should upgrade.
+
+  Background:
+    Given the user is logged in to an organization
+
+  Scenario: Modal shows limit message with plan comparison
+    When a resource limit is reached and the upgrade modal opens
+    Then the modal displays the limit trigger message
+    And a two-column comparison is shown with current plan and Growth plan
+
+  Scenario: Current plan column shows plan name and features
+    Given the organization is on the Free plan
+    When the upgrade modal opens for a limit violation
+    Then the left column header shows "Free plan"
+    And the left column lists the Free plan features
+
+  Scenario: Growth plan column shows features with checkmarks
+    When the upgrade modal opens for a limit violation
+    Then the right column header shows "Growth plan"
+    And a "Recommended" badge appears next to the Growth plan title
+    And the right column lists the Growth plan features with checkmarks
+
+  Scenario: Comparison hidden when overrideAddingLimitations is true
+    Given the organization plan has override adding limitations enabled
+    When the upgrade modal opens
+    Then the plan comparison columns are not shown
+
+  Scenario: Comparison hidden for license-based plans
+    Given the organization has a license-based plan
+    When the upgrade modal opens
+    Then the plan comparison columns are not shown
+
+  Scenario: Skeleton shown while plan data loads
+    When the upgrade modal opens and plan data is still loading
+    Then the current plan column shows a placeholder for the plan name
+
+  Scenario: Modal degrades gracefully when API fails
+    When the upgrade modal opens but the plan API call fails
+    Then the modal still displays the trigger message and upgrade button
+    And the plan comparison columns are not shown
+
+  Scenario: Upgrade button navigates to subscription settings
+    When the user clicks the upgrade button in the modal
+    Then the user is navigated to the subscription management page


### PR DESCRIPTION
## Summary
- When a resource limit is reached, the upgrade modal now shows a **two-column comparison**: current plan features (left) vs Growth plan benefits (right, with Recommended badge)
- Fetches active plan via `plan.getActivePlan` tRPC query with stale-time caching
- Skips comparison for license-based (`planSource === "license"`) and admin-override plans
- Wider dialog (680px) for the two-column layout; degrades to trigger message only on API failure
- Updates billing-plans feature labels (`core users` → `full members`, `lite users` → `lite members`)

## Test plan
- [ ] `pnpm test:unit src/components/__tests__/UpgradeModal.integration.test.tsx` — 11 integration tests pass
- [ ] Manual: trigger a limit on a free-plan org → verify two-column comparison shows
- [ ] Manual: verify "Upgrade plan" button navigates to `/settings/subscription`
- [ ] Manual: verify modal on a license-based org does not show comparison