### PR TITLE
fix(prompts): prevent version history popover re-opening on page reload

### DIFF
--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/DraggableTabsBrowserStore.ts
@@ -487,6 +487,25 @@ function createDraggableTabsBrowserStore(projectId: string) {
         name: storageKey,
         storage: createJSONStorage(() => localStorage),
 
+        // Strip transient UI flags before writing to localStorage so they
+        // don't re-trigger on page reload.
+        partialize: (state) => ({
+          ...state,
+          windows: state.windows.map((w) => ({
+            ...w,
+            tabs: w.tabs.map((t) => ({
+              ...t,
+              data: {
+                ...t.data,
+                meta: {
+                  ...t.data.meta,
+                  openHistoryOnLoad: undefined,
+                },
+              },
+            })),
+          })),
+        }),
+
         // Validate and handle corrupted data during rehydration
         onRehydrateStorage: () => (state, error) => {
           if (error) {


### PR DESCRIPTION
## Summary

- Clicking "View history" on a prompt was opening the history popover correctly on first click, but the popover would re-open automatically on every subsequent page reload
- If "View history" had been clicked multiple times (creating multiple tabs with the flag), multiple popovers would open simultaneously on load

## Root Cause

`openHistoryOnLoad` is a transient one-shot UI trigger stored in the tab's `meta` object. The Zustand store uses `persist` middleware to write the entire state to `localStorage`, so this flag was being persisted and re-read on every page load — causing the `initialOpen` effect in `VersionHistoryListPopover` to fire again.

## Fix

Added `partialize` to the Zustand persist config to strip `openHistoryOnLoad` from all tab meta before serialising to localStorage. The flag still works correctly in memory (clicking "View history" sets it, the tab mounts, the popover opens once), but it is never written to disk so it cannot re-trigger on reload.

## Test plan

- [ ] Click "View history" on a prompt — history popover opens
- [ ] Reload the page — history popover does **not** re-open automatically
- [ ] Click "View history" multiple times — only one popover opens, not multiple

🤖 Generated with [Claude Code](https://claude.com/claude-code)