### PR TITLE
feat: add reusable announcement banner component

### DIFF
--- a/langwatch/src/components/AnnouncementBanner.tsx
+++ b/langwatch/src/components/AnnouncementBanner.tsx
@@ -1,0 +1,88 @@
+import { Alert, Button, CloseButton, HStack, Text } from "@chakra-ui/react";
+import { useLocalStorage } from "usehooks-ts";
+import { LuArrowRight } from "react-icons/lu";
+
+export type Announcement = {
+  /** Unique key used for localStorage dismiss state */
+  id: string;
+  message: string;
+  linkUrl: string;
+  linkLabel?: string;
+  /** Banner auto-hides on or after this date */
+  expiresAt: Date;
+};
+
+const announcements: Announcement[] = [
+  {
+    id: "litellm-vulnerability-2026-03",
+    message:
+      "Your data is safe — LangWatch was not affected by the recent LiteLLM vulnerability.",
+    linkUrl:
+      "https://langwatch.ai/blog/a-note-on-the-litellm-vulnerability",
+    linkLabel: "Read our full statement",
+    expiresAt: new Date("2026-03-27T00:00:00Z"),
+  },
+];
+
+function AnnouncementItem({ announcement }: { announcement: Announcement }) {
+  const [dismissed, setDismissed] = useLocalStorage(
+    `langwatch-announcement-${announcement.id}-dismissed`,
+    false,
+  );
+
+  if (dismissed || new Date() >= announcement.expiresAt) {
+    return null;
+  }
+
+  return (
+    <Alert.Root
+      status="info"
+      width="full"
+      border="1px solid"
+      borderColor="colorPalette.muted"
+      marginX={4}
+      marginTop={3}
+      borderRadius="lg"
+      maxWidth="calc(100% - 22px)"
+    >
+      <Alert.Indicator />
+      <Alert.Content>
+        <HStack width="full">
+          <Text>{announcement.message}</Text>
+          <Button
+            size="xs"
+            variant="outline"
+            colorPalette="blue"
+            asChild
+          >
+            <a
+              href={announcement.linkUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {announcement.linkLabel ?? "Learn more"}{" "}
+              <LuArrowRight size={12} />
+            </a>
+          </Button>
+        </HStack>
+      </Alert.Content>
+      <CloseButton
+        size="sm"
+        position="absolute"
+        right={2}
+        top={2}
+        onClick={() => setDismissed(true)}
+      />
+    </Alert.Root>
+  );
+}
+
+export function AnnouncementBanner() {
+  return (
+    <>
+      {announcements.map((a) => (
+        <AnnouncementItem key={a.id} announcement={a} />
+      ))}
+    </>
+  );
+}

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -34,6 +34,7 @@ import { findCurrentRoute, projectRoutes, type Route } from "../utils/routes";
 import { trackEvent } from "../utils/tracking";
 import { CurrentDrawer } from "./CurrentDrawer";
 import { SavedViewsBar } from "./messages/SavedViewsBar";
+import { AnnouncementBanner } from "./AnnouncementBanner";
 import { SdkRadarBanner } from "./SdkRadarBanner";
 import { SavedViewsProvider } from "../hooks/useSavedViews";
 import { FullLogo } from "./icons/FullLogo";
@@ -627,6 +628,7 @@ export const DashboardLayout = ({
                 </Alert.Root>
               )}
 
+            <AnnouncementBanner />
             <SdkRadarBanner />
 
             {ssoStatus?.pendingSsoSetup && (


### PR DESCRIPTION
## Summary
- Adds a reusable `AnnouncementBanner` component to the dashboard layout
- Banners are dismissable (persisted via localStorage) and auto-expire after a configured date
- First announcement: LiteLLM vulnerability statement (expires March 27, 2026)
- Future announcements can be added by appending to the `announcements` array

<img width="1509" height="590" alt="image" src="https://github.com/user-attachments/assets/232742d9-4645-49d6-89c0-a072aa312d33" />

<img width="1512" height="504" alt="image" src="https://github.com/user-attachments/assets/b16a3985-b653-4845-bc57-db1d777f1f55" />



## Test plan
- [ ] Verify banner appears on the dashboard
- [ ] Verify clicking the X dismisses the banner and it stays dismissed on refresh
- [ ] Verify the "Read our full statement" link opens the blog post in a new tab
- [ ] Verify banner does not appear after March 27