### PR TITLE
fix(ci): address free plan prompt limit in SDK tests

### DIFF
--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -95,6 +95,7 @@ jobs:
       DISABLE_PII_REDACTION: "true"
       SKIP_CLICKHOUSE_MIGRATE: "true"
       SKIP_REDIS: "true"
+      LANGWATCH_LICENSE_PUBLIC_KEY: ${{ secrets.TEST_LICENSE_PUBLIC_KEY }}
 
     services:
       opensearch:

--- a/langwatch/prisma/seed.ts
+++ b/langwatch/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { nanoid } from "nanoid";
+import { ENTERPRISE_LICENSE_KEY } from "../ee/licensing/__tests__/fixtures/testLicenses";
 
 const prisma = new PrismaClient();
 
@@ -12,11 +13,12 @@ async function main() {
 
   console.log(`🌱 Seeding database with API key: ${apiKey}`);
 
-  // Create organization
+  // Create organization with enterprise license to avoid free plan limits in E2E tests
   const organization = await prisma.organization.create({
     data: {
       name: "CI Test Organization",
       slug: `ci-test-org-${nanoid()}`,
+      license: ENTERPRISE_LICENSE_KEY,
     },
   });
 


### PR DESCRIPTION
## Summary

- SDK E2E tests fail with `resource_limit_exceeded` because the seeded test organization has no license (free plan: max 3 prompts)
- Assigns an enterprise test license to the CI test organization in the seed script
- Adds `LANGWATCH_LICENSE_PUBLIC_KEY` so the server can verify the test license

## Context

The `sdk-javascript-ci` E2E pipeline creates prompts via API, hitting the free plan limit of 3. Integration tests solve this by assigning `ENTERPRISE_LICENSE_KEY` to the test org + setting `TEST_PUBLIC_KEY` for verification.

## Test plan

- [ ] SDK E2E tests pass without `resource_limit_exceeded` errors