### PR TITLE
fix(scenarios): use pre-assigned scenarioRunId in failure handler

### DIFF
--- a/langwatch/src/server/scenarios/__tests__/scenario-failure-handler.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-failure-handler.unit.test.ts
@@ -121,6 +121,28 @@ describe("ScenarioFailureHandler", () => {
       });
     });
 
+    describe("given no events exist but scenarioRunId is pre-assigned", () => {
+      beforeEach(() => {
+        mockService.getRunDataForBatchRun.mockResolvedValue({ changed: true, runs: [] });
+      });
+
+      describe("when called with a pre-assigned scenarioRunId", () => {
+        it("uses the pre-assigned scenarioRunId instead of generating a new one", async () => {
+          await handler.ensureFailureEventsEmitted({
+            ...baseJobData,
+            scenarioRunId: "scenariorun_preassigned123",
+            error: "Child process exited with code 1",
+          });
+
+          const runStartedCall = mockService.saveScenarioEvent.mock.calls[0]?.[0] as Record<string, unknown>;
+          expect(runStartedCall.scenarioRunId).toBe("scenariorun_preassigned123");
+
+          const runFinishedCall = mockService.saveScenarioEvent.mock.calls[1]?.[0] as Record<string, unknown>;
+          expect(runFinishedCall.scenarioRunId).toBe("scenariorun_preassigned123");
+        });
+      });
+    });
+
     describe("given RUN_STARTED event already exists", () => {
       const existingScenarioRunId = "scenariorun_existing123";
 

--- a/langwatch/src/server/scenarios/__tests__/scenario-processor-failure-handler.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-processor-failure-handler.unit.test.ts
@@ -62,6 +62,7 @@ describe("handleFailedJobResult", () => {
         scenarioId: "scen_456",
         setId: "set_789",
         batchRunId: "batch_abc",
+        scenarioRunId: "scenariorun_test123",
         error: "Prefetch failed: Scenario not found",
         name: "Test Scenario",
         description: "Test description for the scenario",

--- a/langwatch/src/server/scenarios/scenario-failure-handler.ts
+++ b/langwatch/src/server/scenarios/scenario-failure-handler.ts
@@ -29,6 +29,8 @@ export interface FailureEventParams {
   scenarioId: string;
   setId: string;
   batchRunId: string;
+  /** Pre-assigned scenario run ID from the job queue. Used to prevent duplicate run entries when ES hasn't indexed the SDK's RUN_STARTED event yet. */
+  scenarioRunId?: string;
   error?: string;
   /** Scenario name for display in UI */
   name?: string;
@@ -116,7 +118,7 @@ export class ScenarioFailureHandler {
         }
 
         const timestamp = Date.now();
-        const scenarioRunId = existingRun?.scenarioRunId ?? this.generateScenarioRunId();
+        const scenarioRunId = existingRun?.scenarioRunId ?? params.scenarioRunId ?? this.generateScenarioRunId();
         span.setAttribute("scenario.run.id", scenarioRunId);
 
         // If no RUN_STARTED event exists, emit one

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -119,6 +119,7 @@ export async function handleFailedJobResult(
     scenarioId: jobData.scenarioId,
     setId: jobData.setId,
     batchRunId: jobData.batchRunId,
+    scenarioRunId: jobData.scenarioRunId,
     error,
     name: scenario?.name,
     description: scenario?.situation,

--- a/specs/scenarios/scenario-failure-handler.feature
+++ b/specs/scenarios/scenario-failure-handler.feature
@@ -20,6 +20,15 @@ Feature: Scenario Failure Handler
     And both events share the same scenarioRunId
 
   @unit
+  Scenario: Use pre-assigned scenarioRunId when no events exist in Elasticsearch
+    Given a scenario job failed with error "Child process exited with code 1"
+    And no events exist in Elasticsearch for this batchRunId
+    And the job data includes a pre-assigned scenarioRunId
+    When ScenarioFailureHandler.ensureFailureEventsEmitted is called
+    Then the pre-assigned scenarioRunId is used for both events
+    And no new scenarioRunId is generated
+
+  @unit
   Scenario: Emit only RUN_FINISHED when RUN_STARTED exists
     Given a scenario job failed with error "Scenario execution timed out"
     And a RUN_STARTED event exists for this batchRunId


### PR DESCRIPTION
## Summary
- **Bug**: When a scenario fails and the SDK's `RUN_STARTED` event hasn't been indexed in ES yet, the `ScenarioFailureHandler` generated a new `scenarioRunId` instead of using the pre-assigned one from job data, creating duplicate run cards in the UI.
- **Fix**: Added `scenarioRunId` to `FailureEventParams`, passed it from `handleFailedJobResult`, and used it as fallback before generating a new ID (`existingRun?.scenarioRunId ?? params.scenarioRunId ?? this.generateScenarioRunId()`).
- **Tests**: Added regression tests for both the failure handler and the processor integration.

Closes #2265

## Test plan
- [x] New unit test: failure handler uses pre-assigned scenarioRunId when no events exist in ES
- [x] Updated unit test: processor passes scenarioRunId to failure emitter
- [x] All 21 existing tests still pass
- [x] No new typecheck errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2265