### PR TITLE
feat(skills): multi-assistant adapter pattern for scenario tests

### DIFF
--- a/skills/_tests/analytics.scenario.test.ts
+++ b/skills/_tests/analytics.scenario.test.ts
@@ -6,10 +6,8 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import {
-  createClaudeCodeAgent,
-  toolCallFix,
-} from "./helpers/claude-code-adapter";
+import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,33 +15,26 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
+const runner = getRunner();
+const runnerUnavailable = !isRunnerAvailable();
 const judgeModel = openai("gpt-5-mini");
 
+const skillPath = path.resolve(__dirname, "../analytics/SKILL.md");
+
 describe("Analytics Skill", () => {
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable || !runner.capabilities.supportsMcp)(
     "queries agent performance from an empty directory",
     async () => {
       const tempFolder = fs.mkdtempSync(
         path.join(os.tmpdir(), "langwatch-skill-analytics-")
       );
 
-      const skillDir = path.join(tempFolder, ".skills", "analytics");
-      fs.mkdirSync(skillDir, { recursive: true });
-      fs.copyFileSync(
-        path.resolve(__dirname, "../analytics/SKILL.md"),
-        path.join(skillDir, "SKILL.md")
-      );
-      const sharedDir = path.join(skillDir, "_shared");
-      fs.mkdirSync(sharedDir, { recursive: true });
-      const sharedSrc = path.resolve(__dirname, "../_shared");
-      fs.cpSync(sharedSrc, sharedDir, { recursive: true });
-
       const result = await scenario.run({
         name: "Agent performance analytics",
         description:
           "User wants to understand how their agent has been performing.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,

--- a/skills/_tests/evaluations.scenario.test.ts
+++ b/skills/_tests/evaluations.scenario.test.ts
@@ -7,7 +7,7 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { createAgent, isRunnerAvailable } from "./helpers/agent-factory";
 import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -16,7 +16,6 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
-const runner = getRunner();
 const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");

--- a/skills/_tests/evaluations.scenario.test.ts
+++ b/skills/_tests/evaluations.scenario.test.ts
@@ -7,10 +7,8 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import {
-  createClaudeCodeAgent,
-  toolCallFix,
-} from "./helpers/claude-code-adapter";
+import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,22 +16,12 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
+const runner = getRunner();
+const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");
 
-function copySkillToWorkDir(tempFolder: string) {
-  const skillDir = path.join(tempFolder, ".skills", "evaluations");
-  fs.mkdirSync(skillDir, { recursive: true });
-  fs.copyFileSync(
-    path.resolve(__dirname, "../evaluations/SKILL.md"),
-    path.join(skillDir, "SKILL.md")
-  );
-  const sharedDir = path.join(skillDir, "_shared");
-  fs.mkdirSync(sharedDir, { recursive: true });
-  execSync(
-    `cp -r ${path.resolve(__dirname, "../_shared")}/* ${sharedDir}/`
-  );
-}
+const skillPath = path.resolve(__dirname, "../evaluations/SKILL.md");
 
 function findNewPythonFiles(dir: string, excludeNames: string[] = ["main.py"]): string[] {
   const results: string[] = [];
@@ -60,7 +48,7 @@ function findNewPythonFiles(dir: string, excludeNames: string[] = ["main.py"]): 
 }
 
 describe("Evaluations Skill", () => {
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates an evaluation experiment for a Python OpenAI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -70,14 +58,13 @@ describe("Evaluations Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python OpenAI evaluation experiment",
         description:
           "Creating an evaluation experiment for a Python OpenAI chatbot that replies with tweet-like responses and emojis.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -123,7 +110,7 @@ describe("Evaluations Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates an evaluation experiment for a TypeScript Vercel AI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -133,14 +120,13 @@ describe("Evaluations Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-vercel")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Vercel AI evaluation experiment",
         description:
           "Creating an evaluation experiment for a TypeScript Vercel AI chatbot.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -181,7 +167,7 @@ describe("Evaluations Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates an evaluation experiment for a Python LangGraph agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -190,14 +176,13 @@ describe("Evaluations Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-langgraph")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python LangGraph evaluation experiment",
         description:
           "Creating an evaluation experiment for a Python LangGraph agent.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -232,7 +217,7 @@ describe("Evaluations Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates a targeted evaluation for RAG faithfulness",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -241,14 +226,13 @@ describe("Evaluations Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Targeted RAG faithfulness evaluation",
         description:
           "Adding a specific evaluation for checking if the agent's responses are faithful to the context provided.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -280,7 +264,7 @@ describe("Evaluations Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates domain-specific evaluation for a RAG agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -289,14 +273,13 @@ describe("Evaluations Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-rag-agent")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "RAG agent domain-specific evaluation",
         description:
           "Creating an evaluation experiment for a TerraVerde farm advisory RAG agent.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,

--- a/skills/_tests/helpers/__tests__/agent-factory.unit.test.ts
+++ b/skills/_tests/helpers/__tests__/agent-factory.unit.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe("Agent Factory", () => {
+  describe("getRunner()", () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.AGENT_UNDER_TEST;
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.AGENT_UNDER_TEST;
+      } else {
+        process.env.AGENT_UNDER_TEST = originalEnv;
+      }
+      vi.resetModules();
+    });
+
+    describe("when AGENT_UNDER_TEST is not set", () => {
+      it("defaults to the Claude Code runner", async () => {
+        delete process.env.AGENT_UNDER_TEST;
+        const { getRunner } = await import("../agent-factory.js");
+        const runner = getRunner();
+        expect(runner.name).toBe("claude-code");
+      });
+    });
+
+    describe("when AGENT_UNDER_TEST is set to 'codex'", () => {
+      it("selects the Codex runner", async () => {
+        process.env.AGENT_UNDER_TEST = "codex";
+        const { getRunner } = await import("../agent-factory.js");
+        const runner = getRunner();
+        expect(runner.name).toBe("codex");
+      });
+    });
+
+    describe("when AGENT_UNDER_TEST is set to 'claude-code'", () => {
+      it("selects the Claude Code runner", async () => {
+        process.env.AGENT_UNDER_TEST = "claude-code";
+        const { getRunner } = await import("../agent-factory.js");
+        const runner = getRunner();
+        expect(runner.name).toBe("claude-code");
+      });
+    });
+
+    describe("when AGENT_UNDER_TEST is set to an unknown value", () => {
+      it("throws an error listing valid names", async () => {
+        process.env.AGENT_UNDER_TEST = "unknown-assistant";
+        const { getRunner } = await import("../agent-factory.js");
+        expect(() => getRunner()).toThrow("unknown-assistant");
+        expect(() => getRunner()).toThrow("claude-code");
+        expect(() => getRunner()).toThrow("codex");
+      });
+    });
+  });
+
+  describe("createAgent()", () => {
+    describe("when called without AGENT_UNDER_TEST set", () => {
+      it("delegates to the default Claude Code runner", async () => {
+        delete process.env.AGENT_UNDER_TEST;
+        const { createAgent, getRunner } = await import(
+          "../agent-factory.js"
+        );
+        const runner = getRunner();
+        expect(runner.name).toBe("claude-code");
+      });
+    });
+  });
+});
+
+describe("Claude Code Runner", () => {
+  describe("capabilities", () => {
+    it("declares MCP support as true", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      expect(runner.capabilities.supportsMcp).toBe(true);
+    });
+
+    it("uses .skills as the skills directory", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      expect(runner.capabilities.skillsDirectory).toBe(".skills");
+    });
+
+    it("declares CLAUDE.md as the config file", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      expect(runner.capabilities.configFile).toBe("CLAUDE.md");
+    });
+  });
+
+  describe("buildArgs()", () => {
+    it("includes --output-format stream-json", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        mcpConfigPath: undefined,
+      });
+      expect(args).toContain("--output-format");
+      expect(args).toContain("stream-json");
+    });
+
+    it("includes -p for prompt mode", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        mcpConfigPath: undefined,
+      });
+      expect(args).toContain("-p");
+    });
+
+    it("includes --dangerously-skip-permissions and --verbose", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        mcpConfigPath: undefined,
+      });
+      expect(args).toContain("--dangerously-skip-permissions");
+      expect(args).toContain("--verbose");
+    });
+
+    it("includes --mcp-config when mcpConfigPath is provided", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      const args = runner.buildArgs({
+        prompt: "test",
+        mcpConfigPath: "/tmp/mcp.json",
+      });
+      expect(args).toContain("--mcp-config");
+      expect(args).toContain("/tmp/mcp.json");
+    });
+
+    it("omits --mcp-config when mcpConfigPath is undefined", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      const args = runner.buildArgs({
+        prompt: "test",
+        mcpConfigPath: undefined,
+      });
+      expect(args).not.toContain("--mcp-config");
+    });
+  });
+
+  describe("parseStreamJsonOutput()", () => {
+    it("extracts messages from stream-json NDJSON lines", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      const output = [
+        JSON.stringify({
+          message: { role: "assistant", content: "hello" },
+        }),
+        JSON.stringify({ type: "progress", data: "thinking..." }),
+        JSON.stringify({
+          message: { role: "assistant", content: "world" },
+        }),
+      ].join("\n");
+
+      const messages = runner.parseStreamJsonOutput(output);
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toEqual({ role: "assistant", content: "hello" });
+      expect(messages[1]).toEqual({ role: "assistant", content: "world" });
+    });
+
+    it("skips malformed JSON lines gracefully", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner();
+      const output = [
+        "not json",
+        JSON.stringify({
+          message: { role: "assistant", content: "ok" },
+        }),
+      ].join("\n");
+
+      const messages = runner.parseStreamJsonOutput(output);
+      expect(messages).toHaveLength(1);
+    });
+  });
+});
+
+describe("Codex Runner", () => {
+  describe("capabilities", () => {
+    it("declares MCP support as false", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+      expect(runner.capabilities.supportsMcp).toBe(false);
+    });
+
+    it("uses .agents/skills as the skills directory", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+      expect(runner.capabilities.skillsDirectory).toBe(".agents/skills");
+    });
+
+    it("has no config file", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+      expect(runner.capabilities.configFile).toBeUndefined();
+    });
+  });
+
+  describe("buildArgs()", () => {
+    it("includes exec --full-auto --json flags", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+      const args = runner.buildArgs({ prompt: "test prompt" });
+      expect(args).toContain("exec");
+      expect(args).toContain("--full-auto");
+      expect(args).toContain("--json");
+    });
+
+    it("includes the prompt as the last argument", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+      const args = runner.buildArgs({ prompt: "my test prompt" });
+      expect(args[args.length - 1]).toBe("my test prompt");
+    });
+  });
+
+  describe("parseJsonlOutput()", () => {
+    it("extracts assistant message content from item.completed events", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+
+      const fixtureContent = fs.readFileSync(
+        path.join(__dirname, "fixtures/codex-output.jsonl"),
+        "utf8"
+      );
+
+      const messages = runner.parseJsonlOutput(fixtureContent);
+
+      // Should have 2 assistant messages (the 2 item.completed with role "assistant")
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toEqual({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "I will help you instrument your code with LangWatch.",
+          },
+        ],
+      });
+      expect(messages[1]).toEqual({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Done! I added LangWatch tracing to your project.",
+          },
+        ],
+      });
+    });
+
+    it("ignores non-message events", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+
+      const output = [
+        JSON.stringify({ type: "thread.started", thread_id: "abc" }),
+        JSON.stringify({ type: "turn.completed", output: [] }),
+      ].join("\n");
+
+      const messages = runner.parseJsonlOutput(output);
+      expect(messages).toHaveLength(0);
+    });
+
+    it("skips malformed JSON lines gracefully", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+
+      const output = [
+        "not json",
+        JSON.stringify({
+          type: "item.completed",
+          item: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "hello" }],
+          },
+        }),
+      ].join("\n");
+
+      const messages = runner.parseJsonlOutput(output);
+      expect(messages).toHaveLength(1);
+    });
+  });
+
+  describe("when MCP is requested", () => {
+    it("proceeds without error and writes no MCP config", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      const runner = new CodexRunner();
+
+      const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "codex-mcp-test-")
+      );
+
+      // Creating an agent with skipMcp=false should not throw
+      // and should not write any MCP config file
+      expect(() =>
+        runner.createAgent({ workingDirectory: tempDir })
+      ).not.toThrow();
+
+      const mcpConfigPath = path.join(tempDir, ".mcp-config.json");
+      expect(fs.existsSync(mcpConfigPath)).toBe(false);
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+  });
+});
+
+describe("Skill Directory Placement", () => {
+  describe("when skillPath points to a SKILL.md with _shared/ sibling", () => {
+    let tempSkillSrc: string;
+    let tempWorkDir: string;
+
+    beforeEach(() => {
+      tempSkillSrc = fs.mkdtempSync(
+        path.join(os.tmpdir(), "skill-src-")
+      );
+      // Create skill structure: skillName/SKILL.md + _shared/
+      const skillDir = path.join(tempSkillSrc, "tracing");
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, "SKILL.md"),
+        "# Tracing Skill"
+      );
+
+      const sharedDir = path.join(tempSkillSrc, "_shared");
+      fs.mkdirSync(sharedDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sharedDir, "mcp-setup.md"),
+        "# MCP Setup"
+      );
+      fs.writeFileSync(
+        path.join(sharedDir, "api-key-setup.md"),
+        "# API Key"
+      );
+
+      tempWorkDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "skill-workdir-")
+      );
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempSkillSrc, { recursive: true, force: true });
+      fs.rmSync(tempWorkDir, { recursive: true, force: true });
+    });
+
+    it("copies SKILL.md to <skillsDir>/<name>/SKILL.md for Claude Code", async () => {
+      const { copySkillTree } = await import("../shared.js");
+      const skillPath = path.join(tempSkillSrc, "tracing", "SKILL.md");
+      copySkillTree({
+        skillPath,
+        workingDirectory: tempWorkDir,
+        skillsDirectory: ".skills",
+      });
+
+      const dest = path.join(tempWorkDir, ".skills", "tracing", "SKILL.md");
+      expect(fs.existsSync(dest)).toBe(true);
+      expect(fs.readFileSync(dest, "utf8")).toBe("# Tracing Skill");
+    });
+
+    it("copies _shared/ directory alongside the skill", async () => {
+      const { copySkillTree } = await import("../shared.js");
+      const skillPath = path.join(tempSkillSrc, "tracing", "SKILL.md");
+      copySkillTree({
+        skillPath,
+        workingDirectory: tempWorkDir,
+        skillsDirectory: ".skills",
+      });
+
+      const sharedDest = path.join(
+        tempWorkDir,
+        ".skills",
+        "tracing",
+        "_shared"
+      );
+      expect(fs.existsSync(sharedDest)).toBe(true);
+      expect(
+        fs.existsSync(path.join(sharedDest, "mcp-setup.md"))
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(sharedDest, "api-key-setup.md"))
+      ).toBe(true);
+    });
+
+    it("copies to Codex skills directory when configured", async () => {
+      const { copySkillTree } = await import("../shared.js");
+      const skillPath = path.join(tempSkillSrc, "tracing", "SKILL.md");
+      copySkillTree({
+        skillPath,
+        workingDirectory: tempWorkDir,
+        skillsDirectory: ".agents/skills",
+      });
+
+      const dest = path.join(
+        tempWorkDir,
+        ".agents",
+        "skills",
+        "tracing",
+        "SKILL.md"
+      );
+      expect(fs.existsSync(dest)).toBe(true);
+    });
+  });
+});
+
+describe("Claude Code Config File Generation", () => {
+  let tempWorkDir: string;
+  let tempSkillSrc: string;
+
+  beforeEach(() => {
+    tempWorkDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "claude-config-test-")
+    );
+    tempSkillSrc = fs.mkdtempSync(
+      path.join(os.tmpdir(), "skill-src-config-")
+    );
+    const skillDir = path.join(tempSkillSrc, "tracing");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      "# Tracing Skill"
+    );
+    const sharedDir = path.join(tempSkillSrc, "_shared");
+    fs.mkdirSync(sharedDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sharedDir, "mcp-setup.md"),
+      "# MCP"
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempWorkDir, { recursive: true, force: true });
+    fs.rmSync(tempSkillSrc, { recursive: true, force: true });
+  });
+
+  describe("when Claude Code runner has a skillPath", () => {
+    it("generates CLAUDE.md pointing to the skills directory", async () => {
+      const { generateConfigFile } = await import("../shared.js");
+      generateConfigFile({
+        configFile: "CLAUDE.md",
+        workingDirectory: tempWorkDir,
+        skillsDirectory: ".skills",
+        skillName: "tracing",
+      });
+
+      const claudeMdPath = path.join(tempWorkDir, "CLAUDE.md");
+      expect(fs.existsSync(claudeMdPath)).toBe(true);
+      const content = fs.readFileSync(claudeMdPath, "utf8");
+      expect(content).toContain(".skills");
+    });
+  });
+
+  describe("when runner has no configFile", () => {
+    it("generates no config file", async () => {
+      const { generateConfigFile } = await import("../shared.js");
+      generateConfigFile({
+        configFile: undefined,
+        workingDirectory: tempWorkDir,
+        skillsDirectory: ".agents/skills",
+        skillName: "tracing",
+      });
+
+      // No CLAUDE.md or any config file should exist
+      expect(fs.existsSync(path.join(tempWorkDir, "CLAUDE.md"))).toBe(
+        false
+      );
+    });
+  });
+});
+
+describe("Missing Binary Handling", () => {
+  describe("when the runner binary is not found", () => {
+    it("throws a descriptive error for Codex", async () => {
+      const { CodexRunner } = await import("../runners/codex.js");
+      // Override the binary to something that doesn't exist
+      const runner = new CodexRunner(
+        "/nonexistent/path/to/codex-binary"
+      );
+      expect(runner.isBinaryAvailable()).toBe(false);
+    });
+
+    it("throws a descriptive error for Claude Code", async () => {
+      const { ClaudeCodeRunner } = await import(
+        "../runners/claude-code.js"
+      );
+      const runner = new ClaudeCodeRunner(
+        "/nonexistent/path/to/claude-binary"
+      );
+      expect(runner.isBinaryAvailable()).toBe(false);
+    });
+  });
+});
+
+describe("Log Prefix", () => {
+  it("Claude Code runner uses 'claude-code' as name", async () => {
+    const { ClaudeCodeRunner } = await import(
+      "../runners/claude-code.js"
+    );
+    const runner = new ClaudeCodeRunner();
+    expect(runner.name).toBe("claude-code");
+  });
+
+  it("Codex runner uses 'codex' as name", async () => {
+    const { CodexRunner } = await import("../runners/codex.js");
+    const runner = new CodexRunner();
+    expect(runner.name).toBe("codex");
+  });
+});

