### PR TITLE
fix: Python scenario events rejected due to null trace_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,33 @@
 <a href="https://www.npmjs.com/package/langwatch" target="_blank"><img src="https://img.shields.io/npm/dm/langwatch?logo=npm&logoColor=white&label=npm%20langwatch&color=blue" alt="langwatch npm package"></a>
 <a href="https://twitter.com/intent/follow?screen_name=langwatchai" target="_blank">
    <img src="https://img.shields.io/twitter/follow/langwatchai?logo=X&color=%20%23f5f5f5"
-      alt="follow on X(Twitter)"></a>
+      alt="follow on X"></a>
 </p>
 
 <video src="https://github.com/user-attachments/assets/ff49882d-4e9d-4b7c-819b-be690fba9387" autoplay loop muted playsinline width="100%" style="display: block; aspect-ratio: 16 / 9;"></video>
 
 ## Why LangWatch?
 
-**LangWatch is the leading LLM Ops platform on evaluation capabilities and user-friendly collaboration** — evaluate, debug, and optimize your Agents and LLM pipelines together with your team, locally or in the cloud, with Open-Telemetry native integrations.
+LangWatch is an AI engineering platform for building, testing, and operating LLM-powered systems, from prompt workflows to full-stack, tool-using agents.
 
-## Core Features
+Built for teams that need regression testing, simulations, and production observability without building custom tooling.
 
