### PR TITLE
feat: enable PostHog frontend error capture and session recording

### DIFF
--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -17,6 +17,11 @@ export function usePostHog() {
       posthog.init(posthogKey, {
         api_host: posthogHost ?? "https://eu.i.posthog.com",
         person_profiles: "always",
+        autocapture: true,
+        capture_exceptions: true,
+        session_recording: {
+          recordCrossOriginIframes: true,
+        },
         loaded: (posthog) => {
           if (publicEnv.data?.NODE_ENV === "development") posthog.debug();
         },


### PR DESCRIPTION
## Summary
- Enables `capture_exceptions: true` in PostHog init so all unhandled frontend JS errors are automatically captured as `$exception` events
- Enables `session_recording` so each error is linked to a session replay showing exactly what the user was doing
- Adds `autocapture: true` explicitly for clarity

## Context
Frontend errors were only being captured if they hit the `global-error.tsx` boundary or were explicitly wrapped in `captureException()`. This change enables PostHog's built-in automatic exception capture, which hooks into `window.onerror` and `unhandledrejection` to catch all frontend errors.

Session recordings allow us to replay the user's session when an error occurred, making debugging much easier.

## Test plan
- [ ] Deploy to dev and trigger a frontend error (e.g. throw in a component)
- [ ] Verify the error appears in PostHog under Error Tracking
- [ ] Verify session recording is linked to the error event
- [ ] Verify no performance regression on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)