### PR TITLE
feat(scenarios): add thinking indicator to conversation thread

### DIFF
--- a/langwatch/src/components/simulations/ConversationArea.tsx
+++ b/langwatch/src/components/simulations/ConversationArea.tsx
@@ -1,0 +1,47 @@
+import { Box } from "@chakra-ui/react";
+import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
+import type { ScenarioMessageSnapshotEvent } from "~/server/scenarios/scenario-event.types";
+import { CustomCopilotKitChat } from "./CustomCopilotKitChat";
+import { ThinkingIndicator } from "./ThinkingIndicator";
+
+function isWaitingForResponse(status: ScenarioRunStatus): boolean {
+  return (
+    status === ScenarioRunStatus.IN_PROGRESS ||
+    status === ScenarioRunStatus.PENDING
+  );
+}
+
+interface ConversationAreaProps {
+  messages: ScenarioMessageSnapshotEvent["messages"];
+  status: ScenarioRunStatus;
+}
+
+/**
+ * Renders the conversation thread for a scenario run.
+ * Shows messages via CopilotKit and a thinking indicator when the run
+ * is still in progress. Renders nothing when there are no messages
+ * and the run is not active.
+ */
+export function ConversationArea({ messages, status }: ConversationAreaProps) {
+  const hasMessages = messages.length > 0;
+  const waiting = isWaitingForResponse(status);
+
+  if (!hasMessages && !waiting) {
+    return null;
+  }
+
+  return (
+    <Box paddingX={6} paddingY={6} background="bg.muted">
+      {hasMessages && (
+        <Box borderRadius="md" overflow="hidden">
+          <CustomCopilotKitChat
+            messages={messages}
+            hideInput
+            smallerView={false}
+          />
+        </Box>
+      )}
+      {waiting && <ThinkingIndicator />}
+    </Box>
+  );
+}

--- a/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -28,7 +28,7 @@ import { api } from "~/utils/api";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
 import { TraceDetails } from "../traces/TraceDetails";
 import { Drawer } from "../ui/drawer";
-import { CustomCopilotKitChat } from "./CustomCopilotKitChat";
+import { ConversationArea } from "./ConversationArea";
 import { ScenarioRunActions } from "./ScenarioRunActions";
 import { ScenarioRunStatusIcon } from "./ScenarioRunStatusIcon";
 import { SimulationConsole } from "./simulation-console/SimulationConsole";
