### PR TITLE
fix(suites): replace percentage with passed/failed status labels

### DIFF
--- a/langwatch/src/components/suites/BatchSection.tsx
+++ b/langwatch/src/components/suites/BatchSection.tsx
@@ -12,6 +12,7 @@ import {
   computeIterationMap,
 } from "./run-history-transforms";
 import { ScenarioRunContent } from "./ScenarioRunContent";
+import { formatSummaryStatusLabel } from "./format-run-status-label";
 import { formatTimeAgoCompact } from "~/utils/formatTimeAgo";
 import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
 import type { ViewMode } from "./useRunHistoryStore";
@@ -63,7 +64,7 @@ export function BatchSection({
           fontWeight="medium"
           color={batchSummary.failedCount > 0 ? "red.600" : "green.600"}
         >
-          {Math.round(batchSummary.passRate)}%
+          {formatSummaryStatusLabel(batchSummary)}
         </Text>
       </HStack>
 

--- a/langwatch/src/components/suites/GroupRow.tsx
+++ b/langwatch/src/components/suites/GroupRow.tsx
@@ -19,6 +19,7 @@ import type { RunGroup, RunGroupSummary } from "./run-history-transforms";
 import { groupRunsByBatchId } from "./run-history-transforms";
 import { BatchSection } from "./BatchSection";
 import { RunSummaryFooter } from "./RunSummaryFooter";
+import { formatSummaryStatusLabel } from "./format-run-status-label";
 import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
 import type { ViewMode } from "./useRunHistoryStore";
 
@@ -89,7 +90,7 @@ export function GroupRow({
           fontWeight="medium"
           color={summary.failedCount > 0 ? "red.600" : "green.600"}
         >
-          {Math.round(summary.passRate)}%
+          {formatSummaryStatusLabel(summary)}
         </Text>
         <Box flex={1} />
         <Text fontSize="xs" color="fg.muted">

--- a/langwatch/src/components/suites/RunRow.tsx
+++ b/langwatch/src/components/suites/RunRow.tsx
@@ -17,6 +17,7 @@ import type { BatchRun, BatchRunSummary } from "./run-history-transforms";
 import { computeIterationMap, getScenarioDisplayNames } from "./run-history-transforms";
 import { ScenarioRunContent } from "./ScenarioRunContent";
 import { RunSummaryFooter } from "./RunSummaryFooter";
+import { formatSummaryStatusLabel } from "./format-run-status-label";
 import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
 import type { ViewMode } from "./useRunHistoryStore";
 
@@ -117,7 +118,7 @@ export function RunRow({
           fontWeight="medium"
           color={summary.failedCount > 0 ? "red.600" : "green.600"}
         >
-          {Math.round(summary.passRate)}%
+          {formatSummaryStatusLabel(summary)}
         </Text>
       </HStack>
 

--- a/langwatch/src/components/suites/ScenarioTargetRow.tsx
+++ b/langwatch/src/components/suites/ScenarioTargetRow.tsx
@@ -1,7 +1,9 @@
 /**
  * Row inside an expanded run showing a scenario x target pair result.
  *
- * Displays: [status_icon] [target: scenario_name (#N)] [pass%] ([pass/total]) [duration]
+ * Displays: [status_icon] [target: scenario_name (#N)] [passed/failed (met/total)] [duration]
+ *
+ * @see specs/features/suites/suite-list-view-status.feature
  */
 
 import { HStack, Text } from "@chakra-ui/react";
@@ -9,6 +11,7 @@ import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
 import { SCENARIO_RUN_STATUS_CONFIG } from "~/components/simulations/scenario-run-status-config";
 import { STATUS_ICON_CONFIG } from "./status-icons";
 import { buildDisplayTitle } from "./run-history-transforms";
+import { formatRunStatusLabel } from "./format-run-status-label";
 import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
 
 type ScenarioTargetRowProps = {
@@ -68,15 +71,12 @@ export function ScenarioTargetRow({
         {displayName}
       </Text>
       <HStack gap={2} flexShrink={0}>
-        {config.isComplete ? (
-          <Text fontSize="xs" color={config.fgColor}>
-            {scenarioRun.status === ScenarioRunStatus.SUCCESS ? "100%" : config.label}
-          </Text>
-        ) : (
-          <Text fontSize="xs" color={config.fgColor}>
-            {config.label}
-          </Text>
-        )}
+        <Text fontSize="xs" color={config.fgColor}>
+          {formatRunStatusLabel({
+            status: scenarioRun.status,
+            results: scenarioRun.results ?? undefined,
+          })}
+        </Text>
         {scenarioRun.durationInMs > 0 && (
           <Text fontSize="xs" color="fg.muted">
             {formatDuration(scenarioRun.durationInMs)}

--- a/langwatch/src/components/suites/__tests__/BatchSection.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/BatchSection.integration.test.tsx
@@ -59,7 +59,7 @@ describe("<BatchSection/>", () => {
       expect(screen.getByTestId("batch-sub-header")).toBeInTheDocument();
     });
 
-    it("displays pass rate percentage", () => {
+    it("displays passed/failed status with scenario count", () => {
       const batch = makeBatchRun({
         scenarioRuns: [
           makeScenarioRunData({ scenarioRunId: "run_1", status: ScenarioRunStatus.SUCCESS }),
@@ -77,7 +77,8 @@ describe("<BatchSection/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.getByText("passed (2/2)")).toBeInTheDocument();
+      expect(screen.queryByText("100%")).not.toBeInTheDocument();
     });
 
     it("renders ScenarioRunContent with the batch scenario runs", () => {

--- a/langwatch/src/components/suites/__tests__/RunHistoryGroupBy.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunHistoryGroupBy.integration.test.tsx
@@ -203,7 +203,7 @@ describe("<GroupRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText(`${Math.round(summary.passRate)}%`)).toBeInTheDocument();
+      expect(screen.getByText("failed (1/2)")).toBeInTheDocument();
       expect(screen.getAllByText("2 runs").length).toBeGreaterThanOrEqual(1);
     });
 
@@ -286,7 +286,7 @@ describe("<GroupRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText(`${Math.round(summary.passRate)}%`)).toBeInTheDocument();
+      expect(screen.getByText("failed (2/3)")).toBeInTheDocument();
       expect(screen.getAllByText("3 runs").length).toBeGreaterThanOrEqual(1);
     });
   });
@@ -385,7 +385,7 @@ describe("<GroupRow/>", () => {
       );
 
       const batchHeader = screen.getByTestId("batch-sub-header");
-      expect(within(batchHeader).getByText("100%")).toBeInTheDocument();
+      expect(within(batchHeader).getByText("passed (1/1)")).toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/components/suites/__tests__/RunRow.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunRow.integration.test.tsx
@@ -25,7 +25,7 @@ describe("<RunRow/>", () => {
   });
 
   describe("when collapsed", () => {
-    it("displays pass rate percentage", () => {
+    it("displays passed/failed status with scenario count", () => {
       render(
         <RunRow
           batchRun={makeBatchRun()}
@@ -38,7 +38,8 @@ describe("<RunRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.getByText("passed (2/2)")).toBeInTheDocument();
+      expect(screen.queryByText("100%")).not.toBeInTheDocument();
     });
 
     it("does not display scenario x target rows", () => {
@@ -168,11 +169,11 @@ describe("<RunRow/>", () => {
   });
 
   describe("when summary shows failures", () => {
-    it("displays pass rate with failure indicator", () => {
+    it("displays 'failed' with scenario count", () => {
       render(
         <RunRow
           batchRun={makeBatchRun()}
-          summary={makeSummary({ passRate: 88, failedCount: 1 })}
+          summary={makeSummary({ passedCount: 2, failedCount: 1 })}
           isExpanded={false}
           onToggle={vi.fn()}
           resolveTargetName={() => "Prod Agent"}
@@ -181,7 +182,7 @@ describe("<RunRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("88%")).toBeInTheDocument();
+      expect(screen.getByText("failed (2/3)")).toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/components/suites/__tests__/ScenarioTargetRow.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ScenarioTargetRow.integration.test.tsx
@@ -12,7 +12,7 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
+import { ScenarioRunStatus, Verdict } from "~/server/scenarios/scenario-event.enums";
 import { ScenarioTargetRow } from "../ScenarioTargetRow";
 import { makeScenarioRunData } from "./test-helpers";
 
@@ -42,7 +42,7 @@ describe("<ScenarioTargetRow/>", () => {
       ).toBeInTheDocument();
     });
 
-    it("displays 100% pass rate for SUCCESS status", () => {
+    it("displays 'passed' with criteria count for SUCCESS status", () => {
       render(
         <ScenarioTargetRow
           scenarioRun={makeScenarioRunData()}
@@ -52,7 +52,8 @@ describe("<ScenarioTargetRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.getByText("passed (1/1)")).toBeInTheDocument();
+      expect(screen.queryByText("100%")).not.toBeInTheDocument();
     });
 
     it("displays duration formatted as seconds", () => {
@@ -126,11 +127,17 @@ describe("<ScenarioTargetRow/>", () => {
   });
 
   describe("given a failed scenario run (ERROR status)", () => {
-    it("displays 'failed' label for ERROR status", () => {
+    it("displays 'failed' with criteria count for ERROR status", () => {
       render(
         <ScenarioTargetRow
           scenarioRun={makeScenarioRunData({
             status: ScenarioRunStatus.ERROR,
+            results: {
+              verdict: Verdict.FAILURE,
+              reasoning: "Error occurred",
+              metCriteria: ["c1"],
+              unmetCriteria: ["c2", "c3"],
+            },
           })}
           targetName="Prod Agent"
           onClick={vi.fn()}
@@ -138,16 +145,22 @@ describe("<ScenarioTargetRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("failed")).toBeInTheDocument();
+      expect(screen.getByText("failed (1/3)")).toBeInTheDocument();
     });
   });
 
   describe("given a failed scenario run (FAILED status)", () => {
-    it("displays 'failed' label for FAILED status", () => {
+    it("displays 'failed' with criteria count for FAILED status", () => {
       render(
         <ScenarioTargetRow
           scenarioRun={makeScenarioRunData({
             status: ScenarioRunStatus.FAILED,
+            results: {
+              verdict: Verdict.FAILURE,
+              reasoning: "Criteria not met",
+              metCriteria: ["c1", "c2"],
+              unmetCriteria: ["c3"],
+            },
           })}
           targetName="Prod Agent"
           onClick={vi.fn()}
@@ -155,7 +168,25 @@ describe("<ScenarioTargetRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("failed")).toBeInTheDocument();
+      expect(screen.getByText("failed (2/3)")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a successful run with no criteria results", () => {
+    it("displays 'passed' without count", () => {
+      render(
+        <ScenarioTargetRow
+          scenarioRun={makeScenarioRunData({
+            status: ScenarioRunStatus.SUCCESS,
+            results: null,
+          })}
+          targetName="Prod Agent"
+          onClick={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByText("passed")).toBeInTheDocument();
     });
   });
 
@@ -174,7 +205,7 @@ describe("<ScenarioTargetRow/>", () => {
       );
 
       expect(screen.getByText("running")).toBeInTheDocument();
-      expect(screen.queryByText("100%")).not.toBeInTheDocument();
+      expect(screen.queryByText(/passed/)).not.toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/components/suites/__tests__/formatRunStatusLabel.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/formatRunStatusLabel.unit.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for formatRunStatusLabel.
+ *
+ * @see specs/features/suites/suite-list-view-status.feature
+ */
+import { describe, expect, it } from "vitest";
+import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
+import { formatRunStatusLabel, formatSummaryStatusLabel } from "../format-run-status-label";
+
+describe("formatRunStatusLabel()", () => {
+  describe("when status is success", () => {
+    describe("when the run has met and unmet criteria", () => {
+      it("returns 'passed' with criteria count", () => {
+        const result = formatRunStatusLabel({
+          status: ScenarioRunStatus.SUCCESS,
+          results: {
+            metCriteria: ["c1", "c2", "c3", "c4", "c5"],
+            unmetCriteria: [],
+          },
+        });
+        expect(result).toBe("passed (5/5)");
+      });
+    });
+
+    describe("when the run has no evaluation results", () => {
+      it("returns 'passed' without count", () => {
+        const result = formatRunStatusLabel({
+          status: ScenarioRunStatus.SUCCESS,
+          results: undefined,
+        });
+        expect(result).toBe("passed");
+      });
+    });
+
+    describe("when the run has null results", () => {
+      it("returns 'passed' without count", () => {
+        const result = formatRunStatusLabel({
+          status: ScenarioRunStatus.SUCCESS,
+          results: null,
+        });
+        expect(result).toBe("passed");
+      });
+    });
+
+    describe("when the run has zero criteria", () => {
+      it("returns 'passed' without count", () => {
+        const result = formatRunStatusLabel({
+          status: ScenarioRunStatus.SUCCESS,
+          results: {
+            metCriteria: [],
+            unmetCriteria: [],
+          },
+        });
+        expect(result).toBe("passed");
+      });
+    });
+  });
+
+  describe("when status is failed", () => {
+    describe("when the run has met and unmet criteria", () => {
+      it("returns 'failed' with criteria count", () => {
+        const result = formatRunStatusLabel({
+          status: ScenarioRunStatus.FAILED,
+          results: {
+            metCriteria: ["c1", "c2", "c3"],
+            unmetCriteria: ["c4", "c5"],
+          },
+        });
+        expect(result).toBe("failed (3/5)");
+      });
+    });
+
+    describe("when the run has zero criteria", () => {
+      it("returns 'failed' without count", () => {
+        const result = formatRunStatusLabel({
+          status: ScenarioRunStatus.FAILED,
+          results: {
+            metCriteria: [],
+            unmetCriteria: [],
+          },
+        });
+        expect(result).toBe("failed");
+      });
+    });
+
+    describe("when the run has no evaluation results", () => {
+      it("returns 'failed' without count", () => {
+        const result = formatRunStatusLabel({
+          status: ScenarioRunStatus.FAILED,
+          results: undefined,
+        });
+        expect(result).toBe("failed");
+      });
+    });
+  });
+
+  describe("when status is error", () => {
+    it("returns 'failed' with criteria count if available", () => {
+      const result = formatRunStatusLabel({
+        status: ScenarioRunStatus.ERROR,
+        results: {
+          metCriteria: ["c1"],
+          unmetCriteria: ["c2", "c3"],
+        },
+      });
+      expect(result).toBe("failed (1/3)");
+    });
+  });
+
+  describe("when status is in_progress", () => {
+    it("returns 'running' without criteria count", () => {
+      const result = formatRunStatusLabel({
+        status: ScenarioRunStatus.IN_PROGRESS,
+        results: undefined,
+      });
+      expect(result).toBe("running");
+    });
+  });
+
+  describe("when status is pending", () => {
+    it("returns 'pending' without criteria count", () => {
+      const result = formatRunStatusLabel({
+        status: ScenarioRunStatus.PENDING,
+        results: undefined,
+      });
+      expect(result).toBe("pending");
+    });
+  });
+
+  describe("when status is stalled", () => {
+    it("returns 'stalled' without criteria count", () => {
+      const result = formatRunStatusLabel({
+        status: ScenarioRunStatus.STALLED,
+        results: undefined,
+      });
+      expect(result).toBe("stalled");
+    });
+  });
+
+  describe("when status is cancelled", () => {
+    it("returns 'cancelled' without criteria count", () => {
+      const result = formatRunStatusLabel({
+        status: ScenarioRunStatus.CANCELLED,
+        results: undefined,
+      });
+      expect(result).toBe("cancelled");
+    });
+  });
+});
+
+describe("formatSummaryStatusLabel()", () => {
+  const makeSummary = (overrides: Partial<Parameters<typeof formatSummaryStatusLabel>[0]> = {}) => ({
+    passRate: 0,
+    passedCount: 0,
+    failedCount: 0,
+    stalledCount: 0,
+    cancelledCount: 0,
+    totalCount: 0,
+    inProgressCount: 0,
+    ...overrides,
+  });
+
+  describe("when all scenarios passed", () => {
+    it("returns 'passed' with scenario count", () => {
+      const result = formatSummaryStatusLabel(makeSummary({
+        passedCount: 5,
+        totalCount: 5,
+      }));
+      expect(result).toBe("passed (5/5)");
+    });
+  });
+
+  describe("when some scenarios failed", () => {
+    it("returns 'failed' with passed/finished count", () => {
+      const result = formatSummaryStatusLabel(makeSummary({
+        passedCount: 3,
+        failedCount: 2,
+        totalCount: 5,
+      }));
+      expect(result).toBe("failed (3/5)");
+    });
+  });
+
+  describe("when all scenarios are in progress", () => {
+    it("returns 'running'", () => {
+      const result = formatSummaryStatusLabel(makeSummary({
+        inProgressCount: 3,
+        totalCount: 3,
+      }));
+      expect(result).toBe("running");
+    });
+  });
+
+  describe("when no scenarios exist", () => {
+    it("returns 'pending'", () => {
+      const result = formatSummaryStatusLabel(makeSummary());
+      expect(result).toBe("pending");
+    });
+  });
+
+  describe("when some scenarios are stalled", () => {
+    it("includes stalled in finished count", () => {
+      const result = formatSummaryStatusLabel(makeSummary({
+        passedCount: 2,
+        failedCount: 1,
+        stalledCount: 1,
+        totalCount: 4,
+      }));
+      expect(result).toBe("failed (2/4)");
+    });
+  });
+
+  describe("when some are finished and some still running", () => {
+    it("shows only finished scenarios in count", () => {
+      const result = formatSummaryStatusLabel(makeSummary({
+        passedCount: 3,
+        failedCount: 0,
+        inProgressCount: 2,
+        totalCount: 5,
+      }));
+      expect(result).toBe("passed (3/3)");
+    });
+  });
+});

--- a/langwatch/src/components/suites/format-run-status-label.ts
+++ b/langwatch/src/components/suites/format-run-status-label.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure formatting function for scenario run status labels.
+ *
+ * Converts raw status + evaluation results into a human-readable label
+ * like "passed (4/5)" or "failed (3/5)". Non-terminal statuses return
+ * their existing labels unchanged.
+ *
+ * @see specs/features/suites/suite-list-view-status.feature
+ */
+
+import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
+import type { RunGroupSummary } from "./run-history-transforms";
+
+type CriteriaResults = {
+  metCriteria: string[];
+  unmetCriteria: string[];
+};
+
+type FormatRunStatusLabelInput = {
+  status: ScenarioRunStatus;
+  results?: CriteriaResults | null;
+};
+
+const STATUS_LABELS: Record<ScenarioRunStatus, string> = {
+  [ScenarioRunStatus.SUCCESS]: "passed",
+  [ScenarioRunStatus.FAILED]: "failed",
+  [ScenarioRunStatus.ERROR]: "failed",
+  [ScenarioRunStatus.CANCELLED]: "cancelled",
+  [ScenarioRunStatus.STALLED]: "stalled",
+  [ScenarioRunStatus.IN_PROGRESS]: "running",
+  [ScenarioRunStatus.PENDING]: "pending",
+};
+
+const TERMINAL_WITH_CRITERIA: Set<ScenarioRunStatus> = new Set([
+  ScenarioRunStatus.SUCCESS,
+  ScenarioRunStatus.FAILED,
+  ScenarioRunStatus.ERROR,
+]);
+
+/**
+ * Formats a scenario run status into a display label with optional criteria count.
+ *
+ * Terminal statuses (success, failed, error) show "passed" or "failed" with
+ * criteria count in parentheses when criteria exist, e.g. "passed (4/5)".
+ * Non-terminal statuses return their label as-is: "running", "pending", etc.
+ */
+export function formatRunStatusLabel({
+  status,
+  results,
+}: FormatRunStatusLabelInput): string {
+  const label = STATUS_LABELS[status];
+
+  if (!TERMINAL_WITH_CRITERIA.has(status) || !results) {
+    return label;
+  }
+
+  const met = results.metCriteria.length;
+  const total = met + results.unmetCriteria.length;
+
+  if (total === 0) {
+    return label;
+  }
+
+  return `${label} (${met}/${total})`;
+}
+
+/**
+ * Formats a batch/group summary into a display label with scenario counts.
+ *
+ * Shows "passed (4/5)" or "failed (3/5)" where the numbers represent
+ * how many scenarios passed out of total finished scenarios.
+ * Non-terminal summaries (all in-progress) return "running".
+ */
+export function formatSummaryStatusLabel(summary: RunGroupSummary): string {
+  const finishedCount =
+    summary.passedCount +
+    summary.failedCount +
+    summary.stalledCount +
+    summary.cancelledCount;
+
+  if (finishedCount === 0) {
+    if (summary.inProgressCount > 0) return "running";
+    return "pending";
+  }
+
+  const label = summary.failedCount > 0 ? "failed" : "passed";
+  return `${label} (${summary.passedCount}/${finishedCount})`;
+}

--- a/specs/features/suites/suite-list-view-status.feature
+++ b/specs/features/suites/suite-list-view-status.feature
@@ -1,0 +1,94 @@
+Feature: Suite list view status with criteria count
+  As a LangWatch user
+  I want the list view to show passed/failed status with criteria counts
+  So that I can see at a glance whether a scenario passed and how many criteria were met
+
+  # The list view currently shows inconsistent values like "100%" for success
+  # and "failed" for failures. This feature standardizes the status display
+  # to always show "passed" or "failed" with criteria counts in parentheses,
+  # e.g. "passed (4/5)" or "failed (3/5)".
+
+  Background:
+    Given I am logged into project "my-project"
+    And the feature flag "release_ui_suites_enabled" is enabled
+
+  # --- Status label formatting ---
+
+  @unit
+  Scenario: Successful run shows "passed" with criteria count
+    Given a scenario run with status "success"
+    And the run has 5 met criteria and 0 unmet criteria
+    When the status label is computed
+    Then the label reads "passed (5/5)"
+
+  @unit
+  Scenario: Failed run shows "failed" with criteria count
+    Given a scenario run with status "failed"
+    And the run has 3 met criteria and 2 unmet criteria
+    When the status label is computed
+    Then the label reads "failed (3/5)"
+
+  @unit
+  Scenario: Run with no criteria results shows status without count
+    Given a scenario run with status "success"
+    And the run has no evaluation results
+    When the status label is computed
+    Then the label reads "passed"
+
+  @unit
+  Scenario: Run with zero criteria shows status without count
+    Given a scenario run with status "failed"
+    And the run has 0 met criteria and 0 unmet criteria
+    When the status label is computed
+    Then the label reads "failed"
+
+  # --- Non-terminal statuses remain unchanged ---
+
+  @unit
+  Scenario: In-progress run shows "running" without criteria count
+    Given a scenario run with status "in_progress"
+    When the status label is computed
+    Then the label reads "running"
+
+  @unit
+  Scenario: Pending run shows "pending" without criteria count
+    Given a scenario run with status "pending"
+    When the status label is computed
+    Then the label reads "pending"
+
+  # --- List view rendering ---
+
+  @integration
+  Scenario: List view row displays passed status with criteria count
+    Given a suite run contains a scenario that passed with 4/5 criteria met
+    When I view the run in list view
+    Then the scenario row shows "passed (4/5)"
+    And does not show "100%"
+
+  @integration
+  Scenario: List view row displays failed status with criteria count
+    Given a suite run contains a scenario that failed with 2/5 criteria met
+    When I view the run in list view
+    Then the scenario row shows "failed (2/5)"
+
+  # --- Iteration display ---
+
+  @integration
+  Scenario: List view row with iteration shows iteration number in title
+    Given a suite run contains a scenario with iteration 1 of 3
+    When I view the run in list view
+    Then the scenario title includes "(#1)"
+
+  # --- Consistency across views ---
+
+  @integration
+  Scenario: Suite detail panel list view uses the same status format
+    Given a suite has a completed run with mixed pass/fail results
+    When I view the suite detail panel in list view
+    Then all scenario rows show "passed" or "failed" with criteria counts
+
+  @integration
+  Scenario: All runs panel list view uses the same status format
+    Given multiple suites have completed runs
+    When I view the all runs panel in list view
+    Then all scenario rows show "passed" or "failed" with criteria counts


### PR DESCRIPTION
## Summary
- Replace percentage display (e.g. "100%") with "passed (4/5)" / "failed (3/5)" labels across all list view components (`RunRow`, `GroupRow`, `BatchSection`, `ScenarioTargetRow`)
- Add `formatRunStatusLabel` for individual scenario criteria counts and `formatSummaryStatusLabel` for batch/group scenario counts
- Add BDD feature spec and comprehensive unit + integration tests

Closes #1987

## Test plan
- [x] Unit tests for `formatRunStatusLabel` (12 tests) and `formatSummaryStatusLabel` (6 tests) — all passing
- [x] Integration tests for `ScenarioTargetRow` (14 tests), `RunRow` (15 tests), `BatchSection` (3 tests), `RunHistoryGroupBy` (13 tests) — all passing
- [ ] Visual verification in browser that list view shows "passed/failed (N/M)" instead of percentages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1987