### PR TITLE
feat(nurturing): hooks and reactors for Customer.io sync (R2-R7)

### DIFF
--- a/langwatch/ee/billing/nurturing/hooks/activityTracking.ts
+++ b/langwatch/ee/billing/nurturing/hooks/activityTracking.ts
@@ -1,0 +1,80 @@
+import { getApp } from "../../../../src/server/app-layer/app";
+import { captureException } from "../../../../src/utils/posthogErrorCapture";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * In-memory cache of the last time each user was identified for activity tracking.
+ * Keyed by userId, value is the timestamp of the last identify call.
+ *
+ * NOTE: debounce is process-local. In multi-instance deployments, each instance
+ * tracks independently. This is acceptable — Customer.io's 3000 req/3s limit
+ * is unlikely to be hit, and duplicate identify calls are idempotent.
+ */
+const lastActivitySentAt = new Map<string, number>();
+
+/**
+ * Timestamp of the last sweep pass. Sweeps run at most once per hour
+ * to avoid O(n) iteration overhead on every call.
+ */
+let lastSweepAt = 0;
+
+/**
+ * Evicts entries older than ONE_HOUR_MS from the debounce cache.
+ * Only runs at most once per hour to keep per-call cost constant.
+ */
+function sweepExpiredEntries(now: number): void {
+  if (now - lastSweepAt < ONE_HOUR_MS) return;
+  for (const [cachedUserId, sentAt] of lastActivitySentAt) {
+    if (now - sentAt >= ONE_HOUR_MS) {
+      lastActivitySentAt.delete(cachedUserId);
+    }
+  }
+  lastSweepAt = now;
+}
+
+/**
+ * Pushes last_active_at to Customer.io for inactivity detection.
+ *
+ * Debounced to at most once per hour per user to avoid excessive API calls.
+ * Fire-and-forget: never throws, never blocks the session callback.
+ */
+export function fireActivityTrackingNurturing({
+  userId,
+}: {
+  userId: string;
+}): void {
+  const now = Date.now();
+  sweepExpiredEntries(now);
+  const lastSent = lastActivitySentAt.get(userId);
+
+  if (lastSent && now - lastSent < ONE_HOUR_MS) {
+    return;
+  }
+
+  lastActivitySentAt.set(userId, now);
+
+  void getApp()
+    .nurturing?.identifyUser({
+      userId,
+      traits: { last_active_at: new Date(now).toISOString() },
+    })
+    ?.catch(captureException);
+}
+
+/**
+ * Resets the debounce cache. Only exposed for testing.
+ * @internal
+ */
+export function resetActivityTrackingCache(): void {
+  lastActivitySentAt.clear();
+  lastSweepAt = 0;
+}
+
+/**
+ * Returns a snapshot of the cache for testing.
+ * @internal
+ */
+export function getActivityTrackingCacheSize(): number {
+  return lastActivitySentAt.size;
+}

