### PR TITLE
fix(prompts): coerce trace LLM params in Open in Prompts flow

### DIFF
--- a/langwatch/src/prompts/prompt-playground/hooks/__tests__/useLoadSpanIntoPromptPlayground.integration.test.ts
+++ b/langwatch/src/prompts/prompt-playground/hooks/__tests__/useLoadSpanIntoPromptPlayground.integration.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { createDefaultPromptFormValues } from "../useLoadSpanIntoPromptPlayground";
+import { DEFAULT_MODEL } from "~/utils/constants";
+import type { RouterOutputs } from "~/utils/api";
+
+type SpanData = RouterOutputs["spans"]["getForPromptStudio"];
+
+function buildSpanData(
+  overrides: Partial<SpanData["llmConfig"]> = {},
+): SpanData {
+  return {
+    spanId: "span-1",
+    traceId: "trace-1",
+    spanName: "test-span",
+    messages: [],
+    llmConfig: {
+      model: "openai/gpt-4",
+      systemPrompt: "You are a helpful assistant.",
+      temperature: 0.5,
+      maxTokens: 512,
+      topP: null,
+      litellmParams: {},
+      ...overrides,
+    },
+    vendor: "openai",
+    error: null,
+    timestamps: undefined,
+    metrics: null,
+  };
+}
+
+describe("createDefaultPromptFormValues()", () => {
+  describe("when trace data has string numbers for LLM config fields", () => {
+    it("coerces string temperature to a number", () => {
+      const spanData = buildSpanData({
+        temperature: "0.7" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.temperature).toBe(0.7);
+    });
+
+    it("coerces string maxTokens to a number", () => {
+      const spanData = buildSpanData({
+        maxTokens: "1024" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.maxTokens).toBe(1024);
+    });
+
+    it("coerces string topP to a number", () => {
+      const spanData = buildSpanData({
+        topP: "0.9" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.topP).toBe(0.9);
+    });
+  });
+
+  describe("when trace data has non-parseable values", () => {
+    it("falls back to undefined for garbage temperature", () => {
+      const spanData = buildSpanData({
+        temperature: "not-a-number" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.temperature).toBeUndefined();
+    });
+
+    it("falls back to undefined for garbage maxTokens", () => {
+      const spanData = buildSpanData({
+        maxTokens: "garbage" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.maxTokens).toBeUndefined();
+    });
+
+    it("falls back to undefined for boolean temperature", () => {
+      const spanData = buildSpanData({
+        temperature: true as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.temperature).toBeUndefined();
+    });
+
+    it("falls back to undefined for object temperature", () => {
+      const spanData = buildSpanData({
+        temperature: { value: 0.5 } as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.temperature).toBeUndefined();
+    });
+  });
+
+  describe("when trace data has all null/missing LLM config", () => {
+    it("does not throw and returns valid form values", () => {
+      const spanData = buildSpanData({
+        model: null,
+        temperature: null,
+        maxTokens: null,
+        topP: null,
+      });
+
+      expect(() => createDefaultPromptFormValues(spanData)).not.toThrow();
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.model).toBe(DEFAULT_MODEL);
+      expect(result.version.configData.llm.temperature).toBeUndefined();
+      expect(result.version.configData.llm.maxTokens).toBeUndefined();
+    });
+  });
+
+  describe("when trace data has empty string model", () => {
+    it("falls back to default model", () => {
+      const spanData = buildSpanData({
+        model: "" as string,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.model).toBe(DEFAULT_MODEL);
+    });
+  });
+
+  describe("when trace data has mixed valid and invalid fields", () => {
+    it("coerces valid string numbers and drops invalid ones", () => {
+      const spanData = buildSpanData({
+        temperature: "0.3" as unknown as number,
+        maxTokens: "invalid" as unknown as number,
+        topP: "0.95" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.temperature).toBe(0.3);
+      expect(result.version.configData.llm.maxTokens).toBeUndefined();
+      expect(result.version.configData.llm.topP).toBe(0.95);
+    });
+  });
+});

--- a/langwatch/src/prompts/prompt-playground/hooks/__tests__/useLoadSpanIntoPromptPlayground.unit.test.ts
+++ b/langwatch/src/prompts/prompt-playground/hooks/__tests__/useLoadSpanIntoPromptPlayground.unit.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { createDefaultPromptFormValues } from "../useLoadSpanIntoPromptPlayground";
+import {
+  createDefaultPromptFormValues,
+  coerceToNumber,
+} from "../useLoadSpanIntoPromptPlayground";
 import { DEFAULT_MODEL } from "~/utils/constants";
 import type { RouterOutputs } from "~/utils/api";
 
@@ -28,6 +31,72 @@ function buildSpanData(
     metrics: null,
   };
 }
+
+describe("coerceToNumber()", () => {
+  describe("when value is a number", () => {
+    it("returns the number as-is", () => {
+      expect(coerceToNumber(0.7)).toBe(0.7);
+    });
+
+    it("returns zero", () => {
+      expect(coerceToNumber(0)).toBe(0);
+    });
+
+    it("returns undefined for NaN", () => {
+      expect(coerceToNumber(NaN)).toBeUndefined();
+    });
+
+    it("returns undefined for Infinity", () => {
+      expect(coerceToNumber(Infinity)).toBeUndefined();
+    });
+  });
+
+  describe("when value is a string", () => {
+    it("parses a numeric string", () => {
+      expect(coerceToNumber("0.7")).toBe(0.7);
+    });
+
+    it("parses an integer string", () => {
+      expect(coerceToNumber("1024")).toBe(1024);
+    });
+
+    it("trims whitespace before parsing", () => {
+      expect(coerceToNumber("  0.9  ")).toBe(0.9);
+    });
+
+    it("returns undefined for empty string", () => {
+      expect(coerceToNumber("")).toBeUndefined();
+    });
+
+    it("returns undefined for non-numeric string", () => {
+      expect(coerceToNumber("not-a-number")).toBeUndefined();
+    });
+  });
+
+  describe("when value is null or undefined", () => {
+    it("returns undefined for null", () => {
+      expect(coerceToNumber(null)).toBeUndefined();
+    });
+
+    it("returns undefined for undefined", () => {
+      expect(coerceToNumber(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("when value is an unsupported type", () => {
+    it("returns undefined for boolean", () => {
+      expect(coerceToNumber(true)).toBeUndefined();
+    });
+
+    it("returns undefined for object", () => {
+      expect(coerceToNumber({ value: 0.5 })).toBeUndefined();
+    });
+
+    it("returns undefined for array", () => {
+      expect(coerceToNumber([0.5])).toBeUndefined();
+    });
+  });
+});
 
 describe("createDefaultPromptFormValues()", () => {
   describe("when maxTokens is null", () => {

--- a/langwatch/src/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground.ts
+++ b/langwatch/src/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground.ts
@@ -83,8 +83,35 @@ function useSpanIdFromUrl() {
 }
 
 /**
+ * Safely coerces a value to a number, returning undefined for anything that
+ * cannot be cleanly converted. Trace data may store numeric LLM params as
+ * strings (e.g. "0.7"), booleans, or objects -- this function handles all
+ * of those without throwing.
+ *
+ * @param value - The value to coerce (number, string, null, or unknown)
+ * @returns The numeric value, or undefined if coercion is not possible
+ */
+export function coerceToNumber(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return undefined;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Creates default form values for a new prompt config.
  * Single Responsibility: Generate initial prompt configuration structure from span data.
+ *
+ * Applies lenient coercion to numeric fields because trace data from customer
+ * LLM calls may store parameters as strings instead of numbers.  Values that
+ * cannot be coerced are silently dropped (set to undefined) so that the
+ * "Open in Prompts" flow never fails due to unexpected trace data shapes.
+ *
  * @param spanData - The span data containing LLM configuration
  * @returns Initial form values for a new prompt
  */
@@ -116,9 +143,10 @@ export function createDefaultPromptFormValues(
         prompt: systemPrompt,
         llm: {
           // The model should always be available here, but we fall back to the default model if it's not.
-          model: spanData.llmConfig.model ?? DEFAULT_MODEL,
-          temperature: spanData.llmConfig.temperature ?? undefined,
-          maxTokens: spanData.llmConfig.maxTokens ?? undefined,
+          model: spanData.llmConfig.model || DEFAULT_MODEL,
+          temperature: coerceToNumber(spanData.llmConfig.temperature),
+          maxTokens: coerceToNumber(spanData.llmConfig.maxTokens),
+          topP: coerceToNumber(spanData.llmConfig.topP),
         },
         inputs: [],
         outputs: [{ identifier: "output", type: "str" }],


### PR DESCRIPTION
## Summary

- **Bug:** "Open in Prompts" button failed with Zod validation error (`Expected number, received string`) because trace data stores LLM params like `temperature` as strings
- **Fix:** Added `coerceToNumber()` helper that leniently converts string numbers to actual numbers, dropping anything unparseable (returns `undefined` instead of throwing)
- **Applied to:** `temperature`, `maxTokens`, `topP` in `createDefaultPromptFormValues()`
- **Also fixed:** empty string `model` now falls back to `DEFAULT_MODEL` (changed `??` to `||`)

## Test plan

- [x] 14 unit tests for `coerceToNumber()` covering numbers, strings, null, NaN, Infinity, booleans, objects, arrays
- [x] 10 integration tests for `createDefaultPromptFormValues()` covering string numbers, garbage values, all-null config, empty model, mixed valid/invalid fields
- [x] `pnpm typecheck` passes (no new errors)
- [x] All existing prompt tests pass (272 tests)