### PR TITLE
fix(python-sdk): make langchain-core an optional dependency

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -40,10 +40,10 @@ dependencies = [
     "attrs>=24",
     "pksuid>=1.1.2",
     "pyyaml>=6.0.2",
-    "langchain-core>=1.0.0,<2.0.0",
 ]
 
 [project.optional-dependencies]
+langchain = ["langchain-core>=0.3.0,<2.0.0"]
 dspy = ["dspy-ai>=3.0.3,<4"]
 litellm = ["litellm>=1.52.1"]
 dev = ["ruff>=0.11.1"]


### PR DESCRIPTION
## Summary

- Moves `langchain-core` from hard dependency to optional extra: `pip install langwatch[langchain]`
- Widens constraint to `>=0.3.0,<2.0.0` to support both pre-1.0 (Langflow) and 1.x users
- Mirrors the same fix done for the TypeScript SDK in PR #2227

**Root cause:** `langchain-core>=1.0.0` was a required dependency since v0.7.0 (PR #780), but the SDK only uses it in `langwatch/langchain.py` (the LangChain callback handler). The SDK already handles missing `langchain-core` gracefully via lazy imports and try/except guards.

**Verified:**
- `import langwatch` works without `langchain-core` installed
- `pip install langwatch[langchain]` enables LangChain integration
- No transitive `langchain-core` deps from other required packages

## Test plan

- [x] `import langwatch` succeeds without langchain-core
- [x] `import langwatch.langchain` succeeds with `[langchain]` extra
- [x] Unit tests pass
- [ ] CI passes