### PR TITLE
feat(prompts): dynamic LLM parameter mapping for Open in Prompts

### DIFF
--- a/langwatch/src/prompts/prompt-playground/__tests__/llmParameterMap.unit.test.ts
+++ b/langwatch/src/prompts/prompt-playground/__tests__/llmParameterMap.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  LLM_PARAMETER_MAP,
+  KNOWN_PARAM_ALIASES,
+} from "../llmParameterMap";
+
+describe("LLM_PARAMETER_MAP", () => {
+  it("has no duplicate formField values", () => {
+    const formFields = LLM_PARAMETER_MAP.map((p) => p.formField);
+    expect(formFields).toEqual([...new Set(formFields)]);
+  });
+
+  it("has no duplicate otelAttr values (ignoring nulls)", () => {
+    const otelAttrs = LLM_PARAMETER_MAP.map((p) => p.otelAttr).filter(
+      (a): a is string => a !== null,
+    );
+    expect(otelAttrs).toEqual([...new Set(otelAttrs)]);
+  });
+
+  it("has no duplicate traceAliases across entries", () => {
+    const allAliases = LLM_PARAMETER_MAP.flatMap((p) => p.traceAliases);
+    expect(allAliases).toEqual([...new Set(allAliases)]);
+  });
+
+  it("has at least one traceAlias per entry", () => {
+    for (const entry of LLM_PARAMETER_MAP) {
+      expect(entry.traceAliases.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("uses only valid coercion types", () => {
+    for (const entry of LLM_PARAMETER_MAP) {
+      expect(["number", "string"]).toContain(entry.coercion);
+    }
+  });
+
+  describe("when checking known parameters", () => {
+    it("includes temperature", () => {
+      const entry = LLM_PARAMETER_MAP.find(
+        (p) => p.formField === "temperature",
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.otelAttr).toBe("gen_ai.request.temperature");
+      expect(entry!.coercion).toBe("number");
+    });
+
+    it("includes reasoning as a string parameter", () => {
+      const entry = LLM_PARAMETER_MAP.find(
+        (p) => p.formField === "reasoning",
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.coercion).toBe("string");
+      expect(entry!.traceAliases).toContain("reasoning_effort");
+    });
+  });
+});
+
+describe("KNOWN_PARAM_ALIASES", () => {
+  it("contains all traceAliases from the map", () => {
+    for (const entry of LLM_PARAMETER_MAP) {
+      for (const alias of entry.traceAliases) {
+        expect(KNOWN_PARAM_ALIASES.has(alias)).toBe(true);
+      }
+    }
+  });
+
+  it("has the correct total count", () => {
+    const expectedCount = LLM_PARAMETER_MAP.reduce(
+      (sum, p) => sum + p.traceAliases.length,
+      0,
+    );
+    expect(KNOWN_PARAM_ALIASES.size).toBe(expectedCount);
+  });
+});

--- a/langwatch/src/prompts/prompt-playground/hooks/__tests__/useLoadSpanIntoPromptPlayground.integration.test.ts
+++ b/langwatch/src/prompts/prompt-playground/hooks/__tests__/useLoadSpanIntoPromptPlayground.integration.test.ts
@@ -19,6 +19,14 @@ function buildSpanData(
       temperature: 0.5,
       maxTokens: 512,
       topP: null,
+      frequencyPenalty: null,
+      presencePenalty: null,
+      seed: null,
+      topK: null,
+      minP: null,
+      repetitionPenalty: null,
+      reasoning: null,
+      verbosity: null,
       litellmParams: {},
       ...overrides,
     },
@@ -148,6 +156,79 @@ describe("createDefaultPromptFormValues()", () => {
       expect(result.version.configData.llm.temperature).toBe(0.3);
       expect(result.version.configData.llm.maxTokens).toBeUndefined();
       expect(result.version.configData.llm.topP).toBe(0.95);
+    });
+  });
+
+  describe("when trace data has all new numeric parameters as strings", () => {
+    it("coerces all string-typed numeric parameters", () => {
+      const spanData = buildSpanData({
+        temperature: "0.7" as unknown as number,
+        maxTokens: "2048" as unknown as number,
+        frequencyPenalty: "0.5" as unknown as number,
+        presencePenalty: "0.3" as unknown as number,
+        seed: "42" as unknown as number,
+        topK: "50" as unknown as number,
+        minP: "0.1" as unknown as number,
+        repetitionPenalty: "1.2" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.temperature).toBe(0.7);
+      expect(result.version.configData.llm.maxTokens).toBe(2048);
+      expect(result.version.configData.llm.frequencyPenalty).toBe(0.5);
+      expect(result.version.configData.llm.presencePenalty).toBe(0.3);
+      expect(result.version.configData.llm.seed).toBe(42);
+      expect(result.version.configData.llm.topK).toBe(50);
+      expect(result.version.configData.llm.minP).toBe(0.1);
+      expect(result.version.configData.llm.repetitionPenalty).toBe(1.2);
+    });
+  });
+
+  describe("when trace data has all null/missing LLM config including new params", () => {
+    it("does not throw and returns valid form values with all params unset", () => {
+      const spanData = buildSpanData({
+        model: null,
+        temperature: null,
+        maxTokens: null,
+        topP: null,
+        frequencyPenalty: null,
+        presencePenalty: null,
+        seed: null,
+        topK: null,
+        minP: null,
+        repetitionPenalty: null,
+        reasoning: null,
+        verbosity: null,
+      });
+
+      expect(() => createDefaultPromptFormValues(spanData)).not.toThrow();
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.model).toBe(DEFAULT_MODEL);
+      expect(result.version.configData.llm.frequencyPenalty).toBeUndefined();
+      expect(result.version.configData.llm.presencePenalty).toBeUndefined();
+      expect(result.version.configData.llm.seed).toBeUndefined();
+      expect(result.version.configData.llm.topK).toBeUndefined();
+      expect(result.version.configData.llm.minP).toBeUndefined();
+      expect(result.version.configData.llm.repetitionPenalty).toBeUndefined();
+      expect(result.version.configData.llm.reasoning).toBeUndefined();
+      expect(result.version.configData.llm.verbosity).toBeUndefined();
+    });
+  });
+
+  describe("when trace data has reasoning and verbosity strings", () => {
+    it("preserves reasoning and verbosity values", () => {
+      const spanData = buildSpanData({
+        reasoning: "high",
+        verbosity: "verbose",
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.reasoning).toBe("high");
+      expect(result.version.configData.llm.verbosity).toBe("verbose");
     });
   });
 });

--- a/langwatch/src/prompts/prompt-playground/hooks/__tests__/useLoadSpanIntoPromptPlayground.unit.test.ts
+++ b/langwatch/src/prompts/prompt-playground/hooks/__tests__/useLoadSpanIntoPromptPlayground.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   createDefaultPromptFormValues,
   coerceToNumber,
+  coerceToString,
 } from "../useLoadSpanIntoPromptPlayground";
 import { DEFAULT_MODEL } from "~/utils/constants";
 import type { RouterOutputs } from "~/utils/api";
