### PR TITLE
fix: copy worktree hook to .git/hooks/ instead of core.hooksPath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ COMPOSE = docker compose -f compose.dev.yml
 
 # Install git hooks (idempotent, runs automatically before dev targets)
 setup-hooks:
-	@git config core.hooksPath .githooks
+	@cp .githooks/post-checkout .git/hooks/post-checkout 2>/dev/null || true
 
 # Minimal: postgres + redis + app (no opensearch)
 dev: setup-hooks

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -18,7 +18,7 @@
     "lint": "pnpm exec biome check src/",
     "lint:fix": "pnpm exec biome check src/ --write",
     "format": "pnpm exec biome format src/ --write",
-    "postinstall": "git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .githooks || true",
+    "postinstall": "cp ../.githooks/post-checkout ../.git/hooks/post-checkout 2>/dev/null || true",
     "dev": "pnpm run start:prepare:files && NODE_ENV=development START_WORKERS=true pnpm start",
     "start": "./scripts/start.sh",
     "start:app": "tsx src/server.ts",


### PR DESCRIPTION
## Problem

The previous approach (`core.hooksPath = .githooks`) resolves relative to the **new worktree's root**. If the worktree's branch doesn't have `.githooks/` committed (e.g. branches created before #1901 was merged), the hook isn't found.

## Fix

Copy the hook directly to `.git/hooks/post-checkout` instead. This directory is shared across all worktrees regardless of which branch they're on.

- `postinstall`: `cp ../.githooks/post-checkout ../.git/hooks/post-checkout`
- `make setup-hooks`: `cp .githooks/post-checkout .git/hooks/post-checkout`

Both silently no-op when files don't exist (Docker, CI).