### PR TITLE
feat(skills): create-agent skill for scaffolding projects from scratch

### DIFF
--- a/skills/.env.example
+++ b/skills/.env.example
@@ -1,0 +1,2 @@
+LANGWATCH_API_KEY=your-langwatch-api-key
+OPENAI_API_KEY=your-openai-api-key

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,62 @@
+# LangWatch Skills
+
+Customer-facing Agent Skills following the [agentskills.io](https://agentskills.io) open standard. Each skill teaches AI coding agents (Claude Code, Cursor, Codex, etc.) how to perform LangWatch workflows autonomously.
+
+## Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `create-agent` | Scaffold a complete AI agent project from scratch with LangWatch instrumentation, prompt versioning, evaluation experiments, and scenario tests |
+
+## Installation
+
+### Via skills CLI
+```bash
+npx skills add langwatch/langwatch --skill create-agent
+```
+
+### Via compiled prompt (copy-paste)
+Pre-generated prompts are available in `_compiled/`:
+- `create-agent.platform.txt` — for use on LangWatch onboarding pages (API key placeholder)
+- `create-agent.docs.txt` — for use in documentation (asks user for API key)
+
+### Manual
+Copy `skills/create-agent/SKILL.md` and its `references/` directory into your project.
+
+## Structure
+
+```
+skills/
+├── create-agent/           # Skill: scaffold agent projects from scratch
+│   ├── SKILL.md            # Main skill file (<500 lines)
+│   └── references/         # Framework-specific guides (loaded on demand)
+├── _shared/                # Shared references used by all skills
+│   ├── mcp-setup.md        # MCP server installation
+│   ├── api-key-setup.md    # API key configuration
+│   ├── llms-txt-fallback.md # Fallback when MCP unavailable
+│   └── guard-rails.md      # Known agent failure modes
+├── _compiler/              # Prompt compiler (SKILL.md → copy-paste prompts)
+├── _compiled/              # Pre-generated prompts (do not edit manually)
+└── _tests/                 # Scenario tests proving skills work
+```
+
+## Adding a New Skill
+
+1. Create a directory: `skills/<skill-name>/`
+2. Add a `SKILL.md` with agentskills.io frontmatter (`name`, `description`, `license`, `compatibility`)
+3. Keep body under 500 lines — use `references/` for extended content
+4. Run `bash skills/_compiled/generate.sh` to compile prompts
+5. Add scenario tests in `skills/_tests/`
+
+## Developing
+
+```bash
+# Run compiler unit tests
+npx vitest run --config skills/_tests/vitest.config.ts skills/_compiler/__tests__/
+
+# Run scenario tests (requires Claude Code signed in, skips in CI)
+cd skills/_tests && pnpm test
+
+# Regenerate compiled prompts
+bash skills/_compiled/generate.sh
+```

--- a/skills/_compiled/README.md
+++ b/skills/_compiled/README.md
@@ -1,0 +1,40 @@
+# Compiled Prompts
+
+Pre-generated, self-contained prompts derived from `skills/*/SKILL.md` files. All file references (`_shared/`, `references/`) are inlined so the prompt can be used as-is.
+
+## Files
+
+Each skill has two versions:
+- `*.platform.txt` -- API key placeholder `{{LANGWATCH_API_KEY}}` for platform pages (replace with the user's actual key)
+- `*.docs.txt` -- Instructs the agent to ask the user for their API key (for documentation pages, links to https://app.langwatch.ai/authorize)
+
+## Usage in Frontend
+
+```typescript
+const prompt = fs.readFileSync('skills/_compiled/create-agent.platform.txt', 'utf8');
+const withKey = prompt.replace(/\{\{LANGWATCH_API_KEY\}\}/g, user.apiKey);
+// Use as system prompt
+```
+
+## Regenerating
+
+After modifying any `SKILL.md`, `_shared/*.md`, or `references/*.md` file:
+
+```bash
+bash skills/_compiled/generate.sh
+```
+
+Or compile a single skill:
+
+```bash
+npx tsx skills/_compiler/compile.ts --skills create-agent --mode platform
+npx tsx skills/_compiler/compile.ts --skills create-agent --mode docs
+```
+
+## How the Compiler Works
+
+1. Parses YAML frontmatter from `SKILL.md`
+2. Resolves `[text](_shared/file.md)` and `[text](references/file.md)` links by inlining file content
+3. Resolves cross-references within inlined content (e.g., shared files referencing other shared files)
+4. Applies API key mode (platform: template placeholder, docs: ask-user instruction)
+5. Wraps output in a system instruction envelope

--- a/skills/_compiled/create-agent.docs.txt
+++ b/skills/_compiled/create-agent.docs.txt
@@ -1,0 +1,901 @@
+You are helping the user set up a new AI agent project with LangWatch instrumentation. Follow these instructions carefully.
+
+IMPORTANT: You will need the user's LangWatch API key. Ask them for it before starting, and direct them to https://app.langwatch.ai/authorize if they don't have one.
+
+# Create an AI Agent Project from Scratch
+
+**API Key**: Before proceeding, ask the user for their LangWatch API key.
+They can get one at: https://app.langwatch.ai/authorize
+Use the provided key wherever you see `ASK_USER_FOR_API_KEY` below.
+
+
+This skill scaffolds a complete agent project in an empty directory, fully instrumented with LangWatch. You get tracing, versioned prompts, evaluation experiments, and scenario tests from the start.
+
+## Interactive Discovery
+
+Before scaffolding, gather the following from the user. If any is missing, ask.
+
+**Framework** (pick one):
+
+| Framework | Language | Source Dir |
+|-----------|----------|------------|
+| Agno | Python | `app/` |
+| LangGraph (Python) | Python | `app/` |
+| Google ADK | Python | `app/` |
+| Mastra | TypeScript | `src/` |
+| LangGraph (TypeScript) | TypeScript | `src/` |
+| Vercel AI SDK | TypeScript | `src/` |
+
+**LLM Provider** (pick one): OpenAI, Anthropic, Gemini, Bedrock, OpenRouter, Grok
+
+**Project goal**: What does the agent do? (e.g., "customer support agent that answers billing questions")
+
+## Detect Context
+
+Before proceeding, check the target directory:
+
+- **Empty or near-empty** (only README, .git, LICENSE, etc.): Proceed with scaffolding.
+- **Contains source code** (`.py`, `.ts`, `.tsx`, `.js` files, `package.json` with dependencies, `pyproject.toml` with dependencies): STOP. Warn the user that this directory already has a project. Suggest using the **tracing** or **level-up** skills instead to add LangWatch to an existing codebase.
+
+## Kickoff Sequence
+
+Execute these 9 steps in order. Do not skip or reorder them.
+
+### Step 1: Read Documentation via MCP
+
+Set up the LangWatch MCP server first so you have access to documentation throughout the process.
+
+# Installing the LangWatch MCP Server
+
+## Claude Code
+
+Run:
+```bash
+claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_API_KEY
+```
+
+Or add to `.mcp.json` (project-level) or `~/.claude.json` (global):
+```json
+{
+  "mcpServers": {
+    "langwatch": {
+      "command": "npx",
+      "args": ["-y", "@langwatch/mcp-server"],
+      "env": {
+        "LANGWATCH_API_KEY": "ASK_USER_FOR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+## Other Editors
+
+Add the JSON config above to your editor's MCP settings file.
+
+The API key can be set via `LANGWATCH_API_KEY` env var or `--apiKey` flag.
+Use `LANGWATCH_ENDPOINT` / `--endpoint` to override the default endpoint (`https://app.langwatch.ai`). If MCP installation fails, see # Fetching LangWatch Docs Without MCP
+
+If the MCP server cannot be installed, fetch documentation directly via HTTP.
+
+## Integration Docs
+
+1. Fetch the index: `https://langwatch.ai/docs/llms.txt`
+2. Pick a topic from the listing
+3. Fetch the page by appending `.md` (e.g., `https://langwatch.ai/docs/integration/python/guide.md`)
+
+## Scenario (Agent Testing) Docs
+
+1. Fetch the index: `https://langwatch.ai/scenario/llms.txt`
+2. Follow the same pattern for individual pages
+
+## Notes
+
+- The MCP server is always preferred -- it provides richer tools beyond docs.
+- Use `WebFetch` or `curl` to retrieve these URLs. to fetch docs via URLs.
+
+Once MCP is available:
+
+1. Call `fetch_langwatch_docs` (no args) to see the docs index
+2. Read the integration guide for the selected framework
+3. Call `fetch_scenario_docs` (no args) to read the Scenario SDK docs
+4. Read the Prompts CLI docs at `https://langwatch.ai/docs/prompt-management/cli.md`
+
+Then read the framework reference for the selected framework ONLY:
+
+| Framework | Reference File |
+|-----------|----------------|
+| Agno | # Agno Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add agno openai duckduckgo-search
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add agno dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. Agno integrates via the standard Python tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Agno documentation in your coding assistant:
+
+```json
+{
+  "agno": {
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "mcp-remote", "https://docs.agno.com/mcp"]
+  }
+}
+```
+
+## Core Patterns
+
+**Basic Agent:**
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    instructions="You are a helpful assistant",
+    markdown=True,
+)
+agent.print_response("Your query", stream=True)
+```
+
+**Agent with Tools:**
+```python
+from agno.tools.duckduckgo import DuckDuckGoTools
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[DuckDuckGoTools()],
+    instructions="Search the web for information",
+)
+```
+
+**Structured Output:**
+```python
+from pydantic import BaseModel
+
+class Result(BaseModel):
+    summary: str
+    findings: list[str]
+
+agent = Agent(model=OpenAIChat(id="gpt-4o"), output_schema=Result)
+result: Result = agent.run(query).content
+```
+
+## Known Pitfalls
+
+- **NEVER create agents in loops** -- reuse agent instances for performance (significant overhead otherwise)
+- Always use `output_schema` for structured responses
+- PostgreSQL in production, SQLite for dev only
+- Start with single agent (covers 90% of use cases), scale to Team/Workflow only when needed
+- Do not forget `search_knowledge=True` when using knowledge bases
+
+## Resources
+
+- https://docs.agno.com/ |
+| Mastra | # Mastra Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpx mastra init --default
+```
+
+Run `mastra init` right after `pnpm init`, before setting up the rest of the project. Then explore the generated structure and remove what is not needed.
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. Mastra integrates via the standard TypeScript tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Mastra documentation in your coding assistant:
+
+```json
+{
+  "mastra": {
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "@mastra/mcp-docs-server"]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init`
+2. `pnpx mastra init --default` (creates project structure)
+3. Explore the generated folders, remove what is not needed
+4. Implement the agent per user requirements
+5. Open the UI with `pnpx mastra dev`
+
+## Core Patterns
+
+- Use the Mastra MCP server to learn about Mastra APIs and best practices
+- Follow Mastra's TypeScript patterns and conventions
+- Leverage Mastra's integration ecosystem
+- Consult the MCP: "How do I [do X] in Mastra?"
+
+## Known Pitfalls
+
+- Always run `mastra init --default` before adding other project setup
+- Use the Mastra MCP for documentation rather than relying on stale examples
+
+## Resources
+
+- Use the Mastra MCP for up-to-date documentation |
+| LangGraph (Python) | # LangGraph Python Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add langgraph langchain-core langchain-openai
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add LangGraph dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. LangGraph/LangChain integrates via LangChain's callback pattern for tracing.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get LangGraph and LangChain documentation:
+
+```json
+{
+  "langgraph-py": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "LangGraph:https://langchain-ai.github.io/langgraph/llms.txt LangChain:https://python.langchain.com/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `uv init` to create a new project
+2. Add dependencies: `uv add langgraph langchain-core langchain-openai`
+3. Implement the requested agent logic and write tests
+4. Run with `uv run app.py` to validate behaviour
+
+## Core Patterns
+
+- Use the LangGraph MCP for learning about LangGraph and LangChain
+- Use LangChain's Python integrations for tools, memory, and models
+- Follow LangGraph's node/state patterns when structuring agents
+- Leverage LangChain's ecosystem for additional capabilities
+
+## Known Pitfalls
+
+- Always consult the LangGraph MCP for up-to-date API patterns
+- Follow LangGraph's node/state architecture rather than freestyle code
+- Use LangChain integrations for tools and models rather than raw API calls
+
+## Resources
+
+- Use the LangGraph MCP for up-to-date LangGraph and LangChain documentation |
+| LangGraph (TypeScript) | # LangGraph TypeScript Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpm add @langchain/langgraph @langchain/core @langchain/openai
+```
+
+No dedicated CLI scaffolder. Use `pnpm init` then add LangGraph dependencies and set up TypeScript configuration.
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. LangGraph.js integrates via LangChain.js callback pattern for tracing.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get LangGraph.js and LangChain.js documentation:
+
+```json
+{
+  "langgraph-ts": {
+    "type": "stdio",
+    "command": "npx",
+    "args": [
+      "-y", "mcpdoc",
+      "--urls", "LangGraphJS:https://langchain-ai.github.io/langgraphjs/llms.txt LangChainJS:https://js.langchain.com/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init` to create a new project
+2. `pnpm add @langchain/langgraph @langchain/core @langchain/openai`
+3. Set up TypeScript configuration
+4. Implement the agent per user requirements
+5. Run with `pnpm tsx src/index.ts`
+
+## Key Concepts
+
+- **StateGraph**: Define your agent's state and transitions
+- **Nodes**: Functions that process state and return updates
+- **Edges**: Define flow between nodes (conditional or direct)
+- **Checkpointer**: Enable conversation memory and state persistence
+
+## Core Patterns
+
+- Use the LangGraph MCP for learning about LangGraph.js
+- Use LangGraph's built-in agent capabilities (StateGraph, nodes, edges)
+- Follow LangGraph's TypeScript patterns and conventions
+- Leverage LangChain.js integration ecosystem
+
+## Known Pitfalls
+
+- Always set up TypeScript configuration before implementing
+- Use StateGraph patterns for agent architecture, not freestyle code
+- Consult the LangGraph MCP for up-to-date API patterns
+
+## Resources
+
+- Use the LangGraph MCP for up-to-date LangGraph.js documentation |
+| Google ADK | # Google ADK Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add google-adk
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add Google ADK dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. Google ADK integrates via the standard Python tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Google ADK documentation:
+
+```json
+{
+  "google-adk": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "Google-Adk:https://github.com/google/adk-python/blob/main/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `uv init` to create a new project
+2. `uv add google-adk` (plus `litellm` if using non-Google models)
+3. Set up API key in `.env` (check which env var is needed in app.py)
+4. Implement agent logic following Google ADK patterns
+5. Run with `uv run app.py` to validate behaviour
+
+## Core Patterns
+
+**Gemini (native):** `Agent(name="my_agent", model="gemini-2.0-flash-exp", ...)`
+
+**Non-Google models (LiteLLM):**
+```python
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+
+agent = Agent(name="my_agent", model=LiteLlm(model="openai/gpt-4.1"), ...)
+```
+
+## LLM Provider Configuration
+
+- **Gemini:** Uses Google AI SDK + ADK's native integrations
+- **Other providers (OpenAI, Anthropic, etc.):** Uses LiteLLM wrapper inside a Google ADK Agent
+- The framework is always Google ADK regardless of model provider -- NEVER switch frameworks
+- Use the `.env` file to set the right keys for the chosen provider
+
+## Known Pitfalls
+
+- Google ADK is the framework; the LLM provider is just the model backend -- do not confuse them
+- When using non-Google models, always use the LiteLLM wrapper inside ADK Agent
+- Never switch to a different agent framework when a non-Google model is selected
+- Always consult the Google ADK MCP for up-to-date API patterns
+
+## Resources
+
+- Use the Google ADK MCP for up-to-date documentation |
+| Vercel AI SDK | # Vercel AI SDK Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpm add ai @ai-sdk/openai
+```
+
+For other model providers, install the corresponding package (e.g., `@ai-sdk/anthropic`, `@ai-sdk/google`).
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. Vercel AI SDK integrates via the standard TypeScript tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Vercel AI SDK documentation:
+
+```json
+{
+  "vercel-ai": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "Vercel:https://ai-sdk.dev/docs/introduction",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init` to create a new project
+2. `pnpm add ai @ai-sdk/openai` (or other provider packages)
+3. Set up TypeScript configuration
+4. Implement the agent per user requirements
+5. Run with `pnpm tsx src/index.ts` or integrate with your chosen web framework
+
+## Key Concepts
+
+- **Unified Provider Architecture**: Consistent interface across multiple AI model providers
+- **generateText**: Generate text using any supported model
+- **streamText**: Stream text responses for real-time interactions
+- **Framework Integration**: Works with Next.js, React, Svelte, Vue, and Node.js
+
+## Core Patterns
+
+- Use the Vercel AI SDK MCP for learning about the SDK
+- Use Vercel AI SDK's unified provider architecture
+- Follow Vercel AI SDK's TypeScript patterns and conventions
+- Leverage framework integrations (Next.js, React, Svelte, Vue, Node.js)
+
+## Known Pitfalls
+
+- Always set up TypeScript configuration before implementing
+- Use the correct provider package for your chosen model (`@ai-sdk/openai`, `@ai-sdk/anthropic`, etc.)
+- Consult the Vercel AI SDK MCP for up-to-date API patterns
+
+## Resources
+
+- Use the AI SDK MCP for up-to-date documentation
+- https://ai-sdk.dev/docs/introduction |
+
+Do NOT read references for frameworks the user did not select.
+
+### Step 2: Scaffold Project Structure
+
+Create the full directory tree before writing any application code:
+
+```
+my-agent/
+├── <app/ or src/>         # Python: app/  |  TypeScript: src/
+├── prompts/
+├── tests/
+│   ├── evaluations/
+│   └── scenarios/
+├── .env
+├── .env.example
+├── .mcp.json
+├── .mcp.json.example
+├── .cursor/mcp.json       # Symlink → ../.mcp.json
+├── .gitignore
+├── AGENTS.md
+├── CLAUDE.md              # Contains: @AGENTS.md
+└── pyproject.toml / package.json
+```
+
+**`.env.example`** -- committed, placeholder values only:
+```
+LANGWATCH_API_KEY=ASK_USER_FOR_API_KEY
+OPENAI_API_KEY=your-openai-api-key
+# Adjust provider key to match the selected LLM provider
+```
+
+**`.env`** -- gitignored, real keys from user's environment:
+```
+LANGWATCH_API_KEY=<actual key if available>
+```
+
+**`.mcp.json`** -- gitignored, contains both LangWatch and framework-specific MCP servers. See the framework reference for the framework MCP config. Combine with the LangWatch MCP:
+```json
+{
+  "mcpServers": {
+    "langwatch": {
+      "command": "npx",
+      "args": ["-y", "@langwatch/mcp-server"],
+      "env": {
+        "LANGWATCH_API_KEY": "<key>"
+      }
+    }
+  }
+}
+```
+
+**`.mcp.json.example`** -- committed, same structure with placeholder keys.
+
+**`.cursor/mcp.json`** -- create as a symlink to `../.mcp.json` for Cursor compatibility.
+
+**`.gitignore`** -- must include:
+```
+.env
+.mcp.json
+.cursor/
+__pycache__/
+node_modules/
+.venv/
+```
+
+**`CLAUDE.md`**:
+```
+@AGENTS.md
+```
+
+**`AGENTS.md`** -- see the AGENTS.md Template section below for what to include.
+
+### Step 3: Set Up Language Environment and Install Dependencies
+
+Follow the framework reference for scaffolding commands.
+
+**Python frameworks** (Agno, LangGraph Python, Google ADK):
+1. Verify Python is installed: `python3 --version`. If missing, report the error and provide installation guidance. Do not leave a half-scaffolded project.
+2. Run the setup commands from the framework reference (e.g., `uv init`, `uv add ...`)
+3. Add LangWatch: `uv add langwatch`
+4. Add test dependencies: `uv add --dev pytest langwatch-scenario`
+
+**TypeScript frameworks** (Mastra, LangGraph TS, Vercel AI SDK):
+1. Verify Node.js is installed: `node --version`. If missing, report the error and provide installation guidance.
+2. Run the setup commands from the framework reference (e.g., `pnpm init`, `pnpm add ...`)
+3. Add LangWatch: `pnpm add langwatch`
+4. Add test dependencies: `pnpm add -D @langwatch/scenario vitest`
+5. Set up `tsconfig.json` if not already created by the framework scaffolder
+
+If dependency installation fails, report the error clearly and provide manual installation instructions. Leave the project structure intact so the user can recover.
+
+### Step 4: Instrument with LangWatch Tracing
+
+Follow the integration guide you read in Step 1 for the specific framework. The general patterns are:
+
+**Python:**
+```python
+import langwatch
+langwatch.setup()
+
+@langwatch.trace()
+def run_agent(user_input: str):
+    # agent logic here
+    pass
+```
+
+**TypeScript:**
+```typescript
+import { LangWatch } from "langwatch";
+const langwatch = new LangWatch();
+```
+
+IMPORTANT: The exact pattern depends on the framework. Follow the docs you read, not these examples.
+
+### Step 5: Create Versioned Prompts via Prompt CLI
+
+1. Install the CLI: `npm install -g langwatch` (or `npx langwatch`)
+2. Initialize: `langwatch prompt init`
+3. Get the API key: see # LangWatch API Key Setup
+
+1. Check if `LANGWATCH_API_KEY` is already set in your environment or `.env` file.
+2. If missing, get one at: https://app.langwatch.ai/authorize
+3. Add it to your project's `.env` file (check for duplicates first):
+```
+LANGWATCH_API_KEY=sk-lw-...
+```
+4. The MCP server also needs the key -- pass it via `--apiKey` flag or `LANGWATCH_API_KEY` env var.
+
+MCP Setup (see above)
+4. Create the main prompt: `langwatch prompt create main-prompt`
+5. Edit `prompts/main-prompt.yaml` with content tailored to the user's agent goal:
+   ```yaml
+   model: gpt-4o  # or the selected provider's model
+   temperature: 0.7
+   messages:
+     - role: system
+       content: |
+         <system prompt tailored to the agent's goal>
+     - role: user
+       content: |
+         {{ user_input }}
+   ```
+6. Sync: `langwatch prompt sync`
+7. Update the agent code to load the prompt via `langwatch.prompts.get("main-prompt")` instead of hardcoding it
+
+Do NOT hardcode prompts in application code. Do NOT add try/catch fallbacks around prompt fetching.
+
+### Step 6: Write Evaluation Experiment
+
+**Python projects** -- create a Jupyter notebook at `tests/evaluations/evaluation.ipynb`:
+- Use `langwatch.experiment.init()` to set up the experiment
+- Generate a CSV dataset of 10-20 examples tailored to the agent's domain
+- Include at least one evaluator (LLM-as-judge for quality is a good default)
+- Run the notebook to verify it produces results
+
+**TypeScript projects** -- create a script at `tests/evaluations/evaluation.ts`:
+- Use the LangWatch experiments SDK
+- Generate a dataset tailored to the agent's domain
+- Include at least one evaluator
+- Make it runnable with `npx tsx tests/evaluations/evaluation.ts`
+
+Evaluations are for batch metrics on single input/output pairs (RAG accuracy, classification, etc.). Do NOT use evaluations for multi-turn agent testing -- that is what scenarios are for.
+
+### Step 7: Write Scenario Simulation Tests
+
+Use `@langwatch/scenario` (TypeScript) or `langwatch-scenario` (Python) -- NEVER invent a custom testing framework.
+
+1. Read the Scenario docs via MCP: call `fetch_scenario_docs`
+2. Create test files in `tests/scenarios/`
+3. Write at least one scenario that validates the agent's core behavior:
+   - Define an `AgentAdapter` that connects to your agent
+   - Use `UserSimulatorAgent` to simulate realistic user messages
+   - Use `JudgeAgent` with natural language criteria (NOT regex or string matching)
+4. Test multi-turn conversations that verify the agent achieves its goal
+
+### Step 8: Run Tests to Verify
+
+Run the scenario tests:
+- Python: `uv run pytest tests/scenarios/`
+- TypeScript: `pnpm vitest run tests/scenarios/`
+
+If tests fail, fix the issues and re-run. Do NOT declare the project complete until tests pass. "It should work" is not verification.
+
+### Step 9: Tell the User How to Start
+
+Tell the user the command to start their agent or dev server. Do NOT start it yourself -- long-running processes block the agent.
+
+Examples:
+- Agno: `uv run python app/main.py`
+- Mastra: `pnpx mastra dev`
+- LangGraph Python: `uv run python app/main.py`
+- Vercel AI SDK: `pnpm tsx src/index.ts`
+
+Include the URL they can visit if the framework provides a web UI.
+
+## AGENTS.md Template
+
+The generated `AGENTS.md` must include these sections:
+
+```markdown
+# <Project Name>
+
+<Brief description of the agent and its goal>
+
+## Development
+
+### Running
+<command to start the agent>
+
+### Testing
+<command to run scenario tests>
+
+## Principles
+
+### 1. Agent Testing with Scenarios
+- Use `@langwatch/scenario` (TS) or `langwatch-scenario` (Python) for testing
+- Test multi-turn conversations, not just single exchanges
+- Use natural language judge criteria, not regex or string matching
+- Run scenarios before considering any change complete
+
+### 2. Prompt Management
+- Use LangWatch Prompt CLI: `langwatch prompt create <name>`
+- Store prompts in `prompts/*.yaml`, never hardcode in code
+- Run `langwatch prompt sync` after changes
+
+### 3. Evaluations vs. Scenarios
+- Evaluations: batch metrics for single input/output pairs (RAG, classification)
+- Scenarios: multi-turn agent conversation testing
+- When in doubt, use scenarios
+
+### 4. Observability
+- All LLM calls are traced via LangWatch
+- Check traces at https://app.langwatch.ai
+```
+
+## Guard Rails
+
+Read # Guard Rails -- Known Agent Failure Modes
+
+## Testing
+
+- DO NOT invent custom testing frameworks (e.g. `agent_tester`, `simulation_framework`, `langwatch.testing`). Use `@langwatch/scenario` (TS) or `langwatch-scenario` (Python). The Scenario SDK already handles user simulation, judging, multi-turn conversations, and tool call verification.
+- DO NOT use regex or word matching in scenario judge criteria. Use natural language criteria with `JudgeAgent` -- it is more robust and meaningful than brittle pattern matching.
+- DO NOT use evaluations for multi-turn agent testing. Evaluations are for single input/output metrics (RAG accuracy, classification). Use Scenario tests for multi-turn agent flows.
+- DO NOT skip running tests after implementation. Always run scenarios and verify they pass before considering work done. "It should work" is not verification.
+
+## Prompts
+
+- NEVER hardcode prompts in application code or inline strings. Store all prompts in `prompts/*.yaml` files managed by LangWatch Prompt CLI (`langwatch prompt create <name>`, `langwatch prompt sync`).
+- DO NOT add try/catch around prompt fetching or duplicate prompts as fallbacks. Prompt CLI files are local and reliable.
+
+## Notebooks
+
+- DO NOT just write Jupyter notebooks without executing them. Evaluation notebooks under `tests/evaluations/` must be run to verify they produce correct results. Writing a notebook is not the same as running it.
+
+## Environment
+
+- DO NOT start long-running dev servers yourself. They block the agent process. Instead, tell the user how to start the server and give them the URL. Let the user run it themselves.
+- DO NOT commit `.mcp.json` with real API keys. The `.mcp.json` file contains secrets. Use `.mcp.json.example` with placeholder values for git, and add `.mcp.json` to `.gitignore`.
+- DO NOT commit `.env` files. Use `.env.example` for templates. API keys are already in `.env` -- do not re-set them.
+
+## Agent Construction
+
+- DO NOT create agent instances inside loops (especially Agno). Agent construction has significant overhead. Create the agent once, reuse it for multiple queries.
+
+## Documentation
+
+- ALWAYS use the LangWatch MCP (`fetch_langwatch_docs`, `fetch_scenario_docs`) to access documentation. DO NOT fetch docs from random URLs, hallucinate API signatures, or guess framework patterns. Read the actual docs for the specific framework.
+- DO NOT use `platform_*` MCP tools when writing code. The `platform_create_scenario`, `platform_create_evaluator`, etc. tools are for no-code platform operations. When you have a codebase, write test files and code instead.
+
+## Workflow
+
+- DO NOT mix kickoff/setup steps with reference documentation. Kickoff instructions (numbered steps the agent executes once) must be clearly separated from ongoing reference material (patterns, rules, examples).
+- DO NOT skip verification. After implementation: run scenario tests, check they pass, instrument with LangWatch, confirm traces appear. Only then is the work done. The critical rules:
+
+- **Testing**: Use `@langwatch/scenario` / `langwatch-scenario`. Never invent custom test frameworks. Never use regex in judge criteria. Use natural language criteria with `JudgeAgent`.
+- **Prompts**: Use Prompt CLI (`langwatch prompt create`, `langwatch prompt sync`). Never hardcode in code. No try/catch fallbacks.
+- **Documentation**: Use MCP (`fetch_langwatch_docs`, `fetch_scenario_docs`) for docs. Never guess URLs or API signatures.
+- **Environment**: Never start long-running dev servers. Never commit `.env` or `.mcp.json` with real keys. Use `.example` files for git.
+- **MCP tools**: Never use `platform_*` MCP tools (platform_create_scenario, etc.) when writing code. Those are for no-code platform operations.
+- **Agent construction**: Never create agent instances inside loops (especially Agno). Create once, reuse.
+- **Notebooks**: Always run evaluation notebooks, not just write them. Writing is not verification.
+- **Workflow**: Read docs first (Step 1), scaffold second (Step 2), verify last (Step 8). Never skip verification.
+
+## Common Mistakes
+
+| Mistake | Correct Approach |
+|---------|-----------------|
+| Hardcoding prompts in agent code | Use `langwatch prompt create` and load via `langwatch.prompts.get()` |
+| Inventing a custom test framework | Use `@langwatch/scenario` or `langwatch-scenario` |
+| Using regex/string matching in scenario judges | Use natural language criteria with `JudgeAgent` |
+| Skipping MCP docs and guessing APIs | Call `fetch_langwatch_docs` and `fetch_scenario_docs` first |
+| Starting the dev server for the user | Tell the user the command and URL, let them run it |
+| Committing `.env` or `.mcp.json` with real keys | Use `.env.example` and `.mcp.json.example` for git |
+| Using `platform_*` MCP tools to create scenarios | Write test files in `tests/scenarios/` instead |
+| Creating agents inside loops (Agno) | Create the agent instance once, reuse it |
+| Writing evaluation notebook without running it | Execute the notebook to verify it produces results |
+| Mixing evaluations and scenarios | Evaluations = batch metrics. Scenarios = multi-turn agent tests |
+| Reading all framework references | Read ONLY the reference for the selected framework |
+| Scaffolding before reading docs | Step 1 is always reading docs via MCP |

--- a/skills/_compiled/create-agent.platform.txt
+++ b/skills/_compiled/create-agent.platform.txt
@@ -1,0 +1,894 @@
+You are helping the user set up a new AI agent project with LangWatch instrumentation. Follow these instructions carefully.
+
+# Create an AI Agent Project from Scratch
+
+This skill scaffolds a complete agent project in an empty directory, fully instrumented with LangWatch. You get tracing, versioned prompts, evaluation experiments, and scenario tests from the start.
+
+## Interactive Discovery
+
+Before scaffolding, gather the following from the user. If any is missing, ask.
+
+**Framework** (pick one):
+
+| Framework | Language | Source Dir |
+|-----------|----------|------------|
+| Agno | Python | `app/` |
+| LangGraph (Python) | Python | `app/` |
+| Google ADK | Python | `app/` |
+| Mastra | TypeScript | `src/` |
+| LangGraph (TypeScript) | TypeScript | `src/` |
+| Vercel AI SDK | TypeScript | `src/` |
+
+**LLM Provider** (pick one): OpenAI, Anthropic, Gemini, Bedrock, OpenRouter, Grok
+
+**Project goal**: What does the agent do? (e.g., "customer support agent that answers billing questions")
+
+## Detect Context
+
+Before proceeding, check the target directory:
+
+- **Empty or near-empty** (only README, .git, LICENSE, etc.): Proceed with scaffolding.
+- **Contains source code** (`.py`, `.ts`, `.tsx`, `.js` files, `package.json` with dependencies, `pyproject.toml` with dependencies): STOP. Warn the user that this directory already has a project. Suggest using the **tracing** or **level-up** skills instead to add LangWatch to an existing codebase.
+
+## Kickoff Sequence
+
+Execute these 9 steps in order. Do not skip or reorder them.
+
+### Step 1: Read Documentation via MCP
+
+Set up the LangWatch MCP server first so you have access to documentation throughout the process.
+
+# Installing the LangWatch MCP Server
+
+## Claude Code
+
+Run:
+```bash
+claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey {{LANGWATCH_API_KEY}}
+```
+
+Or add to `.mcp.json` (project-level) or `~/.claude.json` (global):
+```json
+{
+  "mcpServers": {
+    "langwatch": {
+      "command": "npx",
+      "args": ["-y", "@langwatch/mcp-server"],
+      "env": {
+        "LANGWATCH_API_KEY": "{{LANGWATCH_API_KEY}}"
+      }
+    }
+  }
+}
+```
+
+## Other Editors
+
+Add the JSON config above to your editor's MCP settings file.
+
+The API key can be set via `LANGWATCH_API_KEY` env var or `--apiKey` flag.
+Use `LANGWATCH_ENDPOINT` / `--endpoint` to override the default endpoint (`https://app.langwatch.ai`). If MCP installation fails, see # Fetching LangWatch Docs Without MCP
+
+If the MCP server cannot be installed, fetch documentation directly via HTTP.
+
+## Integration Docs
+
+1. Fetch the index: `https://langwatch.ai/docs/llms.txt`
+2. Pick a topic from the listing
+3. Fetch the page by appending `.md` (e.g., `https://langwatch.ai/docs/integration/python/guide.md`)
+
+## Scenario (Agent Testing) Docs
+
+1. Fetch the index: `https://langwatch.ai/scenario/llms.txt`
+2. Follow the same pattern for individual pages
+
+## Notes
+
+- The MCP server is always preferred -- it provides richer tools beyond docs.
+- Use `WebFetch` or `curl` to retrieve these URLs. to fetch docs via URLs.
+
+Once MCP is available:
+
+1. Call `fetch_langwatch_docs` (no args) to see the docs index
+2. Read the integration guide for the selected framework
+3. Call `fetch_scenario_docs` (no args) to read the Scenario SDK docs
+4. Read the Prompts CLI docs at `https://langwatch.ai/docs/prompt-management/cli.md`
+
+Then read the framework reference for the selected framework ONLY:
+
+| Framework | Reference File |
+|-----------|----------------|
+| Agno | # Agno Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add agno openai duckduckgo-search
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add agno dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. Agno integrates via the standard Python tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Agno documentation in your coding assistant:
+
+```json
+{
+  "agno": {
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "mcp-remote", "https://docs.agno.com/mcp"]
+  }
+}
+```
+
+## Core Patterns
+
+**Basic Agent:**
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    instructions="You are a helpful assistant",
+    markdown=True,
+)
+agent.print_response("Your query", stream=True)
+```
+
+**Agent with Tools:**
+```python
+from agno.tools.duckduckgo import DuckDuckGoTools
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[DuckDuckGoTools()],
+    instructions="Search the web for information",
+)
+```
+
+**Structured Output:**
+```python
+from pydantic import BaseModel
+
+class Result(BaseModel):
+    summary: str
+    findings: list[str]
+
+agent = Agent(model=OpenAIChat(id="gpt-4o"), output_schema=Result)
+result: Result = agent.run(query).content
+```
+
+## Known Pitfalls
+
+- **NEVER create agents in loops** -- reuse agent instances for performance (significant overhead otherwise)
+- Always use `output_schema` for structured responses
+- PostgreSQL in production, SQLite for dev only
+- Start with single agent (covers 90% of use cases), scale to Team/Workflow only when needed
+- Do not forget `search_knowledge=True` when using knowledge bases
+
+## Resources
+
+- https://docs.agno.com/ |
+| Mastra | # Mastra Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpx mastra init --default
+```
+
+Run `mastra init` right after `pnpm init`, before setting up the rest of the project. Then explore the generated structure and remove what is not needed.
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. Mastra integrates via the standard TypeScript tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Mastra documentation in your coding assistant:
+
+```json
+{
+  "mastra": {
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "@mastra/mcp-docs-server"]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init`
+2. `pnpx mastra init --default` (creates project structure)
+3. Explore the generated folders, remove what is not needed
+4. Implement the agent per user requirements
+5. Open the UI with `pnpx mastra dev`
+
+## Core Patterns
+
+- Use the Mastra MCP server to learn about Mastra APIs and best practices
+- Follow Mastra's TypeScript patterns and conventions
+- Leverage Mastra's integration ecosystem
+- Consult the MCP: "How do I [do X] in Mastra?"
+
+## Known Pitfalls
+
+- Always run `mastra init --default` before adding other project setup
+- Use the Mastra MCP for documentation rather than relying on stale examples
+
+## Resources
+
+- Use the Mastra MCP for up-to-date documentation |
+| LangGraph (Python) | # LangGraph Python Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add langgraph langchain-core langchain-openai
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add LangGraph dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. LangGraph/LangChain integrates via LangChain's callback pattern for tracing.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get LangGraph and LangChain documentation:
+
+```json
+{
+  "langgraph-py": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "LangGraph:https://langchain-ai.github.io/langgraph/llms.txt LangChain:https://python.langchain.com/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `uv init` to create a new project
+2. Add dependencies: `uv add langgraph langchain-core langchain-openai`
+3. Implement the requested agent logic and write tests
+4. Run with `uv run app.py` to validate behaviour
+
+## Core Patterns
+
+- Use the LangGraph MCP for learning about LangGraph and LangChain
+- Use LangChain's Python integrations for tools, memory, and models
+- Follow LangGraph's node/state patterns when structuring agents
+- Leverage LangChain's ecosystem for additional capabilities
+
+## Known Pitfalls
+
+- Always consult the LangGraph MCP for up-to-date API patterns
+- Follow LangGraph's node/state architecture rather than freestyle code
+- Use LangChain integrations for tools and models rather than raw API calls
+
+## Resources
+
+- Use the LangGraph MCP for up-to-date LangGraph and LangChain documentation |
+| LangGraph (TypeScript) | # LangGraph TypeScript Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpm add @langchain/langgraph @langchain/core @langchain/openai
+```
+
+No dedicated CLI scaffolder. Use `pnpm init` then add LangGraph dependencies and set up TypeScript configuration.
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. LangGraph.js integrates via LangChain.js callback pattern for tracing.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get LangGraph.js and LangChain.js documentation:
+
+```json
+{
+  "langgraph-ts": {
+    "type": "stdio",
+    "command": "npx",
+    "args": [
+      "-y", "mcpdoc",
+      "--urls", "LangGraphJS:https://langchain-ai.github.io/langgraphjs/llms.txt LangChainJS:https://js.langchain.com/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init` to create a new project
+2. `pnpm add @langchain/langgraph @langchain/core @langchain/openai`
+3. Set up TypeScript configuration
+4. Implement the agent per user requirements
+5. Run with `pnpm tsx src/index.ts`
+
+## Key Concepts
+
+- **StateGraph**: Define your agent's state and transitions
+- **Nodes**: Functions that process state and return updates
+- **Edges**: Define flow between nodes (conditional or direct)
+- **Checkpointer**: Enable conversation memory and state persistence
+
+## Core Patterns
+
+- Use the LangGraph MCP for learning about LangGraph.js
+- Use LangGraph's built-in agent capabilities (StateGraph, nodes, edges)
+- Follow LangGraph's TypeScript patterns and conventions
+- Leverage LangChain.js integration ecosystem
+
+## Known Pitfalls
+
+- Always set up TypeScript configuration before implementing
+- Use StateGraph patterns for agent architecture, not freestyle code
+- Consult the LangGraph MCP for up-to-date API patterns
+
+## Resources
+
+- Use the LangGraph MCP for up-to-date LangGraph.js documentation |
+| Google ADK | # Google ADK Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add google-adk
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add Google ADK dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. Google ADK integrates via the standard Python tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Google ADK documentation:
+
+```json
+{
+  "google-adk": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "Google-Adk:https://github.com/google/adk-python/blob/main/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `uv init` to create a new project
+2. `uv add google-adk` (plus `litellm` if using non-Google models)
+3. Set up API key in `.env` (check which env var is needed in app.py)
+4. Implement agent logic following Google ADK patterns
+5. Run with `uv run app.py` to validate behaviour
+
+## Core Patterns
+
+**Gemini (native):** `Agent(name="my_agent", model="gemini-2.0-flash-exp", ...)`
+
+**Non-Google models (LiteLLM):**
+```python
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+
+agent = Agent(name="my_agent", model=LiteLlm(model="openai/gpt-4.1"), ...)
+```
+
+## LLM Provider Configuration
+
+- **Gemini:** Uses Google AI SDK + ADK's native integrations
+- **Other providers (OpenAI, Anthropic, etc.):** Uses LiteLLM wrapper inside a Google ADK Agent
+- The framework is always Google ADK regardless of model provider -- NEVER switch frameworks
+- Use the `.env` file to set the right keys for the chosen provider
+
+## Known Pitfalls
+
+- Google ADK is the framework; the LLM provider is just the model backend -- do not confuse them
+- When using non-Google models, always use the LiteLLM wrapper inside ADK Agent
+- Never switch to a different agent framework when a non-Google model is selected
+- Always consult the Google ADK MCP for up-to-date API patterns
+
+## Resources
+
+- Use the Google ADK MCP for up-to-date documentation |
+| Vercel AI SDK | # Vercel AI SDK Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpm add ai @ai-sdk/openai
+```
+
+For other model providers, install the corresponding package (e.g., `@ai-sdk/anthropic`, `@ai-sdk/google`).
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. Vercel AI SDK integrates via the standard TypeScript tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Vercel AI SDK documentation:
+
+```json
+{
+  "vercel-ai": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "Vercel:https://ai-sdk.dev/docs/introduction",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init` to create a new project
+2. `pnpm add ai @ai-sdk/openai` (or other provider packages)
+3. Set up TypeScript configuration
+4. Implement the agent per user requirements
+5. Run with `pnpm tsx src/index.ts` or integrate with your chosen web framework
+
+## Key Concepts
+
+- **Unified Provider Architecture**: Consistent interface across multiple AI model providers
+- **generateText**: Generate text using any supported model
+- **streamText**: Stream text responses for real-time interactions
+- **Framework Integration**: Works with Next.js, React, Svelte, Vue, and Node.js
+
+## Core Patterns
+
+- Use the Vercel AI SDK MCP for learning about the SDK
+- Use Vercel AI SDK's unified provider architecture
+- Follow Vercel AI SDK's TypeScript patterns and conventions
+- Leverage framework integrations (Next.js, React, Svelte, Vue, Node.js)
+
+## Known Pitfalls
+
+- Always set up TypeScript configuration before implementing
+- Use the correct provider package for your chosen model (`@ai-sdk/openai`, `@ai-sdk/anthropic`, etc.)
+- Consult the Vercel AI SDK MCP for up-to-date API patterns
+
+## Resources
+
+- Use the AI SDK MCP for up-to-date documentation
+- https://ai-sdk.dev/docs/introduction |
+
+Do NOT read references for frameworks the user did not select.
+
+### Step 2: Scaffold Project Structure
+
+Create the full directory tree before writing any application code:
+
+```
+my-agent/
+├── <app/ or src/>         # Python: app/  |  TypeScript: src/
+├── prompts/
+├── tests/
+│   ├── evaluations/
+│   └── scenarios/
+├── .env
+├── .env.example
+├── .mcp.json
+├── .mcp.json.example
+├── .cursor/mcp.json       # Symlink → ../.mcp.json
+├── .gitignore
+├── AGENTS.md
+├── CLAUDE.md              # Contains: @AGENTS.md
+└── pyproject.toml / package.json
+```
+
+**`.env.example`** -- committed, placeholder values only:
+```
+LANGWATCH_API_KEY={{LANGWATCH_API_KEY}}
+OPENAI_API_KEY=your-openai-api-key
+# Adjust provider key to match the selected LLM provider
+```
+
+**`.env`** -- gitignored, real keys from user's environment:
+```
+LANGWATCH_API_KEY=<actual key if available>
+```
+
+**`.mcp.json`** -- gitignored, contains both LangWatch and framework-specific MCP servers. See the framework reference for the framework MCP config. Combine with the LangWatch MCP:
+```json
+{
+  "mcpServers": {
+    "langwatch": {
+      "command": "npx",
+      "args": ["-y", "@langwatch/mcp-server"],
+      "env": {
+        "LANGWATCH_API_KEY": "<key>"
+      }
+    }
+  }
+}
+```
+
+**`.mcp.json.example`** -- committed, same structure with placeholder keys.
+
+**`.cursor/mcp.json`** -- create as a symlink to `../.mcp.json` for Cursor compatibility.
+
+**`.gitignore`** -- must include:
+```
+.env
+.mcp.json
+.cursor/
+__pycache__/
+node_modules/
+.venv/
+```
+
+**`CLAUDE.md`**:
+```
+@AGENTS.md
+```
+
+**`AGENTS.md`** -- see the AGENTS.md Template section below for what to include.
+
+### Step 3: Set Up Language Environment and Install Dependencies
+
+Follow the framework reference for scaffolding commands.
+
+**Python frameworks** (Agno, LangGraph Python, Google ADK):
+1. Verify Python is installed: `python3 --version`. If missing, report the error and provide installation guidance. Do not leave a half-scaffolded project.
+2. Run the setup commands from the framework reference (e.g., `uv init`, `uv add ...`)
+3. Add LangWatch: `uv add langwatch`
+4. Add test dependencies: `uv add --dev pytest langwatch-scenario`
+
+**TypeScript frameworks** (Mastra, LangGraph TS, Vercel AI SDK):
+1. Verify Node.js is installed: `node --version`. If missing, report the error and provide installation guidance.
+2. Run the setup commands from the framework reference (e.g., `pnpm init`, `pnpm add ...`)
+3. Add LangWatch: `pnpm add langwatch`
+4. Add test dependencies: `pnpm add -D @langwatch/scenario vitest`
+5. Set up `tsconfig.json` if not already created by the framework scaffolder
+
+If dependency installation fails, report the error clearly and provide manual installation instructions. Leave the project structure intact so the user can recover.
+
+### Step 4: Instrument with LangWatch Tracing
+
+Follow the integration guide you read in Step 1 for the specific framework. The general patterns are:
+
+**Python:**
+```python
+import langwatch
+langwatch.setup()
+
+@langwatch.trace()
+def run_agent(user_input: str):
+    # agent logic here
+    pass
+```
+
+**TypeScript:**
+```typescript
+import { LangWatch } from "langwatch";
+const langwatch = new LangWatch();
+```
+
+IMPORTANT: The exact pattern depends on the framework. Follow the docs you read, not these examples.
+
+### Step 5: Create Versioned Prompts via Prompt CLI
+
+1. Install the CLI: `npm install -g langwatch` (or `npx langwatch`)
+2. Initialize: `langwatch prompt init`
+3. Get the API key: see # LangWatch API Key Setup
+
+1. Check if `LANGWATCH_API_KEY` is already set in your environment or `.env` file.
+2. If missing, get one at: https://app.langwatch.ai/authorize
+3. Add it to your project's `.env` file (check for duplicates first):
+```
+LANGWATCH_API_KEY=sk-lw-...
+```
+4. The MCP server also needs the key -- pass it via `--apiKey` flag or `LANGWATCH_API_KEY` env var.
+
+MCP Setup (see above)
+4. Create the main prompt: `langwatch prompt create main-prompt`
+5. Edit `prompts/main-prompt.yaml` with content tailored to the user's agent goal:
+   ```yaml
+   model: gpt-4o  # or the selected provider's model
+   temperature: 0.7
+   messages:
+     - role: system
+       content: |
+         <system prompt tailored to the agent's goal>
+     - role: user
+       content: |
+         {{ user_input }}
+   ```
+6. Sync: `langwatch prompt sync`
+7. Update the agent code to load the prompt via `langwatch.prompts.get("main-prompt")` instead of hardcoding it
+
+Do NOT hardcode prompts in application code. Do NOT add try/catch fallbacks around prompt fetching.
+
+### Step 6: Write Evaluation Experiment
+
+**Python projects** -- create a Jupyter notebook at `tests/evaluations/evaluation.ipynb`:
+- Use `langwatch.experiment.init()` to set up the experiment
+- Generate a CSV dataset of 10-20 examples tailored to the agent's domain
+- Include at least one evaluator (LLM-as-judge for quality is a good default)
+- Run the notebook to verify it produces results
+
+**TypeScript projects** -- create a script at `tests/evaluations/evaluation.ts`:
+- Use the LangWatch experiments SDK
+- Generate a dataset tailored to the agent's domain
+- Include at least one evaluator
+- Make it runnable with `npx tsx tests/evaluations/evaluation.ts`
+
+Evaluations are for batch metrics on single input/output pairs (RAG accuracy, classification, etc.). Do NOT use evaluations for multi-turn agent testing -- that is what scenarios are for.
+
+### Step 7: Write Scenario Simulation Tests
+
+Use `@langwatch/scenario` (TypeScript) or `langwatch-scenario` (Python) -- NEVER invent a custom testing framework.
+
+1. Read the Scenario docs via MCP: call `fetch_scenario_docs`
+2. Create test files in `tests/scenarios/`
+3. Write at least one scenario that validates the agent's core behavior:
+   - Define an `AgentAdapter` that connects to your agent
+   - Use `UserSimulatorAgent` to simulate realistic user messages
+   - Use `JudgeAgent` with natural language criteria (NOT regex or string matching)
+4. Test multi-turn conversations that verify the agent achieves its goal
+
+### Step 8: Run Tests to Verify
+
+Run the scenario tests:
+- Python: `uv run pytest tests/scenarios/`
+- TypeScript: `pnpm vitest run tests/scenarios/`
+
+If tests fail, fix the issues and re-run. Do NOT declare the project complete until tests pass. "It should work" is not verification.
+
+### Step 9: Tell the User How to Start
+
+Tell the user the command to start their agent or dev server. Do NOT start it yourself -- long-running processes block the agent.
+
+Examples:
+- Agno: `uv run python app/main.py`
+- Mastra: `pnpx mastra dev`
+- LangGraph Python: `uv run python app/main.py`
+- Vercel AI SDK: `pnpm tsx src/index.ts`
+
+Include the URL they can visit if the framework provides a web UI.
+
+## AGENTS.md Template
+
+The generated `AGENTS.md` must include these sections:
+
+```markdown
+# <Project Name>
+
+<Brief description of the agent and its goal>
+
+## Development
+
+### Running
+<command to start the agent>
+
+### Testing
+<command to run scenario tests>
+
+## Principles
+
+### 1. Agent Testing with Scenarios
+- Use `@langwatch/scenario` (TS) or `langwatch-scenario` (Python) for testing
+- Test multi-turn conversations, not just single exchanges
+- Use natural language judge criteria, not regex or string matching
+- Run scenarios before considering any change complete
+
+### 2. Prompt Management
+- Use LangWatch Prompt CLI: `langwatch prompt create <name>`
+- Store prompts in `prompts/*.yaml`, never hardcode in code
+- Run `langwatch prompt sync` after changes
+
+### 3. Evaluations vs. Scenarios
+- Evaluations: batch metrics for single input/output pairs (RAG, classification)
+- Scenarios: multi-turn agent conversation testing
+- When in doubt, use scenarios
+
+### 4. Observability
+- All LLM calls are traced via LangWatch
+- Check traces at https://app.langwatch.ai
+```
+
+## Guard Rails
+
+Read # Guard Rails -- Known Agent Failure Modes
+
+## Testing
+
+- DO NOT invent custom testing frameworks (e.g. `agent_tester`, `simulation_framework`, `langwatch.testing`). Use `@langwatch/scenario` (TS) or `langwatch-scenario` (Python). The Scenario SDK already handles user simulation, judging, multi-turn conversations, and tool call verification.
+- DO NOT use regex or word matching in scenario judge criteria. Use natural language criteria with `JudgeAgent` -- it is more robust and meaningful than brittle pattern matching.
+- DO NOT use evaluations for multi-turn agent testing. Evaluations are for single input/output metrics (RAG accuracy, classification). Use Scenario tests for multi-turn agent flows.
+- DO NOT skip running tests after implementation. Always run scenarios and verify they pass before considering work done. "It should work" is not verification.
+
+## Prompts
+
+- NEVER hardcode prompts in application code or inline strings. Store all prompts in `prompts/*.yaml` files managed by LangWatch Prompt CLI (`langwatch prompt create <name>`, `langwatch prompt sync`).
+- DO NOT add try/catch around prompt fetching or duplicate prompts as fallbacks. Prompt CLI files are local and reliable.
+
+## Notebooks
+
+- DO NOT just write Jupyter notebooks without executing them. Evaluation notebooks under `tests/evaluations/` must be run to verify they produce correct results. Writing a notebook is not the same as running it.
+
+## Environment
+
+- DO NOT start long-running dev servers yourself. They block the agent process. Instead, tell the user how to start the server and give them the URL. Let the user run it themselves.
+- DO NOT commit `.mcp.json` with real API keys. The `.mcp.json` file contains secrets. Use `.mcp.json.example` with placeholder values for git, and add `.mcp.json` to `.gitignore`.
+- DO NOT commit `.env` files. Use `.env.example` for templates. API keys are already in `.env` -- do not re-set them.
+
+## Agent Construction
+
+- DO NOT create agent instances inside loops (especially Agno). Agent construction has significant overhead. Create the agent once, reuse it for multiple queries.
+
+## Documentation
+
+- ALWAYS use the LangWatch MCP (`fetch_langwatch_docs`, `fetch_scenario_docs`) to access documentation. DO NOT fetch docs from random URLs, hallucinate API signatures, or guess framework patterns. Read the actual docs for the specific framework.
+- DO NOT use `platform_*` MCP tools when writing code. The `platform_create_scenario`, `platform_create_evaluator`, etc. tools are for no-code platform operations. When you have a codebase, write test files and code instead.
+
+## Workflow
+
+- DO NOT mix kickoff/setup steps with reference documentation. Kickoff instructions (numbered steps the agent executes once) must be clearly separated from ongoing reference material (patterns, rules, examples).
+- DO NOT skip verification. After implementation: run scenario tests, check they pass, instrument with LangWatch, confirm traces appear. Only then is the work done. The critical rules:
+
+- **Testing**: Use `@langwatch/scenario` / `langwatch-scenario`. Never invent custom test frameworks. Never use regex in judge criteria. Use natural language criteria with `JudgeAgent`.
+- **Prompts**: Use Prompt CLI (`langwatch prompt create`, `langwatch prompt sync`). Never hardcode in code. No try/catch fallbacks.
+- **Documentation**: Use MCP (`fetch_langwatch_docs`, `fetch_scenario_docs`) for docs. Never guess URLs or API signatures.
+- **Environment**: Never start long-running dev servers. Never commit `.env` or `.mcp.json` with real keys. Use `.example` files for git.
+- **MCP tools**: Never use `platform_*` MCP tools (platform_create_scenario, etc.) when writing code. Those are for no-code platform operations.
+- **Agent construction**: Never create agent instances inside loops (especially Agno). Create once, reuse.
+- **Notebooks**: Always run evaluation notebooks, not just write them. Writing is not verification.
+- **Workflow**: Read docs first (Step 1), scaffold second (Step 2), verify last (Step 8). Never skip verification.
+
+## Common Mistakes
+
+| Mistake | Correct Approach |
+|---------|-----------------|
+| Hardcoding prompts in agent code | Use `langwatch prompt create` and load via `langwatch.prompts.get()` |
+| Inventing a custom test framework | Use `@langwatch/scenario` or `langwatch-scenario` |
+| Using regex/string matching in scenario judges | Use natural language criteria with `JudgeAgent` |
+| Skipping MCP docs and guessing APIs | Call `fetch_langwatch_docs` and `fetch_scenario_docs` first |
+| Starting the dev server for the user | Tell the user the command and URL, let them run it |
+| Committing `.env` or `.mcp.json` with real keys | Use `.env.example` and `.mcp.json.example` for git |
+| Using `platform_*` MCP tools to create scenarios | Write test files in `tests/scenarios/` instead |
+| Creating agents inside loops (Agno) | Create the agent instance once, reuse it |
+| Writing evaluation notebook without running it | Execute the notebook to verify it produces results |
+| Mixing evaluations and scenarios | Evaluations = batch metrics. Scenarios = multi-turn agent tests |
+| Reading all framework references | Read ONLY the reference for the selected framework |
+| Scaffolding before reading docs | Step 1 is always reading docs via MCP |

--- a/skills/_compiled/generate.sh
+++ b/skills/_compiled/generate.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Generate compiled prompts from SKILL.md sources.
+# Run from the repo root: bash skills/_compiled/generate.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPILER="npx tsx $REPO_ROOT/skills/_compiler/compile.ts"
+OUT_DIR="$SCRIPT_DIR"
+
+# Discover all skills (directories under skills/ that contain SKILL.md)
+SKILLS=$(find "$REPO_ROOT/skills" -maxdepth 2 -name "SKILL.md" -exec dirname {} \; | xargs -I {} basename {} | sort)
+
+for skill in $SKILLS; do
+  echo "Compiling $skill..."
+  $COMPILER --skills "$skill" --mode platform > "$OUT_DIR/$skill.platform.txt"
+  $COMPILER --skills "$skill" --mode docs > "$OUT_DIR/$skill.docs.txt"
+done
+
+echo "Done. Generated $(ls -1 "$OUT_DIR"/*.txt 2>/dev/null | wc -l | tr -d ' ') files in $OUT_DIR/"

--- a/skills/_compiler/__tests__/compile.unit.test.ts
+++ b/skills/_compiler/__tests__/compile.unit.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFrontmatter,
+  resolveReferences,
+  applyApiKeyMode,
+  wrapInEnvelope,
+  compileSkill,
+} from "../compile.js";
+import path from "path";
+
+const SKILLS_ROOT = path.resolve(__dirname, "../../");
+const SKILL_DIR = path.join(SKILLS_ROOT, "create-agent");
+const SHARED_DIR = path.join(SKILLS_ROOT, "_shared");
+
+describe("parseFrontmatter()", () => {
+  describe("when given valid SKILL.md content", () => {
+    it("extracts the frontmatter fields", () => {
+      const content = [
+        "---",
+        "name: test-skill",
+        "description: A test skill",
+        "license: MIT",
+        "---",
+        "",
+        "# Body content",
+      ].join("\n");
+
+      const result = parseFrontmatter(content);
+
+      expect(result.frontmatter.name).toBe("test-skill");
+      expect(result.frontmatter.description).toBe("A test skill");
+      expect(result.frontmatter.license).toBe("MIT");
+    });
+
+    it("returns the body without frontmatter", () => {
+      const content = [
+        "---",
+        "name: test-skill",
+        "description: A test skill",
+        "---",
+        "",
+        "# Body content",
+        "Some text here.",
+      ].join("\n");
+
+      const result = parseFrontmatter(content);
+
+      expect(result.body).toBe("# Body content\nSome text here.");
+    });
+  });
+
+  describe("when given content without frontmatter markers", () => {
+    it("throws an error", () => {
+      const content = "# No frontmatter here";
+
+      expect(() => parseFrontmatter(content)).toThrow("Invalid SKILL.md format");
+    });
+  });
+});
+
+describe("resolveReferences()", () => {
+  describe("when body contains _shared/ references", () => {
+    it("inlines the content of the referenced file", () => {
+      const body = "Some text.\n\nSee [MCP Setup](_shared/mcp-setup.md) for installation instructions.\n\nMore text.";
+
+      const result = resolveReferences({ body, skillDir: SKILL_DIR, sharedDir: SHARED_DIR });
+
+      expect(result).not.toContain("[MCP Setup](_shared/mcp-setup.md)");
+      expect(result).toContain("# Installing the LangWatch MCP Server");
+      expect(result).toContain("Some text.");
+      expect(result).toContain("More text.");
+    });
+  });
+
+  describe("when body contains references/ links", () => {
+    it("inlines the content of the referenced file", () => {
+      const body = "Read the guide:\n\n| Agno | [references/agno.md](references/agno.md) |";
+
+      const result = resolveReferences({ body, skillDir: SKILL_DIR, sharedDir: SHARED_DIR });
+
+      expect(result).not.toContain("[references/agno.md](references/agno.md)");
+      expect(result).toContain("# Agno Framework Reference");
+    });
+  });
+
+  describe("when body contains a reference to a nonexistent file", () => {
+    it("leaves a bracketed placeholder", () => {
+      const body = "See [Missing](_shared/nonexistent.md) for details.";
+
+      const result = resolveReferences({ body, skillDir: SKILL_DIR, sharedDir: SHARED_DIR });
+
+      expect(result).toContain("[Unresolved reference: _shared/nonexistent.md]");
+    });
+  });
+
+  describe("when body contains cross-references within shared files", () => {
+    it("resolves nested references from shared files", () => {
+      // api-key-setup.md references mcp-setup.md via a relative link
+      const body = "Get your key: see [API Key Setup](_shared/api-key-setup.md).";
+
+      const result = resolveReferences({ body, skillDir: SKILL_DIR, sharedDir: SHARED_DIR });
+
+      expect(result).toContain("# LangWatch API Key Setup");
+    });
+
+    it("removes relative cross-references within inlined shared content", () => {
+      const body = "Get your key: see [API Key Setup](_shared/api-key-setup.md).";
+
+      const result = resolveReferences({ body, skillDir: SKILL_DIR, sharedDir: SHARED_DIR });
+
+      // The inlined api-key-setup.md has [MCP Setup](mcp-setup.md) which should be resolved
+      expect(result).not.toMatch(/\[[^\]]+\]\([^)]*\.md\)/);
+    });
+  });
+});
+
+describe("applyApiKeyMode()", () => {
+  describe("when mode is platform", () => {
+    it("replaces YOUR_API_KEY with the template placeholder", () => {
+      const content = 'claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey YOUR_API_KEY';
+
+      const result = applyApiKeyMode({ content, mode: "platform" });
+
+      expect(result).toContain("{{LANGWATCH_API_KEY}}");
+      expect(result).not.toContain("YOUR_API_KEY");
+    });
+
+    it("replaces your-langwatch-api-key placeholders", () => {
+      const content = "LANGWATCH_API_KEY=your-langwatch-api-key";
+
+      const result = applyApiKeyMode({ content, mode: "platform" });
+
+      expect(result).toContain("{{LANGWATCH_API_KEY}}");
+    });
+  });
+
+  describe("when mode is docs", () => {
+    it("replaces YOUR_API_KEY with an ask-user instruction", () => {
+      const content = "Use --apiKey YOUR_API_KEY for setup.";
+
+      const result = applyApiKeyMode({ content, mode: "docs" });
+
+      expect(result).not.toContain("YOUR_API_KEY");
+      expect(result).toContain("ASK_USER_FOR_API_KEY");
+    });
+
+    it("includes the authorize URL", () => {
+      const content = "Some content with YOUR_API_KEY placeholder.";
+
+      const result = applyApiKeyMode({ content, mode: "docs" });
+
+      expect(result).toContain("https://app.langwatch.ai/authorize");
+    });
+  });
+});
+
+describe("wrapInEnvelope()", () => {
+  describe("when mode is platform", () => {
+    it("adds a system instruction header", () => {
+      const result = wrapInEnvelope({ content: "body content", mode: "platform", skillName: "create-agent" });
+
+      expect(result).toContain("body content");
+      expect(result).toMatch(/^You are/); // starts with system instruction
+    });
+  });
+
+  describe("when mode is docs", () => {
+    it("includes an instruction to ask for the API key", () => {
+      const result = wrapInEnvelope({ content: "body content", mode: "docs", skillName: "create-agent" });
+
+      expect(result).toContain("https://app.langwatch.ai/authorize");
+      expect(result).toContain("body content");
+    });
+  });
+});
+
+describe("compileSkill()", () => {
+  describe("when compiling create-agent in platform mode", () => {
+    it("produces self-contained output with no unresolved file references", () => {
+      const result = compileSkill({ skillName: "create-agent", mode: "platform" });
+
+      // No unresolved markdown links to local files
+      const unresolvedLinks = result.match(/\[[^\]]+\]\((?:_shared|references)\/[^)]+\)/g);
+      expect(unresolvedLinks).toBeNull();
+    });
+
+    it("contains the LANGWATCH_API_KEY template placeholder", () => {
+      const result = compileSkill({ skillName: "create-agent", mode: "platform" });
+
+      expect(result).toContain("{{LANGWATCH_API_KEY}}");
+    });
+
+    it("keeps framework selection interactive", () => {
+      const result = compileSkill({ skillName: "create-agent", mode: "platform" });
+
+      // Should still have the framework table for user to choose
+      expect(result).toContain("Agno");
+      expect(result).toContain("Mastra");
+      expect(result).toContain("Vercel AI SDK");
+      expect(result).toContain("LangGraph");
+      expect(result).toContain("Google ADK");
+    });
+
+    it("includes inlined shared content", () => {
+      const result = compileSkill({ skillName: "create-agent", mode: "platform" });
+
+      // Should have the inlined MCP setup content
+      expect(result).toContain("Installing the LangWatch MCP Server");
+    });
+
+    it("includes inlined framework reference content", () => {
+      const result = compileSkill({ skillName: "create-agent", mode: "platform" });
+
+      // Should have all framework references inlined
+      expect(result).toContain("Agno Framework Reference");
+      expect(result).toContain("Mastra Framework Reference");
+    });
+  });
+
+  describe("when compiling create-agent in docs mode", () => {
+    it("instructs the agent to ask the user for their API key", () => {
+      const result = compileSkill({ skillName: "create-agent", mode: "docs" });
+
+      expect(result).toContain("https://app.langwatch.ai/authorize");
+    });
+
+    it("produces self-contained output with no unresolved file references", () => {
+      const result = compileSkill({ skillName: "create-agent", mode: "docs" });
+
+      const unresolvedLinks = result.match(/\[[^\]]+\]\((?:_shared|references)\/[^)]+\)/g);
+      expect(unresolvedLinks).toBeNull();
+    });
+  });
+
+  describe("when skill does not exist", () => {
+    it("throws an error", () => {
+      expect(() => compileSkill({ skillName: "nonexistent", mode: "platform" })).toThrow(
+        "Skill not found: nonexistent"
+      );
+    });
+  });
+});

--- a/skills/_compiler/__tests__/compile.unit.test.ts
+++ b/skills/_compiler/__tests__/compile.unit.test.ts
@@ -157,7 +157,7 @@ describe("applyApiKeyMode()", () => {
 describe("wrapInEnvelope()", () => {
   describe("when mode is platform", () => {
     it("adds a system instruction header", () => {
-      const result = wrapInEnvelope({ content: "body content", mode: "platform", skillName: "create-agent" });
+      const result = wrapInEnvelope({ content: "body content", mode: "platform" });
 
       expect(result).toContain("body content");
       expect(result).toMatch(/^You are/); // starts with system instruction
@@ -166,7 +166,7 @@ describe("wrapInEnvelope()", () => {
 
   describe("when mode is docs", () => {
     it("includes an instruction to ask for the API key", () => {
-      const result = wrapInEnvelope({ content: "body content", mode: "docs", skillName: "create-agent" });
+      const result = wrapInEnvelope({ content: "body content", mode: "docs" });
 
       expect(result).toContain("https://app.langwatch.ai/authorize");
       expect(result).toContain("body content");

--- a/skills/_compiler/compile.ts
+++ b/skills/_compiler/compile.ts
@@ -57,8 +57,14 @@ export function parseFrontmatter(content: string): ParsedSkill {
     }
   }
 
+  if (!frontmatter.name || !frontmatter.description) {
+    throw new Error(
+      "Invalid SKILL.md frontmatter: 'name' and 'description' are required"
+    );
+  }
+
   return {
-    frontmatter: frontmatter as unknown as SkillFrontmatter,
+    frontmatter: frontmatter as SkillFrontmatter,
     body,
   };
 }
@@ -204,11 +210,9 @@ export function applyApiKeyMode({
 export function wrapInEnvelope({
   content,
   mode,
-  skillName,
 }: {
   content: string;
   mode: CompileMode;
-  skillName: string;
 }): string {
   const header =
     mode === "platform"
@@ -259,7 +263,7 @@ export function compileSkill({
   body = applyApiKeyMode({ content: body, mode });
 
   // Wrap in envelope
-  return wrapInEnvelope({ content: body, mode, skillName });
+  return wrapInEnvelope({ content: body, mode });
 }
 
 // ──────────────────────────────────────────────────
@@ -297,9 +301,15 @@ function parseArgs(): CliOptions {
       case "--skills":
         skills = args[++i]!.split(",");
         break;
-      case "--mode":
-        mode = args[++i] as CompileMode;
+      case "--mode": {
+        const modeArg = args[++i];
+        if (modeArg !== "platform" && modeArg !== "docs") {
+          console.error(`Error: --mode must be "platform" or "docs", got "${modeArg}"`);
+          process.exit(1);
+        }
+        mode = modeArg;
         break;
+      }
       case "--help":
         console.log(
           `Usage: compile.ts --skills <skill1,skill2> --mode <platform|docs>

--- a/skills/_compiler/compile.ts
+++ b/skills/_compiler/compile.ts
@@ -1,0 +1,345 @@
+#!/usr/bin/env npx tsx
+/**
+ * Prompt compiler -- generates self-contained copy-paste prompts from SKILL.md files.
+ *
+ * Parses SKILL.md frontmatter, resolves all file references (shared and local),
+ * applies API key mode (platform or docs), and wraps in a prompt envelope.
+ *
+ * Usage:
+ *   npx tsx skills/_compiler/compile.ts --skills create-agent --mode platform
+ *   npx tsx skills/_compiler/compile.ts --skills create-agent --mode docs
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// ──────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────
+
+export interface SkillFrontmatter {
+  name: string;
+  description: string;
+  license?: string;
+  compatibility?: string;
+}
+
+export interface ParsedSkill {
+  frontmatter: SkillFrontmatter;
+  body: string;
+}
+
+export type CompileMode = "platform" | "docs";
+
+// ──────────────────────────────────────────────────
+// Parsing
+// ──────────────────────────────────────────────────
+
+/**
+ * Parses YAML frontmatter and body from SKILL.md content.
+ * Expects content delimited by `---` markers at the top.
+ */
+export function parseFrontmatter(content: string): ParsedSkill {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) {
+    throw new Error("Invalid SKILL.md format: missing frontmatter delimiters");
+  }
+
+  const frontmatterRaw = match[1]!;
+  const body = match[2]!.trim();
+
+  const frontmatter: Record<string, string> = {};
+  for (const line of frontmatterRaw.split("\n")) {
+    const kvMatch = line.match(/^(\w[\w-]*?):\s*(.+)$/);
+    if (kvMatch) {
+      frontmatter[kvMatch[1]!] = kvMatch[2]!.trim();
+    }
+  }
+
+  return {
+    frontmatter: frontmatter as unknown as SkillFrontmatter,
+    body,
+  };
+}
+
+// ──────────────────────────────────────────────────
+// Reference resolution
+// ──────────────────────────────────────────────────
+
+/**
+ * Resolves markdown file references by inlining their content.
+ *
+ * Handles three patterns:
+ * - `[text](_shared/file.md)` -- shared references, resolved from sharedDir
+ * - `[text](references/file.md)` -- local references, resolved from skillDir
+ * - `[text](file.md)` -- relative cross-references within inlined shared content
+ *
+ * References with surrounding prose (e.g., "See [text](file) for details.")
+ * are replaced with just the inlined content.
+ */
+export function resolveReferences({
+  body,
+  skillDir,
+  sharedDir,
+}: {
+  body: string;
+  skillDir: string;
+  sharedDir: string;
+}): string {
+  // First pass: resolve _shared/ and references/ links
+  const referencePattern =
+    /(?:See\s+)?\[([^\]]+)\]\(((?:_shared|references)\/[^)]+\.md)\)(?:\s+for[^.\n]*\.)?/g;
+
+  let result = body.replace(referencePattern, (_match, _linkText: string, refPath: string) => {
+    // Try resolving from the skill directory first (for references/ paths)
+    const fromSkillDir = path.join(skillDir, refPath);
+    if (fs.existsSync(fromSkillDir)) {
+      return fs.readFileSync(fromSkillDir, "utf8").trim();
+    }
+
+    // Try resolving from the shared directory (for _shared/ paths)
+    const fromSharedDir = path.join(sharedDir, path.basename(refPath));
+    if (fs.existsSync(fromSharedDir)) {
+      return fs.readFileSync(fromSharedDir, "utf8").trim();
+    }
+
+    return `[Unresolved reference: ${refPath}]`;
+  });
+
+  // Second pass: resolve relative .md links from inlined shared files
+  // These are cross-references like [MCP Setup](mcp-setup.md) within shared content.
+  // Since the referenced content is typically already inlined elsewhere in the doc,
+  // we replace the link with "(see above)" to avoid duplication.
+  const relativeRefPattern =
+    /(?:See\s+)?\[([^\]]+)\]\(([^/)][^)]*\.md)\)(?:\s+for[^.\n]*\.)?/g;
+
+  result = result.replace(relativeRefPattern, (_match, linkText: string, refPath: string) => {
+    // Skip URLs (http/https links)
+    if (refPath.startsWith("http")) {
+      return _match;
+    }
+    // Check if the file exists in shared dir -- if so, it was inlined above
+    const fromSharedDir = path.join(sharedDir, refPath);
+    if (fs.existsSync(fromSharedDir)) {
+      return `${linkText} (see above)`;
+    }
+    // Check in skill dir
+    const fromSkillDir = path.join(skillDir, refPath);
+    if (fs.existsSync(fromSkillDir)) {
+      return `${linkText} (see above)`;
+    }
+    // Leave as-is if not a resolvable local file
+    return _match;
+  });
+
+  return result;
+}
+
+// ──────────────────────────────────────────────────
+// API key mode handling
+// ──────────────────────────────────────────────────
+
+/** Placeholder strings that represent API keys in SKILL.md and shared files. */
+const API_KEY_PLACEHOLDERS = [
+  "YOUR_API_KEY",
+  "your-langwatch-api-key",
+  "your-api-key-here",
+];
+
+/**
+ * Applies API key handling based on compile mode.
+ *
+ * - **platform**: Replaces all API key placeholders with `{{LANGWATCH_API_KEY}}`
+ * - **docs**: Replaces placeholders with `ASK_USER_FOR_API_KEY` and prepends
+ *   an instruction block telling the agent to ask the user for their key.
+ */
+export function applyApiKeyMode({
+  content,
+  mode,
+}: {
+  content: string;
+  mode: CompileMode;
+}): string {
+  if (mode === "platform") {
+    let result = content;
+    for (const placeholder of API_KEY_PLACEHOLDERS) {
+      result = result.replaceAll(placeholder, "{{LANGWATCH_API_KEY}}");
+    }
+    return result;
+  }
+
+  // Docs mode: replace placeholders and add instruction
+  let result = content;
+  for (const placeholder of API_KEY_PLACEHOLDERS) {
+    result = result.replaceAll(placeholder, "ASK_USER_FOR_API_KEY");
+  }
+
+  const askBlock = [
+    "",
+    "**API Key**: Before proceeding, ask the user for their LangWatch API key.",
+    "They can get one at: https://app.langwatch.ai/authorize",
+    "Use the provided key wherever you see `ASK_USER_FOR_API_KEY` below.",
+    "",
+  ].join("\n");
+
+  // Insert the ask block after the first heading
+  const firstHeadingEnd = result.indexOf("\n", result.indexOf("# "));
+  if (firstHeadingEnd !== -1) {
+    result = result.slice(0, firstHeadingEnd) + "\n" + askBlock + result.slice(firstHeadingEnd);
+  } else {
+    result = askBlock + "\n" + result;
+  }
+
+  return result;
+}
+
+// ──────────────────────────────────────────────────
+// Prompt envelope
+// ──────────────────────────────────────────────────
+
+/**
+ * Wraps compiled content in a system instruction envelope.
+ */
+export function wrapInEnvelope({
+  content,
+  mode,
+  skillName,
+}: {
+  content: string;
+  mode: CompileMode;
+  skillName: string;
+}): string {
+  const header =
+    mode === "platform"
+      ? "You are helping the user set up a new AI agent project with LangWatch instrumentation. Follow these instructions carefully."
+      : [
+          "You are helping the user set up a new AI agent project with LangWatch instrumentation. Follow these instructions carefully.",
+          "",
+          "IMPORTANT: You will need the user's LangWatch API key. Ask them for it before starting, and direct them to https://app.langwatch.ai/authorize if they don't have one.",
+        ].join("\n");
+
+  return `${header}\n\n${content}`;
+}
+
+// ──────────────────────────────────────────────────
+// High-level compilation
+// ──────────────────────────────────────────────────
+
+/**
+ * Compiles a single skill into a self-contained prompt string.
+ *
+ * @param skillName - Directory name under skills/ (e.g., "create-agent")
+ * @param mode - "platform" or "docs"
+ * @returns The fully compiled, self-contained prompt text
+ */
+export function compileSkill({
+  skillName,
+  mode,
+}: {
+  skillName: string;
+  mode: CompileMode;
+}): string {
+  const skillsRoot = findSkillsRoot();
+  const skillDir = path.join(skillsRoot, skillName);
+  const skillMdPath = path.join(skillDir, "SKILL.md");
+  const sharedDir = path.join(skillsRoot, "_shared");
+
+  if (!fs.existsSync(skillMdPath)) {
+    throw new Error(`Skill not found: ${skillName} (expected ${skillMdPath})`);
+  }
+
+  const content = fs.readFileSync(skillMdPath, "utf8");
+  const parsed = parseFrontmatter(content);
+
+  // Resolve all file references
+  let body = resolveReferences({ body: parsed.body, skillDir, sharedDir });
+
+  // Apply API key mode
+  body = applyApiKeyMode({ content: body, mode });
+
+  // Wrap in envelope
+  return wrapInEnvelope({ content: body, mode, skillName });
+}
+
+// ──────────────────────────────────────────────────
+// Path resolution
+// ──────────────────────────────────────────────────
+
+function findSkillsRoot(): string {
+  // When running as a module (tests), use __dirname relative path
+  // When running as CLI, use the script location
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    return path.resolve(path.dirname(thisFile), "..");
+  } catch {
+    // Fallback: look relative to cwd
+    return path.resolve(process.cwd(), "skills");
+  }
+}
+
+// ──────────────────────────────────────────────────
+// CLI
+// ──────────────────────────────────────────────────
+
+interface CliOptions {
+  skills: string[];
+  mode: CompileMode;
+}
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  let skills: string[] = [];
+  let mode: CompileMode = "docs";
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--skills":
+        skills = args[++i]!.split(",");
+        break;
+      case "--mode":
+        mode = args[++i] as CompileMode;
+        break;
+      case "--help":
+        console.log(
+          `Usage: compile.ts --skills <skill1,skill2> --mode <platform|docs>
+
+Options:
+  --skills    Comma-separated skill names (e.g., create-agent)
+  --mode      Output mode: "platform" (API key placeholder) or "docs" (asks user for key)
+
+Examples:
+  npx tsx compile.ts --skills create-agent --mode platform
+  npx tsx compile.ts --skills create-agent --mode docs`
+        );
+        process.exit(0);
+    }
+  }
+
+  if (skills.length === 0) {
+    console.error("Error: --skills is required. Use --help for usage.");
+    process.exit(1);
+  }
+
+  return { skills, mode };
+}
+
+/** Entry point -- only runs when invoked as a CLI script, not when imported. */
+function main(): void {
+  const options = parseArgs();
+
+  for (const skillName of options.skills) {
+    const result = compileSkill({ skillName, mode: options.mode });
+    console.log(result);
+  }
+}
+
+// Run CLI when executed directly
+const isDirectExecution =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  (process.argv[1].endsWith("compile.ts") || process.argv[1].endsWith("compile.js"));
+
+if (isDirectExecution) {
+  main();
+}

