### PR TITLE
chore: switch default evaluator model from gpt-5 to gpt-5-mini

### DIFF
--- a/langevals/evaluators/langevals/tests/test_llm_answer_match.py
+++ b/langevals/evaluators/langevals/tests/test_llm_answer_match.py
@@ -12,7 +12,7 @@ def test_llm_answer_match():
         expected_output="rock",
     )
     evaluator = LLMAnswerMatchEvaluator(
-        settings=LLMAnswerMatchSettings(model="openai/gpt-5")
+        settings=LLMAnswerMatchSettings(model="openai/gpt-5-mini")
     )
     result = evaluator.evaluate(entry)
 
@@ -28,7 +28,7 @@ def test_llm_answer_match_without_question():
         expected_output="rock",
     )
     evaluator = LLMAnswerMatchEvaluator(
-        settings=LLMAnswerMatchSettings(model="openai/gpt-5")
+        settings=LLMAnswerMatchSettings(model="openai/gpt-5-mini")
     )
     result = evaluator.evaluate(entry)
 
@@ -44,7 +44,7 @@ def test_llm_answer_does_not_match_match():
         expected_output="pop",
     )
     evaluator = LLMAnswerMatchEvaluator(
-        settings=LLMAnswerMatchSettings(model="openai/gpt-5")
+        settings=LLMAnswerMatchSettings(model="openai/gpt-5-mini")
     )
     result = evaluator.evaluate(entry)
 

--- a/langevals/evaluators/langevals/tests/test_llm_boolean.py
+++ b/langevals/evaluators/langevals/tests/test_llm_boolean.py
@@ -18,7 +18,7 @@ def test_custom_llm_boolean_evaluator():
         contexts=["London is the capital of France."],
     )
     settings = CustomLLMBooleanSettings(
-        model="openai/gpt-5",
+        model="openai/gpt-5-mini",
         prompt="You are an LLM evaluator. We need the guarantee that the output is using the provided context and not it's own brain, please evaluate as False if is not.",
     )
 
@@ -39,7 +39,7 @@ def test_custom_llm_boolean_evaluator_skips_if_context_is_too_large():
         contexts=["London is the capital of France."] * 300,
     )
     settings = CustomLLMBooleanSettings(
-        model="openai/gpt-5",
+        model="openai/gpt-5-mini",
         prompt="You are an LLM evaluator. We need the guarantee that the output is using the provided context and not it's own brain, please evaluate as False if is not.",
         max_tokens=2048,
     )

--- a/langevals/evaluators/langevals/tests/test_llm_category.py
+++ b/langevals/evaluators/langevals/tests/test_llm_category.py
@@ -19,7 +19,7 @@ def test_custom_llm_category_evaluator():
         contexts=["London is the capital of France."],
     )
     settings = CustomLLMCategorySettings(
-        model="openai/gpt-5",
+        model="openai/gpt-5-mini",
         prompt="You are an LLM category evaluator. Please categorize the answer in one of the following categories",
         categories=[
             CustomLLMCategoryDefinition(
@@ -49,7 +49,7 @@ def test_custom_llm_category_evaluator_skips_if_context_is_too_large():
         contexts=["London is the capital of France."] * 300,
     )
     settings = CustomLLMCategorySettings(
-        model="openai/gpt-5",
+        model="openai/gpt-5-mini",
         prompt="You are an LLM category evaluator. Please categorize the answer in one of the following categories",
         categories=[
             CustomLLMCategoryDefinition(

--- a/langevals/evaluators/langevals/tests/test_off_topic.py
+++ b/langevals/evaluators/langevals/tests/test_off_topic.py
@@ -18,7 +18,7 @@ def test_off_topic_evaluator():
             AllowedTopic(topic="email_delete", description="Delete an email"),
             AllowedTopic(topic="email_write", description="Write an email"),
         ],
-        model="openai/gpt-5"
+        model="openai/gpt-5-mini"
     )
     evaluator = OffTopicEvaluator(settings=settings)
     result = evaluator.evaluate(entry)

--- a/langevals/evaluators/langevals/tests/test_query_resolution.py
+++ b/langevals/evaluators/langevals/tests/test_query_resolution.py
@@ -18,7 +18,7 @@ def test_query_resolution_conversation_evaluator_pass_for_simple_greetings():
         output="Hello, I am an assistant and I don't have feelings",
     )
     conversation = QueryResolutionEntry(conversation=[response1])
-    settings = QueryResolutionSettings(model="openai/gpt-5", max_tokens=10000)
+    settings = QueryResolutionSettings(model="openai/gpt-5-mini", max_tokens=10000)
     evaluator = QueryResolutionEvaluator(settings=settings)
     result = evaluator.evaluate(conversation)
 
@@ -37,7 +37,7 @@ def test_query_resolution_conversation_evaluator_pass():
         output="There is no president in the Netherlands. The system of government is constitutional monarchy.",
     )
     conversation = QueryResolutionEntry(conversation=[response1, response2])
-    settings = QueryResolutionSettings(model="openai/gpt-5", max_tokens=10000)
+    settings = QueryResolutionSettings(model="openai/gpt-5-mini", max_tokens=10000)
     evaluator = QueryResolutionEvaluator(settings=settings)
     result = evaluator.evaluate(conversation)
 
@@ -57,7 +57,7 @@ def test_query_resolution_conversation_evaluator_fail():
         output="There is no president in the Netherlands.",
     )
     conversation = QueryResolutionEntry(conversation=[response1, response2])