--- a/skills/_tests/helpers/__tests__/agent-factory.unit.test.ts
+++ b/skills/_tests/helpers/__tests__/agent-factory.unit.test.ts
@@ -76,9 +76,7 @@ describe("Agent Factory", () => {
     describe("when called without AGENT_UNDER_TEST set", () => {
       it("delegates to the default Claude Code runner", async () => {
         delete process.env.AGENT_UNDER_TEST;
-        const { createAgent, getRunner } = await import(
-          "../agent-factory.js"
-        );
+        const { getRunner } = await import("../agent-factory.js");
         const runner = getRunner();
         expect(runner.name).toBe("claude-code");
       });
@@ -520,7 +518,7 @@ describe("Cursor Runner", () => {
 
   describe("when MCP is configured", () => {
     it("writes .cursor/mcp.json in the working directory", async () => {
-      const { CursorRunner } = await import("../runners/cursor.js");
+      await import("../runners/cursor.js");
       // Use a real temp directory to verify MCP config writing
       const tempDir = fs.mkdtempSync(
         path.join(os.tmpdir(), "cursor-mcp-test-")

--- a/skills/_tests/helpers/__tests__/agent-factory.unit.test.ts
+++ b/skills/_tests/helpers/__tests__/agent-factory.unit.test.ts
@@ -238,12 +238,13 @@ describe("Codex Runner", () => {
   });
 
   describe("buildArgs()", () => {
-    it("includes exec --full-auto --json flags", async () => {
+    it("includes exec --full-auto --skip-git-repo-check --json flags", async () => {
       const { CodexRunner } = await import("../runners/codex.js");
       const runner = new CodexRunner();
       const args = runner.buildArgs({ prompt: "test prompt" });
       expect(args).toContain("exec");
       expect(args).toContain("--full-auto");
+      expect(args).toContain("--skip-git-repo-check");
       expect(args).toContain("--json");
     });
 
@@ -409,6 +410,19 @@ describe("Cursor Runner", () => {
       expect(args).toContain("--trust");
     });
 
+    it("includes --model auto for plan compatibility", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        workingDirectory: "/tmp/test",
+        includeMcpApproval: false,
+      });
+      expect(args).toContain("--model");
+      const modelIndex = args.indexOf("--model");
+      expect(args[modelIndex + 1]).toBe("auto");
+    });
+
     it("includes --workspace with the working directory", async () => {
       const { CursorRunner } = await import("../runners/cursor.js");
       const runner = new CursorRunner();
@@ -471,20 +485,22 @@ describe("Cursor Runner", () => {
       expect(messages).toHaveLength(2);
       expect(messages[0]).toEqual({
         role: "assistant",
-        content: "I will help you instrument your code with LangWatch.",
+        content: [{ type: "text", text: "I will help you instrument your code with LangWatch." }],
       });
       expect(messages[1]).toEqual({
         role: "assistant",
-        content: "Done! I added LangWatch tracing to your project.",
+        content: [{ type: "text", text: "Done! I added LangWatch tracing to your project." }],
       });
     });
 
-    it("skips non-message lines", async () => {
+    it("skips non-assistant lines", async () => {
       const { CursorRunner } = await import("../runners/cursor.js");
       const runner = new CursorRunner();
       const output = [
-        JSON.stringify({ type: "status", status: "thinking" }),
-        JSON.stringify({ type: "done", status: "completed" }),
+        JSON.stringify({ type: "system", subtype: "init", model: "Auto" }),
+        JSON.stringify({ type: "user", message: { role: "user", content: [{ type: "text", text: "hi" }] } }),
+        JSON.stringify({ type: "thinking", subtype: "delta", text: "hmm" }),
+        JSON.stringify({ type: "result", subtype: "success", duration_ms: 100 }),
       ].join("\n");
 
       const messages = runner.parseStreamJsonOutput(output);
@@ -497,7 +513,8 @@ describe("Cursor Runner", () => {
       const output = [
         "not json",
         JSON.stringify({
-          message: { role: "assistant", content: "ok" },
+          type: "assistant",
+          message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
         }),
       ].join("\n");
 

--- a/skills/_tests/helpers/__tests__/agent-factory.unit.test.ts
+++ b/skills/_tests/helpers/__tests__/agent-factory.unit.test.ts
@@ -51,6 +51,15 @@ describe("Agent Factory", () => {
       });
     });
 
+    describe("when AGENT_UNDER_TEST is set to 'cursor'", () => {
+      it("selects the Cursor runner", async () => {
+        process.env.AGENT_UNDER_TEST = "cursor";
+        const { getRunner } = await import("../agent-factory.js");
+        const runner = getRunner();
+        expect(runner.name).toBe("cursor");
+      });
+    });
+
     describe("when AGENT_UNDER_TEST is set to an unknown value", () => {
       it("throws an error listing valid names", async () => {
         process.env.AGENT_UNDER_TEST = "unknown-assistant";
@@ -58,6 +67,7 @@ describe("Agent Factory", () => {
         expect(() => getRunner()).toThrow("unknown-assistant");
         expect(() => getRunner()).toThrow("claude-code");
         expect(() => getRunner()).toThrow("codex");
+        expect(() => getRunner()).toThrow("cursor");
       });
     });
   });
@@ -338,6 +348,201 @@ describe("Codex Runner", () => {
   });
 });
 
+describe("Cursor Runner", () => {
+  describe("capabilities", () => {
+    it("declares MCP support as true", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      expect(runner.capabilities.supportsMcp).toBe(true);
+    });
+
+    it("uses .cursor/rules as the skills directory", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      expect(runner.capabilities.skillsDirectory).toBe(".cursor/rules");
+    });
+
+    it("declares .cursorrules as the config file", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      expect(runner.capabilities.configFile).toBe(".cursorrules");
+    });
+
+    it("uses 'cursor' as name", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      expect(runner.name).toBe("cursor");
+    });
+  });
+
+  describe("buildArgs()", () => {
+    it("includes -p for prompt mode", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        workingDirectory: "/tmp/test",
+        includeMcpApproval: false,
+      });
+      expect(args).toContain("-p");
+    });
+
+    it("includes --output-format stream-json", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        workingDirectory: "/tmp/test",
+        includeMcpApproval: false,
+      });
+      expect(args).toContain("--output-format");
+      expect(args).toContain("stream-json");
+    });
+
+    it("includes --force and --trust flags", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        workingDirectory: "/tmp/test",
+        includeMcpApproval: false,
+      });
+      expect(args).toContain("--force");
+      expect(args).toContain("--trust");
+    });
+
+    it("includes --workspace with the working directory", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        workingDirectory: "/tmp/my-project",
+        includeMcpApproval: false,
+      });
+      expect(args).toContain("--workspace");
+      const workspaceIndex = args.indexOf("--workspace");
+      expect(args[workspaceIndex + 1]).toBe("/tmp/my-project");
+    });
+
+    it("includes --approve-mcps when MCP approval is requested", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        workingDirectory: "/tmp/test",
+        includeMcpApproval: true,
+      });
+      expect(args).toContain("--approve-mcps");
+    });
+
+    it("omits --approve-mcps when MCP approval is not requested", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const args = runner.buildArgs({
+        prompt: "test prompt",
+        workingDirectory: "/tmp/test",
+        includeMcpApproval: false,
+      });
+      expect(args).not.toContain("--approve-mcps");
+    });
+
+    it("includes the prompt as the last argument", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const args = runner.buildArgs({
+        prompt: "my test prompt",
+        workingDirectory: "/tmp/test",
+        includeMcpApproval: false,
+      });
+      expect(args[args.length - 1]).toBe("my test prompt");
+    });
+  });
+
+  describe("parseStreamJsonOutput()", () => {
+    it("extracts messages from stream-json NDJSON lines", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+
+      const fixtureContent = fs.readFileSync(
+        path.join(__dirname, "fixtures/cursor-output.jsonl"),
+        "utf8"
+      );
+
+      const messages = runner.parseStreamJsonOutput(fixtureContent);
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toEqual({
+        role: "assistant",
+        content: "I will help you instrument your code with LangWatch.",
+      });
+      expect(messages[1]).toEqual({
+        role: "assistant",
+        content: "Done! I added LangWatch tracing to your project.",
+      });
+    });
+
+    it("skips non-message lines", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const output = [
+        JSON.stringify({ type: "status", status: "thinking" }),
+        JSON.stringify({ type: "done", status: "completed" }),
+      ].join("\n");
+
+      const messages = runner.parseStreamJsonOutput(output);
+      expect(messages).toHaveLength(0);
+    });
+
+    it("skips malformed JSON lines gracefully", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner();
+      const output = [
+        "not json",
+        JSON.stringify({
+          message: { role: "assistant", content: "ok" },
+        }),
+      ].join("\n");
+
+      const messages = runner.parseStreamJsonOutput(output);
+      expect(messages).toHaveLength(1);
+    });
+  });
+
+  describe("isBinaryAvailable()", () => {
+    it("returns false when binary path does not exist", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner(
+        "/nonexistent/path/to/cursor-agent-binary"
+      );
+      expect(runner.isBinaryAvailable()).toBe(false);
+    });
+  });
+
+  describe("when MCP is configured", () => {
+    it("writes .cursor/mcp.json in the working directory", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      // Use a real temp directory to verify MCP config writing
+      const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "cursor-mcp-test-")
+      );
+
+      // The runner needs a binary to create an agent, but we can
+      // verify the MCP file structure expectation through the factory
+      // For now, just verify the config path convention
+      const mcpConfigDir = path.join(tempDir, ".cursor");
+      fs.mkdirSync(mcpConfigDir, { recursive: true });
+      const mcpConfigPath = path.join(mcpConfigDir, "mcp.json");
+      fs.writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers: {} }));
+
+      expect(fs.existsSync(mcpConfigPath)).toBe(true);
+      const config = JSON.parse(fs.readFileSync(mcpConfigPath, "utf8"));
+      expect(config).toHaveProperty("mcpServers");
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+  });
+});
+
 describe("Skill Directory Placement", () => {
   describe("when skillPath points to a SKILL.md with _shared/ sibling", () => {
     let tempSkillSrc: string;
@@ -520,6 +725,14 @@ describe("Missing Binary Handling", () => {
       );
       expect(runner.isBinaryAvailable()).toBe(false);
     });
+
+    it("reports binary unavailable for Cursor", async () => {
+      const { CursorRunner } = await import("../runners/cursor.js");
+      const runner = new CursorRunner(
+        "/nonexistent/path/to/cursor-agent-binary"
+      );
+      expect(runner.isBinaryAvailable()).toBe(false);
+    });
   });
 });
 
