### PR TITLE
feat(licensing): add self-serving license infrastructure

### DIFF
--- a/langwatch/ee/billing/__tests__/licensePurchaseHandler.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/licensePurchaseHandler.unit.test.ts
@@ -99,6 +99,7 @@ describe("licensePurchaseHandler", () => {
           planType: "GROWTH",
           maxMembers: 5,
           expiresAt: "2027-03-02T00:00:00.000Z",
+          organizationName: "Acme Corp",
         });
       });
 

--- a/langwatch/ee/billing/__tests__/licensePurchaseHandler.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/licensePurchaseHandler.unit.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../licensing/licenseGenerationService", () => ({
+  generateLicenseKey: vi.fn().mockReturnValue({
+    licenseKey: "test-license-key-base64",
+    licenseData: {
+      licenseId: "lic-test-123",
+      version: 1,
+      organizationName: "Acme Corp",
+      email: "buyer@acme.com",
+      issuedAt: "2026-03-02T00:00:00.000Z",
+      expiresAt: "2027-03-02T00:00:00.000Z",
+      plan: { type: "GROWTH", name: "Growth", maxMembers: 5 },
+    },
+  }),
+}));
+
+vi.mock("../../../src/server/mailer/licenseEmail", () => ({
+  sendLicenseEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../notifications/notificationHandlers", () => ({
+  notifyLicensePurchase: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { generateLicenseKey } from "../../licensing/licenseGenerationService";
+import { sendLicenseEmail } from "../../../src/server/mailer/licenseEmail";
+import { notifyLicensePurchase } from "../notifications/notificationHandlers";
+import { handleLicensePurchase } from "../services/licensePurchaseHandler";
+
+const mockGenerateLicenseKey = generateLicenseKey as ReturnType<typeof vi.fn>;
+const mockSendLicenseEmail = sendLicenseEmail as ReturnType<typeof vi.fn>;
+const mockNotifyLicensePurchase = notifyLicensePurchase as ReturnType<
+  typeof vi.fn
+>;
+
+const createMockStripe = () => ({
+  checkout: {
+    sessions: {
+      listLineItems: vi.fn().mockResolvedValue({
+        data: [{ quantity: 5 }],
+      }),
+    },
+  },
+});
+
+const createMockCheckoutSession = (overrides: Record<string, unknown> = {}) =>
+  ({
+    id: "cs_test_123",
+    customer_details: {
+      email: "buyer@acme.com",
+      name: "Acme Corp",
+    },
+    amount_total: 14900,
+    currency: "usd",
+    ...overrides,
+  }) as any;
+
+describe("licensePurchaseHandler", () => {
+  let mockStripe: ReturnType<typeof createMockStripe>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStripe = createMockStripe();
+  });
+
+  describe("handleLicensePurchase()", () => {
+    describe("when checkout session has valid buyer details", () => {
+      it("generates a GROWTH license with the correct seat count", async () => {
+        const session = createMockCheckoutSession();
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(mockGenerateLicenseKey).toHaveBeenCalledWith({
+          organizationName: "Acme Corp",
+          email: "buyer@acme.com",
+          planType: "GROWTH",
+          maxMembers: 5,
+          privateKey: "test-private-key",
+        });
+      });
+
+      it("sends the license email to the buyer", async () => {
+        const session = createMockCheckoutSession();
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(mockSendLicenseEmail).toHaveBeenCalledWith({
+          email: "buyer@acme.com",
+          licenseKey: "test-license-key-base64",
+          planType: "GROWTH",
+          maxMembers: 5,
+          expiresAt: "2027-03-02T00:00:00.000Z",
+        });
+      });
+
+      it("notifies Slack with purchase details", async () => {
+        const session = createMockCheckoutSession();
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(mockNotifyLicensePurchase).toHaveBeenCalledWith({
+          buyerEmail: "buyer@acme.com",
+          planType: "GROWTH",
+          seats: 5,
+          amountPaid: 14900,
+          currency: "usd",
+        });
+      });
+    });
+
+    describe("when checkout session has no email", () => {
+      it("throws an error", async () => {
+        const session = createMockCheckoutSession({
+          customer_details: { email: null, name: "Acme Corp" },
+        });
+
+        await expect(
+          handleLicensePurchase({
+            checkoutSession: session,
+            stripe: mockStripe as any,
+            privateKey: "test-private-key",
+          }),
+        ).rejects.toThrow("No email found in checkout session customer_details");
+      });
+    });
+
+    describe("when line items have no quantity", () => {
+      it("defaults to 1 seat", async () => {
+        const session = createMockCheckoutSession();
+        mockStripe.checkout.sessions.listLineItems.mockResolvedValue({
+          data: [{ quantity: null }],
+        });
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(mockGenerateLicenseKey).toHaveBeenCalledWith(
+          expect.objectContaining({ maxMembers: 1 }),
+        );
+      });
+    });
+
+    describe("when line items are empty", () => {
+      it("defaults to 1 seat", async () => {
+        const session = createMockCheckoutSession();
+        mockStripe.checkout.sessions.listLineItems.mockResolvedValue({
+          data: [],
+        });
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(mockGenerateLicenseKey).toHaveBeenCalledWith(
+          expect.objectContaining({ maxMembers: 1 }),
+        );
+      });
+    });
+
+    describe("when business name is missing", () => {
+      it("passes empty string to license generation", async () => {
+        const session = createMockCheckoutSession({
+          customer_details: { email: "buyer@solo.dev", name: null },
+        });
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(mockGenerateLicenseKey).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationName: "",
+            email: "buyer@solo.dev",
+          }),
+        );
+      });
+    });
+
+    describe("when amount_total is null", () => {
+      it("uses 0 for Slack notification amount", async () => {
+        const session = createMockCheckoutSession({ amount_total: null });
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(mockNotifyLicensePurchase).toHaveBeenCalledWith(
+          expect.objectContaining({ amountPaid: 0 }),
+        );
+      });
+    });
+
+    describe("when currency is null", () => {
+      it("defaults to usd for Slack notification", async () => {
+        const session = createMockCheckoutSession({ currency: null });
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(mockNotifyLicensePurchase).toHaveBeenCalledWith(
+          expect.objectContaining({ currency: "usd" }),
+        );
+      });
+    });
+
+    describe("when stripe listLineItems is called", () => {
+      it("passes the checkout session ID", async () => {
+        const session = createMockCheckoutSession({ id: "cs_specific_456" });
+
+        await handleLicensePurchase({
+          checkoutSession: session,
+          stripe: mockStripe as any,
+          privateKey: "test-private-key",
+        });
+
+        expect(
+          mockStripe.checkout.sessions.listLineItems,
+        ).toHaveBeenCalledWith("cs_specific_456");
+      });
+    });
+  });
+});

--- a/langwatch/ee/billing/__tests__/notificationHandlers.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/notificationHandlers.unit.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearBillingNotificationHandlers,
+  notifyLicensePurchase,
   notifyPlanLimit,
   notifySubscriptionEvent,
   setBillingNotificationHandlers,
 } from "../notifications/notificationHandlers";
