### PR TITLE
fix(billing): remove message cap from growth seat event plans

### DIFF
--- a/langwatch/ee/billing/planLimits.ts
+++ b/langwatch/ee/billing/planLimits.ts
@@ -2,6 +2,12 @@ import type { PlanInfo } from "../licensing/planInfo";
 import { PlanTypes, type PlanTypes as PlanType } from "./planTypes";
 import { GROWTH_SEAT_PLAN_TYPES } from "./utils/growthSeatEvent";
 
+/**
+ * Sentinel value representing no message cap.
+ * When a limit is set to this value, it means there is no limit.
+ */
+export const UNLIMITED_MESSAGES = 999_999_999;
+
 const PAID_FEATURES = {
   maxWorkflows: 9999,
   maxPrompts: 9999,
@@ -162,7 +168,7 @@ export const PLAN_LIMITS: Record<PlanType, PlanInfo> = {
         name: "Growth",
         maxMembers: 20,
         maxProjects: 99,
-        maxMessagesPerMonth: 200_000,
+        maxMessagesPerMonth: UNLIMITED_MESSAGES,
         evaluationsCredit: 9999,
         userPrice: { EUR: 29, USD: 32 },
         prices: { USD: 0, EUR: 0 },

--- a/langwatch/src/components/subscription/billing-plans.ts
+++ b/langwatch/src/components/subscription/billing-plans.ts
@@ -6,6 +6,7 @@
  */
 
 import { Currency } from "@prisma/client";
+import { UNLIMITED_MESSAGES } from "../../../ee/billing/planLimits";
 import { formatNumber } from "~/utils/formatNumber";
 
 export type { Currency } from "../../../ee/billing/pricing";
@@ -96,9 +97,11 @@ export function buildTieredCapabilities({
       ? `Up to ${formatNumber(maxMembers)} core users`
       : "Custom core user limits";
   const eventsText =
-    maxMessagesPerMonth > 0
-      ? `${formatNumber(maxMessagesPerMonth)} events included`
-      : "Custom event limits";
+    maxMessagesPerMonth >= UNLIMITED_MESSAGES
+      ? "Unlimited events"
+      : maxMessagesPerMonth > 0
+        ? `${formatNumber(maxMessagesPerMonth)} events included`
+        : "Custom event limits";
   const projectsText =
     maxProjects >= 9999
       ? "Unlimited projects"

--- a/langwatch/src/server/license-enforcement/usage-stats.service.ts
+++ b/langwatch/src/server/license-enforcement/usage-stats.service.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient } from "@prisma/client";
+import { UNLIMITED_MESSAGES } from "../../../ee/billing/planLimits";
 import type { PlanInfo } from "../../../ee/licensing/planInfo";
 import type { PlanProvider } from "../app-layer/subscription/plan-provider";
 import type { UsageUnit } from "../app-layer/usage/usage-meter-policy";
@@ -34,7 +35,8 @@ export function getMessageLimitStatus(
   current: number,
   max: number,
 ): MessageLimitStatus {
-  if (max === 0 || max === Number.MAX_SAFE_INTEGER) return "ok";
+  if (max === 0 || max === Number.MAX_SAFE_INTEGER || max >= UNLIMITED_MESSAGES)
+    return "ok";
   if (current >= max) return "exceeded";
   if (current >= max * MESSAGE_LIMIT_WARNING_THRESHOLD) return "warning";
   return "ok";
@@ -47,14 +49,16 @@ export function buildMessageLimitInfo(
   current: number,
   max: number,
 ): MessageLimitInfo {
-  const percentage = max > 0 ? current / max : 0;
   const status = getMessageLimitStatus(current, max);
   const currentFormatted = formatNumber(current);
-  const maxFormatted = formatNumber(max);
+  const isUnlimited = max >= UNLIMITED_MESSAGES;
+  const maxFormatted = isUnlimited ? "Unlimited" : formatNumber(max);
+  const percentage = max > 0 && !isUnlimited ? current / max : 0;
   const percentageFormatted = formatPercent(percentage);
 
-  const message =
-    status === "exceeded"
+  const message = isUnlimited
+    ? `You have used ${currentFormatted} messages this month (Unlimited plan).`
+    : status === "exceeded"
       ? `You reached the limit of ${maxFormatted} messages for this month, new messages will not be processed.`
       : `You have used ${percentageFormatted} of your monthly message limit (${currentFormatted} / ${maxFormatted}).`;
 


### PR DESCRIPTION
## Summary

- Growth seat event plans (`GROWTH_SEAT_*`) bill per-event via Stripe metered billing and should have no message limit
- The code default in `planLimits.ts` was `200_000`, causing traces to be blocked (429) and spurious usage warning emails when orgs exceeded 200K messages
- Introduces `UNLIMITED_MESSAGES = 999_999_999` constant (fits PostgreSQL INTEGER) and uses it as the code default for growth seat plans
- Updates display logic in `billing-plans.ts` and `usage-stats.service.ts` to show "Unlimited" instead of the raw number

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit langwatch/ee/billing` — all pass
- [x] `pnpm test:unit langwatch/src/server/license-enforcement` — all pass
- [x] `pnpm test:unit langwatch/src/components/subscription` — all pass (pre-existing failures unchanged)
- [x] `pnpm test:unit langwatch/src/components/license` — all pass