### PR TITLE
fix: skip litellm_bot test on RateLimitError from Cerebras

### DIFF
--- a/python-sdk/tests/test_examples.py
+++ b/python-sdk/tests/test_examples.py
@@ -206,6 +206,7 @@ async def test_example(example_file: str):
                         # "Error code: 404",
                         # "This is a chat model and not supported in the v1/completions endpoint",
                         "Rate limit",
+                        "RateLimitError",
                         "API Error",
                         "Connection error",
                         "Timeout",


### PR DESCRIPTION
## Summary
- The existing skip logic in `test_examples.py` checks for `"Rate limit"` (with a space) but Cerebras returns `"RateLimitError"` (no space), causing CI failures on transient rate limiting
- Adds `"RateLimitError"` to the error indicator skip list

## Test plan
- [ ] Re-run the e2e tests and confirm `litellm_bot.py` is skipped instead of failing when Cerebras rate limits