### PR TITLE
fix: harden private dataplane routing against data leakage and config errors

### DIFF
--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import type { ClickHouseClient } from "@clickhouse/client";
-import { getClickHouseClientForProject, type ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import { getClickHouseClientForProject, isClickHouseEnabled, type ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { esClient, TRACE_INDEX, traceIndexId } from "../elasticsearch";
 import { EventSourcing } from "../event-sourcing";
 import { PipelineRegistry, type AppCommands } from "../event-sourcing/pipelineRegistry";
@@ -88,7 +88,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
   const { prisma } = require("../db") as { prisma: PrismaClient; };
   const config = createAppConfigFromEnv({ processRole: options?.processRole });
 
-  const clickhouseEnabled = !!(config.enableClickhouse && config.clickhouseUrl);
+  const clickhouseEnabled = !!(config.enableClickhouse && config.clickhouseUrl) || isClickHouseEnabled();
 
   // Resolver: given a tenantId (projectId), returns the right ClickHouse client
   const resolveClickHouseClient: ClickHouseClientResolver = async (tenantId: string): Promise<ClickHouseClient> => {

--- a/langwatch/src/server/app-layer/simulations/__tests__/date-filtering.unit.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/date-filtering.unit.test.ts
@@ -54,7 +54,7 @@ describe("SimulationClickHouseRepository date filtering", () => {
 
   beforeEach(() => {
     clickhouse = createMockClickHouse();
-    repo = new SimulationClickHouseRepository(clickhouse);
+    repo = new SimulationClickHouseRepository(async () => clickhouse);
   });
 
   describe("getRunDataForAllSuites()", () => {

--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -61,7 +61,7 @@ let repo: SimulationClickHouseRepository;
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
-  repo = new SimulationClickHouseRepository(ch);
+  repo = new SimulationClickHouseRepository(async () => ch);
 }, 60_000);
 
 afterAll(async () => {

--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.unit.test.ts
@@ -60,7 +60,7 @@ describe("SimulationClickHouseRepository", () => {
 
   beforeEach(() => {
     clickhouse = createMockClickHouse();
-    repo = new SimulationClickHouseRepository(clickhouse);
+    repo = new SimulationClickHouseRepository(async () => clickhouse);
   });
 
   describe("getBatchRunCountForScenarioSet()", () => {

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -125,13 +125,10 @@ interface CursorPayload {
 }
 
 export class SimulationClickHouseRepository implements SimulationRepository {
-  constructor(private readonly clickhouseOrResolver: ClickHouseClient | ClickHouseClientResolver) {}
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
 
   private async getClient(tenantId: string): Promise<ClickHouseClient> {
-    if (typeof this.clickhouseOrResolver === "function") {
-      return this.clickhouseOrResolver(tenantId);
-    }
-    return this.clickhouseOrResolver;
+    return this.resolveClient(tenantId);
   }
 
   private async queryRows<T>(

--- a/langwatch/src/server/app-layer/suites/repositories/suite-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/suites/repositories/suite-run.clickhouse.repository.ts
@@ -4,13 +4,10 @@ import type { SuiteRunStateData } from "~/server/event-sourcing/pipelines/suite-
 import type { SuiteRunReadRepository } from "./suite-run.repository";
 
 export class SuiteRunClickHouseRepository implements SuiteRunReadRepository {
-  constructor(private readonly clickhouseOrResolver: ClickHouseClient | ClickHouseClientResolver) {}
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
 
   private async getClient(tenantId: string): Promise<ClickHouseClient> {
-    if (typeof this.clickhouseOrResolver === "function") {
-      return this.clickhouseOrResolver(tenantId);
-    }
-    return this.clickhouseOrResolver;
+    return this.resolveClient(tenantId);
   }
 
   async getSuiteRunState(params: {

--- a/langwatch/src/server/clickhouse/clickhouseClient.ts
+++ b/langwatch/src/server/clickhouse/clickhouseClient.ts
@@ -1,4 +1,5 @@
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
+import { createResilientClickHouseClient } from "~/server/app-layer/clients/clickhouse.resilient";
 import { createLogger } from "~/utils/logger/server";
 import { prisma } from "../db";
 import { _getSharedClickHouseClient } from "./client";
@@ -32,7 +33,12 @@ const privateClickHouseUrls = parsePrivateClickHouseEnvVars();
 function parsePrivateClickHouseEnvVars(): Map<string, string> {
   const map = new Map<string, string>();
   for (const [key, value] of Object.entries(process.env)) {
-    if (!key.startsWith(PRIVATE_CH_ENV_PREFIX) || !value) continue;
+    if (!key.startsWith(PRIVATE_CH_ENV_PREFIX)) continue;
+
+    if (!value || value.trim() === "") {
+      logger.warn({ envVar: key }, "Skipping private ClickHouse env var: empty value");
+      continue;
+    }
 
     // Format: CLICKHOUSE_URL__<label>__<orgId>
     // Strip prefix, then take the last segment after "__" as orgId
@@ -40,10 +46,16 @@ function parsePrivateClickHouseEnvVars(): Map<string, string> {
     const lastSep = suffix.lastIndexOf("__");
     const orgId = lastSep >= 0 ? suffix.slice(lastSep + 2) : suffix;
 
-    if (orgId) {
-      map.set(orgId, value);
-      logger.info({ orgId, envVar: key }, "Loaded private ClickHouse URL from env var");
+    if (!orgId) continue;
+
+    if (map.has(orgId)) {
+      throw new Error(
+        `Duplicate private ClickHouse config for orgId "${orgId}": env var "${key}" conflicts with an earlier definition. Each orgId must map to exactly one ClickHouse URL.`,
+      );
     }
+
+    map.set(orgId, value);
+    logger.info({ orgId, envVar: key }, "Loaded private ClickHouse URL from env var");
   }
   if (map.size > 0) {
     logger.info({ count: map.size }, "Private ClickHouse instances configured");
@@ -74,7 +86,9 @@ export async function getClickHouseClientForProject(
       select: { team: { select: { organizationId: true } } },
     });
     if (!project) {
-      return _getSharedClickHouseClient();
+      throw new Error(
+        `Cannot resolve ClickHouse client: project "${projectId}" not found. Refusing to fall back to shared client to prevent data leakage.`,
+      );
     }
     orgId = project.team.organizationId;
     projectOrgCache.set(projectId, orgId);
@@ -115,7 +129,16 @@ export async function getAllClickHouseInstances(): Promise<Array<{
     instances.push({ target: "shared", client: shared });
   }
 
+  const seenUrls = new Set<string>();
   for (const [orgId, url] of privateClickHouseUrls) {
+    if (seenUrls.has(url)) {
+      logger.info(
+        { orgId, url },
+        "Skipping duplicate private ClickHouse URL (already included for another org)",
+      );
+      continue;
+    }
+    seenUrls.add(url);
     instances.push({
       target: orgId,
       client: getOrCreateCustomClient(orgId, url),
@@ -126,11 +149,11 @@ export async function getAllClickHouseInstances(): Promise<Array<{
 }
 
 /**
- * Returns whether the shared ClickHouse instance is configured and available.
- * Use for feature-gating (e.g., deciding Real vs Null repository).
+ * Returns whether any ClickHouse instance is configured and available
+ * (shared or private). Use for feature-gating (e.g., deciding Real vs Null repository).
  */
 export function isClickHouseEnabled(): boolean {
-  return _getSharedClickHouseClient() !== null;
+  return _getSharedClickHouseClient() !== null || privateClickHouseUrls.size > 0;
 }
 
 /** Re-export for infrastructure-only use (metrics collection, not tenant data). */
@@ -156,13 +179,14 @@ function getOrCreateCustomClient(
     // If not a valid URL, pass raw — ClickHouse client may still accept it
   }
 
-  const client = createClient({
+  const raw = createClient({
     url: parsedUrl,
     clickhouse_settings: {
       date_time_input_format: "best_effort",
     },
   });
 
+  const client = createResilientClickHouseClient({ client: raw });
   customClientCache.set(organizationId, client);
   return client;
 }

--- a/langwatch/src/server/dataplane-s3.ts
+++ b/langwatch/src/server/dataplane-s3.ts
@@ -10,18 +10,21 @@
  * When no private config exists for an organization, callers fall back to the
  * shared S3 env vars (S3_ENDPOINT, S3_BUCKET_NAME, etc.).
  */
+import { z } from "zod";
 import { createLogger } from "~/utils/logger/server";
 import { prisma } from "./db";
 
 const logger = createLogger("langwatch:dataplane:s3");
 
+const dataplaneS3ConfigSchema = z.object({
+  endpoint: z.string().min(1, "endpoint must not be empty"),
+  bucket: z.string().min(1, "bucket must not be empty"),
+  accessKeyId: z.string().min(1, "accessKeyId must not be empty"),
+  secretAccessKey: z.string().min(1, "secretAccessKey must not be empty"),
+});
+
 /** Configuration for a private S3 dataplane bucket. */
-export interface DataplaneS3Config {
-  endpoint: string;
-  bucket: string;
-  accessKeyId: string;
-  secretAccessKey: string;
-}
+export type DataplaneS3Config = z.infer<typeof dataplaneS3ConfigSchema>;
 
 const PRIVATE_S3_ENV_PREFIX = "DATAPLANE_S3__";
 
@@ -59,20 +62,22 @@ function parsePrivateS3EnvVars(): Map<string, DataplaneS3Config> {
       continue;
     }
 
-    if (!isValidS3Config(parsed)) {
+    const result = dataplaneS3ConfigSchema.safeParse(parsed);
+    if (!result.success) {
       logger.warn(
-        { orgId, envVar: key },
-        "Skipping private S3 config: missing required fields (endpoint, bucket, accessKeyId, secretAccessKey)",
+        { orgId, envVar: key, errors: result.error.flatten().fieldErrors },
+        "Skipping private S3 config: validation failed",
       );
       continue;
     }
 
-    map.set(orgId, {
-      endpoint: parsed.endpoint,
-      bucket: parsed.bucket,
-      accessKeyId: parsed.accessKeyId,
-      secretAccessKey: parsed.secretAccessKey,
-    });
+    if (map.has(orgId)) {
+      throw new Error(
+        `Duplicate private S3 config for orgId "${orgId}": env var "${key}" conflicts with an earlier definition. Each orgId must map to exactly one S3 config.`,
+      );
+    }
+
+    map.set(orgId, result.data);
     logger.info(
       { orgId, envVar: key },
       "Loaded private S3 config from env var",
@@ -87,26 +92,6 @@ function parsePrivateS3EnvVars(): Map<string, DataplaneS3Config> {
   }
 
   return map;
-}
-
-function isValidS3Config(
-  value: unknown,
-): value is {
-  endpoint: string;
-  bucket: string;
-  accessKeyId: string;
-  secretAccessKey: string;
-} {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.endpoint === "string" &&
-    typeof obj.bucket === "string" &&
-    typeof obj.accessKeyId === "string" &&
-    typeof obj.secretAccessKey === "string"
-  );
 }
 
 /** Cache of projectId -> organizationId to avoid repeated DB lookups. */

--- a/langwatch/src/server/event-sourcing/__tests__/integration/testHelpers.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/integration/testHelpers.ts
@@ -76,7 +76,7 @@ export function createTestPipeline(): PipelineWithCommandHandlers<
 
   // Create stores
   const eventStore = new EventStoreClickHouse(
-    new EventRepositoryClickHouse(clickHouseClient),
+    new EventRepositoryClickHouse(async () => clickHouseClient),
   );
 
   const eventSourcing = EventSourcing.createWithStores({

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/__tests__/evaluationProcessing.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/__tests__/evaluationProcessing.integration.test.ts
@@ -146,7 +146,7 @@ function createEvaluationTestPipeline(): PipelineWithCommandHandlers<
 
   // Create stores
   const eventStore = new EventStoreClickHouse(
-    new EventRepositoryClickHouse(clickHouseClient),
+    new EventRepositoryClickHouse(async () => clickHouseClient),
   );
 
   const eventSourcing = EventSourcing.createWithStores({

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/__tests__/experimentRunProcessing.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/__tests__/experimentRunProcessing.integration.test.ts
@@ -67,7 +67,7 @@ function createExperimentRunTestPipeline(): PipelineWithCommandHandlers<
   }
 
   const eventStore = new EventStoreClickHouse(
-    new EventRepositoryClickHouse(clickHouseClient),
+    new EventRepositoryClickHouse(async () => clickHouseClient),
   );
 
   const eventSourcing = EventSourcing.createWithStores({

--- a/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/__tests__/suiteRunProcessing.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/__tests__/suiteRunProcessing.integration.test.ts
@@ -115,7 +115,7 @@ function createSuiteRunTestPipeline(): PipelineWithCommandHandlers<
 
   // Create stores
   const eventStore = new EventStoreClickHouse(
-    new EventRepositoryClickHouse(clickHouseClient),
+    new EventRepositoryClickHouse(async () => clickHouseClient),
   );
 
   const eventSourcing = EventSourcing.createWithStores({

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/traceProcessing.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/traceProcessing.integration.test.ts
@@ -111,7 +111,7 @@ function createTraceTestPipeline(): PipelineWithCommandHandlers<
   }
 
   const eventStore = new EventStoreClickHouse(
-    new EventRepositoryClickHouse(clickHouseClient),
+    new EventRepositoryClickHouse(async () => clickHouseClient),
   );
 
   const eventSourcing = EventSourcing.createWithStores({

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.integration.test.ts
@@ -133,7 +133,7 @@ describe.skipIf(!hasTestcontainers)(
       // instances causes competing global queue consumers where one skips
       // the other's jobs as "unknown pipeline".
       const eventStore = new EventStoreClickHouse(
-        new EventRepositoryClickHouse(clickHouseClient),
+        new EventRepositoryClickHouse(async () => clickHouseClient),
       );
       const eventSourcing = EventSourcing.createWithStores({
         eventStore,

--- a/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.countEventsBefore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.countEventsBefore.unit.test.ts
@@ -20,7 +20,7 @@ describe("EventStoreClickHouse - countEventsBefore", () => {
     } as unknown as ClickHouseClient;
 
     store = new EventStoreClickHouse(
-      new EventRepositoryClickHouse(mockClickHouseClient),
+      new EventRepositoryClickHouse(async () => mockClickHouseClient),
     );
   });
 

--- a/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryClickHouse.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryClickHouse.test.ts
@@ -29,7 +29,7 @@ describe("EventRepositoryClickHouse.getEventRecords", () => {
       },
     });
 
-    const repository = new EventRepositoryClickHouse(client);
+    const repository = new EventRepositoryClickHouse(async () => client);
     const rows = await repository.getEventRecords("tenant", "agg", "id");
 
     expect(rows[0]?.EventPayload).toEqual({
@@ -47,7 +47,7 @@ describe("EventRepositoryClickHouse.getEventRecords", () => {
       }),
     );
 
-    const repository = new EventRepositoryClickHouse(client);
+    const repository = new EventRepositoryClickHouse(async () => client);
     const rows = await repository.getEventRecords("tenant", "agg", "id");
 
     expect(rows[0]?.EventPayload).toEqual(

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
@@ -60,13 +60,10 @@ export class EventRepositoryClickHouse implements EventRepository {
     "langwatch:trace-processing:event-repository:clickhouse",
   );
 
-  constructor(private readonly clickHouseClientOrResolver: ClickHouseClient | ClickHouseClientResolver) {}
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
 
   private async getClient(tenantId: string): Promise<ClickHouseClient> {
-    if (typeof this.clickHouseClientOrResolver === "function") {
-      return this.clickHouseClientOrResolver(tenantId);
-    }
-    return this.clickHouseClientOrResolver;
+    return this.resolveClient(tenantId);
   }
 
   async getEventRecords(


### PR DESCRIPTION
## Summary

Addresses all CodeRabbit review findings from #2535 (9 major/critical issues + 1 minor).

## Fixes

**Critical:**
- `ClickHouseClientResolver` type kept as non-null `Promise<ClickHouseClient>` — resolver in presets.ts throws if client is null, preventing silent null dereference in repositories

**Major (data isolation):**
- `getClickHouseClientForProject()` throws on unknown projectId instead of falling back to shared client — prevents data leaking to wrong instance
- `isClickHouseEnabled()` now checks both shared AND private routes — private-only deployments work correctly
- `clickhouseEnabled` in presets.ts accounts for private-only deployments via `isClickHouseEnabled()`

**Major (config safety):**
- Duplicate org routes in `CLICKHOUSE_URL__*` env vars throw at startup instead of silently overwriting
- Duplicate org routes in `DATAPLANE_S3__*` env vars throw at startup
- `getAllClickHouseInstances()` deduplicates by URL — prevents running migrations twice on the same backend

**Major (type safety):**
- All 3 repositories with `ClickHouseClient | ClickHouseClientResolver` union now accept only `ClickHouseClientResolver` — no escape hatch bypassing per-org routing
- 11 test files updated to wrap raw clients in `async () => client` resolvers

**Major (resilience):**
- Private ClickHouse clients now wrapped with `createResilientClickHouseClient` — same retry-with-backoff as shared client

**Minor:**
- S3 config validation uses Zod schema with `min(1)` — catches empty string values that manual check allowed

## Test plan

- [x] Typecheck clean
- [x] 5/5 integration tests pass (ClickHouse routing with 2 containers)
- [x] 38 unit tests pass (including updated repository tests)