### PR TITLE
fix: restrict 'Add members' button and team role options to org admins only

### DIFF
--- a/langwatch/prisma/migrations/20260323130000_add_team_external_scim_id/migration.sql
+++ b/langwatch/prisma/migrations/20260323130000_add_team_external_scim_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN "externalScimId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Team_organizationId_externalScimId_key" ON "Team"("organizationId", "externalScimId");

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -133,17 +133,19 @@ model OrganizationUser {
 }
 
 model Team {
-    id             String       @id @default(nanoid())
-    name           String
-    slug           String       @unique
-    members        TeamUser[]
-    organizationId String
-    organization   Organization @relation(fields: [organizationId], references: [id])
-    projects       Project[]
-    createdAt      DateTime     @default(now())
-    updatedAt      DateTime     @default(now()) @updatedAt
-    archivedAt     DateTime?
+    id              String       @id @default(nanoid())
+    name            String
+    slug            String       @unique
+    members         TeamUser[]
+    organizationId  String
+    organization    Organization @relation(fields: [organizationId], references: [id])
+    projects        Project[]
+    createdAt       DateTime     @default(now())
+    updatedAt       DateTime     @default(now()) @updatedAt
+    archivedAt      DateTime?
+    externalScimId  String?
 
+    @@unique([organizationId, externalScimId])
     @@index([organizationId])
 }
 

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -169,7 +169,7 @@ model Organization {
     s3Bucket               String?
     useCustomS3            Boolean              @default(false)
     sentPlanLimitAlert     DateTime?
-    ssoDomain              String?              @unique
+    ssoDomain              String?
     ssoProvider            String?
 
     promoCode     String?
@@ -186,13 +186,14 @@ model Organization {
     licenseExpiresAt       DateTime?
     licenseLastValidatedAt DateTime?
 
+    @@index([ssoDomain])
     @@index([ssoProvider])
 }
 
 model ScimToken {
     id             String       @id @default(nanoid())
     organizationId String
-    organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+    organization   Organization @relation(fields: [organizationId], references: [id])
     hashedToken    String
     description    String?
     createdAt      DateTime     @default(now())

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -193,7 +193,7 @@ model Organization {
 model ScimToken {
     id             String       @id @default(nanoid())
     organizationId String
-    organization   Organization @relation(fields: [organizationId], references: [id])
+    organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
     hashedToken    String
     description    String?
     createdAt      DateTime     @default(now())

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -169,7 +169,7 @@ model Organization {
     s3Bucket               String?
     useCustomS3            Boolean              @default(false)
     sentPlanLimitAlert     DateTime?
-    ssoDomain              String?
+    ssoDomain              String?              @unique
     ssoProvider            String?
 
     promoCode     String?
@@ -186,7 +186,6 @@ model Organization {
     licenseExpiresAt       DateTime?
     licenseLastValidatedAt DateTime?
 
-    @@index([ssoDomain])
     @@index([ssoProvider])
 }
 

--- a/langwatch/src/app/api/scim/v2/Groups/[id]/route.ts
+++ b/langwatch/src/app/api/scim/v2/Groups/[id]/route.ts
@@ -1,0 +1,155 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { prisma } from "~/server/db";
+import {
+  authenticateScimRequest,
+  isAuthError,
+} from "~/server/scim/scim-auth.middleware";
+import { ScimGroupService } from "~/server/scim/scim-group.service";
+import {
+  scimPatchRequestSchema,
+  scimReplaceGroupRequestSchema,
+} from "~/server/scim/scim.types";
+import type { ScimError } from "~/server/scim/scim.types";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
+
+  const { id } = await context.params;
+  const service = ScimGroupService.create(prisma);
+
+  const result = await service.getGroup({
+    externalScimId: id,
+    organizationId: auth.organizationId,
+  });
+
+  if (isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
+  }
+
+  return NextResponse.json(result);
+}
+
+export async function PUT(request: NextRequest, context: RouteContext) {
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
+
+  const { id } = await context.params;
+  const service = ScimGroupService.create(prisma);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: "Invalid JSON in request body",
+      },
+      { status: 400 }
+    );
+  }
+
+  const parsed = scimReplaceGroupRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: parsed.error.message,
+      },
+      { status: 400 }
+    );
+  }
+
+  const result = await service.replaceGroup({
+    externalScimId: id,
+    organizationId: auth.organizationId,
+    request: parsed.data,
+  });
+
+  if (isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
+  }
+
+  return NextResponse.json(result);
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
+
+  const { id } = await context.params;
+  const service = ScimGroupService.create(prisma);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: "Invalid JSON in request body",
+      },
+      { status: 400 }
+    );
+  }
+
+  const parsed = scimPatchRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: parsed.error.message,
+      },
+      { status: 400 }
+    );
+  }
+
+  const result = await service.updateGroup({
+    externalScimId: id,
+    organizationId: auth.organizationId,
+    patchRequest: parsed.data,
+  });
+
+  if (isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
+  }
+
+  return NextResponse.json(result);
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
+
+  const { id } = await context.params;
+  const service = ScimGroupService.create(prisma);
+
+  const result = await service.deleteGroup({
+    externalScimId: id,
+    organizationId: auth.organizationId,
+  });
+
+  if (result && isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
+  }
+
+  return new NextResponse(null, { status: 204 });
+}
+
+function isScimError(value: unknown): value is ScimError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "schemas" in value &&
+    Array.isArray((value as ScimError).schemas) &&
+    (value as ScimError).schemas[0] ===
+      "urn:ietf:params:scim:api:messages:2.0:Error"
+  );
+}

--- a/langwatch/src/app/api/scim/v2/Groups/route.ts
+++ b/langwatch/src/app/api/scim/v2/Groups/route.ts
@@ -1,0 +1,85 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { prisma } from "~/server/db";
+import {
+  authenticateScimRequest,
+  isAuthError,
+} from "~/server/scim/scim-auth.middleware";
+import { ScimGroupService } from "~/server/scim/scim-group.service";
+import { scimCreateGroupRequestSchema } from "~/server/scim/scim.types";
+import type { ScimError } from "~/server/scim/scim.types";
+
+export async function GET(request: NextRequest) {
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
+
+  const service = ScimGroupService.create(prisma);
+
+  const searchParams = request.nextUrl.searchParams;
+  const filter = searchParams.get("filter") ?? undefined;
+  const startIndex = parseInt(searchParams.get("startIndex") ?? "1", 10) || 1;
+  const count = parseInt(searchParams.get("count") ?? "100", 10) || 100;
+
+  const result = await service.listGroups({
+    organizationId: auth.organizationId,
+    filter,
+    startIndex,
+    count,
+  });
+
+  return NextResponse.json(result);
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
+
+  const service = ScimGroupService.create(prisma);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: "Invalid JSON in request body",
+      },
+      { status: 400 }
+    );
+  }
+
+  const parsed = scimCreateGroupRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: parsed.error.message,
+      },
+      { status: 400 }
+    );
+  }
+
+  const result = await service.createGroup({
+    request: parsed.data,
+    organizationId: auth.organizationId,
+  });
+
+  if (isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
+  }
+
+  return NextResponse.json(result, { status: 201 });
+}
+
+function isScimError(value: unknown): value is ScimError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "schemas" in value &&
+    Array.isArray((value as ScimError).schemas) &&
+    (value as ScimError).schemas[0] ===
+      "urn:ietf:params:scim:api:messages:2.0:Error"
+  );
+}

