### PR TITLE
fix(studio): prevent evaluator node from duplicating input handles on reload

### DIFF
--- a/langwatch/src/optimization_studio/hooks/__tests__/useEvaluatorPickerFlow.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/__tests__/useEvaluatorPickerFlow.unit.test.ts
@@ -429,6 +429,8 @@ describe("useEvaluatorPickerFlow()", () => {
           data: expect.objectContaining({
             name: "New Evaluator",
             evaluator: "evaluators/new-eval-id",
+            inputs: [],
+            outputs: [{ identifier: "passed", type: "bool" }],
           }),
         }),
       );

--- a/langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts
+++ b/langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts
@@ -122,15 +122,18 @@ export function useEvaluatorPickerFlow() {
             if (pendingEvaluatorRef.current) {
               const { inputs, outputs } = saved.evaluatorType
                 ? computeFieldsFromEvaluatorType(saved.evaluatorType)
-                : { inputs: undefined, outputs: undefined };
+                : {
+                    inputs: [] as Field[],
+                    outputs: [{ identifier: "passed", type: "bool" as const }] as Field[],
+                  };
 
               setNode({
                 id: pendingEvaluatorRef.current,
                 data: {
                   name: saved.name,
                   evaluator: `evaluators/${saved.id}`,
-                  ...(inputs ? { inputs } : {}),
-                  ...(outputs ? { outputs } : {}),
+                  inputs,
+                  outputs,
                 } as Partial<Component>,
               });
               const nodeId = pendingEvaluatorRef.current;


### PR DESCRIPTION
## Summary

- When creating a workflow evaluator via `onCreateNew` (no evaluatorType), inputs/outputs defaulted to `undefined`, causing `setNode`'s shallow merge to preserve stale template inputs. On reload these produced duplicate handles.
- Explicitly sets `inputs: []` and `outputs` to a sensible default in `useEvaluatorPickerFlow`'s `onCreateNew` path
- Removes a `useEffect` in `EvaluatorPropertiesPanel` that replaced saved DSL inputs with API-canonical fields on load, which disconnected existing edges

## Test plan

- [x] Unit tests pass for `useEvaluatorPickerFlow`
- [ ] Create a new evaluator workflow from the custom evaluator template
- [ ] Verify the signature node has correct inputs (e.g., `llm_output`) after reload
- [ ] Verify edges remain connected after reload
- [ ] Verify creating a new evaluator via onCreateNew sets empty inputs (no stale template fields)

Closes #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)