### PR TITLE
feat: release SDK radar behind PostHog feature flag

### DIFF
--- a/langwatch/src/components/SdkRadarBanner.tsx
+++ b/langwatch/src/components/SdkRadarBanner.tsx
@@ -9,11 +9,15 @@ import { api } from "~/utils/api";
 
 export function SdkRadarBanner() {
   const router = useRouter();
-  const { project } = useOrganizationTeamProject();
+  const { project, organization } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
   const { openDrawer } = useDrawer();
   const { isSnoozed } = useSdkRadarUpdateSnooze(project?.id);
   const { enabled: sdkRadarEnabled } = useFeatureFlag(
     "release_ui_sdk_radar_banner_card_enabled",
+    { organizationId: organization?.id },
   );
 
   const stats = api.sdkRadar.getVersionStats.useQuery(

--- a/langwatch/src/components/home/SdkRadarCard.tsx
+++ b/langwatch/src/components/home/SdkRadarCard.tsx
@@ -9,11 +9,15 @@ import { HomeCard } from "./HomeCard";
 import numeral from "numeral";
 
 export function SdkRadarCard() {
-  const { project } = useOrganizationTeamProject();
+  const { project, organization } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
   const { isSnoozed, snooze } = useSdkRadarUpdateSnooze(project?.id);
   const { openDrawer } = useDrawer();
   const { enabled: sdkRadarEnabled } = useFeatureFlag(
     "release_ui_sdk_radar_banner_card_enabled",
+    { organizationId: organization?.id },
   );
 
   const stats = api.sdkRadar.getVersionStats.useQuery(


### PR DESCRIPTION
## Summary
- Pass `organizationId` to the `useFeatureFlag` hook in both `SdkRadarCard` and `SdkRadarBanner`, enabling per-organization targeting via PostHog
- Disable onboarding redirects in `useOrganizationTeamProject` calls to prevent side effects from these components
- The feature is gated behind the existing `release_ui_sdk_radar_banner_card_enabled` PostHog flag

## Test plan
- [ ] Verify SDK radar card/banner only show when the PostHog flag is enabled for the organization
- [ ] Verify no onboarding redirects are triggered by the SDK radar components
- [ ] Verify the feature flag can be toggled per organization in PostHog