### PR TITLE
fix(analytics): suppress PostHog tracking during impersonation without race condition

### DIFF
--- a/langwatch/src/app/api/evaluations/v3/execute/route.ts
+++ b/langwatch/src/app/api/evaluations/v3/execute/route.ts
@@ -150,6 +150,7 @@ app.post("/execute", zValidator("json", executionRequestSchema), async (c) => {
               userId: session.user.id,
               event: "evaluation_ran",
               projectId,
+              session,
             });
           }
           break;

--- a/langwatch/src/hooks/__tests__/usePostHogIdentify.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/usePostHogIdentify.unit.test.ts
@@ -8,18 +8,27 @@
  * - Calls posthog.group with organization data
  * - Calls posthog.reset on logout (userId disappears)
  * - Tracks upgrade_modal_shown via Zustand subscribe
+ * - Suppresses all PostHog capturing during impersonation
+ * - Re-enables tracking when transitioning back from impersonation
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { cleanup, renderHook } from "@testing-library/react";
 
-const { mockIdentify, mockGroup, mockReset, mockCapture } = vi.hoisted(
-  () => ({
-    mockIdentify: vi.fn(),
-    mockGroup: vi.fn(),
-    mockReset: vi.fn(),
-    mockCapture: vi.fn(),
-  }),
-);
+const {
+  mockIdentify,
+  mockGroup,
+  mockReset,
+  mockCapture,
+  mockOptOutCapturing,
+  mockOptInCapturing,
+} = vi.hoisted(() => ({
+  mockIdentify: vi.fn(),
+  mockGroup: vi.fn(),
+  mockReset: vi.fn(),
+  mockCapture: vi.fn(),
+  mockOptOutCapturing: vi.fn(),
+  mockOptInCapturing: vi.fn(),
+}));
 
 vi.mock("posthog-js", () => ({
   default: {
@@ -27,14 +36,26 @@ vi.mock("posthog-js", () => ({
     group: mockGroup,
     reset: mockReset,
     capture: mockCapture,
+    opt_out_capturing: mockOptOutCapturing,
+    opt_in_capturing: mockOptInCapturing,
+    __loaded: true,
   },
 }));
 
 import { useUpgradeModalStore } from "../../stores/upgradeModalStore";
 import { usePostHogIdentify } from "../usePostHogIdentify";
 
-describe("usePostHogIdentify", () => {
+type Session = {
+  user: {
+    id: string;
+    email?: string | null;
+    impersonator?: { email?: string | null };
+  };
+} | null;
+
+describe("usePostHogIdentify()", () => {
   beforeEach(() => {
+    cleanup();
     vi.clearAllMocks();
     useUpgradeModalStore.getState().close();
   });
@@ -43,7 +64,7 @@ describe("usePostHogIdentify", () => {
     useUpgradeModalStore.getState().close();
   });
 
-  describe("when session has a user", () => {
+  describe("when session has a normal user", () => {
     it("identifies user with userId and email", () => {
       renderHook(() =>
         usePostHogIdentify({
@@ -71,6 +92,19 @@ describe("usePostHogIdentify", () => {
         email: undefined,
       });
     });
+
+    it("does not call opt_in_capturing or opt_out_capturing", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: { user: { id: "user-1", email: "test@example.com" } },
+          organization: undefined,
+          planType: undefined,
+        }),
+      );
+
+      expect(mockOptInCapturing).not.toHaveBeenCalled();
+      expect(mockOptOutCapturing).not.toHaveBeenCalled();
+    });
   });
 
   describe("when session is null", () => {
@@ -90,11 +124,7 @@ describe("usePostHogIdentify", () => {
   describe("when user logs out", () => {
     it("calls posthog.reset", () => {
       const { rerender } = renderHook(
-        ({
-          session,
-        }: {
-          session: { user: { id: string; email?: string | null } } | null;
-        }) =>
+        ({ session }: { session: Session }) =>
           usePostHogIdentify({
             session,
             organization: undefined,
@@ -104,7 +134,7 @@ describe("usePostHogIdentify", () => {
           initialProps: {
             session: {
               user: { id: "user-1", email: "test@example.com" },
-            } as { user: { id: string; email?: string | null } } | null,
+            } as Session,
           },
         },
       );
@@ -121,11 +151,7 @@ describe("usePostHogIdentify", () => {
   describe("when user switches from A to B", () => {
     it("calls posthog.reset before identifying new user", () => {
       const { rerender } = renderHook(
-        ({
-          session,
-        }: {
-          session: { user: { id: string; email?: string | null } } | null;
-        }) =>
+        ({ session }: { session: Session }) =>
           usePostHogIdentify({
             session,
             organization: undefined,
@@ -135,7 +161,7 @@ describe("usePostHogIdentify", () => {
           initialProps: {
             session: {
               user: { id: "user-1", email: "a@example.com" },
-            } as { user: { id: string; email?: string | null } } | null,
+            } as Session,
           },
         },
       );
@@ -152,6 +178,136 @@ describe("usePostHogIdentify", () => {
       expect(mockReset).toHaveBeenCalledTimes(1);
       expect(mockIdentify).toHaveBeenCalledWith("user-2", {
         email: "b@example.com",
+      });
+    });
+  });
+
+  describe("when session has an impersonator", () => {
+    it("opts out of PostHog capturing", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: {
+            user: {
+              id: "user-1",
+              email: "impersonated@example.com",
+              impersonator: { email: "admin@example.com" },
+            },
+          },
+          organization: { id: "org-1", name: "Acme Corp" },
+          planType: "pro",
+        }),
+      );
+
+      expect(mockOptOutCapturing).toHaveBeenCalled();
+    });
+
+    it("does not call identify", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: {
+            user: {
+              id: "user-1",
+              impersonator: { email: "admin@example.com" },
+            },
+          },
+          organization: undefined,
+          planType: undefined,
+        }),
+      );
+
+      expect(mockIdentify).not.toHaveBeenCalled();
+    });
+
+    it("does not call group even when organization is provided", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: {
+            user: {
+              id: "user-1",
+              impersonator: { email: "admin@example.com" },
+            },
+          },
+          organization: { id: "org-1", name: "Acme Corp" },
+          planType: "pro",
+        }),
+      );
+
+      expect(mockGroup).not.toHaveBeenCalled();
+    });
+
+    it("does not track upgrade modal opens", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: {
+            user: {
+              id: "user-1",
+              impersonator: { email: "admin@example.com" },
+            },
+          },
+          organization: undefined,
+          planType: undefined,
+        }),
+      );
+
+      useUpgradeModalStore.getState().open("workflows", 5, 5);
+
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when session has no impersonator", () => {
+    it("does not call opt_in_capturing or opt_out_capturing on initial render", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: { user: { id: "user-1", email: "test@example.com" } },
+          organization: undefined,
+          planType: undefined,
+        }),
+      );
+
+      expect(mockOptInCapturing).not.toHaveBeenCalled();
+      expect(mockOptOutCapturing).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when impersonation ends", () => {
+    it("re-enables capturing and re-identifies user", () => {
+      const { rerender } = renderHook(
+        ({ session }: { session: Session }) =>
+          usePostHogIdentify({
+            session,
+            organization: undefined,
+            planType: undefined,
+          }),
+        {
+          initialProps: {
+            session: {
+              user: {
+                id: "user-1",
+                email: "impersonated@example.com",
+                impersonator: { email: "admin@example.com" },
+              },
+            } as Session,
+          },
+        },
+      );
+
+      expect(mockOptOutCapturing).toHaveBeenCalled();
+      expect(mockIdentify).not.toHaveBeenCalled();
+
+      vi.clearAllMocks();
+
+      // Transition to normal session (impersonation ends)
+      rerender({
+        session: {
+          user: { id: "real-user", email: "real@example.com" },
+        },
+      });
+
+      expect(mockOptInCapturing).toHaveBeenCalled();
+      expect(mockReset).toHaveBeenCalled();
+      expect(mockIdentify).toHaveBeenCalledWith("real-user", {
+        email: "real@example.com",
       });
     });
   });
@@ -225,7 +381,6 @@ describe("usePostHogIdentify", () => {
         }),
       );
 
-      // Open upgrade modal
       useUpgradeModalStore.getState().open("workflows", 5, 5);
 
       expect(mockCapture).toHaveBeenCalledWith("upgrade_modal_shown", {

--- a/langwatch/src/hooks/usePostHogIdentify.ts
+++ b/langwatch/src/hooks/usePostHogIdentify.ts
@@ -7,15 +7,42 @@ export function usePostHogIdentify({
   organization,
   planType,
 }: {
-  session: { user?: { id: string; email?: string | null } } | null;
+  session: {
+    user?: {
+      id: string;
+      email?: string | null;
+      impersonator?: { email?: string | null };
+    };
+  } | null;
   organization: { id: string; name: string } | undefined;
   planType: string | undefined;
 }) {
   const prevUserIdRef = useRef<string | null>(null);
+  const wasImpersonatingRef = useRef<boolean>(false);
 
-  // 1. Identify user
+  const isImpersonating = !!session?.user?.impersonator;
+
+  // 1. Identify user (or suppress during impersonation)
   useEffect(() => {
     if (typeof window === "undefined") return;
+
+    if (isImpersonating) {
+      posthog.opt_out_capturing();
+      wasImpersonatingRef.current = true;
+      return;
+    }
+
+    // Only re-enable capturing when transitioning back from impersonation,
+    // never unconditionally. This avoids the race condition where
+    // opt_in_capturing() triggers sessionRecording.startIfEnabledOrStop()
+    // before the session recording script finishes loading async.
+    if (wasImpersonatingRef.current) {
+      if (posthog.__loaded) {
+        posthog.opt_in_capturing();
+      }
+      posthog.reset();
+      wasImpersonatingRef.current = false;
+    }
 
     const userId = session?.user?.id;
     const prevUserId = prevUserIdRef.current;
@@ -34,23 +61,31 @@ export function usePostHogIdentify({
       email: session?.user?.email ?? undefined,
     });
     prevUserIdRef.current = userId;
-  }, [session?.user?.id, session?.user?.email]);
+  }, [session?.user?.id, session?.user?.email, isImpersonating]);
 
   // 2. Group by organization (re-runs on org switch)
   useEffect(() => {
     if (typeof window === "undefined") return;
+    if (isImpersonating) return;
     if (!session?.user?.id || !organization?.id) return;
 
     posthog.group("organization", organization.id, {
       name: organization.name,
       ...(planType ? { planType } : {}),
     });
-  }, [session?.user?.id, organization?.id, organization?.name, planType]);
+  }, [
+    session?.user?.id,
+    organization?.id,
+    organization?.name,
+    planType,
+    isImpersonating,
+  ]);
 
   // 3. Track upgrade modal opens via Zustand subscribe
   useEffect(() => {
     const unsubscribe = useUpgradeModalStore.subscribe((state, prevState) => {
       if (typeof window === "undefined") return;
+      if (isImpersonating) return;
       if (state.isOpen && !prevState.isOpen && state.variant) {
         posthog.capture("upgrade_modal_shown", {
           mode: state.variant.mode,
@@ -65,5 +100,5 @@ export function usePostHogIdentify({
       }
     });
     return unsubscribe;
-  }, []);
+  }, [isImpersonating]);
 }

--- a/langwatch/src/server/__tests__/posthog.unit.test.ts
+++ b/langwatch/src/server/__tests__/posthog.unit.test.ts
@@ -7,6 +7,7 @@
  * - Captures events with correct distinctId, event name, and properties
  * - Includes projectId in properties when provided
  * - Silently no-ops when POSTHOG_KEY is not set
+ * - Skips capture when session has an impersonator
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
@@ -38,7 +39,7 @@ vi.mock("~/env.mjs", () => ({
 
 import { trackServerEvent } from "../posthog";
 
-describe("trackServerEvent", () => {
+describe("trackServerEvent()", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -113,5 +114,113 @@ describe("trackServerEvent", () => {
         properties: { inviteCount: 3 },
       });
     });
+  });
+
+  describe("when session has an impersonator", () => {
+    it("skips capture", () => {
+      trackServerEvent({
+        userId: "user-123",
+        event: "scenario_created",
+        projectId: "proj-456",
+        session: {
+          user: {
+            impersonator: { email: "admin@example.com" },
+          },
+        },
+      });
+
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when session has no impersonator", () => {
+    it("captures event normally", () => {
+      trackServerEvent({
+        userId: "user-123",
+        event: "scenario_created",
+        projectId: "proj-456",
+        session: {
+          user: {},
+        },
+      });
+
+      expect(mockCapture).toHaveBeenCalledWith({
+        distinctId: "user-123",
+        event: "scenario_created",
+        properties: { projectId: "proj-456" },
+      });
+    });
+  });
+
+  describe("when no session is provided", () => {
+    it("captures event for backwards compatibility", () => {
+      trackServerEvent({
+        userId: "user-123",
+        event: "evaluation_ran",
+        projectId: "proj-789",
+      });
+
+      expect(mockCapture).toHaveBeenCalledWith({
+        distinctId: "user-123",
+        event: "evaluation_ran",
+        properties: { projectId: "proj-789" },
+      });
+    });
+  });
+
+  describe("when session is explicitly null", () => {
+    it("captures event for backwards compatibility", () => {
+      trackServerEvent({
+        userId: "user-123",
+        event: "evaluation_ran",
+        projectId: "proj-789",
+        session: null,
+      });
+
+      expect(mockCapture).toHaveBeenCalledWith({
+        distinctId: "user-123",
+        event: "evaluation_ran",
+        properties: { projectId: "proj-789" },
+      });
+    });
+  });
+});
+
+describe("trackServerEvent() when POSTHOG_KEY is not set", () => {
+  it("skips capture silently", async () => {
+    vi.resetModules();
+
+    vi.doMock("~/env.mjs", () => ({
+      env: {
+        POSTHOG_KEY: undefined,
+        POSTHOG_HOST: undefined,
+      },
+    }));
+
+    vi.doMock("posthog-node", () => ({
+      PostHog: function () {
+        return { capture: mockCapture, shutdown: vi.fn() };
+      },
+    }));
+
+    vi.doMock("~/utils/logger/server", () => ({
+      createLogger: () => ({
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      }),
+    }));
+
+    mockCapture.mockClear();
+
+    const { trackServerEvent: trackNoKey } = await import("../posthog");
+
+    trackNoKey({
+      userId: "user-123",
+      event: "some_event",
+    });
+
+    expect(mockCapture).not.toHaveBeenCalled();
   });
 });

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -80,6 +80,7 @@ export const evaluationsRouter = createTRPCRouter({
           userId: ctx.session.user.id,
           event: "evaluation_ran",
           projectId: input.projectId,
+          session: ctx.session,
         });
       }
 

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -974,6 +974,7 @@ export const organizationRouter = createTRPCRouter({
           userId: ctx.session.user.id,
           event: "team_member_invited",
           properties: { inviteCount: createdRecords.length },
+          session: ctx.session,
         });
       }
 

--- a/langwatch/src/server/api/routers/scenarios/scenario-crud.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-crud.router.ts
@@ -45,7 +45,12 @@ export const scenarioCrudRouter = createTRPCRouter({
         lastUpdatedById: ctx.session.user.id,
       });
 
-      trackServerEvent({ userId: ctx.session.user.id, event: "scenario_created", projectId: input.projectId });
+      trackServerEvent({
+        userId: ctx.session.user.id,
+        event: "scenario_created",
+        projectId: input.projectId,
+        session: ctx.session,
+      });
 
       logger.info({ projectId: input.projectId, scenarioId: result.id }, "Scenario created");
       return result;

--- a/langwatch/src/server/auth.ts
+++ b/langwatch/src/server/auth.ts
@@ -39,6 +39,7 @@ declare module "next-auth" {
   interface Session extends DefaultSession {
     user: DefaultSession["user"] & {
       id: string;
+      impersonator?: { email?: string | null };
     };
   }
 }

--- a/langwatch/src/server/license-enforcement/enforcement.middleware.ts
+++ b/langwatch/src/server/license-enforcement/enforcement.middleware.ts
@@ -87,6 +87,7 @@ export async function enforceLicenseLimit(
           current: error.current,
           max: error.max,
         },
+        session: ctx.session,
       });
       throw new TRPCError({
         code: "FORBIDDEN",

--- a/langwatch/src/server/posthog.ts
+++ b/langwatch/src/server/posthog.ts
@@ -22,20 +22,25 @@ export function getPostHogInstance(): PostHog | null {
 /**
  * Fire-and-forget server-side event tracking.
  * Silently no-ops when POSTHOG_KEY is not set (self-hosted without PostHog).
+ * Suppresses capture when the session indicates admin impersonation.
  */
 export function trackServerEvent({
   userId,
   event,
   properties,
   projectId,
+  session,
 }: {
   userId: string;
   event: string;
   properties?: Record<string, unknown>;
   projectId?: string;
+  session?: { user?: { impersonator?: { email?: string | null } } } | null;
 }) {
   const posthog = getPostHogInstance();
   if (!posthog) return;
+  if (session?.user?.impersonator) return;
+
   posthog.capture({
     distinctId: userId,
     event,


### PR DESCRIPTION
## Summary
- Re-implements impersonation analytics suppression from b6b955a31 (reverted in #2398)
- Fixes the race condition where `opt_in_capturing()` was called unconditionally on every render, triggering `sessionRecording.startIfEnabledOrStop()` before the session recording script loaded
- **Key fix:** `opt_in_capturing()` now only fires during the impersonation→normal transition (guarded by `wasImpersonatingRef`), never on every render

## Changes
- **Client:** `usePostHogIdentify` calls `opt_out_capturing()` during impersonation, `opt_in_capturing()` only on transition back (guarded by `posthog.__loaded`)
- **Server:** `trackServerEvent` accepts optional `session` param, skips capture when `session.user.impersonator` is present
- **Types:** Added `impersonator` to next-auth Session user type
- **Callers:** All 5 `trackServerEvent` call sites pass session context

## Test plan
- [x] 20 client-side tests passing (6 new impersonation cases)
- [x] 10 server-side tests passing (4 new impersonation cases)
- [ ] Manual verification: normal users see no change in PostHog tracking
- [ ] Manual verification: impersonated sessions produce no PostHog events

---

Closes #6564
