### PR TITLE
docs: add .claude/ and specs/ as low-risk paths

### DIFF
--- a/docs/LOW_RISK_PULL_REQUESTS.md
+++ b/docs/LOW_RISK_PULL_REQUESTS.md
@@ -16,6 +16,8 @@ A PR may be treated as **low risk** only if:
 - It is limited to:
   - UI text, layout, or styling.
   - Documentation, comments, or code formatting.
+  - Claude Code agent configuration (`.claude/` directory).
+  - BDD feature specs (`specs/` directory).
   - Other configuration or code that is explicitly documented as low risk and easy to revert.
 
 If you are unsure, do **not** use `low-risk-change`; request a normal review instead.


### PR DESCRIPTION
## Summary

- Adds `.claude/` (agent configuration) and `specs/` (BDD feature specs) to the low-risk change policy in `docs/LOW_RISK_PULL_REQUESTS.md`
- Neither directory affects runtime behavior, so changes there should qualify as low-risk

Closes #2138

## Test plan

- [ ] Verify the low-risk evaluation workflow picks up the updated policy and correctly classifies PRs touching only `.claude/` or `specs/` as low-risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2138