### PR TITLE
feat: auto-copy .env files into new git worktrees

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copies .env files from the main checkout into newly created worktrees.
+# Installed via: git config core.hooksPath .githooks
+
+prev_head="$1"
+new_head="$2"
+branch_flag="$3"
+
+# Only act on branch checkouts (not file checkouts)
+[ "$branch_flag" = "1" ] || exit 0
+
+# Only act inside worktrees, not the main checkout
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+[ "$git_dir" != "$git_common_dir" ] || exit 0
+
+main_checkout="$(cd "$git_common_dir/.." && pwd)"
+worktree_root="$(git rev-parse --show-toplevel)"
+
+# Directories that may contain .env files
+env_dirs=("langwatch" "langwatch_nlp" "langevals" "python-sdk" "typescript-sdk" "mcp-server")
+
+copied=0
+for dir in "${env_dirs[@]}"; do
+  src="${main_checkout}/${dir}"
+  dest="${worktree_root}/${dir}"
+
+  [ -d "$src" ] || continue
+  [ -d "$dest" ] || continue
+
+  for f in "${src}"/.env*; do
+    [ -f "$f" ] || continue
+    cp "$f" "${dest}/"
+    copied=$((copied + 1))
+  done
+done
+
+if [ "$copied" -gt 0 ]; then
+  echo "post-checkout: Copied $copied .env file(s) from main checkout into worktree."
+fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: start sync-all-openapi user-delete-dry-run user-delete es-delete-dry-run es-delete
 .PHONY: dev dev-nlp dev-scenarios dev-full down logs clean ps quickstart worktree
+.PHONY: setup-hooks
 
 # =============================================================================
 # DOCKER DEV ENVIRONMENT (compose.dev.yml)
@@ -9,28 +10,32 @@
 
 COMPOSE = docker compose -f compose.dev.yml
 
+# Install git hooks (idempotent, runs automatically before dev targets)
+setup-hooks:
+	@git config core.hooksPath .githooks
+
 # Minimal: postgres + redis + app (no opensearch)
-dev:
+dev: setup-hooks
 	$(COMPOSE) up
 
 # + opensearch (for traces/search features)
-dev-search:
+dev-search: setup-hooks
 	$(COMPOSE) --profile search up
 
 # + NLP service + langevals (for evaluations)
-dev-nlp:
+dev-nlp: setup-hooks
 	$(COMPOSE) --profile nlp up
 
 # + scenario worker + bullboard + NLP (no opensearch needed)
-dev-scenarios:
+dev-scenarios: setup-hooks
 	$(COMPOSE) --profile scenarios up
 
 # + AI test server (for HTTP agent testing)
-dev-test:
+dev-test: setup-hooks
 	$(COMPOSE) --profile test up
 
 # Everything
-dev-full:
+dev-full: setup-hooks
 	$(COMPOSE) --profile full up
 
 # Stop all services

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -18,6 +18,7 @@
     "lint": "pnpm exec biome check src/",
     "lint:fix": "pnpm exec biome check src/ --write",
     "format": "pnpm exec biome format src/ --write",
+    "postinstall": "git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .githooks || true",
     "dev": "pnpm run start:prepare:files && NODE_ENV=development START_WORKERS=true pnpm start",
     "start": "./scripts/start.sh",
     "start:app": "tsx src/server.ts",

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -121,12 +121,14 @@ main() {
     git worktree add -b "$branch" "$dir" origin/main
   fi
 
-  # Copy .env files from repo root and subdirectories that need them.
+  # Copy .env files from subdirectories that need them.
   # Warns when a required .env is missing so the developer knows to create one.
   local env_warnings=0
-  for src_dir in "." "langwatch" "langwatch_nlp"; do
-    local dest="${dir}"
-    [ "$src_dir" != "." ] && dest="${dir}/${src_dir}"
+  for src_dir in "langwatch" "langwatch_nlp" "langevals" "python-sdk" "typescript-sdk" "mcp-server"; do
+    local dest="${dir}/${src_dir}"
+
+    # Skip directories that don't exist in the worktree
+    [ -d "$dest" ] || continue
 
     local has_env=false
     for f in "${src_dir}"/.env*; do
@@ -137,9 +139,7 @@ main() {
 
     # Check that a .env file (not just .env.example) was copied
     if [ "$has_env" = false ] || [ ! -f "${src_dir}/.env" ]; then
-      local display_dir="$src_dir"
-      [ "$src_dir" = "." ] && display_dir="(repo root)"
-      echo "WARNING: ${display_dir}/.env not found in main checkout" >&2
+      echo "WARNING: ${src_dir}/.env not found in main checkout" >&2
       if [ -f "${src_dir}/.env.example" ]; then
         echo "  → cp ${src_dir}/.env.example ${src_dir}/.env  (then re-run or copy manually)" >&2
       fi


### PR DESCRIPTION
## Summary

- Add a `post-checkout` git hook (`.githooks/post-checkout`) that detects worktree creation and automatically copies `.env*` files from the main checkout into the new worktree
- Auto-install hooks via `postinstall` in `langwatch/package.json` and `setup-hooks` Make target (dependency of all `dev*` targets)
- Update `scripts/worktree.sh` to cover all subdirectories: `langwatch`, `langwatch_nlp`, `langevals`, `python-sdk`, `typescript-sdk`, `mcp-server`

## How it works

- **`pnpm install`** → `postinstall` runs `git config core.hooksPath .githooks` (no-ops safely in Docker/CI where there's no git repo)
- **`make dev`** → `setup-hooks` prerequisite does the same
- **Any `git worktree add`** (manual, `make worktree`, or Claude Code) → `post-checkout` hook fires, detects it's inside a worktree, and copies `.env*` files from the main checkout

## Test plan

- [ ] Run `pnpm install` in `langwatch/` and verify `git config core.hooksPath` is set to `.githooks`
- [ ] Create a worktree with `make worktree <name>` and verify `.env` files are copied
- [ ] Create a worktree with Claude Code and verify `.env` files are copied
- [ ] Verify Docker build still works (`pnpm install` no-ops the hook setup)