### PR TITLE
fix(suites): drawer navigation, table width, and quick-run callbacks (#1956)

### DIFF
--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -3,6 +3,7 @@ import type { Scenario } from "@prisma/client";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { getComplexProps, setFlowCallbacks, useDrawer, useDrawerParams } from "../../hooks/useDrawer";
+import { useDrawerRunCallbacks } from "../../hooks/useDrawerRunCallbacks";
 import { AgentTypeSelectorDrawer } from "../agents/AgentTypeSelectorDrawer";
 import { checkCompoundLimits } from "../../hooks/useCompoundLicenseCheck";
 import { useLicenseEnforcement } from "../../hooks/useLicenseEnforcement";
@@ -58,9 +59,13 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
   const utils = api.useContext();
   const [formInstance, setFormInstance] =
     useState<UseFormReturn<ScenarioFormData> | null>(null);
+  const { onRunComplete, onRunFailed } = useDrawerRunCallbacks();
+
   const { runScenario, isRunning } = useRunScenario({
     projectId: project?.id,
     projectSlug: project?.slug,
+    onRunComplete,
+    onRunFailed,
   });
   const scenarioId = props.scenarioId;
 

--- a/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -18,6 +18,7 @@ import { ScenarioFormDrawer } from "~/components/scenarios/ScenarioFormDrawer";
 import type { TargetValue } from "~/components/scenarios/TargetSelector";
 import { buildDisplayTitle } from "~/components/suites/run-history-transforms";
 import { useDrawer, useDrawerParams } from "~/hooks/useDrawer";
+import { useDrawerRunCallbacks } from "~/hooks/useDrawerRunCallbacks";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRunScenario } from "~/hooks/useRunScenario";
 import { useScenarioTarget } from "~/hooks/useScenarioTarget";
@@ -100,9 +101,13 @@ export function ScenarioRunDetailDrawer({
     });
   }, [scenarioState?.name, scenarioState?.metadata, targetNameMap]);
 
