### PR TITLE
fix(studio): prevent evaluator node from duplicating input handles on reload

### DIFF
--- a/langwatch/src/optimization_studio/components/properties/EvaluatorPropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/EvaluatorPropertiesPanel.tsx
@@ -1,6 +1,6 @@
 import { Button, HStack, Spacer, Spinner, VStack } from "@chakra-ui/react";
 import { type Node, useUpdateNodeInternals } from "@xyflow/react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useDebouncedCallback } from "use-debounce";
 import { useShallow } from "zustand/react/shallow";
@@ -128,6 +128,47 @@ function DbEvaluatorPanel({
     }
     return evaluatorDef;
   }, [evaluatorQuery.data?.fields, evaluatorDef]);
+
+  // Sync node inputs/outputs with evaluator fields when API data arrives.
+  // This prevents stale template inputs from persisting after reload
+  // (e.g., evaluator created via onCreateNew without evaluatorType).
+  const hasSyncedFieldsRef = useRef(false);
+  useEffect(() => {
+    const apiFields = evaluatorQuery.data?.fields;
+    const apiOutputFields = evaluatorQuery.data?.outputFields;
+    if (!apiFields || apiFields.length === 0 || hasSyncedFieldsRef.current)
+      return;
+
+    const currentInputIds = (node.data.inputs ?? [])
+      .map((f) => f.identifier)
+      .sort()
+      .join(",");
+    const apiInputIds = apiFields
+      .map((f) => f.identifier)
+      .sort()
+      .join(",");
+
+    if (currentInputIds !== apiInputIds) {
+      const inputs: Field[] = apiFields.map((f) => ({
+        identifier: f.identifier,
+        type: f.type as Field["type"],
+        ...(f.optional ? { optional: true } : {}),
+      }));
+      const outputs: Field[] | undefined = apiOutputFields?.map((f) => ({
+        identifier: f.identifier,
+        type: f.type as Field["type"],
+      }));
+      setNode({
+        id: node.id,
+        data: {
+          inputs,
+          ...(outputs ? { outputs } : {}),
+        },
+      });
+      updateNodeInternals(node.id);
+    }
+    hasSyncedFieldsRef.current = true;
+  }, [evaluatorQuery.data, node.id, node.data.inputs, setNode, updateNodeInternals]);
 
   const isWorkflowEvaluator = evaluatorQuery.data?.type === "workflow";
 

--- a/langwatch/src/optimization_studio/hooks/__tests__/useEvaluatorPickerFlow.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/__tests__/useEvaluatorPickerFlow.unit.test.ts
@@ -429,6 +429,8 @@ describe("useEvaluatorPickerFlow()", () => {
           data: expect.objectContaining({
             name: "New Evaluator",
             evaluator: "evaluators/new-eval-id",
+            inputs: [],
+            outputs: [{ identifier: "passed", type: "bool" }],
           }),
         }),
       );

--- a/langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts
+++ b/langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts
@@ -122,15 +122,18 @@ export function useEvaluatorPickerFlow() {
             if (pendingEvaluatorRef.current) {
               const { inputs, outputs } = saved.evaluatorType
                 ? computeFieldsFromEvaluatorType(saved.evaluatorType)
-                : { inputs: undefined, outputs: undefined };
+                : {
+                    inputs: [] as Field[],
+                    outputs: [{ identifier: "passed", type: "bool" as const }] as Field[],
+                  };
 
               setNode({
                 id: pendingEvaluatorRef.current,
                 data: {
                   name: saved.name,
                   evaluator: `evaluators/${saved.id}`,
-                  ...(inputs ? { inputs } : {}),
-                  ...(outputs ? { outputs } : {}),
+                  inputs,
+                  outputs,
                 } as Partial<Component>,
               });
               const nodeId = pendingEvaluatorRef.current;


### PR DESCRIPTION
## Summary

- **useEvaluatorPickerFlow**: When creating a workflow evaluator (no `evaluatorType`), set `inputs`/`outputs` to explicit defaults (`[]` and `[{passed: bool}]`) instead of `undefined`, preventing stale template inputs from persisting via shallow merge
- **EvaluatorPropertiesPanel**: Sync node inputs with evaluator API fields on load, so reloading the page replaces stale template inputs with the correct fields from the API

Closes #2329

## Test plan

- [x] Unit test updated to assert explicit `inputs: []` and `outputs: [{passed, bool}]` on workflow evaluator creation
- [x] All 16 tests in `useEvaluatorPickerFlow.unit.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2329