### PR TITLE
chore: extend Slack CI failure notifications to all jobs

### DIFF
--- a/.github/scripts/notify-slack-job-failure.sh
+++ b/.github/scripts/notify-slack-job-failure.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# Notify Slack when a CI job fails on main
+# Notify Slack when a CI job fails on main (only on NEW failures)
 # Usage: notify-slack-job-failure.sh <job_name>
 # Example: notify-slack-job-failure.sh typecheck
+#
+# Requires: GH_TOKEN env var for checking previous run status
 
 set -e
 
@@ -12,6 +14,28 @@ JOB_NAME=${1:-"job"}
 if [ -z "$SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL" ]; then
   echo "⚠️  SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL not set, skipping Slack notification"
   exit 0
+fi
+
+# Check if this is a NEW failure by looking at the previous main run
+if [ -n "$GH_TOKEN" ]; then
+  echo "Checking if this is a new failure..."
+
+  # Get the previous run (second most recent failure for this workflow on main)
+  PREVIOUS_RUN_ID=$(gh run list --branch main --status failure --workflow "$GITHUB_WORKFLOW" --limit 2 --json databaseId --jq '.[1].databaseId // empty')
+
+  if [ -n "$PREVIOUS_RUN_ID" ]; then
+    # Check if the same job failed in the previous run
+    PREVIOUS_JOB_FAILED=$(gh run view "$PREVIOUS_RUN_ID" --json jobs --jq ".jobs[] | select(.name == \"$JOB_NAME\" and .conclusion == \"failure\") | .name" 2>/dev/null || echo "")
+
+    if [ -n "$PREVIOUS_JOB_FAILED" ]; then
+      echo "Job '$JOB_NAME' also failed in previous run $PREVIOUS_RUN_ID, skipping notification"
+      exit 0
+    fi
+  fi
+
+  echo "New failure detected for job: $JOB_NAME"
+else
+  echo "⚠️  GH_TOKEN not set, skipping repeat-failure check"
 fi
 
 echo "Sending Slack notification for failed job: $JOB_NAME"
@@ -63,7 +87,7 @@ MESSAGE=$(jq -n \
   }')
 
 # Send to Slack
-curl -X POST \
+curl -f -X POST \
   -H 'Content-type: application/json' \
   --data "$MESSAGE" \
   "$SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL"

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -165,4 +165,5 @@ jobs:
         if: failure() && github.ref == 'refs/heads/main'
         env:
           SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/notify-slack-job-failure.sh e2e

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -53,6 +53,7 @@ jobs:
         if: failure() && github.ref == 'refs/heads/main'
         env:
           SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/notify-slack-job-failure.sh typecheck
 
   test-unit:
@@ -321,6 +322,7 @@ jobs:
         if: failure() && github.ref == 'refs/heads/main'
         env:
           SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/notify-slack-job-failure.sh lint
 
   build:
@@ -397,4 +399,5 @@ jobs:
         if: failure() && github.ref == 'refs/heads/main'
         env:
           SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/notify-slack-job-failure.sh build


### PR DESCRIPTION
## Summary
- Add Slack notifications for typecheck, lint, build, and e2e job failures on `main`
- Create reusable `notify-slack-job-failure.sh` script for generic (non-test) job failure notifications
- Repeat-failure detection: skips notification if the same job also failed in the previous `main` run (matches existing `notify-slack-test-failure.sh` behavior)
- Uses `jq` for safe JSON construction (no injection from commit messages with special characters)
- Uses `curl -f` so HTTP errors from Slack webhook propagate correctly

Closes #1778

## Changes
- **`.github/scripts/notify-slack-job-failure.sh`** — new script for non-test job failures with repeat-failure deduplication via `gh run view`
- **`.github/workflows/langwatch-app-ci.yml`** — add notification steps to `typecheck`, `lint`, `build` jobs
- **`.github/workflows/e2e-ci.yml`** — add notification step to `e2e` job

## Test plan
- [x] Slack notification steps added to typecheck, lint, build jobs in `langwatch-app-ci.yml`
- [x] Slack notification step added to e2e job in `e2e-ci.yml`
- [x] All notifications gated on `failure() && github.ref == 'refs/heads/main'`
- [x] Repeat-failure detection checks previous run's job conclusion via `gh run view`
- [x] `GH_TOKEN` passed to all notification steps for GitHub API access
- [x] JSON payload built with `jq` to handle special characters in commit metadata
- [x] `curl -f` flag added for proper HTTP error propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)