### PR TITLE
fix(evaluations-v3): show loading spinner for freshly added evaluator on run all rows

### DIFF
--- a/langwatch/src/evaluations-v3/hooks/__tests__/useExecuteEvaluation.test.tsx
+++ b/langwatch/src/evaluations-v3/hooks/__tests__/useExecuteEvaluation.test.tsx
@@ -1303,6 +1303,61 @@ describe("useExecuteEvaluation", () => {
       });
     });
 
+    describe("when evaluator has never been run (no prior results)", () => {
+      it("sets evaluator results to running status for a brand new evaluator", async () => {
+        setupStore();
+
+        useEvaluationsV3Store.setState((state) => ({
+          ...state,
+          evaluators: [
+            {
+              id: "eval-new",
+              evaluatorType: "langevals/exact_match",
+              settings: {},
+              inputs: [],
+              mappings: {},
+            },
+          ],
+          results: {
+            ...state.results,
+            targetOutputs: {
+              "target-1": [{ output: "Hello" }, { output: "World" }],
+            },
+            targetMetadata: {
+              "target-1": [
+                { cost: 0.01, duration: 100, traceId: "trace-1" },
+                { cost: 0.02, duration: 200, traceId: "trace-2" },
+              ],
+            },
+            // No evaluatorResults for eval-new — it was just added
+            evaluatorResults: {},
+          },
+        }));
+
+        mockFetchSSE.mockImplementation(async () => {
+          await new Promise(() => {});
+        });
+
+        const { result } = renderHook(() => useExecuteEvaluation());
+
+        act(() => {
+          void result.current.runEvaluatorOnAllRows("target-1", "eval-new");
+        });
+
+        await waitFor(() => {
+          const state = useEvaluationsV3Store.getState();
+
+          // eval-new should be set to "running" even though it never had results before
+          expect(
+            state.results.evaluatorResults["target-1"]?.["eval-new"]?.[0],
+          ).toEqual({ status: "running" });
+          expect(
+            state.results.evaluatorResults["target-1"]?.["eval-new"]?.[1],
+          ).toEqual({ status: "running" });
+        });
+      });
+    });
+
     describe("when scope is evaluator (single cell rerun)", () => {
       it("preserves existing target outputs when rerunning evaluator", async () => {
         setupStore();

--- a/langwatch/src/evaluations-v3/hooks/useExecuteEvaluation.ts
+++ b/langwatch/src/evaluations-v3/hooks/useExecuteEvaluation.ts
@@ -483,11 +483,18 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
             const newTargetResults = { ...newEvaluatorResults[cell.targetId] };
             for (const evaluatorId of evaluatorIds) {
               const evalResults = newTargetResults[evaluatorId];
-              if (evalResults && evalResults[cell.rowIndex] !== undefined) {
+              if (isEvaluatorOnlyScope) {
+                // Always set to "running" for evaluator scopes, even if no
+                // prior results exist (freshly added evaluator)
+                const newEvalResults = evalResults ? [...evalResults] : [];
+                newEvalResults[cell.rowIndex] = { status: "running" };
+                newTargetResults[evaluatorId] = newEvalResults;
+              } else if (
+                evalResults &&
+                evalResults[cell.rowIndex] !== undefined
+              ) {
                 const newEvalResults = [...evalResults];
-                newEvalResults[cell.rowIndex] = isEvaluatorOnlyScope
-                  ? { status: "running" }
-                  : undefined;
+                newEvalResults[cell.rowIndex] = undefined;
                 newTargetResults[evaluatorId] = newEvalResults;
               }
             }


### PR DESCRIPTION
## Summary

- When a brand new evaluator (never ran, no prior results) triggers "Run on all rows", the spinners didn't appear because the `execute()` path only updated existing result entries via `evalResults[cell.rowIndex]` — but for a fresh evaluator, `evalResults` was `undefined` so the guard `if (evalResults && ...)` skipped the block entirely
- Now creates the results array and sets `{ status: "running" }` even when no prior results exist

## Test plan

- [x] New test: "sets evaluator results to running status for a brand new evaluator" (was failing before fix, passes after)
- [x] All 22 hook tests pass
- [ ] Manual: Add a new evaluator after targets have output → click "Run on all rows" → spinners appear on all chips