### PR TITLE
chore(deps): bump Node.js dependencies - batch 3

### DIFF
--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -81,7 +81,7 @@
         "eslint": "^9.32.0",
         "fets": "^0.8.5",
         "fishery": "^2.3.1",
-        "langchain": ">=0.3.0 <1.0.0",
+        "langchain": ">=0.3.0 <2.0.0",
         "msw": "^2.10.4",
         "nock": "^14.0.8",
         "openapi-msw": "^1.2.0",
@@ -127,7 +127,7 @@
         "@opentelemetry/context-zone": ">=1.19.0 <3.0.0",
         "@opentelemetry/sdk-node": ">=0.200.0 <1.0.0",
         "@opentelemetry/sdk-trace-web": ">=1.19.0 <3.0.0",
-        "langchain": ">=0.3.0 <1.0.0"
+        "langchain": ">=0.3.0 <2.0.0"
     },
     "pnpm": {
         "overrides": {

--- a/typescript-sdk/pnpm-lock.yaml
+++ b/typescript-sdk/pnpm-lock.yaml
@@ -156,7 +156,7 @@ importers:
         specifier: ^2.3.1
         version: 2.3.1
       langchain:
-        specifier: '>=0.3.0 <1.0.0'
+        specifier: '>=0.3.0 <2.0.0'
         version: 0.3.34(@langchain/core@0.3.77(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.205.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(openai@5.12.2(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.205.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(openai@5.12.2(zod@4.3.6))
       msw:
         specifier: ^2.10.4


### PR DESCRIPTION
## Summary

- **typescript-sdk**: widen \`langchain\` peer/dev dependency range \`<1.0.0\` → \`<2.0.0\`

Note: \`@hono/node-server\` + \`hono\` updates were already covered by #1967.

## Closes

Closes #1518

## Deferred (major/breaking)

- #1629 (lucide-react): stale – main already at 0.575.0 > PR target
- #1626 (@ai-sdk/react): stale – main already at ^2.0.109
- #1948, #1616: lockfile-only, incorporated naturally
- #1619 (@copilotkit): 1.8→1.51 major jump, needs investigation
- #1824, #1859 (@langchain/community): major version in examples, needs verification
- All other major bumps (elastic, tanstack, trpc, ai-sdk, zod, hookform, testcontainers)

## Test plan

- [ ] CI typecheck passes
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)