### PR TITLE
fix: trace details drawer cannot be closed

### DIFF
--- a/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -421,6 +421,7 @@ export function ScenarioRunDetailDrawer({
         onOpenChange={() => setTraceDrawerTraceId(null)}
         placement="end"
         size="xl"
+        modal={true}
       >
         <Drawer.Content paddingX={0} maxWidth="70%">
           <Drawer.CloseTrigger zIndex={10} />


### PR DESCRIPTION
## Summary
- Fixes the trace details drawer in the Scenario Run Detail view not responding to any close mechanism (X button, Escape key, clicking outside)
- Root cause: the `DrawerRoot` wrapper defaults to `modal={false}`, which disables close interactions for locally-managed child drawers
- Fix: add `modal={true}` to the child trace drawer's `Drawer.Root` to override the non-modal default

Closes #2201

## Test plan
- [ ] Open a scenario run detail drawer
- [ ] Click on a trace to open the child trace details drawer
- [ ] Verify the X button closes the drawer
- [ ] Verify pressing Escape closes the drawer
- [ ] Verify clicking outside (on the backdrop) closes the drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2201