### PR TITLE
feat(suites): show time-ago metric on individual run detail view

### DIFF
--- a/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -145,7 +145,7 @@ export function ScenarioRunDetailDrawer({
   // Relative time that auto-updates every 30s while the drawer is open
   const [timeAgo, setTimeAgo] = useState<string | undefined>(undefined);
   useEffect(() => {
-    if (!scenarioState?.timestamp) {
+    if (!open || !scenarioState?.timestamp) {
       setTimeAgo(undefined);
       return;
     }
@@ -153,7 +153,7 @@ export function ScenarioRunDetailDrawer({
     update();
     const interval = setInterval(update, 30_000);
     return () => clearInterval(interval);
-  }, [scenarioState?.timestamp]);
+  }, [open, scenarioState?.timestamp]);
 
   const suiteId = scenarioState?.metadata?.langwatch?.simulationSuiteId;
 


### PR DESCRIPTION
## Summary

- Adds a "Ran" time-ago metric (e.g. "2 hours ago", "3 days ago") next to the duration metric in the scenario run detail drawer
- Uses the existing `formatTimeAgo` utility for humanized relative time formatting
- Auto-updates every 30 seconds while the drawer stays open

Closes #1994

## Test plan

- [ ] Open a suite run detail drawer and verify the "Ran" metric appears next to "Duration"
- [ ] Confirm it shows humanized relative time (e.g. "2 hours ago")
- [ ] Leave the drawer open for 30+ seconds and verify the time updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)