### PR TITLE
refactor: use named params and shared type for updateMetadata

### DIFF
--- a/langwatch/src/server/app-layer/projects/project.service.ts
+++ b/langwatch/src/server/app-layer/projects/project.service.ts
@@ -2,6 +2,7 @@ import type { Project } from "@prisma/client";
 import type {
   ProjectRepository,
   ProjectWithTeam,
+  UpdateProjectMetadataInput,
 } from "./repositories/project.repository";
 
 /** All boolean fields on Project whose name starts with "feature". */
@@ -18,11 +19,8 @@ export class ProjectService {
     return this.repo.getWithTeam(id);
   }
 
-  async updateMetadata(
-    id: string,
-    data: { firstMessage: boolean; integrated: boolean; language: string },
-  ): Promise<void> {
-    return this.repo.updateMetadata(id, data);
+  async updateMetadata(input: UpdateProjectMetadataInput): Promise<void> {
+    return this.repo.updateMetadata(input);
   }
 
   async isFeatureEnabled(

--- a/langwatch/src/server/app-layer/projects/repositories/project.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/projects/repositories/project.prisma.repository.ts
@@ -1,5 +1,5 @@
 import type { PrismaClient, Project } from "@prisma/client";
-import type { ProjectRepository, ProjectWithTeam } from "./project.repository";
+import type { ProjectRepository, ProjectWithTeam, UpdateProjectMetadataInput } from "./project.repository";
 
 export class PrismaProjectRepository implements ProjectRepository {
   constructor(private readonly prisma: PrismaClient) {}
@@ -15,10 +15,7 @@ export class PrismaProjectRepository implements ProjectRepository {
     });
   }
 
-  async updateMetadata(
-    id: string,
-    data: { firstMessage: boolean; integrated: boolean; language: string },
-  ): Promise<void> {
+  async updateMetadata({ id, data }: UpdateProjectMetadataInput): Promise<void> {
     await this.prisma.project.update({ where: { id }, data });
   }
 }

--- a/langwatch/src/server/app-layer/projects/repositories/project.repository.ts
+++ b/langwatch/src/server/app-layer/projects/repositories/project.repository.ts
@@ -2,13 +2,15 @@ import type { Project, Team } from "@prisma/client";
 
 export type ProjectWithTeam = Project & { team: Team };
 
+export type UpdateProjectMetadataInput = {
+  id: string;
+  data: { firstMessage: boolean; integrated: boolean; language: string };
+};
+
 export interface ProjectRepository {
   getById(id: string): Promise<Project | null>;
   getWithTeam(id: string): Promise<ProjectWithTeam | null>;
-  updateMetadata(
-    id: string,
-    data: { firstMessage: boolean; integrated: boolean; language: string },
-  ): Promise<void>;
+  updateMetadata({ id, data }: UpdateProjectMetadataInput): Promise<void>;
 }
 
 export class NullProjectRepository implements ProjectRepository {
@@ -20,10 +22,7 @@ export class NullProjectRepository implements ProjectRepository {
     return null;
   }
 
-  async updateMetadata(
-    _id: string,
-    _data: { firstMessage: boolean; integrated: boolean; language: string },
-  ): Promise<void> {
+  async updateMetadata(_input: UpdateProjectMetadataInput): Promise<void> {
     // no-op
   }
 }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
@@ -113,10 +113,10 @@ describe("createProjectMetadataReactor()", () => {
 
       await reactor.handle(event, context);
 
-      expect(mockProjects.updateMetadata).toHaveBeenCalledWith(
-        tenantId,
-        expect.objectContaining({ firstMessage: true }),
-      );
+      expect(mockProjects.updateMetadata).toHaveBeenCalledWith({
+        id: tenantId,
+        data: expect.objectContaining({ firstMessage: true }),
+      });
     });
 
     it("sets integrated to true for non-optimization-studio traces", async () => {
@@ -126,10 +126,10 @@ describe("createProjectMetadataReactor()", () => {
 
       await reactor.handle(event, context);
 
-      expect(mockProjects.updateMetadata).toHaveBeenCalledWith(
-        tenantId,
-        expect.objectContaining({ integrated: true }),
-      );
+      expect(mockProjects.updateMetadata).toHaveBeenCalledWith({
+        id: tenantId,
+        data: expect.objectContaining({ integrated: true }),
+      });
     });
   });
 
@@ -153,10 +153,10 @@ describe("createProjectMetadataReactor()", () => {
 
       await reactor.handle(event, context);
 
-      expect(mockProjects.updateMetadata).toHaveBeenCalledWith(
-        tenantId,
-        expect.objectContaining({ language: "python" }),
-      );
+      expect(mockProjects.updateMetadata).toHaveBeenCalledWith({
+        id: tenantId,
+        data: expect.objectContaining({ language: "python" }),
+      });
     });
   });
 
