### PR TITLE
fix(studio): play button menu hidden behind drawer

### DIFF
--- a/langwatch/src/optimization_studio/components/nodes/Nodes.tsx
+++ b/langwatch/src/optimization_studio/components/nodes/Nodes.tsx
@@ -547,7 +547,7 @@ export function ComponentExecutionButton({
               <Play size={iconSize} />
             </Button>
           </Menu.Trigger>
-          <Menu.Content zIndex={1600}>
+          <Menu.Content zIndex="popover">
             <Menu.Item
               value="run-manual"
               onClick={() => node && startComponentExecution({ node })}


### PR DESCRIPTION
## Summary

Fixes #2185

- **Prevent drawer from opening on play-button click**: Added `stopPropagation()` on pointer/click events to prevent ReactFlow from selecting the node (which triggers the drawer)
- **Remove NodeToolbar wrapper from menu**: The `Menu.Content` already portals to `document.body`, so wrapping it in `NodeToolbar` was unnecessary and caused z-index/visibility issues
- **Use semantic z-index token**: Menu uses `zIndex="popover"` matching other menus in the codebase

## What was happening

1. Clicking play selected the node → opened the drawer → drawer covered the menu
2. Closing drawer deselected the node → `NodeToolbar` hid → menu disappeared
3. First click on unselected node: `NodeToolbar` wasn't visible yet, so menu didn't render properly

## Test plan

- [ ] Click play button on a node — menu appears immediately (single click)
- [ ] Menu appears above/in front of any open drawer
- [ ] Closing the drawer does not close the menu
- [ ] "Run with manual input" and "Run workflow until here" options work correctly
- [ ] Stop button still works during execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)