### PR TITLE
chore(deps): bump GitHub Actions versions (5 dependabot PRs)

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: agentic-e2e-tests/playwright-report/
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results
           path: agentic-e2e-tests/test-results/

--- a/.github/workflows/langwatch-server-publish.yml
+++ b/.github/workflows/langwatch-server-publish.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -43,7 +43,7 @@ jobs:
           uv run python -m build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           packages_dir: python-sdk/dist/
           user: __token__

--- a/.github/workflows/pr-conventional-commits-title.yml
+++ b/.github/workflows/pr-conventional-commits-title.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR Title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/sdk-go-cd.yml
+++ b/.github/workflows/sdk-go-cd.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache-dependency-path: sdk-go/go.sum

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           cache: true
@@ -86,7 +86,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           cache: true

--- a/.github/workflows/sdk-python-cd.yml
+++ b/.github/workflows/sdk-python-cd.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -37,7 +37,7 @@ jobs:
           uv run python -m build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           packages_dir: python-sdk/dist/
           user: __token__


### PR DESCRIPTION
## Summary

Consolidates 5 dependabot GitHub Actions PRs, all with clean CI.

| Action | Old | New |
|--------|-----|-----|
| `actions/upload-artifact` | v4 | v6 |
| `actions/setup-python` | v4 | v6 |
| `actions/setup-go` | v5 | v6 |
| `pypa/gh-action-pypi-publish` | pinned SHA | updated pinned SHA |
| `amannn/action-semantic-pull-request` | v5 | v6 |

### Closes dependabot PRs
#1604 #1603 #1602 #1601 #1600

## Test plan
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)