### PR TITLE
fix: retrigger approval check on push/rebase

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -2,7 +2,7 @@ name: Approval or Exception Required
 
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
## Summary
- Add `opened`, `reopened`, and `synchronize` to the `pull_request` trigger types in `approval-or-hotfix.yml`
- Previously the check only triggered on `labeled`/`unlabeled` and `pull_request_review.submitted`, so a rebase would leave the check stale and block merge

## Test plan
- [x] One-line change to trigger types, no logic changes