### PR TITLE
fix(suites): remove stale x/n format from header counts and sidebar

### DIFF
--- a/langwatch/src/components/suites/SuiteSidebar.tsx
+++ b/langwatch/src/components/suites/SuiteSidebar.tsx
@@ -384,7 +384,7 @@ function RunSummaryLine({
     <HStack gap={1}>
       <StatusIcon passed={passedCount} total={totalCount} />
       <Text fontSize="xs">
-        {passedCount}/{totalCount} passed
+        {passedCount} passed
         {lastRunTimestamp && (
           <Text as="span" color="fg.muted">
             {" · "}

--- a/langwatch/src/components/suites/__tests__/BatchSection.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/BatchSection.integration.test.tsx
@@ -77,7 +77,7 @@ describe("<BatchSection/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("passed (2/2)")).toBeInTheDocument();
+      expect(screen.getByText("passed")).toBeInTheDocument();
       expect(screen.queryByText("100%")).not.toBeInTheDocument();
     });
 

--- a/langwatch/src/components/suites/__tests__/ExternalSetsSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ExternalSetsSidebar.integration.test.tsx
@@ -126,7 +126,7 @@ describe("<SuiteSidebar/> External Sets", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText(/15\/20 passed/)).toBeInTheDocument();
+      expect(screen.getByText(/15 passed/)).toBeInTheDocument();
     });
 
     it("does not display a Run button on external set items", () => {

--- a/langwatch/src/components/suites/__tests__/GroupRow.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/GroupRow.integration.test.tsx
@@ -72,7 +72,7 @@ describe("<GroupRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("failed (4/5)")).toBeInTheDocument();
+      expect(screen.getByText("failed")).toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/components/suites/__tests__/RunHistoryGroupBy.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunHistoryGroupBy.integration.test.tsx
@@ -203,7 +203,7 @@ describe("<GroupRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("failed (1/2)")).toBeInTheDocument();
+      expect(screen.getByText("failed")).toBeInTheDocument();
       expect(screen.getAllByText("2 runs").length).toBeGreaterThanOrEqual(1);
     });
 
@@ -286,7 +286,7 @@ describe("<GroupRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("failed (2/3)")).toBeInTheDocument();
+      expect(screen.getByText("failed")).toBeInTheDocument();
       expect(screen.getAllByText("3 runs").length).toBeGreaterThanOrEqual(1);
     });
   });
@@ -385,7 +385,7 @@ describe("<GroupRow/>", () => {
       );
 
       const batchHeader = screen.getByTestId("batch-sub-header");
-      expect(within(batchHeader).getByText("passed (1/1)")).toBeInTheDocument();
+      expect(within(batchHeader).getByText("passed")).toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/components/suites/__tests__/RunRow.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunRow.integration.test.tsx
@@ -38,7 +38,7 @@ describe("<RunRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("passed (2/2)")).toBeInTheDocument();
+      expect(screen.getByText("passed")).toBeInTheDocument();
       expect(screen.queryByText("100%")).not.toBeInTheDocument();
     });
 
@@ -182,7 +182,7 @@ describe("<RunRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("failed (2/3)")).toBeInTheDocument();
+      expect(screen.getByText("failed")).toBeInTheDocument();
     });
   });
 
@@ -341,7 +341,7 @@ describe("<RunRow/>", () => {
         { wrapper: Wrapper },
       );
 
-      expect(screen.getByText("failed (8/10)")).toBeInTheDocument();
+      expect(screen.getByText("failed")).toBeInTheDocument();
       expect(screen.getByText("8 passed")).toBeInTheDocument();
       expect(screen.getByText("2 failed")).toBeInTheDocument();
     });

--- a/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
@@ -235,7 +235,7 @@ describe("<SuiteSidebar/>", () => {
         ],
       ]);
 
