### PR TITLE
feat(rbac): lite member permission infrastructure

### DIFF
--- a/langwatch/src/components/CurrentDrawer.tsx
+++ b/langwatch/src/components/CurrentDrawer.tsx
@@ -1,3 +1,4 @@
+import { OrganizationUserRole } from "@prisma/client";
 import { useRouter } from "next/router";
 import qs from "qs";
 import { useEffect, useMemo } from "react";
@@ -7,11 +8,19 @@ import {
   getComplexProps,
   getFlowCallbacks,
 } from "../hooks/useDrawer";
+import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
+import { useUpgradeModalStore } from "../stores/upgradeModalStore";
 import { drawers } from "./drawerRegistry";
 import { DrawerOffsetProvider } from "./ui/drawer";
 
 // Re-export for backward compatibility
 export { useDrawer } from "../hooks/useDrawer";
+
+/** Drawers that EXTERNAL users cannot open, mapped to their restriction resource. */
+const restrictedDrawers: Partial<Record<DrawerType, string>> = {
+  traceDetails: "traces",
+  addDatasetRecord: "datasets",
+};
 
 type DrawerProps = {
   open: string;
@@ -19,6 +28,7 @@ type DrawerProps = {
 
 export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
   const router = useRouter();
+  const { organizationRole } = useOrganizationTeamProject();
   const queryString = router.asPath.split("?")[1] ?? "";
   const queryParams = qs.parse(queryString.replaceAll("%2C", ","), {
     allowDots: true,
@@ -28,9 +38,41 @@ export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
   const queryDrawer = queryParams.drawer as DrawerProps | undefined;
 
   const drawerType = queryDrawer?.open as DrawerType | undefined;
-  const CurrentDrawerComponent = drawerType
-    ? (drawers[drawerType] as React.FC<Record<string, unknown>>)
-    : undefined;
+
+  // Intercept restricted drawers for EXTERNAL users.
+  // Instead of rendering the drawer, show the restriction modal
+  // and clear the drawer from the URL. This protects ALL entry points:
+  // direct clicks, command bar, deep links, and any future call sites.
+  const restrictedResource = drawerType ? restrictedDrawers[drawerType] : undefined;
+  const isRestricted =
+    !!restrictedResource && organizationRole === OrganizationUserRole.EXTERNAL;
+
+  useEffect(() => {
+    if (!isRestricted || !restrictedResource) return;
+
+    useUpgradeModalStore
+      .getState()
+      .openLiteMemberRestriction({ resource: restrictedResource });
+
+    // Clear drawer from URL so it doesn't persist in browser history
+    void router.push(
+      "?" +
+        qs.stringify(
+          Object.fromEntries(
+            Object.entries(router.query).filter(
+              ([key]) => !key.startsWith("drawer."),
+            ),
+          ),
+        ),
+      undefined,
+      { shallow: true },
+    );
+  }, [isRestricted]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const CurrentDrawerComponent =
+    drawerType && !isRestricted
+      ? (drawers[drawerType] as React.FC<Record<string, unknown>>)
+      : undefined;
 
   // Dev warning: detect duplicate drawer rendering via DOM check
   useEffect(() => {

--- a/langwatch/src/components/UpgradeModal.tsx
+++ b/langwatch/src/components/UpgradeModal.tsx
@@ -252,19 +252,6 @@ function LiteMemberRestrictionContent({
   variant: Extract<UpgradeModalVariant, { mode: "liteMemberRestriction" }>;
   onClose: () => void;
 }) {
-  const router = useRouter();
-  const { project } = useOrganizationTeamProject();
-  const { url: planManagementUrl, buttonLabel } = usePlanManagementUrl();
-
-  const handleUpgrade = () => {
-    trackEvent("subscription_hook_click", {
-      project_id: project?.id,
-      hook: "lite_member_restriction",
-    });
-    void router.push(planManagementUrl);
-    onClose();
-  };
-
   return (
     <>
       <Dialog.Header>
@@ -274,17 +261,14 @@ function LiteMemberRestrictionContent({
       <Dialog.Body>
         <VStack gap={4} align="start">
           <Text>
-            This feature is not available for your current role. Upgrade your
-            plan to unlock full access.
+            This feature is not available for your current role. Contact your
+            organization admin for access.
           </Text>
         </VStack>
       </Dialog.Body>
       <Dialog.Footer>
-        <Button variant="ghost" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button colorPalette="blue" onClick={handleUpgrade}>
-          {buttonLabel}
+        <Button colorPalette="blue" onClick={onClose}>
+          Dismiss
         </Button>
       </Dialog.Footer>
     </>

--- a/langwatch/src/components/__tests__/CurrentDrawer.integration.test.tsx
+++ b/langwatch/src/components/__tests__/CurrentDrawer.integration.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { OrganizationUserRole } from "@prisma/client";
+import { CurrentDrawer } from "../CurrentDrawer";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockQuery: Record<string, string> = {};
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    query: mockQuery,
+    asPath:
+      Object.keys(mockQuery).length > 0
+        ? "?" + new URLSearchParams(mockQuery).toString()
+        : "/",
+    push: mockPush,
+    replace: mockReplace,
+  }),
+}));
+
+vi.mock("../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(),
+}));
+
+const mockOpenLiteMemberRestriction = vi.fn();
+const mockClose = vi.fn();
+
+vi.mock("../../stores/upgradeModalStore", () => ({
+  useUpgradeModalStore: Object.assign(
+    vi.fn(() => ({
+      openLiteMemberRestriction: mockOpenLiteMemberRestriction,
+    })),
+    {
+      getState: () => ({
+        openLiteMemberRestriction: mockOpenLiteMemberRestriction,
+        close: mockClose,
+      }),
+    },
+  ),
+}));
+
+// Mock the drawer registry so we don't need to render real drawers
+vi.mock("../drawerRegistry", () => ({
+  drawers: {
+    traceDetails: function MockTraceDetailsDrawer() {
+      return <div data-testid="trace-details-drawer">Trace Details</div>;
+    },
+    promptList: function MockPromptListDrawer() {
+      return <div data-testid="prompt-list-drawer">Prompt List</div>;
+    },
+  },
+}));
+
+vi.mock("../ui/drawer", () => ({
+  DrawerOffsetProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+
+const mockUseOrganizationTeamProject = vi.mocked(useOrganizationTeamProject);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupOrganizationRole(role: OrganizationUserRole | undefined) {
+  mockUseOrganizationTeamProject.mockReturnValue({
+    organizationRole: role,
+  } as ReturnType<typeof useOrganizationTeamProject>);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("<CurrentDrawer/>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery = {};
+    setupOrganizationRole(OrganizationUserRole.MEMBER);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when drawer type is traceDetails", () => {
+    beforeEach(() => {
+      mockQuery = { "drawer.open": "traceDetails", "drawer.traceId": "t-1" };
+    });
+
+    describe("when user is EXTERNAL", () => {
+      beforeEach(() => {
+        setupOrganizationRole(OrganizationUserRole.EXTERNAL);
+      });
+
+      it("does not render the trace details drawer", () => {
+        const { queryByTestId } = render(<CurrentDrawer />);
+
+        expect(queryByTestId("trace-details-drawer")).toBeNull();
+      });
+
+      it("opens the lite member restriction modal", () => {
+        render(<CurrentDrawer />);
+
+        expect(mockOpenLiteMemberRestriction).toHaveBeenCalledWith({
+          resource: "traces",
+        });
+      });
+
+      it("clears the drawer URL params", () => {
+        render(<CurrentDrawer />);
+
+        expect(mockPush).toHaveBeenCalled();
+        const pushUrl = mockPush.mock.calls[0]?.[0] as string;
+        expect(pushUrl).not.toContain("drawer");
+      });
+    });
+
+    describe("when user is MEMBER", () => {
+      beforeEach(() => {
+        setupOrganizationRole(OrganizationUserRole.MEMBER);
+      });
+
+      it("renders the trace details drawer", () => {
+        const { getByTestId } = render(<CurrentDrawer />);
+
+        expect(getByTestId("trace-details-drawer")).toBeTruthy();
+      });
+
+      it("does not open the restriction modal", () => {
+        render(<CurrentDrawer />);
+
+        expect(mockOpenLiteMemberRestriction).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when user is ADMIN", () => {
+      beforeEach(() => {
+        setupOrganizationRole(OrganizationUserRole.ADMIN);
+      });
+
+      it("renders the trace details drawer", () => {
+        const { getByTestId } = render(<CurrentDrawer />);
+
+        expect(getByTestId("trace-details-drawer")).toBeTruthy();
+      });
+
+      it("does not open the restriction modal", () => {
+        render(<CurrentDrawer />);
+
+        expect(mockOpenLiteMemberRestriction).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when drawer type is not traceDetails", () => {
+    beforeEach(() => {
+      mockQuery = { "drawer.open": "promptList" };
+    });
+
+    describe("when user is EXTERNAL", () => {
+      beforeEach(() => {
+        setupOrganizationRole(OrganizationUserRole.EXTERNAL);
+      });
+
+      it("renders the drawer normally", () => {
+        const { getByTestId } = render(<CurrentDrawer />);
+
+        expect(getByTestId("prompt-list-drawer")).toBeTruthy();
+      });
+
+      it("does not open the restriction modal", () => {
+        render(<CurrentDrawer />);
+
+        expect(mockOpenLiteMemberRestriction).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when no drawer is open", () => {
+    beforeEach(() => {
+      mockQuery = {};
+    });
+
+    it("renders nothing", () => {
+      const { container } = render(<CurrentDrawer />);
+
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("does not open the restriction modal", () => {
+      render(<CurrentDrawer />);
+
+      expect(mockOpenLiteMemberRestriction).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/components/__tests__/UpgradeModal.unit.test.tsx
+++ b/langwatch/src/components/__tests__/UpgradeModal.unit.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { UpgradeModal } from "../UpgradeModal";
+import type { UpgradeModalVariant } from "../../stores/upgradeModalStore";
+
+// Mock dependencies used by other content variants
+vi.mock("next/router", () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    pathname: "/[project]/evaluations",
+    query: {},
+  })),
+}));
+
+vi.mock("../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(() => ({
+    project: { id: "project-1" },
+  })),
+}));
+
+vi.mock("../../hooks/usePlanManagementUrl", () => ({
+  usePlanManagementUrl: vi.fn(() => ({
+    url: "/settings/plan",
+    buttonLabel: "Manage Plan",
+  })),
+}));
+
+vi.mock("../../utils/tracking", () => ({
+  trackEvent: vi.fn(),
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>,
+  );
+}
+
+describe("<UpgradeModal />", () => {
+  describe("when variant is liteMemberRestriction", () => {
+    const variant: UpgradeModalVariant = {
+      mode: "liteMemberRestriction",
+      resource: "scenarios",
+    };
+
+    let onClose: () => void;
+
+    beforeEach(() => {
+      onClose = vi.fn();
+    });
+
+    it("renders the 'Feature Not Available' title", () => {
+      renderWithProviders(
+        <UpgradeModal open={true} onClose={onClose} variant={variant} />,
+      );
+
+      expect(screen.getByText("Feature Not Available")).toBeDefined();
+    });
+
+    it("renders role-based messaging without billing references", () => {
+      renderWithProviders(
+        <UpgradeModal open={true} onClose={onClose} variant={variant} />,
+      );
+
+      // Chakra Dialog renders content twice; use getAllByText
+      const textElements = screen.getAllByText(
+        "This feature is not available for your current role. Contact your organization admin for access.",
+      );
+      expect(textElements.length).toBeGreaterThan(0);
+
+      expect(screen.queryByText(/plan/i)).toBeNull();
+      expect(screen.queryByText(/billing/i)).toBeNull();
+      expect(screen.queryByText(/pricing/i)).toBeNull();
+      expect(screen.queryByText(/upgrade/i)).toBeNull();
+    });
+
+    it("does not render an 'Upgrade' button", () => {
+      renderWithProviders(
+        <UpgradeModal open={true} onClose={onClose} variant={variant} />,
+      );
+
+      expect(screen.queryByRole("button", { name: /upgrade/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /manage plan/i })).toBeNull();
+    });
+
+    it("renders a Dismiss button that calls onClose", () => {
+      renderWithProviders(
+        <UpgradeModal open={true} onClose={onClose} variant={variant} />,
+      );
+
+      // Chakra Dialog may render duplicate nodes; use last match
+      const dismissButtons = screen.getAllByRole("button", { name: "Dismiss" });
+      expect(dismissButtons.length).toBeGreaterThan(0);
+
+      fireEvent.click(dismissButtons[dismissButtons.length - 1]!);
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useLiteMemberGuard.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useLiteMemberGuard.integration.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { OrganizationUserRole } from "@prisma/client";
+import { useLiteMemberGuard } from "../useLiteMemberGuard";
+
+vi.mock("../useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(),
+}));
+
+import { useOrganizationTeamProject } from "../useOrganizationTeamProject";
+
+const mockUseOrganizationTeamProject = vi.mocked(useOrganizationTeamProject);
+
+function setupMocks({
+  organizationRole,
+}: {
+  organizationRole: OrganizationUserRole | undefined;
+}) {
+  mockUseOrganizationTeamProject.mockReturnValue({
+    organizationRole,
+  } as ReturnType<typeof useOrganizationTeamProject>);
+}
+
+describe("useLiteMemberGuard()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when user is EXTERNAL", () => {
+    it("returns isLiteMember true", () => {
+      setupMocks({
+        organizationRole: OrganizationUserRole.EXTERNAL,
+      });
+
+      const { result } = renderHook(() => useLiteMemberGuard());
+
+      expect(result.current.isLiteMember).toBe(true);
+    });
+
+    it("does not return isRestricted", () => {
+      setupMocks({
+        organizationRole: OrganizationUserRole.EXTERNAL,
+      });
+
+      const { result } = renderHook(() => useLiteMemberGuard());
+
+      expect(result.current).not.toHaveProperty("isRestricted");
+    });
+  });
+
+  describe("when user is MEMBER", () => {
+    it("returns isLiteMember false", () => {
+      setupMocks({
+        organizationRole: OrganizationUserRole.MEMBER,
+      });
+
+      const { result } = renderHook(() => useLiteMemberGuard());
+
+      expect(result.current.isLiteMember).toBe(false);
+    });
+  });
+
+  describe("when user is ADMIN", () => {
+    it("returns isLiteMember false", () => {
+      setupMocks({
+        organizationRole: OrganizationUserRole.ADMIN,
+      });
+
+      const { result } = renderHook(() => useLiteMemberGuard());
+
+      expect(result.current.isLiteMember).toBe(false);
+    });
+  });
+
+  describe("when organizationRole is undefined", () => {
+    it("returns isLiteMember false", () => {
+      setupMocks({
+        organizationRole: undefined,
+      });
+
+      const { result } = renderHook(() => useLiteMemberGuard());
+
+      expect(result.current.isLiteMember).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useTraceDetailsDrawer.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useTraceDetailsDrawer.integration.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTraceDetailsDrawer } from "../useTraceDetailsDrawer";
+import type { DrawerProps } from "../../components/drawerRegistry";
+
+vi.mock("../useDrawer", () => ({
+  useDrawer: vi.fn(),
+}));
+
+import { useDrawer } from "../useDrawer";
+
+const mockUseDrawer = vi.mocked(useDrawer);
+const mockOpenDrawer = vi.fn();
+
+describe("useTraceDetailsDrawer()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDrawer.mockReturnValue({
+      openDrawer: mockOpenDrawer,
+    } as unknown as ReturnType<typeof useDrawer>);
+  });
+
+  describe("when called with props", () => {
+    it("delegates to openDrawer with traceDetails and props", () => {
+      const traceProps: Partial<DrawerProps<"traceDetails">> = {
+        traceId: "trace-123",
+      };
+      const { result } = renderHook(() => useTraceDetailsDrawer());
+
+      act(() => {
+        result.current.openTraceDetailsDrawer(traceProps);
+      });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith("traceDetails", traceProps);
+    });
+  });
+
+  describe("when called without props", () => {
+    it("delegates to openDrawer with traceDetails and undefined", () => {
+      const { result } = renderHook(() => useTraceDetailsDrawer());
+
+      act(() => {
+        result.current.openTraceDetailsDrawer();
+      });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith("traceDetails", undefined);
+    });
+  });
+});

--- a/langwatch/src/hooks/useLiteMemberGuard.ts
+++ b/langwatch/src/hooks/useLiteMemberGuard.ts
@@ -1,0 +1,22 @@
+import { OrganizationUserRole } from "@prisma/client";
+import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
+
+/**
+ * Guard hook that determines whether the current user is a lite member.
+ *
+ * Lite members are users with the EXTERNAL organization role.
+ * They can navigate all pages freely but cannot create, edit, or
+ * delete resources. Mutations are blocked server-side and the
+ * global error handler opens a restriction modal.
+ *
+ * @returns `isLiteMember` - true if the user has the EXTERNAL organization role
+ */
+export function useLiteMemberGuard(): {
+  isLiteMember: boolean;
+} {
+  const { organizationRole } = useOrganizationTeamProject();
+
+  const isLiteMember = organizationRole === OrganizationUserRole.EXTERNAL;
+
+  return { isLiteMember };
+}

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -1,7 +1,9 @@
 import { useRouter } from "next/router";
 import { useEffect, useMemo } from "react";
 import { useLocalStorage } from "usehooks-ts";
+import { OrganizationUserRole } from "@prisma/client";
 import {
+  EXTERNAL_MEMBER_PERMISSIONS,
   hasPermissionWithHierarchy,
   organizationRoleHasPermission,
   type Permission,
@@ -281,6 +283,7 @@ export const useOrganizationTeamProject = (
       isPublicRoute,
       isOrganizationFeatureEnabled: () => false,
       isDemo,
+      organizationRole: undefined,
     };
   }
 
@@ -341,6 +344,11 @@ export const useOrganizationTeamProject = (
       return hasPermissionWithHierarchy(userPermissions, permission);
     }
 
+    // EXTERNAL users get restricted defaults instead of full team role permissions
+    if (organizationRole === OrganizationUserRole.EXTERNAL) {
+      return hasPermissionWithHierarchy(EXTERNAL_MEMBER_PERMISSIONS, permission);
+    }
+
     // Only fall back to built-in team role if NO custom role exists
     return teamRoleHasPermission(teamMember.role, permission);
   };
@@ -392,5 +400,6 @@ export const useOrganizationTeamProject = (
     modelProviders: modelProviders.data,
     isOrganizationFeatureEnabled,
     isDemo,
+    organizationRole,
   };
 };

--- a/langwatch/src/hooks/useTraceDetailsDrawer.ts
+++ b/langwatch/src/hooks/useTraceDetailsDrawer.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import type { DrawerProps } from "../components/drawerRegistry";
+import { useDrawer } from "./useDrawer";
+
+/**
+ * Convenience hook for opening the trace details drawer.
+ *
+ * EXTERNAL user restriction is enforced centrally in `CurrentDrawer` —
+ * any `openDrawer("traceDetails", ...)` call (whether through this hook
+ * or directly) is automatically intercepted for EXTERNAL users.
+ *
+ * This hook exists as a convenience wrapper for components that want a
+ * purpose-specific function instead of the generic `openDrawer`.
+ */
+export function useTraceDetailsDrawer() {
+  const { openDrawer } = useDrawer();
+
+  const openTraceDetailsDrawer = useCallback(
+    (props?: Partial<DrawerProps<"traceDetails">>) => {
+      openDrawer("traceDetails", props);
+    },
+    [openDrawer],
+  );
+
+  return { openTraceDetailsDrawer };
+}

--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -6,13 +6,18 @@ import {
   checkPermissionOrPubliclyShared,
   checkProjectPermission,
   checkTeamPermission,
+  EXTERNAL_MEMBER_PERMISSIONS,
   hasOrganizationPermission,
   hasProjectPermission,
   hasTeamPermission,
+  resolveProjectPermission,
+  resolveTeamPermission,
   type Permission,
+  type PermissionResult,
   skipPermissionCheck,
   skipPermissionCheckProjectCreation,
 } from "../rbac";
+import { LiteMemberRestrictedError } from "~/server/app-layer/permissions/errors";
 
 // Mock Prisma client
 const mockPrisma = {
@@ -31,6 +36,9 @@ const mockPrisma = {
   },
   teamUserCustomRole: {
     findFirst: vi.fn(),
+  },
+  customRole: {
+    findUnique: vi.fn(),
   },
   publicShare: {
     findFirst: vi.fn(),
@@ -84,6 +92,7 @@ describe("RBAC Integration Tests", () => {
         team: {
           id: "team-123",
           members: [], // No members
+          organization: { members: [] },
         },
       });
 
@@ -100,10 +109,9 @@ describe("RBAC Integration Tests", () => {
         team: {
           id: "team-123",
           members: [{ userId: "user-123", role: TeamUserRole.ADMIN }],
+          organization: { members: [] },
         },
       });
-
-      mockPrisma.teamUserCustomRole.findFirst.mockResolvedValue(null);
 
       const result = await hasProjectPermission(
         { prisma: mockPrisma, session: mockSession },
@@ -118,6 +126,7 @@ describe("RBAC Integration Tests", () => {
         team: {
           id: "team-123",
           members: [{ userId: "user-123", role: TeamUserRole.VIEWER }],
+          organization: { members: [] },
         },
       });
 
@@ -324,6 +333,7 @@ describe("RBAC Integration Tests", () => {
           team: {
             id: "team-123",
             members: [],
+            organization: { members: [] },
           },
         });
 
@@ -345,10 +355,9 @@ describe("RBAC Integration Tests", () => {
           team: {
             id: "team-123",
             members: [{ userId: "user-123", role: TeamUserRole.ADMIN }],
+            organization: { members: [] },
           },
         });
-
-        mockPrisma.teamUserCustomRole.findFirst.mockResolvedValue(null);
 
         const middleware = checkProjectPermission(
           "workflows:view" as Permission,
@@ -496,11 +505,13 @@ describe("RBAC Integration Tests", () => {
         mockPrisma.project.findUnique.mockResolvedValue({
           team: {
             id: "team-123",
+            organizationId: "org-1",
             members: [{ userId: "user-123", role: TeamUserRole.ADMIN }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
           },
         });
-
-        mockPrisma.teamUserCustomRole.findFirst.mockResolvedValue(null);
 
         const middleware = checkPermissionOrPubliclyShared(
           checkProjectPermission("workflows:view" as Permission),
@@ -523,6 +534,7 @@ describe("RBAC Integration Tests", () => {
           team: {
             id: "team-123",
             members: [],
+            organization: { members: [] },
           },
         });
 
@@ -553,6 +565,7 @@ describe("RBAC Integration Tests", () => {
           team: {
             id: "team-123",
             members: [],
+            organization: { members: [] },
           },
         });
 
@@ -570,6 +583,1055 @@ describe("RBAC Integration Tests", () => {
             next: mockNext,
           }),
         ).rejects.toThrow(TRPCError);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // resolveProjectPermission
+  // ==========================================================================
+
+  describe("resolveProjectPermission", () => {
+    function setupProjectMocks({
+      orgRole,
+      teamRole,
+      hasTeamMember = true,
+    }: {
+      orgRole?: OrganizationUserRole;
+      teamRole?: TeamUserRole;
+      hasTeamMember?: boolean;
+    }) {
+      mockPrisma.project.findUnique.mockResolvedValue({
+        team: {
+          id: "team-1",
+          organizationId: "org-1",
+          members: hasTeamMember
+            ? [{ userId: "user-123", role: teamRole ?? TeamUserRole.MEMBER }]
+            : [],
+          organization: {
+            members: orgRole ? [{ role: orgRole }] : [],
+          },
+        },
+      });
+    }
+
+    describe("when user is an org ADMIN and team MEMBER", () => {
+      it("grants permission and returns ADMIN org role", async () => {
+        setupProjectMocks({
+          orgRole: OrganizationUserRole.ADMIN,
+          teamRole: TeamUserRole.MEMBER,
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.ADMIN);
+      });
+    });
+
+    describe("when user is an org MEMBER and team MEMBER", () => {
+      it("grants permission and returns MEMBER org role", async () => {
+        setupProjectMocks({
+          orgRole: OrganizationUserRole.MEMBER,
+          teamRole: TeamUserRole.MEMBER,
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+      });
+    });
+
+    describe("when user is an org EXTERNAL and team VIEWER", () => {
+      it("grants view permission and returns EXTERNAL org role", async () => {
+        setupProjectMocks({
+          orgRole: OrganizationUserRole.EXTERNAL,
+          teamRole: TeamUserRole.VIEWER,
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+      });
+    });
+
+    describe("when user is not an org member", () => {
+      it("denies permission and returns null org role", async () => {
+        setupProjectMocks({ hasTeamMember: false });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBeNull();
+      });
+    });
+
+    describe("when project is a demo project", () => {
+      it("grants permission and returns null org role", async () => {
+        process.env.DEMO_PROJECT_ID = "demo-project-1";
+        try {
+          const result = await resolveProjectPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "demo-project-1",
+            "analytics:view" as Permission,
+          );
+
+          expect(result.permitted).toBe(true);
+          expect(result.organizationRole).toBeNull();
+        } finally {
+          delete process.env.DEMO_PROJECT_ID;
+        }
+      });
+    });
+
+    describe("when user is unauthenticated", () => {
+      it("denies permission and returns null org role", async () => {
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: null },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBeNull();
+      });
+    });
+
+    describe("when user has CUSTOM role with granted permissions", () => {
+      it("grants permission and returns org role", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [
+              {
+                userId: "user-123",
+                role: TeamUserRole.CUSTOM,
+                assignedRoleId: "custom-role-1",
+              },
+            ],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        mockPrisma.customRole.findUnique.mockResolvedValue({
+          permissions: ["analytics:view", "datasets:view"],
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+      });
+    });
+
+    describe("when user has CUSTOM role without requested permission", () => {
+      it("denies permission and returns org role", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [
+              {
+                userId: "user-123",
+                role: TeamUserRole.CUSTOM,
+                assignedRoleId: "custom-role-1",
+              },
+            ],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        mockPrisma.customRole.findUnique.mockResolvedValue({
+          permissions: ["analytics:view"],
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "datasets:manage" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+      });
+    });
+
+    describe("when verifying permission decisions are unchanged (regression)", () => {
+      it.each([
+        { teamRole: TeamUserRole.ADMIN, permission: "analytics:view", expected: true },
+        { teamRole: TeamUserRole.ADMIN, permission: "datasets:manage", expected: true },
+        { teamRole: TeamUserRole.ADMIN, permission: "team:manage", expected: true },
+        { teamRole: TeamUserRole.MEMBER, permission: "analytics:view", expected: true },
+        { teamRole: TeamUserRole.MEMBER, permission: "datasets:manage", expected: true },
+        { teamRole: TeamUserRole.MEMBER, permission: "team:manage", expected: false },
+        { teamRole: TeamUserRole.VIEWER, permission: "analytics:view", expected: true },
+        { teamRole: TeamUserRole.VIEWER, permission: "datasets:manage", expected: false },
+        { teamRole: TeamUserRole.VIEWER, permission: "team:manage", expected: false },
+      ])(
+        "returns permitted=$expected for $teamRole with $permission",
+        async ({ teamRole, permission, expected }) => {
+          setupProjectMocks({
+            orgRole: OrganizationUserRole.MEMBER,
+            teamRole,
+          });
+
+          const result = await resolveProjectPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "project-1",
+            permission as Permission,
+          );
+
+          expect(result.permitted).toBe(expected);
+          expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+        },
+      );
+    });
+
+    describe("when verifying org role is carried for each org role type", () => {
+      it.each([
+        OrganizationUserRole.ADMIN,
+        OrganizationUserRole.MEMBER,
+        OrganizationUserRole.EXTERNAL,
+      ])("returns org role %s", async (orgRole) => {
+        setupProjectMocks({
+          orgRole,
+          teamRole: TeamUserRole.MEMBER,
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.organizationRole).toBe(orgRole);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // resolveTeamPermission
+  // ==========================================================================
+
+  describe("resolveTeamPermission", () => {
+    function setupTeamMocks({
+      orgRole,
+      teamRole,
+      hasTeamUser = true,
+    }: {
+      orgRole?: OrganizationUserRole;
+      teamRole?: TeamUserRole;
+      hasTeamUser?: boolean;
+    }) {
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "team-1",
+        organizationId: "org-1",
+      });
+
+      mockPrisma.organizationUser.findFirst.mockResolvedValue(
+        orgRole ? { role: orgRole } : null,
+      );
+
+      mockPrisma.teamUser.findFirst.mockResolvedValue(
+        hasTeamUser && teamRole
+          ? { userId: "user-123", teamId: "team-1", role: teamRole }
+          : null,
+      );
+    }
+
+    describe("when user is an org ADMIN (admin bypass, not a team member)", () => {
+      it("grants permission and returns ADMIN org role", async () => {
+        setupTeamMocks({
+          orgRole: OrganizationUserRole.ADMIN,
+          hasTeamUser: false,
+        });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:manage" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.ADMIN);
+      });
+    });
+
+    describe("when user is an org MEMBER and team MEMBER", () => {
+      it("grants permission and returns MEMBER org role", async () => {
+        setupTeamMocks({
+          orgRole: OrganizationUserRole.MEMBER,
+          teamRole: TeamUserRole.MEMBER,
+        });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.MEMBER);
+      });
+    });
+
+    describe("when user is an org EXTERNAL and team VIEWER", () => {
+      it("grants allowed permission and returns EXTERNAL org role", async () => {
+        setupTeamMocks({
+          orgRole: OrganizationUserRole.EXTERNAL,
+          teamRole: TeamUserRole.VIEWER,
+        });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+      });
+
+      it("denies manage permission and returns EXTERNAL org role", async () => {
+        setupTeamMocks({
+          orgRole: OrganizationUserRole.EXTERNAL,
+          teamRole: TeamUserRole.VIEWER,
+        });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:manage" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+      });
+    });
+
+    describe("when user is not an org member", () => {
+      it("denies permission and returns null org role", async () => {
+        setupTeamMocks({ hasTeamUser: false });
+
+        const result = await resolveTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBeNull();
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Boolean API regression guards
+  // ==========================================================================
+
+  describe("boolean API regression", () => {
+    describe("when hasProjectPermission is called", () => {
+      it("returns true (boolean) when user has permission", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [{ userId: "user-123", role: TeamUserRole.MEMBER }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const result = await hasProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "analytics:view" as Permission,
+        );
+
+        expect(result).toBe(true);
+        expect(typeof result).toBe("boolean");
+      });
+
+      it("returns false (boolean) when user lacks permission", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [{ userId: "user-123", role: TeamUserRole.VIEWER }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const result = await hasProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "datasets:manage" as Permission,
+        );
+
+        expect(result).toBe(false);
+        expect(typeof result).toBe("boolean");
+      });
+    });
+
+    describe("when hasTeamPermission is called", () => {
+      it("returns true (boolean) when user has permission", async () => {
+        mockPrisma.team.findUnique.mockResolvedValue({
+          id: "team-1",
+          organizationId: "org-1",
+        });
+
+        mockPrisma.organizationUser.findFirst.mockResolvedValue({
+          role: OrganizationUserRole.MEMBER,
+        });
+
+        mockPrisma.teamUser.findFirst.mockResolvedValue({
+          userId: "user-123",
+          teamId: "team-1",
+          role: TeamUserRole.MEMBER,
+        });
+
+        const result = await hasTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:view" as Permission,
+        );
+
+        expect(result).toBe(true);
+        expect(typeof result).toBe("boolean");
+      });
+
+      it("returns false (boolean) when user lacks permission", async () => {
+        mockPrisma.team.findUnique.mockResolvedValue({
+          id: "team-1",
+          organizationId: "org-1",
+        });
+
+        mockPrisma.organizationUser.findFirst.mockResolvedValue({
+          role: OrganizationUserRole.MEMBER,
+        });
+
+        mockPrisma.teamUser.findFirst.mockResolvedValue({
+          userId: "user-123",
+          teamId: "team-1",
+          role: TeamUserRole.VIEWER,
+        });
+
+        const result = await hasTeamPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "team-1",
+          "team:manage" as Permission,
+        );
+
+        expect(result).toBe(false);
+        expect(typeof result).toBe("boolean");
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Middleware passes org role to downstream context
+  // ==========================================================================
+
+  describe("middleware org role propagation", () => {
+    describe("when checkProjectPermission middleware runs for a permitted user", () => {
+      it("sets organizationRole on context", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [{ userId: "user-123", role: TeamUserRole.MEMBER }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkProjectPermission(
+          "analytics:view" as Permission,
+        );
+
+        await middleware({
+          ctx,
+          input: { projectId: "project-1" },
+          next: mockNext,
+        });
+
+        expect(ctx.organizationRole).toBe(OrganizationUserRole.MEMBER);
+        expect(ctx.permissionChecked).toBe(true);
+      });
+    });
+
+    describe("when checkTeamPermission middleware runs for a permitted user", () => {
+      it("sets organizationRole on context", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        mockPrisma.team.findUnique.mockResolvedValue({
+          id: "team-1",
+          organizationId: "org-1",
+        });
+
+        mockPrisma.organizationUser.findFirst.mockResolvedValue({
+          role: OrganizationUserRole.ADMIN,
+        });
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkTeamPermission("team:view" as Permission);
+
+        await middleware({
+          ctx,
+          input: { teamId: "team-1" },
+          next: mockNext,
+        });
+
+        expect(ctx.organizationRole).toBe(OrganizationUserRole.ADMIN);
+        expect(ctx.permissionChecked).toBe(true);
+      });
+    });
+
+    describe("when checkProjectPermission middleware denies access", () => {
+      it("throws UNAUTHORIZED", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+        };
+
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [],
+            organization: {
+              members: [],
+            },
+          },
+        });
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkProjectPermission(
+          "analytics:view" as Permission,
+        );
+
+        await expect(
+          middleware({
+            ctx,
+            input: { projectId: "project-1" },
+            next: mockNext,
+          }),
+        ).rejects.toThrow(TRPCError);
+      });
+    });
+
+    describe("when checkTeamPermission middleware denies access", () => {
+      it("throws UNAUTHORIZED", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+        };
+
+        mockPrisma.team.findUnique.mockResolvedValue({
+          id: "team-1",
+          organizationId: "org-1",
+        });
+
+        mockPrisma.organizationUser.findFirst.mockResolvedValue(null);
+        mockPrisma.teamUser.findFirst.mockResolvedValue(null);
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkTeamPermission("team:view" as Permission);
+
+        await expect(
+          middleware({
+            ctx,
+            input: { teamId: "team-1" },
+            next: mockNext,
+          }),
+        ).rejects.toThrow(TRPCError);
+      });
+    });
+
+    describe("when public share fallback middleware runs for a permitted user", () => {
+      it("passes org role via checkProjectPermission", async () => {
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [{ userId: "user-123", role: TeamUserRole.MEMBER }],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkPermissionOrPubliclyShared(
+          checkProjectPermission("analytics:view" as Permission),
+          { resourceType: "TRACE", resourceParam: "traceId" },
+        );
+
+        await middleware({
+          ctx,
+          input: { projectId: "project-1", traceId: "trace-1" },
+          next: mockNext,
+        });
+
+        expect(ctx.organizationRole).toBe(OrganizationUserRole.MEMBER);
+        expect(ctx.permissionChecked).toBe(true);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // EXTERNAL (lite member) restriction logic
+  // ==========================================================================
+
+  describe("EXTERNAL (lite member) restriction logic", () => {
+    function setupProjectWithExternalUser({
+      teamRole = TeamUserRole.VIEWER,
+      assignedRoleId,
+    }: {
+      teamRole?: TeamUserRole;
+      assignedRoleId?: string;
+    } = {}) {
+      mockPrisma.project.findUnique.mockResolvedValue({
+        team: {
+          id: "team-1",
+          organizationId: "org-1",
+          members: [
+            {
+              userId: "user-123",
+              role: teamRole,
+              assignedRoleId: assignedRoleId ?? null,
+            },
+          ],
+          organization: {
+            members: [{ role: OrganizationUserRole.EXTERNAL }],
+          },
+        },
+      });
+    }
+
+    function setupTeamWithExternalUser({
+      teamRole = TeamUserRole.VIEWER,
+      assignedRoleId,
+    }: {
+      teamRole?: TeamUserRole;
+      assignedRoleId?: string;
+    } = {}) {
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "team-1",
+        organizationId: "org-1",
+      });
+
+      mockPrisma.organizationUser.findFirst.mockResolvedValue({
+        role: OrganizationUserRole.EXTERNAL,
+      });
+
+      mockPrisma.teamUser.findFirst.mockResolvedValue({
+        userId: "user-123",
+        teamId: "team-1",
+        role: teamRole,
+        assignedRoleId: assignedRoleId ?? null,
+      });
+    }
+
+    describe("when EXTERNAL user requests a mutate permission via project", () => {
+      it.each([
+        "datasets:manage",
+        "prompts:manage",
+        "annotations:manage",
+        "evaluations:manage",
+        "workflows:manage",
+        "scenarios:manage",
+        "secrets:manage",
+        "team:manage",
+        "project:manage",
+        "project:create",
+        "project:update",
+        "project:delete",
+        "triggers:manage",
+      ] as Permission[])(
+        "denies %s",
+        async (permission) => {
+          setupProjectWithExternalUser();
+
+          const result = await resolveProjectPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "project-1",
+            permission,
+          );
+
+          expect(result.permitted).toBe(false);
+          expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+        },
+      );
+    });
+
+    describe("when EXTERNAL user requests an allowed view permission via project", () => {
+      it.each([
+        "project:view",
+        "analytics:view",
+        "traces:view",
+        "annotations:view",
+        "evaluations:view",
+        "datasets:view",
+        "workflows:view",
+        "prompts:view",
+        "scenarios:view",
+        "secrets:view",
+        "team:view",
+      ] as Permission[])(
+        "grants %s",
+        async (permission) => {
+          setupProjectWithExternalUser();
+
+          const result = await resolveProjectPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "project-1",
+            permission,
+          );
+
+          expect(result.permitted).toBe(true);
+          expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+        },
+      );
+    });
+
+    describe("when EXTERNAL user requests a mutate permission via team", () => {
+      it.each([
+        "datasets:manage",
+        "prompts:manage",
+        "annotations:manage",
+        "evaluations:manage",
+        "workflows:manage",
+        "scenarios:manage",
+        "secrets:manage",
+        "team:manage",
+      ] as Permission[])(
+        "denies %s",
+        async (permission) => {
+          setupTeamWithExternalUser();
+
+          const result = await resolveTeamPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "team-1",
+            permission,
+          );
+
+          expect(result.permitted).toBe(false);
+          expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+        },
+      );
+    });
+
+    describe("when EXTERNAL user requests an allowed view permission via team", () => {
+      it.each([
+        "project:view",
+        "analytics:view",
+        "traces:view",
+        "annotations:view",
+        "evaluations:view",
+        "datasets:view",
+        "workflows:view",
+        "prompts:view",
+        "scenarios:view",
+        "secrets:view",
+        "team:view",
+      ] as Permission[])(
+        "grants %s",
+        async (permission) => {
+          setupTeamWithExternalUser();
+
+          const result = await resolveTeamPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "team-1",
+            permission,
+          );
+
+          expect(result.permitted).toBe(true);
+          expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+        },
+      );
+    });
+
+    describe("when EXTERNAL user has a custom role granting additional permissions", () => {
+      it("grants the custom role permission (overrides restricted defaults)", async () => {
+        setupProjectWithExternalUser({
+          teamRole: TeamUserRole.CUSTOM,
+          assignedRoleId: "custom-role-1",
+        });
+
+        mockPrisma.customRole.findUnique.mockResolvedValue({
+          permissions: ["datasets:view", "prompts:view"],
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "datasets:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+      });
+
+      it("denies permissions not in the custom role", async () => {
+        setupProjectWithExternalUser({
+          teamRole: TeamUserRole.CUSTOM,
+          assignedRoleId: "custom-role-1",
+        });
+
+        mockPrisma.customRole.findUnique.mockResolvedValue({
+          permissions: ["datasets:view"],
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "prompts:view" as Permission,
+        );
+
+        expect(result.permitted).toBe(false);
+        expect(result.organizationRole).toBe(OrganizationUserRole.EXTERNAL);
+      });
+    });
+
+    describe("when non-EXTERNAL user (MEMBER) has VIEWER team role", () => {
+      it.each([
+        "datasets:view",
+        "prompts:view",
+        "secrets:view",
+      ] as Permission[])(
+        "grants %s",
+        async (permission) => {
+          mockPrisma.project.findUnique.mockResolvedValue({
+            team: {
+              id: "team-1",
+              organizationId: "org-1",
+              members: [
+                { userId: "user-123", role: TeamUserRole.VIEWER, assignedRoleId: null },
+              ],
+              organization: {
+                members: [{ role: OrganizationUserRole.MEMBER }],
+              },
+            },
+          });
+
+          const result = await resolveProjectPermission(
+            { prisma: mockPrisma, session: mockSession },
+            "project-1",
+            permission,
+          );
+
+          expect(result.permitted).toBe(true);
+        },
+      );
+    });
+
+    describe("when non-EXTERNAL user (ADMIN org role) accesses resources", () => {
+      it("grants full team-role-based access", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [
+              { userId: "user-123", role: TeamUserRole.ADMIN, assignedRoleId: null },
+            ],
+            organization: {
+              members: [{ role: OrganizationUserRole.ADMIN }],
+            },
+          },
+        });
+
+        const result = await resolveProjectPermission(
+          { prisma: mockPrisma, session: mockSession },
+          "project-1",
+          "datasets:manage" as Permission,
+        );
+
+        expect(result.permitted).toBe(true);
+        expect(result.organizationRole).toBe(OrganizationUserRole.ADMIN);
+      });
+    });
+
+    describe("when checkProjectPermission middleware denies EXTERNAL user", () => {
+      it("throws TRPCError with LiteMemberRestrictedError cause", async () => {
+        setupProjectWithExternalUser();
+
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkProjectPermission("datasets:manage" as Permission);
+
+        try {
+          await middleware({
+            ctx,
+            input: { projectId: "project-1" },
+            next: mockNext,
+          });
+          expect.unreachable("Expected middleware to throw");
+        } catch (error) {
+          expect(error).toBeInstanceOf(TRPCError);
+          const trpcError = error as TRPCError;
+          expect(trpcError.code).toBe("UNAUTHORIZED");
+          expect(trpcError.message).toBe("This feature is not available for your account");
+          expect(trpcError.cause).toBeInstanceOf(LiteMemberRestrictedError);
+          expect((trpcError.cause as LiteMemberRestrictedError).meta.resource).toBe("datasets");
+        }
+      });
+    });
+
+    describe("when checkTeamPermission middleware denies EXTERNAL user", () => {
+      it("throws TRPCError with LiteMemberRestrictedError cause", async () => {
+        setupTeamWithExternalUser();
+
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkTeamPermission("datasets:manage" as Permission);
+
+        try {
+          await middleware({
+            ctx,
+            input: { teamId: "team-1" },
+            next: mockNext,
+          });
+          expect.unreachable("Expected middleware to throw");
+        } catch (error) {
+          expect(error).toBeInstanceOf(TRPCError);
+          const trpcError = error as TRPCError;
+          expect(trpcError.code).toBe("UNAUTHORIZED");
+          expect(trpcError.message).toBe("This feature is not available for your account");
+          expect(trpcError.cause).toBeInstanceOf(LiteMemberRestrictedError);
+          expect((trpcError.cause as LiteMemberRestrictedError).meta.resource).toBe("datasets");
+        }
+      });
+    });
+
+    describe("when checkProjectPermission middleware denies non-EXTERNAL user", () => {
+      it("throws generic UNAUTHORIZED without LiteMemberRestrictedError", async () => {
+        mockPrisma.project.findUnique.mockResolvedValue({
+          team: {
+            id: "team-1",
+            organizationId: "org-1",
+            members: [],
+            organization: {
+              members: [{ role: OrganizationUserRole.MEMBER }],
+            },
+          },
+        });
+
+        const ctx = {
+          prisma: mockPrisma,
+          session: mockSession,
+          permissionChecked: false,
+          publiclyShared: false,
+          organizationRole: undefined as OrganizationUserRole | null | undefined,
+        };
+
+        const mockNext = vi.fn().mockResolvedValue("success");
+        const middleware = checkProjectPermission("datasets:view" as Permission);
+
+        try {
+          await middleware({
+            ctx,
+            input: { projectId: "project-1" },
+            next: mockNext,
+          });
+          expect.unreachable("Expected middleware to throw");
+        } catch (error) {
+          expect(error).toBeInstanceOf(TRPCError);
+          const trpcError = error as TRPCError;
+          expect(trpcError.code).toBe("UNAUTHORIZED");
+          expect(trpcError.message).toBe("You do not have permission to access this project resource");
+          expect(trpcError.cause).toBeUndefined();
+        }
+      });
+    });
+
+    describe("when EXTERNAL_MEMBER_PERMISSIONS constant is defined", () => {
+      it("matches the VIEWER role permission set exactly", () => {
+        expect(EXTERNAL_MEMBER_PERMISSIONS).toEqual([
+          "project:view",
+          "analytics:view",
+          "traces:view",
+          "annotations:view",
+          "evaluations:view",
+          "datasets:view",
+          "workflows:view",
+          "prompts:view",
+          "scenarios:view",
+          "secrets:view",
+          "team:view",
+        ]);
       });
     });
   });

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -6,6 +6,7 @@ import {
 import { TRPCError } from "@trpc/server";
 import type { Session } from "next-auth";
 import { env } from "~/env.mjs";
+import { LiteMemberRestrictedError } from "~/server/app-layer/permissions/errors";
 
 // ============================================================================
 // PERMISSION DEFINITIONS
@@ -93,9 +94,6 @@ const TEAM_ROLE_PERMISSIONS: Record<TeamUserRole, Permission[]> = {
     // Triggers
     "triggers:view",
     "triggers:manage",
-    // Workflows
-    "workflows:view",
-    "workflows:manage",
     // Prompts
     "prompts:view",
     "prompts:manage",
@@ -136,9 +134,6 @@ const TEAM_ROLE_PERMISSIONS: Record<TeamUserRole, Permission[]> = {
     // Triggers
     "triggers:view",
     "triggers:manage",
-    // Workflows
-    "workflows:view",
-    "workflows:manage",
     // Prompts
     "prompts:view",
     "prompts:manage",
@@ -217,6 +212,29 @@ const ORGANIZATION_ROLE_PERMISSIONS: Record<
   [OrganizationUserRole.MEMBER]: ["organization:view"],
   [OrganizationUserRole.EXTERNAL]: ["organization:view"], // Limited view for Lite Member users
 };
+
+/**
+ * Default permission set for EXTERNAL (lite member) users.
+ * Currently identical to VIEWER — lite members can view all resources but
+ * cannot create, edit, or manage them. Maintained as a separate constant so
+ * it can diverge from VIEWER independently if needed.
+ *
+ * Custom roles, when assigned to EXTERNAL users, override these defaults
+ * (see resolveProjectPermission).
+ */
+export const EXTERNAL_MEMBER_PERMISSIONS: Permission[] = [
+  "project:view",
+  "analytics:view",
+  "traces:view",
+  "annotations:view",
+  "evaluations:view",
+  "datasets:view",
+  "workflows:view",
+  "prompts:view",
+  "scenarios:view",
+  "secrets:view",
+  "team:view",
+];
 
 // ============================================================================
 // PERMISSION CHECKING
@@ -326,6 +344,19 @@ export function canDelete(role: TeamUserRole, resource: Resource): boolean {
 }
 
 // ============================================================================
+// PERMISSION RESULT TYPE
+// ============================================================================
+
+/**
+ * Result of resolving a permission check, including the user's organization role.
+ * Used by resolve* functions to provide richer context than a simple boolean.
+ */
+export type PermissionResult = {
+  permitted: boolean;
+  organizationRole: OrganizationUserRole | null;
+};
+
+// ============================================================================
 // MIDDLEWARE & CONTEXT HELPERS
 // ============================================================================
 
@@ -335,6 +366,7 @@ type PermissionMiddlewareParams<InputType> = {
     session: Session;
     permissionChecked: boolean;
     publiclyShared: boolean;
+    organizationRole?: OrganizationUserRole | null;
   };
   input: InputType;
   next: () => any;
@@ -354,13 +386,27 @@ export const checkProjectPermission =
     input,
     next,
   }: PermissionMiddlewareParams<{ projectId: string }>) => {
-    if (!(await hasProjectPermission(ctx, input.projectId, permission))) {
+    const { permitted, organizationRole } = await resolveProjectPermission(
+      ctx,
+      input.projectId,
+      permission,
+    );
+
+    if (!permitted) {
+      if (organizationRole === OrganizationUserRole.EXTERNAL) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "This feature is not available for your account",
+          cause: new LiteMemberRestrictedError(permission.split(":")[0] ?? "unknown"),
+        });
+      }
       throw new TRPCError({
         code: "UNAUTHORIZED",
         message: "You do not have permission to access this project resource",
       });
     }
 
+    ctx.organizationRole = organizationRole;
     ctx.permissionChecked = true;
     return next();
   };
@@ -375,13 +421,27 @@ export const checkTeamPermission =
     input,
     next,
   }: PermissionMiddlewareParams<{ teamId: string }>) => {
-    if (!(await hasTeamPermission(ctx, input.teamId, permission))) {
+    const { permitted, organizationRole } = await resolveTeamPermission(
+      ctx,
+      input.teamId,
+      permission,
+    );
+
+    if (!permitted) {
+      if (organizationRole === OrganizationUserRole.EXTERNAL) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "This feature is not available for your account",
+          cause: new LiteMemberRestrictedError(permission.split(":")[0] ?? "unknown"),
+        });
+      }
       throw new TRPCError({
         code: "UNAUTHORIZED",
         message: "You do not have permission to access this team resource",
       });
     }
 
+    ctx.organizationRole = organizationRole;
     ctx.permissionChecked = true;
     return next();
   };
@@ -415,20 +475,21 @@ export const checkOrganizationPermission =
 // ============================================================================
 
 /**
- * Check if user has a specific permission for a project
+ * Resolve a project permission check, returning the permission decision
+ * along with the user's organization role.
  */
-export async function hasProjectPermission(
+export async function resolveProjectPermission(
   ctx: { prisma: PrismaClient; session: Session | null },
   projectId: string,
   permission: Permission,
-): Promise<boolean> {
+): Promise<PermissionResult> {
   if (!ctx.session?.user) {
-    return false;
+    return { permitted: false, organizationRole: null };
   }
 
   // Check demo project access
   if (isDemoProject(projectId, permission)) {
-    return true;
+    return { permitted: true, organizationRole: null };
   }
 
   const projectTeam = await ctx.prisma.project.findUnique?.({
@@ -437,6 +498,7 @@ export async function hasProjectPermission(
       team: {
         select: {
           id: true,
+          organizationId: true,
           members: {
             where: { userId: ctx.session.user.id },
             select: {
@@ -446,17 +508,25 @@ export async function hasProjectPermission(
               assignedRoleId: true,
             },
           },
+          organization: {
+            select: {
+              members: {
+                where: { userId: ctx.session.user.id },
+                select: { role: true },
+              },
+            },
+          },
         },
       },
     },
   });
 
-  const teamMember = projectTeam?.team.members.find(
-    (member) => member.userId === ctx.session?.user.id,
-  );
+  const organizationRole =
+    projectTeam?.team.organization?.members[0]?.role ?? null;
+  const teamMember = projectTeam?.team.members[0];
 
   if (!teamMember) {
-    return false;
+    return { permitted: false, organizationRole };
   }
 
   // Check user's individual permissions (custom role or built-in role)
@@ -476,27 +546,63 @@ export async function hasProjectPermission(
 
       // If custom role has permissions, use them; otherwise fall back to built-in role
       if (userPermissions.length > 0) {
-        return hasPermissionWithHierarchy(userPermissions, permission);
+        return {
+          permitted: hasPermissionWithHierarchy(userPermissions, permission),
+          organizationRole,
+        };
       }
       // Fall back to built-in role if custom role has no permissions
-      return teamRoleHasPermission(teamMember.role, permission);
+      // EXTERNAL users get restricted defaults instead of full team role
+      if (organizationRole === OrganizationUserRole.EXTERNAL) {
+        return {
+          permitted: hasPermissionWithHierarchy(EXTERNAL_MEMBER_PERMISSIONS, permission),
+          organizationRole,
+        };
+      }
+      return {
+        permitted: teamRoleHasPermission(teamMember.role, permission),
+        organizationRole,
+      };
     }
   }
 
   // Only fall back to built-in team role if NO custom role exists
-  return teamRoleHasPermission(teamMember.role, permission);
+  // EXTERNAL users get restricted defaults instead of full VIEWER permissions
+  if (organizationRole === OrganizationUserRole.EXTERNAL) {
+    return {
+      permitted: hasPermissionWithHierarchy(EXTERNAL_MEMBER_PERMISSIONS, permission),
+      organizationRole,
+    };
+  }
+  return {
+    permitted: teamRoleHasPermission(teamMember.role, permission),
+    organizationRole,
+  };
 }
 
 /**
- * Check if user has a specific permission for a team
+ * Check if user has a specific permission for a project
  */
-export async function hasTeamPermission(
-  ctx: { prisma: PrismaClient; session: Session },
-  teamId: string,
+export async function hasProjectPermission(
+  ctx: { prisma: PrismaClient; session: Session | null },
+  projectId: string,
   permission: Permission,
 ): Promise<boolean> {
+  const result = await resolveProjectPermission(ctx, projectId, permission);
+  return result.permitted;
+}
+
+/**
+ * Resolve a team permission check, returning the permission decision
+ * along with the user's organization role.
+ */
+export async function resolveTeamPermission(
+  ctx: { prisma: PrismaClient; session: Session | null },
+  teamId: string,
+  permission: Permission,
+): Promise<PermissionResult> {
   if (!ctx.session?.user) {
-    return false;
+    return { permitted: false, organizationRole: null };
   }
 
   const team = await ctx.prisma.team.findUnique?.({
@@ -505,7 +611,7 @@ export async function hasTeamPermission(
   });
 
   if (!team?.organizationId) {
-    return false;
+    return { permitted: false, organizationRole: null };
   }
 
   // Check organization admin override
@@ -516,9 +622,11 @@ export async function hasTeamPermission(
     },
   });
 
+  const organizationRole = organizationUser?.role ?? null;
+
   // Organization ADMINs can do anything on all teams
   if (organizationUser?.role === OrganizationUserRole.ADMIN) {
-    return true;
+    return { permitted: true, organizationRole };
   }
 
   // Check team membership
@@ -536,7 +644,7 @@ export async function hasTeamPermission(
   });
 
   if (!teamUser) {
-    return false;
+    return { permitted: false, organizationRole };
   }
 
   // Check user's individual permissions (custom role or built-in role)
@@ -554,13 +662,35 @@ export async function hasTeamPermission(
         ? rawPermissions
         : [];
       if (hasPermissionWithHierarchy(userPermissions, permission)) {
-        return true;
+        return { permitted: true, organizationRole };
       }
     }
   }
 
   // Fall back to user's built-in team role only
-  return teamRoleHasPermission(teamUser.role, permission);
+  // EXTERNAL users get restricted defaults instead of full team role permissions
+  if (organizationRole === OrganizationUserRole.EXTERNAL) {
+    return {
+      permitted: hasPermissionWithHierarchy(EXTERNAL_MEMBER_PERMISSIONS, permission),
+      organizationRole,
+    };
+  }
+  return {
+    permitted: teamRoleHasPermission(teamUser.role, permission),
+    organizationRole,
+  };
+}
+
+/**
+ * Check if user has a specific permission for a team
+ */
+export async function hasTeamPermission(
+  ctx: { prisma: PrismaClient; session: Session | null },
+  teamId: string,
+  permission: Permission,
+): Promise<boolean> {
+  const result = await resolveTeamPermission(ctx, teamId, permission);
+  return result.permitted;
 }
 
 /**

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -30,6 +30,7 @@ import { getLogLevelFromStatusCode } from "../middleware/requestLogging";
 import { createLogger } from "../../utils/logger/server";
 import { captureException } from "../../utils/posthogErrorCapture";
 import { auditLog } from "../auditLog";
+import type { OrganizationUserRole } from "@prisma/client";
 import type { PermissionMiddleware } from "./rbac";
 
 const logger = createLogger("langwatch:trpc");
@@ -48,6 +49,7 @@ interface CreateContextOptions {
   session: Session | null;
   permissionChecked?: boolean;
   publiclyShared?: boolean;
+  organizationRole?: OrganizationUserRole | null;
 }
 
 /**
@@ -68,6 +70,7 @@ export const createInnerTRPCContext = (opts: CreateContextOptions) => {
     prisma,
     permissionChecked: opts.permissionChecked ?? false,
     publiclyShared: opts.publiclyShared ?? false,
+    organizationRole: opts.organizationRole ?? undefined,
   };
 };
 

--- a/langwatch/src/utils/__tests__/api.unit.test.ts
+++ b/langwatch/src/utils/__tests__/api.unit.test.ts
@@ -3,6 +3,7 @@ import { TRPCClientError } from "@trpc/client";
 import {
   extractLimitExceededInfo,
   extractLiteMemberRestrictionInfo,
+  isHandledByGlobalHandler,
   isHandledByGlobalLicenseHandler,
   isHandledByLiteMemberHandler,
   markAsHandledByLicenseHandler,
@@ -332,6 +333,30 @@ describe("Global mutation error handler", () => {
     it("handles null/undefined gracefully", () => {
       expect(isHandledByGlobalLicenseHandler(null)).toBe(false);
       expect(isHandledByGlobalLicenseHandler(undefined)).toBe(false);
+    });
+  });
+
+  describe("isHandledByGlobalHandler (combined check)", () => {
+    it("returns false for unhandled errors", () => {
+      const error = new Error("Some error");
+      expect(isHandledByGlobalHandler(error)).toBe(false);
+    });
+
+    it("returns true for license-handled errors", () => {
+      const error = new Error("Limit exceeded");
+      markAsHandledByLicenseHandler(error);
+      expect(isHandledByGlobalHandler(error)).toBe(true);
+    });
+
+    it("returns true for lite-member-handled errors", () => {
+      const error = new Error("Restricted");
+      markAsHandledByLiteMemberHandler(error);
+      expect(isHandledByGlobalHandler(error)).toBe(true);
+    });
+
+    it("handles null/undefined gracefully", () => {
+      expect(isHandledByGlobalHandler(null)).toBe(false);
+      expect(isHandledByGlobalHandler(undefined)).toBe(false);
     });
   });
 

--- a/langwatch/src/utils/api.ts
+++ b/langwatch/src/utils/api.ts
@@ -130,20 +130,14 @@ export const api = createTRPCNext<AppRouter>({
         }),
         queryCache: new QueryCache({
           onError: (error) => {
+            // Silently mark lite member restriction errors on queries.
+            // Queries may fail on allowed pages (e.g., cost:view on analytics)
+            // — the component handles missing data gracefully.
+            // Only mutations and route guards should trigger the modal.
             const restrictionInfo = extractLiteMemberRestrictionInfo(error);
-            if (!restrictionInfo) return;
-
-            if (error instanceof Error) {
+            if (restrictionInfo && error instanceof Error) {
               markAsHandledByLiteMemberHandler(error);
             }
-
-            if (useUpgradeModalStore.getState().isOpen) return;
-
-            useUpgradeModalStore
-              .getState()
-              .openLiteMemberRestriction({
-                resource: restrictionInfo.resource,
-              });
           },
         }),
         defaultOptions: {

--- a/langwatch/src/utils/serverHelpers.ts
+++ b/langwatch/src/utils/serverHelpers.ts
@@ -13,6 +13,7 @@ async function createInnerTRPCContext(context: GetServerSidePropsContext) {
     res: undefined,
     permissionChecked: false,
     publiclyShared: false,
+    organizationRole: undefined,
   };
 }
 

--- a/langwatch/src/utils/trpcError.ts
+++ b/langwatch/src/utils/trpcError.ts
@@ -63,6 +63,29 @@ export function isHandledByLiteMemberHandler(error: unknown): boolean {
   return error instanceof Error && handledLiteMemberErrors.has(error);
 }
 
+/**
+ * Check if an error was already handled by any global error handler
+ * (license limit or lite member restriction).
+ * Use this single check in component-level onError callbacks to avoid
+ * showing duplicate error messages (toast + modal).
+ *
+ * @example
+ * ```tsx
+ * const mutation = api.prompts.create.useMutation({
+ *   onError: (error) => {
+ *     if (isHandledByGlobalHandler(error)) return;
+ *     toaster.create({ title: "Error", description: error.message });
+ *   },
+ * });
+ * ```
+ */
+export function isHandledByGlobalHandler(error: unknown): boolean {
+  return (
+    isHandledByGlobalLicenseHandler(error) ||
+    isHandledByLiteMemberHandler(error)
+  );
+}
+
 // --- Lite member restriction extractor ---
 export interface LiteMemberRestrictionInfo {
   resource?: string;

--- a/specs/rbac/fetch-org-role-permission-resolution.feature
+++ b/specs/rbac/fetch-org-role-permission-resolution.feature
@@ -1,0 +1,101 @@
+@unit
+Feature: Organization role awareness across the platform
+  As a LangWatch platform
+  I need to know each user's organization role (admin, member, or lite member)
+  So that features can tailor access and experience based on role
+
+  Background:
+    Given an organization "acme" with a project "chatbot"
+
+  # ============================================================================
+  # The platform recognizes each organization role type
+  # ============================================================================
+
+  Scenario Outline: Platform identifies the user's organization role
+    Given a user who is a <orgRole> in organization "acme"
+    And the user has access to project "chatbot"
+    When the user accesses the project
+    Then the platform identifies them as <orgRole>
+
+    Examples:
+      | orgRole  |
+      | ADMIN    |
+      | MEMBER   |
+      | EXTERNAL |
+
+  Scenario: Non-members are denied access
+    Given a user who is not a member of organization "acme"
+    When the user tries to access project "chatbot"
+    Then access is denied
+
+  Scenario: Demo projects are accessible without organization membership
+    Given project "chatbot" is a demo project
+    When any user accesses the project
+    Then access is granted
+    And no organization role is associated
+
+  # ============================================================================
+  # Existing permissions are unchanged
+  # ============================================================================
+
+  Scenario Outline: Team role permissions are unaffected by org role awareness
+    Given a user who is a MEMBER in organization "acme"
+    And the user is a <teamRole> on the project's team
+    When the user attempts an action requiring "<permission>"
+    Then the action is <outcome>
+
+    Examples:
+      | teamRole | permission       | outcome |
+      | ADMIN    | analytics:view   | allowed |
+      | ADMIN    | datasets:manage  | allowed |
+      | ADMIN    | team:manage      | allowed |
+      | MEMBER   | analytics:view   | allowed |
+      | MEMBER   | datasets:manage  | allowed |
+      | MEMBER   | team:manage      | denied  |
+      | VIEWER   | analytics:view   | allowed |
+      | VIEWER   | datasets:manage  | denied  |
+      | VIEWER   | team:manage      | denied  |
+
+  # ============================================================================
+  # Custom roles work alongside org role awareness
+  # ============================================================================
+
+  Scenario: Custom role grants are honored and org role is still known
+    Given a user who is a MEMBER in organization "acme"
+    And the user has a custom role with permissions ["analytics:view", "datasets:view"]
+    When the user views analytics
+    Then the action is allowed
+    And the platform identifies them as MEMBER
+
+  Scenario: Custom role restrictions are honored and org role is still known
+    Given a user who is a MEMBER in organization "acme"
+    And the user has a custom role with permissions ["analytics:view"]
+    When the user attempts to manage datasets
+    Then the action is denied
+    And the platform identifies them as MEMBER
+
+  # ============================================================================
+  # Org admins retain elevated access
+  # ============================================================================
+
+  Scenario: Org admin can manage any team regardless of team membership
+    Given a user who is an ADMIN in organization "acme"
+    And the user is not a member of any team
+    When the user manages a team in "acme"
+    Then the action is allowed
+
+  # ============================================================================
+  # Frontend knows the user's role
+  # ============================================================================
+
+  @integration
+  Scenario Outline: The UI reflects the user's organization role
+    Given a user who is a <orgRole> in organization "acme"
+    When the user loads the platform
+    Then the UI knows the user is a <orgRole>
+
+    Examples:
+      | orgRole  |
+      | ADMIN    |
+      | MEMBER   |
+      | EXTERNAL |


### PR DESCRIPTION
## Summary
Backend + frontend infrastructure for lite member (EXTERNAL role) restrictions. All additive — no existing behavior changes.

**Backend:**
- EXTERNAL user permission set in `rbac.ts` (restricted to view-only)
- Expose `organizationRole` in tRPC context
- 1074 lines of RBAC integration tests

**Frontend infrastructure:**
- `useLiteMemberGuard` hook for component-level permission checks
- `useTraceDetailsDrawer` hook for RBAC-aware trace detail opening
- `hasPermission` helper on `useOrganizationTeamProject`
- `restrictedDrawers` map in `CurrentDrawer` for centralized drawer blocking
- Lite member restriction modal in `UpgradeModal`
- `isHandledByGlobalHandler` in `trpcError.ts` for unified error dedup
- RBAC error interception in `api.ts` MutationCache

Split from #2261 (2/3). PR C will wire these guards into all pages/components.

## Test plan
- [ ] Verify existing RBAC permissions are unchanged for ADMIN/MEMBER roles
- [ ] Verify EXTERNAL users get restricted permission set
- [ ] Verify restriction modal shows when EXTERNAL user opens a blocked drawer
- [ ] Run `pnpm test:unit` and `pnpm test:integration` for RBAC tests