### PR TITLE
fix: grant cost visibility to API key-authenticated requests

### DIFF
--- a/langwatch/src/server/api/utils.ts
+++ b/langwatch/src/server/api/utils.ts
@@ -52,10 +52,13 @@ export async function getProtectionsForProject(
   prisma: PrismaClient,
   { projectId }: { projectId: string } & Record<string, unknown>,
 ): Promise<Protections> {
-  return await getUserProtectionsForProject(
+  const protections = await getUserProtectionsForProject(
     { prisma, session: null, publiclyShared: false },
     { projectId },
   );
+
+  // API key holders have full project access — all roles grant cost:view
+  return { ...protections, canSeeCosts: true };
 }
 
 // New function for internal operations that need full access


### PR DESCRIPTION
## Summary

- `getProtectionsForProject()` passed `session: null` to `getUserProtectionsForProject()`, causing `hasProjectPermission()` to always return `false` for `cost:view` on API-key-authenticated requests
- This stripped `total_cost` from trace metrics and `cost` from span metrics in `POST /api/traces/search` and `GET /api/trace/{id}` responses
- Fix: override `canSeeCosts: true` since API key holders have full project access and all roles (ADMIN, MEMBER, VIEWER) already grant `cost:view`

Introduced in addc78232 (PR #278) when the protections/redaction system was added with a sessionless API path.

## Test plan

- [x] Existing trace API unit tests pass (11/11)
- [ ] Verify `POST /api/traces/search` with `X-Auth-Token` returns `total_cost` in `metrics`
- [ ] Verify `GET /api/trace/{id}` with `X-Auth-Token` returns `total_cost` in `metrics`
- [ ] Verify span-level `cost` is also present in API responses