### PR TITLE
fix(scenarios): include hostname in 'Unable to resolve hostname' errors

### DIFF
--- a/langwatch/src/utils/ssrfProtection.ts
+++ b/langwatch/src/utils/ssrfProtection.ts
@@ -473,7 +473,7 @@ export function createSSRFValidator(config: SSRFConfig) {
         "DNS resolution failed during SSRF check - blocking request",
       );
       throw new Error(
-        "Unable to resolve hostname. Please verify the URL is correct and the server is reachable.",
+        `Unable to resolve hostname "${hostname}". Please verify the URL is correct and the server is reachable.`,
       );
     }
 
@@ -490,7 +490,7 @@ export function createSSRFValidator(config: SSRFConfig) {
         "No DNS records found - blocking request",
       );
       throw new Error(
-        "Unable to resolve hostname. Please verify the URL is correct.",
+        `Unable to resolve hostname "${hostname}". Please verify the URL is correct.`,
       );
     }
 


### PR DESCRIPTION
## Summary
- Include the hostname in "Unable to resolve hostname" error messages from the SSRF protection layer, so users can see which URL failed to resolve
- The original issue was a user-configured hostname that was simply invalid — the SSRF layer correctly rejected it, but the error gave no indication of *which* hostname failed

Closes #2525

## Test plan
- [x] Unit tests pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)