### PR TITLE
feat(rbac): fetch org role during permission resolution

### DIFF
--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -281,6 +281,7 @@ export const useOrganizationTeamProject = (
       isPublicRoute,
       isOrganizationFeatureEnabled: () => false,
       isDemo,
+      organizationRole: undefined,
     };
   }
 
@@ -392,5 +393,6 @@ export const useOrganizationTeamProject = (
     modelProviders: modelProviders.data,
     isOrganizationFeatureEnabled,
     isDemo,
+    organizationRole,
   };
 };

--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -685,17 +685,18 @@ describe("RBAC Integration Tests", () => {
     describe("when project is a demo project", () => {
       it("grants permission and returns null org role", async () => {
         process.env.DEMO_PROJECT_ID = "demo-project-1";
+        try {
+          const result = await resolveProjectPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "demo-project-1",
+            "analytics:view" as Permission,
+          );
 
-        const result = await resolveProjectPermission(
-          { prisma: mockPrisma, session: mockSession },
-          "demo-project-1",
-          "analytics:view" as Permission,
-        );
-
-        expect(result.permitted).toBe(true);
-        expect(result.organizationRole).toBeNull();
-
-        delete process.env.DEMO_PROJECT_ID;
+          expect(result.permitted).toBe(true);
+          expect(result.organizationRole).toBeNull();
+        } finally {
+          delete process.env.DEMO_PROJECT_ID;
+        }
       });
     });
 

--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -9,7 +9,10 @@ import {
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
+  resolveProjectPermission,
+  resolveTeamPermission,
   type Permission,
+  type PermissionResult,
   skipPermissionCheck,
   skipPermissionCheckProjectCreation,
 } from "../rbac";
@@ -31,6 +34,9 @@ const mockPrisma = {
   },
   teamUserCustomRole: {
     findFirst: vi.fn(),
+  },
+  customRole: {
+    findUnique: vi.fn(),
   },
   publicShare: {
     findFirst: vi.fn(),
@@ -84,6 +90,7 @@ describe("RBAC Integration Tests", () => {
         team: {
           id: "team-123",
           members: [], // No members
+          organization: { members: [] },
         },
       });
 
@@ -100,10 +107,9 @@ describe("RBAC Integration Tests", () => {
         team: {
           id: "team-123",
           members: [{ userId: "user-123", role: TeamUserRole.ADMIN }],
+          organization: { members: [] },
         },
       });
-
-      mockPrisma.teamUserCustomRole.findFirst.mockResolvedValue(null);
 
       const result = await hasProjectPermission(
         { prisma: mockPrisma, session: mockSession },
@@ -118,6 +124,7 @@ describe("RBAC Integration Tests", () => {
         team: {
           id: "team-123",
           members: [{ userId: "user-123", role: TeamUserRole.VIEWER }],
+          organization: { members: [] },
         },
       });
 
@@ -324,6 +331,7 @@ describe("RBAC Integration Tests", () => {
           team: {
             id: "team-123",
             members: [],
+            organization: { members: [] },
           },
         });
 
@@ -345,10 +353,9 @@ describe("RBAC Integration Tests", () => {
           team: {
             id: "team-123",
             members: [{ userId: "user-123", role: TeamUserRole.ADMIN }],
+            organization: { members: [] },
           },
         });
-
-        mockPrisma.teamUserCustomRole.findFirst.mockResolvedValue(null);
 
         const middleware = checkProjectPermission(
           "workflows:view" as Permission,
@@ -496,11 +503,13 @@ describe("RBAC Integration Tests", () => {
         mockPrisma.project.findUnique.mockResolvedValue({
           team: {
             id: "team-123",
+            organizationId: "org-1",
             members: [{ userId: "user-123", role: TeamUserRole.ADMIN }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
           },
         });
-
-        mockPrisma.teamUserCustomRole.findFirst.mockResolvedValue(null);
 
         const middleware = checkPermissionOrPubliclyShared(
           checkProjectPermission("workflows:view" as Permission),
@@ -523,6 +532,7 @@ describe("RBAC Integration Tests", () => {
           team: {
             id: "team-123",
             members: [],
+            organization: { members: [] },
           },
         });
 
@@ -553,6 +563,7 @@ describe("RBAC Integration Tests", () => {
           team: {
             id: "team-123",
             members: [],
+            organization: { members: [] },
           },
         });
 
@@ -570,6 +581,639 @@ describe("RBAC Integration Tests", () => {
             next: mockNext,
           }),
         ).rejects.toThrow(TRPCError);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // resolveProjectPermission
+  // ==========================================================================
+
+  describe("resolveProjectPermission", () => {
+    function setupProjectMocks({
+      orgRole,
+      teamRole,
+      hasTeamMember = true,
+    }: {
+      orgRole?: OrganizationUserRole;
+      teamRole?: TeamUserRole;
+      hasTeamMember?: boolean;
+    }) {
+      mockPrisma.project.findUnique.mockResolvedValue({
+        team: {
+          id: "team-1",
+          organizationId: "org-1",
+          members: hasTeamMember
+            ? [{ userId: "user-123", role: teamRole ?? TeamUserRole.MEMBER }]
+            : [],
+          organization: {
+            members: orgRole ? [{ role: orgRole }] : [],
+          },
+        },
+      });
+    }
+
+    describe("when user is an org ADMIN and team MEMBER", () => {
+      it("grants permission and returns ADMIN org role", async () => {
+        setupProjectMocks({
+          orgRole: OrganizationUserRole.ADMIN,
+          teamRole: TeamUserRole.MEMBER,
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.ADMIN);
+      });
+    });
+
+    describe("when user is an org MEMBER and team MEMBER", () => {
+      it("grants permission and returns MEMBER org role", async () => {
+        setupProjectMocks({
+          orgRole: OrganizationUserRole.MEMBER,
+          teamRole: TeamUserRole.MEMBER,
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+      });
+    });
+
+    describe("when user is an org EXTERNAL and team VIEWER", () => {
+      it("grants view permission and returns EXTERNAL org role", async () => {
+        setupProjectMocks({
+          orgRole: OrganizationUserRole.EXTERNAL,
+          teamRole: TeamUserRole.VIEWER,
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+      });
+    });
+
+    describe("when user is not an org member", () => {
+      it("denies permission and returns null org role", async () => {
+        setupProjectMocks({ hasTeamMember: false });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBeNull();
+      });
+    });
+
+    describe("when project is a demo project", () => {
+      it("grants permission and returns null org role", async () => {
+        process.env.DEMO_PROJECT_ID = "demo-project-1";
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "demo-project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBeNull();
+
+        delete process.env.DEMO_PROJECT_ID;
+      });
+    });
+
+    describe("when user is unauthenticated", () => {
+      it("denies permission and returns null org role", async () => {
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: null },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBeNull();
+      });
+    });
+
+    describe("when user has CUSTOM role with granted permissions", () => {
+      it("grants permission and returns org role", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [
+              {
+                userId: "user-123",
+                role: TeamUserRole.CUSTOM,
+                assignedRoleId: "custom-role-1",
+              },
+            ],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        mockPrisma.customRole.findUnique.mockResolvedValue({
+          permissions: ["analytics:view", "datasets:view"],
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+      });
+    });
+
+    describe("when user has CUSTOM role without requested permission", () => {
+      it("denies permission and returns org role", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [
+              {
+                userId: "user-123",
+                role: TeamUserRole.CUSTOM,
+                assignedRoleId: "custom-role-1",
+              },
+            ],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        mockPrisma.customRole.findUnique.mockResolvedValue({
+          permissions: ["analytics:view"],
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "datasets:manage" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+      });
+    });
+
+    describe("when verifying permission decisions are unchanged (regression)", () => {
+      it.each([
+        { teamRole: TeamUserRole.ADMIN, permission: "analytics:view", expected: true },
+        { teamRole: TeamUserRole.ADMIN, permission: "datasets:manage", expected: true },
+        { teamRole: TeamUserRole.ADMIN, permission: "team:manage", expected: true },
+        { teamRole: TeamUserRole.MEMBER, permission: "analytics:view", expected: true },
+        { teamRole: TeamUserRole.MEMBER, permission: "datasets:manage", expected: true },
+        { teamRole: TeamUserRole.MEMBER, permission: "team:manage", expected: false },
+        { teamRole: TeamUserRole.VIEWER, permission: "analytics:view", expected: true },
+        { teamRole: TeamUserRole.VIEWER, permission: "datasets:manage", expected: false },
+        { teamRole: TeamUserRole.VIEWER, permission: "team:manage", expected: false },
+      ])(
+        "returns permitted=$expected for $teamRole with $permission",
+        async ({ teamRole, permission, expected }) => {
+          setupProjectMocks({
+            orgRole: OrganizationUserRole.MEMBER,
+            teamRole,
+          });
+
+          const result = await resolveProjectPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "project-1",
+            permission as Permission,
+          );
+
+          expect(result.permitted).toBe(expected);
+          expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+        },
+      );
+    });
+
+    describe("when verifying org role is carried for each org role type", () => {
+      it.each([
+        OrganizationUserRole.ADMIN,
+        OrganizationUserRole.MEMBER,
+        OrganizationUserRole.EXTERNAL,
+      ])("returns org role %s", async (orgRole) => {
+        setupProjectMocks({
+          orgRole,
+          teamRole: TeamUserRole.MEMBER,
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.organizationRole).toBe(orgRole);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // resolveTeamPermission
+  // ==========================================================================
+
+  describe("resolveTeamPermission", () => {
+    function setupTeamMocks({
+      orgRole,
+      teamRole,
+      hasTeamUser = true,
+    }: {
+      orgRole?: OrganizationUserRole;
+      teamRole?: TeamUserRole;
+      hasTeamUser?: boolean;
+    }) {
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "team-1",
+        organizationId: "org-1",
+      });
+
+      mockPrisma.organizationUser.findFirst.mockResolvedValue(
+        orgRole ? { role: orgRole } : null,
+      );
+
+      mockPrisma.teamUser.findFirst.mockResolvedValue(
+        hasTeamUser && teamRole
+          ? { userId: "user-123", teamId: "team-1", role: teamRole }
+          : null,
+      );
+    }
+
+    describe("when user is an org ADMIN (admin bypass, not a team member)", () => {
+      it("grants permission and returns ADMIN org role", async () => {
+        setupTeamMocks({
+          orgRole: OrganizationUserRole.ADMIN,
+          hasTeamUser: false,
+        });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:manage" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.ADMIN);
+      });
+    });
+
+    describe("when user is an org MEMBER and team MEMBER", () => {
+      it("grants permission and returns MEMBER org role", async () => {
+        setupTeamMocks({
+          orgRole: OrganizationUserRole.MEMBER,
+          teamRole: TeamUserRole.MEMBER,
+        });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+      });
+    });
+
+    describe("when user is an org EXTERNAL and team VIEWER", () => {
+      it("grants view permission and returns EXTERNAL org role", async () => {
+        setupTeamMocks({
+          orgRole: OrganizationUserRole.EXTERNAL,
+          teamRole: TeamUserRole.VIEWER,
+        });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+      });
+    });
+
+    describe("when user is not an org member", () => {
+      it("denies permission and returns null org role", async () => {
+        setupTeamMocks({ hasTeamUser: false });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBeNull();
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Boolean API regression guards
+  // ==========================================================================
+
+  describe("boolean API regression", () => {
+    describe("when hasProjectPermission is called", () => {
+      it("returns true (boolean) when user has permission", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [{ userId: "user-123", role: TeamUserRole.MEMBER }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const result = await hasProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result).toBe(true);
+        expect(typeof result).toBe("boolean");
+      });
+
+      it("returns false (boolean) when user lacks permission", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [{ userId: "user-123", role: TeamUserRole.VIEWER }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const result = await hasProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "datasets:manage" as Permission,
+        );
+
+        expect(result).toBe(false);
+        expect(typeof result).toBe("boolean");
+      });
+    });
+
+    describe("when hasTeamPermission is called", () => {
+      it("returns true (boolean) when user has permission", async () => {
+        mockPrisma.team.findUnique.mockResolvedValue({
+          id: "team-1",
+          organizationId: "org-1",
+        });
+
+        mockPrisma.organizationUser.findFirst.mockResolvedValue({
+          role: OrganizationUserRole.MEMBER,
+        });
+
+        mockPrisma.teamUser.findFirst.mockResolvedValue({
+          userId: "user-123",
+          teamId: "team-1",
+          role: TeamUserRole.MEMBER,
+        });
+
+        const result = await hasTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:view" as Permission,
+        );
+
+        expect(result).toBe(true);
+        expect(typeof result).toBe("boolean");
+      });
+
+      it("returns false (boolean) when user lacks permission", async () => {
+        mockPrisma.team.findUnique.mockResolvedValue({
+          id: "team-1",
+          organizationId: "org-1",
+        });
+
+        mockPrisma.organizationUser.findFirst.mockResolvedValue({
+          role: OrganizationUserRole.MEMBER,
+        });
+
+        mockPrisma.teamUser.findFirst.mockResolvedValue({
+          userId: "user-123",
+          teamId: "team-1",
+          role: TeamUserRole.VIEWER,
+        });
+
+        const result = await hasTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:manage" as Permission,
+        );
+
+        expect(result).toBe(false);
+        expect(typeof result).toBe("boolean");
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Middleware passes org role to downstream context
+  // ==========================================================================
+
+  describe("middleware org role propagation", () => {
+    describe("when checkProjectPermission middleware runs for a permitted user", () => {
+      it("sets organizationRole on context", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [{ userId: "user-123", role: TeamUserRole.MEMBER }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkProjectPermission(
+          "analytics:view" as Permission,
+        );
+
+        await middleware({
+          ctx,
+          input: { projectId: "project-1" },
+          next: mockNext,
+        });
+
+        expect(ctx.organizationRole).toBe(OrganizationUserRole.MEMBER);
+        expect(ctx.permissionChecked).toBe(true);
+      });
+    });
+
+    describe("when checkTeamPermission middleware runs for a permitted user", () => {
+      it("sets organizationRole on context", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        mockPrisma.team.findUnique.mockResolvedValue({
+          id: "team-1",
+          organizationId: "org-1",
+        });
+
+        mockPrisma.organizationUser.findFirst.mockResolvedValue({
+          role: OrganizationUserRole.ADMIN,
+        });
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkTeamPermission("team:view" as Permission);
+
+        await middleware({
+          ctx,
+          input: { teamId: "team-1" },
+          next: mockNext,
+        });
+
+        expect(ctx.organizationRole).toBe(OrganizationUserRole.ADMIN);
+        expect(ctx.permissionChecked).toBe(true);
+      });
+    });
+
+    describe("when checkProjectPermission middleware denies access", () => {
+      it("throws UNAUTHORIZED", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+        };
+
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [],
+            organization: {
+              members: [],
+            },
+          },
+        });
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkProjectPermission(
+          "analytics:view" as Permission,
+        );
+
+        await expect(
+          middleware({
+            ctx,
+            input: { projectId: "project-1" },
+            next: mockNext,
+          }),
+        ).rejects.toThrow(TRPCError);
+      });
+    });
+
+    describe("when checkTeamPermission middleware denies access", () => {
+      it("throws UNAUTHORIZED", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+        };
+
+        mockPrisma.team.findUnique.mockResolvedValue({
+          id: "team-1",
+          organizationId: "org-1",
+        });
+
+        mockPrisma.organizationUser.findFirst.mockResolvedValue(null);
+        mockPrisma.teamUser.findFirst.mockResolvedValue(null);
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkTeamPermission("team:view" as Permission);
+
+        await expect(
+          middleware({
+            ctx,
+            input: { teamId: "team-1" },
+            next: mockNext,
+          }),
+        ).rejects.toThrow(TRPCError);
+      });
+    });
+
+    describe("when public share fallback middleware runs for a permitted user", () => {
+      it("passes org role via checkProjectPermission", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [{ userId: "user-123", role: TeamUserRole.MEMBER }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkPermissionOrPubliclyShared(
+          checkProjectPermission("analytics:view" as Permission),
+          { resourceType: "TRACE", resourceParam: "traceId" },
+        );
+
+        await middleware({
+          ctx,
+          input: { projectId: "project-1", traceId: "trace-1" },
+          next: mockNext,
+        });
+
+        expect(ctx.organizationRole).toBe(OrganizationUserRole.MEMBER);
+        expect(ctx.permissionChecked).toBe(true);
       });
     });
   });

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -326,6 +326,19 @@ export function canDelete(role: TeamUserRole, resource: Resource): boolean {
 }
 
 // ============================================================================
+// PERMISSION RESULT TYPE
+// ============================================================================
+
+/**
+ * Result of resolving a permission check, including the user's organization role.
+ * Used by resolve* functions to provide richer context than a simple boolean.
+ */
+export type PermissionResult = {
+  permitted: boolean;
+  organizationRole: OrganizationUserRole | null;
+};
+
+// ============================================================================
 // MIDDLEWARE & CONTEXT HELPERS
 // ============================================================================
 
@@ -335,6 +348,7 @@ type PermissionMiddlewareParams<InputType> = {
     session: Session;
     permissionChecked: boolean;
     publiclyShared: boolean;
+    organizationRole?: OrganizationUserRole | null;
   };
   input: InputType;
   next: () => any;
@@ -354,13 +368,20 @@ export const checkProjectPermission =
     input,
     next,
   }: PermissionMiddlewareParams<{ projectId: string }>) => {
-    if (!(await hasProjectPermission(ctx, input.projectId, permission))) {
+    const { permitted, organizationRole } = await resolveProjectPermission(
+      ctx,
+      input.projectId,
+      permission,
+    );
+
+    if (!permitted) {
       throw new TRPCError({
         code: "UNAUTHORIZED",
         message: "You do not have permission to access this project resource",
       });
     }
 
+    ctx.organizationRole = organizationRole;
     ctx.permissionChecked = true;
     return next();
   };
@@ -375,13 +396,20 @@ export const checkTeamPermission =
     input,
     next,
   }: PermissionMiddlewareParams<{ teamId: string }>) => {
-    if (!(await hasTeamPermission(ctx, input.teamId, permission))) {
+    const { permitted, organizationRole } = await resolveTeamPermission(
+      ctx,
+      input.teamId,
+      permission,
+    );
+
+    if (!permitted) {
       throw new TRPCError({
         code: "UNAUTHORIZED",
         message: "You do not have permission to access this team resource",
       });
     }
 
+    ctx.organizationRole = organizationRole;
     ctx.permissionChecked = true;
     return next();
   };
@@ -415,20 +443,21 @@ export const checkOrganizationPermission =
 // ============================================================================
 
 /**
- * Check if user has a specific permission for a project
+ * Resolve a project permission check, returning the permission decision
+ * along with the user's organization role.
  */
-export async function hasProjectPermission(
+export async function resolveProjectPermission(
   ctx: { prisma: PrismaClient; session: Session | null },
   projectId: string,
   permission: Permission,
-): Promise<boolean> {
+): Promise<PermissionResult> {
   if (!ctx.session?.user) {
-    return false;
+    return { permitted: false, organizationRole: null };
   }
 
   // Check demo project access
   if (isDemoProject(projectId, permission)) {
-    return true;
+    return { permitted: true, organizationRole: null };
   }
 
   const projectTeam = await ctx.prisma.project.findUnique?.({
@@ -437,6 +466,7 @@ export async function hasProjectPermission(
       team: {
         select: {
           id: true,
+          organizationId: true,
           members: {
             where: { userId: ctx.session.user.id },
             select: {
@@ -446,17 +476,25 @@ export async function hasProjectPermission(
               assignedRoleId: true,
             },
           },
+          organization: {
+            select: {
+              members: {
+                where: { userId: ctx.session.user.id },
+                select: { role: true },
+              },
+            },
+          },
         },
       },
     },
   });
 
-  const teamMember = projectTeam?.team.members.find(
-    (member) => member.userId === ctx.session?.user.id,
-  );
+  const organizationRole =
+    projectTeam?.team.organization?.members[0]?.role ?? null;
+  const teamMember = projectTeam?.team.members[0];
 
   if (!teamMember) {
-    return false;
+    return { permitted: false, organizationRole };
   }
 
   // Check user's individual permissions (custom role or built-in role)
@@ -476,27 +514,49 @@ export async function hasProjectPermission(
 
       // If custom role has permissions, use them; otherwise fall back to built-in role
       if (userPermissions.length > 0) {
-        return hasPermissionWithHierarchy(userPermissions, permission);
+        return {
+          permitted: hasPermissionWithHierarchy(userPermissions, permission),
+          organizationRole,
+        };
       }
       // Fall back to built-in role if custom role has no permissions
-      return teamRoleHasPermission(teamMember.role, permission);
+      return {
+        permitted: teamRoleHasPermission(teamMember.role, permission),
+        organizationRole,
+      };
     }
   }
 
   // Only fall back to built-in team role if NO custom role exists
-  return teamRoleHasPermission(teamMember.role, permission);
+  return {
+    permitted: teamRoleHasPermission(teamMember.role, permission),
+    organizationRole,
+  };
 }
 
 /**
- * Check if user has a specific permission for a team
+ * Check if user has a specific permission for a project
  */
-export async function hasTeamPermission(
-  ctx: { prisma: PrismaClient; session: Session },
-  teamId: string,
+export async function hasProjectPermission(
+  ctx: { prisma: PrismaClient; session: Session | null },
+  projectId: string,
   permission: Permission,
 ): Promise<boolean> {
+  const result = await resolveProjectPermission(ctx, projectId, permission);
+  return result.permitted;
+}
+
+/**
+ * Resolve a team permission check, returning the permission decision
+ * along with the user's organization role.
+ */
+export async function resolveTeamPermission(
+  ctx: { prisma: PrismaClient; session: Session | null },
+  teamId: string,
+  permission: Permission,
+): Promise<PermissionResult> {
   if (!ctx.session?.user) {
-    return false;
+    return { permitted: false, organizationRole: null };
   }
 
   const team = await ctx.prisma.team.findUnique?.({
@@ -505,7 +565,7 @@ export async function hasTeamPermission(
   });
 
   if (!team?.organizationId) {
-    return false;
+    return { permitted: false, organizationRole: null };
   }
 
   // Check organization admin override
@@ -516,9 +576,11 @@ export async function hasTeamPermission(
     },
   });
 
+  const organizationRole = organizationUser?.role ?? null;
+
   // Organization ADMINs can do anything on all teams
   if (organizationUser?.role === OrganizationUserRole.ADMIN) {
-    return true;
+    return { permitted: true, organizationRole };
   }
 
   // Check team membership
@@ -536,7 +598,7 @@ export async function hasTeamPermission(
   });
 
   if (!teamUser) {
-    return false;
+    return { permitted: false, organizationRole };
   }
 
   // Check user's individual permissions (custom role or built-in role)
@@ -554,13 +616,28 @@ export async function hasTeamPermission(
         ? rawPermissions
         : [];
       if (hasPermissionWithHierarchy(userPermissions, permission)) {
-        return true;
+        return { permitted: true, organizationRole };
       }
     }
   }
 
   // Fall back to user's built-in team role only
-  return teamRoleHasPermission(teamUser.role, permission);
+  return {
+    permitted: teamRoleHasPermission(teamUser.role, permission),
+    organizationRole,
+  };
+}
+
+/**
+ * Check if user has a specific permission for a team
+ */
+export async function hasTeamPermission(
+  ctx: { prisma: PrismaClient; session: Session | null },
+  teamId: string,
+  permission: Permission,
+): Promise<boolean> {
+  const result = await resolveTeamPermission(ctx, teamId, permission);
+  return result.permitted;
 }
 
 /**

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -30,6 +30,7 @@ import { getLogLevelFromStatusCode } from "../middleware/requestLogging";
 import { createLogger } from "../../utils/logger/server";
 import { captureException } from "../../utils/posthogErrorCapture";
 import { auditLog } from "../auditLog";
+import type { OrganizationUserRole } from "@prisma/client";
 import type { PermissionMiddleware } from "./rbac";
 
 const logger = createLogger("langwatch:trpc");
@@ -48,6 +49,7 @@ interface CreateContextOptions {
   session: Session | null;
   permissionChecked?: boolean;
   publiclyShared?: boolean;
+  organizationRole?: OrganizationUserRole | null;
 }
 
 /**
@@ -68,6 +70,7 @@ export const createInnerTRPCContext = (opts: CreateContextOptions) => {
     prisma,
     permissionChecked: opts.permissionChecked ?? false,
     publiclyShared: opts.publiclyShared ?? false,
+    organizationRole: opts.organizationRole ?? undefined,
   };
 };
 

--- a/langwatch/src/utils/serverHelpers.ts
+++ b/langwatch/src/utils/serverHelpers.ts
@@ -13,6 +13,7 @@ async function createInnerTRPCContext(context: GetServerSidePropsContext) {
     res: undefined,
     permissionChecked: false,
     publiclyShared: false,
+    organizationRole: undefined,
   };
 }
 

--- a/specs/rbac/fetch-org-role-permission-resolution.feature
+++ b/specs/rbac/fetch-org-role-permission-resolution.feature
@@ -1,0 +1,212 @@
+@unit
+Feature: Fetch org role during permission resolution
+  As a LangWatch developer
+  I want the user's organization role available during permission resolution
+  So that downstream features can use it to restrict access based on org role
+
+  Background:
+    Given a user "user-123" exists
+    And an organization "org-1" exists
+    And a team "team-1" exists in organization "org-1"
+    And a project "project-1" exists in team "team-1"
+
+  # ============================================================================
+  # Project permission resolution carries org role
+  # ============================================================================
+
+  Scenario: Project permission result includes org role for an org admin
+    Given user "user-123" is an ADMIN in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    Then the permission is granted
+    And the org role in the result is ADMIN
+
+  Scenario: Project permission result includes org role for an org member
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    Then the permission is granted
+    And the org role in the result is MEMBER
+
+  Scenario: Project permission result includes org role for an external user
+    Given user "user-123" is an EXTERNAL in organization "org-1"
+    And user "user-123" is a VIEWER of team "team-1"
+    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    Then the permission is granted
+    And the org role in the result is EXTERNAL
+
+  Scenario: Project permission result has no org role when user is not an org member
+    Given user "user-123" is not a member of organization "org-1"
+    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    Then the permission is denied
+    And the org role in the result is null
+
+  Scenario: Demo project permission result has no org role
+    Given project "project-1" is a demo project
+    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    Then the permission is granted
+    And the org role in the result is null
+
+  # ============================================================================
+  # Team permission resolution carries org role
+  # ============================================================================
+
+  Scenario: Team permission result includes org role for an org admin via admin bypass
+    Given user "user-123" is an ADMIN in organization "org-1"
+    And user "user-123" is not a member of team "team-1"
+    When team permission "team:manage" is checked for user "user-123" on team "team-1"
+    Then the permission is granted
+    And the org role in the result is ADMIN
+
+  Scenario: Team permission result includes org role for an org member
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When team permission "team:view" is checked for user "user-123" on team "team-1"
+    Then the permission is granted
+    And the org role in the result is MEMBER
+
+  Scenario: Team permission result includes org role for an external user
+    Given user "user-123" is an EXTERNAL in organization "org-1"
+    And user "user-123" is a VIEWER of team "team-1"
+    When team permission "team:view" is checked for user "user-123" on team "team-1"
+    Then the permission is granted
+    And the org role in the result is EXTERNAL
+
+  Scenario: Team permission result has no org role when user is not an org member
+    Given user "user-123" is not a member of organization "org-1"
+    When team permission "team:view" is checked for user "user-123" on team "team-1"
+    Then the permission is denied
+    And the org role in the result is null
+
+  # ============================================================================
+  # Backward-compatible boolean API unchanged
+  # ============================================================================
+
+  Scenario: Boolean permission check still returns true when user has permission
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When project permission "analytics:view" is boolean-checked for user "user-123" on project "project-1"
+    Then the boolean result is true
+
+  Scenario: Boolean permission check still returns false when user lacks permission
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a VIEWER of team "team-1"
+    When project permission "datasets:manage" is boolean-checked for user "user-123" on project "project-1"
+    Then the boolean result is false
+
+  Scenario: Boolean team permission check still returns true when user has permission
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When team permission "team:view" is boolean-checked for user "user-123" on team "team-1"
+    Then the boolean result is true
+
+  Scenario: Boolean team permission check still returns false when user lacks permission
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a VIEWER of team "team-1"
+    When team permission "team:manage" is boolean-checked for user "user-123" on team "team-1"
+    Then the boolean result is false
+
+  # ============================================================================
+  # Permission decisions unchanged (regression guard)
+  # ============================================================================
+
+  Scenario Outline: Permission decisions are unchanged for all team roles
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a <teamRole> of team "team-1"
+    When project permission "<permission>" is checked for user "user-123" on project "project-1"
+    Then the permission is <outcome>
+
+    Examples:
+      | teamRole | permission       | outcome |
+      | ADMIN    | analytics:view   | granted |
+      | ADMIN    | datasets:manage  | granted |
+      | ADMIN    | team:manage      | granted |
+      | MEMBER   | analytics:view   | granted |
+      | MEMBER   | datasets:manage  | granted |
+      | MEMBER   | team:manage      | denied  |
+      | VIEWER   | analytics:view   | granted |
+      | VIEWER   | datasets:manage  | denied  |
+      | VIEWER   | team:manage      | denied  |
+
+  Scenario: Custom role grant carries org role
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a CUSTOM member of team "team-1" with permissions ["analytics:view", "datasets:view"]
+    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    Then the permission is granted
+    And the org role in the result is MEMBER
+
+  Scenario: Custom role denial carries org role
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a CUSTOM member of team "team-1" with permissions ["analytics:view"]
+    When project permission "datasets:manage" is checked for user "user-123" on project "project-1"
+    Then the permission is denied
+    And the org role in the result is MEMBER
+
+  # ============================================================================
+  # Middleware passes org role to downstream context
+  # ============================================================================
+
+  Scenario: Project permission middleware passes org role to downstream context
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When the project permission middleware runs for "analytics:view" on project "project-1"
+    Then downstream context includes org role MEMBER
+
+  Scenario: Team permission middleware passes org role to downstream context
+    Given user "user-123" is an ADMIN in organization "org-1"
+    When the team permission middleware runs for "team:view" on team "team-1"
+    Then downstream context includes org role ADMIN
+
+  Scenario: Project permission middleware still denies unauthorized users
+    Given user "user-123" is not a member of any team
+    When the project permission middleware runs for "analytics:view" on project "project-1"
+    Then the request is denied with UNAUTHORIZED
+
+  Scenario: Team permission middleware still denies unauthorized users
+    Given user "user-123" is not a member of any team
+    When the team permission middleware runs for "team:view" on team "team-1"
+    Then the request is denied with UNAUTHORIZED
+
+  Scenario: Public share fallback middleware passes org role when permitted
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When the public share fallback middleware runs for "analytics:view" on project "project-1"
+    Then downstream context includes org role MEMBER
+
+  # ============================================================================
+  # Frontend hook exposes org role
+  # ============================================================================
+
+  @integration
+  Scenario: Organization team project hook exposes org role for a member
+    Given user "user-123" is a MEMBER in organization "org-1"
+    When the organization team project hook resolves
+    Then the hook result includes org role MEMBER
+
+  @integration
+  Scenario: Organization team project hook exposes org role for an external user
+    Given user "user-123" is an EXTERNAL in organization "org-1"
+    When the organization team project hook resolves
+    Then the hook result includes org role EXTERNAL
+
+  @integration
+  Scenario: Organization team project hook exposes org role for an admin
+    Given user "user-123" is an ADMIN in organization "org-1"
+    When the organization team project hook resolves
+    Then the hook result includes org role ADMIN
+
+  # ============================================================================
+  # Org role correctly resolved across all org role types
+  # ============================================================================
+
+  Scenario Outline: Org role is carried for each org role type
+    Given user "user-123" is an <orgRole> in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    Then the org role in the result is <orgRole>
+
+    Examples:
+      | orgRole  |
+      | ADMIN    |
+      | MEMBER   |
+      | EXTERNAL |

--- a/specs/rbac/fetch-org-role-permission-resolution.feature
+++ b/specs/rbac/fetch-org-role-permission-resolution.feature
@@ -1,8 +1,8 @@
 @unit
-Feature: Fetch org role during permission resolution
+Feature: Organization role available during permission checks
   As a LangWatch developer
-  I want the user's organization role available during permission resolution
-  So that downstream features can use it to restrict access based on org role
+  I want the user's organization role included in permission check results
+  So that downstream features can restrict access based on org role
 
   Background:
     Given a user "user-123" exists
@@ -11,109 +11,81 @@ Feature: Fetch org role during permission resolution
     And a project "project-1" exists in team "team-1"
 
   # ============================================================================
-  # Project permission resolution carries org role
+  # Project permission checks include the user's organization role
   # ============================================================================
 
-  Scenario: Project permission result includes org role for an org admin
+  Scenario: Admin's org role is included when checking project permissions
     Given user "user-123" is an ADMIN in organization "org-1"
     And user "user-123" is a MEMBER of team "team-1"
-    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    When permission "analytics:view" is checked for user "user-123" on project "project-1"
     Then the permission is granted
-    And the org role in the result is ADMIN
+    And the result includes organization role ADMIN
 
-  Scenario: Project permission result includes org role for an org member
+  Scenario: Member's org role is included when checking project permissions
     Given user "user-123" is a MEMBER in organization "org-1"
     And user "user-123" is a MEMBER of team "team-1"
-    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    When permission "analytics:view" is checked for user "user-123" on project "project-1"
     Then the permission is granted
-    And the org role in the result is MEMBER
+    And the result includes organization role MEMBER
 
-  Scenario: Project permission result includes org role for an external user
-    Given user "user-123" is an EXTERNAL in organization "org-1"
+  Scenario: External user's org role is included when checking project permissions
+    Given user "user-123" is an EXTERNAL member of organization "org-1"
     And user "user-123" is a VIEWER of team "team-1"
-    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    When permission "analytics:view" is checked for user "user-123" on project "project-1"
     Then the permission is granted
-    And the org role in the result is EXTERNAL
+    And the result includes organization role EXTERNAL
 
-  Scenario: Project permission result has no org role when user is not an org member
+  Scenario: No org role when user is not in the organization
     Given user "user-123" is not a member of organization "org-1"
-    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    When permission "analytics:view" is checked for user "user-123" on project "project-1"
     Then the permission is denied
-    And the org role in the result is null
+    And no organization role is returned
 
-  Scenario: Demo project permission result has no org role
+  Scenario: Demo project grants access without an org role
     Given project "project-1" is a demo project
-    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    When permission "analytics:view" is checked for user "user-123" on project "project-1"
     Then the permission is granted
-    And the org role in the result is null
+    And no organization role is returned
 
   # ============================================================================
-  # Team permission resolution carries org role
+  # Team permission checks include the user's organization role
   # ============================================================================
 
-  Scenario: Team permission result includes org role for an org admin via admin bypass
+  Scenario: Org admin bypasses team membership and org role is included
     Given user "user-123" is an ADMIN in organization "org-1"
     And user "user-123" is not a member of team "team-1"
     When team permission "team:manage" is checked for user "user-123" on team "team-1"
     Then the permission is granted
-    And the org role in the result is ADMIN
+    And the result includes organization role ADMIN
 
-  Scenario: Team permission result includes org role for an org member
+  Scenario: Member's org role is included when checking team permissions
     Given user "user-123" is a MEMBER in organization "org-1"
     And user "user-123" is a MEMBER of team "team-1"
     When team permission "team:view" is checked for user "user-123" on team "team-1"
     Then the permission is granted
-    And the org role in the result is MEMBER
+    And the result includes organization role MEMBER
 
-  Scenario: Team permission result includes org role for an external user
-    Given user "user-123" is an EXTERNAL in organization "org-1"
+  Scenario: External user's org role is included when checking team permissions
+    Given user "user-123" is an EXTERNAL member of organization "org-1"
     And user "user-123" is a VIEWER of team "team-1"
     When team permission "team:view" is checked for user "user-123" on team "team-1"
     Then the permission is granted
-    And the org role in the result is EXTERNAL
+    And the result includes organization role EXTERNAL
 
-  Scenario: Team permission result has no org role when user is not an org member
+  Scenario: No org role for team checks when user is not in the organization
     Given user "user-123" is not a member of organization "org-1"
     When team permission "team:view" is checked for user "user-123" on team "team-1"
     Then the permission is denied
-    And the org role in the result is null
+    And no organization role is returned
 
   # ============================================================================
-  # Backward-compatible boolean API unchanged
-  # ============================================================================
-
-  Scenario: Boolean permission check still returns true when user has permission
-    Given user "user-123" is a MEMBER in organization "org-1"
-    And user "user-123" is a MEMBER of team "team-1"
-    When project permission "analytics:view" is boolean-checked for user "user-123" on project "project-1"
-    Then the boolean result is true
-
-  Scenario: Boolean permission check still returns false when user lacks permission
-    Given user "user-123" is a MEMBER in organization "org-1"
-    And user "user-123" is a VIEWER of team "team-1"
-    When project permission "datasets:manage" is boolean-checked for user "user-123" on project "project-1"
-    Then the boolean result is false
-
-  Scenario: Boolean team permission check still returns true when user has permission
-    Given user "user-123" is a MEMBER in organization "org-1"
-    And user "user-123" is a MEMBER of team "team-1"
-    When team permission "team:view" is boolean-checked for user "user-123" on team "team-1"
-    Then the boolean result is true
-
-  Scenario: Boolean team permission check still returns false when user lacks permission
-    Given user "user-123" is a MEMBER in organization "org-1"
-    And user "user-123" is a VIEWER of team "team-1"
-    When team permission "team:manage" is boolean-checked for user "user-123" on team "team-1"
-    Then the boolean result is false
-
-  # ============================================================================
-  # Permission decisions unchanged (regression guard)
+  # Existing permission behavior is unchanged
   # ============================================================================
 
   Scenario Outline: Permission decisions are unchanged for all team roles
     Given user "user-123" is a MEMBER in organization "org-1"
     And user "user-123" is a <teamRole> of team "team-1"
-    When project permission "<permission>" is checked for user "user-123" on project "project-1"
+    When permission "<permission>" is checked for user "user-123" on project "project-1"
     Then the permission is <outcome>
 
     Examples:
@@ -128,82 +100,110 @@ Feature: Fetch org role during permission resolution
       | VIEWER   | datasets:manage  | denied  |
       | VIEWER   | team:manage      | denied  |
 
-  Scenario: Custom role grant carries org role
+  Scenario: Boolean permission API still returns true when granted
     Given user "user-123" is a MEMBER in organization "org-1"
-    And user "user-123" is a CUSTOM member of team "team-1" with permissions ["analytics:view", "datasets:view"]
-    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When permission "analytics:view" is boolean-checked for user "user-123" on project "project-1"
+    Then the boolean result is true
+
+  Scenario: Boolean permission API still returns false when denied
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a VIEWER of team "team-1"
+    When permission "datasets:manage" is boolean-checked for user "user-123" on project "project-1"
+    Then the boolean result is false
+
+  Scenario: Boolean team permission API still returns true when granted
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a MEMBER of team "team-1"
+    When team permission "team:view" is boolean-checked for user "user-123" on team "team-1"
+    Then the boolean result is true
+
+  Scenario: Boolean team permission API still returns false when denied
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" is a VIEWER of team "team-1"
+    When team permission "team:manage" is boolean-checked for user "user-123" on team "team-1"
+    Then the boolean result is false
+
+  # ============================================================================
+  # Custom roles include org role in result
+  # ============================================================================
+
+  Scenario: Custom role grant includes org role in result
+    Given user "user-123" is a MEMBER in organization "org-1"
+    And user "user-123" has a custom role on team "team-1" with permissions ["analytics:view", "datasets:view"]
+    When permission "analytics:view" is checked for user "user-123" on project "project-1"
     Then the permission is granted
-    And the org role in the result is MEMBER
+    And the result includes organization role MEMBER
 
-  Scenario: Custom role denial carries org role
+  Scenario: Custom role denial includes org role in result
     Given user "user-123" is a MEMBER in organization "org-1"
-    And user "user-123" is a CUSTOM member of team "team-1" with permissions ["analytics:view"]
-    When project permission "datasets:manage" is checked for user "user-123" on project "project-1"
+    And user "user-123" has a custom role on team "team-1" with permissions ["analytics:view"]
+    When permission "datasets:manage" is checked for user "user-123" on project "project-1"
     Then the permission is denied
-    And the org role in the result is MEMBER
+    And the result includes organization role MEMBER
 
   # ============================================================================
-  # Middleware passes org role to downstream context
+  # Org role is available in request context after authorization
   # ============================================================================
 
-  Scenario: Project permission middleware passes org role to downstream context
+  Scenario: Project-scoped request makes org role available to subsequent handlers
     Given user "user-123" is a MEMBER in organization "org-1"
     And user "user-123" is a MEMBER of team "team-1"
-    When the project permission middleware runs for "analytics:view" on project "project-1"
-    Then downstream context includes org role MEMBER
+    When a project-scoped request for "analytics:view" on project "project-1" is authorized
+    Then the request context includes organization role MEMBER
 
-  Scenario: Team permission middleware passes org role to downstream context
+  Scenario: Team-scoped request makes org role available to subsequent handlers
     Given user "user-123" is an ADMIN in organization "org-1"
-    When the team permission middleware runs for "team:view" on team "team-1"
-    Then downstream context includes org role ADMIN
+    When a team-scoped request for "team:view" on team "team-1" is authorized
+    Then the request context includes organization role ADMIN
 
-  Scenario: Project permission middleware still denies unauthorized users
+  Scenario: Unauthorized project-scoped request is still denied
     Given user "user-123" is not a member of any team
-    When the project permission middleware runs for "analytics:view" on project "project-1"
+    When a project-scoped request for "analytics:view" on project "project-1" is authorized
     Then the request is denied with UNAUTHORIZED
 
-  Scenario: Team permission middleware still denies unauthorized users
+  Scenario: Unauthorized team-scoped request is still denied
     Given user "user-123" is not a member of any team
-    When the team permission middleware runs for "team:view" on team "team-1"
+    When a team-scoped request for "team:view" on team "team-1" is authorized
     Then the request is denied with UNAUTHORIZED
 
-  Scenario: Public share fallback middleware passes org role when permitted
+  Scenario: Public share fallback makes org role available when permitted
     Given user "user-123" is a MEMBER in organization "org-1"
     And user "user-123" is a MEMBER of team "team-1"
-    When the public share fallback middleware runs for "analytics:view" on project "project-1"
-    Then downstream context includes org role MEMBER
+    When a public-share-fallback request for "analytics:view" on project "project-1" is authorized
+    Then the request context includes organization role MEMBER
 
   # ============================================================================
-  # Frontend hook exposes org role
+  # Frontend exposes organization role
   # ============================================================================
 
   @integration
-  Scenario: Organization team project hook exposes org role for a member
+  Scenario: Frontend context includes org role for a member
     Given user "user-123" is a MEMBER in organization "org-1"
-    When the organization team project hook resolves
-    Then the hook result includes org role MEMBER
+    When the frontend loads organization and project context
+    Then the context includes organization role MEMBER
 
   @integration
-  Scenario: Organization team project hook exposes org role for an external user
-    Given user "user-123" is an EXTERNAL in organization "org-1"
-    When the organization team project hook resolves
-    Then the hook result includes org role EXTERNAL
+  Scenario: Frontend context includes org role for an external user
+    Given user "user-123" is an EXTERNAL member of organization "org-1"
+    When the frontend loads organization and project context
+    Then the context includes organization role EXTERNAL
 
   @integration
-  Scenario: Organization team project hook exposes org role for an admin
+  Scenario: Frontend context includes org role for an admin
     Given user "user-123" is an ADMIN in organization "org-1"
-    When the organization team project hook resolves
-    Then the hook result includes org role ADMIN
+    When the frontend loads organization and project context
+    Then the context includes organization role ADMIN
 
   # ============================================================================
-  # Org role correctly resolved across all org role types
+  # Org role resolved for all org role types
   # ============================================================================
 
-  Scenario Outline: Org role is carried for each org role type
+  Scenario Outline: Org role is included for each org role type
     Given user "user-123" is an <orgRole> in organization "org-1"
     And user "user-123" is a MEMBER of team "team-1"
-    When project permission "analytics:view" is checked for user "user-123" on project "project-1"
-    Then the org role in the result is <orgRole>
+    When permission "analytics:view" is checked for user "user-123" on project "project-1"
+    Then the result includes organization role <orgRole>
 
     Examples:
       | orgRole  |

--- a/specs/rbac/lite-member-restrictions.feature
+++ b/specs/rbac/lite-member-restrictions.feature
@@ -1,0 +1,140 @@
+Feature: Lite member access restrictions
+  As a LangWatch platform owner
+  I want lite members (EXTERNAL org role) restricted to observability and execution
+  So that leadership and support users can monitor and trigger runs
+  without accessing engineering-level debugging or configuration tools
+
+  Lite members are non-technical users (leadership, customers, support).
+  Engineers are full members. Both contribute data visible in the platform.
+
+  Background:
+    Given an organization "acme" with a project "chatbot"
+    And a lite member "sarah" in organization "acme"
+    And a full member "dev" in organization "acme"
+
+  # ============================================================================
+  # What lite members CAN see
+  # ============================================================================
+
+  Scenario: Lite member views analytics dashboards
+    When sarah opens the analytics page
+    Then she sees the full analytics dashboard
+
+  Scenario: Lite member views the traces list
+    When sarah opens the messages page
+    Then she sees the list of traces
+
+  Scenario: Lite member views scenario results
+    When sarah opens the simulations page
+    Then she sees scenario results and run history
+
+  Scenario: Lite member views evaluation outcomes
+    When sarah opens the evaluations page
+    Then she sees evaluation results and scores
+
+  Scenario: Lite member views experiment results
+    When sarah opens the experiments page
+    Then she sees experiment results and graphs
+
+  Scenario: Lite member browses the full sidebar
+    When sarah logs in to the platform
+    Then she sees all sidebar items
+    And no items are hidden or grayed out
+
+  # ============================================================================
+  # What lite members CAN do
+  # ============================================================================
+
+  Scenario: Lite member runs an existing scenario against a connected agent
+    Given a scenario "happy-path" exists in project "chatbot"
+    And an agent is connected to the project
+    When sarah runs scenario "happy-path"
+    Then the scenario executes against the agent
+    And sarah sees the results
+
+  # ============================================================================
+  # What lite members CANNOT do — trace debugging
+  # ============================================================================
+
+  Scenario: Lite member cannot debug individual traces
+    When sarah tries to open a trace detail view to inspect spans
+    Then she sees a restriction modal explaining the limitation
+    And no trace debug data is shown
+
+  # ============================================================================
+  # What lite members CANNOT do — create or edit from the platform
+  # ============================================================================
+
+  Scenario: Lite member cannot create a scenario
+    When sarah tries to create a new scenario
+    Then she sees a restriction modal explaining the limitation
+
+  Scenario: Lite member cannot edit a scenario
+    Given a scenario "happy-path" exists
+    When sarah tries to edit scenario "happy-path"
+    Then she sees a restriction modal explaining the limitation
+
+  Scenario: Lite member cannot create an evaluation
+    When sarah tries to create a new evaluation
+    Then she sees a restriction modal explaining the limitation
+
+  Scenario: Lite member cannot create an experiment
+    When sarah tries to create a new experiment
+    Then she sees a restriction modal explaining the limitation
+
+  Scenario: Lite member cannot create or edit prompts
+    When sarah tries to create a new prompt
+    Then she sees a restriction modal explaining the limitation
+
+  Scenario: Lite member cannot create or edit datasets
+    When sarah tries to create a new dataset
+    Then she sees a restriction modal explaining the limitation
+
+  Scenario: Lite member cannot create or edit workflows
+    When sarah tries to create a new workflow
+    Then she sees a restriction modal explaining the limitation
+
+  Scenario: Lite member cannot manage team settings
+    When sarah tries to modify team settings
+    Then she sees a restriction modal explaining the limitation
+
+  # ============================================================================
+  # Restriction UX
+  # ============================================================================
+
+  Scenario: Restriction modal explains the limitation clearly
+    When sarah triggers any restricted action
+    Then a modal appears with title "Feature Not Available"
+    And the modal explains the action is not available for her role
+    And the modal offers a path to upgrade or contact an admin
+
+  Scenario: Restricted action preserves the current page URL
+    Given sarah is on the scenarios page viewing results
+    When she tries to create a new scenario
+    Then the restriction modal appears
+    And the URL does not change
+    And she can dismiss the modal and continue browsing results
+
+  # ============================================================================
+  # Full members are unaffected
+  # ============================================================================
+
+  Scenario: Full member retains all capabilities
+    When dev logs in to the platform
+    Then dev can view, create, edit, and delete all resources
+    And dev can debug individual traces
+    And dev experiences no restriction modals
+
+  # ============================================================================
+  # Code-created resources are visible to lite members
+  # ============================================================================
+
+  Scenario: Scenarios created via SDK are visible to lite members
+    Given dev creates a scenario via the Python SDK
+    When sarah opens the simulations page
+    Then she sees the SDK-created scenario and its results
+
+  Scenario: Evaluations run via SDK are visible to lite members
+    Given dev runs an evaluation via the SDK
+    When sarah opens the evaluations page
+    Then she sees the SDK-created evaluation results


### PR DESCRIPTION
## Summary

- New `resolveProjectPermission()` and `resolveTeamPermission()` functions that return `PermissionResult { permitted, organizationRole }`
- Existing `hasProjectPermission`/`hasTeamPermission` delegate to them — still return `boolean`, zero blast radius to 60+ callers
- Middleware `checkProjectPermission`/`checkTeamPermission` attach `organizationRole` to tRPC context
- Frontend hook `useOrganizationTeamProject()` exposes `organizationRole`
- 63 integration tests covering all org role types, demo projects, custom roles, regression matrix

Closes #2011

> **Note:** The EXTERNAL → LITE_MEMBER rename (#2019) was originally included but has been deferred to a follow-up PR due to on-prem deployment safety concerns (code/migration ordering).

## Test plan

- [x] All 63 integration tests pass
- [x] Typecheck clean
- [x] Boolean API regression guards (hasProjectPermission/hasTeamPermission still return boolean)
- [x] Middleware propagates organizationRole to ctx
- [x] Demo project edge case handled