### PR TITLE
test(suites): unify external set sidebar item coverage (#2281)

### DIFF
--- a/langwatch/src/components/suites/__tests__/ExternalSetsSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ExternalSetsSidebar.integration.test.tsx
@@ -311,6 +311,77 @@ describe("<SuiteSidebar/> External Sets", () => {
     });
   });
 
+  describe("given an external set with no runs", () => {
+    it("displays only the name with no summary line", () => {
+      render(
+        <SuiteSidebar
+          {...defaultProps}
+          externalSets={[
+            makeExternalSet({
+              scenarioSetId: "New Set",
+              passedCount: 0,
+              totalCount: 0,
+              lastRunTimestamp: 0,
+            }),
+          ]}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByText("New Set")).toBeInTheDocument();
+      expect(screen.queryByText(/passed/)).not.toBeInTheDocument();
+      expect(screen.queryByTestId("status-icon-pass")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("status-icon-fail")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given an external set with runs", () => {
+    it("displays recency indicator alongside pass count", () => {
+      vi.useFakeTimers();
+      const now = new Date("2025-01-15T12:00:00Z").getTime();
+      vi.setSystemTime(now);
+
+      try {
+        render(
+          <SuiteSidebar
+            {...defaultProps}
+            externalSets={[
+              makeExternalSet({
+                scenarioSetId: "ci-smoke-tests",
+                passedCount: 15,
+                totalCount: 20,
+                lastRunTimestamp: now - 30 * 60 * 1000,
+              }),
+            ]}
+          />,
+          { wrapper: Wrapper },
+        );
+
+        expect(screen.getByText(/15 passed/)).toBeInTheDocument();
+        expect(screen.getByText(/30m ago/)).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not show a three-dot menu button", () => {
+      render(
+        <SuiteSidebar
+          {...defaultProps}
+          externalSets={[
+            makeExternalSet({ scenarioSetId: "ci-smoke-tests" }),
+          ]}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      const items = screen.getAllByTestId("external-set-list-item");
+      expect(
+        within(items[0]!).queryByTestId("suite-menu-button"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("ordering", () => {
     it("displays external sets ordered by most recent run first", () => {
       // Backend returns sets ordered by most recent run first

--- a/specs/features/suites/unified-sidebar-list-items.feature
+++ b/specs/features/suites/unified-sidebar-list-items.feature
@@ -1,0 +1,57 @@
+Feature: Unified sidebar list items for suites and external sets
+  As a LangWatch user
+  I want external set items in the sidebar to look the same as suite items
+  So that I have a consistent experience regardless of where the evaluation runs originated
+
+  Background:
+    Given I am logged into project "my-project"
+
+  # The core unification behavior: both item types display the same information
+  # using shared building blocks (status icon, summary line, layout wrapper).
+  # Each keeps its own component but composes from the same pieces.
+
+  @integration
+  Scenario: External set item displays the same information as a suite item
+    Given suite "Billing Tests" last ran 1 hour ago with 8/10 passing
+    And scenarioSetId "ci-smoke-tests" last ran 30 minutes ago with 15/20 passing
+    When I view the suites sidebar
+    Then both "Billing Tests" and "ci-smoke-tests" display a name, status icon, pass count, and recency
+
+  @integration
+  Scenario: External set item does not show a Run button
+    Given scenarioSetId "ci-smoke-tests" last ran 1 hour ago with 15/20 passing
+    When I view the suites sidebar
+    Then the "ci-smoke-tests" list item does not contain a Run button
+
+  @integration
+  Scenario: Suite item shows a Run button
+    Given suite "Billing Tests" exists with completed runs
+    When I view the suites sidebar
+    Then the "Billing Tests" list item contains a Run button
+
+  @integration
+  Scenario: External set item does not show a three-dot context menu on hover
+    Given scenarioSetId "ci-smoke-tests" last ran 1 hour ago with 15/20 passing
+    When I hover over "ci-smoke-tests" in the sidebar
+    Then no three-dot menu button appears for "ci-smoke-tests"
+
+  @integration
+  Scenario: Suite item shows a three-dot context menu on hover
+    Given suite "Billing Tests" exists with completed runs
+    When I hover over "Billing Tests" in the sidebar
+    Then a three-dot menu button appears for "Billing Tests"
+
+  # Component rendering tests verify the external set list item composes
+  # shared building blocks (StatusIcon, RunSummaryLine) like the suite list item.
+
+  @integration
+  Scenario: External set list item displays pass count and recency using shared building blocks
+    Given an external set list item with name "ci-smoke-tests" and 15/20 passed 30 minutes ago
+    When the list item renders
+    Then it displays a status icon, "15 passed", and a recency indicator
+
+  @integration
+  Scenario: External set list item displays no summary when there are no runs
+    Given an external set list item with name "New Set" and no run summary
+    When the list item renders
+    Then it displays only the name with no summary line


### PR DESCRIPTION
## Summary

- External set list items already compose the same shared building blocks (`StatusIcon`, `RunSummaryLine`, `SidebarListItemWrapper`) as suite items — no component changes needed
- Added 3 missing integration tests: recency display with fake timers, no-runs empty state, three-dot menu absence
- Created feature spec (`unified-sidebar-list-items.feature`) documenting the visual parity contract

Closes #2281

## Test plan

- [x] `pnpm test:unit ExternalSetsSidebar.integration.test.tsx` — 17/17 passing
- [x] Recency test uses `vi.useFakeTimers()` to avoid minute-boundary flakes
- [x] Browser verification: page skeleton loads correctly (full data verification requires ClickHouse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2281