### PR TITLE
refactor(scenarios): rename scenario-run.service to scenario-run.utils

### DIFF
--- a/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
@@ -5,7 +5,7 @@ import type { PrismaClient } from "@prisma/client";
 import { getApp } from "~/server/app-layer/app";
 import { SimulationService } from "~/server/simulations/simulation.service";
 import { ScenarioJobRepository } from "~/server/scenarios/scenario-job.repository";
-import { mergeRunData } from "~/server/scenarios/scenario-run.service";
+import { mergeRunData } from "~/server/scenarios/scenario-run.utils";
 import { scenarioQueue } from "~/server/scenarios/scenario.queue";
 import { isSuiteSetId } from "~/server/suites/suite-set-id";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";

--- a/langwatch/src/server/scenarios/__tests__/scenario-run-utils.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-run-utils.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for ScenarioRunService merge and deduplication logic.
+ * Unit tests for scenario-run merge and deduplication logic.
  *
  * Covers:
  * - ES wins when both sources have data for the same run
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from "vitest";
 import { ScenarioRunStatus } from "../../scenarios/scenario-event.enums";
-import { buildDeduplicationKey, mergeRunData } from "../scenario-run.service";
+import { buildDeduplicationKey, mergeRunData } from "../scenario-run.utils";
 import type { ScenarioRunData } from "../scenario-event.types";
 
 function makeRunData(overrides: Partial<ScenarioRunData> = {}): ScenarioRunData {

--- a/langwatch/src/server/scenarios/scenario-run.utils.ts
+++ b/langwatch/src/server/scenarios/scenario-run.utils.ts
@@ -1,5 +1,5 @@
 /**
- * ScenarioRunService
+ * Scenario Run Merge Helpers
  *
  * Merges data from two sources:
  * 1. ES/ClickHouse scenario events (completed/in-progress runs)


### PR DESCRIPTION
## Summary
- Renames `scenario-run.service.ts` → `scenario-run.utils.ts` — the file exports pure helper functions (`buildDeduplicationKey`, `mergeRunData`), not a service class
- Renames test file `scenario-run-service.unit.test.ts` → `scenario-run-utils.unit.test.ts`
- Updates imports in `scenario-events.router.ts` and the test file

Closes #2049

## Test plan
- [x] All 9 existing unit tests pass with updated imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2049