### PR TITLE
fix: analytics dashboard shows application traces when filtered

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
@@ -102,10 +102,11 @@ describe("filter-translator", () => {
           expect(result.requiredJoins).toHaveLength(0);
         });
 
-        it("translates application origin as empty-or-null check", () => {
+        it("translates application origin as empty-or-null-or-literal check", () => {
           const result = translateFilter("traces.origin", ["application"]);
           expect(result.whereClause).toContain("ts.Attributes['langwatch.origin'] = ''");
           expect(result.whereClause).toContain("IS NULL");
+          expect(result.whereClause).toContain("= 'application'");
           expect(result.params).toEqual({});
         });
 

--- a/langwatch/src/server/analytics/clickhouse/filter-translator.ts
+++ b/langwatch/src/server/analytics/clickhouse/filter-translator.ts
@@ -272,7 +272,7 @@ function translateOriginFilter(values: string[]): FilterTranslation {
 
   if (hasApplication) {
     parts.push(
-      `(${ts}.Attributes['langwatch.origin'] = '' OR ${ts}.Attributes['langwatch.origin'] IS NULL)`,
+      `(${ts}.Attributes['langwatch.origin'] = '' OR ${ts}.Attributes['langwatch.origin'] IS NULL OR ${ts}.Attributes['langwatch.origin'] = 'application')`,
     );
   }
 


### PR DESCRIPTION
Closes #2425

## Summary

- Analytics dashboard do not show applications traces when it is selected in the filters.
