### PR TITLE
feat(event-sourcing): hierarchical group keys to eliminate cross-type queue contention

### DIFF
--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -116,7 +116,10 @@ export class ProjectionRouter<
 
     const reactorDefs: Record<string, {
       name: string;
+      parentProjection: string;
+      parentType: "fold" | "map";
       handler: { handle: (payload: { event: EventType; foldState: unknown }) => Promise<void> };
+      groupKeyFn?: (payload: { event: EventType; foldState: unknown }) => string;
       options?: {
         killSwitch?: KillSwitchOptions;
         disabled?: boolean;
@@ -125,11 +128,13 @@ export class ProjectionRouter<
       };
     }> = {};
 
-    for (const [_foldName, reactors] of this.reactorsForFold) {
+    for (const [foldName, reactors] of this.reactorsForFold) {
       for (const reactor of reactors) {
         if (this.isReactorExcluded(reactor)) continue;
         reactorDefs[reactor.name] = {
           name: reactor.name,
+          parentProjection: foldName,
+          parentType: "fold" as const,
           handler: {
             handle: async (payload: { event: EventType; foldState: unknown }) => {
               await reactor.handle(payload.event, {
@@ -139,6 +144,7 @@ export class ProjectionRouter<
               });
             },
           },
+          groupKeyFn: reactor.options?.groupKeyFn,
           options: {
             killSwitch: reactor.options?.killSwitch,
             disabled: reactor.options?.disabled,
@@ -151,11 +157,13 @@ export class ProjectionRouter<
       }
     }
 
-    for (const [_mapName, reactors] of this.reactorsForMap) {
+    for (const [mapName, reactors] of this.reactorsForMap) {
       for (const reactor of reactors) {
         if (this.isReactorExcluded(reactor)) continue;
         reactorDefs[reactor.name] = {
           name: reactor.name,
+          parentProjection: mapName,
+          parentType: "map" as const,
           handler: {
             handle: async (payload: { event: EventType; foldState: unknown }) => {
               await reactor.handle(payload.event, {
@@ -165,6 +173,7 @@ export class ProjectionRouter<
               });
             },
           },
+          groupKeyFn: reactor.options?.groupKeyFn,
           options: {
             killSwitch: reactor.options?.killSwitch,
             disabled: reactor.options?.disabled,

--- a/langwatch/src/server/event-sourcing/reactors/reactor.types.ts
+++ b/langwatch/src/server/event-sourcing/reactors/reactor.types.ts
@@ -25,6 +25,8 @@ export interface ReactorOptions {
   makeJobId?: (payload: { event: Event; foldState: unknown }) => string;
   /** Process roles where this reactor runs. Omit to run everywhere. */
   runIn?: ProcessRole[];
+  /** Custom group key function for queue routing. Overrides the domain part of the hierarchical key. */
+  groupKeyFn?: (payload: { event: Event; foldState: unknown }) => string;
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.commandGroupKey.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.commandGroupKey.test.ts
@@ -136,7 +136,7 @@ describe("QueueManager.initializeCommandQueues with getGroupKey", () => {
 
       const groupKey = entry?.groupKeyFn(payload);
       expect(groupKey).toBe(
-        `${tenantId}:${aggregateType}:exp1:run1:item:42`,
+        `${tenantId}/command/recordResult/${aggregateType}:exp1:run1:item:42`,
       );
     });
   });
@@ -174,7 +174,7 @@ describe("QueueManager.initializeCommandQueues with getGroupKey", () => {
       };
 
       const groupKey = entry?.groupKeyFn(payload);
-      expect(groupKey).toBe(`${tenantId}:${aggregateType}:exp1:run1`);
+      expect(groupKey).toBe(`${tenantId}/command/startRun/${aggregateType}:exp1:run1`);
     });
   });
 
@@ -220,7 +220,7 @@ describe("QueueManager.initializeCommandQueues with getGroupKey", () => {
       };
 
       const groupKey = entry?.groupKeyFn(payload);
-      expect(groupKey).toBe(`${tenantId}:${aggregateType}:custom:exp1:run1`);
+      expect(groupKey).toBe(`${tenantId}/command/recordResult/${aggregateType}:custom:exp1:run1`);
     });
   });
 });
@@ -281,7 +281,7 @@ describe("QueueManager.initializeHandlerQueues with groupKeyFn", () => {
       };
 
       const groupKey = entry?.groupKeyFn(event);
-      expect(groupKey).toBe(`${tenantId}:result:run1:item:5`);
+      expect(groupKey).toBe(`${tenantId}/map/resultStorage/result:run1:item:5`);
     });
   });
 
