### PR TITLE
feat(orchestrator): add lightweight bug-fix workflow

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -39,7 +39,52 @@ The issue is the source of truth for requirements and acceptance criteria.
 
 Be aware of context size. When context grows large, ask the user if they'd like to compact before continuing. Agents work in isolated forks and return summaries.
 
-## Flow
+## Bug Detection
+
+Before starting any workflow, classify the issue as a **bug** or **feature**:
+
+1. **GitHub label** — the issue has the label `bug`
+2. **Title keywords** — the title contains any of these words (case-insensitive, word boundaries): `fix`, `bug`, `broken`
+3. **Issue template** — the issue was created from the `bug_report` template
+
+If **ANY** of these match → use the **Bug-Fix Workflow** below.
+Otherwise → use the **Feature Workflow** (the full plan → code → review loop).
+
+## Bug-Fix Workflow
+
+A shorter workflow for bug fixes. Skips planning, challenge, user approval, test review, and E2E — focuses on investigation, minimal fix with regression test, verification, and review.
+
+### 1. Investigate
+- Mark task as `in_progress`
+- Invoke `/code` with the issue description and instruction to investigate the root cause
+- Coder agent explores the codebase and reports findings
+
+### 2. Fix
+- Invoke `/code` with investigation findings and instruction to make the minimal fix
+- Coder agent implements the fix with TDD:
+  - Write a regression test that fails without the fix
+  - Make the fix
+  - Verify the test passes
+
+> **Note:** Steps 2 and 3 can overlap — the coder agent in step 2 should run typecheck and tests as part of its TDD cycle. Step 3 is the orchestrator's verification.
+
+### 3. Verify
+- Run `pnpm typecheck` and `pnpm test:unit` / `pnpm test:integration`
+- If failures → invoke `/code` with the errors
+- Max 3 iterations, then escalate to user
+
+### 4. Review
+- Invoke `/review` to run quality gate
+- If issues found → invoke `/code` with reviewer feedback
+- If approved → mark task as `completed`
+
+### 5. Complete
+- Verify all tasks are completed
+- Report summary to user
+
+## Feature Workflow
+
+Used for feature requests, enhancements, and all non-bug issues.
 
 ### 1. Plan (Required)
 - Check if a feature file exists in `specs/features/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,12 +97,20 @@ specs/               # BDD feature specs
 
 ## Orchestration Model
 
-Implementation tasks use `/orchestrate` to manage the plan → code → review → e2e loop:
+Implementation tasks use `/orchestrate` to manage work. The orchestrator detects whether an issue is a **bug fix** or a **feature** and selects the appropriate workflow.
 
 - `/orchestrate <requirements>` - Enter orchestration mode
 - `/implement #123` - Fetch GitHub issue → invoke `/orchestrate`
 
-The orchestrator:
+**Bug detection:** Issues are classified as bugs when they have a "bug" label, title keywords ("fix", "bug", "broken"), or use a bug report issue template. Everything else follows the feature workflow.
+
+**Bug-fix workflow:** investigate → fix → verify → review
+1. Investigates the root cause using `/code` (coder agent)
+2. Applies the fix and runs existing tests to verify
+3. Delegates to `/review` (uncle-bob-reviewer + cupid-reviewer agents in parallel)
+4. Skips `/plan` and spec creation — bugs fix existing behavior, not add new behavior
+
+**Feature workflow:** plan → code → review → e2e
 1. **Creates a task checklist** using TaskCreate to map acceptance criteria
 2. Delegates to `/plan` (self-contained), `/code` (coder agent), `/review` (uncle-bob-reviewer + cupid-reviewer agents in parallel)
 3. **Verifies with E2E tests** via `/e2e` (if feature has `@e2e` scenarios)