--- a/skills/_shared/api-key-setup.md
+++ b/skills/_shared/api-key-setup.md
@@ -1,0 +1,11 @@
+# LangWatch API Key Setup
+
+1. Check if `LANGWATCH_API_KEY` is already set in your environment or `.env` file.
+2. If missing, get one at: https://app.langwatch.ai/authorize
+3. Add it to your project's `.env` file (check for duplicates first):
+```
+LANGWATCH_API_KEY=sk-lw-...
+```
+4. The MCP server also needs the key -- pass it via `--apiKey` flag or `LANGWATCH_API_KEY` env var.
+
+See [MCP Setup](mcp-setup.md) for full server configuration.

--- a/skills/_shared/guard-rails.md
+++ b/skills/_shared/guard-rails.md
@@ -1,0 +1,37 @@
+# Guard Rails -- Known Agent Failure Modes
+
+## Testing
+
+- DO NOT invent custom testing frameworks (e.g. `agent_tester`, `simulation_framework`, `langwatch.testing`). Use `@langwatch/scenario` (TS) or `langwatch-scenario` (Python). The Scenario SDK already handles user simulation, judging, multi-turn conversations, and tool call verification.
+- DO NOT use regex or word matching in scenario judge criteria. Use natural language criteria with `JudgeAgent` -- it is more robust and meaningful than brittle pattern matching.
+- DO NOT use evaluations for multi-turn agent testing. Evaluations are for single input/output metrics (RAG accuracy, classification). Use Scenario tests for multi-turn agent flows.
+- DO NOT skip running tests after implementation. Always run scenarios and verify they pass before considering work done. "It should work" is not verification.
+
+## Prompts
+
+- NEVER hardcode prompts in application code or inline strings. Store all prompts in `prompts/*.yaml` files managed by LangWatch Prompt CLI (`langwatch prompt create <name>`, `langwatch prompt sync`).
+- DO NOT add try/catch around prompt fetching or duplicate prompts as fallbacks. Prompt CLI files are local and reliable.
+
+## Notebooks
+
+- DO NOT just write Jupyter notebooks without executing them. Evaluation notebooks under `tests/evaluations/` must be run to verify they produce correct results. Writing a notebook is not the same as running it.
+
+## Environment
+
+- DO NOT start long-running dev servers yourself. They block the agent process. Instead, tell the user how to start the server and give them the URL. Let the user run it themselves.
+- DO NOT commit `.mcp.json` with real API keys. The `.mcp.json` file contains secrets. Use `.mcp.json.example` with placeholder values for git, and add `.mcp.json` to `.gitignore`.
+- DO NOT commit `.env` files. Use `.env.example` for templates. API keys are already in `.env` -- do not re-set them.
+
+## Agent Construction
+
+- DO NOT create agent instances inside loops (especially Agno). Agent construction has significant overhead. Create the agent once, reuse it for multiple queries.
+
+## Documentation
+
+- ALWAYS use the LangWatch MCP (`fetch_langwatch_docs`, `fetch_scenario_docs`) to access documentation. DO NOT fetch docs from random URLs, hallucinate API signatures, or guess framework patterns. Read the actual docs for the specific framework.
+- DO NOT use `platform_*` MCP tools when writing code. The `platform_create_scenario`, `platform_create_evaluator`, etc. tools are for no-code platform operations. When you have a codebase, write test files and code instead.
+
+## Workflow
+
+- DO NOT mix kickoff/setup steps with reference documentation. Kickoff instructions (numbered steps the agent executes once) must be clearly separated from ongoing reference material (patterns, rules, examples).
+- DO NOT skip verification. After implementation: run scenario tests, check they pass, instrument with LangWatch, confirm traces appear. Only then is the work done.

