### PR TITLE
fix: scroll behavior broken on scenario run detail drawer

### DIFF
--- a/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -372,59 +372,59 @@ export function ScenarioRunDetailDrawer({
               </VStack>
 
               {/* Body — conversation on top, results on bottom */}
-                {/* Conversation — hidden when empty (e.g. stalled runs) */}
-                {((scenarioState.messages ?? []).length > 0 || (streamingMessages ?? []).length > 0) && (
+              {/* Conversation — hidden when empty (e.g. stalled runs) */}
+              {((scenarioState.messages ?? []).length > 0 || (streamingMessages ?? []).length > 0) && (
+                <Box
+                  paddingX={6}
+                  paddingY={6}
+                  background="bg.muted"
+                >
+                  <Box borderRadius="md" overflow="hidden">
+                    <ScenarioMessageRenderer
+                      messages={scenarioState.messages ?? []}
+                      streamingMessages={streamingMessages}
+                      variant="drawer"
+                    />
+                  </Box>
+                </Box>
+              )}
+
+              {/* Results */}
+              <Box
+                flex={1}
+                width="full"
+                borderTop={((scenarioState.messages ?? []).length > 0 || (streamingMessages ?? []).length > 0) ? "1px" : undefined}
+                borderColor="border.muted"
+                position="relative"
+                className="group"
+                css={{
+                  "& > div:first-child": { borderRadius: 0, minHeight: "100%", height: "100%" },
+                }}
+              >
+                <SimulationConsole
+                  results={scenarioState.results}
+                  scenarioName={scenarioState.name ?? undefined}
+                  status={scenarioState.status}
+                  durationInMs={scenarioState.durationInMs}
+                />
+                {scenarioState.results && (
                   <Box
-                    paddingX={6}
-                    paddingY={6}
-                    background="bg.muted"
+                    position="absolute"
+                    top={2}
+                    right={2}
+                    opacity={0}
+                    _groupHover={{ opacity: 1 }}
+                    transition="opacity 0.2s"
                   >
-                    <Box borderRadius="md" overflow="hidden">
-                      <ScenarioMessageRenderer
-                        messages={scenarioState.messages ?? []}
-                        streamingMessages={streamingMessages}
-                        variant="drawer"
-                      />
-                    </Box>
+                    <CopyButton
+                      value={formatResultsForCopy(
+                        scenarioState.results,
+                      )}
+                      label="Results"
+                    />
                   </Box>
                 )}
-
-                {/* Results */}
-                <Box
-                  flex={1}
-                  width="full"
-                  borderTop={((scenarioState.messages ?? []).length > 0 || (streamingMessages ?? []).length > 0) ? "1px" : undefined}
-                  borderColor="border.muted"
-                  position="relative"
-                  className="group"
-                  css={{
-                    "& > div:first-child": { borderRadius: 0, minHeight: "100%", height: "100%" },
-                  }}
-                >
-                  <SimulationConsole
-                    results={scenarioState.results}
-                    scenarioName={scenarioState.name ?? undefined}
-                    status={scenarioState.status}
-                    durationInMs={scenarioState.durationInMs}
-                  />
-                  {scenarioState.results && (
-                    <Box
-                      position="absolute"
-                      top={2}
-                      right={2}
-                      opacity={0}
-                      _groupHover={{ opacity: 1 }}
-                      transition="opacity 0.2s"
-                    >
-                      <CopyButton
-                        value={formatResultsForCopy(
-                          scenarioState.results,
-                        )}
-                        label="Results"
-                      />
-                    </Box>
-                  )}
-                </Box>
+              </Box>
               </Drawer.Body>
           )}
         </Drawer.Content>


### PR DESCRIPTION
## Summary

- Fixes the scroll behavior on the scenario run detail drawer where scrolling didn't work when hovering over the header area
- Moved the sticky header VStack from being a **sibling** of `Drawer.Body` to a **child** inside it, so CSS `position: sticky` works correctly
- Follows the same pattern used by `TraceDetailsDrawer` / `TraceDetails`

## Root Cause

The sticky header was a sibling of the scroll container (`Drawer.Body`), not a child inside it. CSS `position: sticky` only works when the element is inside a scroll container. Since the header was outside, scroll events over the header didn't propagate to the body.

## Changes

- `ScenarioRunDetailDrawer.tsx`: Removed outer `VStack` wrapper, moved sticky header inside `Drawer.Body`
- All existing sticky header styles preserved (`position="sticky"`, `top={0}`, `zIndex={2}`, backdrop blur)

Closes #2283

## Test plan

- [x] Existing integration tests pass (5/5)
- [x] Typecheck passes (pre-existing errors in unrelated files only)
- [x] Code review passed (uncle-bob + cupid reviewers)
- [ ] Manual browser verification of scroll behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

# Related Issue

- Resolve #2283