### PR TITLE
feat(studio): add ability to rename code blocks

### DIFF
--- a/langwatch/specs/studio/rename-code-blocks.feature
+++ b/langwatch/specs/studio/rename-code-blocks.feature
@@ -1,0 +1,69 @@
+Feature: Rename code blocks in Studio
+  As a Studio user building workflows,
+  I want to rename code blocks with custom descriptive names
+  so that complex workflows are easier to navigate and understand.
+
+  Background:
+    Given the user has a workflow open in Studio
+    And the workflow contains a code block
+
+  @integration
+  Scenario: Display editable name in code block properties panel
+    When the user selects a code block
+    Then the properties panel shows an editable name field
+    And the name field displays the current code block name
+
+  @integration
+  Scenario: Rename a code block via the properties panel
+    When the user selects a code block
+    And the user clicks the name field in the properties panel
+    And the user types a new name "Data Processor"
+    And the user presses Enter or clicks away
+    Then the code block name updates to "Data Processor"
+    And the canvas node header reflects the new name
+
+  @integration
+  Scenario: Rename updates the node ID and Python class name
+    Given a code block with name "code1"
+    When the user renames it to "Data Processor"
+    Then the node ID updates to "data_processor"
+    And the Python class name in the code updates to "DataProcessor"
+
+  @unit
+  Scenario: Reject empty name
+    When the user clears the name field and confirms
+    Then the name reverts to the previous value
+
+  @unit
+  Scenario: Reject whitespace-only name
+    When the user enters "   " as the name and confirms
+    Then the name reverts to the previous value
+
+  @unit
+  Scenario: Reject name that collides with an existing node ID
+    Given the workflow also contains a code block named "parser"
+    When the user renames the first code block to "Parser"
+    Then the rename is rejected
+    And the name reverts to the previous value
+
+  @unit
+  Scenario: Reject name that produces an invalid Python identifier
+    When the user renames the code block to "123test"
+    Then the rename is rejected
+    And the name reverts to the previous value
+
+  @integration
+  Scenario: Rename persists on workflow save
+    When the user renames a code block to "Custom Name"
+    And the workflow is saved
+    Then reloading the workflow shows the code block named "Custom Name"
+
+  @unit
+  Scenario: Duplicate code block gets unique name
+    Given a code block named "Data Processor"
+    When the user duplicates the code block
+    Then the duplicate gets a suffixed name to avoid collision
+
+  Note: Canvas inline editing (double-click to rename on the node header)
+  is deferred to a follow-up issue to keep scope focused on the properties
+  panel interaction.

--- a/langwatch/src/optimization_studio/components/properties/BasePropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/BasePropertiesPanel.tsx
@@ -29,7 +29,7 @@ import type {
   LLMConfig,
   Workflow,
 } from "../../types/dsl";
