### PR TITLE
fix(typecheck): remove stale satisfactionScore references

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.unit.test.ts
@@ -62,7 +62,6 @@ function createFoldState(
     outputFromRootSpan: false,
     outputSpanEndTimeMs: 0,
     blockedByGuardrail: false,
-    satisfactionScore: null,
     topicId: null,
     subTopicId: null,
     hasAnnotation: null,

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -63,7 +63,6 @@ export function createEvaluationTriggerReactor(
       // Additional metadata for expanded precondition matching
       const topicId = foldState.topicId ?? undefined;
       const subTopicId = foldState.subTopicId ?? undefined;
-      const satisfactionScore = foldState.satisfactionScore ?? undefined;
       const spanModels = foldState.models.length > 0 ? foldState.models : undefined;
       const customMetadata = extractCustomMetadata(attrs);
       const computedInput = foldState.computedInput ?? undefined;
@@ -92,7 +91,6 @@ export function createEvaluationTriggerReactor(
             topicId,
             subTopicId,
             customMetadata,
-            satisfactionScore,
             spanModels,
             computedInput,
             computedOutput,


### PR DESCRIPTION
## Summary

- Removes `satisfactionScore` variable declaration (line 66) from `evaluationTrigger.reactor.ts` — the field was removed from `TraceSummaryData` in commit 7eef52aa9
- Removes `satisfactionScore` from the payload object (line 95) in the same file
- Removes `satisfactionScore: null` from the test fixture in `customEvaluationSync.reactor.unit.test.ts`

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] No functional change — pure dead-code removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2778