@@ -180,10 +180,10 @@ describe("createProjectMetadataReactor()", () => {
 
       await reactor.handle(event, context);
 
-      expect(mockProjects.updateMetadata).toHaveBeenCalledWith(
-        tenantId,
-        expect.objectContaining({ language: "typescript" }),
-      );
+      expect(mockProjects.updateMetadata).toHaveBeenCalledWith({
+        id: tenantId,
+        data: expect.objectContaining({ language: "typescript" }),
+      });
     });
   });
 
@@ -207,10 +207,10 @@ describe("createProjectMetadataReactor()", () => {
 
       await reactor.handle(event, context);
 
-      expect(mockProjects.updateMetadata).toHaveBeenCalledWith(
-        tenantId,
-        expect.objectContaining({ language: "other" }),
-      );
+      expect(mockProjects.updateMetadata).toHaveBeenCalledWith({
+        id: tenantId,
+        data: expect.objectContaining({ language: "other" }),
+      });
     });
   });
 
@@ -270,10 +270,10 @@ describe("createProjectMetadataReactor()", () => {
 
       await reactor.handle(event, context);
 
-      expect(mockProjects.updateMetadata).toHaveBeenCalledWith(
-        tenantId,
-        expect.objectContaining({ integrated: false }),
-      );
+      expect(mockProjects.updateMetadata).toHaveBeenCalledWith({
+        id: tenantId,
+        data: expect.objectContaining({ integrated: false }),
+      });
     });
 
     it("sets language to 'other'", async () => {
@@ -286,10 +286,10 @@ describe("createProjectMetadataReactor()", () => {
 
       await reactor.handle(event, context);
 
-      expect(mockProjects.updateMetadata).toHaveBeenCalledWith(
-        tenantId,
-        expect.objectContaining({ language: "other" }),
-      );
+      expect(mockProjects.updateMetadata).toHaveBeenCalledWith({
+        id: tenantId,
+        data: expect.objectContaining({ language: "other" }),
+      });
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
@@ -66,10 +66,13 @@ export function createProjectMetadataReactor(
                 ? "typescript"
                 : "other";
 
-        await deps.projects.updateMetadata(tenantId, {
-          firstMessage: true,
-          integrated: isOptimizationStudio ? project.integrated : true,
-          language,
+        await deps.projects.updateMetadata({
+          id: tenantId,
+          data: {
+            firstMessage: true,
+            integrated: isOptimizationStudio ? project.integrated : true,
+            language,
+          },
         });
 
       } catch (error) {


### PR DESCRIPTION
## Summary

- Extracted `UpdateProjectMetadataInput` type from the repository contract to eliminate inline type duplication across service, repository, and reactor
- Switched `updateMetadata` to a single destructured object parameter (`{ id, data }`) matching project conventions for named params
- Updated all test assertions to match the new call signature

Addresses CodeRabbit review comment on #2424.

## Test plan

- [x] 13/13 unit tests pass: `pnpm test:unit src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts`