### PR TITLE
fix(csp): use wildcard domains for Google services

### DIFF
--- a/langwatch/next.config.mjs
+++ b/langwatch/next.config.mjs
@@ -18,9 +18,9 @@ const isProduction =
 
 const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://www.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://ssl.google-analytics.com https://www.google.com https://*.reo.dev;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev;
     style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.pendo.io https://client.crisp.chat https://*.google.com https://*.reo.dev;
-    img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://www.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev;
+    img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://*.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev;
     font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://client.crisp.chat https://www.google.com https://*.reo.dev;
     object-src 'none';
     base-uri 'self';
@@ -28,8 +28,8 @@ const cspHeader = `
     frame-ancestors 'none';
     ${isProduction ? "upgrade-insecure-requests;" : ""}
     worker-src 'self' blob:;
-    connect-src 'self' https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://www.googletagmanager.com https://analytics.google.com https://ssl.google-analytics.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev;
-    frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://www.googletagmanager.com https://www.google.com https://*.reo.dev;
+    connect-src 'self' https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev;
+    frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://*.googletagmanager.com https://www.google.com https://*.reo.dev;
 
 `;
 


### PR DESCRIPTION
## Summary

- Replace `www.googletagmanager.com` with `*.googletagmanager.com` across all CSP directives (`script-src`, `img-src`, `connect-src`, `frame-src`) to cover all GTM subdomains
- Remove explicit `ssl.google-analytics.com` entries — already covered by the existing `*.google-analytics.com` wildcard

## Test plan

- [ ] Verify GTM scripts load without CSP violations in browser console
- [ ] Verify Google Analytics events fire correctly
- [ ] Check no new CSP violations appear in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)