### PR TITLE
fix(security): pin litellm<=1.82.6 to mitigate supply chain attack

### DIFF
--- a/langevals/evaluators/langevals/pyproject.toml
+++ b/langevals/evaluators/langevals/pyproject.toml
@@ -10,7 +10,7 @@ license = {text = "MIT"}
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "langevals-core>=0.1.0",
-    "litellm>=1.79.0",
+    "litellm>=1.79.0,<=1.82.6",
     "openai>=1.59.7",
     "numpy>=1.26.4",
     "dspy>=2.6.8",

--- a/langevals/evaluators/legacy/pyproject.toml
+++ b/langevals/evaluators/legacy/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "langchain-core>=0.2.0,<1.3.0",
     "langchain_community>=0.2.16,<0.5.0",
     "datasets>=2.14.6",
-    "litellm>=1.79.0",
+    "litellm>=1.79.0,<=1.82.6",
     "pysbd>=0.3.4",
     "appdirs>=1.4.4",
 ]

--- a/langevals/evaluators/ragas/pyproject.toml
+++ b/langevals/evaluators/ragas/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "ragas==0.2.9",
     "langchain-openai>=0.1.23",
     "langchain_community>=0.2.16",
-    "litellm>=1.79.0",
+    "litellm>=1.79.0,<=1.82.6",
     "rapidfuzz>=3.11.0",
     "sacrebleu>=2.5.1",
     "rouge-score>=0.1.2",

--- a/langevals/langevals_core/pyproject.toml
+++ b/langevals/langevals_core/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pydantic>=2.4.0",
     "pandas>=2.2.2",
     "tqdm>=4.66.4",
-    "litellm>=1.79.0",
+    "litellm>=1.79.0,<=1.82.6",
     "openai>=1.107.0",
     "tenacity>=8.4.0",
     "vertexai>=1.71.1",

--- a/langevals/notebooks/pyproject.toml
+++ b/langevals/notebooks/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 dev = [
     "toml>=0.10.2",
     "grevillea>=0.0.1",
-    "litellm>=1.79.0",
+    "litellm>=1.79.0,<=1.82.6",
     "instructor>=1.2.2",
     "pytest-xdist>=3.5.0",
     "flaky>=3.8.1",

--- a/langevals/pyproject.toml
+++ b/langevals/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "toml>=0.10.2",
     "tomli-w>=1.0.0",
     "grevillea>=0.0.1",
-    "litellm>=1.79.0",
+    "litellm>=1.79.0,<=1.82.6",
     "instructor>=1.2.2",
     "pytest-xdist>=3.5.0",
     "flaky>=3.8.1",

--- a/langwatch_nlp/pyproject.toml
+++ b/langwatch_nlp/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "jsonpath-ng>=1.7.0,<2",
     "langevals-core>=0.1.21,<0.2",
     "langwatch>=0.1.37,<0.11",
-    "litellm[proxy]>=1.81.3",
+    "litellm[proxy]>=1.81.3,<=1.82.6",
     "mangum>=0.17.0,<0.22",
     "nanoid>=2.0.0,<3",
     "numpy>=1.26.4,<3",

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "ipykernel>=6.30.1",
     "langwatch",
-    "litellm>=1.77.0",
+    "litellm>=1.77.0,<=1.82.6",
     "mcp[cli]>=1.13.1",
     "pandas>=2.3.2",
     "tenacity>=9.1.2",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.3.0,<2.0.0"]
 dspy = ["dspy-ai>=3.0.3,<4"]
-litellm = ["litellm>=1.52.1"]
+litellm = ["litellm>=1.52.1,<=1.82.6"]
 dev = ["ruff>=0.11.1"]
 tests = [
     "pytest>=7.4.2,<8.0.0",
@@ -86,7 +86,7 @@ examples = [
     "langchain-openai>=0.3.0,<1.0.0",
     "langchain-text-splitters>=0.3.0,<1.0.0",
     "langchain-google-vertexai>=2.0.0,<4.0.0",
-    "litellm>=1.52.1",
+    "litellm>=1.52.1,<=1.82.6",
     "openinference-instrumentation-dspy>=0.1.23,<0.2.0",
     "opentelemetry-instrumentation-fastapi>=0.53b1",
     "langgraph>=1.0.0,<2.0.0",


### PR DESCRIPTION
## Summary

- Pins `litellm<=1.82.6` across all 9 `pyproject.toml` files (langwatch_nlp, langevals, python-sdk, mcp-server)
- litellm **1.82.7–1.82.8 were compromised** via PyPI account takeover by the TeamPCP threat actor
- Malicious versions contain crypto-stealing malware with auto-execution via Python `.pth` files

## Impact assessment

**We are not affected.** All lockfiles pin versions below the compromised range:

| Component | Locked Version | Safe? |
|-----------|---------------|-------|
| langwatch_nlp | 1.82.2 | Yes |
| langevals | 1.80.0 | Yes |
| mcp-server | 1.77.0 | Yes |
| python-sdk | 1.75.7 | Yes |

However, the open-ended `>=` specifiers would allow pulling compromised versions on `uv lock --upgrade`. This PR adds upper bounds to prevent that.

## Notes

- Lockfiles are unchanged — litellm is currently quarantined on PyPI so re-resolution is not possible
- Once BerriAI publishes a verified clean release, we should bump the upper bound
- Reference: https://news.ycombinator.com/item?id=47501729

## Test plan

- [x] Verify all pyproject.toml files have `<=1.82.6` upper bound
- [x] Verify lockfiles still resolve (no changes needed — already pinned to safe versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)