--- a/skills/_shared/llms-txt-fallback.md
+++ b/skills/_shared/llms-txt-fallback.md
@@ -1,0 +1,19 @@
+# Fetching LangWatch Docs Without MCP
+
+If the MCP server cannot be installed, fetch documentation directly via HTTP.
+
+## Integration Docs
+
+1. Fetch the index: `https://langwatch.ai/docs/llms.txt`
+2. Pick a topic from the listing
+3. Fetch the page by appending `.md` (e.g., `https://langwatch.ai/docs/integration/python/guide.md`)
+
+## Scenario (Agent Testing) Docs
+
+1. Fetch the index: `https://langwatch.ai/scenario/llms.txt`
+2. Follow the same pattern for individual pages
+
+## Notes
+
+- The MCP server is always preferred -- it provides richer tools beyond docs.
+- Use `WebFetch` or `curl` to retrieve these URLs.

--- a/skills/_shared/mcp-setup.md
+++ b/skills/_shared/mcp-setup.md
@@ -1,0 +1,30 @@
+# Installing the LangWatch MCP Server
+
+## Claude Code
+
+Run:
+```bash
+claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey YOUR_API_KEY
+```
+
+Or add to `.mcp.json` (project-level) or `~/.claude.json` (global):
+```json
+{
+  "mcpServers": {
+    "langwatch": {
+      "command": "npx",
+      "args": ["-y", "@langwatch/mcp-server"],
+      "env": {
+        "LANGWATCH_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+## Other Editors
+
+Add the JSON config above to your editor's MCP settings file.
+
+The API key can be set via `LANGWATCH_API_KEY` env var or `--apiKey` flag.
+Use `LANGWATCH_ENDPOINT` / `--endpoint` to override the default endpoint (`https://app.langwatch.ai`).

