### PR TITLE
fix: restrict 'Add members' button and team role options to org admins only

### DIFF
--- a/langwatch/src/components/AddMembersForm.tsx
+++ b/langwatch/src/components/AddMembersForm.tsx
@@ -59,6 +59,8 @@ interface AddMembersFormProps {
   hasEmailProvider?: boolean;
   onClose?: () => void;
   onCloseText?: string;
+  /** Whether the user submitting this form is an org admin. Controls which team roles are selectable. */
+  isInviterAdmin?: boolean;
 }
 
 /**
@@ -74,6 +76,7 @@ export function AddMembersForm({
   hasEmailProvider = false,
   onClose,
   onCloseText = "Cancel",
+  isInviterAdmin = true,
 }: AddMembersFormProps) {
   const {
     register,
@@ -142,6 +145,7 @@ export function AddMembersForm({
             organizationId={organizationId}
             setValue={setValue}
             onRemove={() => remove(index)}
+            isInviterAdmin={isInviterAdmin}
           />
         ))}
         <Button type="button" onClick={onAddField} marginTop={2}>
@@ -188,6 +192,7 @@ function MemberRow({
   organizationId,
   setValue,
   onRemove,
+  isInviterAdmin,
 }: {
   index: number;
   control: Control<MembersForm>;
@@ -198,6 +203,7 @@ function MemberRow({
   organizationId: string;
   setValue: UseFormSetValue<MembersForm>;
   onRemove: () => void;
+  isInviterAdmin: boolean;
 }) {
   const {
     fields: teamFields,
@@ -420,6 +426,7 @@ function MemberRow({
                         organizationId={organizationId}
                         orgRole={orgRole}
                         setValue={setValue}
+                        isInviterAdmin={isInviterAdmin}
                       />
                     </Table.Cell>
                     <Table.Cell paddingLeft={0} paddingRight={0} paddingY={2}>
@@ -511,14 +518,16 @@ function TeamSelect({
 }
 
 /**
- * Get the appropriate team role options based on org role
+ * Get the appropriate team role options based on org role and whether the inviter is an admin.
  * - EXTERNAL (Viewer): only Viewer
- * - MEMBER: all except Viewer (+ custom roles)
- * - ADMIN: all roles (+ custom roles)
+ * - MEMBER invitee role + non-admin inviter: only Member (no Admin, no Viewer)
+ * - MEMBER invitee role + admin inviter: all except Viewer (+ custom roles)
+ * - ADMIN invitee role (only selectable by org admins): all roles (+ custom roles)
  */
 function getFilteredTeamRoles(
   orgRole: OrganizationUserRole,
   customRoles: Array<{ id: string; name: string; description?: string | null }>,
+  isInviterAdmin: boolean,
 ): RoleOption[] {
   const baseRoles = Object.values(teamRolesOptions);
 
@@ -536,14 +545,18 @@ function getFilteredTeamRoles(
   }
 
   if (orgRole === OrganizationUserRole.MEMBER) {
-    // Member: all except Viewer, plus custom roles
+    if (!isInviterAdmin) {
+      // Non-admin inviter: can only assign Member role, not Admin
+      return [teamRolesOptions.MEMBER];
+    }
+    // Admin inviter: all except Viewer, plus custom roles
     return [
       ...baseRoles.filter((r) => r.value !== TeamUserRole.VIEWER),
       ...customRoleOptions,
     ];
   }
 
-  // Admin: all roles plus custom roles
+  // Admin invitee org role (only reachable by org admins): all roles plus custom roles
   return [...baseRoles, ...customRoleOptions];
 }
 
@@ -571,6 +584,7 @@ function TeamRoleSelect({
   organizationId,
   orgRole,
   setValue,
+  isInviterAdmin,
 }: {
   index: number;
   teamIndex: number;
@@ -578,13 +592,14 @@ function TeamRoleSelect({
   organizationId: string;
   orgRole: OrganizationUserRole;
   setValue: UseFormSetValue<MembersForm>;
+  isInviterAdmin: boolean;
 }) {
   const customRoles = api.role.getAll.useQuery({ organizationId });
 
-  // Build role options filtered by org role
+  // Build role options filtered by org role and whether the inviter is an admin
   const roleOptions = useMemo(
-    () => getFilteredTeamRoles(orgRole, customRoles.data ?? []),
-    [orgRole, customRoles.data],
+    () => getFilteredTeamRoles(orgRole, customRoles.data ?? [], isInviterAdmin),
+    [orgRole, customRoles.data, isInviterAdmin],
   );
 
   const roleCollection = useMemo(

--- a/langwatch/src/pages/settings/members.tsx
+++ b/langwatch/src/pages/settings/members.tsx
@@ -249,10 +249,12 @@ function MembersList({
         <HStack width="full">
           <Heading>Organization Members</Heading>
           <Spacer />
-          <PageLayout.HeaderButton onClick={onAddMembersOpen}>
-            <Plus size={20} />
-            Add members
-          </PageLayout.HeaderButton>
+          {hasOrganizationManagePermission && (
+            <PageLayout.HeaderButton onClick={onAddMembersOpen}>
+              <Plus size={20} />
+              Add members
+            </PageLayout.HeaderButton>
+          )}
         </HStack>
         <Card.Root width="full" overflow="hidden">
           <Card.Body paddingY={0} paddingX={0}>
@@ -417,6 +419,7 @@ function MembersList({
               isLoading={isSubmitting}
               hasEmailProvider={hasEmailProvider ?? false}
               onClose={onAddMembersClose}
+              isInviterAdmin={hasOrganizationManagePermission}
             />
           </Dialog.Body>
         </Dialog.Content>


### PR DESCRIPTION
## Summary

- **Hide 'Add members' button for non-org-admins**: Org Members (including those who are Team Admins) could previously open the invite dialog on `settings/members`. The button is now only rendered when the current user has `organization:manage` permission.
- **Cap team role options at Member for non-admin inviters**: `AddMembersForm` / `getFilteredTeamRoles` now accept an `isInviterAdmin` flag. When `false`, the team role dropdown for each invitee is limited to `Member` only — removing `Admin` and custom roles. Previously an Org Member could request that an invitee be assigned Team Admin, which is a privilege escalation.
- **Backend is already safe**: `createInvites` enforces `org:manage` and `createInviteRequest` enforces `z.enum(["MEMBER", "EXTERNAL"])` for org role. These UI changes bring the frontend in line with those server-side guards.

## Test plan

- [ ] Log in as an Org Admin → "Add members" button is visible, Team Admin role is selectable in the team role dropdown
- [ ] Log in as an Org Member (even if Team Admin on some team) → "Add members" button is hidden entirely
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test:unit src/tests/settings` passes

Made with [Cursor](https://cursor.com)