### PR TITLE
feat(nurturing): signup, adoption, and activity hooks (R2 + R6 + R7)

### DIFF
--- a/langwatch/ee/billing/nurturing/hooks/activityTracking.ts
+++ b/langwatch/ee/billing/nurturing/hooks/activityTracking.ts
@@ -1,0 +1,80 @@
+import { getApp } from "../../../../src/server/app-layer/app";
+import { captureException } from "../../../../src/utils/posthogErrorCapture";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * In-memory cache of the last time each user was identified for activity tracking.
+ * Keyed by userId, value is the timestamp of the last identify call.
+ *
+ * NOTE: debounce is process-local. In multi-instance deployments, each instance
+ * tracks independently. This is acceptable — Customer.io's 3000 req/3s limit
+ * is unlikely to be hit, and duplicate identify calls are idempotent.
+ */
+const lastActivitySentAt = new Map<string, number>();
+
+/**
+ * Timestamp of the last sweep pass. Sweeps run at most once per hour
+ * to avoid O(n) iteration overhead on every call.
+ */
+let lastSweepAt = 0;
+
+/**
+ * Evicts entries older than ONE_HOUR_MS from the debounce cache.
+ * Only runs at most once per hour to keep per-call cost constant.
+ */
+function sweepExpiredEntries(now: number): void {
+  if (now - lastSweepAt < ONE_HOUR_MS) return;
+  for (const [cachedUserId, sentAt] of lastActivitySentAt) {
+    if (now - sentAt >= ONE_HOUR_MS) {
+      lastActivitySentAt.delete(cachedUserId);
+    }
+  }
+  lastSweepAt = now;
+}
+
+/**
+ * Pushes last_active_at to Customer.io for inactivity detection.
+ *
+ * Debounced to at most once per hour per user to avoid excessive API calls.
+ * Fire-and-forget: never throws, never blocks the session callback.
+ */
+export function fireActivityTrackingNurturing({
+  userId,
+}: {
+  userId: string;
+}): void {
+  const now = Date.now();
+  sweepExpiredEntries(now);
+  const lastSent = lastActivitySentAt.get(userId);
+
+  if (lastSent && now - lastSent < ONE_HOUR_MS) {
+    return;
+  }
+
+  lastActivitySentAt.set(userId, now);
+
+  void getApp()
+    .nurturing.identifyUser({
+      userId,
+      traits: { last_active_at: new Date(now).toISOString() },
+    })
+    .catch(captureException);
+}
+
+/**
+ * Resets the debounce cache. Only exposed for testing.
+ * @internal
+ */
+export function resetActivityTrackingCache(): void {
+  lastActivitySentAt.clear();
+  lastSweepAt = 0;
+}
+
+/**
+ * Returns a snapshot of the cache for testing.
+ * @internal
+ */
+export function getActivityTrackingCacheSize(): number {
+  return lastActivitySentAt.size;
+}

