### PR TITLE
fix(sidebar): align Chat and Support labels with Settings

### DIFF
--- a/langwatch/src/components/sidebar/SupportMenu.tsx
+++ b/langwatch/src/components/sidebar/SupportMenu.tsx
@@ -31,6 +31,7 @@ export const SupportMenu = ({ showLabel = true }: SupportMenuProps) => {
         <Box
           as="button"
           width={showLabel ? "full" : "auto"}
+          textAlign="left"
           cursor="pointer"
           aria-label="Chat"
           onClick={(e) => {
@@ -65,6 +66,7 @@ export const SupportMenu = ({ showLabel = true }: SupportMenuProps) => {
           <Box
             as="button"
             width={showLabel ? "full" : "auto"}
+            textAlign="left"
             cursor="pointer"
             aria-label="Support"
             onMouseEnter={() => setIsOpen(true)}


### PR DESCRIPTION
## Summary
- Adds `textAlign="left"` to the Chat and Support button wrappers in the sidebar
- Native `<button>` elements default to `text-align: center`, causing misalignment with Settings (which uses an `<a>` tag)

## Test plan
- [ ] Verify Chat and Support labels are left-aligned, matching Settings
- [ ] Check compact sidebar mode still works correctly