### PR TITLE
fix: replace SELECT * with explicit columns in topic clustering query

### DIFF
--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -360,7 +360,7 @@ async function fetchTracesFromClickHouse(
         SubTopicId,
         toString(toUnixTimestamp64Milli(OccurredAt)) AS OccurredAtMs
       FROM (
-        SELECT *
+        SELECT TraceId, ComputedInput, TopicId, SubTopicId, OccurredAt, UpdatedAt
         FROM trace_summaries
         WHERE ${whereClause}
         ORDER BY TraceId, UpdatedAt DESC


### PR DESCRIPTION
## Summary
- Replaces `SELECT *` with explicit column list (`TraceId, ComputedInput, TopicId, SubTopicId, OccurredAt, UpdatedAt`) in the `fetchTracesFromClickHouse` subquery in `topicClustering.ts`
- This prevents ClickHouse from deserializing wide Map columns (`ScenarioRoleCosts`, `ScenarioRoleLatencies`, `ScenarioRoleSpans`) that are not needed by the query
- Fixes OOM error: "Amount of memory requested to allocate is more than allowed" caused by a corrupted/oversized `ScenarioRoleCosts` value in partition `202608_38113_50621_339_50834`

## Test plan
- [ ] Verify topic clustering still works correctly (only 5 columns are used by the outer query, all are included)
- [ ] Confirm the OOM error no longer occurs when the topic clustering job runs