-- [**Observability**](https://docs.langwatch.ai/integration/overview) - Add tracing to your LLM, based on the OpenTelemetry standard, allowing LangWatch to provide real-time powers.
-- [**Evaluation**](https://docs.langwatch.ai/llm-evaluation/offline-evaluation) - Run real-time and offline evaluations against production or synthetic datasets. Compare performance across various matrices (prompts, modules, hosting providers, and complete LLM pipelines).
-- [**Datasets**](https://docs.langwatch.ai/datasets/overview) - Automatically created from traced messages, or upload, datasets which can be used across the platform for evals.
-- [**Optimization Studio**](https://docs.langwatch.ai/optimization-studio/overview) – Build and run evaluations faster with our no+lo 🧘 code studio. If you need more flexibility, you have access to the DSL that powers it too.
-- [**Prompt Management & Optimization**](https://docs.langwatch.ai/features/prompt-versioning) – Version prompts, test changes on datasets, and improve real-world performance. Auto-optimize with DSPy's MIPROv2 to generate better prompts and few-shot examples.
-- [**Annotations**](https://docs.langwatch.ai/features/annotations) - Human in the Loop, done right. Accelerate better data creation by combining domain expert input with smart workflows. Use LangWatch's intuitive annotation interface to collaborate directly with experts while keeping full control over your code. Quickly generate high-quality labels, catch edge cases, and fine-tune datasets to build more accurate, robust AI models.
+- [**Agent-first, not prompt-first**](https://docs.langwatch.ai/better-agents/overview)
+  Built for **multi-step, tool-using agents** (memory, routing, retries), not just single-shot prompt evals.
 
-LangWatch is framework- and LLM-agnostic, with support for (LangGraph, DSPy, Langflow, Flowise, Vercel, Mastra, Agno and others) and LLM providers (OpenAI, Azure, Bedrock, Gemini, Deepseek, Groq, MistralAI, VertexAI, LiteLLM, and others) via [OpenTelemetry](https://opentelemetry.io/).
+- [**End-to-end agent simulations**](https://langwatch.ai/scenario/)
+  Run realistic scenarios against your **full stack** (tools, state, user simulator, judge) and pinpoint where your agents break, and why? down to each decision.
 
-Our use of **open** and **community-driven** **standards** enables your team to be flexible to the rapidly changing AI ecosystem without worrying about compatibility.
+- **Eval + observability + prompts in one loop**
+  [Trace](https://docs.langwatch.ai/integration/overview) → [dataset](https://docs.langwatch.ai/datasets/overview) → [evaluate](https://docs.langwatch.ai/llm-evaluation/offline-evaluation) → [optimize prompts/models](https://docs.langwatch.ai/optimization-studio/overview) → re-test. No glue code, no tool sprawl.
+
+- [**Open standards, no lock-in**](https://docs.langwatch.ai/integration/opentelemetry/guide)
+  OpenTelemetry/OTLP-native. Framework- and LLM-provider agnostic by design.
+
+- [**Collaboration that doesn't slow shipping**](https://docs.langwatch.ai/features/annotations)
+  Review runs, annotate failures, and ship fixes faster. Let domain experts label edge cases with [annotations & queues](https://docs.langwatch.ai/features/annotations), keep prompts in Git with the [GitHub integration](https://docs.langwatch.ai/prompt-management/features/essential/github-integration), and [link prompt versions to traces](https://docs.langwatch.ai/prompt-management/features/advanced/link-to-traces).
+
+LangWatch helps you observe, test, and debug LLM-powered systems by combining traces, simulations, evaluations, and production monitoring in one place
 
 ## Getting Started
 
@@ -38,7 +44,7 @@ Our use of **open** and **community-driven** **standards** enables your team to 
 
 The easiest way to get started with LangWatch.
 
-[Create a free account](https://app.langwatch.ai) to get started.
+[Create a free account](https://app.langwatch.ai) → create a project → get started/ copy your API key.
 
 ### Local setup 💻
 
@@ -49,38 +55,29 @@ git clone https://github.com/langwatch/langwatch.git
 cd langwatch
 cp langwatch/.env.example langwatch/.env
 docker compose up -d --wait --build
-open http://localhost:5560
 ```
+Once running, LangWatch will be available at `http://localhost:5560`, where you can create your first project and API key.
 
-You'll be launched right into our onboarding flow. Welcome aboard 🫡.
-
-### Self-hosted ⚓️
+### Deployment options ⚓️
 
 Run LangWatch on your own infrastructure:
 
 - [Docker Compose](https://docs.langwatch.ai/self-hosting/open-source#docker-compose) - Run LangWatch on your own machine.
-- [Kubernetes (Helm)](https://docs.langwatch.ai/self-hosting/open-source#helm-chart-for-langwatch) - Run LangWatch on a Kubernetes cluster using Helm for a production-ready setup.
-- [OnPrem](https://docs.langwatch.ai/self-hosting/onprem) - For high-scale deployments, we offer cloud specific setups for AWS, Google Cloud and Azure.
-- [Hybrid (OnPrem data)](https://docs.langwatch.ai/self-hosting/hybrid) - For companies that have strict data residency and control requirements, without needing to go fully on-prem.
+- [Kubernetes (Helm)](https://docs.langwatch.ai/self-hosting/open-source#helm-chart-for-langwatch) - Run LangWatch on a Kubernetes cluster using Helm.
+- [OnPrem](https://docs.langwatch.ai/self-hosting/onprem) - Cloud-specific setups for AWS, Google Cloud, and Azure.
 
-### Other Flavours 🍦
-
-<details>
-<summary>Self-hosted (OnPrem) ⚓️</summary>
-LangWatch offers a fully self-hosted version of the platform for companies that require strict data control and compliance, complete with Azure AD support.
-
-Read more about it on our [docs](https://docs.langwatch.ai/self-hosting/overview).
-
-</details>
 <details>
 <summary>Hybrid (OnPrem data) 🔀</summary>
-LangWatch offers a hybrid setup for companies that have strict data control and compliance requirements, without needing to go fully on-prem.
 
-Read more about it on our [docs](https://docs.langwatch.ai/hybrid-setup/overview).
+For companies that have strict data residency and control requirements, without needing to go fully on-prem.
+
+Read more about it on our [docs](https://docs.langwatch.ai/self-hosting/hybrid).
 
 </details>
+
 <details>
 <summary>Local Development 👩‍💻</summary>
+
 You can also run LangWatch locally without docker to develop and help contribute to the project.
 
 Start just the databases using docker and leave it running:
@@ -100,55 +97,26 @@ make start
 
 ## 🚀 Quick Start
 
-Get observing in minutes. Now you have an account and have created a project inside LangWatch, let's get your messages flowing through LangWatch.
+Ship safer agents in minutes. [Create a free account](https://app.langwatch.ai), then dive into these guides:
 
-> [!NOTE]
-> Not using Python or OpenAI? Don't worry, we have your back. [Visit our docs](https://docs.langwatch.ai/integration/overview) for full guides for other popular languages, LLM providers, and frameworks.
-
-### Install and configure SDK
-
-Available for install via `pip`, or `uv`. The SDK will also check your environment variables by default for your API key and endpoint.
-
-```bash
-pip install langwatch
-```
-
-```python
-LANGWATCH_API_KEY="sk-lw-..."
-
-# This is only needed if you aren't using LangWatch Cloud.
-# LANGWATCH_ENDPOINT="https://self-hosted-url.internal/"
-```
-
-### Create your first trace and auto-instrument OpenAI
-
-```python
-import langwatch
-from openai import OpenAI
-
-client = OpenAI()
-
-@langwatch.trace()
-def main():
-    langwatch.get_current_trace().autotrack_openai_calls(client)
-    ...
-```
-
-### See your traces in LangWatch
-
-![A view of a trace in the LangWatch app](assets/trace-view.webp)
-
-You can also view a public share of the trace [**here**](https://app.langwatch.ai/share/pA8sBaRf5Nn2sa7OkhJfi).
+- **[Run your first agent simulation](https://langwatch.ai/scenario/introduction/getting-started)** - Test agents against realistic scenarios before production
+- **[Set up evaluations](https://docs.langwatch.ai/llm-evaluation/offline-evaluation)** - Measure quality, performance, and reliability
+- **[Send your first traces](https://docs.langwatch.ai/integration/overview)** - Integrate LangWatch with your stack
+- **[Get started with LangWatch MCP](https://langwatch.ai/docs/integration/mcp)** - Use LangWatch in Claude Desktop and other MCP clients
 
 ## 🗺️ Integrations
 
-LangWatch builds and maintains several integrations listed below, additionally our tracing platform is built on top of [OpenTelemetry](https://opentelemetry.io/), so we support any OpenTelemetry compatible library out of the box.
+LangWatch builds and maintains several integrations listed below. Our tracing platform is built on top of [OpenTelemetry](https://opentelemetry.io/), so we support any OpenTelemetry-compatible library out of the box.
 
 We also support various community standards, such as [OpenInference](https://github.com/Arize-ai/openinference), [OpenLLMetry](https://github.com/traceloop/openllmetry), and more.
 
+### Agent Simulation
+
+Test your agents before they hit production using [Scenarios](https://github.com/langwatch/scenario) — our lightweight simulation framework for stress testing agents against real-world situations. [Get started here](https://scenario.langwatch.ai/).
+
 ### Python 🐍
 
-Our Python SDK supports the following auto-instrumentors.
+Our Python SDK supports the following auto-instrumentors:
 
 - [OpenAI](https://docs.langwatch.ai/integration/python/guide#open-ai)
 - [Azure](https://docs.langwatch.ai/integration/python/guide#azure)
@@ -156,16 +124,19 @@ Our Python SDK supports the following auto-instrumentors.
 - [DSPy](https://docs.langwatch.ai/integration/python/guide#ds-py)
 - [LangChain](https://docs.langwatch.ai/integration/python/guide#lang-chain)
 
-Through OpenTelemetry, we also support all the frameworks and providers that support them, such as:
+<details>
+<summary>Additional frameworks via OpenTelemetry</summary>
 
 - AWS Bedrock
 - Haystack
 - CrewAI
 - Autogen
-- Grok
-- …and many more
+- Groq
+- ...and many more
 
 You can find a [full guide](https://docs.langwatch.ai/integration/opentelemetry/guide) on our docs.
+
+</details>
 
 ### JavaScript ☕️
 
@@ -176,21 +147,13 @@ Our JavaScript SDK supports the following instrumentors:
 - [Azure](https://docs.langwatch.ai/integration/typescript/guide#azure)
 - [LangChain.js](https://docs.langwatch.ai/integration/typescript/guide#lang-chain-js)
 
-### Agent Simulation
-
-Test your agents before they hit production using [Scenarios](https://github.com/langwatch/scenario) — our lightweight simulation framework for stress testing agents against real-world situations. [Get started here](https://scenario.langwatch.ai/)
-
 ### Platforms
 
 - [LangFlow](https://docs.langwatch.ai/integration/langflow)
 - [Flowise](https://docs.langwatch.ai/integration/flowise)
+- [n8n](https://docs.langwatch.ai/integration/n8n)
 
 Are you using a platform that could benefit from a direct LangWatch integration? We'd love to hear from you, please [**fill out this very quick form.**](https://www.notion.so/1e35e165d48280468247fcbdc3349077?pvs=21)
-
-## 🥰 Community
-
-- Join our [Discord](https://discord.gg/kT4PhDS2gH) community
-- Follow our [Twitter](https://x.com/LangWatchAI)
 
 ## 💬 Support
 
@@ -198,6 +161,7 @@ Have questions or need help? We're here to support you in multiple ways:
 
 - **Documentation:** Our comprehensive [documentation](https://docs.langwatch.ai) covers everything from getting started to advanced features.
 - **Discord Community:** Join our [Discord server](https://discord.gg/kT4PhDS2gH) for real-time help from our team and community.
+- **X (Twitter):** Follow us on [X](https://x.com/LangWatchAI) for updates and announcements.
 - **GitHub Issues:** Report bugs or request features through our [GitHub repository](https://github.com/langwatch/langwatch).
 - **Enterprise Support:** Enterprise customers receive priority support with dedicated response times. Our [pricing page](https://langwatch.ai/pricing) contains more information.
 
@@ -213,7 +177,7 @@ Please read our [LICENSE.md](/LICENSE.md) file.
 
 ## 👮‍♀️ Security + Compliance
 
-As a platform that has access to data that is highly likely to be be sensitive, we take security incredibly seriously and treat it as a core part of our culture.
+As a platform that has access to data that is highly likely to be sensitive, we take security incredibly seriously and treat it as a core part of our culture.
 
 | Legal Framework | Current Status                                                                 |
 | --------------- | ------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 ## Why LangWatch?
 
-LangWatch is an AI engineering platform for building, testing, and operating LLM-powered systems, from prompt workflows to full-stack, tool-using agents.
-
+The platform for LLM evaluations and AI agent testing.
+We help teams test, simulate, evaluate, and monitor LLM-powered agents end-to-end — before release and in production.
 Built for teams that need regression testing, simulations, and production observability without building custom tooling.
 
 - [**End-to-end agent simulations**](https://langwatch.ai/scenario/)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Built for teams that need regression testing, simulations, and production observ
 - [**Collaboration that doesn't slow shipping**](https://docs.langwatch.ai/features/annotations)
   Review runs, annotate failures, and ship fixes faster. Let domain experts label edge cases with [annotations & queues](https://docs.langwatch.ai/features/annotations), keep prompts in Git with the [GitHub integration](https://docs.langwatch.ai/prompt-management/features/essential/github-integration), and [link prompt versions to traces](https://docs.langwatch.ai/prompt-management/features/advanced/link-to-traces).
 
-LangWatch helps you observe, test, and debug LLM-powered systems by combining traces, simulations, evaluations, and production monitoring in one place
+LangWatch gives you full visibility into agent behavior and the tools to systematically improve reliability, performance, and cost, while keeping you in control of your AI system
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ LangWatch is an AI engineering platform for building, testing, and operating LLM
 
 Built for teams that need regression testing, simulations, and production observability without building custom tooling.
 
-- [**Agent-first, not prompt-first**](https://docs.langwatch.ai/better-agents/overview)
-  Built for **multi-step, tool-using agents** (memory, routing, retries), not just single-shot prompt evals.
-
 - [**End-to-end agent simulations**](https://langwatch.ai/scenario/)
   Run realistic scenarios against your **full stack** (tools, state, user simulator, judge) and pinpoint where your agents break, and why? down to each decision.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![logo.webp](assets/logo-header.webp)
+<img width="1212" height="395" alt="012d1688-24ae-4759-ae70-5f8f81a13c0e" src="https://github.com/user-attachments/assets/27b6e50e-efde-41cf-9f7c-94b829b25a8c" />
+
 
 <h3 align="center">
     <a href="https://langwatch.ai">Website</a> · <a href="https://docs.langwatch.ai">Docs</a> · <a href="https://discord.gg/kT4PhDS2gH">Discord</a> · <a href="https://docs.langwatch.ai/self-hosting/overview">Self-hosting</a>

--- a/README.md
+++ b/README.md
@@ -104,52 +104,31 @@ Ship safer agents in minutes. [Create a free account](https://app.langwatch.ai),
 
 ## 🗺️ Integrations
 
+
 LangWatch builds and maintains several integrations listed below. Our tracing platform is built on top of [OpenTelemetry](https://opentelemetry.io/), so we support any OpenTelemetry-compatible library out of the box.
 
-We also support various community standards, such as [OpenInference](https://github.com/Arize-ai/openinference), [OpenLLMetry](https://github.com/traceloop/openllmetry), and more.
+**Frameworks:**  
+[LangChain](https://langwatch.ai/docs/integration/python/integrations/langchain) ·
+[LangGraph](https://langwatch.ai/docs/integration/python/integrations/langgraph) ·
+[Vercel AI SDK](https://langwatch.ai/docs/integration/typescript/integrations/vercel-ai) ·
+[Mastra](https://langwatch.ai/docs/integration/typescript/integrations/mastra) ·
+[CrewAI](https://langwatch.ai/docs/integration/python/integrations/crewai) ·
+[Google ADK](https://langwatch.ai/docs/integration/python/integrations/google-ai)
 
-### Agent Simulation
-
-Test your agents before they hit production using [Scenarios](https://github.com/langwatch/scenario) — our lightweight simulation framework for stress testing agents against real-world situations. [Get started here](https://scenario.langwatch.ai/).
-
-### Python 🐍
-
-Our Python SDK supports the following auto-instrumentors:
-
-- [OpenAI](https://docs.langwatch.ai/integration/python/guide#open-ai)
-- [Azure](https://docs.langwatch.ai/integration/python/guide#azure)
-- [LiteLLM](https://docs.langwatch.ai/integration/python/guide#lite-llm)
-- [DSPy](https://docs.langwatch.ai/integration/python/guide#ds-py)
-- [LangChain](https://docs.langwatch.ai/integration/python/guide#lang-chain)
-
-<details>
-<summary>Additional frameworks via OpenTelemetry</summary>
-
-- AWS Bedrock
-- Haystack
-- CrewAI
-- Autogen
-- Groq
-- ...and many more
-
-You can find a [full guide](https://docs.langwatch.ai/integration/opentelemetry/guide) on our docs.
-
-</details>
-
-### JavaScript ☕️
-
-Our JavaScript SDK supports the following instrumentors:
-
-- [Vercel AI SDK](https://docs.langwatch.ai/integration/typescript/guide#vercel-ai-sdk)
-- [OpenAI](https://docs.langwatch.ai/integration/typescript/guide#open-ai)
-- [Azure](https://docs.langwatch.ai/integration/typescript/guide#azure)
-- [LangChain.js](https://docs.langwatch.ai/integration/typescript/guide#lang-chain-js)
+**Model Providers:**  
+[OpenAI](https://langwatch.ai/docs/integration/python/integrations/openai) ·
+[Anthropic](https://langwatch.ai/docs/integration/python/integrations/anthropic) ·
+[Azure](https://langwatch.ai/docs/integration/python/integrations/azure) ·
+[Google Cloud](https://langwatch.ai/docs/integration/python/integrations/google-cloud) ·
+[AWS](https://langwatch.ai/docs/integration/python/integrations/aws) ·
+[Groq](https://langwatch.ai/docs/integration/python/integrations/groq) ·
+[Ollama](https://langwatch.ai/docs/integration/python/integrations/ollama)
 
 ### Platforms
 
-- [LangFlow](https://docs.langwatch.ai/integration/langflow)
-- [Flowise](https://docs.langwatch.ai/integration/flowise)
-- [n8n](https://docs.langwatch.ai/integration/n8n)
+[LangFlow](https://docs.langwatch.ai/integration/langflow) · [Flowise](https://docs.langwatch.ai/integration/flowise) · [n8n](https://docs.langwatch.ai/integration/n8n)
+
+*and many more…*
 
 Are you using a platform that could benefit from a direct LangWatch integration? We'd love to hear from you, please [**fill out this very quick form.**](https://www.notion.so/1e35e165d48280468247fcbdc3349077?pvs=21)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<img width="1212" height="395" alt="012d1688-24ae-4759-ae70-5f8f81a13c0e" src="https://github.com/user-attachments/assets/27b6e50e-efde-41cf-9f7c-94b829b25a8c" />
-
+![logo.webp](assets/logo-header.webp)
 
 <h3 align="center">
     <a href="https://langwatch.ai">Website</a> · <a href="https://docs.langwatch.ai">Docs</a> · <a href="https://discord.gg/kT4PhDS2gH">Discord</a> · <a href="https://docs.langwatch.ai/self-hosting/overview">Self-hosting</a>
@@ -11,30 +10,27 @@
 <a href="https://www.npmjs.com/package/langwatch" target="_blank"><img src="https://img.shields.io/npm/dm/langwatch?logo=npm&logoColor=white&label=npm%20langwatch&color=blue" alt="langwatch npm package"></a>
 <a href="https://twitter.com/intent/follow?screen_name=langwatchai" target="_blank">
    <img src="https://img.shields.io/twitter/follow/langwatchai?logo=X&color=%20%23f5f5f5"
-      alt="follow on X"></a>
+      alt="follow on X(Twitter)"></a>
 </p>
 
 <video src="https://github.com/user-attachments/assets/ff49882d-4e9d-4b7c-819b-be690fba9387" autoplay loop muted playsinline width="100%" style="display: block; aspect-ratio: 16 / 9;"></video>
 
 ## Why LangWatch?
 
-The platform for LLM evaluations and AI agent testing.
-We help teams test, simulate, evaluate, and monitor LLM-powered agents end-to-end — before release and in production.
-Built for teams that need regression testing, simulations, and production observability without building custom tooling.
+**LangWatch is the leading LLM Ops platform on evaluation capabilities and user-friendly collaboration** — evaluate, debug, and optimize your Agents and LLM pipelines together with your team, locally or in the cloud, with Open-Telemetry native integrations.
 
-- [**End-to-end agent simulations**](https://langwatch.ai/scenario/)
-  Run realistic scenarios against your **full stack** (tools, state, user simulator, judge) and pinpoint where your agents break, and why? down to each decision.
+## Core Features
 
-- **Eval + observability + prompts in one loop**
-  [Trace](https://docs.langwatch.ai/integration/overview) → [dataset](https://docs.langwatch.ai/datasets/overview) → [evaluate](https://docs.langwatch.ai/llm-evaluation/offline-evaluation) → [optimize prompts/models](https://docs.langwatch.ai/optimization-studio/overview) → re-test. No glue code, no tool sprawl.
+- [**Observability**](https://docs.langwatch.ai/integration/overview) - Add tracing to your LLM, based on the OpenTelemetry standard, allowing LangWatch to provide real-time powers.
+- [**Evaluation**](https://docs.langwatch.ai/llm-evaluation/offline-evaluation) - Run real-time and offline evaluations against production or synthetic datasets. Compare performance across various matrices (prompts, modules, hosting providers, and complete LLM pipelines).
+- [**Datasets**](https://docs.langwatch.ai/datasets/overview) - Automatically created from traced messages, or upload, datasets which can be used across the platform for evals.
+- [**Optimization Studio**](https://docs.langwatch.ai/optimization-studio/overview) – Build and run evaluations faster with our no+lo 🧘 code studio. If you need more flexibility, you have access to the DSL that powers it too.
+- [**Prompt Management & Optimization**](https://docs.langwatch.ai/features/prompt-versioning) – Version prompts, test changes on datasets, and improve real-world performance. Auto-optimize with DSPy's MIPROv2 to generate better prompts and few-shot examples.
+- [**Annotations**](https://docs.langwatch.ai/features/annotations) - Human in the Loop, done right. Accelerate better data creation by combining domain expert input with smart workflows. Use LangWatch's intuitive annotation interface to collaborate directly with experts while keeping full control over your code. Quickly generate high-quality labels, catch edge cases, and fine-tune datasets to build more accurate, robust AI models.
 
-- [**Open standards, no lock-in**](https://docs.langwatch.ai/integration/opentelemetry/guide)
-  OpenTelemetry/OTLP-native. Framework- and LLM-provider agnostic by design.
+LangWatch is framework- and LLM-agnostic, with support for (LangGraph, DSPy, Langflow, Flowise, Vercel, Mastra, Agno and others) and LLM providers (OpenAI, Azure, Bedrock, Gemini, Deepseek, Groq, MistralAI, VertexAI, LiteLLM, and others) via [OpenTelemetry](https://opentelemetry.io/).
 
-- [**Collaboration that doesn't slow shipping**](https://docs.langwatch.ai/features/annotations)
-  Review runs, annotate failures, and ship fixes faster. Let domain experts label edge cases with [annotations & queues](https://docs.langwatch.ai/features/annotations), keep prompts in Git with the [GitHub integration](https://docs.langwatch.ai/prompt-management/features/essential/github-integration), and [link prompt versions to traces](https://docs.langwatch.ai/prompt-management/features/advanced/link-to-traces).
-
-LangWatch gives you full visibility into agent behavior and the tools to systematically improve reliability, performance, and cost, while keeping you in control of your AI system
+Our use of **open** and **community-driven** **standards** enables your team to be flexible to the rapidly changing AI ecosystem without worrying about compatibility.
 
 ## Getting Started
 
@@ -42,7 +38,7 @@ LangWatch gives you full visibility into agent behavior and the tools to systema
 
 The easiest way to get started with LangWatch.
 
-[Create a free account](https://app.langwatch.ai) → create a project → get started/ copy your API key.
+[Create a free account](https://app.langwatch.ai) to get started.
 
 ### Local setup 💻
 
@@ -53,29 +49,38 @@ git clone https://github.com/langwatch/langwatch.git
 cd langwatch
 cp langwatch/.env.example langwatch/.env
 docker compose up -d --wait --build
+open http://localhost:5560
 ```
-Once running, LangWatch will be available at `http://localhost:5560`, where you can create your first project and API key.
 
-### Deployment options ⚓️
+You'll be launched right into our onboarding flow. Welcome aboard 🫡.
+
+### Self-hosted ⚓️
 
 Run LangWatch on your own infrastructure:
 
 - [Docker Compose](https://docs.langwatch.ai/self-hosting/open-source#docker-compose) - Run LangWatch on your own machine.
-- [Kubernetes (Helm)](https://docs.langwatch.ai/self-hosting/open-source#helm-chart-for-langwatch) - Run LangWatch on a Kubernetes cluster using Helm.
-- [OnPrem](https://docs.langwatch.ai/self-hosting/onprem) - Cloud-specific setups for AWS, Google Cloud, and Azure.
+- [Kubernetes (Helm)](https://docs.langwatch.ai/self-hosting/open-source#helm-chart-for-langwatch) - Run LangWatch on a Kubernetes cluster using Helm for a production-ready setup.
+- [OnPrem](https://docs.langwatch.ai/self-hosting/onprem) - For high-scale deployments, we offer cloud specific setups for AWS, Google Cloud and Azure.
+- [Hybrid (OnPrem data)](https://docs.langwatch.ai/self-hosting/hybrid) - For companies that have strict data residency and control requirements, without needing to go fully on-prem.
+
+### Other Flavours 🍦
 
 <details>
-<summary>Hybrid (OnPrem data) 🔀</summary>
+<summary>Self-hosted (OnPrem) ⚓️</summary>
+LangWatch offers a fully self-hosted version of the platform for companies that require strict data control and compliance, complete with Azure AD support.
 
-For companies that have strict data residency and control requirements, without needing to go fully on-prem.
-
-Read more about it on our [docs](https://docs.langwatch.ai/self-hosting/hybrid).
+Read more about it on our [docs](https://docs.langwatch.ai/self-hosting/overview).
 
 </details>
+<details>
+<summary>Hybrid (OnPrem data) 🔀</summary>
+LangWatch offers a hybrid setup for companies that have strict data control and compliance requirements, without needing to go fully on-prem.
 
+Read more about it on our [docs](https://docs.langwatch.ai/hybrid-setup/overview).
+
+</details>
 <details>
 <summary>Local Development 👩‍💻</summary>
-
 You can also run LangWatch locally without docker to develop and help contribute to the project.
 
 Start just the databases using docker and leave it running:
@@ -95,42 +100,97 @@ make start
 
 ## 🚀 Quick Start
 
-Ship safer agents in minutes. [Create a free account](https://app.langwatch.ai), then dive into these guides:
+Get observing in minutes. Now you have an account and have created a project inside LangWatch, let's get your messages flowing through LangWatch.
 
-- **[Run your first agent simulation](https://langwatch.ai/scenario/introduction/getting-started)** - Test agents against realistic scenarios before production
-- **[Set up evaluations](https://docs.langwatch.ai/llm-evaluation/offline-evaluation)** - Measure quality, performance, and reliability
-- **[Send your first traces](https://docs.langwatch.ai/integration/overview)** - Integrate LangWatch with your stack
-- **[Get started with LangWatch MCP](https://langwatch.ai/docs/integration/mcp)** - Use LangWatch in Claude Desktop and other MCP clients
+> [!NOTE]
+> Not using Python or OpenAI? Don't worry, we have your back. [Visit our docs](https://docs.langwatch.ai/integration/overview) for full guides for other popular languages, LLM providers, and frameworks.
+
+### Install and configure SDK
+
+Available for install via `pip`, or `uv`. The SDK will also check your environment variables by default for your API key and endpoint.
+
+```bash
+pip install langwatch
+```
+
+```python
+LANGWATCH_API_KEY="sk-lw-..."
+
+# This is only needed if you aren't using LangWatch Cloud.
+# LANGWATCH_ENDPOINT="https://self-hosted-url.internal/"
+```
+
+### Create your first trace and auto-instrument OpenAI
+
+```python
+import langwatch
+from openai import OpenAI
+
+client = OpenAI()
+
+@langwatch.trace()
+def main():
+    langwatch.get_current_trace().autotrack_openai_calls(client)
+    ...
+```
+
+### See your traces in LangWatch
+
+![A view of a trace in the LangWatch app](assets/trace-view.webp)
+
+You can also view a public share of the trace [**here**](https://app.langwatch.ai/share/pA8sBaRf5Nn2sa7OkhJfi).
 
 ## 🗺️ Integrations
 
+LangWatch builds and maintains several integrations listed below, additionally our tracing platform is built on top of [OpenTelemetry](https://opentelemetry.io/), so we support any OpenTelemetry compatible library out of the box.
 
-LangWatch builds and maintains several integrations listed below. Our tracing platform is built on top of [OpenTelemetry](https://opentelemetry.io/), so we support any OpenTelemetry-compatible library out of the box.
+We also support various community standards, such as [OpenInference](https://github.com/Arize-ai/openinference), [OpenLLMetry](https://github.com/traceloop/openllmetry), and more.
 
-**Frameworks:**  
-[LangChain](https://langwatch.ai/docs/integration/python/integrations/langchain) ·
-[LangGraph](https://langwatch.ai/docs/integration/python/integrations/langgraph) ·
-[Vercel AI SDK](https://langwatch.ai/docs/integration/typescript/integrations/vercel-ai) ·
-[Mastra](https://langwatch.ai/docs/integration/typescript/integrations/mastra) ·
-[CrewAI](https://langwatch.ai/docs/integration/python/integrations/crewai) ·
-[Google ADK](https://langwatch.ai/docs/integration/python/integrations/google-ai)
+### Python 🐍
 
-**Model Providers:**  
-[OpenAI](https://langwatch.ai/docs/integration/python/integrations/openai) ·
-[Anthropic](https://langwatch.ai/docs/integration/python/integrations/anthropic) ·
-[Azure](https://langwatch.ai/docs/integration/python/integrations/azure) ·
-[Google Cloud](https://langwatch.ai/docs/integration/python/integrations/google-cloud) ·
-[AWS](https://langwatch.ai/docs/integration/python/integrations/aws) ·
-[Groq](https://langwatch.ai/docs/integration/python/integrations/groq) ·
-[Ollama](https://langwatch.ai/docs/integration/python/integrations/ollama)
+Our Python SDK supports the following auto-instrumentors.
+
+- [OpenAI](https://docs.langwatch.ai/integration/python/guide#open-ai)
+- [Azure](https://docs.langwatch.ai/integration/python/guide#azure)
+- [LiteLLM](https://docs.langwatch.ai/integration/python/guide#lite-llm)
+- [DSPy](https://docs.langwatch.ai/integration/python/guide#ds-py)
+- [LangChain](https://docs.langwatch.ai/integration/python/guide#lang-chain)
+
+Through OpenTelemetry, we also support all the frameworks and providers that support them, such as:
+
+- AWS Bedrock
+- Haystack
+- CrewAI
+- Autogen
+- Grok
+- …and many more
+
+You can find a [full guide](https://docs.langwatch.ai/integration/opentelemetry/guide) on our docs.
+
+### JavaScript ☕️
+
+Our JavaScript SDK supports the following instrumentors:
+
+- [Vercel AI SDK](https://docs.langwatch.ai/integration/typescript/guide#vercel-ai-sdk)
+- [OpenAI](https://docs.langwatch.ai/integration/typescript/guide#open-ai)
+- [Azure](https://docs.langwatch.ai/integration/typescript/guide#azure)
+- [LangChain.js](https://docs.langwatch.ai/integration/typescript/guide#lang-chain-js)
+
+### Agent Simulation
+
+Test your agents before they hit production using [Scenarios](https://github.com/langwatch/scenario) — our lightweight simulation framework for stress testing agents against real-world situations. [Get started here](https://scenario.langwatch.ai/)
 
 ### Platforms
 
-[LangFlow](https://docs.langwatch.ai/integration/langflow) · [Flowise](https://docs.langwatch.ai/integration/flowise) · [n8n](https://docs.langwatch.ai/integration/n8n)
-
-*and many more…*
+- [LangFlow](https://docs.langwatch.ai/integration/langflow)
+- [Flowise](https://docs.langwatch.ai/integration/flowise)
 
 Are you using a platform that could benefit from a direct LangWatch integration? We'd love to hear from you, please [**fill out this very quick form.**](https://www.notion.so/1e35e165d48280468247fcbdc3349077?pvs=21)
+
+## 🥰 Community
+
+- Join our [Discord](https://discord.gg/kT4PhDS2gH) community
+- Follow our [Twitter](https://x.com/LangWatchAI)
 
 ## 💬 Support
 
@@ -138,7 +198,6 @@ Have questions or need help? We're here to support you in multiple ways:
 
 - **Documentation:** Our comprehensive [documentation](https://docs.langwatch.ai) covers everything from getting started to advanced features.
 - **Discord Community:** Join our [Discord server](https://discord.gg/kT4PhDS2gH) for real-time help from our team and community.
-- **X (Twitter):** Follow us on [X](https://x.com/LangWatchAI) for updates and announcements.
 - **GitHub Issues:** Report bugs or request features through our [GitHub repository](https://github.com/langwatch/langwatch).
 - **Enterprise Support:** Enterprise customers receive priority support with dedicated response times. Our [pricing page](https://langwatch.ai/pricing) contains more information.
 
@@ -154,7 +213,7 @@ Please read our [LICENSE.md](/LICENSE.md) file.
 
 ## 👮‍♀️ Security + Compliance
 
-As a platform that has access to data that is highly likely to be sensitive, we take security incredibly seriously and treat it as a core part of our culture.
+As a platform that has access to data that is highly likely to be be sensitive, we take security incredibly seriously and treat it as a core part of our culture.
 
 | Legal Framework | Current Status                                                                 |
 | --------------- | ------------------------------------------------------------------------------ |

--- a/langwatch/src/app/api/scenario-events/[[...route]]/scenario-event.repository.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/scenario-event.repository.ts
@@ -318,7 +318,7 @@ export class ScenarioEventRepository {
               // Calculate success rate from finished runs only
               finished_runs: {
                 filter: {
-                  term: { type: "scenario_run_finished" },
+                  term: { type: ScenarioEventType.RUN_FINISHED },
                 },
                 aggs: {
                   total_runs: {

--- a/langwatch/src/app/api/scenario-events/[[...route]]/schemas/event-schemas.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/schemas/event-schemas.ts
@@ -99,7 +99,7 @@ export const scenarioMessageSnapshotSchema = MessagesSnapshotEventSchema.merge(
         z.union([MessageSchema, chatMessageSchema]),
         z.object({
           id: z.string().optional(),
-          trace_id: z.string().optional(),
+          trace_id: z.string().optional().nullable(),
         }),
       ),
     ),

--- a/langwatch/src/components/simulations/utils/convert-scenario-messages.ts
+++ b/langwatch/src/components/simulations/utils/convert-scenario-messages.ts
@@ -70,7 +70,7 @@ function extractToolCalls(
       ),
     });
 
-    actionExecutionMessage.traceId = message.trace_id;
+    actionExecutionMessage.traceId = message.trace_id ?? undefined;
 
     return actionExecutionMessage;
   });
@@ -99,7 +99,7 @@ function convertMessageContent(
       role: message.role as MessageRole,
       content: content,
     });
-    textMessage.traceId = message.trace_id;
+    textMessage.traceId = message.trace_id ?? undefined;
     return [textMessage];
   }
 
@@ -122,7 +122,7 @@ function convertMixedContent(
         role: originalMessage.role as MessageRole,
         content: item.text,
       });
-      textMessage.traceId = originalMessage.trace_id;
+      textMessage.traceId = originalMessage.trace_id ?? undefined;
       messages.push(textMessage);
     } else if (typeof item === "object" && item.image) {
       const imageMessage = createImageMessage(
@@ -143,7 +143,7 @@ function convertMixedContent(
         name: item.name,
         arguments: item.arguments ?? item.input,
       });
-      actionExecutionMessage.traceId = originalMessage.trace_id;
+      actionExecutionMessage.traceId = originalMessage.trace_id ?? undefined;
       messages.push(actionExecutionMessage);
     } else if (item.type === "tool_result") {
       const resultMessage: ResultMessage & { traceId?: string } =
@@ -152,7 +152,7 @@ function convertMixedContent(
           actionName: item.name ?? "tool_result",
           result: item.content,
         });
-      resultMessage.traceId = originalMessage.trace_id;
+      resultMessage.traceId = originalMessage.trace_id ?? undefined;
       messages.push(resultMessage);
     }
   });
@@ -208,6 +208,6 @@ function createToolResultMessage(
       ),
     },
   );
-  resultMessage.traceId = message.trace_id;
+  resultMessage.traceId = message.trace_id ?? undefined;
   return resultMessage;
 }


### PR DESCRIPTION
## Summary

Python scenario runs (all types, not just red team) were silently failing to appear in the LangWatch UI. This PR fixes two independent bugs in the scenario events pipeline.

## Bug 1: `trace_id: null` fails Zod validation (main blocker)

**Root cause:** The Python scenario SDK sets `trace_id` on every message via `additional_properties`. When a message has no trace ID (which is most messages), Python sends `"trace_id": null` in the JSON payload. The Zod schema had `trace_id: z.string().optional()` which accepts `string | undefined` but **rejects `null`**.

**Impact:** Every `SCENARIO_MESSAGE_SNAPSHOT` event containing any message with `trace_id: null` failed validation → 400 error → event never saved to Elasticsearch → conversation messages and results never appeared in the UI.

**Why this only surfaced now:** JS-driven scenarios (triggered from the UI via `simulation-runner.service.ts`) use the JS SDK which either omits `trace_id` entirely or sends `undefined` — both accepted by Zod. The bug only manifests when using the Python SDK to report events.

**Fix:**
- `event-schemas.ts`: Changed to `.optional().nullable()` so the API accepts `null`
- `convert-scenario-messages.ts`: Added `?? undefined` coercion at all 6 sites where `trace_id` (now `string | null | undefined`) is assigned to `traceId` (`string | undefined`)

## Bug 2: Hardcoded lowercase event type in ES query

**Root cause:** `getScenarioSetsDataForProject()` (powers the simulations landing page) had a hardcoded `term: { type: "scenario_run_finished" }` — but events are stored as `"SCENARIO_RUN_FINISHED"`. Elasticsearch `term` queries are exact match, so this filter never matched.

**Impact:** The success rate aggregation on the simulations landing page always returned 0, even when finished runs existed.

**Fix:** Changed to `ScenarioEventType.RUN_FINISHED` enum value (`"SCENARIO_RUN_FINISHED"`).

## Test plan
- [x] `pnpm typecheck` passes clean
- [x] `pnpm test:unit` — 4294 tests pass, 0 failures
- [x] Verified Zod schema accepts `trace_id: null`, `trace_id: undefined`, and `trace_id: "some-id"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)