@@ -341,22 +341,11 @@ export function ScenarioRunDetailDrawer({
                 flexDirection="column"
                 width="full"
               >
-                {/* Conversation — hidden when empty (e.g. stalled runs) */}
-                {(scenarioState.messages ?? []).length > 0 && (
-                  <Box
-                    paddingX={6}
-                    paddingY={6}
-                    background="bg.muted"
-                  >
-                    <Box borderRadius="md" overflow="hidden">
-                      <CustomCopilotKitChat
-                        messages={scenarioState.messages ?? []}
-                        hideInput
-                        smallerView={false}
-                      />
-                    </Box>
-                  </Box>
-                )}
+                {/* Conversation — shows thinking indicator when in progress */}
+                <ConversationArea
+                  messages={scenarioState.messages ?? []}
+                  status={scenarioState.status}
+                />
 
                 {/* Results */}
                 <Box

--- a/langwatch/src/components/simulations/ThinkingIndicator.tsx
+++ b/langwatch/src/components/simulations/ThinkingIndicator.tsx
@@ -1,0 +1,45 @@
+import { Box, HStack } from "@chakra-ui/react";
+
+const pulsingDotCss = {
+  "@keyframes pulseOpacity": {
+    "0%, 100%": { opacity: 0.3 },
+    "50%": { opacity: 1 },
+  },
+};
+
+function PulsingDot({ delay }: { delay: string }) {
+  return (
+    <Box
+      as="span"
+      fontSize="sm"
+      color="fg.muted"
+      css={{
+        ...pulsingDotCss,
+        animation: `pulseOpacity 1.4s ease-in-out ${delay} infinite`,
+      }}
+    >
+      ●
+    </Box>
+  );
+}
+
+/**
+ * Three animated dots indicating that the system is processing.
+ * Left-aligned to match assistant message bubble positioning.
+ */
+export function ThinkingIndicator() {
+  return (
+    <HStack
+      role="status"
+      aria-label="Processing"
+      gap={1}
+      paddingY={2}
+      paddingX={1}
+      justify="flex-start"
+    >
+      <PulsingDot delay="0s" />
+      <PulsingDot delay="0.2s" />
+      <PulsingDot delay="0.4s" />
+    </HStack>
+  );
+}

--- a/langwatch/src/components/simulations/__tests__/ThinkingIndicator.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ThinkingIndicator.integration.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the ThinkingIndicator component.
+ * Verifies the three-dot animated indicator renders correctly
+ * with proper alignment and accessibility.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThinkingIndicator } from "../ThinkingIndicator";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("<ThinkingIndicator/>", () => {
+  afterEach(cleanup);
+
+  describe("when rendered", () => {
+    it("renders three dots", () => {
+      render(<ThinkingIndicator />, { wrapper: Wrapper });
+
+      const dots = screen.getAllByText("●");
+      expect(dots).toHaveLength(3);
+    });
+
+    it("has an accessible status label", () => {
+      render(<ThinkingIndicator />, { wrapper: Wrapper });
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("is left-aligned", () => {
+      render(<ThinkingIndicator />, { wrapper: Wrapper });
+
+      const container = screen.getByRole("status");
+      expect(container).toHaveStyle({ "justify-content": "flex-start" });
+    });
+  });
+});

--- a/langwatch/src/components/simulations/__tests__/ThinkingIndicatorInDrawer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ThinkingIndicatorInDrawer.integration.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests verifying ThinkingIndicator is shown/hidden
+ * based on scenario run status within the drawer conversation area.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
+
+// Mock CopilotKit chat to avoid pulling in Prisma and other heavy deps
+vi.mock("../CustomCopilotKitChat", () => ({
+  CustomCopilotKitChat: () => <div data-testid="mock-chat">chat</div>,
+}));
+
+import { ConversationArea } from "../ConversationArea";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("ConversationArea", () => {
+  afterEach(cleanup);
+
+  describe("when status is IN_PROGRESS with no messages", () => {
+    it("renders the thinking indicator", () => {
+      render(
+        <ConversationArea
+          messages={[]}
+          status={ScenarioRunStatus.IN_PROGRESS}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  describe("when status is PENDING with no messages", () => {
+    it("renders the thinking indicator", () => {
+      render(
+        <ConversationArea
+          messages={[]}
+          status={ScenarioRunStatus.PENDING}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  describe("when status is SUCCESS", () => {
+    it("does not render the thinking indicator", () => {
+      render(
+        <ConversationArea
+          messages={[]}
+          status={ScenarioRunStatus.SUCCESS}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("does not render the conversation area when there are no messages", () => {
+      const { container } = render(
+        <ConversationArea
+          messages={[]}
+          status={ScenarioRunStatus.SUCCESS}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("when status is FAILED", () => {
+    it("does not render the thinking indicator", () => {
+      render(
+        <ConversationArea
+          messages={[]}
+          status={ScenarioRunStatus.FAILED}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an animated three-dot pulsing indicator to the scenario conversation thread when a run is `IN_PROGRESS` or `PENDING`
- Extracts conversation rendering into a dedicated `ConversationArea` component for cleaner separation
- Indicator appears even with zero messages so the UI never shows an empty/unresponsive state

Closes #2274

## Test plan
- [x] `ThinkingIndicator.integration.test.tsx` — renders three dots, accessible `role="status"`, left-aligned
- [x] `ThinkingIndicatorInDrawer.integration.test.tsx` — shows for IN_PROGRESS/PENDING, hides for SUCCESS/FAILED, works with empty messages
- [ ] Manual: open a scenario run detail drawer while a run is in progress and verify animated dots appear below messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2274