### PR TITLE
fix: include all span params in AI-readable trace format for evaluators

### DIFF
--- a/langwatch/src/server/tracer/__tests__/spanToReadableSpan.test.ts
+++ b/langwatch/src/server/tracer/__tests__/spanToReadableSpan.test.ts
@@ -613,6 +613,241 @@ describe("langwatchSpanToReadableSpan", () => {
     });
   });
 
+  describe("params flattening", () => {
+    it("flattens nested params to dot-notation attributes", () => {
+      const span = makeBaseSpan({
+        params: {
+          ai: {
+            toolCall: {
+              name: "searchPropertiesTool",
+              id: "call_sdwWCkaRfGBee3MKlvP88t0j",
+            },
+          },
+        },
+      });
+      const result = langwatchSpanToReadableSpan(span);
+      expect(result.attributes["ai.toolCall.name"]).toBe(
+        "searchPropertiesTool",
+      );
+      expect(result.attributes["ai.toolCall.id"]).toBe(
+        "call_sdwWCkaRfGBee3MKlvP88t0j",
+      );
+    });
+
+    it("JSON.stringifies arrays at leaf positions", () => {
+      const span = makeBaseSpan({
+        params: {
+          ai: {
+            toolCall: {
+              args: { unitTypes: ["TWO_BED_UNIT"] },
+            },
+          },
+        },
+      });
+      const result = langwatchSpanToReadableSpan(span);
+      expect(result.attributes["ai.toolCall.args.unitTypes"]).toBe(
+        JSON.stringify(["TWO_BED_UNIT"]),
+      );
+    });
+
+    it("flattens result object extracting primitives and stringifying arrays", () => {
+      const span = makeBaseSpan({
+        params: {
+          ai: {
+            toolCall: {
+              result: {
+                stringResponse: "Here are the matching properties",
+                taskCompletion: false,
+                taskJsonData: {
+                  resultCount: 1,
+                  listings: [
+                    {
+                      groupId: 84964,
+                      name: "Tura Leeds",
+                      location: "Whitehall Riverside, Leeds, LS1 4FE",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      });
+      const result = langwatchSpanToReadableSpan(span);
+      expect(result.attributes["ai.toolCall.result.stringResponse"]).toBe(
+        "Here are the matching properties",
+      );
+      expect(result.attributes["ai.toolCall.result.taskCompletion"]).toBe(
+        false,
+      );
+      expect(
+        result.attributes["ai.toolCall.result.taskJsonData.resultCount"],
+      ).toBe(1);
+      expect(
+        result.attributes["ai.toolCall.result.taskJsonData.listings"],
+      ).toBe(
+        JSON.stringify([
+          {
+            groupId: 84964,
+            name: "Tura Leeds",
+            location: "Whitehall Riverside, Leeds, LS1 4FE",
+          },
+        ]),
+      );
+    });
+
+    it("maps scope.name from params", () => {
+      const span = makeBaseSpan({
+        params: {
+          scope: { name: "ai" },
+        },
+      });
+      const result = langwatchSpanToReadableSpan(span);
+      expect(result.attributes["scope.name"]).toBe("ai");
+    });
+
+    it("excludes _keys field from flattened attributes", () => {
+      const span = makeBaseSpan({
+        params: {
+          ai: {
+            toolCall: {
+              name: "searchPropertiesTool",
+            },
+          },
+          _keys: ["ai.toolCall.name"],
+        },
+      });
+      const result = langwatchSpanToReadableSpan(span);
+      expect(result.attributes["_keys"]).toBeUndefined();
+      expect(result.attributes["ai.toolCall.name"]).toBe(
+        "searchPropertiesTool",
+      );
+    });
+
+    it("handles null params without error", () => {
+      const span = makeBaseSpan({ params: null });
+      const result = langwatchSpanToReadableSpan(span);
+      expect(result.attributes["ai.toolCall.name"]).toBeUndefined();
+    });
+
+    it("handles undefined params without error", () => {
+      const span = makeBaseSpan({ params: undefined });
+      const result = langwatchSpanToReadableSpan(span);
+      expect(result.attributes["ai.toolCall.name"]).toBeUndefined();
+    });
+
+    it("preserves existing gen_ai.request.* mappings alongside flattened params", () => {
+      const span = makeBaseSpan({
+        params: {
+          temperature: 0.7,
+          max_tokens: 1024,
+          top_p: 0.9,
+          ai: { operationId: "ai.toolCall" },
+        },
+      });
+      const result = langwatchSpanToReadableSpan(span);
+      // Existing specific mappings
+      expect(result.attributes["gen_ai.request.temperature"]).toBe(0.7);
+      expect(result.attributes["gen_ai.request.max_tokens"]).toBe(1024);
+      expect(result.attributes["gen_ai.request.top_p"]).toBe(0.9);
+      // Flattened raw versions
+      expect(result.attributes["temperature"]).toBe(0.7);
+      expect(result.attributes["max_tokens"]).toBe(1024);
+      expect(result.attributes["top_p"]).toBe(0.9);
+      expect(result.attributes["ai.operationId"]).toBe("ai.toolCall");
+    });
+
+    it("skips null and undefined values during flattening", () => {
+      const span = makeBaseSpan({
+        params: {
+          ai: {
+            toolCall: {
+              name: "myTool",
+              result: null,
+              metadata: undefined,
+            },
+          },
+        },
+      });
+      const result = langwatchSpanToReadableSpan(span);
+      expect(result.attributes["ai.toolCall.name"]).toBe("myTool");
+      expect(result.attributes["ai.toolCall.result"]).toBeUndefined();
+      expect(result.attributes["ai.toolCall.metadata"]).toBeUndefined();
+    });
+
+    it("converts full real trace tool call span with all attributes", () => {
+      const span = makeBaseSpan({
+        name: "ai.toolCall",
+        type: "span",
+        input: null,
+        output: null,
+        params: {
+          ai: {
+            operationId: "ai.toolCall",
+            telemetry: { functionId: "agent-chat" },
+            toolCall: {
+              name: "searchPropertiesTool",
+              id: "call_sdwWCkaRfGBee3MKlvP88t0j",
+              args: { unitTypes: ["TWO_BED_UNIT"] },
+              result: {
+                stringResponse:
+                  "Here are the matching properties (property groups):\nProperty Group ID: 84964; Name: Tura Leeds; Location: Whitehall Riverside, Leeds, LS1 4FE; Available unit types: 1 bed (1160-1325), 2 beds (1437-1702)",
+                taskCompletion: false,
+                taskJsonData: {
+                  resultCount: 1,
+                  listings: [
+                    {
+                      groupId: 84964,
+                      name: "Tura Leeds",
+                      location: "Whitehall Riverside, Leeds, LS1 4FE",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          scope: { name: "ai" },
+          _keys: ["ai.toolCall.name", "ai.toolCall.id"],
+        },
+      });
+      const result = langwatchSpanToReadableSpan(span);
+
+      expect(result.attributes["ai.toolCall.name"]).toBe(
+        "searchPropertiesTool",
+      );
+      expect(result.attributes["ai.toolCall.id"]).toBe(
+        "call_sdwWCkaRfGBee3MKlvP88t0j",
+      );
+      expect(result.attributes["ai.toolCall.args.unitTypes"]).toBe(
+        JSON.stringify(["TWO_BED_UNIT"]),
+      );
+      expect(result.attributes["ai.toolCall.result.stringResponse"]).toBe(
+        "Here are the matching properties (property groups):\nProperty Group ID: 84964; Name: Tura Leeds; Location: Whitehall Riverside, Leeds, LS1 4FE; Available unit types: 1 bed (1160-1325), 2 beds (1437-1702)",
+      );
+      expect(result.attributes["ai.toolCall.result.taskCompletion"]).toBe(
+        false,
+      );
+      expect(
+        result.attributes["ai.toolCall.result.taskJsonData.resultCount"],
+      ).toBe(1);
+      expect(
+        result.attributes["ai.toolCall.result.taskJsonData.listings"],
+      ).toBe(
+        JSON.stringify([
+          {
+            groupId: 84964,
+            name: "Tura Leeds",
+            location: "Whitehall Riverside, Leeds, LS1 4FE",
+          },
+        ]),
+      );
+      expect(result.attributes["ai.operationId"]).toBe("ai.toolCall");
+      expect(result.attributes["ai.telemetry.functionId"]).toBe("agent-chat");
+      expect(result.attributes["scope.name"]).toBe("ai");
+      expect(result.attributes["_keys"]).toBeUndefined();
+    });
+  });
+
   describe("edge cases", () => {
     it("handles empty spans array via map", () => {
       const spans: Span[] = [];

--- a/langwatch/src/server/tracer/spanToReadableSpan.ts
+++ b/langwatch/src/server/tracer/spanToReadableSpan.ts
@@ -40,6 +40,40 @@ function spanTypeToKind(type: SpanTypes): SpanKind {
   }
 }
 
+/**
+ * Recursively flattens a nested params object into dot-notation OTEL attributes.
+ *
+ * - Primitive values (string, number, boolean) are set directly
+ * - Plain objects are recursed into
+ * - Arrays are JSON.stringified
+ * - null/undefined values are skipped
+ * - The `_keys` field is skipped (indexing artifact)
+ */
+function flattenParams({
+  params,
+  prefix,
+  attrs,
+}: {
+  params: Record<string, unknown>;
+  prefix: string;
+  attrs: Attributes;
+}): void {
+  for (const [key, value] of Object.entries(params)) {
+    if (key === "_keys") continue;
+    if (value == null) continue;
+
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      attrs[fullKey] = value;
+    } else if (Array.isArray(value)) {
+      attrs[fullKey] = JSON.stringify(value);
+    } else if (typeof value === "object") {
+      flattenParams({ params: value as Record<string, unknown>, prefix: fullKey, attrs });
+    }
+  }
+}
+
 function buildAttributes(span: Span): Attributes {
   const attrs: Attributes = {};
 
@@ -87,6 +121,8 @@ function buildAttributes(span: Span): Attributes {
       attrs["gen_ai.request.max_tokens"] = span.params.max_tokens;
     if (span.params.top_p != null)
       attrs["gen_ai.request.top_p"] = span.params.top_p;
+
+    flattenParams({ params: span.params, prefix: "", attrs });
   }
 
   // Metrics


### PR DESCRIPTION
## Summary

- Fixes #1978 — tool call results were missing from the AI-readable trace format used by evaluators, causing false hallucination flags
- `buildAttributes()` only extracted 3 specific params (`temperature`, `max_tokens`, `top_p`) — all other params data (tool calls, prompt messages, SDK metadata) was silently dropped
- Adds `flattenParams()` that recursively flattens ALL nested params into dot-notation OTEL attributes (primitives set directly, arrays JSON-stringified, `_keys` indexing artifact skipped)

## Test plan

- [x] 10 new unit tests covering params flattening (nested objects, arrays, nulls, `_keys` exclusion, real trace data)
- [x] All 87 existing tests still pass
- [x] Full real trace example from issue verified: `ai.toolCall.name`, `ai.toolCall.args`, `ai.toolCall.result.stringResponse` etc. all present as attributes

# Related Issue

- Resolve #1978