### PR TITLE
feat(nurturing): register CIO reactors in event sourcing pipelines

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
@@ -18,6 +18,7 @@ export interface EvaluationProcessingPipelineDeps {
     makeJobId(payload: any): string;
   };
   esSyncReactor: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
+  customerIoEvaluationSyncReactor?: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
 }
 
 /**
@@ -33,13 +34,23 @@ export interface EvaluationProcessingPipelineDeps {
  * - completeEvaluation: Records eval result to CH (API handler path)
  */
 export function createEvaluationProcessingPipeline(deps: EvaluationProcessingPipelineDeps) {
-  return definePipeline<EvaluationProcessingEvent>()
+  let builder = definePipeline<EvaluationProcessingEvent>()
     .withName("evaluation_processing")
     .withAggregateType("evaluation")
     .withFoldProjection("evaluationRun", createEvaluationRunFoldProjection({
       store: deps.evalRunStore,
     }))
-    .withReactor("evaluationRun", "evaluationEsSync", deps.esSyncReactor)
+    .withReactor("evaluationRun", "evaluationEsSync", deps.esSyncReactor);
+
+  if (deps.customerIoEvaluationSyncReactor) {
+    builder = builder.withReactor(
+      "evaluationRun",
+      "customerIoEvaluationSync",
+      deps.customerIoEvaluationSyncReactor,
+    );
+  }
+
+  return builder
     .withCommand("executeEvaluation", deps.ExecuteEvaluationCommand, {
       delay: 30_000,
       deduplication: {

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/pipeline.ts
@@ -17,6 +17,7 @@ export interface SimulationProcessingPipelineDeps {
   snapshotUpdateBroadcastReactor: ReactorDefinition<SimulationProcessingEvent, SimulationRunStateData>;
   suiteRunSyncReactor: ReactorDefinition<SimulationProcessingEvent, SimulationRunStateData>;
   traceMetricsSyncReactor: ReactorDefinition<SimulationProcessingEvent, SimulationRunStateData>;
+  customerIoSimulationSyncReactor?: ReactorDefinition<SimulationProcessingEvent, SimulationRunStateData>;
 }
 
 /**
@@ -37,7 +38,7 @@ export interface SimulationProcessingPipelineDeps {
  * - deleteRun: Emits SimulationRunDeletedEvent for soft-delete
  */
 export function createSimulationProcessingPipeline(deps: SimulationProcessingPipelineDeps) {
-  return definePipeline<SimulationProcessingEvent>()
+  let builder = definePipeline<SimulationProcessingEvent>()
     .withName("simulation_processing")
     .withAggregateType("simulation_run")
     .withFoldProjection("simulationRunState", createSimulationRunStateFoldProjection({
@@ -45,7 +46,17 @@ export function createSimulationProcessingPipeline(deps: SimulationProcessingPip
     }))
     .withReactor("simulationRunState", "snapshotUpdateBroadcast", deps.snapshotUpdateBroadcastReactor)
     .withReactor("simulationRunState", "suiteRunSync", deps.suiteRunSyncReactor)
-    .withReactor("simulationRunState", "traceMetricsSync", deps.traceMetricsSyncReactor)
+    .withReactor("simulationRunState", "traceMetricsSync", deps.traceMetricsSyncReactor);
+
+  if (deps.customerIoSimulationSyncReactor) {
+    builder = builder.withReactor(
+      "simulationRunState",
+      "customerIoSimulationSync",
+      deps.customerIoSimulationSyncReactor,
+    );
+  }
+
+  return builder
     .withCommand("queueRun", QueueRunCommand)
     .withCommand("startRun", StartRunCommand)
     .withCommand("messageSnapshot", MessageSnapshotCommand)

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -28,6 +28,7 @@ export interface TraceProcessingPipelineDeps {
   projectMetadataReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   simulationMetricsSyncReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   spanStorageBroadcastReactor: ReactorDefinition<TraceProcessingEvent>;
+  customerIoTraceSyncReactor?: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
 }
 
 /**
@@ -38,7 +39,7 @@ export interface TraceProcessingPipelineDeps {
  * individual spans to the stored_spans table (map projection).
  */
 export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps) {
-  return definePipeline<TraceProcessingEvent>()
+  let builder = definePipeline<TraceProcessingEvent>()
     .withName("trace_processing")
     .withAggregateType("trace")
     .withFoldProjection("traceSummary", createTraceSummaryFoldProjection({
@@ -58,7 +59,17 @@ export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps)
     .withReactor("traceSummary", "traceUpdateBroadcast", deps.traceUpdateBroadcastReactor)
     .withReactor("traceSummary", "projectMetadata", deps.projectMetadataReactor)
     .withReactor("traceSummary", "simulationMetricsSync", deps.simulationMetricsSyncReactor)
-    .withReactor("spanStorage", "spanStorageBroadcast", deps.spanStorageBroadcastReactor)
+    .withReactor("spanStorage", "spanStorageBroadcast", deps.spanStorageBroadcastReactor);
+
+  if (deps.customerIoTraceSyncReactor) {
+    builder = builder.withReactor(
+      "traceSummary",
+      "customerIoTraceSync",
+      deps.customerIoTraceSyncReactor,
+    );
+  }
+
+  return builder
     .withCommand("recordSpan", RecordSpanCommand)
     .withCommand("assignTopic", AssignTopicCommand)
     .withCommand("recordLog", RecordLogCommand)


### PR DESCRIPTION
## Summary

Adds optional Customer.io sync reactor slots to 3 event sourcing pipelines:

- **trace_processing** — `customerIoTraceSyncReactor` (first trace milestones + debounced updates)
- **evaluation_processing** — `customerIoEvaluationSyncReactor` (first eval milestones + debounced updates)
- **simulation_processing** — `customerIoSimulationSyncReactor` (first simulation run + debounced updates)

All conditional — only registered when the reactor dep is provided. Zero behavioral change when reactors are absent.

3 files, +39 lines. Pure additive pipeline wiring.

## Test plan

- [x] Typecheck clean (only pre-existing SCIM error)
- [x] No new runtime code — just optional deps + conditional `.withReactor()` calls