### PR TITLE
fix(simulations): add ClickHouse partition pruning to listing pages

### DIFF
--- a/langwatch/src/pages/[project]/simulations/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/index.tsx
@@ -1,7 +1,8 @@
-import { Grid, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
+import { Grid, HStack, Spacer, Spinner, Text, VStack } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 import { DashboardLayout } from "~/components/DashboardLayout";
+import { PeriodSelector, usePeriodSelector } from "~/components/PeriodSelector";
 import { SetCard } from "~/components/simulations";
 import ScenarioInfoCard from "~/components/simulations/ScenarioInfoCard";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
@@ -14,6 +15,7 @@ import { sortScenarioSets } from "~/features/simulations/sort-scenario-sets";
 function SimulationsPageContent() {
   const router = useRouter();
   const { project } = useOrganizationTeamProject();
+  const { period, setPeriod } = usePeriodSelector(30);
 
   const {
     data: scenarioSetsData,
@@ -21,7 +23,11 @@ function SimulationsPageContent() {
     error,
     refetch,
   } = api.scenarios.getScenarioSetsData.useQuery(
-    { projectId: project?.id ?? "" },
+    {
+      projectId: project?.id ?? "",
+      startDate: period.startDate.getTime(),
+      endDate: period.endDate.getTime(),
+    },
     {
       refetchInterval: 60_000,
       enabled: !!project,
@@ -55,6 +61,8 @@ function SimulationsPageContent() {
           <PageLayout.Header>
             <HStack justify="space-between" align="center" w="full">
               <PageLayout.Heading>Simulation Sets</PageLayout.Heading>
+              <Spacer />
+              <PeriodSelector period={period} setPeriod={setPeriod} />
             </HStack>
           </PageLayout.Header>
         )}

--- a/langwatch/src/pages/[project]/simulations/suites/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/suites/index.tsx
@@ -66,7 +66,11 @@ function SuitesPageContent() {
   );
 
   const { data: externalSets } = api.scenarios.getExternalSetSummaries.useQuery(
-    { projectId: project?.id ?? "" },
+    {
+      projectId: project?.id ?? "",
+      startDate: period.startDate.getTime(),
+      endDate: period.endDate.getTime(),
+    },
     { enabled: !!project, refetchInterval: 15000 },
   );
 

--- a/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-events.router.ts
@@ -131,15 +131,16 @@ async function fetchSuiteRunData({
 export const scenarioEventsRouter = createTRPCRouter({
   // Get scenario sets data for a project
   getScenarioSetsData: protectedProcedure
-    .input(projectSchema)
+    .input(projectSchema.extend(dateRangeFields))
     .use(checkProjectPermission("scenarios:view"))
     .query(async ({ input, ctx }) => {
       logger.debug({ projectId: input.projectId }, "Fetching scenario sets data");
       const service = SimulationService.create(ctx.prisma);
-      const data = await service.getScenarioSetsDataForProject({
+      return service.getScenarioSetsDataForProject({
         projectId: input.projectId,
+        startDate: input.startDate,
+        endDate: input.endDate,
       });
-      return data;
     }),
 
   // Unified endpoint: fetches suite run data for a single suite or all suites
@@ -323,13 +324,15 @@ export const scenarioEventsRouter = createTRPCRouter({
 
   // Get summaries for external (SDK/CI) scenario sets
   getExternalSetSummaries: protectedProcedure
-    .input(projectSchema)
+    .input(projectSchema.extend(dateRangeFields))
     .use(checkProjectPermission("scenarios:view"))
     .query(async ({ input, ctx }) => {
       logger.debug({ projectId: input.projectId }, "Fetching external set summaries");
       const service = SimulationService.create(ctx.prisma);
       return service.getExternalSetSummaries({
         projectId: input.projectId,
+        startDate: input.startDate,
+        endDate: input.endDate,
       });
     }),
 

--- a/langwatch/src/server/simulations/clickhouse-simulation.service.ts
+++ b/langwatch/src/server/simulations/clickhouse-simulation.service.ts
@@ -47,6 +47,38 @@ function buildDateHavingFilter({
   return { clause: parts.length > 0 ? parts.join(" AND ") : null, params };
 }
 
+/**
+ * Builds a WHERE clause fragment that filters on the `StartedAt` partition key
+ * to enable partition pruning. When the table is `PARTITION BY toYearWeek(StartedAt)`,
+ * adding StartedAt bounds lets ClickHouse skip cold (S3) partitions entirely.
+ *
+ * Uses separate param names (`whereStartDateMs`, `whereEndDateMs`) to avoid
+ * collision with the HAVING filter params.
+ */
+function buildStartedAtWhereFilter({
+  startDate,
+  endDate,
+}: {
+  startDate?: number;
+  endDate?: number;
+}): { clause: string | null; params: Record<string, string> } {
+  const parts: string[] = [];
+  const params: Record<string, string> = {};
+  if (startDate !== undefined) {
+    parts.push(
+      "StartedAt >= fromUnixTimestamp64Milli(toUInt64({whereStartDateMs:String}))",
+    );
+    params.whereStartDateMs = String(startDate);
+  }
+  if (endDate !== undefined) {
+    parts.push(
+      "StartedAt <= fromUnixTimestamp64Milli(toUInt64({whereEndDateMs:String}))",
+    );
+    params.whereEndDateMs = String(endDate);
+  }
+  return { clause: parts.length > 0 ? parts.join(" AND ") : null, params };
+}
+
 const RUN_COLUMNS = `
   ScenarioRunId, ScenarioId, BatchRunId, ScenarioSetId,
   Status, Name, Description,
@@ -107,9 +139,18 @@ export class ClickHouseSimulationService {
    */
   async getScenarioSetsData({
     projectId,
+    startDate,
+    endDate,
   }: {
     projectId: string;
+    startDate?: number;
+    endDate?: number;
   }): Promise<ScenarioSetData[]> {
+    const startedAtFilter = buildStartedAtWhereFilter({ startDate, endDate });
+    const startedAtClause = startedAtFilter.clause
+      ? `AND ${startedAtFilter.clause}`
+      : "";
+
     const rows = await this.queryRows<{
       ScenarioSetId: string;
       ScenarioCount: string;
@@ -118,18 +159,22 @@ export class ClickHouseSimulationService {
       `SELECT
         ScenarioSetId,
         toString(count(*)) AS ScenarioCount,
-        toString(toUnixTimestamp64Milli(max(UpdatedAt))) AS LastRunAt
+        toString(toUnixTimestamp64Milli(max(LatestUpdatedAt))) AS LastRunAt
        FROM (
-         SELECT *
+         SELECT
+           ScenarioSetId,
+           ScenarioRunId,
+           argMax(UpdatedAt, UpdatedAt) AS LatestUpdatedAt,
+           argMax(ArchivedAt, UpdatedAt) AS LatestArchivedAt
          FROM ${TABLE_NAME}
          WHERE TenantId = {tenantId:String}
-         ORDER BY ScenarioRunId, UpdatedAt DESC
-         LIMIT 1 BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
+           ${startedAtClause}
+         GROUP BY ScenarioSetId, ScenarioRunId
        )
-       WHERE ArchivedAt IS NULL
+       WHERE LatestArchivedAt IS NULL
        GROUP BY ScenarioSetId
        ORDER BY LastRunAt DESC`,
-      { tenantId: projectId },
+      { tenantId: projectId, ...startedAtFilter.params },
     );
 
     return rows.map((row) => ({
@@ -547,6 +592,11 @@ export class ClickHouseSimulationService {
     const dateFilter = buildDateHavingFilter({ startDate, endDate });
     const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.clause].filter(Boolean).join(" AND ")}`;
 
+    const startedAtFilter = buildStartedAtWhereFilter({ startDate, endDate });
+    const startedAtClause = startedAtFilter.clause
+      ? `AND ${startedAtFilter.clause}`
+      : "";
+
     const batchRows = await this.queryRows<{
       BatchRunId: string;
       MaxCreatedAt: string;
@@ -559,6 +609,7 @@ export class ClickHouseSimulationService {
          FROM ${TABLE_NAME}
          WHERE TenantId = {tenantId:String}
            AND ScenarioSetId = {scenarioSetId:String}
+           ${startedAtClause}
          ORDER BY ScenarioRunId, UpdatedAt DESC
          LIMIT 1 BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
        )
@@ -572,6 +623,7 @@ export class ClickHouseSimulationService {
         scenarioSetId,
         ...(decoded ? { cursorTs: decoded.ts, cursorBatchRunId: decoded.batchRunId } : {}),
         ...dateFilter.params,
+        ...startedAtFilter.params,
         fetchLimit: String(validatedLimit + 1),
       },
     );
@@ -630,6 +682,11 @@ export class ClickHouseSimulationService {
     const dateFilter = buildDateHavingFilter({ startDate, endDate });
     const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.clause].filter(Boolean).join(" AND ")}`;
 
+    const startedAtFilter = buildStartedAtWhereFilter({ startDate, endDate });
+    const startedAtClause = startedAtFilter.clause
+      ? `AND ${startedAtFilter.clause}`
+      : "";
+
     const batchRows = await this.queryRows<{
       BatchRunId: string;
       MaxCreatedAt: string;
@@ -644,6 +701,7 @@ export class ClickHouseSimulationService {
          FROM ${TABLE_NAME}
          WHERE TenantId = {tenantId:String}
            AND ScenarioSetId LIKE '__internal__%__suite'
+           ${startedAtClause}
          ORDER BY ScenarioRunId, UpdatedAt DESC
          LIMIT 1 BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
        )
@@ -656,6 +714,7 @@ export class ClickHouseSimulationService {
         tenantId: projectId,
         ...(decoded ? { cursorTs: decoded.ts, cursorBatchRunId: decoded.batchRunId } : {}),
         ...dateFilter.params,
+        ...startedAtFilter.params,
         fetchLimit: String(validatedLimit + 1),
       },
     );
@@ -692,9 +751,18 @@ export class ClickHouseSimulationService {
    */
   async getExternalSetSummaries({
     projectId,
+    startDate,
+    endDate,
   }: {
     projectId: string;
+    startDate?: number;
+    endDate?: number;
   }): Promise<ExternalSetSummary[]> {
+    const startedAtFilter = buildStartedAtWhereFilter({ startDate, endDate });
+    const startedAtClause = startedAtFilter.clause
+      ? `AND ${startedAtFilter.clause}`
+      : "";
+
     // Step 1: Get latest batch per external set
     const setRows = await this.queryRows<{
       ScenarioSetId: string;
@@ -716,6 +784,7 @@ export class ClickHouseSimulationService {
            FROM ${TABLE_NAME}
            WHERE TenantId = {tenantId:String}
              AND NOT startsWith(ScenarioSetId, '__internal__')
+             ${startedAtClause}
            ORDER BY ScenarioRunId, UpdatedAt DESC
            LIMIT 1 BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
          )
@@ -724,7 +793,7 @@ export class ClickHouseSimulationService {
        )
        GROUP BY ScenarioSetId
        ORDER BY LastRunAt DESC`,
-      { tenantId: projectId },
+      { tenantId: projectId, ...startedAtFilter.params },
     );
 
     if (setRows.length === 0) return [];
@@ -747,12 +816,13 @@ export class ClickHouseSimulationService {
          FROM ${TABLE_NAME}
          WHERE TenantId = {tenantId:String}
            AND BatchRunId IN ({batchRunIds:Array(String)})
+           ${startedAtClause}
          ORDER BY ScenarioRunId, UpdatedAt DESC
          LIMIT 1 BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
        )
        WHERE ArchivedAt IS NULL
        GROUP BY ScenarioSetId, BatchRunId`,
-      { tenantId: projectId, batchRunIds },
+      { tenantId: projectId, batchRunIds, ...startedAtFilter.params },
     );
 
     const statsMap = new Map(

--- a/langwatch/src/server/simulations/simulation.service.ts
+++ b/langwatch/src/server/simulations/simulation.service.ts
@@ -46,11 +46,15 @@ export class SimulationService {
 
   async getScenarioSetsDataForProject({
     projectId,
+    startDate,
+    endDate,
   }: {
     projectId: string;
+    startDate?: number;
+    endDate?: number;
   }) {
     if (await this.isClickHouseEnabled(projectId)) {
-      return this.chService!.getScenarioSetsData({ projectId });
+      return this.chService!.getScenarioSetsData({ projectId, startDate, endDate });
     }
     return this.esService.getScenarioSetsDataForProject({ projectId });
   }
@@ -153,6 +157,8 @@ export class SimulationService {
 
   async getExternalSetSummaries(params: {
     projectId: string;
+    startDate?: number;
+    endDate?: number;
   }) {
     if (await this.isClickHouseEnabled(params.projectId)) {
       return this.chService!.getExternalSetSummaries(params);

--- a/langwatch/src/utils/api.ts
+++ b/langwatch/src/utils/api.ts
@@ -79,7 +79,6 @@ export const api = createTRPCNext<AppRouter>({
             // when condition is false, use batching
             false: httpBatchLink({
               url: `${getBaseUrl()}/api/trpc`,
-              // Split batches if URL would exceed this length to avoid 431 errors
               maxURLLength: 4000,
             }),
           }),


### PR DESCRIPTION
## Summary
- The `simulation_runs` table has 2,600+ unmerged parts on S3 cold storage due to 30-day TTL. All listing page queries scan every part, taking 2-3 seconds
- Adds `StartedAt` WHERE clauses to inner subqueries of 4 ClickHouse methods (`getScenarioSetsData`, `getExternalSetSummaries`, `getRunDataForAllSuites`, `getRunDataForScenarioSet`) to enable partition pruning — ClickHouse skips cold S3 partitions entirely when the date range falls within hot storage
- Adds `PeriodSelector` (30-day default) to `/simulations` page
- Passes date range to `getExternalSetSummaries` on `/suites` page (was ignoring the existing PeriodSelector)
- Also cleans up debug timing logs and reverts temporary `httpBatchLink` → `httpLink` change

<img width="879" height="307" alt="image" src="https://github.com/user-attachments/assets/572509d6-1be2-4a8a-b9eb-eb8f070c88b2" />

## Test plan
- [ ] Load `/simulations` — PeriodSelector visible, query completes in <200ms (vs 2-3s before)
- [ ] Load `/suites` — `getExternalSetSummaries` also fast
- [ ] Change PeriodSelector to wider range — results update, older sets appear
- [ ] `pnpm typecheck` passes
- [ ] Existing tests pass (50/50 green)