### PR TITLE
fix: sort thread messages chronologically in ClickHouse path

### DIFF
--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -269,7 +269,20 @@ export class ClickHouseTraceService {
           }
 
           // Fetch full traces with spans
-          return this.getTracesWithSpans(projectId, traceIds, protections);
+          const traces = await this.getTracesWithSpans(
+            projectId,
+            traceIds,
+            protections,
+          );
+          if (!traces) return null;
+
+          // Re-sort by timestamp — getTracesWithSpans returns in TraceId
+          // order which doesn't match the chronological order we need.
+          traces.sort(
+            (a, b) =>
+              (a.timestamps.started_at ?? 0) - (b.timestamps.started_at ?? 0),
+          );
+          return traces;
         } catch (error) {
           this.logger.error(
             {
@@ -360,7 +373,20 @@ export class ClickHouseTraceService {
           }
 
           // Fetch full traces with spans
-          return this.getTracesWithSpans(projectId, traceIds, protections);
+          const traces = await this.getTracesWithSpans(
+            projectId,
+            traceIds,
+            protections,
+          );
+          if (!traces) return null;
+
+          // Re-sort by timestamp — getTracesWithSpans returns in TraceId
+          // order which doesn't match the chronological order we need.
+          traces.sort(
+            (a, b) =>
+              (a.timestamps.started_at ?? 0) - (b.timestamps.started_at ?? 0),
+          );
+          return traces;
         } catch (error) {
           this.logger.error(
             {


### PR DESCRIPTION
## Summary

- Thread messages in the conversation view appeared out of chronological order when using the ClickHouse backend
- **Root cause:** `getTracesByThreadId` fetches TraceIds sorted by `CreatedAt ASC`, but `fetchTracesWithSpansJoined` returns results ordered by `TraceId` (alphabetical UUID order), losing the chronological ordering
- Adds a `timestamps.started_at` sort after fetching full traces in both `getTracesByThreadId` and `getTracesWithSpansByThreadIds`
- The Elasticsearch path was not affected (already sorts by `timestamps.started_at ASC`)

## Test plan

- [ ] Open a thread with multiple messages in the messages view
- [ ] Verify messages appear in chronological order (oldest first)
- [ ] Verify the same for threads viewed via the grouped-by-thread-id list