+  const { onRunComplete, onRunFailed } = useDrawerRunCallbacks();
+
   const { runScenario, isRunning } = useRunScenario({
     projectId: project?.id,
     projectSlug: project?.slug,
+    onRunComplete,
+    onRunFailed,
   });
 
   const {

--- a/langwatch/src/components/suites/AllRunsPanel.tsx
+++ b/langwatch/src/components/suites/AllRunsPanel.tsx
@@ -138,7 +138,6 @@ export function AllRunsPanel({ period }: AllRunsPanelProps) {
     { enabled: !!project },
   );
 
-
   const targetNameMap = useTargetNameMap();
 
   const resolveTargetName = useCallback(
@@ -273,9 +272,9 @@ export function AllRunsPanel({ period }: AllRunsPanelProps) {
   }
 
   return (
-    <VStack align="stretch" gap={4} height="100%" overflow="auto" paddingX={6} paddingY={4}>
+    <VStack align="stretch" gap={0} height="100%" overflow="auto" paddingY={4}>
       {/* Header */}
-      <Box>
+      <Box paddingX={6} paddingBottom={4}>
         <Text fontSize="xl" fontWeight="bold">
           All Runs
         </Text>
@@ -288,19 +287,21 @@ export function AllRunsPanel({ period }: AllRunsPanelProps) {
       </Box>
 
       {/* Filters */}
-      <RunHistoryFilters
-        scenarioOptions={scenarioOptions}
-        filters={filters}
-        onFiltersChange={setFilters}
-        groupBy={groupBy}
-        onGroupByChange={setGroupBy}
-        viewMode={viewMode}
-        onViewModeChange={setViewMode}
-      />
+      <Box paddingX={6} paddingBottom={4}>
+        <RunHistoryFilters
+          scenarioOptions={scenarioOptions}
+          filters={filters}
+          onFiltersChange={setFilters}
+          groupBy={groupBy}
+          onGroupByChange={setGroupBy}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+        />
+      </Box>
 
       {/* Run list */}
       {(groupBy === "none" ? batchRuns.length : groups.length) === 0 ? (
-        <Box paddingY={8} textAlign="center">
+        <Box paddingX={6} paddingY={8} textAlign="center">
           <Text color="fg.muted">
             {filters.scenarioId || filters.passFailStatus
               ? "No runs match the selected filters."
@@ -309,7 +310,7 @@ export function AllRunsPanel({ period }: AllRunsPanelProps) {
         </Box>
       ) : (
         <>
-          <VStack align="stretch" gap={3}>
+          <VStack align="stretch" gap={0}>
             {groupBy === "none"
               ? batchRuns.map((batchRun) => {
                   const summary = computeBatchRunSummary({ batchRun });
@@ -354,7 +355,7 @@ export function AllRunsPanel({ period }: AllRunsPanelProps) {
 
           {/* Load More button */}
           {hasMore && (
-            <Box paddingTop={4} display="flex" justifyContent="center">
+            <Box paddingX={6} paddingTop={4} display="flex" justifyContent="center">
               <Button variant="outline" onClick={handleLoadMore}>
                 Load More...
               </Button>
@@ -364,7 +365,9 @@ export function AllRunsPanel({ period }: AllRunsPanelProps) {
       )}
 
       {/* Footer */}
-      <RunHistoryFooter totals={totals} />
+      <Box paddingX={6}>
+        <RunHistoryFooter totals={totals} />
+      </Box>
     </VStack>
   );
 }

--- a/langwatch/src/components/suites/ExternalSetDetailPanel.tsx
+++ b/langwatch/src/components/suites/ExternalSetDetailPanel.tsx
@@ -12,12 +12,11 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { useRouter } from "next/router";
 import { useCallback, useMemo, useState } from "react";
+import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
 import { api } from "~/utils/api";
-import { buildRoutePath } from "~/utils/routes";
 import {
   computeBatchRunSummary,
   groupRunsByBatchId,
@@ -32,7 +31,7 @@ export function ExternalSetDetailPanel({
   scenarioSetId,
 }: ExternalSetDetailPanelProps) {
   const { project } = useOrganizationTeamProject();
-  const router = useRouter();
+  const { openDrawer } = useDrawer();
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
   const {
@@ -69,16 +68,11 @@ export function ExternalSetDetailPanel({
 
   const handleScenarioRunClick = useCallback(
     (run: ScenarioRunData) => {
-      if (!project) return;
-      const path = buildRoutePath("simulations_run", {
-        project: project.slug,
-        scenarioSetId,
-        batchRunId: run.batchRunId,
-        scenarioRunId: run.scenarioRunId,
+      openDrawer("scenarioRunDetail", {
+        urlParams: { scenarioRunId: run.scenarioRunId },
       });
-      void router.push(path);
     },
-    [project, router, scenarioSetId],
+    [openDrawer],
   );
 
   // External sets have no target resolution

--- a/langwatch/src/components/suites/__tests__/ExternalSetDetailPanel.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ExternalSetDetailPanel.integration.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for ExternalSetDetailPanel component.
+ *
+ * Verifies that clicking a run row opens the drawer instead of navigating.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExternalSetDetailPanel } from "../ExternalSetDetailPanel";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+// Hoisted mocks
+const mockOpenDrawer = vi.hoisted(() => vi.fn());
+const mockRouterPush = vi.hoisted(() => vi.fn());
+const mockRunDataQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: mockOpenDrawer,
+    closeDrawer: vi.fn(),
+    drawerOpen: vi.fn(),
+    goBack: vi.fn(),
+    canGoBack: false,
+    currentDrawer: undefined,
+    setFlowCallbacks: vi.fn(),
+    getFlowCallbacks: vi.fn(),
+  }),
+  useDrawerParams: () => ({}),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj_1", slug: "test-project" },
+  }),
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    query: {},
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    scenarios: {
+      getAllScenarioSetRunData: {
+        useQuery: mockRunDataQuery,
+      },
+    },
+  },
+}));
+
+describe("<ExternalSetDetailPanel/>", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe("when clicking a scenario run row", () => {
+    it("opens the drawer instead of navigating to a new page", () => {
+      const runs = [
+        {
+          batchRunId: "batch_1",
+          scenarioRunId: "run_1",
+          scenarioId: "scen_1",
+          status: "SUCCESS",
+          timestamp: Date.now(),
+          results: null,
+          messages: [],
+          name: "Test Scenario",
+          description: null,
+          durationInMs: 100,
+        },
+      ];
+
+      mockRunDataQuery.mockReturnValue({
+        data: runs,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<ExternalSetDetailPanel scenarioSetId="ext-set-1" />, { wrapper: Wrapper });
+
+      // Expand the batch run row first
+      const runRowHeader = screen.getByTestId("run-row-header");
+      fireEvent.click(runRowHeader);
+
+      // Click the scenario run card inside the expanded row
+      const scenarioCard = screen.getByLabelText(/View details for/);
+      fireEvent.click(scenarioCard);
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith("scenarioRunDetail", {
+        urlParams: { scenarioRunId: "run_1" },
+      });
+      expect(mockRouterPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given loading state", () => {
+    it("displays loading spinner", () => {
+      mockRunDataQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      });
+
+      const { container } = render(<ExternalSetDetailPanel scenarioSetId="ext-set-1" />, {
+        wrapper: Wrapper,
+      });
+
+      expect(container.querySelector(".chakra-spinner")).toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useDrawerRunCallbacks.test.tsx
+++ b/langwatch/src/hooks/__tests__/useDrawerRunCallbacks.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useDrawerRunCallbacks } from "../useDrawerRunCallbacks";
+
+const mockOpenDrawer = vi.hoisted(() => vi.fn());
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: mockOpenDrawer,
+    closeDrawer: vi.fn(),
+  }),
+}));
+
+describe("useDrawerRunCallbacks()", () => {
+  describe("when onRunComplete is called", () => {
+    it("opens the scenarioRunDetail drawer with the run id", () => {
+      const { result } = renderHook(() => useDrawerRunCallbacks());
+
+      result.current.onRunComplete({ scenarioRunId: "run-abc" });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith("scenarioRunDetail", {
+        urlParams: { scenarioRunId: "run-abc" },
+      });
+    });
+  });
+
+  describe("when onRunFailed is called", () => {
+    it("opens the scenarioRunDetail drawer with the run id", () => {
+      const { result } = renderHook(() => useDrawerRunCallbacks());
+
+      result.current.onRunFailed({ scenarioRunId: "run-xyz" });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith("scenarioRunDetail", {
+        urlParams: { scenarioRunId: "run-xyz" },
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useRunScenario.test.tsx
+++ b/langwatch/src/hooks/__tests__/useRunScenario.test.tsx
@@ -5,14 +5,6 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { useRunScenario } from "../useRunScenario";
 
-// Mock Next.js router
-const mockPush = vi.fn();
-vi.mock("next/router", () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
-}));
-
 // Mock tRPC api
 const mockMutateAsync = vi.fn();
 vi.mock("~/utils/api", () => ({
@@ -47,13 +39,9 @@ vi.mock("../../components/ui/toaster", () => ({
 }));
 
 // Mock pollForScenarioRun
+const mockPollForScenarioRun = vi.hoisted(() => vi.fn());
 vi.mock("~/utils/pollForScenarioRun", () => ({
-  pollForScenarioRun: vi.fn().mockResolvedValue({ success: true, scenarioRunId: "run-123" }),
-}));
-
-// Mock buildRoutePath
-vi.mock("~/utils/routes", () => ({
-  buildRoutePath: vi.fn().mockReturnValue("/mock/route"),
+  pollForScenarioRun: mockPollForScenarioRun,
 }));
 
 // Create a variable for mock that can be modified per test
@@ -74,6 +62,7 @@ describe("useRunScenario()", () => {
       setId: "set-123",
       batchRunId: "batch-123",
     });
+    mockPollForScenarioRun.mockResolvedValue({ success: true, scenarioRunId: "run-123" });
     // Reset to having providers by default
     mockHasEnabledProviders = true;
   });
@@ -138,6 +127,97 @@ describe("useRunScenario()", () => {
       });
 
       expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when run completes successfully", () => {
+    it("calls onRunComplete callback with run result", async () => {
+      const onRunComplete = vi.fn();
+      const { result } = renderHook(() =>
+        useRunScenario({
+          projectId: "project-123",
+          projectSlug: "my-project",
+          onRunComplete,
+        })
+      );
+
+      await result.current.runScenario({
+        scenarioId: "scenario-123",
+        target: { type: "prompt", id: "prompt-123" },
+      });
+
+      await waitFor(() => {
+        expect(onRunComplete).toHaveBeenCalledWith({
+          scenarioRunId: "run-123",
+          setId: "set-123",
+          batchRunId: "batch-123",
+        });
+      });
+    });
+
+    it("completes without error when no onRunComplete callback is provided", async () => {
+      const { result } = renderHook(() =>
+        useRunScenario({
+          projectId: "project-123",
+          projectSlug: "my-project",
+        })
+      );
+
+      await result.current.runScenario({
+        scenarioId: "scenario-123",
+        target: { type: "prompt", id: "prompt-123" },
+      });
+
+      // Mutation was called and polling completed without throwing
+      expect(mockMutateAsync).toHaveBeenCalled();
+      expect(mockPollForScenarioRun).toHaveBeenCalled();
+    });
+  });
+
+  describe("when run fails with an error", () => {
+    beforeEach(() => {
+      mockPollForScenarioRun.mockResolvedValue({
+        success: false,
+        error: "run_error",
+        scenarioRunId: "failed-run-123",
+      });
+    });
+
+    it("shows error toast with action that calls onRunFailed", async () => {
+      const onRunFailed = vi.fn();
+      const { result } = renderHook(() =>
+        useRunScenario({
+          projectId: "project-123",
+          projectSlug: "my-project",
+          onRunFailed,
+        })
+      );
+
+      await result.current.runScenario({
+        scenarioId: "scenario-123",
+        target: { type: "prompt", id: "prompt-123" },
+      });
+
+      await waitFor(() => {
+        expect(mockToasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "Scenario run failed",
+            type: "error",
+          })
+        );
+      });
+
+      // Simulate clicking the toast action
+      const toastCall = mockToasterCreate.mock.calls[0]![0] as {
+        action?: { onClick: () => void };
+      };
+      toastCall.action?.onClick();
+
+      expect(onRunFailed).toHaveBeenCalledWith({
+        scenarioRunId: "failed-run-123",
+        setId: "set-123",
+        batchRunId: "batch-123",
+      });
     });
   });
 });

--- a/langwatch/src/hooks/useDrawerRunCallbacks.ts
+++ b/langwatch/src/hooks/useDrawerRunCallbacks.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+import { useDrawer } from "./useDrawer";
+
+/**
+ * Returns callbacks that navigate to the scenario run detail drawer.
+ *
+ * Shared between ScenarioRunDetailDrawer and ScenarioFormDrawer to avoid
+ * duplicating the `openDrawer("scenarioRunDetail", ...)` pattern.
+ */
+export function useDrawerRunCallbacks() {
+  const { openDrawer } = useDrawer();
+
+  const onRunComplete = useCallback(
+    (result: { scenarioRunId: string }) => {
+      openDrawer("scenarioRunDetail", {
+        urlParams: { scenarioRunId: result.scenarioRunId },
+      });
+    },
+    [openDrawer],
+  );
+
+  return { onRunComplete, onRunFailed: onRunComplete };
+}

--- a/langwatch/src/hooks/useRunScenario.tsx
+++ b/langwatch/src/hooks/useRunScenario.tsx
@@ -1,16 +1,24 @@
 import { Text, VStack } from "@chakra-ui/react";
-import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 import type { TargetValue } from "../components/scenarios/TargetSelector";
 import { toaster } from "../components/ui/toaster";
 import { api } from "../utils/api";
 import { pollForScenarioRun } from "../utils/pollForScenarioRun";
-import { buildRoutePath } from "../utils/routes";
 import { useModelProvidersSettings } from "./useModelProvidersSettings";
+
+interface RunCompleteResult {
+  scenarioRunId: string;
+  setId: string;
+  batchRunId: string;
+}
 
 interface UseRunScenarioOptions {
   projectId: string | undefined;
   projectSlug: string | undefined;
+  /** Called when the run completes successfully. Navigate to the result here. */
+  onRunComplete?: (result: RunCompleteResult) => void;
+  /** Called when the run fails. Use this to show the failed run (e.g., open a drawer). */
+  onRunFailed?: (result: RunCompleteResult) => void;
 }
 
 interface RunScenarioParams {
@@ -22,8 +30,9 @@ interface RunScenarioParams {
 export function useRunScenario({
   projectId,
   projectSlug,
+  onRunComplete,
+  onRunFailed,
 }: UseRunScenarioOptions) {
-  const router = useRouter();
   const utils = api.useContext();
   const runMutation = api.scenarios.run.useMutation();
   const [isPolling, setIsPolling] = useState(false);
@@ -87,32 +96,24 @@ export function useRunScenario({
         );
 
         if (result.success) {
-          void router.push(
-            buildRoutePath("simulations_run", {
-              project: projectSlug,
-              scenarioSetId: returnedSetId,
-              batchRunId,
-              scenarioRunId: result.scenarioRunId,
-            }),
-          );
+          onRunComplete?.({
+            scenarioRunId: result.scenarioRunId,
+            setId: returnedSetId,
+            batchRunId,
+          });
         } else if (result.error === "run_error") {
-          const runPath = result.scenarioRunId
-            ? buildRoutePath("simulations_run", {
-                project: projectSlug,
-                scenarioSetId: returnedSetId,
-                batchRunId,
-                scenarioRunId: result.scenarioRunId,
-              })
+          const runResult = result.scenarioRunId
+            ? { scenarioRunId: result.scenarioRunId, setId: returnedSetId, batchRunId }
             : null;
           toaster.create({
             title: "Scenario run failed",
             description: "The scenario encountered an error during execution.",
             type: "error",
             meta: { closable: true },
-            action: runPath
+            action: runResult
               ? {
                   label: "View failed run",
-                  onClick: () => void router.push(runPath),
+                  onClick: () => onRunFailed?.(runResult),
                 }
               : undefined,
           });
@@ -138,7 +139,7 @@ export function useRunScenario({
         setIsPolling(false);
       }
     },
-    [projectId, projectSlug, hasEnabledProviders, runMutation, router, utils],
+    [projectId, projectSlug, hasEnabledProviders, runMutation, onRunComplete, onRunFailed, utils],
   );
 
   return {

--- a/langwatch/src/pages/[project]/simulations/[scenarioSetId]/[batchRunId]/[scenarioRunId]/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/[scenarioSetId]/[batchRunId]/[scenarioRunId]/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, HStack, Skeleton, Text, VStack } from "@chakra-ui/react";
 import { ArrowLeft, Clock } from "lucide-react";
+import { useRouter } from "next/router";
 import { useCallback, useMemo, useState } from "react";
 import { RunScenarioModal } from "~/components/scenarios/RunScenarioModal";
 import { ScenarioFormDrawerFromUrl } from "~/components/scenarios/ScenarioFormDrawer";
@@ -22,18 +23,36 @@ import { useSimulationRouter } from "~/hooks/simulations";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useSimulationUpdateListener } from "~/hooks/useSimulationUpdateListener";
 import { api } from "~/utils/api";
+import { buildRoutePath } from "~/utils/routes";
 
 // Main component
 export default function IndividualScenarioRunPage() {
   const [showPreviousRuns, setShowPreviousRuns] = useState(false);
   const [runModalOpen, setRunModalOpen] = useState(false);
-  const { goToSimulationBatchRuns, scenarioRunId } = useSimulationRouter();
+  const { goToSimulationBatchRuns, scenarioRunId, scenarioSetId, batchRunId } = useSimulationRouter();
   const { project } = useOrganizationTeamProject();
-  const { scenarioSetId, batchRunId } = useSimulationRouter();
+  const router = useRouter();
   const { openDrawer, drawerOpen } = useDrawer();
+
+  const navigateToRunPage = useCallback(
+    (result: { scenarioRunId: string; setId: string; batchRunId: string }) => {
+      void router.push(
+        buildRoutePath("simulations_run", {
+          project: project?.slug ?? "",
+          scenarioSetId: result.setId,
+          batchRunId: result.batchRunId,
+          scenarioRunId: result.scenarioRunId,
+        }),
+      );
+    },
+    [router, project?.slug],
+  );
+
   const { runScenario, isRunning } = useRunScenario({
     projectId: project?.id,
     projectSlug: project?.slug,
+    onRunComplete: navigateToRunPage,
+    onRunFailed: navigateToRunPage,
   });
   // Fetch scenario run data using the correct API
   const { data: scenarioState, refetch } = api.scenarios.getRunState.useQuery(

--- a/specs/features/suites/suite-bugfixes-1956.feature
+++ b/specs/features/suites/suite-bugfixes-1956.feature
@@ -1,0 +1,45 @@
+Feature: Suite bugfixes - drawer navigation, table width, and quick run
+  As a user viewing suite runs
+  I want consistent drawer-based navigation, full-width tables, and proper quick-run behavior
+  So that I stay in context without being sent to deprecated pages
+
+  # Bug 1: ExternalSetDetailPanel navigates to old run page
+
+  @integration
+  Scenario: Clicking a run in external set detail opens the drawer
+    Given the ExternalSetDetailPanel is rendered with run data
+    When I click on a scenario run row
+    Then the scenario run detail drawer opens with that run's ID
+    And the browser does not navigate to a new page
+
+  # Bug 2: All Runs page tables are not full width
+
+  @integration
+  Scenario: Run rows in All Runs panel span the full available width
+    Given the AllRunsPanel is rendered with batch run data
+    Then the run list container has no horizontal padding
+    And the header, filter, empty state, load-more, and footer sections have horizontal padding
+
+  # Bug 3: Quick run navigation uses callbacks instead of hardcoded navigation
+
+  @integration
+  Scenario: Quick run from drawer navigates to runs page via URL with drawer params
+    Given I trigger a quick run from the scenario run detail drawer
+    When the run completes successfully
+    Then I am navigated to the suite runs page with drawer params in the URL
+    And the scenario run detail drawer opens with the new run's ID on page load
+
+  @integration
+  Scenario: Quick run failure shows toast with drawer link instead of page link
+    Given I trigger a quick run from the scenario run detail drawer
+    When the run fails with an error
+    Then I see an error toast
+    And the toast action opens the scenario run detail drawer for the failed run
+
+  # Regression guard: standalone run page still works
+
+  @integration
+  Scenario: Run Again from standalone run page stays on the standalone page
+    Given I am on the standalone scenario run page
+    When I click Run Again and the run completes
+    Then I remain on the standalone run page with the new run displayed


### PR DESCRIPTION
## Summary

Fixes three bugs found during bug bash (#1956):

- **ExternalSetDetailPanel** navigated to the deprecated standalone run page via `router.push` — now uses `openDrawer("scenarioRunDetail", ...)` matching all other suite components
- **AllRunsPanel** tables were narrower than individual suite detail views due to `paddingX` on the outer VStack — moved padding to individual children (header, filters, empty state, load-more, footer) so run rows span full width
- **useRunScenario** hardcoded `router.push` for navigation after quick runs — refactored to accept `onRunComplete`/`onRunFailed` callbacks so each consumer controls its own navigation (drawer consumers open the drawer, standalone page stays on the page)

Also extracted a shared `useDrawerRunCallbacks` hook to eliminate duplication between `ScenarioRunDetailDrawer` and `ScenarioFormDrawer`.

## Test plan

- [x] 10 tests passing (useRunScenario: 6, useDrawerRunCallbacks: 2, ExternalSetDetailPanel: 2)
- [x] No new typecheck errors in modified files
- [ ] Click a scenario run in an **external set** panel → opens the drawer, does not navigate away
- [ ] Verify all suite detail panels open the drawer on click (regression check)
- [ ] Compare table width on All Runs vs individual suite detail → consistent full-width
- [ ] Quick run from a drawer → navigates to runs page with drawer open
- [ ] "Run Again" on standalone run page → stays on standalone page (regression guard)

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1956