### PR TITLE
fix(analytics): fix multiple chart rendering and query bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ specs/               # BDD feature specs
 | Using gpt-4o or gpt-4.1-mini in tests, scenarios, or fixtures | Always use `gpt-5-mini` — it's the cheapest and most capable model. Default to `openai("gpt-5-mini")` for scenario judges, user simulators, and test fixtures |
 | Only verifying tests parse (CI=1) without running them end-to-end | Always run scenario tests end-to-end locally (`npx vitest run file.test.ts` without CI flag) to verify they actually pass with Claude Code |
 | Returning JSX from hooks | Hooks return state and callbacks, never JSX. If a hook needs to "render" something (dialog, tooltip), return props/state and let the consumer render the component explicitly. Use `.ts` for hooks, `.tsx` for components |
+| Using `form.watch()` in child components that receive `form` as a prop | Use `useWatch({ control: form.control, name: "field" })` instead — `form.watch()` doesn't trigger re-renders in child components (especially inside `useFieldArray` items). Only the form owner component should use `form.watch()` |
 
 ## TypeScript
 

--- a/langwatch/src/components/analytics/CustomGraph.tsx
+++ b/langwatch/src/components/analytics/CustomGraph.tsx
@@ -396,10 +396,9 @@ const CustomGraph_ = React.memo(
     );
 
     const sortedKeys = expectedKeys
-      .filter((key) => keysToSum[key]! !== 0)
       .toSorted((a, b) => {
-        const totalA = keysToSum[a]!;
-        const totalB = keysToSum[b]!;
+        const totalA = keysToSum[a] ?? 0;
+        const totalB = keysToSum[b] ?? 0;
 
         return totalB - totalA;
       });
@@ -799,7 +798,7 @@ const CustomGraph_ = React.memo(
               }}
               style={{ cursor: handleDataPointClick ? "pointer" : "default" }}
             >
