### PR TITLE
fix(suites): sort external sets by most recent run in sidebar

### DIFF
--- a/langwatch/src/components/suites/SuiteSidebar.tsx
+++ b/langwatch/src/components/suites/SuiteSidebar.tsx
@@ -86,10 +86,13 @@ export function SuiteSidebar({
   }, [suites, searchQuery]);
 
   const filteredExternalSets = useMemo(() => {
-    if (!searchQuery.trim()) return externalSets;
-    const query = searchQuery.toLowerCase();
-    return externalSets.filter((s) =>
-      s.scenarioSetId.toLowerCase().includes(query),
+    const filtered = searchQuery.trim()
+      ? externalSets.filter((s) =>
+          s.scenarioSetId.toLowerCase().includes(searchQuery.toLowerCase()),
+        )
+      : externalSets;
+    return [...filtered].sort(
+      (a, b) => b.lastRunTimestamp - a.lastRunTimestamp,
     );
   }, [externalSets, searchQuery]);
 

--- a/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
@@ -695,4 +695,31 @@ describe("<SuiteSidebar/>", () => {
       });
     });
   });
+
+  describe("given external sets with different timestamps", () => {
+    const externalSets = [
+      { scenarioSetId: "oldest-set", passedCount: 3, totalCount: 5, lastRunTimestamp: 1000 },
+      { scenarioSetId: "newest-set", passedCount: 5, totalCount: 5, lastRunTimestamp: 3000 },
+      { scenarioSetId: "middle-set", passedCount: 4, totalCount: 5, lastRunTimestamp: 2000 },
+    ];
+
+    describe("when rendered in the expanded sidebar", () => {
+      it("sorts external sets by most recent run first", () => {
+        render(
+          <SuiteSidebar
+            {...defaultProps}
+            externalSets={externalSets}
+          />,
+          { wrapper: Wrapper },
+        );
+
+        const items = screen.getAllByTestId("external-set-list-item");
+        const labels = items.map((el) => el.textContent);
+
+        expect(labels[0]).toContain("newest-set");
+        expect(labels[1]).toContain("middle-set");
+        expect(labels[2]).toContain("oldest-set");
+      });
+    });
+  });
 });

--- a/langwatch/src/server/scenarios/scenario-event.service.ts
+++ b/langwatch/src/server/scenarios/scenario-event.service.ts
@@ -885,12 +885,14 @@ export class ScenarioEventService {
         // ES path cannot resolve per-run pass/fail status; return zero counts
         // so the sidebar hides the summary line rather than showing misleading data.
         // ClickHouse is the primary backend for accurate pass/fail stats.
-        return externalSets.map((s) => ({
-          scenarioSetId: s.scenarioSetId,
-          passedCount: 0,
-          totalCount: 0,
-          lastRunTimestamp: s.lastRunAt,
-        }));
+        return externalSets
+          .map((s) => ({
+            scenarioSetId: s.scenarioSetId,
+            passedCount: 0,
+            totalCount: 0,
+            lastRunTimestamp: s.lastRunAt,
+          }))
+          .sort((a, b) => b.lastRunTimestamp - a.lastRunTimestamp);
       },
     );
   }


### PR DESCRIPTION
## Summary
- External sets (SDK/CI runs) in the Suites sidebar were not sorted by most recent run, unlike regular suites
- Added descending sort by `lastRunTimestamp` in the frontend `useMemo` (covers all backends)
- Added sort in the ES fallback path for backend consistency (ClickHouse path already had `ORDER BY LastRunAt DESC`)

Closes #2280

## Test plan
- [x] Regression test: `SuiteSidebar.integration.test.tsx` — "sorts external sets by most recent run first"
- [x] All 39 existing SuiteSidebar tests pass
- [ ] Manual: verify external sets appear newest-first in sidebar (requires ClickHouse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2280