### PR TITLE
fix: studio shows unsaved changes after DB load

### DIFF
--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
@@ -566,4 +566,98 @@ describe("workflowStoreCore", () => {
       expect(result[0]?.value).not.toContain("def __call__");
     });
   });
+
+  describe("hasPendingChanges (regression: #2270)", () => {
+    let testStore: StoreApi<WorkflowStore>;
+
+    beforeEach(() => {
+      testStore = createStore<WorkflowStore>(storeCreator as any);
+    });
+
+    function buildDbDsl() {
+      return {
+        spec_version: "1.4" as const,
+        name: "My Workflow",
+        icon: "🧩",
+        description: "A test workflow",
+        version: "1.0",
+        nodes: [
+          makeNode({
+            id: "node1",
+            inputs: [{ identifier: "input", type: "str" }],
+            outputs: [{ identifier: "output", type: "str" }],
+          }),
+        ],
+        edges: [],
+        default_llm: {
+          model: "openai/gpt-5-mini",
+          max_tokens: 2048,
+          temperature: 0,
+          litellm_params: {},
+        },
+        template_adapter: "default",
+        enable_tracing: true,
+        workflow_type: "workflow" as const,
+        state: {},
+      };
+    }
+
+    /**
+     * Replicates the [workflow].tsx DB load sequence. The `snapshotBaseline`
+     * flag controls whether the fix (setAutosavedWorkflow after load) is
+     * applied — when false, this is the pre-fix behavior.
+     */
+    function loadFromDb(
+      dbDsl: ReturnType<typeof buildDbDsl>,
+      { snapshotBaseline }: { snapshotBaseline: boolean },
+    ) {
+      testStore.getState().setAutosavedWorkflow(undefined);
+      testStore.getState().setWorkflow({
+        ...dbDsl,
+        workflow_id: "wf_123",
+        nodes: dbDsl.nodes.map((node: any) => ({
+          ...node,
+          selected: false,
+        })),
+      } as any);
+      testStore.getState().setLastCommittedWorkflow(dbDsl as any);
+
+      if (snapshotBaseline) {
+        const loadedWorkflow = testStore.getState().getWorkflow();
+        testStore.getState().setAutosavedWorkflow(loadedWorkflow);
+      }
+    }
+
+    describe("when workflow is loaded from DB and autosave baseline is set from normalized state", () => {
+      it("reports no pending changes", () => {
+        loadFromDb(buildDbDsl(), { snapshotBaseline: true });
+
+        expect(testStore.getState().hasPendingChanges()).toBe(false);
+      });
+    });
+
+    describe("when workflow is loaded from DB without snapshotting the autosave baseline", () => {
+      it("leaves autosave baseline undefined, disabling dirty-state detection until AutoSave fires", () => {
+        loadFromDb(buildDbDsl(), { snapshotBaseline: false });
+
+        // Pre-fix: autosavedWorkflow stays undefined → hasPendingChanges short-circuits
+        // to false, but this is a false negative — the baseline is missing, so any
+        // store mutation before AutoSave's debounce fires will be silently absorbed
+        // into the baseline, making it impossible to detect as a change.
+        expect(testStore.getState().getAutosavedWorkflow()).toBeUndefined();
+      });
+    });
+
+    describe("when autosave baseline is set and user makes a change", () => {
+      it("reports pending changes", () => {
+        loadFromDb(buildDbDsl(), { snapshotBaseline: true });
+
+        expect(testStore.getState().hasPendingChanges()).toBe(false);
+
+        testStore.getState().setWorkflow({ name: "Renamed Workflow" });
+
+        expect(testStore.getState().hasPendingChanges()).toBe(true);
+      });
+    });
+  });
 });

--- a/langwatch/src/pages/[project]/studio/[workflow].tsx
+++ b/langwatch/src/pages/[project]/studio/[workflow].tsx
@@ -61,6 +61,10 @@ export default function Studio() {
         })),
       });
       setLastCommittedWorkflow(dsl);
+      // Snapshot the normalized store state as autosave baseline so
+      // hasPendingChanges() does not falsely detect dirty state after load
+      const loadedWorkflow = _useWorkflowStore.getState().getWorkflow();
+      setAutosavedWorkflow(loadedWorkflow);
       setCurrentVersionId(workflow.data?.currentVersion?.id);
     } else {
       reset();


### PR DESCRIPTION
## Why

Closes #2270

After loading a workflow from the DB, the Studio immediately showed an **"unsaved changes"** indicator even though the user had made no edits. This was a false-positive dirty state that eroded trust in the save/autosave system.

## What changed

- **Snapshot autosave baseline on DB load** — after setting the workflow and `lastCommittedWorkflow` from the DB payload, immediately call `setAutosavedWorkflow(getWorkflow())` to capture the _normalized_ store state as the baseline. `hasPendingChanges()` compares against this baseline; without it the comparison had no reference point until AutoSave's debounce fired, leaving a window where any store normalization diff would register as a "change".
- **Regression tests added** — three new unit-test scenarios in `workflowStoreCore.unit.test.ts` covering: no pending changes after load, baseline-less behavior (pre-fix), and pending changes after a real user edit.

## How it works

The store normalizes the raw DB DSL when `setWorkflow` is called (e.g. it adds `selected: false` to nodes). If `autosavedWorkflow` is `undefined` after load, the first AutoSave debounce sets it to the _normalized_ snapshot — but any interaction that touches the store before that fires can produce a spurious diff between the raw DSL baseline and the normalized state. Snapshotting `getWorkflow()` immediately (post-normalization) closes the gap.

## Test plan

```bash
cd langwatch
pnpm test:unit src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
```

The three `hasPendingChanges (regression: #2270)` scenarios:
1. Load from DB + snapshot → `hasPendingChanges()` returns `false` ✅
2. Load from DB without snapshot → `autosavedWorkflow` is `undefined` (pre-fix baseline documented) ✅
3. Load from DB + snapshot + rename workflow → `hasPendingChanges()` returns `true` ✅

## Anything surprising?

The fix snapshots the normalized store state (via `getWorkflow()`) not the raw DSL. This is intentional — `hasPendingChanges()` compares store state to store state, so the baseline must also be store state, not the raw DB payload.
