### PR TITLE
fix(scenarios): apply stall detection to BullMQ active jobs at read time

### DIFF
--- a/langwatch/src/server/scenarios/__tests__/scenario-job-repository.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-job-repository.unit.test.ts
@@ -170,12 +170,35 @@ describe("normalizeJob()", () => {
     });
   });
 
-  describe("given an active BullMQ job with a stale timestamp", () => {
+  describe("given an active BullMQ job with a stale processedOn", () => {
+    const data = makeJobData();
+    const staleProcessedOn = Date.now() - STALL_THRESHOLD_MS - 1000;
+    const job = makeJob({ data, processedOn: staleProcessedOn });
+
+    it("returns STALLED status", () => {
+      const result = normalizeJob({ job, state: "active" });
+      expect(result?.status).toBe(ScenarioRunStatus.STALLED);
+    });
+  });
+
+  describe("given an active BullMQ job that waited in queue longer than threshold", () => {
+    const data = makeJobData();
+    const oldEnqueueTime = Date.now() - STALL_THRESHOLD_MS - 60_000;
+    const recentProcessedOn = Date.now() - 5_000;
+    const job = makeJob({ data, timestamp: oldEnqueueTime, processedOn: recentProcessedOn });
+
+    it("returns RUNNING because processedOn is recent", () => {
+      const result = normalizeJob({ job, state: "active" });
+      expect(result?.status).toBe(ScenarioRunStatus.RUNNING);
+    });
+  });
+
+  describe("given an active BullMQ job with stale timestamp but no processedOn", () => {
     const data = makeJobData();
     const staleTimestamp = Date.now() - STALL_THRESHOLD_MS - 1000;
     const job = makeJob({ data, timestamp: staleTimestamp });
 
-    it("returns STALLED status", () => {
+    it("falls back to timestamp and returns STALLED", () => {
       const result = normalizeJob({ job, state: "active" });
       expect(result?.status).toBe(ScenarioRunStatus.STALLED);
     });

--- a/langwatch/src/server/scenarios/scenario-job.repository.ts
+++ b/langwatch/src/server/scenarios/scenario-job.repository.ts
@@ -50,6 +50,7 @@ export interface MinimalJob {
   id?: string | null;
   data: ScenarioJob;
   timestamp?: number;
+  processedOn?: number;
 }
 
 /** Parameters for normalizing a single BullMQ job into a ScenarioRunData row. */
@@ -73,7 +74,7 @@ export function normalizeJob({ job, state }: NormalizeJobParams): ScenarioRunDat
 
   const status = mapBullMQStateToStatus({
     state,
-    jobTimestamp: job.timestamp,
+    jobTimestamp: job.processedOn ?? job.timestamp,
   });
 
   return {
@@ -107,7 +108,7 @@ export function normalizeJob({ job, state }: NormalizeJobParams): ScenarioRunDat
  */
 export interface ScenarioQueueAdapter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getJobs(states: any): Promise<Array<{ id?: string | null; data: any; timestamp?: number }>>;
+  getJobs(states: any): Promise<Array<{ id?: string | null; data: any; timestamp?: number; processedOn?: number }>>;
 }
 
 type JobState = "waiting" | "active" | "completed" | "failed";
@@ -125,7 +126,7 @@ const STATE_PRIORITY: Record<JobState, number> = {
  * when a job moves between states. Higher-priority state wins.
  */
 function collapseJobsById(params: {
-  jobsByState: Array<{ jobs: Array<{ id?: string | null; data: unknown; timestamp?: number }>; state: JobState }>;
+  jobsByState: Array<{ jobs: Array<{ id?: string | null; data: unknown; timestamp?: number; processedOn?: number }>; state: JobState }>;
 }): Array<{ job: MinimalJob; state: JobState }> {
   const byId = new Map<string, { job: MinimalJob; state: JobState }>();
 


### PR DESCRIPTION
## Summary

- `mapBullMQStateToStatus()` now accepts an optional `jobTimestamp` and returns `STALLED` instead of `RUNNING` when an active BullMQ job exceeds `STALL_THRESHOLD_MS` — catching workers that died before emitting a `RUN_STARTED` event
- Uses `processedOn` (processing-start time) instead of `timestamp` (enqueue time) to avoid false stalls on jobs that legitimately waited in the queue
- Refactored the function signature from positional args to a named parameter object, following repo conventions
- `normalizeJob()` passes `job.processedOn ?? job.timestamp` through so stale BullMQ-only entries are no longer stuck as "running" forever in the UI

Closes #2342

## Test plan

- [x] Unit tests for stall detection edge cases (within threshold, at threshold, exceeding threshold)
- [x] Unit tests for backwards compatibility (no `jobTimestamp` → still returns `RUNNING`)
- [x] Test for job that waited in queue > threshold then just became active (not falsely STALLED)
- [x] Existing `normalizeJob()` tests updated and passing
- [x] All 34 tests in `scenario-job-repository.unit.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)