### PR TITLE
fix: reduce Redis CPU from GroupQueue dispatch loop

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -761,6 +761,71 @@ describe("GroupStagingScripts", () => {
   });
 
   describe("dispatchBatch", () => {
+    describe("when all groups have active keys", () => {
+      it("exits early without scanning additional passes", async () => {
+        // Stage jobs in multiple groups and dispatch them all so every group has an active key
+        const groupCount = 10;
+        for (let i = 0; i < groupCount; i++) {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: `j${i}`,
+              groupId: `group-${i}`,
+              dispatchAfterMs: 100,
+            }),
+          );
+        }
+
+        // Dispatch all — each group now has an active key
+        const firstBatch = await scripts.dispatchBatch({
+          nowMs: 200,
+          activeTtlSec: 60,
+          maxJobs: groupCount,
+        });
+        expect(firstBatch).toHaveLength(groupCount);
+
+        // Stage more jobs in each group (they can't dispatch due to active keys)
+        for (let i = 0; i < groupCount; i++) {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: `j${i}-second`,
+              groupId: `group-${i}`,
+              dispatchAfterMs: 100,
+            }),
+          );
+        }
+
+        // This dispatch should find nothing eligible and exit early
+        const secondBatch = await scripts.dispatchBatch({
+          nowMs: 200,
+          activeTtlSec: 60,
+          maxJobs: groupCount,
+        });
+        expect(secondBatch).toHaveLength(0);
+      });
+    });
+
+    describe("when some groups become eligible after first pass dispatches", () => {
+      it("does not dispatch from the same group twice in one call", async () => {
+        // Stage two jobs in the same group
+        await scripts.stage(
+          makeJob({ stagedJobId: "j1", groupId: "group-a", dispatchAfterMs: 100 }),
+        );
+        await scripts.stage(
+          makeJob({ stagedJobId: "j2", groupId: "group-a", dispatchAfterMs: 200 }),
+        );
+
+        // dispatchBatch should only dispatch j1 (per-group FIFO: active key blocks j2)
+        const results = await scripts.dispatchBatch({
+          nowMs: 300,
+          activeTtlSec: 60,
+          maxJobs: 10,
+        });
+
+        expect(results).toHaveLength(1);
+        expect(results[0]!.stagedJobId).toBe("j1");
+      });
+    });
+
     describe("when paused jobs exist", () => {
     it("skips paused groups and returns only non-paused", async () => {
       await scripts.stage(

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/dispatcher.ts
@@ -41,6 +41,11 @@ export class GroupQueueDispatcher {
           do {
             dispatched = await this.dispatchBatch();
           } while (dispatched > 0 && !this.shutdownRequested);
+
+          // Drain signals that arrived during dispatch to prevent
+          // immediate re-wake from stale notifications
+          const signalKey = this.params.scripts.getSignalKey();
+          await this.params.blockingConnection.del(signalKey);
         } catch (error) {
           if (this.shutdownRequested) break;
 
@@ -98,6 +103,9 @@ export class GroupQueueDispatcher {
       signalKey,
       this.params.signalTimeoutSec,
     );
+    // Drain remaining buffered signals — the upcoming dispatchBatch
+    // handles multiple jobs in one Lua call, so N signals = 1 cycle.
+    await this.params.blockingConnection.del(signalKey);
   }
 
   private async dispatchBatch(): Promise<number> {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -42,7 +42,7 @@ const GROUP_QUEUE_CONFIG = {
   /** TTL for the active key (safety net for crashes), in seconds */
   activeTtlSec: 300,
   /** BRPOP timeout in seconds (fallback polling interval) */
-  signalTimeoutSec: 1,
+  signalTimeoutSec: 5,
   /** Interval for collecting queue metrics in milliseconds */
   metricsIntervalMs: 15000,
   /** Maximum time to wait for graceful shutdown in milliseconds */
@@ -655,6 +655,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     this.shutdownRequested = true;
     this.metricsCollector?.stop();
     this.dispatcher?.requestShutdown();
+    // Wake the BRPOP so the dispatcher exits immediately
+    await this.redisConnection
+      .lpush(this.scripts.getSignalKey(), "1")
+      .catch(() => {});
     this.logger.debug(
       { queueName: this.queueName },
       "Closing group queue processor",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -216,6 +216,8 @@ for pass = 1, maxPasses do
   local groups = redis.call("ZREVRANGE", readyKey, scanStart, scanEnd)
   if #groups == 0 then break end
 
+  local passDispatched = 0
+
   for _, groupId in ipairs(groups) do
     if dispatched >= maxJobs then break end
 
@@ -275,12 +277,14 @@ for pass = 1, maxPasses do
             results[#results + 1] = jobDataJson or ""
             results[#results + 1] = tostring(originalScore)
             dispatched = dispatched + 1
+            passDispatched = passDispatched + 1
           end
         end
       end
     end
   end
 
+  if passDispatched == 0 then break end
   scanStart = scanStart + scanWindow
 end
 
@@ -713,7 +717,7 @@ export class GroupStagingScripts {
    * slot is freed immediately.
    *
    * The active key TTL is set to match the backoff period so the key expires
-   * naturally. On the next dispatcher poll (≤1s) the retry job is dispatched.
+   * naturally. On the next dispatcher poll (≤5s) the retry job is dispatched.
    * This is fully Redis-driven — no Node.js timers, survives restarts.
    *
    * @returns true if re-staged, false if stale (active key doesn't match)


### PR DESCRIPTION
## Summary

- **Lua early exit**: `DISPATCH_BATCH_LUA` now breaks out of the multi-pass scan loop when a pass dispatches zero jobs, avoiding 3–5x redundant group scans when all slots are busy
- **Signal draining**: DEL the signal list after BRPOP and after the dispatch loop to collapse N buffered completion signals into 1 dispatch cycle (highest impact fix)
- **BRPOP timeout 1s→5s**: reduces idle polling from 1/sec to 0.2/sec; adds a wake signal on shutdown so the dispatcher exits immediately despite the longer timeout

## Test plan

- [ ] Integration tests pass: `pnpm test:integration scripts.integration.test.ts`
- [ ] Typecheck passes: `pnpm typecheck`
- [ ] After deploy: CloudWatch `EngineCPUUtilization` drops from 70–100% to <30% under same load
- [ ] After deploy: `EvalBasedCmds` drops 10–100x during burst periods