--- a/langwatch/ee/billing/nurturing/hooks/activityTracking.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/activityTracking.unit.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fireActivityTrackingNurturing,
+  resetActivityTrackingCache,
+  getActivityTrackingCacheSize,
+} from "./activityTracking";
+
+// Suppress logger output
+vi.mock("../../../../src/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock("../../../../src/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockNurturing = {
+  identifyUser: vi.fn().mockResolvedValue(undefined),
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+  groupUser: vi.fn().mockResolvedValue(undefined),
+  batch: vi.fn().mockResolvedValue(undefined),
+};
+
+let currentNurturing: typeof mockNurturing | undefined = mockNurturing;
+
+vi.mock("../../../../src/server/app-layer/app", () => ({
+  getApp: () => ({
+    get nurturing() {
+      return currentNurturing;
+    },
+  }),
+}));
+
+describe("Activity tracking hook", () => {
+  describe("given an active NurturingService", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      currentNurturing = mockNurturing;
+      resetActivityTrackingCache();
+      vi.useRealTimers();
+    });
+
+    describe("when the auth session callback fires", () => {
+      it("identifies user with last_active_at set to the current time", () => {
+        const now = new Date("2026-03-15T12:00:00.000Z");
+        vi.setSystemTime(now);
+
+        fireActivityTrackingNurturing({ userId: "user-1" });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: { last_active_at: "2026-03-15T12:00:00.000Z" },
+        });
+
+        vi.useRealTimers();
+      });
+    });
+
+    describe("when a user refreshes their session multiple times within one hour", () => {
+      it("makes at most one Customer.io identify call per hour", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        fireActivityTrackingNurturing({ userId: "user-1" });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(1);
+
+        vi.useRealTimers();
+      });
+
+      it("allows a new call after one hour has passed", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(1);
+
+        // Advance past the 1-hour debounce window
+        vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(2);
+
+        vi.useRealTimers();
+      });
+
+      it("tracks separate users independently", () => {
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        fireActivityTrackingNurturing({ userId: "user-2" });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("when expired entries accumulate in the debounce cache", () => {
+      it("evicts entries older than one hour during the next call", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+        // Populate cache with multiple users
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        fireActivityTrackingNurturing({ userId: "user-2" });
+        fireActivityTrackingNurturing({ userId: "user-3" });
+        expect(getActivityTrackingCacheSize()).toBe(3);
+
+        // Advance past the 1-hour window so entries are expired
+        vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+        // Next call triggers sweep and evicts expired entries
+        fireActivityTrackingNurturing({ userId: "user-4" });
+
+        // Only user-4 remains (user-1..3 were evicted by sweep)
+        expect(getActivityTrackingCacheSize()).toBe(1);
+
+        vi.useRealTimers();
+      });
+
+      it("does not sweep more than once per hour", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+        // First call triggers sweep (lastSweepAt is 0)
+        fireActivityTrackingNurturing({ userId: "user-1" });
+        expect(getActivityTrackingCacheSize()).toBe(1);
+
+        // Advance 30 minutes — not enough for another sweep
+        vi.advanceTimersByTime(30 * 60 * 1000);
+        fireActivityTrackingNurturing({ userId: "user-2" });
+        expect(getActivityTrackingCacheSize()).toBe(2);
+
+        // Advance another 31 minutes (total 61 min from start)
+        // user-1 is now expired but sweep hasn't run since 30min mark
+        vi.advanceTimersByTime(31 * 60 * 1000);
+        fireActivityTrackingNurturing({ userId: "user-3" });
+
+        // Sweep should have run: user-1 expired (61 min old), user-2 still valid (31 min old)
+        // user-3 just added. So cache = user-2 + user-3 = 2
+        expect(getActivityTrackingCacheSize()).toBe(2);
+
+        vi.useRealTimers();
+      });
+    });
+
+    describe("when Customer.io API is unavailable", () => {
+      it("does not throw (fire-and-forget)", async () => {
+        const { captureException } = await import(
+          "../../../../src/utils/posthogErrorCapture"
+        );
+        mockNurturing.identifyUser.mockRejectedValueOnce(
+          new Error("CIO unavailable"),
+        );
+
+        expect(() =>
+          fireActivityTrackingNurturing({ userId: "user-1" }),
+        ).not.toThrow();
+
+        await vi.waitFor(() => {
+          expect(captureException).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("given nurturing is undefined", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      currentNurturing = undefined;
+      resetActivityTrackingCache();
+    });
+
+    describe("when the auth session callback fires", () => {
+      it("silently skips without calling any nurturing methods", () => {
+        fireActivityTrackingNurturing({ userId: "user-1" });
+
+        expect(mockNurturing.identifyUser).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/ee/billing/nurturing/hooks/featureAdoption.ts
+++ b/langwatch/ee/billing/nurturing/hooks/featureAdoption.ts
@@ -1,0 +1,120 @@
+import { getApp } from "../../../../src/server/app-layer/app";
+import { captureException } from "../../../../src/utils/posthogErrorCapture";
+
+/**
+ * Fires nurturing calls when a team member is invited.
+ *
+ * Updates the user's team_member_count trait and tracks the event.
+ * All calls are fire-and-forget.
+ */
+export function fireTeamMemberInvitedNurturing({
+  userId,
+  teamMemberCount,
+  role,
+}: {
+  userId: string;
+  teamMemberCount: number;
+  role: string;
+}): void {
+  const nurturing = getApp().nurturing;
+  if (!nurturing) return;
+
+  void nurturing
+    .identifyUser({ userId, traits: { team_member_count: teamMemberCount } })
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({ userId, event: "team_member_invited", properties: {
+      role,
+    }})
+    .catch(captureException);
+}
+
+/**
+ * Fires nurturing calls when a workflow is created.
+ *
+ * Updates the user's workflow_count trait and tracks the event.
+ * All calls are fire-and-forget.
+ */
+export function fireWorkflowCreatedNurturing({
+  userId,
+  workflowCount,
+  workflowId,
+  projectId,
+}: {
+  userId: string;
+  workflowCount: number;
+  workflowId: string;
+  projectId: string;
+}): void {
+  const nurturing = getApp().nurturing;
+  if (!nurturing) return;
+
+  void nurturing
+    .identifyUser({ userId, traits: { workflow_count: workflowCount } })
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({ userId, event: "workflow_created", properties: {
+      workflow_id: workflowId,
+      project_id: projectId,
+    }})
+    .catch(captureException);
+}
+
+/**
+ * Fires nurturing calls when a scenario is created.
+ *
+ * Updates the user's scenario_count trait and tracks the event.
+ * All calls are fire-and-forget.
+ */
+export function fireScenarioCreatedNurturing({
+  userId,
+  scenarioCount,
+  scenarioId,
+  projectId,
+}: {
+  userId: string;
+  scenarioCount: number;
+  scenarioId: string;
+  projectId: string;
+}): void {
+  const nurturing = getApp().nurturing;
+  if (!nurturing) return;
+
+  void nurturing
+    .identifyUser({ userId, traits: { scenario_count: scenarioCount } })
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({ userId, event: "scenario_created", properties: {
+      scenario_id: scenarioId,
+      project_id: projectId,
+    }})
+    .catch(captureException);
+}
+
+/**
+ * Fires nurturing event when an experiment is run.
+ *
+ * Fire-and-forget.
+ */
+export function fireExperimentRanNurturing({
+  userId,
+  experimentId,
+  projectId,
+}: {
+  userId: string;
+  experimentId?: string;
+  projectId: string;
+}): void {
+  const nurturing = getApp().nurturing;
+  if (!nurturing) return;
+
+  void nurturing
+    .trackEvent({ userId, event: "experiment_ran", properties: {
+      experiment_id: experimentId,
+      project_id: projectId,
+    }})
+    .catch(captureException);
+}

--- a/langwatch/ee/billing/nurturing/hooks/featureAdoption.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/featureAdoption.unit.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fireTeamMemberInvitedNurturing,
+  fireWorkflowCreatedNurturing,
+  fireScenarioCreatedNurturing,
+  fireExperimentRanNurturing,
+} from "./featureAdoption";
+
+// Suppress logger output
+vi.mock("../../../../src/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock("../../../../src/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockNurturing = {
+  identifyUser: vi.fn().mockResolvedValue(undefined),
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+  groupUser: vi.fn().mockResolvedValue(undefined),
+  batch: vi.fn().mockResolvedValue(undefined),
+};
+
+let currentNurturing: typeof mockNurturing | undefined = mockNurturing;
+
+vi.mock("../../../../src/server/app-layer/app", () => ({
+  getApp: () => ({
+    get nurturing() {
+      return currentNurturing;
+    },
+  }),
+}));
+
+describe("Feature adoption hooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentNurturing = mockNurturing;
+  });
+
+  describe("fireTeamMemberInvitedNurturing()", () => {
+    describe("when an invite is sent", () => {
+      it("identifies user with updated team_member_count", () => {
+        fireTeamMemberInvitedNurturing({
+          userId: "user-1",
+          teamMemberCount: 5,
+          role: "member",
+        });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: { team_member_count: 5 },
+        });
+      });
+
+      it("tracks team_member_invited event with role", () => {
+        fireTeamMemberInvitedNurturing({
+          userId: "user-1",
+          teamMemberCount: 5,
+          role: "member",
+        });
+
+        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "team_member_invited",
+          properties: { role: "member" },
+        });
+      });
+    });
+
+    describe("when nurturing is undefined", () => {
+      it("silently skips without calling any nurturing methods", () => {
+        currentNurturing = undefined;
+
+        fireTeamMemberInvitedNurturing({
+          userId: "user-1",
+          teamMemberCount: 5,
+          role: "member",
+        });
+
+        expect(mockNurturing.identifyUser).not.toHaveBeenCalled();
+        expect(mockNurturing.trackEvent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when Customer.io API is unavailable", () => {
+      it("does not throw (fire-and-forget)", async () => {
+        const { captureException } = await import(
+          "../../../../src/utils/posthogErrorCapture"
+        );
+        mockNurturing.identifyUser.mockRejectedValueOnce(
+          new Error("CIO unavailable"),
+        );
+
+        expect(() =>
+          fireTeamMemberInvitedNurturing({
+            userId: "user-1",
+            teamMemberCount: 5,
+            role: "member",
+          }),
+        ).not.toThrow();
+
+        await vi.waitFor(() => {
+          expect(captureException).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("fireWorkflowCreatedNurturing()", () => {
+    describe("when the workflow is saved", () => {
+      it("identifies user with updated workflow_count", () => {
+        fireWorkflowCreatedNurturing({
+          userId: "user-1",
+          workflowCount: 3,
+          workflowId: "wf-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: { workflow_count: 3 },
+        });
+      });
+
+      it("tracks workflow_created event with workflow_id and project_id", () => {
+        fireWorkflowCreatedNurturing({
+          userId: "user-1",
+          workflowCount: 3,
+          workflowId: "wf-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "workflow_created",
+          properties: { workflow_id: "wf-1", project_id: "proj-1" },
+        });
+      });
+    });
+
+    describe("when nurturing is undefined", () => {
+      it("silently skips without calling any nurturing methods", () => {
+        currentNurturing = undefined;
+
+        fireWorkflowCreatedNurturing({
+          userId: "user-1",
+          workflowCount: 3,
+          workflowId: "wf-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.identifyUser).not.toHaveBeenCalled();
+        expect(mockNurturing.trackEvent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when Customer.io API is unavailable", () => {
+      it("does not throw (fire-and-forget)", async () => {
+        const { captureException } = await import(
+          "../../../../src/utils/posthogErrorCapture"
+        );
+        mockNurturing.identifyUser.mockRejectedValueOnce(
+          new Error("CIO unavailable"),
+        );
+
+        expect(() =>
+          fireWorkflowCreatedNurturing({
+            userId: "user-1",
+            workflowCount: 3,
+            workflowId: "wf-1",
+            projectId: "proj-1",
+          }),
+        ).not.toThrow();
+
+        await vi.waitFor(() => {
+          expect(captureException).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("fireScenarioCreatedNurturing()", () => {
+    describe("when the scenario is saved", () => {
+      it("identifies user with updated scenario_count", () => {
+        fireScenarioCreatedNurturing({
+          userId: "user-1",
+          scenarioCount: 7,
+          scenarioId: "sc-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: { scenario_count: 7 },
+        });
+      });
+
+      it("tracks scenario_created event with scenario_id and project_id", () => {
+        fireScenarioCreatedNurturing({
+          userId: "user-1",
+          scenarioCount: 7,
+          scenarioId: "sc-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "scenario_created",
+          properties: { scenario_id: "sc-1", project_id: "proj-1" },
+        });
+      });
+    });
+
+    describe("when nurturing is undefined", () => {
+      it("silently skips without calling any nurturing methods", () => {
+        currentNurturing = undefined;
+
+        fireScenarioCreatedNurturing({
+          userId: "user-1",
+          scenarioCount: 7,
+          scenarioId: "sc-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.identifyUser).not.toHaveBeenCalled();
+        expect(mockNurturing.trackEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("fireExperimentRanNurturing()", () => {
+    describe("when the experiment completes", () => {
+      it("tracks experiment_ran event with experiment_id and project_id", () => {
+        fireExperimentRanNurturing({
+          userId: "user-1",
+          experimentId: "exp-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "experiment_ran",
+          properties: { experiment_id: "exp-1", project_id: "proj-1" },
+        });
+      });
+
+      it("does not call identifyUser (no count trait for experiments)", () => {
+        fireExperimentRanNurturing({
+          userId: "user-1",
+          experimentId: "exp-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.identifyUser).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when nurturing is undefined", () => {
+      it("silently skips without calling any nurturing methods", () => {
+        currentNurturing = undefined;
+
+        fireExperimentRanNurturing({
+          userId: "user-1",
+          experimentId: "exp-1",
+          projectId: "proj-1",
+        });
+
+        expect(mockNurturing.trackEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/ee/billing/nurturing/hooks/index.ts
+++ b/langwatch/ee/billing/nurturing/hooks/index.ts
@@ -1,0 +1,20 @@
+export { fireSignupNurturingCalls } from "./signupIdentification";
+export {
+  fireTeamMemberInvitedNurturing,
+  fireWorkflowCreatedNurturing,
+  fireScenarioCreatedNurturing,
+  fireExperimentRanNurturing,
+} from "./featureAdoption";
+export {
+  fireActivityTrackingNurturing,
+  resetActivityTrackingCache,
+} from "./activityTracking";
+export {
+  fireProductInterestNurturing,
+  mapProductSelectionToTrait,
+} from "./productInterest";
+export type { ProductInterestValue } from "./productInterest";
+export {
+  firePromptCreatedNurturing,
+  afterPromptCreated,
+} from "./promptCreation";

--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
@@ -1,0 +1,81 @@
+import { getApp } from "../../../../src/server/app-layer/app";
+import { captureException } from "../../../../src/utils/posthogErrorCapture";
+import type { CioPersonTraits } from "../types";
+
+/**
+ * Identifies a new user in Customer.io during onboarding.
+ *
+ * Fires three calls — identifyUser, groupUser, trackEvent —
+ * all fire-and-forget so that Customer.io failures never block onboarding.
+ */
+export function fireSignupNurturingCalls({
+  userId,
+  email,
+  name,
+  organizationId,
+  organizationName,
+  signUpData,
+}: {
+  userId: string;
+  email: string | null | undefined;
+  name: string | null | undefined;
+  organizationId: string;
+  organizationName: string;
+  signUpData?: {
+    yourRole?: string | null;
+    companySize?: string | null;
+    usage?: string | null;
+    solution?: string | null;
+    featureUsage?: string | null;
+    utmCampaign?: string | null;
+    howDidYouHearAboutUs?: string | null;
+  } | null;
+}): void {
+  const nurturing = getApp().nurturing;
+  if (!nurturing) return;
+
+  const traits: Partial<CioPersonTraits> = {
+    ...(email ? { email } : {}),
+    ...(name ? { name } : {}),
+    ...(signUpData?.yourRole ? { role: signUpData.yourRole } : {}),
+    ...(signUpData?.companySize
+      ? { company_size: signUpData.companySize }
+      : {}),
+    ...(signUpData?.usage ? { signup_usage: signUpData.usage } : {}),
+    ...(signUpData?.solution ? { signup_solution: signUpData.solution } : {}),
+    ...(signUpData?.featureUsage
+      ? { signup_feature_usage: signUpData.featureUsage }
+      : {}),
+    ...(signUpData?.utmCampaign
+      ? { utm_campaign: signUpData.utmCampaign }
+      : {}),
+    ...(signUpData?.howDidYouHearAboutUs
+      ? { how_heard: signUpData.howDidYouHearAboutUs }
+      : {}),
+    has_traces: false,
+    has_evaluations: false,
+    has_prompts: false,
+    has_simulations: false,
+    createdAt: new Date().toISOString(),
+  };
+
+  void nurturing
+    .identifyUser({ userId, traits })
+    .catch(captureException);
+
+  void nurturing
+    .groupUser({ userId, groupId: organizationId, traits: {
+      name: organizationName,
+      ...(signUpData?.companySize
+        ? { company_size: signUpData.companySize }
+        : {}),
+      plan: "free",
+    }})
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({ userId, event: "signed_up", properties: {
+      ...(signUpData ?? {}),
+    }})
+    .catch(captureException);
+}

--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.unit.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireSignupNurturingCalls } from "./signupIdentification";
+
+// Suppress logger output
+vi.mock("../../../../src/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock("../../../../src/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockNurturing = {
+  identifyUser: vi.fn().mockResolvedValue(undefined),
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+  groupUser: vi.fn().mockResolvedValue(undefined),
+  batch: vi.fn().mockResolvedValue(undefined),
+};
+
+let currentNurturing: typeof mockNurturing | undefined = mockNurturing;
+
+vi.mock("../../../../src/server/app-layer/app", () => ({
+  getApp: () => ({
+    get nurturing() {
+      return currentNurturing;
+    },
+  }),
+}));
+
+describe("Signup identification hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentNurturing = mockNurturing;
+  });
+
+  describe("when the onboarding flow completes", () => {
+    const baseArgs = {
+      userId: "user-123",
+      email: "jane@example.com",
+      name: "Jane Doe",
+      organizationId: "org-456",
+      organizationName: "Acme Corp",
+      signUpData: {
+        yourRole: "engineer",
+        companySize: "11-50",
+        usage: "monitoring",
+        solution: "llm-ops",
+        featureUsage: "evaluations",
+        utmCampaign: "launch-week",
+        howDidYouHearAboutUs: "twitter",
+      },
+    };
+
+    it("identifies user in Customer.io with email, name, role, and company_size", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          email: "jane@example.com",
+          name: "Jane Doe",
+          role: "engineer",
+          company_size: "11-50",
+        }),
+      });
+    });
+
+    it("includes has_traces false and has_evaluations false in traits", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          has_traces: false,
+          has_evaluations: false,
+        }),
+      });
+    });
+
+    it("includes has_prompts false and has_simulations false in traits", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          has_prompts: false,
+          has_simulations: false,
+        }),
+      });
+    });
+
+    it("includes signup_usage, signup_solution, and signup_feature_usage in traits", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          signup_usage: "monitoring",
+          signup_solution: "llm-ops",
+          signup_feature_usage: "evaluations",
+        }),
+      });
+    });
+
+    it("includes utm_campaign and how_heard when present", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          utm_campaign: "launch-week",
+          how_heard: "twitter",
+        }),
+      });
+    });
+
+    it("includes createdAt as an ISO 8601 timestamp", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      const args = mockNurturing.identifyUser.mock.calls[0]![0];
+      expect(args.traits.createdAt).toBeDefined();
+      expect(new Date(args.traits.createdAt).toISOString()).toBe(args.traits.createdAt);
+    });
+
+    it("associates user with organization via group call", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.groupUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        groupId: "org-456",
+        traits: expect.objectContaining({
+          name: "Acme Corp",
+          company_size: "11-50",
+          plan: "free",
+        }),
+      });
+    });
+
+    it("tracks signed_up event with signup metadata", () => {
+      fireSignupNurturingCalls(baseArgs);
+
+      expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+        userId: "user-123",
+        event: "signed_up",
+        properties: expect.objectContaining({
+          yourRole: "engineer",
+          companySize: "11-50",
+        }),
+      });
+    });
+  });
+
+  describe("when signup data has no optional marketing fields", () => {
+    it("omits utm_campaign and how_heard from traits", () => {
+      fireSignupNurturingCalls({
+        userId: "user-123",
+        email: "jane@example.com",
+        name: "Jane Doe",
+        organizationId: "org-456",
+        organizationName: "Acme Corp",
+        signUpData: {
+          yourRole: "engineer",
+          companySize: "11-50",
+        },
+      });
+
+      const args = mockNurturing.identifyUser.mock.calls[0]![0];
+      expect(args.traits.utm_campaign).toBeUndefined();
+      expect(args.traits.how_heard).toBeUndefined();
+    });
+  });
+
+  describe("when Customer.io API is unavailable", () => {
+    it("does not throw (fire-and-forget)", async () => {
+      const { captureException } = await import(
+        "../../../../src/utils/posthogErrorCapture"
+      );
+      mockNurturing.identifyUser.mockRejectedValueOnce(
+        new Error("CIO unavailable"),
+      );
+
+      expect(() =>
+        fireSignupNurturingCalls({
+          userId: "user-123",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          organizationId: "org-456",
+          organizationName: "Acme Corp",
+        }),
+      ).not.toThrow();
+
+      // Wait for the rejected promise to be caught
+      await vi.waitFor(() => {
+        expect(captureException).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when nurturing is undefined (no Customer.io key)", () => {
+    it("silently skips without calling any nurturing methods", () => {
+      currentNurturing = undefined;
+
+      fireSignupNurturingCalls({
+        userId: "user-123",
+        email: "jane@example.com",
+        name: "Jane Doe",
+        organizationId: "org-456",
+        organizationName: "Acme Corp",
+      });
+
+      expect(mockNurturing.identifyUser).not.toHaveBeenCalled();
+      expect(mockNurturing.groupUser).not.toHaveBeenCalled();
+      expect(mockNurturing.trackEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/app/api/evaluations/v3/execute/route.ts
+++ b/langwatch/src/app/api/evaluations/v3/execute/route.ts
@@ -22,6 +22,7 @@ import {
 import { executionRequestSchema } from "~/server/evaluations-v3/execution/types";
 import { createLogger } from "~/utils/logger/server";
 import { trackServerEvent } from "~/server/posthog";
+import { fireExperimentRanNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
 import { captureException } from "~/utils/posthogErrorCapture";
 
 const logger = createLogger("langwatch:evaluations-v3:execute");
@@ -149,6 +150,11 @@ app.post("/execute", zValidator("json", executionRequestSchema), async (c) => {
             trackServerEvent({
               userId: session.user.id,
               event: "evaluation_ran",
+              projectId,
+            });
+            fireExperimentRanNurturing({
+              userId: session.user.id,
+              experimentId: request.experimentId,
               projectId,
             });
           }

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -5,6 +5,7 @@ import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { trackServerEvent } from "~/server/posthog";
+
 import { createLogger } from "~/utils/logger/server";
 import { runEvaluationForTrace } from "../../background/workers/evaluationsWorker";
 import {

--- a/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
+++ b/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { captureException } from "~/utils/posthogErrorCapture";
+import { fireSignupNurturingCalls } from "~/../ee/billing/nurturing/hooks/signupIdentification";
+import {
+  fireProductInterestNurturing,
+  mapProductSelectionToTrait,
+} from "~/../ee/billing/nurturing/hooks/productInterest";
 
 import { skipPermissionCheck } from "../../rbac";
 import { organizationRouter } from "../organization";
@@ -14,6 +19,35 @@ import { signUpDataSchema } from "./schemas/sign-up-data.schema";
  * Router for handling onboarding-related operations.
  */
 export const onboardingRouter = createTRPCRouter({
+  /**
+   * Sets the product_interest trait in Customer.io after the user picks
+   * a flavour on the onboarding "Pick your flavour" screen.
+   *
+   * This is a separate call from signup identification because
+   * initializeOrganization fires BEFORE the flavour screen.
+   * Fire-and-forget: the mutation resolves immediately.
+   */
+  setProductInterest: protectedProcedure
+    .input(
+      z.object({
+        productInterest: z.enum([
+          "observability",
+          "evaluations",
+          "prompt-management",
+          "agent-simulations",
+        ]),
+      }),
+    )
+    .use(skipPermissionCheck)
+    .mutation(({ input, ctx }) => {
+      const traitValue = mapProductSelectionToTrait(input.productInterest);
+      fireProductInterestNurturing({
+        userId: ctx.session.user.id,
+        productInterest: traitValue,
+      });
+      return { success: true };
+    }),
+
   /**
    * Initializes an organization and its associated project.
    *
@@ -89,6 +123,15 @@ export const onboardingRouter = createTRPCRouter({
         } catch (error) {
           captureException(error);
         }
+
+        fireSignupNurturingCalls({
+          userId: ctx.session.user.id,
+          email: ctx.session.user.email,
+          name: ctx.session.user.name,
+          organizationId: orgResult.organization.id,
+          organizationName: orgResult.organization.name,
+          signUpData: input.signUpData,
+        });
 
         // Return success response with team and project slugs
         return {

--- a/langwatch/src/server/api/routers/onboarding/onboarding.router.unit.test.ts
+++ b/langwatch/src/server/api/routers/onboarding/onboarding.router.unit.test.ts
@@ -48,6 +48,12 @@ vi.mock("~/server/app-layer/app", () => ({
       sendSlackSignupEvent: mockSendSlackSignupEvent,
       sendHubspotSignupForm: mockSendHubspotSignupForm,
     },
+    nurturing: {
+      identifyUser: vi.fn().mockResolvedValue(undefined),
+      trackEvent: vi.fn().mockResolvedValue(undefined),
+      groupUser: vi.fn().mockResolvedValue(undefined),
+      batch: vi.fn().mockResolvedValue(undefined),
+    },
   }),
 }));
 

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -31,6 +31,7 @@ import { isTeamRoleAllowedForOrganizationRole, type TeamRoleValue } from "~/util
 import { slugify } from "~/utils/slugify";
 import { getApp } from "~/server/app-layer/app";
 import { trackServerEvent } from "~/server/posthog";
+import { fireTeamMemberInvitedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
 import { elasticsearchMigrate } from "../../../tasks/elasticMigrate";
 import {
   INVITE_EXPIRATION_MS,
@@ -975,6 +976,15 @@ export const organizationRouter = createTRPCRouter({
           event: "team_member_invited",
           properties: { inviteCount: createdRecords.length },
         });
+
+        const memberCount = organization.members.length + createdRecords.length;
+        for (const record of createdRecords) {
+          fireTeamMemberInvitedNurturing({
+            userId: ctx.session.user.id,
+            teamMemberCount: memberCount,
+            role: record.invite.role,
+          });
+        }
       }
 
       const invites = await Promise.all(

--- a/langwatch/src/server/api/routers/scenarios/scenario-crud.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-crud.router.ts
@@ -5,6 +5,8 @@ import { enforceLicenseLimit } from "~/server/license-enforcement";
 import { ScenarioNotFoundError } from "~/server/scenarios/errors";
 import { ScenarioService } from "~/server/scenarios/scenario.service";
 import { trackServerEvent } from "~/server/posthog";
+import { fireScenarioCreatedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
+import { captureException } from "~/utils/posthogErrorCapture";
 import { createLogger } from "~/utils/logger/server";
 import { checkProjectPermission } from "../../rbac";
 import { projectSchema } from "./schemas";
@@ -46,6 +48,20 @@ export const scenarioCrudRouter = createTRPCRouter({
       });
 
       trackServerEvent({ userId: ctx.session.user.id, event: "scenario_created", projectId: input.projectId });
+
+      void ctx.prisma.scenario
+        .count({
+          where: { projectId: input.projectId, archivedAt: null },
+        })
+        .then((count) => {
+          fireScenarioCreatedNurturing({
+            userId: ctx.session.user.id,
+            scenarioCount: count,
+            scenarioId: result.id,
+            projectId: input.projectId,
+          });
+        })
+        .catch(captureException);
 
       logger.info({ projectId: input.projectId, scenarioId: result.id }, "Scenario created");
       return result;

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -22,6 +22,8 @@ import { enforceLicenseLimit } from "../../license-enforcement";
 import { getVercelAIModel } from "../../modelProviders/utils";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { fireWorkflowCreatedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
+import { captureException } from "~/utils/posthogErrorCapture";
 
 export const workflowRouter = createTRPCRouter({
   create: protectedProcedure
@@ -72,6 +74,20 @@ export const workflowRouter = createTRPCRouter({
           },
         });
       }
+
+      void ctx.prisma.workflow
+        .count({
+          where: { projectId: input.projectId, archivedAt: null },
+        })
+        .then((count) => {
+          fireWorkflowCreatedNurturing({
+            userId: ctx.session.user.id,
+            workflowCount: count,
+            workflowId: workflow.id,
+            projectId: input.projectId,
+          });
+        })
+        .catch(captureException);
 
       return { workflow, version };
     }),

--- a/langwatch/src/server/auth.ts
+++ b/langwatch/src/server/auth.ts
@@ -26,6 +26,7 @@ import { dependencies } from "../injection/dependencies.server";
 import { getNextAuthSessionToken } from "../utils/auth";
 import { createLogger } from "../utils/logger/server";
 import { captureException } from "../utils/posthogErrorCapture";
+import { fireActivityTrackingNurturing } from "../../ee/billing/nurturing/hooks/activityTracking";
 
 const logger = createLogger("langwatch:auth");
 
@@ -77,6 +78,8 @@ export const authOptions = (
           throw new Error("User not found");
         }
 
+        fireActivityTrackingNurturing({ userId: user_.id });
+
         return {
           ...session,
           user: {
@@ -86,6 +89,8 @@ export const authOptions = (
           },
         };
       }
+
+      fireActivityTrackingNurturing({ userId: user.id });
 
       return {
         ...session,

--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -20,6 +20,7 @@ import type {
 import { BILLING_REPORTING_PIPELINE_NAME } from "./pipelines/billing-reporting/pipeline";
 import { createBillingMeterDispatchReactor } from "./projections/global/billingMeterDispatch.reactor";
 import { orgBillableEventsMeterProjection } from "./projections/global/orgBillableEventsMeter.mapProjection";
+import type { ReactorDefinition } from "./reactors/reactor.types";
 
 import { projectDailySdkUsageProjection } from "./projections/global/projectDailySdkUsage.foldProjection";
 import { ProjectionRegistry } from "./projections/projectionRegistry";
@@ -129,6 +130,30 @@ export class EventSourcing {
 
   get isEnabled(): boolean {
     return this._enabled;
+  }
+
+  /**
+   * Register a reactor on a global fold projection.
+   *
+   * Must be called before the projection registry is initialized
+   * (i.e., before the first pipeline is registered).
+   *
+   * Silently skips registration when the fold projection does not exist
+   * (e.g. `projectDailySdkUsage` is only registered in SaaS mode).
+   */
+  registerGlobalFoldReactor(
+    foldName: string,
+    reactor: ReactorDefinition<Event>,
+  ): void {
+    try {
+      this.projectionRegistry.registerReactor(foldName, reactor);
+    } catch (error) {
+      // Fold not registered — skip silently
+      logger.debug(
+        { foldName, reactorName: reactor.name },
+        "Skipping global fold reactor — fold not registered",
+      );
+    }
   }
 
   get eventStore(): EventStore | undefined {

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -4,6 +4,7 @@ import { prepareLitellmParams } from "~/server/api/routers/modelProviders.utils"
 import { getProjectEmbeddingsModel } from "~/server/embeddings";
 import { OPENAI_EMBEDDING_DIMENSION } from "~/utils/constants";
 import { createLogger } from "~/utils/logger/server";
+import type { NurturingService } from "../../../ee/billing/nurturing/nurturing.service";
 import { queryBillableEventsTotal } from "../../../ee/billing/services/billableEventsQuery";
 import type { UsageReportingService } from "../../../ee/billing/services/usageReportingService";
 
@@ -60,8 +61,12 @@ import { LogRecordAppendStore } from "./pipelines/trace-processing/projections/l
 import { MetricRecordAppendStore } from "./pipelines/trace-processing/projections/metricRecordStorage.store";
 import { SpanAppendStore } from "./pipelines/trace-processing/projections/spanStorage.store";
 import { TraceSummaryStore } from "./pipelines/trace-processing/projections/traceSummary.store";
+import { createCustomerIoEvaluationSyncReactor } from "./pipelines/evaluation-processing/reactors/customerIoEvaluationSync.reactor";
+import { createCustomerIoSimulationSyncReactor } from "./pipelines/simulation-processing/reactors/customerIoSimulationSync.reactor";
+import { createCustomerIoTraceSyncReactor } from "./pipelines/trace-processing/reactors/customerIoTraceSync.reactor";
 import { createCustomEvaluationSyncReactor } from "./pipelines/trace-processing/reactors/customEvaluationSync.reactor";
 import { createProjectMetadataReactor } from "./pipelines/trace-processing/reactors/projectMetadata.reactor";
+import { createCustomerIoDailyUsageSyncReactor } from "./projections/global/customerIoDailyUsageSync.reactor";
 import {
   createEvaluationTriggerReactor,
   createDeferredEvaluationHandler,
@@ -91,6 +96,7 @@ export interface PipelineRegistryDeps {
   };
   esSync: EvaluationEsSyncReactorDeps;
   usageReportingService?: UsageReportingService;
+  nurturing?: NurturingService;
 }
 
 /**
@@ -104,6 +110,18 @@ export class PipelineRegistry {
   constructor(private readonly deps: PipelineRegistryDeps) {}
 
   registerAll() {
+    // Register global fold reactors before any pipelines (must be before initialize)
+    if (this.deps.nurturing) {
+      this.deps.eventSourcing.registerGlobalFoldReactor(
+        "projectDailySdkUsage",
+        createCustomerIoDailyUsageSyncReactor({
+          projects: this.deps.projects,
+          prisma: this.deps.prisma,
+          nurturing: this.deps.nurturing,
+        }),
+      );
+    }
+
     const evalPipeline = this.registerEvaluationPipeline();
     const tracePipeline = this.registerTracePipeline(evalPipeline);
     const suiteRunPipeline = this.registerSuiteRunPipeline();
@@ -133,6 +151,14 @@ export class PipelineRegistry {
 
     const esSyncReactor = createEvaluationEsSyncReactor(this.deps.esSync);
 
+    const customerIoEvaluationSyncReactor = this.deps.nurturing
+      ? createCustomerIoEvaluationSyncReactor({
+          projects: this.deps.projects,
+          nurturing: this.deps.nurturing,
+          evaluationCountFn: this.createEvaluationCountFn(),
+        })
+      : undefined;
+
     return this.deps.eventSourcing.register(
       createEvaluationProcessingPipeline({
         evalRunStore: new EvaluationRunStore(
@@ -140,6 +166,7 @@ export class PipelineRegistry {
         ),
         ExecuteEvaluationCommand,
         esSyncReactor,
+        customerIoEvaluationSyncReactor,
       }),
     );
   }
@@ -213,6 +240,13 @@ export class PipelineRegistry {
       ? new MetricRecordStorageClickHouseRepository(this.deps.clickhouse)
       : new NullMetricRecordStorageRepository();
 
+    const customerIoTraceSyncReactor = this.deps.nurturing
+      ? createCustomerIoTraceSyncReactor({
+          projects: this.deps.projects,
+          nurturing: this.deps.nurturing,
+        })
+      : undefined;
+
     const tracePipeline = this.deps.eventSourcing.register(
       createTraceProcessingPipeline({
         spanAppendStore: new SpanAppendStore(this.deps.traces.spans.repository),
@@ -224,6 +258,7 @@ export class PipelineRegistry {
         traceUpdateBroadcastReactor,
         projectMetadataReactor,
         spanStorageBroadcastReactor,
+        customerIoTraceSyncReactor,
       }),
     );
 
@@ -308,11 +343,20 @@ export class PipelineRegistry {
       completeSuiteRunItem: suiteRunCommands.completeSuiteRunItem,
     });
 
+    const customerIoSimulationSyncReactor = this.deps.nurturing
+      ? createCustomerIoSimulationSyncReactor({
+          projects: this.deps.projects,
+          nurturing: this.deps.nurturing,
+          simulationCountFn: this.createSimulationCountFn(),
+        })
+      : undefined;
+
     return this.deps.eventSourcing.register(
       createSimulationProcessingPipeline({
         simulationRunStore,
         snapshotUpdateBroadcastReactor,
         suiteRunSyncReactor,
+        customerIoSimulationSyncReactor,
       }),
     );
   }
@@ -335,6 +379,88 @@ export class PipelineRegistry {
         ReportUsageForMonthCommand,
       }),
     );
+  }
+
+  /**
+   * Creates a function that counts completed evaluations for an organization
+   * by querying evaluation_runs in ClickHouse. Returns null when ClickHouse
+   * is unavailable or on query failure so callers can distinguish "no data"
+   * from "zero evaluations".
+   */
+  private createEvaluationCountFn(): (organizationId: string) => Promise<number | null> {
+    const clickhouse = this.deps.clickhouse;
+    const prisma = this.deps.prisma;
+
+    return async (organizationId: string): Promise<number | null> => {
+      if (!clickhouse) return null;
+
+      try {
+        // Get all project IDs for this org
+        const teams = await prisma.team.findMany({
+          where: { organizationId },
+          select: { projects: { select: { id: true } } },
+        });
+        const projectIds = teams.flatMap((t) => t.projects.map((p) => p.id));
+        if (projectIds.length === 0) return 0;
+
+        const result = await clickhouse.query({
+          query: `
+            SELECT count(DISTINCT EvaluationId) as cnt
+            FROM evaluation_runs
+            WHERE TenantId IN ({projectIds:Array(String)})
+              AND Status = 'processed'
+          `,
+          query_params: { projectIds },
+          format: "JSONEachRow",
+        });
+        const rows = await result.json<{ cnt: string }>();
+        return Number(rows[0]?.cnt ?? 0);
+      } catch (error) {
+        logger.warn({ error }, "ClickHouse evaluation count query failed — skipping milestone check");
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Creates a function that counts finished simulation runs for an organization
+   * by querying simulation_runs in ClickHouse. Returns null when ClickHouse
+   * is unavailable or on query failure so callers can distinguish "no data"
+   * from "zero simulations".
+   */
+  private createSimulationCountFn(): (organizationId: string) => Promise<number | null> {
+    const clickhouse = this.deps.clickhouse;
+    const prisma = this.deps.prisma;
+
+    return async (organizationId: string): Promise<number | null> => {
+      if (!clickhouse) return null;
+
+      try {
+        // Get all project IDs for this org
+        const teams = await prisma.team.findMany({
+          where: { organizationId },
+          select: { projects: { select: { id: true } } },
+        });
+        const projectIds = teams.flatMap((t) => t.projects.map((p) => p.id));
+        if (projectIds.length === 0) return 0;
+
+        const result = await clickhouse.query({
+          query: `
+            SELECT count(DISTINCT ScenarioRunId) as cnt
+            FROM simulation_runs
+            WHERE TenantId IN ({projectIds:Array(String)})
+              AND Status IN ('SUCCESS', 'FAILURE')
+          `,
+          query_params: { projectIds },
+          format: "JSONEachRow",
+        });
+        const rows = await result.json<{ cnt: string }>();
+        return Number(rows[0]?.cnt ?? 0);
+      } catch (error) {
+        logger.warn({ error }, "ClickHouse simulation count query failed — skipping milestone check");
+        return null;
+      }
+    };
   }
 
   private registerExperimentRunPipeline() {

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
@@ -18,6 +18,7 @@ export interface EvaluationProcessingPipelineDeps {
     makeJobId(payload: any): string;
   };
   esSyncReactor: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
+  customerIoEvaluationSyncReactor?: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
 }
 
 /**
@@ -33,13 +34,23 @@ export interface EvaluationProcessingPipelineDeps {
  * - completeEvaluation: Records eval result to CH (API handler path)
  */
 export function createEvaluationProcessingPipeline(deps: EvaluationProcessingPipelineDeps) {
-  return definePipeline<EvaluationProcessingEvent>()
+  let builder = definePipeline<EvaluationProcessingEvent>()
     .withName("evaluation_processing")
     .withAggregateType("evaluation")
     .withFoldProjection("evaluationRun", createEvaluationRunFoldProjection({
       store: deps.evalRunStore,
     }))
-    .withReactor("evaluationRun", "evaluationEsSync", deps.esSyncReactor)
+    .withReactor("evaluationRun", "evaluationEsSync", deps.esSyncReactor);
+
+  if (deps.customerIoEvaluationSyncReactor) {
+    builder = builder.withReactor(
+      "evaluationRun",
+      "customerIoEvaluationSync",
+      deps.customerIoEvaluationSyncReactor,
+    );
+  }
+
+  return builder
     .withCommand("executeEvaluation", deps.ExecuteEvaluationCommand, {
       delay: 30_000,
       deduplication: {

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/customerIoEvaluationSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/customerIoEvaluationSync.reactor.unit.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EvaluationRunData } from "~/server/app-layer/evaluations/types";
+import type { NurturingService } from "../../../../../../../ee/billing/nurturing/nurturing.service";
+import type { ProjectService } from "../../../../../app-layer/projects/project.service";
+import type { ReactorContext } from "../../../../reactors/reactor.types";
+import type { EvaluationProcessingEvent } from "../../schemas/events";
+import {
+  createCustomerIoEvaluationSyncReactor,
+  type CustomerIoEvaluationSyncReactorDeps,
+} from "../customerIoEvaluationSync.reactor";
+
+// Suppress logger output
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+function createFoldState(
+  overrides: Partial<EvaluationRunData> = {},
+): EvaluationRunData {
+  return {
+    evaluationId: "eval-1",
+    evaluatorId: "evaluator-1",
+    evaluatorType: "llm_judge",
+    evaluatorName: "Toxicity Check",
+    traceId: "trace-1",
+    isGuardrail: false,
+    status: "processed",
+    score: 0.85,
+    passed: true,
+    label: null,
+    details: null,
+    error: null,
+    errorDetails: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    archivedAt: null,
+    scheduledAt: null,
+    startedAt: null,
+    completedAt: Date.now(),
+    costId: null,
+    ...overrides,
+  } as EvaluationRunData;
+}
+
+function createEvent(
+  overrides: Record<string, unknown> = {},
+): EvaluationProcessingEvent {
+  return {
+    id: "event-1",
+    aggregateId: "eval-1",
+    aggregateType: "evaluation",
+    tenantId: "project-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.evaluation.completed",
+    version: 1,
+    data: {
+      evaluationId: "eval-1",
+      status: "processed",
+      score: 0.85,
+      passed: true,
+    },
+    metadata: {},
+    ...overrides,
+  } as unknown as EvaluationProcessingEvent;
+}
+
+function createContext(
+  foldState: EvaluationRunData,
+  tenantId = "project-1",
+): ReactorContext<EvaluationRunData> {
+  return {
+    tenantId,
+    aggregateId: "eval-1",
+    foldState,
+  };
+}
+
+function createMockNurturing(): NurturingService {
+  return {
+    identifyUser: vi.fn().mockResolvedValue(undefined),
+    trackEvent: vi.fn().mockResolvedValue(undefined),
+    groupUser: vi.fn().mockResolvedValue(undefined),
+    batch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as NurturingService;
+}
+
+function createMockProjectService(
+  overrides: Partial<{ resolveOrgAdmin: ReturnType<typeof vi.fn> }> = {},
+): ProjectService {
+  return {
+    resolveOrgAdmin: vi.fn().mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      firstMessage: false,
+    }),
+    ...overrides,
+  } as unknown as ProjectService;
+}
+
+function createDeps(
+  overrides: Partial<CustomerIoEvaluationSyncReactorDeps> = {},
+): CustomerIoEvaluationSyncReactorDeps {
+  return {
+    projects: createMockProjectService(),
+    nurturing: createMockNurturing(),
+    evaluationCountFn: vi.fn().mockResolvedValue(0),
+    ...overrides,
+  };
+}
+
+describe("customerIoEvaluationSync reactor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("makeJobId", () => {
+    it("returns cio-eval-sync-{projectId}-{evaluationId}", () => {
+      const deps = createDeps();
+      const reactor = createCustomerIoEvaluationSyncReactor(deps);
+      const event = createEvent({ tenantId: "project-42", aggregateId: "eval-99" });
+
+      const jobId = reactor.options!.makeJobId!({
+        event,
+        foldState: createFoldState(),
+      });
+
+      expect(jobId).toBe("cio-eval-sync-project-42-eval-99");
+    });
+  });
+
+  describe("given an organization with no prior evaluations", () => {
+    describe("when the first evaluation is processed", () => {
+      it("identifies user with has_evaluations true and evaluation_count 1", async () => {
+        const deps = createDeps({
+          evaluationCountFn: vi.fn().mockResolvedValue(0),
+        });
+        const reactor = createCustomerIoEvaluationSyncReactor(deps);
+
+        await reactor.handle(
+          createEvent(),
+          createContext(createFoldState()),
+        );
+
+        expect(deps.nurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: expect.objectContaining({
+            has_evaluations: true,
+            evaluation_count: 1,
+            first_evaluation_at: expect.any(String),
+          }),
+        });
+      });
+
+      it("tracks first_evaluation_created event", async () => {
+        const deps = createDeps({
+          evaluationCountFn: vi.fn().mockResolvedValue(0),
+        });
+        const reactor = createCustomerIoEvaluationSyncReactor(deps);
+
+        await reactor.handle(
+          createEvent(),
+          createContext(createFoldState({ evaluatorType: "llm_judge" })),
+        );
+
+        expect(deps.nurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "first_evaluation_created",
+          properties: expect.objectContaining({
+            evaluation_type: "llm_judge",
+            project_id: "project-1",
+          }),
+        });
+      });
+    });
+  });
+
+  describe("given an organization that already has evaluations", () => {
+    describe("when a new evaluation is processed", () => {
+      it("identifies user with updated evaluation_count and last_evaluation_at", async () => {
+        const deps = createDeps({
+          evaluationCountFn: vi.fn().mockResolvedValue(5),
+        });
+        const reactor = createCustomerIoEvaluationSyncReactor(deps);
+
+        await reactor.handle(
+          createEvent(),
+          createContext(createFoldState({ score: 0.85, passed: true })),
+        );
+
+        expect(deps.nurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: expect.objectContaining({
+            evaluation_count: 6,
+            last_evaluation_at: expect.any(String),
+          }),
+        });
+      });
+
+      it("tracks evaluation_ran event", async () => {
+        const deps = createDeps({
+          evaluationCountFn: vi.fn().mockResolvedValue(5),
+        });
+        const reactor = createCustomerIoEvaluationSyncReactor(deps);
+        const foldState = createFoldState({
+          evaluationId: "eval-42",
+          score: 0.85,
+          passed: true,
+        });
+
+        await reactor.handle(createEvent(), createContext(foldState));
+
+        expect(deps.nurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "evaluation_ran",
+          properties: expect.objectContaining({
+            evaluation_id: "eval-42",
+            score: 0.85,
+            passed: true,
+          }),
+        });
+      });
+    });
+  });
+
+  describe("given the evaluation count query fails", () => {
+    describe("when evaluationCountFn returns null", () => {
+      it("skips nurturing sync to avoid false milestones", async () => {
+        const deps = createDeps({
+          evaluationCountFn: vi.fn().mockResolvedValue(null),
+        });
+        const reactor = createCustomerIoEvaluationSyncReactor(deps);
+
+        await reactor.handle(
+          createEvent(),
+          createContext(createFoldState()),
+        );
+
+        expect(deps.nurturing.identifyUser).not.toHaveBeenCalled();
+        expect(deps.nurturing.trackEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given the project is not found", () => {
+    it("does not call nurturing methods", async () => {
+      const deps = createDeps({
+        projects: createMockProjectService({
+          resolveOrgAdmin: vi.fn().mockResolvedValue({
+            userId: null,
+            organizationId: null,
+            firstMessage: false,
+          }),
+        }),
+      });
+      const reactor = createCustomerIoEvaluationSyncReactor(deps);
+
+      await reactor.handle(
+        createEvent(),
+        createContext(createFoldState()),
+      );
+
+      expect(deps.nurturing.identifyUser).not.toHaveBeenCalled();
+      expect(deps.nurturing.trackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the evaluation is not in a completed state", () => {
+    it("does not call nurturing methods", async () => {
+      const deps = createDeps();
+      const reactor = createCustomerIoEvaluationSyncReactor(deps);
+
+      await reactor.handle(
+        createEvent({ type: "lw.evaluation.scheduled" } as any),
+        createContext(createFoldState({ status: "scheduled" })),
+      );
+
+      expect(deps.nurturing.identifyUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the nurturing service throws", () => {
+    it("does not propagate the error", async () => {
+      const nurturing = createMockNurturing();
+      vi.mocked(nurturing.identifyUser).mockRejectedValue(
+        new Error("CIO down"),
+      );
+      const deps = createDeps({ nurturing });
+      const reactor = createCustomerIoEvaluationSyncReactor(deps);
+
+      await expect(
+        reactor.handle(createEvent(), createContext(createFoldState())),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/customerIoEvaluationSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/customerIoEvaluationSync.reactor.ts
@@ -1,0 +1,138 @@
+import type { NurturingService } from "../../../../../../ee/billing/nurturing/nurturing.service";
+import type { ProjectService } from "../../../../app-layer/projects/project.service";
+import { CIO_REACTOR_DEBOUNCE_TTL_MS } from "../../trace-processing/reactors/customerIoTraceSync.reactor";
+import { createLogger } from "../../../../../utils/logger/server";
+import { captureException } from "../../../../../utils/posthogErrorCapture";
+import type { ReactorContext, ReactorDefinition } from "../../../reactors/reactor.types";
+import type { EvaluationRunData } from "~/server/app-layer/evaluations/types";
+import type { EvaluationProcessingEvent } from "../schemas/events";
+import { isEvaluationCompletedEvent, isEvaluationReportedEvent } from "../schemas/events";
+
+const logger = createLogger(
+  "langwatch:evaluation-processing:customer-io-evaluation-sync-reactor",
+);
+
+export interface CustomerIoEvaluationSyncReactorDeps {
+  projects: ProjectService;
+  nurturing: NurturingService;
+  /** Returns the count of existing completed evaluations for the org, or null on failure. */
+  evaluationCountFn: (organizationId: string) => Promise<number | null>;
+}
+
+/**
+ * Reactor that syncs evaluation milestones and metrics to Customer.io.
+ *
+ * Registered on the evaluation_processing pipeline after the evaluationRun fold.
+ *
+ * Only fires on completed or reported events (terminal states).
+ *
+ * First evaluation (org has no prior evaluations):
+ *   - Identifies user with has_evaluations, evaluation_count: 1, first_evaluation_at
+ *   - Tracks "first_evaluation_created" event
+ *
+ * Subsequent evaluations:
+ *   - Identifies user with evaluation_count, last_evaluation_at
+ *   - Tracks "evaluation_ran" event
+ *   - Debounced via makeJobId with 5-minute TTL
+ *
+ * All nurturing calls are fire-and-forget with captureException.
+ */
+export function createCustomerIoEvaluationSyncReactor(
+  deps: CustomerIoEvaluationSyncReactorDeps,
+): ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData> {
+  return {
+    name: "customerIoEvaluationSync",
+    options: {
+      makeJobId: (payload) =>
+        `cio-eval-sync-${payload.event.tenantId}-${payload.event.aggregateId}`,
+      ttl: CIO_REACTOR_DEBOUNCE_TTL_MS,
+    },
+
+    async handle(
+      event: EvaluationProcessingEvent,
+      context: ReactorContext<EvaluationRunData>,
+    ): Promise<void> {
+      // Only sync on terminal events
+      if (!isEvaluationCompletedEvent(event) && !isEvaluationReportedEvent(event)) {
+        return;
+      }
+
+      const { tenantId: projectId, foldState } = context;
+
+      try {
+        const { userId, organizationId } = await deps.projects.resolveOrgAdmin(projectId);
+
+        if (!userId || !organizationId) {
+          logger.warn(
+            { projectId },
+            "No admin user found for project — skipping CIO evaluation sync",
+          );
+          return;
+        }
+
+        const now = new Date().toISOString();
+
+        const existingCount = await deps.evaluationCountFn(organizationId);
+        if (existingCount === null) {
+          logger.warn(
+            { projectId },
+            "Could not determine evaluation count — skipping CIO evaluation sync",
+          );
+          return;
+        }
+        const isFirstEvaluation = existingCount === 0;
+
+        if (isFirstEvaluation) {
+          // Fire-and-forget: do not block reactor processing
+          void deps.nurturing
+            .identifyUser({ userId, traits: {
+              has_evaluations: true,
+              evaluation_count: 1,
+              first_evaluation_at: now,
+            }})
+            .catch((error) => {
+              logger.error({ projectId, error }, "Failed to identify user for first evaluation");
+              captureException(error);
+            });
+          void deps.nurturing
+            .trackEvent({ userId, event: "first_evaluation_created", properties: {
+              evaluation_type: foldState.evaluatorType,
+              project_id: projectId,
+            }})
+            .catch((error) => {
+              logger.error({ projectId, error }, "Failed to track first_evaluation_created event");
+              captureException(error);
+            });
+        } else {
+          const newCount = existingCount + 1;
+          // Fire-and-forget: do not block reactor processing
+          void deps.nurturing
+            .identifyUser({ userId, traits: {
+              evaluation_count: newCount,
+              last_evaluation_at: now,
+            }})
+            .catch((error) => {
+              logger.error({ projectId, error }, "Failed to identify user for evaluation update");
+              captureException(error);
+            });
+          void deps.nurturing
+            .trackEvent({ userId, event: "evaluation_ran", properties: {
+              evaluation_id: foldState.evaluationId,
+              score: foldState.score,
+              passed: foldState.passed,
+            }})
+            .catch((error) => {
+              logger.error({ projectId, error }, "Failed to track evaluation_ran event");
+              captureException(error);
+            });
+        }
+      } catch (error) {
+        logger.error(
+          { projectId, error },
+          "Failed to process CIO evaluation sync — non-fatal",
+        );
+        captureException(error);
+      }
+    },
+  };
+}

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -27,6 +27,7 @@ export interface TraceProcessingPipelineDeps {
   traceUpdateBroadcastReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   projectMetadataReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   spanStorageBroadcastReactor: ReactorDefinition<TraceProcessingEvent>;
+  customerIoTraceSyncReactor?: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
 }
 
 /**
@@ -37,7 +38,7 @@ export interface TraceProcessingPipelineDeps {
  * individual spans to the stored_spans table (map projection).
  */
 export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps) {
-  return definePipeline<TraceProcessingEvent>()
+  let builder = definePipeline<TraceProcessingEvent>()
     .withName("trace_processing")
     .withAggregateType("trace")
     .withFoldProjection("traceSummary", createTraceSummaryFoldProjection({
@@ -56,7 +57,17 @@ export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps)
     .withReactor("traceSummary", "customEvaluationSync", deps.customEvaluationSyncReactor)
     .withReactor("traceSummary", "traceUpdateBroadcast", deps.traceUpdateBroadcastReactor)
     .withReactor("traceSummary", "projectMetadata", deps.projectMetadataReactor)
-    .withReactor("spanStorage", "spanStorageBroadcast", deps.spanStorageBroadcastReactor)
+    .withReactor("spanStorage", "spanStorageBroadcast", deps.spanStorageBroadcastReactor);
+
+  if (deps.customerIoTraceSyncReactor) {
+    builder = builder.withReactor(
+      "traceSummary",
+      "customerIoTraceSync",
+      deps.customerIoTraceSyncReactor,
+    );
+  }
+
+  return builder
     .withCommand("recordSpan", RecordSpanCommand)
     .withCommand("assignTopic", AssignTopicCommand)
     .withCommand("recordLog", RecordLogCommand)

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customerIoTraceSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customerIoTraceSync.reactor.unit.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import type { NurturingService } from "../../../../../../../ee/billing/nurturing/nurturing.service";
+import type { ProjectService } from "../../../../../app-layer/projects/project.service";
+import type { ReactorContext } from "../../../../reactors/reactor.types";
+import type { TraceProcessingEvent } from "../../schemas/events";
+import {
+  createCustomerIoTraceSyncReactor,
+  type CustomerIoTraceSyncReactorDeps,
+} from "../customerIoTraceSync.reactor";
+
+// Suppress logger output
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+function createFoldState(
+  overrides: Partial<TraceSummaryData> = {},
+): TraceSummaryData {
+  return {
+    traceId: "trace-1",
+    spanCount: 1,
+    totalDurationMs: 100,
+    computedIOSchemaVersion: "2025-12-18",
+    computedInput: "hello",
+    computedOutput: "world",
+    timeToFirstTokenMs: null,
+    timeToLastTokenMs: null,
+    tokensPerSecond: null,
+    containsErrorStatus: false,
+    containsOKStatus: true,
+    errorMessage: null,
+    models: [],
+    totalCost: null,
+    tokensEstimated: false,
+    totalPromptTokenCount: null,
+    totalCompletionTokenCount: null,
+    outputFromRootSpan: false,
+    outputSpanEndTimeMs: 0,
+    blockedByGuardrail: false,
+    topicId: null,
+    subTopicId: null,
+    hasAnnotation: null,
+    occurredAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    attributes: {},
+    ...overrides,
+  };
+}
+
+function createEvent(
+  overrides: Record<string, unknown> = {},
+): TraceProcessingEvent {
+  return {
+    id: "event-1",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "project-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.span_received",
+    version: 1,
+    data: {
+      span: {} as any,
+      resource: null,
+      instrumentationScope: null,
+      piiRedactionLevel: "STRICT",
+    },
+    metadata: { spanId: "span-1", traceId: "trace-1" },
+    ...overrides,
+  } as unknown as TraceProcessingEvent;
+}
+
+function createContext(
+  foldState: TraceSummaryData,
+  tenantId = "project-1",
+): ReactorContext<TraceSummaryData> {
+  return {
+    tenantId,
+    aggregateId: "trace-1",
+    foldState,
+  };
+}
+
+function createMockNurturing(): NurturingService {
+  return {
+    identifyUser: vi.fn().mockResolvedValue(undefined),
+    trackEvent: vi.fn().mockResolvedValue(undefined),
+    groupUser: vi.fn().mockResolvedValue(undefined),
+    batch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as NurturingService;
+}
+
+function createMockProjectService(
+  overrides: Partial<{ resolveOrgAdmin: ReturnType<typeof vi.fn> }> = {},
+): ProjectService {
+  return {
+    resolveOrgAdmin: vi.fn().mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      firstMessage: false,
+    }),
+    ...overrides,
+  } as unknown as ProjectService;
+}
+
+function createDeps(
+  overrides: Partial<CustomerIoTraceSyncReactorDeps> = {},
+): CustomerIoTraceSyncReactorDeps {
+  return {
+    projects: createMockProjectService(),
+    nurturing: createMockNurturing(),
+    ...overrides,
+  };
+}
+
+describe("customerIoTraceSync reactor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("makeJobId", () => {
+    it("returns cio-trace-sync-{projectId}", () => {
+      const deps = createDeps();
+      const reactor = createCustomerIoTraceSyncReactor(deps);
+      const event = createEvent({ tenantId: "project-42" });
+
+      const jobId = reactor.options!.makeJobId!({
+        event,
+        foldState: createFoldState(),
+      });
+
+      expect(jobId).toBe("cio-trace-sync-project-42");
+    });
+  });
+
+  describe("given a project that has never received a trace", () => {
+    describe("when the first trace is processed", () => {
+      it("identifies user with has_traces true, sdk metadata, and trace timestamp", async () => {
+        const deps = createDeps();
+        const reactor = createCustomerIoTraceSyncReactor(deps);
+        const traceTime = new Date("2026-03-15T10:00:00Z").getTime();
+        const state = createFoldState({
+          occurredAt: traceTime,
+          attributes: {
+            "sdk.language": "python",
+            "langwatch.sdk.framework": "openai",
+          },
+        });
+
+        await reactor.handle(createEvent(), createContext(state));
+
+        expect(deps.nurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: expect.objectContaining({
+            has_traces: true,
+            sdk_language: "python",
+            sdk_framework: "openai",
+            first_trace_at: "2026-03-15T10:00:00.000Z",
+          }),
+        });
+      });
+
+      it("tracks first_trace_integrated event", async () => {
+        const deps = createDeps();
+        const reactor = createCustomerIoTraceSyncReactor(deps);
+        const state = createFoldState({
+          attributes: {
+            "sdk.language": "python",
+            "langwatch.sdk.framework": "openai",
+          },
+        });
+
+        await reactor.handle(createEvent(), createContext(state));
+
+        expect(deps.nurturing.trackEvent).toHaveBeenCalledWith({
+          userId: "user-1",
+          event: "first_trace_integrated",
+          properties: expect.objectContaining({
+            sdk_language: "python",
+            sdk_framework: "openai",
+            project_id: "project-1",
+          }),
+        });
+      });
+    });
+  });
+
+  describe("given a project that already has traces", () => {
+    describe("when a new trace is processed", () => {
+      it("identifies user with last_trace_at", async () => {
+        const deps = createDeps({
+          projects: createMockProjectService({
+            resolveOrgAdmin: vi.fn().mockResolvedValue({
+              userId: "user-1",
+              organizationId: "org-1",
+              firstMessage: true,
+            }),
+          }),
+        });
+        const reactor = createCustomerIoTraceSyncReactor(deps);
+        const traceTime = new Date("2026-03-15T10:00:00Z").getTime();
+        const state = createFoldState({ spanCount: 5, occurredAt: traceTime });
+
+        await reactor.handle(createEvent(), createContext(state));
+
+        expect(deps.nurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: {
+            last_trace_at: "2026-03-15T10:00:00.000Z",
+          },
+        });
+      });
+
+      it("does not track first_trace_integrated event", async () => {
+        const deps = createDeps({
+          projects: createMockProjectService({
+            resolveOrgAdmin: vi.fn().mockResolvedValue({
+              userId: "user-1",
+              organizationId: "org-1",
+              firstMessage: true,
+            }),
+          }),
+        });
+        const reactor = createCustomerIoTraceSyncReactor(deps);
+        const state = createFoldState({ spanCount: 5 });
+
+        await reactor.handle(createEvent(), createContext(state));
+
+        expect(deps.nurturing.trackEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given the project is not found", () => {
+    it("does not call nurturing methods", async () => {
+      const deps = createDeps({
+        projects: createMockProjectService({
+          resolveOrgAdmin: vi.fn().mockResolvedValue({
+            userId: null,
+            organizationId: null,
+            firstMessage: false,
+          }),
+        }),
+      });
+      const reactor = createCustomerIoTraceSyncReactor(deps);
+
+      await reactor.handle(createEvent(), createContext(createFoldState()));
+
+      expect(deps.nurturing.identifyUser).not.toHaveBeenCalled();
+      expect(deps.nurturing.trackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given no admin user found", () => {
+    it("does not call nurturing methods", async () => {
+      const deps = createDeps({
+        projects: createMockProjectService({
+          resolveOrgAdmin: vi.fn().mockResolvedValue({
+            userId: null,
+            organizationId: null,
+            firstMessage: false,
+          }),
+        }),
+      });
+      const reactor = createCustomerIoTraceSyncReactor(deps);
+
+      await reactor.handle(createEvent(), createContext(createFoldState()));
+
+      expect(deps.nurturing.identifyUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the nurturing service throws", () => {
+    it("does not propagate the error", async () => {
+      const nurturing = createMockNurturing();
+      vi.mocked(nurturing.identifyUser).mockRejectedValue(
+        new Error("CIO down"),
+      );
+      const deps = createDeps({ nurturing });
+      const reactor = createCustomerIoTraceSyncReactor(deps);
+
+      // Should not throw
+      await expect(
+        reactor.handle(createEvent(), createContext(createFoldState())),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("when the first trace is detected via firstMessage flag", () => {
+    it("calls resolveOrgAdmin on the project service", async () => {
+      const deps = createDeps();
+      const reactor = createCustomerIoTraceSyncReactor(deps);
+
+      await reactor.handle(createEvent(), createContext(createFoldState()));
+
+      expect(deps.projects.resolveOrgAdmin).toHaveBeenCalledWith("project-1");
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/customerIoTraceSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/customerIoTraceSync.reactor.ts
@@ -1,0 +1,115 @@
+import type { NurturingService } from "../../../../../../ee/billing/nurturing/nurturing.service";
+import type { ProjectService } from "../../../../app-layer/projects/project.service";
+import { createLogger } from "../../../../../utils/logger/server";
+import { captureException } from "../../../../../utils/posthogErrorCapture";
+import type { ReactorContext, ReactorDefinition } from "../../../reactors/reactor.types";
+import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
+import type { TraceProcessingEvent } from "../schemas/events";
+
+const logger = createLogger(
+  "langwatch:trace-processing:customer-io-trace-sync-reactor",
+);
+
+/** Debounce TTL shared across all Customer.io reactor registrations. */
+export const CIO_REACTOR_DEBOUNCE_TTL_MS = 300_000;
+
+export interface CustomerIoTraceSyncReactorDeps {
+  projects: ProjectService;
+  nurturing: NurturingService;
+}
+
+/**
+ * Reactor that syncs trace milestones and metrics to Customer.io.
+ *
+ * Registered on the trace_processing pipeline after the traceSummary fold.
+ *
+ * First trace (Project.firstMessage is false):
+ *   - Identifies user with has_traces, sdk_language, sdk_framework, first_trace_at
+ *   - Tracks "first_trace_integrated" event
+ *
+ * Subsequent traces (Project.firstMessage is true):
+ *   - Identifies user with last_trace_at
+ *   - Debounced via makeJobId with 5-minute TTL
+ *
+ * Reads Project.firstMessage from DB to detect first trace rather than
+ * duplicating the detection logic from projectMetadata reactor.
+ *
+ * All nurturing calls are fire-and-forget with captureException.
+ */
+export function createCustomerIoTraceSyncReactor(
+  deps: CustomerIoTraceSyncReactorDeps,
+): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
+  return {
+    name: "customerIoTraceSync",
+    options: {
+      makeJobId: (payload) =>
+        `cio-trace-sync-${payload.event.tenantId}`,
+      ttl: CIO_REACTOR_DEBOUNCE_TTL_MS,
+    },
+
+    async handle(
+      _event: TraceProcessingEvent,
+      context: ReactorContext<TraceSummaryData>,
+    ): Promise<void> {
+      const { tenantId: projectId, foldState } = context;
+
+      try {
+        const { userId, firstMessage } = await deps.projects.resolveOrgAdmin(projectId);
+
+        if (!userId) {
+          logger.warn(
+            { projectId },
+            "No admin user found for project — skipping CIO trace sync",
+          );
+          return;
+        }
+
+        const sdkLanguage = foldState.attributes["sdk.language"] ?? "unknown";
+        const sdkFramework =
+          foldState.attributes["langwatch.sdk.framework"] ?? "unknown";
+        const traceOccurredAt = new Date(foldState.occurredAt).toISOString();
+
+        if (!firstMessage) {
+          // First trace — fire immediately, fire-and-forget
+          void deps.nurturing
+            .identifyUser({ userId, traits: {
+              has_traces: true,
+              sdk_language: sdkLanguage,
+              sdk_framework: sdkFramework,
+              first_trace_at: traceOccurredAt,
+            }})
+            .catch((error) => {
+              logger.error({ projectId, error }, "Failed to identify user for first trace");
+              captureException(error);
+            });
+          void deps.nurturing
+            .trackEvent({ userId, event: "first_trace_integrated", properties: {
+              sdk_language: sdkLanguage,
+              sdk_framework: sdkFramework,
+              project_id: projectId,
+            }})
+            .catch((error) => {
+              logger.error({ projectId, error }, "Failed to track first_trace_integrated event");
+              captureException(error);
+            });
+        } else {
+          // Subsequent trace — debounced via makeJobId, fire-and-forget
+          void deps.nurturing
+            .identifyUser({ userId, traits: {
+              last_trace_at: traceOccurredAt,
+            }})
+            .catch((error) => {
+              logger.error({ projectId, error }, "Failed to identify user for trace update");
+              captureException(error);
+            });
+        }
+      } catch (error) {
+        logger.error(
+          { projectId, error },
+          "Failed to process CIO trace sync — non-fatal",
+        );
+        captureException(error);
+      }
+    },
+  };
+}

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/customerIoDailyUsageSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/customerIoDailyUsageSync.reactor.unit.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NurturingService } from "../../../../../../ee/billing/nurturing/nurturing.service";
+import type { ProjectService } from "../../../../app-layer/projects/project.service";
+import type { ReactorContext } from "../../../reactors/reactor.types";
+import type { Event } from "../../../domain/types";
+import type { ProjectDailySdkUsageState } from "../projectDailySdkUsage.store";
+import {
+  createCustomerIoDailyUsageSyncReactor,
+  type CustomerIoDailyUsageSyncReactorDeps,
+} from "../customerIoDailyUsageSync.reactor";
+
+// Suppress logger output
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+function createFoldState(
+  overrides: Partial<ProjectDailySdkUsageState> = {},
+): ProjectDailySdkUsageState {
+  return {
+    projectId: "project-1",
+    date: "2026-03-15",
+    sdkName: "langwatch-python",
+    sdkVersion: "1.0.0",
+    sdkLanguage: "python",
+    count: 1,
+    lastEventTimestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function createEvent(tenantId = "project-1"): Event {
+  return {
+    id: "event-1",
+    aggregateId: `project-1:2026-03-15:langwatch-python:1.0.0:python`,
+    aggregateType: "global",
+    tenantId,
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.span_received",
+    version: 1,
+    data: {},
+    metadata: {},
+  } as unknown as Event;
+}
+
+function createContext(
+  foldState: ProjectDailySdkUsageState,
+): ReactorContext<ProjectDailySdkUsageState> {
+  return {
+    tenantId: foldState.projectId,
+    aggregateId: `${foldState.projectId}:${foldState.date}:${foldState.sdkName}:${foldState.sdkVersion}:${foldState.sdkLanguage}`,
+    foldState,
+  };
+}
+
+function createMockNurturing(): NurturingService {
+  return {
+    identifyUser: vi.fn().mockResolvedValue(undefined),
+    trackEvent: vi.fn().mockResolvedValue(undefined),
+    groupUser: vi.fn().mockResolvedValue(undefined),
+    batch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as NurturingService;
+}
+
+function createDeps(
+  overrides: Partial<CustomerIoDailyUsageSyncReactorDeps> = {},
+): CustomerIoDailyUsageSyncReactorDeps {
+  return {
+    projects: {
+      resolveOrgAdmin: vi.fn().mockResolvedValue({
+        userId: "user-1",
+        organizationId: "org-1",
+        firstMessage: false,
+      }),
+    } as unknown as ProjectService,
+    prisma: {
+      projectDailySdkUsage: {
+        aggregate: vi.fn().mockResolvedValue({
+          _sum: { count: 150 },
+        }),
+        findMany: vi.fn().mockResolvedValue([
+          { count: 42 },
+        ]),
+      },
+    } as any,
+    nurturing: createMockNurturing(),
+    ...overrides,
+  };
+}
+
+describe("customerIoDailyUsageSync reactor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("given the projectDailySdkUsage fold has completed for a project", () => {
+    describe("when the daily usage sync reactor runs", () => {
+      it("identifies user with trace_count as cumulative total", async () => {
+        const deps = createDeps();
+        const reactor = createCustomerIoDailyUsageSyncReactor(deps);
+        const state = createFoldState();
+
+        await reactor.handle(createEvent(), createContext(state));
+
+        expect(deps.nurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: expect.objectContaining({
+            trace_count: 150,
+          }),
+        });
+      });
+
+      it("includes daily_trace_count from today", async () => {
+        const deps = createDeps();
+        const reactor = createCustomerIoDailyUsageSyncReactor(deps);
+        const state = createFoldState();
+
+        await reactor.handle(createEvent(), createContext(state));
+
+        expect(deps.nurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: expect.objectContaining({
+            daily_trace_count: 42,
+          }),
+        });
+      });
+
+      it("includes trace_count_updated_at as ISO 8601 timestamp", async () => {
+        const deps = createDeps();
+        const reactor = createCustomerIoDailyUsageSyncReactor(deps);
+        const state = createFoldState();
+
+        await reactor.handle(createEvent(), createContext(state));
+
+        expect(deps.nurturing.identifyUser).toHaveBeenCalledWith({
+          userId: "user-1",
+          traits: expect.objectContaining({
+            trace_count_updated_at: expect.stringMatching(
+              /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+            ),
+          }),
+        });
+      });
+    });
+  });
+
+  describe("given the project is not found", () => {
+    it("does not call nurturing methods", async () => {
+      const deps = createDeps({
+        projects: {
+          resolveOrgAdmin: vi.fn().mockResolvedValue({
+            userId: null,
+            organizationId: null,
+            firstMessage: false,
+          }),
+        } as any,
+      });
+      const reactor = createCustomerIoDailyUsageSyncReactor(deps);
+
+      await reactor.handle(
+        createEvent(),
+        createContext(createFoldState()),
+      );
+
+      expect(deps.nurturing.identifyUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given the nurturing service throws", () => {
+    it("does not propagate the error", async () => {
+      const nurturing = createMockNurturing();
+      vi.mocked(nurturing.identifyUser).mockRejectedValue(
+        new Error("CIO down"),
+      );
+      const deps = createDeps({ nurturing });
+      const reactor = createCustomerIoDailyUsageSyncReactor(deps);
+
+      await expect(
+        reactor.handle(createEvent(), createContext(createFoldState())),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("when cumulative total is zero", () => {
+    it("sends trace_count as 0", async () => {
+      const deps = createDeps({
+        prisma: {
+          project: {
+            findUnique: vi.fn().mockResolvedValue({
+              id: "project-1",
+              team: {
+                organization: {
+                  members: [{ userId: "user-1", role: "ADMIN" }],
+                },
+              },
+            }),
+          },
+          projectDailySdkUsage: {
+            aggregate: vi.fn().mockResolvedValue({ _sum: { count: null } }),
+            findMany: vi.fn().mockResolvedValue([]),
+          },
+        } as any,
+      });
+      const reactor = createCustomerIoDailyUsageSyncReactor(deps);
+
+      await reactor.handle(
+        createEvent(),
+        createContext(createFoldState()),
+      );
+
+      expect(deps.nurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-1",
+        traits: expect.objectContaining({
+          trace_count: 0,
+          daily_trace_count: 0,
+        }),
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/global/customerIoDailyUsageSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/customerIoDailyUsageSync.reactor.ts
@@ -1,0 +1,112 @@
+import type { PrismaClient } from "@prisma/client";
+import type { NurturingService } from "../../../../../ee/billing/nurturing/nurturing.service";
+import type { ProjectService } from "../../../app-layer/projects/project.service";
+import { CIO_REACTOR_DEBOUNCE_TTL_MS } from "../../pipelines/trace-processing/reactors/customerIoTraceSync.reactor";
+import { createLogger } from "../../../../utils/logger/server";
+import { captureException } from "../../../../utils/posthogErrorCapture";
+import type { Event } from "../../domain/types";
+import type { ReactorDefinition } from "../../reactors/reactor.types";
+import type { ProjectDailySdkUsageState } from "./projectDailySdkUsage.store";
+
+const logger = createLogger(
+  "langwatch:global:customer-io-daily-usage-sync-reactor",
+);
+
+export interface CustomerIoDailyUsageSyncReactorDeps {
+  projects: ProjectService;
+  prisma: PrismaClient;
+  nurturing: NurturingService;
+}
+
+/**
+ * Reactor that pushes aggregated daily usage metrics to Customer.io
+ * after the projectDailySdkUsage fold completes.
+ *
+ * Registered on the global projectDailySdkUsage fold projection.
+ *
+ * Sends cumulative totals (not reset counters):
+ *   - trace_count: total traces across all days
+ *   - daily_trace_count: traces for today
+ *   - trace_count_updated_at: ISO 8601 timestamp of the fold completion
+ *
+ * Debounced via makeJobId with 5-minute TTL to avoid excessive CIO calls
+ * during high-volume ingestion.
+ *
+ * All nurturing calls are fire-and-forget with captureException.
+ */
+export function createCustomerIoDailyUsageSyncReactor(
+  deps: CustomerIoDailyUsageSyncReactorDeps,
+): ReactorDefinition<Event, ProjectDailySdkUsageState> {
+  return {
+    name: "customerIoDailyUsageSync",
+    options: {
+      makeJobId: (payload) =>
+        `cio-daily-usage-${payload.event.tenantId}`,
+      ttl: CIO_REACTOR_DEBOUNCE_TTL_MS,
+    },
+
+    async handle(_event, context) {
+      const { foldState } = context;
+      const projectId = foldState.projectId;
+
+      if (!projectId) {
+        return;
+      }
+
+      try {
+        const { userId } = await deps.projects.resolveOrgAdmin(projectId);
+
+        if (!userId) {
+          logger.warn(
+            { projectId },
+            "No admin user found for project — skipping CIO daily usage sync",
+          );
+          return;
+        }
+
+        // Cumulative total across all days
+        const cumulativeResult = await deps.prisma.projectDailySdkUsage.aggregate({
+          where: { projectId },
+          _sum: { count: true },
+        });
+        const traceCount = cumulativeResult._sum.count ?? 0;
+
+        // Today's date in UTC
+        const today = new Date().toISOString().split("T")[0]!;
+
+        // Daily count for today
+        const todayRows = await deps.prisma.projectDailySdkUsage.findMany({
+          where: { projectId, date: today },
+          select: { count: true },
+        });
+        const dailyTraceCount = todayRows.reduce(
+          (sum, row) => sum + row.count,
+          0,
+        );
+
+        const now = new Date().toISOString();
+
+        // Fire-and-forget: do not block reactor processing
+        void deps.nurturing
+          .identifyUser({ userId, traits: {
+            trace_count: traceCount,
+            daily_trace_count: dailyTraceCount,
+            trace_count_updated_at: now,
+          }})
+          .catch((error) => {
+            logger.error(
+              { projectId, error },
+              "Failed to identify user for daily usage sync",
+            );
+            captureException(error);
+          });
+      } catch (error) {
+        logger.error(
+          { projectId, error },
+          "Failed to process CIO daily usage sync — non-fatal",
+        );
+        captureException(error);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds all nurturing hooks and event sourcing reactors that push traits/events to Customer.io.

**Hooks (fire-and-forget from platform routers):**
- **R2:** Signup identification — `identifyUser` + `groupUser` + `trackEvent("signed_up")`
- **R6:** Feature adoption — `team_member_invited`, `workflow_created`, `scenario_created`, `experiment_ran`
- **R7:** Activity tracking — `last_active_at` on login with hourly debounce

**Reactors (event sourcing pipelines):**
- **R3:** `customerIoTraceSync` — first trace milestones + debounced trait updates
- **R4:** `customerIoEvaluationSync` — first eval milestones + debounced updates
- **R5:** `customerIoDailyUsageSync` — cumulative usage from daily fold

All calls gated on nurturing service existence (`if (!nurturing) return`) and fire-and-forget (`.catch(captureException)`). Zero impact when no `CUSTOMER_IO_API_KEY`.

Closes #2428, closes #2429

**Depends on:** #2465 (merged)
**Next:** PR 3 — Iteration 2 (R10-R13: product_interest, has_prompts, has_simulations)

## Test plan

- [x] 57 unit tests passing (6 test files)
- [ ] Verify signup creates person in CIO with traits + signed_up event
- [ ] Verify trace ingestion fires first_trace_integrated event
- [ ] Verify evaluation fires first_evaluation_created event