### PR TITLE
fix: re-run approval check after low-risk label is applied

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -19,9 +19,18 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
 
+            // Fetch current labels from the API instead of the event payload,
+            // because labels added by GITHUB_TOKEN actions don't trigger new
+            // workflow runs, so the payload may be stale.
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+
             // Labels that allow bypass
             const exceptionLabels = ["hotfix", "low-risk-change"];
-            const hasExceptionLabel = pr.labels.some(label => exceptionLabels.includes(label.name));
+            const hasExceptionLabel = labels.some(label => exceptionLabels.includes(label.name));
 
             // Get PR reviews
             const reviews = await github.rest.pulls.listReviews({
@@ -41,7 +50,7 @@ jobs:
             const approvalCount = approvedUsers.size;
 
             if (hasExceptionLabel) {
-              core.info(`PR has exception label (${pr.labels.map(l => l.name).join(", ")}). Passing check.`);
+              core.info(`PR has exception label (${labels.map(l => l.name).join(", ")}). Passing check.`);
               return;
             }
 

--- a/.github/workflows/low-risk-evaluation.yml
+++ b/.github/workflows/low-risk-evaluation.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
+  actions: write
 
 jobs:
   evaluate:
@@ -199,6 +200,36 @@ jobs:
                   "This classification allows merging without manual review once all required CI checks are passing and branch protection rules are satisfied.",
                 ].join("\n"),
               });
+
+              // Re-run the approval check — labels added by GITHUB_TOKEN don't
+              // fire the "labeled" event for other workflows.
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              const headSha = pr.data.head.sha;
+
+              // Find the failed workflow run for the approval check
+              const workflowRuns = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "approval-or-hotfix.yml",
+                head_sha: headSha,
+                status: "completed",
+              });
+
+              for (const run of workflowRuns.data.workflow_runs) {
+                if (run.conclusion === "failure") {
+                  await github.rest.actions.reRunWorkflow({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id,
+                  });
+                  core.info(`Re-ran approval workflow run ${run.id}.`);
+                  break;
+                }
+              }
 
               core.info(`PR #${prNumber} labeled as low-risk-change.`);
             } else {


### PR DESCRIPTION
## Summary
- **approval-or-hotfix.yml**: Fetch labels from the API (`listLabelsOnIssue`) instead of the stale event payload (`pr.labels`), so re-runs always see the latest state
- **low-risk-evaluation.yml**: After applying the `low-risk-change` label, find and re-run the failed approval workflow via `actions.reRunWorkflow` so the check updates automatically

## Context
Labels added by `GITHUB_TOKEN` don't fire the `labeled` event for other workflows (GitHub anti-recursion). This caused `check-approval-or-label` to stay failed even after the `low-risk-change` label was applied by the evaluation workflow. Same fix already verified on [langwatch/scenario#247](https://github.com/langwatch/scenario/pull/247).

## Test plan
- [ ] Open a PR that qualifies as low-risk
- [ ] Verify `low-risk-evaluation` applies the label and then re-runs `check-approval-or-label`
- [ ] Verify `check-approval-or-label` passes on the re-run (fetches fresh labels from API)