### PR TITLE
ci: fix stub job name mismatches, add path filters to CodeQL, create missing stubs

### DIFF
--- a/.github/workflows/codeql-unmodified.yml
+++ b/.github/workflows/codeql-unmodified.yml
@@ -1,0 +1,31 @@
+# Complementary stub for codeql.yml
+# Job names and paths-ignore MUST mirror the real workflow's jobs and paths.
+name: codeql
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "langwatch/**"
+      - "langwatch_nlp/**"
+      - "langwatch_server/**"
+      - "python-sdk/**"
+      - "typescript-sdk/**"
+      - "mcp-server/**"
+      - "langevals/**"
+      - "sdk-go/**"
+      - ".github/workflows/codeql.yml"
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+          - language: python
+    steps:
+      - run: echo "Skipping CodeQL analysis — no code files changed"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,16 @@ on:
     branches: ["main"]
     # Draft PRs are excluded by specifying only these types
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "langwatch/**"
+      - "langwatch_nlp/**"
+      - "langwatch_server/**"
+      - "python-sdk/**"
+      - "typescript-sdk/**"
+      - "mcp-server/**"
+      - "langevals/**"
+      - "sdk-go/**"
+      - ".github/workflows/codeql.yml"
   schedule:
     - cron: "00 08 * * *"
 

--- a/.github/workflows/e2e-ci-unmodified.yml
+++ b/.github/workflows/e2e-ci-unmodified.yml
@@ -1,0 +1,16 @@
+# Complementary stub for e2e-ci.yml
+# Job names and paths-ignore MUST mirror the real workflow's jobs and paths.
+name: e2e-ci
+
+on:
+  pull_request:
+    paths-ignore:
+      - "langwatch/**"
+      - "agentic-e2e-tests/**"
+      - ".github/workflows/e2e-ci.yml"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no modifications, skipping e2e tests"

--- a/.github/workflows/langwatch-app-ci-unmodified.yml
+++ b/.github/workflows/langwatch-app-ci-unmodified.yml
@@ -1,20 +1,29 @@
+# Complementary stub for langwatch-app-ci.yml
+# Job names and paths-ignore MUST mirror the real workflow's jobs and paths.
 name: langwatch-app-ci
 
 on:
   pull_request:
     paths-ignore:
       - "langwatch/**"
+      - ".github/workflows/langwatch-app-ci.yml"
+      - ".github/.release-please-manifest.json"
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "no modifications, skipping tests"
-
   typecheck:
     runs-on: ubuntu-latest
     steps:
       - run: echo "no modifications, skipping typecheck"
+
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no modifications, skipping unit tests"
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "no modifications, skipping integration tests"
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/mcp-javascript-ci-unmodified.yml
+++ b/.github/workflows/mcp-javascript-ci-unmodified.yml
@@ -1,22 +1,20 @@
+# Complementary stub for mcp-javascript-ci.yml
+# Job names and paths-ignore MUST mirror the real workflow's jobs and paths.
 name: mcp-javascript-ci
 
 on:
   pull_request:
     paths-ignore:
       - "mcp-server/**"
+      - ".github/.release-please-manifest.json"
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "no modifications, skipping tests"
-        
   typecheck:
     runs-on: ubuntu-latest
     steps:
       - run: echo "no modifications, skipping typecheck"
-        
-  build:
+
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "no modifications, skipping build"
+      - run: echo "no modifications, skipping build and tests"

--- a/.github/workflows/sdk-go-ci-unmodified.yml
+++ b/.github/workflows/sdk-go-ci-unmodified.yml
@@ -1,9 +1,12 @@
+# Complementary stub for sdk-go-ci.yml
+# Job names and paths-ignore MUST mirror the real workflow's jobs and paths.
 name: sdk-go-ci
 
 on:
   pull_request:
     paths-ignore:
       - "sdk-go/**"
+      - ".github/.release-please-manifest.json"
 
 jobs:
   test:

