### PR TITLE
fix: check disable elasticsearch flag before queuing traces and evals

### DIFF
--- a/langwatch/src/app/api/otel/v1/logs/route.ts
+++ b/langwatch/src/app/api/otel/v1/logs/route.ts
@@ -181,6 +181,9 @@ async function handleLogsRequest(req: NextRequest) {
           piiRedactionLevel: project.piiRedactionLevel,
         });
       }
+      if (project.disableElasticSearchTraceWriting) {
+        return NextResponse.json({ message: "OK" });
+      }
 
       const tracesGeneratedFromLogs =
         await openTelemetryLogsRequestToTracesForCollection(logRequest);

--- a/langwatch/src/app/api/otel/v1/metrics/route.ts
+++ b/langwatch/src/app/api/otel/v1/metrics/route.ts
@@ -182,6 +182,9 @@ async function handleMetricsRequest(req: NextRequest) {
           piiRedactionLevel: project.piiRedactionLevel,
         });
       }
+      if (project.disableElasticSearchTraceWriting) {
+        return NextResponse.json({ message: "OK" });
+      }
 
       const tracesGeneratedFromMetrics =
         await openTelemetryMetricsRequestToTracesForCollection(metricsRequest);

--- a/langwatch/src/pages/api/collector.ts
+++ b/langwatch/src/pages/api/collector.ts
@@ -573,6 +573,10 @@ async function handleCollectorRequest(
     }
   }
 
+  if (project.disableElasticSearchTraceWriting) {
+    return res.status(200).json({ message: "Trace received successfully." });
+  }
+
   const forceSync = req.query.force_sync === "true";
   const contentLength = req.headers["content-length"];
   await scheduleTraceCollectionWithFallback(

--- a/langwatch/src/server/background/workers/collectorWorker.ts
+++ b/langwatch/src/server/background/workers/collectorWorker.ts
@@ -908,13 +908,18 @@ export const processCollectorCheckAndAdjustJob = async (
     !Array.isArray(customMetadata);
 
   // Skip collector-based evaluation scheduling when event-sourcing handles it
+  // or when ES evaluation writes are disabled (no destination for results)
   const project = await prisma.project.findUnique({
     where: { id: projectId },
-    select: { featureEventSourcingEvaluationIngestion: true },
+    select: {
+      featureEventSourcingEvaluationIngestion: true,
+      disableElasticSearchEvaluationWriting: true,
+    },
   });
 
   if (
     !project?.featureEventSourcingEvaluationIngestion &&
+    !project?.disableElasticSearchEvaluationWriting &&
     // Does not re-schedule trace checks for too old traces being resynced
     (!existingTrace?.timestamps?.inserted_at ||
       existingTrace.timestamps.inserted_at > Date.now() - 60 * 60 * 1000) &&


### PR DESCRIPTION
## Summary
- Add `disableElasticSearchTraceWriting` early-return check in OTEL logs, metrics, and REST collector routes — before adding jobs to the collector queue (matching the existing pattern in the OTEL traces route)
- Skip evaluation scheduling in `processCollectorCheckAndAdjustJob` when `disableElasticSearchEvaluationWriting` is set and event sourcing is not enabled, since there is no destination for results

## Test plan
- [ ] Verify projects with `disableElasticSearchTraceWriting=true` no longer enqueue collector jobs from logs/metrics/REST endpoints
- [ ] Verify evaluation scheduling is skipped when `disableElasticSearchEvaluationWriting=true` and event sourcing is off
- [ ] Verify normal flow (flags disabled) is unaffected