### PR TITLE
fix(dataset): honor entrySelection 'first' in getFullDataset

### DIFF
--- a/langwatch/src/server/api/routers/datasetRecord.utils.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.utils.ts
@@ -221,13 +221,16 @@ export const getFullDataset = async ({
     });
 
     if (
+      entrySelection === "first" ||
       entrySelection === "random" ||
       entrySelection === "last" ||
       typeof entrySelection === "number"
     ) {
       let skip = 0;
 
-      if (entrySelection === "last") {
+      if (entrySelection === "first") {
+        skip = 0;
+      } else if (entrySelection === "last") {
         skip = Math.max(count - 1, 0);
       } else if (entrySelection === "random") {
         skip = Math.floor(Math.random() * count);


### PR DESCRIPTION
## Summary
- handle `entrySelection === first` in `getFullDataset` single-record branch
- keep first-record behavior explicit with `skip = 0`
- preserve existing behavior for `last`, `random`, and numeric selections

## Issue linkage
Fixes #2162

## Validation
- `git diff --check` ✅

## Notes on broader checks
- `pnpm dlx @biomejs/biome@2.3.8 check src/server/api/routers/datasetRecord.utils.ts` was attempted, but Biome surfaced project-wide internal type-limit diagnostics in unrelated files in this fresh clone environment, so a clean lint pass could not be completed here.