--- a/.github/workflows/sdk-javascript-ci-unmodified.yml
+++ b/.github/workflows/sdk-javascript-ci-unmodified.yml
@@ -1,22 +1,21 @@
+# Complementary stub for sdk-javascript-ci.yml
+# Job names and paths-ignore MUST mirror the real workflow's jobs and paths.
 name: sdk-javascript-ci
 
 on:
   pull_request:
     paths-ignore:
       - "typescript-sdk/**"
+      - ".github/workflows/sdk-javascript-ci.yml"
+      - ".github/.release-please-manifest.json"
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "no modifications, skipping tests"
-        
-  typecheck:
+      - run: echo "no modifications, skipping ci"
+
+  e2e:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "no modifications, skipping typecheck"
-        
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "no modifications, skipping build"
+      - run: echo "no modifications, skipping e2e"

--- a/.github/workflows/sdk-python-ci-unmodified.yml
+++ b/.github/workflows/sdk-python-ci-unmodified.yml
@@ -1,9 +1,12 @@
+# Complementary stub for sdk-python-ci.yml
+# Job names and paths-ignore MUST mirror the real workflow's jobs and paths.
 name: sdk-python-ci
 
 on:
   pull_request:
     paths-ignore:
       - "python-sdk/**"
+      - ".github/.release-please-manifest.json"
 
 jobs:
   test:

--- a/specs/ci/path-filters.feature
+++ b/specs/ci/path-filters.feature
@@ -1,0 +1,69 @@
+Feature: CI path filters skip unnecessary workflows on non-code changes
+  As a developer
+  I want CI to skip expensive workflows when only docs, specs, or config files change
+  So that PR feedback is faster and CI minutes are not wasted
+
+  Background:
+    Given the repository uses complementary workflow pairs
+    And each real workflow has a matching "-unmodified" stub
+    And stub job names match real workflow job names exactly
+
+  # ============================================================================
+  # Stub job name alignment (Phase 1 — fix pre-existing bugs)
+  # ============================================================================
+
+  Scenario: langwatch-app-ci stub matches real workflow job names
+    Given langwatch-app-ci.yml defines jobs "typecheck", "test-unit", "test-integration", "lint", "build"
+    When a PR does not touch langwatch/ files
+    Then langwatch-app-ci-unmodified.yml reports success for the same job names
+
+  Scenario: mcp-javascript-ci stub matches real workflow job names
+    Given mcp-javascript-ci.yml defines jobs "typecheck", "build_and_test"
+    When a PR does not touch mcp-server/ files
+    Then mcp-javascript-ci-unmodified.yml reports success for the same job names
+
+  Scenario: sdk-javascript-ci stub matches real workflow job names
+    Given sdk-javascript-ci.yml defines jobs "ci", "e2e"
+    When a PR does not touch typescript-sdk/ files
+    Then sdk-javascript-ci-unmodified.yml reports success for the same job names
+
+  # ============================================================================
+  # Missing stubs (Phase 2)
+  # ============================================================================
+
+  Scenario: e2e-ci has a complementary stub
+    Given e2e-ci.yml triggers on langwatch/ and agentic-e2e-tests/ changes
+    When a PR does not touch those directories
+    Then e2e-ci-unmodified.yml reports success for all e2e-ci job names
+
+  Scenario: codeql has a complementary stub
+    Given codeql.yml triggers on code file changes only
+    When a PR touches only documentation or config files
+    Then codeql-unmodified.yml reports success for analyze jobs
+
+  # ============================================================================
+  # Path filter behavior
+  # ============================================================================
+
+  Scenario: CodeQL skips docs-only PRs
+    When a PR changes only files in docs/, .claude/, specs/, or markdown files
+    Then codeql.yml does not run
+    And codeql-unmodified.yml reports success for required checks
+
+  Scenario: Push to main always runs all workflows
+    When a commit is pushed to the main branch
+    Then all workflows run regardless of which files changed
+
+  # ============================================================================
+  # Safety invariants
+  # ============================================================================
+
+  Scenario: No PR is permanently blocked by missing status checks
+    Given all workflow pairs have matching job names
+    When any combination of files is changed in a PR
+    Then every required status check receives a result from either the real workflow or its stub
+
+  Scenario: Negation patterns are not used in path filters
+    Given the complementary pair system cannot support negation
+    Then no workflow uses negation patterns like "!path" in paths filters
+    And path exclusions are achieved only through the stub's paths-ignore


