### PR TITLE
feat(nurturing): add nurturing service foundation

### DIFF
--- a/langwatch/ee/billing/nurturing/nurturing.service.ts
+++ b/langwatch/ee/billing/nurturing/nurturing.service.ts
@@ -1,0 +1,192 @@
+import { createLogger } from "../../../src/utils/logger/server";
+import { captureException } from "../../../src/utils/posthogErrorCapture";
+import type { AppConfig } from "../../../src/server/app-layer/config";
+import type {
+  CioBatchCall,
+  CioEventName,
+  CioOrgTraits,
+  CioPersonTraits,
+} from "./types";
+
+const logger = createLogger("ee:nurturing-service");
+
+const EXTERNAL_SERVICE_TIMEOUT_MS = 10_000;
+
+const REGIONAL_ENDPOINTS = {
+  us: "https://cdp.customer.io/v1",
+  eu: "https://cdp-eu.customer.io/v1",
+} as const;
+
+type Region = keyof typeof REGIONAL_ENDPOINTS;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export type NurturingServiceOptions = {
+  config: Pick<AppConfig, "customerIoApiKey" | "customerIoRegion">;
+  fetchFn?: typeof fetch;
+};
+
+// ---------------------------------------------------------------------------
+// NurturingService — Customer.io Pipelines API client
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps the Customer.io Pipelines API with fire-and-forget semantics.
+ *
+ * Follows the same private-constructor / create / createNull pattern
+ * as {@link NotificationService}.
+ */
+export class NurturingService {
+  private readonly apiKey: string | undefined;
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof fetch;
+  private readonly _enabled: boolean;
+
+  private constructor(options: NurturingServiceOptions & { enabled?: boolean }) {
+    this.apiKey = options.config.customerIoApiKey;
+    this._enabled = options.enabled ?? !!this.apiKey;
+    const region = options.config.customerIoRegion as Region | undefined;
+    this.baseUrl = region ? REGIONAL_ENDPOINTS[region] : REGIONAL_ENDPOINTS.eu;
+    this.fetchFn =
+      options.fetchFn ?? ((...args) => fetch(...args)) as typeof fetch;
+  }
+
+  /**
+   * Returns true when a real API key is configured.
+   * Use this to gate reactor registration and avoid unnecessary query costs
+   * in self-hosted deployments without Customer.io.
+   */
+  get isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  /**
+   * Factory method for creating an active NurturingService.
+   * If the API key is falsy, all methods behave as silent no-ops.
+   */
+  static create(options: NurturingServiceOptions): NurturingService {
+    return new NurturingService(options);
+  }
+
+  /**
+   * Null-object factory: every method is a silent no-op.
+   * Use in tests or self-hosted deployments where Customer.io is not configured.
+   */
+  static createNull(): NurturingService {
+    return new NurturingService({
+      config: { customerIoApiKey: undefined, customerIoRegion: "us" },
+      enabled: false,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /** Identify a user with person-level traits in Customer.io. */
+  async identifyUser({
+    userId,
+    traits,
+  }: {
+    userId: string;
+    traits: Partial<CioPersonTraits>;
+  }): Promise<void> {
+    await this.post("/identify", { userId, traits });
+  }
+
+  /** Track a named event for a user in Customer.io. */
+  async trackEvent({
+    userId,
+    event,
+    properties,
+  }: {
+    userId: string;
+    event: CioEventName;
+    properties?: Record<string, unknown>;
+  }): Promise<void> {
+    await this.post("/track", { userId, name: event, data: properties });
+  }
+
+  /** Associate a user with an organization (group) in Customer.io. */
+  async groupUser({
+    userId,
+    groupId,
+    traits,
+  }: {
+    userId: string;
+    groupId: string;
+    traits?: Partial<CioOrgTraits>;
+  }): Promise<void> {
+    await this.post("/group", { userId, groupId, traits });
+  }
+
+  /** Send multiple operations in a single batch request. */
+  async batch(calls: CioBatchCall[]): Promise<void> {
+    const batchItems = calls.map((call) => {
+      switch (call.type) {
+        case "identify":
+          return { type: "identify", userId: call.userId, traits: call.traits };
+        case "track":
+          return {
+            type: "track",
+            userId: call.userId,
+            name: call.event,
+            data: call.properties,
+          };
+        case "group":
+          return {
+            type: "group",
+            userId: call.userId,
+            groupId: call.groupId,
+            traits: call.traits,
+          };
+      }
+    });
+    await this.post("/batch", { batch: batchItems });
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal
+  // -------------------------------------------------------------------------
+
+  private async post(path: string, body: unknown): Promise<void> {
+    if (!this.apiKey) {
+      return;
+    }
+
+    const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      EXTERNAL_SERVICE_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await this.fetchFn(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization:
+            "Basic " + Buffer.from(`${this.apiKey}:`).toString("base64"),
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const error = new Error(
+          `Customer.io ${path} request failed: ${response.status}`,
+        );
+        logger.error({ error, path, status: response.status }, error.message);
+        captureException(error);
+      }
+    } catch (error) {
+      logger.error({ error, path }, `Failed to send Customer.io ${path} call`);
+      captureException(error);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/langwatch/ee/billing/nurturing/nurturing.service.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/nurturing.service.unit.test.ts
@@ -1,0 +1,326 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { NurturingService } from "./nurturing.service";
+import type { CioBatchCall } from "./types";
+
+// Suppress logger output and captureException in tests
+vi.mock("../../../src/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock("../../../src/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createMockFetch(
+  response: Partial<Response> = { ok: true, status: 200 },
+) {
+  return vi.fn().mockResolvedValue(response);
+}
+
+function createService({
+  apiKey = "test-api-key",
+  region = "us" as "us" | "eu",
+  fetchFn = createMockFetch(),
+} = {}) {
+  return {
+    service: NurturingService.create({
+      config: { customerIoApiKey: apiKey, customerIoRegion: region },
+      fetchFn,
+    }),
+    fetchFn,
+  };
+}
+
+describe("NurturingService", () => {
+  describe("identifyUser()", () => {
+    describe("when created with an API key and region 'us'", () => {
+      it("sends HTTP request to cdp.customer.io/v1/identify with Basic Auth", async () => {
+        const { service, fetchFn } = createService();
+
+        await service.identifyUser({ userId: "user-123", traits: { email: "test@example.com" } });
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        const [url, options] = fetchFn.mock.calls[0]!;
+        expect(url).toBe("https://cdp.customer.io/v1/identify");
+        expect(options.method).toBe("POST");
+
+        const authHeader = options.headers["Authorization"];
+        const expectedAuth =
+          "Basic " + Buffer.from("test-api-key:").toString("base64");
+        expect(authHeader).toBe(expectedAuth);
+      });
+
+      it("includes user ID and traits in the request body", async () => {
+        const { service, fetchFn } = createService();
+
+        await service.identifyUser({ userId: "user-123", traits: {
+          email: "test@example.com",
+          name: "Jane Doe",
+        }});
+
+        const body = JSON.parse(fetchFn.mock.calls[0]![1].body);
+        expect(body).toEqual({
+          userId: "user-123",
+          traits: { email: "test@example.com", name: "Jane Doe" },
+        });
+      });
+    });
+
+    describe("when created with region 'eu'", () => {
+      it("sends request to cdp-eu.customer.io/v1/identify", async () => {
+        const { service, fetchFn } = createService({ region: "eu" });
+
+        await service.identifyUser({ userId: "user-123", traits: { email: "test@example.com" } });
+
+        const [url] = fetchFn.mock.calls[0]!;
+        expect(url).toBe("https://cdp-eu.customer.io/v1/identify");
+      });
+    });
+  });
+
+  describe("trackEvent()", () => {
+    describe("when called with user ID, event name, and properties", () => {
+      it("sends event payload to the track endpoint", async () => {
+        const { service, fetchFn } = createService();
+
+        await service.trackEvent({ userId: "user-123", event: "signed_up", properties: {
+          role: "engineer",
+        }});
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        const [url, options] = fetchFn.mock.calls[0]!;
+        expect(url).toBe("https://cdp.customer.io/v1/track");
+        expect(options.method).toBe("POST");
+
+        const body = JSON.parse(options.body);
+        expect(body).toEqual({
+          userId: "user-123",
+          name: "signed_up",
+          data: { role: "engineer" },
+        });
+      });
+    });
+  });
+
+  describe("groupUser()", () => {
+    describe("when called with user ID, group ID, and org traits", () => {
+      it("sends org traits to the group endpoint", async () => {
+        const { service, fetchFn } = createService();
+
+        await service.groupUser({ userId: "user-123", groupId: "org-456", traits: {
+          name: "Acme Corp",
+          plan: "free",
+        }});
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        const [url, options] = fetchFn.mock.calls[0]!;
+        expect(url).toBe("https://cdp.customer.io/v1/group");
+        expect(options.method).toBe("POST");
+
+        const body = JSON.parse(options.body);
+        expect(body).toEqual({
+          userId: "user-123",
+          groupId: "org-456",
+          traits: { name: "Acme Corp", plan: "free" },
+        });
+      });
+    });
+  });
+
+  describe("batch()", () => {
+    describe("when called with multiple identify and track calls", () => {
+      it("sends a single HTTP request to the batch endpoint containing all calls", async () => {
+        const { service, fetchFn } = createService();
+
+        const calls: CioBatchCall[] = [
+          {
+            type: "identify",
+            userId: "user-1",
+            traits: { email: "a@b.com" },
+          },
+          {
+            type: "track",
+            userId: "user-1",
+            event: "signed_up",
+            properties: { role: "admin" },
+          },
+          {
+            type: "group",
+            userId: "user-1",
+            groupId: "org-1",
+            traits: { name: "Org" },
+          },
+        ];
+
+        await service.batch(calls);
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        const [url, options] = fetchFn.mock.calls[0]!;
+        expect(url).toBe("https://cdp.customer.io/v1/batch");
+        expect(options.method).toBe("POST");
+
+        const body = JSON.parse(options.body);
+        expect(body).toEqual({
+          batch: [
+            {
+              type: "identify",
+              userId: "user-1",
+              traits: { email: "a@b.com" },
+            },
+            {
+              type: "track",
+              userId: "user-1",
+              name: "signed_up",
+              data: { role: "admin" },
+            },
+            {
+              type: "group",
+              userId: "user-1",
+              groupId: "org-1",
+              traits: { name: "Org" },
+            },
+          ],
+        });
+      });
+    });
+  });
+
+  describe("when the Customer.io API does not respond within 10 seconds", () => {
+    it("aborts the request", async () => {
+      const { captureException } = await import(
+        "../../../src/utils/posthogErrorCapture"
+      );
+      const slowFetch = vi.fn().mockImplementation((_url, options) => {
+        return new Promise((_resolve, reject) => {
+          // Simulate the abort signal triggering
+          if (options?.signal) {
+            options.signal.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          }
+        });
+      });
+
+      const service = NurturingService.create({
+        config: { customerIoApiKey: "key", customerIoRegion: "us" },
+        fetchFn: slowFetch as unknown as typeof fetch,
+      });
+
+      // Use fake timers to trigger the timeout immediately
+      vi.useFakeTimers();
+      const promise = service.identifyUser({ userId: "user-1", traits: { email: "a@b.com" } });
+      vi.advanceTimersByTime(10_000);
+      await promise;
+      vi.useRealTimers();
+
+      expect(captureException).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the Customer.io API returns a 500 error", () => {
+    it("resolves without throwing", async () => {
+      const { service } = createService({
+        fetchFn: createMockFetch({ ok: false, status: 500 }),
+      });
+
+      await expect(
+        service.identifyUser({ userId: "user-123", traits: { email: "test@example.com" } }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("captures the error for observability", async () => {
+      const { captureException } = await import(
+        "../../../src/utils/posthogErrorCapture"
+      );
+      const { service } = createService({
+        fetchFn: createMockFetch({ ok: false, status: 500 }),
+      });
+
+      await service.identifyUser({ userId: "user-123", traits: { email: "test@example.com" } });
+
+      expect(captureException).toHaveBeenCalled();
+    });
+  });
+
+  describe("isEnabled", () => {
+    describe("when created with a valid API key", () => {
+      it("returns true", () => {
+        const { service } = createService({ apiKey: "test-key" });
+        expect(service.isEnabled).toBe(true);
+      });
+    });
+
+    describe("when created with a falsy API key", () => {
+      it("returns false", () => {
+        const fetchFn = createMockFetch();
+        const service = NurturingService.create({
+          config: { customerIoApiKey: undefined, customerIoRegion: "us" },
+          fetchFn,
+        });
+        expect(service.isEnabled).toBe(false);
+      });
+    });
+
+    describe("when created via createNull()", () => {
+      it("returns false", () => {
+        const service = NurturingService.createNull();
+        expect(service.isEnabled).toBe(false);
+      });
+    });
+  });
+
+  describe("when created via createNull()", () => {
+    it("resolves identifyUser without making HTTP requests", async () => {
+      const service = NurturingService.createNull();
+
+      // Does not throw, returns void
+      await expect(
+        service.identifyUser({ userId: "user-123", traits: { email: "test@example.com" } }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("resolves trackEvent without making HTTP requests", async () => {
+      const service = NurturingService.createNull();
+
+      await expect(
+        service.trackEvent({ userId: "user-123", event: "signed_up" }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("resolves groupUser without making HTTP requests", async () => {
+      const service = NurturingService.createNull();
+
+      await expect(
+        service.groupUser({ userId: "user-123", groupId: "org-1" }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("resolves batch without making HTTP requests", async () => {
+      const service = NurturingService.createNull();
+
+      await expect(service.batch([])).resolves.toBeUndefined();
+    });
+  });
+
+  describe("when created with a falsy API key", () => {
+    it("behaves as a no-op without making HTTP requests", async () => {
+      const fetchFn = createMockFetch();
+      const service = NurturingService.create({
+        config: { customerIoApiKey: undefined, customerIoRegion: "us" },
+        fetchFn,
+      });
+
+      await service.identifyUser({ userId: "user-123", traits: { email: "test@example.com" } });
+
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/ee/billing/nurturing/nurturing.service.wiring.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/nurturing.service.wiring.unit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { NurturingService } from "./nurturing.service";
+
+/**
+ * Wiring unit tests for NurturingService app construction patterns.
+ *
+ * These test the service construction patterns that presets.ts uses
+ * without importing the full App dependency graph (which requires
+ * generated Prisma/ES types). The actual wiring in presets.ts follows
+ * the same pattern tested here.
+ */
+
+// Suppress logger and captureException
+vi.mock("../../../src/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock("../../../src/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("NurturingService app wiring", () => {
+  describe("when the app config includes a customerIoApiKey", () => {
+    it("creates an active NurturingService instance", () => {
+      const service = NurturingService.create({
+        config: {
+          customerIoApiKey: "test-key",
+          customerIoRegion: "us",
+        },
+      });
+
+      expect(service).toBeInstanceOf(NurturingService);
+    });
+
+    it("makes HTTP requests when methods are called", async () => {
+      const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(null, { status: 200 }),
+      );
+      const service = NurturingService.create({
+        config: { customerIoApiKey: "test-key", customerIoRegion: "us" },
+        fetchFn,
+      });
+
+      await service.identifyUser({ userId: "user-1", traits: { email: "a@b.com" } });
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the app config has no customerIoApiKey", () => {
+    it("creates a null NurturingService that silently no-ops", async () => {
+      // This mirrors what presets.ts does: NurturingService.createNull()
+      const service = NurturingService.createNull();
+
+      expect(service).toBeInstanceOf(NurturingService);
+      await expect(
+        service.identifyUser({ userId: "u1", traits: { email: "a@b.com" } }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("creates a no-op service when apiKey is falsy via create()", async () => {
+      const fetchFn = vi.fn<typeof fetch>();
+      // This mirrors what presets.ts does when config.customerIoApiKey is undefined
+      const service = NurturingService.create({
+        config: { customerIoApiKey: undefined, customerIoRegion: "us" },
+        fetchFn,
+      });
+
+      await service.identifyUser({ userId: "u1", traits: { email: "a@b.com" } });
+
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the app config has no customerIoRegion", () => {
+    it("defaults to the EU regional endpoint", async () => {
+      const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(null, { status: 200 }),
+      );
+      const service = NurturingService.create({
+        config: { customerIoApiKey: "key", customerIoRegion: undefined },
+        fetchFn,
+      });
+
+      await service.identifyUser({ userId: "user-1", traits: { email: "a@b.com" } });
+
+      const [url] = fetchFn.mock.calls[0]!;
+      expect(url).toContain("cdp-eu.customer.io");
+    });
+  });
+
+  describe("when createTestApp is called", () => {
+    it("NurturingService.createNull() produces a no-op instance", async () => {
+      // createTestApp() uses NurturingService.createNull()
+      const service = NurturingService.createNull();
+
+      expect(service).toBeInstanceOf(NurturingService);
+      await expect(
+        service.identifyUser({ userId: "u1", traits: {} }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("when region is set to 'eu'", () => {
+    it("routes requests to the EU endpoint", async () => {
+      const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(null, { status: 200 }),
+      );
+      const service = NurturingService.create({
+        config: { customerIoApiKey: "key", customerIoRegion: "eu" },
+        fetchFn,
+      });
+
+      await service.identifyUser({ userId: "user-1", traits: { email: "a@b.com" } });
+
+      const [url] = fetchFn.mock.calls[0]!;
+      expect(url).toContain("cdp-eu.customer.io");
+    });
+  });
+});

--- a/langwatch/ee/billing/nurturing/types.ts
+++ b/langwatch/ee/billing/nurturing/types.ts
@@ -1,0 +1,113 @@
+/**
+ * Customer.io trait schema contract.
+ *
+ * Defines the complete data model pushed to Customer.io by reactors and hooks.
+ * All call sites use these typed parameters instead of ad-hoc Record<string, unknown>.
+ */
+
+// ---------------------------------------------------------------------------
+// Person traits (via /identify)
+// ---------------------------------------------------------------------------
+
+export interface CioPersonTraits {
+  // Onboarding
+  email: string;
+  name: string;
+  role: string;
+  company_size: string;
+  signup_usage: string;
+  signup_solution: string;
+  signup_feature_usage: string;
+  utm_campaign: string;
+  how_heard: string;
+  createdAt: string;
+  product_interest: string;
+
+  // Trace milestones (customerIoTraceSync reactor)
+  has_traces: boolean;
+  sdk_language: string;
+  sdk_framework: string;
+  first_trace_at: string;
+  trace_count: number;
+  daily_trace_count: number;
+  last_trace_at: string;
+  trace_count_updated_at: string;
+
+  // Evaluation milestones (customerIoEvaluationSync reactor)
+  has_evaluations: boolean;
+  evaluation_count: number;
+  first_evaluation_at: string;
+  last_evaluation_at: string;
+
+  // Prompt milestones (prompt creation hook)
+  has_prompts: boolean;
+  prompt_count: number;
+
+  // Simulation milestones (customerIoSimulationSync reactor)
+  has_simulations: boolean;
+  simulation_count: number;
+  first_simulation_at: string;
+  last_simulation_at: string;
+
+  // Feature adoption
+  team_member_count: number;
+  workflow_count: number;
+  scenario_count: number;
+
+  // Activity tracking
+  last_active_at: string;
+
+  // Billing
+  plan: string;
+}
+
+// ---------------------------------------------------------------------------
+// Organization traits (via /group)
+// ---------------------------------------------------------------------------
+
+export interface CioOrgTraits {
+  name: string;
+  plan: string;
+  company_size: string;
+  member_count: number;
+  project_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Event names (via /track)
+// ---------------------------------------------------------------------------
+
+export type CioEventName =
+  | "signed_up"
+  | "first_trace_integrated"
+  | "first_evaluation_created"
+  | "evaluation_ran"
+  | "scenario_created"
+  | "team_member_invited"
+  | "workflow_created"
+  | "experiment_ran"
+  | "first_prompt_created"
+  | "first_simulation_ran";
+
+// ---------------------------------------------------------------------------
+// Batch call discriminated union
+// ---------------------------------------------------------------------------
+
+export type CioBatchCall =
+  | {
+      type: "identify";
+      userId: string;
+      traits: Partial<CioPersonTraits>;
+    }
+  | {
+      type: "track";
+      userId: string;
+      event: CioEventName;
+      properties?: Record<string, unknown>;
+    }
+  | {
+      type: "group";
+      userId: string;
+      groupId: string;
+      traits?: Partial<CioOrgTraits>;
+    };

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -125,6 +125,10 @@ export function createEnvConfig() {
       HUBSPOT_REACHED_LIMIT_FORM_ID: z.string().optional(),
       HUBSPOT_FORM_ID: z.string().optional(),
 
+      // Customer.io Nurturing
+      CUSTOMER_IO_API_KEY: z.string().optional(),
+      CUSTOMER_IO_REGION: z.enum(["us", "eu"]).optional(),
+
       // Notifications
       SLACK_PLAN_LIMIT_CHANNEL: z.string().optional(),
       SLACK_CHANNEL_SIGNUPS: z.string().optional(),
@@ -239,6 +243,8 @@ export function createEnvConfig() {
       HUBSPOT_PORTAL_ID: process.env.HUBSPOT_PORTAL_ID,
       HUBSPOT_REACHED_LIMIT_FORM_ID: process.env.HUBSPOT_REACHED_LIMIT_FORM_ID,
       HUBSPOT_FORM_ID: process.env.HUBSPOT_FORM_ID,
+      CUSTOMER_IO_API_KEY: process.env.CUSTOMER_IO_API_KEY,
+      CUSTOMER_IO_REGION: process.env.CUSTOMER_IO_REGION,
       SLACK_PLAN_LIMIT_CHANNEL: process.env.SLACK_PLAN_LIMIT_CHANNEL,
       SLACK_CHANNEL_SIGNUPS: process.env.SLACK_CHANNEL_SIGNUPS,
       SLACK_CHANNEL_SUBSCRIPTIONS: process.env.SLACK_CHANNEL_SUBSCRIPTIONS,

--- a/langwatch/src/server/app-layer/app.ts
+++ b/langwatch/src/server/app-layer/app.ts
@@ -24,6 +24,7 @@ export class App {
   readonly planProvider: AppDependencies["planProvider"];
   readonly subscription?: AppDependencies["subscription"];
   readonly notifications: AppDependencies["notifications"];
+  readonly nurturing: AppDependencies["nurturing"];
   readonly usageLimits: AppDependencies["usageLimits"];
 
   /** Keeps EventSourcing infrastructure safe from the greedy garbage men */
@@ -42,6 +43,7 @@ export class App {
     this.planProvider = deps.planProvider;
     this.subscription = deps.subscription;
     this.notifications = deps.notifications;
+    this.nurturing = deps.nurturing;
     this.usageLimits = deps.usageLimits;
     this.broadcast = deps.broadcast;
     this.traces = { ...deps.traces, ...deps.commands.traces };

--- a/langwatch/src/server/app-layer/config.ts
+++ b/langwatch/src/server/app-layer/config.ts
@@ -32,6 +32,10 @@ export interface AppConfig {
   // undefined: backward-compatible "all" mode
   processRole?: ProcessRole;
 
+  // Customer.io nurturing
+  customerIoApiKey?: string;
+  customerIoRegion?: "us" | "eu";
+
   // SaaS mode
   isSaas?: boolean;
 
@@ -63,6 +67,8 @@ export function createAppConfigFromEnv(overrides?: {
     hubspotPortalId: env.HUBSPOT_PORTAL_ID,
     hubspotReachedLimitFormId: env.HUBSPOT_REACHED_LIMIT_FORM_ID,
     hubspotFormId: env.HUBSPOT_FORM_ID,
+    customerIoApiKey: env.CUSTOMER_IO_API_KEY,
+    customerIoRegion: env.CUSTOMER_IO_REGION,
     enableEventSourcing: env.ENABLE_EVENT_SOURCING,
     processRole: overrides?.processRole,
     isSaas: env.IS_SAAS,

--- a/langwatch/src/server/app-layer/dependencies.ts
+++ b/langwatch/src/server/app-layer/dependencies.ts
@@ -20,6 +20,7 @@ import type { TraceSummaryService } from "./traces/trace-summary.service";
 import type { PlanProvider } from "./subscription/plan-provider";
 import type { SubscriptionService } from "./subscription/subscription.service";
 import type { NotificationService } from "../../../ee/billing/notifications/notification.service";
+import type { NurturingService } from "../../../ee/billing/nurturing/nurturing.service";
 import type { UsageLimitService } from "../../../ee/billing/notifications/usage-limit.service";
 import type { UsageService } from "./usage/usage.service";
 
@@ -57,6 +58,7 @@ export interface AppDependencies {
   planProvider: PlanProvider;
   subscription?: SubscriptionService;
   notifications: NotificationService;
+  nurturing: NurturingService;
   usageLimits: UsageLimitService;
   commands: AppCommands;
 

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -64,6 +64,7 @@ import { OrganizationRepository } from "../repositories/organization.repository"
 import { StripeUsageReportingService } from "../../../ee/billing/services/usageReportingService";
 import { meters } from "../../../ee/billing/stripe/stripePriceCatalog";
 import { NotificationService } from "../../../ee/billing/notifications/notification.service";
+import { NurturingService } from "../../../ee/billing/nurturing/nurturing.service";
 import { NotificationRepository } from "../../../ee/billing/notifications/repositories/notification.repository";
 import { UsageLimitService } from "../../../ee/billing/notifications/usage-limit.service";
 import { traced } from "./tracing";
@@ -225,6 +226,15 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     config.disableTokenization ? new NullTokenizerClient() : new TiktokenClient(),
   );
 
+  const nurturing = config.customerIoApiKey
+    ? NurturingService.create({
+        config: {
+          customerIoApiKey: config.customerIoApiKey,
+          customerIoRegion: config.customerIoRegion,
+        },
+      })
+    : NurturingService.createNull();
+
   const es = new EventSourcing({
     clickhouse: clickhouse ?? void 0,
     redis,
@@ -244,6 +254,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     evaluations: { runs: evaluations.runs, execution: evaluations.execution },
     esSync: { esClient, traceIndex: TRACE_INDEX, traceIndexId, prisma },
     usageReportingService,
+    nurturing,
   });
   const commands = registry.registerAll();
 
@@ -350,6 +361,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     planProvider,
     subscription,
     notifications,
+    nurturing,
     usageLimits,
     commands,
     _eventSourcing: es,
@@ -427,6 +439,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
     }),
     subscription: undefined,
     notifications: NotificationService.createNull(),
+    nurturing: NurturingService.createNull(),
     usageLimits: UsageLimitService.createNull(),
     commands: {
       traces: { recordSpan: noop, assignTopic: noop, recordLog: noop, recordMetric: noop, resolveOrigin: noop } satisfies AppCommands["traces"],

--- a/langwatch/src/server/app-layer/projects/project.service.ts
+++ b/langwatch/src/server/app-layer/projects/project.service.ts
@@ -1,11 +1,27 @@
 import type { Project } from "@prisma/client";
+import { createLogger } from "~/utils/logger/server";
+import { captureException } from "~/utils/posthogErrorCapture";
 import type {
   ProjectRepository,
   ProjectWithTeam,
 } from "./repositories/project.repository";
 
+const logger = createLogger("langwatch:project-service");
+
 /** All boolean fields on Project whose name starts with "feature". */
 export type ProjectFeatureFlag = Extract<keyof Project, `feature${string}`>;
+
+export interface OrgAdminResolution {
+  userId: string | null;
+  organizationId: string | null;
+  firstMessage: boolean;
+}
+
+const NULL_RESOLUTION: OrgAdminResolution = {
+  userId: null,
+  organizationId: null,
+  firstMessage: false,
+};
 
 export class ProjectService {
   constructor(readonly repo: ProjectRepository) {}
@@ -31,5 +47,32 @@ export class ProjectService {
   ): Promise<boolean> {
     const project = await this.repo.getById(projectId);
     return project ? Boolean(project[flag]) : false;
+  }
+
+  /**
+   * Resolves the org admin userId from a projectId by traversing
+   * Project -> Team -> Organization -> OrganizationUser (ADMIN).
+   *
+   * Returns nulls and defaults when the project or admin is not found,
+   * or when the database lookup fails (non-fatal).
+   */
+  async resolveOrgAdmin(projectId: string): Promise<OrgAdminResolution> {
+    try {
+      const result = await this.repo.getWithOrgAdmin(projectId);
+      if (!result) return NULL_RESOLUTION;
+
+      return {
+        userId: result.adminUserId,
+        organizationId: result.organizationId,
+        firstMessage: result.firstMessage,
+      };
+    } catch (error) {
+      logger.error(
+        { projectId, error },
+        "Failed to resolve org admin — returning null resolution",
+      );
+      captureException(error);
+      return NULL_RESOLUTION;
+    }
   }
 }

--- a/langwatch/src/server/app-layer/projects/repositories/project.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/projects/repositories/project.prisma.repository.ts
@@ -1,5 +1,9 @@
 import type { PrismaClient, Project } from "@prisma/client";
-import type { ProjectRepository, ProjectWithTeam } from "./project.repository";
+import type {
+  ProjectRepository,
+  ProjectWithOrgAdmin,
+  ProjectWithTeam,
+} from "./project.repository";
 
 export class PrismaProjectRepository implements ProjectRepository {
   constructor(private readonly prisma: PrismaClient) {}
@@ -15,10 +19,36 @@ export class PrismaProjectRepository implements ProjectRepository {
     });
   }
 
-  async updateMetadata(
-    id: string,
-    data: { firstMessage: boolean; integrated: boolean; language: string },
-  ): Promise<void> {
-    await this.prisma.project.update({ where: { id }, data });
+  async getWithOrgAdmin(id: string): Promise<ProjectWithOrgAdmin | null> {
+    const project = await this.prisma.project.findUnique({
+      where: { id },
+      select: {
+        firstMessage: true,
+        team: {
+          select: {
+            organization: {
+              select: {
+                id: true,
+                members: {
+                  where: { role: "ADMIN" },
+                  select: { userId: true },
+                  orderBy: { createdAt: "asc" },
+                  take: 1,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!project) return null;
+
+    const org = project.team?.organization;
+    return {
+      firstMessage: project.firstMessage,
+      organizationId: org?.id ?? null,
+      adminUserId: org?.members?.[0]?.userId ?? null,
+    };
   }
 }

--- a/langwatch/src/server/app-layer/projects/repositories/project.repository.ts
+++ b/langwatch/src/server/app-layer/projects/repositories/project.repository.ts
@@ -2,13 +2,16 @@ import type { Project, Team } from "@prisma/client";
 
 export type ProjectWithTeam = Project & { team: Team };
 
+export interface ProjectWithOrgAdmin {
+  firstMessage: boolean;
+  organizationId: string | null;
+  adminUserId: string | null;
+}
+
 export interface ProjectRepository {
   getById(id: string): Promise<Project | null>;
   getWithTeam(id: string): Promise<ProjectWithTeam | null>;
-  updateMetadata(
-    id: string,
-    data: { firstMessage: boolean; integrated: boolean; language: string },
-  ): Promise<void>;
+  getWithOrgAdmin(id: string): Promise<ProjectWithOrgAdmin | null>;
 }
 
 export class NullProjectRepository implements ProjectRepository {
@@ -20,10 +23,7 @@ export class NullProjectRepository implements ProjectRepository {
     return null;
   }
 
-  async updateMetadata(
-    _id: string,
-    _data: { firstMessage: boolean; integrated: boolean; language: string },
-  ): Promise<void> {
-    // no-op
+  async getWithOrgAdmin(_id: string): Promise<ProjectWithOrgAdmin | null> {
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

- Adds `NurturingService` (`ee/billing/nurturing/`) wrapping the Customer.io Pipelines API
- Follows the `NotificationService` pattern: private constructor, `static create()`/`createNull()`, wired through App
- Typed trait schema: `CioPersonTraits`, `CioOrgTraits`, `CioEventName`
- `isEnabled` gate — zero overhead when no API key configured
- Fire-and-forget with `captureException`, 10s timeout, regional endpoints (US/EU)
- `resolveOrgAdmin` on `ProjectService` for reactor userId resolution

Closes #2427

## Test plan

- [x] 24 unit tests passing (service + wiring)
- [ ] Verify self-hosted (no API key) has zero impact