### PR TITLE
fix: set temperature to 1 for gpt-5-mini in low-risk evaluation

### DIFF
--- a/.github/workflows/low-risk-evaluation.yml
+++ b/.github/workflows/low-risk-evaluation.yml
@@ -95,7 +95,7 @@ jobs:
             --arg diff "$PR_DIFF" \
             '{
               model: "gpt-5-mini",
-              temperature: 0,
+              temperature: 1,
               response_format: {
                 type: "json_schema",
                 json_schema: {


### PR DESCRIPTION
## Summary
- `gpt-5-mini` no longer supports `temperature: 0` — only the default value (`1`) is allowed
- This was causing the low-risk PR evaluation workflow to fail with: `Unsupported value: 'temperature' does not support 0 with this model`

## Test plan
- [ ] Verify the low-risk evaluation workflow runs successfully on a PR