### PR TITLE
fix(studio): publish button hangs due to form validation mismatch

### DIFF
--- a/langwatch/src/optimization_studio/components/Publish.tsx
+++ b/langwatch/src/optimization_studio/components/Publish.tsx
@@ -457,6 +457,7 @@ function PublishModalContent({
     setLastCommittedWorkflow,
     setCurrentVersionId,
     currentVersionId,
+    checkCanCommitNewVersion,
   } = useWorkflowStore(
     ({
       workflow_id: workflowId,
@@ -465,6 +466,7 @@ function PublishModalContent({
       setLastCommittedWorkflow,
       setCurrentVersionId,
       currentVersionId,
+      checkCanCommitNewVersion,
     }) => ({
       workflowId,
       getWorkflow,
@@ -472,6 +474,7 @@ function PublishModalContent({
       setLastCommittedWorkflow,
       setCurrentVersionId,
       currentVersionId,
+      checkCanCommitNewVersion,
     }),
   );
 
@@ -529,7 +532,7 @@ function PublishModalContent({
 
       let versionId: string | undefined;
 
-      if (canSave) {
+      if (checkCanCommitNewVersion()) {
         try {
           const versionResponse = await commitVersion.mutateAsync({
             projectId: project.id,
@@ -602,7 +605,7 @@ function PublishModalContent({
       );
     },
     [
-      canSave,
+      checkCanCommitNewVersion,
       commitVersion,
       currentVersionId,
       getWorkflow,

--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
@@ -61,6 +61,45 @@ function makeEdge({
 }
 
 describe("workflowStoreCore", () => {
+  describe("checkCanCommitNewVersion()", () => {
+    let testStore: StoreApi<WorkflowStore>;
+
+    beforeEach(() => {
+      testStore = createStore<WorkflowStore>(storeCreator as any);
+    });
+
+    describe("when lastCommittedWorkflow is undefined", () => {
+      it("returns false", () => {
+        testStore.setState({ lastCommittedWorkflow: undefined });
+        expect(testStore.getState().checkCanCommitNewVersion()).toBe(false);
+      });
+    });
+
+    describe("when the current workflow matches the last committed workflow", () => {
+      it("returns false even when the API-level latestVersion.autoSaved would be true", () => {
+        // This is the regression case for the publish-hang bug:
+        // useVersionState.canSaveNewVersion is true when latestVersion.autoSaved is set,
+        // but checkCanCommitNewVersion() must return false when no DSL changes exist,
+        // so onSubmit can skip committing and publish the existing version directly.
+        const workflow = testStore.getState().getWorkflow();
+        testStore.getState().setLastCommittedWorkflow(workflow);
+
+        expect(testStore.getState().checkCanCommitNewVersion()).toBe(false);
+      });
+    });
+
+    describe("when the current workflow differs from the last committed workflow", () => {
+      it("returns true", () => {
+        const initial = testStore.getState().getWorkflow();
+        testStore.getState().setLastCommittedWorkflow(initial);
+
+        testStore.getState().setWorkflow({ name: "Changed Name" });
+
+        expect(testStore.getState().checkCanCommitNewVersion()).toBe(true);
+      });
+    });
+  });
+
   describe("removeInvalidEdges", () => {
     describe("when edges reference valid nodes and handles", () => {
       it("keeps the edges", () => {


### PR DESCRIPTION
## Summary

- Publish button silently failed when `VersionToBeUsed` showed a read-only display (no commit message input) but `onSubmit` still tried to commit a new version
- Replaced `canSave` (API-level `latestVersion.autoSaved` flag) with `checkCanCommitNewVersion()` (DSL-diff based) in the submit handler so the commit decision matches what the UI renders
- When no DSL changes exist, publish now skips the commit step and publishes the current version directly

## Test plan

- [x] Unit tests for `checkCanCommitNewVersion()` covering: undefined baseline, matching workflow, differing workflow
- [ ] Manual: import a workflow, make no changes, open Publish modal, click Publish — should publish successfully
- [ ] Manual: make a change, publish — should commit new version then publish

Fixes #2512

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2512