@@ -536,5 +749,11 @@ describe("Log Prefix", () => {
     const { CodexRunner } = await import("../runners/codex.js");
     const runner = new CodexRunner();
     expect(runner.name).toBe("codex");
+  });
+
+  it("Cursor runner uses 'cursor' as name", async () => {
+    const { CursorRunner } = await import("../runners/cursor.js");
+    const runner = new CursorRunner();
+    expect(runner.name).toBe("cursor");
   });
 });

--- a/skills/_tests/helpers/__tests__/fixtures/codex-output.jsonl
+++ b/skills/_tests/helpers/__tests__/fixtures/codex-output.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"thread_abc123"}
+{"type":"item.completed","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I will help you instrument your code with LangWatch."}]}}
+{"type":"item.completed","item":{"type":"function_call","name":"read_file","arguments":"{\"path\":\"main.py\"}"}}
+{"type":"item.completed","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done! I added LangWatch tracing to your project."}]}}
+{"type":"turn.completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done! I added LangWatch tracing to your project."}]}]}

--- a/skills/_tests/helpers/__tests__/fixtures/cursor-output.jsonl
+++ b/skills/_tests/helpers/__tests__/fixtures/cursor-output.jsonl
@@ -1,0 +1,5 @@
+{"type":"status","status":"thinking"}
+{"message":{"role":"assistant","content":"I will help you instrument your code with LangWatch."}}
+{"type":"tool_use","name":"read_file","input":{"path":"main.py"}}
+{"message":{"role":"assistant","content":"Done! I added LangWatch tracing to your project."}}
+{"type":"done","status":"completed"}

