### PR TITLE
fix: restore Chakra default shadows for light mode

### DIFF
--- a/langwatch/src/pages/_app.tsx
+++ b/langwatch/src/pages/_app.tsx
@@ -474,48 +474,6 @@ export const system = createSystem(defaultConfig, {
           },
         },
       },
-      shadows: {
-        "2xs": {
-          value: {
-            _light:
-              "0 0 0 0 #000, 0 0 0 0 #000, 0px 1px 2px 0px rgba(0, 0, 0, 0.03)",
-            _dark:
-              "0 0 0 0 #000, 0 0 0 0 #000, 0px 1px 2px 0px rgba(0, 0, 0, 0.15)",
-          },
-        },
-        xs: {
-          value: {
-            _light:
-              "0 0 0 0 #000, 0 0 0 0 #000, 0px 1px 5px 0px rgba(0, 0, 0, 0.05)",
-            _dark:
-              "0 0 0 0 #000, 0 0 0 0 #000, 0px 1px 5px 0px rgba(0, 0, 0, 0.25)",
-          },
-        },
-        sm: {
-          value: {
-            _light:
-              "1px 1px 2px color-mix(in srgb, var(--chakra-colors-gray-900) 15%, transparent), 0px 0px 1px color-mix(in srgb, var(--chakra-colors-gray-900) 30%, transparent)",
-            _dark:
-              "1px 1px 3px rgba(0, 0, 0, 0.4), 0px 0px 1px rgba(0, 0, 0, 0.6)",
-          },
-        },
-        md: {
-          value: {
-            _light:
-              "0px 4px 6px -1px rgba(0, 0, 0, 0.1), 0px 2px 4px -2px rgba(0, 0, 0, 0.1)",
-            _dark:
-              "0px 4px 6px -1px rgba(0, 0, 0, 0.4), 0px 2px 4px -2px rgba(0, 0, 0, 0.3)",
-          },
-        },
-        lg: {
-          value: {
-            _light:
-              "0px 10px 15px -3px rgba(0, 0, 0, 0.1), 0px 4px 6px -4px rgba(0, 0, 0, 0.1)",
-            _dark:
-              "0px 10px 15px -3px rgba(0, 0, 0, 0.4), 0px 4px 6px -4px rgba(0, 0, 0, 0.3)",
-          },
-        },
-      },
     },
     recipes: {
       heading: defineRecipe({


### PR DESCRIPTION
## Summary
- Remove custom shadow overrides (2xs, xs, sm, md, lg) that produced weaker shadows than Chakra's built-in defaults
- Chakra's default shadows use `{colors.gray.900/10}` + `{colors.gray.900/30}` color-mix, producing richer depth in light mode
- Dark mode also benefits from Chakra's built-in dark shadow handling

## Test plan
- [x] Verify card shadows on prompts page match production depth
- [x] Verify suites page content box shadow is visible
- [x] Check dark mode shadows still look good