### PR TITLE
fix: wait for postgres before running migrations

### DIFF
--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -14,20 +14,10 @@ if [[ "$START_WORKERS" = "true" || "$START_WORKERS" = "1" ]]; then
   START_WORKERS_COMMAND="pnpm run start:workers && exit 1"
 fi
 
-START_QUICKWIT_COMMAND=""
-if grep -q "^ELASTICSEARCH_NODE_URL=\"\?quickwit://" .env || ([ -n "$ELASTICSEARCH_NODE_URL" ] && [[ "$ELASTICSEARCH_NODE_URL" =~ ^quickwit:// ]]); then
-  START_QUICKWIT_COMMAND="pnpm run start:quickwit"
-  START_APP_COMMAND="./scripts/wait-for-quickwit.sh && pnpm run start:prepare:db && pnpm run start:app"
-  RUNTIME_ENV="$RUNTIME_ENV RUST_LOG=error"
-
-  if [ ! -d "quickwit" ]; then
-    echo "Quickwit was not found, installing it..."
-    pnpm run setup:quickwit
-  fi
-else
-  # Wait for postgres to be reachable before running migrations
+wait_for_postgres() {
   if [ -n "$DATABASE_URL" ]; then
     echo "Waiting for database to be ready..."
+    db_ready=false
     for i in $(seq 1 30); do
       if node -e "
         const url = new URL(process.env.DATABASE_URL.replace('postgresql://', 'http://'));
@@ -37,12 +27,32 @@ else
         setTimeout(() => process.exit(1), 2000);
       " 2>/dev/null; then
         echo "Database is reachable"
+        db_ready=true
         break
       fi
       echo "Database not ready yet, retrying in 2s... ($i/30)"
       sleep 2
     done
+    if [ "$db_ready" != "true" ]; then
+      echo "Database was not reachable after 30 attempts; aborting startup."
+      exit 1
+    fi
   fi
+}
+
+START_QUICKWIT_COMMAND=""
+if grep -q "^ELASTICSEARCH_NODE_URL=\"\?quickwit://" .env || ([ -n "$ELASTICSEARCH_NODE_URL" ] && [[ "$ELASTICSEARCH_NODE_URL" =~ ^quickwit:// ]]); then
+  wait_for_postgres
+  START_QUICKWIT_COMMAND="pnpm run start:quickwit"
+  START_APP_COMMAND="./scripts/wait-for-quickwit.sh && pnpm run start:prepare:db && pnpm run start:app"
+  RUNTIME_ENV="$RUNTIME_ENV RUST_LOG=error"
+
+  if [ ! -d "quickwit" ]; then
+    echo "Quickwit was not found, installing it..."
+    pnpm run setup:quickwit
+  fi
+else
+  wait_for_postgres
   pnpm run start:prepare:db
 fi
 

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -25,7 +25,25 @@ if grep -q "^ELASTICSEARCH_NODE_URL=\"\?quickwit://" .env || ([ -n "$ELASTICSEAR
     pnpm run setup:quickwit
   fi
 else
- pnpm run start:prepare:db
+  # Wait for postgres to be reachable before running migrations
+  if [ -n "$DATABASE_URL" ]; then
+    echo "Waiting for database to be ready..."
+    for i in $(seq 1 30); do
+      if node -e "
+        const url = new URL(process.env.DATABASE_URL.replace('postgresql://', 'http://'));
+        const net = require('net');
+        const s = net.connect({host: url.hostname, port: url.port || 5432}, () => { s.end(); process.exit(0); });
+        s.on('error', () => process.exit(1));
+        setTimeout(() => process.exit(1), 2000);
+      " 2>/dev/null; then
+        echo "Database is reachable"
+        break
+      fi
+      echo "Database not ready yet, retrying in 2s... ($i/30)"
+      sleep 2
+    done
+  fi
+  pnpm run start:prepare:db
 fi
 
 COMMANDS=()


### PR DESCRIPTION
## Summary
- Adds a retry loop to `start.sh` that waits for postgres TCP connectivity before running `prisma migrate deploy`
- Retries up to 30 times (2s apart) using Node.js `net.connect` against the `DATABASE_URL` host
- Fixes `P1001: Can't reach database server` errors on Docker Compose startup when postgres is technically healthy but not yet reachable from the app container

## Problem
Even with `depends_on: condition: service_healthy` in Docker Compose, there can be a brief window where DNS resolution or TCP connectivity to the postgres container isn't ready when the app starts running migrations. This causes the app to crash on first startup.

## Test plan
- [ ] `docker compose up -d --wait --build` starts without P1001 errors
- [ ] App successfully runs migrations on first attempt after postgres becomes reachable
- [ ] No regression when postgres is already available (immediate pass-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)