@@ -22,6 +23,14 @@ function buildSpanData(
       temperature: 0.5,
       maxTokens: 512,
       topP: null,
+      frequencyPenalty: null,
+      presencePenalty: null,
+      seed: null,
+      topK: null,
+      minP: null,
+      repetitionPenalty: null,
+      reasoning: null,
+      verbosity: null,
       litellmParams: {},
       ...overrides,
     },
@@ -98,6 +107,62 @@ describe("coerceToNumber()", () => {
   });
 });
 
+describe("coerceToString()", () => {
+  describe("when value is a string", () => {
+    it("returns the string as-is", () => {
+      expect(coerceToString("medium")).toBe("medium");
+    });
+
+    it("returns undefined for empty string", () => {
+      expect(coerceToString("")).toBeUndefined();
+    });
+  });
+
+  describe("when value is a number", () => {
+    it("converts a finite number to string", () => {
+      expect(coerceToString(42)).toBe("42");
+    });
+
+    it("returns undefined for NaN", () => {
+      expect(coerceToString(NaN)).toBeUndefined();
+    });
+
+    it("returns undefined for Infinity", () => {
+      expect(coerceToString(Infinity)).toBeUndefined();
+    });
+  });
+
+  describe("when value is a boolean", () => {
+    it("converts true to string", () => {
+      expect(coerceToString(true)).toBe("true");
+    });
+
+    it("converts false to string", () => {
+      expect(coerceToString(false)).toBe("false");
+    });
+  });
+
+  describe("when value is null or undefined", () => {
+    it("returns undefined for null", () => {
+      expect(coerceToString(null)).toBeUndefined();
+    });
+
+    it("returns undefined for undefined", () => {
+      expect(coerceToString(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("when value is an unsupported type", () => {
+    it("returns undefined for object", () => {
+      expect(coerceToString({ value: "foo" })).toBeUndefined();
+    });
+
+    it("returns undefined for array", () => {
+      expect(coerceToString(["foo"])).toBeUndefined();
+    });
+  });
+});
+
 describe("createDefaultPromptFormValues()", () => {
   describe("when maxTokens is null", () => {
     it("creates form values successfully with undefined maxTokens", () => {
@@ -144,6 +209,97 @@ describe("createDefaultPromptFormValues()", () => {
       const result = createDefaultPromptFormValues(spanData);
 
       expect(result.version.configData.llm.model).toBe(DEFAULT_MODEL);
+    });
+  });
+
+  describe("when all numeric parameters are present", () => {
+    it("populates all numeric parameters in the form", () => {
+      const spanData = buildSpanData({
+        temperature: 0.8,
+        maxTokens: 2048,
+        topP: 0.95,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.3,
+        seed: 42,
+        topK: 50,
+        minP: 0.1,
+        repetitionPenalty: 1.2,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.frequencyPenalty).toBe(0.5);
+      expect(result.version.configData.llm.presencePenalty).toBe(0.3);
+      expect(result.version.configData.llm.seed).toBe(42);
+      expect(result.version.configData.llm.topK).toBe(50);
+      expect(result.version.configData.llm.minP).toBe(0.1);
+      expect(result.version.configData.llm.repetitionPenalty).toBe(1.2);
+    });
+  });
+
+  describe("when reasoning effort is present", () => {
+    it("populates the reasoning parameter", () => {
+      const spanData = buildSpanData({ reasoning: "medium" });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.reasoning).toBe("medium");
+    });
+  });
+
+  describe("when string-typed numeric parameters are provided", () => {
+    it("coerces string frequency_penalty to number", () => {
+      const spanData = buildSpanData({
+        frequencyPenalty: "0.5" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.frequencyPenalty).toBe(0.5);
+    });
+  });
+
+  describe("when unknown or garbage parameter values are provided", () => {
+    it("leaves uncoercible parameters unset", () => {
+      const spanData = buildSpanData({
+        temperature: { value: 0.5 } as unknown as number,
+        frequencyPenalty: true as unknown as number,
+        seed: "not-a-number" as unknown as number,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.temperature).toBeUndefined();
+      expect(result.version.configData.llm.frequencyPenalty).toBeUndefined();
+      expect(result.version.configData.llm.seed).toBeUndefined();
+    });
+  });
+
+  describe("when only some parameters are specified", () => {
+    it("populates only temperature and seed", () => {
+      const spanData = buildSpanData({
+        temperature: 0.5,
+        seed: 123,
+        maxTokens: null,
+        topP: null,
+        frequencyPenalty: null,
+        presencePenalty: null,
+        topK: null,
+        minP: null,
+        repetitionPenalty: null,
+        reasoning: null,
+        verbosity: null,
+      });
+
+      const result = createDefaultPromptFormValues(spanData);
+
+      expect(result.version.configData.llm.temperature).toBe(0.5);
+      expect(result.version.configData.llm.seed).toBe(123);
+      expect(result.version.configData.llm.maxTokens).toBeUndefined();
+      expect(result.version.configData.llm.topP).toBeUndefined();
+      expect(result.version.configData.llm.frequencyPenalty).toBeUndefined();
+      expect(result.version.configData.llm.presencePenalty).toBeUndefined();
+      expect(result.version.configData.llm.reasoning).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground.ts
+++ b/langwatch/src/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground.ts
@@ -5,6 +5,7 @@ import { toaster } from "~/components/ui/toaster";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { formSchema } from "~/prompts/schemas";
 import type { PromptConfigFormValues } from "~/prompts/types";
+import { LLM_PARAMETER_MAP } from "~/prompts/prompt-playground/llmParameterMap";
 import type { ChatMessage } from "~/server/tracer/types";
 import { api, type RouterOutputs } from "~/utils/api";
 import { DEFAULT_MODEL } from "~/utils/constants";
@@ -104,6 +105,22 @@ export function coerceToNumber(value: unknown): number | undefined {
 }
 
 /**
+ * Safely coerces a value to a string, returning undefined for anything that
+ * cannot be meaningfully converted. Nulls, undefined, objects, and arrays
+ * are rejected.  Numbers and booleans are converted via String().
+ *
+ * @param value - The value to coerce
+ * @returns The string value, or undefined if coercion is not possible
+ */
+export function coerceToString(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "string") return value === "" ? undefined : value;
+  if (typeof value === "number") return Number.isFinite(value) ? String(value) : undefined;
+  if (typeof value === "boolean") return String(value);
+  return undefined;
+}
+
+/**
  * Creates default form values for a new prompt config.
  * Single Responsibility: Generate initial prompt configuration structure from span data.
  *
@@ -135,19 +152,29 @@ export function createDefaultPromptFormValues(
     logger.warn({ spanData }, "System prompt is empty. This is not expected.");
   }
 
+  // Build LLM config dynamically from the parameter map
+  const llm: Record<string, unknown> = {
+    model: spanData.llmConfig.model || DEFAULT_MODEL,
+  };
+
+  for (const param of LLM_PARAMETER_MAP) {
+    const raw = (spanData.llmConfig as Record<string, unknown>)[
+      param.formField
+    ];
+    const coerced =
+      param.coercion === "number" ? coerceToNumber(raw) : coerceToString(raw);
+    if (coerced !== undefined) {
+      llm[param.formField] = coerced;
+    }
+  }
+
   return formSchema.parse({
     handle: null,
     scope: "PROJECT",
     version: {
       configData: {
         prompt: systemPrompt,
-        llm: {
-          // The model should always be available here, but we fall back to the default model if it's not.
-          model: spanData.llmConfig.model || DEFAULT_MODEL,
-          temperature: coerceToNumber(spanData.llmConfig.temperature),
-          maxTokens: coerceToNumber(spanData.llmConfig.maxTokens),
-          topP: coerceToNumber(spanData.llmConfig.topP),
-        },
+        llm,
         inputs: [],
         outputs: [{ identifier: "output", type: "str" }],
         messages: [{ role: "system", content: systemPrompt }],

--- a/langwatch/src/prompts/prompt-playground/llmParameterMap.ts
+++ b/langwatch/src/prompts/prompt-playground/llmParameterMap.ts
@@ -1,0 +1,108 @@
+/**
+ * Declarative mapping between playground form fields, OTel GenAI semantic
+ * convention attributes, and legacy trace parameter aliases.
+ *
+ * Each entry describes one LLM parameter that the "Open in Prompts" flow
+ * knows how to extract from trace data and populate in the playground form.
+ *
+ * - `formField`     – key used in `PromptStudioSpanResult.llmConfig` and the
+ *                     playground form's `llm` object.
+ * - `otelAttr`      – OTel `gen_ai.request.*` attribute name stored in
+ *                     ClickHouse span attributes.  `null` when no OTel
+ *                     convention exists for this parameter.
+ * - `traceAliases`  – legacy / SDK-specific key names found in Elasticsearch
+ *                     `span.params`.  First match wins.
+ * - `coercion`      – target type for the form field ("number" or "string").
+ */
+
+export type ParamCoercion = "number" | "string";
+
+export interface LlmParameterMapping {
+  formField: string;
+  otelAttr: string | null;
+  traceAliases: string[];
+  coercion: ParamCoercion;
+}
+
+export const LLM_PARAMETER_MAP: readonly LlmParameterMapping[] = [
+  {
+    formField: "temperature",
+    otelAttr: "gen_ai.request.temperature",
+    traceAliases: ["temperature"],
+    coercion: "number",
+  },
+  {
+    formField: "maxTokens",
+    otelAttr: "gen_ai.request.max_tokens",
+    traceAliases: ["max_tokens", "maxTokens"],
+    coercion: "number",
+  },
+  {
+    formField: "topP",
+    otelAttr: "gen_ai.request.top_p",
+    traceAliases: ["top_p", "topP"],
+    coercion: "number",
+  },
+  {
+    formField: "frequencyPenalty",
+    otelAttr: "gen_ai.request.frequency_penalty",
+    traceAliases: ["frequency_penalty", "frequencyPenalty"],
+    coercion: "number",
+  },
+  {
+    formField: "presencePenalty",
+    otelAttr: "gen_ai.request.presence_penalty",
+    traceAliases: ["presence_penalty", "presencePenalty"],
+    coercion: "number",
+  },
+  {
+    formField: "seed",
+    otelAttr: "gen_ai.request.seed",
+    traceAliases: ["seed"],
+    coercion: "number",
+  },
+  {
+    formField: "topK",
+    otelAttr: null,
+    traceAliases: ["top_k", "topK"],
+    coercion: "number",
+  },
+  {
+    formField: "minP",
+    otelAttr: null,
+    traceAliases: ["min_p", "minP"],
+    coercion: "number",
+  },
+  {
+    formField: "repetitionPenalty",
+    otelAttr: null,
+    traceAliases: ["repetition_penalty", "repetitionPenalty"],
+    coercion: "number",
+  },
+  {
+    formField: "reasoning",
+    otelAttr: null,
+    traceAliases: [
+      "reasoning",
+      "reasoning_effort",
+      "thinkingLevel",
+      "effort",
+    ],
+    coercion: "string",
+  },
+  {
+    formField: "verbosity",
+    otelAttr: null,
+    traceAliases: ["verbosity"],
+    coercion: "string",
+  },
+];
+
+/**
+ * Set of all known trace-level parameter alias names.
+ * Used by the Elasticsearch extractor to separate known LLM parameters
+ * (mapped to dedicated fields) from unknown ones (placed in `litellmParams`).
+ */
+export const KNOWN_PARAM_ALIASES = new Set(
+  LLM_PARAMETER_MAP.flatMap((p) => p.traceAliases),
+);

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -18,6 +18,7 @@ import type {
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { generateClickHouseFilterConditions } from "~/server/filters/clickhouse";
 import type { Span, Trace } from "~/server/tracer/types";
+import { LLM_PARAMETER_MAP } from "~/prompts/prompt-playground/llmParameterMap";
 import { createLogger } from "~/utils/logger/server";
 import {
   applyTraceProtections,
@@ -955,12 +956,33 @@ export class ClickHouseTraceService {
       (attrs["gen_ai.request.model"] as string) ??
       (attrs["llm.model"] as string) ??
       null;
-    const temperature = (attrs["gen_ai.request.temperature"] as number) ?? null;
-    const maxTokens = (attrs["gen_ai.request.max_tokens"] as number) ?? null;
-    const topP = (attrs["gen_ai.request.top_p"] as number) ?? null;
     const vendor = (attrs["gen_ai.system"] as string) ?? null;
 
-    const systemPrompt = messages.find((m) => m.role === "system")?.content;
+    // Build llmConfig dynamically from the parameter map
+    const llmConfig: PromptStudioSpanResult["llmConfig"] = {
+      model,
+      systemPrompt: messages.find((m) => m.role === "system")?.content,
+      temperature: null,
+      maxTokens: null,
+      topP: null,
+      frequencyPenalty: null,
+      presencePenalty: null,
+      seed: null,
+      topK: null,
+      minP: null,
+      repetitionPenalty: null,
+      reasoning: null,
+      verbosity: null,
+      litellmParams: {},
+    };
+
+    for (const param of LLM_PARAMETER_MAP) {
+      if (param.otelAttr === null) continue;
+      const raw = attrs[param.otelAttr];
+      if (raw != null) {
+        (llmConfig as Record<string, unknown>)[param.formField] = raw;
+      }
+    }
 
     // Extract metrics
     const promptTokens = attrs["gen_ai.usage.prompt_tokens"] as
@@ -985,14 +1007,7 @@ export class ClickHouseTraceService {
       traceId: row.TraceId,
       spanName: row.SpanName ?? null,
       messages,
-      llmConfig: {
-        model,
-        systemPrompt,
-        temperature,
-        maxTokens,
-        topP,
-        litellmParams: {},
-      },
+      llmConfig,
       vendor,
       error,
       timestamps: {

--- a/langwatch/src/server/traces/elasticsearch-trace.service.ts
+++ b/langwatch/src/server/traces/elasticsearch-trace.service.ts
@@ -22,6 +22,10 @@ import type {
   LLMSpan,
   Trace,
 } from "~/server/tracer/types";
+import {
+  LLM_PARAMETER_MAP,
+  KNOWN_PARAM_ALIASES,
+} from "~/prompts/prompt-playground/llmParameterMap";
 import type {
   AggregationFiltersInput,
   CustomersAndLabelsResult,
@@ -530,22 +534,43 @@ export class ElasticsearchTraceService {
       messages.push({ role: "assistant", content });
     }
 
-    // Extract LLM config
+    // Extract LLM config dynamically from the parameter map
     const params = span.params ?? {};
     const systemPrompt = messages.find((m) => m.role === "system")?.content;
-    const litellmParams: Record<string, unknown> = {};
 
-    const excludeKeys = new Set([
-      "temperature",
-      "max_tokens",
-      "maxTokens",
-      "top_p",
-      "topP",
-      "_keys",
-    ]);
+    const llmConfig: PromptStudioSpanResult["llmConfig"] = {
+      model: span.model ?? null,
+      systemPrompt,
+      temperature: null,
+      maxTokens: null,
+      topP: null,
+      frequencyPenalty: null,
+      presencePenalty: null,
+      seed: null,
+      topK: null,
+      minP: null,
+      repetitionPenalty: null,
+      reasoning: null,
+      verbosity: null,
+      litellmParams: {},
+    };
+
+    for (const param of LLM_PARAMETER_MAP) {
+      // First matching alias wins
+      for (const alias of param.traceAliases) {
+        if (alias in params && params[alias] != null) {
+          (llmConfig as Record<string, unknown>)[param.formField] =
+            params[alias];
+          break;
+        }
+      }
+    }
+
+    // Collect unknown params into litellmParams
+    const excludeKeys = new Set([...KNOWN_PARAM_ALIASES, "_keys"]);
     for (const [key, value] of Object.entries(params)) {
       if (!excludeKeys.has(key)) {
-        litellmParams[key] = value;
+        llmConfig.litellmParams[key] = value;
       }
     }
 
@@ -554,14 +579,7 @@ export class ElasticsearchTraceService {
       traceId: trace.trace_id,
       spanName: span.name ?? null,
       messages,
-      llmConfig: {
-        model: span.model ?? null,
-        systemPrompt,
-        temperature: (params.temperature as number) ?? null,
-        maxTokens: ((params.max_tokens ?? params.maxTokens) as number) ?? null,
-        topP: ((params.top_p ?? params.topP) as number) ?? null,
-        litellmParams,
-      },
+      llmConfig,
       vendor: span.vendor ?? null,
       error: span.error ?? null,
       timestamps: span.timestamps,

--- a/langwatch/src/server/traces/types.ts
+++ b/langwatch/src/server/traces/types.ts
@@ -82,6 +82,14 @@ export interface PromptStudioSpanResult {
     temperature: number | null;
     maxTokens: number | null;
     topP: number | null;
+    frequencyPenalty: number | null;
+    presencePenalty: number | null;
+    seed: number | null;
+    topK: number | null;
+    minP: number | null;
+    repetitionPenalty: number | null;
+    reasoning: string | null;
+    verbosity: string | null;
     litellmParams: Record<string, unknown>;
   };
   vendor: string | null;

--- a/specs/prompts/open-trace-in-playground.feature
+++ b/specs/prompts/open-trace-in-playground.feature
@@ -6,10 +6,7 @@ Feature: Open trace in Playground
   Background:
     Given a project with traced LLM calls
 
-  # The bridge function converts trace data (which uses null for absent values)
-  # into form values (which use undefined for absent values).
-  # Fix approach: null-to-undefined coercion at the bridge, matching existing
-  # temperature pattern. The Zod schema and form value types stay unchanged.
+  # --- Existing: basic null-to-undefined coercion ---
 
   @unit
   Scenario: Trace without max tokens specified opens in Playground
@@ -39,3 +36,76 @@ Feature: Open trace in Playground
     Given the traced LLM call did not specify a model
     When I open the trace in the Playground
     Then the Playground loads with the default model
+
+  # --- Dynamic parameter mapping from trace to playground ---
+
+  # The trace-to-playground bridge should extract ALL known LLM parameters
+  # from trace data — not just temperature/maxTokens/topP. Parameters come
+  # from OTel GenAI semantic conventions (gen_ai.request.*) and are stored
+  # as span attributes. The bridge uses a declarative parameter map to
+  # convert trace attribute names → playground form field names with the
+  # appropriate type coercion (number or string).
+  #
+  # The playground form schema already supports all these parameters.
+  # The model registry (llmModels.json + custom models) defines which
+  # parameters each model supports — the UI uses that to show/hide controls,
+  # but the bridge should extract everything available from the trace
+  # regardless of model support.
+
+  @unit
+  Scenario: Trace with all OTel numeric parameters maps them to the playground
+    Given the traced LLM call includes frequency_penalty, presence_penalty, seed, top_k, min_p, and repetition_penalty
+    When I open the trace in the Playground
+    Then all numeric parameters are populated in the playground form
+    And no validation errors occur
+
+  @unit
+  Scenario: Trace with reasoning effort maps it to the playground
+    Given the traced LLM call includes a reasoning effort parameter
+    When I open the trace in the Playground
+    Then the reasoning parameter is populated in the playground form
+
+  @unit
+  Scenario: Trace with string-typed numeric parameters coerces them
+    Given the traced LLM call has temperature as string "0.7"
+    And the traced LLM call has max_tokens as string "2048"
+    And the traced LLM call has frequency_penalty as string "0.5"
+    When I open the trace in the Playground
+    Then all values are coerced to their correct numeric types
+
+  @unit
+  Scenario: Trace with unknown or garbage parameter values skips them gracefully
+    Given the traced LLM call has temperature as an object
+    And the traced LLM call has frequency_penalty as boolean true
+    And the traced LLM call has seed as string "not-a-number"
+    When I open the trace in the Playground
+    Then the Playground loads without validation errors
+    And uncoercible parameters are left unset
+
+  @unit
+  Scenario: Trace with only some parameters populates only those
+    Given the traced LLM call specifies only temperature and seed
+    When I open the trace in the Playground
+    Then temperature and seed are populated
+    And all other parameters are left unset
+
+  # --- Backend extraction: ClickHouse and Elasticsearch ---
+
+  @integration
+  Scenario: ClickHouse backend extracts all OTel gen_ai.request attributes
+    Given a span stored in ClickHouse with gen_ai.request.* attributes for all supported parameters
+    When the getForPromptStudio API is called
+    Then all parameters are returned in the llmConfig response
+
+  @integration
+  Scenario: Elasticsearch backend extracts all parameters from span params
+    Given a span stored in Elasticsearch with LLM params for all supported parameters
+    When the getForPromptStudio API is called
+    Then all parameters are returned in the llmConfig response
+
+  @integration
+  Scenario: Extra unknown parameters from traces go into litellmParams
+    Given a span with non-standard parameters like custom_param or vendor_specific_setting
+    When the getForPromptStudio API is called
+    Then unknown parameters appear in litellmParams
+    And known parameters appear in their dedicated fields


### PR DESCRIPTION
## Summary

- **Problem:** "Open in Prompts" only extracted 3 LLM params (temperature, maxTokens, topP) from traces. Modern models use many more (reasoning effort, frequency_penalty, seed, top_k, etc.) that were lost when opening a trace in the playground.
- **Solution:** Declarative `LLM_PARAMETER_MAP` — a single const array that maps OTel attributes + trace aliases → playground form fields with type coercion. Adding a new parameter = adding one entry to the array.
- **Scope:** 4 layers updated: API types, ClickHouse extractor, Elasticsearch extractor, frontend bridge function

### Changes
- New `llmParameterMap.ts` with 11 parameter entries (6 OTel-backed + 5 trace-only)
- Expanded `PromptStudioSpanResult.llmConfig` with 8 new fields
- Both extractors now loop over the map instead of hardcoding field names
- Bridge function applies `coerceToNumber()` / `coerceToString()` per map entry
- Auto-derived exclude set for litellmParams (no manual maintenance)

### Reasoning effort
The Python SDK already captures `reasoning_effort` in span params (OpenAI + LiteLLM). The parameter map includes aliases for `reasoning`, `reasoning_effort`, `thinkingLevel`, and `effort` to handle all vendor variants.

## Test plan
- [x] 9 unit tests for parameter map (no duplicates, valid structure)
- [x] 35 unit tests for bridge function + coercion utilities
- [x] 13 integration tests for end-to-end form value creation
- [x] All 57 tests passing