### PR TITLE
fix: support code agents as suite targets

### DIFF
--- a/langwatch/src/components/suites/TargetPicker.tsx
+++ b/langwatch/src/components/suites/TargetPicker.tsx
@@ -12,9 +12,15 @@ import { Tooltip } from "../ui/tooltip";
 import { Checkbox } from "../ui/checkbox";
 import { SearchInput } from "../ui/SearchInput";
 
+const targetTypeLabels: Record<SuiteTarget["type"], string> = {
+  http: "HTTP",
+  prompt: "Prompt",
+  code: "Code",
+};
+
 interface AvailableTarget {
   name: string;
-  type: "http" | "prompt" | "code";
+  type: SuiteTarget["type"];
   referenceId: string;
 }
 
@@ -123,7 +129,7 @@ export function TargetPicker({
                     {target.name}
                   </Text>
                   <Text fontSize="xs" color="fg.muted">
-                    ({target.type === "http" ? "HTTP" : target.type === "code" ? "Code" : "Prompt"})
+                    ({targetTypeLabels[target.type]})
                   </Text>
                 </HStack>
               </Checkbox>

--- a/langwatch/src/components/suites/__tests__/TargetPicker.unit.test.tsx
+++ b/langwatch/src/components/suites/__tests__/TargetPicker.unit.test.tsx
@@ -50,6 +50,25 @@ function renderPicker(overrides: Partial<TargetPickerProps> = {}) {
 describe("<TargetPicker />", () => {
   afterEach(cleanup);
 
+  describe("given a code agent target", () => {
+    describe("when the picker renders", () => {
+      it("displays the Code type label", () => {
+        renderPicker({
+          targets: [
+            { name: "Code Agent", type: "code", referenceId: "agent_code" },
+            { name: "HTTP Agent", type: "http", referenceId: "agent_http" },
+            { name: "Test Prompt", type: "prompt", referenceId: "prompt_1" },
+          ],
+          totalCount: 3,
+        });
+
+        expect(screen.getByText("(Code)")).toBeInTheDocument();
+        expect(screen.getByText("(HTTP)")).toBeInTheDocument();
+        expect(screen.getByText("(Prompt)")).toBeInTheDocument();
+      });
+    });
+  });
+
   describe("given no archived targets", () => {
     describe("when the picker renders", () => {
       it("does not show the archived-targets section", () => {

--- a/langwatch/src/components/suites/__tests__/useSuiteForm-agent-filtering.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/useSuiteForm-agent-filtering.integration.test.tsx
@@ -1,10 +1,13 @@
 /**
  * @vitest-environment jsdom
  *
- * Tests for agent type filtering in useSuiteForm.availableTargets.
+ * Regression tests for issue #2477: code agents must be supported as
+ * suite targets alongside http agents, while unsupported agent types
+ * (signature, workflow) must still be excluded from availableTargets.
  *
- * HTTP and code agents are supported as suite targets.
- * Signature and workflow agents are excluded (not supported by the adapter layer).
+ * The set of allowed agent target types is derived from
+ * `suiteAgentTargetTypes` (see `~/server/suites/types`), so these tests
+ * pin the current contract: http + code in, everything else out.
  */
 
 import { renderHook } from "@testing-library/react";

--- a/langwatch/src/components/suites/__tests__/useSuiteForm-agent-filtering.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/useSuiteForm-agent-filtering.integration.test.tsx
@@ -6,7 +6,7 @@
  * (signature, workflow) must still be excluded from availableTargets.
  *
  * The set of allowed agent target types is derived from
- * `suiteAgentTargetTypes` (see `~/server/suites/types`), so these tests
+ * `SUITE_AGENT_TARGET_TYPES` (see `~/server/suites/types`), so these tests
  * pin the current contract: http + code in, everything else out.
  */
 

--- a/langwatch/src/components/suites/__tests__/useSuiteForm.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/useSuiteForm.unit.test.ts
@@ -466,19 +466,21 @@ describe("useSuiteForm()", () => {
       });
     });
 
-    describe("when a workflow agent is provided", () => {
-      it("maps it with type 'http' (non-code agents default to http)", () => {
+    describe("when an unsupported agent type is provided", () => {
+      it("excludes workflow agents from available targets", () => {
         const { result } = renderHook(() =>
           useSuiteForm({
             ...baseParams,
             agents: [
-              { id: "agent_1", name: "Workflow Agent", type: "workflow" },
+              { id: "agent_1", name: "HTTP Agent", type: "http" },
+              { id: "agent_2", name: "Workflow Agent", type: "workflow" },
+              { id: "agent_3", name: "Signature Agent", type: "signature" },
             ],
           }),
         );
 
         expect(result.current.availableTargets).toEqual([
-          { name: "Workflow Agent", type: "http", referenceId: "agent_1" },
+          { name: "HTTP Agent", type: "http", referenceId: "agent_1" },
           { name: "test-prompt", type: "prompt", referenceId: "prompt_1" },
         ]);
       });

--- a/langwatch/src/components/suites/__tests__/useSuiteForm.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/useSuiteForm.unit.test.ts
@@ -446,6 +446,44 @@ describe("useSuiteForm()", () => {
       });
     });
 
+    describe("when a code agent is provided", () => {
+      it("maps it with type 'code' instead of 'http'", () => {
+        const { result } = renderHook(() =>
+          useSuiteForm({
+            ...baseParams,
+            agents: [
+              { id: "agent_1", name: "Prod Agent", type: "http" },
+              { id: "agent_2", name: "Code Agent", type: "code" },
+            ],
+          }),
+        );
+
+        expect(result.current.availableTargets).toEqual([
+          { name: "Prod Agent", type: "http", referenceId: "agent_1" },
+          { name: "Code Agent", type: "code", referenceId: "agent_2" },
+          { name: "test-prompt", type: "prompt", referenceId: "prompt_1" },
+        ]);
+      });
+    });
+
+    describe("when a workflow agent is provided", () => {
+      it("maps it with type 'http' (non-code agents default to http)", () => {
+        const { result } = renderHook(() =>
+          useSuiteForm({
+            ...baseParams,
+            agents: [
+              { id: "agent_1", name: "Workflow Agent", type: "workflow" },
+            ],
+          }),
+        );
+
+        expect(result.current.availableTargets).toEqual([
+          { name: "Workflow Agent", type: "http", referenceId: "agent_1" },
+          { name: "test-prompt", type: "prompt", referenceId: "prompt_1" },
+        ]);
+      });
+    });
+
     describe("when a prompt has no handle", () => {
       it("falls back to prompt id as the name", () => {
         const { result } = renderHook(() =>

--- a/langwatch/src/components/suites/useArchivedItemsResolution.ts
+++ b/langwatch/src/components/suites/useArchivedItemsResolution.ts
@@ -6,6 +6,7 @@
  */
 
 import { useMemo } from "react";
+import type { SuiteTarget } from "~/server/suites/types";
 import { api } from "~/utils/api";
 
 interface ArchivedScenarioRef {
@@ -13,7 +14,7 @@ interface ArchivedScenarioRef {
 }
 
 interface ArchivedTargetRef {
-  type: "http" | "prompt" | "code";
+  type: SuiteTarget["type"];
   referenceId: string;
 }
 

--- a/langwatch/src/components/suites/useSuiteForm.ts
+++ b/langwatch/src/components/suites/useSuiteForm.ts
@@ -52,7 +52,7 @@ interface Scenario {
 interface Agent {
   id: string;
   name: string;
-  type: string;
+  type: "http" | "code" | string;
 }
 
 interface Prompt {

--- a/langwatch/src/components/suites/useSuiteForm.ts
+++ b/langwatch/src/components/suites/useSuiteForm.ts
@@ -49,10 +49,13 @@ interface Scenario {
   labels: string[];
 }
 
+/** Agent types that can be used as suite targets (must be in suiteTargetSchema). */
+const supportedAgentTypes = new Set<string>(["http", "code"]);
+
 interface Agent {
   id: string;
   name: string;
-  type: "http" | "code" | string;
+  type: string;
 }
 
 interface Prompt {
@@ -122,9 +125,8 @@ export function useSuiteForm({
     const result: AvailableTarget[] = [];
     if (agents) {
       for (const agent of agents) {
-        // Only http and code agents are supported as suite targets
-        if (agent.type !== "http" && agent.type !== "code") continue;
-        result.push({ name: agent.name, type: agent.type, referenceId: agent.id });
+        if (!supportedAgentTypes.has(agent.type)) continue;
+        result.push({ name: agent.name, type: agent.type as SuiteTarget["type"], referenceId: agent.id });
       }
     }
     if (prompts) {

--- a/langwatch/src/components/suites/useSuiteForm.ts
+++ b/langwatch/src/components/suites/useSuiteForm.ts
@@ -62,7 +62,7 @@ interface Prompt {
 
 interface AvailableTarget {
   name: string;
-  type: "http" | "prompt" | "code";
+  type: SuiteTarget["type"];
   referenceId: string;
 }
 

--- a/langwatch/src/components/suites/useSuiteForm.ts
+++ b/langwatch/src/components/suites/useSuiteForm.ts
@@ -15,8 +15,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { MAX_REPEAT_COUNT } from "~/server/suites/constants";
 import {
+  isSuiteAgentTargetType,
   parseSuiteTargets,
-  suiteAgentTargetTypes,
   suiteTargetSchema,
   type SuiteTarget,
 } from "~/server/suites/types";
@@ -49,7 +49,6 @@ interface Scenario {
   name: string;
   labels: string[];
 }
-
 
 interface Agent {
   id: string;
@@ -124,8 +123,8 @@ export function useSuiteForm({
     const result: AvailableTarget[] = [];
     if (agents) {
       for (const agent of agents) {
-        if (!suiteAgentTargetTypes.has(agent.type)) continue;
-        result.push({ name: agent.name, type: agent.type as SuiteTarget["type"], referenceId: agent.id });
+        if (!isSuiteAgentTargetType(agent.type)) continue;
+        result.push({ name: agent.name, type: agent.type, referenceId: agent.id });
       }
     }
     if (prompts) {

--- a/langwatch/src/components/suites/useSuiteForm.ts
+++ b/langwatch/src/components/suites/useSuiteForm.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import { MAX_REPEAT_COUNT } from "~/server/suites/constants";
 import {
   parseSuiteTargets,
+  suiteAgentTargetTypes,
   suiteTargetSchema,
   type SuiteTarget,
 } from "~/server/suites/types";
@@ -49,8 +50,6 @@ interface Scenario {
   labels: string[];
 }
 
-/** Agent types that can be used as suite targets (must be in suiteTargetSchema). */
-const supportedAgentTypes = new Set<string>(["http", "code"]);
 
 interface Agent {
   id: string;
@@ -125,7 +124,7 @@ export function useSuiteForm({
     const result: AvailableTarget[] = [];
     if (agents) {
       for (const agent of agents) {
-        if (!supportedAgentTypes.has(agent.type)) continue;
+        if (!suiteAgentTargetTypes.has(agent.type)) continue;
         result.push({ name: agent.name, type: agent.type as SuiteTarget["type"], referenceId: agent.id });
       }
     }

--- a/langwatch/src/server/app-layer/suites/suite-run.service.ts
+++ b/langwatch/src/server/app-layer/suites/suite-run.service.ts
@@ -5,6 +5,7 @@ import type { StartSuiteRunCommandData } from "~/server/event-sourcing/pipelines
 import type { QueueRunCommandData } from "~/server/event-sourcing/pipelines/simulation-processing/schemas/commands";
 import { generateBatchRunId } from "~/server/scenarios/scenario.ids";
 import { getSuiteSetId } from "~/server/suites/suite-set-id";
+import type { SuiteTarget } from "~/server/suites/types";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { createLogger } from "~/utils/logger/server";
 import { traced } from "../tracing";
@@ -39,7 +40,7 @@ export type SuiteRunResult = {
 
 /** Target reference for scheduling */
 export type SuiteRunTarget = {
-  type: "http" | "prompt" | "code";
+  type: SuiteTarget["type"];
   referenceId: string;
 };
 

--- a/langwatch/src/server/scenarios/simulation-runner.service.ts
+++ b/langwatch/src/server/scenarios/simulation-runner.service.ts
@@ -200,6 +200,10 @@ export class SimulationRunnerService {
           projectId,
           prisma: this.prisma,
         });
+      // Code agents execute in a child process (see scenario-child-process.ts + data-prefetcher.ts),
+      // which bypasses this in-process adapter resolver. SuiteRunService.startRun routes code targets
+      // through that path; this branch only fires if something incorrectly calls resolveAdapter for a
+      // code target, which is a bug — throw loudly.
       case "code":
         throw new Error(
           "Code agent targets are only supported via the child process execution path",

--- a/langwatch/src/server/suites/__tests__/suite.service.unit.test.ts
+++ b/langwatch/src/server/suites/__tests__/suite.service.unit.test.ts
@@ -611,6 +611,46 @@ describe("SuiteService", () => {
       });
     });
 
+    describe("given a mix of http and code agent targets", () => {
+      const mixedTargets = [
+        { type: "http", referenceId: "agent_1" },
+        { type: "code", referenceId: "agent_2" },
+      ] as SuiteTarget[];
+
+      describe("when the suite run is triggered", () => {
+        it("batches both into the agent repository call", async () => {
+          const { service, agentRepo } = createService();
+          const suite = makeSuite({
+            scenarioIds: ["scen_1"],
+            targets: mixedTargets,
+          });
+
+          await service.run({
+            suite, ...RUN_DEFAULTS,
+          });
+
+          expect(agentRepo.findManyIncludingArchived).toHaveBeenCalledWith({
+            ids: ["agent_1", "agent_2"],
+            projectId: "proj_1",
+          });
+        });
+
+        it("does not invoke the llm config repository", async () => {
+          const { service, llmConfigRepo } = createService();
+          const suite = makeSuite({
+            scenarioIds: ["scen_1"],
+            targets: mixedTargets,
+          });
+
+          await service.run({
+            suite, ...RUN_DEFAULTS,
+          });
+
+          expect(llmConfigRepo.findExistingIds).not.toHaveBeenCalled();
+        });
+      });
+    });
+
     describe("given idempotencyKey is provided", () => {
       describe("when the suite run is triggered", () => {
         it("passes idempotencyKey through to suiteRunService", async () => {

--- a/langwatch/src/server/suites/suite.service.ts
+++ b/langwatch/src/server/suites/suite.service.ts
@@ -16,7 +16,7 @@ import {
   type CreateSuiteInput,
   type UpdateSuiteInput,
 } from "./suite.repository";
-import { parseSuiteTargets, type SuiteTarget } from "./types";
+import { isSuiteAgentTargetType, parseSuiteTargets, type SuiteTarget } from "./types";
 import {
   AllScenariosArchivedError,
   AllTargetsArchivedError,
@@ -331,7 +331,7 @@ export class SuiteService {
       scenarioRows.map((r) => [r.id, r.name]),
     );
 
-    const agentIds = targets.filter((t) => t.type !== "prompt").map((t) => t.referenceId);
+    const agentIds = targets.filter((t) => isSuiteAgentTargetType(t.type)).map((t) => t.referenceId);
     const promptIds = targets.filter((t) => t.type === "prompt").map((t) => t.referenceId);
 
     const agentRows = agentIds.length > 0
@@ -485,8 +485,9 @@ export class SuiteService {
   }): Promise<ResolvedTargetReferences> {
     const { targets, projectId, organizationId } = params;
 
-    // Partition targets: anything that isn't a prompt is an agent (all agent types live in the Agent table)
-    const agentTargets = targets.filter((t) => t.type !== "prompt");
+    // Partition targets by type. Use a positive filter so that future SuiteTarget["type"] additions
+    // must be explicitly handled here instead of silently routing into the agent path.
+    const agentTargets = targets.filter((t) => isSuiteAgentTargetType(t.type));
     const promptTargets = targets.filter((t) => t.type === "prompt");
 
     // Batch agent targets (both HTTP and code agents live in the Agent table)

--- a/langwatch/src/server/suites/suite.service.ts
+++ b/langwatch/src/server/suites/suite.service.ts
@@ -331,7 +331,7 @@ export class SuiteService {
       scenarioRows.map((r) => [r.id, r.name]),
     );
 
-    const agentIds = targets.filter((t) => t.type === "http" || t.type === "code").map((t) => t.referenceId);
+    const agentIds = targets.filter((t) => t.type !== "prompt").map((t) => t.referenceId);
     const promptIds = targets.filter((t) => t.type === "prompt").map((t) => t.referenceId);
 
     const agentRows = agentIds.length > 0
@@ -485,8 +485,8 @@ export class SuiteService {
   }): Promise<ResolvedTargetReferences> {
     const { targets, projectId, organizationId } = params;
 
-    // Partition targets by type (parseSuiteTargets validates types upstream)
-    const agentTargets = targets.filter((t) => t.type === "http" || t.type === "code");
+    // Partition targets: anything that isn't a prompt is an agent (all agent types live in the Agent table)
+    const agentTargets = targets.filter((t) => t.type !== "prompt");
     const promptTargets = targets.filter((t) => t.type === "prompt");
 
     // Batch agent targets (both HTTP and code agents live in the Agent table)

--- a/langwatch/src/server/suites/types.ts
+++ b/langwatch/src/server/suites/types.ts
@@ -15,10 +15,24 @@ export const suiteTargetSchema = z.object({
 
 export type SuiteTarget = z.infer<typeof suiteTargetSchema>;
 
-/** Agent types that are valid suite targets (all suite target types except "prompt"). */
-export const suiteAgentTargetTypes: Set<string> = new Set(
-  suiteTargetSchema.shape.type.options.filter((t) => t !== "prompt"),
-);
+/** Agent target types — every suite target type except "prompt". Must stay in sync with suiteTargetSchema. */
+export const SUITE_AGENT_TARGET_TYPES = ["http", "code"] as const;
+export type SuiteAgentTargetType = (typeof SUITE_AGENT_TARGET_TYPES)[number];
+
+/** Type guard: narrows `type` to `SuiteAgentTargetType`. */
+export function isSuiteAgentTargetType(type: string): type is SuiteAgentTargetType {
+  return (SUITE_AGENT_TARGET_TYPES as readonly string[]).includes(type);
+}
+
+// Compile-time guard: SUITE_AGENT_TARGET_TYPES must stay in sync with suiteTargetSchema (minus "prompt").
+type _SchemaAgentTypes = Exclude<SuiteTarget["type"], "prompt">;
+type _Assert = SuiteAgentTargetType extends _SchemaAgentTypes
+  ? _SchemaAgentTypes extends SuiteAgentTargetType
+    ? true
+    : never
+  : never;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _suiteAgentTargetTypesDriftCheck: _Assert = true;
 
 /** Parse and validate suite targets from Prisma's Json field */
 export function parseSuiteTargets(raw: unknown): SuiteTarget[] {

--- a/langwatch/src/server/suites/types.ts
+++ b/langwatch/src/server/suites/types.ts
@@ -15,6 +15,11 @@ export const suiteTargetSchema = z.object({
 
 export type SuiteTarget = z.infer<typeof suiteTargetSchema>;
 
+/** Agent types that are valid suite targets (all suite target types except "prompt"). */
+export const suiteAgentTargetTypes = new Set(
+  suiteTargetSchema.shape.type.options.filter((t: string) => t !== "prompt"),
+);
+
 /** Parse and validate suite targets from Prisma's Json field */
 export function parseSuiteTargets(raw: unknown): SuiteTarget[] {
   return z.array(suiteTargetSchema).parse(raw);

--- a/langwatch/src/server/suites/types.ts
+++ b/langwatch/src/server/suites/types.ts
@@ -16,8 +16,8 @@ export const suiteTargetSchema = z.object({
 export type SuiteTarget = z.infer<typeof suiteTargetSchema>;
 
 /** Agent types that are valid suite targets (all suite target types except "prompt"). */
-export const suiteAgentTargetTypes = new Set(
-  suiteTargetSchema.shape.type.options.filter((t: string) => t !== "prompt"),
+export const suiteAgentTargetTypes: Set<string> = new Set(
+  suiteTargetSchema.shape.type.options.filter((t) => t !== "prompt"),
 );
 
 /** Parse and validate suite targets from Prisma's Json field */


### PR DESCRIPTION
## Summary
- Adds `"code"` to the suite target type enum across all layers (schema, service types, form logic, UI picker, reference resolution)
- Code agents were hardcoded as `"http"` type, causing "HTTP agent not found" errors when running suites with code agent targets
- Regression tests added for useSuiteForm and TargetPicker

Fixes #2477

## Test plan
- [x] Unit tests: 54 tests pass (37 useSuiteForm + 17 TargetPicker)
- [x] Typecheck: no new errors
- [x] Browser verification: code agent displays with "(Code)" label and can be selected as suite target

## Browser Test: code-agent-suites

| # | Scenario | Result | Screenshot |
|---|----------|--------|------------|
| 1 | Sign in to the app | PASS | ![01](https://i.img402.dev/py053oau0t.png) |
| 2 | Create a code agent | PASS | ![02](https://i.img402.dev/1l0awryikk.png) ![03](https://i.img402.dev/3un0jzp81r.png) |
| 3 | Navigate to Run Plans page | PASS | ![04](https://i.img402.dev/cooz9294cd.png) |
| 4 | Open New Run Plan dialog | PASS | ![05](https://i.img402.dev/bfjsein3kk.png) |
| 5 | Verify code agent shows "Code" label | PASS | ![06](https://i.img402.dev/rjjwpvyflq.png) |
| 6 | Select code agent as target | PASS | ![07](https://i.img402.dev/1hfxj162yq.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2477