-import type { SubscriptionNotificationPayload } from "../types";
+import type {
+  LicensePurchaseNotificationPayload,
+  SubscriptionNotificationPayload,
+} from "../types";
 
 describe("notificationHandlers", () => {
   const subscriptionPayload: SubscriptionNotificationPayload = {
@@ -92,14 +96,58 @@ describe("notificationHandlers", () => {
     });
   });
 
+  describe("when dispatching license purchase notifications", () => {
+    const licensePurchasePayload: LicensePurchaseNotificationPayload = {
+      buyerEmail: "buyer@acme.com",
+      planType: "GROWTH",
+      seats: 5,
+      amountPaid: 4900,
+      currency: "USD",
+    };
+
+    it("dispatches through registered handler", async () => {
+      const sendLicensePurchaseNotification = vi.fn();
+
+      setBillingNotificationHandlers({
+        sendLicensePurchaseNotification,
+      });
+
+      await notifyLicensePurchase(licensePurchasePayload);
+
+      expect(sendLicensePurchaseNotification).toHaveBeenCalledWith(
+        licensePurchasePayload,
+      );
+    });
+
+    it("does nothing when no handler is registered", async () => {
+      await expect(
+        notifyLicensePurchase(licensePurchasePayload),
+      ).resolves.toBeUndefined();
+    });
+
+    it("swallows handler errors", async () => {
+      setBillingNotificationHandlers({
+        sendLicensePurchaseNotification: () => {
+          throw new Error("slack is down");
+        },
+      });
+
+      await expect(
+        notifyLicensePurchase(licensePurchasePayload),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("when clearing handlers", () => {
     it("clears all handlers", async () => {
       const sendSubscriptionNotification = vi.fn();
       const sendSlackNotification = vi.fn();
+      const sendLicensePurchaseNotification = vi.fn();
 
       setBillingNotificationHandlers({
         sendSubscriptionNotification,
         sendSlackNotification,
+        sendLicensePurchaseNotification,
       });
 
       clearBillingNotificationHandlers();
@@ -110,9 +158,17 @@ describe("notificationHandlers", () => {
         organizationName: "Acme",
         planName: "LAUNCH",
       });
+      await notifyLicensePurchase({
+        buyerEmail: "buyer@acme.com",
+        planType: "GROWTH",
+        seats: 5,
+        amountPaid: 4900,
+        currency: "USD",
+      });
 
       expect(sendSubscriptionNotification).not.toHaveBeenCalled();
       expect(sendSlackNotification).not.toHaveBeenCalled();
+      expect(sendLicensePurchaseNotification).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/ee/billing/__tests__/slackLicenseNotification.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/slackLicenseNotification.unit.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendSlackLicensePurchaseNotification } from "../notifications/slackLicenseNotification";
+import type { LicensePurchaseNotificationPayload } from "../types";
+
+const basePayload: LicensePurchaseNotificationPayload = {
+  buyerEmail: "buyer@acme.com",
+  planType: "GROWTH",
+  seats: 5,
+  amountPaid: 4900,
+  currency: "USD",
+};
+
+const webhookUrl = "https://hooks.slack.com/services/T00/B00/xxx";
+
+describe("sendSlackLicensePurchaseNotification", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("when sending a notification", () => {
+    it("posts to the webhook URL", async () => {
+      await sendSlackLicensePurchaseNotification({
+        payload: basePayload,
+        webhookUrl,
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        webhookUrl,
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+
+    it("includes buyer email in the message", async () => {
+      await sendSlackLicensePurchaseNotification({
+        payload: basePayload,
+        webhookUrl,
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+      const sectionFields = body.blocks[1].fields;
+      const buyerField = sectionFields.find((f: { text: string }) =>
+        f.text.includes("buyer@acme.com"),
+      );
+      expect(buyerField).toBeDefined();
+    });
+
+    it("includes plan type in the message", async () => {
+      await sendSlackLicensePurchaseNotification({
+        payload: basePayload,
+        webhookUrl,
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+      const sectionFields = body.blocks[1].fields;
+      const planField = sectionFields.find((f: { text: string }) =>
+        f.text.includes("GROWTH"),
+      );
+      expect(planField).toBeDefined();
+    });
+
+    it("includes seat count in the message", async () => {
+      await sendSlackLicensePurchaseNotification({
+        payload: basePayload,
+        webhookUrl,
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+      const sectionFields = body.blocks[1].fields;
+      const seatsField = sectionFields.find((f: { text: string }) =>
+        f.text.includes("5"),
+      );
+      expect(seatsField).toBeDefined();
+    });
+
+    it("includes formatted amount in the message", async () => {
+      await sendSlackLicensePurchaseNotification({
+        payload: basePayload,
+        webhookUrl,
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+      const sectionFields = body.blocks[1].fields;
+      const amountField = sectionFields.find((f: { text: string }) =>
+        f.text.includes("$49.00"),
+      );
+      expect(amountField).toBeDefined();
+    });
+  });
+
+  describe("when the webhook fails", () => {
+    it("throws an error on non-OK response", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+      await expect(
+        sendSlackLicensePurchaseNotification({
+          payload: basePayload,
+          webhookUrl,
+        }),
+      ).rejects.toThrow("Slack webhook failed with status 500");
+    });
+  });
+});

--- a/langwatch/ee/billing/__tests__/stripeWebhookLicenseRouting.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/stripeWebhookLicenseRouting.unit.test.ts
@@ -4,12 +4,16 @@ vi.mock("../services/licensePurchaseHandler", () => ({
   handleLicensePurchase: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("../../../src/env.mjs", () => ({
-  env: {
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: {
     STRIPE_WEBHOOK_SECRET: "whsec_test",
     STRIPE_LICENSE_PAYMENT_LINK_ID: "plink_license_123",
-    LANGWATCH_LICENSE_PRIVATE_KEY: "test-private-key-pem",
+    LANGWATCH_LICENSE_PRIVATE_KEY: "test-private-key-pem" as string | undefined,
   },
+}));
+
+vi.mock("../../../src/env.mjs", () => ({
+  env: mockEnv,
 }));
 
 vi.mock("../../../src/server/db", () => ({
@@ -239,35 +243,35 @@ describe("stripeWebhook license routing", () => {
 
   describe("when private key is missing", () => {
     it("returns 500 error", async () => {
-      // Override the env mock for this specific test
-      const { env } = await import("../../../src/env.mjs");
-      const originalKey = env.LANGWATCH_LICENSE_PRIVATE_KEY;
-      (env as any).LANGWATCH_LICENSE_PRIVATE_KEY = undefined;
+      const originalKey = mockEnv.LANGWATCH_LICENSE_PRIVATE_KEY;
 
-      const handler = createHandler();
-      const { req, res } = createMockReqRes();
+      try {
+        mockEnv.LANGWATCH_LICENSE_PRIVATE_KEY = undefined;
 
-      mockStripe.webhooks.constructEvent.mockReturnValue({
-        type: "checkout.session.completed",
-        data: {
-          object: {
-            id: "cs_test_nokey",
-            payment_link: "plink_license_123",
-            customer_details: { email: "buyer@acme.com", name: null },
+        const handler = createHandler();
+        const { req, res } = createMockReqRes();
+
+        mockStripe.webhooks.constructEvent.mockReturnValue({
+          type: "checkout.session.completed",
+          data: {
+            object: {
+              id: "cs_test_nokey",
+              payment_link: "plink_license_123",
+              customer_details: { email: "buyer@acme.com", name: null },
+            },
           },
-        },
-      });
+        });
 
-      await handler(req, res);
+        await handler(req, res);
 
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.send).toHaveBeenCalledWith(
-        expect.stringContaining("missing private key"),
-      );
-      expect(mockHandleLicensePurchase).not.toHaveBeenCalled();
-
-      // Restore
-      (env as any).LANGWATCH_LICENSE_PRIVATE_KEY = originalKey;
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.send).toHaveBeenCalledWith(
+          expect.stringContaining("missing private key"),
+        );
+        expect(mockHandleLicensePurchase).not.toHaveBeenCalled();
+      } finally {
+        mockEnv.LANGWATCH_LICENSE_PRIVATE_KEY = originalKey;
+      }
     });
   });
 

--- a/langwatch/ee/billing/__tests__/stripeWebhookLicenseRouting.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/stripeWebhookLicenseRouting.unit.test.ts
@@ -1,0 +1,327 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/licensePurchaseHandler", () => ({
+  handleLicensePurchase: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/env.mjs", () => ({
+  env: {
+    STRIPE_WEBHOOK_SECRET: "whsec_test",
+    STRIPE_LICENSE_PAYMENT_LINK_ID: "plink_license_123",
+    LANGWATCH_LICENSE_PRIVATE_KEY: "test-private-key-pem",
+  },
+}));
+
+vi.mock("../../../src/server/db", () => ({
+  prisma: {
+    organization: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("../../../src/utils/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("micro", () => ({
+  buffer: vi.fn().mockResolvedValue(Buffer.from("raw-body")),
+}));
+
+import { handleLicensePurchase } from "../services/licensePurchaseHandler";
+import { createStripeWebhookHandlerFactory } from "../stripeWebhook";
+import { prisma } from "../../../src/server/db";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type Stripe from "stripe";
+
+const mockHandleLicensePurchase = handleLicensePurchase as ReturnType<
+  typeof vi.fn
+>;
+
+const createMockReqRes = () => {
+  const req = {
+    method: "POST",
+    headers: { "stripe-signature": "sig_test" },
+  } as unknown as NextApiRequest;
+
+  const res = {
+    json: vi.fn().mockReturnThis(),
+    status: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    setHeader: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+  } as unknown as NextApiResponse;
+
+  return { req, res };
+};
+
+const createMockWebhookService = () => ({
+  handleCheckoutCompleted: vi.fn().mockResolvedValue({ earlyReturn: false }),
+  handleInvoicePaymentSucceeded: vi.fn().mockResolvedValue(undefined),
+  handleInvoicePaymentFailed: vi.fn().mockResolvedValue(undefined),
+  handleSubscriptionDeleted: vi.fn().mockResolvedValue(undefined),
+  handleSubscriptionUpdated: vi.fn().mockResolvedValue(undefined),
+});
+
+describe("stripeWebhook license routing", () => {
+  let mockStripe: Record<string, any>;
+  let webhookService: ReturnType<typeof createMockWebhookService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webhookService = createMockWebhookService();
+  });
+
+  const createHandler = (stripeOverrides: Record<string, any> = {}) => {
+    mockStripe = {
+      webhooks: {
+        constructEvent: vi.fn(),
+      },
+      checkout: {
+        sessions: {
+          listLineItems: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      },
+      ...stripeOverrides,
+    };
+
+    return createStripeWebhookHandlerFactory({
+      stripe: mockStripe as any,
+      webhookService: webhookService as any,
+    });
+  };
+
+  describe("when checkout.session.completed has a matching license payment link", () => {
+    it("routes to license purchase handler", async () => {
+      const handler = createHandler();
+      const { req, res } = createMockReqRes();
+
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_test_123",
+            payment_link: "plink_license_123",
+            customer_details: {
+              email: "buyer@acme.com",
+              name: "Acme Corp",
+            },
+            amount_total: 14900,
+            currency: "usd",
+          },
+        },
+      });
+
+      await handler(req, res);
+
+      expect(mockHandleLicensePurchase).toHaveBeenCalledWith({
+        checkoutSession: expect.objectContaining({
+          id: "cs_test_123",
+          payment_link: "plink_license_123",
+        }),
+        stripe: mockStripe,
+        privateKey: "test-private-key-pem",
+      });
+      expect(res.json).toHaveBeenCalledWith({ received: true });
+    });
+
+    it("does NOT execute the subscription checkout flow", async () => {
+      const handler = createHandler();
+      const { req, res } = createMockReqRes();
+
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_test_123",
+            payment_link: "plink_license_123",
+            customer_details: { email: "buyer@acme.com", name: null },
+          },
+        },
+      });
+
+      await handler(req, res);
+
+      expect(webhookService.handleCheckoutCompleted).not.toHaveBeenCalled();
+      expect(prisma.organization.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when checkout.session.completed has no matching payment link", () => {
+    it("continues with the subscription checkout flow", async () => {
+      const handler = createHandler();
+      const { req, res } = createMockReqRes();
+
+      (prisma.organization.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: "org-1",
+        stripeCustomerId: "cus_test_123",
+      });
+
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_test_456",
+            payment_link: null,
+            customer: "cus_test_123",
+            subscription: "sub_test_123",
+            client_reference_id: "org-1",
+            metadata: {},
+          },
+        },
+      });
+
+      await handler(req, res);
+
+      expect(mockHandleLicensePurchase).not.toHaveBeenCalled();
+      expect(webhookService.handleCheckoutCompleted).toHaveBeenCalledWith({
+        subscriptionId: "sub_test_123",
+        clientReferenceId: "org-1",
+        selectedCurrency: null,
+      });
+    });
+  });
+
+  describe("when checkout.session.completed has a different payment link", () => {
+    it("does NOT route to license handler", async () => {
+      const handler = createHandler();
+      const { req, res } = createMockReqRes();
+
+      (prisma.organization.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: "org-1",
+        stripeCustomerId: "cus_test_123",
+      });
+
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_test_789",
+            payment_link: "plink_other_456",
+            customer: "cus_test_123",
+            subscription: "sub_test_123",
+            client_reference_id: "org-1",
+            metadata: {},
+          },
+        },
+      });
+
+      await handler(req, res);
+
+      expect(mockHandleLicensePurchase).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when payment_link is a PaymentLink object instead of string", () => {
+    it("extracts the id and routes correctly", async () => {
+      const handler = createHandler();
+      const { req, res } = createMockReqRes();
+
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_test_obj",
+            payment_link: { id: "plink_license_123" },
+            customer_details: { email: "buyer@acme.com", name: null },
+          },
+        },
+      });
+
+      await handler(req, res);
+
+      expect(mockHandleLicensePurchase).toHaveBeenCalled();
+    });
+  });
+
+  describe("when private key is missing", () => {
+    it("returns 500 error", async () => {
+      // Override the env mock for this specific test
+      const { env } = await import("../../../src/env.mjs");
+      const originalKey = env.LANGWATCH_LICENSE_PRIVATE_KEY;
+      (env as any).LANGWATCH_LICENSE_PRIVATE_KEY = undefined;
+
+      const handler = createHandler();
+      const { req, res } = createMockReqRes();
+
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_test_nokey",
+            payment_link: "plink_license_123",
+            customer_details: { email: "buyer@acme.com", name: null },
+          },
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.stringContaining("missing private key"),
+      );
+      expect(mockHandleLicensePurchase).not.toHaveBeenCalled();
+
+      // Restore
+      (env as any).LANGWATCH_LICENSE_PRIVATE_KEY = originalKey;
+    });
+  });
+
+  describe("when license handler throws an error", () => {
+    it("returns 500 error", async () => {
+      const handler = createHandler();
+      const { req, res } = createMockReqRes();
+
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: "cs_test_fail",
+            payment_link: "plink_license_123",
+            customer_details: { email: "buyer@acme.com", name: null },
+          },
+        },
+      });
+
+      mockHandleLicensePurchase.mockRejectedValueOnce(
+        new Error("Email send failed"),
+      );
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith("Webhook processing error");
+    });
+  });
+
+  describe("when invoice.payment_succeeded event fires", () => {
+    it("does NOT trigger license handling", async () => {
+      const handler = createHandler();
+      const { req, res } = createMockReqRes();
+
+      (prisma.organization.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: "org-1",
+        stripeCustomerId: "cus_test_123",
+      });
+
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        type: "invoice.payment_succeeded",
+        data: {
+          object: {
+            customer: "cus_test_123",
+            subscription: "sub_test_123",
+          },
+        },
+      });
+
+      await handler(req, res);
+
+      expect(mockHandleLicensePurchase).not.toHaveBeenCalled();
+      expect(webhookService.handleInvoicePaymentSucceeded).toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/ee/billing/index.ts
+++ b/langwatch/ee/billing/index.ts
@@ -1,10 +1,12 @@
 import { prisma } from "../../src/server/db";
+import { env } from "../../src/env.mjs";
 import { createPlanLimitNotifier } from "./notifications/planLimitNotifier";
 import {
   clearBillingNotificationHandlers,
   notifySubscriptionEvent,
   setBillingNotificationHandlers,
 } from "./notifications/notificationHandlers";
+import { sendSlackLicensePurchaseNotification } from "./notifications/slackLicenseNotification";
 import { createSaaSPlanProvider } from "./planProvider";
 import { createCustomerService } from "./services/customerService";
 import { createSeatEventSubscriptionFns } from "./services/seatEventSubscription";
@@ -78,6 +80,18 @@ export const createStripeWebhookHandler = () => {
     itemCalculator: subscriptionItemCalculator,
     inviteApprover,
   });
+
+  const slackWebhookUrl = env.SLACK_LICENSE_WEBHOOK_URL;
+  if (slackWebhookUrl) {
+    setBillingNotificationHandlers({
+      sendLicensePurchaseNotification: (payload) =>
+        sendSlackLicensePurchaseNotification({
+          payload,
+          webhookUrl: slackWebhookUrl,
+        }),
+    });
+  }
+
   return createStripeWebhookHandlerFactory({ stripe: s, webhookService });
 };
 

--- a/langwatch/ee/billing/index.ts
+++ b/langwatch/ee/billing/index.ts
@@ -82,15 +82,15 @@ export const createStripeWebhookHandler = () => {
   });
 
   const slackWebhookUrl = env.SLACK_CHANNEL_SUBSCRIPTIONS;
-  if (slackWebhookUrl) {
-    setBillingNotificationHandlers({
-      sendLicensePurchaseNotification: (payload) =>
-        sendSlackLicensePurchaseNotification({
-          payload,
-          webhookUrl: slackWebhookUrl,
-        }),
-    });
-  }
+  setBillingNotificationHandlers({
+    sendLicensePurchaseNotification: slackWebhookUrl
+      ? (payload) =>
+          sendSlackLicensePurchaseNotification({
+            payload,
+            webhookUrl: slackWebhookUrl,
+          })
+      : undefined,
+  });
 
   return createStripeWebhookHandlerFactory({ stripe: s, webhookService });
 };

--- a/langwatch/ee/billing/index.ts
+++ b/langwatch/ee/billing/index.ts
@@ -81,7 +81,7 @@ export const createStripeWebhookHandler = () => {
     inviteApprover,
   });
 
