### PR TITLE
fix: accept null status field in OTLP span schema

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/__tests__/otlp.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/__tests__/otlp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { bytesSchema, idSchema } from "../otlp";
+import { bytesSchema, idSchema, spanSchema } from "../otlp";
 
 describe("otlp schemas", () => {
   describe("idSchema", () => {
@@ -103,6 +103,81 @@ describe("otlp schemas", () => {
         expect(result.success).toBe(true);
         if (result.success) {
           expect(result.data).toBe("");
+        }
+      });
+    });
+  });
+
+  describe("spanSchema", () => {
+    function makeValidSpan(overrides: Record<string, unknown> = {}) {
+      return {
+        traceId: "aaaa0000000000000000000000000001",
+        spanId: "bbbb000000000001",
+        name: "test-span",
+        kind: 1,
+        startTimeUnixNano: "1700000000000000000",
+        endTimeUnixNano: "1700000001000000000",
+        attributes: [],
+        events: [],
+        links: [],
+        status: { code: null, message: null },
+        droppedAttributesCount: 0,
+        droppedEventsCount: 0,
+        droppedLinksCount: 0,
+        ...overrides,
+      };
+    }
+
+    describe("when status is a valid object", () => {
+      it("accepts status with code and message", () => {
+        const span = makeValidSpan({ status: { code: 1, message: "OK" } });
+
+        const result = spanSchema.safeParse(span);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.status).toEqual({ code: 1, message: "OK" });
+        }
+      });
+    });
+
+    describe("when status is null (.NET OTEL SDK)", () => {
+      it("accepts null status and defaults to code=null, message=null", () => {
+        const span = makeValidSpan({ status: null });
+
+        const result = spanSchema.safeParse(span);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.status).toEqual({ code: null, message: null });
+        }
+      });
+    });
+
+    describe("when status is undefined", () => {
+      it("accepts undefined status and defaults to code=null, message=null", () => {
+        const span = makeValidSpan();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (span as any).status;
+
+        const result = spanSchema.safeParse(span);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.status).toEqual({ code: null, message: null });
+        }
+      });
+    });
+
+    describe("when status has empty object (no code/message)", () => {
+      it("accepts empty status object", () => {
+        const span = makeValidSpan({ status: {} });
+
+        const result = spanSchema.safeParse(span);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.status).toEqual({});
         }
       });
     });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/otlp.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/schemas/otlp.ts
@@ -164,7 +164,11 @@ export const spanSchema = z.object({
   attributes: z.array(keyValueSchema),
   events: z.array(eventSchema).optional().default([]),
   links: z.array(linkSchema).optional().default([]),
-  status: statusSchema,
+  status: statusSchema
+    .nullable()
+    .optional()
+    .default({ message: null, code: null })
+    .transform((v) => v ?? { message: null, code: null }),
   flags: z.number().optional().nullable(),
   droppedAttributesCount: z.number().optional().nullable().default(0),
   droppedEventsCount: z.number().optional().nullable().default(0),


### PR DESCRIPTION
## Summary
- The .NET OTEL SDK sends `status: null` for spans that don't explicitly set a status
- The Zod `spanSchema` required `status` to be a non-null object, causing `safeParse` to fail and silently dropping those spans from the ClickHouse ingestion pipeline
- The ES pipeline uses a different transformation (`otel.traces.ts`) that isn't affected, leading to span count discrepancies between CH and ES
- Confirmed in CloudWatch logs: `ZodError: Expected object at path ["status"], received null` for `project_bgThj9GhdGZk8iTdMCLfo`

## Changes
- Made `status` nullable/optional with a default of `{ message: null, code: null }` and a transform to coalesce `null` → default
- Added 4 tests covering null, undefined, valid, and empty status objects

## Test plan
- [x] Existing 11 otlp schema tests pass
- [x] 4 new spanSchema tests pass (null, undefined, valid object, empty object)
- [x] Downstream code (`span-normalization.service.ts`) is safe — the transform guarantees a non-null object