@@ -322,7 +322,7 @@ describe("QueueManager.initializeHandlerQueues with groupKeyFn", () => {
 
       const groupKey = entry?.groupKeyFn(event);
       expect(groupKey).toBe(
-        `${tenantId}:${aggregateType}:exp1:run1`,
+        `${tenantId}/map/resultStorage/${aggregateType}:exp1:run1`,
       );
     });
   });

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.groupKeyFn.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.groupKeyFn.test.ts
@@ -64,7 +64,7 @@ describe("QueueManager.initializeProjectionQueues with groupKeyFn", () => {
         tenantId,
       );
       const groupKey = entry?.groupKeyFn(event);
-      expect(groupKey).toBe(`${tenantId}:by-tenant:${tenantId}`);
+      expect(groupKey).toBe(`${tenantId}/fold/myProjection/by-tenant:${tenantId}`);
     });
   });
 
@@ -104,7 +104,7 @@ describe("QueueManager.initializeProjectionQueues with groupKeyFn", () => {
       );
       const groupKey = entry?.groupKeyFn(event);
       expect(groupKey).toBe(
-        `${tenantId}:${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+        `${tenantId}/fold/myProjection/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
       );
     });
   });
@@ -154,13 +154,13 @@ describe("QueueManager.initializeProjectionQueues with groupKeyFn", () => {
       // Custom projection uses its custom groupKeyFn
       const customEntry = globalJobRegistry.get("test-pipeline:projection:customProjection");
       const customGroupKey = customEntry?.groupKeyFn(event);
-      expect(customGroupKey).toBe(`${tenantId}:custom:${event.id}`);
+      expect(customGroupKey).toBe(`${tenantId}/fold/customProjection/custom:${event.id}`);
 
       // Default projection uses aggregate-based groupKey
       const defaultEntry = globalJobRegistry.get("test-pipeline:projection:defaultProjection");
       const defaultGroupKey = defaultEntry?.groupKeyFn(event);
       expect(defaultGroupKey).toBe(
-        `${tenantId}:${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+        `${tenantId}/fold/defaultProjection/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
       );
     });
   });

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.reactorGroupKey.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.reactorGroupKey.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Event } from "../../../domain/types";
+import type { EventSourcedQueueProcessor } from "../../../queues";
+import {
+  createTestAggregateType,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../__tests__/testHelpers";
+import type { JobRegistryEntry } from "../queueManager";
+import { QueueManager } from "../queueManager";
+
+function createMockSharedQueue(): EventSourcedQueueProcessor<any> {
+  return {
+    send: vi.fn().mockResolvedValue(void 0),
+    sendBatch: vi.fn().mockResolvedValue(void 0),
+    close: vi.fn().mockResolvedValue(void 0),
+    waitUntilReady: vi.fn().mockResolvedValue(void 0),
+  };
+}
+
+describe("QueueManager.initializeReactorQueues with hierarchical group keys", () => {
+  const aggregateType = createTestAggregateType();
+  const tenantId = createTestTenantId();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("when reactor has fold parent", () => {
+    it("includes parent fold name in hierarchical group key", () => {
+      const mockQueueProcessor = createMockSharedQueue();
+      const globalJobRegistry = new Map<string, JobRegistryEntry>();
+
+      const manager = new QueueManager({
+        aggregateType,
+        pipelineName: "test-pipeline",
+        globalQueue: mockQueueProcessor,
+        globalJobRegistry,
+      });
+
+      manager.initializeReactorQueues(
+        {
+          evaluationTrigger: {
+            name: "evaluationTrigger",
+            parentProjection: "traceSummary",
+            parentType: "fold" as const,
+            handler: { handle: vi.fn().mockResolvedValue(void 0) },
+          },
+        },
+        vi.fn(),
+      );
+
+      const entry = globalJobRegistry.get("test-pipeline:reactor:evaluationTrigger");
+      const event = createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType,
+        tenantId,
+      );
+
+      const groupKey = entry?.groupKeyFn({ event, foldState: {} });
+      expect(groupKey).toBe(
+        `${tenantId}/fold/traceSummary/reactor/evaluationTrigger/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+      );
+    });
+  });
+
+  describe("when reactor has map parent", () => {
+    it("includes parent map name in hierarchical group key", () => {
+      const mockQueueProcessor = createMockSharedQueue();
+      const globalJobRegistry = new Map<string, JobRegistryEntry>();
+
+      const manager = new QueueManager({
+        aggregateType,
+        pipelineName: "test-pipeline",
+        globalQueue: mockQueueProcessor,
+        globalJobRegistry,
+      });
+
+      manager.initializeReactorQueues(
+        {
+          spanStorageBroadcast: {
+            name: "spanStorageBroadcast",
+            parentProjection: "spanStorage",
+            parentType: "map" as const,
+            handler: { handle: vi.fn().mockResolvedValue(void 0) },
+          },
+        },
+        vi.fn(),
+      );
+
+      const entry = globalJobRegistry.get("test-pipeline:reactor:spanStorageBroadcast");
+      const event = createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType,
+        tenantId,
+      );
+
+      const groupKey = entry?.groupKeyFn({ event, foldState: {} });
+      expect(groupKey).toBe(
+        `${tenantId}/map/spanStorage/reactor/spanStorageBroadcast/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+      );
+    });
+  });
+
+  describe("when reactor has custom groupKeyFn", () => {
+    it("uses custom groupKeyFn for domain part of hierarchical key", () => {
+      const mockQueueProcessor = createMockSharedQueue();
+      const globalJobRegistry = new Map<string, JobRegistryEntry>();
+
+      const manager = new QueueManager({
+        aggregateType,
+        pipelineName: "test-pipeline",
+        globalQueue: mockQueueProcessor,
+        globalJobRegistry,
+      });
+
+      const customGroupKeyFn = (payload: { event: Event; foldState: unknown }) =>
+        `custom:${(payload.event as any).data?.runId}`;
+
+      manager.initializeReactorQueues(
+        {
+          customReactor: {
+            name: "customReactor",
+            parentProjection: "traceSummary",
+            parentType: "fold" as const,
+            handler: { handle: vi.fn().mockResolvedValue(void 0) },
+            groupKeyFn: customGroupKeyFn,
+          },
+        },
+        vi.fn(),
+      );
+
+      const entry = globalJobRegistry.get("test-pipeline:reactor:customReactor");
+      const event = {
+        ...createTestEvent(TEST_CONSTANTS.AGGREGATE_ID, aggregateType, tenantId),
+        data: { runId: "run-42" },
+      };
+
+      const groupKey = entry?.groupKeyFn({ event, foldState: {} });
+      expect(groupKey).toBe(
+        `${tenantId}/fold/traceSummary/reactor/customReactor/custom:run-42`,
+      );
+    });
+  });
+
+  describe("when multiple reactors share a fold parent", () => {
+    it("produces different group keys for different reactors on same aggregate", () => {
+      const mockQueueProcessor = createMockSharedQueue();
+      const globalJobRegistry = new Map<string, JobRegistryEntry>();
+
+      const manager = new QueueManager({
+        aggregateType,
+        pipelineName: "test-pipeline",
+        globalQueue: mockQueueProcessor,
+        globalJobRegistry,
+      });
+
+      manager.initializeReactorQueues(
+        {
+          evaluationTrigger: {
+            name: "evaluationTrigger",
+            parentProjection: "traceSummary",
+            parentType: "fold" as const,
+            handler: { handle: vi.fn().mockResolvedValue(void 0) },
+          },
+          customEvalSync: {
+            name: "customEvalSync",
+            parentProjection: "traceSummary",
+            parentType: "fold" as const,
+            handler: { handle: vi.fn().mockResolvedValue(void 0) },
+          },
+        },
+        vi.fn(),
+      );
+
+      const event = createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        aggregateType,
+        tenantId,
+      );
+      const payload = { event, foldState: {} };
+
+      const evalTriggerEntry = globalJobRegistry.get("test-pipeline:reactor:evaluationTrigger");
+      const customSyncEntry = globalJobRegistry.get("test-pipeline:reactor:customEvalSync");
+
+      const evalKey = evalTriggerEntry?.groupKeyFn(payload);
+      const syncKey = customSyncEntry?.groupKeyFn(payload);
+
+      // Same aggregate, different reactors → different group keys (no FIFO contention)
+      expect(evalKey).not.toBe(syncKey);
+      expect(evalKey).toBe(
+        `${tenantId}/fold/traceSummary/reactor/evaluationTrigger/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+      );
+      expect(syncKey).toBe(
+        `${tenantId}/fold/traceSummary/reactor/customEvalSync/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.test.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/__tests__/queueManager.test.ts
@@ -68,9 +68,15 @@ function createMockReactorDefinition(
     delay?: number;
     deduplication?: DeduplicationStrategy<{ event: Event; foldState: unknown }>;
   },
+  parent?: {
+    parentProjection: string;
+    parentType: "fold" | "map";
+  },
 ) {
   return {
     name,
+    parentProjection: parent?.parentProjection ?? "defaultFold",
+    parentType: parent?.parentType ?? ("fold" as const),
     handler: {
       handle: vi.fn().mockResolvedValue(void 0),
     },
@@ -225,18 +231,18 @@ describe("QueueManager", () => {
         tenantId,
       );
 
-      // Handler job groupKey
+      // Handler job groupKey — hierarchical: tenantId/map/name/domainKey
       const handlerEntry = globalJobRegistry.get("test-pipeline:handler:h1");
       const handlerGroupKey = handlerEntry?.groupKeyFn(event);
       expect(handlerGroupKey).toBe(
-        `${tenantId}:${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+        `${tenantId}/map/h1/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
       );
 
-      // Projection job groupKey
+      // Projection job groupKey — hierarchical: tenantId/fold/name/domainKey
       const projectionEntry = globalJobRegistry.get("test-pipeline:projection:p1");
       const projectionGroupKey = projectionEntry?.groupKeyFn(event);
       expect(projectionGroupKey).toBe(
-        `${tenantId}:${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+        `${tenantId}/fold/p1/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
       );
     });
 
@@ -700,7 +706,7 @@ describe("QueueManager", () => {
       );
     });
 
-    it("uses default groupKey based on aggregate for projections", () => {
+    it("uses hierarchical groupKey based on aggregate for projections", () => {
       const mockQueueProcessor = createMockSharedQueue();
       const globalJobRegistry = new Map<string, JobRegistryEntry>();
 
@@ -726,7 +732,7 @@ describe("QueueManager", () => {
       );
       const groupKey = entry?.groupKeyFn(event);
       expect(groupKey).toBe(
-        `${tenantId}:${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+        `${tenantId}/fold/projection1/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
       );
     });
   });
@@ -999,7 +1005,7 @@ describe("QueueManager", () => {
       );
     });
 
-    it("reactor groupKey uses event fields", () => {
+    it("reactor groupKey uses hierarchical format with parent projection", () => {
       const mockQueueProcessor = createMockSharedQueue();
       const globalJobRegistry = new Map<string, JobRegistryEntry>();
 
@@ -1011,7 +1017,7 @@ describe("QueueManager", () => {
       });
 
       manager.initializeReactorQueues(
-        { reactor1: createMockReactorDefinition("reactor1") },
+        { reactor1: createMockReactorDefinition("reactor1", undefined, { parentProjection: "traceSummary", parentType: "fold" }) },
         vi.fn(),
       );
 
@@ -1027,7 +1033,7 @@ describe("QueueManager", () => {
         foldState: {},
       });
       expect(groupKey).toBe(
-        `${tenantId}:${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
+        `${tenantId}/fold/traceSummary/reactor/reactor1/${aggregateType}:${TEST_CONSTANTS.AGGREGATE_ID}`,
       );
     });
 

--- a/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
@@ -85,6 +85,25 @@ export class QueueManager<EventType extends Event = Event> {
     return `${String(event.tenantId)}:${event.aggregateType}:${String(event.aggregateId)}`;
   }
 
+  /**
+   * Builds a hierarchical group key function: `${tenantId}/${jobPath}/${domainKey}`.
+   *
+   * - jobPath reflects the pipeline topology (e.g. `fold/traceSummary/reactor/evaluationTrigger`)
+   * - domainKey defaults to `${aggregateType}:${aggregateId}`, overridable via custom fn
+   */
+  private buildGroupKey({
+    jobPath,
+    getTenantId,
+    domainKeyFn,
+  }: {
+    jobPath: string;
+    getTenantId: (payload: any) => string;
+    domainKeyFn: (payload: any) => string;
+  }): (payload: any) => string {
+    return (payload: any) =>
+      `${getTenantId(payload)}/${jobPath}/${domainKeyFn(payload)}`;
+  }
+
   private key(
     type: "handler" | "projection" | "command" | "reactor",
     name: string,
@@ -213,9 +232,13 @@ export class QueueManager<EventType extends Event = Event> {
       }
 
       const customGroupKeyFn = handlerDef.options.groupKeyFn;
-      const groupKeyFn = customGroupKeyFn
-        ? (event: any) => `${String(event.tenantId)}:${customGroupKeyFn(event)}`
-        : (event: any) => `${String(event.tenantId)}:${event.aggregateType}:${String(event.aggregateId)}`;
+      const groupKeyFn = this.buildGroupKey({
+        jobPath: `map/${handlerName}`,
+        getTenantId: (event: any) => String(event.tenantId),
+        domainKeyFn: customGroupKeyFn
+          ? (event: any) => customGroupKeyFn(event)
+          : (event: any) => `${event.aggregateType}:${String(event.aggregateId)}`,
+      });
       const entry: JobRegistryEntry = {
         groupKeyFn,
         scoreFn: (event: any) => event.createdAt,
@@ -269,12 +292,15 @@ export class QueueManager<EventType extends Event = Event> {
       }
 
       const customGroupKeyFn = projectionDef.groupKeyFn;
+      const groupKeyFn = this.buildGroupKey({
+        jobPath: `fold/${projectionName}`,
+        getTenantId: (event: any) => String(event.tenantId),
+        domainKeyFn: customGroupKeyFn
+          ? (event: any) => customGroupKeyFn(event)
+          : (event: any) => `${event.aggregateType}:${String(event.aggregateId)}`,
+      });
       const entry: JobRegistryEntry = {
-        groupKeyFn: customGroupKeyFn
-          ? (event: any) =>
-              `${String(event.tenantId)}:${customGroupKeyFn(event)}`
-          : (event: any) =>
-              `${String(event.tenantId)}:${event.aggregateType}:${String(event.aggregateId)}`,
+        groupKeyFn,
         scoreFn: (event: any) => event.createdAt,
         process: async (event: any) => {
           await onEvent(projectionName, event, {
@@ -387,11 +413,16 @@ export class QueueManager<EventType extends Event = Event> {
         },
       );
 
-      const jobEntry: JobRegistryEntry = {
-        groupKeyFn: (payload: any) => {
+      const commandGroupKeyFn = this.buildGroupKey({
+        jobPath: `command/${cmdName}`,
+        getTenantId: (payload: any) => String(payload.tenantId),
+        domainKeyFn: (payload: any) => {
           const key = cmdEntry.getGroupKey ? cmdEntry.getGroupKey(payload) : cmdEntry.getAggregateId(payload);
-          return `${String(payload.tenantId)}:${this.aggregateType}:${String(key)}`;
+          return `${this.aggregateType}:${String(key)}`;
         },
+      });
+      const jobEntry: JobRegistryEntry = {
+        groupKeyFn: commandGroupKeyFn,
         scoreFn: (payload: any) => payload.occurredAt as number,
         process: async (payload: any) => {
           await processCommand({
@@ -468,7 +499,10 @@ export class QueueManager<EventType extends Event = Event> {
   initializeReactorQueues(
     reactors: Record<string, {
       name: string;
+      parentProjection: string;
+      parentType: "fold" | "map";
       handler: { handle: (payload: { event: EventType; foldState: unknown }) => Promise<void> };
+      groupKeyFn?: (payload: { event: EventType; foldState: unknown }) => string;
       options?: {
         killSwitch?: KillSwitchOptions;
         disabled?: boolean;
@@ -487,9 +521,16 @@ export class QueueManager<EventType extends Event = Event> {
     }
 
     for (const [reactorName, reactorDef] of Object.entries(reactors)) {
+      const customGroupKeyFn = reactorDef.groupKeyFn;
+      const reactorGroupKeyFn = this.buildGroupKey({
+        jobPath: `${reactorDef.parentType}/${reactorDef.parentProjection}/reactor/${reactorName}`,
+        getTenantId: (payload: any) => String(payload.event.tenantId),
+        domainKeyFn: customGroupKeyFn
+          ? (payload: any) => customGroupKeyFn(payload)
+          : (payload: any) => `${payload.event.aggregateType}:${String(payload.event.aggregateId)}`,
+      });
       const entry: JobRegistryEntry = {
-        groupKeyFn: (payload: any) =>
-          `${String(payload.event.tenantId)}:${payload.event.aggregateType}:${String(payload.event.aggregateId)}`,
+        groupKeyFn: reactorGroupKeyFn,
         scoreFn: (payload: any) => payload.event.createdAt,
         process: async (payload: any) => {
           await onEvent(reactorName, payload, {


### PR DESCRIPTION
Different job types (fold, map, reactor, command) sharing the same aggregate produced identical group keys, causing FIFO contention — a slow reactor could block fold processing for that aggregate. Hierarchical keys isolate each job type: `${tenantId}/${jobPath}/${domainKey}` where jobPath reflects the pipeline tree (e.g. `fold/traceSummary/reactor/evaluationTrigger`).