### PR TITLE
fix: use tool mode for AI scenario generation to prevent schema mismatch

### DIFF
--- a/langwatch/src/app/api/scenario/generate/__tests__/route.unit.test.ts
+++ b/langwatch/src/app/api/scenario/generate/__tests__/route.unit.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { generateObject } from "ai";
+
+vi.mock("ai", () => ({
+  generateObject: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn().mockResolvedValue({ user: { id: "user-1" } }),
+}));
+
+vi.mock("../../../../../server/auth", () => ({
+  authOptions: vi.fn(),
+}));
+
+vi.mock("../../../../../server/api/rbac", () => ({
+  hasProjectPermission: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../../../../server/db", () => ({
+  prisma: {},
+}));
+
+vi.mock("../../../../../server/modelProviders/utils", () => ({
+  getVercelAIModel: vi.fn().mockResolvedValue({ modelId: "test-model" }),
+}));
+
+vi.mock("../../../../../utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+import { POST } from "../route";
+
+function createRequest(body: unknown): Request {
+  return new Request("http://localhost/api/scenario/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/scenario/generate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when generating a scenario", () => {
+    it("calls generateObject with mode 'tool' for cross-provider compatibility", async () => {
+      const mockResult = {
+        object: {
+          name: "Test Scenario",
+          situation: "A test situation",
+          criteria: ["criterion 1"],
+        },
+      };
+
+      (generateObject as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockResult
+      );
+
+      await POST(
+        createRequest({
+          prompt: "Generate a test scenario",
+          currentScenario: null,
+          projectId: "project-123",
+        }) as never
+      );
+
+      expect(generateObject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "tool",
+        })
+      );
+    });
+  });
+});

--- a/langwatch/src/app/api/scenario/generate/route.ts
+++ b/langwatch/src/app/api/scenario/generate/route.ts
@@ -109,6 +109,7 @@ export async function POST(req: NextRequest) {
 
     const result = await generateObject({
       model,
+      mode: "tool",
       schema: scenarioSchema,
       system: SYSTEM_PROMPT,
       prompt: userPrompt,

--- a/langwatch/src/components/scenarios/services/__tests__/scenarioGeneration.unit.test.ts
+++ b/langwatch/src/components/scenarios/services/__tests__/scenarioGeneration.unit.test.ts
@@ -122,5 +122,41 @@ describe("generateScenarioWithAI()", () => {
         generateScenarioWithAI("test prompt", "project-123", null)
       ).rejects.toThrow("Invalid response: missing scenario data");
     });
+
+    it("throws error when criteria contains objects instead of strings", async () => {
+      const malformedScenario = {
+        name: "Test Scenario",
+        situation: "A situation",
+        criteria: [
+          { criterion: "Agent acknowledges the error" },
+          { criterion: "Agent offers a solution" },
+        ],
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ scenario: malformedScenario }),
+      });
+
+      await expect(
+        generateScenarioWithAI("test prompt", "project-123", null)
+      ).rejects.toThrow("Invalid scenario data");
+    });
+
+    it("throws error when name is missing", async () => {
+      const malformedScenario = {
+        situation: "A situation",
+        criteria: ["criterion 1"],
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ scenario: malformedScenario }),
+      });
+
+      await expect(
+        generateScenarioWithAI("test prompt", "project-123", null)
+      ).rejects.toThrow("Invalid scenario data");
+    });
   });
 });

--- a/langwatch/src/components/scenarios/services/scenarioGeneration.ts
+++ b/langwatch/src/components/scenarios/services/scenarioGeneration.ts
@@ -1,15 +1,20 @@
+import { z } from "zod";
+
 // ─────────────────────────────────────────────────────────────────────────────
-// Types
+// Schema & Types
 // ─────────────────────────────────────────────────────────────────────────────
+
+/** Zod schema for validating AI-generated scenario responses */
+export const generatedScenarioSchema = z.object({
+  name: z.string(),
+  situation: z.string(),
+  criteria: z.array(z.string()),
+});
 
 /**
  * Represents a generated scenario from the AI
  */
-export type GeneratedScenario = {
-  name: string;
-  situation: string;
-  criteria: string[];
-};
+export type GeneratedScenario = z.infer<typeof generatedScenarioSchema>;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Service
@@ -52,5 +57,10 @@ export async function generateScenarioWithAI(
     throw new Error("Invalid response: missing scenario data");
   }
 
-  return data.scenario;
+  const parsed = generatedScenarioSchema.safeParse(data.scenario);
+  if (!parsed.success) {
+    throw new Error(`Invalid scenario data: ${parsed.error.message}`);
+  }
+
+  return parsed.data;
 }


### PR DESCRIPTION
## Summary
- Switches `generateObject` from default `json` mode to explicit `tool` mode for reliable cross-provider structured output through litellm
- Adds client-side Zod validation as defense-in-depth to catch malformed AI responses before they reach the form
- Adds regression tests covering the mode change and malformed response rejection

## What was the bug?
The AI scenario generation modal failed with "object schema mismatch" when the project's default model provider didn't properly support `response_format: { type: "json_object" }` through litellm. The LLM would return criteria as objects (`[{criterion: "..."}]`) instead of strings (`["..."]`).

## How it was fixed
1. **Server**: Added `mode: "tool"` to the `generateObject` call, which uses function calling to constrain output to the exact Zod schema
2. **Client**: Added Zod `safeParse` validation in `generateScenarioWithAI` to reject malformed responses early with clear error messages

## Test plan
- [x] Regression test verifies `generateObject` is called with `mode: "tool"`
- [x] Regression test verifies criteria containing objects (instead of strings) is rejected
- [x] Regression test verifies missing required fields are rejected
- [x] All 9 tests pass

Closes #2284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2284