### PR TITLE
fix: filter evaluation analytics to only processed runs, fix category evaluator No data

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -232,7 +232,7 @@ const groupByExpressions: Partial<
     requiredJoins: ["evaluation_runs"],
     handlesUnknown: true,
     additionalWhere: groupByKey
-      ? `${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed'`
+      ? `${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed' AND ${tableAliases.evaluation_runs}.Passed IS NOT NULL`
       : undefined,
   }),
 
@@ -1014,10 +1014,8 @@ function buildDateBucketedPipelineQuery({
       : `if(${groupByColumn} IS NULL, 'unknown', toString(${groupByColumn})) AS group_key`
     : null;
 
-  let fullFilterWhere = filterWhere;
-  if (groupByAdditionalWhere) {
-    fullFilterWhere += ` AND ${groupByAdditionalWhere}`;
-  }
+  // NOTE: filterWhere already includes groupByAdditionalWhere (added in buildTimeseriesQuery)
+  const fullFilterWhere = filterWhere;
 
   // Skip HAVING group_key != '' for boolean fields and columns that already handle unknown
   const skipGroupKeyHaving =


### PR DESCRIPTION
## Summary

- **"unknown" in boolean evaluator charts**: The `evaluation_passed` groupBy's `additionalWhere` filtered by `EvaluatorId` but not by `Status`. Non-processed evaluation runs (error, skipped, in_progress) with `Passed=NULL` leaked through as "unknown". Added `AND es.Status = 'processed'`.
- **`evaluation_label` groupBy ignored `groupByKey`**: Labels from ALL evaluators were mixed together and non-processed runs were included. Now filters by both `EvaluatorId` and `Status = 'processed'`.
- **Category evaluator horizontal bar "No data"**: The CTE-based query path for `timeScale: "full"` doesn't support `GROUP BY group_key`. When groupBy is present, we now fall through to the standard query path which handles grouped results correctly.

## Test plan
- [x] All 217 existing analytics tests pass
- [x] Verified via ClickHouse MCP that dev data has error/skipped/in_progress evaluation runs with `Passed=NULL` that were leaking through
- [ ] Deploy to staging and verify boolean evaluator charts no longer show "unknown" for non-processed runs
- [ ] Verify category evaluator horizontal bar charts now show data instead of "No data"