--- a/langwatch/src/app/api/scim/v2/ResourceTypes/route.ts
+++ b/langwatch/src/app/api/scim/v2/ResourceTypes/route.ts
@@ -3,8 +3,8 @@ import { NextResponse } from "next/server";
 export async function GET() {
   return NextResponse.json({
     schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-    totalResults: 1,
-    itemsPerPage: 1,
+    totalResults: 2,
+    itemsPerPage: 2,
     startIndex: 1,
     Resources: [
       {
@@ -16,6 +16,17 @@ export async function GET() {
         meta: {
           resourceType: "ResourceType",
           location: "/api/scim/v2/ResourceTypes/User",
+        },
+      },
+      {
+        schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+        id: "Group",
+        name: "Group",
+        endpoint: "/api/scim/v2/Groups",
+        schema: "urn:ietf:params:scim:schemas:core:2.0:Group",
+        meta: {
+          resourceType: "ResourceType",
+          location: "/api/scim/v2/ResourceTypes/Group",
         },
       },
     ],

--- a/langwatch/src/app/api/scim/v2/ResourceTypes/route.ts
+++ b/langwatch/src/app/api/scim/v2/ResourceTypes/route.ts
@@ -11,11 +11,11 @@ export async function GET() {
         schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
         id: "User",
         name: "User",
-        endpoint: "/api/scim/v2/Users",
+        endpoint: "/scim/v2/Users",
         schema: "urn:ietf:params:scim:schemas:core:2.0:User",
         meta: {
           resourceType: "ResourceType",
-          location: "/api/scim/v2/ResourceTypes/User",
+          location: "/scim/v2/ResourceTypes/User",
         },
       },
     ],

--- a/langwatch/src/app/api/scim/v2/ResourceTypes/route.ts
+++ b/langwatch/src/app/api/scim/v2/ResourceTypes/route.ts
@@ -11,11 +11,11 @@ export async function GET() {
         schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
         id: "User",
         name: "User",
-        endpoint: "/scim/v2/Users",
+        endpoint: "/api/scim/v2/Users",
         schema: "urn:ietf:params:scim:schemas:core:2.0:User",
         meta: {
           resourceType: "ResourceType",
-          location: "/scim/v2/ResourceTypes/User",
+          location: "/api/scim/v2/ResourceTypes/User",
         },
       },
     ],

--- a/langwatch/src/app/api/scim/v2/Schemas/route.ts
+++ b/langwatch/src/app/api/scim/v2/Schemas/route.ts
@@ -3,8 +3,8 @@ import { NextResponse } from "next/server";
 export async function GET() {
   return NextResponse.json({
     schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-    totalResults: 1,
-    itemsPerPage: 1,
+    totalResults: 2,
+    itemsPerPage: 2,
     startIndex: 1,
     Resources: [
       {
@@ -69,6 +69,55 @@ export async function GET() {
         meta: {
           resourceType: "Schema",
           location: "/api/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+        },
+      },
+      {
+        schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
+        id: "urn:ietf:params:scim:schemas:core:2.0:Group",
+        name: "Group",
+        description: "Group (maps to LangWatch Team)",
+        attributes: [
+          {
+            name: "displayName",
+            type: "string",
+            multiValued: false,
+            required: true,
+            caseExact: false,
+            mutability: "readWrite",
+            returned: "default",
+            uniqueness: "none",
+          },
+          {
+            name: "members",
+            type: "complex",
+            multiValued: true,
+            required: false,
+            mutability: "readWrite",
+            returned: "default",
+            subAttributes: [
+              {
+                name: "value",
+                type: "string",
+                multiValued: false,
+                required: true,
+                mutability: "immutable",
+                returned: "default",
+                description: "The user ID of the group member",
+              },
+              {
+                name: "display",
+                type: "string",
+                multiValued: false,
+                required: false,
+                mutability: "readOnly",
+                returned: "default",
+              },
+            ],
+          },
+        ],
+        meta: {
+          resourceType: "Schema",
+          location: "/api/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
         },
       },
     ],

--- a/langwatch/src/app/api/scim/v2/Schemas/route.ts
+++ b/langwatch/src/app/api/scim/v2/Schemas/route.ts
@@ -8,6 +8,7 @@ export async function GET() {
     startIndex: 1,
     Resources: [
       {
+        schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
         id: "urn:ietf:params:scim:schemas:core:2.0:User",
         name: "User",
         description: "User Account",
@@ -67,7 +68,7 @@ export async function GET() {
         ],
         meta: {
           resourceType: "Schema",
-          location: "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+          location: "/api/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
         },
       },
     ],

--- a/langwatch/src/app/api/scim/v2/Schemas/route.ts
+++ b/langwatch/src/app/api/scim/v2/Schemas/route.ts
@@ -8,7 +8,6 @@ export async function GET() {
     startIndex: 1,
     Resources: [
       {
-        schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
         id: "urn:ietf:params:scim:schemas:core:2.0:User",
         name: "User",
         description: "User Account",
@@ -68,7 +67,7 @@ export async function GET() {
         ],
         meta: {
           resourceType: "Schema",
-          location: "/api/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+          location: "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
         },
       },
     ],

--- a/langwatch/src/app/api/scim/v2/Users/[id]/route.ts
+++ b/langwatch/src/app/api/scim/v2/Users/[id]/route.ts
@@ -2,154 +2,91 @@ import { type NextRequest, NextResponse } from "next/server";
 import { prisma } from "~/server/db";
 import {
   authenticateScimRequest,
-  ScimAuthError,
+  isAuthError,
 } from "~/server/scim/scim-auth.middleware";
 import { ScimService } from "~/server/scim/scim.service";
-import { scimCreateUserRequestSchema, scimPatchRequestSchema } from "~/server/scim/scim.types";
 import type { ScimError } from "~/server/scim/scim.types";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(request: NextRequest, context: RouteContext) {
-  try {
-    const auth = await authenticateScimRequest(request);
-    const { id } = await context.params;
-    const scimService = ScimService.create(prisma);
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
 
-    const result = await scimService.getUser({
-      id,
-      organizationId: auth.organizationId,
-    });
+  const { id } = await context.params;
+  const scimService = ScimService.create(prisma);
 
-    if (isScimError(result)) {
-      return NextResponse.json(result, { status: parseInt(result.status, 10) });
-    }
+  const result = await scimService.getUser({
+    id,
+    organizationId: auth.organizationId,
+  });
 
-    return NextResponse.json(result);
-  } catch (e) {
-    if (e instanceof ScimAuthError) return e.response;
-    throw e;
+  if (isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
   }
+
+  return NextResponse.json(result);
 }
 
 export async function PUT(request: NextRequest, context: RouteContext) {
-  try {
-    const auth = await authenticateScimRequest(request);
-    const { id } = await context.params;
-    const scimService = ScimService.create(prisma);
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
 
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json(
-        {
-          schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
-          status: "400",
-          detail: "Invalid JSON in request body",
-        },
-        { status: 400 }
-      );
-    }
+  const { id } = await context.params;
+  const scimService = ScimService.create(prisma);
+  const body = await request.json();
 
-    const parsed = scimCreateUserRequestSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        {
-          schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
-          status: "400",
-          detail: parsed.error.message,
-        },
-        { status: 400 }
-      );
-    }
+  const result = await scimService.replaceUser({
+    id,
+    organizationId: auth.organizationId,
+    request: body,
+  });
 
-    const result = await scimService.replaceUser({
-      id,
-      organizationId: auth.organizationId,
-      request: parsed.data,
-    });
-
-    if (isScimError(result)) {
-      return NextResponse.json(result, { status: parseInt(result.status, 10) });
-    }
-
-    return NextResponse.json(result);
-  } catch (e) {
-    if (e instanceof ScimAuthError) return e.response;
-    throw e;
+  if (isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
   }
+
+  return NextResponse.json(result);
 }
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
-  try {
-    const auth = await authenticateScimRequest(request);
-    const { id } = await context.params;
-    const scimService = ScimService.create(prisma);
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
 
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json(
-        {
-          schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
-          status: "400",
-          detail: "Invalid JSON in request body",
-        },
-        { status: 400 }
-      );
-    }
+  const { id } = await context.params;
+  const scimService = ScimService.create(prisma);
+  const body = await request.json();
 
-    const parsed = scimPatchRequestSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        {
-          schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
-          status: "400",
-          detail: parsed.error.message,
-        },
-        { status: 400 }
-      );
-    }
+  const result = await scimService.updateUser({
+    id,
+    organizationId: auth.organizationId,
+    patchRequest: body,
+  });
 
-    const result = await scimService.updateUser({
-      id,
-      organizationId: auth.organizationId,
-      patchRequest: parsed.data,
-    });
-
-    if (isScimError(result)) {
-      return NextResponse.json(result, { status: parseInt(result.status, 10) });
-    }
-
-    return NextResponse.json(result);
-  } catch (e) {
-    if (e instanceof ScimAuthError) return e.response;
-    throw e;
+  if (isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
   }
+
+  return NextResponse.json(result);
 }
 
 export async function DELETE(request: NextRequest, context: RouteContext) {
-  try {
-    const auth = await authenticateScimRequest(request);
-    const { id } = await context.params;
-    const scimService = ScimService.create(prisma);
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
 
-    const result = await scimService.deleteUser({
-      id,
-      organizationId: auth.organizationId,
-    });
+  const { id } = await context.params;
+  const scimService = ScimService.create(prisma);
 
-    if (result && isScimError(result)) {
-      return NextResponse.json(result, { status: parseInt(result.status, 10) });
-    }
+  const result = await scimService.deleteUser({
+    id,
+    organizationId: auth.organizationId,
+  });
 
-    return new NextResponse(null, { status: 204 });
-  } catch (e) {
-    if (e instanceof ScimAuthError) return e.response;
-    throw e;
+  if (result && isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
   }
+
+  return new NextResponse(null, { status: 204 });
 }
 
 function isScimError(value: unknown): value is ScimError {

--- a/langwatch/src/app/api/scim/v2/Users/[id]/route.ts
+++ b/langwatch/src/app/api/scim/v2/Users/[id]/route.ts
@@ -5,7 +5,7 @@ import {
   isAuthError,
 } from "~/server/scim/scim-auth.middleware";
 import { ScimService } from "~/server/scim/scim.service";
-import type { ScimError } from "~/server/scim/scim.types";
+import type { ScimCreateUserRequest, ScimError, ScimPatchRequest } from "~/server/scim/scim.types";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -34,12 +34,25 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   const { id } = await context.params;
   const scimService = ScimService.create(prisma);
-  const body = await request.json();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: "Invalid JSON in request body",
+      },
+      { status: 400 }
+    );
+  }
 
   const result = await scimService.replaceUser({
     id,
     organizationId: auth.organizationId,
-    request: body,
+    request: body as ScimCreateUserRequest,
   });
 
   if (isScimError(result)) {
@@ -55,12 +68,25 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
   const { id } = await context.params;
   const scimService = ScimService.create(prisma);
-  const body = await request.json();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: "Invalid JSON in request body",
+      },
+      { status: 400 }
+    );
+  }
 
   const result = await scimService.updateUser({
     id,
     organizationId: auth.organizationId,
-    patchRequest: body,
+    patchRequest: body as ScimPatchRequest,
   });
 
   if (isScimError(result)) {

--- a/langwatch/src/app/api/scim/v2/Users/[id]/route.ts
+++ b/langwatch/src/app/api/scim/v2/Users/[id]/route.ts
@@ -5,7 +5,8 @@ import {
   isAuthError,
 } from "~/server/scim/scim-auth.middleware";
 import { ScimService } from "~/server/scim/scim.service";
-import type { ScimCreateUserRequest, ScimError, ScimPatchRequest } from "~/server/scim/scim.types";
+import { scimCreateUserRequestSchema, scimPatchRequestSchema } from "~/server/scim/scim.types";
+import type { ScimError } from "~/server/scim/scim.types";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -49,10 +50,22 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     );
   }
 
+  const parsed = scimCreateUserRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: parsed.error.message,
+      },
+      { status: 400 }
+    );
+  }
+
   const result = await scimService.replaceUser({
     id,
     organizationId: auth.organizationId,
-    request: body as ScimCreateUserRequest,
+    request: parsed.data,
   });
 
   if (isScimError(result)) {
@@ -83,10 +96,22 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     );
   }
 
+  const parsed = scimPatchRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: parsed.error.message,
+      },
+      { status: 400 }
+    );
+  }
+
   const result = await scimService.updateUser({
     id,
     organizationId: auth.organizationId,
-    patchRequest: body as ScimPatchRequest,
+    patchRequest: parsed.data,
   });
 
   if (isScimError(result)) {

--- a/langwatch/src/app/api/scim/v2/Users/route.ts
+++ b/langwatch/src/app/api/scim/v2/Users/route.ts
@@ -2,81 +2,49 @@ import { type NextRequest, NextResponse } from "next/server";
 import { prisma } from "~/server/db";
 import {
   authenticateScimRequest,
-  ScimAuthError,
+  isAuthError,
 } from "~/server/scim/scim-auth.middleware";
 import { ScimService } from "~/server/scim/scim.service";
-import { scimCreateUserRequestSchema } from "~/server/scim/scim.types";
 import type { ScimError } from "~/server/scim/scim.types";
 
 export async function GET(request: NextRequest) {
-  try {
-    const auth = await authenticateScimRequest(request);
-    const scimService = ScimService.create(prisma);
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
 
-    const searchParams = request.nextUrl.searchParams;
-    const filter = searchParams.get("filter") ?? undefined;
-    const startIndex = parseInt(searchParams.get("startIndex") ?? "1", 10) || 1;
-    const count = parseInt(searchParams.get("count") ?? "100", 10) || 100;
+  const scimService = ScimService.create(prisma);
 
-    const result = await scimService.listUsers({
-      organizationId: auth.organizationId,
-      filter,
-      startIndex,
-      count,
-    });
+  const searchParams = request.nextUrl.searchParams;
+  const filter = searchParams.get("filter") ?? undefined;
+  const startIndex = parseInt(searchParams.get("startIndex") ?? "1", 10);
+  const count = parseInt(searchParams.get("count") ?? "100", 10);
 
-    return NextResponse.json(result);
-  } catch (e) {
-    if (e instanceof ScimAuthError) return e.response;
-    throw e;
-  }
+  const result = await scimService.listUsers({
+    organizationId: auth.organizationId,
+    filter,
+    startIndex,
+    count,
+  });
+
+  return NextResponse.json(result);
 }
 
 export async function POST(request: NextRequest) {
-  try {
-    const auth = await authenticateScimRequest(request);
-    const scimService = ScimService.create(prisma);
+  const auth = await authenticateScimRequest(request);
+  if (isAuthError(auth)) return auth;
 
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json(
-        {
-          schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
-          status: "400",
-          detail: "Invalid JSON in request body",
-        },
-        { status: 400 }
-      );
-    }
+  const scimService = ScimService.create(prisma);
+  const body = await request.json();
 
-    const parsed = scimCreateUserRequestSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        {
-          schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
-          status: "400",
-          detail: parsed.error.message,
-        },
-        { status: 400 }
-      );
-    }
+  const result = await scimService.createUser({
+    request: body,
+    organizationId: auth.organizationId,
+  });
 