-    settings = QueryResolutionSettings(model="openai/gpt-5", max_tokens=10000)
+    settings = QueryResolutionSettings(model="openai/gpt-5-mini", max_tokens=10000)
     evaluator = QueryResolutionEvaluator(settings=settings)
     result = evaluator.evaluate(conversation)
 
@@ -73,7 +73,7 @@ def test_query_resolution_conversation_evaluator_fails_with_i_dont_know():
         output="Sorry, I don't have any information about the current time",
     )
     conversation = QueryResolutionEntry(conversation=[response1])
-    settings = QueryResolutionSettings(model="openai/gpt-5", max_tokens=10000)
+    settings = QueryResolutionSettings(model="openai/gpt-5-mini", max_tokens=10000)
     evaluator = QueryResolutionEvaluator(settings=settings)
     result = evaluator.evaluate(conversation)
 
@@ -87,7 +87,7 @@ def test_product_sentiment_polarity_evaluator_skipped_for_non_product_related_ou
     response1 = ConversationEntry(input="", output="")
     response2 = ConversationEntry(input="", output="")
     conversation = QueryResolutionEntry(conversation=[response1, response2])
-    settings = QueryResolutionSettings(model="openai/gpt-5", max_tokens=10000)
+    settings = QueryResolutionSettings(model="openai/gpt-5-mini", max_tokens=10000)
     evaluator = QueryResolutionEvaluator(settings=settings)
     result = evaluator.evaluate(conversation)
 

