### PR TITLE
fix: include version.txt in skills publish sync

### DIFF
--- a/skills/_publish/sync.sh
+++ b/skills/_publish/sync.sh
@@ -27,4 +27,8 @@ for recipe in skills/recipes/*/SKILL.md; do
   echo "  ✓ recipes/$name"
 done
 
+# Version file
+cp "skills/version.txt" "$TARGET_DIR/version.txt"
+echo "  ✓ version.txt"
+
 echo "Done."


### PR DESCRIPTION
The sync script was missing version.txt — now copies it to langwatch/skills repo so the version is visible there too.