### PR TITLE
fix: short-circuit dead cost queries, batch TriggerSent IN clause, add Cost index

### DIFF
--- a/langwatch/prisma/migrations/20260325120000_add_cost_project_created_at_index/migration.sql
+++ b/langwatch/prisma/migrations/20260325120000_add_cost_project_created_at_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Cost_projectId_createdAt_idx" ON "Cost"("projectId", "createdAt");

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -409,6 +409,7 @@ model Cost {
     @@index([referenceType, referenceId])
     @@index([costType])
     @@index([projectId])
+    @@index([projectId, createdAt])
 }
 
 model Topic {

--- a/langwatch/src/pages/api/cron/triggers/__tests__/utils.test.ts
+++ b/langwatch/src/pages/api/cron/triggers/__tests__/utils.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TraceGroups } from "../types";
-import { checkThreshold, getLatestUpdatedAt } from "../utils";
+import {
+  checkThreshold,
+  getLatestUpdatedAt,
+  triggerSentForMany,
+} from "../utils";
+
+const mockFindMany = vi.fn();
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    triggerSent: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+    },
+  },
+}));
 
 describe("checkThreshold", () => {
   describe("when operator is 'gt'", () => {
@@ -151,6 +165,100 @@ describe("getLatestUpdatedAt", () => {
       };
 
       expect(getLatestUpdatedAt(traces)).toBe(5000);
+    });
+  });
+});
+
+describe("triggerSentForMany()", () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  describe("when traceIds is empty", () => {
+    it("returns empty array without querying", async () => {
+      const result = await triggerSentForMany("trigger-1", [], "project-1");
+
+      expect(result).toEqual([]);
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when traceIds fit in a single chunk", () => {
+    it("makes one query with all traceIds", async () => {
+      const traceIds = ["trace-1", "trace-2", "trace-3"];
+      mockFindMany.mockResolvedValue([{ traceId: "trace-1" }]);
+
+      const result = await triggerSentForMany(
+        "trigger-1",
+        traceIds,
+        "project-1",
+      );
+
+      expect(mockFindMany).toHaveBeenCalledTimes(1);
+      expect(mockFindMany).toHaveBeenCalledWith({
+        where: {
+          triggerId: "trigger-1",
+          traceId: { in: traceIds },
+          projectId: "project-1",
+        },
+      });
+      expect(result).toEqual([{ traceId: "trace-1" }]);
+    });
+  });
+
+  describe("when traceIds exceed chunk size", () => {
+    it("splits into multiple queries and merges results", async () => {
+      // Create 1200 trace IDs to force 3 chunks (500 + 500 + 200)
+      const traceIds = Array.from({ length: 1200 }, (_, i) => `trace-${i}`);
+
+      mockFindMany
+        .mockResolvedValueOnce([{ traceId: "trace-0" }])
+        .mockResolvedValueOnce([{ traceId: "trace-500" }])
+        .mockResolvedValueOnce([{ traceId: "trace-1000" }]);
+
+      const result = await triggerSentForMany(
+        "trigger-1",
+        traceIds,
+        "project-1",
+      );
+
+      expect(mockFindMany).toHaveBeenCalledTimes(3);
+
+      // First chunk: 0-499
+      const firstCall = mockFindMany.mock.calls[0]![0];
+      expect(firstCall.where.traceId.in).toHaveLength(500);
+      expect(firstCall.where.traceId.in[0]).toBe("trace-0");
+
+      // Second chunk: 500-999
+      const secondCall = mockFindMany.mock.calls[1]![0];
+      expect(secondCall.where.traceId.in).toHaveLength(500);
+      expect(secondCall.where.traceId.in[0]).toBe("trace-500");
+
+      // Third chunk: 1000-1199
+      const thirdCall = mockFindMany.mock.calls[2]![0];
+      expect(thirdCall.where.traceId.in).toHaveLength(200);
+      expect(thirdCall.where.traceId.in[0]).toBe("trace-1000");
+
+      // Results merged
+      expect(result).toEqual([
+        { traceId: "trace-0" },
+        { traceId: "trace-500" },
+        { traceId: "trace-1000" },
+      ]);
+    });
+  });
+
+  describe("when traceIds exactly equal chunk size", () => {
+    it("makes exactly one query", async () => {
+      const traceIds = Array.from({ length: 500 }, (_, i) => `trace-${i}`);
+      mockFindMany.mockResolvedValue([]);
+
+      await triggerSentForMany("trigger-1", traceIds, "project-1");
+
+      expect(mockFindMany).toHaveBeenCalledTimes(1);
+      expect(mockFindMany.mock.calls[0]![0].where.traceId.in).toHaveLength(
+        500,
+      );
     });
   });
 });

--- a/langwatch/src/pages/api/cron/triggers/utils.ts
+++ b/langwatch/src/pages/api/cron/triggers/utils.ts
@@ -50,19 +50,37 @@ export const addTriggersSent = async (
   }
 };
 