--- a/specs/features/devtools/orchestrator-bug-fix-workflow.feature
+++ b/specs/features/devtools/orchestrator-bug-fix-workflow.feature
@@ -1,0 +1,123 @@
+Feature: Lightweight bug-fix workflow for orchestrator
+  As a developer using the orchestrator
+  I want bug issues to follow a shorter workflow than feature issues
+  So that simple fixes are not slowed down by unnecessary planning and approval steps
+
+  # --- Bug detection logic (pure logic) ---
+
+  @unit
+  Scenario: Detects bug by GitHub label
+    Given an issue with label "bug"
+    When the orchestrator classifies the issue
+    Then it is classified as a bug
+
+  @unit
+  Scenario: Detects bug by title keyword "fix"
+    Given an issue with title "Fix broken trace rendering"
+    When the orchestrator classifies the issue
+    Then it is classified as a bug
+
+  @unit
+  Scenario: Detects bug by title keyword "bug"
+    Given an issue with title "Bug: sidebar collapses on refresh"
+    When the orchestrator classifies the issue
+    Then it is classified as a bug
+
+  @unit
+  Scenario: Detects bug by title keyword "broken"
+    Given an issue with title "Broken pagination on traces page"
+    When the orchestrator classifies the issue
+    Then it is classified as a bug
+
+  @unit
+  Scenario: Does not classify feature requests as bugs
+    Given an issue with title "Add dark mode support"
+    And the issue has label "enhancement"
+    When the orchestrator classifies the issue
+    Then it is classified as a feature
+
+  @unit
+  Scenario: Detects bug by issue template
+    Given an issue created from the "bug_report" template
+    When the orchestrator classifies the issue
+    Then it is classified as a bug
+
+  # --- Bug-fix workflow skips heavyweight steps ---
+
+  @integration
+  Scenario: Bug-fix workflow skips plan creation
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then no feature file is created
+    And the plan step is skipped
+
+  @integration
+  Scenario: Bug-fix workflow skips challenge step
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then the challenge step is skipped
+
+  @integration
+  Scenario: Bug-fix workflow skips user approval
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then the user approval step is skipped
+
+  @integration
+  Scenario: Bug-fix workflow skips test review
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then the test review step is skipped
+
+  @integration
+  Scenario: Bug-fix workflow skips E2E generation
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then the E2E verification step is skipped
+
+  # --- Bug-fix workflow retains essential steps ---
+
+  @integration
+  Scenario: Bug-fix workflow runs investigation step
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then the coder agent is invoked to investigate the root cause
+
+  @integration
+  Scenario: Bug-fix workflow runs fix step
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then the coder agent is invoked to make the minimal fix
+
+  @integration
+  Scenario: Bug-fix workflow requires a regression test
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then the coder agent is instructed to add a regression test
+    And the regression test must fail without the fix and pass with it
+
+  @integration
+  Scenario: Bug-fix workflow runs verification
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then typecheck is run
+    And tests are run
+
+  @integration
+  Scenario: Bug-fix workflow runs review
+    Given an issue classified as a bug
+    When the orchestrator runs the bug-fix workflow
+    Then the review step is executed
+
+  # --- Feature workflow is unchanged ---
+
+  @integration
+  Scenario: Feature issues still use the full workflow
+    Given an issue classified as a feature
+    When the orchestrator runs
+    Then the plan step is executed
+    And the challenge step is executed
+    And the user approval step is executed
+    And the test review step is executed
+    And the implement step is executed
+    And the review step is executed


### PR DESCRIPTION
## Summary
- Adds bug detection logic to the orchestrator (label "bug", title keywords "fix"/"bug"/"broken", bug_report template)
- Routes bug issues through a lightweight workflow: investigate → fix → verify → review
- Skips plan/challenge/approval/test-review/e2e steps for bug fixes
- Feature workflow remains unchanged for non-bug issues

Closes #2132

## Test plan
- [ ] Verify orchestrator uses bug-fix workflow when issue has "bug" label
- [ ] Verify orchestrator uses bug-fix workflow when title contains "fix"/"bug"/"broken"
- [ ] Verify feature issues still go through full plan → code → review loop
- [ ] Verify bug-fix workflow still runs review and verification steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2132