### PR TITLE
fix: hide restricted actions from lite members across UI

### DIFF
--- a/langwatch/src/components/AnnotationsLayout.tsx
+++ b/langwatch/src/components/AnnotationsLayout.tsx
@@ -5,6 +5,7 @@ import { Check, Edit, Inbox, Plus, Users } from "react-feather";
 import { DashboardLayout } from "~/components/DashboardLayout";
 import { MenuLink } from "~/components/MenuLink";
 import { useDrawer } from "~/hooks/useDrawer";
+import { useLiteMemberGuard } from "~/hooks/useLiteMemberGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useRequiredSession } from "~/hooks/useRequiredSession";
 import { api } from "~/utils/api";
@@ -17,6 +18,7 @@ export default function AnnotationsLayout({
   const { data: session } = useRequiredSession();
   const user = session?.user;
   const { project } = useOrganizationTeamProject();
+  const { isLiteMember } = useLiteMemberGuard();
 
   // Use optimized count endpoints instead of fetching full data
   const pendingItemsCount = api.annotation.getPendingItemsCount.useQuery(
@@ -120,12 +122,14 @@ export default function AnnotationsLayout({
               <Text fontSize="sm" fontWeight="500" paddingX={4} paddingY={2}>
                 My Queues
               </Text>
-              <Plus
-                onClick={() => openDrawer("addAnnotationQueue", undefined)}
-                width={18}
-                height={18}
-                cursor="pointer"
-              />
+              {!isLiteMember && (
+                <Plus
+                  onClick={() => openDrawer("addAnnotationQueue", undefined)}
+                  width={18}
+                  height={18}
+                  cursor="pointer"
+                />
+              )}
             </HStack>
             {queueItemsCounts.data?.map((queue) => (
               <MenuLink

--- a/langwatch/src/components/SettingsLayout.tsx
+++ b/langwatch/src/components/SettingsLayout.tsx
@@ -12,7 +12,7 @@ export default function SettingsLayout({
   children,
   isSubscription,
 }: PropsWithChildren<{ isSubscription?: boolean }>) {
-  const { project } = useOrganizationTeamProject({
+  const { project, hasPermission } = useOrganizationTeamProject({
     redirectToOnboarding: false,
   });
   const publicEnv = usePublicEnv();
@@ -52,7 +52,7 @@ export default function SettingsLayout({
           {isEnterprise && (
             <MenuLink href="/settings/roles">Roles & Permissions</MenuLink>
           )}
-          {isEnterprise && (
+          {isEnterprise && hasPermission("organization:manage") && (
             <MenuLink href="/settings/audit-log">Audit Log</MenuLink>
           )}
 

--- a/langwatch/src/components/settings/LLMModelCost.tsx
+++ b/langwatch/src/components/settings/LLMModelCost.tsx
@@ -17,6 +17,7 @@ import { toaster } from "../../components/ui/toaster";
 import { Tooltip } from "../../components/ui/tooltip";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
+import { isHandledByGlobalHandler } from "../../utils/trpcError";
 import SettingsLayout from "../SettingsLayout";
 import { PageLayout } from "../ui/layouts/PageLayout";
 
@@ -240,7 +241,8 @@ function ActionsMenu({
                     });
                     void llmModelCosts.refetch();
                   },
-                  onError: () => {
+                  onError: (error) => {
+                    if (isHandledByGlobalHandler(error)) return;
                     toaster.create({
                       title: "Error",
                       description: "Error deleting LLM model cost",

--- a/langwatch/src/components/settings/__tests__/LLMModelCostDrawer.lite-member.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/LLMModelCostDrawer.lite-member.integration.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCloseDrawer,
+  mockToasterCreate,
+  mockCreateOrUpdateMutate,
+  mockIsHandledByGlobalHandler,
+  mockMutationError,
+  mockLlmModelCostsData,
+} = vi.hoisted(() => {
+  return {
+    mockCloseDrawer: vi.fn(),
+    mockToasterCreate: vi.fn(),
+    mockCreateOrUpdateMutate: vi.fn(),
+    mockIsHandledByGlobalHandler: vi.fn((_error: unknown) => false),
+    mockMutationError: {
+      current: null as Error | null,
+    },
+    mockLlmModelCostsData: {
+      current: [
+        {
+          id: "cost-1",
+          model: "gpt-4",
+          regex: "gpt-4.*",
+          inputCostPerToken: 0.00003,
+          outputCostPerToken: 0.00006,
+          projectId: "proj-1",
+          updatedAt: new Date(),
+        },
+      ] as Array<{
+        id?: string;
+        model: string;
+        regex: string;
+        inputCostPerToken: number;
+        outputCostPerToken: number;
+        projectId?: string;
+        updatedAt?: Date;
+      }>,
+    },
+  };
+});
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1" },
+    project: { id: "proj-1", slug: "test-project" },
+    hasPermission: () => true,
+    hasOrgPermission: () => false,
+    hasAnyPermission: () => false,
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: mockCloseDrawer,
+  }),
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: {
+    create: (...args: unknown[]) => mockToasterCreate(...args),
+  },
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    llmModelCost: {
+      getAllForProject: {
+        useQuery: () => ({
+          data: mockLlmModelCostsData.current,
+          isLoading: false,
+          refetch: vi.fn(),
+        }),
+      },
+      createOrUpdate: {
+        useMutation: () => ({
+          mutate: (data: unknown, options: { onError?: (error: unknown) => void }) => {
+            mockCreateOrUpdateMutate(data, options);
+
+            if (mockMutationError.current) {
+              options.onError?.(mockMutationError.current);
+            }
+          },
+          isLoading: false,
+        }),
+      },
+      delete: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/utils/trpcError", () => ({
+  isHandledByGlobalHandler: (error: unknown) =>
+    mockIsHandledByGlobalHandler(error),
+}));
+
+// Lazy imports to ensure mocks are set up first
+const { LLMModelCostDrawer } = await import(
+  "~/components/settings/LLMModelCostDrawer"
+);
+
+const Wrapper = ({ children }: { children?: ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderDrawer(props: { id?: string; cloneModel?: string } = {}) {
+  return render(
+    <LLMModelCostDrawer {...props} />,
+    { wrapper: Wrapper },
+  );
+}
+
+async function submitStoredModelCost() {
+  fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+  await vi.waitFor(() => {
+    expect(mockCreateOrUpdateMutate).toHaveBeenCalledTimes(1);
+  });
+}
+
+describe("Feature: LLM model cost drawer save errors", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutationError.current = null;
+    mockIsHandledByGlobalHandler.mockReturnValue(false);
+    mockLlmModelCostsData.current = [
+      {
+        id: "cost-1",
+        model: "gpt-4",
+        regex: "gpt-4.*",
+        inputCostPerToken: 0.00003,
+        outputCostPerToken: 0.00006,
+        projectId: "proj-1",
+        updatedAt: new Date(),
+      },
+    ];
+  });
+
+  describe("<LLMModelCostDrawer/>", () => {
+    describe("when the save error was already handled globally", () => {
+      it("LLM model cost drawer skips the generic error toast after a primary error UI is shown", async () => {
+        const error = new Error("Lite member restricted");
+        mockMutationError.current = error;
+        mockIsHandledByGlobalHandler.mockImplementation(
+          (candidate: unknown) => candidate === error,
+        );
+
+        renderDrawer({ id: "cost-1" });
+
+        await submitStoredModelCost();
+
+        expect(mockToasterCreate).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the save error was not handled globally", () => {
+      it("LLM model cost drawer shows the generic error toast when no primary error UI is shown", async () => {
+        mockMutationError.current = new Error("Network error");
+
+        renderDrawer({ id: "cost-1" });
+
+        await submitStoredModelCost();
+
+        expect(mockToasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "Error",
+            description: "Network error",
+            type: "error",
+          }),
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/pages/[project]/datasets.tsx
+++ b/langwatch/src/pages/[project]/datasets.tsx
@@ -32,15 +32,18 @@ import { UploadCSVModal } from "../../components/datasets/UploadCSVModal";
 import { Link } from "../../components/ui/link";
 import { Menu } from "../../components/ui/menu";
 import { toaster } from "../../components/ui/toaster";
+import { useLiteMemberGuard } from "../../hooks/useLiteMemberGuard";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import type { AppRouter } from "../../server/api/root";
 import type { DatasetColumns } from "../../server/datasets/types";
 import { api } from "../../utils/api";
+import { isHandledByGlobalHandler } from "../../utils/trpcError";
 
 function DatasetsPage() {
   const addEditDatasetDrawer = useDisclosure();
   const uploadCSVModal = useDisclosure();
   const { project } = useOrganizationTeamProject();
+  const { isLiteMember } = useLiteMemberGuard();
   const router = useRouter();
   const { openDrawer } = useDrawer();
   const queryClient = api.useContext();
@@ -122,7 +125,8 @@ function DatasetsPage() {
             },
           });
         },
-        onError: () => {
+        onError: (error) => {
+          if (isHandledByGlobalHandler(error)) return;
           toaster.create({
             title: "Failed to delete dataset",
             description:
@@ -267,34 +271,38 @@ function DatasetsPage() {
                                     <Copy size={16} /> Replicate to another
                                     project
                                   </Menu.Item>
-                                  <Menu.Item
-                                    value="edit"
-                                    onClick={(event) => {
-                                      event.stopPropagation();
-                                      setEditDataset({
-                                        datasetId: dataset.id,
-                                        name: dataset.name,
-                                        columnTypes:
-                                          dataset.columnTypes as DatasetColumns,
-                                      });
-                                      addEditDatasetDrawer.onOpen();
-                                    }}
-                                  >
-                                    <Edit size={16} /> Edit dataset
-                                  </Menu.Item>
-                                  <Menu.Item
-                                    value="delete"
-                                    color="red.600"
-                                    onClick={(event) => {
-                                      event.stopPropagation();
-                                      showDeleteDialog({
-                                        id: dataset.id,
-                                        name: dataset.name,
-                                      });
-                                    }}
-                                  >
-                                    <Trash2 size={16} /> Delete dataset
-                                  </Menu.Item>
+                                  {!isLiteMember && (
+                                    <>
+                                      <Menu.Item
+                                        value="edit"
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          setEditDataset({
+                                            datasetId: dataset.id,
+                                            name: dataset.name,
+                                            columnTypes:
+                                              dataset.columnTypes as DatasetColumns,
+                                          });
+                                          addEditDatasetDrawer.onOpen();
+                                        }}
+                                      >
+                                        <Edit size={16} /> Edit dataset
+                                      </Menu.Item>
+                                      <Menu.Item
+                                        value="delete"
+                                        color="red.600"
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          showDeleteDialog({
+                                            id: dataset.id,
+                                            name: dataset.name,
+                                          });
+                                        }}
+                                      >
+                                        <Trash2 size={16} /> Delete dataset
+                                      </Menu.Item>
+                                    </>
+                                  )}
                               </Menu.Content>
                             </Menu.Root>
                           </Table.Cell>

--- a/langwatch/src/pages/[project]/evaluations.tsx
+++ b/langwatch/src/pages/[project]/evaluations.tsx
@@ -45,6 +45,7 @@ import { toaster } from "../../components/ui/toaster";
 import { withPermissionGuard } from "../../components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
+import { isHandledByGlobalHandler } from "../../utils/trpcError";
 
 function EvaluationsV2() {
   const { project, hasPermission } = useOrganizationTeamProject();
@@ -94,7 +95,8 @@ function EvaluationsV2() {
           },
         });
       },
-      onError: () => {
+      onError: (error) => {
+        if (isHandledByGlobalHandler(error)) return;
         toaster.create({
           title: "Error deleting experiment",
           description:
@@ -513,21 +515,25 @@ function EvaluationsV2() {
                                               Replicate to another project
                                             </Menu.Item>
                                           )}
-                                          <Menu.Item
-                                            value="delete"
-                                            color="red.500"
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              handleDeleteExperiment(
-                                                experiment.id,
-                                                experiment.name ??
-                                                  experiment.slug,
-                                              );
-                                            }}
-                                          >
-                                            <LuTrash size={16} />
-                                            Delete
-                                          </Menu.Item>
+                                          {hasPermission(
+                                            "evaluations:manage",
+                                          ) && (
+                                            <Menu.Item
+                                              value="delete"
+                                              color="red.500"
+                                              onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleDeleteExperiment(
+                                                  experiment.id,
+                                                  experiment.name ??
+                                                    experiment.slug,
+                                                );
+                                              }}
+                                            >
+                                              <LuTrash size={16} />
+                                              Delete
+                                            </Menu.Item>
+                                          )}
                                         </Menu.Content>
                                       </Menu.Root>
                                     </Box>

--- a/langwatch/src/pages/settings/annotation-scores.tsx
+++ b/langwatch/src/pages/settings/annotation-scores.tsx
@@ -17,6 +17,7 @@ import { Edit, MoreVertical, Plus, ThumbsUp, Trash } from "react-feather";
 import { NoDataInfoBlock } from "~/components/NoDataInfoBlock";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
 import { useDrawer } from "~/hooks/useDrawer";
+import { useLiteMemberGuard } from "~/hooks/useLiteMemberGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { DeleteConfirmationDialog } from "../../components/annotations/DeleteConfirmationDialog";
 import SettingsLayout from "../../components/SettingsLayout";
@@ -27,9 +28,12 @@ import { toaster } from "../../components/ui/toaster";
 import { Tooltip } from "../../components/ui/tooltip";
 import { withPermissionGuard } from "../../components/WithPermissionGuard";
 import { api } from "../../utils/api";
+import { isHandledByGlobalHandler } from "../../utils/trpcError";
 
 function AnnotationScorePage() {
-  const { project, hasPermission } = useOrganizationTeamProject();
+  const { project } = useOrganizationTeamProject();
+  const { isLiteMember } = useLiteMemberGuard();
+  const canManage = !isLiteMember;
 
   const { openDrawer, drawerOpen: isDrawerOpen, closeDrawer } = useDrawer();
 
@@ -60,7 +64,8 @@ function AnnotationScorePage() {
         onSuccess: () => {
           void getAllAnnotationScores.refetch();
         },
-        onError: () => {
+        onError: (error) => {
+          if (isHandledByGlobalHandler(error)) return;
           toaster.create({
             title: "Update score",
             type: "error",
@@ -97,7 +102,8 @@ function AnnotationScorePage() {
               },
             });
           },
-          onError: () => {
+          onError: (error) => {
+            if (isHandledByGlobalHandler(error)) return;
             toaster.create({
               title: "Delete score",
               type: "error",
@@ -120,11 +126,13 @@ function AnnotationScorePage() {
         <HStack width="full" marginTop={2}>
           <Heading as="h2">Annotation Scoring</Heading>
           <Spacer />
-          <PageLayout.HeaderButton
-            onClick={() => openDrawer("addOrEditAnnotationScore")}
-          >
-            <Plus /> Add new score metric
-          </PageLayout.HeaderButton>
+          {canManage && (
+            <PageLayout.HeaderButton
+              onClick={() => openDrawer("addOrEditAnnotationScore")}
+            >
+              <Plus /> Add new score metric
+            </PageLayout.HeaderButton>
+          )}
         </HStack>
         {getAllAnnotationScores.data &&
         getAllAnnotationScores.data.length == 0 ? (
@@ -155,24 +163,26 @@ function AnnotationScorePage() {
                 <Table.ColumnHeader>Score Type</Table.ColumnHeader>
                 <Table.ColumnHeader>Score Options</Table.ColumnHeader>
                 <Table.ColumnHeader>Enabled</Table.ColumnHeader>
-                <Table.ColumnHeader>Actions</Table.ColumnHeader>
+                {canManage && (
+                  <Table.ColumnHeader>Actions</Table.ColumnHeader>
+                )}
               </Table.Row>
             </Table.Header>
             <Table.Body>
               {getAllAnnotationScores.isLoading ? (
                 <>
                   <Table.Row>
-                    <Table.Cell colSpan={6}>
+                    <Table.Cell colSpan={canManage ? 6 : 5}>
                       <Skeleton height="20px" />
                     </Table.Cell>
                   </Table.Row>
                   <Table.Row>
-                    <Table.Cell colSpan={6}>
+                    <Table.Cell colSpan={canManage ? 6 : 5}>
                       <Skeleton height="20px" />
                     </Table.Cell>
                   </Table.Row>
                   <Table.Row>
-                    <Table.Cell colSpan={6}>
+                    <Table.Cell colSpan={canManage ? 6 : 5}>
                       <Skeleton height="20px" />
                     </Table.Cell>
                   </Table.Row>
@@ -206,54 +216,57 @@ function AnnotationScorePage() {
                       <Table.Cell textAlign="center">
                         <Switch
                           checked={score.active}
+                          disabled={!canManage}
                           onCheckedChange={() => {
                             handleToggleScore(score.id, !score.active);
                           }}
                         />
                       </Table.Cell>
-                      <Table.Cell>
-                        <Menu.Root>
-                          <Menu.Trigger asChild>
-                            <Button variant={"ghost"}>
-                              <MoreVertical />
-                            </Button>
-                          </Menu.Trigger>
-                          <Menu.Content>
-                            <Menu.Item
-                              value="edit"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                openDrawer("addOrEditAnnotationScore", {
-                                  annotationScoreId: score.id,
-                                  onClose: () => closeDrawer(),
-                                });
-                              }}
-                            >
-                              <Box display="flex" alignItems="center" gap={2}>
-                                <Edit size={14} />
-                                Edit
-                              </Box>
-                            </Menu.Item>
-                            <Menu.Item
-                              value="delete"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                handleDeleteScore(score.id);
-                              }}
-                            >
-                              <Box
-                                display="flex"
-                                alignItems="center"
-                                gap={2}
-                                color="red.600"
+                      {canManage && (
+                        <Table.Cell>
+                          <Menu.Root>
+                            <Menu.Trigger asChild>
+                              <Button variant={"ghost"}>
+                                <MoreVertical />
+                              </Button>
+                            </Menu.Trigger>
+                            <Menu.Content>
+                              <Menu.Item
+                                value="edit"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  openDrawer("addOrEditAnnotationScore", {
+                                    annotationScoreId: score.id,
+                                    onClose: () => closeDrawer(),
+                                  });
+                                }}
                               >
-                                <Trash size={14} />
-                                Delete
-                              </Box>
-                            </Menu.Item>
-                          </Menu.Content>
-                        </Menu.Root>
-                      </Table.Cell>
+                                <Box display="flex" alignItems="center" gap={2}>
+                                  <Edit size={14} />
+                                  Edit
+                                </Box>
+                              </Menu.Item>
+                              <Menu.Item
+                                value="delete"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  handleDeleteScore(score.id);
+                                }}
+                              >
+                                <Box
+                                  display="flex"
+                                  alignItems="center"
+                                  gap={2}
+                                  color="red.600"
+                                >
+                                  <Trash size={14} />
+                                  Delete
+                                </Box>
+                              </Menu.Item>
+                            </Menu.Content>
+                          </Menu.Root>
+                        </Table.Cell>
+                      )}
                     </Table.Row>
                   );
                 })

--- a/langwatch/src/pages/settings/audit-log.tsx
+++ b/langwatch/src/pages/settings/audit-log.tsx
@@ -557,6 +557,6 @@ function AuditLogPage() {
   );
 }
 
-export default withPermissionGuard("organization:view", {
+export default withPermissionGuard("organization:manage", {
   layoutComponent: SettingsLayout,
 })(AuditLogPage);

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -2149,7 +2149,7 @@ export const organizationRouter = createTRPCRouter({
         endDate: z.number().optional(), // End date timestamp (milliseconds)
       }),
     )
-    .use(checkOrganizationPermission("organization:view"))
+    .use(checkOrganizationPermission("organization:manage"))
     .query(async ({ ctx, input }) => {
       await assertEnterprisePlan({
         organizationId: input.organizationId,

--- a/langwatch/src/tests/pages/datasets.lite-member.integration.test.tsx
+++ b/langwatch/src/tests/pages/datasets.lite-member.integration.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the Datasets page permission-based UI visibility.
+ *
+ * Verifies that edit/delete menu items are gated behind
+ * the `datasets:manage` permission for lite members.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockIsLiteMemberRef, mockDatasetsList, mockDeleteMutate } =
+  vi.hoisted(() => {
+    return {
+      mockIsLiteMemberRef: {
+        current: false,
+      },
+      mockDatasetsList: {
+        current: [] as Array<{
+          id: string;
+          slug: string;
+          name: string;
+          schema: null;
+          columnTypes: Array<{ name: string }>;
+          createdAt: Date;
+          updatedAt: Date;
+          archivedAt: null;
+          projectId: string;
+          useS3?: boolean;
+          s3RecordCount?: number;
+          _count: { datasetRecords: number };
+        }>,
+      },
+      mockDeleteMutate: vi.fn(),
+    };
+  });
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    query: {},
+    push: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1" },
+    organizations: [{ id: "org-1", name: "Test Org" }],
+    project: { id: "proj-1", slug: "test-project" },
+    hasOrgPermission: () => false,
+    hasAnyPermission: () => false,
+  }),
+}));
+
+vi.mock("~/hooks/useLiteMemberGuard", () => ({
+  useLiteMemberGuard: () => ({
+    isLiteMember: mockIsLiteMemberRef.current,
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn(),
+    closeDrawer: vi.fn(),
+    drawerOpen: vi.fn(),
+    goBack: vi.fn(),
+    canGoBack: false,
+    currentDrawer: undefined,
+    setFlowCallbacks: vi.fn(),
+    getFlowCallbacks: vi.fn(),
+  }),
+}));
+
+vi.mock("~/hooks/useDeleteDatasetConfirmation", () => ({
+  useDeleteDatasetConfirmation: () => ({
+    showDeleteDialog: vi.fn(),
+    DeleteDialog: () => <div data-testid="delete-dialog" />,
+  }),
+}));
+
+vi.mock("~/components/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({
+      limits: { getUsage: { invalidate: vi.fn() } },
+      licenseEnforcement: { checkLimit: { invalidate: vi.fn() } },
+    }),
+    dataset: {
+      getAll: {
+        useQuery: () => ({
+          data: mockDatasetsList.current,
+          isLoading: false,
+          refetch: vi.fn(),
+        }),
+      },
+      deleteById: {
+        useMutation: () => ({
+          mutate: mockDeleteMutate,
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: {
+    create: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("~/utils/trpcError", () => ({
+  isHandledByGlobalHandler: vi.fn(() => false),
+}));
+
+vi.mock("~/components/datasets/UploadCSVModal", () => ({
+  UploadCSVModal: () => <div data-testid="upload-csv-modal" />,
+}));
+
+vi.mock("~/components/AddOrEditDatasetDrawer", () => ({
+  AddOrEditDatasetDrawer: () => (
+    <div data-testid="add-edit-dataset-drawer" />
+  ),
+}));
+
+vi.mock("~/components/datasets/CopyDatasetDialog", () => ({
+  CopyDatasetDialog: () => <div data-testid="copy-dataset-dialog" />,
+}));
+
+vi.mock("~/components/NoDataInfoBlock", () => ({
+  NoDataInfoBlock: () => <div data-testid="no-data-info-block" />,
+}));
+
+vi.mock("~/components/WithPermissionGuard", () => ({
+  withPermissionGuard: () => (C: any) => C,
+}));
+
+vi.mock("~/components/ui/layouts/PageLayout", () => ({
+  PageLayout: {
+    Header: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Heading: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    HeaderButton: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Container: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Content: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+  },
+}));
+
+vi.mock("~/components/ui/menu", () => ({
+  Menu: {
+    Root: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Trigger: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Content: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Item: ({
+      children,
+      ...props
+    }: {
+      children?: ReactNode;
+      [key: string]: any;
+    }) => <div {...props}>{children}</div>,
+  },
+}));
+
+vi.mock("~/components/ui/link", () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: {
+    children?: ReactNode;
+    href?: string;
+    [key: string]: any;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Lazy import to ensure mocks are set up first
+const { default: DatasetsPage } = await import(
+  "~/pages/[project]/datasets"
+);
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <DatasetsPage />
+    </ChakraProvider>,
+  );
+}
+
+describe("Datasets page permission visibility", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLiteMemberRef.current = false;
+    mockDatasetsList.current = [
+      {
+        id: "ds-1",
+        slug: "test-dataset",
+        name: "Test Dataset",
+        schema: null,
+        columnTypes: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        archivedAt: null,
+        projectId: "proj-1",
+        _count: { datasetRecords: 5 },
+      },
+    ];
+  });
+
+  describe("when user is not a lite member", () => {
+    beforeEach(() => {
+      mockIsLiteMemberRef.current = false;
+    });
+
+    it("shows edit and delete menu items", () => {
+      renderPage();
+
+      expect(screen.getByText("Edit dataset")).toBeTruthy();
+      expect(screen.getByText("Delete dataset")).toBeTruthy();
+    });
+  });
+
+  describe("when user is a lite member", () => {
+    beforeEach(() => {
+      mockIsLiteMemberRef.current = true;
+    });
+
+    it("hides edit and delete menu items", () => {
+      renderPage();
+
+      expect(screen.queryByText("Edit dataset")).toBeNull();
+      expect(screen.queryByText("Delete dataset")).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/tests/pages/evaluations.lite-member.integration.test.tsx
+++ b/langwatch/src/tests/pages/evaluations.lite-member.integration.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the Evaluations page permission-based UI visibility.
+ *
+ * Verifies that delete and replicate menu items are gated behind
+ * the `evaluations:manage` permission for lite members.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHasPermissionRef, mockExperimentsList, mockDeleteMutate } =
+  vi.hoisted(() => {
+    return {
+      mockHasPermissionRef: {
+        current: (_permission: string): boolean => true,
+      },
+      mockExperimentsList: {
+        current: [] as Array<{
+          id: string;
+          name: string;
+          slug: string;
+          type: string;
+          createdAt: string;
+          updatedAt: number;
+          workbenchState: null;
+          runsSummary: {
+            count: number;
+            primaryMetric: undefined;
+            latestRun: { timestamps: undefined };
+          };
+          dataset: null;
+        }>,
+      },
+      mockDeleteMutate: vi.fn(),
+    };
+  });
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    query: { project: "test-project" },
+    push: vi.fn(),
+    isReady: true,
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1" },
+    organizations: [{ id: "org-1", name: "Test Org" }],
+    project: { id: "proj-1", slug: "test-project" },
+    hasPermission: (permission: string) =>
+      mockHasPermissionRef.current(permission),
+    hasOrgPermission: () => false,
+    hasAnyPermission: () => false,
+  }),
+}));
+
+vi.mock("~/components/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("~/components/WithPermissionGuard", () => ({
+  withPermissionGuard: () => (C: any) => C,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({}),
+    experiments: {
+      getAllForEvaluationsList: {
+        useQuery: () => ({
+          data: {
+            experiments: mockExperimentsList.current,
+            totalHits: mockExperimentsList.current.length,
+          },
+          isLoading: false,
+          isFetching: false,
+          refetch: vi.fn(),
+        }),
+      },
+      deleteExperiment: {
+        useMutation: ({ onSuccess }: any = {}) => ({
+          mutate: mockDeleteMutate,
+          isPending: false,
+        }),
+      },
+    },
+    monitors: {
+      getAllForProject: {
+        useQuery: () => ({
+          data: [],
+          isLoading: false,
+          isError: false,
+          refetch: vi.fn(),
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/utils/trpcError", () => ({
+  isHandledByGlobalHandler: vi.fn(() => false),
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: {
+    create: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("~/components/evaluations/NewEvaluationMenu", () => ({
+  NewEvaluationMenu: () => <div data-testid="new-evaluation-menu" />,
+}));
+
+vi.mock("~/components/evaluations/CopyEvaluationDialog", () => ({
+  CopyEvaluationDialog: () => <div data-testid="copy-evaluation-dialog" />,
+}));
+
+vi.mock("~/components/evaluations/MonitorsSection", () => ({
+  MonitorsSection: () => <div data-testid="monitors-section" />,
+}));
+
+vi.mock("~/components/NavigationFooter", () => ({
+  useNavigationFooter: () => ({
+    pageOffset: 0,
+    pageSize: 25,
+    useUpdateTotalHits: vi.fn(),
+  }),
+  NavigationFooter: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("~/components/OverflownText", () => ({
+  OverflownTextWithTooltip: ({ children }: { children?: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+vi.mock("~/components/NoDataInfoBlock", () => ({
+  NoDataInfoBlock: () => <div data-testid="no-data-info-block" />,
+}));
+
+vi.mock("~/components/ui/layouts/PageLayout", () => ({
+  PageLayout: {
+    Header: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Heading: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    HeaderButton: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Container: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Content: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+  },
+}));
+
+vi.mock("~/components/ui/menu", () => ({
+  Menu: {
+    Root: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Trigger: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Content: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Item: ({
+      children,
+      ...props
+    }: {
+      children?: ReactNode;
+      [key: string]: any;
+    }) => <div {...props}>{children}</div>,
+  },
+}));
+
+vi.mock("~/components/ui/link", () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: {
+    children?: ReactNode;
+    href?: string;
+    [key: string]: any;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock(
+  "~/components/evaluations/wizard/hooks/evaluation-wizard-store/useEvaluationWizardStore",
+  () => ({
+    TASK_TYPES: {
+      real_time: "real_time",
+      llm_app: "llm_app",
+      prompt_creation: "prompt_creation",
+      custom_evaluator: "custom_evaluator",
+      scan: "scan",
+    },
+  }),
+);
+
+vi.mock(
+  "~/components/experiments/BatchEvaluationV2/BatchEvaluationSummary",
+  () => ({
+    formatEvaluationSummary: vi.fn(() => ""),
+  }),
+);
+
+vi.mock("@prisma/client", () => ({
+  ExperimentType: {
+    BATCH_EVALUATION: "BATCH_EVALUATION",
+    BATCH_EVALUATION_V2: "BATCH_EVALUATION_V2",
+    DSPY: "DSPY",
+    EVALUATIONS_V3: "EVALUATIONS_V3",
+  },
+}));
+
+// Lazy import to ensure mocks are set up first
+const { default: EvaluationsPage } = await import(
+  "~/pages/[project]/evaluations"
+);
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <EvaluationsPage />
+    </ChakraProvider>,
+  );
+}
+
+describe("Evaluations page permission visibility", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasPermissionRef.current = () => true;
+    mockExperimentsList.current = [
+      {
+        id: "exp-1",
+        name: "Test Evaluation",
+        slug: "test-evaluation",
+        type: "BATCH_EVALUATION" as const,
+        createdAt: new Date().toISOString(),
+        updatedAt: Date.now(),
+        workbenchState: null,
+        runsSummary: {
+          count: 0,
+          primaryMetric: undefined,
+          latestRun: { timestamps: undefined },
+        },
+        dataset: null,
+      },
+    ];
+  });
+
+  describe("when user has evaluations:manage permission", () => {
+    beforeEach(() => {
+      mockHasPermissionRef.current = () => true;
+    });
+
+    it("displays the delete menu item", () => {
+      renderPage();
+
+      expect(screen.getByText("Delete")).toBeTruthy();
+    });
+
+    it("displays the replicate menu item", () => {
+      renderPage();
+
+      expect(
+        screen.getByText("Replicate to another project"),
+      ).toBeTruthy();
+    });
+  });
+
+  describe("when user lacks evaluations:manage permission", () => {
+    beforeEach(() => {
+      mockHasPermissionRef.current = (permission: string) =>
+        permission !== "evaluations:manage";
+    });
+
+    it("hides the delete menu item", () => {
+      renderPage();
+
+      expect(screen.queryByText("Delete")).toBeNull();
+    });
+
+    it("hides the replicate menu item", () => {
+      renderPage();
+
+      expect(
+        screen.queryByText("Replicate to another project"),
+      ).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/tests/settings/annotation-scores.lite-member.integration.test.tsx
+++ b/langwatch/src/tests/settings/annotation-scores.lite-member.integration.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the Annotation Scores settings page.
+ *
+ * Verifies permission-based UI visibility:
+ * - "Add new score metric" button gated by annotations:manage
+ * - "Actions" column header gated by annotations:manage
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockIsLiteMemberRef,
+  mockScoresList,
+  mockToggleMutate,
+  mockDeleteMutate,
+} = vi.hoisted(() => {
+  return {
+    mockIsLiteMemberRef: {
+      current: false,
+    },
+    mockScoresList: {
+      current: [] as Array<{
+        id: string;
+        name: string;
+        description: string;
+        dataType: string;
+        options: Array<{ label: string; value: number }>;
+        active: boolean;
+        projectId: string;
+      }>,
+    },
+    mockToggleMutate: vi.fn(),
+    mockDeleteMutate: vi.fn(),
+  };
+});
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    query: {},
+    push: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1" },
+    organizations: [{ id: "org-1", name: "Test Org" }],
+    project: { id: "proj-1", slug: "test-project" },
+    hasOrgPermission: () => false,
+    hasAnyPermission: () => false,
+  }),
+}));
+
+vi.mock("~/hooks/useLiteMemberGuard", () => ({
+  useLiteMemberGuard: () => ({
+    isLiteMember: mockIsLiteMemberRef.current,
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn(),
+    drawerOpen: () => false,
+    closeDrawer: vi.fn(),
+  }),
+}));
+
+vi.mock("~/components/SettingsLayout", () => ({
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("~/components/WithPermissionGuard", () => ({
+  withPermissionGuard: () => (C: any) => C,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    annotationScore: {
+      getAll: {
+        useQuery: () => ({
+          data: mockScoresList.current,
+          isLoading: false,
+          refetch: vi.fn(),
+        }),
+      },
+      toggle: {
+        useMutation: () => ({
+          mutate: mockToggleMutate,
+          isPending: false,
+        }),
+      },
+      delete: {
+        useMutation: () => ({
+          mutate: mockDeleteMutate,
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock("~/utils/trpcError", () => ({
+  isHandledByGlobalHandler: () => false,
+}));
+
+vi.mock("~/components/annotations/DeleteConfirmationDialog", () => ({
+  DeleteConfirmationDialog: () => <div data-testid="delete-dialog" />,
+}));
+
+vi.mock("~/components/NoDataInfoBlock", () => ({
+  NoDataInfoBlock: () => <div data-testid="no-data-info-block" />,
+}));
+
+vi.mock("~/components/ui/layouts/PageLayout", () => ({
+  PageLayout: {
+    Header: ({ children }: { children?: ReactNode }) => (
+      <div data-testid="page-header">{children}</div>
+    ),
+    Heading: ({ children }: { children?: ReactNode }) => (
+      <div data-testid="page-heading">{children}</div>
+    ),
+    HeaderButton: ({
+      children,
+      ...props
+    }: {
+      children?: ReactNode;
+      onClick?: () => void;
+    }) => (
+      <button data-testid="header-button" {...props}>
+        {children}
+      </button>
+    ),
+    Container: ({ children }: { children?: ReactNode }) => (
+      <div data-testid="page-container">{children}</div>
+    ),
+    Content: ({ children }: { children?: ReactNode }) => (
+      <div data-testid="page-content">{children}</div>
+    ),
+  },
+}));
+
+vi.mock("~/components/ui/menu", () => ({
+  Menu: {
+    Root: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Trigger: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Content: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Item: ({
+      children,
+      ...props
+    }: {
+      children?: ReactNode;
+      value?: string;
+      onClick?: (e: any) => void;
+    }) => <div {...props}>{children}</div>,
+  },
+}));
+
+vi.mock("~/components/ui/switch", () => ({
+  Switch: ({
+    checked,
+    disabled,
+    onCheckedChange,
+  }: {
+    checked?: boolean;
+    disabled?: boolean;
+    onCheckedChange?: () => void;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      disabled={disabled}
+      onChange={onCheckedChange}
+      data-testid="switch"
+    />
+  ),
+}));
+
+vi.mock("~/components/ui/link", () => ({
+  Link: ({
+    children,
+    href,
+  }: {
+    children?: ReactNode;
+    href?: string;
+    isExternal?: boolean;
+    color?: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("~/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children?: ReactNode; content?: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@prisma/client", () => ({
+  AnnotationScoreDataType: {
+    CATEGORICAL: "CATEGORICAL",
+    CHECKBOX: "CHECKBOX",
+  },
+}));
+
+// Lazy import to ensure mocks are set up first
+const { default: AnnotationScorePage } = await import(
+  "~/pages/settings/annotation-scores"
+);
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <AnnotationScorePage />
+    </ChakraProvider>,
+  );
+}
+
+const sampleScores = [
+  {
+    id: "score-1",
+    name: "Quality",
+    description: "Quality score",
+    dataType: "CATEGORICAL",
+    options: [
+      { label: "Good", value: 1 },
+      { label: "Bad", value: 0 },
+    ],
+    active: true,
+    projectId: "proj-1",
+  },
+];
+
+describe("Annotation scores settings page", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLiteMemberRef.current = false;
+    mockScoresList.current = sampleScores;
+  });
+
+  describe("when user is not a lite member", () => {
+    beforeEach(() => {
+      mockIsLiteMemberRef.current = false;
+    });
+
+    it("displays the add new score metric button", () => {
+      renderPage();
+
+      expect(screen.getByText("Add new score metric")).toBeTruthy();
+    });
+
+    it("displays the actions column", () => {
+      renderPage();
+
+      expect(screen.getByText("Actions")).toBeTruthy();
+    });
+  });
+
+  describe("when user is a lite member", () => {
+    beforeEach(() => {
+      mockIsLiteMemberRef.current = true;
+    });
+
+    it("hides the add new score metric button", () => {
+      renderPage();
+
+      expect(screen.queryByText("Add new score metric")).toBeNull();
+    });
+
+    it("hides the actions column", () => {
+      renderPage();
+
+      expect(screen.queryByText("Actions")).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/utils/__tests__/trpcError.lite-member.unit.test.ts
+++ b/langwatch/src/utils/__tests__/trpcError.lite-member.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the isHandledByGlobalHandler error deduplication pattern.
+ *
+ * Tests the mark-and-check mechanism that prevents duplicate toast+modal
+ * errors when global handlers (license limit or lite member restriction)
+ * have already handled a mutation error.
+ *
+ * Related component integration tests:
+ * - components/settings/__tests__/LLMModelCostDrawer.lite-member.integration.test.tsx
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isHandledByGlobalHandler,
+  isHandledByLiteMemberHandler,
+  isHandledByGlobalLicenseHandler,
+  markAsHandledByLiteMemberHandler,
+  markAsHandledByLicenseHandler,
+} from "../trpcError";
+
+describe("isHandledByGlobalHandler()", () => {
+  describe("when error is marked by lite member handler", () => {
+    it("returns true", () => {
+      const error = new Error("Lite member restricted");
+      markAsHandledByLiteMemberHandler(error);
+
+      expect(isHandledByGlobalHandler(error)).toBe(true);
+    });
+  });
+
+  describe("when error is marked by license handler", () => {
+    it("returns true", () => {
+      const error = new Error("License limit exceeded");
+      markAsHandledByLicenseHandler(error);
+
+      expect(isHandledByGlobalHandler(error)).toBe(true);
+    });
+  });
+
+  describe("when error is not marked by any handler", () => {
+    it("returns false", () => {
+      const error = new Error("Network error");
+
+      expect(isHandledByGlobalHandler(error)).toBe(false);
+    });
+  });
+
+  describe("when error is null or undefined", () => {
+    it("returns false for null", () => {
+      expect(isHandledByGlobalHandler(null)).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(isHandledByGlobalHandler(undefined)).toBe(false);
+    });
+  });
+
+  describe("when error is a non-Error value", () => {
+    it("returns false for string", () => {
+      expect(isHandledByGlobalHandler("some error string")).toBe(false);
+    });
+
+    it("returns false for number", () => {
+      expect(isHandledByGlobalHandler(42)).toBe(false);
+    });
+  });
+});
+
+describe("markAsHandledByLiteMemberHandler()", () => {
+  it("marks the error so isHandledByLiteMemberHandler returns true", () => {
+    const error = new Error("Restricted");
+
+    expect(isHandledByLiteMemberHandler(error)).toBe(false);
+    markAsHandledByLiteMemberHandler(error);
+    expect(isHandledByLiteMemberHandler(error)).toBe(true);
+  });
+
+  it("does not affect other error instances", () => {
+    const error1 = new Error("Restricted");
+    const error2 = new Error("Also restricted");
+
+    markAsHandledByLiteMemberHandler(error1);
+
+    expect(isHandledByLiteMemberHandler(error1)).toBe(true);
+    expect(isHandledByLiteMemberHandler(error2)).toBe(false);
+  });
+});
+
+describe("markAsHandledByLicenseHandler()", () => {
+  it("marks the error so isHandledByGlobalLicenseHandler returns true", () => {
+    const error = new Error("Limit exceeded");
+
+    expect(isHandledByGlobalLicenseHandler(error)).toBe(false);
+    markAsHandledByLicenseHandler(error);
+    expect(isHandledByGlobalLicenseHandler(error)).toBe(true);
+  });
+
+  it("does not affect other error instances", () => {
+    const error1 = new Error("Limit exceeded");
+    const error2 = new Error("Also exceeded");
+
+    markAsHandledByLicenseHandler(error1);
+
+    expect(isHandledByGlobalLicenseHandler(error1)).toBe(true);
+    expect(isHandledByGlobalLicenseHandler(error2)).toBe(false);
+  });
+});
+
+describe("error deduplication pattern", () => {
+  describe("when both handlers mark the same error", () => {
+    it("returns true for isHandledByGlobalHandler", () => {
+      const error = new Error("Double handled");
+      markAsHandledByLiteMemberHandler(error);
+      markAsHandledByLicenseHandler(error);
+
+      expect(isHandledByGlobalHandler(error)).toBe(true);
+      expect(isHandledByLiteMemberHandler(error)).toBe(true);
+      expect(isHandledByGlobalLicenseHandler(error)).toBe(true);
+    });
+  });
+
+  describe("when simulating onError callback pattern", () => {
+    it("prevents toast when error is pre-handled", () => {
+      const error = new Error("Restricted");
+      markAsHandledByLiteMemberHandler(error);
+
+      // Simulate the pattern used in LLMModelCostDrawer.tsx onError:
+      // if (isHandledByGlobalHandler(error)) return;
+      // toaster.create(...)
+      let toastCalled = false;
+      if (!isHandledByGlobalHandler(error)) {
+        toastCalled = true;
+      }
+
+      expect(toastCalled).toBe(false);
+    });
+
+    it("allows toast when error is not pre-handled", () => {
+      const error = new Error("Network error");
+
+      let toastCalled = false;
+      if (!isHandledByGlobalHandler(error)) {
+        toastCalled = true;
+      }
+
+      expect(toastCalled).toBe(true);
+    });
+  });
+});

--- a/specs/settings/llm-model-cost-drawer-error-handling.feature
+++ b/specs/settings/llm-model-cost-drawer-error-handling.feature
@@ -1,0 +1,18 @@
+Feature: LLM model cost drawer save errors
+  As a project member editing model pricing
+  I want save failures to show a single clear error surface
+  So that restriction or limit messages are not stacked with a generic toast
+
+  @regression @integration
+  Scenario: LLM model cost drawer skips the generic error toast after a primary error UI is shown
+    Given I submit the LLM model cost drawer
+    And the save request fails after another part of the app already showed the primary error UI
+    When the drawer handles the save error
+    Then I do not see a generic error toast
+
+  @integration
+  Scenario: LLM model cost drawer shows the generic error toast when no primary error UI is shown
+    Given I submit the LLM model cost drawer
+    And the save request fails before any other part of the app shows a primary error UI
+    When the drawer handles the save error
+    Then I see a generic error toast with the save error message


### PR DESCRIPTION
## Summary
- **Audit Log**: Hide sidebar menu item for non-admin organization users
- **Datasets**: Hide edit/delete menu items for users without `datasets:manage` permission; prevent duplicate toast on restricted delete
- **Evaluations**: Hide delete menu item for users without `evaluations:manage` permission (matches existing replicate guard); prevent duplicate toast
- **Annotations**: Hide "+" buttons (queue creation and score creation), disable toggle switch, hide edit/delete actions and "Actions" column for users without `annotations:manage`; prevent duplicate toasts
- **Model Costs**: Fix double error display (modal + toast) on restricted create/update/delete by checking `isHandledByGlobalHandler` before showing toast

## Test plan
- [ ] Log in as a lite member — verify:
  - Audit Log is not visible in Settings sidebar
  - Datasets page: edit/delete menu items are hidden
  - Annotation Scores page: "+" button, toggle, edit/delete actions are hidden
  - Annotations sidebar: queue "+" button is hidden
  - Evaluations page: delete menu item is hidden
  - Model Costs: no duplicate toast+modal on restricted actions
- [ ] Log in as an admin — verify all actions remain available