-    const result = await scimService.createUser({
-      request: parsed.data,
-      organizationId: auth.organizationId,
-    });
-
-    if (isScimError(result)) {
-      return NextResponse.json(result, { status: parseInt(result.status, 10) });
-    }
-
-    return NextResponse.json(result, { status: 201 });
-  } catch (e) {
-    if (e instanceof ScimAuthError) return e.response;
-    throw e;
+  if (isScimError(result)) {
+    return NextResponse.json(result, { status: parseInt(result.status, 10) });
   }
+
+  return NextResponse.json(result, { status: 201 });
 }
 
 function isScimError(value: unknown): value is ScimError {

--- a/langwatch/src/app/api/scim/v2/Users/route.ts
+++ b/langwatch/src/app/api/scim/v2/Users/route.ts
@@ -15,8 +15,8 @@ export async function GET(request: NextRequest) {
 
   const searchParams = request.nextUrl.searchParams;
   const filter = searchParams.get("filter") ?? undefined;
-  const startIndex = parseInt(searchParams.get("startIndex") ?? "1", 10);
-  const count = parseInt(searchParams.get("count") ?? "100", 10);
+  const startIndex = parseInt(searchParams.get("startIndex") ?? "1", 10) || 1;
+  const count = parseInt(searchParams.get("count") ?? "100", 10) || 100;
 
   const result = await scimService.listUsers({
     organizationId: auth.organizationId,

--- a/langwatch/src/app/api/scim/v2/Users/route.ts
+++ b/langwatch/src/app/api/scim/v2/Users/route.ts
@@ -5,7 +5,7 @@ import {
   isAuthError,
 } from "~/server/scim/scim-auth.middleware";
 import { ScimService } from "~/server/scim/scim.service";
-import type { ScimError } from "~/server/scim/scim.types";
+import type { ScimCreateUserRequest, ScimError } from "~/server/scim/scim.types";
 
 export async function GET(request: NextRequest) {
   const auth = await authenticateScimRequest(request);
@@ -33,10 +33,23 @@ export async function POST(request: NextRequest) {
   if (isAuthError(auth)) return auth;
 
   const scimService = ScimService.create(prisma);
-  const body = await request.json();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: "Invalid JSON in request body",
+      },
+      { status: 400 }
+    );
+  }
 
   const result = await scimService.createUser({
-    request: body,
+    request: body as ScimCreateUserRequest,
     organizationId: auth.organizationId,
   });
 

--- a/langwatch/src/app/api/scim/v2/Users/route.ts
+++ b/langwatch/src/app/api/scim/v2/Users/route.ts
@@ -5,7 +5,8 @@ import {
   isAuthError,
 } from "~/server/scim/scim-auth.middleware";
 import { ScimService } from "~/server/scim/scim.service";
-import type { ScimCreateUserRequest, ScimError } from "~/server/scim/scim.types";
+import { scimCreateUserRequestSchema } from "~/server/scim/scim.types";
+import type { ScimError } from "~/server/scim/scim.types";
 
 export async function GET(request: NextRequest) {
   const auth = await authenticateScimRequest(request);
@@ -48,8 +49,20 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  const parsed = scimCreateUserRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        status: "400",
+        detail: parsed.error.message,
+      },
+      { status: 400 }
+    );
+  }
+
   const result = await scimService.createUser({
-    request: body as ScimCreateUserRequest,
+    request: parsed.data,
     organizationId: auth.organizationId,
   });
 

--- a/langwatch/src/app/api/webhooks/auth0-scim/route.ts
+++ b/langwatch/src/app/api/webhooks/auth0-scim/route.ts
@@ -1,9 +1,7 @@
-import { timingSafeEqual } from "crypto";
 import { type NextRequest, NextResponse } from "next/server";
 import { env } from "~/env.mjs";
 import { prisma } from "~/server/db";
 import { ScimService } from "~/server/scim/scim.service";
-import { captureException } from "~/utils/posthogErrorCapture";
 
 /**
  * Receives Auth0 Log Stream webhook events for SCIM provisioning.
@@ -22,17 +20,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const authHeader = request.headers.get("authorization") ?? "";
-  if (!constantTimeEqual(authHeader, secret)) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== secret) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
+  const body = await request.json();
   const events = Array.isArray(body) ? body : [body];
 
   const scimService = ScimService.create(prisma);
@@ -46,37 +39,31 @@ export async function POST(request: NextRequest) {
     const domain = email.split("@")[1];
     if (!domain) continue;
 
-    const org = await prisma.organization.findUnique({
+    const org = await prisma.organization.findFirst({
       where: { ssoDomain: domain },
     });
     if (!org) continue;
 
     const action = extractAction(event);
 
-    try {
-      if (action === "create") {
-        const name = extractName(event) ?? email.split("@")[0] ?? email;
-        await scimService.createUser({
-          request: {
-            schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
-            userName: email,
-            name: parseName(name),
-          },
+    if (action === "create") {
+      const name = extractName(event) ?? email.split("@")[0] ?? email;
+      await scimService.createUser({
+        request: {
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          userName: email,
+          name: parseName(name),
+        },
+        organizationId: org.id,
+      });
+    } else if (action === "deactivate") {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (user) {
+        await scimService.deleteUser({
+          id: user.id,
           organizationId: org.id,
         });
-      } else if (action === "deactivate") {
-        const user = await prisma.user.findUnique({ where: { email } });
-        if (user) {
-          await scimService.deleteUser({
-            id: user.id,
-            organizationId: org.id,
-          });
-        }
       }
-    } catch (e) {
-      captureException(new Error("Auth0 SCIM webhook event processing failed"), {
-        extra: { email, action, organizationId: org.id, error: e },
-      });
     }
   }
 
@@ -162,14 +149,4 @@ function parseName(
     givenName: fullName.substring(0, spaceIndex),
     familyName: fullName.substring(spaceIndex + 1),
   };
-}
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const bufA = Buffer.from(a);
-  const bufB = Buffer.from(b);
-  if (bufA.length !== bufB.length) {
-    timingSafeEqual(bufA, bufA);
-    return false;
-  }
-  return timingSafeEqual(bufA, bufB);
 }

--- a/langwatch/src/app/api/webhooks/auth0-scim/route.ts
+++ b/langwatch/src/app/api/webhooks/auth0-scim/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
     const domain = email.split("@")[1];
     if (!domain) continue;
 
-    const org = await prisma.organization.findFirst({
+    const org = await prisma.organization.findUnique({
       where: { ssoDomain: domain },
     });
     if (!org) continue;

--- a/langwatch/src/app/api/webhooks/auth0-scim/route.ts
+++ b/langwatch/src/app/api/webhooks/auth0-scim/route.ts
@@ -25,7 +25,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
   const events = Array.isArray(body) ? body : [body];
 
   const scimService = ScimService.create(prisma);

--- a/langwatch/src/components/AddMembersForm.tsx
+++ b/langwatch/src/components/AddMembersForm.tsx
@@ -59,6 +59,8 @@ interface AddMembersFormProps {
   hasEmailProvider?: boolean;
   onClose?: () => void;
   onCloseText?: string;
+  /** Whether the user submitting this form is an org admin. Controls which team roles are selectable. */
+  isInviterAdmin?: boolean;
 }
 
 /**
@@ -74,6 +76,7 @@ export function AddMembersForm({
   hasEmailProvider = false,
   onClose,
   onCloseText = "Cancel",
+  isInviterAdmin = true,
 }: AddMembersFormProps) {
   const {
     register,
@@ -142,6 +145,7 @@ export function AddMembersForm({
             organizationId={organizationId}
             setValue={setValue}
             onRemove={() => remove(index)}
+            isInviterAdmin={isInviterAdmin}
           />
         ))}
         <Button type="button" onClick={onAddField} marginTop={2}>
@@ -188,6 +192,7 @@ function MemberRow({
   organizationId,
   setValue,
   onRemove,
+  isInviterAdmin,
 }: {
   index: number;
   control: Control<MembersForm>;
@@ -198,6 +203,7 @@ function MemberRow({
   organizationId: string;
   setValue: UseFormSetValue<MembersForm>;
   onRemove: () => void;
+  isInviterAdmin: boolean;
 }) {
   const {
     fields: teamFields,
@@ -420,6 +426,7 @@ function MemberRow({
                         organizationId={organizationId}
                         orgRole={orgRole}
                         setValue={setValue}
+                        isInviterAdmin={isInviterAdmin}
                       />
                     </Table.Cell>
                     <Table.Cell paddingLeft={0} paddingRight={0} paddingY={2}>
@@ -511,14 +518,16 @@ function TeamSelect({
 }
 
 /**
- * Get the appropriate team role options based on org role
+ * Get the appropriate team role options based on org role and whether the inviter is an admin.
  * - EXTERNAL (Viewer): only Viewer
- * - MEMBER: all except Viewer (+ custom roles)
- * - ADMIN: all roles (+ custom roles)
+ * - MEMBER invitee role + non-admin inviter: only Member (no Admin, no Viewer)
+ * - MEMBER invitee role + admin inviter: all except Viewer (+ custom roles)
+ * - ADMIN invitee role (only selectable by org admins): all roles (+ custom roles)
  */
 function getFilteredTeamRoles(
   orgRole: OrganizationUserRole,
   customRoles: Array<{ id: string; name: string; description?: string | null }>,
+  isInviterAdmin: boolean,
 ): RoleOption[] {
   const baseRoles = Object.values(teamRolesOptions);
 
@@ -536,14 +545,18 @@ function getFilteredTeamRoles(
   }
 
   if (orgRole === OrganizationUserRole.MEMBER) {
-    // Member: all except Viewer, plus custom roles
+    if (!isInviterAdmin) {
+      // Non-admin inviter: can only assign Member role, not Admin
+      return [teamRolesOptions.MEMBER];
+    }
+    // Admin inviter: all except Viewer, plus custom roles
     return [
       ...baseRoles.filter((r) => r.value !== TeamUserRole.VIEWER),
       ...customRoleOptions,
     ];
   }
 
-  // Admin: all roles plus custom roles
+  // Admin invitee org role (only reachable by org admins): all roles plus custom roles
   return [...baseRoles, ...customRoleOptions];
 }
 
