### PR TITLE
fix(plans): hide discontinued pricing notice for free plan users

### DIFF
--- a/langwatch/src/components/plans/PlansComparisonPage.tsx
+++ b/langwatch/src/components/plans/PlansComparisonPage.tsx
@@ -218,7 +218,7 @@ export function PlansComparisonPage({
   pricingModel,
 }: PlansComparisonPageProps) {
   const currentPlan = resolveCurrentComparisonPlan(activePlan);
-  const showTieredNotice = pricingModel === "TIERED";
+  const showTieredNotice = pricingModel === "TIERED" && !activePlan?.free;
 
   const detectedCurrency = api.currency.detectCurrency.useQuery({});
   const [selectedCurrency, setSelectedCurrency] = useState<Currency | null>(null);

--- a/langwatch/src/components/plans/__tests__/PlansComparisonPage.integration.test.tsx
+++ b/langwatch/src/components/plans/__tests__/PlansComparisonPage.integration.test.tsx
@@ -167,6 +167,20 @@ describe("<PlansComparisonPage/>", () => {
       expect(link).toHaveAttribute("href", "/settings/subscription");
     });
 
+    it("does not show discontinued pricing notice for free plan on TIERED organizations", () => {
+      render(
+        <PlansComparisonPage
+          activePlan={{ type: "FREE", free: true }}
+          pricingModel="TIERED"
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(
+        screen.queryByTestId("tiered-discontinued-notice"),
+      ).not.toBeInTheDocument();
+    });
+
     it("does not show discontinued pricing notice for SEAT_EVENT organizations", () => {
       render(
         <PlansComparisonPage


### PR DESCRIPTION
## Summary
- Free plan users on TIERED organizations no longer see the "Your current pricing model has been discontinued" alert on the plans page
- Added `!activePlan?.free` guard to `showTieredNotice` condition
- Added integration test covering the free plan + TIERED scenario

## Test plan
- [x] Existing integration tests pass (11/11)
- [x] New test verifies notice is hidden for free plan on TIERED orgs