### PR TITLE
fix: add missing safety evaluators to type selector drawer

### DIFF
--- a/langwatch/src/components/evaluators/EvaluatorTypeSelectorDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorTypeSelectorDrawer.tsx
@@ -47,7 +47,9 @@ const categoryEvaluators: Record<
   safety: [
     "presidio/pii_detection",
     "azure/prompt_injection",
+    "azure/jailbreak",
     "azure/content_safety",
+    "openai/moderation",
   ],
 };
 


### PR DESCRIPTION
## Summary
- Adds `azure/jailbreak` (Azure Jailbreak Detection) and `openai/moderation` (OpenAI Moderation) to the safety category in `EvaluatorTypeSelectorDrawer`
- Both evaluators were fully defined in `AVAILABLE_EVALUATORS` but missing from the hardcoded `categoryEvaluators` map, so they never appeared in the drawer

## Test plan
- [ ] Open the evaluator creation drawer, select "Safety" category
- [ ] Verify all 5 safety evaluators now appear: Presidio PII Detection, Azure Prompt Shield, Azure Jailbreak Detection, Azure Content Safety, OpenAI Moderation