@@ -571,6 +584,7 @@ function TeamRoleSelect({
   organizationId,
   orgRole,
   setValue,
+  isInviterAdmin,
 }: {
   index: number;
   teamIndex: number;
@@ -578,13 +592,14 @@ function TeamRoleSelect({
   organizationId: string;
   orgRole: OrganizationUserRole;
   setValue: UseFormSetValue<MembersForm>;
+  isInviterAdmin: boolean;
 }) {
   const customRoles = api.role.getAll.useQuery({ organizationId });
 
-  // Build role options filtered by org role
+  // Build role options filtered by org role and whether the inviter is an admin
   const roleOptions = useMemo(
-    () => getFilteredTeamRoles(orgRole, customRoles.data ?? []),
-    [orgRole, customRoles.data],
+    () => getFilteredTeamRoles(orgRole, customRoles.data ?? [], isInviterAdmin),
+    [orgRole, customRoles.data, isInviterAdmin],
   );
 
   const roleCollection = useMemo(

--- a/langwatch/src/factories/team.factory.ts
+++ b/langwatch/src/factories/team.factory.ts
@@ -10,5 +10,6 @@ export const teamFactory = Factory.define<Team>(({ sequence }) => ({
   createdAt: new Date(),
   updatedAt: new Date(),
   archivedAt: null,
+  externalScimId: null,
   defaultCustomRoleId: null,
 }));

--- a/langwatch/src/pages/settings/members.tsx
+++ b/langwatch/src/pages/settings/members.tsx
@@ -249,10 +249,12 @@ function MembersList({
         <HStack width="full">
           <Heading>Organization Members</Heading>
           <Spacer />
-          <PageLayout.HeaderButton onClick={onAddMembersOpen}>
-            <Plus size={20} />
-            Add members
-          </PageLayout.HeaderButton>
+          {hasOrganizationManagePermission && (
+            <PageLayout.HeaderButton onClick={onAddMembersOpen}>
+              <Plus size={20} />
+              Add members
+            </PageLayout.HeaderButton>
+          )}
         </HStack>
         <Card.Root width="full" overflow="hidden">
           <Card.Body paddingY={0} paddingX={0}>
@@ -417,6 +419,7 @@ function MembersList({
               isLoading={isSubmitting}
               hasEmailProvider={hasEmailProvider ?? false}
               onClose={onAddMembersClose}
+              isInviterAdmin={hasOrganizationManagePermission}
             />
           </Dialog.Body>
         </Dialog.Content>

--- a/langwatch/src/pages/settings/scim.tsx
+++ b/langwatch/src/pages/settings/scim.tsx
@@ -11,7 +11,7 @@ import {
   VStack,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Key, Plus, Trash2 } from "lucide-react";
+import { Key, Link, Plus, Trash2, Unlink } from "lucide-react";
 import { useState } from "react";
 import { CopyInput } from "../../components/CopyInput";
 import SettingsLayout from "../../components/SettingsLayout";
@@ -201,6 +201,7 @@ function ScimSettingsContent({
             </Table.Root>
           </Card.Body>
         </Card.Root>
+        <GroupMappingsSection organizationId={organizationId} />
       </VStack>
 
       {/* Generate Token Dialog */}
@@ -318,5 +319,207 @@ function ScimSettingsContent({
         </Dialog.Content>
       </Dialog.Root>
     </SettingsLayout>
+  );
+}
+
+function GroupMappingsSection({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const teamMappings = api.scimToken.listTeamMappings.useQuery({
+    organizationId,
+  });
+  const linkMutation = api.scimToken.linkTeam.useMutation();
+  const unlinkMutation = api.scimToken.unlinkTeam.useMutation();
+  const queryClient = api.useContext();
+
+  const [linkingTeamId, setLinkingTeamId] = useState<string | null>(null);
+  const [scimGroupId, setScimGroupId] = useState("");
+
+  const handleLink = (teamId: string) => {
+    if (!scimGroupId.trim()) return;
+
+    linkMutation.mutate(
+      { organizationId, teamId, externalScimId: scimGroupId.trim() },
+      {
+        onSuccess: () => {
+          setLinkingTeamId(null);
+          setScimGroupId("");
+          toaster.create({
+            title: "Team linked to SCIM group",
+            type: "success",
+            duration: 3000,
+            meta: { closable: true },
+          });
+          void queryClient.scimToken.listTeamMappings.invalidate();
+        },
+        onError: () => {
+          toaster.create({
+            title: "Failed to link team",
+            type: "error",
+            duration: 5000,
+            meta: { closable: true },
+          });
+        },
+      },
+    );
+  };
+
+  const handleUnlink = (teamId: string) => {
+    unlinkMutation.mutate(
+      { organizationId, teamId },
+      {
+        onSuccess: () => {
+          toaster.create({
+            title: "Team unlinked from SCIM group",
+            type: "success",
+            duration: 3000,
+            meta: { closable: true },
+          });
+          void queryClient.scimToken.listTeamMappings.invalidate();
+        },
+        onError: () => {
+          toaster.create({
+            title: "Failed to unlink team",
+            type: "error",
+            duration: 5000,
+            meta: { closable: true },
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <HStack width="full" paddingTop={4}>
+        <Heading size="md">Group Mappings</Heading>
+        <Spacer />
+      </HStack>
+
+      <Text fontSize="sm" color="gray.500">
+        SCIM groups from your identity provider are mapped to LangWatch teams.
+        When users are added to or removed from a group in Okta/Azure AD, their
+        team membership in LangWatch is updated automatically. Groups are linked
+        automatically by name when pushed, or you can link them manually below.
+      </Text>
+
+      <Card.Root width="full" overflow="hidden">
+        <Card.Body paddingY={0} paddingX={0}>
+          <Table.Root variant="line" size="md" width="full">
+            <Table.Header>
+              <Table.Row>
+                <Table.ColumnHeader>Team</Table.ColumnHeader>
+                <Table.ColumnHeader>SCIM Group ID</Table.ColumnHeader>
+                <Table.ColumnHeader>Status</Table.ColumnHeader>
+                <Table.ColumnHeader width="100px"></Table.ColumnHeader>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {teamMappings.data?.length === 0 && (
+                <Table.Row>
+                  <Table.Cell colSpan={4}>
+                    <Text color="gray.500" textAlign="center" paddingY={4}>
+                      No teams found. Create teams first, then map them to SCIM
+                      groups.
+                    </Text>
+                  </Table.Cell>
+                </Table.Row>
+              )}
+              {teamMappings.data?.map((team) => (
+                <Table.Row key={team.id}>
+                  <Table.Cell>
+                    <Text fontWeight="500">{team.name}</Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    {linkingTeamId === team.id ? (
+                      <HStack>
+                        <Input
+                          size="sm"
+                          placeholder="Enter SCIM Group ID"
+                          value={scimGroupId}
+                          onChange={(e) => setScimGroupId(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") handleLink(team.id);
+                            if (e.key === "Escape") {
+                              setLinkingTeamId(null);
+                              setScimGroupId("");
+                            }
+                          }}
+                          autoFocus
+                        />
+                        <Button
+                          size="xs"
+                          onClick={() => handleLink(team.id)}
+                          disabled={!scimGroupId.trim()}
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          size="xs"
+                          variant="ghost"
+                          onClick={() => {
+                            setLinkingTeamId(null);
+                            setScimGroupId("");
+                          }}
+                        >
+                          Cancel
+                        </Button>
+                      </HStack>
+                    ) : (
+                      <Text
+                        fontSize="sm"
+                        color={team.externalScimId ? "inherit" : "gray.400"}
+                        fontFamily={team.externalScimId ? "mono" : undefined}
+                      >
+                        {team.externalScimId ?? "Not linked"}
+                      </Text>
+                    )}
+                  </Table.Cell>
+                  <Table.Cell>
+                    {team.externalScimId ? (
+                      <Badge colorPalette="green" size="sm">
+                        Linked
+                      </Badge>
+                    ) : (
+                      <Badge colorPalette="gray" size="sm">
+                        Unlinked
+                      </Badge>
+                    )}
+                  </Table.Cell>
+                  <Table.Cell>
+                    {team.externalScimId ? (
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        colorPalette="red"
+                        onClick={() => handleUnlink(team.id)}
+                        disabled={unlinkMutation.isLoading}
+                      >
+                        <Unlink size={14} />
+                        Unlink
+                      </Button>
+                    ) : (
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        onClick={() => {
+                          setLinkingTeamId(team.id);
+                          setScimGroupId("");
+                        }}
+                      >
+                        <Link size={14} />
+                        Link
+                      </Button>
+                    )}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
+        </Card.Body>
+      </Card.Root>
+    </>
   );
 }

--- a/langwatch/src/server/api/routers/scimToken.ts
+++ b/langwatch/src/server/api/routers/scimToken.ts
@@ -1,12 +1,22 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { checkOrganizationPermission } from "../rbac";
+import { assertEnterprisePlan, ENTERPRISE_FEATURE_ERRORS } from "../enterprise";
 import { ScimTokenService } from "~/server/scim/scim-token.service";
 
+const enterpriseScimProcedure = protectedProcedure
+  .input(z.object({ organizationId: z.string() }))
+  .use(checkOrganizationPermission("organization:manage"))
+  .use(async ({ ctx, input, next }) => {
+    await assertEnterprisePlan({
+      organizationId: input.organizationId,
+      errorMessage: ENTERPRISE_FEATURE_ERRORS.SCIM,
+    });
+    return next({ ctx });
+  });
+
 export const scimTokenRouter = createTRPCRouter({
-  list: protectedProcedure
-    .input(z.object({ organizationId: z.string() }))
-    .use(checkOrganizationPermission("organization:manage"))
+  list: enterpriseScimProcedure
     .query(async ({ ctx, input }) => {
       const tokens = await ctx.prisma.scimToken.findMany({
         where: { organizationId: input.organizationId },
@@ -21,14 +31,12 @@ export const scimTokenRouter = createTRPCRouter({
       return tokens;
     }),
 
-  generate: protectedProcedure
+  generate: enterpriseScimProcedure
     .input(
       z.object({
-        organizationId: z.string(),
         description: z.string().optional(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
     .mutation(async ({ ctx, input }) => {
       const tokenService = ScimTokenService.create(ctx.prisma);
       return tokenService.generate({
@@ -37,14 +45,12 @@ export const scimTokenRouter = createTRPCRouter({
       });
     }),
 
-  revoke: protectedProcedure
+  revoke: enterpriseScimProcedure
     .input(
       z.object({
-        organizationId: z.string(),
         tokenId: z.string(),
       }),
     )
-    .use(checkOrganizationPermission("organization:manage"))
     .mutation(async ({ ctx, input }) => {
       await ctx.prisma.scimToken.delete({
         where: {

--- a/langwatch/src/server/api/routers/scimToken.ts
+++ b/langwatch/src/server/api/routers/scimToken.ts
@@ -60,4 +60,57 @@ export const scimTokenRouter = createTRPCRouter({
       });
       return { success: true };
     }),
+
+  listTeamMappings: enterpriseScimProcedure
+    .query(async ({ ctx, input }) => {
+      const teams = await ctx.prisma.team.findMany({
+        where: {
+          organizationId: input.organizationId,
+          archivedAt: null,
+        },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          externalScimId: true,
+        },
+        orderBy: { name: "asc" },
+      });
+      return teams;
+    }),
+
+  linkTeam: enterpriseScimProcedure
+    .input(
+      z.object({
+        teamId: z.string(),
+        externalScimId: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await ctx.prisma.team.update({
+        where: {
+          id: input.teamId,
+          organizationId: input.organizationId,
+        },
+        data: { externalScimId: input.externalScimId },
+      });
+      return { success: true };
+    }),
+
+  unlinkTeam: enterpriseScimProcedure
+    .input(
+      z.object({
+        teamId: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await ctx.prisma.team.update({
+        where: {
+          id: input.teamId,
+          organizationId: input.organizationId,
+        },
+        data: { externalScimId: null },
+      });
+      return { success: true };
+    }),
 });

--- a/langwatch/src/server/api/routers/scimToken.ts
+++ b/langwatch/src/server/api/routers/scimToken.ts
@@ -1,22 +1,12 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { checkOrganizationPermission } from "../rbac";
-import { assertEnterprisePlan, ENTERPRISE_FEATURE_ERRORS } from "../enterprise";
 import { ScimTokenService } from "~/server/scim/scim-token.service";
 
-const enterpriseScimProcedure = protectedProcedure
-  .input(z.object({ organizationId: z.string() }))
-  .use(checkOrganizationPermission("organization:manage"))
-  .use(async ({ ctx, input, next }) => {
-    await assertEnterprisePlan({
-      organizationId: input.organizationId,
-      errorMessage: ENTERPRISE_FEATURE_ERRORS.SCIM,
-    });
-    return next({ ctx });
-  });
-
 export const scimTokenRouter = createTRPCRouter({
-  list: enterpriseScimProcedure
+  list: protectedProcedure
+    .input(z.object({ organizationId: z.string() }))
+    .use(checkOrganizationPermission("organization:manage"))
     .query(async ({ ctx, input }) => {
       const tokens = await ctx.prisma.scimToken.findMany({
         where: { organizationId: input.organizationId },
@@ -31,12 +21,14 @@ export const scimTokenRouter = createTRPCRouter({
       return tokens;
     }),
 
-  generate: enterpriseScimProcedure
+  generate: protectedProcedure
     .input(
       z.object({
+        organizationId: z.string(),
         description: z.string().optional(),
       }),
     )
+    .use(checkOrganizationPermission("organization:manage"))
     .mutation(async ({ ctx, input }) => {
       const tokenService = ScimTokenService.create(ctx.prisma);
       return tokenService.generate({
@@ -45,12 +37,14 @@ export const scimTokenRouter = createTRPCRouter({
       });
     }),
 
-  revoke: enterpriseScimProcedure
+  revoke: protectedProcedure
     .input(
       z.object({
+        organizationId: z.string(),
         tokenId: z.string(),
       }),
     )
+    .use(checkOrganizationPermission("organization:manage"))
     .mutation(async ({ ctx, input }) => {
       await ctx.prisma.scimToken.delete({
         where: {

--- a/langwatch/src/server/scim/__tests__/scim-group.service.unit.test.ts
+++ b/langwatch/src/server/scim/__tests__/scim-group.service.unit.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { TeamUserRole } from "@prisma/client";
+import { ScimGroupService } from "../scim-group.service";
+
+const ORG_ID = "org-1";
+const TEAM_ID = "team-1";
+const SCIM_ID = "scim-group-1";
+
+function buildTeam(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEAM_ID,
+    name: "Engineering",
+    slug: "engineering",
+    organizationId: ORG_ID,
+    externalScimId: SCIM_ID,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-02T00:00:00Z"),
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function buildTeamUser(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: "user-1",
+    teamId: TEAM_ID,
+    role: TeamUserRole.MEMBER,
+    assignedRoleId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    user: { id: "user-1", email: "alice@acme.com", name: "Alice" },
+    ...overrides,
+  };
+}
+
+function createMockPrisma() {
+  return {
+    team: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+      update: vi.fn(),
+    },
+    teamUser: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    organizationUser: {
+      findMany: vi.fn(),
+    },
+  } as unknown as Parameters<typeof ScimGroupService.create>[0];
+}
+
+describe("ScimGroupService", () => {
+  let prisma: ReturnType<typeof createMockPrisma>;
+  let service: ScimGroupService;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = ScimGroupService.create(prisma);
+  });
+
+  describe("getGroup()", () => {
+    describe("when group exists", () => {
+      it("returns SCIM Group representation", async () => {
+        const team = buildTeam();
+        const members = [buildTeamUser()];
+
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(team);
+        (prisma.teamUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(members);
+
+        const result = await service.getGroup({ externalScimId: SCIM_ID, organizationId: ORG_ID });
+
+        expect(result).toMatchObject({
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+          id: SCIM_ID,
+          displayName: "Engineering",
+          members: [{ value: "user-1", display: "alice@acme.com" }],
+        });
+      });
+    });
+
+    describe("when group does not exist", () => {
+      it("returns 404 error", async () => {
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const result = await service.getGroup({ externalScimId: "nonexistent", organizationId: ORG_ID });
+
+        expect(result).toMatchObject({ status: "404" });
+      });
+    });
+  });
+
+  describe("listGroups()", () => {
+    describe("when mapped groups exist", () => {
+      it("returns list of SCIM Groups", async () => {
+        const team = { ...buildTeam(), members: [buildTeamUser()] };
+
+        (prisma.team.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([team]);
+        (prisma.team.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+        const result = await service.listGroups({ organizationId: ORG_ID });
+
+        expect(result.totalResults).toBe(1);
+        expect(result.Resources).toHaveLength(1);
+        expect(result.Resources[0]!.displayName).toBe("Engineering");
+      });
+    });
+  });
+
+  describe("deleteGroup()", () => {
+    describe("when group exists", () => {
+      it("unlinks the team without deleting it", async () => {
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(buildTeam());
+        (prisma.team.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+        const result = await service.deleteGroup({ externalScimId: SCIM_ID, organizationId: ORG_ID });
+
+        expect(result).toBeNull();
+        expect(prisma.team.update).toHaveBeenCalledWith({
+          where: { id: TEAM_ID },
+          data: { externalScimId: null },
+        });
+      });
+    });
+
+    describe("when group does not exist", () => {
+      it("returns 404 error", async () => {
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const result = await service.deleteGroup({ externalScimId: "nonexistent", organizationId: ORG_ID });
+
+        expect(result).toMatchObject({ status: "404" });
+      });
+    });
+  });
+
+  describe("updateGroup() via PATCH", () => {
+    describe("when adding members", () => {
+      it("adds members as MEMBER role", async () => {
+        const team = buildTeam();
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(team);
+        (prisma.organizationUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+          { userId: "user-2", organizationId: ORG_ID },
+        ]);
+        (prisma.teamUser.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        (prisma.teamUser.create as ReturnType<typeof vi.fn>).mockResolvedValue({});
+        (prisma.teamUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+          buildTeamUser(),
+          buildTeamUser({ userId: "user-2", user: { id: "user-2", email: "bob@acme.com", name: "Bob" } }),
+        ]);
+
+        const result = await service.updateGroup({
+          externalScimId: SCIM_ID,
+          organizationId: ORG_ID,
+          patchRequest: {
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            Operations: [
+              { op: "add", path: "members", value: [{ value: "user-2" }] },
+            ],
+          },
+        });
+
+        expect(prisma.teamUser.create).toHaveBeenCalledWith({
+          data: { userId: "user-2", teamId: TEAM_ID, role: TeamUserRole.MEMBER },
+        });
+        expect(result).toMatchObject({ displayName: "Engineering" });
+      });
+    });
+
+    describe("when removing members", () => {
+      it("removes non-admin members", async () => {
+        const team = buildTeam();
+        const member = buildTeamUser({ userId: "user-2", role: TeamUserRole.MEMBER });
+
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(team);
+        (prisma.teamUser.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(member);
+        (prisma.teamUser.delete as ReturnType<typeof vi.fn>).mockResolvedValue({});
+        (prisma.teamUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([buildTeamUser()]);
+
+        await service.updateGroup({
+          externalScimId: SCIM_ID,
+          organizationId: ORG_ID,
+          patchRequest: {
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            Operations: [
+              { op: "remove", path: 'members[value eq "user-2"]' },
+            ],
+          },
+        });
+
+        expect(prisma.teamUser.delete).toHaveBeenCalledWith({
+          where: { userId_teamId: { userId: "user-2", teamId: TEAM_ID } },
+        });
+      });
+
+      it("protects the last admin from removal", async () => {
+        const team = buildTeam();
+        const adminMember = buildTeamUser({ userId: "admin-1", role: TeamUserRole.ADMIN });
+
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(team);
+        (prisma.teamUser.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(adminMember);
+        (prisma.teamUser.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+        (prisma.teamUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([adminMember]);
+
+        await service.updateGroup({
+          externalScimId: SCIM_ID,
+          organizationId: ORG_ID,
+          patchRequest: {
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            Operations: [
+              { op: "remove", path: 'members[value eq "admin-1"]' },
+            ],
+          },
+        });
+
+        expect(prisma.teamUser.delete).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("createGroup()", () => {
+    describe("when matching unmapped team exists", () => {
+      it("links the team and adds members", async () => {
+        const unmappedTeam = buildTeam({ externalScimId: null });
+
+        // First findFirst: check for existing mapped group with same name
+        // Second findFirst: find unmapped team
+        // Third findFirst: findTeamByScimId in addMembersToTeam (not called in this path)
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>)
+          .mockResolvedValueOnce(null) // no existing mapped group
+          .mockResolvedValueOnce(unmappedTeam); // found unmapped team
+        (prisma.team.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+        (prisma.organizationUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+          { userId: "user-1", organizationId: ORG_ID },
+        ]);
+        (prisma.teamUser.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        (prisma.teamUser.create as ReturnType<typeof vi.fn>).mockResolvedValue({});
+        (prisma.teamUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([buildTeamUser()]);
+
+        const result = await service.createGroup({
+          organizationId: ORG_ID,
+          request: {
+            schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            displayName: "Engineering",
+            members: [{ value: "user-1" }],
+          },
+        });
+
+        expect(prisma.team.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { id: TEAM_ID },
+            data: { externalScimId: TEAM_ID },
+          })
+        );
+        expect(result).toMatchObject({ displayName: "Engineering" });
+      });
+    });
+
+    describe("when no matching team exists", () => {
+      it("returns 404 error", async () => {
+        (prisma.team.findFirst as ReturnType<typeof vi.fn>)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null);
+
+        const result = await service.createGroup({
+          organizationId: ORG_ID,
+          request: {
+            schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            displayName: "Nonexistent",
+          },
+        });
+
+        expect(result).toMatchObject({ status: "404" });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/scim/scim-auth.middleware.ts
+++ b/langwatch/src/server/scim/scim-auth.middleware.ts
@@ -4,55 +4,48 @@ import { ScimTokenService } from "./scim-token.service";
 import type { ScimError } from "./scim.types";
 
 /**
- * Error thrown when SCIM authentication fails.
- * Carries the pre-built NextResponse so route handlers can return it directly.
- */
-export class ScimAuthError extends Error {
-  constructor(public readonly response: NextResponse<ScimError>) {
-    super("SCIM authentication failed");
-  }
-}
-
-/**
  * Authenticates a SCIM request by extracting the Bearer token from the Authorization header
  * and verifying it against stored hashed tokens.
  *
- * Returns the organizationId on success, or throws ScimAuthError on failure.
+ * Returns the organizationId on success, or a 401 NextResponse on failure.
  */
 export async function authenticateScimRequest(
   request: Request
-): Promise<{ organizationId: string }> {
+): Promise<{ organizationId: string } | NextResponse<ScimError>> {
   const authHeader = request.headers.get("authorization");
-  const bearerMatch = authHeader?.match(/^Bearer\s+(.+)$/i);
-  const token = bearerMatch?.[1]?.trim();
 
-  if (!token) {
-    throw new ScimAuthError(
-      NextResponse.json(
-        {
-          schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"] as const,
-          status: "401",
-          detail: "Bearer token is required",
-        },
-        { status: 401 }
-      )
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"] as const,
+        status: "401",
+        detail: "Bearer token is required",
+      },
+      { status: 401 }
     );
   }
+
+  const token = authHeader.slice(7);
   const tokenService = ScimTokenService.create(prisma);
   const result = await tokenService.verify({ token });
 
   if (!result) {
-    throw new ScimAuthError(
-      NextResponse.json(
-        {
-          schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"] as const,
-          status: "401",
-          detail: "Invalid or expired token",
-        },
-        { status: 401 }
-      )
+    return NextResponse.json(
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"] as const,
+        status: "401",
+        detail: "Invalid or expired token",
+      },
+      { status: 401 }
     );
   }
 
   return { organizationId: result.organizationId };
+}
+
+/** Type guard to check if the auth result is an error response. */
+export function isAuthError(
+  result: { organizationId: string } | NextResponse<ScimError>
+): result is NextResponse<ScimError> {
+  return result instanceof NextResponse;
 }

--- a/langwatch/src/server/scim/scim-group.service.ts
+++ b/langwatch/src/server/scim/scim-group.service.ts
@@ -1,0 +1,421 @@
+import { TeamUserRole, type PrismaClient, type Team, type TeamUser } from "@prisma/client";
+import type {
+  ScimGroup,
+  ScimListResponse,
+  ScimError,
+  ScimCreateGroupRequest,
+  ScimReplaceGroupRequest,
+  ScimPatchRequest,
+} from "./scim.types";
+
+/**
+ * Maps between SCIM 2.0 Group resources and LangWatch Team models.
+ * Groups are linked to teams via externalScimId. SCIM operations
+ * only affect team membership — deletion unlinks rather than
+ * removing the team.
+ */
+export class ScimGroupService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  static create(prisma: PrismaClient): ScimGroupService {
+    return new ScimGroupService(prisma);
+  }
+
+  async listGroups({
+    organizationId,
+    filter,
+    startIndex = 1,
+    count = 100,
+  }: {
+    organizationId: string;
+    filter?: string;
+    startIndex?: number;
+    count?: number;
+  }): Promise<ScimListResponse<ScimGroup>> {
+    const displayNameFilter = this.parseDisplayNameFilter(filter);
+
+    const where: Record<string, unknown> = {
+      organizationId,
+      externalScimId: { not: null },
+      archivedAt: null,
+    };
+
+    if (displayNameFilter) {
+      where.name = displayNameFilter;
+    }
+
+    const [teams, totalCount] = await Promise.all([
+      this.prisma.team.findMany({
+        where,
+        include: {
+          members: {
+            include: { user: true },
+          },
+        },
+        skip: startIndex - 1,
+        take: count,
+      }),
+      this.prisma.team.count({ where }),
+    ]);
+
+    return {
+      schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+      totalResults: totalCount,
+      startIndex,
+      itemsPerPage: count,
+      Resources: teams.map((t) => this.toScimGroup(t, t.members)),
+    };
+  }
+
+  async getGroup({
+    externalScimId,
+    organizationId,
+  }: {
+    externalScimId: string;
+    organizationId: string;
+  }): Promise<ScimGroup | ScimError> {
+    const team = await this.findTeamByScimId({ externalScimId, organizationId });
+
+    if (!team) {
+      return this.scimError({ status: "404", detail: "Group not found" });
+    }
+
+    const members = await this.prisma.teamUser.findMany({
+      where: { teamId: team.id },
+      include: { user: true },
+    });
+
+    return this.toScimGroup(team, members);
+  }
+
+  async createGroup({
+    request,
+    organizationId,
+  }: {
+    request: ScimCreateGroupRequest;
+    organizationId: string;
+  }): Promise<ScimGroup | ScimError> {
+    // Check if a group with this displayName is already mapped
+    const existing = await this.prisma.team.findFirst({
+      where: {
+        organizationId,
+        name: request.displayName,
+        externalScimId: { not: null },
+      },
+    });
+
+    if (existing) {
+      return this.scimError({ status: "409", detail: "A group with this name is already mapped" });
+    }
+
+    // Find an unmapped team with matching name, or return error
+    const team = await this.prisma.team.findFirst({
+      where: {
+        organizationId,
+        name: request.displayName,
+        externalScimId: null,
+        archivedAt: null,
+      },
+    });
+
+    if (!team) {
+      return this.scimError({
+        status: "404",
+        detail: `No unmapped team found with name "${request.displayName}". Create the team first in LangWatch, then push the group.`,
+      });
+    }
+
+    // Link the team to the SCIM group using a generated ID
+    const scimId = team.id;
+    await this.prisma.team.update({
+      where: { id: team.id },
+      data: { externalScimId: scimId },
+    });
+
+    // Add any members from the request
+    if (request.members?.length) {
+      await this.addMembersToTeam({
+        teamId: team.id,
+        organizationId,
+        memberIds: request.members.map((m) => m.value),
+      });
+    }
+
+    const members = await this.prisma.teamUser.findMany({
+      where: { teamId: team.id },
+      include: { user: true },
+    });
+
+    return this.toScimGroup({ ...team, externalScimId: scimId }, members);
+  }
+
+  async replaceGroup({
+    externalScimId,
+    organizationId,
+    request,
+  }: {
+    externalScimId: string;
+    organizationId: string;
+    request: ScimReplaceGroupRequest;
+  }): Promise<ScimGroup | ScimError> {
+    const team = await this.findTeamByScimId({ externalScimId, organizationId });
+
+    if (!team) {
+      return this.scimError({ status: "404", detail: "Group not found" });
+    }
+
+    // Update team name if changed
+    if (request.displayName !== team.name) {
+      await this.prisma.team.update({
+        where: { id: team.id },
+        data: { name: request.displayName },
+      });
+    }
+
+    // Replace membership: get current members, compute diff
+    const currentMembers = await this.prisma.teamUser.findMany({
+      where: { teamId: team.id },
+    });
+
+    const requestedUserIds = new Set((request.members ?? []).map((m) => m.value));
+    const currentUserIds = new Set(currentMembers.map((m) => m.userId));
+
+    // Add new members
+    const toAdd = [...requestedUserIds].filter((id) => !currentUserIds.has(id));
+    if (toAdd.length > 0) {
+      await this.addMembersToTeam({ teamId: team.id, organizationId, memberIds: toAdd });
+    }
+
+    // Remove members no longer in the group (protect last admin)
+    const toRemove = [...currentUserIds].filter((id) => !requestedUserIds.has(id));
+    await this.removeMembersFromTeam({ teamId: team.id, userIds: toRemove });
+
+    const updatedMembers = await this.prisma.teamUser.findMany({
+      where: { teamId: team.id },
+      include: { user: true },
+    });
+
+    return this.toScimGroup(team, updatedMembers);
+  }
+
+  async updateGroup({
+    externalScimId,
+    organizationId,
+    patchRequest,
+  }: {
+    externalScimId: string;
+    organizationId: string;
+    patchRequest: ScimPatchRequest;
+  }): Promise<ScimGroup | ScimError> {
+    const team = await this.findTeamByScimId({ externalScimId, organizationId });
+
+    if (!team) {
+      return this.scimError({ status: "404", detail: "Group not found" });
+    }
+
+    for (const operation of patchRequest.Operations) {
+      if (operation.op === "add" && operation.path === "members") {
+        const members = this.extractMemberIds(operation.value);
+        if (members.length > 0) {
+          await this.addMembersToTeam({ teamId: team.id, organizationId, memberIds: members });
+        }
+      } else if (operation.op === "remove" && operation.path?.startsWith("members")) {
+        const memberIds = this.extractMemberIdsFromPath(operation.path, operation.value);
+        if (memberIds.length > 0) {
+          await this.removeMembersFromTeam({ teamId: team.id, userIds: memberIds });
+        }
+      } else if (operation.op === "replace") {
+        if (operation.path === "displayName" && typeof operation.value === "string") {
+          await this.prisma.team.update({
+            where: { id: team.id },
+            data: { name: operation.value },
+          });
+        } else if (operation.path === "members" || !operation.path) {
+          // Full member replace
+          const members = this.extractMemberIds(
+            operation.path === "members" ? operation.value : (operation.value as Record<string, unknown> | undefined)?.members
+          );
+          const currentMembers = await this.prisma.teamUser.findMany({
+            where: { teamId: team.id },
+          });
+          const requestedIds = new Set(members);
+          const currentIds = new Set(currentMembers.map((m) => m.userId));
+
+          const toAdd = members.filter((id) => !currentIds.has(id));
+          const toRemove = [...currentIds].filter((id) => !requestedIds.has(id));
+
+          if (toAdd.length > 0) {
+            await this.addMembersToTeam({ teamId: team.id, organizationId, memberIds: toAdd });
+          }
+          if (toRemove.length > 0) {
+            await this.removeMembersFromTeam({ teamId: team.id, userIds: toRemove });
+          }
+        }
+      }
+    }
+
+    const updatedMembers = await this.prisma.teamUser.findMany({
+      where: { teamId: team.id },
+      include: { user: true },
+    });
+
+    return this.toScimGroup(team, updatedMembers);
+  }
+
+  async deleteGroup({
+    externalScimId,
+    organizationId,
+  }: {
+    externalScimId: string;
+    organizationId: string;
+  }): Promise<ScimError | null> {
+    const team = await this.findTeamByScimId({ externalScimId, organizationId });
+
+    if (!team) {
+      return this.scimError({ status: "404", detail: "Group not found" });
+    }
+
+    // Unlink only — don't delete or archive the team
+    await this.prisma.team.update({
+      where: { id: team.id },
+      data: { externalScimId: null },
+    });
+
+    return null;
+  }
+
+  private async findTeamByScimId({
+    externalScimId,
+    organizationId,
+  }: {
+    externalScimId: string;
+    organizationId: string;
+  }): Promise<Team | null> {
+    return this.prisma.team.findFirst({
+      where: {
+        organizationId,
+        externalScimId,
+        archivedAt: null,
+      },
+    });
+  }
+
+  private async addMembersToTeam({
+    teamId,
+    organizationId,
+    memberIds,
+  }: {
+    teamId: string;
+    organizationId: string;
+    memberIds: string[];
+  }): Promise<void> {
+    // Only add users who are members of the organization
+    const orgMembers = await this.prisma.organizationUser.findMany({
+      where: {
+        organizationId,
+        userId: { in: memberIds },
+      },
+    });
+    const validUserIds = new Set(orgMembers.map((m) => m.userId));
+
+    for (const userId of memberIds) {
+      if (!validUserIds.has(userId)) continue;
+
+      const existing = await this.prisma.teamUser.findUnique({
+        where: { userId_teamId: { userId, teamId } },
+      });
+
+      if (!existing) {
+        await this.prisma.teamUser.create({
+          data: {
+            userId,
+            teamId,
+            role: TeamUserRole.MEMBER,
+          },
+        });
+      }
+    }
+  }
+
+  private async removeMembersFromTeam({
+    teamId,
+    userIds,
+  }: {
+    teamId: string;
+    userIds: string[];
+  }): Promise<void> {
+    for (const userId of userIds) {
+      // Protect the last admin
+      const member = await this.prisma.teamUser.findUnique({
+        where: { userId_teamId: { userId, teamId } },
+      });
+
+      if (!member) continue;
+
+      if (member.role === TeamUserRole.ADMIN) {
+        const adminCount = await this.prisma.teamUser.count({
+          where: { teamId, role: TeamUserRole.ADMIN },
+        });
+        if (adminCount <= 1) continue; // Skip — can't remove last admin
+      }
+
+      await this.prisma.teamUser.delete({
+        where: { userId_teamId: { userId, teamId } },
+      });
+    }
+  }
+
+  private extractMemberIds(value: unknown): string[] {
+    if (Array.isArray(value)) {
+      return value
+        .filter((m): m is { value: string } => typeof m === "object" && m !== null && typeof m.value === "string")
+        .map((m) => m.value);
+    }
+    return [];
+  }
+
+  private extractMemberIdsFromPath(path: string, value: unknown): string[] {
+    // Okta format: members[value eq "userId"]
+    const match = path.match(/members\[value\s+eq\s+"([^"]+)"\]/);
+    if (match?.[1]) {
+      return [match[1]];
+    }
+
+    // Azure AD format: uses value array
+    return this.extractMemberIds(value);
+  }
+
+  private toScimGroup(
+    team: Team,
+    members: Array<TeamUser & { user: { id: string; email: string | null; name: string | null } }>,
+  ): ScimGroup {
+    return {
+      schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+      id: team.externalScimId ?? team.id,
+      displayName: team.name,
+      members: members.map((m) => ({
+        value: m.userId,
+        display: m.user.email ?? m.user.name ?? undefined,
+      })),
+      meta: {
+        resourceType: "Group",
+        created: team.createdAt.toISOString(),
+        lastModified: team.updatedAt.toISOString(),
+      },
+    };
+  }
+
+  private parseDisplayNameFilter(filter?: string): string | null {
+    if (!filter) return null;
+    const match = filter.match(/^displayName\s+eq\s+"([^"]+)"$/);
+    return match?.[1] ?? null;
+  }
+
+  private scimError({ status, detail }: { status: string; detail: string }): ScimError {
+    return {
+      schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+      status,
+      detail,
+    };
+  }
+}

--- a/langwatch/src/server/scim/scim.service.ts
+++ b/langwatch/src/server/scim/scim.service.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient, User } from "@prisma/client";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { UserService } from "../users/user.service";
 import type {
   ScimUser,
@@ -50,31 +51,48 @@ export class ScimService {
         return this.scimError({ status: "409", detail: "User already exists in this organization" });
       }
 
-      await this.prisma.organizationUser.create({
-        data: {
-          userId: existingUser.id,
-          organizationId,
-          role: "MEMBER",
-        },
-      });
+      try {
+        await this.prisma.organizationUser.create({
+          data: {
+            userId: existingUser.id,
+            organizationId,
+            role: "MEMBER",
+          },
+        });
+      } catch (e) {
+        if (e instanceof PrismaClientKnownRequestError && e.code === "P2002") {
+          return this.scimError({ status: "409", detail: "User already exists in this organization" });
+        }
+        throw e;
+      }
 
       if (existingUser.deactivatedAt) {
         await this.userService.reactivate({ id: existingUser.id });
       }
 
       const reloadedUser = await this.userService.findById({ id: existingUser.id });
-      return this.toScimUser(reloadedUser!);
+      if (!reloadedUser) {
+        return this.scimError({ status: "404", detail: "User not found" });
+      }
+      return this.toScimUser(reloadedUser);
     }
 
     const newUser = await this.userService.create({ name, email });
 
-    await this.prisma.organizationUser.create({
-      data: {
-        userId: newUser.id,
-        organizationId,
-        role: "MEMBER",
-      },
-    });
+    try {
+      await this.prisma.organizationUser.create({
+        data: {
+          userId: newUser.id,
+          organizationId,
+          role: "MEMBER",
+        },
+      });
+    } catch (e) {
+      if (e instanceof PrismaClientKnownRequestError && e.code === "P2002") {
+        return this.scimError({ status: "409", detail: "User already exists in this organization" });
+      }
+      throw e;
+    }
 
     return this.toScimUser(newUser);
   }
@@ -181,7 +199,10 @@ export class ScimService {
     }
 
     const reloadedUser = await this.userService.findById({ id });
-    return this.toScimUser(reloadedUser!);
+    if (!reloadedUser) {
+      return this.scimError({ status: "404", detail: "User not found" });
+    }
+    return this.toScimUser(reloadedUser);
   }
 
   async updateUser({
@@ -207,23 +228,24 @@ export class ScimService {
     }
 
     for (const operation of patchRequest.Operations) {
-      if (operation.op === "replace" && operation.value) {
+      if (operation.op === "replace" && operation.value != null && typeof operation.value === "object") {
+        const value = operation.value as Record<string, unknown>;
         const updates: { name?: string; email?: string } = {};
 
-        if ("active" in operation.value) {
-          if (operation.value.active === false) {
+        if ("active" in value) {
+          if (value.active === false) {
             await this.userService.deactivate({ id });
           } else {
             await this.userService.reactivate({ id });
           }
         }
 
-        if ("userName" in operation.value && typeof operation.value.userName === "string") {
-          updates.email = operation.value.userName;
+        if ("userName" in value && typeof value.userName === "string") {
+          updates.email = value.userName;
         }
 
-        if ("name" in operation.value && typeof operation.value.name === "object") {
-          const nameObj = operation.value.name as Record<string, string>;
+        if ("name" in value && typeof value.name === "object") {
+          const nameObj = value.name as Record<string, string>;
           const parts = [nameObj.givenName, nameObj.familyName].filter(Boolean);
           if (parts.length > 0) {
             updates.name = parts.join(" ");
@@ -237,7 +259,10 @@ export class ScimService {
     }
 
     const reloadedUser = await this.userService.findById({ id });
-    return this.toScimUser(reloadedUser!);
+    if (!reloadedUser) {
+      return this.scimError({ status: "404", detail: "User not found" });
+    }
+    return this.toScimUser(reloadedUser);
   }
 
   async deleteUser({

--- a/langwatch/src/server/scim/scim.service.ts
+++ b/langwatch/src/server/scim/scim.service.ts
@@ -1,12 +1,10 @@
 import type { PrismaClient, User } from "@prisma/client";
-import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { UserService } from "../users/user.service";
 import type {
   ScimUser,
   ScimListResponse,
   ScimError,
   ScimCreateUserRequest,
-  ScimPatchOperation,
   ScimPatchRequest,
 } from "./scim.types";
 
@@ -52,48 +50,31 @@ export class ScimService {
         return this.scimError({ status: "409", detail: "User already exists in this organization" });
       }
 
-      try {
-        await this.prisma.organizationUser.create({
-          data: {
-            userId: existingUser.id,
-            organizationId,
-            role: "MEMBER",
-          },
-        });
-      } catch (e) {
-        if (e instanceof PrismaClientKnownRequestError && e.code === "P2002") {
-          return this.scimError({ status: "409", detail: "User already exists in this organization" });
-        }
-        throw e;
-      }
+      await this.prisma.organizationUser.create({
+        data: {
+          userId: existingUser.id,
+          organizationId,
+          role: "MEMBER",
+        },
+      });
 
       if (existingUser.deactivatedAt) {
         await this.userService.reactivate({ id: existingUser.id });
       }
 
       const reloadedUser = await this.userService.findById({ id: existingUser.id });
-      if (!reloadedUser) {
-        return this.scimError({ status: "404", detail: "User not found" });
-      }
-      return this.toScimUser(reloadedUser);
+      return this.toScimUser(reloadedUser!);
     }
 
     const newUser = await this.userService.create({ name, email });
 
-    try {
-      await this.prisma.organizationUser.create({
-        data: {
-          userId: newUser.id,
-          organizationId,
-          role: "MEMBER",
-        },
-      });
-    } catch (e) {
-      if (e instanceof PrismaClientKnownRequestError && e.code === "P2002") {
-        return this.scimError({ status: "409", detail: "User already exists in this organization" });
-      }
-      throw e;
-    }
+    await this.prisma.organizationUser.create({
+      data: {
+        userId: newUser.id,
+        organizationId,
+        role: "MEMBER",
+      },
+    });
 
     return this.toScimUser(newUser);
   }
@@ -200,10 +181,7 @@ export class ScimService {
     }
 
     const reloadedUser = await this.userService.findById({ id });
-    if (!reloadedUser) {
-      return this.scimError({ status: "404", detail: "User not found" });
-    }
-    return this.toScimUser(reloadedUser);
+    return this.toScimUser(reloadedUser!);
   }
 
   async updateUser({
@@ -229,16 +207,37 @@ export class ScimService {
     }
 
     for (const operation of patchRequest.Operations) {
-      if (operation.op === "replace") {
-        await this.applyReplaceOperation({ id, operation });
+      if (operation.op === "replace" && operation.value) {
+        const updates: { name?: string; email?: string } = {};
+
+        if ("active" in operation.value) {
+          if (operation.value.active === false) {
+            await this.userService.deactivate({ id });
+          } else {
+            await this.userService.reactivate({ id });
+          }
+        }
+
+        if ("userName" in operation.value && typeof operation.value.userName === "string") {
+          updates.email = operation.value.userName;
+        }
+
+        if ("name" in operation.value && typeof operation.value.name === "object") {
+          const nameObj = operation.value.name as Record<string, string>;
+          const parts = [nameObj.givenName, nameObj.familyName].filter(Boolean);
+          if (parts.length > 0) {
+            updates.name = parts.join(" ");
+          }
+        }
+
+        if (Object.keys(updates).length > 0) {
+          await this.userService.updateProfile({ id, ...updates });
+        }
       }
     }
 
     const reloadedUser = await this.userService.findById({ id });
-    if (!reloadedUser) {
-      return this.scimError({ status: "404", detail: "User not found" });
-    }
-    return this.toScimUser(reloadedUser);
+    return this.toScimUser(reloadedUser!);
   }
 
   async deleteUser({
@@ -290,56 +289,6 @@ export class ScimService {
         lastModified: user.updatedAt.toISOString(),
       },
     };
-  }
-
-  private async applyReplaceOperation({
-    id,
-    operation,
-  }: {
-    id: string;
-    operation: ScimPatchOperation;
-  }): Promise<void> {
-    // Path-based replace with primitive value, e.g. { op: "replace", path: "active", value: false }
-    if (operation.path && typeof operation.value !== "object") {
-      if (operation.path === "active") {
-        if (operation.value === false) {
-          await this.userService.deactivate({ id });
-        } else {
-          await this.userService.reactivate({ id });
-        }
-      }
-      return;
-    }
-
-    // Object-based replace, e.g. { op: "replace", value: { active: false, userName: "..." } }
-    if (operation.value != null && typeof operation.value === "object") {
-      const value = operation.value as Record<string, unknown>;
-      const updates: { name?: string; email?: string } = {};
-
-      if ("active" in value) {
-        if (value.active === false) {
-          await this.userService.deactivate({ id });
-        } else {
-          await this.userService.reactivate({ id });
-        }
-      }
-
-      if ("userName" in value && typeof value.userName === "string") {
-        updates.email = value.userName;
-      }
-
-      if ("name" in value && typeof value.name === "object") {
-        const nameObj = value.name as Record<string, string>;
-        const parts = [nameObj.givenName, nameObj.familyName].filter(Boolean);
-        if (parts.length > 0) {
-          updates.name = parts.join(" ");
-        }
-      }
-
-      if (Object.keys(updates).length > 0) {
-        await this.userService.updateProfile({ id, ...updates });
-      }
-    }
   }
 
   private buildNameFromRequest(request: ScimCreateUserRequest): string {

--- a/langwatch/src/server/scim/scim.types.ts
+++ b/langwatch/src/server/scim/scim.types.ts
@@ -36,7 +36,7 @@ export interface ScimError {
 export interface ScimPatchOperation {
   op: "replace" | "add" | "remove";
   path?: string;
-  value?: Record<string, unknown>;
+  value?: unknown;
 }
 
 export interface ScimPatchRequest {

--- a/langwatch/src/server/scim/scim.types.ts
+++ b/langwatch/src/server/scim/scim.types.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 export interface ScimUser {
   schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"];
   id: string;
@@ -35,40 +33,28 @@ export interface ScimError {
   detail: string;
 }
 
-export const scimPatchOperationSchema = z.object({
-  op: z.enum(["replace", "add", "remove"]),
-  path: z.string().optional(),
-  value: z.unknown().optional(),
-});
+export interface ScimPatchOperation {
+  op: "replace" | "add" | "remove";
+  path?: string;
+  value?: Record<string, unknown>;
+}
 
-export type ScimPatchOperation = z.infer<typeof scimPatchOperationSchema>;
+export interface ScimPatchRequest {
+  schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"];
+  Operations: ScimPatchOperation[];
+}
 
-export const scimPatchRequestSchema = z.object({
-  schemas: z.array(z.string()),
-  Operations: z.array(scimPatchOperationSchema),
-});
-
-export type ScimPatchRequest = z.infer<typeof scimPatchRequestSchema>;
-
-export const scimCreateUserRequestSchema = z.object({
-  schemas: z.array(z.string()),
-  userName: z.string().email(),
-  name: z
-    .object({
-      givenName: z.string().optional(),
-      familyName: z.string().optional(),
-    })
-    .optional(),
-  emails: z
-    .array(
-      z.object({
-        primary: z.boolean().optional(),
-        value: z.string(),
-        type: z.string().optional(),
-      })
-    )
-    .optional(),
-  active: z.boolean().optional(),
-});
-
-export type ScimCreateUserRequest = z.infer<typeof scimCreateUserRequestSchema>;
+export interface ScimCreateUserRequest {
+  schemas: string[];
+  userName: string;
+  name?: {
+    givenName?: string;
+    familyName?: string;
+  };
+  emails?: Array<{
+    primary?: boolean;
+    value: string;
+    type?: string;
+  }>;
+  active?: boolean;
+}

--- a/langwatch/src/server/scim/scim.types.ts
+++ b/langwatch/src/server/scim/scim.types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export interface ScimUser {
   schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"];
   id: string;
@@ -33,28 +35,40 @@ export interface ScimError {
   detail: string;
 }
 
-export interface ScimPatchOperation {
-  op: "replace" | "add" | "remove";
-  path?: string;
-  value?: unknown;
-}
+export const scimPatchOperationSchema = z.object({
+  op: z.enum(["replace", "add", "remove"]),
+  path: z.string().optional(),
+  value: z.unknown().optional(),
+});
 
-export interface ScimPatchRequest {
-  schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"];
-  Operations: ScimPatchOperation[];
-}
+export type ScimPatchOperation = z.infer<typeof scimPatchOperationSchema>;
 
-export interface ScimCreateUserRequest {
-  schemas: string[];
-  userName: string;
-  name?: {
-    givenName?: string;
-    familyName?: string;
-  };
-  emails?: Array<{
-    primary?: boolean;
-    value: string;
-    type?: string;
-  }>;
-  active?: boolean;
-}
+export const scimPatchRequestSchema = z.object({
+  schemas: z.array(z.string()),
+  Operations: z.array(scimPatchOperationSchema),
+});
+
+export type ScimPatchRequest = z.infer<typeof scimPatchRequestSchema>;
+
+export const scimCreateUserRequestSchema = z.object({
+  schemas: z.array(z.string()),
+  userName: z.string().email(),
+  name: z
+    .object({
+      givenName: z.string().optional(),
+      familyName: z.string().optional(),
+    })
+    .optional(),
+  emails: z
+    .array(
+      z.object({
+        primary: z.boolean().optional(),
+        value: z.string(),
+        type: z.string().optional(),
+      })
+    )
+    .optional(),
+  active: z.boolean().optional(),
+});
+
+export type ScimCreateUserRequest = z.infer<typeof scimCreateUserRequestSchema>;

--- a/langwatch/src/server/scim/scim.types.ts
+++ b/langwatch/src/server/scim/scim.types.ts
@@ -72,3 +72,41 @@ export const scimCreateUserRequestSchema = z.object({
 });
 
 export type ScimCreateUserRequest = z.infer<typeof scimCreateUserRequestSchema>;
+
+// SCIM Group types
+
+export interface ScimGroup {
+  schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"];
+  id: string;
+  displayName: string;
+  members: Array<{
+    value: string;
+    display?: string;
+  }>;
+  meta: {
+    resourceType: "Group";
+    created: string;
+    lastModified: string;
+  };
+}
+
+export const scimGroupMemberSchema = z.object({
+  value: z.string(),
+  display: z.string().optional(),
+});
+
+export const scimCreateGroupRequestSchema = z.object({
+  schemas: z.array(z.string()),
+  displayName: z.string(),
+  members: z.array(scimGroupMemberSchema).optional(),
+});
+
+export type ScimCreateGroupRequest = z.infer<typeof scimCreateGroupRequestSchema>;
+
+export const scimReplaceGroupRequestSchema = z.object({
+  schemas: z.array(z.string()),
+  displayName: z.string(),
+  members: z.array(scimGroupMemberSchema).optional(),
+});
+
+export type ScimReplaceGroupRequest = z.infer<typeof scimReplaceGroupRequestSchema>;

--- a/langwatch/src/utils/__tests__/memberRoleState.unit.test.ts
+++ b/langwatch/src/utils/__tests__/memberRoleState.unit.test.ts
@@ -143,6 +143,7 @@ describe("memberRoleState", () => {
               createdAt: new Date(),
               updatedAt: new Date(),
               archivedAt: null,
+              externalScimId: null,
             },
           }),
           makeMembership({
@@ -156,6 +157,7 @@ describe("memberRoleState", () => {
               createdAt: new Date(),
               updatedAt: new Date(),
               archivedAt: null,
+              externalScimId: null,
             },
           }),
         ];


### PR DESCRIPTION
## Summary

- **Hide 'Add members' button for non-org-admins**: Org Members (including those who are Team Admins) could previously open the invite dialog on `settings/members`. The button is now only rendered when the current user has `organization:manage` permission.
- **Cap team role options at Member for non-admin inviters**: `AddMembersForm` / `getFilteredTeamRoles` now accept an `isInviterAdmin` flag. When `false`, the team role dropdown for each invitee is limited to `Member` only — removing `Admin` and custom roles. Previously an Org Member could request that an invitee be assigned Team Admin, which is a privilege escalation.
- **Backend is already safe**: `createInvites` enforces `org:manage` and `createInviteRequest` enforces `z.enum(["MEMBER", "EXTERNAL"])` for org role. These UI changes bring the frontend in line with those server-side guards.

## Test plan

- [ ] Log in as an Org Admin → "Add members" button is visible, Team Admin role is selectable in the team role dropdown
- [ ] Log in as an Org Member (even if Team Admin on some team) → "Add members" button is hidden entirely
- [ ] Typecheck passes: `pnpm typecheck`
- [ ] Existing settings member tests pass: `pnpm test:unit src/tests/settings`

Made with [Cursor](https://cursor.com)