### PR TITLE
fix(studio): publish hang, import version, sticky evaluator details

### DIFF
--- a/langwatch/src/optimization_studio/components/Evaluate.tsx
+++ b/langwatch/src/optimization_studio/components/Evaluate.tsx
@@ -34,7 +34,6 @@ import { useWorkflowStore } from "../hooks/useWorkflowStore";
 import type { Entry } from "../types/dsl";
 import { trainTestSplit } from "../utils/datasetUtils";
 import { AddModelProviderKey } from "./AddModelProviderKey";
-import { useVersionState } from "./History";
 import { VersionToBeUsed } from "./VersionToBeUsed";
 
 export function Evaluate() {
@@ -109,6 +108,7 @@ export function EvaluateModalContent({
     setLastCommittedWorkflow,
     setCurrentVersionId,
     currentVersionId,
+    checkCanCommitNewVersion,
   } = useWorkflowStore(
     ({
       workflow_id: workflowId,
@@ -119,6 +119,7 @@ export function EvaluateModalContent({
       setLastCommittedWorkflow,
       setCurrentVersionId,
       currentVersionId,
+      checkCanCommitNewVersion,
     }) => ({
       workflowId,
       getWorkflow,
@@ -128,6 +129,7 @@ export function EvaluateModalContent({
       setLastCommittedWorkflow,
       setCurrentVersionId,
       currentVersionId,
+      checkCanCommitNewVersion,
     }),
   );
 
@@ -212,7 +214,7 @@ export function EvaluateModalContent({
     return 0;
   }, [evaluateOn, total, train.length, test.length]);
 
-  const { canSaveNewVersion: canSave } = useVersionState({ project });
+  const canSave = checkCanCommitNewVersion();
   const trpc = api.useContext();
 
   const commitVersion = api.workflow.commitVersion.useMutation();

--- a/langwatch/src/optimization_studio/components/Optimize.tsx
+++ b/langwatch/src/optimization_studio/components/Optimize.tsx
@@ -124,6 +124,7 @@ export function OptimizeModalContent({
     setLastCommittedWorkflow,
     setCurrentVersionId,
     currentVersionId,
+    checkCanCommitNewVersion,
   } = useWorkflowStore(
     ({
       workflow_id: workflowId,
@@ -136,6 +137,7 @@ export function OptimizeModalContent({
       setLastCommittedWorkflow,
       setCurrentVersionId,
       currentVersionId,
+      checkCanCommitNewVersion,
     }) => ({
       workflowId,
       getWorkflow,
@@ -147,6 +149,7 @@ export function OptimizeModalContent({
       setLastCommittedWorkflow,
       setCurrentVersionId,
       currentVersionId,
+      checkCanCommitNewVersion,
     }),
   );
 
@@ -189,7 +192,7 @@ export function OptimizeModalContent({
     },
   );
 
-  const { versions, canSaveNewVersion: canSave } =
+  const { versions } =
     useVersionState({
       project,
       form: form as unknown as UseFormReturn<{
@@ -198,6 +201,7 @@ export function OptimizeModalContent({
       }>,
       allowSaveIfAutoSaveIsCurrentButNotLatest: false,
     });
+  const canSave = checkCanCommitNewVersion();
 
   const commitVersion = api.workflow.commitVersion.useMutation();
   const { startOptimizationExecution } = useOptimizationExecution();

--- a/langwatch/src/optimization_studio/components/Publish.tsx
+++ b/langwatch/src/optimization_studio/components/Publish.tsx
@@ -457,6 +457,7 @@ function PublishModalContent({
     setLastCommittedWorkflow,
     setCurrentVersionId,
     currentVersionId,
+    checkCanCommitNewVersion,
   } = useWorkflowStore(
     ({
       workflow_id: workflowId,
@@ -465,6 +466,7 @@ function PublishModalContent({
       setLastCommittedWorkflow,
       setCurrentVersionId,
       currentVersionId,
+      checkCanCommitNewVersion,
     }) => ({
       workflowId,
       getWorkflow,
@@ -472,6 +474,7 @@ function PublishModalContent({
       setLastCommittedWorkflow,
       setCurrentVersionId,
       currentVersionId,
+      checkCanCommitNewVersion,
     }),
   );
 
@@ -494,13 +497,19 @@ function PublishModalContent({
 
   const {
     versions,
-    canSaveNewVersion: canSave,
     versionToBeEvaluated,
   } = useVersionState({
     project,
     form,
     allowSaveIfAutoSaveIsCurrentButNotLatest: false,
   });
+
+  // Use the same check as VersionToBeUsed to decide whether a new commit is needed.
+  // canSaveNewVersion (from useVersionState) may be true due to autoSaved conditions
+  // even when there are no actual DSL changes, which causes a mismatch: the UI shows
+  // CurrentVersionDisplay (no commit message input) but onSubmit tries to commit,
+  // fails form validation silently, and the button appears to hang.
+  const canSave = checkCanCommitNewVersion();
 
   const publishWorkflow = api.workflow.publish.useMutation();
 

--- a/langwatch/src/optimization_studio/components/workflow/NewWorkflowForm.tsx
+++ b/langwatch/src/optimization_studio/components/workflow/NewWorkflowForm.tsx
@@ -193,6 +193,7 @@ export const NewWorkflowForm = ({
 
     const newWorkflow: Workflow = {
       ...template,
+      version: "1",
       name: data.name,
       description: data.description,
       icon: data.icon ?? defaultIcon,

--- a/langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts
+++ b/langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts
@@ -51,7 +51,6 @@ function computeFieldsFromEvaluatorType(evaluatorType: string): {
   if (def.result.score) outputs.push({ identifier: "score", type: "float" });
   if (def.result.passed) outputs.push({ identifier: "passed", type: "bool" });
   if (def.result.label) outputs.push({ identifier: "label", type: "str" });
-  outputs.push({ identifier: "details", type: "str" });
 
   return { inputs, outputs };
 }

--- a/langwatch/src/server/evaluations-v3/execution/resultMapper.ts
+++ b/langwatch/src/server/evaluations-v3/execution/resultMapper.ts
@@ -239,7 +239,13 @@ export const mapEvaluatorResult = (
           label: typeof executionState.outputs?.label === 'string'
             ? executionState.outputs.label
             : undefined,
-          details: executionState.outputs?.details as string | undefined,
+          // Only include details when it's a non-empty string.
+          // Python's EvaluationResultWithMetadata always serializes details
+          // (default None -> null), so we filter out null/undefined to prevent
+          // the "sticky details" bug where details appears even after removal.
+          details: typeof executionState.outputs?.details === 'string' && executionState.outputs.details
+            ? executionState.outputs.details
+            : undefined,
           cost: executionState.cost
             ? { currency: "USD", amount: executionState.cost }
             : undefined,

--- a/langwatch/src/server/evaluators/__tests__/evaluator.service.test.ts
+++ b/langwatch/src/server/evaluators/__tests__/evaluator.service.test.ts
@@ -168,7 +168,7 @@ describe("EvaluatorService", () => {
       expect(result!.fields).toEqual([]);
     });
 
-    it("computes output fields with only passed + details for exact_match", async () => {
+    it("computes output fields with only passed for exact_match (no sticky details)", async () => {
       const mockPrisma = {} as PrismaClient;
       const mockRepository = {
         findById: vi.fn().mockResolvedValue({
@@ -186,11 +186,10 @@ describe("EvaluatorService", () => {
 
       expect(result!.outputFields).toEqual([
         { identifier: "passed", type: "bool" },
-        { identifier: "details", type: "str" },
       ]);
     });
 
-    it("computes output fields with score + details for ragas", async () => {
+    it("computes output fields with only score for ragas (no sticky details)", async () => {
       const mockPrisma = {} as PrismaClient;
       const mockRepository = {
         findById: vi.fn().mockResolvedValue({
@@ -208,11 +207,10 @@ describe("EvaluatorService", () => {
 
       expect(result!.outputFields).toEqual([
         { identifier: "score", type: "float" },
-        { identifier: "details", type: "str" },
       ]);
     });
 
-    it("computes all output fields for PII detection (score + passed + label + details)", async () => {
+    it("computes output fields for PII detection (score + passed + label, no sticky details)", async () => {
       const mockPrisma = {} as PrismaClient;
       const mockRepository = {
         findById: vi.fn().mockResolvedValue({
@@ -232,7 +230,6 @@ describe("EvaluatorService", () => {
         { identifier: "score", type: "float" },
         { identifier: "passed", type: "bool" },
         { identifier: "label", type: "str" },
-        { identifier: "details", type: "str" },
       ]);
     });
 

--- a/langwatch/src/server/evaluators/evaluator.service.ts
+++ b/langwatch/src/server/evaluators/evaluator.service.ts
@@ -169,7 +169,9 @@ export class EvaluatorService {
   /**
    * Computes output fields for a built-in evaluator from its result definition.
    * Only includes score/passed/label when the evaluator actually produces them.
-   * Always includes details since all evaluators can produce a freeform explanation.
+   * Does NOT unconditionally add `details` -- it is included as a default when
+   * creating NEW evaluator nodes (see useEvaluatorPickerFlow), but users can
+   * remove it. Respecting the declared outputFields prevents "sticky" fields.
    */
   private computeBuiltInOutputFields(evaluatorType: string): EvaluatorField[] {
     const def = AVAILABLE_EVALUATORS[evaluatorType as EvaluatorTypes];
@@ -179,10 +181,8 @@ export class EvaluatorService {
     if (def.result.score) fields.push({ identifier: "score", type: "float" });
     if (def.result.passed) fields.push({ identifier: "passed", type: "bool" });
     if (def.result.label) fields.push({ identifier: "label", type: "str" });
-    // details is always available on EvaluationResult
-    fields.push({ identifier: "details", type: "str" });
 
-    return fields.length > 1 ? fields : STANDARD_EVALUATOR_OUTPUT_FIELDS;
+    return fields.length > 0 ? fields : STANDARD_EVALUATOR_OUTPUT_FIELDS;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes three interrelated bugs in the Workflow Studio:

- **Publish/Evaluate/Optimize buttons hang**: `canSaveNewVersion` (from `useVersionState`) and `checkCanCommitNewVersion` (zustand store) disagreed on whether a new version was needed. When the UI showed no commit message input but `onSubmit` required one, form validation silently failed. Unified all three components to use `checkCanCommitNewVersion()`.

- **Imported workflows keep original version**: `NewWorkflowForm` spread `...template` including `version` into the create API. Added `version: "1"` override so imports always start fresh.

- **Evaluator `details` output is sticky**: `details` was unconditionally injected at multiple hardcoded points, ignoring user removal from the End node. Removed forced injection from `evaluator.service.ts` and `useEvaluatorPickerFlow.ts`. Made `resultMapper` only include `details` when it's a non-empty string.

Closes #2474

## Test plan

- [x] `pnpm typecheck` — no new errors (pre-existing Prisma errors only)
- [x] `pnpm test:unit evaluator.service.test.ts` — 14/14 pass
- [ ] Manual: Import a workflow → version shows "1"
- [ ] Manual: Open Publish modal with no changes → button works (publishes current version)
- [ ] Manual: Remove `details` from End node → run evaluation → no `details` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2474