### PR TITLE
feat: add langwatch.source=platform for platform-originated traces

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
@@ -371,3 +371,115 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
     });
   });
 });
+
+describe("applySpanToSummary() langwatch.source hoisting", () => {
+  let extractSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    extractSpy = vi.spyOn(
+      TraceIOExtractionService.prototype,
+      "extractRichIOFromSpan",
+    );
+    extractSpy.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when span has langwatch.source as span attribute", () => {
+    it("hoists source to trace summary attributes", () => {
+      const span = createTestSpan({
+        parentSpanId: null,
+        spanAttributes: {
+          "langwatch.source": "platform",
+        },
+      });
+
+      const state = applySpanToSummary(createInitState(), span);
+
+      expect(state.attributes["langwatch.source"]).toBe("platform");
+    });
+  });
+
+  describe("when span has langwatch.source as resource attribute", () => {
+    it("hoists source from resource attributes", () => {
+      const span = createTestSpan({
+        parentSpanId: null,
+        resourceAttributes: {
+          "langwatch.source": "platform",
+        },
+        spanAttributes: {},
+      });
+
+      const state = applySpanToSummary(createInitState(), span);
+
+      expect(state.attributes["langwatch.source"]).toBe("platform");
+    });
+  });
+
+  describe("when root span overrides child span source", () => {
+    it("uses root span source value", () => {
+      const childSpan = createTestSpan({
+        id: "child-1",
+        spanId: "child-1",
+        parentSpanId: "root-1",
+        spanAttributes: {
+          "langwatch.source": "sdk",
+        },
+      });
+
+      const rootSpan = createTestSpan({
+        id: "root-1",
+        spanId: "root-1",
+        parentSpanId: null,
+        spanAttributes: {
+          "langwatch.source": "platform",
+        },
+      });
+
+      let state = applySpanToSummary(createInitState(), childSpan);
+      state = applySpanToSummary(state, rootSpan);
+
+      expect(state.attributes["langwatch.source"]).toBe("platform");
+    });
+  });
+
+  describe("when no span sets langwatch.source", () => {
+    it("does not set langwatch.source in summary attributes", () => {
+      const span = createTestSpan({
+        parentSpanId: null,
+        spanAttributes: {},
+      });
+
+      const state = applySpanToSummary(createInitState(), span);
+
+      expect(state.attributes["langwatch.source"]).toBeUndefined();
+    });
+  });
+
+  describe("when child span has source and root span does not", () => {
+    it("preserves child span source value", () => {
+      const childSpan = createTestSpan({
+        id: "child-1",
+        spanId: "child-1",
+        parentSpanId: "root-1",
+        spanAttributes: {
+          "langwatch.source": "platform",
+        },
+      });
+
+      const rootSpan = createTestSpan({
+        id: "root-1",
+        spanId: "root-1",
+        parentSpanId: null,
+        spanAttributes: {},
+      });
+
+      let state = applySpanToSummary(createInitState(), childSpan);
+      state = applySpanToSummary(state, rootSpan);
+
+      expect(state.attributes["langwatch.source"]).toBe("platform");
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -393,10 +393,15 @@ function extractAttributesFromSpan(
 	if (typeof langgraphThreadId === "string")
 		attributes["langgraph.thread_id"] = langgraphThreadId;
 
-	// Scope attribute — forwarded for hoisting logic in applySpanToSummary
+	// Scope attributes — forwarded for hoisting logic in applySpanToSummary
 	const langwatchOrigin = spanAttrs["langwatch.origin"];
 	if (typeof langwatchOrigin === "string")
 		attributes["langwatch.origin"] = langwatchOrigin;
+
+	const langwatchSource = spanAttrs["langwatch.source"]
+		?? resourceAttrs["langwatch.source"];
+	if (typeof langwatchSource === "string")
+		attributes["langwatch.source"] = langwatchSource;
 
 	// Labels (canonical key only — canonicalization already promoted from metadata)
 	const labels = spanAttrs[ATTR_KEYS.LANGWATCH_LABELS];
@@ -693,6 +698,20 @@ export function applySpanToSummary(
       // No signal from this span — preserve existing hoisted value
       mergedAttributes["langwatch.origin"] = state.attributes["langwatch.origin"];
     }
+  }
+
+  // Hoist langwatch.source with first-wins, root-override semantics
+  const explicitSource = spanAttributes["langwatch.source"];
+  if (typeof explicitSource === "string" && explicitSource !== "") {
+    if (isRootSpan) {
+      mergedAttributes["langwatch.source"] = explicitSource;
+    } else if (!state.attributes["langwatch.source"]) {
+      mergedAttributes["langwatch.source"] = explicitSource;
+    } else {
+      mergedAttributes["langwatch.source"] = state.attributes["langwatch.source"];
+    }
+  } else if (state.attributes["langwatch.source"]) {
+    mergedAttributes["langwatch.source"] = state.attributes["langwatch.source"];
   }
 
   // Track output source in attributes for cross-span override decisions

--- a/langwatch/src/server/scenarios/__tests__/scenario.processor.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario.processor.unit.test.ts
@@ -7,31 +7,33 @@ import { describe, expect, it } from "vitest";
 import { buildOtelResourceAttributes } from "../scenario.processor";
 
 describe("buildOtelResourceAttributes", () => {
-  it("returns undefined for empty labels", () => {
-    expect(buildOtelResourceAttributes([])).toBeUndefined();
+  it("always includes langwatch.source=platform", () => {
+    expect(buildOtelResourceAttributes([])).toBe(
+      "langwatch.source=platform",
+    );
   });
 
-  it("formats single label as OTEL resource attribute", () => {
+  it("formats single label as OTEL resource attribute with source", () => {
     expect(buildOtelResourceAttributes(["support"])).toBe(
-      "scenario.labels=support",
+      "langwatch.source=platform,scenario.labels=support",
     );
   });
 
   it("formats multiple labels as comma-separated OTEL resource attribute", () => {
     expect(buildOtelResourceAttributes(["support", "billing"])).toBe(
-      "scenario.labels=support,billing",
+      "langwatch.source=platform,scenario.labels=support,billing",
     );
   });
 
   it("escapes commas in label values", () => {
     expect(buildOtelResourceAttributes(["support,tier1"])).toBe(
-      "scenario.labels=support\\,tier1",
+      "langwatch.source=platform,scenario.labels=support\\,tier1",
     );
   });
 
   it("escapes equals signs in label values", () => {
     expect(buildOtelResourceAttributes(["priority=high"])).toBe(
-      "scenario.labels=priority\\=high",
+      "langwatch.source=platform,scenario.labels=priority\\=high",
     );
   });
 });

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -142,15 +142,19 @@ function createJobLogger(job: Job<ScenarioJob, ScenarioJobResult, string>, jobDa
 }
 
 /**
- * Build OTEL resource attributes string for scenario labels.
- * Returns undefined if no labels are present.
+ * Build OTEL resource attributes string for scenario labels and platform source.
+ * Always includes langwatch.source=platform; appends scenario.labels if labels are present.
  * @internal Exported for testing
  */
-export function buildOtelResourceAttributes(labels: string[]): string | undefined {
-  if (!labels.length) return undefined;
-  // Escape backslashes first, then commas and equals per OTEL spec
-  const escapedLabels = labels.map((l) => l.replace(/\\/g, "\\\\").replace(/[,=]/g, "\\$&"));
-  return `scenario.labels=${escapedLabels.join(",")}`;
+export function buildOtelResourceAttributes(labels: string[]): string {
+  // Always include langwatch.source=platform for platform-originated scenario traces
+  const parts = ["langwatch.source=platform"];
+  if (labels.length) {
+    // Escape backslashes first, then commas and equals per OTEL spec
+    const escapedLabels = labels.map((l) => l.replace(/\\/g, "\\\\").replace(/[,=]/g, "\\$&"));
+    parts.push(`scenario.labels=${escapedLabels.join(",")}`);
+  }
+  return parts.join(",");
 }
 
 /**
@@ -320,7 +324,7 @@ async function spawnScenarioChildProcess(
       LANGWATCH_API_KEY: telemetry.apiKey,
       LANGWATCH_ENDPOINT: telemetry.endpoint,
       SCENARIO_HEADLESS: "true", // Prevent SDK from trying to open browser
-      ...(otelResourceAttrs && { OTEL_RESOURCE_ATTRIBUTES: otelResourceAttrs }),
+      OTEL_RESOURCE_ATTRIBUTES: otelResourceAttrs,
     });
 
     // tsx is available since the worker runs via tsx

--- a/langwatch_nlp/langwatch_nlp/studio/utils.py
+++ b/langwatch_nlp/langwatch_nlp/studio/utils.py
@@ -555,9 +555,12 @@ def optional_langwatch_trace(
         metadata=metadata if metadata is not None else {},
         disable_sending=do_not_trace,
     ) as trace:
-        # Set langwatch.origin as a direct span attribute (not inside metadata JSON)
-        if origin and trace and trace.root_span:
-            trace.root_span.set_attributes({"langwatch.origin": origin})
+        # Set langwatch.origin and langwatch.source as direct span attributes
+        if trace and trace.root_span:
+            attrs: dict[str, str] = {"langwatch.source": "platform"}
+            if origin:
+                attrs["langwatch.origin"] = origin
+            trace.root_span.set_attributes(attrs)
         if do_not_trace:
             yield None
         else:


### PR DESCRIPTION
## Summary
- Adds `langwatch.source="platform"` span attribute to all traces generated by the LangWatch platform itself
- Distinguishes platform traces (evaluations, playground, workflows, scenarios) from user application traces
- Hoists the attribute to trace summary level for efficient filtering

## Changes

### NLP Studio (`langwatch_nlp/studio/utils.py`)
- `optional_langwatch_trace()` now always sets `langwatch.source="platform"` as a span attribute
- Covers: evaluations-v3, prompt playground, workflow execution

### Scenario Worker (`scenario.processor.ts`)
- `buildOtelResourceAttributes()` always includes `langwatch.source=platform` in OTEL resource attributes
- Ensures platform scenario suite traces are marked (even though they use `@langwatch/scenario` SDK)

### Fold Projection (`traceSummary.foldProjection.ts`)
- Extracts `langwatch.source` from both span attributes and resource attributes
- Hoists to trace summary with first-wins, root-override semantics (same pattern as `langwatch.origin`)

## How it works
| Trace Source | `langwatch.origin` | `langwatch.source` |
|---|---|---|
| User app (SDK instrumentation) | _(absent)_ | _(absent)_ |
| User SDK experiment | `evaluation` | _(absent)_ |
| User @langwatch/scenario test | `simulation` | _(absent)_ |
| Platform evaluations-v3 | `evaluation` | `platform` |
| Platform prompt playground | `playground` | `platform` |
| Platform workflow studio | `workflow` | `platform` |
| Platform scenario suite | `simulation` | `platform` |

## Test plan
- [x] 23 origin hoisting tests pass (existing)
- [x] 5 new source hoisting tests pass
- [x] 5 scenario processor tests updated and pass
- [x] All 187 projection + scenario tests pass