### PR TITLE
fix(prompts): pin 'input' variable first in sorted inputs list

### DIFF
--- a/langwatch/src/server/prompt-config/__tests__/mergeAutoDetectedInputs.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/mergeAutoDetectedInputs.unit.test.ts
@@ -134,12 +134,23 @@ describe("mergeAutoDetectedInputs()", () => {
         const identifiers = result.map((i) => i.identifier);
         expect(identifiers).toEqual(["alpha", "middle", "zebra"]);
       });
+
+      it("pins 'input' first, then sorts the rest alphabetically", () => {
+        const result = mergeAutoDetectedInputs({
+          prompt: "{{zebra}} {{input}} {{alpha}}",
+          messages: [],
+          inputs: [],
+        });
+
+        const identifiers = result.map((i) => i.identifier);
+        expect(identifiers).toEqual(["input", "alpha", "zebra"]);
+      });
     });
   });
 
   describe("given a CLI default input that does not appear in template", () => {
     describe("when merging", () => {
-      it("keeps the CLI default input alongside auto-detected variables", () => {
+      it("keeps the CLI default input first, then auto-detected variables", () => {
         const result = mergeAutoDetectedInputs({
           prompt: "hello {{name}}",
           messages: [],
@@ -147,8 +158,7 @@ describe("mergeAutoDetectedInputs()", () => {
         });
 
         const identifiers = result.map((i) => i.identifier);
-        expect(identifiers).toContain("input");
-        expect(identifiers).toContain("name");
+        expect(identifiers).toEqual(["input", "name"]);
       });
     });
   });
@@ -185,8 +195,9 @@ describe("mergeAutoDetectedInputs()", () => {
           expect(input.type).toBe("str");
         }
 
-        // Should be sorted alphabetically
-        expect(identifiers).toEqual([...identifiers].sort());
+        // "input" should be first, then the rest alphabetically
+        expect(identifiers[0]).toBe("input");
+        expect(identifiers.slice(1)).toEqual([...identifiers.slice(1)].sort());
       });
     });
   });

--- a/langwatch/src/server/prompt-config/mergeAutoDetectedInputs.ts
+++ b/langwatch/src/server/prompt-config/mergeAutoDetectedInputs.ts
@@ -13,7 +13,8 @@ interface PromptInput {
  * - Extracts variables from the `prompt` field and all `messages[*].content`
  * - Explicit inputs preserve their type (e.g., "json" is not overwritten to "str")
  * - New auto-detected variables default to type "str"
- * - Result is sorted alphabetically by identifier for deterministic ordering
+ * - The locked "input" variable always sorts first
+ * - Remaining inputs are sorted alphabetically for deterministic ordering
  */
 export function mergeAutoDetectedInputs({
   prompt,
@@ -59,8 +60,12 @@ export function mergeAutoDetectedInputs({
     }
   }
 
-  // Convert to array and sort alphabetically by identifier
+  // Convert to array and sort: "input" first (locked variable), then alphabetically
   return Array.from(mergedMap.entries())
     .map(([identifier, type]) => ({ identifier, type }))
-    .sort((a, b) => a.identifier.localeCompare(b.identifier));
+    .sort((a, b) => {
+      if (a.identifier === "input") return -1;
+      if (b.identifier === "input") return 1;
+      return a.identifier.localeCompare(b.identifier);
+    });
 }

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -698,9 +698,11 @@ export class PromptService {
       model: existingPrompt.model,
       prompt: existingPrompt.prompt,
       messages: existingPrompt.messages.filter((msg) => msg.role !== "system"),
-      inputs: [...existingPrompt.inputs].sort((a, b) =>
-        a.identifier.localeCompare(b.identifier),
-      ),
+      inputs: [...existingPrompt.inputs].sort((a, b) => {
+        if (a.identifier === "input") return -1;
+        if (b.identifier === "input") return 1;
+        return a.identifier.localeCompare(b.identifier);
+      }),
       outputs: existingPrompt.outputs,
       // response_format is derived from outputs, not stored separately
       // Include all sampling parameters only when defined


### PR DESCRIPTION
## Summary

The locked "input" variable was being sorted alphabetically alongside other variables, placing it after `bar`, `baz`, `foo` etc. in the UI. Since "input" is a fixed/locked variable, it should always appear first.

**Fix:** Updated the sort comparator in both `mergeAutoDetectedInputs()` and the `remoteConfigData.inputs` sort in `syncPrompt()` to pin "input" first, then sort the rest alphabetically.

## Test plan

- [x] New test: "pins 'input' first, then sorts the rest alphabetically" 
- [x] Updated test: "keeps the CLI default input first, then auto-detected variables"
- [x] Updated test: complex real-world prompt verifies "input" is first
- [x] All 11 mergeAutoDetectedInputs tests pass