### PR TITLE
feat(suites): rename Suites to Run Plans and Runs to Run History in UI

### DIFF
--- a/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -168,7 +168,7 @@ export function ScenarioRunDetailDrawer({
       { label: "Scenario ID", value: scenarioId },
       { label: "Batch Run ID", value: batchRunId },
       { label: "Run ID", value: scenarioRunId },
-      ...(suiteId ? [{ label: "Suite ID", value: suiteId }] : []),
+      ...(suiteId ? [{ label: "Run Plan ID", value: suiteId }] : []),
     ];
   }, [scenarioId, batchRunId, scenarioRunId, suiteId]);
 

--- a/langwatch/src/components/suites/SuiteArchiveDialog.tsx
+++ b/langwatch/src/components/suites/SuiteArchiveDialog.tsx
@@ -29,7 +29,7 @@ export function SuiteArchiveDialog({
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title fontSize="md" fontWeight="500">
-            Archive suite?
+            Archive run plan?
           </Dialog.Title>
         </Dialog.Header>
         <Dialog.Body>
@@ -40,7 +40,7 @@ export function SuiteArchiveDialog({
               </Text>
             </Text>
             <Text color="fg.muted" fontSize="sm">
-              Archived suites will no longer appear in the sidebar. Test runs are preserved.
+              Archived run plans will no longer appear in the sidebar. Test runs are preserved.
             </Text>
           </VStack>
         </Dialog.Body>

--- a/langwatch/src/components/suites/SuiteDetailPanel.tsx
+++ b/langwatch/src/components/suites/SuiteDetailPanel.tsx
@@ -256,12 +256,12 @@ export function SuiteEmptyState({ onNewSuite }: { onNewSuite: () => void }) {
           <EmptyState.Indicator>
             <FolderOpen size={32} />
           </EmptyState.Indicator>
-          <EmptyState.Title>No suite selected</EmptyState.Title>
+          <EmptyState.Title>No run plan selected</EmptyState.Title>
           <EmptyState.Description>
-            Select a suite from the sidebar or create a new one
+            Select a run plan from the sidebar or create a new one
           </EmptyState.Description>
           <Button colorPalette="blue" onClick={onNewSuite}>
-            <Plus size={16} /> New Suite
+            <Plus size={16} /> New Run Plan
           </Button>
         </EmptyState.Content>
       </EmptyState.Root>

--- a/langwatch/src/components/suites/SuiteFormDrawer.tsx
+++ b/langwatch/src/components/suites/SuiteFormDrawer.tsx
@@ -100,7 +100,7 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
   );
 
   const isEditMode = !!suiteId;
-  const title = isEditMode ? "Edit Suite" : "New Suite";
+  const title = isEditMode ? "Edit Run Plan" : "New Run Plan";
 
   const suiteForm = useSuiteForm({
     suite: suite ?? null,
@@ -156,14 +156,14 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
       onSaved?.(data);
       closeDrawer();
       toaster.create({
-        title: "Suite created",
+        title: "Run plan created",
         type: "success",
         meta: { closable: true },
       });
     },
     onError: (err) => {
       toaster.create({
-        title: "Failed to create suite",
+        title: "Failed to create run plan",
         description: err.message,
         type: "error",
         meta: { closable: true },
@@ -181,14 +181,14 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
       onSaved?.(data);
       closeDrawer();
       toaster.create({
-        title: "Suite updated",
+        title: "Run plan updated",
         type: "success",
         meta: { closable: true },
       });
     },
     onError: (err) => {
       toaster.create({
-        title: "Failed to update suite",
+        title: "Failed to update run plan",
         description: err.message,
         type: "error",
         meta: { closable: true },
@@ -274,7 +274,7 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
                 Name *
               </Text>
               <Input
-                placeholder="e.g., Critical Path Suite"
+                placeholder="e.g., Critical Path Run Plan"
                 {...form.register("name")}
                 borderColor={errors.name ? "red.500" : undefined}
               />

--- a/langwatch/src/components/suites/SuiteSidebar.tsx
+++ b/langwatch/src/components/suites/SuiteSidebar.tsx
@@ -260,7 +260,7 @@ export function SuiteSidebar({
             paddingY={4}
             textAlign="center"
           >
-            No suites yet
+            No run plans yet
           </Text>
         )}
         {hasNoResults &&
@@ -272,7 +272,7 @@ export function SuiteSidebar({
               paddingY={4}
               textAlign="center"
             >
-              No matching suites
+              No matching run plans
             </Text>
           )}
         {filteredSuites.map((suite) => (

--- a/langwatch/src/components/suites/__tests__/ExternalSetsSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ExternalSetsSidebar.integration.test.tsx
@@ -306,7 +306,7 @@ describe("<SuiteSidebar/> External Sets", () => {
         expect(
           screen.queryByTestId("external-sets-header"),
         ).not.toBeInTheDocument();
-        expect(screen.getByText("No matching suites")).toBeInTheDocument();
+        expect(screen.getByText("No matching run plans")).toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/suites/__tests__/SuiteArchiveDialog.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteArchiveDialog.integration.test.tsx
@@ -33,10 +33,10 @@ describe("<SuiteArchiveDialog/>", () => {
   });
 
   describe("given the dialog is open", () => {
-    it("displays 'Archive suite?' as the title", () => {
+    it("displays 'Archive run plan?' as the title", () => {
       render(<SuiteArchiveDialog {...defaultProps} />, { wrapper: Wrapper });
 
-      expect(screen.getByText("Archive suite?")).toBeInTheDocument();
+      expect(screen.getByText("Archive run plan?")).toBeInTheDocument();
     });
 
     it("displays the suite name", () => {
@@ -49,7 +49,7 @@ describe("<SuiteArchiveDialog/>", () => {
       render(<SuiteArchiveDialog {...defaultProps} />, { wrapper: Wrapper });
 
       expect(
-        screen.getByText("Archived suites will no longer appear in the sidebar. Test runs are preserved."),
+        screen.getByText("Archived run plans will no longer appear in the sidebar. Test runs are preserved."),
       ).toBeInTheDocument();
     });
 

--- a/langwatch/src/components/suites/__tests__/SuiteDetailPanel.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteDetailPanel.integration.test.tsx
@@ -324,11 +324,11 @@ describe("<SuiteEmptyState/>", () => {
     );
 
     expect(
-      screen.getByText("Select a suite from the sidebar or create a new one"),
+      screen.getByText("Select a run plan from the sidebar or create a new one"),
     ).toBeInTheDocument();
   });
 
-  describe("when New Suite button is clicked", () => {
+  describe("when New Run Plan button is clicked", () => {
     it("calls onNewSuite", async () => {
       const user = userEvent.setup();
       const onNewSuite = vi.fn();
@@ -342,7 +342,7 @@ describe("<SuiteEmptyState/>", () => {
         },
       );
 
-      await user.click(screen.getByText("New Suite"));
+      await user.click(screen.getByText("New Run Plan"));
       expect(onNewSuite).toHaveBeenCalledOnce();
     });
   });

--- a/langwatch/src/components/suites/__tests__/SuiteFormDrawer.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteFormDrawer.integration.test.tsx
@@ -10,7 +10,7 @@
  * `useDrawer().drawerOpen("suiteEditor")` and edit mode is
  * determined by `useDrawerParams().suiteId`.
  *
- * @see specs/suites/suite-workflow.feature - "Create / Edit Suite"
+ * @see specs/suites/suite-workflow.feature - "Create / Edit Run Plan"
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
@@ -226,17 +226,17 @@ describe("<SuiteFormDrawer/>", () => {
   });
 
   describe("given the drawer is open in create mode", () => {
-    it("displays the 'New Suite' title", () => {
+    it("displays the 'New Run Plan' title", () => {
       render(<SuiteFormDrawer />, { wrapper: Wrapper });
 
-      expect(screen.getByText("New Suite")).toBeInTheDocument();
+      expect(screen.getByText("New Run Plan")).toBeInTheDocument();
     });
 
     it("renders fields for Name, Description, Scenarios, and Targets", () => {
       render(<SuiteFormDrawer />, { wrapper: Wrapper });
 
       expect(
-        screen.getByPlaceholderText("e.g., Critical Path Suite"),
+        screen.getByPlaceholderText("e.g., Critical Path Run Plan"),
       ).toBeInTheDocument();
       expect(
         screen.getByPlaceholderText("Core journeys that must pass before deploy"),
@@ -273,7 +273,7 @@ describe("<SuiteFormDrawer/>", () => {
 
         // Type a name
         const nameInput = screen.getByPlaceholderText(
-          "e.g., Critical Path Suite",
+          "e.g., Critical Path Run Plan",
         );
         await user.type(nameInput, "Test Suite");
 
@@ -294,7 +294,7 @@ describe("<SuiteFormDrawer/>", () => {
 
         // Type a name
         const nameInput = screen.getByPlaceholderText(
-          "e.g., Critical Path Suite",
+          "e.g., Critical Path Run Plan",
         );
         await user.type(nameInput, "Test Suite");
 
@@ -332,7 +332,7 @@ describe("<SuiteFormDrawer/>", () => {
 
         // Type in the name field
         const nameInput = screen.getByPlaceholderText(
-          "e.g., Critical Path Suite",
+          "e.g., Critical Path Run Plan",
         );
         await user.type(nameInput, "My Suite");
 
@@ -362,7 +362,7 @@ describe("<SuiteFormDrawer/>", () => {
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
 
         const nameInput = screen.getByPlaceholderText(
-          "e.g., Critical Path Suite",
+          "e.g., Critical Path Run Plan",
         ) as HTMLInputElement;
         expect(nameInput.value).toBe("Regression Suite");
       });
@@ -378,12 +378,12 @@ describe("<SuiteFormDrawer/>", () => {
         expect(descInput.value).toBe("Runs every deploy");
       });
 
-      it("displays the Edit Suite title", () => {
+      it("displays the Edit Run Plan title", () => {
         mocks.mockGetByIdData = makeSuiteConfig();
 
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
 
-        expect(screen.getByText("Edit Suite")).toBeInTheDocument();
+        expect(screen.getByText("Edit Run Plan")).toBeInTheDocument();
       });
     });
   });
@@ -435,7 +435,7 @@ describe("<SuiteFormDrawer/>", () => {
 
         // Fill in required fields
         const nameInput = screen.getByPlaceholderText(
-          "e.g., Critical Path Suite",
+          "e.g., Critical Path Run Plan",
         );
         await user.type(nameInput, "Test Suite");
 
@@ -500,7 +500,7 @@ describe("<SuiteFormDrawer/>", () => {
         await user.click(screen.getByRole("button", { name: "Add Scenario" }));
 
         // Parent suite editor content remains in the DOM
-        expect(screen.getByPlaceholderText("e.g., Critical Path Suite")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("e.g., Critical Path Run Plan")).toBeInTheDocument();
         expect(screen.getByText("Scenarios *")).toBeInTheDocument();
       });
     });
@@ -511,7 +511,7 @@ describe("<SuiteFormDrawer/>", () => {
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
 
         // Enter a name to establish form state
-        const nameInput = screen.getByPlaceholderText("e.g., Critical Path Suite");
+        const nameInput = screen.getByPlaceholderText("e.g., Critical Path Run Plan");
         await user.type(nameInput, "My Suite");
 
         // Open scenario editor
@@ -525,7 +525,7 @@ describe("<SuiteFormDrawer/>", () => {
         expect(screen.queryByTestId("scenario-editor-child-drawer")).not.toBeInTheDocument();
 
         // Suite editor still shows form state
-        const nameInputAfter = screen.getByPlaceholderText("e.g., Critical Path Suite") as HTMLInputElement;
+        const nameInputAfter = screen.getByPlaceholderText("e.g., Critical Path Run Plan") as HTMLInputElement;
         expect(nameInputAfter.value).toBe("My Suite");
       });
     });
@@ -547,7 +547,7 @@ describe("<SuiteFormDrawer/>", () => {
         await user.click(screen.getByRole("button", { name: "Add Target" }));
 
         // Parent suite editor content remains in the DOM
-        expect(screen.getByPlaceholderText("e.g., Critical Path Suite")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("e.g., Critical Path Run Plan")).toBeInTheDocument();
         expect(screen.getByText("Scenarios *")).toBeInTheDocument();
       });
     });
@@ -558,7 +558,7 @@ describe("<SuiteFormDrawer/>", () => {
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
 
         // Enter a name to establish form state
-        const nameInput = screen.getByPlaceholderText("e.g., Critical Path Suite");
+        const nameInput = screen.getByPlaceholderText("e.g., Critical Path Run Plan");
         await user.type(nameInput, "My Suite");
 
         // Open agent editor
@@ -572,7 +572,7 @@ describe("<SuiteFormDrawer/>", () => {
         expect(screen.queryByTestId("agent-http-editor-child-drawer")).not.toBeInTheDocument();
 
         // Suite editor still shows form state
-        const nameInputAfter = screen.getByPlaceholderText("e.g., Critical Path Suite") as HTMLInputElement;
+        const nameInputAfter = screen.getByPlaceholderText("e.g., Critical Path Run Plan") as HTMLInputElement;
         expect(nameInputAfter.value).toBe("My Suite");
       });
     });
@@ -583,7 +583,7 @@ describe("<SuiteFormDrawer/>", () => {
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
 
         // Fill in name
-        const nameInput = screen.getByPlaceholderText("e.g., Critical Path Suite");
+        const nameInput = screen.getByPlaceholderText("e.g., Critical Path Run Plan");
         await user.type(nameInput, "My Suite");
 
         // Select a scenario
@@ -594,7 +594,7 @@ describe("<SuiteFormDrawer/>", () => {
         fireEvent.click(screen.getByText("Close Scenario Editor"));
 
         // Verify form state is preserved (re-query to avoid stale node references)
-        const nameInputAfter = screen.getByPlaceholderText("e.g., Critical Path Suite") as HTMLInputElement;
+        const nameInputAfter = screen.getByPlaceholderText("e.g., Critical Path Run Plan") as HTMLInputElement;
         expect(nameInputAfter.value).toBe("My Suite");
         const scenarioCheckboxAfter = screen.getAllByRole("checkbox")[0] as HTMLInputElement;
         expect(scenarioCheckboxAfter).toBeChecked();

--- a/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
@@ -63,7 +63,7 @@ describe("<SuiteSidebar/>", () => {
         wrapper: Wrapper,
       });
 
-      expect(screen.getByText("No suites yet")).toBeInTheDocument();
+      expect(screen.getByText("No run plans yet")).toBeInTheDocument();
     });
 
     it("displays the All Runs link", () => {
@@ -211,7 +211,7 @@ describe("<SuiteSidebar/>", () => {
         const searchInput = screen.getByPlaceholderText("Search...");
         await user.type(searchInput, "nonexistent");
 
-        expect(screen.getByText("No matching suites")).toBeInTheDocument();
+        expect(screen.getByText("No matching run plans")).toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/suites/__tests__/SuiteUrlRouting.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteUrlRouting.integration.test.tsx
@@ -139,7 +139,7 @@ vi.mock("~/components/suites/SuiteDetailPanel", () => ({
   SuiteDetailPanel: ({ suite }: { suite: { name: string } }) => (
     <div data-testid="suite-detail-panel">{suite.name} details</div>
   ),
-  SuiteEmptyState: () => <div data-testid="suite-empty-state">No suite selected</div>,
+  SuiteEmptyState: () => <div data-testid="suite-empty-state">No run plan selected</div>,
 }));
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/langwatch/src/components/suites/__tests__/SuitesPageLayout.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuitesPageLayout.integration.test.tsx
@@ -129,7 +129,7 @@ describe("Suites Page Layout (Issue #1671)", () => {
   });
 
   describe("when rendering the suites page", () => {
-    it("renders PageLayout.Header with a 'Suites' heading", async () => {
+    it("renders PageLayout.Header with a 'Run Plans' heading", async () => {
       // Dynamic import to ensure mocks are applied
       const { default: SuitesPage } = await import(
         "~/pages/[project]/simulations/suites/index"
@@ -137,7 +137,7 @@ describe("Suites Page Layout (Issue #1671)", () => {
 
       render(<SuitesPage />, { wrapper: Wrapper });
 
-      const heading = screen.getByRole("heading", { name: "Suites" });
+      const heading = screen.getByRole("heading", { name: "Run Plans" });
       expect(heading).toBeInTheDocument();
     });
 

--- a/langwatch/src/components/suites/useRunSuite.tsx
+++ b/langwatch/src/components/suites/useRunSuite.tsx
@@ -58,12 +58,12 @@ export function useRunSuite(options: UseRunSuiteOptions = {}) {
 
         const suiteIdForEdit = variables.id;
         toaster.create({
-          title: `Suite run scheduled (${result.jobCount} jobs)`,
+          title: `Run plan scheduled (${result.jobCount} jobs)`,
           description: `${parts.join(" and ")} skipped.`,
           type: "warning",
           meta: { closable: true },
           action: {
-            label: "Edit Suite",
+            label: "Edit Run Plan",
             onClick: () => {
               openDrawer("suiteEditor", {
                 urlParams: { suiteId: suiteIdForEdit },
@@ -73,7 +73,7 @@ export function useRunSuite(options: UseRunSuiteOptions = {}) {
         });
       } else {
         toaster.create({
-          title: `Suite run scheduled (${result.jobCount} jobs)`,
+          title: `Run plan scheduled (${result.jobCount} jobs)`,
           type: "success",
           meta: { closable: true },
         });
@@ -91,14 +91,14 @@ export function useRunSuite(options: UseRunSuiteOptions = {}) {
         (err.message.includes("All scenarios") ||
           err.message.includes("All targets"));
       toaster.create({
-        title: isAllArchived ? "Cannot run suite" : "Failed to run suite",
+        title: isAllArchived ? "Cannot start run plan" : "Run plan failed to start",
         description: err.message,
         type: "error",
         meta: { closable: true },
         ...(isAllArchived
           ? {
               action: {
-                label: "Edit Suite",
+                label: "Edit Run Plan",
                 onClick: () => {
                   openDrawer("suiteEditor", {
                     urlParams: { suiteId: suiteIdForToast },

--- a/langwatch/src/pages/[project]/simulations/[scenarioSetId]/[batchRunId]/[scenarioRunId]/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/[scenarioSetId]/[batchRunId]/[scenarioRunId]/index.tsx
@@ -87,7 +87,7 @@ export default function IndividualScenarioRunPage() {
     if (scenarioId) ids.push({ label: "Scenario ID", value: scenarioId });
     if (batchRunId) ids.push({ label: "Batch Run ID", value: batchRunId });
     if (scenarioRunId) ids.push({ label: "Run ID", value: scenarioRunId });
-    if (suiteId) ids.push({ label: "Suite ID", value: suiteId });
+    if (suiteId) ids.push({ label: "Run Plan ID", value: suiteId });
     return ids;
   }, [scenarioId, batchRunId, scenarioRunId, suiteId]);
 

--- a/langwatch/src/pages/[project]/simulations/suites/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/suites/index.tsx
@@ -129,14 +129,14 @@ function SuitesPageContent() {
       }
       setArchiveConfirmId(null);
       toaster.create({
-        title: "Suite archived",
+        title: "Run plan archived",
         type: "success",
         meta: { closable: true },
       });
     },
     onError: (err) => {
       toaster.create({
-        title: "Failed to archive suite",
+        title: "Failed to archive run plan",
         description: err.message,
         type: "error",
         meta: { closable: true },
@@ -149,14 +149,14 @@ function SuitesPageContent() {
       void utils.suites.getAll.invalidate();
       navigateToSuite(data.slug);
       toaster.create({
-        title: "Suite duplicated",
+        title: "Run plan duplicated",
         type: "success",
         meta: { closable: true },
       });
     },
     onError: (err) => {
       toaster.create({
-        title: "Failed to duplicate suite",
+        title: "Failed to duplicate run plan",
         description: err.message,
         type: "error",
         meta: { closable: true },
@@ -246,11 +246,11 @@ function SuitesPageContent() {
     <DashboardLayout>
       <PageLayout.Header>
         <HStack justify="space-between" align="center" w="full">
-          <PageLayout.Heading>Suites</PageLayout.Heading>
+          <PageLayout.Heading>Run Plans</PageLayout.Heading>
           <Spacer />
           <PeriodSelector period={period} setPeriod={setPeriod} />
           <PageLayout.HeaderButton onClick={handleNewSuite}>
-            <Plus size={16} /> New Suite
+            <Plus size={16} /> New Run Plan
           </PageLayout.HeaderButton>
         </HStack>
       </PageLayout.Header>

--- a/langwatch/src/utils/__tests__/featureIcons.unit.test.ts
+++ b/langwatch/src/utils/__tests__/featureIcons.unit.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @see specs/features/suites/rename-suites-to-runs.feature - Feature icon label scenarios
+ */
+import { describe, expect, it } from "vitest";
+import { featureIcons } from "../featureIcons";
+
+describe("featureIcons", () => {
+  describe("when the suites feature icon configuration is read", () => {
+    it("has label 'Run Plans'", () => {
+      expect(featureIcons.suites.label).toBe("Run Plans");
+    });
+  });
+
+  describe("when the simulation runs feature icon configuration is read", () => {
+    it("has label 'Run History'", () => {
+      expect(featureIcons.simulation_runs.label).toBe("Run History");
+    });
+  });
+});

--- a/langwatch/src/utils/__tests__/routes.unit.test.ts
+++ b/langwatch/src/utils/__tests__/routes.unit.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @see specs/features/suites/rename-suites-to-runs.feature - Route title scenarios
+ */
+import { describe, expect, it } from "vitest";
+import { projectRoutes } from "../routes";
+
+describe("projectRoutes", () => {
+  describe("when the suites route configuration is read", () => {
+    it("has title 'Run Plans'", () => {
+      expect(projectRoutes.suites.title).toBe("Run Plans");
+    });
+  });
+
+  describe("when the simulation runs route configuration is read", () => {
+    it("has title 'Run History'", () => {
+      expect(projectRoutes.simulation_runs.title).toBe("Run History");
+    });
+  });
+});

--- a/langwatch/src/utils/featureIcons.ts
+++ b/langwatch/src/utils/featureIcons.ts
@@ -77,12 +77,12 @@ export const featureIcons: Record<FeatureKey, FeatureConfig> = {
   simulation_runs: {
     icon: PlayCircle,
     color: "pink.500",
-    label: "Runs",
+    label: "Run History",
   },
   suites: {
     icon: FolderOpen,
     color: "pink.500",
-    label: "Suites",
+    label: "Run Plans",
   },
   evaluations: {
     icon: CheckSquare,

--- a/langwatch/src/utils/routes.ts
+++ b/langwatch/src/utils/routes.ts
@@ -128,7 +128,7 @@ export const projectRoutes = {
   },
   simulation_runs: {
     path: "/[project]/simulations",
-    title: "Runs",
+    title: "Run History",
     parent: "simulations",
   },
   scenarios: {
@@ -138,7 +138,7 @@ export const projectRoutes = {
   },
   suites: {
     path: "/[project]/simulations/suites",
-    title: "Suites",
+    title: "Run Plans",
     parent: "simulations",
   },
   simulations_batch: {

--- a/specs/features/suites/rename-suites-to-runs.feature
+++ b/specs/features/suites/rename-suites-to-runs.feature
@@ -1,0 +1,122 @@
+Feature: Rename Suites to Run Plans and Simulation Runs to Run History in UI
+  As a user
+  I want the UI to use "Run Plans" instead of "Suites" and "Run History" instead of "Runs"
+  So that the terminology is clearer and avoids naming collisions
+
+  Background:
+    Given the user is logged in and has a project
+
+  # --- Navigation & Page Structure ---
+
+  @e2e
+  Scenario: Sidebar displays "Run Plans" instead of "Suites"
+    When the user views the sidebar navigation under Simulations
+    Then the item formerly labeled "Suites" reads "Run Plans"
+
+  @e2e
+  Scenario: Sidebar displays "Run History" instead of "Runs"
+    When the user views the sidebar navigation under Simulations
+    Then the item formerly labeled "Runs" reads "Run History"
+
+  @integration
+  Scenario: Page header displays "Run Plans"
+    When the user navigates to the suites list page
+    Then the page heading reads "Run Plans"
+
+  @unit
+  Scenario: Route title is "Run Plans"
+    When the suites route configuration is read
+    Then its title property is "Run Plans"
+
+  @unit
+  Scenario: Feature icon label for suites is "Run Plans"
+    When the suites feature icon configuration is read
+    Then its label property is "Run Plans"
+
+  @unit
+  Scenario: Route title for simulation runs is "Run History"
+    When the simulation runs route configuration is read
+    Then its title property is "Run History"
+
+  @unit
+  Scenario: Feature icon label for simulation runs is "Run History"
+    When the simulation runs feature icon configuration is read
+    Then its label property is "Run History"
+
+  # --- Create / Edit Forms ---
+
+  @integration
+  Scenario: Form drawer title reads "New Run Plan" for creation
+    When the user opens the form to create a new run plan
+    Then the drawer title reads "New Run Plan"
+
+  @integration
+  Scenario: Form drawer title reads "Edit Run Plan" for editing
+    Given a run plan already exists
+    When the user opens the form to edit that run plan
+    Then the drawer title reads "Edit Run Plan"
+
+  @integration
+  Scenario: Form placeholder uses "Run Plan" terminology
+    When the user opens the form to create a new run plan
+    Then the name field placeholder reads "e.g., Critical Path Run Plan"
+
+  # --- Toast Messages ---
+
+  @integration
+  Scenario: Success toast after creating a run plan
+    When the user successfully creates a run plan
+    Then a toast displays "Run plan created"
+
+  @integration
+  Scenario: Success toast after updating a run plan
+    When the user successfully updates a run plan
+    Then a toast displays "Run plan updated"
+
+  @integration
+  Scenario: Success toast after archiving a run plan
+    When the user archives a run plan
+    Then a toast displays "Run plan archived"
+
+  @integration
+  Scenario: Success toast after duplicating a run plan
+    When the user duplicates a run plan
+    Then a toast displays "Run plan duplicated"
+
+  # --- Dialogs & Empty States ---
+
+  @integration
+  Scenario: Archive confirmation dialog uses "run plan"
+    When the user initiates archiving a run plan
+    Then the confirmation dialog title reads "Archive run plan?"
+    And the dialog body mentions "archived run plans"
+
+  @integration
+  Scenario: Empty state when no run plans exist
+    Given no run plans exist in the project
+    When the user views the run plans sidebar
+    Then the empty state reads "No run plans yet"
+
+  @integration
+  Scenario: Empty state when search has no matches
+    Given run plans exist but none match the search query
+    When the user searches in the run plans sidebar
+    Then the empty state reads "No matching run plans"
+
+  @integration
+  Scenario: Detail panel empty state
+    When no run plan is selected
+    Then the detail panel reads "No run plan selected"
+    And shows a prompt to "Select a run plan from the sidebar"
+
+  @integration
+  Scenario: Detail panel empty state button
+    When no run plan is selected
+    Then the detail panel shows a "New Run Plan" button
+
+  # --- Header Button ---
+
+  @integration
+  Scenario: Page header button reads "New Run Plan"
+    When the user views the suites list page
+    Then the header button reads "New Run Plan"


### PR DESCRIPTION
## Summary

Closes #2285

Display-only rename of all user-facing strings throughout the Suites/Simulations UI:

- **Suites → Run Plans** (sidebar, page header, forms, toasts, dialogs, empty states)
- **Runs → Run History** (sidebar navigation, route title, feature icon)
- **New Suite → New Run Plan** / **Edit Suite → Edit Run Plan**
- **Suite ID → Run Plan ID** in detail panels
- All toast messages, error messages, archive dialogs, and empty states updated

No database models, API endpoints, or code identifiers were changed.

## Changed Files (20)

| Area | Files |
|------|-------|
| Navigation & config | `routes.ts`, `featureIcons.ts` |
| Page & forms | `suites/index.tsx`, `SuiteFormDrawer.tsx`, `SuiteSidebar.tsx`, `SuiteDetailPanel.tsx` |
| Dialogs & hooks | `SuiteArchiveDialog.tsx`, `useRunSuite.tsx` |
| Detail panels | `ScenarioRunDetailDrawer.tsx`, `simulations/[...]/index.tsx` |
| Tests (updated) | 7 integration test files updated to match new strings |
| Tests (new) | `routes.unit.test.ts`, `featureIcons.unit.test.ts` |
| Spec | `specs/features/suites/rename-suites-to-runs.feature` |

## Test plan

- [x] Unit tests for route titles and feature icon labels (4 tests)
- [x] Integration tests for all component string changes (90 tests)
- [x] All 94 suite-related tests pass
- [ ] Browser verification — 4/6 scenarios verified, 2 inconclusive (see below)

## Browser Verification

| # | Scenario | Result | Screenshot |
|---|----------|--------|------------|
| 1 | Sign in | PASS | ![01](https://i.img402.dev/970v2abrq6.png) |
| 2 | Sidebar: "Run Plans" and "Run History" | PASS | ![02](https://i.img402.dev/g6kik4bz69.png) |
| 3 | Run Plans page header + "New Run Plan" button | PASS | ![03](https://i.img402.dev/k0ugfdyhod.png) |
| 4 | New Run Plan drawer title + placeholder | PASS | ![04](https://i.img402.dev/07nulpnfu6.png) |
| 5 | Close drawer | N/A | No screenshot — trivial UI action, not verifiable from screenshot |
| 6 | Run History page from sidebar | FAIL | ![05](https://i.img402.dev/tw4nyohmtt.png) — ECONNREFUSED 127.0.0.1:7280 (backend not running in test env; page didn't load) |

> **Note:** Scenario 6 failed due to the test environment backend (port 7280) not being available, not a code issue. The sidebar label "Run History" is confirmed in scenario 2. The string renames are fully covered by the 94 automated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2285