### PR TITLE
fix(event-sourcing): enable sequential consistency for fold projections

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -135,6 +135,7 @@ export class EvaluationRunClickHouseRepository
         `,
         query_params: { tenantId, evaluationId },
         format: "JSONEachRow",
+        clickhouse_settings: { select_sequential_consistency: "1" },
       });
 
       const rows = await result.json<ClickHouseEvaluationRunRecord>();

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -145,6 +145,7 @@ export class TraceSummaryClickHouseRepository implements TraceSummaryRepository 
         `,
         query_params: { tenantId, traceId },
         format: "JSONEachRow",
+        clickhouse_settings: { select_sequential_consistency: "1" },
       });
 
       const rows = await result.json<ClickHouseSummaryRecord>();

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
@@ -168,6 +168,7 @@ export class ExperimentRunStateRepositoryClickHouse<
         `,
         query_params: { tenantId: context.tenantId, runId, experimentId },
         format: "JSONEachRow",
+        clickhouse_settings: { select_sequential_consistency: "1" },
       });
 
       const rows = await result.json<ClickHouseExperimentRunRecord>();

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
@@ -176,6 +176,7 @@ export class SimulationRunStateRepositoryClickHouse<
         `,
         query_params: { tenantId: context.tenantId, scenarioRunId },
         format: "JSONEachRow",
+        clickhouse_settings: { select_sequential_consistency: "1" },
       });
 
       const rows = await result.json<ClickHouseSimulationRunRecord>();


### PR DESCRIPTION
Fold projections read current state from ClickHouse before applying the next event. With async inserts and multi-replica setups, a read can hit a replica that hasn't replicated the previous write yet, returning null and causing the fold to apply on top of init state — losing identity fields set by earlier events (e.g. evaluatorId from ScheduledEvent lost when CompletedEvent applies on empty state).

Add `select_sequential_consistency` to the read path of all four CH-backed fold projection repositories so the replica confirms it is caught up before answering. Scoped only to fold projection reads, not app-layer queries.