--- a/langwatch/ee/billing/nurturing/hooks/activityTracking.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/activityTracking.unit.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fireActivityTrackingNurturing,
+  resetActivityTrackingCache,
+  getActivityTrackingCacheSize,
+} from "./activityTracking";
+
+// Suppress logger output
+vi.mock("../../../../src/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock("../../../../src/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockNurturing = {
+  identifyUser: vi.fn().mockResolvedValue(undefined),
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+  groupUser: vi.fn().mockResolvedValue(undefined),
+  batch: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("../../../../src/server/app-layer/app", () => ({
+  getApp: () => ({
+    nurturing: mockNurturing,
+  }),
+}));
+
+describe("Activity tracking hook", () => {
+  describe("given an active NurturingService", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetActivityTrackingCache();
+      vi.useRealTimers();
+    });
+
+    describe("when the auth session callback fires", () => {
+      it("identifies user with last_active_at set to the current time", () => {
+        const now = new Date("2026-03-15T12:00:00.000Z");
+        vi.setSystemTime(now);
+
+        fireActivityTrackingNurturing({ userId: "user-1" });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: { last_active_at: "2026-03-15T12:00:00.000Z" },
+        });
+
+        vi.useRealTimers();
+      });
+    });
+
+    describe("when a user refreshes their session multiple times within one hour", () => {
+      it("makes at most one Customer.io identify call per hour", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        fireActivityTrackingNurturing({ userId: "user-1" });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(1);
+
+        vi.useRealTimers();
+      });
+
+      it("allows a new call after one hour has passed", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(1);
+
+        // Advance past the 1-hour debounce window
+        vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(2);
+
+        vi.useRealTimers();
+      });
+
+      it("tracks separate users independently", () => {
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        fireActivityTrackingNurturing({ userId: "user-2" });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("when expired entries accumulate in the debounce cache", () => {
+      it("evicts entries older than one hour during the next call", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+        // Populate cache with multiple users
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        fireActivityTrackingNurturing({ userId: "user-2" });
+        fireActivityTrackingNurturing({ userId: "user-3" });
+        expect(getActivityTrackingCacheSize()).toBe(3);
+
+        // Advance past the 1-hour window so entries are expired
+        vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+        // Next call triggers sweep and evicts expired entries
+        fireActivityTrackingNurturing({ userId: "user-4" });
+
+        // Only user-4 remains (user-1..3 were evicted by sweep)
+        expect(getActivityTrackingCacheSize()).toBe(1);
+
+        vi.useRealTimers();
+      });
+
+      it("does not sweep more than once per hour", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+        // First call triggers sweep (lastSweepAt is 0)
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        expect(getActivityTrackingCacheSize()).toBe(1);
+
+        // Advance 30 minutes — not enough for another sweep
+        vi.advanceTimersByTime(30 * 60 * 1000);
+        fireActivityTrackingNurturing({ userId: "user-2" });
+        expect(getActivityTrackingCacheSize()).toBe(2);
+
+        // Advance another 31 minutes (total 61 min from start)
+        // user-1 is now expired but sweep hasn't run since 30min mark
+        vi.advanceTimersByTime(31 * 60 * 1000);
+        fireActivityTrackingNurturing({ userId: "user-3" });
+
+        // Sweep should have run: user-1 expired (61 min old), user-2 still valid (31 min old)
+        // user-3 just added. So cache = user-2 + user-3 = 2
+        expect(getActivityTrackingCacheSize()).toBe(2);
+
+        vi.useRealTimers();
+      });
+    });
+
+    describe("when Customer.io API is unavailable", () => {
+      it("does not throw (fire-and-forget)", async () => {
+        const { captureException } = await import(
+          "../../../../src/utils/posthogErrorCapture"
+        );
+        mockNurturing.identifyUser.mockRejectedValueOnce(
+          new Error("CIO unavailable"),
+        );
+
+        expect(() =>
+          fireActivityTrackingNurturing({ userId: "user-1" }),
+        ).not.toThrow();
+
+        await vi.waitFor(() => {
+          expect(captureException).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/langwatch/ee/billing/nurturing/hooks/featureAdoption.ts
+++ b/langwatch/ee/billing/nurturing/hooks/featureAdoption.ts
@@ -1,0 +1,116 @@
+import { getApp } from "../../../../src/server/app-layer/app";
+import { captureException } from "../../../../src/utils/posthogErrorCapture";
+
+/**
+ * Fires nurturing calls when a team member is invited.
+ *
+ * Updates the user's team_member_count trait and tracks the event.
+ * All calls are fire-and-forget.
+ */
+export function fireTeamMemberInvitedNurturing({
+  userId,
+  teamMemberCount,
+  role,
+}: {
+  userId: string;
+  teamMemberCount: number;
+  role: string;
+}): void {
+  const nurturing = getApp().nurturing;
+
+  void nurturing
+    .identifyUser({ userId, traits: { team_member_count: teamMemberCount } })
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({ userId, event: "team_member_invited", properties: {
+      role,
+    }})
+    .catch(captureException);
+}
+
+/**
+ * Fires nurturing calls when a workflow is created.
+ *
+ * Updates the user's workflow_count trait and tracks the event.
+ * All calls are fire-and-forget.
+ */
+export function fireWorkflowCreatedNurturing({
+  userId,
+  workflowCount,
+  workflowId,
+  projectId,
+}: {
+  userId: string;
+  workflowCount: number;
+  workflowId: string;
+  projectId: string;
+}): void {
+  const nurturing = getApp().nurturing;
+
+  void nurturing
+    .identifyUser({ userId, traits: { workflow_count: workflowCount } })
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({ userId, event: "workflow_created", properties: {
+      workflow_id: workflowId,
+      project_id: projectId,
+    }})
+    .catch(captureException);
+}
+
+/**
+ * Fires nurturing calls when a scenario is created.
+ *
+ * Updates the user's scenario_count trait and tracks the event.
+ * All calls are fire-and-forget.
+ */
+export function fireScenarioCreatedNurturing({
+  userId,
+  scenarioCount,
+  scenarioId,
+  projectId,
+}: {
+  userId: string;
+  scenarioCount: number;
+  scenarioId: string;
+  projectId: string;
+}): void {
+  const nurturing = getApp().nurturing;
+
+  void nurturing
+    .identifyUser({ userId, traits: { scenario_count: scenarioCount } })
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({ userId, event: "scenario_created", properties: {
+      scenario_id: scenarioId,
+      project_id: projectId,
+    }})
+    .catch(captureException);
+}
+
+/**
+ * Fires nurturing event when an experiment is run.
+ *
+ * Fire-and-forget.
+ */
+export function fireExperimentRanNurturing({
+  userId,
+  experimentId,
+  projectId,
+}: {
+  userId: string;
+  experimentId?: string;
+  projectId: string;
+}): void {
+  const nurturing = getApp().nurturing;
+
+  void nurturing
+    .trackEvent({ userId, event: "experiment_ran", properties: {
+      experiment_id: experimentId,
+      project_id: projectId,
+    }})
+    .catch(captureException);
+}

--- a/langwatch/ee/billing/nurturing/hooks/featureAdoption.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/featureAdoption.unit.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fireTeamMemberInvitedNurturing,
+  fireWorkflowCreatedNurturing,
+  fireScenarioCreatedNurturing,
+  fireExperimentRanNurturing,
+} from "./featureAdoption";
+
+// Suppress logger output
+vi.mock("../../../../src/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock("../../../../src/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockNurturing = {
+  identifyUser: vi.fn().mockResolvedValue(undefined),
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+  groupUser: vi.fn().mockResolvedValue(undefined),
+  batch: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("../../../../src/server/app-layer/app", () => ({
+  getApp: () => ({
+    nurturing: mockNurturing,
+  }),
+}));
+
+describe("Feature adoption hooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("fireTeamMemberInvitedNurturing()", () => {
+    describe("when an invite is sent", () => {
+      it("identifies user with updated team_member_count", () => {
+        fireTeamMemberInvitedNurturing({
+          userId: "user-1",
+          teamMemberCount: 5,
+          role: "member",
+        });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: { team_member_count: 5 },
+        });
+      });
+
+      it("tracks team_member_invited event with role", () => {
+        fireTeamMemberInvitedNurturing({
+          userId: "user-1",
+          teamMemberCount: 5,
+          role: "member",
+        });
+
+        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "team_member_invited",
+          properties: { role: "member" },
+        });
+      });
+    });
+
+    describe("when Customer.io API is unavailable", () => {
+      it("does not throw (fire-and-forget)", async () => {
+        const { captureException } = await import(
+          "../../../../src/utils/posthogErrorCapture"
+        );
+        mockNurturing.identifyUser.mockRejectedValueOnce(
+          new Error("CIO unavailable"),
+        );
+
+        expect(() =>
+          fireTeamMemberInvitedNurturing({
+            userId: "user-1",
+            teamMemberCount: 5,
+            role: "member",
+          }),
+        ).not.toThrow();
+
+        await vi.waitFor(() => {
+          expect(captureException).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("fireWorkflowCreatedNurturing()", () => {
+    describe("when the workflow is saved", () => {
+      it("identifies user with updated workflow_count", () => {
+        fireWorkflowCreatedNurturing({
+          userId: "user-1",
+          workflowCount: 3,
+          workflowId: "wf-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: { workflow_count: 3 },
+        });
+      });
+
+      it("tracks workflow_created event with workflow_id and project_id", () => {
+        fireWorkflowCreatedNurturing({
+          userId: "user-1",
+          workflowCount: 3,
+          workflowId: "wf-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "workflow_created",
+          properties: { workflow_id: "wf-1", project_id: "proj-1" },
+        });
+      });
+    });
+
+    describe("when Customer.io API is unavailable", () => {
+      it("does not throw (fire-and-forget)", async () => {
+        const { captureException } = await import(
+          "../../../../src/utils/posthogErrorCapture"
+        );
+        mockNurturing.identifyUser.mockRejectedValueOnce(
+          new Error("CIO unavailable"),
+        );
+
+        expect(() =>
+          fireWorkflowCreatedNurturing({
+            userId: "user-1",
+            workflowCount: 3,
+            workflowId: "wf-1",
+            projectId: "proj-1",
+          }),
+        ).not.toThrow();
+
+        await vi.waitFor(() => {
+          expect(captureException).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("fireScenarioCreatedNurturing()", () => {
+    describe("when the scenario is saved", () => {
+      it("identifies user with updated scenario_count", () => {
+        fireScenarioCreatedNurturing({
+          userId: "user-1",
+          scenarioCount: 7,
+          scenarioId: "sc-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: { scenario_count: 7 },
+        });
+      });
+
+      it("tracks scenario_created event with scenario_id and project_id", () => {
+        fireScenarioCreatedNurturing({
+          userId: "user-1",
+          scenarioCount: 7,
+          scenarioId: "sc-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "scenario_created",
+          properties: { scenario_id: "sc-1", project_id: "proj-1" },
+        });
+      });
+    });
+  });
+
+  describe("fireExperimentRanNurturing()", () => {
+    describe("when the experiment completes", () => {
+      it("tracks experiment_ran event with experiment_id and project_id", () => {
+        fireExperimentRanNurturing({
+          userId: "user-1",
+          experimentId: "exp-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "experiment_ran",
+          properties: { experiment_id: "exp-1", project_id: "proj-1" },
+        });
+      });
+
+      it("does not call identifyUser (no count trait for experiments)", () => {
+        fireExperimentRanNurturing({
+          userId: "user-1",
+          experimentId: "exp-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.identifyUser).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/ee/billing/nurturing/hooks/index.ts
+++ b/langwatch/ee/billing/nurturing/hooks/index.ts
@@ -1,0 +1,20 @@
+export { fireSignupNurturingCalls } from "./signupIdentification";
+export {
+  fireTeamMemberInvitedNurturing,
+  fireWorkflowCreatedNurturing,
+  fireScenarioCreatedNurturing,
+  fireExperimentRanNurturing,
+} from "./featureAdoption";
+export {
+  fireActivityTrackingNurturing,
+  resetActivityTrackingCache,
+} from "./activityTracking";
+export {
+  fireProductInterestNurturing,
+  mapProductSelectionToTrait,
+} from "./productInterest";
+export type { ProductInterestValue } from "./productInterest";
+export {
+  firePromptCreatedNurturing,
+  afterPromptCreated,
+} from "./promptCreation";

--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
@@ -1,0 +1,80 @@
+import { getApp } from "../../../../src/server/app-layer/app";
+import { captureException } from "../../../../src/utils/posthogErrorCapture";
+import type { CioPersonTraits } from "../types";
+
+/**
+ * Identifies a new user in Customer.io during onboarding.
+ *
+ * Fires three calls — identifyUser, groupUser, trackEvent —
+ * all fire-and-forget so that Customer.io failures never block onboarding.
+ */
+export function fireSignupNurturingCalls({
+  userId,
+  email,
+  name,
+  organizationId,
+  organizationName,
+  signUpData,
+}: {
+  userId: string;
+  email: string | null | undefined;
+  name: string | null | undefined;
+  organizationId: string;
+  organizationName: string;
+  signUpData?: {
+    yourRole?: string | null;
+    companySize?: string | null;
+    usage?: string | null;
+    solution?: string | null;
+    featureUsage?: string | null;
+    utmCampaign?: string | null;
+    howDidYouHearAboutUs?: string | null;
+  } | null;
+}): void {
+  const nurturing = getApp().nurturing;
+
+  const traits: Partial<CioPersonTraits> = {
+    ...(email ? { email } : {}),
+    ...(name ? { name } : {}),
+    ...(signUpData?.yourRole ? { role: signUpData.yourRole } : {}),
+    ...(signUpData?.companySize
+      ? { company_size: signUpData.companySize }
+      : {}),
+    ...(signUpData?.usage ? { signup_usage: signUpData.usage } : {}),
+    ...(signUpData?.solution ? { signup_solution: signUpData.solution } : {}),
+    ...(signUpData?.featureUsage
+      ? { signup_feature_usage: signUpData.featureUsage }
+      : {}),
+    ...(signUpData?.utmCampaign
+      ? { utm_campaign: signUpData.utmCampaign }
+      : {}),
+    ...(signUpData?.howDidYouHearAboutUs
+      ? { how_heard: signUpData.howDidYouHearAboutUs }
+      : {}),
+    has_traces: false,
+    has_evaluations: false,
+    has_prompts: false,
+    has_simulations: false,
+    createdAt: new Date().toISOString(),
+  };
+
+  void nurturing
+    .identifyUser({ userId, traits })
+    .catch(captureException);
+
+  void nurturing
+    .groupUser({ userId, groupId: organizationId, traits: {
+      name: organizationName,
+      ...(signUpData?.companySize
+        ? { company_size: signUpData.companySize }
+        : {}),
+      plan: "free",
+    }})
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({ userId, event: "signed_up", properties: {
+      ...(signUpData ?? {}),
+    }})
+    .catch(captureException);
+}

--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.unit.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NurturingService } from "../nurturing.service";
+import { fireSignupNurturingCalls } from "./signupIdentification";
+
+// Suppress logger output
+vi.mock("../../../../src/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock("../../../../src/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockNurturing = {
+  identifyUser: vi.fn().mockResolvedValue(undefined),
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+  groupUser: vi.fn().mockResolvedValue(undefined),
+  batch: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("../../../../src/server/app-layer/app", () => ({
+  getApp: () => ({
+    nurturing: mockNurturing,
+  }),
+}));
+
+describe("Signup identification hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when the onboarding flow completes", () => {
+    const baseArgs = {
+      userId: "user-123",
+      email: "jane@example.com",
+      name: "Jane Doe",
+      organizationId: "org-456",
+      organizationName: "Acme Corp",
+      signUpData: {
+        yourRole: "engineer",
+        companySize: "11-50",
+        usage: "monitoring",
+        solution: "llm-ops",
+        featureUsage: "evaluations",
+        utmCampaign: "launch-week",
+        howDidYouHearAboutUs: "twitter",
+      },
+    };
+
+    it("identifies user in Customer.io with email, name, role, and company_size", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          email: "jane@example.com",
+          name: "Jane Doe",
+          role: "engineer",
+          company_size: "11-50",
+        }),
+      });
+    });
+
+    it("includes has_traces false and has_evaluations false in traits", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          has_traces: false,
+          has_evaluations: false,
+        }),
+      });
+    });
+
+    it("includes has_prompts false and has_simulations false in traits", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          has_prompts: false,
+          has_simulations: false,
+        }),
+      });
+    });
+
+    it("includes signup_usage, signup_solution, and signup_feature_usage in traits", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          signup_usage: "monitoring",
+          signup_solution: "llm-ops",
+          signup_feature_usage: "evaluations",
+        }),
+      });
+    });
+
+    it("includes utm_campaign and how_heard when present", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          utm_campaign: "launch-week",
+          how_heard: "twitter",
+        }),
+      });
+    });
+
+    it("includes createdAt as an ISO 8601 timestamp", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      const args = mockNurturing.identifyUser.mock.calls[0]![0];
+      expect(args.traits.createdAt).toBeDefined();
+      expect(new Date(args.traits.createdAt).toISOString()).toBe(args.traits.createdAt);
+    });
+
+    it("associates user with organization via group call", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.groupUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        groupId: "org-456",
+        traits: expect.objectContaining({
+          name: "Acme Corp",
+          company_size: "11-50",
+          plan: "free",
+        }),
+      });
+    });
+
+    it("tracks signed_up event with signup metadata", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+        userId: "user-123",
+        event: "signed_up",
+        properties: expect.objectContaining({
+          yourRole: "engineer",
+          companySize: "11-50",
+        }),
+      });
+    });
+  });
+
+  describe("when signup data has no optional marketing fields", () => {
+    it("omits utm_campaign and how_heard from traits", () => {
+      fireSignupNurturingCalls({
+        userId: "user-123",
+        email: "jane@example.com",
+        name: "Jane Doe",
+        organizationId: "org-456",
+        organizationName: "Acme Corp",
+        signUpData: {
+          yourRole: "engineer",
+          companySize: "11-50",
+        },
+      });
+
+      const args = mockNurturing.identifyUser.mock.calls[0]![0];
+      expect(args.traits.utm_campaign).toBeUndefined();
+      expect(args.traits.how_heard).toBeUndefined();
+    });
+  });
+
+  describe("when Customer.io API is unavailable", () => {
+    it("does not throw (fire-and-forget)", async () => {
+      const { captureException } = await import(
+        "../../../../src/utils/posthogErrorCapture"
+      );
+      mockNurturing.identifyUser.mockRejectedValueOnce(
+        new Error("CIO unavailable"),
+      );
+
+      expect(() =>
+        fireSignupNurturingCalls({
+          userId: "user-123",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          organizationId: "org-456",
+          organizationName: "Acme Corp",
+        }),
+      ).not.toThrow();
+
+      // Wait for the rejected promise to be caught
+      await vi.waitFor(() => {
+        expect(captureException).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when no Customer.io key is configured (null service)", () => {
+    it("completes without errors", () => {
+      const nullService = NurturingService.createNull();
+      mockNurturing.identifyUser.mockImplementation(
+        nullService.identifyUser.bind(nullService),
+      );
+      mockNurturing.groupUser.mockImplementation(
+        nullService.groupUser.bind(nullService),
+      );
+      mockNurturing.trackEvent.mockImplementation(
+        nullService.trackEvent.bind(nullService),
+      );
+
+      expect(() =>
+        fireSignupNurturingCalls({
+          userId: "user-123",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          organizationId: "org-456",
+          organizationName: "Acme Corp",
+        }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/langwatch/src/app/api/evaluations/v3/execute/route.ts
+++ b/langwatch/src/app/api/evaluations/v3/execute/route.ts
@@ -22,6 +22,7 @@ import {
 import { executionRequestSchema } from "~/server/evaluations-v3/execution/types";
 import { createLogger } from "~/utils/logger/server";
 import { trackServerEvent } from "~/server/posthog";
+import { fireExperimentRanNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
 import { captureException } from "~/utils/posthogErrorCapture";
 
 const logger = createLogger("langwatch:evaluations-v3:execute");
@@ -149,6 +150,11 @@ app.post("/execute", zValidator("json", executionRequestSchema), async (c) => {
             trackServerEvent({
               userId: session.user.id,
               event: "evaluation_ran",
+              projectId,
+            });
+            fireExperimentRanNurturing({
+              userId: session.user.id,
+              experimentId: request.experimentId,
               projectId,
             });
           }

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -5,6 +5,7 @@ import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { trackServerEvent } from "~/server/posthog";
+
 import { createLogger } from "~/utils/logger/server";
 import { runEvaluationForTrace } from "../../background/workers/evaluationsWorker";
 import {

--- a/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
+++ b/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { captureException } from "~/utils/posthogErrorCapture";
+import { fireSignupNurturingCalls } from "~/../ee/billing/nurturing/hooks/signupIdentification";
+import {
+  fireProductInterestNurturing,
+  mapProductSelectionToTrait,
+} from "~/../ee/billing/nurturing/hooks/productInterest";
 
 import { skipPermissionCheck } from "../../rbac";
 import { organizationRouter } from "../organization";
@@ -14,6 +19,35 @@ import { signUpDataSchema } from "./schemas/sign-up-data.schema";
  * Router for handling onboarding-related operations.
  */
 export const onboardingRouter = createTRPCRouter({
+  /**
+   * Sets the product_interest trait in Customer.io after the user picks
+   * a flavour on the onboarding "Pick your flavour" screen.
+   *
+   * This is a separate call from signup identification because
+   * initializeOrganization fires BEFORE the flavour screen.
+   * Fire-and-forget: the mutation resolves immediately.
+   */
+  setProductInterest: protectedProcedure
+    .input(
+      z.object({
+        productInterest: z.enum([
+          "observability",
+          "evaluations",
+          "prompt-management",
+          "agent-simulations",
+        ]),
+      }),
+    )
+    .use(skipPermissionCheck)
+    .mutation(({ input, ctx }) => {
+      const traitValue = mapProductSelectionToTrait(input.productInterest);
+      fireProductInterestNurturing({
+        userId: ctx.session.user.id,
+        productInterest: traitValue,
+      });
+      return { success: true };
+    }),
+
   /**
    * Initializes an organization and its associated project.
    *
@@ -89,6 +123,15 @@ export const onboardingRouter = createTRPCRouter({
         } catch (error) {
           captureException(error);
         }
+
+        fireSignupNurturingCalls({
+          userId: ctx.session.user.id,
+          email: ctx.session.user.email,
+          name: ctx.session.user.name,
+          organizationId: orgResult.organization.id,
+          organizationName: orgResult.organization.name,
+          signUpData: input.signUpData,
+        });
 
         // Return success response with team and project slugs
         return {

--- a/langwatch/src/server/api/routers/onboarding/onboarding.router.unit.test.ts
+++ b/langwatch/src/server/api/routers/onboarding/onboarding.router.unit.test.ts
@@ -48,6 +48,12 @@ vi.mock("~/server/app-layer/app", () => ({
       sendSlackSignupEvent: mockSendSlackSignupEvent,
       sendHubspotSignupForm: mockSendHubspotSignupForm,
     },
+    nurturing: {
+      identifyUser: vi.fn().mockResolvedValue(undefined),
+      trackEvent: vi.fn().mockResolvedValue(undefined),
+      groupUser: vi.fn().mockResolvedValue(undefined),
+      batch: vi.fn().mockResolvedValue(undefined),
+    },
   }),
 }));
 

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -31,6 +31,7 @@ import { isTeamRoleAllowedForOrganizationRole, type TeamRoleValue } from "~/util
 import { slugify } from "~/utils/slugify";
 import { getApp } from "~/server/app-layer/app";
 import { trackServerEvent } from "~/server/posthog";
+import { fireTeamMemberInvitedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
 import { elasticsearchMigrate } from "../../../tasks/elasticMigrate";
 import {
   INVITE_EXPIRATION_MS,
@@ -975,6 +976,15 @@ export const organizationRouter = createTRPCRouter({
           event: "team_member_invited",
           properties: { inviteCount: createdRecords.length },
         });
+
+        const memberCount = organization.members.length + createdRecords.length;
+        for (const record of createdRecords) {
+          fireTeamMemberInvitedNurturing({
+            userId: ctx.session.user.id,
+            teamMemberCount: memberCount,
+            role: record.invite.role,
+          });
+        }
       }
 
       const invites = await Promise.all(

--- a/langwatch/src/server/api/routers/scenarios/scenario-crud.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-crud.router.ts
@@ -5,6 +5,8 @@ import { enforceLicenseLimit } from "~/server/license-enforcement";
 import { ScenarioNotFoundError } from "~/server/scenarios/errors";
 import { ScenarioService } from "~/server/scenarios/scenario.service";
 import { trackServerEvent } from "~/server/posthog";
+import { fireScenarioCreatedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
+import { captureException } from "~/utils/posthogErrorCapture";
 import { createLogger } from "~/utils/logger/server";
 import { checkProjectPermission } from "../../rbac";
 import { projectSchema } from "./schemas";
@@ -46,6 +48,20 @@ export const scenarioCrudRouter = createTRPCRouter({
       });
 
       trackServerEvent({ userId: ctx.session.user.id, event: "scenario_created", projectId: input.projectId });
+
+      void ctx.prisma.scenario
+        .count({
+          where: { projectId: input.projectId, archivedAt: null },
+        })
+        .then((count) => {
+          fireScenarioCreatedNurturing({
+            userId: ctx.session.user.id,
+            scenarioCount: count,
+            scenarioId: result.id,
+            projectId: input.projectId,
+          });
+        })
+        .catch(captureException);
 
       logger.info({ projectId: input.projectId, scenarioId: result.id }, "Scenario created");
       return result;

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -22,6 +22,8 @@ import { enforceLicenseLimit } from "../../license-enforcement";
 import { getVercelAIModel } from "../../modelProviders/utils";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { fireWorkflowCreatedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
+import { captureException } from "~/utils/posthogErrorCapture";
 
 export const workflowRouter = createTRPCRouter({
   create: protectedProcedure
@@ -72,6 +74,20 @@ export const workflowRouter = createTRPCRouter({
           },
         });
       }
+
+      void ctx.prisma.workflow
+        .count({
+          where: { projectId: input.projectId, archivedAt: null },
+        })
+        .then((count) => {
+          fireWorkflowCreatedNurturing({
+            userId: ctx.session.user.id,
+            workflowCount: count,
+            workflowId: workflow.id,
+            projectId: input.projectId,
+          });
+        })
+        .catch(captureException);
 
       return { workflow, version };
     }),

--- a/langwatch/src/server/auth.ts
+++ b/langwatch/src/server/auth.ts
@@ -26,6 +26,7 @@ import { dependencies } from "../injection/dependencies.server";
 import { getNextAuthSessionToken } from "../utils/auth";
 import { createLogger } from "../utils/logger/server";
 import { captureException } from "../utils/posthogErrorCapture";
+import { fireActivityTrackingNurturing } from "../../ee/billing/nurturing/hooks/activityTracking";
 
 const logger = createLogger("langwatch:auth");
 
@@ -77,6 +78,8 @@ export const authOptions = (
           throw new Error("User not found");
         }
 
+        fireActivityTrackingNurturing({ userId: user_.id });
+
         return {
           ...session,
           user: {
@@ -86,6 +89,8 @@ export const authOptions = (
           },
         };
       }
+
+      fireActivityTrackingNurturing({ userId: user.id });
 
       return {
         ...session,


### PR DESCRIPTION
## Summary

- **R2:** Signup identification — identifyUser + groupUser + trackEvent("signed_up") in onboarding router
- **R6:** Feature adoption hooks — team_member_invited, workflow_created, scenario_created, experiment_ran at existing PostHog call sites
- **R7:** Activity tracking — `last_active_at` trait on login with hourly debounce (process-local Map + TTL sweep)

All hooks are fire-and-forget with `.catch(captureException)`.

**Base:** `feat/nurturing-foundation` (#2449)
Closes #2428

## Test plan

- [x] 28 unit tests passing (signup + adoption + activity hooks)
- [ ] Verify signup creates person in CIO dashboard
- [ ] Verify activity tracking debounce works across sessions