### PR TITLE
fix(clickhouse): increase connection pool to prevent stream sharing errors

### DIFF
--- a/langwatch/src/server/app-layer/clients/clickhouse.factory.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse.factory.ts
@@ -21,7 +21,7 @@ export function createClickHouseClientFromConfig(
   const raw = createClient({
     url,
     clickhouse_settings: { date_time_input_format: "best_effort" },
-    max_open_connections: 50,
+    max_open_connections: 25,
     keep_alive: {
       enabled: true,
       idle_socket_ttl: 1500,

--- a/langwatch/src/server/clickhouse/client.ts
+++ b/langwatch/src/server/clickhouse/client.ts
@@ -44,7 +44,7 @@ export function getClickHouseClient(): ClickHouseClient | null {
       clickhouse_settings: {
         date_time_input_format: "best_effort",
       },
-      max_open_connections: 50,
+      max_open_connections: 25,
       keep_alive: {
         enabled: true,
         idle_socket_ttl: 1500,


### PR DESCRIPTION
## Summary
- Increases `max_open_connections` from default 10 to 50 in both ClickHouse client creation sites (`client.ts` and `clickhouse.factory.ts`)
- Lowers `keep_alive.idle_socket_ttl` from default 2500ms to 1500ms to retire idle sockets sooner
- Fixes repeated ClickHouse errors: `"Request stream is shared by multiple threads. HTTP keep alive is not possible."`

## Root cause
Under high concurrency, the default 10-connection pool becomes saturated. When the pool runs out of idle connections, a connection still considered in-flight by the server gets reused, triggering the error.

## Test plan
- [ ] Deploy and monitor ClickHouse logs — the "Request stream is shared by multiple threads" error should stop or significantly decrease
- [ ] Monitor `clickhouse_connections_active` metric to ensure the pool isn't exhausting connections