### PR TITLE
fix(scenarios): auto-update suites UI on dedupe via SSE invalidation

### DIFF
--- a/langwatch/src/components/suites/RunHistoryPanel.tsx
+++ b/langwatch/src/components/suites/RunHistoryPanel.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ScenarioRunData } from "~/server/scenarios/scenario-event.types";
 import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { useSimulationUpdateListener } from "~/hooks/useSimulationUpdateListener";
 import { useTargetNameMap } from "~/hooks/useTargetNameMap";
 import { useDrawer } from "~/hooks/useDrawer";
 import { api } from "~/utils/api";
@@ -131,6 +132,14 @@ export function RunHistoryPanel({
       refetchInterval: pages.length <= 1 ? 5000 : undefined,
     },
   );
+
+  // Subscribe to real-time SSE updates so the panel refreshes on simulation
+  // events (e.g. deduplicated runs) regardless of pagination state.
+  useSimulationUpdateListener({
+    projectId: project?.id ?? "",
+    enabled: !!project,
+    filter: scenarioSetId ? { scenarioSetId } : undefined,
+  });
 
   // Accumulate pages as data arrives
   useEffect(() => {

--- a/langwatch/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts
@@ -32,12 +32,18 @@ vi.mock("../usePageVisibility", () => ({
   usePageVisibility: () => mockIsVisible,
 }));
 
+const mockInvalidateBatchHistory = vi.fn();
+const mockInvalidateSuiteRunData = vi.fn();
+
 vi.mock("../../utils/api", () => ({
   api: {
     useContext: () => ({
       scenarios: {
         getScenarioSetBatchHistory: {
-          invalidate: vi.fn(),
+          invalidate: mockInvalidateBatchHistory,
+        },
+        getSuiteRunData: {
+          invalidate: mockInvalidateSuiteRunData,
         },
       },
     }),
@@ -249,6 +255,38 @@ describe("useSimulationUpdateListener()", () => {
       });
 
       expect(refetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when an SSE event fires", () => {
+    it("invalidates getSuiteRunData so RunHistoryPanel refreshes", () => {
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          refetch: refetchSpy,
+        }),
+      );
+
+      act(() => {
+        simulateSSEEvent({ event: "simulation_updated" });
+      });
+
+      expect(mockInvalidateSuiteRunData).toHaveBeenCalledTimes(1);
+    });
+
+    it("invalidates getScenarioSetBatchHistory for sidebar refresh", () => {
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          refetch: refetchSpy,
+        }),
+      );
+
+      act(() => {
+        simulateSSEEvent({ event: "simulation_updated" });
+      });
+
+      expect(mockInvalidateBatchHistory).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/langwatch/src/hooks/useSimulationUpdateListener.ts
+++ b/langwatch/src/hooks/useSimulationUpdateListener.ts
@@ -76,6 +76,8 @@ export function useSimulationUpdateListener({
 
     // Invalidate sidebar batch history queries so they refetch too
     void trpcUtils.scenarios.getScenarioSetBatchHistory.invalidate();
+    // Invalidate suite run data queries so RunHistoryPanel refreshes
+    void trpcUtils.scenarios.getSuiteRunData.invalidate();
 
     if (refetch) {
       void refetch();


### PR DESCRIPTION
## Summary
- Add `useSimulationUpdateListener` to `RunHistoryPanel` so scenario runs refresh via SSE events when deduplication occurs, instead of relying solely on polling that stops after pagination
- Invalidate `getSuiteRunData` in the SSE listener alongside the existing `getScenarioSetBatchHistory` invalidation
- Add regression tests confirming both queries are invalidated on SSE events

Closes #2255

## Root cause
The Suites page and `RunHistoryPanel` component didn't use `useSimulationUpdateListener` for real-time SSE updates (the old Simulations page did). Additionally, `useSimulationUpdateListener` only invalidated `getScenarioSetBatchHistory`, not `getSuiteRunData`. Polling in `RunHistoryPanel` also stops after the user paginates past page 1.

## Changes
- **`langwatch/src/hooks/useSimulationUpdateListener.ts`** — Added `getSuiteRunData.invalidate()` to the `fireUpdate` callback
- **`langwatch/src/components/suites/RunHistoryPanel.tsx`** — Added `useSimulationUpdateListener()` hook with optional `scenarioSetId` filter
- **`langwatch/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts`** — Added 2 regression tests

## Test plan
- [x] Regression tests pass (11/11 in useSimulationUpdateListener)
- [x] Typecheck passes (all errors are pre-existing Prisma client issues)
- [x] Browser verification: Suites page renders correctly with all UI elements

## Browser Test: dedupe-auto-update

| # | Scenario | Result | Screenshot |
|---|----------|--------|------------|
| 1 | Sign in to app | PASS | ![02](https://i.img402.dev/1wh3d491uh.png) |
| 2 | Navigate to Suites page | PASS | ![03](https://i.img402.dev/scuibgp2j5.png) |
| 3 | Suites page renders correctly | PASS | ![03](https://i.img402.dev/scuibgp2j5.png) |
| 4 | Runs page data loading | PARTIAL (ClickHouse not in lite dev) | ![04](https://i.img402.dev/hnzv0dcpt3.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2255