### PR TITLE
fix(ui): target project dropdown opens behind Replicate Workflow modal

### DIFF
--- a/langwatch/src/components/ui/ReplicateToProjectDialog.tsx
+++ b/langwatch/src/components/ui/ReplicateToProjectDialog.tsx
@@ -125,7 +125,7 @@ export function ReplicateToProjectDialog({
                 <Select.Trigger>
                   <Select.ValueText placeholder="Select project" />
                 </Select.Trigger>
-                <Select.Content zIndex="popover" paddingY={2}>
+                <Select.Content zIndex={1501} paddingY={2}>
                   {projectCollection.items.map((proj) => {
                     const perm = proj.hasCreatePermission;
                     return (


### PR DESCRIPTION
## Summary
- Fix z-index on Target Project `Select.Content` in `ReplicateToProjectDialog` from `"popover"` (1000) to `1501`, so it renders above the modal overlay (z-index 1400)
- Follows established pattern from #2469/#2470 (optimizer dropdown fix)

Closes #2505

## Test plan
- [ ] Open Replicate Workflow modal
- [ ] Click "Target Project" dropdown
- [ ] Verify dropdown renders above the modal and is selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2505