### PR TITLE
fix: add retry with backoff for ClickHouse inserts on transient errors

### DIFF
--- a/langwatch/src/server/app-layer/clients/__tests__/clickhouse.resilient.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/__tests__/clickhouse.resilient.unit.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  createResilientClickHouseClient,
+  isTransientClickHouseError,
+} from "../clickhouse.resilient";
+
+function makeMockClient(overrides?: Partial<ClickHouseClient>) {
+  return {
+    insert: vi.fn(),
+    query: vi.fn(),
+    command: vi.fn(),
+    exec: vi.fn(),
+    close: vi.fn(),
+    ping: vi.fn(),
+    ...overrides,
+  } as unknown as ClickHouseClient;
+}
+
+describe("createResilientClickHouseClient", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when insert succeeds on first attempt", () => {
+    it("calls insert once and returns the result", async () => {
+      const result = { executed: true };
+      const mock = makeMockClient({ insert: vi.fn().mockResolvedValue(result) });
+      const client = createResilientClickHouseClient({
+        client: mock,
+        maxRetries: 3,
+        baseDelayMs: 1,
+      });
+
+      const actual = await client.insert({
+        table: "test",
+        values: [],
+        format: "JSONEachRow",
+      });
+
+      expect(actual).toBe(result);
+      expect(mock.insert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when insert fails with transient error then succeeds", () => {
+    it("retries and returns the result", async () => {
+      const transientError = new Error("MEMORY_LIMIT_EXCEEDED");
+      const result = { executed: true };
+      const mock = makeMockClient({
+        insert: vi
+          .fn()
+          .mockRejectedValueOnce(transientError)
+          .mockResolvedValueOnce(result),
+      });
+      const client = createResilientClickHouseClient({
+        client: mock,
+        maxRetries: 3,
+        baseDelayMs: 1,
+      });
+
+      const actual = await client.insert({
+        table: "test",
+        values: [],
+        format: "JSONEachRow",
+      });
+
+      expect(actual).toBe(result);
+      expect(mock.insert).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("when insert fails with non-transient error", () => {
+    it("throws immediately without retrying", async () => {
+      const schemaError = new Error("Table does_not_exist doesn't exist");
+      const mock = makeMockClient({
+        insert: vi.fn().mockRejectedValue(schemaError),
+      });
+      const client = createResilientClickHouseClient({
+        client: mock,
+        maxRetries: 3,
+        baseDelayMs: 1,
+      });
+
+      await expect(
+        client.insert({ table: "test", values: [], format: "JSONEachRow" }),
+      ).rejects.toThrow("Table does_not_exist doesn't exist");
+      expect(mock.insert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when all retries are exhausted", () => {
+    it("calls maxRetries+1 times then throws the final error", async () => {
+      const transientError = new Error("MEMORY_LIMIT_EXCEEDED");
+      const mock = makeMockClient({
+        insert: vi.fn().mockRejectedValue(transientError),
+      });
+      const client = createResilientClickHouseClient({
+        client: mock,
+        maxRetries: 2,
+        baseDelayMs: 1,
+      });
+
+      await expect(
+        client.insert({ table: "test", values: [], format: "JSONEachRow" }),
+      ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+      expect(mock.insert).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("when query, command, or close is called", () => {
+    it("passes through to the underlying client", async () => {
+      const queryResult = { data: [] };
+      const mock = makeMockClient({
+        query: vi.fn().mockResolvedValue(queryResult),
+        command: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      });
+      const client = createResilientClickHouseClient({
+        client: mock,
+        maxRetries: 3,
+      });
+
+      const qr = await client.query({ query: "SELECT 1" });
+      expect(qr).toBe(queryResult);
+      expect(mock.query).toHaveBeenCalledTimes(1);
+
+      await client.command({ query: "CREATE TABLE ..." });
+      expect(mock.command).toHaveBeenCalledTimes(1);
+
+      await client.close();
+      expect(mock.close).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("isTransientClickHouseError", () => {
+  describe("when error contains MEMORY_LIMIT_EXCEEDED", () => {
+    it("returns true", () => {
+      expect(
+        isTransientClickHouseError(new Error("MEMORY_LIMIT_EXCEEDED")),
+      ).toBe(true);
+    });
+  });
+
+  describe("when error has a network code", () => {
+    it("returns true for ECONNRESET", () => {
+      const err = new Error("connection reset");
+      (err as NodeJS.ErrnoException).code = "ECONNRESET";
+      expect(isTransientClickHouseError(err)).toBe(true);
+    });
+
+    it("returns true for ETIMEDOUT", () => {
+      const err = new Error("timed out");
+      (err as NodeJS.ErrnoException).code = "ETIMEDOUT";
+      expect(isTransientClickHouseError(err)).toBe(true);
+    });
+  });
+
+  describe("when error message contains timeout", () => {
+    it("returns true", () => {
+      expect(
+        isTransientClickHouseError(new Error("Request Timeout")),
+      ).toBe(true);
+    });
+  });
+
+  describe("when error has HTTP 503 status", () => {
+    it("returns true", () => {
+      const err = new Error("Service Unavailable") as Error & {
+        statusCode: number;
+      };
+      err.statusCode = 503;
+      expect(isTransientClickHouseError(err)).toBe(true);
+    });
+  });
+
+  describe("when error has HTTP 429 status", () => {
+    it("returns true", () => {
+      const err = new Error("Too Many Requests") as Error & {
+        statusCode: number;
+      };
+      err.statusCode = 429;
+      expect(isTransientClickHouseError(err)).toBe(true);
+    });
+  });
+
+  describe("when error is non-transient", () => {
+    it("returns false for schema errors", () => {
+      expect(
+        isTransientClickHouseError(new Error("Table foo doesn't exist")),
+      ).toBe(false);
+    });
+
+    it("returns false for non-Error values", () => {
+      expect(isTransientClickHouseError("string error")).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/clients/clickhouse.factory.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse.factory.ts
@@ -1,4 +1,5 @@
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
+import { createResilientClickHouseClient } from "./clickhouse.resilient";
 
 export interface ClickHouseFactoryOptions {
   url?: string;
@@ -17,8 +18,10 @@ export function createClickHouseClientFromConfig(
     // If not a valid URL, pass the raw string — ClickHouse client may still accept it
   }
 
-  return createClient({
+  const raw = createClient({
     url,
     clickhouse_settings: { date_time_input_format: "best_effort" },
   });
+
+  return createResilientClickHouseClient({ client: raw });
 }

--- a/langwatch/src/server/app-layer/clients/clickhouse.resilient.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse.resilient.ts
@@ -1,0 +1,99 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:clickhouse:resilient");
+
+const TRANSIENT_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ENOTFOUND",
+]);
+
+const TRANSIENT_HTTP_STATUSES = new Set([503, 429]);
+
+export function isTransientClickHouseError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const message = error.message;
+
+  if (message.includes("MEMORY_LIMIT_EXCEEDED")) return true;
+  if (/timeout/i.test(message)) return true;
+
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
+
+  const status =
+    (error as { statusCode?: number }).statusCode ??
+    (error as { status?: number }).status;
+  if (status && TRANSIENT_HTTP_STATUSES.has(status)) return true;
+
+  return false;
+}
+
+function jitteredBackoff({
+  attempt,
+  baseDelayMs,
+  maxDelayMs,
+}: {
+  attempt: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}): number {
+  const exponential = baseDelayMs * 2 ** attempt;
+  const jitter = Math.random() * baseDelayMs;
+  return Math.min(exponential + jitter, maxDelayMs);
+}
+
+export function createResilientClickHouseClient({
+  client,
+  maxRetries = 3,
+  baseDelayMs = 500,
+  maxDelayMs = 10_000,
+}: {
+  client: ClickHouseClient;
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}): ClickHouseClient {
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      if (prop !== "insert") {
+        return Reflect.get(target, prop, receiver);
+      }
+
+      return async (...args: unknown[]) => {
+        let lastError: unknown;
+
+        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+          try {
+            return await (target.insert as Function).apply(target, args);
+          } catch (error) {
+            lastError = error;
+
+            if (!isTransientClickHouseError(error) || attempt === maxRetries) {
+              throw error;
+            }
+
+            const delay = jitteredBackoff({ attempt, baseDelayMs, maxDelayMs });
+            logger.warn(
+              {
+                attempt: attempt + 1,
+                maxRetries,
+                delayMs: Math.round(delay),
+                error:
+                  error instanceof Error ? error.message : String(error),
+              },
+              "Transient ClickHouse insert error, retrying",
+            );
+
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
+        }
+
+        throw lastError;
+      };
+    },
+  });
+}

--- a/langwatch/src/server/clickhouse/client.ts
+++ b/langwatch/src/server/clickhouse/client.ts
@@ -1,4 +1,5 @@
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
+import { createResilientClickHouseClient } from "~/server/app-layer/clients/clickhouse.resilient";
 import { createLogger } from "~/utils/logger/server";
 
 const logger = createLogger("langwatch:clickhouse:client");
@@ -38,12 +39,14 @@ export function getClickHouseClient(): ClickHouseClient | null {
       );
     }
 
-    clickHouseClient = createClient({
+    const raw = createClient({
       url,
       clickhouse_settings: {
         date_time_input_format: "best_effort",
       },
     });
+
+    clickHouseClient = createResilientClickHouseClient({ client: raw });
   }
 
   return clickHouseClient;


### PR DESCRIPTION
## Summary

- Adds transparent retry-with-backoff for all ClickHouse `insert` calls via a `Proxy` wrapper on `ClickHouseClient`
- Retries transient errors (MEMORY_LIMIT_EXCEEDED, network errors, timeouts, HTTP 503/429) with jittered exponential backoff (up to 3 retries, 500ms base delay)
- Applied at both client factory entry points (`clickhouse.factory.ts` + legacy `client.ts`), so all 13 repository insert sites get retry behavior with zero call-site changes

## Test plan

- [x] Unit tests for resilient wrapper (13 tests covering success, retry, non-transient throw, exhaustion, passthrough)
- [x] Typecheck passes — return type stays `ClickHouseClient`, no downstream breakage
- [ ] Verify in staging under memory pressure that inserts retry and succeed