### PR TITLE
fix(prompts): prevent false diffs in prompt sync creating unnecessary versions

### DIFF
--- a/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PromptService, type VersionedPrompt } from "../prompt.service";
+
+/**
+ * Tests for syncPrompt covering:
+ * - Root Cause 1: remoteConfigData must include ALL sampling parameters
+ * - Root Cause 3: double transformToDbFormat on create path
+ */
+describe("PromptService", () => {
+  describe("syncPrompt()", () => {
+    let promptService: PromptService;
+    let mockPrisma: any;
+    let mockRepository: any;
+    let mockVersionService: any;
+
+    const projectId = "project-1";
+    const organizationId = "org-1";
+
+    /**
+     * Build a VersionedPrompt with all sampling parameters populated.
+     */
+    function buildExistingPrompt(
+      overrides: Partial<VersionedPrompt> = {},
+    ): VersionedPrompt {
+      return {
+        id: "config-1",
+        name: "test-prompt",
+        handle: "test-prompt",
+        scope: "PROJECT" as const,
+        version: 1,
+        versionId: "version-1",
+        versionCreatedAt: new Date(),
+        model: "gpt-4",
+        temperature: 0.7,
+        maxTokens: 1000,
+        topP: 0.9,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.3,
+        seed: 42,
+        topK: 40,
+        minP: 0.1,
+        repetitionPenalty: 1.1,
+        reasoning: "medium",
+        verbosity: "normal",
+        prompt: "You are a helpful assistant",
+        projectId,
+        organizationId,
+        messages: [
+          { role: "system", content: "You are a helpful assistant" },
+          { role: "user", content: "Hello {{input}}" },
+        ],
+        inputs: [{ identifier: "input", type: "str" as const }],
+        outputs: [{ identifier: "output", type: "str" as const }],
+        authorId: null,
+        updatedAt: new Date(),
+        createdAt: new Date(),
+        ...overrides,
+      };
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+
+      mockPrisma = {
+        $transaction: vi.fn(),
+        project: {
+          findUnique: vi.fn(),
+        },
+      } as any;
+
+      mockRepository = {
+        compareConfigContent: vi.fn(),
+        getConfigVersionByNumber: vi.fn(),
+        getConfigByIdOrHandleWithLatestVersion: vi.fn(),
+        checkModifyPermission: vi.fn().mockResolvedValue({
+          hasPermission: true,
+        }),
+        createConfigWithInitialVersion: vi.fn(),
+        updateConfig: vi.fn(),
+        versions: {
+          getLatestVersion: vi.fn(),
+        },
+        createHandle: vi.fn(),
+      };
+
+      mockVersionService = {
+        assertNoSystemPromptConflict: vi.fn(),
+        createVersion: vi.fn(),
+      };
+
+      promptService = new PromptService(mockPrisma);
+      (promptService as any).repository = mockRepository;
+      (promptService as any).versionService = mockVersionService;
+    });
+
+    describe("when remote prompt exists with all sampling parameters and local matches", () => {
+      it("returns up_to_date when max_tokens, top_p, and other params match", async () => {
+        const existingPrompt = buildExistingPrompt();
+
+        // Spy on getPromptByIdOrHandle to return our prompt with all params
+        vi.spyOn(promptService, "getPromptByIdOrHandle").mockResolvedValue(
+          existingPrompt,
+        );
+
+        // The local config data matches what the server has (in snake_case DB format)
+        const localConfigData = {
+          model: "gpt-4",
+          prompt: "You are a helpful assistant",
+          messages: [{ role: "user" as const, content: "Hello {{input}}" }],
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [{ identifier: "output", type: "str" }],
+          temperature: 0.7,
+          max_tokens: 1000,
+          top_p: 0.9,
+          frequency_penalty: 0.5,
+          presence_penalty: 0.3,
+          seed: 42,
+          top_k: 40,
+          min_p: 0.1,
+          repetition_penalty: 1.1,
+          reasoning: "medium",
+          verbosity: "normal",
+        };
+
+        // The comparison should see them as equal
+        mockRepository.compareConfigContent.mockReturnValue({ isEqual: true });
+
+        const result = await promptService.syncPrompt({
+          idOrHandle: "test-prompt",
+          localConfigData: localConfigData as any,
+          localVersion: 1,
+          projectId,
+          organizationId,
+        });
+
+        expect(result.action).toBe("up_to_date");
+
+        // Verify that compareConfigContent was called with remoteConfigData
+        // that includes ALL sampling parameters, not just temperature
+        const [, remoteArg] =
+          mockRepository.compareConfigContent.mock.calls[0]!;
+        expect(remoteArg).toHaveProperty("max_tokens", 1000);
+        expect(remoteArg).toHaveProperty("top_p", 0.9);
+        expect(remoteArg).toHaveProperty("frequency_penalty", 0.5);
+        expect(remoteArg).toHaveProperty("presence_penalty", 0.3);
+        expect(remoteArg).toHaveProperty("seed", 42);
+        expect(remoteArg).toHaveProperty("top_k", 40);
+        expect(remoteArg).toHaveProperty("min_p", 0.1);
+        expect(remoteArg).toHaveProperty("repetition_penalty", 1.1);
+        expect(remoteArg).toHaveProperty("reasoning", "medium");
+        expect(remoteArg).toHaveProperty("verbosity", "normal");
+      });
+    });
+
+    describe("when remote prompt exists with only some sampling params defined", () => {
+      it("excludes undefined sampling parameters from remoteConfigData", async () => {
+        const existingPrompt = buildExistingPrompt({
+          maxTokens: undefined,
+          topP: undefined,
+          frequencyPenalty: undefined,
+          presencePenalty: undefined,
+          seed: undefined,
+          topK: undefined,
+          minP: undefined,
+          repetitionPenalty: undefined,
+          reasoning: undefined,
+          verbosity: undefined,
+        });
+
+        vi.spyOn(promptService, "getPromptByIdOrHandle").mockResolvedValue(
+          existingPrompt,
+        );
+
+        const localConfigData = {
+          model: "gpt-4",
+          prompt: "You are a helpful assistant",
+          messages: [{ role: "user" as const, content: "Hello {{input}}" }],
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [{ identifier: "output", type: "str" }],
+          temperature: 0.7,
+        };
+
+        mockRepository.compareConfigContent.mockReturnValue({ isEqual: true });
+
+        await promptService.syncPrompt({
+          idOrHandle: "test-prompt",
+          localConfigData: localConfigData as any,
+          localVersion: 1,
+          projectId,
+          organizationId,
+        });
+
+        // remoteConfigData should NOT include undefined fields (to avoid false diffs)
+        const [, remoteArg] =
+          mockRepository.compareConfigContent.mock.calls[0]!;
+        expect(remoteArg).not.toHaveProperty("max_tokens");
+        expect(remoteArg).not.toHaveProperty("top_p");
+        expect(remoteArg).not.toHaveProperty("frequency_penalty");
+        expect(remoteArg).not.toHaveProperty("presence_penalty");
+        expect(remoteArg).not.toHaveProperty("seed");
+      });
+    });
+
+    describe("when prompt does not exist and is created", () => {
+      it("does not double-transform camelCase params through transformToDbFormat", async () => {
+        vi.spyOn(promptService, "getPromptByIdOrHandle").mockResolvedValue(
+          null,
+        );
+
+        const createdPrompt = buildExistingPrompt({ version: 1 });
+        const createSpy = vi
+          .spyOn(promptService, "createPrompt")
+          .mockResolvedValue(createdPrompt);
+
+        const localConfigData = {
+          model: "gpt-4",
+          prompt: "You are a helpful assistant",
+          messages: [{ role: "user" as const, content: "Hello {{input}}" }],
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [{ identifier: "output", type: "str" }],
+          temperature: 0.7,
+          max_tokens: 1000,
+        };
+
+        await promptService.syncPrompt({
+          idOrHandle: "test-prompt",
+          localConfigData: localConfigData as any,
+          projectId,
+          organizationId,
+        });
+
+        // createPrompt should receive camelCase params (since createPrompt
+        // internally calls transformToDbFormat). The data must NOT already be
+        // snake_case'd, otherwise max_tokens becomes undefined after the
+        // double transform.
+        expect(createSpy).toHaveBeenCalledTimes(1);
+        const createArgs = createSpy.mock.calls[0]![0];
+
+        // After transformToDbFormat, snake_case keys like max_tokens should be
+        // passed through. The key check is that max_tokens/maxTokens is present
+        // in some form and not lost.
+        const hasMaxTokens =
+          "maxTokens" in createArgs || "max_tokens" in createArgs;
+        expect(hasMaxTokens).toBe(true);
+
+        // The value should be 1000, not undefined
+        const maxTokensValue =
+          (createArgs as any).maxTokens ?? (createArgs as any).max_tokens;
+        expect(maxTokensValue).toBe(1000);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -27,7 +27,10 @@ import {
   LATEST_SCHEMA_VERSION,
   type LatestConfigVersionSchema,
 } from "./repositories/llm-config-version-schema";
-import { transformCamelToSnake } from "./transformToDbFormat";
+import {
+  transformCamelToSnake,
+  transformSnakeToCamel,
+} from "./transformToDbFormat";
 
 // Extract the configData type from the schema
 type ConfigData = z.infer<
@@ -645,6 +648,13 @@ export class PromptService {
 
     // Case 1: Prompt doesn't exist on server - create new
     if (!existingPrompt) {
+      // Convert snake_case localConfigData to camelCase for createPrompt,
+      // which internally calls transformToDbFormat. Without this conversion,
+      // snake_case keys like max_tokens would be invisible to createPrompt's
+      // named params (maxTokens), causing data loss.
+      const camelCaseData = transformSnakeToCamel(
+        localConfigData as unknown as Record<string, unknown>,
+      );
       const createdPrompt = await this.createPrompt({
         handle: idOrHandle,
         projectId,
@@ -652,7 +662,7 @@ export class PromptService {
         scope: "PROJECT" as PromptScope,
         authorId,
         commitMessage: commitMessage ?? "Synced from local file",
-        ...this.transformToDbFormat(localConfigData),
+        ...camelCaseData,
       });
 
       return {
@@ -669,14 +679,51 @@ export class PromptService {
     });
 
     const remoteVersion = existingPrompt.version;
+
+    // Build remoteConfigData with ALL fields the schema expects.
+    // Only include optional sampling parameters when they are defined
+    // to avoid introducing false diffs from undefined values.
     const remoteConfigData: LatestConfigVersionSchema["configData"] = {
       model: existingPrompt.model,
-      temperature: existingPrompt.temperature,
       prompt: existingPrompt.prompt,
       messages: existingPrompt.messages.filter((msg) => msg.role !== "system"),
       inputs: existingPrompt.inputs,
       outputs: existingPrompt.outputs,
       // response_format is derived from outputs, not stored separately
+      // Include all sampling parameters only when defined
+      ...(existingPrompt.temperature !== undefined && {
+        temperature: existingPrompt.temperature,
+      }),
+      ...(existingPrompt.maxTokens !== undefined && {
+        max_tokens: existingPrompt.maxTokens,
+      }),
+      ...(existingPrompt.topP !== undefined && {
+        top_p: existingPrompt.topP,
+      }),
+      ...(existingPrompt.frequencyPenalty !== undefined && {
+        frequency_penalty: existingPrompt.frequencyPenalty,
+      }),
+      ...(existingPrompt.presencePenalty !== undefined && {
+        presence_penalty: existingPrompt.presencePenalty,
+      }),
+      ...(existingPrompt.seed !== undefined && {
+        seed: existingPrompt.seed,
+      }),
+      ...(existingPrompt.topK !== undefined && {
+        top_k: existingPrompt.topK,
+      }),
+      ...(existingPrompt.minP !== undefined && {
+        min_p: existingPrompt.minP,
+      }),
+      ...(existingPrompt.repetitionPenalty !== undefined && {
+        repetition_penalty: existingPrompt.repetitionPenalty,
+      }),
+      ...(existingPrompt.reasoning !== undefined && {
+        reasoning: existingPrompt.reasoning,
+      }),
+      ...(existingPrompt.verbosity !== undefined && {
+        verbosity: existingPrompt.verbosity,
+      }),
     };
 
     // Case 2: Same version - check content

--- a/langwatch/src/server/prompt-config/repositories/__tests__/compareConfigContent.unit.test.ts
+++ b/langwatch/src/server/prompt-config/repositories/__tests__/compareConfigContent.unit.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { LlmConfigRepository } from "../llm-config.repository";
+
+/**
+ * Tests for compareConfigContent covering:
+ * - Deep nested object comparison (Root Cause 2: JSON.stringify array replacer bug)
+ * - Sampling parameter comparison
+ * - Structured output comparison
+ */
+describe("LlmConfigRepository", () => {
+  describe("compareConfigContent()", () => {
+    const repository = new LlmConfigRepository(null as any);
+
+    const baseConfig = {
+      model: "gpt-4",
+      prompt: "You are a helpful assistant",
+      messages: [{ role: "user" as const, content: "Hello {{input}}" }],
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [{ identifier: "output", type: "str" }],
+      temperature: 0.7,
+    };
+
+    describe("when configs are identical", () => {
+      it("returns isEqual true for identical configs with sampling params", () => {
+        const config = {
+          ...baseConfig,
+          max_tokens: 1000,
+          top_p: 0.9,
+          frequency_penalty: 0.5,
+          presence_penalty: 0.3,
+          seed: 42,
+        };
+
+        const result = repository.compareConfigContent(config, { ...config });
+
+        expect(result.isEqual).toBe(true);
+      });
+
+      it("returns isEqual true for configs with nested message content", () => {
+        const config = {
+          ...baseConfig,
+          messages: [
+            { role: "user" as const, content: "First message {{input}}" },
+            { role: "assistant" as const, content: "I'll help you" },
+            { role: "user" as const, content: "Follow up question" },
+          ],
+        };
+
+        const result = repository.compareConfigContent(config, { ...config });
+
+        expect(result.isEqual).toBe(true);
+      });
+
+      it("returns isEqual true for configs with structured outputs (json_schema)", () => {
+        const config = {
+          ...baseConfig,
+          outputs: [
+            {
+              identifier: "response",
+              type: "json_schema",
+              json_schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  age: { type: "number" },
+                },
+              },
+            },
+          ],
+        };
+
+        const result = repository.compareConfigContent(config, { ...config });
+
+        expect(result.isEqual).toBe(true);
+      });
+    });
+
+    describe("when configs have real differences", () => {
+      it("detects changes in nested message content", () => {
+        const config1 = {
+          ...baseConfig,
+          messages: [{ role: "user" as const, content: "Hello {{input}}" }],
+        };
+
+        const config2 = {
+          ...baseConfig,
+          messages: [
+            { role: "user" as const, content: "Different message {{input}}" },
+          ],
+        };
+
+        const result = repository.compareConfigContent(config1, config2);
+
+        expect(result.isEqual).toBe(false);
+        expect(result.differences).toBeDefined();
+        expect(result.differences).toContain("messages differ");
+      });
+
+      it("detects changes in sampling parameters", () => {
+        const config1 = { ...baseConfig, max_tokens: 1000 };
+        const config2 = { ...baseConfig, max_tokens: 2000 };
+
+        const result = repository.compareConfigContent(config1, config2);
+
+        expect(result.isEqual).toBe(false);
+      });
+
+      it("detects changes in nested input identifiers", () => {
+        const config1 = {
+          ...baseConfig,
+          inputs: [{ identifier: "input", type: "str" }],
+        };
+        const config2 = {
+          ...baseConfig,
+          inputs: [{ identifier: "query", type: "str" }],
+        };
+
+        const result = repository.compareConfigContent(config1, config2);
+
+        expect(result.isEqual).toBe(false);
+        expect(result.differences).toContain("inputs differ");
+      });
+
+      it("detects changes in output json_schema properties", () => {
+        const config1 = {
+          ...baseConfig,
+          outputs: [
+            {
+              identifier: "response",
+              type: "json_schema",
+              json_schema: {
+                type: "object",
+                properties: { name: { type: "string" } },
+              },
+            },
+          ],
+        };
+
+        const config2 = {
+          ...baseConfig,
+          outputs: [
+            {
+              identifier: "response",
+              type: "json_schema",
+              json_schema: {
+                type: "object",
+                properties: { age: { type: "number" } },
+              },
+            },
+          ],
+        };
+
+        const result = repository.compareConfigContent(config1, config2);
+
+        expect(result.isEqual).toBe(false);
+      });
+    });
+
+    describe("when key ordering differs but content is the same", () => {
+      it("returns isEqual true regardless of key order in nested objects", () => {
+        const config1 = {
+          model: "gpt-4",
+          prompt: "You are a helpful assistant",
+          messages: [{ role: "user" as const, content: "Hello" }],
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [{ identifier: "output", type: "str" }],
+          temperature: 0.7,
+          max_tokens: 1000,
+        };
+
+        // Same content, different key order
+        const config2 = {
+          max_tokens: 1000,
+          temperature: 0.7,
+          outputs: [{ type: "str", identifier: "output" }],
+          inputs: [{ type: "str", identifier: "input" }],
+          messages: [{ content: "Hello", role: "user" as const }],
+          prompt: "You are a helpful assistant",
+          model: "gpt-4",
+        };
+
+        const result = repository.compareConfigContent(config1, config2);
+
+        expect(result.isEqual).toBe(true);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
@@ -23,6 +23,22 @@ import {
 const logger = createLogger("langwatch:prompt-config:llm-config.repository");
 
 /**
+ * Recursively sort all object keys for deterministic JSON serialization.
+ * Arrays preserve element order but their object elements get sorted keys.
+ */
+function sortKeysDeep(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortKeysDeep);
+  if (obj && typeof obj === "object" && obj !== null) {
+    return Object.fromEntries(
+      Object.entries(obj)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => [k, sortKeysDeep(v)]),
+    );
+  }
+  return obj;
+}
+
+/**
  * Interface for LLM Config data transfer objects
  */
 export type CreateLlmConfigParams = Omit<
@@ -668,16 +684,10 @@ export class LlmConfigRepository {
       const normalized2 = parseResult2.data;
 
       // Compare normalized configs using deterministic JSON serialization
-      const json1 = JSON.stringify(
-        normalized1,
-        Object.keys(normalized1).sort(),
-        2,
-      );
-      const json2 = JSON.stringify(
-        normalized2,
-        Object.keys(normalized2).sort(),
-        2,
-      );
+      // Deep-sort all keys so nested objects (messages, inputs, outputs)
+      // are compared correctly regardless of property order.
+      const json1 = JSON.stringify(sortKeysDeep(normalized1));
+      const json2 = JSON.stringify(sortKeysDeep(normalized2));
 
       const isEqual = json1 === json2;
 

--- a/langwatch/src/server/prompt-config/transformToDbFormat.ts
+++ b/langwatch/src/server/prompt-config/transformToDbFormat.ts
@@ -65,3 +65,31 @@ export function transformCamelToSnake(
 
   return result;
 }
+
+/**
+ * Transform an object's snake_case keys to camelCase.
+ * Inverse of transformCamelToSnake, used when data arrives in snake_case
+ * (e.g. from the SDK/API) but needs to be passed to methods expecting camelCase.
+ *
+ * @param data - Object with potentially snake_case keys
+ * @returns Object with camelCase keys
+ */
+export function transformSnakeToCamel(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...data };
+  const mapping = buildCamelToSnakeMapping();
+
+  for (const [camelKey, snakeKey] of Object.entries(mapping)) {
+    if (snakeKey in result && result[snakeKey] !== undefined) {
+      result[camelKey] = result[snakeKey];
+      delete result[snakeKey];
+    }
+  }
+
+  // response_format is derived from outputs at read time, never stored directly
+  delete result.responseFormat;
+  delete result.response_format;
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Fixes a bug where `langwatch prompt sync` created a new version every time, even when nothing changed. Three root causes were identified and fixed:

- **Missing sampling parameters in comparison**: `remoteConfigData` only included `temperature` but omitted `max_tokens`, `top_p`, `frequency_penalty`, `presence_penalty`, `seed`, `top_k`, `min_p`, `repetition_penalty`, `reasoning`, `verbosity`. Any prompt with these fields always appeared "changed".
- **Broken nested object comparison**: `JSON.stringify` with an array replacer stripped all nested properties, so messages, inputs, and outputs were compared as `[{}]` — real changes in nested content were invisible.
- **Double `transformToDbFormat` on create path**: The sync create path called `transformToDbFormat` before passing to `createPrompt`, which internally called it again, losing snake_case parameters like `max_tokens`.

## Test plan

- [x] 8 unit tests for `compareConfigContent` covering identical configs, nested diffs, structured outputs, sampling params, and key-order independence
- [x] 3 unit tests for `syncPrompt` covering remoteConfigData completeness, undefined param exclusion, and double-transform prevention
- [x] All 71 prompt-config unit tests pass