--- a/skills/_tests/create-agent.scenario.test.ts
+++ b/skills/_tests/create-agent.scenario.test.ts
@@ -1,0 +1,259 @@
+import scenario from "@langwatch/scenario";
+import fs from "fs";
+import { describe, it, expect } from "vitest";
+import dotenv from "dotenv";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+import { openai } from "@ai-sdk/openai";
+import {
+  createClaudeCodeAgent,
+  toolCallFix,
+} from "./helpers/claude-code-adapter";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+const isCI = !!process.env.CI;
+
+const judgeModel = openai("gpt-4o");
+
+const skillPath = path.resolve(__dirname, "../create-agent/SKILL.md");
+const sharedDir = path.resolve(__dirname, "../_shared");
+const referencesDir = path.resolve(__dirname, "../create-agent/references");
+
+/**
+ * Creates a fresh empty temp directory for a test run.
+ */
+function createEmptyTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `langwatch-create-agent-${prefix}-`));
+}
+
+/**
+ * Checks that expected files and directories exist in the project.
+ */
+function assertProjectStructure(
+  projectDir: string,
+  { sourceDir }: { sourceDir: string }
+): void {
+  const mustExist = [
+    sourceDir,
+    "prompts",
+    "tests/scenarios",
+    "tests/evaluations",
+    ".env",
+    ".env.example",
+    ".mcp.json",
+    ".mcp.json.example",
+    "AGENTS.md",
+  ];
+
+  for (const relativePath of mustExist) {
+    const fullPath = path.join(projectDir, relativePath);
+    expect(
+      fs.existsSync(fullPath),
+      `Expected ${relativePath} to exist in project at ${projectDir}`
+    ).toBe(true);
+  }
+}
+
+/**
+ * Searches for LangWatch instrumentation in source files within the given
+ * directory. Returns true if any source file contains a "langwatch" reference.
+ */
+function hasLangWatchInstrumentation(
+  projectDir: string,
+  sourceDir: string
+): boolean {
+  const srcPath = path.join(projectDir, sourceDir);
+  if (!fs.existsSync(srcPath)) return false;
+
+  const files = fs.readdirSync(srcPath, { recursive: true }) as string[];
+  for (const file of files) {
+    const filePath = path.join(srcPath, String(file));
+    if (!fs.statSync(filePath).isFile()) continue;
+    const content = fs.readFileSync(filePath, "utf8");
+    if (content.toLowerCase().includes("langwatch")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const judgeCriteria = [
+  "Agent created a complete project structure with source directory, prompts, tests, env, and MCP config",
+  "Agent added LangWatch instrumentation to the source code",
+  "Agent created scenario test files",
+];
+
+describe("Create Agent Skill", () => {
+  it.skipIf(isCI)(
+    "scaffolds a Python Agno agent project from an empty directory",
+    async () => {
+      const tempDir = createEmptyTempDir("agno");
+
+      const result = await scenario.run({
+        name: "Python Agno agent creation",
+        description:
+          "Scaffolding a complete Python Agno agent project from an empty directory with LangWatch instrumentation.",
+        agents: [
+          createClaudeCodeAgent({
+            workingDirectory: tempDir,
+            skill: { skillPath, sharedDir, referencesDir },
+          }),
+          scenario.userSimulatorAgent({ model: judgeModel }),
+          scenario.judgeAgent({
+            model: judgeModel,
+            criteria: judgeCriteria,
+          }),
+        ],
+        script: [
+          scenario.user(
+            "Create a customer support agent that answers billing questions. Use Agno as the framework and OpenAI as the LLM provider."
+          ),
+          scenario.agent(),
+          (state) => {
+            toolCallFix(state);
+            assertProjectStructure(tempDir, { sourceDir: "app" });
+            expect(
+              hasLangWatchInstrumentation(tempDir, "app"),
+              "Expected LangWatch instrumentation in app/ source files"
+            ).toBe(true);
+          },
+          scenario.judge(),
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    },
+    600_000
+  );
+
+  it.skipIf(isCI)(
+    "scaffolds a TypeScript Vercel AI SDK agent project from an empty directory",
+    async () => {
+      const tempDir = createEmptyTempDir("vercel-ai");
+
+      const result = await scenario.run({
+        name: "TypeScript Vercel AI SDK agent creation",
+        description:
+          "Scaffolding a complete TypeScript Vercel AI SDK agent project from an empty directory with LangWatch instrumentation.",
+        agents: [
+          createClaudeCodeAgent({
+            workingDirectory: tempDir,
+            skill: { skillPath, sharedDir, referencesDir },
+          }),
+          scenario.userSimulatorAgent({ model: judgeModel }),
+          scenario.judgeAgent({
+            model: judgeModel,
+            criteria: judgeCriteria,
+          }),
+        ],
+        script: [
+          scenario.user(
+            "Create a data analysis agent that helps users explore datasets. Use Vercel AI SDK as the framework and Anthropic as the LLM provider."
+          ),
+          scenario.agent(),
+          (state) => {
+            toolCallFix(state);
+            assertProjectStructure(tempDir, { sourceDir: "src" });
+            expect(
+              hasLangWatchInstrumentation(tempDir, "src"),
+              "Expected LangWatch instrumentation in src/ source files"
+            ).toBe(true);
+          },
+          scenario.judge(),
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    },
+    600_000
+  );
+
+  it.skipIf(isCI)(
+    "creates a Python LangGraph agent from scratch",
+    async () => {
+      const tempDir = createEmptyTempDir("langgraph-py");
+
+      const result = await scenario.run({
+        name: "Python LangGraph agent creation",
+        description:
+          "Scaffolding a complete Python LangGraph agent project from an empty directory with LangWatch instrumentation.",
+        agents: [
+          createClaudeCodeAgent({
+            workingDirectory: tempDir,
+            skill: { skillPath, sharedDir, referencesDir },
+          }),
+          scenario.userSimulatorAgent({ model: judgeModel }),
+          scenario.judgeAgent({
+            model: judgeModel,
+            criteria: judgeCriteria,
+          }),
+        ],
+        script: [
+          scenario.user(
+            "Create a research assistant agent that can search and summarize information. Use LangGraph as the framework with Python and OpenAI as the LLM provider."
+          ),
+          scenario.agent(),
+          (state) => {
+            toolCallFix(state);
+            assertProjectStructure(tempDir, { sourceDir: "app" });
+            expect(
+              hasLangWatchInstrumentation(tempDir, "app"),
+              "Expected LangWatch instrumentation in app/ source files"
+            ).toBe(true);
+          },
+          scenario.judge(),
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    },
+    600_000
+  );
+
+  it.skipIf(isCI)(
+    "creates a TypeScript Mastra agent from scratch",
+    async () => {
+      const tempDir = createEmptyTempDir("mastra");
+
+      const result = await scenario.run({
+        name: "TypeScript Mastra agent creation",
+        description:
+          "Scaffolding a complete TypeScript Mastra agent project from an empty directory with LangWatch instrumentation.",
+        agents: [
+          createClaudeCodeAgent({
+            workingDirectory: tempDir,
+            skill: { skillPath, sharedDir, referencesDir },
+          }),
+          scenario.userSimulatorAgent({ model: judgeModel }),
+          scenario.judgeAgent({
+            model: judgeModel,
+            criteria: judgeCriteria,
+          }),
+        ],
+        script: [
+          scenario.user(
+            "Create a task management agent that helps users organize their work. Use Mastra as the framework and OpenAI as the LLM provider."
+          ),
+          scenario.agent(),
+          (state) => {
+            toolCallFix(state);
+            assertProjectStructure(tempDir, { sourceDir: "src" });
+            expect(
+              hasLangWatchInstrumentation(tempDir, "src"),
+              "Expected LangWatch instrumentation in src/ source files"
+            ).toBe(true);
+          },
+          scenario.judge(),
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    },
+    600_000
+  );
+});

--- a/skills/_tests/helpers/claude-code-adapter.ts
+++ b/skills/_tests/helpers/claude-code-adapter.ts
@@ -1,0 +1,214 @@
+import {
+  type AgentAdapter,
+  AgentRole,
+  type ScenarioExecutionStateLike,
+} from "@langwatch/scenario";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { spawn, execSync } from "child_process";
+import chalk from "chalk";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mcpServerDistPath = path.resolve(
+  __dirname,
+  "../../../mcp-server/dist/index.js"
+);
+
+interface SkillSource {
+  /** Absolute path to the SKILL.md file. */
+  skillPath: string;
+  /** Absolute path to the _shared/ directory to copy alongside the skill. */
+  sharedDir?: string;
+  /** Absolute path to a references/ directory to copy alongside the skill. */
+  referencesDir?: string;
+}
+
+/**
+ * Copies SKILL.md, _shared/, and references/ into the working directory's
+ * `.skills/<skillName>/` folder so Claude Code auto-discovers the skill.
+ */
+function copySkillToWorkDir(
+  workingDirectory: string,
+  skill: SkillSource
+): void {
+  const skillName = path.basename(path.dirname(skill.skillPath));
+  const skillDir = path.join(workingDirectory, ".skills", skillName);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.copyFileSync(skill.skillPath, path.join(skillDir, "SKILL.md"));
+
+  if (skill.sharedDir && fs.existsSync(skill.sharedDir)) {
+    const destShared = path.join(skillDir, "_shared");
+    fs.mkdirSync(destShared, { recursive: true });
+    copyDirRecursive(skill.sharedDir, destShared);
+  }
+
+  if (skill.referencesDir && fs.existsSync(skill.referencesDir)) {
+    const destRefs = path.join(skillDir, "references");
+    fs.mkdirSync(destRefs, { recursive: true });
+    copyDirRecursive(skill.referencesDir, destRefs);
+  }
+}
+
+/**
+ * Recursively copies the contents of `src` into `dest`.
+ * Both directories must already exist.
+ */
+function copyDirRecursive(src: string, dest: string): void {
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(destPath, { recursive: true });
+      copyDirRecursive(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+/**
+ * Creates a Claude Code agent adapter for use with @langwatch/scenario.
+ *
+ * Spawns Claude Code via child_process.spawn with MCP config pointing to the
+ * LangWatch MCP server. Copies SKILL.md, _shared/, and references/ into a
+ * `.skills/` directory in the working dir so Claude Code auto-discovers them.
+ */
+export function createClaudeCodeAgent({
+  workingDirectory,
+  skill,
+}: {
+  workingDirectory: string;
+  skill?: SkillSource;
+}): AgentAdapter {
+  if (skill) {
+    copySkillToWorkDir(workingDirectory, skill);
+  }
+
+  return {
+    role: AgentRole.AGENT,
+    call: async (state) => {
+      const formattedMessages = state.messages
+        .map((message) => `${message.role}: ${message.content}`)
+        .join("\n\n");
+
+      const mcpConfig = {
+        mcpServers: {
+          LangWatch: {
+            command: "node",
+            args: [
+              mcpServerDistPath,
+              "--apiKey",
+              process.env.LANGWATCH_API_KEY!,
+            ],
+          },
+        },
+      };
+
+      const mcpConfigPath = path.join(workingDirectory, ".mcp-test-config.json");
+      fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig));
+
+      return new Promise<string>((resolve, reject) => {
+        const claudeBin =
+          process.env.CLAUDE_BIN ||
+          execSync("which claude", { encoding: "utf8" }).trim();
+
+        const args = [
+          "--output-format",
+          "stream-json",
+          "-p",
+          "--mcp-config",
+          mcpConfigPath,
+          "--dangerously-skip-permissions",
+          "--verbose",
+          formattedMessages,
+        ];
+
+        console.log(chalk.blue("Starting claude in:"), workingDirectory);
+
+        const child = spawn(claudeBin, args, {
+          cwd: workingDirectory,
+          env: { ...process.env, FORCE_COLOR: "0" },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        let output = "";
+
+        child.stdout.on("data", (data: Buffer) => {
+          const text = data.toString();
+          console.log(chalk.cyan("Claude Code:"), text);
+          output += text;
+        });
+
+        child.stderr.on("data", (data: Buffer) => {
+          console.log(chalk.yellow("Claude Code stderr:"), data.toString());
+        });
+
+        child.on("close", (exitCode) => {
+          // Clean up the temp MCP config
+          try {
+            fs.unlinkSync(mcpConfigPath);
+          } catch {
+            // ignore cleanup errors
+          }
+
+          if (exitCode === 0) {
+            const messages: any = output
+              .split("\n")
+              .map((line) => {
+                try {
+                  return JSON.parse(line.trim());
+                } catch {
+                  return null;
+                }
+              })
+              .filter(
+                (message) => message !== null && "message" in message
+              )
+              .map((message) => message.message);
+
+            console.log(
+              chalk.green("Claude Code finished."),
+              `${messages.length} messages parsed.`
+            );
+
+            resolve(messages);
+          } else {
+            reject(
+              new Error(`Claude Code exited with code ${exitCode}`)
+            );
+          }
+        });
+
+        child.on("error", (err) => {
+          reject(err);
+        });
+      });
+    },
+  };
+}
+
+/**
+ * Fixes Anthropic tool use format in message state so it is compatible
+ * with the Vercel AI SDK judge agent.
+ *
+ * Anthropic returns tool_use content blocks that the Vercel AI SDK does
+ * not understand. This converts non-text blocks to text blocks containing
+ * the JSON representation.
+ */
+export function toolCallFix(state: ScenarioExecutionStateLike): void {
+  state.messages.forEach((message) => {
+    if (Array.isArray(message.content)) {
+      message.content.forEach((content, index) => {
+        if (content.type !== "text") {
+          (message.content as any)[index] = {
+            type: "text",
+            text: JSON.stringify(content),
+          };
+        }
+      });
+    }
+  });
+}

--- a/skills/_tests/helpers/claude-code-adapter.ts
+++ b/skills/_tests/helpers/claude-code-adapter.ts
@@ -94,15 +94,18 @@ export function createClaudeCodeAgent({
         .map((message) => `${message.role}: ${message.content}`)
         .join("\n\n");
 
+      const apiKey = process.env.LANGWATCH_API_KEY;
+      if (!apiKey) {
+        throw new Error(
+          "LANGWATCH_API_KEY environment variable is required. Set it in skills/.env"
+        );
+      }
+
       const mcpConfig = {
         mcpServers: {
           LangWatch: {
             command: "node",
-            args: [
-              mcpServerDistPath,
-              "--apiKey",
-              process.env.LANGWATCH_API_KEY!,
-            ],
+            args: [mcpServerDistPath, "--apiKey", apiKey],
           },
         },
       };
@@ -110,7 +113,7 @@ export function createClaudeCodeAgent({
       const mcpConfigPath = path.join(workingDirectory, ".mcp-test-config.json");
       fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig));
 
-      return new Promise<string>((resolve, reject) => {
+      return new Promise<any>((resolve, reject) => {
         const claudeBin =
           process.env.CLAUDE_BIN ||
           execSync("which claude", { encoding: "utf8" }).trim();

--- a/skills/_tests/package.json
+++ b/skills/_tests/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@langwatch/skills-tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "devDependencies": {
+    "@langwatch/scenario": "^0.4.6",
+    "@types/node": "^22.0.0",
+    "chalk": "^5.6.2",
+    "dotenv": "^17.2.2",
+    "tsx": "^4.19.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^3.0.41"
+  }
+}

--- a/skills/_tests/pnpm-lock.yaml
+++ b/skills/_tests/pnpm-lock.yaml
@@ -1,0 +1,3875 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.41
+        version: 3.0.41(zod@4.3.6)
+    devDependencies:
+      '@langwatch/scenario':
+        specifier: ^0.4.6
+        version: 0.4.8(336e9b3437da5f53331c7d3c7995f70d)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      dotenv:
+        specifier: ^17.2.2
+        version: 17.3.1
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2)
+
+packages:
+
+  '@ag-ui/core@0.0.28':
+    resolution: {integrity: sha512-2Vjuxl0gE8E2RFjFccGZNczDw3Xqxve/EfoYRVAFNX3+rY7z64Mj0OWDw5p9L+X8UG0/+t0xYIquQpw7B4NdHA==}
+
+  '@ai-sdk/gateway@3.0.66':
+    resolution: {integrity: sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.41':
+    resolution: {integrity: sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.19':
+    resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@langchain/core@0.3.80':
+    resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
+    engines: {node: '>=18'}
+
+  '@langchain/langgraph-checkpoint@0.1.1':
+    resolution: {integrity: sha512-h2bP0RUikQZu0Um1ZUPErQLXyhzroJqKRbRcxYRTAh49oNlsfeq4A3K4YEDRbGGuyPZI/Jiqwhks1wZwY73AZw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0 || ^1.0.0-alpha'
+
+  '@langchain/langgraph-sdk@0.1.10':
+    resolution: {integrity: sha512-9srSCb2bSvcvehMgjA2sMMwX0o1VUgPN6ghwm5Fwc9JGAKsQa6n1S4eCwy1h4abuYxwajH5n3spBw+4I2WYbgw==}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0 || ^1.0.0-alpha'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@langchain/langgraph@0.4.9':
+    resolution: {integrity: sha512-+rcdTGi4Ium4X/VtIX3Zw4RhxEkYWpwUyz806V6rffjHOAMamg6/WZDxpJbrP33RV/wJG1GH12Z29oX3Pqq3Aw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.58 < 0.4.0'
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
+
+  '@langchain/openai@0.6.17':
+    resolution: {integrity: sha512-JVSzD+FL5v/2UQxKd+ikB1h4PQOtn0VlK8nqW2kPp0fshItCv4utrjBKXC/rubBnSXoRTyonBINe8QRZ6OojVQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.68 <0.4.0'
+
+  '@langchain/textsplitters@0.1.0':
+    resolution: {integrity: sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.21 <0.4.0'
+
+  '@langwatch/scenario@0.4.8':
+    resolution: {integrity: sha512-VM0+SJ8njilJzyL6/Xrdu0nJwKIrfUo0cJ5R58fm1O8tFv0yFlXukQYBrUezac25nVv1VsPZfZnQCXvmguv10A==}
+    engines: {node: '>=20', pnpm: '>=8'}
+    peerDependencies:
+      ai: '>=6.0.0'
+      vitest: '>=3.2.4'
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@openai/agents-core@0.3.9':
+    resolution: {integrity: sha512-6Fr/VkA3lMaTT9EV2+OsmkMX9Yx+/PeWtlmaWNKDRG8D15IWuK13NOC9eFklTsa7otbuwbw/Xmjes+h4Z+CwSQ==}
+    peerDependencies:
+      zod: ^3.25.40 || ^4.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-openai@0.3.9':
+    resolution: {integrity: sha512-duXUt0xU6K/+c7ae4m8BrJIUzZal6Pzln8V0frnJfNyfYO4SvHMV4qwPRzVDvv/ANj4DQXWI2L1JdPxKJeSHkw==}
+    peerDependencies:
+      zod: ^3.25.40 || ^4.0
+
+  '@openai/agents-realtime@0.3.9':
+    resolution: {integrity: sha512-51zHO/zao/LHv70gseU1otTvXyS81tuVaewHlUBiNMXvqSZNkYViiO69hpXMoTYn5c3gCjUrXPxxI+NlHUtaHg==}
+    peerDependencies:
+      zod: ^3.25.40 || ^4.0
+
+  '@openai/agents@0.3.9':
+    resolution: {integrity: sha512-YaKnqv0M6bCVvn47pThkFfyHz8xWJ+0Ll9ZnhvwJZ5gyPX0UxHIUeUs9SMG9BSvNuJNJHlc5uvfUDGYAmKJClw==}
+    peerDependencies:
+      zod: ^3.25.40 || ^4.0
+
+  '@opentelemetry/api-logs@0.205.0':
+    resolution: {integrity: sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.212.0':
+    resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.212.0':
+    resolution: {integrity: sha512-D8sAY6RbqMa1W8lCeiaSL2eMCW2MF87QI3y+I6DQE1j+5GrDMwiKPLdzpa/2/+Zl9v1//74LmooCTCJBvWR8Iw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.5.1':
+    resolution: {integrity: sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/context-zone-peer-dep@2.6.0':
+    resolution: {integrity: sha512-cFSbc+3Osyo3nBmdteNarJaI3GqTRn0YgcEJWt/PkgazLqfwMifPIoSBLpLCZQzGtkTbdef2htgE7Tw6qe/bkw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+      zone.js: ^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0
+
+  '@opentelemetry/context-zone@2.6.0':
+    resolution: {integrity: sha512-uOgV184sK+YHtKekt4JqRHNV93Z9vo13cdWAMBih9UG0xm8WCWCfbhW94NL17V9u9t1R7c/ivaTutA2nwiN9PA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+
+  '@opentelemetry/core@2.1.0':
+    resolution: {integrity: sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.5.1':
+    resolution: {integrity: sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.6.0':
+    resolution: {integrity: sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.212.0':
+    resolution: {integrity: sha512-/0bk6fQG+eSFZ4L6NlckGTgUous/ib5+OVdg0x4OdwYeHzV3lTEo3it1HgnPY6UKpmX7ki+hJvxjsOql8rCeZA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.205.0':
+    resolution: {integrity: sha512-5JteMyVWiro4ghF0tHQjfE6OJcF7UBUcoEqX3UIQ5jutKP1H+fxFdyhqjjpmeHMFxzOHaYuLlNR1Bn7FOjGyJg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.212.0':
+    resolution: {integrity: sha512-JidJasLwG/7M9RTxV/64xotDKmFAUSBc9SNlxI32QYuUMK5rVKhHNWMPDzC7E0pCAL3cu+FyiKvsTwLi2KqPYw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.212.0':
+    resolution: {integrity: sha512-RpKB5UVfxc7c6Ta1UaCrxXDTQ0OD7BCGT66a97Q5zR1x3+9fw4dSaiqMXT/6FAWj2HyFbem6Rcu1UzPZikGTWQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.212.0':
+    resolution: {integrity: sha512-/6Gqf9wpBq22XsomR1i0iPGnbQtCq2Vwnrq5oiDPjYSqveBdK1jtQbhGfmpK2mLLxk4cPDtD1ZEYdIou5K8EaA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.212.0':
+    resolution: {integrity: sha512-8hgBw3aTTRpSTkU4b9MLf/2YVLnfWp+hfnLq/1Fa2cky+vx6HqTodo+Zv1GTIrAKMOOwgysOjufy0gTxngqeBg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.212.0':
+    resolution: {integrity: sha512-C7I4WN+ghn3g7SnxXm2RK3/sRD0k/BYcXaK6lGU3yPjiM7a1M25MLuM6zY3PeVPPzzTZPfuS7+wgn/tHk768Xw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.212.0':
+    resolution: {integrity: sha512-hJFLhCJba5MW5QHexZMHZdMhBfNqNItxOsN0AZojwD1W2kU9xM+BEICowFGJFo/vNV+I2BJvTtmuKafeDSAo7Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.212.0':
+    resolution: {integrity: sha512-9xTuYWp8ClBhljDGAoa0NSsJcsxJsC9zCFKMSZJp1Osb9pjXCMRdA6fwXtlubyqe7w8FH16EWtQNKx/FWi+Ghw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.205.0':
+    resolution: {integrity: sha512-vr2bwwPCSc9u7rbKc74jR+DXFvyMFQo9o5zs+H/fgbK672Whw/1izUKVf+xfWOdJOvuwTnfWxy+VAY+4TSo74Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.212.0':
+    resolution: {integrity: sha512-v/0wMozNoiEPRolzC4YoPo4rAT0q8r7aqdnRw3Nu7IDN0CGFzNQazkfAlBJ6N5y0FYJkban7Aw5WnN73//6YlA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.212.0':
+    resolution: {integrity: sha512-d1ivqPT0V+i0IVOOdzGaLqonjtlk5jYrW7ItutWzXL/Mk+PiYb59dymy/i2reot9dDnBFWfrsvxyqdutGF5Vig==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.5.1':
+    resolution: {integrity: sha512-Me6JVO7WqXGXsgr4+7o+B7qwKJQbt0c8WamFnxpkR43avgG9k/niTntwCaXiXUTjonWy0+61ZuX6CGzj9nn8CQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation@0.212.0':
+    resolution: {integrity: sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.205.0':
+    resolution: {integrity: sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.212.0':
+    resolution: {integrity: sha512-HoMv5pQlzbuxiMS0hN7oiUtg8RsJR5T7EhZccumIWxYfNo/f4wFc7LPDfFK6oHdG2JF/+qTocfqIHoom+7kLpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.212.0':
+    resolution: {integrity: sha512-YidOSlzpsun9uw0iyIWrQp6HxpMtBlECE3tiHGAsnpEqJWbAUWcMnIffvIuvTtTQ1OyRtwwaE79dWSQ8+eiB7g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.205.0':
+    resolution: {integrity: sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.212.0':
+    resolution: {integrity: sha512-bj7zYFOg6Db7NUwsRZQ/WoVXpAf41WY2gsd3kShSfdpZQDRKHWJiRZIg7A8HvWsf97wb05rMFzPbmSHyjEl9tw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.5.1':
+    resolution: {integrity: sha512-AU6sZgunZrZv/LTeHP+9IQsSSH5p3PtOfDPe8VTdwYH69nZCfvvvXehhzu+9fMW2mgJMh5RVpiH8M9xuYOu5Dg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.5.1':
+    resolution: {integrity: sha512-8+SB94/aSIOVGDUPRFSBRHVUm2A8ye1vC6/qcf/D+TF4qat7PC6rbJhRxiUGDXZtMtKEPM/glgv5cBGSJQymSg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.1.0':
+    resolution: {integrity: sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.5.1':
+    resolution: {integrity: sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.6.0':
+    resolution: {integrity: sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.205.0':
+    resolution: {integrity: sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.212.0':
+    resolution: {integrity: sha512-qglb5cqTf0mOC1sDdZ7nfrPjgmAqs2OxkzOPIf2+Rqx8yKBK0pS7wRtB1xH30rqahBIut9QJDbDePyvtyqvH/Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.1.0':
+    resolution: {integrity: sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.5.1':
+    resolution: {integrity: sha512-RKMn3QKi8nE71ULUo0g/MBvq1N4icEBo7cQSKnL3URZT16/YH3nSVgWegOjwx7FRBTrjOIkMJkCUn/ZFIEfn4A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.6.0':
+    resolution: {integrity: sha512-CicxWZxX6z35HR83jl+PLgtFgUrKRQ9LCXyxgenMnz5A1lgYWfAog7VtdOvGkJYyQgMNPhXQwkYrDLujk7z1Iw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.212.0':
+    resolution: {integrity: sha512-tJzVDk4Lo44MdgJLlP+gdYdMnjxSNsjC/IiTxj5CFSnsjzpHXwifgl3BpUX67Ty3KcdubNVfedeBc/TlqHXwwg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.1.0':
+    resolution: {integrity: sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.5.1':
+    resolution: {integrity: sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.6.0':
+    resolution: {integrity: sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.5.1':
+    resolution: {integrity: sha512-9lopQ6ZoElETOEN0csgmtEV5/9C7BMfA7VtF4Jape3i954b6sTY2k3Xw3CxUTKreDck/vpAuJM+EDo4zheUw+A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-web@2.6.0':
+    resolution: {integrity: sha512-xyYmLFatwUeYnB7NtQ2Ydl9Y8uiblN+EDo5YEjnk7ZRMhGFyt1wgPqb8EYvATLuDiRVtxid1fJsL6RH1fCQMIA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/prompts@2.4.9':
+    resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ai@6.0.116:
+    resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  console-table-printer@2.15.0:
+    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
+
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  langchain@0.3.37:
+    resolution: {integrity: sha512-1jPsZ6xsxkcQPUvqRjvfuOLwZLLyt49hzcOK7OYAJovIkkOxd5gzK4Yw6giPUQ8g4XHyvULNlWBz+subdkcokw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/anthropic': '*'
+      '@langchain/aws': '*'
+      '@langchain/cerebras': '*'
+      '@langchain/cohere': '*'
+      '@langchain/core': '>=0.3.58 <0.4.0'
+      '@langchain/deepseek': '*'
+      '@langchain/google-genai': '*'
+      '@langchain/google-vertexai': '*'
+      '@langchain/google-vertexai-web': '*'
+      '@langchain/groq': '*'
+      '@langchain/mistralai': '*'
+      '@langchain/ollama': '*'
+      '@langchain/xai': '*'
+      axios: '*'
+      cheerio: '*'
+      handlebars: ^4.7.8
+      peggy: ^3.0.2
+      typeorm: '*'
+    peerDependenciesMeta:
+      '@langchain/anthropic':
+        optional: true
+      '@langchain/aws':
+        optional: true
+      '@langchain/cerebras':
+        optional: true
+      '@langchain/cohere':
+        optional: true
+      '@langchain/deepseek':
+        optional: true
+      '@langchain/google-genai':
+        optional: true
+      '@langchain/google-vertexai':
+        optional: true
+      '@langchain/google-vertexai-web':
+        optional: true
+      '@langchain/groq':
+        optional: true
+      '@langchain/mistralai':
+        optional: true
+      '@langchain/ollama':
+        optional: true
+      '@langchain/xai':
+        optional: true
+      axios:
+        optional: true
+      cheerio:
+        optional: true
+      handlebars:
+        optional: true
+      peggy:
+        optional: true
+      typeorm:
+        optional: true
+
+  langsmith@0.3.87:
+    resolution: {integrity: sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+
+  langwatch@0.16.1:
+    resolution: {integrity: sha512-R6ceCI4OQ2DvlR2rJ2UksIdET3TXHjYw87xsUbq4AvTJoW7w7BN6hnKznrbxWzU+XlI2ymmBqVZg52EnaR4nTw==}
+    engines: {node: '>=20', pnpm: '>=8'}
+    hasBin: true
+    peerDependencies:
+      '@ai-sdk/openai': '>=2.0.0 <3.0.0'
+      '@langchain/core': '>=0.3.0 <1.0.0'
+      '@langchain/langgraph': '>=0.4.0 <1.0.0'
+      '@langchain/openai': '>=0.6.0 <1.0.0'
+      '@opentelemetry/context-async-hooks': ^2.1.0
+      '@opentelemetry/context-zone': '>=1.19.0 <3.0.0'
+      '@opentelemetry/sdk-node': '>=0.200.0 <1.0.0'
+      '@opentelemetry/sdk-trace-web': '>=1.19.0 <3.0.0'
+      langchain: '>=0.3.0 <1.0.0'
+
+  liquidjs@10.25.0:
+    resolution: {integrity: sha512-XpO7AiGULTG4xcTlwkcTI5JreFG7b6esLCLp+aUSh7YuQErJZEoUXre9u9rbdb0057pfWG4l0VursvLd5Q/eAw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
+  openai@5.12.2:
+    resolution: {integrity: sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@6.29.0:
+    resolution: {integrity: sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openapi-fetch@0.16.0:
+    resolution: {integrity: sha512-EVLlvcUOugBYMXhuITAm2Ihv9EmQ7b9gJYn7hg2wvcf/GxbanhQ9olDz9I3DcS0Jr4Jv/53I2oVuIYQsFHa9mA==}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.0.0:
+    resolution: {integrity: sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
+  xksuid@0.0.4:
+    resolution: {integrity: sha512-uVWuWtTLV0c5glVnRUFVtAT0At/a438v4KCqhmKpkGiU1JXMzmrigEtKzNaQ3D4yHgDbEFl7C5EG688b2FARqA==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zone.js@0.16.1:
+    resolution: {integrity: sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==}
+
+snapshots:
+
+  '@ag-ui/core@0.0.28':
+    dependencies:
+      rxjs: 7.8.1
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
+  '@ai-sdk/openai@3.0.41(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/openai@3.0.41(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@cfworker/json-schema@4.1.1': {}
+
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.3.87(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+
+  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+    optionalDependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+
+  '@langchain/langgraph@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))(zod-to-json-schema@3.25.1(zod@4.3.6))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+      '@langchain/langgraph-checkpoint': 0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))
+      '@langchain/langgraph-sdk': 0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))
+      uuid: 10.0.0
+      zod: 3.25.76
+    optionalDependencies:
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))(ws@8.19.0)':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+      js-tiktoken: 1.0.21
+      openai: 5.12.2(ws@8.19.0)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+      js-tiktoken: 1.0.21
+
+  '@langwatch/scenario@0.4.8(336e9b3437da5f53331c7d3c7995f70d)':
+    dependencies:
+      '@ag-ui/core': 0.0.28
+      '@ai-sdk/openai': 3.0.41(zod@3.25.76)
+      '@openai/agents': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@3.25.76)
+      '@opentelemetry/sdk-node': 0.212.0(@opentelemetry/api@1.9.0)
+      ai: 6.0.116(zod@4.3.6)
+      chalk: 5.6.2
+      langwatch: 0.16.1(649a14e5d1174fefc9d62ebb58f1fc86)
+      open: 11.0.0
+      rxjs: 7.8.2
+      vitest: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2)
+      xksuid: 0.0.4
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@langchain/core'
+      - '@langchain/langgraph'
+      - '@langchain/openai'
+      - '@opentelemetry/api'
+      - '@opentelemetry/context-async-hooks'
+      - '@opentelemetry/context-zone'
+      - '@opentelemetry/sdk-trace-web'
+      - bufferutil
+      - langchain
+      - supports-color
+      - utf-8-validate
+      - ws
+
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.8)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.8
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@openai/agents-core@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@3.25.76)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.29.0(ws@8.19.0)(zod@3.25.76)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@3.25.76)
+      debug: 4.4.3
+      openai: 6.29.0(ws@8.19.0)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.3.9(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@3.25.76)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.19.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@3.25.76)
+      '@openai/agents-openai': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@3.25.76)
+      '@openai/agents-realtime': 0.3.9(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      debug: 4.4.3
+      openai: 6.29.0(ws@8.19.0)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
+  '@opentelemetry/api-logs@0.205.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.212.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/configuration@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      yaml: 2.8.2
+
+  '@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/context-zone-peer-dep@2.6.0(@opentelemetry/api@1.9.0)(zone.js@0.16.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      zone.js: 0.16.1
+
+  '@opentelemetry/context-zone@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/context-zone-peer-dep': 2.6.0(@opentelemetry/api@1.9.0)(zone.js@0.16.1)
+      zone.js: 0.16.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-prometheus@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-zipkin@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-exporter-base@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.212.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/otlp-transformer@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      protobufjs: 8.0.0
+
+  '@opentelemetry/propagator-b3@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resources@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.205.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-logs@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-node@0.212.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.212.0
+      '@opentelemetry/configuration': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-prometheus': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-zipkin': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-node@2.5.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace-web@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/prompts@2.4.9':
+    dependencies:
+      '@types/node': 22.19.15
+      kleur: 3.0.3
+
+  '@types/retry@0.12.0': {}
+
+  '@types/uuid@10.0.0': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@vercel/oidc@3.1.0': {}
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    optional: true
+
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ai@6.0.116(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+    optional: true
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    optional: true
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  base64-js@1.5.1: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  bytes@3.1.2:
+    optional: true
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+    optional: true
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+    optional: true
+
+  camelcase@6.3.0: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  check-error@2.1.3: {}
+
+  cjs-module-lexer@2.2.0: {}
+
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
+  cli-spinners@2.9.2: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clone@1.0.4: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@10.0.1: {}
+
+  commander@12.1.0: {}
+
+  console-table-printer@2.15.0:
+    dependencies:
+      simple-wcswidth: 1.1.2
+
+  content-disposition@1.0.1:
+    optional: true
+
+  content-type@1.0.5:
+    optional: true
+
+  cookie-signature@1.2.2:
+    optional: true
+
+  cookie@0.7.2:
+    optional: true
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    optional: true
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    optional: true
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decamelize@1.2.0: {}
+
+  deep-eql@5.0.2: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
+
+  define-lazy-prop@3.0.0: {}
+
+  depd@2.0.0:
+    optional: true
+
+  dotenv@17.3.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
+
+  ee-first@1.1.1:
+    optional: true
+
+  emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0:
+    optional: true
+
+  es-define-property@1.0.1:
+    optional: true
+
+  es-errors@1.3.0:
+    optional: true
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+    optional: true
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
+  escalade@3.2.0: {}
+
+  escape-html@1.0.3:
+    optional: true
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  etag@1.8.1:
+    optional: true
+
+  eventemitter3@4.0.7: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+    optional: true
+
+  expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+    optional: true
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  fast-deep-equal@3.1.3:
+    optional: true
+
+  fast-uri@3.1.0:
+    optional: true
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  forwarded@0.2.0:
+    optional: true
+
+  fresh@2.0.0:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2:
+    optional: true
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+    optional: true
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  gopd@1.2.0:
+    optional: true
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0:
+    optional: true
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+    optional: true
+
+  hono@4.12.8:
+    optional: true
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    optional: true
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
+
+  ieee754@1.2.1: {}
+
+  import-in-the-middle@2.0.6:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
+  inherits@2.0.4: {}
+
+  ip-address@10.1.0:
+    optional: true
+
+  ipaddr.js@1.9.1:
+    optional: true
+
+  is-docker@3.0.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-interactive@1.0.0: {}
+
+  is-promise@4.0.0:
+    optional: true
+
+  is-unicode-supported@0.1.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  isexe@2.0.0:
+    optional: true
+
+  jose@6.2.1:
+    optional: true
+
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
+
+  js-tokens@9.0.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-schema-traverse@1.0.0:
+    optional: true
+
+  json-schema-typed@8.0.2:
+    optional: true
+
+  json-schema@0.4.0: {}
+
+  jsonpointer@5.0.1: {}
+
+  kleur@3.0.3: {}
+
+  langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0):
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))(ws@8.19.0)
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))
+      js-tiktoken: 1.0.21
+      js-yaml: 4.1.1
+      jsonpointer: 5.0.1
+      langsmith: 0.3.87(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+      openapi-types: 12.1.3
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      yaml: 2.8.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  langsmith@0.3.87(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.7.4
+      uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-proto': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      openai: 6.29.0(ws@8.19.0)(zod@4.3.6)
+
+  langwatch@0.16.1(649a14e5d1174fefc9d62ebb58f1fc86):
+    dependencies:
+      '@ai-sdk/openai': 3.0.41(zod@4.3.6)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))
+      '@langchain/langgraph': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))(zod-to-json-schema@3.25.1(zod@4.3.6))
+      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))(ws@8.19.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/context-zone': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-web': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/prompts': 2.4.9
+      chalk: 4.1.2
+      commander: 12.1.0
+      dotenv: 17.3.1
+      js-yaml: 4.1.1
+      langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.29.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0)
+      liquidjs: 10.25.0
+      open: 11.0.0
+      openapi-fetch: 0.16.0
+      ora: 5.4.1
+      prompts: 2.4.2
+      xksuid: 0.0.4
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+
+  liquidjs@10.25.0:
+    dependencies:
+      commander: 10.0.1
+
+  lodash.camelcase@4.3.0: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  long@5.3.2: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0:
+    optional: true
+
+  media-typer@1.1.0:
+    optional: true
+
+  merge-descriptors@2.0.0:
+    optional: true
+
+  mime-db@1.54.0:
+    optional: true
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+    optional: true
+
+  mimic-fn@2.1.0: {}
+
+  module-details-from-path@1.0.4: {}
+
+  ms@2.1.3: {}
+
+  mustache@4.2.0: {}
+
+  nanoid@3.3.11: {}
+
+  negotiator@1.0.0:
+    optional: true
+
+  object-assign@4.1.1:
+    optional: true
+
+  object-inspect@1.13.4:
+    optional: true
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+    optional: true
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+    optional: true
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
+  openai@5.12.2(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
+
+  openai@6.29.0(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
+
+  openai@6.29.0(ws@8.19.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 4.3.6
+    optional: true
+
+  openapi-fetch@0.16.0:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-types@12.1.3: {}
+
+  openapi-typescript-helpers@0.0.15: {}
+
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
+  p-finally@1.0.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
+  parseurl@1.3.3:
+    optional: true
+
+  path-key@3.1.1:
+    optional: true
+
+  path-to-regexp@8.3.0:
+    optional: true
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pkce-challenge@5.0.1:
+    optional: true
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.15
+      long: 5.3.2
+
+  protobufjs@8.0.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.15
+      long: 5.3.2
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    optional: true
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+    optional: true
+
+  range-parser@1.2.1:
+    optional: true
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+    optional: true
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2:
+    optional: true
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  resolve-pkg-maps@1.0.0: {}
+
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
+  retry@0.13.1: {}
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  run-applescript@7.1.0: {}
+
+  rxjs@7.8.1:
+    dependencies:
+      tslib: 2.8.1
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2:
+    optional: true
+
+  semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  setprototypeof@1.2.0:
+    optional: true
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+    optional: true
+
+  shebang-regex@3.0.0:
+    optional: true
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    optional: true
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+    optional: true
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+    optional: true
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    optional: true
+
+  siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  simple-wcswidth@1.1.2: {}
+
+  sisteransi@1.0.5: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2:
+    optional: true
+
+  std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  toidentifier@1.0.1:
+    optional: true
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0:
+    optional: true
+
+  util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
+
+  uuid@9.0.1: {}
+
+  vary@1.1.2:
+    optional: true
+
+  vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+      tsx: 4.21.0
+      yaml: 2.8.2
+
+  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+    optional: true
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrappy@1.0.2:
+    optional: true
+
+  ws@8.19.0: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
+  xksuid@0.0.4: {}
+
+  y18n@5.0.8: {}
+
+  yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+    optional: true
+
+  zod@3.25.76: {}
+
+  zod@4.3.6: {}
+
+  zone.js@0.16.1: {}

--- a/skills/_tests/tsconfig.json
+++ b/skills/_tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/skills/_tests/vitest.config.ts
+++ b/skills/_tests/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 60 * 60 * 1000, // 1 hour global timeout
+  },
+});

--- a/skills/create-agent/SKILL.md
+++ b/skills/create-agent/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: create-agent
+description: Create a production-ready AI agent project from scratch with LangWatch instrumentation, prompt versioning, evaluation experiments, and scenario tests. Scaffolds complete project structure with your choice of framework (Agno, Mastra, LangGraph, Google ADK, Vercel AI SDK) and LLM provider.
+license: MIT
+compatibility: Requires Node.js for MCP setup. Works with Claude Code, Claude Desktop, and similar coding agents.
+---
+
+# Create an AI Agent Project from Scratch
+
+This skill scaffolds a complete agent project in an empty directory, fully instrumented with LangWatch. You get tracing, versioned prompts, evaluation experiments, and scenario tests from the start.
+
+## Interactive Discovery
+
+Before scaffolding, gather the following from the user. If any is missing, ask.
+
+**Framework** (pick one):
+
+| Framework | Language | Source Dir |
+|-----------|----------|------------|
+| Agno | Python | `app/` |
+| LangGraph (Python) | Python | `app/` |
+| Google ADK | Python | `app/` |
+| Mastra | TypeScript | `src/` |
+| LangGraph (TypeScript) | TypeScript | `src/` |
+| Vercel AI SDK | TypeScript | `src/` |
+
+**LLM Provider** (pick one): OpenAI, Anthropic, Gemini, Bedrock, OpenRouter, Grok
+
+**Project goal**: What does the agent do? (e.g., "customer support agent that answers billing questions")
+
+## Detect Context
+
+Before proceeding, check the target directory:
+
+- **Empty or near-empty** (only README, .git, LICENSE, etc.): Proceed with scaffolding.
+- **Contains source code** (`.py`, `.ts`, `.tsx`, `.js` files, `package.json` with dependencies, `pyproject.toml` with dependencies): STOP. Warn the user that this directory already has a project. Suggest using the **tracing** or **level-up** skills instead to add LangWatch to an existing codebase.
+
+## Kickoff Sequence
+
+Execute these 9 steps in order. Do not skip or reorder them.
+
+### Step 1: Read Documentation via MCP
+
+Set up the LangWatch MCP server first so you have access to documentation throughout the process.
+
+See [MCP Setup](_shared/mcp-setup.md) for installation instructions. If MCP installation fails, see [docs fallback](_shared/llms-txt-fallback.md) to fetch docs via URLs.
+
+Once MCP is available:
+
+1. Call `fetch_langwatch_docs` (no args) to see the docs index
+2. Read the integration guide for the selected framework
+3. Call `fetch_scenario_docs` (no args) to read the Scenario SDK docs
+4. Read the Prompts CLI docs at `https://langwatch.ai/docs/prompt-management/cli.md`
+
+Then read the framework reference for the selected framework ONLY:
+
+| Framework | Reference File |
+|-----------|----------------|
+| Agno | [references/agno.md](references/agno.md) |
+| Mastra | [references/mastra.md](references/mastra.md) |
+| LangGraph (Python) | [references/langgraph-python.md](references/langgraph-python.md) |
+| LangGraph (TypeScript) | [references/langgraph-typescript.md](references/langgraph-typescript.md) |
+| Google ADK | [references/google-adk.md](references/google-adk.md) |
+| Vercel AI SDK | [references/vercel-ai.md](references/vercel-ai.md) |
+
+Do NOT read references for frameworks the user did not select.
+
+### Step 2: Scaffold Project Structure
+
+Create the full directory tree before writing any application code:
+
+```
+my-agent/
+├── <app/ or src/>         # Python: app/  |  TypeScript: src/
+├── prompts/
+├── tests/
+│   ├── evaluations/
+│   └── scenarios/
+├── .env
+├── .env.example
+├── .mcp.json
+├── .mcp.json.example
+├── .cursor/mcp.json       # Symlink → ../.mcp.json
+├── .gitignore
+├── AGENTS.md
+├── CLAUDE.md              # Contains: @AGENTS.md
+└── pyproject.toml / package.json
+```
+
+**`.env.example`** -- committed, placeholder values only:
+```
+LANGWATCH_API_KEY=your-langwatch-api-key
+OPENAI_API_KEY=your-openai-api-key
+# Adjust provider key to match the selected LLM provider
+```
+
+**`.env`** -- gitignored, real keys from user's environment:
+```
+LANGWATCH_API_KEY=<actual key if available>
+```
+
+**`.mcp.json`** -- gitignored, contains both LangWatch and framework-specific MCP servers. See the framework reference for the framework MCP config. Combine with the LangWatch MCP:
+```json
+{
+  "mcpServers": {
+    "langwatch": {
+      "command": "npx",
+      "args": ["-y", "@langwatch/mcp-server"],
+      "env": {
+        "LANGWATCH_API_KEY": "<key>"
+      }
+    }
+  }
+}
+```
+
+**`.mcp.json.example`** -- committed, same structure with placeholder keys.
+
+**`.cursor/mcp.json`** -- create as a symlink to `../.mcp.json` for Cursor compatibility.
+
+**`.gitignore`** -- must include:
+```
+.env
+.mcp.json
+.cursor/
+__pycache__/
+node_modules/
+.venv/
+```
+
+**`CLAUDE.md`**:
+```
+@AGENTS.md
+```
+
+**`AGENTS.md`** -- see the AGENTS.md Template section below for what to include.
+
+### Step 3: Set Up Language Environment and Install Dependencies
+
+Follow the framework reference for scaffolding commands.
+
+**Python frameworks** (Agno, LangGraph Python, Google ADK):
+1. Verify Python is installed: `python3 --version`. If missing, report the error and provide installation guidance. Do not leave a half-scaffolded project.
+2. Run the setup commands from the framework reference (e.g., `uv init`, `uv add ...`)
+3. Add LangWatch: `uv add langwatch`
+4. Add test dependencies: `uv add --dev pytest langwatch-scenario`
+
+**TypeScript frameworks** (Mastra, LangGraph TS, Vercel AI SDK):
+1. Verify Node.js is installed: `node --version`. If missing, report the error and provide installation guidance.
+2. Run the setup commands from the framework reference (e.g., `pnpm init`, `pnpm add ...`)
+3. Add LangWatch: `pnpm add langwatch`
+4. Add test dependencies: `pnpm add -D @langwatch/scenario vitest`
+5. Set up `tsconfig.json` if not already created by the framework scaffolder
+
+If dependency installation fails, report the error clearly and provide manual installation instructions. Leave the project structure intact so the user can recover.
+
+### Step 4: Instrument with LangWatch Tracing
+
+Follow the integration guide you read in Step 1 for the specific framework. The general patterns are:
+
+**Python:**
+```python
+import langwatch
+langwatch.setup()
+
+@langwatch.trace()
+def run_agent(user_input: str):
+    # agent logic here
+    pass
+```
+
+**TypeScript:**
+```typescript
+import { LangWatch } from "langwatch";
+const langwatch = new LangWatch();
+```
+
+IMPORTANT: The exact pattern depends on the framework. Follow the docs you read, not these examples.
+
+### Step 5: Create Versioned Prompts via Prompt CLI
+
+1. Install the CLI: `npm install -g langwatch` (or `npx langwatch`)
+2. Initialize: `langwatch prompt init`
+3. Get the API key: see [API Key Setup](_shared/api-key-setup.md)
+4. Create the main prompt: `langwatch prompt create main-prompt`
+5. Edit `prompts/main-prompt.yaml` with content tailored to the user's agent goal:
+   ```yaml
+   model: gpt-4o  # or the selected provider's model
+   temperature: 0.7
+   messages:
+     - role: system
+       content: |
+         <system prompt tailored to the agent's goal>
+     - role: user
+       content: |
+         {{ user_input }}
+   ```
+6. Sync: `langwatch prompt sync`
+7. Update the agent code to load the prompt via `langwatch.prompts.get("main-prompt")` instead of hardcoding it
+
+Do NOT hardcode prompts in application code. Do NOT add try/catch fallbacks around prompt fetching.
+
+### Step 6: Write Evaluation Experiment
+
+**Python projects** -- create a Jupyter notebook at `tests/evaluations/evaluation.ipynb`:
+- Use `langwatch.experiment.init()` to set up the experiment
+- Generate a CSV dataset of 10-20 examples tailored to the agent's domain
+- Include at least one evaluator (LLM-as-judge for quality is a good default)
+- Run the notebook to verify it produces results
+
+**TypeScript projects** -- create a script at `tests/evaluations/evaluation.ts`:
+- Use the LangWatch experiments SDK
+- Generate a dataset tailored to the agent's domain
+- Include at least one evaluator
+- Make it runnable with `npx tsx tests/evaluations/evaluation.ts`
+
+Evaluations are for batch metrics on single input/output pairs (RAG accuracy, classification, etc.). Do NOT use evaluations for multi-turn agent testing -- that is what scenarios are for.
+
+### Step 7: Write Scenario Simulation Tests
+
+Use `@langwatch/scenario` (TypeScript) or `langwatch-scenario` (Python) -- NEVER invent a custom testing framework.
+
+1. Read the Scenario docs via MCP: call `fetch_scenario_docs`
+2. Create test files in `tests/scenarios/`
+3. Write at least one scenario that validates the agent's core behavior:
+   - Define an `AgentAdapter` that connects to your agent
+   - Use `UserSimulatorAgent` to simulate realistic user messages
+   - Use `JudgeAgent` with natural language criteria (NOT regex or string matching)
+4. Test multi-turn conversations that verify the agent achieves its goal
+
+### Step 8: Run Tests to Verify
+
+Run the scenario tests:
+- Python: `uv run pytest tests/scenarios/`
+- TypeScript: `pnpm vitest run tests/scenarios/`
+
+If tests fail, fix the issues and re-run. Do NOT declare the project complete until tests pass. "It should work" is not verification.
+
+### Step 9: Tell the User How to Start
+
+Tell the user the command to start their agent or dev server. Do NOT start it yourself -- long-running processes block the agent.
+
+Examples:
+- Agno: `uv run python app/main.py`
+- Mastra: `pnpx mastra dev`
+- LangGraph Python: `uv run python app/main.py`
+- Vercel AI SDK: `pnpm tsx src/index.ts`
+
+Include the URL they can visit if the framework provides a web UI.
+
+## AGENTS.md Template
+
+The generated `AGENTS.md` must include these sections:
+
+```markdown
+# <Project Name>
+
+<Brief description of the agent and its goal>
+
+## Development
+
+### Running
+<command to start the agent>
+
+### Testing
+<command to run scenario tests>
+
+## Principles
+
+### 1. Agent Testing with Scenarios
+- Use `@langwatch/scenario` (TS) or `langwatch-scenario` (Python) for testing
+- Test multi-turn conversations, not just single exchanges
+- Use natural language judge criteria, not regex or string matching
+- Run scenarios before considering any change complete
+
+### 2. Prompt Management
+- Use LangWatch Prompt CLI: `langwatch prompt create <name>`
+- Store prompts in `prompts/*.yaml`, never hardcode in code
+- Run `langwatch prompt sync` after changes
+
+### 3. Evaluations vs. Scenarios
+- Evaluations: batch metrics for single input/output pairs (RAG, classification)
+- Scenarios: multi-turn agent conversation testing
+- When in doubt, use scenarios
+
+### 4. Observability
+- All LLM calls are traced via LangWatch
+- Check traces at https://app.langwatch.ai
+```
+
+## Guard Rails
+
+Read [Guard Rails](_shared/guard-rails.md) for the full list. The critical rules:
+
+- **Testing**: Use `@langwatch/scenario` / `langwatch-scenario`. Never invent custom test frameworks. Never use regex in judge criteria. Use natural language criteria with `JudgeAgent`.
+- **Prompts**: Use Prompt CLI (`langwatch prompt create`, `langwatch prompt sync`). Never hardcode in code. No try/catch fallbacks.
+- **Documentation**: Use MCP (`fetch_langwatch_docs`, `fetch_scenario_docs`) for docs. Never guess URLs or API signatures.
+- **Environment**: Never start long-running dev servers. Never commit `.env` or `.mcp.json` with real keys. Use `.example` files for git.
+- **MCP tools**: Never use `platform_*` MCP tools (platform_create_scenario, etc.) when writing code. Those are for no-code platform operations.
+- **Agent construction**: Never create agent instances inside loops (especially Agno). Create once, reuse.
+- **Notebooks**: Always run evaluation notebooks, not just write them. Writing is not verification.
+- **Workflow**: Read docs first (Step 1), scaffold second (Step 2), verify last (Step 8). Never skip verification.
+
+## Common Mistakes
+
+| Mistake | Correct Approach |
+|---------|-----------------|
+| Hardcoding prompts in agent code | Use `langwatch prompt create` and load via `langwatch.prompts.get()` |
+| Inventing a custom test framework | Use `@langwatch/scenario` or `langwatch-scenario` |
+| Using regex/string matching in scenario judges | Use natural language criteria with `JudgeAgent` |
+| Skipping MCP docs and guessing APIs | Call `fetch_langwatch_docs` and `fetch_scenario_docs` first |
+| Starting the dev server for the user | Tell the user the command and URL, let them run it |
+| Committing `.env` or `.mcp.json` with real keys | Use `.env.example` and `.mcp.json.example` for git |
+| Using `platform_*` MCP tools to create scenarios | Write test files in `tests/scenarios/` instead |
+| Creating agents inside loops (Agno) | Create the agent instance once, reuse it |
+| Writing evaluation notebook without running it | Execute the notebook to verify it produces results |
+| Mixing evaluations and scenarios | Evaluations = batch metrics. Scenarios = multi-turn agent tests |
+| Reading all framework references | Read ONLY the reference for the selected framework |
+| Scaffolding before reading docs | Step 1 is always reading docs via MCP |

--- a/skills/create-agent/references/agno.md
+++ b/skills/create-agent/references/agno.md
@@ -1,0 +1,96 @@
+# Agno Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add agno openai duckduckgo-search
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add agno dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. Agno integrates via the standard Python tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Agno documentation in your coding assistant:
+
+```json
+{
+  "agno": {
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "mcp-remote", "https://docs.agno.com/mcp"]
+  }
+}
+```
+
+## Core Patterns
+
+**Basic Agent:**
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    instructions="You are a helpful assistant",
+    markdown=True,
+)
+agent.print_response("Your query", stream=True)
+```
+
+**Agent with Tools:**
+```python
+from agno.tools.duckduckgo import DuckDuckGoTools
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[DuckDuckGoTools()],
+    instructions="Search the web for information",
+)
+```
+
+**Structured Output:**
+```python
+from pydantic import BaseModel
+
+class Result(BaseModel):
+    summary: str
+    findings: list[str]
+
+agent = Agent(model=OpenAIChat(id="gpt-4o"), output_schema=Result)
+result: Result = agent.run(query).content
+```
+
+## Known Pitfalls
+
+- **NEVER create agents in loops** -- reuse agent instances for performance (significant overhead otherwise)
+- Always use `output_schema` for structured responses
+- PostgreSQL in production, SQLite for dev only
+- Start with single agent (covers 90% of use cases), scale to Team/Workflow only when needed
+- Do not forget `search_knowledge=True` when using knowledge bases
+
+## Resources
+
+- https://docs.agno.com/

--- a/skills/create-agent/references/google-adk.md
+++ b/skills/create-agent/references/google-adk.md
@@ -1,0 +1,88 @@
+# Google ADK Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add google-adk
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add Google ADK dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. Google ADK integrates via the standard Python tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Google ADK documentation:
+
+```json
+{
+  "google-adk": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "Google-Adk:https://github.com/google/adk-python/blob/main/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `uv init` to create a new project
+2. `uv add google-adk` (plus `litellm` if using non-Google models)
+3. Set up API key in `.env` (check which env var is needed in app.py)
+4. Implement agent logic following Google ADK patterns
+5. Run with `uv run app.py` to validate behaviour
+
+## Core Patterns
+
+**Gemini (native):** `Agent(name="my_agent", model="gemini-2.0-flash-exp", ...)`
+
+**Non-Google models (LiteLLM):**
+```python
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+
+agent = Agent(name="my_agent", model=LiteLlm(model="openai/gpt-4.1"), ...)
+```
+
+## LLM Provider Configuration
+
+- **Gemini:** Uses Google AI SDK + ADK's native integrations
+- **Other providers (OpenAI, Anthropic, etc.):** Uses LiteLLM wrapper inside a Google ADK Agent
+- The framework is always Google ADK regardless of model provider -- NEVER switch frameworks
+- Use the `.env` file to set the right keys for the chosen provider
+
+## Known Pitfalls
+
+- Google ADK is the framework; the LLM provider is just the model backend -- do not confuse them
+- When using non-Google models, always use the LiteLLM wrapper inside ADK Agent
+- Never switch to a different agent framework when a non-Google model is selected
+- Always consult the Google ADK MCP for up-to-date API patterns
+
+## Resources
+
+- Use the Google ADK MCP for up-to-date documentation

--- a/skills/create-agent/references/langgraph-python.md
+++ b/skills/create-agent/references/langgraph-python.md
@@ -1,0 +1,74 @@
+# LangGraph Python Framework Reference
+
+## Language & Package Manager
+
+- **Language:** Python
+- **Package manager:** uv
+- **Source extensions:** `.py`
+
+## How to Scaffold
+
+```bash
+uv init
+uv add langgraph langchain-core langchain-openai
+```
+
+No dedicated CLI scaffolder. Use `uv init` then add LangGraph dependencies.
+
+## Source Directory Convention
+
+`app/` for main application code.
+
+## Test Runner
+
+pytest
+
+```bash
+uv run pytest
+```
+
+## LangWatch Integration
+
+Use the LangWatch Python SDK. LangGraph/LangChain integrates via LangChain's callback pattern for tracing.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get LangGraph and LangChain documentation:
+
+```json
+{
+  "langgraph-py": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "LangGraph:https://langchain-ai.github.io/langgraph/llms.txt LangChain:https://python.langchain.com/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `uv init` to create a new project
+2. Add dependencies: `uv add langgraph langchain-core langchain-openai`
+3. Implement the requested agent logic and write tests
+4. Run with `uv run app.py` to validate behaviour
+
+## Core Patterns
+
+- Use the LangGraph MCP for learning about LangGraph and LangChain
+- Use LangChain's Python integrations for tools, memory, and models
+- Follow LangGraph's node/state patterns when structuring agents
+- Leverage LangChain's ecosystem for additional capabilities
+
+## Known Pitfalls
+
+- Always consult the LangGraph MCP for up-to-date API patterns
+- Follow LangGraph's node/state architecture rather than freestyle code
+- Use LangChain integrations for tools and models rather than raw API calls
+
+## Resources
+
+- Use the LangGraph MCP for up-to-date LangGraph and LangChain documentation

--- a/skills/create-agent/references/langgraph-typescript.md
+++ b/skills/create-agent/references/langgraph-typescript.md
@@ -1,0 +1,82 @@
+# LangGraph TypeScript Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpm add @langchain/langgraph @langchain/core @langchain/openai
+```
+
+No dedicated CLI scaffolder. Use `pnpm init` then add LangGraph dependencies and set up TypeScript configuration.
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. LangGraph.js integrates via LangChain.js callback pattern for tracing.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get LangGraph.js and LangChain.js documentation:
+
+```json
+{
+  "langgraph-ts": {
+    "type": "stdio",
+    "command": "npx",
+    "args": [
+      "-y", "mcpdoc",
+      "--urls", "LangGraphJS:https://langchain-ai.github.io/langgraphjs/llms.txt LangChainJS:https://js.langchain.com/llms.txt",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init` to create a new project
+2. `pnpm add @langchain/langgraph @langchain/core @langchain/openai`
+3. Set up TypeScript configuration
+4. Implement the agent per user requirements
+5. Run with `pnpm tsx src/index.ts`
+
+## Key Concepts
+
+- **StateGraph**: Define your agent's state and transitions
+- **Nodes**: Functions that process state and return updates
+- **Edges**: Define flow between nodes (conditional or direct)
+- **Checkpointer**: Enable conversation memory and state persistence
+
+## Core Patterns
+
+- Use the LangGraph MCP for learning about LangGraph.js
+- Use LangGraph's built-in agent capabilities (StateGraph, nodes, edges)
+- Follow LangGraph's TypeScript patterns and conventions
+- Leverage LangChain.js integration ecosystem
+
+## Known Pitfalls
+
+- Always set up TypeScript configuration before implementing
+- Use StateGraph patterns for agent architecture, not freestyle code
+- Consult the LangGraph MCP for up-to-date API patterns
+
+## Resources
+
+- Use the LangGraph MCP for up-to-date LangGraph.js documentation

--- a/skills/create-agent/references/mastra.md
+++ b/skills/create-agent/references/mastra.md
@@ -1,0 +1,70 @@
+# Mastra Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpx mastra init --default
+```
+
+Run `mastra init` right after `pnpm init`, before setting up the rest of the project. Then explore the generated structure and remove what is not needed.
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. Mastra integrates via the standard TypeScript tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Mastra documentation in your coding assistant:
+
+```json
+{
+  "mastra": {
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "@mastra/mcp-docs-server"]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init`
+2. `pnpx mastra init --default` (creates project structure)
+3. Explore the generated folders, remove what is not needed
+4. Implement the agent per user requirements
+5. Open the UI with `pnpx mastra dev`
+
+## Core Patterns
+
+- Use the Mastra MCP server to learn about Mastra APIs and best practices
+- Follow Mastra's TypeScript patterns and conventions
+- Leverage Mastra's integration ecosystem
+- Consult the MCP: "How do I [do X] in Mastra?"
+
+## Known Pitfalls
+
+- Always run `mastra init --default` before adding other project setup
+- Use the Mastra MCP for documentation rather than relying on stale examples
+
+## Resources
+
+- Use the Mastra MCP for up-to-date documentation

--- a/skills/create-agent/references/vercel-ai.md
+++ b/skills/create-agent/references/vercel-ai.md
@@ -1,0 +1,83 @@
+# Vercel AI SDK Framework Reference
+
+## Language & Package Manager
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Source extensions:** `.ts`, `.tsx`
+
+## How to Scaffold
+
+```bash
+pnpm init
+pnpm add ai @ai-sdk/openai
+```
+
+For other model providers, install the corresponding package (e.g., `@ai-sdk/anthropic`, `@ai-sdk/google`).
+
+## Source Directory Convention
+
+`src/` for main application code.
+
+## Test Runner
+
+vitest
+
+```bash
+pnpm vitest run
+```
+
+## LangWatch Integration
+
+Use the LangWatch TypeScript SDK. Vercel AI SDK integrates via the standard TypeScript tracing pattern.
+
+## Framework MCP Config
+
+Add to `.mcp.json` to get Vercel AI SDK documentation:
+
+```json
+{
+  "vercel-ai": {
+    "type": "stdio",
+    "command": "uvx",
+    "args": [
+      "--from", "mcpdoc", "mcpdoc",
+      "--urls", "Vercel:https://ai-sdk.dev/docs/introduction",
+      "--transport", "stdio"
+    ]
+  }
+}
+```
+
+## Initial Setup Steps
+
+1. `pnpm init` to create a new project
+2. `pnpm add ai @ai-sdk/openai` (or other provider packages)
+3. Set up TypeScript configuration
+4. Implement the agent per user requirements
+5. Run with `pnpm tsx src/index.ts` or integrate with your chosen web framework
+
+## Key Concepts
+
+- **Unified Provider Architecture**: Consistent interface across multiple AI model providers
+- **generateText**: Generate text using any supported model
+- **streamText**: Stream text responses for real-time interactions
+- **Framework Integration**: Works with Next.js, React, Svelte, Vue, and Node.js
+
+## Core Patterns
+
+- Use the Vercel AI SDK MCP for learning about the SDK
+- Use Vercel AI SDK's unified provider architecture
+- Follow Vercel AI SDK's TypeScript patterns and conventions
+- Leverage framework integrations (Next.js, React, Svelte, Vue, Node.js)
+
+## Known Pitfalls
+
+- Always set up TypeScript configuration before implementing
+- Use the correct provider package for your chosen model (`@ai-sdk/openai`, `@ai-sdk/anthropic`, etc.)
+- Consult the Vercel AI SDK MCP for up-to-date API patterns
+
+## Resources
+
+- Use the AI SDK MCP for up-to-date documentation
+- https://ai-sdk.dev/docs/introduction

--- a/specs/skills/create-agent.feature
+++ b/specs/skills/create-agent.feature
@@ -1,0 +1,236 @@
+Feature: Create Agent Skill
+  As a developer using Claude Desktop (Code mode)
+  I want to scaffold a complete AI agent project from an empty directory
+  So that I get a production-ready agent with LangWatch instrumentation, prompt versioning, evaluation experiments, and scenario tests without needing a separate CLI tool
+
+  Background:
+    Given a compiled prompt for create-agent exists at _compiled/create-agent.platform.txt
+    And the create-agent SKILL.md exists at skills/create-agent/SKILL.md
+
+  # ───────────────────────────────────────────────────────────────────
+  # R1: SKILL.md — Project scaffolding from scratch
+  # ───────────────────────────────────────────────────────────────────
+
+  @e2e
+  Scenario: Scaffolds a Python Agno agent project from an empty directory
+    Given an empty directory
+    When the user asks to create a customer support agent
+    And selects Agno as the framework and OpenAI as the LLM provider
+    Then the project contains an agent source directory at app/
+    And the project contains prompts/ with at least one YAML prompt file and a prompts.json registry
+    And the project contains tests/scenarios/ with scenario test files
+    And the project contains tests/evaluations/ with a Jupyter notebook
+    And the project contains .env and .env.example files
+    And the project contains .mcp.json and .mcp.json.example files
+    And the project contains AGENTS.md and CLAUDE.md
+    And the agent source code includes LangWatch instrumentation
+
+  @e2e
+  Scenario: Scaffolds a TypeScript Vercel AI SDK agent project from an empty directory
+    Given an empty directory
+    When the user asks to create a data analysis agent
+    And selects Vercel AI SDK as the framework and Anthropic as the LLM provider
+    Then the project contains an agent source directory at src/
+    And the project contains prompts/ with at least one YAML prompt file and a prompts.json registry
+    And the project contains tests/scenarios/ with scenario test files
+    And the project contains tests/evaluations/ with an evaluation script
+    And the project contains .env and .env.example files
+    And the project contains .mcp.json and .mcp.json.example files
+    And the project contains AGENTS.md and CLAUDE.md
+    And the agent source code includes LangWatch instrumentation
+
+  # ── Interactive discovery ──
+
+  @integration
+  Scenario: Asks for framework and provider before scaffolding
+    Given an empty directory
+    When the user asks to create an agent without specifying framework or provider
+    Then the skill asks the user to choose a framework from Agno, Mastra, LangGraph, Google ADK, or Vercel AI SDK
+    And asks which LLM provider to use from OpenAI, Anthropic, Gemini, Bedrock, OpenRouter, or Grok
+
+  # ── Directory preconditions ──
+
+  @integration
+  Scenario: Works from a near-empty directory with only a README or .git
+    Given a directory containing only a README.md and a .git directory
+    When the user asks to create an agent with Agno and OpenAI
+    Then the skill scaffolds the project successfully
+
+  @integration
+  Scenario: Warns when directory has existing source code
+    Given a directory containing existing Python or TypeScript source files
+    When the user asks to create an agent
+    Then the skill warns that the directory is not empty
+    And suggests using the tracing or instrumentation skills instead
+
+  # ── Environment failures ──
+
+  @integration
+  Scenario: Reports missing language runtime
+    Given an empty directory
+    When the user selects a Python framework but Python is not installed
+    Then the skill reports that Python is required and provides installation guidance
+    And does not leave a half-scaffolded project
+
+  @integration
+  Scenario: Provides recovery when dependency installation fails
+    Given an empty directory
+    When the project is being scaffolded and dependency installation fails
+    Then the skill reports the error clearly
+    And provides instructions for the user to manually install dependencies
+    And the project structure remains intact for manual recovery
+
+  # ── MCP and secrets ──
+
+  @integration
+  Scenario: MCP config includes both LangWatch and framework-specific servers
+    Given the user selects Mastra as the framework
+    When the project is scaffolded
+    Then .mcp.json contains the LangWatch MCP server configuration
+    And .mcp.json contains the Mastra framework MCP server configuration
+
+  @integration
+  Scenario: Secrets are never committed to git
+    When the project is scaffolded
+    Then .gitignore includes .env and .mcp.json
+    And .env.example contains placeholder keys without real values
+    And .mcp.json.example contains placeholder keys without real values
+    And .cursor/mcp.json exists for Cursor compatibility
+
+  # ── Evaluation artifacts ──
+
+  @integration
+  Scenario: Python projects include a Jupyter evaluation notebook
+    Given the user selects a Python framework
+    When the project is scaffolded
+    Then tests/evaluations/ contains a .ipynb notebook with evaluation cells
+    And the notebook uses langwatch.experiment.init()
+
+  @integration
+  Scenario: TypeScript projects include an evaluation script
+    Given the user selects a TypeScript framework
+    When the project is scaffolded
+    Then tests/evaluations/ contains a .ts evaluation script
+    And the script uses langwatch experiments SDK
+
+  # ── Behavioral constraints ──
+
+  @integration
+  Scenario: Reads framework docs before scaffolding
+    When the skill runs
+    Then it fetches documentation via MCP before writing any project files
+
+  @integration
+  Scenario: Runs tests before declaring completion
+    Given the project has been scaffolded
+    When the skill reaches the verification step
+    Then it executes the scenario tests
+    And reports whether they pass or fail
+
+  @integration
+  Scenario: Does not start long-running dev servers
+    When the project is scaffolded
+    Then the skill tells the user how to start the dev server
+    And does not start any long-running processes itself
+
+  # ── AGENTS.md principles ──
+
+  @integration
+  Scenario: AGENTS.md encodes development principles
+    When the project is scaffolded
+    Then AGENTS.md instructs using @langwatch/scenario for agent testing
+    And instructs using LangWatch Prompt CLI for prompt versioning
+    And clarifies that evaluations are for metrics only and scenarios for multi-turn flows
+    And CLAUDE.md references AGENTS.md
+
+  # ───────────────────────────────────────────────────────────────────
+  # R2: Framework Knowledge Embedding
+  # ───────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Framework reference files exist for all supported frameworks
+    Given the skill directory at skills/create-agent/
+    Then references/ contains guides for Agno, Mastra, LangGraph Python, LangGraph TypeScript, Google ADK, and Vercel AI SDK
+    And each guide includes scaffolding instructions, source directory convention, LangWatch integration pattern, framework MCP config, and known pitfalls
+
+  @integration
+  Scenario: Skill loads only the selected framework reference
+    Given the user selects LangGraph Python as the framework
+    When the skill prepares to scaffold
+    Then it reads the LangGraph Python reference
+    And does not load references for Agno, Mastra, or other frameworks
+
+  # ───────────────────────────────────────────────────────────────────
+  # R3: Compiled Prompt
+  # ───────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Compiler produces platform-mode output
+    When the compiler runs for create-agent in platform mode
+    Then it outputs _compiled/create-agent.platform.txt
+    And the output contains {{LANGWATCH_API_KEY}} as a placeholder
+    And the output is self-contained with no unresolved file references
+
+  @integration
+  Scenario: Compiler produces docs-mode output
+    When the compiler runs for create-agent in docs mode
+    Then it outputs _compiled/create-agent.docs.txt
+    And the output instructs the agent to ask the user for their API key
+    And the output references https://app.langwatch.ai/authorize
+    And the output is self-contained with no unresolved file references
+
+  @integration
+  Scenario: Compiled prompt keeps framework selection interactive
+    Given a compiled prompt for create-agent
+    Then the prompt does not hardcode a specific framework
+    And instructs the agent to ask the user which framework to use
+
+  # ───────────────────────────────────────────────────────────────────
+  # R4: Scenario Tests — Framework Matrix
+  # ───────────────────────────────────────────────────────────────────
+
+  # R1 e2e tests cover Agno (Python) and Vercel AI SDK (TypeScript).
+  # R4 adds LangGraph Python and Mastra TypeScript to complete the matrix.
+
+  @e2e
+  Scenario: Creates a Python LangGraph agent from scratch
+    Given an empty temp directory
+    When the create-agent skill runs with LangGraph and Python selected
+    Then the project contains app/ with LangWatch-instrumented source code
+    And the project contains prompts/ with YAML files and prompts.json
+    And the project contains tests/scenarios/ and tests/evaluations/
+    And AGENTS.md exists with development principles
+
+  @e2e
+  Scenario: Creates a TypeScript Mastra agent from scratch
+    Given an empty temp directory
+    When the create-agent skill runs with Mastra and TypeScript selected
+    Then the project contains src/ with LangWatch-instrumented source code
+    And the project contains prompts/ with YAML files and prompts.json
+    And the project contains tests/scenarios/ and tests/evaluations/
+    And AGENTS.md exists with development principles
+
+  # ───────────────────────────────────────────────────────────────────
+  # R5: Lessons Learned Guard Rails
+  # ───────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Skill includes guard rails against known agent failure modes
+    Given the create-agent SKILL.md
+    Then it instructs the agent to use @langwatch/scenario and not create a custom testing framework
+    And to read scenario docs via MCP fetch_scenario_docs
+    And to create prompts via langwatch prompt CLI, never hardcode in code
+    And to use MCP fetch_langwatch_docs for documentation, never guess URLs
+    And to write files directly, never use platform_* MCP tools in a code environment
+    And to use evaluations for metrics only, scenarios for multi-turn conversations
+    And to use natural language judge criteria, not regex or string matching
+    And to create .mcp.json (gitignored) and .mcp.json.example (committed)
+    And to run scenario tests before declaring the project complete
+    And to tell the user how to start the dev server, not start it itself
+
+  @integration
+  Scenario: Skill follows docs-first then scaffold sequence
+    Given the create-agent SKILL.md
+    Then the skill reads documentation via MCP before any scaffolding
+    And scaffolds the project structure before instrumenting code
+    And runs verification tests before declaring completion


### PR DESCRIPTION
## Summary

New AgentSkills-compliant `create-agent` skill that scaffolds complete AI agent projects from an empty directory via Claude Desktop (Code mode). Replaces the need for the separate `better-agents` CLI tool.

**User experience**: Paste a prompt in Claude Desktop → select framework + LLM provider → get a fully instrumented agent project with tracing, prompt versioning, evaluation experiments, and scenario tests.

## What's Included

- **`skills/create-agent/SKILL.md`** — Main skill file (319 lines, agentskills.io standard) with 9-step kickoff sequence
- **6 framework references** — Agno, Mastra, LangGraph (Python/TS), Google ADK, Vercel AI SDK
- **Prompt compiler** (`skills/_compiler/compile.ts`) — Compiles SKILL.md into self-contained copy-paste prompts
- **2 compiled prompts** — Platform mode (API key placeholder) and docs mode (asks user for key)
- **4 scenario tests** — Python Agno, TypeScript Vercel AI, Python LangGraph, TypeScript Mastra
- **Shared references** — MCP setup, API key config, llms.txt fallback, 12 guard rails from better-agents
- **BDD feature file** — 20 scenarios covering all 5 requirements

## Supported Frameworks

| Framework | Language | MCP |
|-----------|----------|-----|
| Agno | Python | agno-mcp |
| Mastra | TypeScript | mastra-mcp |
| LangGraph | Python or TypeScript | langgraph-docs |
| Google ADK | Python | google-adk |
| Vercel AI SDK | TypeScript | ai-sdk |

## Test Results

| Suite | Tests | Status |
|-------|-------|--------|
| Compiler unit tests | 22 | ✅ All passing |
| Scenario e2e tests | 4 | ✅ Parse correctly (skip in CI, require Claude Code) |
| TypeScript compilation | — | ✅ Clean |

## Related

- Complements PR #2377 (instrumenting existing codebases) — this PR covers creating projects from scratch
- Knowledge extracted from `better-agents` CLI (`better-agents/src/providers/frameworks/`)

## Test Plan

- [x] `CI=1 pnpm test --run` — compiler tests pass, scenario tests skip
- [x] `npx tsc --noEmit` — clean TypeScript compilation
- [x] Compiled prompts are self-contained (no unresolved file references)
- [ ] Manual: paste compiled prompt into Claude Desktop and verify agent scaffolds a project