### PR TITLE
fix(simulations): use useSimulationRouter for set navigation

### DIFF
--- a/langwatch/src/hooks/simulations/__tests__/useSimulationRouter.unit.test.ts
+++ b/langwatch/src/hooks/simulations/__tests__/useSimulationRouter.unit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression tests for useSimulationRouter.
+ *
+ * Verifies that navigation functions construct URLs from the project slug
+ * rather than from router.asPath, which would include query parameters
+ * and produce malformed URLs.
+ *
+ * @see https://github.com/langwatch/langwatch/issues/2297
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+
+let mockQuery: Record<string, string> = {};
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    query: mockQuery,
+    push: mockPush,
+    replace: mockReplace,
+    asPath: "/my-project/simulations?startDate=1234&endDate=5678",
+  }),
+}));
+
+vi.mock("../../useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { slug: "my-project" },
+  }),
+}));
+
+import { useSimulationRouter } from "../useSimulationRouter";
+
+describe("useSimulationRouter", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockQuery = {};
+  });
+
+  describe("goToSimulationSet", () => {
+    describe("when query parameters are present in the URL", () => {
+      it("navigates using project slug, not router.asPath", () => {
+        const { result } = renderHook(() => useSimulationRouter());
+
+        result.current.goToSimulationSet("test-set-123");
+
+        expect(mockPush).toHaveBeenCalledWith(
+          "/my-project/simulations/test-set-123"
+        );
+        expect(mockPush).toHaveBeenCalledTimes(1);
+      });
+
+      it("produces a URL without query parameters", () => {
+        const { result } = renderHook(() => useSimulationRouter());
+
+        result.current.goToSimulationSet("test-set-123");
+
+        const calledUrl = mockPush.mock.calls[0]![0] as string;
+        expect(calledUrl).not.toContain("?");
+        expect(calledUrl).not.toContain("startDate");
+        expect(calledUrl).not.toContain("endDate");
+      });
+    });
+  });
+});

--- a/langwatch/src/pages/[project]/simulations/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/index.tsx
@@ -1,5 +1,4 @@
 import { Grid, HStack, Spacer, Spinner, Text, VStack } from "@chakra-ui/react";
-import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 import { DashboardLayout } from "~/components/DashboardLayout";
 import { PeriodSelector, usePeriodSelector } from "~/components/PeriodSelector";
@@ -9,11 +8,12 @@ import { PageLayout } from "~/components/ui/layouts/PageLayout";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useSimulationUpdateListener } from "~/hooks/useSimulationUpdateListener";
+import { useSimulationRouter } from "~/hooks/simulations/useSimulationRouter";
 import { api } from "~/utils/api";
 import { sortScenarioSets } from "~/features/simulations/sort-scenario-sets";
 
 function SimulationsPageContent() {
-  const router = useRouter();
+  const { goToSimulationSet } = useSimulationRouter();
   const { project } = useOrganizationTeamProject();
   const { period, setPeriod } = usePeriodSelector(30);
 
@@ -49,8 +49,7 @@ function SimulationsPageContent() {
   }, [scenarioSetsData]);
 
   const handleSetClick = (scenarioSetId: string) => {
-    // Navigate to the specific set page using the catch-all route
-    void router.push(`${router.asPath}/${scenarioSetId}`);
+    goToSimulationSet(scenarioSetId);
   };
 
   return (


### PR DESCRIPTION
## Summary

- **Bug:** Clicking older simulation sets (visible after expanding date range from 30 to 90 days) caused a page reload instead of client-side navigation, and broke all subsequent click handlers
- **Root cause:** `handleSetClick` used `router.asPath` to build URLs, which included query parameters from the date range filter, producing malformed URLs like `/project/simulations?startDate=...&endDate=.../setId`
- **Fix:** Replaced with the existing `useSimulationRouter` hook's `goToSimulationSet()` which builds clean URLs from the project slug

## Test plan

- [x] Regression test: `useSimulationRouter.unit.test.ts` verifies navigation produces clean URLs without query param contamination
- [x] Typecheck passes (pre-existing Prisma errors only)
- [x] Code review passed (uncle-bob, cupid, test quality, security)

## Browser Test: simulation-sets-navigation

| # | Scenario | Result | Screenshot |
|---|----------|--------|------------|
| 1 | Sign in to the app | PASS | ![01](https://i.img402.dev/m9p4f8k50e.png) |
| 2 | Navigate to simulation sets page | PASS | ![02](https://i.img402.dev/g8ou4fm7y7.png) |
| 3 | Check simulation sets data | N/A (ClickHouse not in minimal dev) | ![03](https://i.img402.dev/fn6mqbxuas.png) |

> Note: Full end-to-end verification of clicking simulation sets requires ClickHouse (available via `make dev-scenarios`). The page loads correctly and the fix is confirmed via code review and unit tests.

Closes #2297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2297