### PR TITLE
fix(scenarios): add QUEUED to cancellable statuses and route ad-hoc runs through queueRun

### DIFF
--- a/langwatch/src/server/api/routers/scenarios/__tests__/simulation-runner.router.unit.test.ts
+++ b/langwatch/src/server/api/routers/scenarios/__tests__/simulation-runner.router.unit.test.ts
@@ -23,6 +23,21 @@ vi.mock("~/server/scenarios/scenario.queue", () => ({
   scheduleScenarioRun: vi.fn().mockResolvedValue({ id: "job_test_123" }),
 }));
 
+const mockQueueRun = vi.fn().mockResolvedValue(undefined);
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: vi.fn().mockReturnValue({
+    simulations: {
+      queueRun: (...args: unknown[]) => mockQueueRun(...args),
+    },
+  }),
+}));
+
+vi.mock("@langwatch/ksuid", () => ({
+  generate: vi.fn().mockReturnValue({
+    toString: () => "scenariorun_test_456",
+  }),
+}));
+
 vi.mock("~/utils/logger/server", () => ({
   createLogger: vi.fn().mockReturnValue({
     info: vi.fn(),
@@ -82,6 +97,7 @@ describe("simulationRunnerRouter.run", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockQueueRun.mockResolvedValue(undefined);
     caller = createTestCaller();
   });
 
@@ -222,6 +238,67 @@ describe("simulationRunnerRouter.run", () => {
     });
   });
 
+  describe("given validation passes but queueRun command fails", () => {
+    beforeEach(() => {
+      mockPrefetchScenarioData.mockResolvedValue({
+        success: true,
+        data: {
+          context: {
+            projectId: "proj_123",
+            scenarioId: "scen_123",
+            setId: "default",
+            batchRunId: "batch_test_123",
+          },
+          scenario: {
+            id: "scen_123",
+            name: "Test Scenario",
+            situation: "User asks a question",
+            criteria: ["Must respond politely"],
+            labels: [],
+          },
+          adapterData: {
+            type: "prompt",
+            promptId: "prompt_123",
+            systemPrompt: "You are helpful",
+            messages: [],
+          },
+          modelParams: {
+            api_key: "test-key",
+            model: "openai/gpt-4",
+          },
+          nlpServiceUrl: "http://localhost:8080",
+          target: { type: "prompt", referenceId: "prompt_123" },
+        },
+        telemetry: {
+          endpoint: "http://localhost:3000",
+          apiKey: "test-api-key",
+        },
+      });
+    });
+
+    describe("when queueRun command fails", () => {
+      beforeEach(() => {
+        mockQueueRun.mockRejectedValue(new Error("ClickHouse write failed"));
+      });
+
+      it("throws TRPCError with INTERNAL_SERVER_ERROR code", async () => {
+        await expect(caller.run(defaultInput)).rejects.toMatchObject({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to queue scenario run",
+        });
+      });
+
+      it("does not schedule the BullMQ job", async () => {
+        try {
+          await caller.run(defaultInput);
+        } catch {
+          // Expected to throw
+        }
+        expect(mockScheduleScenarioRun).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("given all validation passes", () => {
     beforeEach(() => {
       mockPrefetchScenarioData.mockResolvedValue({
@@ -261,7 +338,23 @@ describe("simulationRunnerRouter.run", () => {
     });
 
     describe("when run is called without explicit setId", () => {
-      it("schedules the scenario run with internal on-platform set ID", async () => {
+      it("dispatches queueRun command before scheduling", async () => {
+        await caller.run(defaultInput);
+
+        const expectedSetId = getOnPlatformSetId(defaultInput.projectId);
+        expect(mockQueueRun).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId: "proj_123",
+            scenarioRunId: "scenariorun_test_456",
+            scenarioId: "scen_123",
+            batchRunId: "batch_test_123",
+            scenarioSetId: expectedSetId,
+            occurredAt: expect.any(Number),
+          }),
+        );
+      });
+
+      it("passes the pre-generated scenarioRunId to scheduleScenarioRun", async () => {
         await caller.run(defaultInput);
 
         const expectedSetId = getOnPlatformSetId(defaultInput.projectId);
@@ -271,11 +364,12 @@ describe("simulationRunnerRouter.run", () => {
           target: { type: "prompt", referenceId: "prompt_123" },
           setId: expectedSetId,
           batchRunId: "batch_test_123",
+          scenarioRunId: "scenariorun_test_456",
           index: 0,
         });
       });
 
-      it("returns scheduled job info with internal set ID", async () => {
+      it("returns scenarioRunId alongside existing fields", async () => {
         const result = await caller.run(defaultInput);
 
         const expectedSetId = getOnPlatformSetId(defaultInput.projectId);
@@ -284,12 +378,13 @@ describe("simulationRunnerRouter.run", () => {
           jobId: "job_test_123",
           setId: expectedSetId,
           batchRunId: "batch_test_123",
+          scenarioRunId: "scenariorun_test_456",
         });
       });
     });
 
     describe("when run is called with explicit setId", () => {
-      it("preserves the user-provided set ID", async () => {
+      it("preserves the user-provided set ID in scheduleScenarioRun", async () => {
         const inputWithSetId = {
           ...defaultInput,
           setId: "production-tests",
@@ -302,8 +397,23 @@ describe("simulationRunnerRouter.run", () => {
           target: { type: "prompt", referenceId: "prompt_123" },
           setId: "production-tests",
           batchRunId: "batch_test_123",
+          scenarioRunId: "scenariorun_test_456",
           index: 0,
         });
+      });
+
+      it("dispatches queueRun with user-provided set ID", async () => {
+        const inputWithSetId = {
+          ...defaultInput,
+          setId: "production-tests",
+        };
+        await caller.run(inputWithSetId);
+
+        expect(mockQueueRun).toHaveBeenCalledWith(
+          expect.objectContaining({
+            scenarioSetId: "production-tests",
+          }),
+        );
       });
 
       it("returns scheduled job info with user-provided set ID", async () => {
@@ -318,6 +428,7 @@ describe("simulationRunnerRouter.run", () => {
           jobId: "job_test_123",
           setId: "production-tests",
           batchRunId: "batch_test_123",
+          scenarioRunId: "scenariorun_test_456",
         });
       });
     });

--- a/langwatch/src/server/api/routers/scenarios/simulation-runner.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/simulation-runner.router.ts
@@ -3,7 +3,9 @@
  */
 
 import { TRPCError } from "@trpc/server";
+import { generate } from "@langwatch/ksuid";
 import { z } from "zod";
+import { getApp } from "~/server/app-layer/app";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import {
   createDataPrefetcherDependencies,
@@ -14,6 +16,7 @@ import {
   generateBatchRunId,
   scheduleScenarioRun,
 } from "~/server/scenarios/scenario.queue";
+import { KSUID_RESOURCES } from "~/utils/constants";
 import { createLogger } from "~/utils/logger/server";
 import { checkProjectPermission } from "../../rbac";
 import { projectSchema } from "./schemas";
@@ -84,14 +87,40 @@ export const simulationRunnerRouter = createTRPCRouter({
         });
       }
 
+      const scenarioRunId = generate(KSUID_RESOURCES.SCENARIO_RUN).toString();
+
       logger.info(
         {
           projectId: input.projectId,
           scenarioId: input.scenarioId,
           batchRunId,
+          scenarioRunId,
         },
         "Scheduling scenario execution",
       );
+
+      // Dispatch queueRun command first so QUEUED state is written to ClickHouse
+      // before the BullMQ job is scheduled — same pattern as SuiteRunService.startRun()
+      try {
+        await getApp().simulations.queueRun({
+          tenantId: input.projectId,
+          scenarioRunId,
+          scenarioId: input.scenarioId,
+          batchRunId,
+          scenarioSetId: setId,
+          occurredAt: Date.now(),
+        });
+      } catch (error) {
+        logger.error(
+          { error, projectId: input.projectId, scenarioRunId, batchRunId },
+          "Failed to queue scenario run",
+        );
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to queue scenario run",
+          cause: error,
+        });
+      }
 
       const job = await scheduleScenarioRun({
         projectId: input.projectId,
@@ -99,10 +128,11 @@ export const simulationRunnerRouter = createTRPCRouter({
         target: input.target,
         setId,
         batchRunId,
+        scenarioRunId,
         index: 0,
       });
 
-      logger.info({ jobId: job.id, batchRunId }, "Scenario scheduled");
+      logger.info({ jobId: job.id, batchRunId, scenarioRunId }, "Scenario scheduled");
 
       // Return honest response: job was scheduled, not executed
       return {
@@ -110,6 +140,7 @@ export const simulationRunnerRouter = createTRPCRouter({
         jobId: job.id,
         setId,
         batchRunId,
+        scenarioRunId,
       };
     }),
 });

--- a/langwatch/src/server/scenarios/__tests__/cancellation-eligibility.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/cancellation-eligibility.unit.test.ts
@@ -4,8 +4,7 @@
  * @see specs/features/suites/cancel-queued-running-jobs.feature (@unit scenarios)
  */
 import { describe, expect, it } from "vitest";
-import { ScenarioRunStatus } from "../scenario-event.enums";
-import { isCancellableStatus } from "../scenario-event.enums";
+import { ScenarioRunStatus, isCancellableStatus } from "../scenario-event.enums";
 
 describe("isCancellableStatus()", () => {
   describe("when status is PENDING", () => {
@@ -47,6 +46,20 @@ describe("isCancellableStatus()", () => {
   describe("when status is CANCELLED", () => {
     it("returns false", () => {
       expect(isCancellableStatus(ScenarioRunStatus.CANCELLED)).toBe(false);
+    });
+  });
+
+  describe("when status is QUEUED", () => {
+    it("returns true", () => {
+      expect(isCancellableStatus(ScenarioRunStatus.QUEUED)).toBe(true);
+    });
+  });
+
+  describe("when status is RUNNING", () => {
+    it("returns false", () => {
+      // RUNNING is a BullMQ active state — cancellation of active jobs uses
+      // a separate abort-signal mechanism, not the status-based check
+      expect(isCancellableStatus(ScenarioRunStatus.RUNNING)).toBe(false);
     });
   });
 });

--- a/langwatch/src/server/scenarios/scenario-event.enums.ts
+++ b/langwatch/src/server/scenarios/scenario-event.enums.ts
@@ -21,10 +21,10 @@ export enum ScenarioEventType {
 }
 
 /**
- * Domain-level statuses persisted in ES/ClickHouse (PENDING, IN_PROGRESS, …) are
- * distinct from the transient BullMQ queue states surfaced in the UI (QUEUED,
- * RUNNING). QUEUED maps to BullMQ "waiting/delayed" and RUNNING maps to BullMQ
- * "active" — they are UI-only overlays that are never written to the database.
+ * Domain-level statuses persisted in ES/ClickHouse (PENDING, IN_PROGRESS, …).
+ * QUEUED and RUNNING were originally transient BullMQ overlays, but QUEUED is
+ * now written to ClickHouse via the fold projection when a queueRun command is
+ * dispatched. RUNNING maps to BullMQ "active" and remains a UI-only overlay.
  */
 export enum ScenarioRunStatus {
   SUCCESS = "SUCCESS",
@@ -42,6 +42,7 @@ export enum ScenarioRunStatus {
 
 /** Statuses that are eligible for cancellation (still in-flight). */
 export const CANCELLABLE_STATUSES = new Set<ScenarioRunStatus>([
+  ScenarioRunStatus.QUEUED,
   ScenarioRunStatus.PENDING,
   ScenarioRunStatus.IN_PROGRESS,
   ScenarioRunStatus.STALLED,
@@ -50,7 +51,7 @@ export const CANCELLABLE_STATUSES = new Set<ScenarioRunStatus>([
 /**
  * Determines whether a scenario run with the given status can be cancelled.
  *
- * Only in-flight statuses (PENDING, IN_PROGRESS, STALLED) are cancellable.
+ * Only in-flight statuses (QUEUED, PENDING, IN_PROGRESS, STALLED) are cancellable.
  * Terminal statuses (SUCCESS, FAILED, ERROR, CANCELLED) are not.
  *
  * @param status - The current status of the scenario run

--- a/specs/scenarios/event-driven-execution-prep.feature
+++ b/specs/scenarios/event-driven-execution-prep.feature
@@ -1,0 +1,47 @@
+Feature: Event-driven execution prep
+  As the scenario execution system
+  I need QUEUED runs to be cancellable and ad-hoc runs to go through queueRun
+  So that both suite and ad-hoc paths write consistent QUEUED state to ClickHouse
+
+  Background:
+    Given the event-sourcing pipeline is active
+
+  # ============================================================================
+  # 1. QUEUED status is cancellable
+  # ============================================================================
+
+  @unit
+  Scenario: QUEUED runs can be cancelled
+    Given a scenario run is in QUEUED status
+    When the system checks whether the run is cancellable
+    Then the run is eligible for cancellation
+
+  @unit
+  Scenario: Terminal statuses remain non-cancellable
+    Given a scenario run is in SUCCESS status
+    When the system checks whether the run is cancellable
+    Then the run is not eligible for cancellation
+
+  # ============================================================================
+  # 2. Ad-hoc runs dispatch queueRun command
+  # ============================================================================
+
+  @integration
+  Scenario: Ad-hoc run dispatches queueRun command before scheduling
+    Given a user triggers an ad-hoc scenario run from the UI
+    When the simulation runner processes the request
+    Then a queueRun command is dispatched with the scenario metadata
+    And the QUEUED state is written to ClickHouse
+    And the BullMQ job is scheduled after the command
+
+  @integration
+  Scenario: Ad-hoc run generates a scenarioRunId and passes it to the job
+    Given a user triggers an ad-hoc scenario run
+    When the simulation runner dispatches the queueRun command
+    Then the same scenarioRunId is used for both the command and the BullMQ job
+
+  @integration
+  Scenario: Ad-hoc run uses the same queueRun path as suite runs
+    Given the suite path dispatches queueRun via SuiteRunService
+    When an ad-hoc run is triggered
+    Then it dispatches queueRun through the same command interface


### PR DESCRIPTION
## Summary

Prep work for #2437 (event-driven execution migration). Fixes two gaps that exist on main today:

- **QUEUED runs can now be cancelled** — `isCancellableStatus()` previously only checked PENDING, IN_PROGRESS, and STALLED, so runs in QUEUED state (written by the fold projection) could not be cancelled
- **Ad-hoc runs now dispatch `queueRun` command** — `simulationRunnerRouter.run()` previously called `scheduleScenarioRun` directly without writing QUEUED state to ClickHouse. Now follows the same pattern as `SuiteRunService.startRun()`: dispatch `queueRun` command first, then schedule the BullMQ job

### Changes

- Add `QUEUED` to `CANCELLABLE_STATUSES` in `scenario-event.enums.ts`
- Update stale enum comment (QUEUED is now persisted via fold projection, not UI-only)
- Pre-generate `scenarioRunId` via KSUID in the router for consistency between command and job
- Add error handling for `queueRun` failures with clear `TRPCError`
- Add feature file with acceptance criteria

Closes #2452

## Test plan

- [x] `isCancellableStatus(QUEUED)` returns true (unit test)
- [x] `isCancellableStatus(RUNNING)` returns false with explanatory comment (unit test)
- [x] Router dispatches `queueRun` before scheduling BullMQ job (unit test)
- [x] Pre-generated `scenarioRunId` passed to both command and job (unit test)
- [x] `scenarioRunId` returned in response (unit test)
- [x] `queueRun` failure prevents BullMQ scheduling and returns clear error (unit test)
- [x] 28 tests pass, typecheck clean (pre-existing `types.generated` errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2452