-      it("displays pass count and total", () => {
+      it("displays pass count", () => {
         render(
           <SuiteSidebar
             {...defaultProps}
@@ -245,7 +245,7 @@ describe("<SuiteSidebar/>", () => {
           { wrapper: Wrapper },
         );
 
-        expect(screen.getByText(/8\/8 passed/)).toBeInTheDocument();
+        expect(screen.getByText(/8 passed/)).toBeInTheDocument();
       });
 
       it("displays a checkmark status icon", () => {
@@ -287,7 +287,7 @@ describe("<SuiteSidebar/>", () => {
         ],
       ]);
 
-      it("displays pass count and total showing the gap", () => {
+      it("displays pass count", () => {
         render(
           <SuiteSidebar
             {...defaultProps}
@@ -297,7 +297,7 @@ describe("<SuiteSidebar/>", () => {
           { wrapper: Wrapper },
         );
 
-        expect(screen.getByText(/9\/12 passed/)).toBeInTheDocument();
+        expect(screen.getByText(/9 passed/)).toBeInTheDocument();
       });
 
       it("displays an error status icon", () => {
@@ -363,7 +363,7 @@ describe("<SuiteSidebar/>", () => {
           { wrapper: Wrapper },
         );
 
-        expect(screen.getByText(/7\/8 passed/)).toBeInTheDocument();
+        expect(screen.getByText(/7 passed/)).toBeInTheDocument();
 
         const updatedSummaries = new Map([
           [
@@ -386,8 +386,8 @@ describe("<SuiteSidebar/>", () => {
           </Wrapper>,
         );
 
-        expect(screen.getByText(/8\/8 passed/)).toBeInTheDocument();
-        expect(screen.queryByText(/7\/8 passed/)).not.toBeInTheDocument();
+        expect(screen.getByText(/8 passed/)).toBeInTheDocument();
+        expect(screen.queryByText(/7 passed/)).not.toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/suites/__tests__/formatRunStatusLabel.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/formatRunStatusLabel.unit.test.ts
@@ -162,23 +162,23 @@ describe("formatSummaryStatusLabel()", () => {
   });
 
   describe("when all scenarios passed", () => {
-    it("returns 'passed' with scenario count", () => {
+    it("returns 'passed' without x/n count", () => {
       const result = formatSummaryStatusLabel(makeSummary({
         passedCount: 5,
         totalCount: 5,
       }));
-      expect(result).toBe("passed (5/5)");
+      expect(result).toBe("passed");
     });
   });
 
   describe("when some scenarios failed", () => {
-    it("returns 'failed' with passed/finished count", () => {
+    it("returns 'failed' without x/n count", () => {
       const result = formatSummaryStatusLabel(makeSummary({
         passedCount: 3,
         failedCount: 2,
         totalCount: 5,
       }));
-      expect(result).toBe("failed (3/5)");
+      expect(result).toBe("failed");
     });
   });
 
@@ -200,26 +200,26 @@ describe("formatSummaryStatusLabel()", () => {
   });
 
   describe("when some scenarios are stalled", () => {
-    it("includes stalled in finished count", () => {
+    it("returns 'failed' without x/n count", () => {
       const result = formatSummaryStatusLabel(makeSummary({
         passedCount: 2,
         failedCount: 1,
         stalledCount: 1,
         totalCount: 4,
       }));
-      expect(result).toBe("failed (2/4)");
+      expect(result).toBe("failed");
     });
   });
 
   describe("when some are finished and some still running", () => {
-    it("shows only finished scenarios in count", () => {
+    it("returns 'passed' without x/n count", () => {
       const result = formatSummaryStatusLabel(makeSummary({
         passedCount: 3,
         failedCount: 0,
         inProgressCount: 2,
         totalCount: 5,
       }));
-      expect(result).toBe("passed (3/3)");
+      expect(result).toBe("passed");
     });
   });
 });

--- a/langwatch/src/components/suites/format-run-status-label.ts
+++ b/langwatch/src/components/suites/format-run-status-label.ts
@@ -1,9 +1,10 @@
 /**
- * Pure formatting function for scenario run status labels.
+ * Pure formatting functions for scenario run status labels.
  *
- * Converts raw status + evaluation results into a human-readable label
- * like "passed (4/5)" or "failed (3/5)". Non-terminal statuses return
- * their existing labels unchanged.
+ * Converts raw status + evaluation results into human-readable labels.
+ * Individual run labels include criteria counts (e.g. "passed (4/5)").
+ * Summary labels return simple "passed" or "failed" without counts,
+ * since counts are displayed separately by RunSummaryCounts.
  *
  * @see specs/features/suites/suite-list-view-status.feature
  */
@@ -67,11 +68,11 @@ export function formatRunStatusLabel({
 }
 
 /**
- * Formats a batch/group summary into a display label with scenario counts.
+ * Formats a batch/group summary into a simple status label.
  *
- * Shows "passed (4/5)" or "failed (3/5)" where the numbers represent
- * how many scenarios passed out of total finished scenarios.
+ * Returns "passed" or "failed" based on whether any scenarios failed.
  * Non-terminal summaries (all in-progress) return "running".
+ * Counts are displayed separately by RunSummaryCounts.
  */
 export function formatSummaryStatusLabel(summary: RunGroupSummary): string {
   const finishedCount =
@@ -85,6 +86,5 @@ export function formatSummaryStatusLabel(summary: RunGroupSummary): string {
     return "pending";
   }
 
-  const label = summary.failedCount > 0 ? "failed" : "passed";
-  return `${label} (${summary.passedCount}/${finishedCount})`;
+  return summary.failedCount > 0 ? "failed" : "passed";
 }


### PR DESCRIPTION
## Summary
- Removes the misleading `x/n` count format from `formatSummaryStatusLabel()` — now returns just `"passed"` or `"failed"` instead of `"passed (4/5)"`
- Removes `x/n` format from `RunSummaryLine` in sidebar — now shows `"8 passed"` instead of `"8/8 passed"`
- Counts are already handled by the `RunSummaryCounts` component, so the duplicate display was both stale and incorrect

## Root Cause
The `x/n` denominator used `finishedCount` (only completed runs) instead of `totalCount`, so launching 36 runs would show `24/36` until all runs finished processing.

Closes #2236

## Test plan
- [x] Updated unit tests for `formatSummaryStatusLabel` (18 tests pass)
- [x] Updated 6 integration test files for affected components
- [x] All 414 suite tests pass

## Browser Test: suites-header-counts

| # | Scenario | Result | Screenshot |
|---|----------|--------|------------|
| 1 | Sign in to app | PASS | \![01](https://i.img402.dev/fin8ln2qwm.png) |
| 2 | Navigate to Suites page | PASS | \![02](https://i.img402.dev/91yg98d71w.png) |
| 3 | Suites page with data | SKIPPED (fresh account) | \![03](https://i.img402.dev/qip0vipcqv.png) |

> Note: x/n format fix confirmed by 414 passing unit/integration tests. Fresh test account has no suite data for visual verification of counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)