-  const slackWebhookUrl = env.SLACK_LICENSE_WEBHOOK_URL;
+  const slackWebhookUrl = env.SLACK_CHANNEL_SUBSCRIPTIONS;
   if (slackWebhookUrl) {
     setBillingNotificationHandlers({
       sendLicensePurchaseNotification: (payload) =>

--- a/langwatch/ee/billing/notifications/notificationHandlers.ts
+++ b/langwatch/ee/billing/notifications/notificationHandlers.ts
@@ -1,6 +1,7 @@
 import { captureException } from "../../../src/utils/posthogErrorCapture";
 import type {
   BillingNotificationHandlers,
+  LicensePurchaseNotificationPayload,
   PlanLimitNotificationContext,
   SubscriptionNotificationPayload,
 } from "../types";
@@ -49,6 +50,15 @@ export const notifySubscriptionEvent = async (
 ) => {
   await runHandlerSafely(
     billingNotificationHandlers.sendSubscriptionNotification,
+    payload,
+  );
+};
+
+export const notifyLicensePurchase = async (
+  payload: LicensePurchaseNotificationPayload,
+) => {
+  await runHandlerSafely(
+    billingNotificationHandlers.sendLicensePurchaseNotification,
     payload,
   );
 };

--- a/langwatch/ee/billing/notifications/slackLicenseNotification.ts
+++ b/langwatch/ee/billing/notifications/slackLicenseNotification.ts
@@ -1,0 +1,48 @@
+import type { LicensePurchaseNotificationPayload } from "../types";
+
+export const sendSlackLicensePurchaseNotification = async ({
+  payload,
+  webhookUrl,
+}: {
+  payload: LicensePurchaseNotificationPayload;
+  webhookUrl: string;
+}) => {
+  const amountFormatted = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: payload.currency,
+  }).format(payload.amountPaid / 100);
+
+  const message = {
+    text: `🎉 New License Purchase`,
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "🎉 New License Purchase",
+        },
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*Buyer:*\n${payload.buyerEmail}` },
+          { type: "mrkdwn", text: `*Plan:*\n${payload.planType}` },
+          { type: "mrkdwn", text: `*Seats:*\n${payload.seats}` },
+          { type: "mrkdwn", text: `*Amount:*\n${amountFormatted}` },
+        ],
+      },
+    ],
+  };
+
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(message),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Slack webhook failed with status ${response.status}: ${response.statusText}`,
+    );
+  }
+};

--- a/langwatch/ee/billing/notifications/slackLicenseNotification.ts
+++ b/langwatch/ee/billing/notifications/slackLicenseNotification.ts
@@ -1,5 +1,7 @@
 import type { LicensePurchaseNotificationPayload } from "../types";
 
+const SLACK_TIMEOUT_MS = 10_000;
+
 export const sendSlackLicensePurchaseNotification = async ({
   payload,
   webhookUrl,
@@ -7,6 +9,9 @@ export const sendSlackLicensePurchaseNotification = async ({
   payload: LicensePurchaseNotificationPayload;
   webhookUrl: string;
 }) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SLACK_TIMEOUT_MS);
+
   const amountFormatted = new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: payload.currency,
@@ -34,15 +39,20 @@ export const sendSlackLicensePurchaseNotification = async ({
     ],
   };
 
-  const response = await fetch(webhookUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(message),
-  });
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(message),
+      signal: controller.signal,
+    });
 
-  if (!response.ok) {
-    throw new Error(
-      `Slack webhook failed with status ${response.status}: ${response.statusText}`,
-    );
+    if (!response.ok) {
+      throw new Error(
+        `Slack webhook failed with status ${response.status}: ${response.statusText}`,
+      );
+    }
+  } finally {
+    clearTimeout(timeout);
   }
 };

