### PR TITLE
fix: add prettier to serverExternalPackages to prevent real runtime crash

### DIFF
--- a/langwatch/next.config.mjs
+++ b/langwatch/next.config.mjs
@@ -98,6 +98,7 @@ const config = {
     "@aws-sdk/client-cloudwatch-logs",
     "@aws-sdk/client-s3",
     "@aws-sdk/client-ses",
+    "prettier",
   ],
 
   experimental: {


### PR DESCRIPTION
@react-email/render imports prettier/plugins/html as an optional dep. The webpack alias `prettier = false` handled this, but Turbopack ignores webpack aliases, causing an unhandled rejection that kills the app.