### PR TITLE
fix(typescript-sdk): move @opentelemetry/api to peerDependencies

### DIFF
--- a/typescript-sdk/examples/evaluation/package-lock.json
+++ b/typescript-sdk/examples/evaluation/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^2.0.6",
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.0.1",
         "@opentelemetry/sdk-node": "^0.203.0",
         "ai": "^5.0.8",
@@ -20,7 +21,7 @@
     },
     "../..": {
       "name": "langwatch",
-      "version": "0.12.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -28,7 +29,7 @@
         "@opentelemetry/core": "^2.0.1",
         "@opentelemetry/exporter-logs-otlp-http": "0.205.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.205.0",
-        "@opentelemetry/instrumentation": "0.205.0",
+        "@opentelemetry/instrumentation": "0.212.0",
         "@opentelemetry/resources": "^2.0.1",
         "@opentelemetry/sdk-logs": "0.205.0",
         "@opentelemetry/sdk-metrics": "^2.0.1",
@@ -37,12 +38,12 @@
         "@types/prompts": "^2.4.9",
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
-        "dotenv": "^16.6.1",
+        "dotenv": "^17.3.1",
         "js-yaml": "^4.1.0",
         "liquidjs": "^10.21.1",
-        "open": "^10.2.0",
-        "openapi-fetch": "^0.14.0",
-        "ora": "^5.4.1",
+        "open": "^11.0.0",
+        "openapi-fetch": "^0.16.0",
+        "ora": "^9.3.0",
         "prompts": "^2.4.2",
         "xksuid": "^0.0.4",
         "zod": "^4.0.14"
@@ -65,11 +66,11 @@
         "@vercel/otel": "^1.13.0",
         "@vitest/coverage-v8": "3.2.4",
         "dotenv-cli": "^11.0.0",
-        "esbuild": "^0.25.8",
+        "esbuild": "^0.27.3",
         "eslint": "^9.32.0",
         "fets": "^0.8.5",
         "fishery": "^2.3.1",
-        "langchain": ">=0.3.0 <1.0.0",
+        "langchain": ">=0.3.0 <2.0.0",
         "msw": "^2.10.4",
         "nock": "^14.0.8",
         "openapi-msw": "^1.2.0",
@@ -94,7 +95,7 @@
         "@opentelemetry/context-zone": ">=1.19.0 <3.0.0",
         "@opentelemetry/sdk-node": ">=0.200.0 <1.0.0",
         "@opentelemetry/sdk-trace-web": ">=1.19.0 <3.0.0",
-        "langchain": ">=0.3.0 <1.0.0"
+        "langchain": ">=0.3.0 <2.0.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -91,10 +91,10 @@
         "typescript-eslint": "^8.38.0",
         "vitest": "^3.2.4",
         "vitest-mock-extended": "^3.1.0",
-        "yaml": "^2.8.1"
+        "yaml": "^2.8.1",
+        "@opentelemetry/api": "^1.9.0"
     },
     "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "0.205.0",
         "@opentelemetry/core": "^2.0.1",
         "@opentelemetry/exporter-logs-otlp-http": "0.205.0",
@@ -119,6 +119,7 @@
         "zod": "^4.0.14"
     },
     "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@ai-sdk/openai": ">=2.0.0 <3.0.0",
         "@langchain/core": ">=0.3.0 <1.0.0",
         "@langchain/langgraph": ">=0.4.0 <1.0.0",

--- a/typescript-sdk/pnpm-lock.yaml
+++ b/typescript-sdk/pnpm-lock.yaml
@@ -25,9 +25,6 @@ importers:
       '@ai-sdk/openai':
         specifier: '>=2.0.0 <3.0.0'
         version: 2.0.32(zod@4.3.6)
-      '@opentelemetry/api':
-        specifier: ^1.9.0
-        version: 1.9.0
       '@opentelemetry/api-logs':
         specifier: 0.205.0
         version: 0.205.0
@@ -113,6 +110,9 @@ importers:
       '@langchain/openai':
         specifier: '>=0.6.0 <1.0.0'
         version: 0.6.13(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.205.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(openai@5.12.2(zod@4.3.6)))
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@opentelemetry/sdk-node':
         specifier: 0.205.0
         version: 0.205.0(@opentelemetry/api@1.9.0)
@@ -1017,66 +1017,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}


### PR DESCRIPTION
## Summary
- Moves `@opentelemetry/api` from `dependencies` to `peerDependencies` to ensure a single shared copy across the user's project
- Adds it to `devDependencies` for SDK development/testing
- Fixes the root cause of duplicate `@opentelemetry/api` copies that led to `NonRecordingSpan` issues (broken context propagation, missing child spans in evaluations)

## Context
When `@opentelemetry/api` was a regular dependency, npm/pnpm could install a separate copy inside `node_modules/langwatch/node_modules/@opentelemetry/api`, leading to two separate `TraceAPI` singletons. This caused `ProxyTracerProvider` instances to not share the registered provider, resulting in `NonRecordingSpan` being created instead of real spans.

Making it a peer dependency follows the [OpenTelemetry JS best practices](https://opentelemetry.io/docs/languages/js/) where `@opentelemetry/api` should be a singleton shared across all packages.

## Test plan
- [x] All 636 unit tests pass
- [x] All 4 experiment origin integration tests pass
- [x] SDK builds successfully