### PR TITLE
test: add event sourcing framework and pipeline test coverage

### DIFF
--- a/langwatch/src/server/event-sourcing/__tests__/runtime/eventSourcing.shutdown.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/runtime/eventSourcing.shutdown.unit.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Event } from "../../domain/types";
+import { EventSourcing } from "../../eventSourcing";
+import { createMockEventStore } from "../../services/__tests__/testHelpers";
+
+/**
+ * Creates a mock global queue with spied close().
+ */
+function createMockGlobalQueue() {
+  return {
+    send: vi.fn().mockResolvedValue(void 0),
+    sendBatch: vi.fn().mockResolvedValue(void 0),
+    close: vi.fn().mockResolvedValue(void 0),
+    waitUntilReady: vi.fn().mockResolvedValue(void 0),
+  };
+}
+
+/**
+ * Creates a mock pipeline entry matching the PipelineWithCommandHandlers shape.
+ * The service.close() is a vi.fn() so we can track calls.
+ */
+function createMockPipeline(name: string) {
+  return {
+    name,
+    aggregateType: "trace" as const,
+    service: {
+      close: vi.fn().mockResolvedValue(void 0),
+      getCommandQueues: vi.fn().mockReturnValue(new Map()),
+    },
+    metadata: {
+      name,
+      aggregateType: "trace" as const,
+      projections: [],
+      mapProjections: [],
+      commands: [],
+    },
+    commands: {},
+  };
+}
+
+describe("EventSourcing.close", () => {
+  beforeEach(() => {
+    vi.stubEnv("BUILD_TIME", "");
+    vi.stubEnv("ENABLE_EVENT_SOURCING", "true");
+    vi.stubEnv("NODE_ENV", "test");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("calls close on all registered pipelines", async () => {
+    const mockEventStore = createMockEventStore<Event>();
+    const mockGlobalQueue = createMockGlobalQueue();
+    const es = EventSourcing.createForTesting({
+      eventStore: mockEventStore,
+      globalQueue: mockGlobalQueue,
+    });
+
+    const pipelineA = createMockPipeline("pipeline-a");
+    const pipelineB = createMockPipeline("pipeline-b");
+
+    // Inject mock pipelines via the private map
+    const pipelines = (es as any).pipelines as Map<string, any>;
+    pipelines.set("pipeline-a", pipelineA);
+    pipelines.set("pipeline-b", pipelineB);
+
+    await es.close();
+
+    expect(pipelineA.service.close).toHaveBeenCalledOnce();
+    expect(pipelineB.service.close).toHaveBeenCalledOnce();
+  });
+
+  it("calls close on the global queue", async () => {
+    const mockGlobalQueue = createMockGlobalQueue();
+    const es = EventSourcing.createForTesting({
+      eventStore: createMockEventStore<Event>(),
+      globalQueue: mockGlobalQueue,
+    });
+
+    await es.close();
+
+    expect(mockGlobalQueue.close).toHaveBeenCalledOnce();
+  });
+
+  it("catches pipeline close errors and continues closing other pipelines", async () => {
+    const mockGlobalQueue = createMockGlobalQueue();
+    const es = EventSourcing.createForTesting({
+      eventStore: createMockEventStore<Event>(),
+      globalQueue: mockGlobalQueue,
+    });
+
+    const failingPipeline = createMockPipeline("failing");
+    failingPipeline.service.close.mockRejectedValue(
+      new Error("close failed"),
+    );
+    const healthyPipeline = createMockPipeline("healthy");
+
+    const pipelines = (es as any).pipelines as Map<string, any>;
+    pipelines.set("failing", failingPipeline);
+    pipelines.set("healthy", healthyPipeline);
+
+    // close() must not throw even though one pipeline fails
+    await expect(es.close()).resolves.toBeUndefined();
+
+    expect(failingPipeline.service.close).toHaveBeenCalledOnce();
+    expect(healthyPipeline.service.close).toHaveBeenCalledOnce();
+    expect(mockGlobalQueue.close).toHaveBeenCalledOnce();
+  });
+
+  it("clears the pipelines map after close", async () => {
+    const es = EventSourcing.createForTesting({
+      eventStore: createMockEventStore<Event>(),
+      globalQueue: createMockGlobalQueue(),
+    });
+
+    const pipeline = createMockPipeline("to-clear");
+    (es as any).pipelines.set("to-clear", pipeline);
+
+    // Pipeline is reachable before close
+    expect(es.getPipeline("to-clear")).toBe(pipeline);
+
+    await es.close();
+
+    expect(() => es.getPipeline("to-clear")).toThrow(
+      'Pipeline "to-clear" not found',
+    );
+  });
+
+  it("closes pipelines before global queue", async () => {
+    const callOrder: string[] = [];
+
+    const mockGlobalQueue = createMockGlobalQueue();
+    mockGlobalQueue.close.mockImplementation(async () => {
+      callOrder.push("global-queue");
+    });
+
+    const es = EventSourcing.createForTesting({
+      eventStore: createMockEventStore<Event>(),
+      globalQueue: mockGlobalQueue,
+    });
+
+    const pipeline = createMockPipeline("ordered");
+    pipeline.service.close.mockImplementation(async () => {
+      callOrder.push("pipeline:ordered");
+    });
+
+    (es as any).pipelines.set("ordered", pipeline);
+
+    await es.close();
+
+    expect(callOrder).toEqual(["pipeline:ordered", "global-queue"]);
+  });
+
+  it("handles close with no registered pipelines", async () => {
+    const mockGlobalQueue = createMockGlobalQueue();
+    const es = EventSourcing.createForTesting({
+      eventStore: createMockEventStore<Event>(),
+      globalQueue: mockGlobalQueue,
+    });
+
+    // No pipelines registered — close must still resolve
+    await expect(es.close()).resolves.toBeUndefined();
+
+    // Global queue is still closed
+    expect(mockGlobalQueue.close).toHaveBeenCalledOnce();
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/reactors/__tests__/experimentRunEsSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/reactors/__tests__/experimentRunEsSync.reactor.unit.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { ReactorContext } from "../../../../reactors/reactor.types";
+import type { ExperimentRunStateData } from "../../projections/experimentRunState.foldProjection";
+import type { ExperimentRunProcessingEvent } from "../../schemas/events";
+import { EXPERIMENT_RUN_EVENT_TYPES } from "../../schemas/constants";
+import {
+  createExperimentRunEsSyncReactor,
+  type ExperimentRunEsSyncReactorDeps,
+} from "../experimentRunEsSync.reactor";
+
+function createMockDeps(): ExperimentRunEsSyncReactorDeps {
+  return {
+    project: {
+      isFeatureEnabled: vi.fn().mockResolvedValue(true),
+      getById: vi.fn().mockResolvedValue({ disableElasticSearchEvaluationWriting: false }),
+    } as any,
+    repository: {
+      create: vi.fn().mockResolvedValue(undefined),
+      upsertResults: vi.fn().mockResolvedValue(undefined),
+      markComplete: vi.fn().mockResolvedValue(undefined),
+    } as any,
+  };
+}
+
+function createMockFoldState(
+  overrides: Partial<ExperimentRunStateData> = {},
+): ExperimentRunStateData {
+  return {
+    RunId: "run-1",
+    ExperimentId: "exp-1",
+    WorkflowVersionId: null,
+    Total: 10,
+    Progress: 0,
+    CompletedCount: 0,
+    FailedCount: 0,
+    TotalCost: null,
+    TotalDurationMs: null,
+    AvgScoreBps: null,
+    PassRateBps: null,
+    Targets: "[]",
+    CreatedAt: 1000000,
+    UpdatedAt: 1000000,
+    StartedAt: null,
+    FinishedAt: null,
+    StoppedAt: null,
+    TotalScoreSum: 0,
+    ScoreCount: 0,
+    PassedCount: 0,
+    GradedCount: 0,
+    ...overrides,
+  };
+}
+
+function createMockContext(
+  foldState?: Partial<ExperimentRunStateData>,
+): ReactorContext<ExperimentRunStateData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "agg-1",
+    foldState: createMockFoldState(foldState),
+  };
+}
+
+function createMockEvent(
+  type: string,
+  data: Record<string, unknown> = {},
+  metadata?: Record<string, unknown>,
+): ExperimentRunProcessingEvent {
+  return {
+    id: "evt-1",
+    aggregateId: "agg-1",
+    aggregateType: "experiment_run",
+    tenantId: "tenant-1",
+    type,
+    version: "2025-02-01",
+    data,
+    createdAt: 1000000,
+    occurredAt: 1000000,
+    metadata,
+  } as ExperimentRunProcessingEvent;
+}
+
+describe("ExperimentRunEsSyncReactor", () => {
+  let deps: ExperimentRunEsSyncReactorDeps;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    deps = createMockDeps();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("when feature flag is disabled", () => {
+    it("skips processing", async () => {
+      (deps.project.isFeatureEnabled as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.STARTED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        total: 10,
+        targets: [],
+      });
+
+      await reactor.handle(event, createMockContext());
+
+      expect(deps.repository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when ES writes are disabled for project", () => {
+    it("skips processing", async () => {
+      (deps.project.getById as ReturnType<typeof vi.fn>).mockResolvedValue({
+        disableElasticSearchEvaluationWriting: true,
+      });
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.STARTED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        total: 10,
+        targets: [],
+      });
+
+      await reactor.handle(event, createMockContext());
+
+      expect(deps.repository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when event has migration source metadata", () => {
+    it("skips processing", async () => {
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(
+        EXPERIMENT_RUN_EVENT_TYPES.STARTED,
+        { runId: "run-1", experimentId: "exp-1", total: 10, targets: [] },
+        { source: "migration" },
+      );
+
+      await reactor.handle(event, createMockContext());
+
+      expect(deps.project.isFeatureEnabled).not.toHaveBeenCalled();
+      expect(deps.repository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when experimentId or runId is missing from fold state", () => {
+    it("skips processing when experimentId is empty", async () => {
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.STARTED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        total: 10,
+        targets: [],
+      });
+
+      await reactor.handle(event, createMockContext({ ExperimentId: "" }));
+
+      expect(deps.repository.create).not.toHaveBeenCalled();
+    });
+
+    it("skips processing when runId is empty", async () => {
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.STARTED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        total: 10,
+        targets: [],
+      });
+
+      await reactor.handle(event, createMockContext({ RunId: "" }));
+
+      expect(deps.repository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when handling STARTED event", () => {
+    it("calls repository.create with correct args", async () => {
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const targets = [{ id: "t1", name: "target1" }];
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.STARTED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        total: 10,
+        targets,
+      });
+
+      await reactor.handle(
+        event,
+        createMockContext({
+          Targets: JSON.stringify(targets),
+          WorkflowVersionId: "wf-1",
+          Total: 10,
+        }),
+      );
+
+      expect(deps.repository.create).toHaveBeenCalledWith({
+        projectId: "tenant-1",
+        experimentId: "exp-1",
+        runId: "run-1",
+        workflowVersionId: "wf-1",
+        total: 10,
+        targets,
+      });
+    });
+
+    it("handles invalid Targets JSON gracefully", async () => {
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.STARTED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        total: 5,
+        targets: [],
+      });
+
+      await reactor.handle(
+        event,
+        createMockContext({ Targets: "not-valid-json" }),
+      );
+
+      expect(deps.repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ targets: [] }),
+      );
+    });
+  });
+
+  describe("when handling TARGET_RESULT event", () => {
+    it("calls repository.upsertResults with dataset", async () => {
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.TARGET_RESULT, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        index: 0,
+        targetId: "t1",
+        entry: { input: "hello" },
+        predicted: { output: "world" },
+        cost: 0.05,
+        duration: 1500,
+        error: null,
+        traceId: "trace-abc",
+      });
+
+      await reactor.handle(event, createMockContext({ Progress: 1 }));
+
+      expect(deps.repository.upsertResults).toHaveBeenCalledWith({
+        projectId: "tenant-1",
+        experimentId: "exp-1",
+        runId: "run-1",
+        dataset: [
+          {
+            index: 0,
+            target_id: "t1",
+            entry: { input: "hello" },
+            predicted: { output: "world" },
+            cost: 0.05,
+            duration: 1500,
+            error: null,
+            trace_id: "trace-abc",
+          },
+        ],
+        progress: 1,
+      });
+    });
+  });
+
+  describe("when handling EVALUATOR_RESULT event", () => {
+    it("calls repository.upsertResults with evaluations", async () => {
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(
+        EXPERIMENT_RUN_EVENT_TYPES.EVALUATOR_RESULT,
+        {
+          runId: "run-1",
+          experimentId: "exp-1",
+          index: 0,
+          targetId: "t1",
+          evaluatorId: "eval-1",
+          evaluatorName: "accuracy",
+          status: "processed",
+          score: 0.95,
+          label: "good",
+          passed: true,
+          details: "all correct",
+          cost: 0.01,
+        },
+      );
+
+      await reactor.handle(event, createMockContext());
+
+      expect(deps.repository.upsertResults).toHaveBeenCalledWith({
+        projectId: "tenant-1",
+        experimentId: "exp-1",
+        runId: "run-1",
+        evaluations: [
+          {
+            evaluator: "eval-1",
+            name: "accuracy",
+            target_id: "t1",
+            index: 0,
+            status: "processed",
+            score: 0.95,
+            label: "good",
+            passed: true,
+            details: "all correct",
+            cost: 0.01,
+          },
+        ],
+      });
+    });
+  });
+
+  describe("when handling COMPLETED event", () => {
+    it("calls repository.markComplete", async () => {
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.COMPLETED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        finishedAt: 2000000,
+        stoppedAt: null,
+      });
+
+      await reactor.handle(event, createMockContext());
+
+      expect(deps.repository.markComplete).toHaveBeenCalledWith({
+        projectId: "tenant-1",
+        experimentId: "exp-1",
+        runId: "run-1",
+        finishedAt: 2000000,
+        stoppedAt: undefined,
+      });
+    });
+  });
+
+  describe("when repository throws", () => {
+    it("retries up to MAX_RETRIES with exponential backoff", async () => {
+      vi.useRealTimers(); // Use real timers for retry delays
+      const error = new Error("ES connection failed");
+      let callCount = 0;
+      (deps.repository.create as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        callCount++;
+        if (callCount < 3) throw error;
+      });
+
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.STARTED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        total: 10,
+        targets: [],
+      });
+
+      // The reactor retries with 1s, 2s delays — mock setTimeout to resolve instantly
+      vi.useFakeTimers();
+      const promise = reactor.handle(event, createMockContext());
+      await vi.advanceTimersByTimeAsync(5000);
+      await promise;
+
+      expect(deps.repository.create).toHaveBeenCalledTimes(3);
+    });
+
+    it("throws after all retries exhausted", async () => {
+      const error = new Error("ES permanently down");
+      (deps.repository.create as ReturnType<typeof vi.fn>).mockRejectedValue(error);
+
+      const reactor = createExperimentRunEsSyncReactor(deps);
+      const event = createMockEvent(EXPERIMENT_RUN_EVENT_TYPES.STARTED, {
+        runId: "run-1",
+        experimentId: "exp-1",
+        total: 10,
+        targets: [],
+      });
+
+      // Attach rejection handler BEFORE advancing timers to avoid unhandled rejection
+      const promise = reactor.handle(event, createMockContext());
+      const caught = promise.catch((e) => e);
+
+      // Advance enough time for all retries (1s + 2s = 3s)
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const result = await caught;
+      expect(result).toBe(error);
+      expect(deps.repository.create).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/deleteRun.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/deleteRun.command.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { DeleteRunCommandData } from "../../schemas/commands";
+import {
+  SIMULATION_RUN_COMMAND_TYPES,
+  SIMULATION_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { DeleteRunCommand } from "../deleteRun.command";
+
+function makeCommand(
+  overrides: Partial<DeleteRunCommandData> = {},
+): Command<DeleteRunCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "run-123",
+    type: SIMULATION_RUN_COMMAND_TYPES.DELETE,
+    data: {
+      tenantId: "tenant-1",
+      scenarioRunId: "run-123",
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<DeleteRunCommandData>;
+}
+
+describe("DeleteRunCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single simulation run deleted event", async () => {
+        const handler = new DeleteRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SIMULATION_RUN_EVENT_TYPES.DELETED);
+      });
+
+      it("maps command data to event data with only scenarioRunId", async () => {
+        const handler = new DeleteRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.data).toMatchObject({
+          scenarioRunId: "run-123",
+        });
+      });
+
+      it("sets correct aggregate fields", async () => {
+        const handler = new DeleteRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.aggregateType).toBe("simulation_run");
+        expect(events[0]!.aggregateId).toBe("run-123");
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the scenarioRunId", () => {
+      expect(DeleteRunCommand.getAggregateId(makeCommand().data)).toBe("run-123");
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns only scenarioRun id", () => {
+      expect(DeleteRunCommand.getSpanAttributes(makeCommand().data)).toEqual({
+        "payload.scenarioRun.id": "run-123",
+      });
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:scenarioRunId:delete-run", () => {
+      expect(DeleteRunCommand.makeJobId(makeCommand().data)).toBe(
+        "tenant-1:run-123:delete-run",
+      );
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(DeleteRunCommand.schema.type).toBe(SIMULATION_RUN_COMMAND_TYPES.DELETE);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/finishRun.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/finishRun.command.unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { FinishRunCommandData } from "../../schemas/commands";
+import {
+  SIMULATION_RUN_COMMAND_TYPES,
+  SIMULATION_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { FinishRunCommand } from "../finishRun.command";
+
+function makeCommand(
+  overrides: Partial<FinishRunCommandData> = {},
+): Command<FinishRunCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "run-123",
+    type: SIMULATION_RUN_COMMAND_TYPES.FINISH,
+    data: {
+      tenantId: "tenant-1",
+      scenarioRunId: "run-123",
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<FinishRunCommandData>;
+}
+
+describe("FinishRunCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single simulation run finished event", async () => {
+        const handler = new FinishRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SIMULATION_RUN_EVENT_TYPES.FINISHED);
+      });
+
+      it("maps command data to event data including optional fields", async () => {
+        const handler = new FinishRunCommand();
+        const events = await handler.handle(
+          makeCommand({ durationMs: 5000, status: "completed" }),
+        );
+
+        expect(events[0]!.data).toMatchObject({
+          scenarioRunId: "run-123",
+          durationMs: 5000,
+          status: "completed",
+        });
+      });
+
+      it("sets correct aggregate fields", async () => {
+        const handler = new FinishRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.aggregateType).toBe("simulation_run");
+        expect(events[0]!.aggregateId).toBe("run-123");
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the scenarioRunId", () => {
+      expect(FinishRunCommand.getAggregateId(makeCommand().data)).toBe("run-123");
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns scenarioRun id, hasResults, and durationMs", () => {
+      expect(
+        FinishRunCommand.getSpanAttributes(
+          makeCommand({ durationMs: 1234 }).data,
+        ),
+      ).toEqual({
+        "payload.scenarioRun.id": "run-123",
+        "payload.hasResults": false,
+        "payload.durationMs": 1234,
+      });
+    });
+
+    it("defaults durationMs to 0 when undefined", () => {
+      expect(FinishRunCommand.getSpanAttributes(makeCommand().data)).toEqual({
+        "payload.scenarioRun.id": "run-123",
+        "payload.hasResults": false,
+        "payload.durationMs": 0,
+      });
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:scenarioRunId:finish-run", () => {
+      expect(FinishRunCommand.makeJobId(makeCommand().data)).toBe(
+        "tenant-1:run-123:finish-run",
+      );
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(FinishRunCommand.schema.type).toBe(SIMULATION_RUN_COMMAND_TYPES.FINISH);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/messageSnapshot.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/messageSnapshot.command.unit.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { MessageSnapshotCommandData } from "../../schemas/commands";
+import {
+  SIMULATION_RUN_COMMAND_TYPES,
+  SIMULATION_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { MessageSnapshotCommand } from "../messageSnapshot.command";
+
+function makeCommand(
+  overrides: Partial<MessageSnapshotCommandData> = {},
+): Command<MessageSnapshotCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "run-123",
+    type: SIMULATION_RUN_COMMAND_TYPES.MESSAGE_SNAPSHOT,
+    data: {
+      tenantId: "tenant-1",
+      scenarioRunId: "run-123",
+      messages: [{ role: "user", content: "hi" }],
+      traceIds: ["trace-1"],
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<MessageSnapshotCommandData>;
+}
+
+describe("MessageSnapshotCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single message snapshot event", async () => {
+        const handler = new MessageSnapshotCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SIMULATION_RUN_EVENT_TYPES.MESSAGE_SNAPSHOT);
+      });
+
+      it("maps command data to event data", async () => {
+        const handler = new MessageSnapshotCommand();
+        const events = await handler.handle(makeCommand({ status: "running" }));
+
+        expect(events[0]!.data).toMatchObject({
+          scenarioRunId: "run-123",
+          messages: [{ role: "user", content: "hi" }],
+          traceIds: ["trace-1"],
+          status: "running",
+        });
+      });
+
+      it("sets correct aggregate fields", async () => {
+        const handler = new MessageSnapshotCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.aggregateType).toBe("simulation_run");
+        expect(events[0]!.aggregateId).toBe("run-123");
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the scenarioRunId", () => {
+      expect(MessageSnapshotCommand.getAggregateId(makeCommand().data)).toBe("run-123");
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns scenarioRun id and message count", () => {
+      expect(MessageSnapshotCommand.getSpanAttributes(makeCommand().data)).toEqual({
+        "payload.scenarioRun.id": "run-123",
+        "payload.message.count": 1,
+      });
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:scenarioRunId:message-snapshot", () => {
+      expect(MessageSnapshotCommand.makeJobId(makeCommand().data)).toBe(
+        "tenant-1:run-123:message-snapshot",
+      );
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(MessageSnapshotCommand.schema.type).toBe(
+        SIMULATION_RUN_COMMAND_TYPES.MESSAGE_SNAPSHOT,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/queueRun.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/queueRun.command.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { QueueRunCommandData } from "../../schemas/commands";
+import {
+  SIMULATION_RUN_COMMAND_TYPES,
+  SIMULATION_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { QueueRunCommand } from "../queueRun.command";
+
+function makeCommand(
+  overrides: Partial<QueueRunCommandData> = {},
+): Command<QueueRunCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "run-123",
+    type: SIMULATION_RUN_COMMAND_TYPES.QUEUE,
+    data: {
+      tenantId: "tenant-1",
+      scenarioRunId: "run-123",
+      scenarioId: "scenario-1",
+      batchRunId: "batch-1",
+      scenarioSetId: "set-1",
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<QueueRunCommandData>;
+}
+
+describe("QueueRunCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single simulation run queued event", async () => {
+        const handler = new QueueRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SIMULATION_RUN_EVENT_TYPES.QUEUED);
+      });
+
+      it("maps command data to event data without tenantId and occurredAt", async () => {
+        const handler = new QueueRunCommand();
+        const events = await handler.handle(
+          makeCommand({ name: "test", description: "desc", metadata: { k: "v" } }),
+        );
+
+        expect(events[0]!.data).toMatchObject({
+          scenarioRunId: "run-123",
+          scenarioId: "scenario-1",
+          batchRunId: "batch-1",
+          scenarioSetId: "set-1",
+          name: "test",
+          description: "desc",
+          metadata: { k: "v" },
+        });
+      });
+
+      it("sets correct aggregate fields", async () => {
+        const handler = new QueueRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.aggregateType).toBe("simulation_run");
+        expect(events[0]!.aggregateId).toBe("run-123");
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the scenarioRunId", () => {
+      expect(QueueRunCommand.getAggregateId(makeCommand().data)).toBe("run-123");
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns scenarioRun, scenario, and batchRun ids", () => {
+      expect(QueueRunCommand.getSpanAttributes(makeCommand().data)).toEqual({
+        "payload.scenarioRun.id": "run-123",
+        "payload.scenario.id": "scenario-1",
+        "payload.batchRun.id": "batch-1",
+      });
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:scenarioRunId:queue-run", () => {
+      expect(QueueRunCommand.makeJobId(makeCommand().data)).toBe(
+        "tenant-1:run-123:queue-run",
+      );
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(QueueRunCommand.schema.type).toBe(SIMULATION_RUN_COMMAND_TYPES.QUEUE);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/startRun.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/startRun.command.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { StartRunCommandData } from "../../schemas/commands";
+import {
+  SIMULATION_RUN_COMMAND_TYPES,
+  SIMULATION_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { StartRunCommand } from "../startRun.command";
+
+function makeCommand(
+  overrides: Partial<StartRunCommandData> = {},
+): Command<StartRunCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "run-123",
+    type: SIMULATION_RUN_COMMAND_TYPES.START,
+    data: {
+      tenantId: "tenant-1",
+      scenarioRunId: "run-123",
+      scenarioId: "scenario-1",
+      batchRunId: "batch-1",
+      scenarioSetId: "set-1",
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<StartRunCommandData>;
+}
+
+describe("StartRunCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single simulation run started event", async () => {
+        const handler = new StartRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SIMULATION_RUN_EVENT_TYPES.STARTED);
+      });
+
+      it("maps command data to event data without tenantId and occurredAt", async () => {
+        const handler = new StartRunCommand();
+        const events = await handler.handle(
+          makeCommand({ name: "test", description: "desc", metadata: { k: "v" } }),
+        );
+
+        expect(events[0]!.data).toMatchObject({
+          scenarioRunId: "run-123",
+          scenarioId: "scenario-1",
+          batchRunId: "batch-1",
+          scenarioSetId: "set-1",
+          name: "test",
+          description: "desc",
+          metadata: { k: "v" },
+        });
+      });
+
+      it("sets correct aggregate fields", async () => {
+        const handler = new StartRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.aggregateType).toBe("simulation_run");
+        expect(events[0]!.aggregateId).toBe("run-123");
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the scenarioRunId", () => {
+      expect(StartRunCommand.getAggregateId(makeCommand().data)).toBe("run-123");
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns scenarioRun, scenario, and batchRun ids", () => {
+      expect(StartRunCommand.getSpanAttributes(makeCommand().data)).toEqual({
+        "payload.scenarioRun.id": "run-123",
+        "payload.scenario.id": "scenario-1",
+        "payload.batchRun.id": "batch-1",
+      });
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:scenarioRunId:start-run", () => {
+      expect(StartRunCommand.makeJobId(makeCommand().data)).toBe(
+        "tenant-1:run-123:start-run",
+      );
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(StartRunCommand.schema.type).toBe(SIMULATION_RUN_COMMAND_TYPES.START);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/textMessageEnd.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/textMessageEnd.command.unit.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { TextMessageEndCommandData } from "../../schemas/commands";
+import {
+  SIMULATION_RUN_COMMAND_TYPES,
+  SIMULATION_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { TextMessageEndCommand } from "../textMessageEnd.command";
+
+function makeCommand(
+  overrides: Partial<TextMessageEndCommandData> = {},
+): Command<TextMessageEndCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "run-123",
+    type: SIMULATION_RUN_COMMAND_TYPES.TEXT_MESSAGE_END,
+    data: {
+      tenantId: "tenant-1",
+      scenarioRunId: "run-123",
+      messageId: "msg-1",
+      role: "assistant",
+      content: "Hello world",
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<TextMessageEndCommandData>;
+}
+
+describe("TextMessageEndCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single text message end event", async () => {
+        const handler = new TextMessageEndCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SIMULATION_RUN_EVENT_TYPES.TEXT_MESSAGE_END);
+      });
+
+      it("maps command data to event data including optional fields", async () => {
+        const handler = new TextMessageEndCommand();
+        const events = await handler.handle(
+          makeCommand({
+            message: { custom: "data" },
+            traceId: "trace-1",
+            messageIndex: 3,
+          }),
+        );
+
+        expect(events[0]!.data).toMatchObject({
+          scenarioRunId: "run-123",
+          messageId: "msg-1",
+          role: "assistant",
+          content: "Hello world",
+          message: { custom: "data" },
+          traceId: "trace-1",
+          messageIndex: 3,
+        });
+      });
+
+      it("sets correct aggregate fields", async () => {
+        const handler = new TextMessageEndCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.aggregateType).toBe("simulation_run");
+        expect(events[0]!.aggregateId).toBe("run-123");
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the scenarioRunId", () => {
+      expect(TextMessageEndCommand.getAggregateId(makeCommand().data)).toBe("run-123");
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns scenarioRun id, message id, role, and content length", () => {
+      expect(TextMessageEndCommand.getSpanAttributes(makeCommand().data)).toEqual({
+        "payload.scenarioRun.id": "run-123",
+        "payload.message.id": "msg-1",
+        "payload.message.role": "assistant",
+        "payload.message.contentLength": 11,
+      });
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:scenarioRunId:text-message-end:messageId", () => {
+      expect(TextMessageEndCommand.makeJobId(makeCommand().data)).toBe(
+        "tenant-1:run-123:text-message-end:msg-1",
+      );
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(TextMessageEndCommand.schema.type).toBe(
+        SIMULATION_RUN_COMMAND_TYPES.TEXT_MESSAGE_END,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/textMessageStart.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/__tests__/textMessageStart.command.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { TextMessageStartCommandData } from "../../schemas/commands";
+import {
+  SIMULATION_RUN_COMMAND_TYPES,
+  SIMULATION_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { TextMessageStartCommand } from "../textMessageStart.command";
+
+function makeCommand(
+  overrides: Partial<TextMessageStartCommandData> = {},
+): Command<TextMessageStartCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "run-123",
+    type: SIMULATION_RUN_COMMAND_TYPES.TEXT_MESSAGE_START,
+    data: {
+      tenantId: "tenant-1",
+      scenarioRunId: "run-123",
+      messageId: "msg-1",
+      role: "assistant",
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<TextMessageStartCommandData>;
+}
+
+describe("TextMessageStartCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single text message start event", async () => {
+        const handler = new TextMessageStartCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SIMULATION_RUN_EVENT_TYPES.TEXT_MESSAGE_START);
+      });
+
+      it("maps command data to event data", async () => {
+        const handler = new TextMessageStartCommand();
+        const events = await handler.handle(makeCommand({ messageIndex: 2 }));
+
+        expect(events[0]!.data).toMatchObject({
+          scenarioRunId: "run-123",
+          messageId: "msg-1",
+          role: "assistant",
+          messageIndex: 2,
+        });
+      });
+
+      it("sets correct aggregate fields", async () => {
+        const handler = new TextMessageStartCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.aggregateType).toBe("simulation_run");
+        expect(events[0]!.aggregateId).toBe("run-123");
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the scenarioRunId", () => {
+      expect(TextMessageStartCommand.getAggregateId(makeCommand().data)).toBe("run-123");
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns scenarioRun id, message id, and role", () => {
+      expect(TextMessageStartCommand.getSpanAttributes(makeCommand().data)).toEqual({
+        "payload.scenarioRun.id": "run-123",
+        "payload.message.id": "msg-1",
+        "payload.message.role": "assistant",
+      });
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:scenarioRunId:text-message-start:messageId", () => {
+      expect(TextMessageStartCommand.makeJobId(makeCommand().data)).toBe(
+        "tenant-1:run-123:text-message-start:msg-1",
+      );
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(TextMessageStartCommand.schema.type).toBe(
+        SIMULATION_RUN_COMMAND_TYPES.TEXT_MESSAGE_START,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/__tests__/suiteRunProcessing.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/__tests__/suiteRunProcessing.integration.test.ts
@@ -1,0 +1,624 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createLogger } from "~/utils/logger/server";
+import type { AggregateType } from "../../../";
+import { createTenantId, definePipeline } from "../../../";
+import {
+  getTestClickHouseClient,
+  getTestRedisConnection,
+} from "../../../__tests__/integration/testContainers";
+import {
+  cleanupTestDataForTenant,
+  createTestTenantId,
+  getTenantIdString,
+} from "../../../__tests__/integration/testHelpers";
+import { EventSourcing } from "../../../eventSourcing";
+import type { PipelineWithCommandHandlers } from "../../../pipeline/types";
+import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
+import type { ProjectionStoreContext } from "../../../projections/projectionStoreContext";
+import { EventStoreClickHouse } from "../../../stores/eventStoreClickHouse";
+import { EventRepositoryClickHouse } from "../../../stores/repositories/eventRepositoryClickHouse";
+import { CompleteSuiteRunItemCommand } from "../commands/completeSuiteRunItem.command";
+import { RecordSuiteRunItemStartedCommand } from "../commands/recordSuiteRunItemStarted.command";
+import { StartSuiteRunCommand } from "../commands/startSuiteRun.command";
+import {
+  createSuiteRunStateFoldProjection,
+  type SuiteRunState,
+  type SuiteRunStateData,
+} from "../projections/suiteRunState.foldProjection";
+import type { SuiteRunProcessingEvent } from "../schemas/events";
+
+const logger = createLogger(
+  "langwatch:event-sourcing:tests:suite-run-processing:integration",
+);
+
+/**
+ * Generates a unique batch run ID for test isolation.
+ */
+function generateTestBatchRunId(): string {
+  return `batch-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+}
+
+/**
+ * Generates a unique suite ID for test isolation.
+ */
+function generateTestSuiteId(): string {
+  return `suite-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+}
+
+/**
+ * Generates a unique scenario run ID for test isolation.
+ */
+function generateTestScenarioRunId(): string {
+  return `scenrun-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+}
+
+/**
+ * Generates a unique pipeline name to avoid conflicts in parallel tests.
+ */
+function generateTestPipelineName(): string {
+  return `suite_run_processing_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * In-memory fold projection store for suite run state.
+ * Used in integration tests to avoid needing a ClickHouse suite_runs table.
+ */
+class InMemorySuiteRunStateStore
+  implements FoldProjectionStore<SuiteRunStateData>
+{
+  private data = new Map<string, SuiteRunStateData>();
+
+  async get(
+    _aggregateId: string,
+    context: ProjectionStoreContext,
+  ): Promise<SuiteRunStateData | null> {
+    const key = `${String(context.tenantId)}:${context.aggregateId}`;
+    return this.data.get(key) ?? null;
+  }
+
+  async store(
+    state: SuiteRunStateData,
+    context: ProjectionStoreContext,
+  ): Promise<void> {
+    const key = `${String(context.tenantId)}:${context.aggregateId}`;
+    this.data.set(key, state);
+  }
+}
+
+/**
+ * Creates a test pipeline for suite run processing using real ClickHouse and Redis,
+ * with an in-memory fold projection store.
+ */
+function createSuiteRunTestPipeline(): PipelineWithCommandHandlers<
+  any,
+  {
+    startSuiteRun: any;
+    recordSuiteRunItemStarted: any;
+    completeSuiteRunItem: any;
+  }
+> & {
+  eventStore: EventStoreClickHouse;
+  pipelineName: string;
+  /** Wait for BullMQ workers to be ready before sending commands */
+  ready: () => Promise<void>;
+} {
+  const pipelineName = generateTestPipelineName();
+  const clickHouseClient = getTestClickHouseClient();
+  const redisConnection = getTestRedisConnection();
+
+  if (!clickHouseClient) {
+    throw new Error(
+      "ClickHouse client not available. Ensure testcontainers are started.",
+    );
+  }
+
+  if (!redisConnection) {
+    throw new Error(
+      "Redis connection not available. Ensure testcontainers are started.",
+    );
+  }
+
+  // Create stores
+  const eventStore = new EventStoreClickHouse(
+    new EventRepositoryClickHouse(clickHouseClient),
+  );
+
+  const eventSourcing = EventSourcing.createWithStores({
+    eventStore,
+    clickhouse: clickHouseClient,
+    redis: redisConnection,
+  });
+
+  // Build pipeline using static definition with definePipeline + register
+  const suiteRunStateStore = new InMemorySuiteRunStateStore();
+
+  const pipelineDefinition = definePipeline<SuiteRunProcessingEvent>()
+    .withName(pipelineName)
+    .withAggregateType("suite_run" as AggregateType)
+    .withCommand("startSuiteRun", StartSuiteRunCommand as any)
+    .withCommand(
+      "recordSuiteRunItemStarted",
+      RecordSuiteRunItemStartedCommand as any,
+    )
+    .withCommand("completeSuiteRunItem", CompleteSuiteRunItemCommand as any)
+    .withFoldProjection(
+      "suiteRunState",
+      createSuiteRunStateFoldProjection({ store: suiteRunStateStore }) as any,
+    )
+    .build();
+
+  const pipeline = eventSourcing.register(pipelineDefinition);
+
+  return {
+    ...pipeline,
+    eventStore,
+    pipelineName,
+    // Wait for BullMQ workers to be ready before sending commands
+    ready: () => pipeline.service.waitUntilReady(),
+  } as PipelineWithCommandHandlers<
+    any,
+    {
+      startSuiteRun: any;
+      recordSuiteRunItemStarted: any;
+      completeSuiteRunItem: any;
+    }
+  > & {
+    eventStore: EventStoreClickHouse;
+    pipelineName: string;
+    ready: () => Promise<void>;
+  };
+}
+
+/**
+ * Small delay to allow ClickHouse to persist data (eventual consistency).
+ * Increased to 200ms for more reliable test stability.
+ */
+const CLICKHOUSE_CONSISTENCY_DELAY_MS = 200;
+
+/**
+ * Waits a short time for ClickHouse eventual consistency.
+ */
+async function waitForClickHouseConsistency(): Promise<void> {
+  await new Promise((resolve) =>
+    setTimeout(resolve, CLICKHOUSE_CONSISTENCY_DELAY_MS),
+  );
+}
+
+/**
+ * Waits for the suite run fold projection to reach the expected status.
+ * The fold projection state IS the checkpoint — no separate checkpoint store needed.
+ */
+async function waitForSuiteRunState(
+  pipeline: ReturnType<typeof createSuiteRunTestPipeline>,
+  batchRunId: string,
+  tenantId: ReturnType<typeof createTenantId>,
+  expectedStatus: string,
+  timeoutMs = 15000,
+): Promise<void> {
+  const startTime = Date.now();
+  const pollIntervalMs = 100;
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const projection = (await pipeline.service.getProjectionByName(
+        "suiteRunState",
+        batchRunId,
+        { tenantId },
+      )) as SuiteRunState | null;
+
+      if (projection && projection.data.Status === expectedStatus) {
+        // Add a delay for ClickHouse eventual consistency
+        // The projection data might not be fully visible immediately
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        return;
+      }
+    } catch (error) {
+      logger.debug(
+        { error: error instanceof Error ? error.message : String(error) },
+        "Error checking suite run state, retrying...",
+      );
+    }
+
+    // Adaptive polling: start fast, increase interval as time passes
+    const elapsed = Date.now() - startTime;
+    const currentInterval =
+      elapsed < 500
+        ? pollIntervalMs
+        : elapsed < 1500
+          ? pollIntervalMs * 2
+          : Math.min(pollIntervalMs * 3, 300);
+    await new Promise((resolve) => setTimeout(resolve, currentInterval));
+  }
+
+  // Final attempt
+  try {
+    const projection = (await pipeline.service.getProjectionByName(
+      "suiteRunState",
+      batchRunId,
+      { tenantId },
+    )) as SuiteRunState | null;
+
+    if (projection && projection.data.Status === expectedStatus) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      return;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  throw new Error(
+    `Timeout waiting for suite run state. Expected status "${expectedStatus}" for batch run ${batchRunId}`,
+  );
+}
+
+// Skip when running without testcontainers (Prisma-only integration tests)
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+);
+
+describe.skipIf(!hasTestcontainers)(
+  "Suite Run Processing Pipeline - Integration Tests",
+  () => {
+    let pipeline: ReturnType<typeof createSuiteRunTestPipeline>;
+    let tenantId: ReturnType<typeof createTestTenantId>;
+    let tenantIdString: string;
+
+    beforeEach(async () => {
+      pipeline = createSuiteRunTestPipeline();
+      tenantId = createTestTenantId();
+      tenantIdString = getTenantIdString(tenantId);
+      // Wait for BullMQ workers to initialize before running tests
+      await pipeline.ready();
+    });
+
+    afterEach(async () => {
+      // Gracefully close pipeline to ensure all BullMQ workers finish
+      await pipeline.service.close();
+      // Wait for BullMQ workers to fully shut down and release Redis connections
+      // Using 1000ms to ensure all async operations complete
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // Clean up test data
+      await cleanupTestDataForTenant(tenantIdString);
+    });
+
+    describe("Full Lifecycle Tests", () => {
+      it("processes complete suite run lifecycle: start -> items -> complete", async () => {
+        const batchRunId = generateTestBatchRunId();
+        const suiteId = generateTestSuiteId();
+        const scenarioRunId1 = generateTestScenarioRunId();
+        const scenarioRunId2 = generateTestScenarioRunId();
+
+        // Start suite run with total=2
+        await pipeline.commands.startSuiteRun.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioSetId: "scenario-set-1",
+          suiteId,
+          total: 2,
+          scenarioIds: ["scenario-1", "scenario-2"],
+          targetIds: ["target-1"],
+          idempotencyKey: `idem-${batchRunId}`,
+          occurredAt: Date.now(),
+        });
+        await waitForClickHouseConsistency();
+
+        // Verify IN_PROGRESS after start
+        await waitForSuiteRunState(
+          pipeline,
+          batchRunId,
+          tenantId,
+          "IN_PROGRESS",
+        );
+
+        // Record item 1 started
+        await pipeline.commands.recordSuiteRunItemStarted.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioRunId: scenarioRunId1,
+          scenarioId: "scenario-1",
+          occurredAt: Date.now(),
+        });
+        await waitForClickHouseConsistency();
+
+        // Complete item 1 as SUCCESS with verdict
+        await pipeline.commands.completeSuiteRunItem.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioRunId: scenarioRunId1,
+          scenarioId: "scenario-1",
+          status: "SUCCESS",
+          verdict: "success",
+          durationMs: 1500,
+          occurredAt: Date.now(),
+        });
+        await waitForClickHouseConsistency();
+
+        // Record item 2 started
+        await pipeline.commands.recordSuiteRunItemStarted.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioRunId: scenarioRunId2,
+          scenarioId: "scenario-2",
+          occurredAt: Date.now(),
+        });
+        await waitForClickHouseConsistency();
+
+        // Complete item 2 as SUCCESS with verdict
+        await pipeline.commands.completeSuiteRunItem.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioRunId: scenarioRunId2,
+          scenarioId: "scenario-2",
+          status: "SUCCESS",
+          verdict: "success",
+          durationMs: 2000,
+          occurredAt: Date.now(),
+        });
+
+        // Wait for fold projection to reach final status
+        await waitForSuiteRunState(
+          pipeline,
+          batchRunId,
+          tenantId,
+          "SUCCESS",
+        );
+
+        // Verify final projection state
+        const projection = (await pipeline.service.getProjectionByName(
+          "suiteRunState",
+          batchRunId,
+          { tenantId },
+        )) as SuiteRunState | null;
+
+        expect(projection).toBeDefined();
+        expect(projection?.data.Status).toBe("SUCCESS");
+        expect(projection?.data.SuiteId).toBe(suiteId);
+        expect(projection?.data.Total).toBe(2);
+        expect(projection?.data.CompletedCount).toBe(2);
+        expect(projection?.data.FailedCount).toBe(0);
+        expect(projection?.data.StartedCount).toBe(2);
+        expect(projection?.data.Progress).toBe(2);
+        expect(projection?.data.PassRateBps).toBe(10000);
+        expect(projection?.data.StartedAt).not.toBeNull();
+        expect(projection?.data.FinishedAt).not.toBeNull();
+      });
+
+      it("derives FAILURE status when any item fails", async () => {
+        const batchRunId = generateTestBatchRunId();
+        const suiteId = generateTestSuiteId();
+        const scenarioRunId1 = generateTestScenarioRunId();
+        const scenarioRunId2 = generateTestScenarioRunId();
+
+        // Start suite run with total=2
+        await pipeline.commands.startSuiteRun.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioSetId: "scenario-set-1",
+          suiteId,
+          total: 2,
+          scenarioIds: ["scenario-1", "scenario-2"],
+          targetIds: ["target-1"],
+          idempotencyKey: `idem-${batchRunId}`,
+          occurredAt: Date.now(),
+        });
+        await waitForClickHouseConsistency();
+
+        // Record and complete item 1 as SUCCESS
+        await pipeline.commands.recordSuiteRunItemStarted.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioRunId: scenarioRunId1,
+          scenarioId: "scenario-1",
+          occurredAt: Date.now(),
+        });
+        await waitForClickHouseConsistency();
+
+        await pipeline.commands.completeSuiteRunItem.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioRunId: scenarioRunId1,
+          scenarioId: "scenario-1",
+          status: "SUCCESS",
+          verdict: "success",
+          durationMs: 1200,
+          occurredAt: Date.now(),
+        });
+        await waitForClickHouseConsistency();
+
+        // Record and complete item 2 as FAILURE
+        await pipeline.commands.recordSuiteRunItemStarted.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioRunId: scenarioRunId2,
+          scenarioId: "scenario-2",
+          occurredAt: Date.now(),
+        });
+        await waitForClickHouseConsistency();
+
+        await pipeline.commands.completeSuiteRunItem.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioRunId: scenarioRunId2,
+          scenarioId: "scenario-2",
+          status: "FAILURE",
+          verdict: "failure",
+          error: "Assertion failed",
+          durationMs: 800,
+          occurredAt: Date.now(),
+        });
+
+        // Wait for fold projection to reach final status
+        await waitForSuiteRunState(
+          pipeline,
+          batchRunId,
+          tenantId,
+          "FAILURE",
+        );
+
+        // Verify final state
+        const projection = (await pipeline.service.getProjectionByName(
+          "suiteRunState",
+          batchRunId,
+          { tenantId },
+        )) as SuiteRunState | null;
+
+        expect(projection?.data.Status).toBe("FAILURE");
+        expect(projection?.data.CompletedCount).toBe(1);
+        expect(projection?.data.FailedCount).toBe(1);
+        expect(projection?.data.Progress).toBe(2);
+        expect(projection?.data.FinishedAt).not.toBeNull();
+      });
+    });
+
+    describe("Concurrent Suite Runs Tests", () => {
+      it("processes multiple suite runs concurrently without interference", async () => {
+        const batchRunId1 = generateTestBatchRunId();
+        const batchRunId2 = generateTestBatchRunId();
+        const suiteId1 = generateTestSuiteId();
+        const suiteId2 = generateTestSuiteId();
+        const scenarioRunId1 = generateTestScenarioRunId();
+        const scenarioRunId2 = generateTestScenarioRunId();
+
+        // Start both suite runs concurrently
+        await Promise.all([
+          pipeline.commands.startSuiteRun.send({
+            tenantId: tenantIdString,
+            batchRunId: batchRunId1,
+            scenarioSetId: "scenario-set-1",
+            suiteId: suiteId1,
+            total: 1,
+            scenarioIds: ["scenario-1"],
+            targetIds: ["target-1"],
+            idempotencyKey: `idem-${batchRunId1}`,
+            occurredAt: Date.now(),
+          }),
+          pipeline.commands.startSuiteRun.send({
+            tenantId: tenantIdString,
+            batchRunId: batchRunId2,
+            scenarioSetId: "scenario-set-2",
+            suiteId: suiteId2,
+            total: 1,
+            scenarioIds: ["scenario-2"],
+            targetIds: ["target-2"],
+            idempotencyKey: `idem-${batchRunId2}`,
+            occurredAt: Date.now(),
+          }),
+        ]);
+
+        // Wait for both to reach IN_PROGRESS
+        await Promise.all([
+          waitForSuiteRunState(pipeline, batchRunId1, tenantId, "IN_PROGRESS"),
+          waitForSuiteRunState(pipeline, batchRunId2, tenantId, "IN_PROGRESS"),
+        ]);
+
+        // Record and complete items for both runs
+        await Promise.all([
+          pipeline.commands.recordSuiteRunItemStarted.send({
+            tenantId: tenantIdString,
+            batchRunId: batchRunId1,
+            scenarioRunId: scenarioRunId1,
+            scenarioId: "scenario-1",
+            occurredAt: Date.now(),
+          }),
+          pipeline.commands.recordSuiteRunItemStarted.send({
+            tenantId: tenantIdString,
+            batchRunId: batchRunId2,
+            scenarioRunId: scenarioRunId2,
+            scenarioId: "scenario-2",
+            occurredAt: Date.now(),
+          }),
+        ]);
+        await waitForClickHouseConsistency();
+
+        await Promise.all([
+          pipeline.commands.completeSuiteRunItem.send({
+            tenantId: tenantIdString,
+            batchRunId: batchRunId1,
+            scenarioRunId: scenarioRunId1,
+            scenarioId: "scenario-1",
+            status: "SUCCESS",
+            verdict: "success",
+            occurredAt: Date.now(),
+          }),
+          pipeline.commands.completeSuiteRunItem.send({
+            tenantId: tenantIdString,
+            batchRunId: batchRunId2,
+            scenarioRunId: scenarioRunId2,
+            scenarioId: "scenario-2",
+            status: "SUCCESS",
+            verdict: "success",
+            occurredAt: Date.now(),
+          }),
+        ]);
+
+        // Wait for both to complete
+        await Promise.all([
+          waitForSuiteRunState(pipeline, batchRunId1, tenantId, "SUCCESS"),
+          waitForSuiteRunState(pipeline, batchRunId2, tenantId, "SUCCESS"),
+        ]);
+
+        // Verify each has its own projection state
+        const [projection1, projection2] = (await Promise.all([
+          pipeline.service.getProjectionByName("suiteRunState", batchRunId1, {
+            tenantId,
+          }),
+          pipeline.service.getProjectionByName("suiteRunState", batchRunId2, {
+            tenantId,
+          }),
+        ])) as [SuiteRunState | null, SuiteRunState | null];
+
+        expect(projection1?.data.SuiteId).toBe(suiteId1);
+        expect(projection2?.data.SuiteId).toBe(suiteId2);
+        expect(projection1?.data.Status).toBe("SUCCESS");
+        expect(projection2?.data.Status).toBe("SUCCESS");
+        expect(projection1?.data.BatchRunId).toBe(batchRunId1);
+        expect(projection2?.data.BatchRunId).toBe(batchRunId2);
+      });
+    });
+
+    describe("State Transitions Tests", () => {
+      it("reaches IN_PROGRESS status after start event", async () => {
+        const batchRunId = generateTestBatchRunId();
+        const suiteId = generateTestSuiteId();
+
+        await pipeline.commands.startSuiteRun.send({
+          tenantId: tenantIdString,
+          batchRunId,
+          scenarioSetId: "scenario-set-1",
+          suiteId,
+          total: 3,
+          scenarioIds: ["scenario-1", "scenario-2", "scenario-3"],
+          targetIds: ["target-1"],
+          idempotencyKey: `idem-${batchRunId}`,
+          occurredAt: Date.now(),
+        });
+
+        await waitForSuiteRunState(
+          pipeline,
+          batchRunId,
+          tenantId,
+          "IN_PROGRESS",
+        );
+
+        // Verify projection populated from start event
+        const projection = (await pipeline.service.getProjectionByName(
+          "suiteRunState",
+          batchRunId,
+          { tenantId },
+        )) as SuiteRunState | null;
+
+        expect(projection?.data.Status).toBe("IN_PROGRESS");
+        expect(projection?.data.SuiteId).toBe(suiteId);
+        expect(projection?.data.Total).toBe(3);
+        expect(projection?.data.ScenarioSetId).toBe("scenario-set-1");
+        expect(projection?.data.BatchRunId).toBe(batchRunId);
+        expect(projection?.data.StartedAt).not.toBeNull();
+        expect(projection?.data.CompletedCount).toBe(0);
+        expect(projection?.data.FailedCount).toBe(0);
+        expect(projection?.data.Progress).toBe(0);
+        expect(projection?.data.FinishedAt).toBeNull();
+      });
+    });
+  },
+  60000,
+); // 60 second timeout for integration tests

