### PR TITLE
refactor: rename langwatch.source to langwatch.origin.source

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
@@ -372,7 +372,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 });
 
-describe("applySpanToSummary() langwatch.source hoisting", () => {
+describe("applySpanToSummary() langwatch.origin.source hoisting", () => {
   let extractSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -387,34 +387,34 @@ describe("applySpanToSummary() langwatch.source hoisting", () => {
     vi.restoreAllMocks();
   });
 
-  describe("when span has langwatch.source as span attribute", () => {
+  describe("when span has langwatch.origin.source as span attribute", () => {
     it("hoists source to trace summary attributes", () => {
       const span = createTestSpan({
         parentSpanId: null,
         spanAttributes: {
-          "langwatch.source": "platform",
+          "langwatch.origin.source": "platform",
         },
       });
 
       const state = applySpanToSummary(createInitState(), span);
 
-      expect(state.attributes["langwatch.source"]).toBe("platform");
+      expect(state.attributes["langwatch.origin.source"]).toBe("platform");
     });
   });
 
-  describe("when span has langwatch.source as resource attribute", () => {
+  describe("when span has langwatch.origin.source as resource attribute", () => {
     it("hoists source from resource attributes", () => {
       const span = createTestSpan({
         parentSpanId: null,
         resourceAttributes: {
-          "langwatch.source": "platform",
+          "langwatch.origin.source": "platform",
         },
         spanAttributes: {},
       });
 
       const state = applySpanToSummary(createInitState(), span);
 
-      expect(state.attributes["langwatch.source"]).toBe("platform");
+      expect(state.attributes["langwatch.origin.source"]).toBe("platform");
     });
   });
 
@@ -425,7 +425,7 @@ describe("applySpanToSummary() langwatch.source hoisting", () => {
         spanId: "child-1",
         parentSpanId: "root-1",
         spanAttributes: {
-          "langwatch.source": "sdk",
+          "langwatch.origin.source": "sdk",
         },
       });
 
@@ -434,19 +434,19 @@ describe("applySpanToSummary() langwatch.source hoisting", () => {
         spanId: "root-1",
         parentSpanId: null,
         spanAttributes: {
-          "langwatch.source": "platform",
+          "langwatch.origin.source": "platform",
         },
       });
 
       let state = applySpanToSummary(createInitState(), childSpan);
       state = applySpanToSummary(state, rootSpan);
 
-      expect(state.attributes["langwatch.source"]).toBe("platform");
+      expect(state.attributes["langwatch.origin.source"]).toBe("platform");
     });
   });
 
-  describe("when no span sets langwatch.source", () => {
-    it("does not set langwatch.source in summary attributes", () => {
+  describe("when no span sets langwatch.origin.source", () => {
+    it("does not set langwatch.origin.source in summary attributes", () => {
       const span = createTestSpan({
         parentSpanId: null,
         spanAttributes: {},
@@ -454,7 +454,7 @@ describe("applySpanToSummary() langwatch.source hoisting", () => {
 
       const state = applySpanToSummary(createInitState(), span);
 
-      expect(state.attributes["langwatch.source"]).toBeUndefined();
+      expect(state.attributes["langwatch.origin.source"]).toBeUndefined();
     });
   });
 
@@ -465,7 +465,7 @@ describe("applySpanToSummary() langwatch.source hoisting", () => {
         spanId: "child-1",
         parentSpanId: "root-1",
         spanAttributes: {
-          "langwatch.source": "platform",
+          "langwatch.origin.source": "platform",
         },
       });
 
@@ -479,7 +479,7 @@ describe("applySpanToSummary() langwatch.source hoisting", () => {
       let state = applySpanToSummary(createInitState(), childSpan);
       state = applySpanToSummary(state, rootSpan);
 
-      expect(state.attributes["langwatch.source"]).toBe("platform");
+      expect(state.attributes["langwatch.origin.source"]).toBe("platform");
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -398,10 +398,10 @@ function extractAttributesFromSpan(
 	if (typeof langwatchOrigin === "string")
 		attributes["langwatch.origin"] = langwatchOrigin;
 
-	const langwatchSource = spanAttrs["langwatch.source"]
-		?? resourceAttrs["langwatch.source"];
+	const langwatchSource = spanAttrs["langwatch.origin.source"]
+		?? resourceAttrs["langwatch.origin.source"];
 	if (typeof langwatchSource === "string")
-		attributes["langwatch.source"] = langwatchSource;
+		attributes["langwatch.origin.source"] = langwatchSource;
 
 	// Labels (canonical key only — canonicalization already promoted from metadata)
 	const labels = spanAttrs[ATTR_KEYS.LANGWATCH_LABELS];
@@ -700,18 +700,18 @@ export function applySpanToSummary(
     }
   }
 
-  // Hoist langwatch.source with first-wins, root-override semantics
-  const explicitSource = spanAttributes["langwatch.source"];
+  // Hoist langwatch.origin.source with first-wins, root-override semantics
+  const explicitSource = spanAttributes["langwatch.origin.source"];
   if (typeof explicitSource === "string" && explicitSource !== "") {
     if (isRootSpan) {
-      mergedAttributes["langwatch.source"] = explicitSource;
-    } else if (!state.attributes["langwatch.source"]) {
-      mergedAttributes["langwatch.source"] = explicitSource;
+      mergedAttributes["langwatch.origin.source"] = explicitSource;
+    } else if (!state.attributes["langwatch.origin.source"]) {
+      mergedAttributes["langwatch.origin.source"] = explicitSource;
     } else {
-      mergedAttributes["langwatch.source"] = state.attributes["langwatch.source"];
+      mergedAttributes["langwatch.origin.source"] = state.attributes["langwatch.origin.source"];
     }
-  } else if (state.attributes["langwatch.source"]) {
-    mergedAttributes["langwatch.source"] = state.attributes["langwatch.source"];
+  } else if (state.attributes["langwatch.origin.source"]) {
+    mergedAttributes["langwatch.origin.source"] = state.attributes["langwatch.origin.source"];
   }
 
   // Track output source in attributes for cross-span override decisions

--- a/langwatch/src/server/scenarios/__tests__/scenario.processor.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario.processor.unit.test.ts
@@ -7,33 +7,33 @@ import { describe, expect, it } from "vitest";
 import { buildOtelResourceAttributes } from "../scenario.processor";
 
 describe("buildOtelResourceAttributes", () => {
-  it("always includes langwatch.source=platform", () => {
+  it("always includes langwatch.origin.source=platform", () => {
     expect(buildOtelResourceAttributes([])).toBe(
-      "langwatch.source=platform",
+      "langwatch.origin.source=platform",
     );
   });
 
   it("formats single label as OTEL resource attribute with source", () => {
     expect(buildOtelResourceAttributes(["support"])).toBe(
-      "langwatch.source=platform,scenario.labels=support",
+      "langwatch.origin.source=platform,scenario.labels=support",
     );
   });
 
   it("formats multiple labels as comma-separated OTEL resource attribute", () => {
     expect(buildOtelResourceAttributes(["support", "billing"])).toBe(
-      "langwatch.source=platform,scenario.labels=support,billing",
+      "langwatch.origin.source=platform,scenario.labels=support,billing",
     );
   });
 
   it("escapes commas in label values", () => {
     expect(buildOtelResourceAttributes(["support,tier1"])).toBe(
-      "langwatch.source=platform,scenario.labels=support\\,tier1",
+      "langwatch.origin.source=platform,scenario.labels=support\\,tier1",
     );
   });
 
   it("escapes equals signs in label values", () => {
     expect(buildOtelResourceAttributes(["priority=high"])).toBe(
-      "langwatch.source=platform,scenario.labels=priority\\=high",
+      "langwatch.origin.source=platform,scenario.labels=priority\\=high",
     );
   });
 });

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -143,12 +143,12 @@ function createJobLogger(job: Job<ScenarioJob, ScenarioJobResult, string>, jobDa
 
 /**
  * Build OTEL resource attributes string for scenario labels and platform source.
- * Always includes langwatch.source=platform; appends scenario.labels if labels are present.
+ * Always includes langwatch.origin.source=platform; appends scenario.labels if labels are present.
  * @internal Exported for testing
  */
 export function buildOtelResourceAttributes(labels: string[]): string {
-  // Always include langwatch.source=platform for platform-originated scenario traces
-  const parts = ["langwatch.source=platform"];
+  // Always include langwatch.origin.source=platform for platform-originated scenario traces
+  const parts = ["langwatch.origin.source=platform"];
   if (labels.length) {
     // Escape backslashes first, then commas and equals per OTEL spec
     const escapedLabels = labels.map((l) => l.replace(/\\/g, "\\\\").replace(/[,=]/g, "\\$&"));

--- a/langwatch_nlp/langwatch_nlp/studio/utils.py
+++ b/langwatch_nlp/langwatch_nlp/studio/utils.py
@@ -555,9 +555,9 @@ def optional_langwatch_trace(
         metadata=metadata if metadata is not None else {},
         disable_sending=do_not_trace,
     ) as trace:
-        # Set langwatch.origin and langwatch.source as direct span attributes
+        # Set langwatch.origin and langwatch.origin.source as direct span attributes
         if trace and trace.root_span:
-            attrs: dict[str, str] = {"langwatch.source": "platform"}
+            attrs: dict[str, str] = {"langwatch.origin.source": "platform"}
             if origin:
                 attrs["langwatch.origin"] = origin
             trace.root_span.set_attributes(attrs)


### PR DESCRIPTION
## Summary
- Renames `langwatch.source` → `langwatch.origin.source` across all platform trace sources
- Groups the "who initiated it" attribute under the `langwatch.origin` namespace alongside `langwatch.origin` (the activity type)
- Avoids confusion between the near-synonyms "origin" and "source" as top-level siblings

## Attribute naming convention
```
langwatch.origin        = "evaluation" | "simulation" | "workflow" | "playground"  (activity type)
langwatch.origin.source = "platform"                                                (who initiated it)
```

## Files changed
- `langwatch_nlp/studio/utils.py` — span attribute key
- `scenario.processor.ts` — OTEL resource attribute key
- `traceSummary.foldProjection.ts` — extraction and hoisting logic
- Tests updated accordingly

## Test plan
- [x] All 28 origin/source hoisting + scenario processor tests pass