### PR TITLE
fix(ui): truncate long metadata values and fix popover arrows

### DIFF
--- a/langwatch/src/components/MetadataTag.tsx
+++ b/langwatch/src/components/MetadataTag.tsx
@@ -7,6 +7,9 @@ import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject"
 
 import { CopyIcon } from "./icons/Copy";
 import { Link as UiLink } from "./ui/link";
+import { Popover } from "./ui/popover";
+
+const MAX_VALUE_LENGTH = 48;
 
 const useCopyToClipboard = () => {
   const [isCopied, setIsCopied] = useState(false);
@@ -50,28 +53,33 @@ export const MetadataTag = ({
     value = renderedValue;
   }
 
+  const isTruncated = value.length > MAX_VALUE_LENGTH;
+  const displayValue = isTruncated
+    ? value.slice(0, MAX_VALUE_LENGTH) + "…"
+    : value;
+
   // Helper: render value as link if it's a URL
-  const renderValue = () => {
+  const renderValue = (text: string) => {
     if (value.startsWith("http")) {
       return (
         <HStack gap={1} color="blue.500">
           <UiLink href={value} target="_blank">
-            {value}
+            {text}
           </UiLink>
           <ExternalLink size={12} />
         </HStack>
       );
     }
-    return value;
+    return text;
   };
 
-  return (
+  const tag = (
     <HStack
       gap={0}
       fontSize="smaller"
       margin={0}
-      onClick={onClick}
-      cursor={onClick ? "pointer" : "default"}
+      onClick={isTruncated ? undefined : onClick}
+      cursor={!isTruncated && onClick ? "pointer" : "default"}
     >
       <Text
         borderWidth={1}
@@ -93,7 +101,7 @@ export const MetadataTag = ({
         gap={1}
         alignItems="center"
       >
-        {renderValue()}
+        {renderValue(displayValue)}
         {copyable && (
           <CopyIcon
             style={{
@@ -111,5 +119,30 @@ export const MetadataTag = ({
         )}
       </HStack>
     </HStack>
+  );
+
+  if (!isTruncated) {
+    return tag;
+  }
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>{tag}</Popover.Trigger>
+      <Popover.Content maxWidth="480px">
+        <Popover.Arrow />
+        <Popover.Body>
+          <Text
+            fontSize="sm"
+            fontFamily="mono"
+            whiteSpace="pre-wrap"
+            wordBreak="break-all"
+            maxHeight="300px"
+            overflowY="auto"
+          >
+            {value}
+          </Text>
+        </Popover.Body>
+      </Popover.Content>
+    </Popover.Root>
   );
 };

--- a/langwatch/src/components/ui/popover.tsx
+++ b/langwatch/src/components/ui/popover.tsx
@@ -33,7 +33,11 @@ export const PopoverArrow = React.forwardRef<
   ChakraPopover.ArrowProps
 >(function PopoverArrow(props, ref) {
   return (
-    <ChakraPopover.Arrow {...props} ref={ref}>
+    <ChakraPopover.Arrow
+      {...props}
+      ref={ref}
+      css={{ "--arrow-size": "12px", "--arrow-background": "var(--popover-bg)" }}
+    >
       <ChakraPopover.ArrowTip />
     </ChakraPopover.Arrow>
   );


### PR DESCRIPTION
## Summary
- **Metadata tag truncation**: Values longer than 48 characters are truncated with `…`. Clicking a truncated tag opens a popover showing the full value (scrollable, monospace). Short values behave as before.
- **Disable filter for long values**: Truncated metadata tags no longer trigger URL filter navigation on click — they open the popover instead.
- **Fix popover arrows globally**: The `--arrow-size` CSS variable from the Chakra recipe wasn't resolving to an actual CSS value, making all popover arrows invisible site-wide. Fixed by explicitly setting `--arrow-size: 12px` on the `PopoverArrow` component.

## Test plan
- [ ] Open a trace with long metadata values (e.g. system_prompt) — verify they're truncated with `…`
- [ ] Click a truncated metadata tag — verify popover opens with full value, no URL filter change
- [ ] Click a short metadata tag — verify it still filters as before
- [ ] Verify popover arrows appear on metadata popovers and other popovers across the app (e.g. Share, Annotation Queue)