### PR TITLE
fix: auto-trigger low-risk evaluation on PRs

### DIFF
--- a/.github/workflows/low-risk-evaluation.yml
+++ b/.github/workflows/low-risk-evaluation.yml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   evaluate:
+    # Skip fork PRs — secrets and write permissions are unavailable
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger (`opened`, `synchronize`, `reopened`) so the workflow runs automatically on every PR instead of requiring manual dispatch
- Resolve PR number from `github.event.pull_request.number` for automatic runs, falling back to `inputs.pr_number` for manual dispatch
- Use dedicated `LOW_RISK_OPENAI_API_KEY` secret (already set in repo) instead of generic `OPENAI_API_KEY`

## Test plan
- [ ] Open or update a PR and verify the workflow triggers automatically
- [ ] Confirm the OpenAI evaluation step succeeds with the new secret
- [ ] Manual `workflow_dispatch` still works with explicit PR number