### PR TITLE
fix(workflow): model dropdown doesn't open inside studio drawer

### DIFF
--- a/langwatch/src/components/llmPromptConfigs/LLMConfigPopover.tsx
+++ b/langwatch/src/components/llmPromptConfigs/LLMConfigPopover.tsx
@@ -163,7 +163,7 @@ export function LLMConfigPopover({
   };
 
   return (
-    <Popover.Content minWidth="260px" maxWidth="100%" zIndex={1401}>
+    <Popover.Content minWidth="260px" maxWidth="100%">
       <VStack paddingY={2} paddingX={2} width="full" align="start" gap={3}>
         {/* Model Selector */}
         <Box width="full">

--- a/langwatch/src/components/llmPromptConfigs/LlmConfigField.tsx
+++ b/langwatch/src/components/llmPromptConfigs/LlmConfigField.tsx
@@ -1,5 +1,6 @@
-import { Box, HStack } from "@chakra-ui/react";
+import { Box, HStack, Popover as ChakraPopover } from "@chakra-ui/react";
 import { ChevronDown } from "lucide-react";
+import { useState } from "react";
 
 import {
   LLMConfigPopover,
@@ -42,6 +43,7 @@ export function LLMConfigField({
   onOutputsChange,
   showStructuredOutputs = false,
 }: LLMConfigFieldProps) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
   const { model } = llmConfig ?? {};
 
   // Check if the model is disabled (has line-through styling)
@@ -49,8 +51,16 @@ export function LLMConfigField({
 
   return (
     <>
-      <Popover.Root positioning={{ placement: "bottom-start" }} closeOnInteractOutside={false}>
-        <Popover.Trigger asChild>
+      <Popover.Root
+        positioning={{ placement: "bottom-start" }}
+        closeOnInteractOutside={false}
+        open={popoverOpen}
+        onOpenChange={({ open }) => setPopoverOpen(open)}
+      >
+        {/* Use Anchor (not Trigger) for positioning only — avoids Zag.js
+            installing an onClick handler that fights with the Drawer's
+            dismissable layer. See #2390. */}
+        <ChakraPopover.Anchor asChild>
           <HStack
             width="full"
             paddingY={2}
@@ -63,13 +73,14 @@ export function LLMConfigField({
             transition="background 0.15s"
             justify="space-between"
             opacity={modelOption?.isDisabled ? 0.5 : 1}
+            onClick={() => setPopoverOpen((prev) => !prev)}
           >
             <LLMModelDisplay model={model ?? ""} />
             <Box color="fg.muted">
               <ChevronDown size={16} />
             </Box>
           </HStack>
-        </Popover.Trigger>
+        </ChakraPopover.Anchor>
 
         <LLMConfigPopover
           values={llmConfig}

--- a/langwatch/src/components/ui/popover.tsx
+++ b/langwatch/src/components/ui/popover.tsx
@@ -15,7 +15,16 @@ export const PopoverContent = React.forwardRef<
   const { portalled = true, portalRef, positionerProps, ...rest } = props;
   return (
     <Portal disabled={!portalled} container={portalRef}>
-      <ChakraPopover.Positioner {...positionerProps}>
+      <ChakraPopover.Positioner
+        {...positionerProps}
+        ref={(node: HTMLElement | null) => {
+          if (node) {
+            // Zag.js sets --z-index inline based on layer stack order, which
+            // can place popovers behind drawers. Force it higher. See #2390.
+            node.style.setProperty("z-index", "2000", "important");
+          }
+        }}
+      >
         <ChakraPopover.Content
           borderRadius="lg"
           background="bg.panel/75"

--- a/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
+++ b/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
@@ -1,4 +1,4 @@
-import { Box, HStack } from "@chakra-ui/react";
+import { Box, HStack, Popover as ChakraPopover } from "@chakra-ui/react";
 import React, { useCallback, useState } from "react";
 import { ChevronDown } from "react-feather";
 import {
@@ -25,10 +25,13 @@ type ModelSelectFieldMiniProps = {
 /**
  * Model Select Field Mini
  *
- * Single Responsibility: Renders a compact LLM model selector field integrated with react-hook-form
+ * Renders a compact LLM model selector field integrated with react-hook-form
  * that displays the current model and opens a configuration popover on click.
  *
- * Can be used within a FormProvider context (uses react-hook-form Controller)
+ * Uses Popover.Anchor instead of Popover.Trigger to avoid Zag.js's internal
+ * onClick handler that conflicts with the Drawer's dismissable layer.
+ * The onClick toggle is handled manually via controlled state.
+ * See: https://github.com/langwatch/langwatch/issues/2390
  */
 export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
   showStructuredOutputs = true,
@@ -37,26 +40,22 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
   const { control, formState, trigger } =
     useFormContext<PromptConfigFormValues>();
 
-  // Outputs field array for structured outputs
   const outputsFieldArray = useFieldArray({
     control,
     name: "version.configData.outputs",
   });
 
-  // Watch outputs for the popover
   const watchedOutputs = useWatch({
     control,
     name: "version.configData.outputs",
   });
 
-  // Convert watched outputs to Output[] for LLMConfigPopover
   const outputs: Output[] = (watchedOutputs ?? []).map((output) => ({
     identifier: output.identifier,
     type: output.type as OutputType,
     json_schema: output.json_schema,
   }));
 
-  // Handle outputs change from LLMConfigPopover
   const handleOutputsChange = useCallback(
     (newOutputs: Output[]) => {
       outputsFieldArray.replace(
@@ -84,7 +83,7 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
             open={popoverOpen}
             onOpenChange={({ open }) => setPopoverOpen(open)}
           >
-            <Popover.Trigger asChild>
+            <ChakraPopover.Anchor asChild>
               <HStack
                 paddingY={2}
                 paddingX={3}
@@ -102,7 +101,7 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
                   <ChevronDown size={16} />
                 </Box>
               </HStack>
-            </Popover.Trigger>
+            </ChakraPopover.Anchor>
             <LLMConfigPopover
               values={field.value}
               onChange={(values) => {


### PR DESCRIPTION
## Summary

- Replaces `Popover.Trigger` with `Popover.Anchor` in `ModelSelectFieldMini` and `LlmConfigField` to avoid Zag.js onClick handler that conflicts with the Drawer dismissable layer
- Forces `z-index: 2000 !important` on all popover positioners via ref callback in `PopoverContent`, overriding Zag.js inline `--z-index: 1401` that rendered popovers behind drawers
- Removes the now-unnecessary `zIndex={1401}` from `LLMConfigPopover`

## Context

PR #2391 attempted to fix this by using controlled popover state with an explicit onClick toggle, but the fix was incomplete:
1. `Popover.Trigger` still installed Zag.js's internal click handler which raced with the manual toggle
2. The popover positioner's z-index (1401) was lower than the drawer, so even when the popover opened, it was hidden behind the drawer

## Test plan

- [ ] Open the workflow editor
- [ ] Click on a Signature (LLM) node to open its drawer
- [ ] Click the model selector dropdown in the prompt panel header
- [ ] Verify the model config popover opens and is visible above the drawer
- [ ] Verify clicking outside closes the popover
- [ ] Verify the popover also works in the "Default LLM" field in workflow properties

Fixes #2390

🤖 Generated with [Claude Code](https://claude.com/claude-code)