--- a/skills/_tests/helpers/__tests__/fixtures/cursor-output.jsonl
+++ b/skills/_tests/helpers/__tests__/fixtures/cursor-output.jsonl
@@ -1,5 +1,8 @@
-{"type":"status","status":"thinking"}
-{"message":{"role":"assistant","content":"I will help you instrument your code with LangWatch."}}
-{"type":"tool_use","name":"read_file","input":{"path":"main.py"}}
-{"message":{"role":"assistant","content":"Done! I added LangWatch tracing to your project."}}
-{"type":"done","status":"completed"}
+{"type":"system","subtype":"init","apiKeySource":"flag","cwd":"/tmp/test","session_id":"abc123","model":"Auto","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"instrument my code"}]},"session_id":"abc123"}
+{"type":"thinking","subtype":"delta","text":"Let me help with that","session_id":"abc123"}
+{"type":"thinking","subtype":"completed","session_id":"abc123"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I will help you instrument your code with LangWatch."}]},"session_id":"abc123"}
+{"type":"tool_use","name":"read_file","input":{"path":"main.py"},"session_id":"abc123"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done! I added LangWatch tracing to your project."}]},"session_id":"abc123"}
+{"type":"result","subtype":"success","duration_ms":5000,"is_error":false,"result":"Done!","session_id":"abc123"}

--- a/skills/_tests/helpers/agent-factory.ts
+++ b/skills/_tests/helpers/agent-factory.ts
@@ -64,14 +64,9 @@ export function createAgent(options: RunnerOptions): AgentAdapter {
  * runner is not installed.
  */
 export function isRunnerAvailable(): boolean {
-  try {
-    const runner = getRunner();
-    // Duck-type check for isBinaryAvailable method
-    if ("isBinaryAvailable" in runner && typeof (runner as any).isBinaryAvailable === "function") {
-      return (runner as any).isBinaryAvailable();
-    }
-    return true;
-  } catch {
-    return false;
+  const runner = getRunner(); // let config errors propagate — don't swallow them
+  if ("isBinaryAvailable" in runner && typeof (runner as any).isBinaryAvailable === "function") {
+    return (runner as any).isBinaryAvailable();
   }
+  return true;
 }

--- a/skills/_tests/helpers/agent-factory.ts
+++ b/skills/_tests/helpers/agent-factory.ts
@@ -2,13 +2,15 @@ import type { AgentAdapter } from "@langwatch/scenario";
 import type { AgentRunner, RunnerOptions } from "./types.js";
 import { ClaudeCodeRunner } from "./runners/claude-code.js";
 import { CodexRunner } from "./runners/codex.js";
+import { CursorRunner } from "./runners/cursor.js";
 
-const VALID_RUNNERS = ["claude-code", "codex"] as const;
+const VALID_RUNNERS = ["claude-code", "codex", "cursor"] as const;
 type RunnerName = (typeof VALID_RUNNERS)[number];
 
 const runnerFactories: Record<RunnerName, () => AgentRunner> = {
   "claude-code": () => new ClaudeCodeRunner(),
   codex: () => new CodexRunner(),
+  cursor: () => new CursorRunner(),
 };
 
 let cachedRunner: AgentRunner | undefined;

--- a/skills/_tests/helpers/agent-factory.ts
+++ b/skills/_tests/helpers/agent-factory.ts
@@ -1,0 +1,75 @@
+import type { AgentAdapter } from "@langwatch/scenario";
+import type { AgentRunner, RunnerOptions } from "./types.js";
+import { ClaudeCodeRunner } from "./runners/claude-code.js";
+import { CodexRunner } from "./runners/codex.js";
+
+const VALID_RUNNERS = ["claude-code", "codex"] as const;
+type RunnerName = (typeof VALID_RUNNERS)[number];
+
+const runnerFactories: Record<RunnerName, () => AgentRunner> = {
+  "claude-code": () => new ClaudeCodeRunner(),
+  codex: () => new CodexRunner(),
+};
+
+let cachedRunner: AgentRunner | undefined;
+let cachedRunnerEnv: string | undefined;
+
+/**
+ * Returns the active AgentRunner based on the AGENT_UNDER_TEST env var.
+ *
+ * Defaults to "claude-code" when the env var is not set.
+ * Throws with a descriptive error listing valid names if the value is unknown.
+ */
+export function getRunner(): AgentRunner {
+  const envValue = process.env.AGENT_UNDER_TEST ?? "claude-code";
+
+  // Cache the runner to avoid re-resolving binaries on every call
+  if (cachedRunner && cachedRunnerEnv === envValue) {
+    return cachedRunner;
+  }
+
+  if (!VALID_RUNNERS.includes(envValue as RunnerName)) {
+    throw new Error(
+      `Unknown AGENT_UNDER_TEST value: "${envValue}". Valid values are: ${VALID_RUNNERS.join(", ")}`
+    );
+  }
+
+  const factory = runnerFactories[envValue as RunnerName];
+  if (!factory) {
+    throw new Error(
+      `No runner factory for "${envValue}". Valid values are: ${VALID_RUNNERS.join(", ")}`
+    );
+  }
+
+  cachedRunner = factory();
+  cachedRunnerEnv = envValue;
+  return cachedRunner;
+}
+
+/**
+ * Creates an AgentAdapter using the active runner.
+ *
+ * Convenience wrapper: equivalent to `getRunner().createAgent(options)`.
+ */
+export function createAgent(options: RunnerOptions): AgentAdapter {
+  return getRunner().createAgent(options);
+}
+
+/**
+ * Check whether the active runner's binary is available.
+ *
+ * Use this to skip the entire test suite gracefully when the selected
+ * runner is not installed.
+ */
+export function isRunnerAvailable(): boolean {
+  try {
+    const runner = getRunner();
+    // Duck-type check for isBinaryAvailable method
+    if ("isBinaryAvailable" in runner && typeof (runner as any).isBinaryAvailable === "function") {
+      return (runner as any).isBinaryAvailable();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/skills/_tests/helpers/claude-code-adapter.ts
+++ b/skills/_tests/helpers/claude-code-adapter.ts
@@ -1,36 +1,22 @@
-import {
-  type AgentAdapter,
-  AgentRole,
-  type ScenarioExecutionStateLike,
-} from "@langwatch/scenario";
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
-import { spawn, execSync } from "child_process";
-import chalk from "chalk";
+/**
+ * Legacy re-export module for backward compatibility.
+ *
+ * Existing test files import from this path. These exports delegate
+ * to the new runner-based module locations.
+ *
+ * @deprecated Import from `./agent-factory` or `./shared` instead.
+ */
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import type { AgentAdapter } from "@langwatch/scenario";
+import { ClaudeCodeRunner } from "./runners/claude-code.js";
+import { toolCallFix as _toolCallFix } from "./shared.js";
 
-const mcpServerDistPath = path.resolve(
-  __dirname,
-  "../../../mcp-server/dist/index.js"
-);
+export { toolCallFix } from "./shared.js";
 
 /**
  * Creates a Claude Code agent adapter for use with @langwatch/scenario.
  *
- * Spawns Claude Code via child_process.spawn with MCP config pointing to the
- * LangWatch MCP server. Optionally copies a SKILL.md into the working directory
- * so Claude Code auto-discovers it.
- *
- * @param workingDirectory - The directory to run Claude Code in
- * @param skillPath - Optional path to a SKILL.md to copy into the working directory
- * @param cleanEnv - When true, strips LANGWATCH_API_KEY, OPENAI_API_KEY, and
- *   ANTHROPIC_API_KEY from the spawned process environment. Use this to test
- *   cold-start flows where the agent must discover keys from .env files.
- * @param skipMcp - When true, omits the MCP config entirely. Use this to test
- *   flows where the agent must discover docs via llms.txt fallback URLs.
+ * @deprecated Use `createAgent()` from `./agent-factory` instead.
  */
 export function createClaudeCodeAgent({
   workingDirectory,
@@ -43,140 +29,6 @@ export function createClaudeCodeAgent({
   cleanEnv?: boolean;
   skipMcp?: boolean;
 }): AgentAdapter {
-  if (skillPath) {
-    const skillName = path.basename(path.dirname(skillPath));
-    const skillDir = path.join(workingDirectory, ".skills", skillName);
-    fs.mkdirSync(skillDir, { recursive: true });
-    fs.copyFileSync(skillPath, path.join(skillDir, "SKILL.md"));
-  }
-
-  return {
-    role: AgentRole.AGENT,
-    call: async (state) => {
-      const formattedMessages = state.messages
-        .map((message) => `${message.role}: ${message.content}`)
-        .join("\n\n");
-
-      const mcpConfigPath = path.join(workingDirectory, ".mcp-config.json");
-
-      if (!skipMcp) {
-        const mcpConfig = {
-          mcpServers: {
-            LangWatch: {
-              command: "node",
-              args: [
-                mcpServerDistPath,
-                "--apiKey",
-                process.env.LANGWATCH_API_KEY!,
-              ],
-            },
-          },
-        };
-        fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig));
-      }
-
-      return new Promise<string>((resolve, reject) => {
-        const claudeBin =
-          process.env.CLAUDE_BIN ||
-          execSync("which claude", { encoding: "utf8" }).trim();
-
-        const args = [
-          "--output-format",
-          "stream-json",
-          "-p",
-          ...(skipMcp ? [] : ["--mcp-config", mcpConfigPath]),
-          "--dangerously-skip-permissions",
-          "--verbose",
-          formattedMessages,
-        ];
-
-        console.log(
-          chalk.blue("Starting claude in:"),
-          workingDirectory
-        );
-
-        const envVars = cleanEnv
-          ? Object.fromEntries(
-              Object.entries(process.env).filter(
-                ([key]) =>
-                  !["LANGWATCH_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"].includes(key)
-              )
-            )
-          : process.env;
-
-        const child = spawn(claudeBin, args, {
-          cwd: workingDirectory,
-          env: { ...envVars, FORCE_COLOR: "0" },
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-
-        let output = "";
-
-        child.stdout.on("data", (data: Buffer) => {
-          const text = data.toString();
-          console.log(chalk.cyan("Claude Code:"), text);
-          output += text;
-        });
-
-        child.stderr.on("data", (data: Buffer) => {
-          console.log(chalk.yellow("Claude Code stderr:"), data.toString());
-        });
-
-        child.on("close", (exitCode) => {
-          if (exitCode === 0) {
-            const messages: any = output
-              .split("\n")
-              .map((line) => {
-                try {
-                  return JSON.parse(line.trim());
-                } catch {
-                  return null;
-                }
-              })
-              .filter(
-                (message) => message !== null && "message" in message
-              )
-              .map((message) => message.message);
-            console.log(
-              "messages",
-              JSON.stringify(messages, undefined, 2)
-            );
-
-            resolve(messages);
-          } else {
-            reject(
-              new Error(`Command failed with exit code ${exitCode}`)
-            );
-          }
-        });
-
-        child.on("error", (err) => {
-          reject(err);
-        });
-      });
-    },
-  };
-}
-
-/**
- * Fixes Anthropic tool use format in message state so it is compatible
- * with the Vercel AI SDK judge agent.
- *
- * Anthropic returns tool_use content blocks that the Vercel AI SDK does
- * not understand. This converts non-text blocks to text blocks containing
- * the JSON representation.
- */
-export function toolCallFix(state: ScenarioExecutionStateLike): void {
-  state.messages.forEach((message) => {
-    if (Array.isArray(message.content)) {
-      message.content.forEach((content, index) => {
-        if (content.type !== "text") {
-          (message.content as any)[index] = {
-            type: "text",
-            text: JSON.stringify(content),
-          };
-        }
-      });
-    }
-  });
+  const runner = new ClaudeCodeRunner();
+  return runner.createAgent({ workingDirectory, skillPath, cleanEnv, skipMcp });
 }

--- a/skills/_tests/helpers/runners/claude-code.ts
+++ b/skills/_tests/helpers/runners/claude-code.ts
@@ -1,0 +1,233 @@
+import {
+  type AgentAdapter,
+  type AgentReturnTypes,
+  AgentRole,
+} from "@langwatch/scenario";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { spawn, execSync } from "child_process";
+import chalk from "chalk";
+import type {
+  AgentRunner,
+  AgentRunnerCapabilities,
+  RunnerOptions,
+} from "../types.js";
+import { copySkillTree, generateConfigFile } from "../shared.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mcpServerDistPath = path.resolve(
+  __dirname,
+  "../../../../mcp-server/dist/index.js"
+);
+
+const LOG_PREFIX = chalk.cyan("[claude-code]");
+
+/**
+ * Resolves the Claude Code binary path.
+ * Checks CLAUDE_BIN env var first, then falls back to `which claude`.
+ */
+function resolveClaudeBinary(overridePath?: string): string | undefined {
+  if (overridePath) {
+    return fs.existsSync(overridePath) ? overridePath : undefined;
+  }
+
+  if (process.env.CLAUDE_BIN) {
+    return process.env.CLAUDE_BIN;
+  }
+
+  try {
+    return execSync("which claude", { encoding: "utf8" }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Claude Code runner for the agent adapter factory.
+ *
+ * Spawns Claude Code via child_process.spawn with MCP config pointing
+ * to the LangWatch MCP server. Normalizes stream-json output internally.
+ */
+export class ClaudeCodeRunner implements AgentRunner {
+  readonly name = "claude-code";
+
+  readonly capabilities: AgentRunnerCapabilities = {
+    supportsMcp: true,
+    skillsDirectory: ".skills",
+    configFile: "CLAUDE.md",
+  };
+
+  private readonly binaryPath: string | undefined;
+
+  constructor(overrideBinaryPath?: string) {
+    this.binaryPath = resolveClaudeBinary(overrideBinaryPath);
+  }
+
+  /** Check whether the claude binary is available. */
+  isBinaryAvailable(): boolean {
+    return this.binaryPath !== undefined;
+  }
+
+  /**
+   * Build the CLI arguments for spawning Claude Code.
+   *
+   * Exposed for unit testing -- not part of the AgentRunner interface.
+   */
+  buildArgs({
+    prompt,
+    mcpConfigPath,
+  }: {
+    prompt: string;
+    mcpConfigPath: string | undefined;
+  }): string[] {
+    return [
+      "--output-format",
+      "stream-json",
+      "-p",
+      ...(mcpConfigPath ? ["--mcp-config", mcpConfigPath] : []),
+      "--dangerously-skip-permissions",
+      "--verbose",
+      prompt,
+    ];
+  }
+
+  /**
+   * Parse Claude Code stream-json NDJSON output into message objects.
+   *
+   * Exposed for unit testing.
+   */
+  parseStreamJsonOutput(output: string): any[] {
+    return output
+      .split("\n")
+      .map((line) => {
+        try {
+          return JSON.parse(line.trim());
+        } catch {
+          return null;
+        }
+      })
+      .filter(
+        (parsed) => parsed !== null && "message" in parsed
+      )
+      .map((parsed) => parsed.message);
+  }
+
+  createAgent(options: RunnerOptions): AgentAdapter {
+    if (!this.binaryPath) {
+      throw new Error(
+        `[claude-code] Claude Code binary not found. Install it from https://docs.anthropic.com/en/docs/claude-code or set CLAUDE_BIN env var.`
+      );
+    }
+
+    const { workingDirectory, skillPath, cleanEnv, skipMcp } = options;
+
+    // Copy skill tree if provided
+    let skillName: string | undefined;
+    if (skillPath) {
+      skillName = copySkillTree({
+        skillPath,
+        workingDirectory,
+        skillsDirectory: this.capabilities.skillsDirectory,
+      });
+
+      generateConfigFile({
+        configFile: this.capabilities.configFile,
+        workingDirectory,
+        skillsDirectory: this.capabilities.skillsDirectory,
+        skillName,
+      });
+    }
+
+    const binaryPath = this.binaryPath;
+
+    return {
+      role: AgentRole.AGENT,
+      call: async (state) => {
+        const formattedMessages = state.messages
+          .map((message) => `${message.role}: ${message.content}`)
+          .join("\n\n");
+
+        const mcpConfigPath = path.join(workingDirectory, ".mcp-config.json");
+
+        if (!skipMcp) {
+          const mcpConfig = {
+            mcpServers: {
+              LangWatch: {
+                command: "node",
+                args: [
+                  mcpServerDistPath,
+                  "--apiKey",
+                  process.env.LANGWATCH_API_KEY!,
+                ],
+              },
+            },
+          };
+          fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig));
+        }
+
+        return new Promise<AgentReturnTypes>((resolve, reject) => {
+          const args = this.buildArgs({
+            prompt: formattedMessages,
+            mcpConfigPath: skipMcp ? undefined : mcpConfigPath,
+          });
+
+          console.log(LOG_PREFIX, chalk.blue("Starting claude in:"), workingDirectory);
+
+          const envVars = cleanEnv
+            ? Object.fromEntries(
+                Object.entries(process.env).filter(
+                  ([key]) =>
+                    ![
+                      "LANGWATCH_API_KEY",
+                      "OPENAI_API_KEY",
+                      "ANTHROPIC_API_KEY",
+                    ].includes(key)
+                )
+              )
+            : process.env;
+
+          const child = spawn(binaryPath, args, {
+            cwd: workingDirectory,
+            env: { ...envVars, FORCE_COLOR: "0" },
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+
+          let output = "";
+
+          child.stdout.on("data", (data: Buffer) => {
+            const text = data.toString();
+            console.log(LOG_PREFIX, text);
+            output += text;
+          });
+
+          child.stderr.on("data", (data: Buffer) => {
+            console.log(LOG_PREFIX, chalk.yellow("stderr:"), data.toString());
+          });
+
+          child.on("close", (exitCode) => {
+            if (exitCode === 0) {
+              const messages = this.parseStreamJsonOutput(output);
+              console.log(
+                LOG_PREFIX,
+                "messages",
+                JSON.stringify(messages, undefined, 2)
+              );
+              resolve(messages);
+            } else {
+              reject(
+                new Error(`[claude-code] Command failed with exit code ${exitCode}`)
+              );
+            }
+          });
+
+          child.on("error", (err) => {
+            reject(err);
+          });
+        });
+      },
+    };
+  }
+}

--- a/skills/_tests/helpers/runners/claude-code.ts
+++ b/skills/_tests/helpers/runners/claude-code.ts
@@ -35,7 +35,9 @@ function resolveClaudeBinary(overridePath?: string): string | undefined {
   }
 
   if (process.env.CLAUDE_BIN) {
-    return process.env.CLAUDE_BIN;
+    return fs.existsSync(process.env.CLAUDE_BIN)
+      ? process.env.CLAUDE_BIN
+      : undefined;
   }
 
   try {
@@ -153,6 +155,12 @@ export class ClaudeCodeRunner implements AgentRunner {
         const mcpConfigPath = path.join(workingDirectory, ".mcp-config.json");
 
         if (!skipMcp) {
+          if (!process.env.LANGWATCH_API_KEY) {
+            throw new Error(
+              "[claude-code] LANGWATCH_API_KEY is required when MCP is enabled."
+            );
+          }
+
           const mcpConfig = {
             mcpServers: {
               LangWatch: {

--- a/skills/_tests/helpers/runners/codex.ts
+++ b/skills/_tests/helpers/runners/codex.ts
@@ -1,0 +1,220 @@
+import {
+  type AgentAdapter,
+  type AgentReturnTypes,
+  AgentRole,
+} from "@langwatch/scenario";
+import fs from "fs";
+import path from "path";
+import { spawn, execSync } from "child_process";
+import chalk from "chalk";
+import type {
+  AgentRunner,
+  AgentRunnerCapabilities,
+  RunnerOptions,
+} from "../types.js";
+import { copySkillTree, generateConfigFile } from "../shared.js";
+
+const LOG_PREFIX = chalk.magenta("[codex]");
+
+/**
+ * Resolves the Codex binary path.
+ * Falls back to `which codex` if no override is provided.
+ */
+function resolveCodexBinary(overridePath?: string): string | undefined {
+  if (overridePath) {
+    return fs.existsSync(overridePath) ? overridePath : undefined;
+  }
+
+  try {
+    return execSync("which codex", { encoding: "utf8" }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Codex runner for the agent adapter factory.
+ *
+ * Spawns Codex via `codex exec --full-auto --json <prompt>`.
+ * Parses JSONL output with event types: thread.started, item.completed, turn.completed.
+ * Extracts assistant message content from item.completed events.
+ *
+ * No MCP support -- capabilities.supportsMcp is false.
+ */
+export class CodexRunner implements AgentRunner {
+  readonly name = "codex";
+
+  readonly capabilities: AgentRunnerCapabilities = {
+    supportsMcp: false,
+    skillsDirectory: ".agents/skills",
+    configFile: undefined,
+  };
+
+  private readonly binaryPath: string | undefined;
+
+  constructor(overrideBinaryPath?: string) {
+    this.binaryPath = resolveCodexBinary(overrideBinaryPath);
+  }
+
+  /** Check whether the codex binary is available. */
+  isBinaryAvailable(): boolean {
+    return this.binaryPath !== undefined;
+  }
+
+  /**
+   * Build the CLI arguments for spawning Codex.
+   *
+   * Exposed for unit testing.
+   */
+  buildArgs({ prompt }: { prompt: string }): string[] {
+    return ["exec", "--full-auto", "--json", prompt];
+  }
+
+  /**
+   * Parse Codex JSONL output into message objects compatible with @langwatch/scenario.
+   *
+   * Extracts assistant message content from item.completed events where the
+   * item type is "message" and role is "assistant". Normalizes output_text
+   * content blocks to text blocks for SDK compatibility.
+   *
+   * Exposed for unit testing.
+   */
+  parseJsonlOutput(output: string): any[] {
+    return output
+      .split("\n")
+      .map((line) => {
+        try {
+          return JSON.parse(line.trim());
+        } catch {
+          return null;
+        }
+      })
+      .filter((parsed): parsed is Record<string, any> => {
+        if (parsed === null) return false;
+        if (parsed.type !== "item.completed") return false;
+        if (!parsed.item) return false;
+        if (parsed.item.type !== "message") return false;
+        if (parsed.item.role !== "assistant") return false;
+        return true;
+      })
+      .map((parsed) => {
+        // Normalize output_text blocks to text blocks
+        const content = Array.isArray(parsed.item.content)
+          ? parsed.item.content.map(
+              (block: { type: string; text: string }) => ({
+                type: "text",
+                text: block.text,
+              })
+            )
+          : parsed.item.content;
+
+        return {
+          role: parsed.item.role,
+          content,
+        };
+      });
+  }
+
+  createAgent(options: RunnerOptions): AgentAdapter {
+    if (!this.binaryPath) {
+      throw new Error(
+        `[codex] Codex binary not found. Install it from https://github.com/openai/codex or via npm: npm install -g @openai/codex`
+      );
+    }
+
+    const { workingDirectory, skillPath, cleanEnv } = options;
+
+    // Copy skill tree if provided
+    if (skillPath) {
+      const skillName = copySkillTree({
+        skillPath,
+        workingDirectory,
+        skillsDirectory: this.capabilities.skillsDirectory,
+      });
+
+      // Codex has no config file -- generateConfigFile is a no-op
+      generateConfigFile({
+        configFile: this.capabilities.configFile,
+        workingDirectory,
+        skillsDirectory: this.capabilities.skillsDirectory,
+        skillName,
+      });
+    }
+
+    // MCP is not supported; no config file is written regardless of skipMcp
+
+    const binaryPath = this.binaryPath;
+
+    return {
+      role: AgentRole.AGENT,
+      call: async (state) => {
+        const formattedMessages = state.messages
+          .map((message) => `${message.role}: ${message.content}`)
+          .join("\n\n");
+
+        return new Promise<AgentReturnTypes>((resolve, reject) => {
+          const args = this.buildArgs({ prompt: formattedMessages });
+
+          console.log(
+            LOG_PREFIX,
+            chalk.blue("Starting codex in:"),
+            workingDirectory
+          );
+
+          const envVars = cleanEnv
+            ? Object.fromEntries(
+                Object.entries(process.env).filter(
+                  ([key]) =>
+                    ![
+                      "LANGWATCH_API_KEY",
+                      "OPENAI_API_KEY",
+                      "ANTHROPIC_API_KEY",
+                    ].includes(key)
+                )
+              )
+            : process.env;
+
+          const child = spawn(binaryPath, args, {
+            cwd: workingDirectory,
+            env: { ...envVars, FORCE_COLOR: "0" },
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+
+          let output = "";
+
+          child.stdout.on("data", (data: Buffer) => {
+            const text = data.toString();
+            console.log(LOG_PREFIX, text);
+            output += text;
+          });
+
+          child.stderr.on("data", (data: Buffer) => {
+            console.log(LOG_PREFIX, chalk.yellow("stderr:"), data.toString());
+          });
+
+          child.on("close", (exitCode) => {
+            if (exitCode === 0) {
+              const messages = this.parseJsonlOutput(output);
+              console.log(
+                LOG_PREFIX,
+                "messages",
+                JSON.stringify(messages, undefined, 2)
+              );
+              resolve(messages);
+            } else {
+              reject(
+                new Error(
+                  `[codex] Command failed with exit code ${exitCode}`
+                )
+              );
+            }
+          });
+
+          child.on("error", (err) => {
+            reject(err);
+          });
+        });
+      },
+    };
+  }
+}

--- a/skills/_tests/helpers/runners/codex.ts
+++ b/skills/_tests/helpers/runners/codex.ts
@@ -99,12 +99,12 @@ export class CodexRunner implements AgentRunner {
       .map((parsed) => {
         // Normalize output_text blocks to text blocks
         const content = Array.isArray(parsed.item.content)
-          ? parsed.item.content.map(
-              (block: { type: string; text: string }) => ({
+          ? parsed.item.content
+              .map((block: { type: string; text?: string }) => ({
                 type: "text",
-                text: block.text,
-              })
-            )
+                text: block.text ?? "",
+              }))
+              .filter((block: { text: string }) => block.text !== "")
           : parsed.item.content;
 
         return {

--- a/skills/_tests/helpers/runners/codex.ts
+++ b/skills/_tests/helpers/runners/codex.ts
@@ -4,7 +4,6 @@ import {
   AgentRole,
 } from "@langwatch/scenario";
 import fs from "fs";
-import path from "path";
 import { spawn, execSync } from "child_process";
 import chalk from "chalk";
 import type {

--- a/skills/_tests/helpers/runners/codex.ts
+++ b/skills/_tests/helpers/runners/codex.ts
@@ -66,7 +66,7 @@ export class CodexRunner implements AgentRunner {
    * Exposed for unit testing.
    */
   buildArgs({ prompt }: { prompt: string }): string[] {
-    return ["exec", "--full-auto", "--json", prompt];
+    return ["exec", "--full-auto", "--skip-git-repo-check", "--json", prompt];
   }
 
   /**

--- a/skills/_tests/helpers/runners/cursor.ts
+++ b/skills/_tests/helpers/runners/cursor.ts
@@ -35,7 +35,9 @@ function resolveCursorBinary(overridePath?: string): string | undefined {
   }
 
   if (process.env.CURSOR_BIN) {
-    return process.env.CURSOR_BIN;
+    return fs.existsSync(process.env.CURSOR_BIN)
+      ? process.env.CURSOR_BIN
+      : undefined;
   }
 
   try {
@@ -174,6 +176,12 @@ export class CursorRunner implements AgentRunner {
           .join("\n\n");
 
         if (!skipMcp) {
+          if (!process.env.LANGWATCH_API_KEY) {
+            throw new Error(
+              "[cursor] LANGWATCH_API_KEY is required when MCP is enabled."
+            );
+          }
+
           const cursorDir = path.join(workingDirectory, ".cursor");
           fs.mkdirSync(cursorDir, { recursive: true });
 

--- a/skills/_tests/helpers/runners/cursor.ts
+++ b/skills/_tests/helpers/runners/cursor.ts
@@ -96,6 +96,8 @@ export class CursorRunner implements AgentRunner {
       "stream-json",
       "--force",
       "--trust",
+      "--model",
+      "auto",
       ...(includeMcpApproval ? ["--approve-mcps"] : []),
       "--workspace",
       workingDirectory,
@@ -106,8 +108,14 @@ export class CursorRunner implements AgentRunner {
   /**
    * Parse cursor-agent stream-json NDJSON output into message objects.
    *
-   * Cursor uses the same stream-json format name as Claude Code.
-   * Extracts objects that contain a `message` property.
+   * Cursor emits lines like:
+   *   {"type":"system","subtype":"init",...}
+   *   {"type":"user","message":{...},...}
+   *   {"type":"thinking","subtype":"delta",...}
+   *   {"type":"assistant","message":{"role":"assistant","content":[...]},...}
+   *   {"type":"result","subtype":"success",...}
+   *
+   * We extract only assistant messages.
    *
    * Exposed for unit testing.
    */
@@ -121,7 +129,12 @@ export class CursorRunner implements AgentRunner {
           return null;
         }
       })
-      .filter((parsed) => parsed !== null && "message" in parsed)
+      .filter(
+        (parsed) =>
+          parsed !== null &&
+          parsed.type === "assistant" &&
+          "message" in parsed
+      )
       .map((parsed) => parsed.message);
   }
 

--- a/skills/_tests/helpers/runners/cursor.ts
+++ b/skills/_tests/helpers/runners/cursor.ts
@@ -1,0 +1,259 @@
+import {
+  type AgentAdapter,
+  type AgentReturnTypes,
+  AgentRole,
+} from "@langwatch/scenario";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { spawn, execSync } from "child_process";
+import chalk from "chalk";
+import type {
+  AgentRunner,
+  AgentRunnerCapabilities,
+  RunnerOptions,
+} from "../types.js";
+import { copySkillTree, generateConfigFile } from "../shared.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mcpServerDistPath = path.resolve(
+  __dirname,
+  "../../../../mcp-server/dist/index.js"
+);
+
+const LOG_PREFIX = chalk.green("[cursor]");
+
+/**
+ * Resolves the cursor-agent binary path.
+ * Checks CURSOR_BIN env var first, then falls back to `which cursor-agent`.
+ */
+function resolveCursorBinary(overridePath?: string): string | undefined {
+  if (overridePath) {
+    return fs.existsSync(overridePath) ? overridePath : undefined;
+  }
+
+  if (process.env.CURSOR_BIN) {
+    return process.env.CURSOR_BIN;
+  }
+
+  try {
+    return execSync("which cursor-agent", { encoding: "utf8" }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Cursor runner for the agent adapter factory.
+ *
+ * Spawns cursor-agent via child_process.spawn with MCP config pointing
+ * to the LangWatch MCP server. Normalizes stream-json output internally.
+ *
+ * Binary: `cursor-agent` (installed via `brew install cursor-cli`)
+ * MCP config: `.cursor/mcp.json` in the working directory
+ * Skills: `.cursor/rules/<name>/SKILL.md`
+ * Config: `.cursorrules`
+ */
+export class CursorRunner implements AgentRunner {
+  readonly name = "cursor";
+
+  readonly capabilities: AgentRunnerCapabilities = {
+    supportsMcp: true,
+    skillsDirectory: ".cursor/rules",
+    configFile: ".cursorrules",
+  };
+
+  private readonly binaryPath: string | undefined;
+
+  constructor(overrideBinaryPath?: string) {
+    this.binaryPath = resolveCursorBinary(overrideBinaryPath);
+  }
+
+  /** Check whether the cursor-agent binary is available. */
+  isBinaryAvailable(): boolean {
+    return this.binaryPath !== undefined;
+  }
+
+  /**
+   * Build the CLI arguments for spawning cursor-agent.
+   *
+   * Exposed for unit testing -- not part of the AgentRunner interface.
+   */
+  buildArgs({
+    prompt,
+    workingDirectory,
+    includeMcpApproval,
+  }: {
+    prompt: string;
+    workingDirectory: string;
+    includeMcpApproval: boolean;
+  }): string[] {
+    return [
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--force",
+      "--trust",
+      ...(includeMcpApproval ? ["--approve-mcps"] : []),
+      "--workspace",
+      workingDirectory,
+      prompt,
+    ];
+  }
+
+  /**
+   * Parse cursor-agent stream-json NDJSON output into message objects.
+   *
+   * Cursor uses the same stream-json format name as Claude Code.
+   * Extracts objects that contain a `message` property.
+   *
+   * Exposed for unit testing.
+   */
+  parseStreamJsonOutput(output: string): any[] {
+    return output
+      .split("\n")
+      .map((line) => {
+        try {
+          return JSON.parse(line.trim());
+        } catch {
+          return null;
+        }
+      })
+      .filter((parsed) => parsed !== null && "message" in parsed)
+      .map((parsed) => parsed.message);
+  }
+
+  createAgent(options: RunnerOptions): AgentAdapter {
+    if (!this.binaryPath) {
+      throw new Error(
+        `[cursor] cursor-agent binary not found. Install it via: brew install cursor-cli (see https://docs.cursor.com/agent-cli)`
+      );
+    }
+
+    const { workingDirectory, skillPath, cleanEnv, skipMcp } = options;
+
+    // Copy skill tree if provided
+    let skillName: string | undefined;
+    if (skillPath) {
+      skillName = copySkillTree({
+        skillPath,
+        workingDirectory,
+        skillsDirectory: this.capabilities.skillsDirectory,
+      });
+
+      generateConfigFile({
+        configFile: this.capabilities.configFile,
+        workingDirectory,
+        skillsDirectory: this.capabilities.skillsDirectory,
+        skillName,
+      });
+    }
+
+    const binaryPath = this.binaryPath;
+
+    return {
+      role: AgentRole.AGENT,
+      call: async (state) => {
+        const formattedMessages = state.messages
+          .map((message) => `${message.role}: ${message.content}`)
+          .join("\n\n");
+
+        if (!skipMcp) {
+          const cursorDir = path.join(workingDirectory, ".cursor");
+          fs.mkdirSync(cursorDir, { recursive: true });
+
+          const mcpConfig = {
+            mcpServers: {
+              LangWatch: {
+                command: "node",
+                args: [
+                  mcpServerDistPath,
+                  "--apiKey",
+                  process.env.LANGWATCH_API_KEY!,
+                ],
+              },
+            },
+          };
+          fs.writeFileSync(
+            path.join(cursorDir, "mcp.json"),
+            JSON.stringify(mcpConfig)
+          );
+        }
+
+        return new Promise<AgentReturnTypes>((resolve, reject) => {
+          const args = this.buildArgs({
+            prompt: formattedMessages,
+            workingDirectory,
+            includeMcpApproval: !skipMcp,
+          });
+
+          console.log(
+            LOG_PREFIX,
+            chalk.blue("Starting cursor-agent in:"),
+            workingDirectory
+          );
+
+          const envVars = cleanEnv
+            ? Object.fromEntries(
+                Object.entries(process.env).filter(
+                  ([key]) =>
+                    ![
+                      "LANGWATCH_API_KEY",
+                      "OPENAI_API_KEY",
+                      "ANTHROPIC_API_KEY",
+                    ].includes(key)
+                )
+              )
+            : process.env;
+
+          // Pass CURSOR_API_KEY via --api-key if available
+          const apiKeyArgs = process.env.CURSOR_API_KEY
+            ? ["--api-key", process.env.CURSOR_API_KEY]
+            : [];
+
+          const child = spawn(binaryPath, [...apiKeyArgs, ...args], {
+            cwd: workingDirectory,
+            env: { ...envVars, FORCE_COLOR: "0" },
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+
+          let output = "";
+
+          child.stdout.on("data", (data: Buffer) => {
+            const text = data.toString();
+            console.log(LOG_PREFIX, text);
+            output += text;
+          });
+
+          child.stderr.on("data", (data: Buffer) => {
+            console.log(LOG_PREFIX, chalk.yellow("stderr:"), data.toString());
+          });
+
+          child.on("close", (exitCode) => {
+            if (exitCode === 0) {
+              const messages = this.parseStreamJsonOutput(output);
+              console.log(
+                LOG_PREFIX,
+                "messages",
+                JSON.stringify(messages, undefined, 2)
+              );
+              resolve(messages);
+            } else {
+              reject(
+                new Error(
+                  `[cursor] Command failed with exit code ${exitCode}`
+                )
+              );
+            }
+          });
+
+          child.on("error", (err) => {
+            reject(err);
+          });
+        });
+      },
+    };
+  }
+}

--- a/skills/_tests/helpers/shared.ts
+++ b/skills/_tests/helpers/shared.ts
@@ -1,0 +1,90 @@
+import type { ScenarioExecutionStateLike } from "@langwatch/scenario";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Copies a skill directory tree (SKILL.md + sibling _shared/) into the
+ * target skills directory inside the working directory.
+ *
+ * The _shared/ directory is resolved relative to the SKILL.md's grandparent
+ * (i.e. the skills root), matching the convention:
+ *   skills/<name>/SKILL.md
+ *   skills/_shared/
+ */
+export function copySkillTree({
+  skillPath,
+  workingDirectory,
+  skillsDirectory,
+}: {
+  skillPath: string;
+  workingDirectory: string;
+  skillsDirectory: string;
+}): string {
+  const skillName = path.basename(path.dirname(skillPath));
+  const destSkillDir = path.join(workingDirectory, skillsDirectory, skillName);
+  fs.mkdirSync(destSkillDir, { recursive: true });
+  fs.copyFileSync(skillPath, path.join(destSkillDir, "SKILL.md"));
+
+  // Copy _shared/ directory from the skills root (sibling of the skill's directory)
+  const skillsRoot = path.dirname(path.dirname(skillPath));
+  const sharedSrc = path.join(skillsRoot, "_shared");
+  if (fs.existsSync(sharedSrc)) {
+    const sharedDest = path.join(destSkillDir, "_shared");
+    fs.mkdirSync(sharedDest, { recursive: true });
+    fs.cpSync(sharedSrc, sharedDest, { recursive: true });
+  }
+
+  return skillName;
+}
+
+/**
+ * Generates a config file (e.g. CLAUDE.md) in the working directory
+ * that points to the skills directory. If configFile is undefined, does nothing.
+ */
+export function generateConfigFile({
+  configFile,
+  workingDirectory,
+  skillsDirectory,
+  skillName,
+}: {
+  configFile: string | undefined;
+  workingDirectory: string;
+  skillsDirectory: string;
+  skillName: string;
+}): void {
+  if (!configFile) {
+    return;
+  }
+
+  const configPath = path.join(workingDirectory, configFile);
+  const content = [
+    `# Auto-generated for skill testing`,
+    ``,
+    `Read and follow the instructions in ${skillsDirectory}/${skillName}/SKILL.md`,
+  ].join("\n");
+
+  fs.writeFileSync(configPath, content);
+}
+
+/**
+ * Fixes Anthropic tool use format in message state so it is compatible
+ * with the Vercel AI SDK judge agent.
+ *
+ * Anthropic returns tool_use content blocks that the Vercel AI SDK does
+ * not understand. This converts non-text blocks to text blocks containing
+ * the JSON representation.
+ */
+export function toolCallFix(state: ScenarioExecutionStateLike): void {
+  state.messages.forEach((message) => {
+    if (Array.isArray(message.content)) {
+      message.content.forEach((content, index) => {
+        if (content.type !== "text") {
+          (message.content as any)[index] = {
+            type: "text",
+            text: JSON.stringify(content),
+          };
+        }
+      });
+    }
+  });
+}

--- a/skills/_tests/helpers/types.ts
+++ b/skills/_tests/helpers/types.ts
@@ -1,0 +1,45 @@
+import type { AgentAdapter } from "@langwatch/scenario";
+
+/**
+ * Declares what a code assistant runner supports.
+ *
+ * Each runner uses these to let tests skip gracefully when a capability
+ * is missing (e.g. MCP not supported by Codex).
+ */
+export interface AgentRunnerCapabilities {
+  /** Whether the runner supports MCP server configuration. */
+  supportsMcp: boolean;
+  /** Directory path (relative to working dir) where skills are placed. */
+  skillsDirectory: string;
+  /** Config file name generated in the working directory, if any. */
+  configFile?: string;
+}
+
+/**
+ * Options passed when creating an agent adapter from a runner.
+ */
+export interface RunnerOptions {
+  /** The directory the spawned assistant process will use as cwd. */
+  workingDirectory: string;
+  /** Path to a SKILL.md file; the runner copies the skill tree into the working directory. */
+  skillPath?: string;
+  /** Strip API keys from the spawned environment. */
+  cleanEnv?: boolean;
+  /** Omit MCP configuration even if the runner supports it. */
+  skipMcp?: boolean;
+}
+
+/**
+ * A code assistant runner that can spawn an agent adapter for scenario tests.
+ *
+ * Implementations exist for Claude Code and Codex. Each runner normalizes
+ * its own output format internally -- callers get a standard AgentAdapter.
+ */
+export interface AgentRunner {
+  /** Human-readable name used for log prefixes and diagnostics. */
+  readonly name: string;
+  /** Capability declarations for this runner. */
+  readonly capabilities: AgentRunnerCapabilities;
+  /** Create an AgentAdapter that spawns the assistant binary. */
+  createAgent(options: RunnerOptions): AgentAdapter;
+}

--- a/skills/_tests/level-up.scenario.test.ts
+++ b/skills/_tests/level-up.scenario.test.ts
@@ -7,7 +7,7 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { createAgent, isRunnerAvailable } from "./helpers/agent-factory";
 import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -16,7 +16,6 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
-const runner = getRunner();
 const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");

--- a/skills/_tests/level-up.scenario.test.ts
+++ b/skills/_tests/level-up.scenario.test.ts
@@ -7,10 +7,8 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import {
-  createClaudeCodeAgent,
-  toolCallFix,
-} from "./helpers/claude-code-adapter";
+import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,25 +16,15 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
+const runner = getRunner();
+const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");
 
-function copySkillToWorkDir(tempFolder: string) {
-  const skillDir = path.join(tempFolder, ".skills", "level-up");
-  fs.mkdirSync(skillDir, { recursive: true });
-  fs.copyFileSync(
-    path.resolve(__dirname, "../level-up/SKILL.md"),
-    path.join(skillDir, "SKILL.md")
-  );
-  const sharedDir = path.join(skillDir, "_shared");
-  fs.mkdirSync(sharedDir, { recursive: true });
-  execSync(
-    `cp -r ${path.resolve(__dirname, "../_shared")}/* ${sharedDir}/`
-  );
-}
+const skillPath = path.resolve(__dirname, "../level-up/SKILL.md");
 
 describe("Level-up Skill", () => {
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "orchestrates all sub-skills for a Python OpenAI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -46,14 +34,13 @@ describe("Level-up Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python OpenAI level-up",
         description:
           "Taking a Python OpenAI bot to the next level with full LangWatch integration.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -87,7 +74,7 @@ describe("Level-up Skill", () => {
     900_000 // 15 min timeout for meta-skill
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "orchestrates all sub-skills for a TypeScript Vercel AI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -96,14 +83,13 @@ describe("Level-up Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-vercel")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Vercel AI level-up",
         description:
           "Taking a TypeScript Vercel AI bot to the next level with full LangWatch integration.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -135,7 +121,7 @@ describe("Level-up Skill", () => {
     900_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "orchestrates all sub-skills for a Python LangGraph agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -144,14 +130,13 @@ describe("Level-up Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-langgraph")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python LangGraph level-up",
         description:
           "Taking a Python LangGraph agent to the next level with full LangWatch integration.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -182,7 +167,7 @@ describe("Level-up Skill", () => {
     900_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "orchestrates all sub-skills for a TypeScript Mastra agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -191,14 +176,13 @@ describe("Level-up Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-mastra")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Mastra level-up",
         description:
           "Taking a TypeScript Mastra agent to the next level with full LangWatch integration.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,

--- a/skills/_tests/package.json
+++ b/skills/_tests/package.json
@@ -7,7 +7,8 @@
     "test": "vitest",
     "test:claude": "AGENT_UNDER_TEST=claude-code vitest run --exclude static-validation.test.ts",
     "test:codex": "AGENT_UNDER_TEST=codex vitest run --exclude static-validation.test.ts",
-    "test:all-agents": "pnpm test:claude && pnpm test:codex"
+    "test:cursor": "AGENT_UNDER_TEST=cursor vitest run --exclude static-validation.test.ts",
+    "test:all-agents": "pnpm test:claude && pnpm test:codex && pnpm test:cursor"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.44",

--- a/skills/_tests/package.json
+++ b/skills/_tests/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "test:claude": "AGENT_UNDER_TEST=claude-code vitest run --exclude static-validation.test.ts",
+    "test:codex": "AGENT_UNDER_TEST=codex vitest run --exclude static-validation.test.ts",
+    "test:all-agents": "pnpm test:claude && pnpm test:codex"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.44",

--- a/skills/_tests/prompts-cli.scenario.test.ts
+++ b/skills/_tests/prompts-cli.scenario.test.ts
@@ -6,7 +6,7 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { createAgent, isRunnerAvailable } from "./helpers/agent-factory";
 import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -15,7 +15,6 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
-const runner = getRunner();
 const runnerUnavailable = !isRunnerAvailable();
 const judgeModel = openai("gpt-5-mini");
 

--- a/skills/_tests/prompts-cli.scenario.test.ts
+++ b/skills/_tests/prompts-cli.scenario.test.ts
@@ -1,16 +1,13 @@
 import scenario, { type ScenarioExecutionStateLike } from "@langwatch/scenario";
 import fs from "fs";
-import { execSync } from "child_process";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import {
-  createClaudeCodeAgent,
-  toolCallFix,
-} from "./helpers/claude-code-adapter";
+import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,6 +15,8 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
+const runner = getRunner();
+const runnerUnavailable = !isRunnerAvailable();
 const judgeModel = openai("gpt-5-mini");
 
 function assertNoInteractiveWorkarounds(
@@ -37,15 +36,17 @@ function assertNoInteractiveWorkarounds(
 }
 
 describe("LangWatch Prompts CLI — Agent Usability", () => {
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "agent discovers and uses CLI to version prompts from scratch",
     async () => {
       const tempFolder = fs.mkdtempSync(
         path.join(os.tmpdir(), "langwatch-cli-prompts-version-")
       );
 
-      execSync(
-        `cp -r ${path.resolve(__dirname, "fixtures/cli-prompts/python-with-prompts")}/* ${tempFolder}/`
+      fs.cpSync(
+        path.resolve(__dirname, "fixtures/cli-prompts/python-with-prompts"),
+        tempFolder,
+        { recursive: true }
       );
 
       fs.writeFileSync(
@@ -58,7 +59,7 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
         description:
           "Developer has a Python project with hardcoded prompts and wants to use the LangWatch Prompts CLI to version them.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -106,7 +107,7 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "agent creates a specific named prompt via CLI",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -132,7 +133,7 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
         description:
           "Developer wants to create a new prompt called refund-handler for customer refund requests using the CLI.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -179,7 +180,7 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "agent uses push --force-local to resolve conflicts non-interactively",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -206,7 +207,7 @@ describe("LangWatch Prompts CLI — Agent Usability", () => {
         description:
           "Agent creates a prompt and pushes it to the platform. If there are conflicts, it should use --force-local to resolve them automatically.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,

--- a/skills/_tests/prompts.scenario.test.ts
+++ b/skills/_tests/prompts.scenario.test.ts
@@ -7,7 +7,7 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { createAgent, isRunnerAvailable } from "./helpers/agent-factory";
 import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -16,7 +16,6 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
-const runner = getRunner();
 const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");

--- a/skills/_tests/prompts.scenario.test.ts
+++ b/skills/_tests/prompts.scenario.test.ts
@@ -7,10 +7,8 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import {
-  createClaudeCodeAgent,
-  toolCallFix,
-} from "./helpers/claude-code-adapter";
+import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,22 +16,12 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
+const runner = getRunner();
+const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");
 
-function copySkillToWorkDir(tempFolder: string) {
-  const skillDir = path.join(tempFolder, ".skills", "prompts");
-  fs.mkdirSync(skillDir, { recursive: true });
-  fs.copyFileSync(
-    path.resolve(__dirname, "../prompts/SKILL.md"),
-    path.join(skillDir, "SKILL.md")
-  );
-  const sharedDir = path.join(skillDir, "_shared");
-  fs.mkdirSync(sharedDir, { recursive: true });
-  execSync(
-    `cp -r ${path.resolve(__dirname, "../_shared")}/* ${sharedDir}/`
-  );
-}
+const skillPath = path.resolve(__dirname, "../prompts/SKILL.md");
 
 function findFiles(dir: string, pattern: RegExp): string[] {
   const results: string[] = [];
@@ -55,7 +43,7 @@ function findFiles(dir: string, pattern: RegExp): string[] {
 }
 
 describe("Prompts Skill", () => {
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "versions prompts in a Python OpenAI bot with LangWatch Prompts CLI",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -65,14 +53,13 @@ describe("Prompts Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python OpenAI prompt versioning",
         description:
           "Setting up prompt versioning in a Python OpenAI bot project using the LangWatch Prompts CLI.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -119,7 +106,7 @@ describe("Prompts Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "versions prompts in a TypeScript Vercel AI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -128,14 +115,13 @@ describe("Prompts Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-vercel")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Vercel AI prompt versioning",
         description:
           "Setting up prompt versioning in a TypeScript Vercel AI bot project.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -180,7 +166,7 @@ describe("Prompts Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "versions prompts in a Python LangGraph agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -189,14 +175,13 @@ describe("Prompts Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-langgraph")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python LangGraph prompt versioning",
         description:
           "Setting up prompt versioning in a Python LangGraph agent project using the LangWatch Prompts CLI.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -243,7 +228,7 @@ describe("Prompts Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "versions prompts in a TypeScript Mastra agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -252,14 +237,13 @@ describe("Prompts Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-mastra")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Mastra prompt versioning",
         description:
           "Setting up prompt versioning in a TypeScript Mastra agent project.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -304,7 +288,7 @@ describe("Prompts Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates a new prompt version for a specific use case",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -313,14 +297,13 @@ describe("Prompts Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Targeted prompt creation",
         description:
           "Adding a new versioned prompt for a specific customer support use case.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,

--- a/skills/_tests/recipes.scenario.test.ts
+++ b/skills/_tests/recipes.scenario.test.ts
@@ -7,10 +7,8 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import {
-  createClaudeCodeAgent,
-  toolCallFix,
-} from "./helpers/claude-code-adapter";
+import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,22 +16,10 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
+const runner = getRunner();
+const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");
-
-function copyRecipeSkillToWorkDir(tempFolder: string, recipeName: string) {
-  const skillDir = path.join(tempFolder, ".skills", recipeName);
-  fs.mkdirSync(skillDir, { recursive: true });
-  fs.copyFileSync(
-    path.resolve(__dirname, `../recipes/${recipeName}/SKILL.md`),
-    path.join(skillDir, "SKILL.md")
-  );
-  const sharedDir = path.join(skillDir, "_shared");
-  fs.mkdirSync(sharedDir, { recursive: true });
-  execSync(
-    `cp -r ${path.resolve(__dirname, "../_shared")}/* ${sharedDir}/`
-  );
-}
 
 function findTestFiles(dir: string, pattern: RegExp): string[] {
   const results: string[] = [];
@@ -82,7 +68,7 @@ function findNewPythonFiles(
 }
 
 describe("Recipes", () => {
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "generates a RAG evaluation dataset from the TerraVerde knowledge base",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -92,14 +78,17 @@ describe("Recipes", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-rag-agent")}/* ${tempFolder}/`
       );
-      copyRecipeSkillToWorkDir(tempFolder, "generate-rag-dataset");
+      const recipeSkillPath = path.resolve(
+        __dirname,
+        "../recipes/generate-rag-dataset/SKILL.md"
+      );
 
       const result = await scenario.run({
         name: "Generate RAG evaluation dataset",
         description:
           "Generate a synthetic evaluation dataset from the TerraVerde farm advisory RAG knowledge base, including diverse question types and context per row.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath: recipeSkillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -179,7 +168,7 @@ describe("Recipes", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates compliance scenario tests for the health agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -189,14 +178,17 @@ describe("Recipes", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-health-agent")}/* ${tempFolder}/`
       );
-      copyRecipeSkillToWorkDir(tempFolder, "test-compliance");
+      const recipeSkillPath = path.resolve(
+        __dirname,
+        "../recipes/test-compliance/SKILL.md"
+      );
 
       const result = await scenario.run({
         name: "Health agent compliance tests",
         description:
           "Create scenario tests that verify the health wellness agent stays observational and does not give prescriptive medical advice. Include boundary enforcement and red team tests.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath: recipeSkillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -270,7 +262,7 @@ describe("Recipes", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable || !runner.capabilities.supportsMcp)(
     "uses MCP to debug instrumentation traces",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -280,14 +272,17 @@ describe("Recipes", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copyRecipeSkillToWorkDir(tempFolder, "debug-instrumentation");
+      const recipeSkillPath = path.resolve(
+        __dirname,
+        "../recipes/debug-instrumentation/SKILL.md"
+      );
 
       const result = await scenario.run({
         name: "Debug instrumentation via MCP",
         description:
           "Use the LangWatch MCP to inspect production traces and identify instrumentation issues or suggest improvements.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath: recipeSkillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,

--- a/skills/_tests/scenarios.scenario.test.ts
+++ b/skills/_tests/scenarios.scenario.test.ts
@@ -7,10 +7,8 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import {
-  createClaudeCodeAgent,
-  toolCallFix,
-} from "./helpers/claude-code-adapter";
+import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,22 +16,12 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
+const runner = getRunner();
+const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");
 
-function copySkillToWorkDir(tempFolder: string) {
-  const skillDir = path.join(tempFolder, ".skills", "scenarios");
-  fs.mkdirSync(skillDir, { recursive: true });
-  fs.copyFileSync(
-    path.resolve(__dirname, "../scenarios/SKILL.md"),
-    path.join(skillDir, "SKILL.md")
-  );
-  const sharedDir = path.join(skillDir, "_shared");
-  fs.mkdirSync(sharedDir, { recursive: true });
-  execSync(
-    `cp -r ${path.resolve(__dirname, "../_shared")}/* ${sharedDir}/`
-  );
-}
+const skillPath = path.resolve(__dirname, "../scenarios/SKILL.md");
 
 function findTestFiles(dir: string, pattern: RegExp): string[] {
   const results: string[] = [];
@@ -51,7 +39,7 @@ function findTestFiles(dir: string, pattern: RegExp): string[] {
 }
 
 describe("Scenarios Skill", () => {
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates scenario tests for a Python OpenAI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -61,14 +49,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python OpenAI scenario tests",
         description:
           "Adding agent simulation tests to a Python OpenAI conversational bot project using the LangWatch Scenario framework.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -132,7 +119,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates scenario tests for a TypeScript Vercel AI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -142,14 +129,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-vercel")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Vercel AI scenario tests",
         description:
           "Adding agent simulation tests to a TypeScript Vercel AI bot project using the LangWatch Scenario framework.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -196,7 +182,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates scenario tests for a Python LangGraph agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -205,14 +191,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-langgraph")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python LangGraph scenario tests",
         description:
           "Adding scenario tests to a Python LangGraph agent project.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -244,7 +229,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates red team tests for a Python OpenAI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -254,14 +239,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python OpenAI red team tests",
         description:
           "Adding adversarial red team tests to a Python OpenAI bot project using the LangWatch Scenario framework's RedTeamAgent.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -306,7 +290,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates red team tests for a TypeScript Vercel AI bot",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -316,14 +300,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-vercel")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Vercel AI red team tests",
         description:
           "Adding adversarial red team tests to a TypeScript Vercel AI bot project using the LangWatch Scenario framework's RedTeamAgent.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -371,7 +354,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates a targeted scenario for a specific behavior",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -381,14 +364,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Targeted scenario for emoji handling",
         description:
           "Adding a specific scenario test for the tweet-like bot to verify it uses emojis correctly.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -421,7 +403,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable || !runner.capabilities.supportsMcp)(
     "uses platform MCP tools when no codebase is present",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -429,14 +411,13 @@ describe("Scenarios Skill", () => {
       );
 
       // No fixture copied — empty directory
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Platform scenario creation",
         description:
           "Creating scenarios on the LangWatch platform when there is no codebase.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -481,7 +462,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates scenario tests for a TypeScript Mastra agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -490,14 +471,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-mastra")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Mastra scenario tests",
         description:
           "Adding scenario tests to a TypeScript Mastra agent project.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -528,7 +508,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "creates domain-specific scenarios for a RAG agent",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -537,14 +517,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-rag-agent")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "RAG agent domain-specific scenarios",
         description:
           "Adding scenario tests to a TerraVerde farm advisory RAG agent that handles irrigation, frost protection, and pest management.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -595,7 +574,7 @@ describe("Scenarios Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "suggests domain-specific improvements after delivering initial scenarios",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -604,14 +583,13 @@ describe("Scenarios Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-rag-agent")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Consultant mode — deeper suggestions",
         description:
           "Agent sets up scenarios for a farm advisory agent, then suggests domain-specific improvements.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,

--- a/skills/_tests/tracing.scenario.test.ts
+++ b/skills/_tests/tracing.scenario.test.ts
@@ -7,10 +7,8 @@ import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { openai } from "@ai-sdk/openai";
-import {
-  createClaudeCodeAgent,
-  toolCallFix,
-} from "./helpers/claude-code-adapter";
+import { createAgent, getRunner, isRunnerAvailable } from "./helpers/agent-factory";
+import { toolCallFix } from "./helpers/shared";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,25 +16,15 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
+const runner = getRunner();
+const runnerUnavailable = !isRunnerAvailable();
 
 const judgeModel = openai("gpt-5-mini");
 
-function copySkillToWorkDir(tempFolder: string) {
-  const skillDir = path.join(tempFolder, ".skills", "tracing");
-  fs.mkdirSync(skillDir, { recursive: true });
-  fs.copyFileSync(
-    path.resolve(__dirname, "../tracing/SKILL.md"),
-    path.join(skillDir, "SKILL.md")
-  );
-  const sharedDir = path.join(skillDir, "_shared");
-  fs.mkdirSync(sharedDir, { recursive: true });
-  execSync(
-    `cp -r ${path.resolve(__dirname, "../_shared")}/* ${sharedDir}/`
-  );
-}
+const skillPath = path.resolve(__dirname, "../tracing/SKILL.md");
 
 describe("Tracing Skill", () => {
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "instruments a Python OpenAI bot with LangWatch",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -46,14 +34,13 @@ describe("Tracing Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python OpenAI instrumentation",
         description:
           "Implementing LangWatch instrumentation in a Python OpenAI bot project.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -86,7 +73,7 @@ describe("Tracing Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "instruments a TypeScript Vercel AI bot with LangWatch",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -96,14 +83,13 @@ describe("Tracing Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-vercel")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Vercel AI instrumentation",
         description:
           "Implementing LangWatch instrumentation in a TypeScript Vercel AI bot project.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -135,7 +121,7 @@ describe("Tracing Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "instruments a Python LangGraph agent with LangWatch",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -145,14 +131,13 @@ describe("Tracing Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-langgraph")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "Python LangGraph instrumentation",
         description:
           "Implementing LangWatch instrumentation in a Python LangGraph agent project.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -184,7 +169,7 @@ describe("Tracing Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "instruments a TypeScript Mastra agent with LangWatch",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -194,14 +179,13 @@ describe("Tracing Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/typescript-mastra")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       const result = await scenario.run({
         name: "TypeScript Mastra instrumentation",
         description:
           "Implementing LangWatch instrumentation in a TypeScript Mastra agent project.",
         agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          createAgent({ workingDirectory: tempFolder, skillPath }),
           scenario.userSimulatorAgent({ model: judgeModel }),
           scenario.judgeAgent({
             model: judgeModel,
@@ -233,7 +217,7 @@ describe("Tracing Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "instruments code without env API key — discovers from .env file",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -243,7 +227,6 @@ describe("Tracing Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       // Write .env with API key — agent must discover this
       fs.writeFileSync(
@@ -256,8 +239,9 @@ describe("Tracing Skill", () => {
         description:
           "Developer instruments code without LANGWATCH_API_KEY in environment. API key is in the project .env file.",
         agents: [
-          createClaudeCodeAgent({
+          createAgent({
             workingDirectory: tempFolder,
+            skillPath,
             cleanEnv: true,
           }),
           scenario.userSimulatorAgent({ model: judgeModel }),
@@ -292,7 +276,7 @@ describe("Tracing Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable || !runner.capabilities.supportsMcp)(
     "instruments code without MCP — uses llms.txt fallback for docs",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -301,7 +285,6 @@ describe("Tracing Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       // Write .env with API key
       fs.writeFileSync(
@@ -314,8 +297,9 @@ describe("Tracing Skill", () => {
         description:
           "Agent instruments code without MCP access, using direct URL fetching for docs.",
         agents: [
-          createClaudeCodeAgent({
+          createAgent({
             workingDirectory: tempFolder,
+            skillPath,
             skipMcp: true,
           }),
           scenario.userSimulatorAgent({ model: judgeModel }),
@@ -346,7 +330,7 @@ describe("Tracing Skill", () => {
     600_000
   );
 
-  it.skipIf(isCI)(
+  it.skipIf(isCI || runnerUnavailable)(
     "asks user for API key when not found in environment or .env",
     async () => {
       const tempFolder = fs.mkdtempSync(
@@ -355,7 +339,6 @@ describe("Tracing Skill", () => {
       execSync(
         `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`
       );
-      copySkillToWorkDir(tempFolder);
 
       // NO .env file — agent must ask user for the key
 
@@ -364,8 +347,9 @@ describe("Tracing Skill", () => {
         description:
           "Agent instruments code but has no API key available. Must ask the user.",
         agents: [
-          createClaudeCodeAgent({
+          createAgent({
             workingDirectory: tempFolder,
+            skillPath,
             cleanEnv: true,
           }),
           scenario.userSimulatorAgent({ model: judgeModel }),

--- a/specs/skills/multi-assistant-adapters.feature
+++ b/specs/skills/multi-assistant-adapters.feature
@@ -1,0 +1,218 @@
+@skills @testing @infrastructure
+Feature: Multi-assistant adapters for skill scenario tests
+  As the LangWatch team
+  We want the same scenario tests to run against Claude Code and Codex
+  So that we can verify skills work across multiple code assistants without duplicating test files
+
+  # Note: Cursor CLI support is deferred — CLI lacks stable non-interactive mode.
+
+  Background:
+    Given scenario tests live in skills/_tests/
+    And a test uses createAgent() to obtain an AgentAdapter
+    And the active runner is selected via the AGENT_UNDER_TEST environment variable
+
+  # ──────────────────────────────────────────────────
+  # R1: AgentRunner interface and types
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Runner exposes name and MCP capability flag
+    Given a runner implementing the AgentRunner interface
+    Then it exposes a name identifying the assistant
+    And it exposes capabilities declaring MCP support, skills directory, and config file
+    And it provides a createAgent method that returns an AgentAdapter
+
+  @unit
+  Scenario: Capabilities accurately reflect assistant limitations
+    Given each runner declares its capabilities at construction time
+    Then the Claude Code runner declares MCP support as true
+    And the Codex runner declares MCP support as false
+    And each runner declares the correct skills directory for its assistant
+
+  # ──────────────────────────────────────────────────
+  # R2: Claude Code runner extraction
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Claude Code runner constructs correct CLI arguments
+    Given the Claude Code runner is configured
+    When it builds the spawn arguments
+    Then the args include --output-format stream-json
+    And the args include -p for prompt mode
+    And the args include --dangerously-skip-permissions and --verbose
+
+  @unit
+  Scenario: Claude Code runner generates MCP config when not skipped
+    Given the Claude Code runner is configured with skipMcp as false
+    When createAgent is called
+    Then a .mcp-config.json file is written to the working directory
+    And the config points to the LangWatch MCP server
+
+  @unit
+  Scenario: Claude Code runner normalizes stream-json output
+    Given Claude Code produces stream-json NDJSON with tool_use content blocks
+    When the runner parses the output
+    Then it normalizes tool_use blocks to text blocks for SDK compatibility
+
+  @integration
+  Scenario: Claude Code runner spawns binary and produces AgentAdapter response
+    Given the Claude Code runner is extracted from claude-code-adapter.ts
+    When a test creates an agent via the Claude Code runner
+    Then it spawns the claude binary successfully
+    And the returned response is compatible with @langwatch/scenario
+
+  @integration
+  Scenario: Legacy import paths resolve to new module locations
+    Given existing test files import from claude-code-adapter.ts
+    When the module is loaded
+    Then all previously exported symbols are still available
+    And they delegate to the new runner and shared utility locations
+
+  # ──────────────────────────────────────────────────
+  # R3: Codex runner
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Codex runner constructs correct CLI arguments
+    Given the Codex runner is configured
+    When it builds the spawn arguments
+    Then the args include exec --full-auto --json flags
+
+  @unit
+  Scenario: Codex runner parses JSONL output from fixture data
+    Given a JSONL fixture containing thread.started, item.completed, and turn.completed events
+    When the Codex output parser processes the fixture
+    Then it extracts the assistant message content from item.completed events
+    And it ignores non-message events
+
+  @unit
+  Scenario: Codex runner normalizes output for SDK compatibility
+    Given Codex produces JSONL with its own content block structure
+    When the runner parses the output
+    Then it normalizes content into the format expected by @langwatch/scenario
+
+  @unit
+  Scenario: Codex runner places skills in the agents directory
+    Given the Codex runner handles skill placement
+    When a skill is provided via skillPath in RunnerOptions
+    Then the skill file is copied to .agents/skills/<name>/SKILL.md
+
+  @unit
+  Scenario: Codex runner operates without MCP silently
+    Given the Codex runner does not support MCP
+    When a test requests MCP configuration
+    Then the runner proceeds without error
+    And no MCP config file is written to the working directory
+
+  @integration
+  Scenario: Codex runner spawns binary and produces AgentAdapter response
+    Given the Codex runner is configured
+    And the codex binary is available on the system path
+    When a test creates an agent via the Codex runner
+    Then it spawns the codex binary successfully
+    And the returned response is compatible with @langwatch/scenario
+
+  # ──────────────────────────────────────────────────
+  # R4: Agent factory and environment variable selection
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Factory defaults to Claude Code when no env var is set
+    Given AGENT_UNDER_TEST is not set
+    When createAgent is called
+    Then the factory selects the Claude Code runner
+
+  @unit
+  Scenario: Factory selects the runner matching the env var
+    Given AGENT_UNDER_TEST is set to "codex"
+    When createAgent is called
+    Then the factory selects the Codex runner
+
+  @unit
+  Scenario: Factory rejects unknown assistant names
+    Given AGENT_UNDER_TEST is set to "unknown-assistant"
+    When createAgent is called
+    Then the factory throws an error identifying the unknown agent name
+    And the error message lists valid assistant names
+
+  # ──────────────────────────────────────────────────
+  # R5: Skill placement abstraction
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Runner copies skill directory tree including _shared content
+    Given a skill at skills/tracing/ contains SKILL.md and _shared/ directory
+    When createAgent is called with a skillPath pointing to SKILL.md
+    Then the runner copies SKILL.md to <skillsDir>/<name>/SKILL.md
+    And the runner copies the _shared/ directory alongside it
+    And the full skill directory tree is preserved
+
+  @unit
+  Scenario: Claude Code runner generates CLAUDE.md pointing to skills
+    Given the Claude Code runner needs a CLAUDE.md referencing skills
+    When createAgent is called with a skillPath
+    Then a CLAUDE.md file is generated in the working directory
+    And it points to the skills directory
+
+  @unit
+  Scenario: Codex runner skips config file generation
+    Given the Codex runner has no configFile defined
+    When createAgent is called with a skillPath
+    Then no config file is generated
+    And skills are placed in the correct directory without additional config
+
+  # ──────────────────────────────────────────────────
+  # R6: Missing binary handling
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Runner throws descriptive error when binary is not found
+    Given the codex binary is not installed on the system
+    When a test attempts to create an agent via the Codex runner
+    Then the runner throws a descriptive error identifying the missing binary
+    And the error message includes installation instructions or a URL
+
+  @unit
+  Scenario: Test suite skips gracefully when selected runner is unavailable
+    Given AGENT_UNDER_TEST is set to "codex"
+    And the codex binary is not installed
+    When the test suite starts
+    Then all tests report as skipped with a reason
+    And no test reports as failed due to the missing binary
+
+  # ──────────────────────────────────────────────────
+  # R7: Test runner scripts
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Default pnpm test runs Claude Code without env var
+    Given a developer runs pnpm test without setting AGENT_UNDER_TEST
+    Then tests run against Claude Code by default
+    And behavior is identical to the pre-migration test command
+
+  # ──────────────────────────────────────────────────
+  # R8: Capability-aware test skipping
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: MCP-dependent tests skip on runners without MCP support
+    Given a test uses it.skipIf based on runner.capabilities.supportsMcp
+    When tests run against the Codex runner
+    Then tests requiring MCP tools are skipped
+    And tests not requiring MCP still execute normally
+
+  @unit
+  Scenario: MCP-dependent tests run on runners with MCP support
+    Given a test uses it.skipIf based on runner.capabilities.supportsMcp
+    When tests run against the Claude Code runner
+    Then all tests execute including MCP-dependent ones
+
+  # ──────────────────────────────────────────────────
+  # R9: Runner attribution in logs
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Log output prefixed with runner name for diagnostics
+    Given a runner is executing a scenario
+    When the runner logs output from the spawned process
+    Then each log line is prefixed with the runner name

--- a/specs/skills/multi-assistant-adapters.feature
+++ b/specs/skills/multi-assistant-adapters.feature
@@ -1,10 +1,8 @@
 @skills @testing @infrastructure
 Feature: Multi-assistant adapters for skill scenario tests
   As the LangWatch team
-  We want the same scenario tests to run against Claude Code and Codex
+  We want the same scenario tests to run against Claude Code, Codex, and Cursor
   So that we can verify skills work across multiple code assistants without duplicating test files
-
-  # Note: Cursor CLI support is deferred — CLI lacks stable non-interactive mode.
 
   Background:
     Given scenario tests live in skills/_tests/
@@ -27,6 +25,7 @@ Feature: Multi-assistant adapters for skill scenario tests
     Given each runner declares its capabilities at construction time
     Then the Claude Code runner declares MCP support as true
     And the Codex runner declares MCP support as false
+    And the Cursor runner declares MCP support as true
     And each runner declares the correct skills directory for its assistant
 
   # ──────────────────────────────────────────────────
@@ -113,6 +112,55 @@ Feature: Multi-assistant adapters for skill scenario tests
     And the returned response is compatible with @langwatch/scenario
 
   # ──────────────────────────────────────────────────
+  # R3b: Cursor runner
+  # ──────────────────────────────────────────────────
+
+  @unit
+  Scenario: Cursor runner constructs correct CLI arguments
+    Given the Cursor runner is configured
+    When it builds the spawn arguments
+    Then the args include -p for non-interactive print mode
+    And the args include --output-format stream-json
+    And the args include --force and --trust
+    And the args include --approve-mcps when MCP is configured
+    And the args include --workspace pointing to the working directory
+
+  @unit
+  Scenario: Cursor runner parses stream-json output
+    Given Cursor produces stream-json NDJSON output
+    When the runner parses the output
+    Then it extracts message objects from the NDJSON lines
+
+  @unit
+  Scenario: Cursor runner places skills in .cursor/rules directory
+    Given the Cursor runner handles skill placement
+    When a skill is provided via skillPath in RunnerOptions
+    Then the skill file is copied to .cursor/rules/<name>/SKILL.md
+
+  @unit
+  Scenario: Cursor runner writes MCP config to .cursor/mcp.json
+    Given the Cursor runner supports MCP
+    And skipMcp is false
+    When createAgent is called
+    Then a .cursor/mcp.json file is written in the working directory
+    And the config points to the LangWatch MCP server
+
+  @unit
+  Scenario: Cursor runner skips MCP config when skipMcp is true
+    Given the Cursor runner supports MCP
+    And skipMcp is true
+    When createAgent is called
+    Then no .cursor/mcp.json file is written
+
+  @integration
+  Scenario: Cursor runner spawns binary and produces AgentAdapter response
+    Given the Cursor runner is configured
+    And the cursor-agent binary is available on the system path
+    When a test creates an agent via the Cursor runner
+    Then it spawns the cursor-agent binary successfully
+    And the returned response is compatible with @langwatch/scenario
+
+  # ──────────────────────────────────────────────────
   # R4: Agent factory and environment variable selection
   # ──────────────────────────────────────────────────
 
@@ -124,9 +172,9 @@ Feature: Multi-assistant adapters for skill scenario tests
 
   @unit
   Scenario: Factory selects the runner matching the env var
-    Given AGENT_UNDER_TEST is set to "codex"
+    Given AGENT_UNDER_TEST is set to "cursor"
     When createAgent is called
-    Then the factory selects the Codex runner
+    Then the factory selects the Cursor runner
 
   @unit
   Scenario: Factory rejects unknown assistant names
@@ -161,21 +209,28 @@ Feature: Multi-assistant adapters for skill scenario tests
     Then no config file is generated
     And skills are placed in the correct directory without additional config
 
+  @unit
+  Scenario: Cursor runner generates .cursorrules pointing to skills
+    Given the Cursor runner needs a .cursorrules referencing skills
+    When createAgent is called with a skillPath
+    Then a .cursorrules file is generated in the working directory
+    And it points to the .cursor/rules skills directory
+
   # ──────────────────────────────────────────────────
   # R6: Missing binary handling
   # ──────────────────────────────────────────────────
 
   @unit
   Scenario: Runner throws descriptive error when binary is not found
-    Given the codex binary is not installed on the system
-    When a test attempts to create an agent via the Codex runner
+    Given the cursor-agent binary is not installed on the system
+    When a test attempts to create an agent via the Cursor runner
     Then the runner throws a descriptive error identifying the missing binary
     And the error message includes installation instructions or a URL
 
   @unit
   Scenario: Test suite skips gracefully when selected runner is unavailable
-    Given AGENT_UNDER_TEST is set to "codex"
-    And the codex binary is not installed
+    Given AGENT_UNDER_TEST is set to "cursor"
+    And the cursor-agent binary is not installed
     When the test suite starts
     Then all tests report as skipped with a reason
     And no test reports as failed due to the missing binary
@@ -204,7 +259,7 @@ Feature: Multi-assistant adapters for skill scenario tests
   @unit
   Scenario: MCP-dependent tests run on runners with MCP support
     Given a test uses it.skipIf based on runner.capabilities.supportsMcp
-    When tests run against the Claude Code runner
+    When tests run against the Cursor runner
     Then all tests execute including MCP-dependent ones
 
   # ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Introduces an `AgentRunner` interface and factory pattern so the same 36 scenario tests can run against **Claude Code**, **Codex**, and **Cursor**
- Tests select the active runner via `AGENT_UNDER_TEST` env var, defaulting to `claude-code`
- Each runner normalizes its own output format internally

## What changed

**New infrastructure** (`skills/_tests/helpers/`):
- `types.ts` — `AgentRunner`, `AgentRunnerCapabilities`, `RunnerOptions` interfaces
- `runners/claude-code.ts` — Extracted from existing adapter, stream-json NDJSON parsing
- `runners/codex.ts` — Codex runner with JSONL parsing, `.agents/skills/` placement, no MCP
- `runners/cursor.ts` — Cursor runner with stream-json parsing, `.cursor/rules/` placement, `.cursor/mcp.json` config
- `agent-factory.ts` — `getRunner()`, `createAgent()`, `isRunnerAvailable()` factory
- `shared.ts` — `copySkillTree()`, `generateConfigFile()`, `toolCallFix()`

**Migrated** all 8 scenario test files from `createClaudeCodeAgent` → `createAgent`:
- Removed per-test `copySkillToWorkDir()` — absorbed by runner via `skillPath` option
- Added `runnerUnavailable` skip condition for missing binaries
- Added `!runner.capabilities.supportsMcp` skip for MCP-dependent tests

**Backward compatibility**: `claude-code-adapter.ts` is now a thin re-export shim

## Runner matrix

| Runner | Binary | MCP | Skills Dir | Config File | Output Format |
|--------|--------|-----|------------|-------------|---------------|
| Claude Code | `claude` | Yes | `.skills/` | `CLAUDE.md` | stream-json NDJSON |
| Codex | `codex` | No | `.agents/skills/` | none | JSONL |
| Cursor | `cursor-agent` | Yes | `.cursor/rules/` | `.cursorrules` | stream-json NDJSON |

## Test plan

- [x] 52 unit tests in `agent-factory.unit.test.ts` (33 original + 19 Cursor)
- [x] All scenario tests parse and skip correctly in CI
- [ ] Manual: `pnpm test:claude` — verify Claude Code behavior unchanged
- [ ] Manual: `AGENT_UNDER_TEST=codex pnpm test:codex` — verify Codex E2E
- [ ] Manual: `AGENT_UNDER_TEST=cursor pnpm test:cursor` — verify Cursor E2E

## Scripts

```bash
pnpm test:claude      # AGENT_UNDER_TEST=claude-code
pnpm test:codex       # AGENT_UNDER_TEST=codex
pnpm test:cursor      # AGENT_UNDER_TEST=cursor
pnpm test:all-agents  # All three sequentially
```