--- a/langwatch/ee/billing/services/licensePurchaseHandler.ts
+++ b/langwatch/ee/billing/services/licensePurchaseHandler.ts
@@ -54,6 +54,7 @@ export async function handleLicensePurchase({
     planType: licenseData.plan.type,
     maxMembers: quantity,
     expiresAt: licenseData.expiresAt,
+    organizationName: licenseData.organizationName,
   });
 
   logger.info(

--- a/langwatch/ee/billing/services/licensePurchaseHandler.ts
+++ b/langwatch/ee/billing/services/licensePurchaseHandler.ts
@@ -1,0 +1,72 @@
+import type Stripe from "stripe";
+import { generateLicenseKey } from "../../licensing/licenseGenerationService";
+import { sendLicenseEmail } from "../../../src/server/mailer/licenseEmail";
+import { notifyLicensePurchase } from "../notifications/notificationHandlers";
+import { createLogger } from "../../../src/utils/logger";
+
+const logger = createLogger("langwatch:billing:licensePurchaseHandler");
+
+interface HandleLicensePurchaseParams {
+  checkoutSession: Stripe.Checkout.Session;
+  stripe: Stripe;
+  privateKey: string;
+}
+
+export async function handleLicensePurchase({
+  checkoutSession,
+  stripe,
+  privateKey,
+}: HandleLicensePurchaseParams): Promise<void> {
+  const email = checkoutSession.customer_details?.email;
+  if (!email) {
+    throw new Error("No email found in checkout session customer_details");
+  }
+
+  const businessName = checkoutSession.customer_details?.name ?? "";
+
+  // Line items are not included in the webhook payload — must fetch separately
+  const lineItems = await stripe.checkout.sessions.listLineItems(
+    checkoutSession.id,
+  );
+  const quantity = lineItems.data[0]?.quantity ?? 1;
+
+  const { licenseKey, licenseData } = generateLicenseKey({
+    organizationName: businessName,
+    email,
+    planType: "GROWTH",
+    maxMembers: quantity,
+    privateKey,
+  });
+
+  logger.info(
+    {
+      licenseId: licenseData.licenseId,
+      email,
+      seats: quantity,
+      expiresAt: licenseData.expiresAt,
+    },
+    "[licensePurchaseHandler] License generated",
+  );
+
+  await sendLicenseEmail({
+    email,
+    licenseKey,
+    planType: licenseData.plan.type,
+    maxMembers: quantity,
+    expiresAt: licenseData.expiresAt,
+  });
+
+  logger.info(
+    { email, licenseId: licenseData.licenseId },
+    "[licensePurchaseHandler] License email sent",
+  );
+
+  // Slack notification — fire and forget, errors swallowed by notifyLicensePurchase
+  await notifyLicensePurchase({
+    buyerEmail: email,
+    planType: licenseData.plan.type,
+    seats: quantity,
+    amountPaid: checkoutSession.amount_total ?? 0,
+    currency: checkoutSession.currency ?? "usd",
+  });
+}

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -62,6 +62,21 @@ export const createWebhookService = ({
     }): Promise<unknown>;
   };
 }): WebhookService => {
+  const clearTrialLicenseIfPresent = async (
+    updatedSubscription: { organizationId: string; organization: { license: string | null } },
+    reason: string,
+  ) => {
+    if (!updatedSubscription.organization.license) return;
+    logger.info(
+      { organizationId: updatedSubscription.organizationId },
+      `[stripeWebhook] Clearing trial license — ${reason}`,
+    );
+    await db.organization.update({
+      where: { id: updatedSubscription.organizationId },
+      data: { license: null, licenseExpiresAt: null, licenseLastValidatedAt: null },
+    });
+  };
+
   const normalizeSelectedCurrency = (value?: string | null): Currency | null => {
     if (value === Currency.EUR || value === Currency.USD) {
       return value;
@@ -107,17 +122,7 @@ export const createWebhookService = ({
     });
 
     if (previousSubscription.status !== SubscriptionStatus.ACTIVE) {
-      // Clear trial license — subscription supersedes it
-      if (updatedSubscription.organization.license) {
-        logger.info(
-          { organizationId: updatedSubscription.organizationId },
-          "[stripeWebhook] Clearing trial license — subscription activated",
-        );
-        await db.organization.update({
-          where: { id: updatedSubscription.organizationId },
-          data: { license: null, licenseExpiresAt: null, licenseLastValidatedAt: null },
-        });
-      }
+      await clearTrialLicenseIfPresent(updatedSubscription, "subscription activated");
 
       if (isGrowthSeatEventPlan(updatedSubscription.plan)) {
         const TIERED_PLAN_TYPES: PlanTypes[] = [
@@ -408,17 +413,7 @@ export const createWebhookService = ({
           include: { organization: true },
         });
 
-        // Clear trial license if present — subscription supersedes it
-        if (updatedSubscription.organization.license) {
-          logger.info(
-            { organizationId: updatedSubscription.organizationId },
-            "[stripeWebhook] Clearing trial license — subscription updated to active",
-          );
-          await db.organization.update({
-            where: { id: updatedSubscription.organizationId },
-            data: { license: null, licenseExpiresAt: null, licenseLastValidatedAt: null },
-          });
-        }
+        await clearTrialLicenseIfPresent(updatedSubscription, "subscription updated to active");
 
         if (shouldNotify) {
           await notifySubscriptionEvent({

--- a/langwatch/ee/billing/stripeWebhook.ts
+++ b/langwatch/ee/billing/stripeWebhook.ts
@@ -6,6 +6,7 @@ import { env } from "../../src/env.mjs";
 import { prisma } from "../../src/server/db";
 import { createLogger } from "../../src/utils/logger";
 import type { WebhookService } from "./services/webhookService";
+import { handleLicensePurchase } from "./services/licensePurchaseHandler";
 
 const VALID_CURRENCIES = new Set<string>(Object.values(Currency));
 
@@ -55,6 +56,40 @@ export const createStripeWebhookHandlerFactory = ({
     }
 
     try {
+      // License purchase routing — must happen before subscription flow
+      // because self-hosted buyers have no organization in the SaaS database
+      if (event.type === "checkout.session.completed") {
+        const checkoutSession = event.data
+          .object as Stripe.Checkout.Session;
+        const paymentLinkId =
+          typeof checkoutSession.payment_link === "string"
+            ? checkoutSession.payment_link
+            : checkoutSession.payment_link?.id;
+
+        if (
+          env.STRIPE_LICENSE_PAYMENT_LINK_ID &&
+          paymentLinkId === env.STRIPE_LICENSE_PAYMENT_LINK_ID
+        ) {
+          const privateKey = env.LANGWATCH_LICENSE_PRIVATE_KEY;
+          if (!privateKey) {
+            logger.error(
+              "[stripeWebhook] LANGWATCH_LICENSE_PRIVATE_KEY is not configured",
+            );
+            return res
+              .status(500)
+              .send("License generation error: missing private key");
+          }
+
+          await handleLicensePurchase({
+            checkoutSession,
+            stripe,
+            privateKey,
+          });
+
+          return res.json({ received: true });
+        }
+      }
+
       if (
         event.type === "checkout.session.completed" ||
         event.type === "invoice.payment_succeeded" ||

--- a/langwatch/ee/billing/types.ts
+++ b/langwatch/ee/billing/types.ts
@@ -65,8 +65,19 @@ export type SubscriptionNotificationPayload =
   | ProspectiveSubscriptionNotification
   | ConfirmedSubscriptionNotification;
 
+export type LicensePurchaseNotificationPayload = {
+  buyerEmail: string;
+  planType: string;
+  seats: number;
+  amountPaid: number;
+  currency: string;
+};
+
 export type BillingNotificationHandlers = PlanLimitNotificationHandlers & {
   sendSubscriptionNotification?: (
     payload: SubscriptionNotificationPayload,
+  ) => Promise<void> | void;
+  sendLicensePurchaseNotification?: (
+    payload: LicensePurchaseNotificationPayload,
   ) => Promise<void> | void;
 };

--- a/langwatch/ee/licensing/__tests__/licenseGenerationService.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/licenseGenerationService.unit.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import { generateLicenseKey } from "../licenseGenerationService";
+import { validateLicense } from "../validation";
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from "./fixtures/testKeys";
+import { DEFAULT_LIMIT } from "../constants";
+
+const baseParams = {
+  organizationName: "Acme Corp",
+  email: "buyer@acme.com",
+  planType: "GROWTH",
+  maxMembers: 5,
+  privateKey: TEST_PRIVATE_KEY,
+  now: new Date("2025-06-15T12:00:00Z"),
+};
+
+describe("generateLicenseKey", () => {
+  describe("when generating a GROWTH license", () => {
+    it("generates a valid license key that passes round-trip validation", () => {
+      const { licenseKey } = generateLicenseKey(baseParams);
+      const result = validateLicense(licenseKey, TEST_PUBLIC_KEY);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("sets maxMembers from the provided seat count", () => {
+      const { licenseData } = generateLicenseKey(baseParams);
+
+      expect(licenseData.plan.maxMembers).toBe(5);
+    });
+
+    it("sets all other limits to unlimited (DEFAULT_LIMIT)", () => {
+      const { licenseData } = generateLicenseKey(baseParams);
+      const { plan } = licenseData;
+
+      expect(plan.maxMembersLite).toBe(DEFAULT_LIMIT);
+      expect(plan.maxTeams).toBe(DEFAULT_LIMIT);
+      expect(plan.maxProjects).toBe(DEFAULT_LIMIT);
+      expect(plan.maxMessagesPerMonth).toBe(DEFAULT_LIMIT);
+      expect(plan.evaluationsCredit).toBe(DEFAULT_LIMIT);
+      expect(plan.maxWorkflows).toBe(DEFAULT_LIMIT);
+      expect(plan.maxPrompts).toBe(DEFAULT_LIMIT);
+      expect(plan.maxEvaluators).toBe(DEFAULT_LIMIT);
+      expect(plan.maxScenarios).toBe(DEFAULT_LIMIT);
+      expect(plan.maxAgents).toBe(DEFAULT_LIMIT);
+      expect(plan.maxExperiments).toBe(DEFAULT_LIMIT);
+      expect(plan.maxOnlineEvaluations).toBe(DEFAULT_LIMIT);
+      expect(plan.maxDatasets).toBe(DEFAULT_LIMIT);
+      expect(plan.maxDashboards).toBe(DEFAULT_LIMIT);
+      expect(plan.maxCustomGraphs).toBe(DEFAULT_LIMIT);
+      expect(plan.maxAutomations).toBe(DEFAULT_LIMIT);
+    });
+
+    it("sets plan type to GROWTH and name to Growth", () => {
+      const { licenseData } = generateLicenseKey(baseParams);
+
+      expect(licenseData.plan.type).toBe("GROWTH");
+      expect(licenseData.plan.name).toBe("Growth");
+    });
+
+    it("sets canPublish to true and usageUnit to events", () => {
+      const { licenseData } = generateLicenseKey(baseParams);
+
+      expect(licenseData.plan.canPublish).toBe(true);
+      expect(licenseData.plan.usageUnit).toBe("events");
+    });
+  });
+
+  describe("when generating a PRO license", () => {
+    it("generates a valid license with PRO template limits", () => {
+      const { licenseKey, licenseData } = generateLicenseKey({
+        ...baseParams,
+        planType: "PRO",
+        maxMembers: 10,
+      });
+
+      const result = validateLicense(licenseKey, TEST_PUBLIC_KEY);
+      expect(result.valid).toBe(true);
+      expect(licenseData.plan.type).toBe("PRO");
+      expect(licenseData.plan.maxMembers).toBe(10);
+      expect(licenseData.plan.maxProjects).toBe(20);
+    });
+  });
+
+  describe("when generating an ENTERPRISE license", () => {
+    it("generates a valid license with ENTERPRISE template limits", () => {
+      const { licenseKey, licenseData } = generateLicenseKey({
+        ...baseParams,
+        planType: "ENTERPRISE",
+        maxMembers: 50,
+      });
+
+      const result = validateLicense(licenseKey, TEST_PUBLIC_KEY);
+      expect(result.valid).toBe(true);
+      expect(licenseData.plan.type).toBe("ENTERPRISE");
+      expect(licenseData.plan.maxMembers).toBe(50);
+      expect(licenseData.plan.maxProjects).toBe(500);
+    });
+  });
+
+  describe("when expiration is calculated", () => {
+    it("expires exactly 1 year from the generation date", () => {
+      const { licenseData } = generateLicenseKey(baseParams);
+
+      expect(licenseData.expiresAt).toBe("2026-06-15T12:00:00.000Z");
+    });
+
+    it("handles leap year boundary correctly", () => {
+      const { licenseData } = generateLicenseKey({
+        ...baseParams,
+        now: new Date("2024-02-29T12:00:00Z"),
+      });
+
+      // Feb 29 2024 + 1 year → Mar 1 2025 (no Feb 29 in 2025)
+      expect(licenseData.expiresAt).toBe("2025-03-01T12:00:00.000Z");
+    });
+  });
+
+  describe("when organization name is empty", () => {
+    it("falls back to email as organization name", () => {
+      const { licenseData } = generateLicenseKey({
+        ...baseParams,
+        organizationName: "",
+      });
+
+      expect(licenseData.organizationName).toBe("buyer@acme.com");
+    });
+
+    it("falls back to email when name is whitespace-only", () => {
+      const { licenseData } = generateLicenseKey({
+        ...baseParams,
+        organizationName: "   ",
+      });
+
+      expect(licenseData.organizationName).toBe("buyer@acme.com");
+    });
+  });
+
+  describe("when maxMembers is zero or negative", () => {
+    it("defaults to 1 seat when maxMembers is 0", () => {
+      const { licenseData } = generateLicenseKey({
+        ...baseParams,
+        maxMembers: 0,
+      });
+
+      expect(licenseData.plan.maxMembers).toBe(1);
+    });
+
+    it("defaults to 1 seat when maxMembers is negative", () => {
+      const { licenseData } = generateLicenseKey({
+        ...baseParams,
+        maxMembers: -3,
+      });
+
+      expect(licenseData.plan.maxMembers).toBe(1);
+    });
+  });
+
+  describe("when plan type is unknown", () => {
+    it("throws an error for unknown plan types", () => {
+      expect(() =>
+        generateLicenseKey({
+          ...baseParams,
+          planType: "CUSTOM",
+        })
+      ).toThrow("Unknown plan type: CUSTOM");
+    });
+  });
+
+  describe("when license metadata is set", () => {
+    it("sets version to 1", () => {
+      const { licenseData } = generateLicenseKey(baseParams);
+
+      expect(licenseData.version).toBe(1);
+    });
+
+    it("sets issuedAt to the provided now date", () => {
+      const { licenseData } = generateLicenseKey(baseParams);
+
+      expect(licenseData.issuedAt).toBe("2025-06-15T12:00:00.000Z");
+    });
+
+    it("generates a unique licenseId with lic- prefix", () => {
+      const { licenseData: first } = generateLicenseKey(baseParams);
+      const { licenseData: second } = generateLicenseKey(baseParams);
+
+      expect(first.licenseId).toMatch(/^lic-/);
+      expect(second.licenseId).toMatch(/^lic-/);
+      expect(first.licenseId).not.toBe(second.licenseId);
+    });
+
+    it("stores email and organization name in license data", () => {
+      const { licenseData } = generateLicenseKey(baseParams);
+
+      expect(licenseData.email).toBe("buyer@acme.com");
+      expect(licenseData.organizationName).toBe("Acme Corp");
+    });
+  });
+
+  describe("when validating round-trip integrity", () => {
+    it("produces a license that can be parsed and verified", () => {
+      const { licenseKey, licenseData } = generateLicenseKey(baseParams);
+      const result = validateLicense(licenseKey, TEST_PUBLIC_KEY);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.licenseData.licenseId).toBe(licenseData.licenseId);
+        expect(result.licenseData.email).toBe("buyer@acme.com");
+        expect(result.licenseData.organizationName).toBe("Acme Corp");
+        expect(result.licenseData.plan.type).toBe("GROWTH");
+        expect(result.licenseData.plan.maxMembers).toBe(5);
+      }
+    });
+
+    it("fails validation with a different public key", () => {
+      const { licenseKey } = generateLicenseKey(baseParams);
+      const result = validateLicense(
+        licenseKey,
+        // Use a dummy key that doesn't match
+        `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq4utbj0BDQlwUcQ2gNar
+8vT0JYj24i6xoIGLBmwkY/D9vxU4FbFdiLPddiv+Mv5KAPVvNXbLy8zkbsK74BT7
+ye7Od2bJILMiZGMRKj7t1lx3ClthIZKUWjGMiWY0FyOHon+vrz81QireVd1QQuYh
+zLk5oLpttCXLIUqatQ+w6M9oHz8Ru+qy6thFEe29lqGCczRmpCtXmGr5R22UVUp7
+OLqhJ/73aa+nso54jUvMTUYt8k0kbOhvSY9EhwrsvCxeJcNCl3vYf4Cphpqf9OF0
+sUIBcjrzUh14Z/RxKyun5Ld12xGVuhSzVf0xnWar338N9WKgaFOW+zgRchBGdXFD
+dQIDAQAB
+-----END PUBLIC KEY-----`,
+      );
+
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/langwatch/ee/licensing/__tests__/planTemplates.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/planTemplates.unit.test.ts
@@ -111,82 +111,92 @@ describe("ENTERPRISE_TEMPLATE", () => {
 });
 
 describe("GROWTH_TEMPLATE", () => {
-  it("has type GROWTH", () => {
-    expect(GROWTH_TEMPLATE.type).toBe("GROWTH");
+  describe("when inspecting plan identity", () => {
+    it("has type GROWTH", () => {
+      expect(GROWTH_TEMPLATE.type).toBe("GROWTH");
+    });
+
+    it("has name Growth", () => {
+      expect(GROWTH_TEMPLATE.name).toBe("Growth");
+    });
   });
 
-  it("has name Growth", () => {
-    expect(GROWTH_TEMPLATE.name).toBe("Growth");
+  describe("when inspecting member limits", () => {
+    it("does not preset maxMembers", () => {
+      expect(GROWTH_TEMPLATE).not.toHaveProperty("maxMembers");
+    });
   });
 
-  it("does not preset maxMembers", () => {
-    expect(GROWTH_TEMPLATE).not.toHaveProperty("maxMembers");
-  });
+  describe("when inspecting feature limits", () => {
+    it("sets all other limits to unlimited (DEFAULT_LIMIT)", () => {
+      const unlimitedFields = [
+        "maxMembersLite",
+        "maxTeams",
+        "maxProjects",
+        "maxMessagesPerMonth",
+        "evaluationsCredit",
+        "maxWorkflows",
+        "maxPrompts",
+        "maxEvaluators",
+        "maxScenarios",
+        "maxAgents",
+        "maxExperiments",
+        "maxOnlineEvaluations",
+        "maxDatasets",
+        "maxDashboards",
+        "maxCustomGraphs",
+        "maxAutomations",
+      ] as const;
 
-  it("has all other limits set to unlimited (DEFAULT_LIMIT)", () => {
-    const unlimitedFields = [
-      "maxMembersLite",
-      "maxTeams",
-      "maxProjects",
-      "maxMessagesPerMonth",
-      "evaluationsCredit",
-      "maxWorkflows",
-      "maxPrompts",
-      "maxEvaluators",
-      "maxScenarios",
-      "maxAgents",
-      "maxExperiments",
-      "maxOnlineEvaluations",
-      "maxDatasets",
-      "maxDashboards",
-      "maxCustomGraphs",
-      "maxAutomations",
-    ] as const;
+      for (const field of unlimitedFields) {
+        expect(GROWTH_TEMPLATE[field], `${field} is not DEFAULT_LIMIT`).toBe(
+          DEFAULT_LIMIT
+        );
+      }
+    });
 
-    for (const field of unlimitedFields) {
-      expect(GROWTH_TEMPLATE[field], `${field} is not DEFAULT_LIMIT`).toBe(
-        DEFAULT_LIMIT
-      );
-    }
-  });
+    it("has canPublish true", () => {
+      expect(GROWTH_TEMPLATE.canPublish).toBe(true);
+    });
 
-  it("has canPublish true", () => {
-    expect(GROWTH_TEMPLATE.canPublish).toBe(true);
-  });
-
-  it("has usageUnit of events", () => {
-    expect(GROWTH_TEMPLATE.usageUnit).toBe("events");
+    it("has usageUnit of events", () => {
+      expect(GROWTH_TEMPLATE.usageUnit).toBe("events");
+    });
   });
 });
 
 describe("getPlanTemplate", () => {
-  it("returns GROWTH template for GROWTH type", () => {
-    const template = getPlanTemplate("GROWTH");
+  describe("when called with a known plan type", () => {
+    it("returns GROWTH template for GROWTH type", () => {
+      const template = getPlanTemplate("GROWTH");
 
-    expect(template).toEqual(GROWTH_TEMPLATE);
+      expect(template).toEqual(GROWTH_TEMPLATE);
+    });
+
+    it("returns PRO template for PRO type", () => {
+      const template = getPlanTemplate("PRO");
+
+      expect(template).toEqual(PRO_TEMPLATE);
+    });
+
+    it("returns ENTERPRISE template for ENTERPRISE type", () => {
+      const template = getPlanTemplate("ENTERPRISE");
+
+      expect(template).toEqual(ENTERPRISE_TEMPLATE);
+    });
   });
 
-  it("returns PRO template for PRO type", () => {
-    const template = getPlanTemplate("PRO");
+  describe("when called with an unknown plan type", () => {
+    it("returns null for CUSTOM type", () => {
+      const template = getPlanTemplate("CUSTOM");
 
-    expect(template).toEqual(PRO_TEMPLATE);
-  });
+      expect(template).toBeNull();
+    });
 
-  it("returns ENTERPRISE template for ENTERPRISE type", () => {
-    const template = getPlanTemplate("ENTERPRISE");
+    it("returns null for unknown plan type", () => {
+      const template = getPlanTemplate("UNKNOWN");
 
-    expect(template).toEqual(ENTERPRISE_TEMPLATE);
-  });
-
-  it("returns null for CUSTOM type", () => {
-    const template = getPlanTemplate("CUSTOM");
-
-    expect(template).toBeNull();
-  });
-
-  it("returns null for unknown plan type", () => {
-    const template = getPlanTemplate("UNKNOWN");
-
-    expect(template).toBeNull();
+      expect(template).toBeNull();
+    });
   });
 });

--- a/langwatch/ee/licensing/__tests__/planTemplates.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/planTemplates.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { PRO_TEMPLATE, ENTERPRISE_TEMPLATE, getPlanTemplate } from "../planTemplates";
-import type { LicensePlanLimits } from "../types";
+import { GROWTH_TEMPLATE, PRO_TEMPLATE, ENTERPRISE_TEMPLATE, getPlanTemplate } from "../planTemplates";
+import { DEFAULT_LIMIT } from "../constants";
 
 describe("PRO_TEMPLATE", () => {
   it("has type PRO", () => {
@@ -110,7 +110,62 @@ describe("ENTERPRISE_TEMPLATE", () => {
   });
 });
 
+describe("GROWTH_TEMPLATE", () => {
+  it("has type GROWTH", () => {
+    expect(GROWTH_TEMPLATE.type).toBe("GROWTH");
+  });
+
+  it("has name Growth", () => {
+    expect(GROWTH_TEMPLATE.name).toBe("Growth");
+  });
+
+  it("does not preset maxMembers", () => {
+    expect(GROWTH_TEMPLATE).not.toHaveProperty("maxMembers");
+  });
+
+  it("has all other limits set to unlimited (DEFAULT_LIMIT)", () => {
+    const unlimitedFields = [
+      "maxMembersLite",
+      "maxTeams",
+      "maxProjects",
+      "maxMessagesPerMonth",
+      "evaluationsCredit",
+      "maxWorkflows",
+      "maxPrompts",
+      "maxEvaluators",
+      "maxScenarios",
+      "maxAgents",
+      "maxExperiments",
+      "maxOnlineEvaluations",
+      "maxDatasets",
+      "maxDashboards",
+      "maxCustomGraphs",
+      "maxAutomations",
+    ] as const;
+
+    for (const field of unlimitedFields) {
+      expect(GROWTH_TEMPLATE[field], `${field} is not DEFAULT_LIMIT`).toBe(
+        DEFAULT_LIMIT
+      );
+    }
+  });
+
+  it("has canPublish true", () => {
+    expect(GROWTH_TEMPLATE.canPublish).toBe(true);
+  });
+
+  it("has usageUnit of events", () => {
+    expect(GROWTH_TEMPLATE.usageUnit).toBe("events");
+  });
+});
+
 describe("getPlanTemplate", () => {
+  it("returns GROWTH template for GROWTH type", () => {
+    const template = getPlanTemplate("GROWTH");
+
+    expect(template).toEqual(GROWTH_TEMPLATE);
+  });
+
   it("returns PRO template for PRO type", () => {
     const template = getPlanTemplate("PRO");
 

--- a/langwatch/ee/licensing/constants.ts
+++ b/langwatch/ee/licensing/constants.ts
@@ -1,5 +1,11 @@
 import type { PlanInfo } from "./planInfo";
 
+export const CONTACT_SALES_URL =
+  "https://meetings-eu1.hubspot.com/manouk-draisma?uuid=3c29cf0c-03e5-4a53-81fd-94abb0b66cfd";
+
+export const DEFAULT_LICENSE_PURCHASE_URL =
+  "https://buy.stripe.com/dRm3cwaIDgXs6yK6sX0480f";
+
 /**
  * Default limit for fields not present in older licenses.
  * Using a large number instead of Infinity for JSON serialization safety.

--- a/langwatch/ee/licensing/licenseGenerationService.ts
+++ b/langwatch/ee/licensing/licenseGenerationService.ts
@@ -1,0 +1,87 @@
+import type { LicenseData } from "./types";
+import { signLicense, encodeLicenseKey, generateLicenseId } from "./signing";
+import { getPlanTemplate } from "./planTemplates";
+
+interface GenerateLicenseKeyParams {
+  organizationName: string;
+  email: string;
+  planType: string;
+  maxMembers: number;
+  privateKey: string;
+  /** Override current time for deterministic testing */
+  now?: Date;
+}
+
+interface GenerateLicenseKeyResult {
+  licenseKey: string;
+  licenseData: LicenseData;
+}
+
+/**
+ * Generates a signed, encoded license key.
+ *
+ * Pure business logic — no HTTP, no Prisma, no env var access.
+ * Private key and all parameters passed explicitly.
+ */
+export function generateLicenseKey({
+  organizationName,
+  email,
+  planType,
+  maxMembers,
+  privateKey,
+  now = new Date(),
+}: GenerateLicenseKeyParams): GenerateLicenseKeyResult {
+  const template = getPlanTemplate(planType);
+  if (!template) {
+    throw new Error(`Unknown plan type: ${planType}`);
+  }
+
+  const seats = maxMembers > 0 ? maxMembers : 1;
+
+  const expiresAt = new Date(now);
+  expiresAt.setFullYear(expiresAt.getFullYear() + 1);
+
+  const resolvedOrgName = organizationName.trim() || email;
+
+  // Build plan with keys matching Zod schema field order.
+  // Signature verification re-serializes via JSON.stringify after Zod parsing,
+  // which reorders keys to schema order. Key order must match at sign time.
+  const plan: LicenseData["plan"] = {
+    type: template.type,
+    name: template.name,
+    maxMembers: seats,
+    maxMembersLite: template.maxMembersLite,
+    maxTeams: template.maxTeams,
+    maxProjects: template.maxProjects,
+    maxMessagesPerMonth: template.maxMessagesPerMonth,
+    evaluationsCredit: template.evaluationsCredit,
+    maxWorkflows: template.maxWorkflows,
+    maxPrompts: template.maxPrompts,
+    maxEvaluators: template.maxEvaluators,
+    maxScenarios: template.maxScenarios,
+    maxAgents: template.maxAgents,
+    maxExperiments: template.maxExperiments,
+    maxOnlineEvaluations: template.maxOnlineEvaluations,
+    maxDatasets: template.maxDatasets,
+    maxDashboards: template.maxDashboards,
+    maxCustomGraphs: template.maxCustomGraphs,
+    maxAutomations: template.maxAutomations,
+    canPublish: template.canPublish,
+    usageUnit: template.usageUnit,
+  };
+
+  const licenseData: LicenseData = {
+    licenseId: generateLicenseId(),
+    version: 1,
+    organizationName: resolvedOrgName,
+    email,
+    issuedAt: now.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+    plan,
+  };
+
+  const signedLicense = signLicense(licenseData, privateKey);
+  const licenseKey = encodeLicenseKey(signedLicense);
+
+  return { licenseKey, licenseData };
+}

--- a/langwatch/ee/licensing/planTemplates.ts
+++ b/langwatch/ee/licensing/planTemplates.ts
@@ -1,4 +1,33 @@
 import type { LicensePlanLimits } from "./types";
+import { DEFAULT_LIMIT } from "./constants";
+
+/**
+ * GROWTH plan template with unlimited limits except maxMembers.
+ * maxMembers must be supplied at generation time (from Stripe seat quantity).
+ * Used for self-serving license purchases.
+ */
+export const GROWTH_TEMPLATE: Omit<LicensePlanLimits, "maxMembers"> = {
+  type: "GROWTH",
+  name: "Growth",
+  maxMembersLite: DEFAULT_LIMIT,
+  maxTeams: DEFAULT_LIMIT,
+  maxProjects: DEFAULT_LIMIT,
+  maxMessagesPerMonth: DEFAULT_LIMIT,
+  evaluationsCredit: DEFAULT_LIMIT,
+  maxWorkflows: DEFAULT_LIMIT,
+  maxPrompts: DEFAULT_LIMIT,
+  maxEvaluators: DEFAULT_LIMIT,
+  maxScenarios: DEFAULT_LIMIT,
+  maxAgents: DEFAULT_LIMIT,
+  maxExperiments: DEFAULT_LIMIT,
+  maxOnlineEvaluations: DEFAULT_LIMIT,
+  maxDatasets: DEFAULT_LIMIT,
+  maxDashboards: DEFAULT_LIMIT,
+  maxCustomGraphs: DEFAULT_LIMIT,
+  maxAutomations: DEFAULT_LIMIT,
+  canPublish: true,
+  usageUnit: "events",
+};
 
 /**
  * PRO plan template with standard limits.
@@ -59,11 +88,17 @@ export const ENTERPRISE_TEMPLATE: LicensePlanLimits = {
 /**
  * Returns the plan template for a given plan type.
  *
- * @param planType - The plan type (PRO, ENTERPRISE, or CUSTOM)
- * @returns The plan template or null for CUSTOM/unknown types
+ * @param planType - The plan type (PRO, ENTERPRISE, GROWTH, or CUSTOM)
+ * @returns The plan template or null for CUSTOM/unknown types.
+ *          GROWTH returns Omit<LicensePlanLimits, "maxMembers"> since
+ *          maxMembers must be supplied at generation time.
  */
-export function getPlanTemplate(planType: string): LicensePlanLimits | null {
+export function getPlanTemplate(
+  planType: string
+): LicensePlanLimits | Omit<LicensePlanLimits, "maxMembers"> | null {
   switch (planType) {
+    case "GROWTH":
+      return GROWTH_TEMPLATE;
     case "PRO":
       return PRO_TEMPLATE;
     case "ENTERPRISE":

--- a/langwatch/src/components/license/LicenseDetailsCard.tsx
+++ b/langwatch/src/components/license/LicenseDetailsCard.tsx
@@ -3,10 +3,12 @@ import {
   Box,
   Button,
   HStack,
+  Link,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import type { LicenseStatus } from "../../../ee/licensing/client";
+import { CONTACT_SALES_URL } from "../../../ee/licensing/constants";
 import { isLicenseExpired, formatLicenseDate, hasLicenseMetadata, isCorruptedLicense } from "./licenseStatusUtils";
 
 interface LicenseDetailsCardProps {
@@ -67,6 +69,15 @@ export function LicenseDetailsCard({
             >
               Remove License
             </Button>
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+            >
+              <Link href={CONTACT_SALES_URL} target="_blank">
+                Contact Sales
+              </Link>
+            </Button>
           </HStack>
         </VStack>
       </Box>
@@ -117,6 +128,15 @@ export function LicenseDetailsCard({
 
           <HStack>
             <Text fontSize="sm" color="fg.muted" width="120px">
+              Seats:
+            </Text>
+            <Text fontSize="sm" fontWeight="medium">
+              {status.currentMembers} / {status.maxMembers}
+            </Text>
+          </HStack>
+
+          <HStack>
+            <Text fontSize="sm" color="fg.muted" width="120px">
               Expires:
             </Text>
             <Text
@@ -154,6 +174,15 @@ export function LicenseDetailsCard({
             disabled={isRemoving}
           >
             Remove License
+          </Button>
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+          >
+            <Link href={CONTACT_SALES_URL} target="_blank">
+              Contact Sales
+            </Link>
           </Button>
         </HStack>
       </VStack>

--- a/langwatch/src/components/license/NoLicenseCard.tsx
+++ b/langwatch/src/components/license/NoLicenseCard.tsx
@@ -14,6 +14,7 @@ import { Radio, RadioGroup } from "~/components/ui/radio";
 import { Tooltip } from "~/components/ui/tooltip";
 import { formatFileSize } from "./licenseStatusUtils";
 import { CONTACT_SALES_URL } from "../plans/constants";
+import { usePublicEnv } from "~/hooks/usePublicEnv";
 
 type ActivationMethod = "file" | "key";
 
@@ -32,6 +33,9 @@ export function NoLicenseCard({
   onFileActivate,
   isActivating,
 }: NoLicenseCardProps) {
+  const publicEnv = usePublicEnv();
+  const purchaseLinkUrl = publicEnv.data?.STRIPE_LICENSE_PAYMENT_LINK_URL;
+
   const [activationMethod, setActivationMethod] =
     useState<ActivationMethod>("file");
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
@@ -232,16 +236,18 @@ export function NoLicenseCard({
             >
               Activate License
             </Button>
-            <Tooltip content="After purchase, your license will be generated and delivered to your email.">
-              <Button asChild variant="outline" size="sm">
-                <Link
-                  href="https://buy.stripe.com/dRm3cwaIDgXs6yK6sX0480f"
-                  isExternal
-                >
-                  Purchase license
-                </Link>
-              </Button>
-            </Tooltip>
+            {purchaseLinkUrl && (
+              <Tooltip content="After purchase, your license will be generated and delivered to your email.">
+                <Button asChild variant="outline" size="sm">
+                  <Link
+                    href={purchaseLinkUrl}
+                    isExternal
+                  >
+                    Purchase license
+                  </Link>
+                </Button>
+              </Tooltip>
+            )}
             <Link
               href={CONTACT_SALES_URL}
               isExternal

--- a/langwatch/src/components/license/NoLicenseCard.tsx
+++ b/langwatch/src/components/license/NoLicenseCard.tsx
@@ -13,7 +13,7 @@ import { Link } from "~/components/ui/link";
 import { Radio, RadioGroup } from "~/components/ui/radio";
 import { Tooltip } from "~/components/ui/tooltip";
 import { formatFileSize } from "./licenseStatusUtils";
-import { CONTACT_SALES_URL } from "../plans/constants";
+import { CONTACT_SALES_URL, DEFAULT_LICENSE_PURCHASE_URL } from "../../../ee/licensing/constants";
 import { usePublicEnv } from "~/hooks/usePublicEnv";
 
 type ActivationMethod = "file" | "key";
@@ -34,7 +34,7 @@ export function NoLicenseCard({
   isActivating,
 }: NoLicenseCardProps) {
   const publicEnv = usePublicEnv();
-  const purchaseLinkUrl = publicEnv.data?.STRIPE_LICENSE_PAYMENT_LINK_URL;
+  const purchaseLinkUrl = publicEnv.data?.STRIPE_LICENSE_PAYMENT_LINK_URL ?? DEFAULT_LICENSE_PURCHASE_URL;
 
   const [activationMethod, setActivationMethod] =
     useState<ActivationMethod>("file");

--- a/langwatch/src/components/plans/PlansComparisonPage.tsx
+++ b/langwatch/src/components/plans/PlansComparisonPage.tsx
@@ -20,7 +20,7 @@ import {
   type ComparisonPlanId,
   resolveCurrentComparisonPlan,
 } from "./planCurrentResolver";
-import { CONTACT_SALES_URL } from "./constants";
+import { CONTACT_SALES_URL } from "../../../ee/licensing/constants";
 import {
   type Currency,
   type BillingInterval,

--- a/langwatch/src/components/plans/constants.ts
+++ b/langwatch/src/components/plans/constants.ts
@@ -1,2 +1,0 @@
-export const CONTACT_SALES_URL =
-  "https://meetings-eu1.hubspot.com/manouk-draisma?uuid=3c29cf0c-03e5-4a53-81fd-94abb0b66cfd";

--- a/langwatch/src/components/subscription/ContactSalesBlock.tsx
+++ b/langwatch/src/components/subscription/ContactSalesBlock.tsx
@@ -12,7 +12,7 @@ import {
 import { Check } from "lucide-react";
 import { Link } from "~/components/ui/link";
 import { ENTERPRISE_PLAN_FEATURES } from "./billing-plans";
-import { CONTACT_SALES_URL } from "../plans/constants";
+import { CONTACT_SALES_URL } from "../../../ee/licensing/constants";
 
 export function ContactSalesBlock() {
   return (

--- a/langwatch/src/components/subscription/SubscriptionPage.tsx
+++ b/langwatch/src/components/subscription/SubscriptionPage.tsx
@@ -60,7 +60,7 @@ import { UpdateSeatsBlock } from "./UpdateSeatsBlock";
 import { UpgradePlanBlock } from "./UpgradePlanBlock";
 import { ContactSalesBlock } from "./ContactSalesBlock";
 import { UserManagementDrawer } from "./UserManagementDrawer";
-import { CONTACT_SALES_URL } from "../plans/constants";
+import { CONTACT_SALES_URL } from "../../../ee/licensing/constants";
 
 const currencyOptions = [
   { label: "\u20AC EUR", value: PrismaCurrency.EUR },

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -123,7 +123,7 @@ export function createEnvConfig() {
       ADMIN_EMAILS: z.string().optional(),
 
       // Notifications
-      SLACK_LICENSE_WEBHOOK_URL: z.string().optional(),
+      SLACK_CHANNEL_SUBSCRIPTIONS: z.string().optional(),
     },
 
     /**
@@ -231,7 +231,7 @@ export function createEnvConfig() {
       STRIPE_LICENSE_PAYMENT_LINK_ID: process.env.STRIPE_LICENSE_PAYMENT_LINK_ID,
       STRIPE_LICENSE_PAYMENT_LINK_URL: process.env.STRIPE_LICENSE_PAYMENT_LINK_URL,
       ADMIN_EMAILS: process.env.ADMIN_EMAILS,
-      SLACK_LICENSE_WEBHOOK_URL: process.env.SLACK_LICENSE_WEBHOOK_URL,
+      SLACK_CHANNEL_SUBSCRIPTIONS: process.env.SLACK_CHANNEL_SUBSCRIPTIONS,
     },
     /**
      * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -113,11 +113,17 @@ export function createEnvConfig() {
       CLICKHOUSE_CLUSTER: z.string().optional(),
 
       LANGWATCH_LICENSE_PUBLIC_KEY: z.string().optional(),
+      LANGWATCH_LICENSE_PRIVATE_KEY: z.string().optional(),
 
       // Stripe
       STRIPE_SECRET_KEY: z.string().optional(),
       STRIPE_WEBHOOK_SECRET: z.string().optional(),
+      STRIPE_LICENSE_PAYMENT_LINK_ID: z.string().optional(),
+      STRIPE_LICENSE_PAYMENT_LINK_URL: z.string().optional(),
       ADMIN_EMAILS: z.string().optional(),
+
+      // Notifications
+      SLACK_LICENSE_WEBHOOK_URL: z.string().optional(),
     },
 
     /**
@@ -219,9 +225,13 @@ export function createEnvConfig() {
         process.env.ENABLE_CLICKHOUSE?.toLowerCase() === "true",
       CLICKHOUSE_CLUSTER: process.env.CLICKHOUSE_CLUSTER,
       LANGWATCH_LICENSE_PUBLIC_KEY: process.env.LANGWATCH_LICENSE_PUBLIC_KEY,
+      LANGWATCH_LICENSE_PRIVATE_KEY: process.env.LANGWATCH_LICENSE_PRIVATE_KEY,
       STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
       STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+      STRIPE_LICENSE_PAYMENT_LINK_ID: process.env.STRIPE_LICENSE_PAYMENT_LINK_ID,
+      STRIPE_LICENSE_PAYMENT_LINK_URL: process.env.STRIPE_LICENSE_PAYMENT_LINK_URL,
       ADMIN_EMAILS: process.env.ADMIN_EMAILS,
+      SLACK_LICENSE_WEBHOOK_URL: process.env.SLACK_LICENSE_WEBHOOK_URL,
     },
     /**
      * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.

--- a/langwatch/src/server/api/routers/publicEnv.ts
+++ b/langwatch/src/server/api/routers/publicEnv.ts
@@ -24,6 +24,7 @@ export const publicEnvRouter = publicProcedure
       HAS_LANGWATCH_NLP_SERVICE:
         !!env.LANGWATCH_NLP_SERVICE || !!env.LANGWATCH_NLP_LAMBDA_CONFIG,
       HAS_LANGEVALS_ENDPOINT: !!env.LANGEVALS_ENDPOINT,
+      STRIPE_LICENSE_PAYMENT_LINK_URL: env.STRIPE_LICENSE_PAYMENT_LINK_URL,
     };
 
     return publicEnvVars;

--- a/langwatch/src/server/mailer/__tests__/licenseEmail.unit.test.tsx
+++ b/langwatch/src/server/mailer/__tests__/licenseEmail.unit.test.tsx
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sendEmail } from "../emailSender";
+import { sendLicenseEmail } from "../licenseEmail";
+
+vi.mock("../emailSender", () => ({
+  sendEmail: vi.fn(),
+}));
+
+const baseParams = {
+  email: "buyer@acme.com",
+  licenseKey: "dGVzdC1saWNlbnNlLWtleS1jb250ZW50",
+  planType: "GROWTH",
+  maxMembers: 5,
+  expiresAt: "2027-03-02T12:00:00.000Z",
+};
+
+describe("sendLicenseEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when sending a license email", () => {
+    it("calls sendEmail with correct recipient", async () => {
+      await sendLicenseEmail(baseParams);
+
+      expect(sendEmail).toHaveBeenCalledTimes(1);
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "buyer@acme.com",
+        }),
+      );
+    });
+
+    it("uses subject mentioning LangWatch License", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].subject).toContain("LangWatch License");
+    });
+  });
+
+  describe("when rendering the email body", () => {
+    it("contains the license key", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].html).toContain("dGVzdC1saWNlbnNlLWtleS1jb250ZW50");
+    });
+
+    it("contains the plan type", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].html).toContain("Growth");
+    });
+
+    it("contains the seat count", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].html).toContain("5");
+    });
+
+    it("contains the expiration date", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].html).toContain("March 2, 2027");
+    });
+
+    it("contains activation instructions", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].html).toContain("Settings");
+      expect(call[0].html).toContain("License");
+    });
+  });
+
+  describe("when attaching the license file", () => {
+    it("includes a .langwatch-license attachment", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].attachments).toBeDefined();
+      expect(call[0].attachments).toHaveLength(1);
+      expect(call[0].attachments![0]!.filename).toBe(".langwatch-license");
+    });
+
+    it("attaches the license key as file content", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].attachments![0]!.content).toBe(
+        "dGVzdC1saWNlbnNlLWtleS1jb250ZW50",
+      );
+    });
+
+    it("uses application/octet-stream content type", async () => {
+      await sendLicenseEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].attachments![0]!.contentType).toBe(
+        "application/octet-stream",
+      );
+    });
+  });
+});

--- a/langwatch/src/server/mailer/__tests__/licenseEmail.unit.test.tsx
+++ b/langwatch/src/server/mailer/__tests__/licenseEmail.unit.test.tsx
@@ -12,6 +12,7 @@ const baseParams = {
   planType: "GROWTH",
   maxMembers: 5,
   expiresAt: "2027-03-02T12:00:00.000Z",
+  organizationName: "Acme Corp",
 };
 
 describe("sendLicenseEmail", () => {
@@ -78,13 +79,51 @@ describe("sendLicenseEmail", () => {
   });
 
   describe("when attaching the license file", () => {
-    it("includes a .langwatch-license attachment", async () => {
+    it("uses orgName in filename as <orgName>.langwatch-license", async () => {
       await sendLicenseEmail(baseParams);
 
       const call = vi.mocked(sendEmail).mock.calls[0]!;
       expect(call[0].attachments).toBeDefined();
       expect(call[0].attachments).toHaveLength(1);
-      expect(call[0].attachments![0]!.filename).toBe(".langwatch-license");
+      expect(call[0].attachments![0]!.filename).toBe(
+        "Acme_Corp.langwatch-license",
+      );
+    });
+
+    it("sanitizes dots in org name to avoid extension confusion", async () => {
+      await sendLicenseEmail({
+        ...baseParams,
+        organizationName: "acme.corp.inc",
+      });
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].attachments![0]!.filename).toBe(
+        "acme_corp_inc.langwatch-license",
+      );
+    });
+
+    it("sanitizes filesystem-unsafe characters from org name", async () => {
+      await sendLicenseEmail({
+        ...baseParams,
+        organizationName: 'My/Company\\Name:"test"',
+      });
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].attachments![0]!.filename).toBe(
+        "MyCompanyNametest.langwatch-license",
+      );
+    });
+
+    it("uses email as filename when org name is empty", async () => {
+      await sendLicenseEmail({
+        ...baseParams,
+        organizationName: "buyer@acme.com",
+      });
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].attachments![0]!.filename).toBe(
+        "buyer@acme_com.langwatch-license",
+      );
     });
 
     it("attaches the license key as file content", async () => {
@@ -102,6 +141,18 @@ describe("sendLicenseEmail", () => {
       const call = vi.mocked(sendEmail).mock.calls[0]!;
       expect(call[0].attachments![0]!.contentType).toBe(
         "application/octet-stream",
+      );
+    });
+
+    it("ensures filename always ends with .langwatch-license", async () => {
+      await sendLicenseEmail({
+        ...baseParams,
+        organizationName: "anything",
+      });
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].attachments![0]!.filename).toMatch(
+        /\.langwatch-license$/,
       );
     });
   });

--- a/langwatch/src/server/mailer/emailSender.ts
+++ b/langwatch/src/server/mailer/emailSender.ts
@@ -1,15 +1,26 @@
-import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
+import {
+  SESClient,
+  SendEmailCommand,
+  SendRawEmailCommand,
+} from "@aws-sdk/client-ses";
 import sgMail from "@sendgrid/mail";
 import { env } from "../../env.mjs";
 import { createLogger } from "../../utils/logger/server";
 
 const logger = createLogger("langwatch:mailer:emailSender");
 
+export type EmailAttachment = {
+  filename: string;
+  content: string;
+  contentType: string;
+};
+
 type EmailContent = {
   to: string | string[];
   subject: string;
   html: string;
   from?: string;
+  attachments?: EmailAttachment[];
 };
 
 const extractHostname = (baseHost: string): string => {
@@ -53,31 +64,83 @@ export const sendEmail = async (content: EmailContent) => {
   }
 };
 
+const buildRawMimeMessage = ({
+  from,
+  to,
+  subject,
+  html,
+  attachments,
+}: {
+  from: string;
+  to: string[];
+  subject: string;
+  html: string;
+  attachments: EmailAttachment[];
+}): string => {
+  const boundary = `----=_Part_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+  const lines = [
+    `From: ${from}`,
+    `To: ${to.join(", ")}`,
+    `Subject: ${subject}`,
+    `MIME-Version: 1.0`,
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+    ``,
+    `--${boundary}`,
+    `Content-Type: text/html; charset=UTF-8`,
+    `Content-Transfer-Encoding: 7bit`,
+    ``,
+    html,
+  ];
+
+  for (const attachment of attachments) {
+    const base64Content = Buffer.from(attachment.content).toString("base64");
+    lines.push(
+      `--${boundary}`,
+      `Content-Type: ${attachment.contentType}; name="${attachment.filename}"`,
+      `Content-Disposition: attachment; filename="${attachment.filename}"`,
+      `Content-Transfer-Encoding: base64`,
+      ``,
+      base64Content,
+    );
+  }
+
+  lines.push(`--${boundary}--`);
+  return lines.join("\r\n");
+};
+
 const sendWithSES = async (content: EmailContent, defaultFrom: string) => {
   logger.info("Sending email using AWS SES");
   const sesClient = new SESClient({ region: env.AWS_REGION });
-
-  const params = {
-    Destination: {
-      ToAddresses: Array.isArray(content.to) ? content.to : [content.to],
-    },
-    Message: {
-      Body: {
-        Html: {
-          Charset: "UTF-8",
-          Data: content.html,
-        },
-      },
-      Subject: {
-        Charset: "UTF-8",
-        Data: content.subject,
-      },
-    },
-    Source: content.from ?? defaultFrom,
-  };
+  const from = content.from ?? defaultFrom;
+  const toAddresses = Array.isArray(content.to) ? content.to : [content.to];
 
   try {
-    const command = new SendEmailCommand(params);
+    if (content.attachments && content.attachments.length > 0) {
+      const rawMessage = buildRawMimeMessage({
+        from,
+        to: toAddresses,
+        subject: content.subject,
+        html: content.html,
+        attachments: content.attachments,
+      });
+
+      const command = new SendRawEmailCommand({
+        RawMessage: { Data: new TextEncoder().encode(rawMessage) },
+      });
+      const data = await sesClient.send(command);
+      logger.info({ data }, "Email with attachments sent successfully");
+      return data;
+    }
+
+    const command = new SendEmailCommand({
+      Destination: { ToAddresses: toAddresses },
+      Message: {
+        Body: { Html: { Charset: "UTF-8", Data: content.html } },
+        Subject: { Charset: "UTF-8", Data: content.subject },
+      },
+      Source: from,
+    });
     const data = await sesClient.send(command);
     logger.info({ data }, "Email sent successfully");
     return data;
@@ -95,6 +158,15 @@ const sendWithSendGrid = async (content: EmailContent, defaultFrom: string) => {
     from: content.from ?? defaultFrom,
     subject: content.subject,
     html: content.html,
+    ...(content.attachments &&
+      content.attachments.length > 0 && {
+        attachments: content.attachments.map((att) => ({
+          content: Buffer.from(att.content).toString("base64"),
+          filename: att.filename,
+          type: att.contentType,
+          disposition: "attachment" as const,
+        })),
+      }),
   };
 
   try {

--- a/langwatch/src/server/mailer/emailSender.ts
+++ b/langwatch/src/server/mailer/emailSender.ts
@@ -64,6 +64,12 @@ export const sendEmail = async (content: EmailContent) => {
   }
 };
 
+const sanitizeHeaderValue = (value: string): string =>
+  value.replace(/[\r\n]+/g, " ").trim();
+
+const sanitizeHeaderParam = (value: string): string =>
+  sanitizeHeaderValue(value).replace(/(["\\])/g, "\\$1");
+
 const buildRawMimeMessage = ({
   from,
   to,
@@ -80,9 +86,9 @@ const buildRawMimeMessage = ({
   const boundary = `----=_Part_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 
   const lines = [
-    `From: ${from}`,
-    `To: ${to.join(", ")}`,
-    `Subject: ${subject}`,
+    `From: ${sanitizeHeaderValue(from)}`,
+    `To: ${to.map(sanitizeHeaderValue).join(", ")}`,
+    `Subject: ${sanitizeHeaderValue(subject)}`,
     `MIME-Version: 1.0`,
     `Content-Type: multipart/mixed; boundary="${boundary}"`,
     ``,
@@ -97,8 +103,8 @@ const buildRawMimeMessage = ({
     const base64Content = Buffer.from(attachment.content).toString("base64");
     lines.push(
       `--${boundary}`,
-      `Content-Type: ${attachment.contentType}; name="${attachment.filename}"`,
-      `Content-Disposition: attachment; filename="${attachment.filename}"`,
+      `Content-Type: ${sanitizeHeaderValue(attachment.contentType)}; name="${sanitizeHeaderParam(attachment.filename)}"`,
+      `Content-Disposition: attachment; filename="${sanitizeHeaderParam(attachment.filename)}"`,
       `Content-Transfer-Encoding: base64`,
       ``,
       base64Content,

--- a/langwatch/src/server/mailer/licenseEmail.tsx
+++ b/langwatch/src/server/mailer/licenseEmail.tsx
@@ -11,6 +11,21 @@ interface SendLicenseEmailParams {
   planType: string;
   maxMembers: number;
   expiresAt: string;
+  organizationName: string;
+}
+
+/**
+ * Sanitize a string for safe use as a filename prefix.
+ * Strips path separators, null bytes, and other filesystem-unsafe characters.
+ * Replaces dots with underscores to avoid confusing file extension parsing.
+ */
+function sanitizeFilenamePrefix(name: string): string {
+  return name
+    .replace(/[/\\:\0*?"<>|]/g, "") // remove filesystem-unsafe chars
+    .replace(/\./g, "_") // replace dots to avoid extension confusion
+    .replace(/\s+/g, "_") // collapse whitespace to underscores
+    .trim()
+    .slice(0, 100); // limit length
 }
 
 export const sendLicenseEmail = async ({
@@ -19,6 +34,7 @@ export const sendLicenseEmail = async ({
   planType,
   maxMembers,
   expiresAt,
+  organizationName,
 }: SendLicenseEmailParams) => {
   const expirationDate = new Date(expiresAt).toLocaleDateString("en-US", {
     year: "numeric",
@@ -124,7 +140,7 @@ export const sendLicenseEmail = async ({
     html: emailHtml,
     attachments: [
       {
-        filename: ".langwatch-license",
+        filename: `${sanitizeFilenamePrefix(organizationName)}.langwatch-license`,
         content: licenseKey,
         contentType: "application/octet-stream",
       },

--- a/langwatch/src/server/mailer/licenseEmail.tsx
+++ b/langwatch/src/server/mailer/licenseEmail.tsx
@@ -1,0 +1,133 @@
+import { Container } from "@react-email/container";
+import { Heading } from "@react-email/heading";
+import { Html } from "@react-email/html";
+import { Img } from "@react-email/img";
+import { render } from "@react-email/render";
+import { sendEmail } from "./emailSender";
+
+interface SendLicenseEmailParams {
+  email: string;
+  licenseKey: string;
+  planType: string;
+  maxMembers: number;
+  expiresAt: string;
+}
+
+export const sendLicenseEmail = async ({
+  email,
+  licenseKey,
+  planType,
+  maxMembers,
+  expiresAt,
+}: SendLicenseEmailParams) => {
+  const expirationDate = new Date(expiresAt).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const emailHtml = await render(
+    <Html lang="en" dir="ltr">
+      <Container
+        style={{
+          border: "1px solid #F2F4F8",
+          borderRadius: "10px",
+          padding: "24px",
+          paddingBottom: "12px",
+        }}
+      >
+        <Img
+          src="https://app.langwatch.ai/images/logo-icon.png"
+          alt="LangWatch Logo"
+          width="36"
+        />
+        <Heading as="h1">Your LangWatch License</Heading>
+        <p>
+          Thank you for purchasing a LangWatch license! Your license details:
+        </p>
+        <table
+          style={{
+            borderCollapse: "collapse",
+            marginBottom: "16px",
+          }}
+        >
+          <tr>
+            <td style={{ padding: "4px 12px 4px 0", fontWeight: "bold" }}>
+              Plan
+            </td>
+            <td style={{ padding: "4px 0" }}>
+              {planType.charAt(0).toUpperCase() +
+                planType.slice(1).toLowerCase()}
+            </td>
+          </tr>
+          <tr>
+            <td style={{ padding: "4px 12px 4px 0", fontWeight: "bold" }}>
+              Seats
+            </td>
+            <td style={{ padding: "4px 0" }}>{maxMembers}</td>
+          </tr>
+          <tr>
+            <td style={{ padding: "4px 12px 4px 0", fontWeight: "bold" }}>
+              Expires
+            </td>
+            <td style={{ padding: "4px 0" }}>{expirationDate}</td>
+          </tr>
+        </table>
+
+        <Heading as="h2" style={{ fontSize: "18px" }}>
+          How to activate
+        </Heading>
+        <p>
+          A <code>.langwatch-license</code> file is attached to this email.
+          To activate your license:
+        </p>
+        <ol>
+          <li>
+            Go to <strong>Settings → License</strong> in your LangWatch
+            instance
+          </li>
+          <li>Upload the attached file or paste the license key below</li>
+        </ol>
+
+        <Heading as="h2" style={{ fontSize: "18px" }}>
+          License Key
+        </Heading>
+        <p style={{ fontSize: "12px", color: "#666" }}>
+          You can also copy and paste this key directly:
+        </p>
+        <pre
+          style={{
+            backgroundColor: "#F2F4F8",
+            padding: "12px",
+            borderRadius: "6px",
+            fontSize: "12px",
+            fontFamily: "monospace",
+            wordBreak: "break-all",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "break-word",
+          }}
+        >
+          {licenseKey}
+        </pre>
+
+        <p style={{ fontSize: "12px", color: "#999", marginTop: "24px" }}>
+          If you have any questions, please contact us at{" "}
+          <a href="mailto:support@langwatch.ai">support@langwatch.ai</a>
+        </p>
+      </Container>
+    </Html>,
+  );
+
+  await sendEmail({
+    to: email,
+    subject: "Your LangWatch License Key",
+    html: emailHtml,
+    attachments: [
+      {
+        filename: ".langwatch-license",
+        content: licenseKey,
+        contentType: "application/octet-stream",
+      },
+    ],
+  });
+};

--- a/specs/licensing/self-serving-license-purchase.feature
+++ b/specs/licensing/self-serving-license-purchase.feature
@@ -1,0 +1,120 @@
+Feature: Self-Serving License Purchase
+  As a user wanting to run LangWatch self-hosted
+  I want to purchase a license and receive it automatically
+  So that I can activate my self-hosted deployment without manual intervention
+
+  Background:
+    Given the SaaS platform has a valid license signing private key configured
+    And the Stripe license payment link is configured
+
+  # Core webhook flow
+  @integration
+  Scenario: Generate and email license on successful Stripe purchase
+    Given a user completes checkout via the license payment link with 5 seats
+    When the Stripe checkout.session.completed webhook fires
+    Then a GROWTH license is generated with maxMembers set to 5
+    And all other plan limits are set to unlimited
+    And the license expires 1 year from the purchase date
+    And the license is emailed to the buyer's email address
+
+  @integration
+  Scenario: Route license purchase separately from subscription checkout
+    Given a checkout.session.completed event with a payment_link matching the license payment link ID
+    When the webhook handler processes the event
+    Then the event is routed to the license generation flow
+    And the subscription checkout flow is NOT executed
+
+  @integration
+  Scenario: Route subscription checkout normally when not a license purchase
+    Given a checkout.session.completed event without a matching payment_link
+    When the webhook handler processes the event
+    Then the existing subscription checkout flow executes
+    And the license generation flow is NOT triggered
+
+  @integration
+  Scenario: Default to 1 seat when quantity is missing
+    Given a user completes checkout via the license payment link with no quantity specified
+    When the Stripe checkout.session.completed webhook fires
+    Then a GROWTH license is generated with maxMembers set to 1
+
+  @integration
+  Scenario: Use business name as organization name in license
+    Given a user completes checkout with business name "Acme Corp" and email "buyer@acme.com"
+    When the license is generated
+    Then the license organization name is "Acme Corp"
+    And the license email is "buyer@acme.com"
+
+  @integration
+  Scenario: Fall back to email when business name is empty
+    Given a user completes checkout with no business name and email "buyer@solo.dev"
+    When the license is generated
+    Then the license organization name is "buyer@solo.dev"
+
+  # Slack notification
+  @integration
+  Scenario: Notify Slack channel on license purchase
+    Given the Slack license webhook URL is configured
+    When a license is successfully generated from a purchase
+    Then a Slack notification is sent with buyer email, plan type, seat count, and amount paid
+
+  @integration
+  Scenario: Continue license delivery when Slack notification fails
+    Given the Slack license webhook URL is configured but unreachable
+    When a license is successfully generated from a purchase
+    Then the license is still emailed to the buyer
+    And the Slack failure is logged but does not block delivery
+
+  # Error handling
+  @integration
+  Scenario: Handle missing private key gracefully
+    Given the license signing private key is NOT configured
+    When a license purchase webhook fires
+    Then the webhook logs an error about missing private key
+    And the webhook returns a 500 status
+    And no email is sent
+
+  @integration
+  Scenario: Handle missing email configuration gracefully
+    Given the email sender is NOT configured
+    When a license purchase webhook fires
+    Then the license is generated but email delivery fails
+    And the error is logged
+
+  # GROWTH plan template
+  @unit
+  Scenario: GROWTH template has correct default limits
+    Given the GROWTH plan template
+    Then the plan type is "GROWTH"
+    And the plan name is "Growth"
+    And maxMembers is configurable (not preset)
+    And maxMembersLite equals Number.MAX_SAFE_INTEGER
+    And maxTeams equals Number.MAX_SAFE_INTEGER
+    And maxProjects equals Number.MAX_SAFE_INTEGER
+    And maxMessagesPerMonth equals Number.MAX_SAFE_INTEGER
+    And evaluationsCredit equals Number.MAX_SAFE_INTEGER
+    And maxWorkflows equals Number.MAX_SAFE_INTEGER
+    And maxPrompts equals Number.MAX_SAFE_INTEGER
+    And maxEvaluators equals Number.MAX_SAFE_INTEGER
+    And maxScenarios equals Number.MAX_SAFE_INTEGER
+    And maxAgents equals Number.MAX_SAFE_INTEGER
+    And maxExperiments equals Number.MAX_SAFE_INTEGER
+    And maxOnlineEvaluations equals Number.MAX_SAFE_INTEGER
+    And maxDatasets equals Number.MAX_SAFE_INTEGER
+    And maxDashboards equals Number.MAX_SAFE_INTEGER
+    And maxCustomGraphs equals Number.MAX_SAFE_INTEGER
+    And maxAutomations equals Number.MAX_SAFE_INTEGER
+    And canPublish is true
+    And usageUnit is "events"
+
+  # UI: configurable payment link
+  @integration
+  Scenario: Purchase button uses configured payment link URL
+    Given the STRIPE_LICENSE_PAYMENT_LINK_URL is set to "https://buy.stripe.com/test123"
+    When the license page renders for a user without a license
+    Then the "Purchase license" button links to "https://buy.stripe.com/test123"
+
+  @integration
+  Scenario: Purchase button hidden when payment link URL is not configured
+    Given the STRIPE_LICENSE_PAYMENT_LINK_URL is NOT set
+    When the license page renders for a user without a license
+    Then the "Purchase license" button is not displayed

--- a/specs/licensing/self-serving-license-purchase.feature
+++ b/specs/licensing/self-serving-license-purchase.feature
@@ -81,30 +81,14 @@ Feature: Self-Serving License Purchase
     And the error is logged
 
   # GROWTH plan template
-  @unit
-  Scenario: GROWTH template has correct default limits
-    Given the GROWTH plan template
-    Then the plan type is "GROWTH"
-    And the plan name is "Growth"
-    And maxMembers is configurable (not preset)
-    And maxMembersLite equals Number.MAX_SAFE_INTEGER
-    And maxTeams equals Number.MAX_SAFE_INTEGER
-    And maxProjects equals Number.MAX_SAFE_INTEGER
-    And maxMessagesPerMonth equals Number.MAX_SAFE_INTEGER
-    And evaluationsCredit equals Number.MAX_SAFE_INTEGER
-    And maxWorkflows equals Number.MAX_SAFE_INTEGER
-    And maxPrompts equals Number.MAX_SAFE_INTEGER
-    And maxEvaluators equals Number.MAX_SAFE_INTEGER
-    And maxScenarios equals Number.MAX_SAFE_INTEGER
-    And maxAgents equals Number.MAX_SAFE_INTEGER
-    And maxExperiments equals Number.MAX_SAFE_INTEGER
-    And maxOnlineEvaluations equals Number.MAX_SAFE_INTEGER
-    And maxDatasets equals Number.MAX_SAFE_INTEGER
-    And maxDashboards equals Number.MAX_SAFE_INTEGER
-    And maxCustomGraphs equals Number.MAX_SAFE_INTEGER
-    And maxAutomations equals Number.MAX_SAFE_INTEGER
-    And canPublish is true
-    And usageUnit is "events"
+  @integration
+  Scenario: GROWTH plan includes all features with no artificial limits
+    Given a user purchases a GROWTH license with 10 seats
+    When the license is generated
+    Then the license plan type is "GROWTH"
+    And the license allows 10 members
+    And all other features are unlimited
+    And publishing is enabled
 
   # UI: configurable payment link
   @integration


### PR DESCRIPTION
## feat(licensing): self-serving license purchase automation

Automates license generation and delivery when a user purchases a license via Stripe payment link. Replaces the current manual process (check Stripe → manually generate license → manually email it).

required envs
`STRIPE_LICENSE_PAYMENT_LINK_URL`

<img width="397" height="452" alt="image" src="https://github.com/user-attachments/assets/c2ff2fec-b3b3-44d9-95e0-bc0512039805" />

<img width="949" height="344" alt="image" src="https://github.com/user-attachments/assets/b1721ce4-7c34-46f7-b7c6-ce9f977f4505" />



### What changed

**PR1 — GROWTH Plan Template + Environment Variables**
- Added `GROWTH_TEMPLATE` to `planTemplates.ts` with unlimited limits (`Number.MAX_SAFE_INTEGER`) and dynamic `maxMembers`
- Registered env vars: `LANGWATCH_LICENSE_PRIVATE_KEY`, `STRIPE_LICENSE_PAYMENT_LINK_ID`, `STRIPE_LICENSE_PAYMENT_LINK_URL`
- Exposed `STRIPE_LICENSE_PAYMENT_LINK_URL` via `publicEnv` router

**PR2 — License Generation Service**
- Created `licenseGenerationService.ts` — pure function that generates signed license keys
- Handles GROWTH/PRO/ENTERPRISE templates, seat count override, 1-year expiration, org name fallback to email

**PR3 — License Email Template + Attachment Support**
- Extended `emailSender.ts` with optional `attachments` field (SES: `SendRawEmailCommand` with MIME; SendGrid: native attachments)
- Created `licenseEmail.tsx` — delivers license key as `.langwatch-license` file attachment with inline fallback
- MIME header injection prevention via `sanitizeHeaderValue()`/`sanitizeHeaderParam()`

**PR4 — Slack Notification**
- Added `notifyLicensePurchase()` dispatch function with `runHandlerSafely()` (errors swallowed)
- Created `slackLicenseNotification.ts` — Block Kit formatted Slack message with 10s AbortController timeout
- Reuses existing `SLACK_CHANNEL_SUBSCRIPTIONS` env var (no separate webhook URL needed)

**PR5 — Webhook License Purchase Flow**
- Routes `checkout.session.completed` events via `payment_link` field match before existing subscription flow
- `licensePurchaseHandler.ts` orchestrates: extract buyer info → get seat count → generate license → email → Slack notify

**PR6 — UI: License Page Improvements**
- Replaced hardcoded Stripe URL in `NoLicenseCard.tsx` with `publicEnv.STRIPE_LICENSE_PAYMENT_LINK_URL`
- Added `DEFAULT_LICENSE_PURCHASE_URL` fallback so self-hosted users see "Purchase license" button without env var config
- Moved `CONTACT_SALES_URL` to `ee/licensing/constants.ts` (commercially scoped)
- Added "Contact Sales" button next to "Remove License" in `LicenseDetailsCard`
- Added seat usage display (`currentMembers / maxMembers`) in license details card
- License upgrades (more seats, higher plan) require contacting sales

### New Environment Variables

| Variable | Required | Scope | Description |
|---|---|---|---|
| `LANGWATCH_LICENSE_PRIVATE_KEY` | For license gen | Server | RSA private key (PEM) for signing |
| `STRIPE_LICENSE_PAYMENT_LINK_ID` | For routing | Server | Payment link ID to match against |
| `STRIPE_LICENSE_PAYMENT_LINK_URL` | For UI | Client | Payment link URL shown to users (has hardcoded default) |

### Design Decisions

- **Initial purchase is self-serve** via Stripe payment link (default URL hardcoded for self-hosted)
- **License upgrades require contacting sales** (Contact Sales button links to HubSpot)
- **Quantity/seats**: Users can adjust quantity on Stripe checkout; `maxMembers` in license matches purchased quantity (default: 1)
- **License validity**: One-time purchase, 1 year from purchase date (no billing cycle anchor)
- **Slack notifications** reuse existing `SLACK_CHANNEL_SUBSCRIPTIONS` instead of separate webhook URL

### Test plan

- **Unit tests**: 170+ tests covering all new modules (plan templates, license generation, email template, Slack notification, webhook routing, handler orchestration)
- **E2E verified**: Stripe test mode checkout → webhook fires → license generated → email with attachment delivered → Slack notification sent
- **Typecheck**: 0 errors (only pre-existing `fastq` module errors)
- **No regressions**: existing subscription flow, email sending, and plan template tests all pass