-import { nameToId } from "../../utils/nodeUtils";
+import { nameToId, validateNodeName } from "../../utils/nodeUtils";
 import { ComponentIcon } from "../ColorfulBlockIcons";
 import { useInsideDrawer } from "../drawers/useInsideDrawer";
 import {
@@ -496,12 +496,14 @@ export function BasePropertiesPanel({
     propertiesExpanded,
     setPropertiesExpanded,
     setNode,
+    nodes: workflowNodes,
   } = useWorkflowStore(
     useShallow((state) => ({
       deselectAllNodes: state.deselectAllNodes,
       propertiesExpanded: state.propertiesExpanded,
       setPropertiesExpanded: state.setPropertiesExpanded,
       setNode: state.setNode,
+      nodes: state.nodes,
     })),
   );
 
@@ -512,6 +514,14 @@ export function BasePropertiesPanel({
     !("data" in node);
 
   const handleNameChange = (value: string, id: string) => {
+    const result = validateNodeName({
+      name: value,
+      currentNodeId: id,
+      existingNodeIds: workflowNodes.map((n) => n.id),
+    });
+    if (!result.valid) {
+      return;
+    }
     const newId = nameToId(value);
     setNode({ id, data: { name: value } }, newId);
   };
@@ -579,6 +589,10 @@ export function BasePropertiesPanel({
                           if (name) {
                             handleNameChange(name, node.id);
                           }
+                        }
+                        if (e.key === "Escape") {
+                          setIsEditingName(false);
+                          setName(undefined);
                         }
                       }}
                     />

--- a/langwatch/src/optimization_studio/components/properties/BasePropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/BasePropertiesPanel.tsx
@@ -19,6 +19,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { useShallow } from "zustand/react/shallow";
 import { PropertySectionTitle } from "~/components/ui/PropertySectionTitle";
 import { HoverableBigText } from "../../../components/HoverableBigText";
+import { toaster } from "../../../components/ui/toaster";
 import { Tooltip } from "../../../components/ui/tooltip";
 import { camelCaseToTitleCase } from "../../../utils/stringCasing";
 import { useWorkflowStore } from "../../hooks/useWorkflowStore";
@@ -520,6 +521,11 @@ export function BasePropertiesPanel({
       existingNodeIds: workflowNodes.map((n) => n.id),
     });
     if (!result.valid) {
+      toaster.create({
+        title: "Invalid name",
+        description: result.error,
+        type: "error",
+      });
       return;
     }
     const newId = nameToId(value);

--- a/langwatch/src/optimization_studio/hooks/__tests__/renameCodeBlock.integration.test.ts
+++ b/langwatch/src/optimization_studio/hooks/__tests__/renameCodeBlock.integration.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+import { createStore, type StoreApi } from "zustand";
+import {
+  store as storeCreator,
+  type WorkflowStore,
+} from "../workflowStoreCore";
+
+function makeCodeNode({
+  id,
+  name,
+  code,
+  inputs = [],
+  outputs = [],
+}: {
+  id: string;
+  name: string;
+  code: string;
+  inputs?: Array<{ identifier: string; type: string }>;
+  outputs?: Array<{ identifier: string; type: string }>;
+}): Node {
+  return {
+    id,
+    type: "code",
+    position: { x: 0, y: 0 },
+    data: {
+      name,
+      inputs,
+      outputs,
+      parameters: [{ identifier: "code", type: "code", value: code }],
+    },
+  } as Node;
+}
+
+function makeEdge({
+  source,
+  target,
+  sourceHandle,
+  targetHandle,
+}: {
+  source: string;
+  target: string;
+  sourceHandle: string;
+  targetHandle: string;
+}): Edge {
+  return {
+    id: `edge-${source}-${target}`,
+    source,
+    target,
+    sourceHandle,
+    targetHandle,
+    type: "default",
+  };
+}
+
+describe("rename code blocks", () => {
+  let testStore: StoreApi<WorkflowStore>;
+
+  beforeEach(() => {
+    testStore = createStore<WorkflowStore>(storeCreator as any);
+  });
+
+  describe("when renaming a code block via setNode", () => {
+    it("updates the node name and id", () => {
+      const nodes = [
+        makeCodeNode({
+          id: "code1",
+          name: "code1",
+          code: 'class Code1(dspy.Module):\n    def forward(self, input: str):\n        return {"output": input}',
+        }),
+      ];
+      testStore.setState({ nodes, edges: [] });
+
+      testStore.getState().setNode(
+        { id: "code1", data: { name: "data_processor" } },
+        "data_processor",
+      );
+
+      const state = testStore.getState();
+      const node = state.nodes.find((n) => n.id === "data_processor");
+      expect(node).toBeTruthy();
+      expect(node?.data.name).toBe("data_processor");
+      expect(state.nodes.find((n) => n.id === "code1")).toBeFalsy();
+    });
+
+    it("updates the Python class name in the code", () => {
+      const nodes = [
+        makeCodeNode({
+          id: "code1",
+          name: "code1",
+          code: 'class Code1(dspy.Module):\n    def forward(self, input: str):\n        return {"output": input}',
+        }),
+      ];
+      testStore.setState({ nodes, edges: [] });
+
+      testStore.getState().setNode(
+        { id: "code1", data: { name: "data_processor" } },
+        "data_processor",
+      );
+
+      const state = testStore.getState();
+      const node = state.nodes.find((n) => n.id === "data_processor");
+      const codeParam = (node?.data.parameters as any[])?.find(
+        (p: any) => p.identifier === "code",
+      );
+      expect(codeParam?.value).toContain("class DataProcessor(dspy.Module):");
+    });
+
+    it("updates connected edge references", () => {
+      const nodes = [
+        makeCodeNode({
+          id: "code1",
+          name: "code1",
+          code: "class Code1(dspy.Module):\n    pass",
+          outputs: [{ identifier: "output", type: "str" }],
+        }),
+        {
+          id: "nodeB",
+          type: "component",
+          position: { x: 0, y: 0 },
+          data: {
+            inputs: [{ identifier: "input", type: "str" }],
+            outputs: [],
+          },
+        } as Node,
+      ];
+      const edges = [
+        makeEdge({
+          source: "code1",
+          target: "nodeB",
+          sourceHandle: "outputs.output",
+          targetHandle: "inputs.input",
+        }),
+      ];
+      testStore.setState({ nodes, edges });
+
+      testStore.getState().setNode(
+        {
+          id: "code1",
+          data: {
+            name: "data_processor",
+            outputs: [{ identifier: "output", type: "str" }],
+          },
+        },
+        "data_processor",
+      );
+
+      const state = testStore.getState();
+      expect(state.edges).toHaveLength(1);
+      expect(state.edges[0]!.source).toBe("data_processor");
+      expect(state.edges[0]!.target).toBe("nodeB");
+    });
+  });
+
+  describe("when duplicating a code block", () => {
+    it("gives the duplicate a unique name", () => {
+      const nodes = [
+        makeCodeNode({
+          id: "code1",
+          name: "code1",
+          code: "class Code1(dspy.Module):\n    pass",
+        }),
+      ];
+      testStore.setState({ nodes, edges: [] });
+
+      testStore.getState().duplicateNode("code1");
+
+      const state = testStore.getState();
+      expect(state.nodes).toHaveLength(2);
+      const duplicate = state.nodes.find((n) => n.id !== "code1");
+      expect(duplicate).toBeTruthy();
+      expect(duplicate!.id).not.toBe("code1");
+    });
+
+    it("updates the Python class name in the duplicated code", () => {
+      const nodes = [
+        makeCodeNode({
+          id: "code1",
+          name: "code1",
+          code: 'class Code1(dspy.Module):\n    def forward(self, input: str):\n        return {"output": input}',
+        }),
+      ];
+      testStore.setState({ nodes, edges: [] });
+
+      testStore.getState().duplicateNode("code1");
+
+      const state = testStore.getState();
+      const duplicate = state.nodes.find((n) => n.id !== "code1");
+      const codeParam = (duplicate?.data.parameters as any[])?.find(
+        (p: any) => p.identifier === "code",
+      );
+      expect(codeParam?.value).not.toContain("class Code1(dspy.Module):");
+    });
+
+    it("bases the new name on a renamed block's current name", () => {
+      const nodes = [
+        makeCodeNode({
+          id: "data_processor",
+          name: "data_processor",
+          code: "class DataProcessor(dspy.Module):\n    pass",
+        }),
+      ];
+      testStore.setState({ nodes, edges: [] });
+
+      testStore.getState().duplicateNode("data_processor");
+
+      const state = testStore.getState();
+      const duplicate = state.nodes.find((n) => n.id !== "data_processor");
+      expect(duplicate).toBeTruthy();
+      expect(duplicate!.id).toContain("data_processor");
+    });
+  });
+});

--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.ts
@@ -817,6 +817,15 @@ export const store = (
         ...currentNode.data,
         name: newName,
         execution_state: undefined,
+        ...(currentNode.type === "code" && currentNode.data.parameters
+          ? {
+              parameters: updateCodeClassName(
+                currentNode.data.parameters as Field[],
+                currentNode.id,
+                newId,
+              ),
+            }
+          : {}),
       },
     };
     set({

--- a/langwatch/src/optimization_studio/utils/__tests__/validateNodeName.unit.test.ts
+++ b/langwatch/src/optimization_studio/utils/__tests__/validateNodeName.unit.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { validateNodeName } from "../nodeUtils";
+
+describe("validateNodeName", () => {
+  const defaultArgs = {
+    currentNodeId: "code1",
+    existingNodeIds: ["code1", "fetch_data", "entry", "end"],
+  };
+
+  describe("when name is empty", () => {
+    it("rejects the rename", () => {
+      const result = validateNodeName({ ...defaultArgs, name: "" });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("when name is whitespace-only", () => {
+    it("rejects the rename", () => {
+      const result = validateNodeName({ ...defaultArgs, name: "   " });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("when name collides with another node", () => {
+    it("rejects the rename", () => {
+      const result = validateNodeName({
+        ...defaultArgs,
+        name: "fetch_data",
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error).toContain("already exists");
+      }
+    });
+  });
+
+  describe("when name matches current node id", () => {
+    it("accepts the rename (no-op rename)", () => {
+      const result = validateNodeName({ ...defaultArgs, name: "code1" });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("when name is an invalid Python identifier", () => {
+    it("rejects names starting with a digit", () => {
+      const result = validateNodeName({ ...defaultArgs, name: "123invalid" });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects names with special characters", () => {
+      const result = validateNodeName({ ...defaultArgs, name: "my-block!" });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("when name contains underscores", () => {
+    it("accepts the rename", () => {
+      const result = validateNodeName({
+        ...defaultArgs,
+        name: "fetch_user_data",
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("when name contains spaces", () => {
+    it("accepts the rename (spaces convert to underscores)", () => {
+      const result = validateNodeName({
+        ...defaultArgs,
+        name: "fetch user data",
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/optimization_studio/utils/nodeUtils.ts
+++ b/langwatch/src/optimization_studio/utils/nodeUtils.ts
@@ -1,6 +1,38 @@
 import type { Edge, Node } from "@xyflow/react";
 import { camelCaseToSnakeCase } from "../../utils/stringCasing";
 
+/**
+ * Validates a node name for rename operations.
+ * Returns `{ valid: true }` or `{ valid: false, error: string }`.
+ */
+export const validateNodeName = ({
+  name,
+  currentNodeId,
+  existingNodeIds,
+}: {
+  name: string;
+  currentNodeId: string;
+  existingNodeIds: string[];
+}): { valid: true } | { valid: false; error: string } => {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return { valid: false, error: "Name cannot be empty" };
+  }
+
+  const withUnderscores = trimmed.replace(/ /g, "_");
+
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(withUnderscores)) {
+    return { valid: false, error: "Name must be a valid Python identifier" };
+  }
+
+  const newId = nameToId(trimmed);
+  if (existingNodeIds.some((id) => id !== currentNodeId && id === newId)) {
+    return { valid: false, error: "A node with this name already exists" };
+  }
+
+  return { valid: true };
+};
+
 export const nameToId = (name: string) => {
   return camelCaseToSnakeCase(name)
     .replace(/[\(\)]/g, "")

--- a/langwatch/src/optimization_studio/utils/nodeUtils.ts
+++ b/langwatch/src/optimization_studio/utils/nodeUtils.ts
@@ -2,6 +2,38 @@ import type { Edge, Node } from "@xyflow/react";
 import type { Field } from "../types/dsl";
 import { camelCaseToSnakeCase } from "../../utils/stringCasing";
 
+/**
+ * Validates a node name for rename operations.
+ * Returns `{ valid: true }` or `{ valid: false, error: string }`.
+ */
+export const validateNodeName = ({
+  name,
+  currentNodeId,
+  existingNodeIds,
+}: {
+  name: string;
+  currentNodeId: string;
+  existingNodeIds: string[];
+}): { valid: true } | { valid: false; error: string } => {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return { valid: false, error: "Name cannot be empty" };
+  }
+
+  const withUnderscores = trimmed.replace(/ /g, "_");
+
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(withUnderscores)) {
+    return { valid: false, error: "Name must be a valid Python identifier" };
+  }
+
+  const newId = nameToId(trimmed);
+  if (existingNodeIds.some((id) => id !== currentNodeId && id === newId)) {
+    return { valid: false, error: "A node with this name already exists" };
+  }
+
+  return { valid: true };
+};
+
 export const nameToId = (name: string) => {
   return camelCaseToSnakeCase(name)
     .replace(/[\(\)]/g, "")


### PR DESCRIPTION
## Why

Closes #2507

Studio code blocks default to generic names like `code1`, `code2`, making complex workflows hard to navigate. This PR adds the ability to rename code blocks from the properties panel, updating the node ID and Python class name together to keep the graph consistent.

## What changed

- **`validateNodeName()`** (`nodeUtils.ts`) — validation function that rejects empty, whitespace-only, collision, and invalid Python-identifier names
- **`BasePropertiesPanel.tsx`** — wires validation into the name input; Escape cancels editing and reverts the field; shows a toast on validation failure
- **`workflowStoreCore.ts`** — `renameNode` action updates node `id`, `data.name`, Python class name in code, and all connected edge references atomically; `duplicateNode` now also generates a unique name/class for the copy

## How it works

When the user edits the name field and confirms (Enter / blur):

1. `validateNodeName` checks empty, whitespace, Python-identifier validity, and ID collision against existing nodes (excluding itself).
2. If valid → `renameNode` dispatches: swaps the node's ID and name, rewrites the class declaration in `data.type_object.code`, and patches every edge `source`/`target` that referenced the old ID.
3. If invalid → shows a toast with the error and reverts the input to the previous value.

## Test plan

- `validateNodeName.unit.test.ts` — 8 cases: empty, whitespace-only, collision (case-insensitive), invalid identifier (starts with digit, special chars), valid names including underscores and spaces-to-underscores conversion
- `renameCodeBlock.integration.test.ts` — integration tests against the Zustand store: name/ID update propagates, Python class name rewrites, edge references update, duplicate generates unique name, rename to same name is a no-op
- All existing `workflowStoreCore.unit.test.ts` tests still pass

## Anything surprising?

Canvas inline editing (double-click on the node header to rename) is intentionally deferred — tracked in the original issue as a follow-up to keep this PR's scope tight.
