### PR TITLE
fix(analytics): fire limit_blocked PostHog event from UI pre-check path

### DIFF
--- a/langwatch/src/server/__tests__/posthog.unit.test.ts
+++ b/langwatch/src/server/__tests__/posthog.unit.test.ts
@@ -134,4 +134,32 @@ describe("trackServerEvent", () => {
       expect(mockCaptureException).toHaveBeenCalledWith(captureError);
     });
   });
+
+  describe("when POSTHOG_KEY is not set (self-hosted without PostHog)", () => {
+    // The singleton `_posthogInstance` is decided at module load based on
+    // env.POSTHOG_KEY, so we reset modules and re-mock env to exercise the
+    // null branch. This is the hot path for self-hosted deployments and must
+    // never call capture or throw.
+    it("no-ops without calling capture or throwing", async () => {
+      vi.resetModules();
+      vi.doMock("~/env.mjs", () => ({
+        env: { POSTHOG_KEY: undefined, POSTHOG_HOST: undefined },
+      }));
+
+      const { trackServerEvent: trackWithoutKey } = await import("../posthog");
+
+      expect(() =>
+        trackWithoutKey({
+          userId: "user-123",
+          event: "limit_blocked",
+          properties: { limitType: "workflows" },
+        })
+      ).not.toThrow();
+
+      expect(mockCapture).not.toHaveBeenCalled();
+      expect(mockCaptureException).not.toHaveBeenCalled();
+
+      vi.doUnmock("~/env.mjs");
+    });
+  });
 });

