### PR TITLE
fix(mcp): fetch spans for ClickHouse traces in search_traces

### DIFF
--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Protections } from "~/server/elasticsearch/protections";
+import type { GetAllTracesForProjectInput } from "../types";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const { mockClickHouseQuery, mockPrismaFindUnique } = vi.hoisted(() => ({
+  mockClickHouseQuery: vi.fn(),
+  mockPrismaFindUnique: vi.fn(),
+}));
+
+vi.mock("~/server/clickhouse/client", () => ({
+  getClickHouseClient: () => ({ query: mockClickHouseQuery }),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {},
+}));
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (
+      _name: string,
+      ...args: unknown[]
+    ) => {
+      const fn = args.length === 1 ? args[0] : args[1];
+      const span = { setAttribute: () => {} };
+      return (fn as (span: { setAttribute: () => void }) => Promise<unknown>)(span);
+    },
+  }),
+}));
+
+// Stub the filter module to return empty conditions
+vi.mock("~/server/filters/clickhouse", () => ({
+  generateClickHouseFilterConditions: () => ({
+    conditions: [],
+    params: {},
+    hasUnsupportedFilters: false,
+  }),
+}));
+
+describe("ClickHouseTraceService", () => {
+  const protections: Protections = {
+    canSeeCosts: true,
+    canSeePiiData: true,
+    canSeeTopics: true,
+  } as Protections;
+
+  const baseInput = {
+    projectId: "proj_123",
+    startDate: Date.now() - 86400000,
+    endDate: Date.now(),
+    pageSize: 2,
+    pageOffset: 0,
+  } as GetAllTracesForProjectInput;
+
+  // A minimal trace summary row from ClickHouse
+  const makeSummaryRow = (traceId: string) => ({
+    ts_TraceId: traceId,
+    ts_SpanCount: 1,
+    ts_TotalDurationMs: 100,
+    ts_ComputedIOSchemaVersion: 1,
+    ts_ComputedInput: '{"type":"text","value":"hello"}',
+    ts_ComputedOutput: '{"type":"text","value":"world"}',
+    ts_TimeToFirstTokenMs: 10,
+    ts_TimeToLastTokenMs: 90,
+    ts_TokensPerSecond: 5,
+    ts_ContainsErrorStatus: false,
+    ts_ContainsOKStatus: true,
+    ts_ErrorMessage: "",
+    ts_Models: ["gpt-4"],
+    ts_TotalCost: 0.01,
+    ts_TokensEstimated: false,
+    ts_TotalPromptTokenCount: 10,
+    ts_TotalCompletionTokenCount: 20,
+    ts_TopicId: "",
+    ts_SubTopicId: "",
+    ts_HasAnnotation: false,
+    ts_Attributes: {},
+    ts_OccurredAt: Date.now(),
+    ts_CreatedAt: Date.now(),
+    ts_UpdatedAt: Date.now(),
+  });
+
+  // A minimal span row from ClickHouse stored_spans table
+  const makeSpanRow = (traceId: string, spanId: string) => ({
+    SpanId: spanId,
+    TraceId: traceId,
+    TenantId: "proj_123",
+    ParentSpanId: null,
+    ParentTraceId: null,
+    ParentIsRemote: null,
+    Sampled: true,
+    StartTime: Date.now(),
+    EndTime: Date.now() + 100,
+    DurationMs: 100,
+    SpanName: "test-span",
+    SpanKind: 1,
+    ResourceAttributes: {},
+    SpanAttributes: {},
+    StatusCode: 1,
+    StatusMessage: "",
+    ScopeName: "test",
+    ScopeVersion: "1.0",
+    Events_Timestamp: [],
+    Events_Name: [],
+    Events_Attributes: [],
+    Links_TraceId: [],
+    Links_SpanId: [],
+    Links_Attributes: [],
+  });
+
+  let ClickHouseTraceService: typeof import("../clickhouse-trace.service").ClickHouseTraceService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockPrismaFindUnique.mockResolvedValue({
+      featureClickHouseDataSourceTraces: true,
+    });
+
+    // Dynamic import to get fresh module after mocks are set
+    const mod = await import("../clickhouse-trace.service");
+    ClickHouseTraceService = mod.ClickHouseTraceService;
+  });
+
+  describe("getAllTracesForProject()", () => {
+    describe("when includeSpans is false or not provided", () => {
+      it("returns traces with empty spans", async () => {
+        const summaryRow = makeSummaryRow("trace-1");
+
+        // First call: count query
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: "1" }]),
+          })
+          // Second call: summary query
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([summaryRow]),
+          })
+          // Third call: evaluation query
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          baseInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        const traces = result!.groups.flat();
+        expect(traces).toHaveLength(1);
+        expect(traces[0]!.spans).toEqual([]);
+      });
+    });
+
+    describe("when includeSpans is true", () => {
+      it("fetches and attaches spans to traces", async () => {
+        const summaryRow = makeSummaryRow("trace-1");
+        const spanRow = makeSpanRow("trace-1", "span-1");
+
+        mockClickHouseQuery
+          // 1st call: count query (fetchTracesWithPagination)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: "1" }]),
+          })
+          // 2nd call: summary query (fetchTracesWithPagination)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([summaryRow]),
+          })
+          // 3rd call: trace summary query (fetchTracesWithSpansJoined - summaries)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([summaryRow]),
+          })
+          // 4th call: spans query (fetchTracesWithSpansJoined - spans)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([spanRow]),
+          })
+          // 5th call: evaluation query
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          baseInput,
+          protections,
+          { includeSpans: true },
+        );
+
+        expect(result).not.toBeNull();
+        const traces = result!.groups.flat();
+        expect(traces).toHaveLength(1);
+        expect(traces[0]!.spans).toHaveLength(1);
+        expect(traces[0]!.spans[0]!.span_id).toBe("span-1");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace.service.unit.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Protections } from "~/server/elasticsearch/protections";
+import type { Trace } from "~/server/tracer/types";
+import type { GetAllTracesForProjectInput } from "../types";
+import { TraceService } from "../trace.service";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const {
+  mockGetAllTracesForProjectCH,
+  mockIsClickHouseEnabled,
+  mockGetAllTracesForProjectES,
+} = vi.hoisted(() => ({
+  mockGetAllTracesForProjectCH: vi.fn(),
+  mockIsClickHouseEnabled: vi.fn(),
+  mockGetAllTracesForProjectES: vi.fn(),
+}));
+
+const mockClickHouseInstance = {
+  isClickHouseEnabled: mockIsClickHouseEnabled,
+  getAllTracesForProject: mockGetAllTracesForProjectCH,
+};
+
+const mockElasticInstance = {
+  getAllTracesForProject: mockGetAllTracesForProjectES,
+};
+
+const mockEvalInstance = {
+  isClickHouseEnabled: vi.fn().mockResolvedValue(false),
+};
+
+vi.mock("../clickhouse-trace.service", () => ({
+  ClickHouseTraceService: Object.assign(vi.fn(), {
+    create: () => mockClickHouseInstance,
+  }),
+}));
+
+vi.mock("../elasticsearch-trace.service", () => ({
+  ElasticsearchTraceService: Object.assign(vi.fn(), {
+    create: () => mockElasticInstance,
+  }),
+}));
+
+vi.mock("~/server/evaluations/evaluation.service", () => ({
+  EvaluationService: Object.assign(vi.fn(), {
+    create: () => mockEvalInstance,
+  }),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {},
+}));
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: (
+      _name: string,
+      _opts: unknown,
+      fn: (span: { setAttribute: () => void }) => Promise<unknown>
+    ) => fn({ setAttribute: () => {} }),
+  }),
+}));
+
+describe("TraceService", () => {
+  const mockPrisma = {} as never;
+  let service: TraceService;
+
+  const protections: Protections = {
+    canSeeCosts: true,
+    canSeePiiData: true,
+    canSeeTopics: true,
+  } as Protections;
+
+  const input = {
+    projectId: "proj_123",
+    startDate: Date.now() - 86400000,
+    endDate: Date.now(),
+    pageSize: 10,
+    pageOffset: 0,
+  } as GetAllTracesForProjectInput;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TraceService(mockPrisma);
+  });
+
+  describe("getAllTracesForProject()", () => {
+    describe("when ClickHouse is enabled", () => {
+      beforeEach(() => {
+        mockIsClickHouseEnabled.mockResolvedValue(true);
+      });
+
+      it("passes options to the ClickHouse service", async () => {
+        const options = { includeSpans: true };
+        mockGetAllTracesForProjectCH.mockResolvedValue({
+          groups: [],
+          totalHits: 0,
+          traceChecks: {},
+        });
+
+        await service.getAllTracesForProject(input, protections, options);
+
+        expect(mockGetAllTracesForProjectCH).toHaveBeenCalledWith(
+          input,
+          protections,
+          options,
+        );
+      });
+
+      it("passes empty options when none provided", async () => {
+        mockGetAllTracesForProjectCH.mockResolvedValue({
+          groups: [],
+          totalHits: 0,
+          traceChecks: {},
+        });
+
+        await service.getAllTracesForProject(input, protections);
+
+        expect(mockGetAllTracesForProjectCH).toHaveBeenCalledWith(
+          input,
+          protections,
+          {},
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -370,6 +370,7 @@ export class ClickHouseTraceService {
   async getAllTracesForProject(
     input: GetAllTracesForProjectInput,
     protections: Protections,
+    options: { includeSpans?: boolean } = {},
   ): Promise<TracesForProjectResult | null> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.getAllTracesForProject",
@@ -456,7 +457,7 @@ export class ClickHouseTraceService {
           }
 
           // Build the query with keyset pagination
-          const { traces, totalHits, lastTrace } =
+          let { traces, totalHits, lastTrace } =
             await this.fetchTracesWithPagination(
               input.projectId,
               pageSize,
@@ -468,6 +469,15 @@ export class ClickHouseTraceService {
               filterConditions,
               filterParams,
             );
+
+          // When includeSpans is requested, fetch and attach actual spans
+          if (options.includeSpans && traces.length > 0) {
+            traces = await this.enrichTracesWithSpans(
+              traces,
+              input.projectId,
+              protections,
+            );
+          }
 
           // Generate new scrollId from last trace
           let newScrollId: string | undefined;
@@ -1321,6 +1331,39 @@ export class ClickHouseTraceService {
     }
 
     return Array.from(groups.values());
+  }
+
+  /**
+   * Enrich traces (which have empty spans) with actual span data from ClickHouse.
+   *
+   * Fetches spans via fetchTracesWithSpansJoined and replaces the empty span
+   * arrays on each trace with the real spans. Traces whose spans are not found
+   * are returned unchanged (with empty spans).
+   *
+   * @internal
+   */
+  private async enrichTracesWithSpans(
+    traces: Trace[],
+    projectId: string,
+    protections: Protections,
+  ): Promise<Trace[]> {
+    const traceIds = traces.map((t) => t.trace_id);
+    const tracesWithSpans = await this.fetchTracesWithSpansJoined(
+      projectId,
+      traceIds,
+    );
+
+    return traces.map((trace) => {
+      const data = tracesWithSpans.get(trace.trace_id);
+      if (!data || data.spans.length === 0) {
+        return trace;
+      }
+      const mappedSpans = mapNormalizedSpansToSpans(data.spans);
+      return applyTraceProtections(
+        mapTraceSummaryToTrace(data.summary, mappedSpans, projectId),
+        protections,
+      );
+    });
   }
 
   /**

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -237,6 +237,7 @@ export class TraceService {
           const result = await this.clickHouseService.getAllTracesForProject(
             input,
             protections,
+            options,
           );
           if (result === null) {
             throw new Error(


### PR DESCRIPTION
## Summary

- **search_traces showed "No spans recorded"**: The `ClickHouseTraceService.getAllTracesForProject()` didn't accept or use the `options` parameter (with `includeSpans` flag). `TraceService` wasn't passing it either. Traces were always mapped with empty spans arrays.
- Added `enrichTracesWithSpans()` method that reuses the existing `fetchTracesWithSpansJoined()` to fetch actual spans from `stored_spans` when `includeSpans: true`
- Default behavior (UI list view) unchanged — spans only fetched when explicitly requested (digest format)

## Test plan

- [x] 2 new unit tests for TraceService options passthrough (`trace.service.unit.test.ts`)
- [x] 2 new unit tests for ClickHouseTraceService span enrichment (`clickhouse-trace.service.unit.test.ts`)
- [x] All 60 tests passing (56 previous + 4 new)