### PR TITLE
fix: rename remaining Suite UI labels to Run Plan

### DIFF
--- a/langwatch/src/components/suites/SuiteSidebar.tsx
+++ b/langwatch/src/components/suites/SuiteSidebar.tsx
@@ -512,7 +512,7 @@ function SuiteListItem({
             </Box>
             <Box
               as="button"
-              aria-label="Suite options"
+              aria-label="Run plan options"
               data-testid="suite-menu-button"
               onClick={(e: React.MouseEvent) => {
                 e.stopPropagation();

--- a/langwatch/src/components/suites/useSuiteRunMutation.ts
+++ b/langwatch/src/components/suites/useSuiteRunMutation.ts
@@ -38,18 +38,18 @@ export function useSuiteRunMutation({
         }
 
         toaster.create({
-          title: `Suite run scheduled (${result.jobCount} jobs)`,
+          title: `Run scheduled (${result.jobCount} jobs)`,
           description: `${parts.join(" and ")} skipped.`,
           type: "warning",
           meta: { closable: true },
           action: {
-            label: "Edit Suite",
+            label: "Edit Run Plan",
             onClick: () => onEditSuite(variables.id),
           },
         });
       } else {
         toaster.create({
-          title: `Suite run scheduled (${result.jobCount} jobs)`,
+          title: `Run scheduled (${result.jobCount} jobs)`,
           type: "success",
           meta: { closable: true },
         });
@@ -62,14 +62,14 @@ export function useSuiteRunMutation({
           err.message.includes("All targets"));
 
       toaster.create({
-        title: isAllArchived ? "Cannot run suite" : "Failed to run suite",
+        title: isAllArchived ? "Cannot execute run plan" : "Failed to execute run plan",
         description: err.message,
         type: "error",
         meta: { closable: true },
         ...(isAllArchived
           ? {
               action: {
-                label: "Edit Suite",
+                label: "Edit Run Plan",
                 onClick: () => onEditSuite(variables.id),
               },
             }

--- a/langwatch/src/pages/[project]/simulations/suites/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/suites/index.tsx
@@ -461,7 +461,7 @@ function MainPanel({
   if (error) {
     return (
       <VStack gap={4} align="center" py={8}>
-        <Text color="red.500">Error loading suites</Text>
+        <Text color="red.500">Error loading run plans</Text>
         <Text fontSize="sm" color="fg.muted">
           {error.message}
         </Text>


### PR DESCRIPTION
## Summary

Closes #2285.

Renames the last remaining user-visible "Suite" strings to "Run Plan" / "Runs" throughout the UI. Most labels were already updated in a prior pass — this PR catches the stragglers:

- **Toast messages** (`useSuiteRunMutation.ts`): "Suite run scheduled" → "Run scheduled", "Cannot run suite" / "Failed to run suite" → "Cannot execute run plan" / "Failed to execute run plan", "Edit Suite" → "Edit Run Plan"
- **Error text** (`suites/index.tsx`): "Error loading suites" → "Error loading run plans"
- **Aria label** (`SuiteSidebar.tsx`): "Suite options" → "Run plan options"

No code identifiers, variable names, routes, database fields, or API endpoints were changed — this is purely a display label update.

## Test plan

- [x] Ran integration tests for `SuiteSidebar`, `SuiteRunConfirmationDialog`, `SuiteContextMenu` — all pass
- [x] Verified 2 pre-existing failures in `SuitesPageLayout` are unrelated (same on `main`)
- [ ] Manual: trigger a suite run and verify toast messages say "Run scheduled"
- [ ] Manual: trigger error states and verify "Cannot execute run plan" / "Failed to execute run plan"
- [ ] Manual: check sidebar context menu aria-label reads "Run plan options"

🤖 Generated with [Claude Code](https://claude.com/claude-code)