### PR TITLE
chore(deps): batch GitHub Actions version bumps (Tier 1b)

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check for approval or exception labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/docker-publish-opensearch-lite.yml
+++ b/.github/workflows/docker-publish-opensearch-lite.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -338,7 +338,7 @@ jobs:
         id: pnpm-cache
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('langwatch/pnpm-lock.yaml') }}
@@ -347,14 +347,14 @@ jobs:
 
       # Cache Prisma client separately for faster regeneration
       - name: Cache Prisma client
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: langwatch/node_modules/.prisma
           key: ${{ runner.os }}-prisma-${{ hashFiles('langwatch/prisma/schema.prisma') }}
 
       # Cache Next.js build artifacts
       - name: Cache Next.js
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             langwatch/.next/cache/webpack
@@ -366,7 +366,7 @@ jobs:
 
       # Cache Turbo build outputs
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: langwatch/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}

--- a/.github/workflows/low-risk-evaluation.yml
+++ b/.github/workflows/low-risk-evaluation.yml
@@ -165,7 +165,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Apply label and comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           QUALIFIES: ${{ steps.oversized.outputs.qualifies || steps.restricted.outputs.qualifies || steps.evaluate.outputs.qualifies }}
@@ -278,7 +278,7 @@ jobs:
             }
 
       - name: Refresh approval check for firefighting or approvals
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:

--- a/.github/workflows/low-risk-label-reset.yml
+++ b/.github/workflows/low-risk-label-reset.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Remove low-risk-change label if present
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/skynet-ci.yml
+++ b/.github/workflows/skynet-ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary

Batches 5 GitHub Actions dependency bumps from open Dependabot PRs. Pure config changes — no code impact.

Closes #2082 #2081 #2080 #2079 #1600

## Changes

| Action | From | To | Files |
|--------|------|----|-------|
| `actions/github-script` | v7 | v8 | approval-or-hotfix, low-risk-evaluation, low-risk-label-reset |
| `actions/setup-node` | v4 | v6 | skynet-ci (already v6 elsewhere) |
| `actions/cache` | v4 | v5 | langwatch-app-ci |
| `docker/login-action` | v3 | v4 | docker-publish, docker-publish-opensearch-lite |
| `actions/upload-artifact` | — | already at v6 | e2e-ci (no change needed) |

## Test plan
- [ ] CI workflows trigger and pass on merge