### PR TITLE
fix(suites): add padding under sidebar search input

### DIFF
--- a/langwatch/src/components/suites/SuiteSidebar.tsx
+++ b/langwatch/src/components/suites/SuiteSidebar.tsx
@@ -224,7 +224,7 @@ export function SuiteSidebar({
         </IconButton>
       </HStack>
 
-      <Box paddingX={3} paddingBottom={2}>
+      <Box paddingX={3} paddingBottom={3}>
         <SearchInput
           size="sm"
           placeholder="Search..."


### PR DESCRIPTION
## Summary

- Increases `paddingBottom` on the sidebar search input wrapper from `2` (8px) to `3` (12px) for consistent spacing with the rest of the sidebar layout

Closes #1991

## Test plan

- [x] Existing SuiteSidebar integration tests pass
- [ ] Visual check: sidebar search input has appropriate spacing below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1991