### PR TITLE
chore: update orchestrate skill to use drive-pr

### DIFF
--- a/.claude/skills/commit-push/SKILL.md
+++ b/.claude/skills/commit-push/SKILL.md
@@ -1,1 +1,0 @@
-Make a conventional commit for all changes and push to remote.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -86,10 +86,11 @@ A shorter workflow for bug fixes. Skips planning, challenge, user approval, and 
 - If verification fails → invoke `/code` with findings, re-run `/browser-test`
   - Max 2 iterations, then escalate to user
 
-### 6. Commit and Draft PR
-- Invoke `/commit-push` to commit all remaining changes and push to remote
+### 6. Commit, PR, and Drive to Green
+- Create a conventional commit for all changes and push to remote
 - Create a **draft** PR using `gh pr create --draft` with a summary of the work done (browser-test screenshots are already in the PR body)
 - Include the issue number in the PR body for linking
+- Invoke `/drive-pr --once` to fix any CI failures and address review comments
 
 ### 7. Verify and Finish
 
@@ -210,10 +211,11 @@ If ANY check fails:
 
 This self-check exists because it's easy to rationalize skipping work. Don't.
 
-### 10. Commit and Draft PR
-- Invoke `/commit-push` to commit all remaining changes and push to remote
+### 10. Commit, PR, and Drive to Green
+- Create a conventional commit for all changes and push to remote
 - Create a **draft** PR using `gh pr create --draft` with a summary of the work done (browser-test screenshots are already in the PR body)
 - Include the issue number in the PR body for linking
+- Invoke `/drive-pr --once` to fix any CI failures and address review comments
 
 ### 11. Verify and Finish
 
@@ -251,6 +253,7 @@ You delegate, you don't implement:
 - `/code` writes code and runs tests
 - `/review` checks quality
 - `/browser-test` verifies features work in a real browser
+- `/drive-pr` fixes CI failures and addresses review comments
 
 You manage infra lifecycle:
 - `scripts/dev-up.sh` starts an isolated dev instance (writes `.dev-port`)


### PR DESCRIPTION
## Summary
- Remove the `commit-push` skill (single-line wrapper that added no value)
- Update orchestrate skill to inline the commit+push step instead of delegating to `/commit-push`
- Add `/drive-pr --once` after PR creation to automatically fix CI failures and address review comments

## Test plan
- [x] Verify orchestrate skill reads correctly
- [x] Confirm commit-push skill is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)