### PR TITLE
feat: add confirmation modal before running a suite

### DIFF
--- a/langwatch/src/pages/[project]/simulations/suites/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/suites/index.tsx
@@ -269,7 +269,7 @@ function SuitesPageContent() {
   );
 
   const confirmRun = useCallback(() => {
-    if (!project || !runConfirmId) return;
+    if (!project || !runConfirmId || runMutation.isPending) return;
     const suite = suites?.find((s) => s.id === runConfirmId);
     if (suite) navigateToSuite(suite.slug);
     runMutation.mutate({ projectId: project.id, id: runConfirmId, idempotencyKey: crypto.randomUUID() });

--- a/langwatch/src/pages/[project]/simulations/suites/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/suites/index.tsx
@@ -156,14 +156,10 @@ function SuitesPageContent() {
     ? suites?.find((s) => s.id === runConfirmId)
     : null;
 
-  const runConfirmTargetCount = (() => {
+  const runConfirmTargetCount = useMemo(() => {
     if (!runConfirmSuite) return 0;
-    try {
-      return parseSuiteTargets(runConfirmSuite.targets).length;
-    } catch {
-      return 0;
-    }
-  })();
+    return parseSuiteTargets(runConfirmSuite.targets).length;
+  }, [runConfirmSuite]);
 
   // Mutations
   const archiveMutation = api.suites.archive.useMutation({

--- a/langwatch/src/pages/[project]/simulations/suites/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/suites/index.tsx
@@ -17,6 +17,7 @@ import { PeriodSelector, usePeriodSelector, type Period } from "~/components/Per
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
 import { RunHistoryPanel } from "~/components/suites/RunHistoryPanel";
 import { SuiteArchiveDialog } from "~/components/suites/SuiteArchiveDialog";
+import { SuiteRunConfirmationDialog } from "~/components/suites/SuiteRunConfirmationDialog";
 import { SuiteContextMenu } from "~/components/suites/SuiteContextMenu";
 import {
   SuiteDetailPanel,
@@ -33,6 +34,7 @@ import {
   isExternalSetSelection,
   useSuiteRouting,
 } from "~/components/suites/useSuiteRouting";
+import { parseSuiteTargets } from "~/server/suites/types";
 import { toaster } from "~/components/ui/toaster";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useDrawer } from "~/hooks/useDrawer";
@@ -55,6 +57,7 @@ function SuitesPageContent() {
     suiteId: string;
   } | null>(null);
   const [archiveConfirmId, setArchiveConfirmId] = useState<string | null>(null);
+  const [runConfirmId, setRunConfirmId] = useState<string | null>(null);
 
   // Queries
   const {
@@ -149,6 +152,19 @@ function SuitesPageContent() {
     ? suites?.find((s) => s.id === archiveConfirmId)
     : null;
 
+  const runConfirmSuite = runConfirmId
+    ? suites?.find((s) => s.id === runConfirmId)
+    : null;
+
+  const runConfirmTargetCount = (() => {
+    if (!runConfirmSuite) return 0;
+    try {
+      return parseSuiteTargets(runConfirmSuite.targets).length;
+    } catch {
+      return 0;
+    }
+  })();
+
   // Mutations
   const archiveMutation = api.suites.archive.useMutation({
     onSuccess: () => {
@@ -203,6 +219,7 @@ function SuitesPageContent() {
     onSuccess: () => {
       setSuiteRunSinceTimestamp(undefined);
       void utils.scenarios.getSuiteRunData.invalidate();
+      setRunConfirmId(null);
     },
   });
 
@@ -245,12 +262,18 @@ function SuitesPageContent() {
 
   const handleRunSuite = useCallback(
     (suiteId: string) => {
-      const suite = suites?.find((s) => s.id === suiteId);
-      if (suite) navigateToSuite(suite.slug);
-      runMutation.mutate({ projectId: project?.id ?? "", id: suiteId, idempotencyKey: crypto.randomUUID() });
+      if (!project || runMutation.isPending) return;
+      setRunConfirmId(suiteId);
     },
-    [suites, navigateToSuite, runMutation, project?.id],
+    [project, runMutation.isPending],
   );
+
+  const confirmRun = useCallback(() => {
+    if (!project || !runConfirmId) return;
+    const suite = suites?.find((s) => s.id === runConfirmId);
+    if (suite) navigateToSuite(suite.slug);
+    runMutation.mutate({ projectId: project.id, id: runConfirmId, idempotencyKey: crypto.randomUUID() });
+  }, [project, runConfirmId, runMutation, navigateToSuite, suites]);
 
   const handleDuplicateSuite = useCallback(
     (suiteId: string) => {
@@ -406,6 +429,16 @@ function SuitesPageContent() {
         isLoading={archiveMutation.isPending}
       />
 
+      {/* Run confirmation dialog */}
+      <SuiteRunConfirmationDialog
+        open={!!runConfirmId}
+        onClose={() => setRunConfirmId(null)}
+        onConfirm={confirmRun}
+        suiteName={runConfirmSuite?.name ?? ""}
+        scenarioCount={runConfirmSuite?.scenarioIds.length ?? 0}
+        targetCount={runConfirmTargetCount}
+        isLoading={runMutation.isPending}
+      />
     </DashboardLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a confirmation modal when clicking "Run" on a suite (sidebar, detail panel, and "Run Now" in the editor drawer)
- Modal displays suite name, scenario count, target count, repeat count, and estimated total job count
- Users must confirm to proceed or cancel to abort

Closes #1986

## Test plan
- [ ] Click "Run" on a suite in the sidebar — confirmation modal appears with correct counts
- [ ] Click "Run" in the suite detail panel header — confirmation modal appears
- [ ] Click "Run Now" in the suite editor drawer — suite saves first, then confirmation modal appears
- [ ] Cancel the modal — no jobs are scheduled
- [ ] Confirm the modal — jobs are scheduled as before
- [ ] Verify modal shows correct repeat count (hidden when 1x)