--- a/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/commands/__tests__/completeSuiteRunItem.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/commands/__tests__/completeSuiteRunItem.command.unit.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { CompleteSuiteRunItemCommandData } from "../../schemas/commands";
+import {
+  SUITE_RUN_COMMAND_TYPES,
+  SUITE_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { CompleteSuiteRunItemCommand } from "../completeSuiteRunItem.command";
+
+function makeCommand(
+  overrides: Partial<CompleteSuiteRunItemCommandData> = {},
+): Command<CompleteSuiteRunItemCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "batch-123",
+    type: SUITE_RUN_COMMAND_TYPES.COMPLETE_ITEM,
+    data: {
+      tenantId: "tenant-1",
+      batchRunId: "batch-123",
+      scenarioRunId: "scenario-run-1",
+      scenarioId: "scenario-1",
+      status: "processed",
+      verdict: "passed",
+      durationMs: 1500,
+      reasoning: "All checks passed",
+      error: undefined,
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<CompleteSuiteRunItemCommandData>;
+}
+
+describe("CompleteSuiteRunItemCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single SuiteRunItemCompletedEvent", async () => {
+        const handler = new CompleteSuiteRunItemCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SUITE_RUN_EVENT_TYPES.ITEM_COMPLETED);
+      });
+
+      it("sets correct aggregate fields on the event", async () => {
+        const handler = new CompleteSuiteRunItemCommand();
+        const events = await handler.handle(makeCommand());
+
+        const event = events[0]!;
+        expect(event.aggregateType).toBe("suite_run");
+        expect(event.aggregateId).toBe("batch-123");
+      });
+
+      it("maps command data to event data", async () => {
+        const handler = new CompleteSuiteRunItemCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.data).toEqual({
+          batchRunId: "batch-123",
+          scenarioRunId: "scenario-run-1",
+          scenarioId: "scenario-1",
+          status: "processed",
+          verdict: "passed",
+          durationMs: 1500,
+          reasoning: "All checks passed",
+          error: undefined,
+        });
+      });
+
+      it("uses the command occurredAt for the event", async () => {
+        const handler = new CompleteSuiteRunItemCommand();
+        const events = await handler.handle(
+          makeCommand({ occurredAt: 1700000099999 }),
+        );
+
+        expect(events[0]!.occurredAt).toBe(1700000099999);
+      });
+    });
+
+    describe("when optional fields are omitted", () => {
+      it("includes undefined optional fields in event data", async () => {
+        const handler = new CompleteSuiteRunItemCommand();
+        const events = await handler.handle(
+          makeCommand({
+            verdict: undefined,
+            durationMs: undefined,
+            reasoning: undefined,
+            error: undefined,
+          }),
+        );
+
+        const event = events[0]!;
+        expect(event.data).toMatchObject({
+          batchRunId: "batch-123",
+          scenarioRunId: "scenario-run-1",
+          scenarioId: "scenario-1",
+          status: "processed",
+        });
+        expect(event.data).toHaveProperty("verdict", undefined);
+        expect(event.data).toHaveProperty("durationMs", undefined);
+        expect(event.data).toHaveProperty("reasoning", undefined);
+        expect(event.data).toHaveProperty("error", undefined);
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the batchRunId", () => {
+      const payload = makeCommand().data;
+      expect(CompleteSuiteRunItemCommand.getAggregateId(payload)).toBe(
+        "batch-123",
+      );
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:batchRunId:scenarioRunId:itemCompleted", () => {
+      const payload = makeCommand().data;
+      expect(CompleteSuiteRunItemCommand.makeJobId(payload)).toBe(
+        "tenant-1:batch-123:scenario-run-1:itemCompleted",
+      );
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns batchRun.id, scenarioRun.id, and status", () => {
+      const payload = makeCommand().data;
+      expect(CompleteSuiteRunItemCommand.getSpanAttributes(payload)).toEqual({
+        "payload.batchRun.id": "batch-123",
+        "payload.scenarioRun.id": "scenario-run-1",
+        "payload.status": "processed",
+      });
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(CompleteSuiteRunItemCommand.schema.type).toBe(
+        SUITE_RUN_COMMAND_TYPES.COMPLETE_ITEM,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/commands/__tests__/recordSuiteRunItemStarted.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/commands/__tests__/recordSuiteRunItemStarted.command.unit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { RecordSuiteRunItemStartedCommandData } from "../../schemas/commands";
+import {
+  SUITE_RUN_COMMAND_TYPES,
+  SUITE_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { RecordSuiteRunItemStartedCommand } from "../recordSuiteRunItemStarted.command";
+
+function makeCommand(
+  overrides: Partial<RecordSuiteRunItemStartedCommandData> = {},
+): Command<RecordSuiteRunItemStartedCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "batch-123",
+    type: SUITE_RUN_COMMAND_TYPES.RECORD_ITEM_STARTED,
+    data: {
+      tenantId: "tenant-1",
+      batchRunId: "batch-123",
+      scenarioRunId: "scenario-run-1",
+      scenarioId: "scenario-1",
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<RecordSuiteRunItemStartedCommandData>;
+}
+
+describe("RecordSuiteRunItemStartedCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single SuiteRunItemStartedEvent", async () => {
+        const handler = new RecordSuiteRunItemStartedCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SUITE_RUN_EVENT_TYPES.ITEM_STARTED);
+      });
+
+      it("sets correct aggregate fields on the event", async () => {
+        const handler = new RecordSuiteRunItemStartedCommand();
+        const events = await handler.handle(makeCommand());
+
+        const event = events[0]!;
+        expect(event.aggregateType).toBe("suite_run");
+        expect(event.aggregateId).toBe("batch-123");
+      });
+
+      it("maps command data to event data", async () => {
+        const handler = new RecordSuiteRunItemStartedCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.data).toEqual({
+          batchRunId: "batch-123",
+          scenarioRunId: "scenario-run-1",
+          scenarioId: "scenario-1",
+        });
+      });
+
+      it("uses the command occurredAt for the event", async () => {
+        const handler = new RecordSuiteRunItemStartedCommand();
+        const events = await handler.handle(
+          makeCommand({ occurredAt: 1700000099999 }),
+        );
+
+        expect(events[0]!.occurredAt).toBe(1700000099999);
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the batchRunId", () => {
+      const payload = makeCommand().data;
+      expect(RecordSuiteRunItemStartedCommand.getAggregateId(payload)).toBe(
+        "batch-123",
+      );
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:batchRunId:scenarioRunId:itemStarted", () => {
+      const payload = makeCommand().data;
+      expect(RecordSuiteRunItemStartedCommand.makeJobId(payload)).toBe(
+        "tenant-1:batch-123:scenario-run-1:itemStarted",
+      );
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns batchRun.id and scenarioRun.id", () => {
+      const payload = makeCommand().data;
+      expect(
+        RecordSuiteRunItemStartedCommand.getSpanAttributes(payload),
+      ).toEqual({
+        "payload.batchRun.id": "batch-123",
+        "payload.scenarioRun.id": "scenario-run-1",
+      });
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(RecordSuiteRunItemStartedCommand.schema.type).toBe(
+        SUITE_RUN_COMMAND_TYPES.RECORD_ITEM_STARTED,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/commands/__tests__/startSuiteRun.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/commands/__tests__/startSuiteRun.command.unit.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { Command } from "../../../../";
+import type { StartSuiteRunCommandData } from "../../schemas/commands";
+import {
+  SUITE_RUN_COMMAND_TYPES,
+  SUITE_RUN_EVENT_TYPES,
+} from "../../schemas/constants";
+import { StartSuiteRunCommand } from "../startSuiteRun.command";
+
+function makeCommand(
+  overrides: Partial<StartSuiteRunCommandData> = {},
+): Command<StartSuiteRunCommandData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "batch-123",
+    type: SUITE_RUN_COMMAND_TYPES.START,
+    data: {
+      tenantId: "tenant-1",
+      batchRunId: "batch-123",
+      scenarioSetId: "scenario-set-1",
+      suiteId: "suite-1",
+      total: 5,
+      scenarioIds: ["s1", "s2"],
+      targetIds: ["t1", "t2"],
+      idempotencyKey: "idem-abc",
+      occurredAt: 1700000000000,
+      ...overrides,
+    },
+  } as Command<StartSuiteRunCommandData>;
+}
+
+describe("StartSuiteRunCommand", () => {
+  describe("handle()", () => {
+    describe("when invoked with valid command data", () => {
+      it("emits a single SuiteRunStartedEvent", async () => {
+        const handler = new StartSuiteRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]!.type).toBe(SUITE_RUN_EVENT_TYPES.STARTED);
+      });
+
+      it("sets correct aggregate fields on the event", async () => {
+        const handler = new StartSuiteRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        const event = events[0]!;
+        expect(event.aggregateType).toBe("suite_run");
+        expect(event.aggregateId).toBe("batch-123");
+      });
+
+      it("maps command data to event data", async () => {
+        const handler = new StartSuiteRunCommand();
+        const events = await handler.handle(makeCommand());
+
+        expect(events[0]!.data).toEqual({
+          batchRunId: "batch-123",
+          scenarioSetId: "scenario-set-1",
+          suiteId: "suite-1",
+          total: 5,
+          scenarioIds: ["s1", "s2"],
+          targetIds: ["t1", "t2"],
+        });
+      });
+
+      it("uses the command occurredAt for the event", async () => {
+        const handler = new StartSuiteRunCommand();
+        const events = await handler.handle(
+          makeCommand({ occurredAt: 1700000099999 }),
+        );
+
+        expect(events[0]!.occurredAt).toBe(1700000099999);
+      });
+    });
+  });
+
+  describe("getAggregateId()", () => {
+    it("returns the batchRunId", () => {
+      const payload = makeCommand().data;
+      expect(StartSuiteRunCommand.getAggregateId(payload)).toBe("batch-123");
+    });
+  });
+
+  describe("makeJobId()", () => {
+    it("returns tenantId:batchRunId:idempotencyKey", () => {
+      const payload = makeCommand().data;
+      expect(StartSuiteRunCommand.makeJobId(payload)).toBe(
+        "tenant-1:batch-123:idem-abc",
+      );
+    });
+  });
+
+  describe("getSpanAttributes()", () => {
+    it("returns batchRun.id, suite.id, and total", () => {
+      const payload = makeCommand().data;
+      expect(StartSuiteRunCommand.getSpanAttributes(payload)).toEqual({
+        "payload.batchRun.id": "batch-123",
+        "payload.suite.id": "suite-1",
+        "payload.total": 5,
+      });
+    });
+  });
+
+  describe("schema", () => {
+    it("has correct command type", () => {
+      expect(StartSuiteRunCommand.schema.type).toBe(
+        SUITE_RUN_COMMAND_TYPES.START,
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/mapProjectionExecutor.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MapProjectionExecutor } from "../mapProjectionExecutor";
+import {
+  createMockAppendStore,
+  createMockMapProjectionDefinition,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../services/__tests__/testHelpers";
+import type { ProjectionStoreContext } from "../projectionStoreContext";
+
+describe("MapProjectionExecutor.execute", () => {
+  const tenantId = createTestTenantId();
+  let executor: MapProjectionExecutor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+    executor = new MapProjectionExecutor();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("when map returns a record", () => {
+    it("appends the record to the store and returns it", async () => {
+      const store = createMockAppendStore<{ name: string }>();
+
+      const mapDef = createMockMapProjectionDefinition("mapper", {
+        store,
+        map: (_event) => ({ name: "mapped-record" }),
+      });
+
+      const event = createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+      );
+
+      const context: ProjectionStoreContext = {
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        tenantId,
+      };
+
+      const result = await executor.execute(mapDef, event, context);
+
+      expect(result).toEqual({ name: "mapped-record" });
+      expect(store.append).toHaveBeenCalledWith(
+        { name: "mapped-record" },
+        context,
+      );
+    });
+  });
+
+  describe("when map returns null", () => {
+    it("does not call store.append and returns null", async () => {
+      const store = createMockAppendStore<{ name: string }>();
+
+      const mapDef = createMockMapProjectionDefinition("mapper", {
+        store,
+        map: (_event) => null,
+      });
+
+      const event = createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+      );
+
+      const context: ProjectionStoreContext = {
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        tenantId,
+      };
+
+      const result = await executor.execute(mapDef, event, context);
+
+      expect(result).toBeNull();
+      expect(store.append).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when map throws", () => {
+    it("propagates the error", async () => {
+      const store = createMockAppendStore<{ name: string }>();
+
+      const mapDef = createMockMapProjectionDefinition("mapper", {
+        store,
+        map: (_event) => {
+          throw new Error("map failed");
+        },
+      });
+
+      const event = createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+      );
+
+      const context: ProjectionStoreContext = {
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        tenantId,
+      };
+
+      await expect(
+        executor.execute(mapDef, event, context),
+      ).rejects.toThrow("map failed");
+    });
+  });
+
+  describe("when store.append throws", () => {
+    it("propagates the error", async () => {
+      const store = createMockAppendStore<{ name: string }>();
+      (store.append as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("append failed"),
+      );
+
+      const mapDef = createMockMapProjectionDefinition("mapper", {
+        store,
+        map: (_event) => ({ name: "mapped-record" }),
+      });
+
+      const event = createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+      );
+
+      const context: ProjectionStoreContext = {
+        aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+        tenantId,
+      };
+
+      await expect(
+        executor.execute(mapDef, event, context),
+      ).rejects.toThrow("append failed");
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -1,0 +1,312 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { Redis } from "ioredis";
+import {
+  startTestContainers,
+  stopTestContainers,
+  getTestRedisConnection,
+} from "../../../__tests__/integration/testContainers";
+import { GroupQueueProcessor } from "../groupQueue";
+import type { EventSourcedQueueDefinition } from "../../queue.types";
+
+// Skip when running without testcontainers (unit-only test runs)
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL ||
+  process.env.CI_CLICKHOUSE_URL ||
+  process.env.REDIS_URL ||
+  process.env.CI_REDIS_URL
+);
+
+type TestPayload = {
+  id: string;
+  groupId: string;
+  value: string;
+};
+
+function createQueueDefinition(
+  overrides: Partial<EventSourcedQueueDefinition<TestPayload>> & {
+    process: (payload: TestPayload) => Promise<void>;
+  },
+): EventSourcedQueueDefinition<TestPayload> {
+  return {
+    name: `{test/gq/${crypto.randomUUID().slice(0, 8)}}`,
+    groupKey: (p) => p.groupId,
+    ...overrides,
+  };
+}
+
+describe.skipIf(!hasTestcontainers)(
+  "GroupQueueProcessor - Orchestration",
+  () => {
+    let redis: Redis;
+    let queues: GroupQueueProcessor<TestPayload>[];
+
+    beforeAll(async () => {
+      await startTestContainers();
+      redis = getTestRedisConnection()!;
+    });
+
+    beforeEach(() => {
+      queues = [];
+    });
+
+    afterEach(async () => {
+      // Close all queues created during the test
+      await Promise.all(
+        queues.map((q) => q.close().catch(() => {})),
+      );
+      await redis.flushall();
+    });
+
+    afterAll(async () => {
+      await stopTestContainers();
+    });
+
+    function createQueue(
+      processFn: (payload: TestPayload) => Promise<void>,
+      overrides?: Partial<EventSourcedQueueDefinition<TestPayload>>,
+    ): GroupQueueProcessor<TestPayload> {
+      const queue = new GroupQueueProcessor<TestPayload>(
+        createQueueDefinition({ process: processFn, ...overrides }),
+        redis,
+      );
+      queues.push(queue);
+      return queue;
+    }
+
+    describe("send()", () => {
+      describe("when a job is sent", () => {
+        it("stages and processes the job with correct payload", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+
+          const queue = createQueue(processed);
+          await queue.waitUntilReady();
+
+          const payload: TestPayload = {
+            id: "job-1",
+            groupId: "group-a",
+            value: "hello",
+          };
+
+          await queue.send(payload);
+
+          // Wait for the job to be processed
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+
+          const receivedPayload = processed.mock.calls[0]![0];
+          expect(receivedPayload.id).toBe("job-1");
+          expect(receivedPayload.groupId).toBe("group-a");
+          expect(receivedPayload.value).toBe("hello");
+        });
+      });
+
+      describe("when deduplication is configured", () => {
+        it("deduplicates jobs with the same dedup key within TTL window", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          // Add a small delay to ensure both sends happen before processing
+          processed.mockImplementation(
+            () => new Promise((resolve) => setTimeout(resolve, 100)),
+          );
+
+          const queue = createQueue(processed, {
+            deduplication: {
+              makeId: (p) => `${p.groupId}:${p.id}`,
+              ttlMs: 5000,
+            },
+          });
+          await queue.waitUntilReady();
+
+          // Send the same logical job twice rapidly
+          await queue.send({
+            id: "dedup-1",
+            groupId: "group-a",
+            value: "first",
+          });
+          await queue.send({
+            id: "dedup-1",
+            groupId: "group-a",
+            value: "second",
+          });
+
+          // Wait for processing
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+
+          // Should have received the second (replaced) payload
+          const receivedPayload = processed.mock.calls[0]![0];
+          expect(receivedPayload.value).toBe("second");
+
+          // Wait a bit more to confirm no second call arrives
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          expect(processed).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe("close()", () => {
+      describe("when close is called after processing", () => {
+        it("resolves and stops accepting new jobs", async () => {
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockResolvedValue(undefined);
+
+          const queue = createQueue(processed);
+          await queue.waitUntilReady();
+
+          await queue.send({
+            id: "job-close",
+            groupId: "group-a",
+            value: "before-close",
+          });
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(1);
+            },
+            { timeout: 5000, interval: 50 },
+          );
+
+          // Remove from tracked queues so afterEach doesn't double-close
+          queues = queues.filter((q) => q !== queue);
+          await expect(queue.close()).resolves.toBeUndefined();
+
+          // Sending after close throws
+          await expect(
+            queue.send({
+              id: "job-after-close",
+              groupId: "group-a",
+              value: "after-close",
+            }),
+          ).rejects.toThrow(/shutdown/i);
+        });
+      });
+    });
+
+    describe("waitUntilReady()", () => {
+      describe("when called on a new queue", () => {
+        it("resolves immediately", async () => {
+          const queue = createQueue(vi.fn().mockResolvedValue(undefined));
+
+          await expect(queue.waitUntilReady()).resolves.toBeUndefined();
+        });
+      });
+    });
+
+    describe("per-group sequential processing", () => {
+      describe("when multiple jobs share the same group key", () => {
+        it("processes them one at a time, not in parallel", async () => {
+          const concurrencyLog: { start: number; end: number }[] = [];
+          let activeConcurrency = 0;
+          let maxConcurrency = 0;
+
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockImplementation(async () => {
+            activeConcurrency++;
+            maxConcurrency = Math.max(maxConcurrency, activeConcurrency);
+            const start = Date.now();
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            const end = Date.now();
+            concurrencyLog.push({ start, end });
+            activeConcurrency--;
+          });
+
+          const queue = createQueue(processed, {
+            options: { globalConcurrency: 5 },
+          });
+          await queue.waitUntilReady();
+
+          // Send 3 jobs with the SAME group key
+          for (let i = 0; i < 3; i++) {
+            await queue.send({
+              id: `seq-${i}`,
+              groupId: "same-group",
+              value: `job-${i}`,
+            });
+          }
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(3);
+            },
+            { timeout: 10000, interval: 50 },
+          );
+
+          // Max concurrency within the same group must be 1
+          expect(maxConcurrency).toBe(1);
+
+          // Verify sequential: each job starts after the previous ends
+          for (let i = 1; i < concurrencyLog.length; i++) {
+            expect(concurrencyLog[i]!.start).toBeGreaterThanOrEqual(
+              concurrencyLog[i - 1]!.end,
+            );
+          }
+        });
+      });
+    });
+
+    describe("cross-group parallel processing", () => {
+      describe("when jobs have different group keys", () => {
+        it("processes them concurrently", async () => {
+          let peakConcurrency = 0;
+          let activeConcurrency = 0;
+          const processedGroups: string[] = [];
+
+          const processed = vi.fn<(payload: TestPayload) => Promise<void>>();
+          processed.mockImplementation(async (payload) => {
+            activeConcurrency++;
+            peakConcurrency = Math.max(peakConcurrency, activeConcurrency);
+            processedGroups.push(payload.groupId);
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            activeConcurrency--;
+          });
+
+          const queue = createQueue(processed, {
+            options: { globalConcurrency: 5 },
+          });
+          await queue.waitUntilReady();
+
+          // Send 2 jobs with DIFFERENT group keys
+          await queue.send({
+            id: "par-1",
+            groupId: "group-alpha",
+            value: "alpha",
+          });
+          await queue.send({
+            id: "par-2",
+            groupId: "group-beta",
+            value: "beta",
+          });
+
+          await vi.waitFor(
+            () => {
+              expect(processed).toHaveBeenCalledTimes(2);
+            },
+            { timeout: 10000, interval: 50 },
+          );
+
+          // Different groups should have been processed concurrently
+          expect(peakConcurrency).toBe(2);
+          expect(processedGroups).toContain("group-alpha");
+          expect(processedGroups).toContain("group-beta");
+        });
+      });
+    });
+  },
+);

--- a/langwatch/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ErrorCategory,
+  SecurityError,
+  ValidationError,
+  ConfigurationError,
+  StoreError,
+  QueueError,
+  HandlerError,
+  ProjectionError,
+  handleError,
+  categorizeError,
+} from "../errorHandling";
+
+const createMockLogger = () => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+  silent: vi.fn(),
+});
+
+describe("Error classes", () => {
+  describe("SecurityError", () => {
+    it("has correct name and CRITICAL category", () => {
+      const err = new SecurityError("op", "breach detected", "tenant-1");
+      expect(err.name).toBe("SecurityError");
+      expect(err.category).toBe(ErrorCategory.CRITICAL);
+    });
+
+    it("getLogContext() includes operation and tenantId", () => {
+      const err = new SecurityError("op", "breach", "t-1");
+      const ctx = err.getLogContext();
+      expect(ctx).toMatchObject({
+        errorName: "SecurityError",
+        errorMessage: "[SECURITY] breach",
+        errorCategory: ErrorCategory.CRITICAL,
+        operation: "op",
+        tenantId: "t-1",
+      });
+    });
+  });
+
+  describe("ValidationError", () => {
+    it("has correct name and CRITICAL category", () => {
+      const err = new ValidationError("bad input", "email", "notanemail");
+      expect(err.name).toBe("ValidationError");
+      expect(err.category).toBe(ErrorCategory.CRITICAL);
+    });
+
+    it("getLogContext() includes field, value, and reason", () => {
+      const err = new ValidationError("bad input", "email", "x");
+      const ctx = err.getLogContext();
+      expect(ctx).toMatchObject({
+        errorName: "ValidationError",
+        errorCategory: ErrorCategory.CRITICAL,
+        field: "email",
+        value: "x",
+        reason: "bad input",
+      });
+    });
+
+    it("message omits field when not provided", () => {
+      const err = new ValidationError("missing data");
+      expect(err.message).toBe("[VALIDATION] missing data");
+    });
+
+    it("message includes field when provided", () => {
+      const err = new ValidationError("too long", "name");
+      expect(err.message).toBe("[VALIDATION] too long (field: name)");
+    });
+  });
+
+  describe("ConfigurationError", () => {
+    it("has correct name and CRITICAL category", () => {
+      const err = new ConfigurationError("Pipeline", "missing handler");
+      expect(err.name).toBe("ConfigurationError");
+      expect(err.category).toBe(ErrorCategory.CRITICAL);
+    });
+
+    it("getLogContext() includes component and details", () => {
+      const err = new ConfigurationError("Pipeline", "missing handler");
+      const ctx = err.getLogContext();
+      expect(ctx).toMatchObject({
+        errorName: "ConfigurationError",
+        errorCategory: ErrorCategory.CRITICAL,
+        component: "Pipeline",
+        details: "missing handler",
+      });
+    });
+  });
+
+  describe("StoreError", () => {
+    it("has correct name", () => {
+      const err = new StoreError(
+        "insert",
+        "clickhouse",
+        "timeout",
+        ErrorCategory.RECOVERABLE,
+      );
+      expect(err.name).toBe("StoreError");
+    });
+
+    it("can be CRITICAL", () => {
+      const err = new StoreError(
+        "insert",
+        "clickhouse",
+        "corruption",
+        ErrorCategory.CRITICAL,
+      );
+      expect(err.category).toBe(ErrorCategory.CRITICAL);
+    });
+
+    it("can be RECOVERABLE", () => {
+      const err = new StoreError(
+        "query",
+        "clickhouse",
+        "timeout",
+        ErrorCategory.RECOVERABLE,
+      );
+      expect(err.category).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("getLogContext() includes operation and store", () => {
+      const err = new StoreError(
+        "insert",
+        "clickhouse",
+        "fail",
+        ErrorCategory.RECOVERABLE,
+      );
+      const ctx = err.getLogContext();
+      expect(ctx).toMatchObject({
+        errorName: "StoreError",
+        errorCategory: ErrorCategory.RECOVERABLE,
+        operation: "insert",
+        store: "clickhouse",
+      });
+    });
+  });
+
+  describe("QueueError", () => {
+    it("has correct name and RECOVERABLE category", () => {
+      const err = new QueueError("events", "enqueue", "redis down");
+      expect(err.name).toBe("QueueError");
+      expect(err.category).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("getLogContext() includes queueName and operation", () => {
+      const ctx = new QueueError("events", "enqueue", "fail").getLogContext();
+      expect(ctx).toMatchObject({
+        errorName: "QueueError",
+        queueName: "events",
+        operation: "enqueue",
+      });
+    });
+  });
+
+  describe("HandlerError", () => {
+    it("has correct name and NON_CRITICAL category", () => {
+      const err = new HandlerError("myHandler", "evt-1", "oops");
+      expect(err.name).toBe("HandlerError");
+      expect(err.category).toBe(ErrorCategory.NON_CRITICAL);
+    });
+
+    it("getLogContext() includes handlerName and eventId", () => {
+      const ctx = new HandlerError("h", "e-1", "fail").getLogContext();
+      expect(ctx).toMatchObject({
+        errorName: "HandlerError",
+        handlerName: "h",
+        eventId: "e-1",
+      });
+    });
+  });
+
+  describe("ProjectionError", () => {
+    it("has correct name and NON_CRITICAL category", () => {
+      const err = new ProjectionError("proj", "evt-1", "oops");
+      expect(err.name).toBe("ProjectionError");
+      expect(err.category).toBe(ErrorCategory.NON_CRITICAL);
+    });
+
+    it("getLogContext() includes projectionName and eventId", () => {
+      const ctx = new ProjectionError("proj", "e-1", "fail").getLogContext();
+      expect(ctx).toMatchObject({
+        errorName: "ProjectionError",
+        projectionName: "proj",
+        eventId: "e-1",
+      });
+    });
+  });
+});
+
+describe("handleError", () => {
+  describe("with BaseEventSourcingError", () => {
+    it("throws when category is CRITICAL", () => {
+      const err = new SecurityError("op", "breach");
+      expect(() => handleError(err, ErrorCategory.NON_CRITICAL)).toThrow(err);
+    });
+
+    it("logs error and does not throw when NON_CRITICAL with logger", () => {
+      const logger = createMockLogger();
+      const err = new HandlerError("h", "e-1", "minor issue");
+      expect(() =>
+        handleError(err, ErrorCategory.CRITICAL, logger as any),
+      ).not.toThrow();
+      expect(logger.error).toHaveBeenCalledOnce();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ errorName: "HandlerError" }),
+        "Non-critical error occurred, continuing operation",
+      );
+    });
+
+    it("does not throw or crash when NON_CRITICAL without logger", () => {
+      const err = new HandlerError("h", "e-1", "minor");
+      expect(() => handleError(err, ErrorCategory.CRITICAL)).not.toThrow();
+    });
+
+    it("logs warning and does not throw when RECOVERABLE with logger", () => {
+      const logger = createMockLogger();
+      const err = new QueueError("q", "enqueue", "redis timeout");
+      expect(() =>
+        handleError(err, ErrorCategory.CRITICAL, logger as any),
+      ).not.toThrow();
+      expect(logger.warn).toHaveBeenCalledOnce();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ errorName: "QueueError" }),
+        "Recoverable error occurred, should retry",
+      );
+    });
+
+    it("does not throw or crash when RECOVERABLE without logger", () => {
+      const err = new QueueError("q", "enqueue", "timeout");
+      expect(() => handleError(err, ErrorCategory.CRITICAL)).not.toThrow();
+    });
+
+    it("merges additional context with error context", () => {
+      const logger = createMockLogger();
+      const err = new HandlerError("h", "e-1", "oops");
+      handleError(err, ErrorCategory.NON_CRITICAL, logger as any, {
+        extra: "data",
+      });
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errorName: "HandlerError",
+          handlerName: "h",
+          eventId: "e-1",
+          extra: "data",
+          err,
+        }),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe("with plain Error", () => {
+    it("throws when category is CRITICAL", () => {
+      const err = new Error("boom");
+      expect(() => handleError(err, ErrorCategory.CRITICAL)).toThrow(err);
+    });
+
+    it("logs error and does not throw when NON_CRITICAL with logger", () => {
+      const logger = createMockLogger();
+      const err = new Error("oops");
+      expect(() =>
+        handleError(err, ErrorCategory.NON_CRITICAL, logger as any),
+      ).not.toThrow();
+      expect(logger.error).toHaveBeenCalledOnce();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "oops", err }),
+        "Non-critical error occurred, continuing operation",
+      );
+    });
+
+    it("logs warning and does not throw when RECOVERABLE with logger", () => {
+      const logger = createMockLogger();
+      const err = new Error("transient");
+      expect(() =>
+        handleError(err, ErrorCategory.RECOVERABLE, logger as any),
+      ).not.toThrow();
+      expect(logger.warn).toHaveBeenCalledOnce();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "transient", err }),
+        "Recoverable error occurred, should retry",
+      );
+    });
+  });
+
+  describe("with non-Error value", () => {
+    it("logs and does not throw when NON_CRITICAL with logger", () => {
+      const logger = createMockLogger();
+      expect(() =>
+        handleError("string error", ErrorCategory.NON_CRITICAL, logger as any),
+      ).not.toThrow();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "string error" }),
+        "Non-critical error occurred, continuing operation",
+      );
+    });
+  });
+});
+
+describe("categorizeError", () => {
+  it("returns CRITICAL for SecurityError", () => {
+    expect(categorizeError(new SecurityError("op", "msg"))).toBe(
+      ErrorCategory.CRITICAL,
+    );
+  });
+
+  it("returns CRITICAL for ValidationError", () => {
+    expect(categorizeError(new ValidationError("reason"))).toBe(
+      ErrorCategory.CRITICAL,
+    );
+  });
+
+  it("returns RECOVERABLE for QueueError", () => {
+    expect(categorizeError(new QueueError("q", "op", "msg"))).toBe(
+      ErrorCategory.RECOVERABLE,
+    );
+  });
+
+  it("returns NON_CRITICAL for HandlerError", () => {
+    expect(categorizeError(new HandlerError("h", "e", "msg"))).toBe(
+      ErrorCategory.NON_CRITICAL,
+    );
+  });
+
+  it("returns NON_CRITICAL for ProjectionError", () => {
+    expect(categorizeError(new ProjectionError("p", "e", "msg"))).toBe(
+      ErrorCategory.NON_CRITICAL,
+    );
+  });
+
+  it("returns RECOVERABLE for plain Error", () => {
+    expect(categorizeError(new Error("unknown"))).toBe(
+      ErrorCategory.RECOVERABLE,
+    );
+  });
+
+  it("returns RECOVERABLE for non-Error value", () => {
+    expect(categorizeError("not an error")).toBe(ErrorCategory.RECOVERABLE);
+  });
+});

--- a/langwatch/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/commands/__tests__/commandDispatcher.unit.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandHandler } from "../../../commands/command";
+import type { CommandSchema } from "../../../commands/commandSchema";
+import type { AggregateType } from "../../../domain/aggregateType";
+import type { CommandType } from "../../../domain/commandType";
+import { createTenantId } from "../../../domain/tenantId";
+import type { Event } from "../../../domain/types";
+import {
+  createTestAggregateType,
+  createTestEvent,
+  createTestTenantId,
+  TEST_CONSTANTS,
+} from "../../__tests__/testHelpers";
+import { ValidationError } from "../../errorHandling";
+import { processCommand } from "../commandDispatcher";
+import type { ProcessCommandParams } from "../commandDispatcher";
+
+// Mock the kill switch module
+vi.mock("../../../utils/killSwitch", () => ({
+  isComponentDisabled: vi.fn().mockResolvedValue(false),
+}));
+
+// Lazy import so the mock is applied before the module loads
+import { isComponentDisabled } from "../../../utils/killSwitch";
+
+const mockedIsComponentDisabled = vi.mocked(isComponentDisabled);
+
+describe("processCommand", () => {
+  const aggregateType: AggregateType = createTestAggregateType();
+  const tenantId = createTestTenantId();
+  const commandType: CommandType = "lw.obs.trace.record_span";
+  const commandName = "recordSpan";
+
+  // Valid payload that commandSchema.validate will "accept"
+  const validPayload = {
+    tenantId: TEST_CONSTANTS.TENANT_ID_VALUE,
+    occurredAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+    someField: "value",
+  };
+
+  // Build a valid event via the test helper
+  function makeValidEvent(overrides?: Partial<Event>): Event {
+    return createTestEvent(
+      overrides?.aggregateId ?? TEST_CONSTANTS.AGGREGATE_ID,
+      overrides?.aggregateType ?? aggregateType,
+      overrides?.tenantId ?? tenantId,
+      overrides?.type ?? TEST_CONSTANTS.EVENT_TYPE_1,
+      overrides?.createdAt ?? TEST_CONSTANTS.BASE_TIMESTAMP,
+    );
+  }
+
+  // ---- Reusable mock factories ----
+
+  function createMockCommandSchema(
+    overrides?: Partial<CommandSchema<any, CommandType>>,
+  ): CommandSchema<any, CommandType> {
+    return {
+      type: commandType,
+      validate: vi.fn().mockReturnValue({
+        success: true,
+        data: validPayload,
+      }),
+      ...overrides,
+    };
+  }
+
+  function createMockHandler(
+    events?: Event[],
+  ): CommandHandler<any, Event> {
+    return {
+      handle: vi.fn().mockResolvedValue(events ?? [makeValidEvent()]),
+    };
+  }
+
+  function createDefaultParams(
+    overrides?: Partial<ProcessCommandParams<Event>>,
+  ): ProcessCommandParams<Event> {
+    return {
+      payload: validPayload,
+      commandType,
+      commandSchema: createMockCommandSchema(),
+      handler: createMockHandler(),
+      getAggregateId: vi.fn().mockReturnValue(TEST_CONSTANTS.AGGREGATE_ID),
+      storeEventsFn: vi.fn().mockResolvedValue(undefined),
+      aggregateType,
+      commandName,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+    mockedIsComponentDisabled.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ─── 1. Valid flow ──────────────────────────────────────────────
+
+  describe("valid flow", () => {
+    it("validates payload, invokes handler, and stores resulting events", async () => {
+      const event = makeValidEvent();
+      const handler = createMockHandler([event]);
+      const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+      const commandSchema = createMockCommandSchema();
+
+      const params = createDefaultParams({
+        commandSchema,
+        handler,
+        storeEventsFn,
+      });
+
+      await processCommand(params);
+
+      expect(commandSchema.validate).toHaveBeenCalledWith(validPayload);
+      expect(handler.handle).toHaveBeenCalledOnce();
+      expect(storeEventsFn).toHaveBeenCalledWith([event], {
+        tenantId: createTenantId(String(validPayload.tenantId)),
+      });
+    });
+  });
+
+  // ─── 2. Schema validation failure ──────────────────────────────
+
+  describe("schema validation failure", () => {
+    it("throws ValidationError when commandSchema.validate returns failure", async () => {
+      const commandSchema = createMockCommandSchema({
+        validate: vi.fn().mockReturnValue({
+          success: false,
+          error: {
+            issues: [
+              { path: ["tenantId"], message: "Required", code: "invalid_type" },
+            ],
+          },
+        }),
+      });
+
+      const params = createDefaultParams({ commandSchema });
+
+      await expect(processCommand(params)).rejects.toThrow(ValidationError);
+      await expect(processCommand(params)).rejects.toThrow(
+        /Invalid payload for command type/,
+      );
+    });
+  });
+
+  // ─── 3. Kill switch enabled ────────────────────────────────────
+
+  describe("kill switch enabled", () => {
+    it("returns without calling handler when component is disabled", async () => {
+      mockedIsComponentDisabled.mockResolvedValue(true);
+
+      const handler = createMockHandler();
+      const storeEventsFn = vi.fn();
+
+      const params = createDefaultParams({ handler, storeEventsFn });
+
+      await processCommand(params);
+
+      expect(handler.handle).not.toHaveBeenCalled();
+      expect(storeEventsFn).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── 4. Handler returns undefined ──────────────────────────────
+
+  describe("handler returns undefined", () => {
+    it("throws ValidationError mentioning 'returned undefined'", async () => {
+      const handler: CommandHandler<any, Event> = {
+        handle: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const params = createDefaultParams({ handler });
+
+      await expect(processCommand(params)).rejects.toThrow(ValidationError);
+      await expect(processCommand(params)).rejects.toThrow(
+        /returned undefined/,
+      );
+    });
+  });
+
+  // ─── 5. Handler returns non-array ──────────────────────────────
+
+  describe("handler returns non-array value", () => {
+    it("throws ValidationError mentioning 'non-array value'", async () => {
+      const handler: CommandHandler<any, Event> = {
+        handle: vi.fn().mockResolvedValue("not-an-array" as any),
+      };
+
+      const params = createDefaultParams({ handler });
+
+      await expect(processCommand(params)).rejects.toThrow(ValidationError);
+      await expect(processCommand(params)).rejects.toThrow(
+        /non-array value/,
+      );
+    });
+  });
+
+  // ─── 6. Handler returns array with undefined at index ──────────
+
+  describe("handler returns array with undefined element", () => {
+    it("throws ValidationError mentioning the index", async () => {
+      const handler: CommandHandler<any, Event> = {
+        handle: vi
+          .fn()
+          .mockResolvedValue([makeValidEvent(), undefined, makeValidEvent()]),
+      };
+
+      const params = createDefaultParams({ handler });
+
+      await expect(processCommand(params)).rejects.toThrow(ValidationError);
+      await expect(processCommand(params)).rejects.toThrow(
+        /undefined at index 1/,
+      );
+    });
+  });
+
+  // ─── 7. Handler returns invalid event ──────────────────────────
+
+  describe("handler returns invalid event", () => {
+    it("throws ValidationError with zod validation details", async () => {
+      const invalidEvent = { id: "some-id" }; // missing required fields
+      const handler: CommandHandler<any, Event> = {
+        handle: vi.fn().mockResolvedValue([invalidEvent]),
+      };
+
+      const params = createDefaultParams({ handler });
+
+      await expect(processCommand(params)).rejects.toThrow(ValidationError);
+      await expect(processCommand(params)).rejects.toThrow(
+        /invalid event at index 0/,
+      );
+    });
+  });
+
+  // ─── 8. Handler returns empty array ────────────────────────────
+
+  describe("handler returns empty array", () => {
+    it("does not call storeEventsFn", async () => {
+      const handler = createMockHandler([]);
+      const storeEventsFn = vi.fn();
+
+      const params = createDefaultParams({ handler, storeEventsFn });
+
+      await processCommand(params);
+
+      expect(storeEventsFn).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── 9. Correct tenantId extraction ────────────────────────────
+
+  describe("tenantId extraction", () => {
+    it("uses createTenantId(String(validated.tenantId)) for tenant isolation", async () => {
+      const numericTenantPayload = {
+        tenantId: 12345,
+        occurredAt: TEST_CONSTANTS.BASE_TIMESTAMP,
+      };
+
+      const commandSchema = createMockCommandSchema({
+        validate: vi.fn().mockReturnValue({
+          success: true,
+          data: numericTenantPayload,
+        }),
+      });
+
+      const storeEventsFn = vi.fn().mockResolvedValue(undefined);
+      const handler = createMockHandler();
+
+      const params = createDefaultParams({
+        commandSchema,
+        handler,
+        storeEventsFn,
+        payload: numericTenantPayload as any,
+      });
+
+      await processCommand(params);
+
+      // storeEventsFn should receive the stringified tenantId
+      const expectedTenantId = createTenantId("12345");
+      expect(storeEventsFn).toHaveBeenCalledWith(
+        expect.any(Array),
+        { tenantId: expectedTenantId },
+      );
+    });
+
+    it("passes validated payload (not raw) to getAggregateId", async () => {
+      const getAggregateId = vi.fn().mockReturnValue("agg-from-validated");
+      const commandSchema = createMockCommandSchema();
+
+      const params = createDefaultParams({ getAggregateId, commandSchema });
+
+      await processCommand(params);
+
+      expect(getAggregateId).toHaveBeenCalledWith(validPayload);
+    });
+  });
+
+  // ─── 10. Kill switch receives correct arguments ────────────────
+
+  describe("kill switch arguments", () => {
+    it("passes aggregateType, componentType, commandName, and tenantId to isComponentDisabled", async () => {
+      const params = createDefaultParams();
+
+      await processCommand(params);
+
+      expect(mockedIsComponentDisabled).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aggregateType,
+          componentType: "command",
+          componentName: commandName,
+          tenantId: createTenantId(String(validPayload.tenantId)),
+        }),
+      );
+    });
+
+    it("forwards killSwitchOptions.customKey when provided", async () => {
+      const params = createDefaultParams({
+        killSwitchOptions: { customKey: "my-custom-key" },
+      });
+
+      await processCommand(params);
+
+      expect(mockedIsComponentDisabled).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customKey: "my-custom-key",
+        }),
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/utils/__tests__/killSwitch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/utils/__tests__/killSwitch.unit.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  generateKillSwitchKey,
+  isComponentDisabled,
+} from "../killSwitch";
+import type { AggregateType } from "../../domain/aggregateType";
+
+const TEST_AGGREGATE_TYPE = "trace" as AggregateType;
+
+function createMockFeatureFlagService() {
+  return {
+    isEnabled: vi.fn().mockResolvedValue(false),
+  };
+}
+
+function createMockLogger() {
+  return {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    silent: vi.fn(),
+  } as any;
+}
+
+describe("generateKillSwitchKey", () => {
+  it("returns es-{aggregateType}-{componentType}-{componentName}-killswitch", () => {
+    expect(
+      generateKillSwitchKey(TEST_AGGREGATE_TYPE, "command", "recordSpan"),
+    ).toBe("es-trace-command-recordSpan-killswitch");
+  });
+
+  it("works with projection componentType", () => {
+    expect(
+      generateKillSwitchKey(TEST_AGGREGATE_TYPE, "projection", "traceSummary"),
+    ).toBe("es-trace-projection-traceSummary-killswitch");
+  });
+
+  it("works with mapProjection componentType", () => {
+    expect(
+      generateKillSwitchKey(TEST_AGGREGATE_TYPE, "mapProjection", "spanStorage"),
+    ).toBe("es-trace-mapProjection-spanStorage-killswitch");
+  });
+});
+
+describe("isComponentDisabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when no featureFlagService is provided", () => {
+    it("returns false immediately", async () => {
+      const result = await isComponentDisabled({
+        featureFlagService: undefined,
+        aggregateType: TEST_AGGREGATE_TYPE,
+        componentType: "command",
+        componentName: "test",
+        tenantId: "tenant-1",
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("when featureFlagService returns true", () => {
+    it("returns true", async () => {
+      const ffs = createMockFeatureFlagService();
+      ffs.isEnabled.mockResolvedValue(true);
+
+      const result = await isComponentDisabled({
+        featureFlagService: ffs as any,
+        aggregateType: TEST_AGGREGATE_TYPE,
+        componentType: "command",
+        componentName: "recordSpan",
+        tenantId: "tenant-1",
+      });
+
+      expect(result).toBe(true);
+      expect(ffs.isEnabled).toHaveBeenCalledWith(
+        "es-trace-command-recordSpan-killswitch",
+        "tenant-1",
+        false,
+      );
+    });
+
+    it("logs debug message when logger is provided", async () => {
+      const ffs = createMockFeatureFlagService();
+      ffs.isEnabled.mockResolvedValue(true);
+      const logger = createMockLogger();
+
+      await isComponentDisabled({
+        featureFlagService: ffs as any,
+        aggregateType: TEST_AGGREGATE_TYPE,
+        componentType: "command",
+        componentName: "recordSpan",
+        tenantId: "tenant-1",
+        logger,
+      });
+
+      expect(logger.debug).toHaveBeenCalled();
+    });
+  });
+
+  describe("when featureFlagService returns false", () => {
+    it("returns false", async () => {
+      const ffs = createMockFeatureFlagService();
+      ffs.isEnabled.mockResolvedValue(false);
+
+      const result = await isComponentDisabled({
+        featureFlagService: ffs as any,
+        aggregateType: TEST_AGGREGATE_TYPE,
+        componentType: "projection",
+        componentName: "test",
+        tenantId: "tenant-1",
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("when customKey is provided", () => {
+    it("uses customKey instead of generated key", async () => {
+      const ffs = createMockFeatureFlagService();
+
+      await isComponentDisabled({
+        featureFlagService: ffs as any,
+        aggregateType: TEST_AGGREGATE_TYPE,
+        componentType: "command",
+        componentName: "test",
+        tenantId: "tenant-1",
+        customKey: "my-custom-flag",
+      });
+
+      expect(ffs.isEnabled).toHaveBeenCalledWith(
+        "my-custom-flag",
+        "tenant-1",
+        false,
+      );
+    });
+  });
+
+  describe("when featureFlagService throws", () => {
+    it("returns false as safe default", async () => {
+      const ffs = createMockFeatureFlagService();
+      ffs.isEnabled.mockRejectedValue(new Error("Feature flag service down"));
+
+      const result = await isComponentDisabled({
+        featureFlagService: ffs as any,
+        aggregateType: TEST_AGGREGATE_TYPE,
+        componentType: "command",
+        componentName: "test",
+        tenantId: "tenant-1",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("logs warning when logger is provided", async () => {
+      const ffs = createMockFeatureFlagService();
+      ffs.isEnabled.mockRejectedValue(new Error("Service unavailable"));
+      const logger = createMockLogger();
+
+      await isComponentDisabled({
+        featureFlagService: ffs as any,
+        aggregateType: TEST_AGGREGATE_TYPE,
+        componentType: "command",
+        componentName: "test",
+        tenantId: "tenant-1",
+        logger,
+      });
+
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("returns false without crash when no logger", async () => {
+      const ffs = createMockFeatureFlagService();
+      ffs.isEnabled.mockRejectedValue(new Error("Boom"));
+
+      const result = await isComponentDisabled({
+        featureFlagService: ffs as any,
+        aggregateType: TEST_AGGREGATE_TYPE,
+        componentType: "command",
+        componentName: "test",
+        tenantId: "tenant-1",
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 18 new test files (165 tests) covering previously untested event sourcing framework components and pipeline handlers
- Framework core: error handling utilities, kill switch, map projection executor, command dispatcher, graceful shutdown
- Pipeline commands: all 7 simulation commands, all 3 suite run commands
- Reactor: experiment run ES sync reactor (feature flags, retry logic, all event types)
- Infrastructure: GroupQueue orchestration (send, dedup, close, sequential/parallel processing), suite run pipeline integration

## Test plan

- [x] All 16 unit tests pass locally (155 tests): `pnpm test:unit`
- [x] GroupQueue integration test passes with testcontainers (6 tests)
- [ ] Suite run integration test requires full CI env (follows existing evaluation processing pattern)
- [x] No existing tests broken