### PR TITLE
feat(elasticsearch): add flags to disable ES writes for fully-migrated ClickHouse customers

### DIFF
--- a/langwatch/prisma/migrations/20260306120000_add_elasticsearch_write_disable_flags/migration.sql
+++ b/langwatch/prisma/migrations/20260306120000_add_elasticsearch_write_disable_flags/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "disableElasticSearchTraceWriting" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Project" ADD COLUMN "disableElasticSearchEvaluationWriting" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Project" ADD COLUMN "disableElasticSearchSimulationWriting" BOOLEAN NOT NULL DEFAULT false;

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -293,6 +293,10 @@ model Project {
     featureClickHouseDataSourceSimulations Boolean @default(false)
     featureClickHouseDataSourceEvaluations Boolean @default(false)
 
+    disableElasticSearchTraceWriting      Boolean @default(false)
+    disableElasticSearchEvaluationWriting Boolean @default(false)
+    disableElasticSearchSimulationWriting Boolean @default(false)
+
     @@index([teamId])
 }
 

--- a/langwatch/src/app/api/evaluations/v3/[slug]/run/route.ts
+++ b/langwatch/src/app/api/evaluations/v3/[slug]/run/route.ts
@@ -215,6 +215,7 @@ app.post("/:slug/run", async (c) => {
           loadedEvaluators,
           saveToEs: true,
           featureEventSourcingEvaluationIngestion: project.featureEventSourcingEvaluationIngestion,
+          disableElasticSearchEvaluationWriting: project.disableElasticSearchEvaluationWriting,
         });
 
         for await (const event of orchestrator) {
@@ -260,6 +261,7 @@ app.post("/:slug/run", async (c) => {
         saveToEs: true,
         runId, // Pass the run ID we generated
         featureEventSourcingEvaluationIngestion: project.featureEventSourcingEvaluationIngestion,
+        disableElasticSearchEvaluationWriting: project.disableElasticSearchEvaluationWriting,
       });
 
       for await (const event of orchestrator) {

--- a/langwatch/src/app/api/evaluations/v3/execute/route.ts
+++ b/langwatch/src/app/api/evaluations/v3/execute/route.ts
@@ -108,7 +108,10 @@ app.post("/execute", zValidator("json", executionRequestSchema), async (c) => {
   // Fetch project feature flag for event sourcing routing
   const project = await prisma.project.findUnique({
     where: { id: projectId },
-    select: { featureEventSourcingEvaluationIngestion: true },
+    select: {
+      featureEventSourcingEvaluationIngestion: true,
+      disableElasticSearchEvaluationWriting: true,
+    },
   });
 
   // Stream SSE events
@@ -131,6 +134,7 @@ app.post("/execute", zValidator("json", executionRequestSchema), async (c) => {
         saveToEs: shouldSaveToEs,
         concurrency: request.concurrency,
         featureEventSourcingEvaluationIngestion: project?.featureEventSourcingEvaluationIngestion ?? false,
+        disableElasticSearchEvaluationWriting: project?.disableElasticSearchEvaluationWriting ?? false,
       });
 
       for await (const event of orchestrator) {

--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -76,12 +76,19 @@ app.post(
     );
 
 
-    // Legacy ES write (always runs so data is available when feature flag is off)
-    const scenarioRunnerService = new ScenarioEventService();
-    await scenarioRunnerService.saveScenarioEvent({
-      projectId: project.id,
-      ...event,
-    });
+    // Legacy ES write (runs when feature flag is off and ES writes are not disabled)
+    if (!project.disableElasticSearchSimulationWriting) {
+      const scenarioRunnerService = new ScenarioEventService();
+      await scenarioRunnerService.saveScenarioEvent({
+        projectId: project.id,
+        ...event,
+      });
+    } else {
+      logger.debug(
+        { projectId: project.id },
+        "Skipping ES scenario event write — disableElasticSearchSimulationWriting is enabled",
+      );
+    }
 
     // Dual-write to ClickHouse via event-sourcing
     if (project.featureEventSourcingSimulationIngestion) {
@@ -126,10 +133,12 @@ export const route = app.delete(
   async (c) => {
     const { project } = c.var;
 
-    const scenarioRunnerService = new ScenarioEventService();
-    await scenarioRunnerService.deleteAllEventsForProject({
-      projectId: project.id,
-    });
+    if (!project.disableElasticSearchSimulationWriting) {
+      const scenarioRunnerService = new ScenarioEventService();
+      await scenarioRunnerService.deleteAllEventsForProject({
+        projectId: project.id,
+      });
+    }
 
     // Also soft-delete in CH (fire-and-forget)
     if (project.featureEventSourcingSimulationIngestion) {

--- a/langwatch/src/factories/project.factory.ts
+++ b/langwatch/src/factories/project.factory.ts
@@ -37,4 +37,7 @@ export const projectFactory = Factory.define<Project>(({ sequence }) => ({
   featureEventSourcingTraceIngestion: false,
   featureEventSourcingSimulationIngestion: false,
   featureEventSourcingEvaluationIngestion: false,
+  disableElasticSearchTraceWriting: false,
+  disableElasticSearchEvaluationWriting: false,
+  disableElasticSearchSimulationWriting: false,
 }));

--- a/langwatch/src/pages/api/evaluations/[evaluator]/[subpath]/evaluate.ts
+++ b/langwatch/src/pages/api/evaluations/[evaluator]/[subpath]/evaluate.ts
@@ -492,7 +492,11 @@ export async function handleEvaluatorCall(
             ...(isGuardrail ? { passed: result!.passed ?? true } : {}),
           };
 
-  if (params.trace_id && !project.featureEventSourcingEvaluationIngestion) {
+  if (
+    params.trace_id &&
+    !project.featureEventSourcingEvaluationIngestion &&
+    !project.disableElasticSearchEvaluationWriting
+  ) {
     await updateEvaluationStatusInES({
       check: {
         evaluation_id: evaluationId,

--- a/langwatch/src/pages/api/evaluations/batch/log_results.ts
+++ b/langwatch/src/pages/api/evaluations/batch/log_results.ts
@@ -371,9 +371,13 @@ const processBatchEvaluation = async (
     },
   };
 
-  // When featureEventSourcingEvaluationIngestion is ON, the experimentRunEsSync
-  // reactor handles ES writes — skip direct writes to avoid double-writing.
-  if (!project.featureEventSourcingEvaluationIngestion) {
+  // Skip direct ES writes when:
+  // - featureEventSourcingEvaluationIngestion is ON (reactor handles it)
+  // - disableElasticSearchEvaluationWriting is ON (ES writes fully disabled)
+  if (
+    !project.featureEventSourcingEvaluationIngestion &&
+    !project.disableElasticSearchEvaluationWriting
+  ) {
     const client = await esClient({ projectId: project.id });
     await client.update({
       index: BATCH_EVALUATION_INDEX.alias,

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -121,7 +121,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     monitors,
     traces: { summary: traceSummary, spans: spanStorage },
     evaluations: { runs: evaluations.runs, execution: evaluations.execution },
-    esSync: { esClient, traceIndex: TRACE_INDEX, traceIndexId },
+    esSync: { esClient, traceIndex: TRACE_INDEX, traceIndexId, prisma },
     usageReportingService,
   });
   const commands = registry.registerAll();

--- a/langwatch/src/server/background/queues/evaluationsQueue.ts
+++ b/langwatch/src/server/background/queues/evaluationsQueue.ts
@@ -9,6 +9,8 @@ import { captureError } from "../../../utils/captureError";
 import { createLogger } from "../../../utils/logger/server";
 import { safeTruncate } from "../../../utils/truncate";
 import { esClient, TRACE_INDEX, traceIndexId } from "../../elasticsearch";
+import { isElasticSearchWriteDisabled } from "../../elasticsearch/isElasticSearchWriteDisabled";
+import { prisma } from "../../db";
 import { connection } from "../../redis";
 import type { ElasticSearchEvaluation } from "../../tracer/types";
 import { EVALUATIONS_QUEUE } from "./constants";
@@ -246,6 +248,21 @@ export const updateEvaluationStatusInES = async ({
   evaluation_thread_id?: string;
   inputs?: Record<string, any>;
 }) => {
+  // Skip ES writes when evaluation ES writes are disabled for this project
+  if (
+    await isElasticSearchWriteDisabled(
+      prisma,
+      trace.project_id,
+      "evaluations",
+    )
+  ) {
+    logger.debug(
+      { projectId: trace.project_id, traceId: trace.trace_id },
+      "Skipping ES evaluation status update — disableElasticSearchEvaluationWriting is enabled",
+    );
+    return;
+  }
+
   const evaluation: ElasticSearchEvaluation = {
     evaluation_id: getEvaluationId(check),
     evaluator_id: getEvaluatorId(check),

--- a/langwatch/src/server/background/workers/collectorWorker.ts
+++ b/langwatch/src/server/background/workers/collectorWorker.ts
@@ -27,6 +27,7 @@ import {
 } from "../../api/utils";
 import { prisma } from "../../db";
 import { esClient, TRACE_INDEX, traceIndexId } from "../../elasticsearch";
+import { isElasticSearchWriteDisabled } from "../../elasticsearch/isElasticSearchWriteDisabled";
 import {
   collectorIndexDelayHistogram,
   recordJobWaitDuration,
@@ -465,9 +466,18 @@ const processCollectorJob_ = async (
     );
   }
 
-  await withSpan("updateTrace", () =>
-    updateTrace(trace, esSpans, evaluations),
-  );
+  const esWriteDisabled = project.disableElasticSearchTraceWriting;
+
+  if (!esWriteDisabled) {
+    await withSpan("updateTrace", () =>
+      updateTrace(trace, esSpans, evaluations),
+    );
+  } else {
+    logger.debug(
+      { projectId: project.id, traceId },
+      "Skipping ES trace write — disableElasticSearchTraceWriting is enabled",
+    );
+  }
 
   if (!existingTrace?.inserted_at) {
     const delay = Date.now() - data.collectedAt;
@@ -476,8 +486,8 @@ const processCollectorJob_ = async (
 
   void markProjectFirstMessage(project, trace.metadata);
 
-  if (env.IS_QUICKWIT) {
-    // Skip check and adjust for quickwit
+  if (env.IS_QUICKWIT || esWriteDisabled) {
+    // Skip check and adjust for quickwit or when ES writes are disabled
     return;
   }
 
@@ -796,6 +806,16 @@ export const processCollectorCheckAndAdjustJob = async (
 ) => {
   logger.debug({ jobId: id }, "post-processing job");
   const { traceId, projectId } = data;
+
+  // Skip entirely when ES trace writes are disabled — this job only reads/writes ES
+  if (await isElasticSearchWriteDisabled(prisma, projectId, "traces")) {
+    logger.debug(
+      { projectId, traceId },
+      "Skipping check-and-adjust — disableElasticSearchTraceWriting is enabled",
+    );
+    return;
+  }
+
   const client = await esClient({ projectId });
   const protections = await getInternalProtectionsForProject(prisma, {
     projectId,

--- a/langwatch/src/server/elasticsearch/__tests__/isElasticSearchWriteDisabled.unit.test.ts
+++ b/langwatch/src/server/elasticsearch/__tests__/isElasticSearchWriteDisabled.unit.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isElasticSearchWriteDisabled,
+} from "../isElasticSearchWriteDisabled";
+
+function createMockPrisma(
+  flags: {
+    disableElasticSearchTraceWriting?: boolean;
+    disableElasticSearchEvaluationWriting?: boolean;
+    disableElasticSearchSimulationWriting?: boolean;
+    featureClickHouseDataSourceTraces?: boolean;
+    featureClickHouseDataSourceEvaluations?: boolean;
+    featureClickHouseDataSourceSimulations?: boolean;
+    featureEventSourcingTraceIngestion?: boolean;
+    featureEventSourcingEvaluationIngestion?: boolean;
+    featureEventSourcingSimulationIngestion?: boolean;
+  } | null,
+) {
+  return {
+    project: {
+      findUnique: vi.fn().mockResolvedValue(flags),
+    },
+  } as any;
+}
+
+describe("isElasticSearchWriteDisabled()", () => {
+  describe("given domain is traces", () => {
+    describe("when disableElasticSearchTraceWriting is false", () => {
+      it("returns false", async () => {
+        const prisma = createMockPrisma({
+          disableElasticSearchTraceWriting: false,
+          featureClickHouseDataSourceTraces: false,
+          featureEventSourcingTraceIngestion: false,
+        });
+
+        const result = await isElasticSearchWriteDisabled(
+          prisma,
+          "trace-default-1",
+          "traces",
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("when disableElasticSearchTraceWriting is true", () => {
+      it("returns true", async () => {
+        const prisma = createMockPrisma({
+          disableElasticSearchTraceWriting: true,
+          featureClickHouseDataSourceTraces: true,
+          featureEventSourcingTraceIngestion: true,
+        });
+
+        const result = await isElasticSearchWriteDisabled(
+          prisma,
+          "trace-disabled-1",
+          "traces",
+        );
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("when ES write is disabled but CH read is not enabled", () => {
+      it("returns true and logs a warning", async () => {
+        const prisma = createMockPrisma({
+          disableElasticSearchTraceWriting: true,
+          featureClickHouseDataSourceTraces: false,
+          featureEventSourcingTraceIngestion: false,
+        });
+
+        const result = await isElasticSearchWriteDisabled(
+          prisma,
+          "trace-no-ch-read-1",
+          "traces",
+        );
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe("given domain is evaluations", () => {
+    describe("when disableElasticSearchEvaluationWriting is false", () => {
+      it("returns false", async () => {
+        const prisma = createMockPrisma({
+          disableElasticSearchEvaluationWriting: false,
+          featureClickHouseDataSourceEvaluations: false,
+          featureEventSourcingEvaluationIngestion: false,
+        });
+
+        const result = await isElasticSearchWriteDisabled(
+          prisma,
+          "eval-default-1",
+          "evaluations",
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("when disableElasticSearchEvaluationWriting is true", () => {
+      it("returns true", async () => {
+        const prisma = createMockPrisma({
+          disableElasticSearchEvaluationWriting: true,
+          featureClickHouseDataSourceEvaluations: true,
+          featureEventSourcingEvaluationIngestion: true,
+        });
+
+        const result = await isElasticSearchWriteDisabled(
+          prisma,
+          "eval-disabled-1",
+          "evaluations",
+        );
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe("given domain is simulations", () => {
+    describe("when disableElasticSearchSimulationWriting is false", () => {
+      it("returns false", async () => {
+        const prisma = createMockPrisma({
+          disableElasticSearchSimulationWriting: false,
+          featureClickHouseDataSourceSimulations: false,
+          featureEventSourcingSimulationIngestion: false,
+        });
+
+        const result = await isElasticSearchWriteDisabled(
+          prisma,
+          "sim-default-1",
+          "simulations",
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("when disableElasticSearchSimulationWriting is true", () => {
+      it("returns true", async () => {
+        const prisma = createMockPrisma({
+          disableElasticSearchSimulationWriting: true,
+          featureClickHouseDataSourceSimulations: true,
+          featureEventSourcingSimulationIngestion: true,
+        });
+
+        const result = await isElasticSearchWriteDisabled(
+          prisma,
+          "sim-disabled-1",
+          "simulations",
+        );
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe("when project is not found", () => {
+    it("returns false", async () => {
+      const prisma = createMockPrisma(null);
+
+      const result = await isElasticSearchWriteDisabled(
+        prisma,
+        "missing-project-1",
+        "traces",
+      );
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/elasticsearch/isElasticSearchWriteDisabled.ts
+++ b/langwatch/src/server/elasticsearch/isElasticSearchWriteDisabled.ts
@@ -1,0 +1,85 @@
+import type { PrismaClient } from "@prisma/client";
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:elasticsearch:write-disabled");
+
+/** Set of projectId:domain keys for which the misconfiguration warning has already been logged */
+const warnedProjects = new Set<string>();
+
+export type ElasticSearchWriteDomain =
+  | "traces"
+  | "evaluations"
+  | "simulations";
+
+/**
+ * Domain-specific mapping from the generic domain name to the corresponding
+ * project flags for disabling ES writes, CH read, and event sourcing write.
+ */
+const FLAG_MAP = {
+  traces: {
+    disableFlag: "disableElasticSearchTraceWriting",
+    chReadFlag: "featureClickHouseDataSourceTraces",
+    esWriteFlag: "featureEventSourcingTraceIngestion",
+  },
+  evaluations: {
+    disableFlag: "disableElasticSearchEvaluationWriting",
+    chReadFlag: "featureClickHouseDataSourceEvaluations",
+    esWriteFlag: "featureEventSourcingEvaluationIngestion",
+  },
+  simulations: {
+    disableFlag: "disableElasticSearchSimulationWriting",
+    chReadFlag: "featureClickHouseDataSourceSimulations",
+    esWriteFlag: "featureEventSourcingSimulationIngestion",
+  },
+} as const;
+
+/**
+ * Check whether Elasticsearch writes are disabled for a given project and
+ * data domain.
+ *
+ * Returns `true` when the project-level `disableElasticSearch*Writing` flag
+ * is ON, meaning the caller should skip any ES indexing.
+ *
+ * Logs a warning (once per project+domain) when ES writes are disabled but
+ * the corresponding ClickHouse read flag or event-sourcing write flag is
+ * not enabled -- this could mean data is being lost.
+ */
+export async function isElasticSearchWriteDisabled(
+  prisma: PrismaClient,
+  projectId: string,
+  domain: ElasticSearchWriteDomain,
+): Promise<boolean> {
+  const { disableFlag, chReadFlag, esWriteFlag } = FLAG_MAP[domain];
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: {
+      [disableFlag]: true,
+      [chReadFlag]: true,
+      [esWriteFlag]: true,
+    },
+  });
+
+  if (!project) {
+    return false;
+  }
+
+  const disabled = Boolean(project[disableFlag]);
+
+  if (disabled) {
+    const chReadEnabled = Boolean(project[chReadFlag]);
+    const esWriteEnabled = Boolean(project[esWriteFlag]);
+    const warnKey = `${projectId}:${domain}`;
+
+    if ((!chReadEnabled || !esWriteEnabled) && !warnedProjects.has(warnKey)) {
+      warnedProjects.add(warnKey);
+      logger.warn(
+        { projectId, domain, chReadEnabled, esWriteEnabled },
+        `Elasticsearch ${domain} writes are disabled but ClickHouse read (${chReadFlag}=${String(chReadEnabled)}) ` +
+          `or event-sourcing write (${esWriteFlag}=${String(esWriteEnabled)}) is not enabled — data may be lost`,
+      );
+    }
+  }
+
+  return disabled;
+}

--- a/langwatch/src/server/evaluations-v3/execution/orchestrator.ts
+++ b/langwatch/src/server/evaluations-v3/execution/orchestrator.ts
@@ -78,6 +78,8 @@ export type OrchestratorInput = {
   concurrency?: number;
   /** When ON, ES writes are handled by event sourcing reactors instead of direct writes */
   featureEventSourcingEvaluationIngestion?: boolean;
+  /** When ON, all direct ES writes for evaluations are skipped entirely */
+  disableElasticSearchEvaluationWriting?: boolean;
 };
 
 /**
@@ -510,6 +512,7 @@ export async function* runOrchestrator(
     runId: providedRunId,
     concurrency: requestedConcurrency,
     featureEventSourcingEvaluationIngestion = false,
+    disableElasticSearchEvaluationWriting = false,
   } = input;
 
   // Use requested concurrency, environment variable, or default
@@ -531,10 +534,14 @@ export async function* runOrchestrator(
   const commands = getApp().experimentRuns;
 
   // Get repository and initialize storage if enabled
-  // When featureEventSourcingEvaluationIngestion is ON, the experimentRunEsSync
-  // reactor handles ES writes — skip direct writes to avoid double-writing.
+  // Skip direct ES writes when:
+  // - featureEventSourcingEvaluationIngestion is ON (reactor handles it)
+  // - disableElasticSearchEvaluationWriting is ON (ES writes fully disabled)
   const repository =
-    saveToEs && experimentId && !featureEventSourcingEvaluationIngestion
+    saveToEs &&
+    experimentId &&
+    !featureEventSourcingEvaluationIngestion &&
+    !disableElasticSearchEvaluationWriting
       ? getDefaultBatchEvaluationRepository()
       : null;
 

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationEsSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationEsSync.reactor.ts
@@ -1,3 +1,4 @@
+import type { PrismaClient } from "@prisma/client";
 import { createLogger } from "../../../../../utils/logger/server";
 import type { ElasticSearchEvaluation } from "../../../../tracer/types";
 import type {
@@ -17,6 +18,7 @@ export interface EvaluationEsSyncReactorDeps {
   esClient: (args: { projectId: string }) => Promise<{ update: (...args: any[]) => Promise<any> }>;
   traceIndex: { alias: string };
   traceIndexId: (args: { traceId: string; projectId: string }) => string;
+  prisma: PrismaClient;
 }
 
 /**
@@ -41,6 +43,19 @@ export function createEvaluationEsSyncReactor(
       if (!isEvaluationCompletedEvent(event)) return;
 
       const { tenantId, foldState } = context;
+
+      // Skip ES sync when evaluation ES writes are disabled for this project
+      const project = await deps.prisma.project.findUnique({
+        where: { id: tenantId },
+        select: { disableElasticSearchEvaluationWriting: true },
+      });
+      if (project?.disableElasticSearchEvaluationWriting) {
+        logger.debug(
+          { tenantId, evaluationId: foldState.evaluationId },
+          "Skipping ES evaluation sync — disableElasticSearchEvaluationWriting is enabled",
+        );
+        return;
+      }
 
       if (!foldState.traceId) {
         logger.debug(

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/reactors/experimentRunEsSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/reactors/experimentRunEsSync.reactor.ts
@@ -47,6 +47,16 @@ export function createExperimentRunEsSyncReactor(
       );
       if (!enabled) return;
 
+      // Skip ES sync when evaluation ES writes are disabled for this project
+      const project = await deps.project.getById(tenantId);
+      if (project?.disableElasticSearchEvaluationWriting) {
+        logger.debug(
+          { tenantId },
+          "Skipping ES evaluation sync — disableElasticSearchEvaluationWriting is enabled",
+        );
+        return;
+      }
+
       const { repository } = deps;
       const experimentId = foldState.ExperimentId;
       const runId = foldState.RunId;

--- a/specs/features/elasticsearch-write-disable-flags.feature
+++ b/specs/features/elasticsearch-write-disable-flags.feature
@@ -1,0 +1,56 @@
+Feature: Elasticsearch write disable flags
+  As a platform operator migrating customers from Elasticsearch to ClickHouse,
+  I want to disable Elasticsearch writes per project for traces, evaluations, and simulations,
+  so that fully-migrated customers stop putting pressure on Elasticsearch.
+
+  Background:
+    Given a project with ClickHouse read and event sourcing write flags enabled
+    And the project has the corresponding ES write disable flag enabled
+
+  @unit
+  Scenario: Trace ingestion skips Elasticsearch when disabled
+    When a trace is ingested for the project
+    Then the trace is written to ClickHouse via event sourcing
+    And the trace is not indexed into Elasticsearch
+
+  @unit
+  Scenario: Trace ingestion still writes to Elasticsearch when flag is off
+    Given a project without the ES write disable flag for traces
+    When a trace is ingested for the project
+    Then the trace is indexed into Elasticsearch as usual
+
+  @unit
+  Scenario: Evaluation results skip Elasticsearch sync when disabled
+    When an evaluation run completes for the project
+    Then the results are written to ClickHouse via event sourcing
+    And the results are not synced to the Elasticsearch batch evaluations index
+
+  @unit
+  Scenario: Evaluation results still sync to Elasticsearch when flag is off
+    Given a project without the ES write disable flag for evaluations
+    When an evaluation run completes for the project
+    Then the results are synced to Elasticsearch as usual
+
+  @unit
+  Scenario: Simulation events skip Elasticsearch when disabled
+    When a simulation event is recorded for the project
+    Then the event is written to ClickHouse via event sourcing
+    And the event is not written to the Elasticsearch scenario events index
+
+  @unit
+  Scenario: Simulation events still write to Elasticsearch when flag is off
+    Given a project without the ES write disable flag for simulations
+    When a simulation event is recorded for the project
+    Then the event is written to Elasticsearch as usual
+
+  @unit
+  Scenario: New flags default to false
+    When a new project is created
+    Then all three ES write disable flags are false by default
+
+  @integration
+  Scenario: Database migration adds the three new columns
+    When the migration runs
+    Then the Project table has a "disableElasticSearchTraceWriting" boolean column defaulting to false
+    And the Project table has a "disableElasticSearchEvaluationWriting" boolean column defaulting to false
+    And the Project table has a "disableElasticSearchSimulationWriting" boolean column defaulting to false


### PR DESCRIPTION
## Summary

- Adds 3 new boolean flags to the `Project` model: `disableElasticSearchTraceWriting`, `disableElasticSearchEvaluationWriting`, `disableElasticSearchSimulationWriting`
- All default to `false` — no behavior change unless explicitly enabled
- When enabled, Elasticsearch writes are skipped at all write points, reducing ES pressure for fully-migrated ClickHouse customers

## Changes

**Schema & Migration:**
- 3 new boolean fields on `Project` (Prisma schema + SQL migration)

**Trace write gating:**
- `collectorWorker.ts`: skips `updateTrace` and `checkAndAdjust` scheduling
- `processCollectorCheckAndAdjustJob`: early return when disabled

**Evaluation write gating:**
- `experimentRunEsSync.reactor.ts`: skips batch evaluation ES sync
- `evaluationEsSync.reactor.ts`: skips per-trace evaluation ES sync
- `log_results.ts`: skips direct ES upsert
- `evaluate.ts`: skips `updateEvaluationStatusInES`
- `evaluationsQueue.ts`: skips ES status updates
- `orchestrator.ts`: skips ES repository when disabled

**Simulation write gating:**
- `scenario-events/app.ts`: skips ES write on POST and DELETE

**Safety:**
- Shared utility `isElasticSearchWriteDisabled()` with runtime misconfiguration warnings when ES writes are disabled but CH read/write flags are not enabled

## Test plan

- [x] 8 unit tests for `isElasticSearchWriteDisabled()` covering all 3 domains, flag on/off, misconfiguration warning, and project not found
- [x] TypeCheck passes (no new errors)
- [ ] Manual: set flag on a project and verify traces/evaluations/simulations stop writing to ES
- [ ] Manual: verify default behavior (flag off) is unchanged