### PR TITLE
fix(command-bar): lazy-load entity queries only when bar is open

### DIFF
--- a/langwatch/src/features/command-bar/CommandBar.tsx
+++ b/langwatch/src/features/command-bar/CommandBar.tsx
@@ -145,7 +145,7 @@ export function CommandBar() {
     idResult,
     searchResults,
     isLoading: searchLoading,
-  } = useCommandSearch(query);
+  } = useCommandSearch(query, isOpen);
   const { groupedItems, addRecentItem } = useRecentItems();
 
   const inputRef = useRef<HTMLInputElement>(null);

--- a/langwatch/src/features/command-bar/useCommandSearch.ts
+++ b/langwatch/src/features/command-bar/useCommandSearch.ts
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { useDebounceValue } from "usehooks-ts";
 import { Bot, BookText, Percent, Table, Workflow } from "lucide-react";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import { useAllPromptsForProject } from "~/prompts/hooks/useAllPromptsForProject";
 import { api } from "~/utils/api";
 import type { SearchResult } from "./types";
 import { SEARCH_DEBOUNCE_MS, MIN_SEARCH_QUERY_LENGTH } from "./constants";
@@ -72,7 +71,7 @@ export function detectEntityId(
  * Hook for searching entities (prompts, agents, datasets, workflows, evaluators).
  * Uses debounced query to prevent excessive API calls.
  */
-export function useCommandSearch(query: string) {
+export function useCommandSearch(query: string, isOpen: boolean) {
   const { project } = useOrganizationTeamProject();
   const projectId = project?.id ?? "";
   const projectSlug = project?.slug ?? "";
@@ -81,23 +80,28 @@ export function useCommandSearch(query: string) {
   const [debouncedQuery] = useDebounceValue(query, SEARCH_DEBOUNCE_MS);
   const shouldSearch = debouncedQuery.length >= MIN_SEARCH_QUERY_LENGTH;
 
-  // Fetch all entities - queries only run when project is available
+  // Only fetch entities when the command bar is open
+  const canFetch = isOpen && !!projectId;
+
   const { data: prompts, isLoading: promptsLoading } =
-    useAllPromptsForProject();
+    api.prompts.getAllPromptsForProject.useQuery(
+      { projectId },
+      { enabled: canFetch }
+    );
 
   const { data: agents, isLoading: agentsLoading } = api.agents.getAll.useQuery(
     { projectId },
-    { enabled: !!projectId }
+    { enabled: canFetch }
   );
 
   const { data: datasets, isLoading: datasetsLoading } =
-    api.dataset.getAll.useQuery({ projectId }, { enabled: !!projectId });
+    api.dataset.getAll.useQuery({ projectId }, { enabled: canFetch });
 
   const { data: workflows, isLoading: workflowsLoading } =
-    api.workflow.getAll.useQuery({ projectId }, { enabled: !!projectId });
+    api.workflow.getAll.useQuery({ projectId }, { enabled: canFetch });
 
   const { data: evaluators, isLoading: evaluatorsLoading } =
-    api.evaluators.getAll.useQuery({ projectId }, { enabled: !!projectId });
+    api.evaluators.getAll.useQuery({ projectId }, { enabled: canFetch });
 
   const isLoading =
     promptsLoading ||


### PR DESCRIPTION
## Summary
- The command bar (`useCommandSearch`) was eagerly fetching datasets, agents, workflows, evaluators, and prompts on **every page load** via `DashboardLayout`, even when the bar was closed
- Gates all 5 entity queries behind `isOpen` so they only fire when the user opens the command bar (Cmd+K)
- Removes unnecessary `useAllPromptsForProject` import in favor of a direct query call with the same `enabled` guard

## Test plan
- [x] Load any page (e.g. `/simulations`) and verify no `dataset.getAll`, `agents.getAll`, `workflow.getAll`, `evaluators.getAll`, or `prompts.getAllPromptsForProject` requests fire in the Network tab
- [x] Open the command bar with Cmd+K and verify the queries fire and search results work as expected
- [x] Close and reopen the command bar — cached results should appear instantly