### PR TITLE
fix(evaluations): update list page to experiments terminology and fix navigation

### DIFF
--- a/langwatch/src/pages/[project]/evaluations.tsx
+++ b/langwatch/src/pages/[project]/evaluations.tsx
@@ -448,18 +448,6 @@ function EvaluationsV2() {
                                           <MoreVertical size={16} />
                                         </Menu.Trigger>
                                         <Menu.Content>
-                                          <Menu.Item
-                                            value="view-results"
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              void router.push(
-                                                `/${project?.slug}/experiments/${experiment.slug}`,
-                                              );
-                                            }}
-                                          >
-                                            <LuEye size={16} />
-                                            View Results
-                                          </Menu.Item>
                                           {experiment.type ===
                                             "EVALUATIONS_V3" && (
                                             <Menu.Item
@@ -493,6 +481,18 @@ function EvaluationsV2() {
                                                 Edit
                                               </Menu.Item>
                                             )}
+                                          <Menu.Item
+                                            value="view-results"
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              void router.push(
+                                                `/${project?.slug}/experiments/${experiment.slug}`,
+                                              );
+                                            }}
+                                          >
+                                            <LuEye size={16} />
+                                            View Results
+                                          </Menu.Item>
                                           {hasPermission(
                                             "evaluations:manage",
                                           ) && (


### PR DESCRIPTION
## Summary
- Replaced internal terminology on the evaluations list page: "Evaluations V3" → "Experiment", "API Batch Evaluation" → "Batch Evaluation"
- Updated all page copy from "Evaluations" to "Experiments" (heading, description, empty states)
- Fixed Edit button: navigates to workbench for experiments, hidden for API batch evaluations
- Added "View Results" menu item that navigates to the experiment results/history page

## Test plan
- [ ] Navigate to /evaluations and verify page title says "Experiments"
- [ ] Verify type column shows "Experiment" and "Batch Evaluation" labels
- [ ] For an Experiment type: verify Edit goes to /experiments/workbench/:slug
- [ ] For a Batch Evaluation type: verify Edit button is not shown
- [ ] For all types: verify "View Results" navigates to /experiments/:slug
- [ ] Verify row click behavior is unchanged