### PR TITLE
fix(ui): fix optimizer dropdown hidden behind optimize modal

### DIFF
--- a/langwatch/src/optimization_studio/components/Optimize.tsx
+++ b/langwatch/src/optimization_studio/components/Optimize.tsx
@@ -548,7 +548,7 @@ const OptimizerSelect = ({
       <Select.Trigger>
         <Select.ValueText placeholder="Select optimizer" />
       </Select.Trigger>
-      <Select.Content zIndex="popover">
+      <Select.Content zIndex={1501}>
         {optimizerOptions.map((option) => (
           <Select.Item item={option} key={option.value}>
             <VStack align="start" width="full">


### PR DESCRIPTION
## Summary

- Fixed optimizer dropdown in the Studio optimize modal being hidden behind the modal layer
- Changed `Select.Content` z-index from `"popover"` (1000) to `1501` — above the modal's z-index (1400)
- Same pattern as #2468 which fixed the identical issue in the Add Members modal

Closes #2469

## Browser Test: optimizer-dropdown-zindex

| # | Step | Result | Screenshot |
|---|------|--------|------------|
| 1 | Sign in to the app | PASS | ![01](https://i.img402.dev/t4m1bihhz1.png) |
| 2 | Navigate to workflow studio page | PASS | ![02](https://i.img402.dev/56n9qs74v4.png) |
| 3 | Click "Optimize" button to open modal | PASS | ![03](https://i.img402.dev/9s27gd1bxo.png) |
| 4 | Click optimizer dropdown inside modal | PASS | ![04](https://i.img402.dev/wtf23rk1c6.png) |
| 5 | Verify dropdown renders above modal | PASS | ![04](https://i.img402.dev/wtf23rk1c6.png) |
| 6 | Select a different optimizer option | PASS | ![05](https://i.img402.dev/vk7eteqh80.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2469