### PR TITLE
fix: delete stale assessment comments and override failed checks on approval

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
+      checks: write
 
     steps:
       - name: Check for approval or exception labels
@@ -35,8 +36,23 @@ jobs:
             const labelNames = labels.map(l => l.name);
 
             // "firefighting" can be added by anyone (human override for urgent fixes)
+            // Helper: write a passing check run so the result sticks
+            // regardless of which event type triggered this workflow.
+            async function passCheck(reason) {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head_sha: pr.head.sha,
+                name: "check-approval-or-label",
+                status: "completed",
+                conclusion: "success",
+                output: { title: "Approved", summary: reason },
+              });
+              core.info(reason);
+            }
+
             if (labelNames.includes("firefighting")) {
-              core.info(`PR has firefighting label. Passing check.`);
+              await passCheck("PR has firefighting label. Passing check.");
               return;
             }
 
@@ -59,7 +75,7 @@ jobs:
               const latest = labelEvents[labelEvents.length - 1];
 
               if (latest?.event === "labeled" && latest?.actor?.login === "github-actions[bot]") {
-                core.info("PR has low-risk-change label applied by automation. Passing check.");
+                await passCheck("PR has low-risk-change label applied by automation. Passing check.");
                 return;
               }
 
@@ -84,7 +100,7 @@ jobs:
             const approvalCount = approvedUsers.size;
 
             if (approvalCount >= 1) {
-              core.info(`PR has ${approvalCount} approval(s). Passing check.`);
+              await passCheck(`PR has ${approvalCount} approval(s). Passing check.`);
               return;
             }
 

--- a/.github/workflows/low-risk-evaluation.yml
+++ b/.github/workflows/low-risk-evaluation.yml
@@ -15,6 +15,10 @@ permissions:
   contents: read
   checks: write
 
+concurrency:
+  group: low-risk-eval-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   evaluate:
     # Skip fork PRs — secrets and write permissions are unavailable


### PR DESCRIPTION
## Summary
1. **Delete stale assessment comments**: Before posting a new low-risk assessment comment, deletes all previous ones from `github-actions[bot]` to prevent clutter on re-evaluation.
2. **Override stale failed checks on approval**: When the approval check passes (via label, approval, or firefighting), it now creates a check run via `checks.create` to ensure the status is green. This fixes the issue where a `pull_request_review` triggered run would pass but the earlier `pull_request` triggered run would remain failed, blocking the PR.

## Root cause
GitHub treats workflow runs from different event types (`pull_request` vs `pull_request_review`) as separate check entries. A passing `pull_request_review` run doesn't override a failed `pull_request` run. Using `checks.create` writes a definitive status that branch protection respects.