### PR TITLE
fix: remove unsupported temperature param, deduplicate approval checks

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: approval-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-approval-or-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/low-risk-evaluation.yml
+++ b/.github/workflows/low-risk-evaluation.yml
@@ -95,7 +95,6 @@ jobs:
             --arg diff "$PR_DIFF" \
             '{
               model: "gpt-5-mini",
-              temperature: 0,
               response_format: {
                 type: "json_schema",
                 json_schema: {


### PR DESCRIPTION
## Summary
- **Remove `temperature: 0`** from low-risk evaluation — `gpt-5-mini` only supports the default (1)
- **Add concurrency group** to approval check workflow — when multiple events fire for the same PR (e.g. `pull_request` + `pull_request_review`), the older run is cancelled instead of showing duplicate failing checks

## Test plan
- [ ] Verify low-risk evaluation succeeds (no more temperature error)
- [ ] Verify only one `check-approval-or-label` check appears per PR