### PR TITLE
feat: enable ES write disable flags by default for SaaS customers

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -2,7 +2,7 @@ name: Approval or Exception Required
 
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
## Summary

- New SaaS projects (`IS_SAAS=true`) now get all 3 ES write disable flags set to `true` by default
- On-prem projects remain unaffected (flags default to `false`)
- Follows the same `Boolean(env.IS_SAAS)` pattern as the existing ClickHouse read and event sourcing write flags

## Changes

- `langwatch/src/server/api/routers/project.ts`: Added `disableElasticSearchTraceWriting`, `disableElasticSearchEvaluationWriting`, `disableElasticSearchSimulationWriting` to project creation defaults

## Context

Depends on #2034 which added the flags and gating logic. This PR ensures every new SaaS customer gets the full ClickHouse pipeline with no ES writes by default.