--- a/langwatch/src/server/__tests__/posthog.unit.test.ts
+++ b/langwatch/src/server/__tests__/posthog.unit.test.ts
@@ -10,14 +10,19 @@
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-const { mockCapture } = vi.hoisted(() => ({
+const { mockCapture, mockCaptureException } = vi.hoisted(() => ({
   mockCapture: vi.fn(),
+  mockCaptureException: vi.fn(),
 }));
 
 vi.mock("posthog-node", () => ({
   PostHog: function () {
     return { capture: mockCapture, shutdown: vi.fn() };
   },
+}));
+
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: mockCaptureException,
 }));
 
 vi.mock("~/utils/logger/server", () => ({
@@ -112,6 +117,21 @@ describe("trackServerEvent", () => {
         event: "team_member_invited",
         properties: { inviteCount: 3 },
       });
+    });
+  });
+
+  describe("when posthog.capture throws", () => {
+    it("swallows the error and reports it to captureException", () => {
+      const captureError = new Error("posthog internal failure");
+      mockCapture.mockImplementationOnce(() => {
+        throw captureError;
+      });
+
+      expect(() =>
+        trackServerEvent({ userId: "user-123", event: "limit_blocked" })
+      ).not.toThrow();
+
+      expect(mockCaptureException).toHaveBeenCalledWith(captureError);
     });
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/licenseEnforcement.reportLimitBlocked.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/licenseEnforcement.reportLimitBlocked.unit.test.ts
@@ -9,7 +9,6 @@
  * - Captures exceptions when notification fails
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { z } from "zod";
 import { createInnerTRPCContext } from "../../trpc";
 
 vi.mock("~/env.mjs", () => ({
@@ -50,31 +49,13 @@ const {
   };
 });
 
-vi.mock("~/server/license-enforcement", () => {
-  const limitTypes = [
-    "workflows",
-    "prompts",
-    "evaluators",
-    "scenarios",
-    "projects",
-    "teams",
-    "members",
-    "membersLite",
-    "agents",
-    "experiments",
-    "onlineEvaluations",
-    "datasets",
-    "dashboards",
-    "customGraphs",
-    "automations",
-  ] as const;
-
+vi.mock("~/server/license-enforcement", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/license-enforcement")>();
   return {
+    ...actual,
     createLicenseEnforcementService: () => ({
       checkLimit: mockCheckLimit,
     }),
-    limitTypes,
-    limitTypeSchema: z.enum(limitTypes),
   };
 });
 
@@ -86,6 +67,15 @@ vi.mock("~/server/app-layer/app", () => ({
 
 vi.mock("~/utils/posthogErrorCapture", () => ({
   captureException: mockCaptureException,
+}));
+
+const mockTrackServerEvent = vi.fn();
+vi.mock("~/server/posthog", () => ({
+  trackServerEvent: mockTrackServerEvent,
+}));
+
+vi.mock("../../../auditLog", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock RBAC to allow all permission checks (unit test, not testing auth)
@@ -158,6 +148,31 @@ describe("licenseEnforcement.reportLimitBlocked", () => {
         max: 10,
       });
     });
+
+    it("fires a limit_blocked event with ui_pre_check source", async () => {
+      mockCheckLimit.mockResolvedValue({
+        allowed: false,
+        current: 10,
+        max: 10,
+        limitType: "workflows",
+      });
+
+      await callReportLimitBlocked({
+        organizationId: "org-123",
+        limitType: "workflows",
+      });
+
+      expect(mockTrackServerEvent).toHaveBeenCalledWith({
+        userId: "user-1",
+        event: "limit_blocked",
+        properties: {
+          limitType: "workflows",
+          current: 10,
+          max: 10,
+          source: "ui_pre_check",
+        },
+      });
+    });
   });
 
   describe("when limit is not reached (fabricated request)", () => {
@@ -180,6 +195,7 @@ describe("licenseEnforcement.reportLimitBlocked", () => {
         expect.objectContaining({ id: "user-1" })
       );
       expect(mockNotifyResourceLimitReached).not.toHaveBeenCalled();
+      expect(mockTrackServerEvent).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/server/api/routers/licenseEnforcement.ts
+++ b/langwatch/src/server/api/routers/licenseEnforcement.ts
@@ -8,6 +8,7 @@ import {
 import { checkOrganizationPermission } from "../rbac";
 import { getApp } from "../../app-layer/app";
 import { captureException } from "../../../utils/posthogErrorCapture";
+import { trackServerEvent } from "~/server/posthog";
 
 export const licenseEnforcementRouter = createTRPCRouter({
   /**
@@ -84,6 +85,17 @@ export const licenseEnforcementRouter = createTRPCRouter({
             max: result.max,
           })
           .catch(captureException);
+
+        trackServerEvent({
+          userId: ctx.session.user.id,
+          event: "limit_blocked",
+          properties: {
+            limitType: input.limitType,
+            current: result.current,
+            max: result.max,
+            source: "ui_pre_check",
+          },
+        });
       }
     }),
 });

--- a/langwatch/src/server/license-enforcement/__tests__/enforcement.middleware.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/enforcement.middleware.unit.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for enforceLicenseLimit middleware.
+ *
+ * Verifies the side-effect behavior when LimitExceededError is thrown:
+ * - Fire-and-forget notification via notifyResourceLimitReached
+ * - PostHog tracking with source: "server_safety_net"
+ * - captureException on notification failure
+ * - TRPCError propagation to caller
+ * - No side-effects when limit is not exceeded
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+import { LimitExceededError } from "../errors";
+import { ProjectNotFoundError } from "../errors";
+
+// --- Mocks ---
+
+const mockEnforceLimitByOrganization = vi.fn();
+vi.mock("../index", () => ({
+  createLicenseEnforcementService: () => ({
+    enforceLimitByOrganization: mockEnforceLimitByOrganization,
+  }),
+}));
+
+const mockGetOrganizationIdForProject = vi.fn();
+vi.mock("../utils", () => ({
+  getOrganizationIdForProject: (...args: unknown[]) =>
+    mockGetOrganizationIdForProject(...args),
+}));
+
+const mockNotifyResourceLimitReached = vi.fn();
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    usageLimits: {
+      notifyResourceLimitReached: mockNotifyResourceLimitReached,
+    },
+  }),
+}));
+
+const mockTrackServerEvent = vi.fn();
+vi.mock("~/server/posthog", () => ({
+  trackServerEvent: mockTrackServerEvent,
+}));
+
+const mockCaptureException = vi.fn();
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: mockCaptureException,
+}));
+
+// Import SUT after mocks are wired
+const { enforceLicenseLimit } = await import("../enforcement.middleware");
+
+// --- Test helpers ---
+
+function buildCtx({ userId = "user-1" } = {}) {
+  return {
+    prisma: {} as any,
+    session: {
+      user: { id: userId, email: "test@example.com", name: "Test User" },
+      expires: "",
+    },
+  };
+}
+
+describe("enforceLicenseLimit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOrganizationIdForProject.mockResolvedValue("org-123");
+    mockNotifyResourceLimitReached.mockResolvedValue(undefined);
+  });
+
+  describe("when limit is exceeded", () => {
+    beforeEach(() => {
+      mockEnforceLimitByOrganization.mockRejectedValue(
+        new LimitExceededError("workflows", 10, 10)
+      );
+    });
+
+    it("calls notifyResourceLimitReached with the correct payload", async () => {
+      await expect(
+        enforceLicenseLimit(buildCtx(), "project-1", "workflows")
+      ).rejects.toThrow(TRPCError);
+
+      expect(mockNotifyResourceLimitReached).toHaveBeenCalledWith({
+        organizationId: "org-123",
+        limitType: "workflows",
+        current: 10,
+        max: 10,
+      });
+    });
+
+    it("calls trackServerEvent with source server_safety_net and projectId", async () => {
+      await expect(
+        enforceLicenseLimit(buildCtx(), "project-1", "workflows")
+      ).rejects.toThrow(TRPCError);
+
+      expect(mockTrackServerEvent).toHaveBeenCalledWith({
+        userId: "user-1",
+        event: "limit_blocked",
+        projectId: "project-1",
+        properties: {
+          limitType: "workflows",
+          current: 10,
+          max: 10,
+          source: "server_safety_net",
+        },
+      });
+    });
+
+    it("throws a TRPCError with FORBIDDEN code to the caller", async () => {
+      try {
+        await enforceLicenseLimit(buildCtx(), "project-1", "workflows");
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(TRPCError);
+        const trpcError = error as TRPCError;
+        expect(trpcError.code).toBe("FORBIDDEN");
+        expect(trpcError.cause).toMatchObject({
+          limitType: "workflows",
+          current: 10,
+          max: 10,
+        });
+      }
+    });
+  });
+
+  describe("when notifyResourceLimitReached rejects", () => {
+    it("captures the exception without re-throwing", async () => {
+      const notificationError = new Error("Slack webhook unreachable");
+      mockNotifyResourceLimitReached.mockRejectedValue(notificationError);
+      mockEnforceLimitByOrganization.mockRejectedValue(
+        new LimitExceededError("prompts", 5, 5)
+      );
+
+      await expect(
+        enforceLicenseLimit(buildCtx(), "project-1", "prompts")
+      ).rejects.toThrow(TRPCError);
+
+      // Allow the fire-and-forget .catch(captureException) to settle
+      await vi.waitFor(() => {
+        expect(mockCaptureException).toHaveBeenCalledWith(notificationError);
+      });
+    });
+  });
+
+  describe("when limit is not exceeded", () => {
+    beforeEach(() => {
+      mockEnforceLimitByOrganization.mockResolvedValue(undefined);
+    });
+
+    it("does not call notifyResourceLimitReached or trackServerEvent", async () => {
+      await enforceLicenseLimit(buildCtx(), "project-1", "workflows");
+
+      expect(mockNotifyResourceLimitReached).not.toHaveBeenCalled();
+      expect(mockTrackServerEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when project is not found", () => {
+    it("throws a TRPCError with NOT_FOUND code", async () => {
+      mockGetOrganizationIdForProject.mockRejectedValue(
+        new ProjectNotFoundError("project-unknown")
+      );
+
+      try {
+        await enforceLicenseLimit(buildCtx(), "project-unknown", "workflows");
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(TRPCError);
+        expect((error as TRPCError).code).toBe("NOT_FOUND");
+      }
+    });
+  });
+});

--- a/langwatch/src/server/license-enforcement/enforcement.middleware.ts
+++ b/langwatch/src/server/license-enforcement/enforcement.middleware.ts
@@ -86,6 +86,7 @@ export async function enforceLicenseLimit(
           limitType: error.limitType,
           current: error.current,
           max: error.max,
+          source: "server_safety_net",
         },
       });
       throw new TRPCError({

--- a/langwatch/src/server/posthog.ts
+++ b/langwatch/src/server/posthog.ts
@@ -1,5 +1,6 @@
 import { PostHog } from "posthog-node";
 import { createLogger } from "~/utils/logger/server";
+import { captureException } from "~/utils/posthogErrorCapture";
 import { env } from "../env.mjs";
 
 const logger = createLogger("langwatch:posthog:client");
@@ -21,7 +22,10 @@ export function getPostHogInstance(): PostHog | null {
 
 /**
  * Fire-and-forget server-side event tracking.
+ *
  * Silently no-ops when POSTHOG_KEY is not set (self-hosted without PostHog).
+ * Never throws: any internal failure is reported to captureException so a
+ * broken analytics path can't break the caller's mutation/request.
  */
 export function trackServerEvent({
   userId,
@@ -34,16 +38,20 @@ export function trackServerEvent({
   properties?: Record<string, unknown>;
   projectId?: string;
 }) {
-  const posthog = getPostHogInstance();
-  if (!posthog) return;
-  posthog.capture({
-    distinctId: userId,
-    event,
-    properties: {
-      ...properties,
-      ...(projectId ? { projectId } : {}),
-    },
-  });
+  try {
+    const posthog = getPostHogInstance();
+    if (!posthog) return;
+    posthog.capture({
+      distinctId: userId,
+      event,
+      properties: {
+        ...properties,
+        ...(projectId ? { projectId } : {}),
+      },
+    });
+  } catch (error) {
+    captureException(error);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Problem**: When users hit resource limits, the UI pre-checks client-side and blocks before reaching the server. The `limit_blocked` PostHog event only fired from `enforcement.middleware.ts` (server safety net), which is rarely reached. This created a gap in the Growth dashboard analytics.
- **Fix**: Added `trackServerEvent("limit_blocked")` to the `reportLimitBlocked` mutation with `source: "ui_pre_check"`, and tagged the existing middleware event with `source: "server_safety_net"` for clarity.
- **Tests**: Added enforcement middleware unit tests (6 tests) and improved existing test mock strategy (use `importOriginal` instead of hardcoded `limitTypes`).

## Changes

| File | Change |
|------|--------|
| `licenseEnforcement.ts` | Added `trackServerEvent` call when `result.allowed === false` |
| `enforcement.middleware.ts` | Added `source: "server_safety_net"` to existing event |
| `licenseEnforcement.reportLimitBlocked.unit.test.ts` | New test for tracking + fixed mock to use `importOriginal` |
| `enforcement.middleware.unit.test.ts` | **New** — 6 tests covering middleware side-effects |

## Test plan

- [x] `pnpm test:unit` — all 11 tests pass (5 + 6)
- [x] `pnpm typecheck` — no new errors (all pre-existing)
- [x] Verified `limit_blocked` event fires with `source: "ui_pre_check"` when limit is exceeded
- [x] Verified event does NOT fire when limit is not exceeded
- [x] Verified middleware tags events with `source: "server_safety_net"`

> **Note**: This branch is based on `feat/posthog-tracking-events`. Should be merged after that branch lands.