### PR DESCRIPTION
## Problem

Docs-only and config-only PRs (editing `.claude/`, `specs/`, markdown files, etc.) trigger the full CI suite — CodeQL analysis, E2E tests, the works. This wastes CI minutes and makes contributors wait for irrelevant checks to pass.

Worse, we discovered several **pre-existing bugs** in how our CI stub system works that were silently undermining our merge gates.

## Background: how our CI gating works

GitHub required status checks stay "pending" forever if no workflow reports a result. To handle this, we use a **complementary pair pattern**: for each workflow with `paths:` filters, there's a matching `-unmodified.yml` stub that fires on the inverse paths and reports instant success. This way, required checks always get a status regardless of which files a PR touches.

## What we found (and fixed)

### 1. Stub job names didn't match real workflow jobs

The `langwatch-app-ci-unmodified.yml` stub defined a job called `test`, but the real workflow defines `typecheck`, `test-unit`, and `test-integration`. Same kind of drift existed for `mcp-javascript-ci` and `sdk-javascript-ci`. This meant the stub was satisfying a check name that the real workflow never reported — so failures in the actual test jobs might not block merges.

**Fix:** Updated all three stubs to define the exact same job names as their real workflows.

### 2. CodeQL had no path filters and no stub

CodeQL ran on every PR to `main` with no path filtering. Adding path filters without a stub would permanently block docs-only PRs (pending check, no workflow to satisfy it).

**Fix:** Added `paths:` filters to `codeql.yml` scoped to actual code directories, and created a new `codeql-unmodified.yml` stub as the complement.

### 3. E2E CI had no stub

Same issue — no stub meant adding path filters would block PRs.

**Fix:** Created `e2e-ci-unmodified.yml`.

### 4. Dual-fire race conditions

PRs touching only `.github/.release-please-manifest.json` could trigger both the real workflow AND its stub simultaneously, creating a race condition on status reporting.

**Fix:** Added the manifest file (and workflow self-references) to `paths-ignore` in the relevant stubs.

## What we deliberately did NOT do

- **No negation patterns** (`!langwatch/**/*.md`) — these break the complementary pair system. A PR touching only `langwatch/README.md` would match neither the real workflow nor the stub, blocking the PR forever.
- **No changes to `push: main` triggers** — downstream workflows (release-please, docker-publish, Slack alerts) depend on every merge firing all workflows.
- **No `dorny/paths-filter` migration** — that's a bigger architectural change that would eliminate the entire complementary pair pattern. Worth doing later, not in this PR.

## Files changed

| File | What changed |
|------|-------------|
| `langwatch-app-ci-unmodified.yml` | Jobs renamed from `test` → `typecheck`, `test-unit`, `test-integration` to match real workflow |
| `mcp-javascript-ci-unmodified.yml` | Jobs renamed from `test`/`typecheck`/`build` → `typecheck`/`build_and_test` to match real workflow |
| `sdk-javascript-ci-unmodified.yml` | Jobs renamed from `test`/`typecheck`/`build` → `ci`/`e2e` to match real workflow |
| `codeql.yml` | Added `paths:` filter scoped to code directories |
| `codeql-unmodified.yml` | **New** — stub for CodeQL when code paths aren't touched |
| `e2e-ci-unmodified.yml` | **New** — stub for E2E CI |
| `sdk-go-ci-unmodified.yml` | Added `.release-please-manifest.json` to `paths-ignore` |
| `sdk-python-ci-unmodified.yml` | Added `.release-please-manifest.json` to `paths-ignore` |
| `specs/ci/path-filters.feature` | **New** — BDD spec documenting the path filter behavior and safety invariants |

## Test plan

- [ ] All CI checks report a status on this PR (no permanently pending checks)
- [ ] Stub job names match real workflow job names (visible in Actions tab)
- [ ] CodeQL does not run on this PR (only workflow/spec files changed)
- [ ] `codeql-unmodified` stub runs and reports success instead

Fixes #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)