### PR TITLE
feat(mcp-server): oauth 2.0 + SSE client compatibility

### DIFF
--- a/mcp-server/src/__tests__/http-transport.integration.test.ts
+++ b/mcp-server/src/__tests__/http-transport.integration.test.ts
@@ -285,7 +285,9 @@ describe("HTTP transport", () => {
             body: `grant_type=client_credentials&client_secret=${BEARER_TOKEN}`,
           }
         );
+        expect(tokenResponse.status).toBe(200);
         const { access_token } = await tokenResponse.json();
+        expect(access_token).toBeTruthy();
 
         // Use OAuth token for MCP initialize
         const response = await fetch(`http://localhost:${port}/mcp`, {
@@ -313,7 +315,9 @@ describe("HTTP transport", () => {
             body: `grant_type=client_credentials&client_secret=${BEARER_TOKEN}`,
           }
         );
+        expect(tokenResponse.status).toBe(200);
         const { access_token } = await tokenResponse.json();
+        expect(access_token).toBeTruthy();
 
         // Use OAuth token for SSE
         const response = await fetch(`http://localhost:${port}/sse`, {

--- a/mcp-server/src/http-server.ts
+++ b/mcp-server/src/http-server.ts
@@ -90,6 +90,7 @@ export async function startHttpServer({
   port: number;
 }): Promise<{ server: Server; port: number }> {
   const app = express();
+  app.set("trust proxy", true);
   app.use(express.json());
 
   // CORS middleware for cross-origin requests (ChatGPT/Claude Chat)
@@ -138,8 +139,7 @@ export async function startHttpServer({
     "/oauth/token",
     express.urlencoded({ extended: false }),
     (req: Request, res: Response) => {
-      const grantType =
-        req.body.grant_type ?? req.query["grant_type"];
+      const grantType = req.body.grant_type;
 
       if (grantType !== "client_credentials") {
         res.status(400).json({
@@ -152,10 +152,9 @@ export async function startHttpServer({
 
       // Accept client_secret as the LangWatch API key.
       // client_id is ignored — the API key identifies the project.
-      const clientSecret =
-        req.body.client_secret ?? req.query["client_secret"];
+      const clientSecret = req.body.client_secret;
 
-      if (!clientSecret) {
+      if (!clientSecret || typeof clientSecret !== "string") {
         res.status(400).json({
           error: "invalid_request",
           error_description:
@@ -168,7 +167,7 @@ export async function startHttpServer({
       const accessToken = generateAccessToken();
 
       oauthTokens.set(accessToken, {
-        apiKey: clientSecret as string,
+        apiKey: clientSecret,
         expiresAt: Date.now() + expiresIn * 1000,
       });
 


### PR DESCRIPTION
## Summary
- Add OAuth 2.0 `client_credentials` flow for Claude Desktop (which only supports OAuth, not raw Bearer tokens)
- Mount `/sse/messages` alongside `/messages` to fix "Endpoint not found" in BoltAI and other clients that resolve the relative URL differently

## OAuth 2.0 endpoints
- `GET /.well-known/oauth-authorization-server` — discovery metadata
- `POST /oauth/token` — exchange `client_secret` (= LangWatch API key) for access token (1h TTL)
- `client_id` is ignored — the API key identifies the project
- Existing Bearer token auth is fully backwards-compatible

## SSE fix
The SSE transport sends `data: /messages?sessionId=...` as a relative URL. Some clients (e.g. BoltAI) resolve it relative to `/sse`, hitting `/sse/messages` which 404'd. Now both paths are handled.

## Test plan
- [x] 7 new OAuth integration tests (discovery, validation, token issuance, MCP+SSE e2e)
- [x] All 19 tests pass
- [x] Verified SSE works end-to-end with Python MCP client against live `mcp.langwatch.ai`