### PR TITLE
fix(ui): replace hardcoded colors with semantic tokens for dark mode

### DIFF
--- a/langwatch/src/components/GenerateApiSnippetButton.tsx
+++ b/langwatch/src/components/GenerateApiSnippetButton.tsx
@@ -26,7 +26,7 @@ export function GenerateApiSnippetButton({
         disabled={!hasHandle}
         size="sm"
         variant="outline"
-        backgroundColor="white"
+        bg="bg"
         onClick={onClick}
       >
         <UnplugIcon />

--- a/langwatch/src/components/license/ResourceLimitRow.tsx
+++ b/langwatch/src/components/license/ResourceLimitRow.tsx
@@ -15,17 +15,17 @@ export function ResourceLimitRow({ label, current, max }: ResourceLimitRowProps)
       paddingY={4}
       paddingX={5}
       borderWidth="1px"
-      borderColor="gray.100"
+      borderColor="border"
       borderRadius="lg"
-      backgroundColor="gray.50"
+      bg="bg.subtle"
     >
-      <Text fontSize="xs" color="gray.500" fontWeight="medium" textTransform="uppercase" letterSpacing="wide">
+      <Text fontSize="xs" color="fg.muted" fontWeight="medium" textTransform="uppercase" letterSpacing="wide">
         {label}
       </Text>
-      <Text fontSize="xl" fontWeight="semibold" color="gray.900">
+      <Text fontSize="xl" fontWeight="semibold" color="fg">
         {current.toLocaleString()}
         {max != null && (
-          <Text as="span" fontSize="sm" fontWeight="normal" color="gray.400">
+          <Text as="span" fontSize="sm" fontWeight="normal" color="fg.muted">
             {" "}/ {formatLimitOrUnlimited(max)}
           </Text>
         )}

--- a/langwatch/src/components/settings/LLMModelCost.tsx
+++ b/langwatch/src/components/settings/LLMModelCost.tsx
@@ -112,8 +112,9 @@ export function LLMModelCost(props: { projectId?: string }) {
                       height="32px"
                       lineHeight="22px"
                       borderRadius="6px"
-                      border="1px solid #EEE"
-                      background="gray.50"
+                      border="1px solid"
+                      borderColor="border"
+                      bg="bg.subtle"
                       paddingY={1}
                       paddingX={2}
                     >

--- a/langwatch/src/pages/settings/usage.tsx
+++ b/langwatch/src/pages/settings/usage.tsx
@@ -49,7 +49,7 @@ function ResourceLimitsCard({
   messagesLabel?: string;
 }) {
   return (
-    <Card.Root borderWidth={1} borderColor="gray.200">
+    <Card.Root borderWidth={1} borderColor="border">
       <Card.Body paddingY={5} paddingX={6}>
         <VStack align="stretch" gap={5}>
           <Flex justifyContent="space-between" alignItems="flex-start">
@@ -69,11 +69,11 @@ function ResourceLimitsCard({
                   {planLabel}
                 </Badge>
               </HStack>
-              <Text color="gray.500" fontSize="sm">
+              <Text color="fg.muted" fontSize="sm">
                 {subtitle}
               </Text>
             </VStack>
-            <Button asChild variant="ghost" size="sm" color="gray.600">
+            <Button asChild variant="ghost" size="sm" color="fg.muted">
               <Link href={actionHref}>
                 {actionLabel} <ArrowRight size={14} />
               </Link>
@@ -151,7 +151,7 @@ function Usage() {
         <Flex justifyContent="space-between" alignItems="flex-start">
           <VStack align="start" gap={1}>
             <Heading size="xl">Usage</Heading>
-            <Text color="gray.500" fontSize="sm">
+            <Text color="fg.muted" fontSize="sm">
               Monitor your resource consumption and plan limits
             </Text>
           </VStack>
@@ -174,7 +174,7 @@ function Usage() {
 
         {/* Self-hosted: Loading state */}
         {isLoadingLimits && (
-          <Card.Root borderWidth={1} borderColor="gray.200">
+          <Card.Root borderWidth={1} borderColor="border">
             <Card.Body paddingY={5} paddingX={6}>
               <VStack align="start" gap={4}>
                 <Text fontWeight="semibold" fontSize="lg">Resource Limits</Text>
@@ -187,9 +187,9 @@ function Usage() {
 
         {/* Self-hosted: Error state */}
         {hasLimitsError && (
-          <Card.Root borderWidth={1} borderColor="red.200" backgroundColor="red.50">
+          <Card.Root borderWidth={1} colorPalette="red" borderColor="colorPalette.muted" bg="colorPalette.subtle">
             <Card.Body paddingY={5} paddingX={6}>
-              <Text color="red.600" fontSize="sm">
+              <Text color="colorPalette.fg" fontSize="sm">
                 Unable to load resource limits. Please refresh the page or
                 contact support if the issue persists.
               </Text>


### PR DESCRIPTION
## Summary
- Replace hardcoded gray/white color values with Chakra v3 semantic tokens (`bg.subtle`, `border`, `fg`, `fg.muted`) across 4 files
- Fixes dark mode rendering on Usage settings page, Model Costs page, and Prompts API button
- Uses the existing adaptive token system instead of `_dark` overrides

## Files changed
- `ResourceLimitRow.tsx` — stat boxes (bg, border, text colors)
- `usage.tsx` — card borders, subtitle text, error state card
- `GenerateApiSnippetButton.tsx` — API button background
- `LLMModelCost.tsx` — regex match rule code badges

## Test plan
- [ ] Verify Usage page (`/settings/usage`) renders correctly in both light and dark mode
- [ ] Verify Model Costs page (`/settings/model-costs`) regex badges are readable in dark mode
- [ ] Verify Prompts page API button is visible in dark mode