### PR TITLE
fix: update ttlReconciler test to include new tables

### DIFF
--- a/langwatch/src/server/clickhouse/__tests__/ttlReconciler.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/ttlReconciler.unit.test.ts
@@ -253,11 +253,14 @@ describe("ttlReconciler", () => {
       const tableNames = TABLE_TTL_CONFIG.map((c) => c.table);
       expect(tableNames).toEqual([
         "billable_events",
+        "dspy_steps",
         "evaluation_runs",
         "event_log",
         "experiment_run_items",
         "experiment_runs",
         "simulation_runs",
+        "stored_log_records",
+        "stored_metric_records",
         "stored_spans",
         "trace_summaries",
       ]);


### PR DESCRIPTION
## Summary
Update the hardcoded expected tables list in the ttlReconciler unit test to include three newly added tables: `dspy_steps`, `stored_log_records`, and `stored_metric_records`.

The test "covers all expected tables" was checking against a stale hardcoded list that did not match the actual contents of `TABLE_TTL_CONFIG`. This fix adds the missing tables in alphabetical order to match how the config is structured.

## Test Plan
- [x] Unit test passes: `pnpm test:unit src/server/clickhouse/__tests__/ttlReconciler.unit.test.ts`
- [x] All 26 tests pass