### PR TITLE
feat: add DISABLE_ELASTIC_SEARCH env var

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -40,7 +40,7 @@
     "prisma:generate:migration": "pnpm prisma migrate dev --create-only",
     "prisma:migrate": "sh -c 'if [ \"$SKIP_PRISMA_MIGRATE\" != \"true\" ]; then pnpm prisma migrate deploy; else echo \"Skipping Prisma migrations\"; fi'",
     "prisma:seed": "tsx prisma/seed.ts",
-    "elastic:migrate": "sh -c 'if [ \"$SKIP_ELASTIC_MIGRATE\" != \"true\" ]; then pnpm run task elasticMigrate; else echo \"Skipping Elasticsearch migrations\"; fi'",
+    "elastic:migrate": "sh -c 'if [ \"$SKIP_ELASTIC_MIGRATE\" != \"true\" ] && [ \"$DISABLE_ELASTIC_SEARCH\" != \"true\" ] && [ \"$DISABLE_ELASTIC_SEARCH\" != \"1\" ]; then pnpm run task elasticMigrate; else echo \"Skipping Elasticsearch migrations\"; fi'",
     "clickhouse:migrate": "sh -c 'if [ \"$SKIP_CLICKHOUSE_MIGRATE\" != \"true\" ]; then pnpm run task clickhouseMigrate; else echo \"Skipping ClickHouse migrations\"; fi'",
     "types:zod:generate": "./scripts/generate-zod-types.sh",
     "copy:langevals-types": "cp ../langevals/ts-integration/evaluators.generated.ts src/server/evaluations/evaluators.generated.ts",

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -42,7 +42,9 @@ export function createEnvConfig() {
       AUTH0_CLIENT_SECRET: z.string().optional(),
       AUTH0_ISSUER: z.string().optional(),
       API_TOKEN_JWT_SECRET: optionalIfBuildTime(z.string().min(1)),
-      ELASTICSEARCH_NODE_URL: optionalIfBuildTime(z.string().min(1)),
+      ELASTICSEARCH_NODE_URL: process.env.DISABLE_ELASTIC_SEARCH === "true" || process.env.DISABLE_ELASTIC_SEARCH === "1"
+        ? z.string().min(1).optional()
+        : optionalIfBuildTime(z.string().min(1)),
       ELASTICSEARCH_API_KEY: z.string().optional(),
       REDIS_URL: z.string().optional(),
       REDIS_CLUSTER_ENDPOINTS: z.string().optional(),
@@ -107,6 +109,7 @@ export function createEnvConfig() {
 
       // Event Sourcing
       ENABLE_EVENT_SOURCING: z.boolean().optional(),
+      DISABLE_ELASTIC_SEARCH: z.boolean().optional(),
       ENABLE_CLICKHOUSE: z.boolean().optional(),
 
       // ClickHouse Migration Configuration
@@ -229,6 +232,9 @@ export function createEnvConfig() {
       ENABLE_EVENT_SOURCING:
         process.env.ENABLE_EVENT_SOURCING === "true" ||
         process.env.ENABLE_EVENT_SOURCING?.toLowerCase() === "true",
+      DISABLE_ELASTIC_SEARCH:
+        process.env.DISABLE_ELASTIC_SEARCH === "1" ||
+        process.env.DISABLE_ELASTIC_SEARCH?.toLowerCase() === "true",
       ENABLE_CLICKHOUSE:
         process.env.ENABLE_CLICKHOUSE === "true" ||
         process.env.ENABLE_CLICKHOUSE?.toLowerCase() === "true",

--- a/langwatch/src/server/elasticsearch.ts
+++ b/langwatch/src/server/elasticsearch.ts
@@ -64,6 +64,10 @@ const getOrgElasticsearchDetailsFromProject = async (projectId: string) => {
 export const esClient = async (
   args?: { projectId: string } | { organizationId: string } | { test: true },
 ) => {
+  if (env.DISABLE_ELASTIC_SEARCH) {
+    return new ElasticClient({ node: "http://bogus:9200" });
+  }
+
   let elasticsearchNodeUrl: string | null = null;
   let elasticsearchApiKey: string | null = null;
 

--- a/langwatch/src/tasks/elasticMigrate.ts
+++ b/langwatch/src/tasks/elasticMigrate.ts
@@ -24,6 +24,11 @@ import {
 const migrations: Record<string, any> = importedMigrations;
 
 export default async function execute() {
+  if (env.DISABLE_ELASTIC_SEARCH) {
+    console.log("Skipping Elasticsearch migrations (DISABLE_ELASTIC_SEARCH is set)");
+    return;
+  }
+
   if (env.IS_QUICKWIT) {
     return quickwitMigrate();
   }


### PR DESCRIPTION
## Summary
- Adds `DISABLE_ELASTIC_SEARCH` environment variable (accepts `true` or `1`)
- When enabled: skips ES migrations and returns a bogus client from `esClient()` so the app can start without an Elasticsearch instance
- Makes `ELASTICSEARCH_NODE_URL` optional when the flag is set

## Test plan
- [ ] Set `DISABLE_ELASTIC_SEARCH=true` without `ELASTICSEARCH_NODE_URL` — app starts without env validation error
- [ ] ES migrations are skipped (logged to console)
- [ ] Existing behavior unchanged when flag is unset