### PR TITLE
fix(ui): fix select dropdowns hidden behind Add Members modal

### DIFF
--- a/langwatch/src/components/AddMembersForm.tsx
+++ b/langwatch/src/components/AddMembersForm.tsx
@@ -328,7 +328,7 @@ function MemberRow({
                 <Select.Trigger>
                   <Select.ValueText placeholder="Select role" />
                 </Select.Trigger>
-                <Select.Content paddingY={2} zIndex="popover" width="320px">
+                <Select.Content paddingY={2} zIndex={1501} width="320px">
                   {orgRoleOptions.map((option) => (
                     <Select.Item key={option.value} item={option}>
                       <VStack align="start" gap={0} flex={1}>
@@ -497,7 +497,7 @@ function TeamSelect({
           <Select.Trigger background="bg" width="full">
             <Select.ValueText placeholder="Select team" />
           </Select.Trigger>
-          <Select.Content paddingY={2} zIndex="popover">
+          <Select.Content paddingY={2} zIndex={1501}>
             {availableOptions.map((option) => (
               <Select.Item key={option.value} item={option}>
                 {option.label}
@@ -629,7 +629,7 @@ function TeamRoleSelect({
             <Select.Trigger background="bg" width="full">
               <Select.ValueText placeholder="Select role" />
             </Select.Trigger>
-            <Select.Content paddingY={2} zIndex="popover" width="320px">
+            <Select.Content paddingY={2} zIndex={1501} width="320px">
               {roleOptions.map((option) => (
                 <Select.Item key={option.value} item={option}>
                   <TeamRoleSelectItemContent option={option} />


### PR DESCRIPTION
## Summary
- Select dropdowns (Org Role, Team, Team Role) in the Add Members modal were rendering behind the dialog backdrop due to `zIndex="popover"` (1500) being equal to the dialog's layer index
- Changed to `zIndex={1501}` on all three `Select.Content` elements to render above the dialog

## Test plan
- [x] Open Settings > Members > click "Add members"
- [x] Click the "Org Role" dropdown — options should appear above the modal
- [x] Click the "Team" dropdown — options should appear above the modal
- [x] Click the "Role" dropdown in Team Assignments — options should appear above the modal