### PR TITLE
fix(typescript-sdk): make langchain and instrumentation peer deps optional

### DIFF
--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -130,6 +130,17 @@
         "@opentelemetry/sdk-trace-web": ">=1.19.0 <3.0.0",
         "langchain": ">=0.3.0 <2.0.0"
     },
+    "peerDependenciesMeta": {
+        "@ai-sdk/openai": { "optional": true },
+        "@langchain/core": { "optional": true },
+        "@langchain/langgraph": { "optional": true },
+        "@langchain/openai": { "optional": true },
+        "@opentelemetry/context-async-hooks": { "optional": true },
+        "@opentelemetry/context-zone": { "optional": true },
+        "@opentelemetry/sdk-node": { "optional": true },
+        "@opentelemetry/sdk-trace-web": { "optional": true },
+        "langchain": { "optional": true }
+    },
     "pnpm": {
         "overrides": {
             "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary
- **Root cause**: `langchain`, `@langchain/core`, `@langchain/langgraph`, `@langchain/openai`, and other instrumentation-only dependencies were listed as **required** `peerDependencies`. Anyone installing `langwatch` was forced to resolve them, even if they never use langchain.
- **The conflict**: `langchain@1.2.30` requires `@langchain/core@^1.1.31`, but `langwatch` declares `@langchain/core@>=0.3.0 <1.0.0` as a peer dep → npm ERESOLVE failure.
- **Fix**: Added `peerDependenciesMeta` marking all instrumentation-only peer deps as `optional: true`. Only `@opentelemetry/api` remains required (it's needed by the core SDK).
- **Temporary workaround**: Python SDK E2E tests pass `npm_config_legacy_peer_deps=true` when calling `npx langwatch@latest` since they install the published 0.17.0 which doesn't have this fix yet. Can be removed after next TS SDK release.

## Test plan
- [ ] `sdk-python-ci / test` e2e tests pass (the 2 ERESOLVE failures)
- [ ] `sdk-typescript-ci` tests still pass
- [ ] After next TS SDK release, verify `npx langwatch@latest` works without legacy-peer-deps