+/**
+ * Fetches TriggerSent records for the given traceIds, chunking the query
+ * to avoid massive IN clauses that exhaust RDS CPU.
+ *
+ * @see https://github.com/langwatch/langwatch/issues/2597
+ */
 export const triggerSentForMany = async (
   triggerId: string,
   traceIds: string[],
   projectId: string,
 ) => {
-  const triggerSent = await prisma.triggerSent.findMany({
-    where: {
-      triggerId,
-      traceId: { in: traceIds },
-      projectId,
-    },
-  });
-  return triggerSent;
+  if (traceIds.length === 0) {
+    return [];
+  }
+
+  const CHUNK_SIZE = 500;
+  const results: Awaited<ReturnType<typeof prisma.triggerSent.findMany>> = [];
+
+  for (let i = 0; i < traceIds.length; i += CHUNK_SIZE) {
+    const chunk = traceIds.slice(i, i + CHUNK_SIZE);
+    const triggerSent = await prisma.triggerSent.findMany({
+      where: {
+        triggerId,
+        traceId: { in: chunk },
+        projectId,
+      },
+    });
+    results.push(...triggerSent);
+  }
+
+  return results;
 };
 
 export const getLatestUpdatedAt = (traces: TraceGroups): number | undefined => {

--- a/langwatch/src/pages/api/dataset/evaluate.ts
+++ b/langwatch/src/pages/api/dataset/evaluate.ts
@@ -110,15 +110,17 @@ export default async function handler(
   const maxMonthlyUsage = await costChecker.maxMonthlyUsageLimit(
     project.team.organizationId,
   );
-  const getCurrentCost = await costChecker.getCurrentMonthCost(
-    project.team.organizationId,
-  );
+  if (maxMonthlyUsage !== Infinity) {
+    const getCurrentCost = await costChecker.getCurrentMonthCost(
+      project.team.organizationId,
+    );
 
-  if (getCurrentCost >= maxMonthlyUsage) {
-    return res.status(200).json({
-      status: "skipped",
-      details: "Monthly usage limit exceeded",
-    });
+    if (getCurrentCost >= maxMonthlyUsage) {
+      return res.status(200).json({
+        status: "skipped",
+        details: "Monthly usage limit exceeded",
+      });
+    }
   }
 
   const { datasetSlug } = params;

--- a/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
@@ -298,6 +298,22 @@ describe("EvaluationExecutionService", () => {
       });
     });
 
+    describe("when maxMonthlyUsageLimit is Infinity", () => {
+      it("skips getCurrentMonthCost call", async () => {
+        const getCurrentMonthCost = vi.fn().mockResolvedValue(0);
+        const { service } = createTestService({
+          costChecker: {
+            maxMonthlyUsageLimit: vi.fn().mockResolvedValue(Infinity),
+            getCurrentMonthCost,
+          },
+        });
+
+        await service.executeForTrace(defaultParams);
+
+        expect(getCurrentMonthCost).not.toHaveBeenCalled();
+      });
+    });
+
     describe("when project is not found", () => {
       it("throws EvaluatorConfigError", async () => {
         const { service } = createTestService({

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -341,11 +341,13 @@ export class EvaluationExecutionService {
     const maxMonthlyUsage = await this.deps.costChecker.maxMonthlyUsageLimit(
       project.team.organizationId,
     );
-    const currentCost = await this.deps.costChecker.getCurrentMonthCost(
-      project.team.organizationId,
-    );
-    if (currentCost >= maxMonthlyUsage) {
-      throw new CostLimitExceededError(project.team.organizationId);
+    if (maxMonthlyUsage !== Infinity) {
+      const currentCost = await this.deps.costChecker.getCurrentMonthCost(
+        project.team.organizationId,
+      );
+      if (currentCost >= maxMonthlyUsage) {
+        throw new CostLimitExceededError(project.team.organizationId);
+      }
     }
 
     // Custom/workflow evaluators

--- a/langwatch/src/server/background/workers/evaluationsWorker.ts
+++ b/langwatch/src/server/background/workers/evaluationsWorker.ts
@@ -509,14 +509,16 @@ export const runEvaluation = async ({
   const maxMonthlyUsage = await costChecker.maxMonthlyUsageLimit(
     project.team.organizationId,
   );
-  const getCurrentCost = await costChecker.getCurrentMonthCost(
-    project.team.organizationId,
-  );
-  if (getCurrentCost >= maxMonthlyUsage) {
-    return {
-      status: "skipped",
-      details: "Monthly usage limit exceeded",
-    };
+  if (maxMonthlyUsage !== Infinity) {
+    const getCurrentCost = await costChecker.getCurrentMonthCost(
+      project.team.organizationId,
+    );
+    if (getCurrentCost >= maxMonthlyUsage) {
+      return {
+        status: "skipped",
+        details: "Monthly usage limit exceeded",
+      };
+    }
   }
 
   if (data.type === "custom") {

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -54,14 +54,17 @@ export const clusterTopicsForProject = async (
   const maxMonthlyUsage = await costChecker.maxMonthlyUsageLimit(
     project.team.organizationId,
   );
-  const getCurrentCost = await costChecker.getCurrentMonthCost(
-    project.team.organizationId,
-  );
-  if (getCurrentCost >= maxMonthlyUsage) {
-    logger.info(
-      { projectId },
-      "skipping clustering for project as monthly limit has been reached",
+  if (maxMonthlyUsage !== Infinity) {
+    const getCurrentCost = await costChecker.getCurrentMonthCost(
+      project.team.organizationId,
     );
+    if (getCurrentCost >= maxMonthlyUsage) {
+      logger.info(
+        { projectId },
+        "skipping clustering for project as monthly limit has been reached",
+      );
+      return;
+    }
   }
 
   const clickhouse = project.featureClickHouseDataSourceTraces


### PR DESCRIPTION
## Summary

Fixes #2597 — RDS CPU credit exhaustion caused by two query patterns consuming nearly all DB load.

- **Short-circuit cost check in worker paths**: `getCurrentMonthCost()` was called on every evaluation, but `maxMonthlyUsageLimit()` has returned `Infinity` since Nov 2025. The query result was always discarded. Now skipped when limit is Infinity. Affects `evaluationsWorker.ts`, `evaluation-execution.service.ts`, `evaluate.ts`, `topicClustering.ts`.
- **Batch TriggerSent IN clause**: `triggerSentForMany()` dumped up to 10,000 traceIds into a single `WHERE traceId IN (...)` query. Now chunks to 500 IDs per query.
- **Add composite index**: `Cost(projectId, createdAt)` index as safety net for when cost limits are re-implemented.
- **Fix latent bug**: `topicClustering.ts` logged "skipping clustering" but never returned, allowing processing to continue past the cost check.

## Test plan

- [x] Unit test: `maxMonthlyUsageLimit` returns Infinity → `getCurrentMonthCost` not called
- [x] Unit test: `triggerSentForMany` chunks 1200 IDs into 3 queries of 500+500+200
- [x] Unit test: empty traceIds array short-circuits without querying
- [x] Typecheck passes
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2597