### PR TITLE
feat: add scenario role and run_id attribute constants to SDKs

### DIFF
--- a/python-sdk/src/langwatch/attributes.py
+++ b/python-sdk/src/langwatch/attributes.py
@@ -72,6 +72,10 @@ class AttributeKey:
     LangWatchEventEvaluationCustom = "langwatch.evaluation.custom"
     LangWatchEventEvaluationLog = "langwatch.evaluation.log"
 
+    # LangWatch Scenario attributes
+    LangWatchScenarioRole = "langwatch.scenario.role"
+    LangWatchScenarioRunId = "langwatch.scenario.run_id"
+
     # LangWatch Prompt attributes
     LangWatchPromptId = "langwatch.prompt.id"
     LangWatchPromptHandle = "langwatch.prompt.handle"

--- a/typescript-sdk/src/observability-sdk/semconv/attributes.ts
+++ b/typescript-sdk/src/observability-sdk/semconv/attributes.ts
@@ -148,6 +148,18 @@ export const ATTR_LANGWATCH_PROMPT_VERSION_NUMBER =
   "langwatch.prompt.version.number";
 
 /**
+ * LangWatch scenario role attribute key
+ * Used to identify the role of an agent in a scenario (User, Agent, Judge)
+ */
+export const ATTR_LANGWATCH_SCENARIO_ROLE = "langwatch.scenario.role";
+
+/**
+ * LangWatch scenario run ID attribute key
+ * Used to link traces back to their parent scenario run
+ */
+export const ATTR_LANGWATCH_SCENARIO_RUN_ID = "langwatch.scenario.run_id";
+
+/**
  * LangWatch LangChain tags attribute key
  * Used to store tags associated with LangChain operations
  */


### PR DESCRIPTION
## Summary
- Adds `LangWatchScenarioRole` and `LangWatchScenarioRunId` to Python SDK `AttributeKey` enum
- Adds `ATTR_LANGWATCH_SCENARIO_ROLE` and `ATTR_LANGWATCH_SCENARIO_RUN_ID` to TypeScript SDK semconv

These are needed by the scenario executor to tag spans with their simulation role (User/Agent/Judge) and run ID, enabling per-role cost/latency metrics extraction in the trace pipeline.

## Test plan
- [ ] Python SDK: verify `from langwatch.attributes import AttributeKey; AttributeKey.LangWatchScenarioRole`
- [ ] TypeScript SDK: verify import and type correctness
- [ ] Release new SDK versions after merge