### PR TITLE
fix: increase free plan project limit, fix dataset drawer tabs, float selection bar

### DIFF
--- a/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
@@ -20,8 +20,8 @@ describe("PLAN_LIMITS", () => {
       expect(PLAN_LIMITS[PlanTypes.ENTERPRISE].maxProjects).toBe(9999);
     });
 
-    it("sets FREE maxProjects to 1", () => {
-      expect(PLAN_LIMITS[PlanTypes.FREE].maxProjects).toBe(1);
+    it("sets FREE maxProjects to 2", () => {
+      expect(PLAN_LIMITS[PlanTypes.FREE].maxProjects).toBe(2);
     });
   });
 });

--- a/langwatch/ee/billing/planLimits.ts
+++ b/langwatch/ee/billing/planLimits.ts
@@ -94,7 +94,7 @@ export const PLAN_LIMITS: Record<PlanType, PlanInfo> = {
     name: "Free",
     free: true,
     maxMembers: 2,
-    maxProjects: 1,
+    maxProjects: 2,
     maxMessagesPerMonth: 50_000,
     maxWorkflows: 3,
     maxPrompts: 3,

--- a/langwatch/src/components/datasets/DatasetMappingPreview.tsx
+++ b/langwatch/src/components/datasets/DatasetMappingPreview.tsx
@@ -228,7 +228,7 @@ export function DatasetMappingPreview({
           >
             <Box
               as="button"
-              onClick={() => setIsThreadMapping(false)}
+              onClick={(e: React.MouseEvent) => { e.preventDefault(); setIsThreadMapping(false); }}
               bg={!isThreadMapping ? "white" : "transparent"}
               _dark={{
                 bg: !isThreadMapping ? "gray.700" : "transparent",
@@ -247,7 +247,7 @@ export function DatasetMappingPreview({
             </Box>
             <Box
               as="button"
-              onClick={() => setIsThreadMapping(true)}
+              onClick={(e: React.MouseEvent) => { e.preventDefault(); setIsThreadMapping(true); }}
               bg={isThreadMapping ? "white" : "transparent"}
               _dark={{
                 bg: isThreadMapping ? "gray.700" : "transparent",

--- a/langwatch/src/components/license/__tests__/ResourceLimitsDisplay.unit.test.ts
+++ b/langwatch/src/components/license/__tests__/ResourceLimitsDisplay.unit.test.ts
@@ -220,7 +220,7 @@ describe("mapUsageToLimits", () => {
       maxMembers: 1,
       maxMembersLite: 0,
       maxTeams: 1,
-      maxProjects: 1,
+      maxProjects: 2,
       maxPrompts: 1,
       maxWorkflows: 1,
       maxScenarios: 1,
@@ -241,7 +241,7 @@ describe("mapUsageToLimits", () => {
     const result = mapUsageToLimits(baseUsage, freePlan);
 
     expect(result.members.max).toBe(1);
-    expect(result.projects.max).toBe(1);
+    expect(result.projects.max).toBe(2);
     expect(result.messagesPerMonth.max).toBe(1000);
     expect(result.evaluationsCredit.max).toBe(10);
   });

--- a/langwatch/src/components/messages/MessagesTable.tsx
+++ b/langwatch/src/components/messages/MessagesTable.tsx
@@ -1450,9 +1450,10 @@ export function MessagesTable({
       {selectedTraceIds.length > 0 && (
         <Box
           position="fixed"
-          bottom={10}
+          bottom={16}
           left="50%"
           transform="translateX(-50%)"
+          zIndex={20}
           backgroundColor="#ffffff"
           padding="8px"
           paddingX="16px"


### PR DESCRIPTION
## Summary
- **Free plan project limit**: Increased `maxProjects` from 1 to 2 for free tier users
- **Dataset drawer tab bug**: Traces/Threads tab buttons inside a `<form>` were defaulting to `type="submit"`, causing immediate form submission when clicking "Threads". Fixed with `e.preventDefault()` in click handlers
- **Selection bar positioning**: Raised the trace selection bar (`bottom: 10` → `16`) and added `zIndex: 20` so it floats clearly above the SavedViewsBar footer

## Test plan
- [ ] `planLimits.unit.test.ts` — passes with updated assertion (`maxProjects: 2`)
- [x] `ResourceLimitsDisplay.unit.test.ts` — passes with updated free plan mock
- [x] `pnpm typecheck` — zero errors
- [ ] Verify in browser: select traces → selection bar floats above footer
- [ ] Verify in browser: Add to Dataset → select dataset → click Threads tab → does NOT submit