### PR TITLE
fix(suites): remove redundant SUITES label from sidebar

### DIFF
--- a/langwatch/src/components/suites/SuiteSidebar.tsx
+++ b/langwatch/src/components/suites/SuiteSidebar.tsx
@@ -210,10 +210,7 @@ export function SuiteSidebar({
       align="stretch"
       gap={0}
     >
-      <HStack paddingX={3} paddingTop={3} paddingBottom={1} justify="space-between">
-        <Text fontSize="xs" fontWeight="bold" color="fg.muted" letterSpacing="wider">
-          SUITES
-        </Text>
+      <HStack paddingX={3} paddingTop={3} paddingBottom={1} justify="flex-end">
         <IconButton
           aria-label="Collapse sidebar"
           size="xs"

--- a/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
@@ -496,6 +496,48 @@ describe("<SuiteSidebar/>", () => {
     });
   });
 
+  describe("when viewing the expanded sidebar (remove-redundant-suites-label)", () => {
+    const suites = [
+      makeSuite({ id: "suite_1", name: "Critical Path", slug: "critical-path" }),
+      makeSuite({ id: "suite_2", name: "Billing Edge", slug: "billing-edge" }),
+    ];
+
+    it("does not display a SUITES section header", () => {
+      render(<SuiteSidebar {...defaultProps} suites={suites} />, {
+        wrapper: Wrapper,
+      });
+
+      expect(screen.queryByText(/^SUITES$/)).not.toBeInTheDocument();
+    });
+
+    it("displays suite names", () => {
+      render(<SuiteSidebar {...defaultProps} suites={suites} />, {
+        wrapper: Wrapper,
+      });
+
+      expect(screen.getByText("Critical Path")).toBeInTheDocument();
+      expect(screen.getByText("Billing Edge")).toBeInTheDocument();
+    });
+
+    it("displays the search box", () => {
+      render(<SuiteSidebar {...defaultProps} suites={suites} />, {
+        wrapper: Wrapper,
+      });
+
+      expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
+    });
+
+    it("displays the collapse button", () => {
+      render(<SuiteSidebar {...defaultProps} suites={suites} />, {
+        wrapper: Wrapper,
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Collapse sidebar" }),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("collapsible sidebar", () => {
     const suites = [
       makeSuite({ id: "suite_1", name: "Critical Path", slug: "critical-path" }),

--- a/langwatch/src/components/suites/__tests__/SuitesPageLayout.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuitesPageLayout.integration.test.tsx
@@ -154,7 +154,7 @@ describe("Suites Page Layout (Issue #1671)", () => {
   });
 
   describe("when rendering the SuiteSidebar", () => {
-    it("renders a 'SUITES' section header in the sidebar", () => {
+    it("does not render a 'SUITES' section header in the sidebar", () => {
       const suites = [makeSuite()];
       render(
         <SuiteSidebar
@@ -167,9 +167,8 @@ describe("Suites Page Layout (Issue #1671)", () => {
         { wrapper: Wrapper },
       );
 
-      // The sidebar has a "SUITES" section header for the collapsible sidebar
       const suitesLabels = screen.queryAllByText(/^SUITES$/);
-      expect(suitesLabels).toHaveLength(1);
+      expect(suitesLabels).toHaveLength(0);
     });
   });
 });

--- a/specs/features/suites/remove-redundant-suites-label.feature
+++ b/specs/features/suites/remove-redundant-suites-label.feature
@@ -1,0 +1,23 @@
+Feature: Remove redundant SUITES label from sidebar
+  As a LangWatch user
+  I want the sidebar to avoid repeating "SUITES" when the page header already says "Suites"
+  So that there is less visual noise and a cleaner layout
+
+  # The sidebar currently displays a "SUITES" section header above the suite list.
+  # This is redundant because the top-level page header already reads "Suites".
+  # Removing it reduces visual clutter while preserving the sidebar's hierarchy
+  # (search box, action buttons, and suite cards remain unchanged).
+
+  @integration
+  Scenario: Sidebar does not display a redundant SUITES label
+    Given the suite sidebar contains suites
+    When I view the suites sidebar in expanded mode
+    Then there is no "SUITES" section header above the suite list
+
+  @integration
+  Scenario: Sidebar still shows suite names and action buttons after label removal
+    Given the suite sidebar contains suites
+    When I view the suites sidebar in expanded mode
+    Then suite names are visible
+    And the search box is visible
+    And the collapse button is visible


### PR DESCRIPTION
## Summary

- Removes the duplicate "SUITES" section header from the sidebar since the page header already says "Suites"
- Keeps the collapse button visible, aligned to the right
- Updates existing tests and adds new integration tests for the change

Closes #1983

## Test plan

- [x] Integration test: sidebar does not display "SUITES" section header
- [x] Integration test: suite names still visible
- [x] Integration test: search box still visible  
- [x] Integration test: collapse button still visible
- [x] Existing test updated to assert label absence
- [x] All 41 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1983