-              {summaryData.current.map((entry, index) => (
+              {sortedCurrentData.map((entry, index) => (
                 <Cell
                   key={`cell-${index}`}
                   fill={colorForSeries(entry.key, index)}
@@ -1006,7 +1005,9 @@ const CustomGraph_ = React.memo(
     return (
       JSON.stringify(prevProps.input) === JSON.stringify(nextProps.input) &&
       JSON.stringify(prevProps.titleProps) ===
-      JSON.stringify(nextProps.titleProps) &&
+        JSON.stringify(nextProps.titleProps) &&
+      JSON.stringify(prevProps.filters) ===
+        JSON.stringify(nextProps.filters) &&
       prevProps.onDataPointClick === nextProps.onDataPointClick
     );
   },
@@ -1084,18 +1085,17 @@ const shapeDataForGraph = (
   const flattenPreviousPeriod =
     timeseries.data && flattenGroupData(input, timeseries.data.previousPeriod);
 
-  const currentAndPreviousData =
-    flattenPreviousPeriod &&
-    flattenCurrentPeriod?.map((entry, index) => {
-      return {
-        ...entry,
-        ...Object.fromEntries(
-          Object.entries(flattenPreviousPeriod[index] ?? {}).map(
-            ([key, value]) => [`previous>${key}`, value ?? 0],
-          ),
+  const currentAndPreviousData = flattenCurrentPeriod?.map((entry, index) => {
+    if (!flattenPreviousPeriod) return entry;
+    return {
+      ...entry,
+      ...Object.fromEntries(
+        Object.entries(flattenPreviousPeriod[index] ?? {}).map(
+          ([key, value]) => [`previous>${key}`, value ?? 0],
         ),
-      };
-    });
+      ),
+    };
+  });
 
   return currentAndPreviousData as
     | ({ date: string } & Record<string, number>)[]
@@ -1153,7 +1153,7 @@ const collectAllDays = (
       if (!result[key]) {
         result[key] = [];
       }
-      result[key]!.push(entry[key]!);
+      result[key]?.push(entry[key] ?? 0);
     }
   }
 

--- a/langwatch/src/hooks/__tests__/useGetRotatingColorForCharts.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useGetRotatingColorForCharts.unit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGetRotatingColorForCharts } from "../useGetRotatingColorForCharts";
+
+vi.mock("../../components/ui/color-mode", () => ({
+  getRawColorValue: vi.fn((color: string) => color),
+}));
+
+import { getRawColorValue } from "../../components/ui/color-mode";
+
+const mockGetRawColorValue = vi.mocked(getRawColorValue);
+
+describe("useGetRotatingColorForCharts()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRawColorValue.mockImplementation((color: string) => color);
+  });
+
+  describe("when color has a numeric suffix (e.g. orangeTones set)", () => {
+    it("applies adjustment to the numeric value and calls getRawColorValue", () => {
+      const { result } = renderHook(() => useGetRotatingColorForCharts());
+      const getColor = result.current;
+
+      // orangeTones index 0 has color "orange.400" (from tones("orange")[0].color)
+      getColor("orangeTones", 0, 50);
+
+      expect(mockGetRawColorValue).toHaveBeenCalledWith("orange.450");
+    });
+
+    it("clamps adjustment so the result stays within 50..900", () => {
+      const { result } = renderHook(() => useGetRotatingColorForCharts());
+      const getColor = result.current;
+
+      // orangeTones index 4 has color "orange.900"; adding 200 should clamp to 900
+      // orangeTones[4].color = "orange.900"
+      getColor("orangeTones", 4, 200);
+
+      expect(mockGetRawColorValue).toHaveBeenCalledWith("orange.900");
+    });
+
+    it("returns the value from getRawColorValue", () => {
+      mockGetRawColorValue.mockReturnValue("#7B341E");
+
+      const { result } = renderHook(() => useGetRotatingColorForCharts());
+      const getColor = result.current;
+
+      const color = getColor("orangeTones", 0);
+
+      expect(color).toBe("#7B341E");
+    });
+  });
+
+  describe("when color has a semantic suffix (e.g. colors set)", () => {
+    it("returns the raw color value without producing NaN in the token name", () => {
+      const { result } = renderHook(() => useGetRotatingColorForCharts());
+      const getColor = result.current;
+
+      // "colors" set index 0 has color "orange.emphasized"
+      // Before the fix, parseInt("emphasized") is NaN, causing "orange.NaN" to be passed
+      getColor("colors", 0);
+
+      // Must be called with the original semantic token, not "orange.NaN"
+      expect(mockGetRawColorValue).toHaveBeenCalledWith("orange.emphasized");
+      expect(mockGetRawColorValue).not.toHaveBeenCalledWith(
+        expect.stringContaining("NaN"),
+      );
+    });
+
+    it("ignores adjustment for semantic suffix colors", () => {
+      const { result } = renderHook(() => useGetRotatingColorForCharts());
+      const getColor = result.current;
+
+      // adjustment should have no effect on semantic tokens
+      getColor("colors", 0, 100);
+
+      expect(mockGetRawColorValue).toHaveBeenCalledWith("orange.emphasized");
+    });
+  });
+});

--- a/langwatch/src/hooks/useGetRotatingColorForCharts.tsx
+++ b/langwatch/src/hooks/useGetRotatingColorForCharts.tsx
@@ -3,16 +3,21 @@ import { type RotatingColorSet, rotatingColors } from "../utils/rotatingColors";
 
 export const useGetRotatingColorForCharts = () => {
   return (set: RotatingColorSet, index: number, adjustment = 0) => {
-    const [name, number] =
-      rotatingColors[set]![index % rotatingColors[set]!.length]!.color.split(
-        ".",
-      );
+    const colorSet = rotatingColors[set];
+    if (!colorSet || colorSet.length === 0) {
+      return getRawColorValue("gray.400");
+    }
+    const color = colorSet[index % colorSet.length]?.color ?? "gray.400";
+    const [name, suffix] = color.split(".");
+
+    // Semantic tokens (e.g. "green.emphasized") don't support numeric adjustment
+    const numericValue = parseInt(suffix ?? "0");
+    if (isNaN(numericValue)) {
+      return getRawColorValue(color);
+    }
 
     return getRawColorValue(
-      `${name}.${Math.max(
-        Math.min(parseInt(number ?? "0") + adjustment, 900),
-        50,
-      )}`,
+      `${name}.${Math.max(Math.min(numericValue + adjustment, 900), 50)}`,
     );
   };
 };

--- a/langwatch/src/pages/[project]/analytics/custom/index.tsx
+++ b/langwatch/src/pages/[project]/analytics/custom/index.tsx
@@ -57,6 +57,7 @@ import {
   type UseFieldArrayReturn,
   useFieldArray,
   useForm,
+  useWatch,
 } from "react-hook-form";
 import { LuChartArea, LuPlus } from "react-icons/lu";
 import { useDebounceValue } from "usehooks-ts";
@@ -546,7 +547,7 @@ export const customGraphFormToCustomGraphInput = (
 
   return {
     graphId: "custom",
-    graphType: formData.graphType!.value,
+    graphType: formData.graphType?.value ?? "line",
     series: formData.series.map((series) => {
       if (series.pipeline.field) {
         return {
@@ -633,14 +634,14 @@ function CustomGraphForm({
 }) {
   const [expandedSeries, setExpandedSeries] = useState<string[]>(["0"]);
   const groupByField = form.control.register("groupBy");
-  const graphType = form.watch("graphType");
-  const groupBy = form.watch("groupBy");
-  const title = form.watch("title");
+  const graphType = useWatch({ control: form.control, name: "graphType" });
+  const groupBy = useWatch({ control: form.control, name: "groupBy" });
+  const title = useWatch({ control: form.control, name: "title" });
+  const series = useWatch({ control: form.control, name: "series" });
   const { showFilters, setShowFilters } = useFilterToggle();
 
-  const joinedSeriesNames = form
-    .watch()
-    .series.map((s) => s.name)
+  const joinedSeriesNames = series
+    .map((s) => s.name)
     .join(", ");
 
   useEffect(() => {
@@ -992,7 +993,7 @@ function SeriesFieldItem({
   setExpandedSeries: Dispatch<SetStateAction<string[]>>;
   customId?: string;
 }) {
-  const colorSet = form.watch(`series.${index}.colorSet`);
+  const colorSet = useWatch({ control: form.control, name: `series.${index}.colorSet` });
   const coneColors = rotatingColors[colorSet].map((color, i) => {
     const color_ = getRawColorValue(color.color);
     const len = rotatingColors[colorSet].length;
@@ -1000,8 +1001,9 @@ function SeriesFieldItem({
     return `${color_} ${(i / len) * 100}%, ${color_} ${((i + 1) / len) * 100}%`;
   });
 
-  const seriesLength = form.watch(`series`).length;
-  const groupBy = form.watch("groupBy");
+  const seriesValues = useWatch({ control: form.control, name: "series" });
+  const seriesLength = seriesValues.length;
+  const groupBy = useWatch({ control: form.control, name: "groupBy" });
 
   // Track the previous groupBy to only auto-set colors when user actually changes it
   const prevGroupByRef = useRef<string | undefined>(undefined);
@@ -1165,21 +1167,31 @@ function SeriesField({
   index: number;
   customId?: string;
 }) {
-  const name = form.watch(`series.${index}.name`);
-  const metric = form.watch(`series.${index}.metric`);
-  const aggregation = form.watch(`series.${index}.aggregation`);
-  const key = form.watch(`series.${index}.key`);
-  const pipelineField = form.watch(`series.${index}.pipeline.field`);
-  const pipelineAggregation = form.watch(
-    `series.${index}.pipeline.aggregation`,
-  );
-  const filters = form.watch(`series.${index}.filters`);
+  const name = useWatch({ control: form.control, name: `series.${index}.name` });
+  const metric = useWatch({ control: form.control, name: `series.${index}.metric` });
+  const aggregation = useWatch({ control: form.control, name: `series.${index}.aggregation` });
+  const key = useWatch({ control: form.control, name: `series.${index}.key` });
+  const pipelineField = useWatch({ control: form.control, name: `series.${index}.pipeline.field` });
+  const pipelineAggregation = useWatch({
+    control: form.control,
+    name: `series.${index}.pipeline.aggregation`,
+  });
+  const filters = useWatch({ control: form.control, name: `series.${index}.filters` });
   const nonEmptyFilters = filterOutEmptyFilters(filters);
 
-  const metricField = form.control.register(`series.${index}.metric`);
   const metric_ = metric ? getMetric(metric) : undefined;
 
   const { openDrawer } = useDrawer();
+
+  // Sync aggregation when metric changes — if the current aggregation
+  // isn't allowed by the new metric, switch to the first allowed one.
+  useEffect(() => {
+    if (metric_ && !metric_.allowedAggregations.includes(aggregation)) {
+      const firstAllowed = metric_.allowedAggregations[0] ?? "avg";
+      form.setValue(`series.${index}.aggregation`, firstAllowed);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [metric]);
 
   useEffect(() => {
     const aggregation_ = aggregation
@@ -1231,32 +1243,36 @@ function SeriesField({
       <Field.Root>
         <Field.Label>Metric</Field.Label>
         <Grid width="full" gap={3} templateColumns="repeat(4, 1fr)">
-          <NativeSelect.Root gridColumn="span 2">
-            <NativeSelect.Field
-              {...metricField}
-              onChange={(e) => {
-                const metric_ = getMetric(e.target.value as any);
-                if (!metric_.allowedAggregations.includes(aggregation)) {
-                  form.setValue(
-                    `series.${index}.aggregation`,
-                    metric_.allowedAggregations[0]!,
-                  );
-                }
-                void metricField.onChange(e);
-              }}
-            >
-              {Object.entries(analyticsMetrics).map(([group, metrics]) => (
-                <optgroup key={group} label={camelCaseToTitleCase(group)}>
-                  {Object.entries(metrics).map(([metricKey, metric]) => (
-                    <option key={metricKey} value={`${group}.${metricKey}`}>
-                      {metric.label}
-                    </option>
+          <Controller
+            control={form.control}
+            name={`series.${index}.metric`}
+            render={({ field: metricField }) => (
+              <NativeSelect.Root gridColumn="span 2">
+                <NativeSelect.Field
+                  value={metricField.value ?? ""}
+                  onChange={(e) => {
+                    metricField.onChange(
+                      e.target.value as FlattenAnalyticsMetricsEnum,
+                    );
+                  }}
+                >
+                  {Object.entries(analyticsMetrics).map(([group, metrics]) => (
+                    <optgroup key={group} label={camelCaseToTitleCase(group)}>
+                      {Object.entries(metrics).map(([metricKey, m]) => (
+                        <option
+                          key={metricKey}
+                          value={`${group}.${metricKey}`}
+                        >
+                          {m.label}
+                        </option>
+                      ))}
+                    </optgroup>
                   ))}
-                </optgroup>
-              ))}
-            </NativeSelect.Field>
-            <NativeSelect.Indicator />
-          </NativeSelect.Root>
+                </NativeSelect.Field>
+                <NativeSelect.Indicator />
+              </NativeSelect.Root>
+            )}
+          />
           {metric_?.requiresKey && (
             <Box gridColumn="span 2">
               <Controller
@@ -1293,7 +1309,13 @@ function SeriesField({
           )}
           <NativeSelect.Root gridColumn="span 1">
             <NativeSelect.Field
-              {...form.control.register(`series.${index}.aggregation`)}
+              value={aggregation}
+              onChange={(e) => {
+                form.setValue(
+                  `series.${index}.aggregation`,
+                  e.target.value as AggregationTypes,
+                );
+              }}
             >
               {metric_?.allowedAggregations.map((agg) => (
                 <option key={agg} value={agg}>
@@ -1529,18 +1551,14 @@ function GraphTypeField({
     })),
   });
 
-  const selectedValue = form.watch("graphType");
-
   return (
     <Controller
       control={form.control}
       name="graphType"
       render={({ field }) => (
         <Select.Root
-          {...field}
-          onChange={undefined}
           collection={graphTypeCollection}
-          value={[field.value!.value]}
+          value={field.value ? [field.value.value] : []}
           onValueChange={(change) => {
             const selectedOption = chartOptions.find(
               (opt) => opt.value === change.value[0],
@@ -1551,10 +1569,10 @@ function GraphTypeField({
           <Select.Trigger>
             <Select.ValueText>
               {() =>
-                selectedValue ? (
+                field.value ? (
                   <HStack gap={2}>
-                    {selectedValue.icon}
-                    <Text>{selectedValue.label}</Text>
+                    {field.value.icon}
+                    <Text>{field.value.label}</Text>
                   </HStack>
                 ) : (
                   <Text>Select graph type</Text>

--- a/langwatch/src/server/analytics/__tests__/registry.unit.test.ts
+++ b/langwatch/src/server/analytics/__tests__/registry.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { analyticsMetrics } from "../registry";
+
+describe("analyticsMetrics", () => {
+  describe("event_details", () => {
+    describe("when calling aggregation()", () => {
+      it("produces a key containing 'event_details', not 'event_score'", () => {
+        const result = analyticsMetrics.events.event_details.aggregation(
+          0,
+          "avg",
+          "key1",
+          "subkey1",
+        );
+
+        const keys = Object.keys(result);
+        expect(keys[0]).toContain("event_details");
+        expect(keys[0]).not.toContain("event_score");
+      });
+    });
+
+    describe("when calling extractionPath()", () => {
+      it("produces a path containing 'event_details', not 'event_score'", () => {
+        const path = analyticsMetrics.events.event_details.extractionPath(
+          0,
+          "avg",
+          "key1",
+          "subkey1",
+        );
+
+        expect(path).toContain("event_details");
+        expect(path).not.toContain("event_score");
+      });
+    });
+  });
+
+  describe("evaluation_pass_rate", () => {
+    it("uses percentage format", () => {
+      expect(analyticsMetrics.evaluations.evaluation_pass_rate.format).toBe(
+        "0%",
+      );
+    });
+  });
+});

--- a/langwatch/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
@@ -228,6 +228,23 @@ describe("column-pruning", () => {
         expect(result.sql).toContain("Events.Name");
       });
     });
+
+    describe("when requesting performance.tokens_per_second", () => {
+      it("includes DurationMs in the stored_spans subquery", () => {
+        const result = buildTimeseriesQuery({
+          ...baseInput,
+          series: [
+            {
+              metric:
+                "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
+              aggregation: "avg" as const,
+            },
+          ],
+        });
+
+        expect(result.sql).toContain("DurationMs");
+      });
+    });
   });
 
   describe("query correctness after pruning", () => {
@@ -337,6 +354,7 @@ describe("column-pruning", () => {
         "SpanAttributes",
         "StartTime",
         "EndTime",
+        "DurationMs",
         "Events.Name",
         "Events.Timestamp",
         "Events.Attributes",

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -86,6 +86,7 @@ export const SPAN_ANALYTICS_COLUMNS = [
   "SpanAttributes",
   "StartTime",
   "EndTime",
+  "DurationMs",
   "StatusCode",
   `"Events.Name"`,
   `"Events.Timestamp"`,

--- a/langwatch/src/server/analytics/registry.ts
+++ b/langwatch/src/server/analytics/registry.ts
@@ -503,7 +503,7 @@ export const analyticsMetrics = {
           );
 
         return {
-          [`${index}__event_score_${aggregation}_${key}_${subkey}`]: {
+          [`${index}__event_details_${aggregation}_${key}_${subkey}`]: {
             nested: {
               path: "events",
             },
@@ -550,7 +550,7 @@ export const analyticsMetrics = {
         key,
         subkey,
       ) => {
-        return `${index}__event_score_${aggregation}_${key}_${subkey}>child>child>child>child`;
+        return `${index}__event_details_${aggregation}_${key}_${subkey}>child>child>child>child`;
       },
       quickwitSupport: false,
     },
@@ -600,7 +600,7 @@ export const analyticsMetrics = {
     evaluation_pass_rate: {
       label: "Evaluation Pass Rate",
       colorSet: "tealTones",
-      format: "0.00a",
+      format: "0%",
       increaseIs: "good",
       allowedAggregations: allAggregationTypes.filter(
         (agg) => agg != "cardinality" && agg != "terms",

--- a/specs/analytics/chart-rendering.feature
+++ b/specs/analytics/chart-rendering.feature
@@ -1,0 +1,89 @@
+Feature: Analytics Chart Rendering
+
+  Charts on the analytics dashboard render data correctly across
+  all graph types, metrics, and color configurations.
+
+  Background:
+    Given a project with analytics data stored in ClickHouse
+
+  # ---------------------------------------------------------------------------
+  # Graph type switching
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Switching from monitor graph to bar chart preserves sparse pass rate data
+    Given a project with sparse evaluation pass rate data
+    When the user views the data as a monitor graph
+    Then the chart displays the pass rate data
+    When the user switches to a bar chart
+    Then the chart still displays the pass rate data
+
+  # ---------------------------------------------------------------------------
+  # Bar chart color alignment
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Bar chart colors align with their data series after sorting
+    Given a bar chart with multiple data series sorted by value
+    When the chart renders
+    Then each bar's color matches its corresponding data series
+
+  # ---------------------------------------------------------------------------
+  # Pass rate formatting
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Evaluation pass rate displays as percentage
+    Given a chart showing evaluation pass rate data
+    When the chart renders the Y-axis and tooltips
+    Then values display as percentages like "85%" not decimals like "0.85"
+
+  # ---------------------------------------------------------------------------
+  # Semantic color tokens
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Charts using semantic color tokens render visible colors
+    Given a chart using the default color set with semantic tokens
+    When the chart renders with color adjustments
+    Then all bars and lines have valid visible colors
+
+  # ---------------------------------------------------------------------------
+  # Filter-driven re-render
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Changing graph filters updates the displayed data
+    Given a chart with active filters
+    When the user changes the filter criteria
+    Then the chart re-renders with the updated filter results
+
+  # ---------------------------------------------------------------------------
+  # Current period without comparison
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Chart renders current data without previous period
+    Given a chart configured without previous period comparison
+    When the timeseries data loads
+    Then the chart displays the current period data
+
+  # ---------------------------------------------------------------------------
+  # Event metrics coexistence
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Event details and event score metrics use distinct aggregation keys
+    Given a dashboard with both event score and event details metrics
+    When both metrics query the same event key and subkey
+    Then each metric returns its own independent data
+
+  # ---------------------------------------------------------------------------
+  # Tokens per second metric completeness
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Tokens per second metric resolves duration from stored spans
+    Given an analytics query for the performance tokens per second metric
+    When the ClickHouse query is built
+    Then the stored spans data includes duration information needed to compute the rate


### PR DESCRIPTION
## Summary

Fixes multiple analytics chart bugs tracked in the #2581 epic.

### Backend fixes
- **DurationMs missing (#2579):** Add `DurationMs` to `SPAN_ANALYTICS_COLUMNS` so `tokens_per_second` ClickHouse queries resolve `ss.DurationMs`
- **Pass rate format (#1496 bug 3):** Change `evaluation_pass_rate` format from `"0.00a"` to `"0%"` — Y-axis now shows `67%` not `0.67`
- **Key collision (#1496 bug 14):** Fix `event_details` aggregation key prefix from `event_score` to `event_details`

### Chart rendering fixes
- **Empty charts on type switch (#1496 bug 1):** Remove zero-sum key filter from `sortedKeys` that hid sparse data
- **Bar chart colors (#1496 bug 2):** Use `sortedCurrentData` for `Cell` color mapping so colors match sorted bars
- **NaN colors (#1496 bug 4):** Handle semantic color tokens (`"green.emphasized"`) in `useGetRotatingColorForCharts` to prevent `parseInt("emphasized")` → NaN
- **Memo comparison (#1496 bug 8):** Add `filters` prop to `CustomGraph` React.memo comparison
- **Previous period (#1496 bug 12):** Fix `shapeDataForGraph` returning `undefined` when no previous period data exists
- **Non-null assertions:** Replace all `!` assertions with optional chaining and nullish coalescing

### Custom graph page fixes
- **Graph type dropdown broken (#2584):** Stop spreading react-hook-form `field` props onto Chakra `Select.Root`
- **Graph type trigger text:** Use `field.value` directly instead of stale `form.watch` value
- **Aggregation dropdown stale (#2585):** Replace `form.watch()` with `useWatch()` for reactive updates in `useFieldArray` items; add `useEffect` to auto-sync aggregation when metric changes
- **Color set selector stale (#2587):** Switch `colorSet` from `form.watch()` to `useWatch()`

### Tests and specs
- BDD feature spec: `specs/analytics/chart-rendering.feature` (8 scenarios)
- Regression tests for `useGetRotatingColorForCharts` semantic token handling
- Regression tests for `event_details` aggregation key naming
- Regression test for `evaluation_pass_rate` format
- Regression test for `DurationMs` in `tokens_per_second` column pruning

## Browser-verified

| Bug | Result |
|-----|--------|
| #2579 — Tokens/sec ClickHouse query | PASS — no 500 error |
| #1496 bug 3 — Pass rate % format | PASS — Y-axis shows 67% |
| #1496 bug 4 — Semantic color tokens | PASS — donut/bar render visible colors |
| #1496 bug 12 — Chart without previous period | PASS — data renders |
| #2584 — Graph type dropdown | PASS — selection works |
| #2585 — Aggregation dropdown updates | PASS — options update on metric change |
| #2587 — Color set selector | PASS — preview updates on change |

Closes #2581
Closes #2579
Closes #1496
Closes #2584
Closes #2585
Closes #2587

🤖 Generated with [Claude Code](https://claude.com/claude-code)