### PR TITLE
fix(scenarios): add missing Metadata column to ClickHouse dedup subquery

### DIFF
--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -110,7 +110,7 @@ const DEDUP_LIST_COLUMNS = `
 /** Inner subquery columns for full-detail queries */
 const DEDUP_RUN_COLUMNS = `
   TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, ScenarioId,
-  Status, Name, Description,
+  Status, Name, Description, Metadata,
   \`Messages.Id\`, \`Messages.Role\`, \`Messages.Content\`,
   \`Messages.TraceId\`, \`Messages.Rest\`,
   TraceIds, Verdict, Reasoning, MetCriteria, UnmetCriteria, Error,


### PR DESCRIPTION
## Summary
- Adds Metadata to DEDUP_RUN_COLUMNS inner subquery to match the outer RUN_COLUMNS SELECT
- Fixes Unknown expression identifier Metadata ClickHouse error on scenarios.getRunState

## Root cause
The outer SELECT (RUN_COLUMNS) references Metadata, but the inner dedup subquery (DEDUP_RUN_COLUMNS) did not include it — ClickHouse can only expose columns explicitly selected by the subquery.

## Test plan
- [ ] Verify scenarios.getRunState no longer throws on scenario runs with metadata