### PR TITLE
fix(scenarios): apply stall detection to BullMQ active jobs at read time

### DIFF
--- a/langwatch/src/server/scenarios/__tests__/scenario-job-repository.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-job-repository.unit.test.ts
@@ -43,13 +43,13 @@ function makeJobData(overrides: Partial<ScenarioJob> = {}): ScenarioJob {
 describe("mapBullMQStateToStatus()", () => {
   describe("when state is 'waiting'", () => {
     it("returns QUEUED status", () => {
-      expect(mapBullMQStateToStatus("waiting")).toBe(ScenarioRunStatus.QUEUED);
+      expect(mapBullMQStateToStatus({ state: "waiting" })).toBe(ScenarioRunStatus.QUEUED);
     });
   });
 
   describe("when state is 'active'", () => {
     it("returns RUNNING status", () => {
-      expect(mapBullMQStateToStatus("active")).toBe(ScenarioRunStatus.RUNNING);
+      expect(mapBullMQStateToStatus({ state: "active" })).toBe(ScenarioRunStatus.RUNNING);
     });
 
     describe("when jobTimestamp is provided", () => {
@@ -57,7 +57,7 @@ describe("mapBullMQStateToStatus()", () => {
         const now = Date.now();
         const recentTimestamp = now - (STALL_THRESHOLD_MS - 1000);
         expect(
-          mapBullMQStateToStatus("active", { jobTimestamp: recentTimestamp, now })
+          mapBullMQStateToStatus({ state: "active", jobTimestamp: recentTimestamp, now })
         ).toBe(ScenarioRunStatus.RUNNING);
       });
 
@@ -65,7 +65,7 @@ describe("mapBullMQStateToStatus()", () => {
         const now = Date.now();
         const staleTimestamp = now - (STALL_THRESHOLD_MS + 1000);
         expect(
-          mapBullMQStateToStatus("active", { jobTimestamp: staleTimestamp, now })
+          mapBullMQStateToStatus({ state: "active", jobTimestamp: staleTimestamp, now })
         ).toBe(ScenarioRunStatus.STALLED);
       });
 
@@ -73,33 +73,33 @@ describe("mapBullMQStateToStatus()", () => {
         const now = Date.now();
         const exactTimestamp = now - STALL_THRESHOLD_MS;
         expect(
-          mapBullMQStateToStatus("active", { jobTimestamp: exactTimestamp, now })
+          mapBullMQStateToStatus({ state: "active", jobTimestamp: exactTimestamp, now })
         ).toBe(ScenarioRunStatus.STALLED);
       });
     });
 
     describe("when jobTimestamp is not provided", () => {
       it("returns RUNNING for backwards compatibility", () => {
-        expect(mapBullMQStateToStatus("active")).toBe(ScenarioRunStatus.RUNNING);
+        expect(mapBullMQStateToStatus({ state: "active" })).toBe(ScenarioRunStatus.RUNNING);
       });
     });
   });
 
   describe("when state is 'completed'", () => {
     it("returns IN_PROGRESS status", () => {
-      expect(mapBullMQStateToStatus("completed")).toBe(ScenarioRunStatus.IN_PROGRESS);
+      expect(mapBullMQStateToStatus({ state: "completed" })).toBe(ScenarioRunStatus.IN_PROGRESS);
     });
   });
 
   describe("when state is 'failed'", () => {
     it("returns ERROR status", () => {
-      expect(mapBullMQStateToStatus("failed")).toBe(ScenarioRunStatus.ERROR);
+      expect(mapBullMQStateToStatus({ state: "failed" })).toBe(ScenarioRunStatus.ERROR);
     });
   });
 
   describe("when state is unknown", () => {
     it("defaults to QUEUED status", () => {
-      expect(mapBullMQStateToStatus("delayed")).toBe(ScenarioRunStatus.QUEUED);
+      expect(mapBullMQStateToStatus({ state: "delayed" })).toBe(ScenarioRunStatus.QUEUED);
     });
   });
 });

--- a/langwatch/src/server/scenarios/scenario-job.repository.ts
+++ b/langwatch/src/server/scenarios/scenario-job.repository.ts
@@ -17,15 +17,19 @@ import { STALL_THRESHOLD_MS } from "./stall-detection";
  * threshold based on its timestamp. This catches workers that died before
  * emitting a RUN_STARTED event.
  */
-export function mapBullMQStateToStatus(
-  state: string,
-  options?: { jobTimestamp: number; now?: number },
-): ScenarioRunStatus {
+export function mapBullMQStateToStatus({
+  state,
+  jobTimestamp,
+  now = Date.now(),
+}: {
+  state: string;
+  jobTimestamp?: number;
+  now?: number;
+}): ScenarioRunStatus {
   switch (state) {
     case "active": {
-      if (options?.jobTimestamp !== undefined) {
-        const now = options.now ?? Date.now();
-        if (now - options.jobTimestamp >= STALL_THRESHOLD_MS) {
+      if (jobTimestamp !== undefined) {
+        if (now - jobTimestamp >= STALL_THRESHOLD_MS) {
           return ScenarioRunStatus.STALLED;
         }
       }
@@ -67,10 +71,10 @@ export function normalizeJob({ job, state }: NormalizeJobParams): ScenarioRunDat
     return null;
   }
 
-  const status = mapBullMQStateToStatus(
+  const status = mapBullMQStateToStatus({
     state,
-    job.timestamp !== undefined ? { jobTimestamp: job.timestamp } : undefined,
-  );
+    jobTimestamp: job.timestamp,
+  });
 
   return {
     scenarioId: data.scenarioId,


### PR DESCRIPTION
## Summary
- Apply stall threshold at read time in `mapBullMQStateToStatus()` so BullMQ-only active jobs that exceed `STALL_THRESHOLD_MS` return `STALLED` instead of `RUNNING`
- Pass `job.timestamp` through `normalizeJob()` to enable the age check
- Prevents orphaned "running" entries when workers crash before emitting `RUN_STARTED`

## Test plan
- [x] Unit tests for `mapBullMQStateToStatus()` — active within threshold → RUNNING, exceeding threshold → STALLED, no timestamp → RUNNING (backwards compat)
- [x] Unit test for `normalizeJob()` — stale timestamp produces STALLED status
- [x] All 32 existing tests pass

Closes #2342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2342