--- a/langevals/evaluators/legacy/langevals_legacy/ragas_lib/common.py
+++ b/langevals/evaluators/legacy/langevals_legacy/ragas_lib/common.py
@@ -50,7 +50,7 @@ env_vars = []
 
 class RagasSettings(EvaluatorSettings):
     model: str = Field(
-        default="openai/gpt-5",
+        default="openai/gpt-5-mini",
         description="The model to use for evaluation.",
     )
     embeddings_model: str = Field(

--- a/langevals/evaluators/ragas/langevals_ragas/lib/common.py
+++ b/langevals/evaluators/ragas/langevals_ragas/lib/common.py
@@ -29,7 +29,7 @@ env_vars = []
 
 class RagasSettings(EvaluatorSettings):
     model: str = Field(
-        default="openai/gpt-5",
+        default="openai/gpt-5-mini",
         description="The model to use for evaluation.",
     )
     max_tokens: int = Field(

--- a/langevals/langevals_core/langevals_core/base_evaluator.py
+++ b/langevals/langevals_core/langevals_core/base_evaluator.py
@@ -48,7 +48,7 @@ MAX_TOKENS_HARD_LIMIT = 1_048_576
 
 class LLMEvaluatorSettings(EvaluatorSettings):
     model: str = Field(
-        default="openai/gpt-5",
+        default="openai/gpt-5-mini",
         description="The model to use for evaluation",
     )
     max_tokens: int = Field(

--- a/langevals/tests/test_azure_evaluation.py
+++ b/langevals/tests/test_azure_evaluation.py
@@ -25,7 +25,7 @@ def test_azure_evaluation_with_custom_deployment():
             model="azure/gpt-4-1106-preview",
             prompt="Is the recipe vegetarian?",
         ),
-        env={"AZURE_DEPLOYMENT_NAME": "gpt-5"},
+        env={"AZURE_DEPLOYMENT_NAME": "gpt-5-mini"},
     )
 
     expect(output="Feta Cheese and Spinach").to_pass(vegetarian_checker)
@@ -45,7 +45,7 @@ def test_azure_evaluation_with_custom_deployment():
 
 def test_ragas_azure_evaluation_with_custom_deployment():
     answer_relevancy_checker = RagasResponseRelevancyEvaluator(
-        settings=RagasSettings(model="azure/gpt-5"),
+        settings=RagasSettings(model="azure/gpt-5-mini"),
         env={"AZURE_DEPLOYMENT_NAME": "gpt-4-turbo-2024-04-09"},
     )
 

--- a/langwatch_nlp/tests/studio/test_parse.py
+++ b/langwatch_nlp/tests/studio/test_parse.py
@@ -41,7 +41,7 @@ llm_field = Field(
     type=FieldType.llm,
     optional=None,
     value=LLMConfig(
-        model="gpt-5",
+        model="gpt-5-mini",
         temperature=0.0,
         max_tokens=100,
     ),

--- a/langwatch_nlp/tests/topic_clustering/test_topic_clustering.py
+++ b/langwatch_nlp/tests/topic_clustering/test_topic_clustering.py
@@ -205,7 +205,7 @@ def create_openai_chat_completion_mock(n):
         "id": "chatcmpl-86zIvz53Wa4qTc1ksUt3coF5yTvm7",
         "object": "chat.completion",
         "created": 1696676313,
-        "model": "gpt-5",
+        "model": "gpt-5-mini",
         "choices": [
             {
                 "index": 0,

--- a/langwatch_nlp/tests/topic_clustering/test_topic_clustering_integration.py
+++ b/langwatch_nlp/tests/topic_clustering/test_topic_clustering_integration.py
@@ -57,7 +57,7 @@ class TestTopicClusteringIntegration:
             json={
                 "litellm_params": {
                     "api_base": os.environ["AZURE_OPENAI_ENDPOINT"],
-                    "model": "azure/gpt-5",
+                    "model": "azure/gpt-5-mini",
                 },
                 "embeddings_litellm_params": {
                     "api_key": os.environ["OPENAI_API_KEY"],
@@ -80,7 +80,7 @@ class TestTopicClusteringIntegration:
             json={
                 "litellm_params": {
                     "api_base": os.environ["AZURE_OPENAI_ENDPOINT"],
-                    "model": "azure/gpt-5",
+                    "model": "azure/gpt-5-mini",
                 },
                 "embeddings_litellm_params": {
                     "api_key": os.environ["OPENAI_API_KEY"],


### PR DESCRIPTION
## Summary
- Changes default LLM evaluator model from `openai/gpt-5` to `openai/gpt-5-mini` across `langevals/` and `langwatch_nlp/`
- Updates 3 source defaults (base_evaluator, ragas common, legacy common) and 9 test files
- Reasoning model detection logic left unchanged — existing patterns (`"gpt-5" in model`, regex) already cover `gpt-5-mini`

## Test plan
- [x] `langwatch_nlp` tests: 99 passed
- [ ] `langevals` tests: require `OPENAI_API_KEY` to run (integration tests hitting the API)
- [x] Verified `evaluators.generated.ts` is a generated file — will update on next `make setup`