### PR TITLE
fix: triggers failing when fetching too many traces at once

### DIFF
--- a/langwatch/src/pages/api/cron/triggers/index.ts
+++ b/langwatch/src/pages/api/cron/triggers/index.ts
@@ -31,6 +31,7 @@ export default async function handler(
     projects = await prisma.project.findMany({
       where: {
         firstMessage: true,
+        archivedAt: null,
       },
     });
 

--- a/langwatch/src/pages/api/cron/triggers/traceBasedTrigger.ts
+++ b/langwatch/src/pages/api/cron/triggers/traceBasedTrigger.ts
@@ -57,14 +57,28 @@ export const processTraceBasedTrigger = async (
     projectId,
     filters: parsedFilters,
     updatedAt: lastRunAt,
-    pageSize: 10_000,
+    pageSize: 500,
     startDate: Date.now() - 1000 * 60 * 60 * 24,
     endDate: Date.now(),
   };
 
   const traceService = TraceService.create(prisma);
   const protections = await getProtectionsForProject(prisma, { projectId });
-  const traces = await traceService.getAllTracesForProject(input, protections);
+
+  const allGroups: TraceGroups["groups"] = [];
+  let scrollId: string | undefined;
+
+  do {
+    const result = await traceService.getAllTracesForProject(
+      input,
+      protections,
+      { scrollId },
+    );
+    allGroups.push(...result.groups);
+    scrollId = result.scrollId ?? undefined;
+  } while (scrollId && allGroups.length < 10_000);
+
+  const traces: TraceGroups = { groups: allGroups };
 
   const tracesToSend = await getTracesToSend(
     traces,


### PR DESCRIPTION
## Summary

- **Skip archived projects**: Add `archivedAt: null` filter to the trigger cron project query, preventing `NotFoundError: No Project found` every 3-minute cycle when archived projects have active triggers
- **Paginate trace queries**: Reduce `pageSize` from 10,000 to 500 and paginate via `scrollId` cursor, avoiding ClickHouse `Field value too long` errors when complex trigger filters serialize as oversized URL params

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test:unit src/pages/api/cron/triggers` passes (pre-existing `addToDataset.test.ts` failures unrelated)
- [ ] Deploy and confirm no more `NotFoundError: No Project found` in cron logs
- [ ] Deploy and confirm no more `Field value too long` in ClickHouse logs