### PR TITLE
fix: extract trace input from JSON wrapper keys in new OTLP flow

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/trace-io-extraction.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-io-extraction.service.unit.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  TraceIOExtractionService,
+} from "../trace-io-extraction.service";
+import type { NormalizedSpan } from "../../../event-sourcing/pipelines/trace-processing/schemas/spans";
+import {
+  NormalizedSpanKind,
+  NormalizedStatusCode,
+} from "../../../event-sourcing/pipelines/trace-processing/schemas/spans";
+
+const service = new TraceIOExtractionService();
+
+function createTestSpan(
+  overrides: Partial<NormalizedSpan> = {},
+): NormalizedSpan {
+  return {
+    id: "span-1",
+    traceId: "trace-1",
+    spanId: "span-1",
+    tenantId: "tenant-1",
+    parentSpanId: null,
+    parentTraceId: null,
+    parentIsRemote: null,
+    sampled: true,
+    startTimeUnixMs: 1000,
+    endTimeUnixMs: 2000,
+    durationMs: 1000,
+    name: "test-span",
+    kind: NormalizedSpanKind.INTERNAL,
+    resourceAttributes: {},
+    spanAttributes: {},
+    events: [],
+    links: [],
+    statusMessage: null,
+    statusCode: NormalizedStatusCode.UNSET,
+    instrumentationScope: { name: "test", version: null },
+    droppedAttributesCount: 0 as const,
+    droppedEventsCount: 0 as const,
+    droppedLinksCount: 0 as const,
+    ...overrides,
+  };
+}
+
+describe("TraceIOExtractionService", () => {
+  describe("extractRichIOFromSpan", () => {
+    describe("when langwatch.input is a JSON object with 'input' key", () => {
+      it("extracts the text from the input key", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": { input: "🐥" },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("🐥");
+        expect(result!.source).toBe("langwatch");
+      });
+    });
+
+    describe("when langwatch.input is a JSON object with 'question' key", () => {
+      it("extracts the text from the question key", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": { question: "What is 2+2?" },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("What is 2+2?");
+      });
+    });
+
+    describe("when langwatch.input is a JSON object with 'query' key", () => {
+      it("extracts the text from the query key", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": { query: "search term" },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("search term");
+      });
+    });
+
+    describe("when langwatch.output is a JSON object with 'output' key", () => {
+      it("extracts the text from the output key", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.output": { output: "The answer is 4" },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "output");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("The answer is 4");
+      });
+    });
+
+    describe("when langwatch.input is a JSON object with 'answer' key", () => {
+      it("extracts the text from the answer key", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": { answer: "42" },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("42");
+      });
+    });
+
+    describe("when langwatch.input is a plain string", () => {
+      it("returns the string directly", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": "hello world",
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("hello world");
+      });
+    });
+
+    describe("when langwatch.input is a JSON object with nested inputs", () => {
+      it("extracts text from LangChain-style inputs wrapper", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": { inputs: { input: "nested hello" } },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("nested hello");
+      });
+    });
+
+    describe("when langwatch.input is a JSON object with no recognized keys", () => {
+      it("returns null", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": { foo: "bar", baz: 123 },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when langwatch.input has message-like structure", () => {
+      it("prefers message extraction over plain JSON extraction", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": { content: "message content", input: "other" },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("message content");
+      });
+    });
+
+    describe("when langwatch.input has 'prompt' key (Haystack)", () => {
+      it("extracts the text from the prompt key", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": { prompt: "Tell me about AI" },
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("Tell me about AI");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/trace-io-extraction.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-io-extraction.service.ts
@@ -320,6 +320,55 @@ function shouldExcludeSpan(span: NormalizedSpan): boolean {
   return type === "evaluation" || type === "guardrail";
 }
 
+/**
+ * Common keys that wrap a single text value in JSON payloads from various
+ * frameworks (LangChain, Haystack, Flowise, Optimization Studio, etc.).
+ * Order matters: first match wins.
+ */
+const COMMON_TEXT_KEYS = [
+  "text",
+  "input",
+  "question",
+  "user_query",
+  "query",
+  "message",
+  "input_value",
+  "output",
+  "answer",
+  "content",
+  "prompt",
+] as const;
+
+/**
+ * Extracts a human-readable text representation from a plain JSON object
+ * that is NOT message-shaped (no role/content structure).
+ *
+ * Handles common wrapper patterns like `{ input: "hello" }` or
+ * `{ question: "what is 2+2?" }` that are used by various frameworks.
+ */
+function extractTextFromPlainJson(obj: Record<string, unknown>): string | null {
+  for (const key of COMMON_TEXT_KEYS) {
+    const val = obj[key];
+    if (val === undefined) continue;
+    if (typeof val === "string") return val;
+    if (typeof val === "number" || typeof val === "boolean") return String(val);
+    // Nested object with a known key (e.g. { inputs: { input: "hello" } })
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      const nested = extractTextFromPlainJson(val as Record<string, unknown>);
+      if (nested) return nested;
+    }
+  }
+
+  // LangChain: { inputs: { input: ... } } / { outputs: { output: ... } }
+  const wrapper = obj.inputs ?? obj.outputs;
+  if (wrapper && typeof wrapper === "object" && !Array.isArray(wrapper)) {
+    const nested = extractTextFromPlainJson(wrapper as Record<string, unknown>);
+    if (nested) return nested;
+  }
+
+  return null;
+}
+
 function messagesToText(
   messages: unknown,
   mode: "input" | "output" = "output",
@@ -353,5 +402,14 @@ function messagesToText(
     return texts.length > 0 ? texts.join("\n") : null;
   }
 
-  return extractMessageContentText(messages);
+  // Try message-shaped extraction first (content, parts, text, value)
+  const messageText = extractMessageContentText(messages);
+  if (messageText) return messageText;
+
+  // Fall back to common JSON wrapper keys (input, question, query, etc.)
+  if (typeof messages === "object" && messages !== null) {
+    return extractTextFromPlainJson(messages as Record<string, unknown>);
+  }
+
+  return null;
 }


### PR DESCRIPTION
When a span's input is a JSON object like {"input": "🐥"}, the new TraceIOExtractionService failed to extract the text because messagesToText only handled message-shaped objects (content/parts/text/value). The old code had specialKeysMapping for common wrapper keys but this logic was not carried over. Add extractTextFromPlainJson as a fallback for non-message JSON objects with common framework keys.