### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/langwatch/src/components/icons/MiniMax.tsx
+++ b/langwatch/src/components/icons/MiniMax.tsx
@@ -1,0 +1,15 @@
+export function MiniMax() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+      <rect width="100" height="100" rx="20" fill="#1A1A2E" />
+      <path
+        d="M20 65V35l15 15L50 35l15 15L80 35v30"
+        stroke="#00D4AA"
+        strokeWidth="6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}

--- a/langwatch/src/server/modelProviders/__tests__/minimax.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/minimax.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration tests for MiniMax provider.
+ *
+ * These tests verify that MiniMax models work correctly with the actual MiniMax API.
+ * Skipped when MINIMAX_API_KEY is not available.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  getModelById,
+  getModelsForProvider,
+  getParameterConstraints,
+  getProviderModelOptions,
+  modelProviders,
+} from "../registry";
+
+const apiKey = process.env.MINIMAX_API_KEY;
+
+interface MiniMaxChatResponse {
+  id: string;
+  object: string;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: { role: string; content: string };
+    finish_reason: string;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+async function callMiniMaxApi(
+  model: string,
+  temperature = 0.7,
+): Promise<MiniMaxChatResponse> {
+  const response = await fetch(
+    "https://api.minimax.io/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 10,
+        temperature,
+        messages: [{ role: "user", content: "Say hi" }],
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`MiniMax API error: ${response.status} - ${errorBody}`);
+  }
+
+  return (await response.json()) as MiniMaxChatResponse;
+}
+
+describe("MiniMax Provider Integration", () => {
+  describe("registry consistency", () => {
+    it("all MiniMax models have provider set to minimax", () => {
+      const models = getModelsForProvider("minimax");
+      for (const model of models) {
+        expect(model.provider).toBe("minimax");
+        expect(model.id).toMatch(/^minimax\//);
+      }
+    });
+
+    it("all MiniMax chat models appear in provider model options", () => {
+      const options = getProviderModelOptions("minimax", "chat");
+      const models = getModelsForProvider("minimax").filter(
+        (m) => m.mode === "chat",
+      );
+      expect(options.length).toBe(models.length);
+    });
+
+    it("M2.7 and M2.7-highspeed models have correct context length", () => {
+      const m27 = getModelById("minimax/minimax-m2.7");
+      const m27hs = getModelById("minimax/minimax-m2.7-highspeed");
+      expect(m27?.contextLength).toBe(1000000);
+      expect(m27hs?.contextLength).toBe(1000000);
+    });
+
+    it("temperature constraints are applied to all MiniMax models", () => {
+      const models = getModelsForProvider("minimax");
+      for (const model of models) {
+        const constraints = getParameterConstraints(model.id);
+        expect(constraints).toBeDefined();
+        expect(constraints?.temperature?.max).toBe(1);
+      }
+    });
+
+    it("provider keysSchema validates correctly", () => {
+      const validResult = modelProviders.minimax.keysSchema.safeParse({
+        MINIMAX_API_KEY: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test",
+      });
+      expect(validResult.success).toBe(true);
+
+      const invalidResult = modelProviders.minimax.keysSchema.safeParse({
+        MINIMAX_API_KEY: "",
+      });
+      expect(invalidResult.success).toBe(false);
+    });
+  });
+
+  describe.skipIf(!apiKey)("MiniMax API calls", () => {
+    it("calls M2.7 model successfully", async () => {
+      const response = await callMiniMaxApi("MiniMax-M2.7", 0.7);
+      expect(response.choices).toHaveLength(1);
+      expect(response.choices[0]?.message.content).toBeTruthy();
+      expect(response.usage.total_tokens).toBeGreaterThan(0);
+    }, 30000);
+
+    it("calls M2.7-highspeed model successfully", async () => {
+      const response = await callMiniMaxApi("MiniMax-M2.7-highspeed", 0.7);
+      expect(response.choices).toHaveLength(1);
+      expect(response.choices[0]?.message.content).toBeTruthy();
+    }, 30000);
+
+    it("respects temperature constraint (max 1.0)", async () => {
+      const response = await callMiniMaxApi("MiniMax-M2.7", 0.5);
+      expect(response.choices[0]?.message.content).toBeTruthy();
+    }, 30000);
+  });
+});

--- a/langwatch/src/server/modelProviders/__tests__/registry.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/registry.unit.test.ts
@@ -382,6 +382,7 @@ describe("Model Provider Definitions", () => {
     expect(modelProviders).toHaveProperty("gemini");
     expect(modelProviders).toHaveProperty("azure");
     expect(modelProviders).toHaveProperty("bedrock");
+    expect(modelProviders).toHaveProperty("minimax");
   });
 
   it("each provider has required fields", () => {
@@ -516,6 +517,150 @@ describe("Parameter Constraints", () => {
         min: 0,
         max: 1,
       });
+    });
+  });
+
+  describe("MiniMax provider constraints", () => {
+    it("returns constraints for MiniMax models", () => {
+      const constraints = getParameterConstraints("minimax/minimax-m2.7");
+
+      expect(constraints).toBeDefined();
+      expect(constraints?.temperature).toEqual({ min: 0, max: 1 });
+    });
+
+    it("returns constraints for MiniMax M2.5 models", () => {
+      const constraints = getParameterConstraints("minimax/minimax-m2.5");
+
+      expect(constraints).toBeDefined();
+      expect(constraints?.temperature?.max).toBe(1);
+    });
+
+    it("has temperature constraint defined", () => {
+      expect(modelProviders.minimax.parameterConstraints).toBeDefined();
+      expect(
+        modelProviders.minimax.parameterConstraints?.temperature,
+      ).toEqual({
+        min: 0,
+        max: 1,
+      });
+    });
+  });
+});
+
+describe("MiniMax Provider", () => {
+  describe("provider definition", () => {
+    it("has correct name", () => {
+      expect(modelProviders.minimax.name).toBe("MiniMax");
+    });
+
+    it("uses MINIMAX_API_KEY", () => {
+      expect(modelProviders.minimax.apiKey).toBe("MINIMAX_API_KEY");
+    });
+
+    it("has no custom endpoint", () => {
+      expect(modelProviders.minimax.endpointKey).toBeUndefined();
+    });
+
+    it("has enabledSince date", () => {
+      expect(modelProviders.minimax.enabledSince).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("keysSchema validation", () => {
+    it("accepts valid API key", () => {
+      const result = modelProviders.minimax.keysSchema.safeParse({
+        MINIMAX_API_KEY: "test-key-123",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects empty API key", () => {
+      const result = modelProviders.minimax.keysSchema.safeParse({
+        MINIMAX_API_KEY: "",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects missing API key", () => {
+      const result = modelProviders.minimax.keysSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("model registry", () => {
+    it("includes MiniMax models in the registry", () => {
+      const providers = getAllProviders();
+      expect(providers).toContain("minimax");
+    });
+
+    it("has M2.7 model in the registry", () => {
+      const model = getModelById("minimax/minimax-m2.7");
+      expect(model).toBeDefined();
+      expect(model?.name).toBe("MiniMax: MiniMax M2.7");
+      expect(model?.provider).toBe("minimax");
+      expect(model?.mode).toBe("chat");
+      expect(model?.contextLength).toBe(1000000);
+    });
+
+    it("has M2.7-highspeed model in the registry", () => {
+      const model = getModelById("minimax/minimax-m2.7-highspeed");
+      expect(model).toBeDefined();
+      expect(model?.name).toBe("MiniMax: MiniMax M2.7 Highspeed");
+      expect(model?.provider).toBe("minimax");
+      expect(model?.mode).toBe("chat");
+    });
+
+    it("has M2.5 model in the registry", () => {
+      const model = getModelById("minimax/minimax-m2.5");
+      expect(model).toBeDefined();
+      expect(model?.provider).toBe("minimax");
+    });
+
+    it("returns MiniMax chat model options", () => {
+      const options = getProviderModelOptions("minimax", "chat");
+      expect(options.length).toBeGreaterThan(0);
+      const values = options.map((o) => o.value);
+      expect(values).toContain("minimax-m2.7");
+      expect(values).toContain("minimax-m2.7-highspeed");
+    });
+
+    it("returns all MiniMax models via getModelsForProvider", () => {
+      const models = getModelsForProvider("minimax");
+      expect(models.length).toBeGreaterThanOrEqual(8);
+      expect(models.every((m) => m.provider === "minimax")).toBe(true);
+    });
+
+    it("M2.7 model has valid pricing", () => {
+      const model = getModelById("minimax/minimax-m2.7");
+      expect(model?.pricing.inputCostPerToken).toBeGreaterThan(0);
+      expect(model?.pricing.outputCostPerToken).toBeGreaterThan(0);
+    });
+
+    it("M2.7-highspeed has lower pricing than M2.7", () => {
+      const m27 = getModelById("minimax/minimax-m2.7");
+      const m27hs = getModelById("minimax/minimax-m2.7-highspeed");
+      expect(m27hs?.pricing.outputCostPerToken).toBeLessThan(
+        m27?.pricing.outputCostPerToken ?? 0,
+      );
+    });
+
+    it("M2.7 model supports temperature parameter", () => {
+      const model = getModelById("minimax/minimax-m2.7");
+      expect(model?.supportedParameters).toContain("temperature");
+    });
+
+    it("MiniMax models appear in allLitellmModels", () => {
+      expect(allLitellmModels["minimax/minimax-m2.7"]).toBeDefined();
+      expect(allLitellmModels["minimax/minimax-m2.7"]?.mode).toBe("chat");
+      expect(allLitellmModels["minimax/minimax-m2.7-highspeed"]).toBeDefined();
+    });
+
+    it("getModelMetadata returns metadata for MiniMax M2.7", () => {
+      const metadata = getModelMetadata("minimax/minimax-m2.7");
+      expect(metadata).not.toBeNull();
+      expect(metadata?.contextLength).toBe(1000000);
+      expect(metadata?.supportedParameters).toContain("temperature");
+      expect(metadata?.pricing.inputCostPerToken).toBeGreaterThan(0);
     });
   });
 });

--- a/langwatch/src/server/modelProviders/iconsMap.tsx
+++ b/langwatch/src/server/modelProviders/iconsMap.tsx
@@ -9,6 +9,7 @@ import { DeepSeek } from "../../components/icons/DeepSeek";
 import { Gemini } from "../../components/icons/Gemini";
 import { GoogleCloud } from "../../components/icons/GoogleCloud";
 import { Groq } from "../../components/icons/Groq";
+import { MiniMax } from "../../components/icons/MiniMax";
 import { OpenAI } from "../../components/icons/OpenAI";
 import { Xai } from "../../components/icons/Xai";
 import type { modelProviders } from "./registry";
@@ -28,4 +29,5 @@ export const modelProviderIcons: Record<
   custom: <Custom />,
   xai: <Xai />,
   cerebras: <Cerebras />,
+  minimax: <MiniMax />,
 };

--- a/langwatch/src/server/modelProviders/llmModels.json
+++ b/langwatch/src/server/modelProviders/llmModels.json
@@ -1,15 +1,15 @@
 {
   "updatedAt": "2026-03-16T03:08:49.943Z",
-  "modelCount": 338,
+  "modelCount": 340,
   "models": {
     "z-ai/glm-5-turbo": {
       "id": "z-ai/glm-5-turbo",
       "name": "Z.ai: GLM 5 Turbo",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 9.6e-7,
-        "outputCostPerToken": 0.0000032,
-        "inputCacheReadPerToken": 1.92e-7
+        "inputCostPerToken": 9.6e-07,
+        "outputCostPerToken": 3.2e-06,
+        "inputCacheReadPerToken": 1.92e-07
       },
       "contextLength": 202752,
       "maxCompletionTokens": 131072,
@@ -41,9 +41,9 @@
       "name": "xAI: Grok 4.20 Multi-Agent Beta",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000006,
-        "inputCacheReadPerToken": 2e-7,
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 6e-06,
+        "inputCacheReadPerToken": 2e-07,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 2000000,
@@ -67,7 +67,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Grok 4.20 Multi-Agent Beta is a variant of xAI’s Grok 4.20 designed for collaborative, agent-based workflows. Multiple agents operate in parallel to conduct deep research, coordinate tool use, and synthesize information across complex tasks. Reasoning effort behavior: - low / medium: 4 agents - high / xhigh: 16 agents",
+      "description": "Grok 4.20 Multi-Agent Beta is a variant of xAI\u2019s Grok 4.20 designed for collaborative, agent-based workflows. Multiple agents operate in parallel to conduct deep research, coordinate tool use, and synthesize information across complex tasks. Reasoning effort behavior: - low / medium: 4 agents - high / xhigh: 16 agents",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -78,9 +78,9 @@
       "name": "xAI: Grok 4.20 Beta",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000006,
-        "inputCacheReadPerToken": 2e-7,
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 6e-06,
+        "inputCacheReadPerToken": 2e-07,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 2000000,
@@ -189,8 +189,8 @@
       "name": "ByteDance Seed: Seed-2.0-Lite",
       "provider": "bytedance-seed",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 0.000002
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 2e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": 131072,
@@ -214,7 +214,7 @@
       },
       "modality": "text+image+video->text",
       "mode": "chat",
-      "description": "Seed-2.0-Lite is a versatile, cost‑efficient enterprise workhorse that delivers strong multimodal and agent capabilities while offering noticeably lower latency, making it a practical default choice for most production workloads across text, vision, and tools. Engineered for high-frequency visual understanding and agentic workflows, it's an ideal choice for deployment at scale with minimal latency.",
+      "description": "Seed-2.0-Lite is a versatile, cost\u2011efficient enterprise workhorse that delivers strong multimodal and agent capabilities while offering noticeably lower latency, making it a practical default choice for most production workloads across text, vision, and tools. Engineered for high-frequency visual understanding and agentic workflows, it's an ideal choice for deployment at scale with minimal latency.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -225,8 +225,8 @@
       "name": "Qwen: Qwen3.5-9B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 5e-8,
-        "outputCostPerToken": 1.5e-7
+        "inputCostPerToken": 5e-08,
+        "outputCostPerToken": 1.5e-07
       },
       "contextLength": 256000,
       "maxCompletionTokens": null,
@@ -268,7 +268,7 @@
       "name": "OpenAI: GPT-5.4 Pro",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00003,
+        "inputCostPerToken": 3e-05,
         "outputCostPerToken": 0.00018,
         "webSearchCostPerQuery": 0.01
       },
@@ -308,9 +308,9 @@
       "name": "OpenAI: GPT-5.4",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.000015,
-        "inputCacheReadPerToken": 2.5e-7,
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1.5e-05,
+        "inputCacheReadPerToken": 2.5e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 1050000,
@@ -338,7 +338,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "GPT-5.4 is OpenAI’s latest frontier model, unifying the Codex and GPT lines into a single system. It features a 1M+ token context window (922K input, 128K output) with support for text and image inputs, enabling high-context reasoning, coding, and multimodal analysis within the same workflow. The model delivers improved performance in coding, document understanding, tool use, and instruction following. It is designed as a strong default for both general-purpose tasks and software engineering, capable of generating production-quality code, synthesizing information across multiple sources, and executing complex multi-step workflows with fewer iterations and greater token efficiency.",
+      "description": "GPT-5.4 is OpenAI\u2019s latest frontier model, unifying the Codex and GPT lines into a single system. It features a 1M+ token context window (922K input, 128K output) with support for text and image inputs, enabling high-context reasoning, coding, and multimodal analysis within the same workflow. The model delivers improved performance in coding, document understanding, tool use, and instruction following. It is designed as a strong default for both general-purpose tasks and software engineering, capable of generating production-quality code, synthesizing information across multiple sources, and executing complex multi-step workflows with fewer iterations and greater token efficiency.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -349,9 +349,9 @@
       "name": "Inception: Mercury 2",
       "provider": "inception",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 7.5e-7,
-        "inputCacheReadPerToken": 2.5e-8
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 7.5e-07,
+        "inputCacheReadPerToken": 2.5e-08
       },
       "contextLength": 128000,
       "maxCompletionTokens": 50000,
@@ -384,9 +384,9 @@
       "name": "OpenAI: GPT-5.3 Chat",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000175,
-        "outputCostPerToken": 0.000014,
-        "inputCacheReadPerToken": 1.75e-7,
+        "inputCostPerToken": 1.75e-06,
+        "outputCostPerToken": 1.4e-05,
+        "inputCacheReadPerToken": 1.75e-07,
         "webSearchCostPerQuery": 0.1
       },
       "contextLength": 128000,
@@ -436,13 +436,13 @@
       "name": "Google: Gemini 3.1 Flash Lite Preview",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 0.0000015,
-        "inputCacheReadPerToken": 2.5e-8,
-        "inputCacheWritePerToken": 8.333333333333334e-8,
-        "imageCostPerToken": 2.5e-7,
-        "audioCostPerToken": 5e-7,
-        "internalReasoningCostPerToken": 0.0000015
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 1.5e-06,
+        "inputCacheReadPerToken": 2.5e-08,
+        "inputCacheWritePerToken": 8.333333333333334e-08,
+        "imageCostPerToken": 2.5e-07,
+        "audioCostPerToken": 5e-07,
+        "internalReasoningCostPerToken": 1.5e-06
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65536,
@@ -487,8 +487,8 @@
       "name": "ByteDance Seed: Seed-2.0-Mini",
       "provider": "bytedance-seed",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 4e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 4e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": 131072,
@@ -523,8 +523,8 @@
       "name": "Google: Nano Banana 2 (Gemini 3.1 Flash Image Preview)",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 5e-7,
-        "outputCostPerToken": 0.000003
+        "inputCostPerToken": 5e-07,
+        "outputCostPerToken": 3e-06
       },
       "contextLength": 65536,
       "maxCompletionTokens": 65536,
@@ -546,7 +546,7 @@
       },
       "modality": "text+image->text+image",
       "mode": "chat",
-      "description": "Gemini 3.1 Flash Image Preview, a.k.a. \"Nano Banana 2,\" is Google’s latest state of the art image generation and editing model, delivering Pro-level visual quality at Flash speed. It combines advanced contextual understanding with fast, cost-efficient inference, making complex image generation and iterative edits significantly more accessible. Aspect ratios can be controlled with the",
+      "description": "Gemini 3.1 Flash Image Preview, a.k.a. \"Nano Banana 2,\" is Google\u2019s latest state of the art image generation and editing model, delivering Pro-level visual quality at Flash speed. It combines advanced contextual understanding with fast, cost-efficient inference, making complex image generation and iterative edits significantly more accessible. Aspect ratios can be controlled with the",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": true,
@@ -567,8 +567,8 @@
       "name": "Qwen: Qwen3.5-35B-A3B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.625e-7,
-        "outputCostPerToken": 0.0000013
+        "inputCostPerToken": 1.625e-07,
+        "outputCostPerToken": 1.3e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": 65536,
@@ -611,8 +611,8 @@
       "name": "Qwen: Qwen3.5-27B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.95e-7,
-        "outputCostPerToken": 0.00000156
+        "inputCostPerToken": 1.95e-07,
+        "outputCostPerToken": 1.56e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": 65536,
@@ -655,8 +655,8 @@
       "name": "Qwen: Qwen3.5-122B-A10B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2.6e-7,
-        "outputCostPerToken": 0.00000208
+        "inputCostPerToken": 2.6e-07,
+        "outputCostPerToken": 2.08e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": 65536,
@@ -699,8 +699,8 @@
       "name": "Qwen: Qwen3.5-Flash",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 4e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 4e-07
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 65536,
@@ -735,8 +735,8 @@
       "name": "LiquidAI: LFM2-24B-A2B",
       "provider": "liquid",
       "pricing": {
-        "inputCostPerToken": 3e-8,
-        "outputCostPerToken": 1.2e-7
+        "inputCostPerToken": 3e-08,
+        "outputCostPerToken": 1.2e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -770,13 +770,13 @@
       "name": "Google: Gemini 3.1 Pro Preview Custom Tools",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000012,
-        "inputCacheReadPerToken": 2e-7,
-        "inputCacheWritePerToken": 3.75e-7,
-        "imageCostPerToken": 0.000002,
-        "audioCostPerToken": 0.000002,
-        "internalReasoningCostPerToken": 0.000012
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 1.2e-05,
+        "inputCacheReadPerToken": 2e-07,
+        "inputCacheWritePerToken": 3.75e-07,
+        "imageCostPerToken": 2e-06,
+        "audioCostPerToken": 2e-06,
+        "internalReasoningCostPerToken": 1.2e-05
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65536,
@@ -821,9 +821,9 @@
       "name": "OpenAI: GPT-5.3-Codex",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000175,
-        "outputCostPerToken": 0.000014,
-        "inputCacheReadPerToken": 1.75e-7,
+        "inputCostPerToken": 1.75e-06,
+        "outputCostPerToken": 1.4e-05,
+        "inputCacheReadPerToken": 1.75e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -845,7 +845,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "GPT-5.3-Codex is OpenAI’s most advanced agentic coding model, combining the frontier software engineering performance of GPT-5.2-Codex with the broader reasoning and professional knowledge capabilities of GPT-5.2. It achieves state-of-the-art results on SWE-Bench Pro and strong performance on Terminal-Bench 2.0 and OSWorld-Verified, reflecting improved multi-language coding, terminal proficiency, and real-world computer-use skills. The model is optimized for long-running, tool-using workflows and supports interactive steering during execution, making it suitable for complex development tasks, debugging, deployment, and iterative product work. Beyond coding, GPT-5.3-Codex performs strongly on structured knowledge-work benchmarks such as GDPval, supporting tasks like document drafting, spreadsheet analysis, slide creation, and operational research across domains. It is trained with enhanced cybersecurity awareness, including vulnerability identification capabilities, and deployed with additional safeguards for high-risk use cases. Compared to prior Codex models, it is more token-efficient and approximately 25% faster, targeting professional end-to-end workflows that span reasoning, execution, and computer interaction.",
+      "description": "GPT-5.3-Codex is OpenAI\u2019s most advanced agentic coding model, combining the frontier software engineering performance of GPT-5.2-Codex with the broader reasoning and professional knowledge capabilities of GPT-5.2. It achieves state-of-the-art results on SWE-Bench Pro and strong performance on Terminal-Bench 2.0 and OSWorld-Verified, reflecting improved multi-language coding, terminal proficiency, and real-world computer-use skills. The model is optimized for long-running, tool-using workflows and supports interactive steering during execution, making it suitable for complex development tasks, debugging, deployment, and iterative product work. Beyond coding, GPT-5.3-Codex performs strongly on structured knowledge-work benchmarks such as GDPval, supporting tasks like document drafting, spreadsheet analysis, slide creation, and operational research across domains. It is trained with enhanced cybersecurity awareness, including vulnerability identification capabilities, and deployed with additional safeguards for high-risk use cases. Compared to prior Codex models, it is more token-efficient and approximately 25% faster, targeting professional end-to-end workflows that span reasoning, execution, and computer interaction.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -869,9 +869,9 @@
       "name": "AionLabs: Aion-2.0",
       "provider": "aion-labs",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 0.0000016,
-        "inputCacheReadPerToken": 2e-7
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 1.6e-06,
+        "inputCacheReadPerToken": 2e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -900,13 +900,13 @@
       "name": "Google: Gemini 3.1 Pro Preview",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000012,
-        "inputCacheReadPerToken": 2e-7,
-        "inputCacheWritePerToken": 3.75e-7,
-        "imageCostPerToken": 0.000002,
-        "audioCostPerToken": 0.000002,
-        "internalReasoningCostPerToken": 0.000012
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 1.2e-05,
+        "inputCacheReadPerToken": 2e-07,
+        "inputCacheWritePerToken": 3.75e-07,
+        "imageCostPerToken": 2e-06,
+        "audioCostPerToken": 2e-06,
+        "internalReasoningCostPerToken": 1.2e-05
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65536,
@@ -930,7 +930,7 @@
       },
       "modality": "text+image+file+audio+video->text",
       "mode": "chat",
-      "description": "Gemini 3.1 Pro Preview is Google’s frontier reasoning model, delivering enhanced software engineering performance, improved agentic reliability, and more efficient token usage across complex workflows. Building on the multimodal foundation of the Gemini 3 series, it combines high-precision reasoning across text, image, video, audio, and code with a 1M-token context window. Reasoning Details must be preserved when using multi-turn tool calling, see our docs here: The 3.1 update introduces measurable gains in SWE benchmarks and real-world coding environments, along with stronger autonomous task execution in structured domains such as finance and spreadsheet-based workflows. Designed for advanced development and agentic systems, Gemini 3.1 Pro Preview improves long-horizon stability and tool orchestration while increasing token efficiency. It introduces a new medium thinking level to better balance cost, speed, and performance. The model excels in agentic coding, structured planning, multimodal analysis, and workflow automation, making it well-suited for autonomous agents, financial modeling, spreadsheet automation, and high-context enterprise tasks.",
+      "description": "Gemini 3.1 Pro Preview is Google\u2019s frontier reasoning model, delivering enhanced software engineering performance, improved agentic reliability, and more efficient token usage across complex workflows. Building on the multimodal foundation of the Gemini 3 series, it combines high-precision reasoning across text, image, video, audio, and code with a 1M-token context window. Reasoning Details must be preserved when using multi-turn tool calling, see our docs here: The 3.1 update introduces measurable gains in SWE benchmarks and real-world coding environments, along with stronger autonomous task execution in structured domains such as finance and spreadsheet-based workflows. Designed for advanced development and agentic systems, Gemini 3.1 Pro Preview improves long-horizon stability and tool orchestration while increasing token efficiency. It introduces a new medium thinking level to better balance cost, speed, and performance. The model excels in agentic coding, structured planning, multimodal analysis, and workflow automation, making it well-suited for autonomous agents, financial modeling, spreadsheet automation, and high-context enterprise tasks.",
       "supportsImageInput": true,
       "supportsAudioInput": true,
       "supportsImageOutput": false,
@@ -951,10 +951,10 @@
       "name": "Anthropic: Claude Sonnet 4.6",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
-        "inputCacheReadPerToken": 3e-7,
-        "inputCacheWritePerToken": 0.00000375,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
+        "inputCacheReadPerToken": 3e-07,
+        "inputCacheWritePerToken": 3.75e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 1000000,
@@ -991,8 +991,8 @@
       "name": "Qwen: Qwen3.5 Plus 2026-02-15",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2.6e-7,
-        "outputCostPerToken": 0.00000156
+        "inputCostPerToken": 2.6e-07,
+        "outputCostPerToken": 1.56e-06
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 65536,
@@ -1027,8 +1027,8 @@
       "name": "Qwen: Qwen3.5 397B A17B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 3.9e-7,
-        "outputCostPerToken": 0.00000234
+        "inputCostPerToken": 3.9e-07,
+        "outputCostPerToken": 2.34e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": 65536,
@@ -1069,8 +1069,8 @@
       "name": "MiniMax: MiniMax M2.5",
       "provider": "minimax",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 0.0000012
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 1.2e-06
       },
       "contextLength": 196608,
       "maxCompletionTokens": 196608,
@@ -1115,8 +1115,8 @@
       "name": "Z.ai: GLM 5",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 7.2e-7,
-        "outputCostPerToken": 0.0000023
+        "inputCostPerToken": 7.2e-07,
+        "outputCostPerToken": 2.3e-06
       },
       "contextLength": 202752,
       "maxCompletionTokens": 131072,
@@ -1148,7 +1148,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "GLM-5 is Z.ai’s flagship open-source foundation model engineered for complex systems design and long-horizon agent workflows. Built for expert developers, it delivers production-grade performance on large-scale programming tasks, rivaling leading closed-source models. With advanced agentic planning, deep backend reasoning, and iterative self-correction, GLM-5 moves beyond code generation to full-system construction and autonomous execution.",
+      "description": "GLM-5 is Z.ai\u2019s flagship open-source foundation model engineered for complex systems design and long-horizon agent workflows. Built for expert developers, it delivers production-grade performance on large-scale programming tasks, rivaling leading closed-source models. With advanced agentic planning, deep backend reasoning, and iterative self-correction, GLM-5 moves beyond code generation to full-system construction and autonomous execution.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -1159,8 +1159,8 @@
       "name": "Qwen: Qwen3 Max Thinking",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 7.8e-7,
-        "outputCostPerToken": 0.0000039
+        "inputCostPerToken": 7.8e-07,
+        "outputCostPerToken": 3.9e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": 32768,
@@ -1195,10 +1195,10 @@
       "name": "Anthropic: Claude Opus 4.6",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000005,
-        "outputCostPerToken": 0.000025,
-        "inputCacheReadPerToken": 5e-7,
-        "inputCacheWritePerToken": 0.00000625,
+        "inputCostPerToken": 5e-06,
+        "outputCostPerToken": 2.5e-05,
+        "inputCacheReadPerToken": 5e-07,
+        "inputCacheWritePerToken": 6.25e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 1000000,
@@ -1224,7 +1224,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Opus 4.6 is Anthropic’s strongest model for coding and long-running professional tasks. It is built for agents that operate across entire workflows rather than single prompts, making it especially effective for large codebases, complex refactors, and multi-step debugging that unfolds over time. The model shows deeper contextual understanding, stronger problem decomposition, and greater reliability on hard engineering tasks than prior generations. Beyond coding, Opus 4.6 excels at sustained knowledge work. It produces near-production-ready documents, plans, and analyses in a single pass, and maintains coherence across very long outputs and extended sessions. This makes it a strong default for tasks that require persistence, judgment, and follow-through, such as technical design, migration planning, and end-to-end project execution. For users upgrading from earlier Opus versions, see our",
+      "description": "Opus 4.6 is Anthropic\u2019s strongest model for coding and long-running professional tasks. It is built for agents that operate across entire workflows rather than single prompts, making it especially effective for large codebases, complex refactors, and multi-step debugging that unfolds over time. The model shows deeper contextual understanding, stronger problem decomposition, and greater reliability on hard engineering tasks than prior generations. Beyond coding, Opus 4.6 excels at sustained knowledge work. It produces near-production-ready documents, plans, and analyses in a single pass, and maintains coherence across very long outputs and extended sessions. This makes it a strong default for tasks that require persistence, judgment, and follow-through, such as technical design, migration planning, and end-to-end project execution. For users upgrading from earlier Opus versions, see our",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -1246,9 +1246,9 @@
       "name": "Qwen: Qwen3 Coder Next",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.2e-7,
-        "outputCostPerToken": 7.5e-7,
-        "inputCacheReadPerToken": 6e-8
+        "inputCostPerToken": 1.2e-07,
+        "outputCostPerToken": 7.5e-07,
+        "inputCacheReadPerToken": 6e-08
       },
       "contextLength": 262144,
       "maxCompletionTokens": 65536,
@@ -1328,9 +1328,9 @@
       "name": "StepFun: Step 3.5 Flash",
       "provider": "stepfun",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 3e-7,
-        "inputCacheReadPerToken": 2e-8
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 3e-07,
+        "inputCacheReadPerToken": 2e-08
       },
       "contextLength": 256000,
       "maxCompletionTokens": 256000,
@@ -1362,9 +1362,9 @@
       "name": "MoonshotAI: Kimi K2.5",
       "provider": "moonshotai",
       "pricing": {
-        "inputCostPerToken": 4.5e-7,
-        "outputCostPerToken": 0.0000022,
-        "inputCacheReadPerToken": 2.25e-7
+        "inputCostPerToken": 4.5e-07,
+        "outputCostPerToken": 2.2e-06,
+        "inputCacheReadPerToken": 2.25e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": 65535,
@@ -1409,9 +1409,9 @@
       "name": "Upstage: Solar Pro 3",
       "provider": "upstage",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 6e-7,
-        "inputCacheReadPerToken": 1.5e-8
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 6e-07,
+        "inputCacheReadPerToken": 1.5e-08
       },
       "contextLength": 128000,
       "maxCompletionTokens": null,
@@ -1443,9 +1443,9 @@
       "name": "MiniMax: MiniMax M2-her",
       "provider": "minimax",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 0.0000012,
-        "inputCacheReadPerToken": 3e-8
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 1.2e-06,
+        "inputCacheReadPerToken": 3e-08
       },
       "contextLength": 65536,
       "maxCompletionTokens": 2048,
@@ -1472,8 +1472,8 @@
       "name": "Writer: Palmyra X5",
       "provider": "writer",
       "pricing": {
-        "inputCostPerToken": 6e-7,
-        "outputCostPerToken": 0.000006
+        "inputCostPerToken": 6e-07,
+        "outputCostPerToken": 6e-06
       },
       "contextLength": 1040000,
       "maxCompletionTokens": 8192,
@@ -1502,9 +1502,9 @@
       "name": "OpenAI: GPT Audio",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001,
-        "audioCostPerToken": 0.000032
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05,
+        "audioCostPerToken": 3.2e-05
       },
       "contextLength": 128000,
       "maxCompletionTokens": 16384,
@@ -1540,9 +1540,9 @@
       "name": "OpenAI: GPT Audio Mini",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 6e-7,
-        "outputCostPerToken": 0.0000024,
-        "audioCostPerToken": 6e-7
+        "inputCostPerToken": 6e-07,
+        "outputCostPerToken": 2.4e-06,
+        "audioCostPerToken": 6e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": 16384,
@@ -1578,9 +1578,9 @@
       "name": "Z.ai: GLM 4.7 Flash",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 6e-8,
-        "outputCostPerToken": 4e-7,
-        "inputCacheReadPerToken": 1.00000002e-8
+        "inputCostPerToken": 6e-08,
+        "outputCostPerToken": 4e-07,
+        "inputCacheReadPerToken": 1.00000002e-08
       },
       "contextLength": 202752,
       "maxCompletionTokens": null,
@@ -1620,9 +1620,9 @@
       "name": "OpenAI: GPT-5.2-Codex",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000175,
-        "outputCostPerToken": 0.000014,
-        "inputCacheReadPerToken": 1.75e-7,
+        "inputCostPerToken": 1.75e-06,
+        "outputCostPerToken": 1.4e-05,
+        "inputCacheReadPerToken": 1.75e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -1644,7 +1644,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "GPT-5.2-Codex is an upgraded version of GPT-5.1-Codex optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks. The model supports building projects from scratch, feature development, debugging, large-scale refactoring, and code review. Compared to GPT-5.1-Codex, 5.2-Codex is more steerable, adheres closely to developer instructions, and produces cleaner, higher-quality code outputs. Reasoning effort can be adjusted with the `reasoning.effort` parameter. Read the Codex integrates into developer environments including the CLI, IDE extensions, GitHub, and cloud tasks. It adapts reasoning effort dynamically—providing fast responses for small tasks while sustaining extended multi-hour runs for large projects. The model is trained to perform structured code reviews, catching critical flaws by reasoning over dependencies and validating behavior against tests. It also supports multimodal inputs such as images or screenshots for UI development and integrates tool use for search, dependency installation, and environment setup. Codex is intended specifically for agentic coding applications.",
+      "description": "GPT-5.2-Codex is an upgraded version of GPT-5.1-Codex optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks. The model supports building projects from scratch, feature development, debugging, large-scale refactoring, and code review. Compared to GPT-5.1-Codex, 5.2-Codex is more steerable, adheres closely to developer instructions, and produces cleaner, higher-quality code outputs. Reasoning effort can be adjusted with the `reasoning.effort` parameter. Read the Codex integrates into developer environments including the CLI, IDE extensions, GitHub, and cloud tasks. It adapts reasoning effort dynamically\u2014providing fast responses for small tasks while sustaining extended multi-hour runs for large projects. The model is trained to perform structured code reviews, catching critical flaws by reasoning over dependencies and validating behavior against tests. It also supports multimodal inputs such as images or screenshots for UI development and integrates tool use for search, dependency installation, and environment setup. Codex is intended specifically for agentic coding applications.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -1668,8 +1668,8 @@
       "name": "AllenAI: Molmo2 8B",
       "provider": "allenai",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 2e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 2e-07
       },
       "contextLength": 36864,
       "maxCompletionTokens": 36864,
@@ -1703,8 +1703,8 @@
       "name": "AllenAI: Olmo 3.1 32B Instruct",
       "provider": "allenai",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 6e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 6e-07
       },
       "contextLength": 65536,
       "maxCompletionTokens": null,
@@ -1731,7 +1731,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Olmo 3.1 32B Instruct is a large-scale, 32-billion-parameter instruction-tuned language model engineered for high-performance conversational AI, multi-turn dialogue, and practical instruction following. As part of the Olmo 3.1 family, this variant emphasizes responsiveness to complex user directions and robust chat interactions while retaining strong capabilities on reasoning and coding benchmarks. Developed by Ai2 under the Apache 2.0 license, Olmo 3.1 32B Instruct reflects the Olmo initiative’s commitment to openness and transparency.",
+      "description": "Olmo 3.1 32B Instruct is a large-scale, 32-billion-parameter instruction-tuned language model engineered for high-performance conversational AI, multi-turn dialogue, and practical instruction following. As part of the Olmo 3.1 family, this variant emphasizes responsiveness to complex user directions and robust chat interactions while retaining strong capabilities on reasoning and coding benchmarks. Developed by Ai2 under the Apache 2.0 license, Olmo 3.1 32B Instruct reflects the Olmo initiative\u2019s commitment to openness and transparency.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -1742,8 +1742,8 @@
       "name": "ByteDance Seed: Seed 1.6 Flash",
       "provider": "bytedance-seed",
       "pricing": {
-        "inputCostPerToken": 7.5e-8,
-        "outputCostPerToken": 3e-7
+        "inputCostPerToken": 7.5e-08,
+        "outputCostPerToken": 3e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": 32768,
@@ -1778,8 +1778,8 @@
       "name": "ByteDance Seed: Seed 1.6",
       "provider": "bytedance-seed",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 0.000002
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 2e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": 32768,
@@ -1814,9 +1814,9 @@
       "name": "MiniMax: MiniMax M2.1",
       "provider": "minimax",
       "pricing": {
-        "inputCostPerToken": 2.7e-7,
-        "outputCostPerToken": 9.5e-7,
-        "inputCacheReadPerToken": 2.90000007e-8
+        "inputCostPerToken": 2.7e-07,
+        "outputCostPerToken": 9.5e-07,
+        "inputCacheReadPerToken": 2.90000007e-08
       },
       "contextLength": 196608,
       "maxCompletionTokens": null,
@@ -1848,7 +1848,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "MiniMax-M2.1 is a lightweight, state-of-the-art large language model optimized for coding, agentic workflows, and modern application development. With only 10 billion activated parameters, it delivers a major jump in real-world capability while maintaining exceptional latency, scalability, and cost efficiency. Compared to its predecessor, M2.1 delivers cleaner, more concise outputs and faster perceived response times. It shows leading multilingual coding performance across major systems and application languages, achieving 49.4% on Multi-SWE-Bench and 72.5% on SWE-Bench Multilingual, and serves as a versatile agent “brain” for IDEs, coding tools, and general-purpose assistance. To avoid degrading this model's performance, MiniMax highly recommends preserving reasoning between turns. Learn more about using reasoning_details to pass back reasoning in our .",
+      "description": "MiniMax-M2.1 is a lightweight, state-of-the-art large language model optimized for coding, agentic workflows, and modern application development. With only 10 billion activated parameters, it delivers a major jump in real-world capability while maintaining exceptional latency, scalability, and cost efficiency. Compared to its predecessor, M2.1 delivers cleaner, more concise outputs and faster perceived response times. It shows leading multilingual coding performance across major systems and application languages, achieving 49.4% on Multi-SWE-Bench and 72.5% on SWE-Bench Multilingual, and serves as a versatile agent \u201cbrain\u201d for IDEs, coding tools, and general-purpose assistance. To avoid degrading this model's performance, MiniMax highly recommends preserving reasoning between turns. Learn more about using reasoning_details to pass back reasoning in our .",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -1859,9 +1859,9 @@
       "name": "Z.ai: GLM 4.7",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 3.8e-7,
-        "outputCostPerToken": 0.00000198,
-        "inputCacheReadPerToken": 1.9e-7
+        "inputCostPerToken": 3.8e-07,
+        "outputCostPerToken": 1.98e-06,
+        "inputCacheReadPerToken": 1.9e-07
       },
       "contextLength": 202752,
       "maxCompletionTokens": null,
@@ -1891,7 +1891,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "GLM-4.7 is Z.ai’s latest flagship model, featuring upgrades in two key areas: enhanced programming capabilities and more stable multi-step reasoning/execution. It demonstrates significant improvements in executing complex agent tasks while delivering more natural conversational experiences and superior front-end aesthetics.",
+      "description": "GLM-4.7 is Z.ai\u2019s latest flagship model, featuring upgrades in two key areas: enhanced programming capabilities and more stable multi-step reasoning/execution. It demonstrates significant improvements in executing complex agent tasks while delivering more natural conversational experiences and superior front-end aesthetics.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -1902,13 +1902,13 @@
       "name": "Google: Gemini 3 Flash Preview",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 5e-7,
-        "outputCostPerToken": 0.000003,
-        "inputCacheReadPerToken": 5e-8,
-        "inputCacheWritePerToken": 8.333333333333334e-8,
-        "imageCostPerToken": 5e-7,
-        "audioCostPerToken": 0.000001,
-        "internalReasoningCostPerToken": 0.000003
+        "inputCostPerToken": 5e-07,
+        "outputCostPerToken": 3e-06,
+        "inputCacheReadPerToken": 5e-08,
+        "inputCacheWritePerToken": 8.333333333333334e-08,
+        "imageCostPerToken": 5e-07,
+        "audioCostPerToken": 1e-06,
+        "internalReasoningCostPerToken": 3e-06
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65536,
@@ -1953,8 +1953,8 @@
       "name": "Mistral: Mistral Small Creative",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 3e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 3e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -1980,8 +1980,8 @@
       "name": "AllenAI: Olmo 3.1 32B Think",
       "provider": "allenai",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 5e-7
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 5e-07
       },
       "contextLength": 65536,
       "maxCompletionTokens": 65536,
@@ -2008,7 +2008,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Olmo 3.1 32B Think is a large-scale, 32-billion-parameter model designed for deep reasoning, complex multi-step logic, and advanced instruction following. Building on the Olmo 3 series, version 3.1 delivers refined reasoning behavior and stronger performance across demanding evaluations and nuanced conversational tasks. Developed by Ai2 under the Apache 2.0 license, Olmo 3.1 32B Think continues the Olmo initiative’s commitment to openness, providing full transparency across model weights, code, and training methodology.",
+      "description": "Olmo 3.1 32B Think is a large-scale, 32-billion-parameter model designed for deep reasoning, complex multi-step logic, and advanced instruction following. Building on the Olmo 3 series, version 3.1 delivers refined reasoning behavior and stronger performance across demanding evaluations and nuanced conversational tasks. Developed by Ai2 under the Apache 2.0 license, Olmo 3.1 32B Think continues the Olmo initiative\u2019s commitment to openness, providing full transparency across model weights, code, and training methodology.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2019,9 +2019,9 @@
       "name": "Xiaomi: MiMo-V2-Flash",
       "provider": "xiaomi",
       "pricing": {
-        "inputCostPerToken": 9e-8,
-        "outputCostPerToken": 2.9e-7,
-        "inputCacheReadPerToken": 4.5e-8
+        "inputCostPerToken": 9e-08,
+        "outputCostPerToken": 2.9e-07,
+        "inputCacheReadPerToken": 4.5e-08
       },
       "contextLength": 262144,
       "maxCompletionTokens": 65536,
@@ -2060,8 +2060,8 @@
       "name": "NVIDIA: Nemotron 3 Nano 30B A3B",
       "provider": "nvidia",
       "pricing": {
-        "inputCostPerToken": 5e-8,
-        "outputCostPerToken": 2e-7
+        "inputCostPerToken": 5e-08,
+        "outputCostPerToken": 2e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": null,
@@ -2100,9 +2100,9 @@
       "name": "OpenAI: GPT-5.2 Chat",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000175,
-        "outputCostPerToken": 0.000014,
-        "inputCacheReadPerToken": 1.75e-7,
+        "inputCostPerToken": 1.75e-06,
+        "outputCostPerToken": 1.4e-05,
+        "inputCacheReadPerToken": 1.75e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 128000,
@@ -2122,7 +2122,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "GPT-5.2 Chat (AKA Instant) is the fast, lightweight member of the 5.2 family, optimized for low-latency chat while retaining strong general intelligence. It uses adaptive reasoning to selectively “think” on harder queries, improving accuracy on math, coding, and multi-step tasks without slowing down typical conversations. The model is warmer and more conversational by default, with better instruction following and more stable short-form reasoning. GPT-5.2 Chat is designed for high-throughput, interactive workloads where responsiveness and consistency matter more than deep deliberation.",
+      "description": "GPT-5.2 Chat (AKA Instant) is the fast, lightweight member of the 5.2 family, optimized for low-latency chat while retaining strong general intelligence. It uses adaptive reasoning to selectively \u201cthink\u201d on harder queries, improving accuracy on math, coding, and multi-step tasks without slowing down typical conversations. The model is warmer and more conversational by default, with better instruction following and more stable short-form reasoning. GPT-5.2 Chat is designed for high-throughput, interactive workloads where responsiveness and consistency matter more than deep deliberation.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2146,7 +2146,7 @@
       "name": "OpenAI: GPT-5.2 Pro",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000021,
+        "inputCostPerToken": 2.1e-05,
         "outputCostPerToken": 0.000168,
         "webSearchCostPerQuery": 0.01
       },
@@ -2169,7 +2169,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "GPT-5.2 Pro is OpenAI’s most advanced model, offering major improvements in agentic coding and long context performance over GPT-5 Pro. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy in high-stakes use cases. It supports test-time routing features and advanced prompt understanding, including user-specified intent like \"think hard about this.\" Improvements include reductions in hallucination, sycophancy, and better performance in coding, writing, and health-related tasks.",
+      "description": "GPT-5.2 Pro is OpenAI\u2019s most advanced model, offering major improvements in agentic coding and long context performance over GPT-5 Pro. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy in high-stakes use cases. It supports test-time routing features and advanced prompt understanding, including user-specified intent like \"think hard about this.\" Improvements include reductions in hallucination, sycophancy, and better performance in coding, writing, and health-related tasks.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2189,9 +2189,9 @@
       "name": "OpenAI: GPT-5.2",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000175,
-        "outputCostPerToken": 0.000014,
-        "inputCacheReadPerToken": 1.75e-7,
+        "inputCostPerToken": 1.75e-06,
+        "outputCostPerToken": 1.4e-05,
+        "inputCacheReadPerToken": 1.75e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -2237,8 +2237,8 @@
       "name": "Mistral: Devstral 2 2512",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.000002
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 2e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": null,
@@ -2262,7 +2262,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Devstral 2 is a state-of-the-art open-source model by Mistral AI specializing in agentic coding. It is a 123B-parameter dense transformer model supporting a 256K context window. Devstral 2 supports exploring codebases and orchestrating changes across multiple files while maintaining architecture-level context. It tracks framework dependencies, detects failures, and retries with corrections—solving challenges like bug fixing and modernizing legacy systems. The model can be fine-tuned to prioritize specific languages or optimize for large enterprise codebases. It is available under a modified MIT license.",
+      "description": "Devstral 2 is a state-of-the-art open-source model by Mistral AI specializing in agentic coding. It is a 123B-parameter dense transformer model supporting a 256K context window. Devstral 2 supports exploring codebases and orchestrating changes across multiple files while maintaining architecture-level context. It tracks framework dependencies, detects failures, and retries with corrections\u2014solving challenges like bug fixing and modernizing legacy systems. The model can be fine-tuned to prioritize specific languages or optimize for large enterprise codebases. It is available under a modified MIT license.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2273,8 +2273,8 @@
       "name": "Relace: Relace Search",
       "provider": "relace",
       "pricing": {
-        "inputCostPerToken": 0.000001,
-        "outputCostPerToken": 0.000003
+        "inputCostPerToken": 1e-06,
+        "outputCostPerToken": 3e-06
       },
       "contextLength": 256000,
       "maxCompletionTokens": 128000,
@@ -2305,8 +2305,8 @@
       "name": "Z.ai: GLM 4.6V",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 9e-7
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 9e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 131072,
@@ -2346,8 +2346,8 @@
       "name": "Nex AGI: DeepSeek V3.1 Nex N1",
       "provider": "nex-agi",
       "pricing": {
-        "inputCostPerToken": 2.7e-7,
-        "outputCostPerToken": 0.000001
+        "inputCostPerToken": 2.7e-07,
+        "outputCostPerToken": 1e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 163840,
@@ -2368,7 +2368,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "DeepSeek V3.1 Nex-N1 is the flagship release of the Nex-N1 series — a post-trained model designed to highlight agent autonomy, tool use, and real-world productivity. Nex-N1 demonstrates competitive performance across all evaluation scenarios, showing particularly strong results in practical coding and HTML generation tasks.",
+      "description": "DeepSeek V3.1 Nex-N1 is the flagship release of the Nex-N1 series \u2014 a post-trained model designed to highlight agent autonomy, tool use, and real-world productivity. Nex-N1 demonstrates competitive performance across all evaluation scenarios, showing particularly strong results in practical coding and HTML generation tasks.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2379,8 +2379,8 @@
       "name": "EssentialAI: Rnj 1 Instruct",
       "provider": "essentialai",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 1.5e-7
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 1.5e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -2442,9 +2442,9 @@
       "name": "OpenAI: GPT-5.1-Codex-Max",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7,
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -2466,7 +2466,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "GPT-5.1-Codex-Max is OpenAI’s latest agentic coding model, designed for long-running, high-context software development tasks. It is based on an updated version of the 5.1 reasoning stack and trained on agentic workflows spanning software engineering, mathematics, and research. GPT-5.1-Codex-Max delivers faster performance, improved reasoning, and higher token efficiency across the development lifecycle.",
+      "description": "GPT-5.1-Codex-Max is OpenAI\u2019s latest agentic coding model, designed for long-running, high-context software development tasks. It is based on an updated version of the 5.1 reasoning stack and trained on agentic workflows spanning software engineering, mathematics, and research. GPT-5.1-Codex-Max delivers faster performance, improved reasoning, and higher token efficiency across the development lifecycle.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2490,8 +2490,8 @@
       "name": "Amazon: Nova 2 Lite",
       "provider": "amazon",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 0.0000025
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 2.5e-06
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 65535,
@@ -2524,8 +2524,8 @@
       "name": "Mistral: Ministral 3 14B 2512",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 2e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 2e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": null,
@@ -2563,8 +2563,8 @@
       "name": "Mistral: Ministral 3 8B 2512",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 1.5e-7
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 1.5e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": null,
@@ -2602,8 +2602,8 @@
       "name": "Mistral: Ministral 3 3B 2512",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 1e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 1e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -2641,8 +2641,8 @@
       "name": "Mistral: Mistral Large 3 2512",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 5e-7,
-        "outputCostPerToken": 0.0000015
+        "inputCostPerToken": 5e-07,
+        "outputCostPerToken": 1.5e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": null,
@@ -2666,7 +2666,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Mistral Large 3 2512 is Mistral’s most capable model to date, featuring a sparse mixture-of-experts architecture with 41B active parameters (675B total), and released under the Apache 2.0 license.",
+      "description": "Mistral Large 3 2512 is Mistral\u2019s most capable model to date, featuring a sparse mixture-of-experts architecture with 41B active parameters (675B total), and released under the Apache 2.0 license.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2677,8 +2677,8 @@
       "name": "Arcee AI: Trinity Mini",
       "provider": "arcee-ai",
       "pricing": {
-        "inputCostPerToken": 4.5e-8,
-        "outputCostPerToken": 1.5e-7
+        "inputCostPerToken": 4.5e-08,
+        "outputCostPerToken": 1.5e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 131072,
@@ -2712,9 +2712,9 @@
       "name": "DeepSeek: DeepSeek V3.2 Speciale",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.0000012,
-        "inputCacheReadPerToken": 2e-7
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 1.2e-06,
+        "inputCacheReadPerToken": 2e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": 163840,
@@ -2753,9 +2753,9 @@
       "name": "DeepSeek: DeepSeek V3.2",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 2.6e-7,
-        "outputCostPerToken": 3.8e-7,
-        "inputCacheReadPerToken": 1.3e-7
+        "inputCostPerToken": 2.6e-07,
+        "outputCostPerToken": 3.8e-07,
+        "inputCacheReadPerToken": 1.3e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": null,
@@ -2798,8 +2798,8 @@
       "name": "Prime Intellect: INTELLECT-3",
       "provider": "prime-intellect",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 0.0000011
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 1.1e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 131072,
@@ -2839,10 +2839,10 @@
       "name": "Anthropic: Claude Opus 4.5",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000005,
-        "outputCostPerToken": 0.000025,
-        "inputCacheReadPerToken": 5e-7,
-        "inputCacheWritePerToken": 0.00000625,
+        "inputCostPerToken": 5e-06,
+        "outputCostPerToken": 2.5e-05,
+        "inputCacheReadPerToken": 5e-07,
+        "inputCacheWritePerToken": 6.25e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -2867,7 +2867,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "Claude Opus 4.5 is Anthropic’s frontier reasoning model optimized for complex software engineering, agentic workflows, and long-horizon computer use. It offers strong multimodal capabilities, competitive performance across real-world coding and reasoning benchmarks, and improved robustness to prompt injection. The model is designed to operate efficiently across varied effort levels, enabling developers to trade off speed, depth, and token usage depending on task requirements. It comes with a new parameter to control token efficiency, which can be accessed using the OpenRouter Verbosity parameter with low, medium, or high. Opus 4.5 supports advanced tool use, extended context management, and coordinated multi-agent setups, making it well-suited for autonomous research, debugging, multi-step planning, and spreadsheet/browser manipulation. It delivers substantial gains in structured reasoning, execution reliability, and alignment compared to prior Opus generations, while reducing token overhead and improving performance on long-running tasks.",
+      "description": "Claude Opus 4.5 is Anthropic\u2019s frontier reasoning model optimized for complex software engineering, agentic workflows, and long-horizon computer use. It offers strong multimodal capabilities, competitive performance across real-world coding and reasoning benchmarks, and improved robustness to prompt injection. The model is designed to operate efficiently across varied effort levels, enabling developers to trade off speed, depth, and token usage depending on task requirements. It comes with a new parameter to control token efficiency, which can be accessed using the OpenRouter Verbosity parameter with low, medium, or high. Opus 4.5 supports advanced tool use, extended context management, and coordinated multi-agent setups, making it well-suited for autonomous research, debugging, multi-step planning, and spreadsheet/browser manipulation. It delivers substantial gains in structured reasoning, execution reliability, and alignment compared to prior Opus generations, while reducing token overhead and improving performance on long-running tasks.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2889,8 +2889,8 @@
       "name": "AllenAI: Olmo 3 32B Think",
       "provider": "allenai",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 5e-7
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 5e-07
       },
       "contextLength": 65536,
       "maxCompletionTokens": 65536,
@@ -2917,7 +2917,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Olmo 3 32B Think is a large-scale, 32-billion-parameter model purpose-built for deep reasoning, complex logic chains and advanced instruction-following scenarios. Its capacity enables strong performance on demanding evaluation tasks and highly nuanced conversational reasoning. Developed by Ai2 under the Apache 2.0 license, Olmo 3 32B Think embodies the Olmo initiative’s commitment to openness, offering full transparency across weights, code and training methodology.",
+      "description": "Olmo 3 32B Think is a large-scale, 32-billion-parameter model purpose-built for deep reasoning, complex logic chains and advanced instruction-following scenarios. Its capacity enables strong performance on demanding evaluation tasks and highly nuanced conversational reasoning. Developed by Ai2 under the Apache 2.0 license, Olmo 3 32B Think embodies the Olmo initiative\u2019s commitment to openness, offering full transparency across weights, code and training methodology.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -2928,8 +2928,8 @@
       "name": "AllenAI: Olmo 3 7B Instruct",
       "provider": "allenai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 2e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 2e-07
       },
       "contextLength": 65536,
       "maxCompletionTokens": 65536,
@@ -2965,8 +2965,8 @@
       "name": "AllenAI: Olmo 3 7B Think",
       "provider": "allenai",
       "pricing": {
-        "inputCostPerToken": 1.2e-7,
-        "outputCostPerToken": 2e-7
+        "inputCostPerToken": 1.2e-07,
+        "outputCostPerToken": 2e-07
       },
       "contextLength": 65536,
       "maxCompletionTokens": 65536,
@@ -3004,13 +3004,13 @@
       "name": "Google: Nano Banana Pro (Gemini 3 Pro Image Preview)",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000012,
-        "inputCacheReadPerToken": 2e-7,
-        "inputCacheWritePerToken": 3.75e-7,
-        "imageCostPerToken": 0.000002,
-        "audioCostPerToken": 0.000002,
-        "internalReasoningCostPerToken": 0.000012
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 1.2e-05,
+        "inputCacheReadPerToken": 2e-07,
+        "inputCacheWritePerToken": 3.75e-07,
+        "imageCostPerToken": 2e-06,
+        "audioCostPerToken": 2e-06,
+        "internalReasoningCostPerToken": 1.2e-05
       },
       "contextLength": 65536,
       "maxCompletionTokens": 32768,
@@ -3032,7 +3032,7 @@
       },
       "modality": "text+image->text+image",
       "mode": "chat",
-      "description": "Nano Banana Pro is Google’s most advanced image-generation and editing model, built on Gemini 3 Pro. It extends the original Nano Banana with significantly improved multimodal reasoning, real-world grounding, and high-fidelity visual synthesis. The model generates context-rich graphics, from infographics and diagrams to cinematic composites, and can incorporate real-time information via Search grounding. It offers industry-leading text rendering in images (including long passages and multilingual layouts), consistent multi-image blending, and accurate identity preservation across up to five subjects. Nano Banana Pro adds fine-grained creative controls such as localized edits, lighting and focus adjustments, camera transformations, and support for 2K/4K outputs and flexible aspect ratios. It is designed for professional-grade design, product visualization, storyboarding, and complex multi-element compositions while remaining efficient for general image creation workflows.",
+      "description": "Nano Banana Pro is Google\u2019s most advanced image-generation and editing model, built on Gemini 3 Pro. It extends the original Nano Banana with significantly improved multimodal reasoning, real-world grounding, and high-fidelity visual synthesis. The model generates context-rich graphics, from infographics and diagrams to cinematic composites, and can incorporate real-time information via Search grounding. It offers industry-leading text rendering in images (including long passages and multilingual layouts), consistent multi-image blending, and accurate identity preservation across up to five subjects. Nano Banana Pro adds fine-grained creative controls such as localized edits, lighting and focus adjustments, camera transformations, and support for 2K/4K outputs and flexible aspect ratios. It is designed for professional-grade design, product visualization, storyboarding, and complex multi-element compositions while remaining efficient for general image creation workflows.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": true,
@@ -3053,9 +3053,9 @@
       "name": "xAI: Grok 4.1 Fast",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 5e-7,
-        "inputCacheReadPerToken": 5e-8,
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 5e-07,
+        "inputCacheReadPerToken": 5e-08,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 2000000,
@@ -3092,13 +3092,13 @@
       "name": "Google: Gemini 3 Pro Preview",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000012,
-        "inputCacheReadPerToken": 2e-7,
-        "inputCacheWritePerToken": 3.75e-7,
-        "imageCostPerToken": 0.000002,
-        "audioCostPerToken": 0.000002,
-        "internalReasoningCostPerToken": 0.000012
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 1.2e-05,
+        "inputCacheReadPerToken": 2e-07,
+        "inputCacheWritePerToken": 3.75e-07,
+        "imageCostPerToken": 2e-06,
+        "audioCostPerToken": 2e-06,
+        "internalReasoningCostPerToken": 1.2e-05
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65536,
@@ -3122,7 +3122,7 @@
       },
       "modality": "text+image+file+audio+video->text",
       "mode": "chat",
-      "description": "Gemini 3 Pro is Google’s flagship frontier model for high-precision multimodal reasoning, combining strong performance across text, image, video, audio, and code with a 1M-token context window. Reasoning Details must be preserved when using multi-turn tool calling, see our docs here: It delivers state-of-the-art benchmark results in general reasoning, STEM problem solving, factual QA, and multimodal understanding, including leading scores on LMArena, GPQA Diamond, MathArena Apex, MMMU-Pro, and Video-MMMU. Interactions emphasize depth and interpretability: the model is designed to infer intent with minimal prompting and produce direct, insight-focused responses. Built for advanced development and agentic workflows, Gemini 3 Pro provides robust tool-calling, long-horizon planning stability, and strong zero-shot generation for complex UI, visualization, and coding tasks. It excels at agentic coding (SWE-Bench Verified, Terminal-Bench 2.0), multimodal analysis, and structured long-form tasks such as research synthesis, planning, and interactive learning experiences. Suitable applications include autonomous agents, coding assistants, multimodal analytics, scientific reasoning, and high-context information processing.",
+      "description": "Gemini 3 Pro is Google\u2019s flagship frontier model for high-precision multimodal reasoning, combining strong performance across text, image, video, audio, and code with a 1M-token context window. Reasoning Details must be preserved when using multi-turn tool calling, see our docs here: It delivers state-of-the-art benchmark results in general reasoning, STEM problem solving, factual QA, and multimodal understanding, including leading scores on LMArena, GPQA Diamond, MathArena Apex, MMMU-Pro, and Video-MMMU. Interactions emphasize depth and interpretability: the model is designed to infer intent with minimal prompting and produce direct, insight-focused responses. Built for advanced development and agentic workflows, Gemini 3 Pro provides robust tool-calling, long-horizon planning stability, and strong zero-shot generation for complex UI, visualization, and coding tasks. It excels at agentic coding (SWE-Bench Verified, Terminal-Bench 2.0), multimodal analysis, and structured long-form tasks such as research synthesis, planning, and interactive learning experiences. Suitable applications include autonomous agents, coding assistants, multimodal analytics, scientific reasoning, and high-context information processing.",
       "supportsImageInput": true,
       "supportsAudioInput": true,
       "supportsImageOutput": false,
@@ -3143,8 +3143,8 @@
       "name": "Deep Cogito: Cogito v2.1 671B",
       "provider": "deepcogito",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00000125
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1.25e-06
       },
       "contextLength": 128000,
       "maxCompletionTokens": null,
@@ -3182,9 +3182,9 @@
       "name": "OpenAI: GPT-5.1",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7,
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -3229,9 +3229,9 @@
       "name": "OpenAI: GPT-5.1 Chat",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7,
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 128000,
@@ -3251,7 +3251,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "GPT-5.1 Chat (AKA Instant is the fast, lightweight member of the 5.1 family, optimized for low-latency chat while retaining strong general intelligence. It uses adaptive reasoning to selectively “think” on harder queries, improving accuracy on math, coding, and multi-step tasks without slowing down typical conversations. The model is warmer and more conversational by default, with better instruction following and more stable short-form reasoning. GPT-5.1 Chat is designed for high-throughput, interactive workloads where responsiveness and consistency matter more than deep deliberation.",
+      "description": "GPT-5.1 Chat (AKA Instant is the fast, lightweight member of the 5.1 family, optimized for low-latency chat while retaining strong general intelligence. It uses adaptive reasoning to selectively \u201cthink\u201d on harder queries, improving accuracy on math, coding, and multi-step tasks without slowing down typical conversations. The model is warmer and more conversational by default, with better instruction following and more stable short-form reasoning. GPT-5.1 Chat is designed for high-throughput, interactive workloads where responsiveness and consistency matter more than deep deliberation.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -3274,9 +3274,9 @@
       "name": "OpenAI: GPT-5.1-Codex",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07
       },
       "contextLength": 400000,
       "maxCompletionTokens": 128000,
@@ -3297,7 +3297,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "GPT-5.1-Codex is a specialized version of GPT-5.1 optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks. The model supports building projects from scratch, feature development, debugging, large-scale refactoring, and code review. Compared to GPT-5.1, Codex is more steerable, adheres closely to developer instructions, and produces cleaner, higher-quality code outputs. Reasoning effort can be adjusted with the `reasoning.effort` parameter. Read the Codex integrates into developer environments including the CLI, IDE extensions, GitHub, and cloud tasks. It adapts reasoning effort dynamically—providing fast responses for small tasks while sustaining extended multi-hour runs for large projects. The model is trained to perform structured code reviews, catching critical flaws by reasoning over dependencies and validating behavior against tests. It also supports multimodal inputs such as images or screenshots for UI development and integrates tool use for search, dependency installation, and environment setup. Codex is intended specifically for agentic coding applications.",
+      "description": "GPT-5.1-Codex is a specialized version of GPT-5.1 optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks. The model supports building projects from scratch, feature development, debugging, large-scale refactoring, and code review. Compared to GPT-5.1, Codex is more steerable, adheres closely to developer instructions, and produces cleaner, higher-quality code outputs. Reasoning effort can be adjusted with the `reasoning.effort` parameter. Read the Codex integrates into developer environments including the CLI, IDE extensions, GitHub, and cloud tasks. It adapts reasoning effort dynamically\u2014providing fast responses for small tasks while sustaining extended multi-hour runs for large projects. The model is trained to perform structured code reviews, catching critical flaws by reasoning over dependencies and validating behavior against tests. It also supports multimodal inputs such as images or screenshots for UI development and integrates tool use for search, dependency installation, and environment setup. Codex is intended specifically for agentic coding applications.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -3320,9 +3320,9 @@
       "name": "OpenAI: GPT-5.1-Codex-Mini",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 0.000002,
-        "inputCacheReadPerToken": 2.5e-8
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 2e-06,
+        "inputCacheReadPerToken": 2.5e-08
       },
       "contextLength": 400000,
       "maxCompletionTokens": 100000,
@@ -3366,9 +3366,9 @@
       "name": "Kwaipilot: KAT-Coder-Pro V1",
       "provider": "kwaipilot",
       "pricing": {
-        "inputCostPerToken": 2.07e-7,
-        "outputCostPerToken": 8.28e-7,
-        "inputCacheReadPerToken": 4.14e-8
+        "inputCostPerToken": 2.07e-07,
+        "outputCostPerToken": 8.28e-07,
+        "inputCacheReadPerToken": 4.14e-08
       },
       "contextLength": 256000,
       "maxCompletionTokens": 128000,
@@ -3407,9 +3407,9 @@
       "name": "MoonshotAI: Kimi K2 Thinking",
       "provider": "moonshotai",
       "pricing": {
-        "inputCostPerToken": 4.7e-7,
-        "outputCostPerToken": 0.000002,
-        "inputCacheReadPerToken": 1.41e-7
+        "inputCostPerToken": 4.7e-07,
+        "outputCostPerToken": 2e-06,
+        "inputCacheReadPerToken": 1.41e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -3439,7 +3439,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Kimi K2 Thinking is Moonshot AI’s most advanced open reasoning model to date, extending the K2 series into agentic, long-horizon reasoning. Built on the trillion-parameter Mixture-of-Experts (MoE) architecture introduced in Kimi K2, it activates 32 billion parameters per forward pass and supports 256 k-token context windows. The model is optimized for persistent step-by-step thought, dynamic tool invocation, and complex reasoning workflows that span hundreds of turns. It interleaves step-by-step reasoning with tool use, enabling autonomous research, coding, and writing that can persist for hundreds of sequential actions without drift. It sets new open-source benchmarks on HLE, BrowseComp, SWE-Multilingual, and LiveCodeBench, while maintaining stable multi-agent behavior through 200–300 tool calls. Built on a large-scale MoE architecture with MuonClip optimization, it combines strong reasoning depth with high inference efficiency for demanding agentic and analytical tasks.",
+      "description": "Kimi K2 Thinking is Moonshot AI\u2019s most advanced open reasoning model to date, extending the K2 series into agentic, long-horizon reasoning. Built on the trillion-parameter Mixture-of-Experts (MoE) architecture introduced in Kimi K2, it activates 32 billion parameters per forward pass and supports 256 k-token context windows. The model is optimized for persistent step-by-step thought, dynamic tool invocation, and complex reasoning workflows that span hundreds of turns. It interleaves step-by-step reasoning with tool use, enabling autonomous research, coding, and writing that can persist for hundreds of sequential actions without drift. It sets new open-source benchmarks on HLE, BrowseComp, SWE-Multilingual, and LiveCodeBench, while maintaining stable multi-agent behavior through 200\u2013300 tool calls. Built on a large-scale MoE architecture with MuonClip optimization, it combines strong reasoning depth with high inference efficiency for demanding agentic and analytical tasks.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -3450,9 +3450,9 @@
       "name": "Amazon: Nova Premier 1.0",
       "provider": "amazon",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.0000125,
-        "inputCacheReadPerToken": 6.25e-7
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1.25e-05,
+        "inputCacheReadPerToken": 6.25e-07
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 32000,
@@ -3471,7 +3471,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Amazon Nova Premier is the most capable of Amazon’s multimodal models for complex reasoning tasks and for use as the best teacher for distilling custom models.",
+      "description": "Amazon Nova Premier is the most capable of Amazon\u2019s multimodal models for complex reasoning tasks and for use as the best teacher for distilling custom models.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -3482,8 +3482,8 @@
       "name": "Perplexity: Sonar Pro Search",
       "provider": "perplexity",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
         "webSearchCostPerQuery": 0.018
       },
       "contextLength": 200000,
@@ -3518,8 +3518,8 @@
       "name": "Mistral: Voxtral Small 24B 2507",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 3e-7,
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 3e-07,
         "audioCostPerToken": 0.0001
       },
       "contextLength": 32000,
@@ -3555,9 +3555,9 @@
       "name": "OpenAI: gpt-oss-safeguard-20b",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 7.5e-8,
-        "outputCostPerToken": 3e-7,
-        "inputCacheReadPerToken": 3.7e-8
+        "inputCostPerToken": 7.5e-08,
+        "outputCostPerToken": 3e-07,
+        "inputCacheReadPerToken": 3.7e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": 65536,
@@ -3591,8 +3591,8 @@
       "name": "NVIDIA: Nemotron Nano 12B 2 VL",
       "provider": "nvidia",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 6e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 6e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -3618,7 +3618,7 @@
       },
       "modality": "text+image+video->text",
       "mode": "chat",
-      "description": "NVIDIA Nemotron Nano 2 VL is a 12-billion-parameter open multimodal reasoning model designed for video understanding and document intelligence. It introduces a hybrid Transformer-Mamba architecture, combining transformer-level accuracy with Mamba’s memory-efficient sequence modeling for significantly higher throughput and lower latency. The model supports inputs of text and multi-image documents, producing natural-language outputs. It is trained on high-quality NVIDIA-curated synthetic datasets optimized for optical-character recognition, chart reasoning, and multimodal comprehension. Nemotron Nano 2 VL achieves leading results on OCRBench v2 and scores ≈ 74 average across MMMU, MathVista, AI2D, OCRBench, OCR-Reasoning, ChartQA, DocVQA, and Video-MME—surpassing prior open VL baselines. With Efficient Video Sampling (EVS), it handles long-form videos while reducing inference cost. Open-weights, training data, and fine-tuning recipes are released under a permissive NVIDIA open license, with deployment supported across NeMo, NIM, and major inference runtimes.",
+      "description": "NVIDIA Nemotron Nano 2 VL is a 12-billion-parameter open multimodal reasoning model designed for video understanding and document intelligence. It introduces a hybrid Transformer-Mamba architecture, combining transformer-level accuracy with Mamba\u2019s memory-efficient sequence modeling for significantly higher throughput and lower latency. The model supports inputs of text and multi-image documents, producing natural-language outputs. It is trained on high-quality NVIDIA-curated synthetic datasets optimized for optical-character recognition, chart reasoning, and multimodal comprehension. Nemotron Nano 2 VL achieves leading results on OCRBench v2 and scores \u2248 74 average across MMMU, MathVista, AI2D, OCRBench, OCR-Reasoning, ChartQA, DocVQA, and Video-MME\u2014surpassing prior open VL baselines. With Efficient Video Sampling (EVS), it handles long-form videos while reducing inference cost. Open-weights, training data, and fine-tuning recipes are released under a permissive NVIDIA open license, with deployment supported across NeMo, NIM, and major inference runtimes.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -3629,9 +3629,9 @@
       "name": "MiniMax: MiniMax M2",
       "provider": "minimax",
       "pricing": {
-        "inputCostPerToken": 2.55e-7,
-        "outputCostPerToken": 0.000001,
-        "inputCacheReadPerToken": 3e-8
+        "inputCostPerToken": 2.55e-07,
+        "outputCostPerToken": 1e-06,
+        "inputCacheReadPerToken": 3e-08
       },
       "contextLength": 196608,
       "maxCompletionTokens": 196608,
@@ -3672,8 +3672,8 @@
       "name": "Qwen: Qwen3 VL 32B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.04e-7,
-        "outputCostPerToken": 4.16e-7
+        "inputCostPerToken": 1.04e-07,
+        "outputCostPerToken": 4.16e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -3705,8 +3705,8 @@
       "name": "LiquidAI: LFM2-8B-A1B",
       "provider": "liquid",
       "pricing": {
-        "inputCostPerToken": 1e-8,
-        "outputCostPerToken": 2e-8
+        "inputCostPerToken": 1e-08,
+        "outputCostPerToken": 2e-08
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -3729,7 +3729,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "LFM2-8B-A1B is an efficient on-device Mixture-of-Experts (MoE) model from Liquid AI’s LFM2 family, built for fast, high-quality inference on edge hardware. It uses 8.3B total parameters with only ~1.5B active per token, delivering strong performance while keeping compute and memory usage low—making it ideal for phones, tablets, and laptops.",
+      "description": "LFM2-8B-A1B is an efficient on-device Mixture-of-Experts (MoE) model from Liquid AI\u2019s LFM2 family, built for fast, high-quality inference on edge hardware. It uses 8.3B total parameters with only ~1.5B active per token, delivering strong performance while keeping compute and memory usage low\u2014making it ideal for phones, tablets, and laptops.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -3740,8 +3740,8 @@
       "name": "LiquidAI: LFM2-2.6B",
       "provider": "liquid",
       "pricing": {
-        "inputCostPerToken": 1e-8,
-        "outputCostPerToken": 2e-8
+        "inputCostPerToken": 1e-08,
+        "outputCostPerToken": 2e-08
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -3775,8 +3775,8 @@
       "name": "IBM: Granite 4.0 Micro",
       "provider": "ibm-granite",
       "pricing": {
-        "inputCostPerToken": 1.7e-8,
-        "outputCostPerToken": 1.1e-7
+        "inputCostPerToken": 1.7e-08,
+        "outputCostPerToken": 1.1e-07
       },
       "contextLength": 131000,
       "maxCompletionTokens": null,
@@ -3808,9 +3808,9 @@
       "name": "OpenAI: GPT-5 Image Mini",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.000002,
-        "inputCacheReadPerToken": 2.5e-7,
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 2e-06,
+        "inputCacheReadPerToken": 2.5e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -3862,10 +3862,10 @@
       "name": "Anthropic: Claude Haiku 4.5",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000001,
-        "outputCostPerToken": 0.000005,
-        "inputCacheReadPerToken": 1e-7,
-        "inputCacheWritePerToken": 0.00000125,
+        "inputCostPerToken": 1e-06,
+        "outputCostPerToken": 5e-06,
+        "inputCacheReadPerToken": 1e-07,
+        "inputCacheWritePerToken": 1.25e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -3890,7 +3890,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Claude Haiku 4.5 is Anthropic’s fastest and most efficient model, delivering near-frontier intelligence at a fraction of the cost and latency of larger Claude models. Matching Claude Sonnet 4’s performance across reasoning, coding, and computer-use tasks, Haiku 4.5 brings frontier-level capability to real-time and high-volume applications. It introduces extended thinking to the Haiku line; enabling controllable reasoning depth, summarized or interleaved thought output, and tool-assisted workflows with full support for coding, bash, web search, and computer-use tools. Scoring >73% on SWE-bench Verified, Haiku 4.5 ranks among the world’s best coding models while maintaining exceptional responsiveness for sub-agents, parallelized execution, and scaled deployment.",
+      "description": "Claude Haiku 4.5 is Anthropic\u2019s fastest and most efficient model, delivering near-frontier intelligence at a fraction of the cost and latency of larger Claude models. Matching Claude Sonnet 4\u2019s performance across reasoning, coding, and computer-use tasks, Haiku 4.5 brings frontier-level capability to real-time and high-volume applications. It introduces extended thinking to the Haiku line; enabling controllable reasoning depth, summarized or interleaved thought output, and tool-assisted workflows with full support for coding, bash, web search, and computer-use tools. Scoring >73% on SWE-bench Verified, Haiku 4.5 ranks among the world\u2019s best coding models while maintaining exceptional responsiveness for sub-agents, parallelized execution, and scaled deployment.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -3901,8 +3901,8 @@
       "name": "Qwen: Qwen3 VL 8B Thinking",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.17e-7,
-        "outputCostPerToken": 0.000001365
+        "inputCostPerToken": 1.17e-07,
+        "outputCostPerToken": 1.365e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -3936,8 +3936,8 @@
       "name": "Qwen: Qwen3 VL 8B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 8e-8,
-        "outputCostPerToken": 5e-7
+        "inputCostPerToken": 8e-08,
+        "outputCostPerToken": 5e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -3976,9 +3976,9 @@
       "name": "OpenAI: GPT-5 Image",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00001,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 0.00000125,
+        "inputCostPerToken": 1e-05,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -4030,9 +4030,9 @@
       "name": "OpenAI: o3 Deep Research",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00001,
-        "outputCostPerToken": 0.00004,
-        "inputCacheReadPerToken": 0.0000025,
+        "inputCostPerToken": 1e-05,
+        "outputCostPerToken": 4e-05,
+        "inputCacheReadPerToken": 2.5e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -4084,9 +4084,9 @@
       "name": "OpenAI: o4 Mini Deep Research",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000008,
-        "inputCacheReadPerToken": 5e-7,
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 8e-06,
+        "inputCacheReadPerToken": 5e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -4116,7 +4116,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "o4-mini-deep-research is OpenAI's faster, more affordable deep research model—ideal for tackling complex, multi-step research tasks. Note: This model always uses the 'web_search' tool which adds additional cost.",
+      "description": "o4-mini-deep-research is OpenAI's faster, more affordable deep research model\u2014ideal for tackling complex, multi-step research tasks. Note: This model always uses the 'web_search' tool which adds additional cost.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -4127,8 +4127,8 @@
       "name": "NVIDIA: Llama 3.3 Nemotron Super 49B V1.5",
       "provider": "nvidia",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 4e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 4e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -4152,7 +4152,7 @@
       "defaultParameters": null,
       "modality": "text->text",
       "mode": "chat",
-      "description": "Llama-3.3-Nemotron-Super-49B-v1.5 is a 49B-parameter, English-centric reasoning/chat model derived from Meta’s Llama-3.3-70B-Instruct with a 128K context. It’s post-trained for agentic workflows (RAG, tool calling) via SFT across math, code, science, and multi-turn chat, followed by multiple RL stages; Reward-aware Preference Optimization (RPO) for alignment, RL with Verifiable Rewards (RLVR) for step-wise reasoning, and iterative DPO to refine tool-use behavior. A distillation-driven Neural Architecture Search (“Puzzle”) replaces some attention blocks and varies FFN widths to shrink memory footprint and improve throughput, enabling single-GPU (H100/H200) deployment while preserving instruction following and CoT quality. In internal evaluations (NeMo-Skills, up to 16 runs, temp = 0.6, top_p = 0.95), the model reports strong reasoning/coding results, e.g., MATH500 pass@1 = 97.4, AIME-2024 = 87.5, AIME-2025 = 82.71, GPQA = 71.97, LiveCodeBench (24.10–25.02) = 73.58, and MMLU-Pro (CoT) = 79.53. The model targets practical inference efficiency (high tokens/s, reduced VRAM) with Transformers/vLLM support and explicit “reasoning on/off” modes (chat-first defaults, greedy recommended when disabled). Suitable for building agents, assistants, and long-context retrieval systems where balanced accuracy-to-cost and reliable tool use matter.",
+      "description": "Llama-3.3-Nemotron-Super-49B-v1.5 is a 49B-parameter, English-centric reasoning/chat model derived from Meta\u2019s Llama-3.3-70B-Instruct with a 128K context. It\u2019s post-trained for agentic workflows (RAG, tool calling) via SFT across math, code, science, and multi-turn chat, followed by multiple RL stages; Reward-aware Preference Optimization (RPO) for alignment, RL with Verifiable Rewards (RLVR) for step-wise reasoning, and iterative DPO to refine tool-use behavior. A distillation-driven Neural Architecture Search (\u201cPuzzle\u201d) replaces some attention blocks and varies FFN widths to shrink memory footprint and improve throughput, enabling single-GPU (H100/H200) deployment while preserving instruction following and CoT quality. In internal evaluations (NeMo-Skills, up to 16 runs, temp = 0.6, top_p = 0.95), the model reports strong reasoning/coding results, e.g., MATH500 pass@1 = 97.4, AIME-2024 = 87.5, AIME-2025 = 82.71, GPQA = 71.97, LiveCodeBench (24.10\u201325.02) = 73.58, and MMLU-Pro (CoT) = 79.53. The model targets practical inference efficiency (high tokens/s, reduced VRAM) with Transformers/vLLM support and explicit \u201creasoning on/off\u201d modes (chat-first defaults, greedy recommended when disabled). Suitable for building agents, assistants, and long-context retrieval systems where balanced accuracy-to-cost and reliable tool use matter.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -4163,8 +4163,8 @@
       "name": "Baidu: ERNIE 4.5 21B A3B Thinking",
       "provider": "baidu",
       "pricing": {
-        "inputCostPerToken": 7e-8,
-        "outputCostPerToken": 2.8e-7
+        "inputCostPerToken": 7e-08,
+        "outputCostPerToken": 2.8e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 65536,
@@ -4199,13 +4199,13 @@
       "name": "Google: Nano Banana (Gemini 2.5 Flash Image)",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 0.0000025,
-        "inputCacheReadPerToken": 3e-8,
-        "inputCacheWritePerToken": 8.333333333333334e-8,
-        "imageCostPerToken": 3e-7,
-        "audioCostPerToken": 0.000001,
-        "internalReasoningCostPerToken": 0.0000025
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 2.5e-06,
+        "inputCacheReadPerToken": 3e-08,
+        "inputCacheWritePerToken": 8.333333333333334e-08,
+        "imageCostPerToken": 3e-07,
+        "audioCostPerToken": 1e-06,
+        "internalReasoningCostPerToken": 2.5e-06
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -4247,8 +4247,8 @@
       "name": "Qwen: Qwen3 VL 30B A3B Thinking",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.3e-7,
-        "outputCostPerToken": 0.00000156
+        "inputCostPerToken": 1.3e-07,
+        "outputCostPerToken": 1.56e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -4286,8 +4286,8 @@
       "name": "Qwen: Qwen3 VL 30B A3B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.3e-7,
-        "outputCostPerToken": 5.2e-7
+        "inputCostPerToken": 1.3e-07,
+        "outputCostPerToken": 5.2e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -4325,7 +4325,7 @@
       "name": "OpenAI: GPT-5 Pro",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000015,
+        "inputCostPerToken": 1.5e-05,
         "outputCostPerToken": 0.00012,
         "webSearchCostPerQuery": 0.01
       },
@@ -4348,7 +4348,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "GPT-5 Pro is OpenAI’s most advanced model, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy in high-stakes use cases. It supports test-time routing features and advanced prompt understanding, including user-specified intent like \"think hard about this.\" Improvements include reductions in hallucination, sycophancy, and better performance in coding, writing, and health-related tasks.",
+      "description": "GPT-5 Pro is OpenAI\u2019s most advanced model, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy in high-stakes use cases. It supports test-time routing features and advanced prompt understanding, including user-specified intent like \"think hard about this.\" Improvements include reductions in hallucination, sycophancy, and better performance in coding, writing, and health-related tasks.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -4368,8 +4368,8 @@
       "name": "Z.ai: GLM 4.6",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 3.9e-7,
-        "outputCostPerToken": 0.0000019
+        "inputCostPerToken": 3.9e-07,
+        "outputCostPerToken": 1.9e-06
       },
       "contextLength": 204800,
       "maxCompletionTokens": 204800,
@@ -4399,7 +4399,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Compared with GLM-4.5, this generation brings several key improvements: Longer context window: The context window has been expanded from 128K to 200K tokens, enabling the model to handle more complex agentic tasks. Superior coding performance: The model achieves higher scores on code benchmarks and demonstrates better real-world performance in applications such as Claude Code、Cline、Roo Code and Kilo Code, including improvements in generating visually polished front-end pages. Advanced reasoning: GLM-4.6 shows a clear improvement in reasoning performance and supports tool use during inference, leading to stronger overall capability. More capable agents: GLM-4.6 exhibits stronger performance in tool using and search-based agents, and integrates more effectively within agent frameworks. Refined writing: Better aligns with human preferences in style and readability, and performs more naturally in role-playing scenarios.",
+      "description": "Compared with GLM-4.5, this generation brings several key improvements: Longer context window: The context window has been expanded from 128K to 200K tokens, enabling the model to handle more complex agentic tasks. Superior coding performance: The model achieves higher scores on code benchmarks and demonstrates better real-world performance in applications such as Claude Code\u3001Cline\u3001Roo Code and Kilo Code, including improvements in generating visually polished front-end pages. Advanced reasoning: GLM-4.6 shows a clear improvement in reasoning performance and supports tool use during inference, leading to stronger overall capability. More capable agents: GLM-4.6 exhibits stronger performance in tool using and search-based agents, and integrates more effectively within agent frameworks. Refined writing: Better aligns with human preferences in style and readability, and performs more naturally in role-playing scenarios.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -4410,10 +4410,10 @@
       "name": "Anthropic: Claude Sonnet 4.5",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
-        "inputCacheReadPerToken": 3e-7,
-        "inputCacheWritePerToken": 0.00000375,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
+        "inputCacheReadPerToken": 3e-07,
+        "inputCacheWritePerToken": 3.75e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 1000000,
@@ -4438,7 +4438,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "Claude Sonnet 4.5 is Anthropic’s most advanced Sonnet model to date, optimized for real-world agents and coding workflows. It delivers state-of-the-art performance on coding benchmarks such as SWE-bench Verified, with improvements across system design, code security, and specification adherence. The model is designed for extended autonomous operation, maintaining task continuity across sessions and providing fact-based progress tracking. Sonnet 4.5 also introduces stronger agentic capabilities, including improved tool orchestration, speculative parallel execution, and more efficient context and memory management. With enhanced context tracking and awareness of token usage across tool calls, it is particularly well-suited for multi-context and long-running workflows. Use cases span software engineering, cybersecurity, financial analysis, research agents, and other domains requiring sustained reasoning and tool use.",
+      "description": "Claude Sonnet 4.5 is Anthropic\u2019s most advanced Sonnet model to date, optimized for real-world agents and coding workflows. It delivers state-of-the-art performance on coding benchmarks such as SWE-bench Verified, with improvements across system design, code security, and specification adherence. The model is designed for extended autonomous operation, maintaining task continuity across sessions and providing fact-based progress tracking. Sonnet 4.5 also introduces stronger agentic capabilities, including improved tool orchestration, speculative parallel execution, and more efficient context and memory management. With enhanced context tracking and awareness of token usage across tool calls, it is particularly well-suited for multi-context and long-running workflows. Use cases span software engineering, cybersecurity, financial analysis, research agents, and other domains requiring sustained reasoning and tool use.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -4449,8 +4449,8 @@
       "name": "DeepSeek: DeepSeek V3.2 Exp",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 2.7e-7,
-        "outputCostPerToken": 4.1e-7
+        "inputCostPerToken": 2.7e-07,
+        "outputCostPerToken": 4.1e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": 65536,
@@ -4491,8 +4491,8 @@
       "name": "TheDrummer: Cydonia 24B V4.1",
       "provider": "thedrummer",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 5e-7
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 5e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 131072,
@@ -4526,8 +4526,8 @@
       "name": "Relace: Relace Apply 3",
       "provider": "relace",
       "pricing": {
-        "inputCostPerToken": 8.5e-7,
-        "outputCostPerToken": 0.00000125
+        "inputCostPerToken": 8.5e-07,
+        "outputCostPerToken": 1.25e-06
       },
       "contextLength": 256000,
       "maxCompletionTokens": 128000,
@@ -4554,13 +4554,13 @@
       "name": "Google: Gemini 2.5 Flash Lite Preview 09-2025",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 4e-7,
-        "inputCacheReadPerToken": 1e-8,
-        "inputCacheWritePerToken": 8.333333333333334e-8,
-        "imageCostPerToken": 1e-7,
-        "audioCostPerToken": 3e-7,
-        "internalReasoningCostPerToken": 4e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 4e-07,
+        "inputCacheReadPerToken": 1e-08,
+        "inputCacheWritePerToken": 8.333333333333334e-08,
+        "imageCostPerToken": 1e-07,
+        "audioCostPerToken": 3e-07,
+        "internalReasoningCostPerToken": 4e-07
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65536,
@@ -4606,8 +4606,8 @@
       "name": "Qwen: Qwen3 VL 235B A22B Thinking",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2.6e-7,
-        "outputCostPerToken": 0.0000026
+        "inputCostPerToken": 2.6e-07,
+        "outputCostPerToken": 2.6e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -4646,9 +4646,9 @@
       "name": "Qwen: Qwen3 VL 235B A22B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 8.8e-7,
-        "inputCacheReadPerToken": 1.1e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 8.8e-07,
+        "inputCacheReadPerToken": 1.1e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": null,
@@ -4678,7 +4678,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Qwen3-VL-235B-A22B Instruct is an open-weight multimodal model that unifies strong text generation with visual understanding across images and video. The Instruct model targets general vision-language use (VQA, document parsing, chart/table extraction, multilingual OCR). The series emphasizes robust perception (recognition of diverse real-world and synthetic categories), spatial understanding (2D/3D grounding), and long-form visual comprehension, with competitive results on public multimodal benchmarks for both perception and reasoning. Beyond analysis, Qwen3-VL supports agentic interaction and tool use: it can follow complex instructions over multi-image, multi-turn dialogues; align text to video timelines for precise temporal queries; and operate GUI elements for automation tasks. The models also enable visual coding workflows—turning sketches or mockups into code and assisting with UI debugging—while maintaining strong text-only performance comparable to the flagship Qwen3 language models. This makes Qwen3-VL suitable for production scenarios spanning document AI, multilingual OCR, software/UI assistance, spatial/embodied tasks, and research on vision-language agents.",
+      "description": "Qwen3-VL-235B-A22B Instruct is an open-weight multimodal model that unifies strong text generation with visual understanding across images and video. The Instruct model targets general vision-language use (VQA, document parsing, chart/table extraction, multilingual OCR). The series emphasizes robust perception (recognition of diverse real-world and synthetic categories), spatial understanding (2D/3D grounding), and long-form visual comprehension, with competitive results on public multimodal benchmarks for both perception and reasoning. Beyond analysis, Qwen3-VL supports agentic interaction and tool use: it can follow complex instructions over multi-image, multi-turn dialogues; align text to video timelines for precise temporal queries; and operate GUI elements for automation tasks. The models also enable visual coding workflows\u2014turning sketches or mockups into code and assisting with UI debugging\u2014while maintaining strong text-only performance comparable to the flagship Qwen3 language models. This makes Qwen3-VL suitable for production scenarios spanning document AI, multilingual OCR, software/UI assistance, spatial/embodied tasks, and research on vision-language agents.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -4689,9 +4689,9 @@
       "name": "Qwen: Qwen3 Max",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 0.0000012,
-        "outputCostPerToken": 0.000006,
-        "inputCacheReadPerToken": 2.4e-7
+        "inputCostPerToken": 1.2e-06,
+        "outputCostPerToken": 6e-06,
+        "inputCacheReadPerToken": 2.4e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": 32768,
@@ -4712,7 +4712,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Qwen3-Max is an updated release built on the Qwen3 series, offering major improvements in reasoning, instruction following, multilingual support, and long-tail knowledge coverage compared to the January 2025 version. It delivers higher accuracy in math, coding, logic, and science tasks, follows complex instructions in Chinese and English more reliably, reduces hallucinations, and produces higher-quality responses for open-ended Q&A, writing, and conversation. The model supports over 100 languages with stronger translation and commonsense reasoning, and is optimized for retrieval-augmented generation (RAG) and tool calling, though it does not include a dedicated “thinking” mode.",
+      "description": "Qwen3-Max is an updated release built on the Qwen3 series, offering major improvements in reasoning, instruction following, multilingual support, and long-tail knowledge coverage compared to the January 2025 version. It delivers higher accuracy in math, coding, logic, and science tasks, follows complex instructions in Chinese and English more reliably, reduces hallucinations, and produces higher-quality responses for open-ended Q&A, writing, and conversation. The model supports over 100 languages with stronger translation and commonsense reasoning, and is optimized for retrieval-augmented generation (RAG) and tool calling, though it does not include a dedicated \u201cthinking\u201d mode.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -4723,9 +4723,9 @@
       "name": "Qwen: Qwen3 Coder Plus",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 6.5e-7,
-        "outputCostPerToken": 0.00000325,
-        "inputCacheReadPerToken": 1.3e-7
+        "inputCostPerToken": 6.5e-07,
+        "outputCostPerToken": 3.25e-06,
+        "inputCacheReadPerToken": 1.3e-07
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 65536,
@@ -4758,9 +4758,9 @@
       "name": "OpenAI: GPT-5 Codex",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07
       },
       "contextLength": 400000,
       "maxCompletionTokens": 128000,
@@ -4781,7 +4781,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "GPT-5-Codex is a specialized version of GPT-5 optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks. The model supports building projects from scratch, feature development, debugging, large-scale refactoring, and code review. Compared to GPT-5, Codex is more steerable, adheres closely to developer instructions, and produces cleaner, higher-quality code outputs. Reasoning effort can be adjusted with the `reasoning.effort` parameter. Read the Codex integrates into developer environments including the CLI, IDE extensions, GitHub, and cloud tasks. It adapts reasoning effort dynamically—providing fast responses for small tasks while sustaining extended multi-hour runs for large projects. The model is trained to perform structured code reviews, catching critical flaws by reasoning over dependencies and validating behavior against tests. It also supports multimodal inputs such as images or screenshots for UI development and integrates tool use for search, dependency installation, and environment setup. Codex is intended specifically for agentic coding applications.",
+      "description": "GPT-5-Codex is a specialized version of GPT-5 optimized for software engineering and coding workflows. It is designed for both interactive development sessions and long, independent execution of complex engineering tasks. The model supports building projects from scratch, feature development, debugging, large-scale refactoring, and code review. Compared to GPT-5, Codex is more steerable, adheres closely to developer instructions, and produces cleaner, higher-quality code outputs. Reasoning effort can be adjusted with the `reasoning.effort` parameter. Read the Codex integrates into developer environments including the CLI, IDE extensions, GitHub, and cloud tasks. It adapts reasoning effort dynamically\u2014providing fast responses for small tasks while sustaining extended multi-hour runs for large projects. The model is trained to perform structured code reviews, catching critical flaws by reasoning over dependencies and validating behavior against tests. It also supports multimodal inputs such as images or screenshots for UI development and integrates tool use for search, dependency installation, and environment setup. Codex is intended specifically for agentic coding applications.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -4803,9 +4803,9 @@
       "name": "DeepSeek: DeepSeek V3.1 Terminus",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 2.1e-7,
-        "outputCostPerToken": 7.9e-7,
-        "inputCacheReadPerToken": 1.300000002e-7
+        "inputCostPerToken": 2.1e-07,
+        "outputCostPerToken": 7.9e-07,
+        "inputCacheReadPerToken": 1.300000002e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": null,
@@ -4846,9 +4846,9 @@
       "name": "xAI: Grok 4 Fast",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 5e-7,
-        "inputCacheReadPerToken": 5e-8,
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 5e-07,
+        "inputCacheReadPerToken": 5e-08,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 2000000,
@@ -4885,9 +4885,9 @@
       "name": "Tongyi DeepResearch 30B A3B",
       "provider": "alibaba",
       "pricing": {
-        "inputCostPerToken": 9e-8,
-        "outputCostPerToken": 4.5e-7,
-        "inputCacheReadPerToken": 9e-8
+        "inputCostPerToken": 9e-08,
+        "outputCostPerToken": 4.5e-07,
+        "inputCacheReadPerToken": 9e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": 131072,
@@ -4928,9 +4928,9 @@
       "name": "Qwen: Qwen3 Coder Flash",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.95e-7,
-        "outputCostPerToken": 9.75e-7,
-        "inputCacheReadPerToken": 3.9e-8
+        "inputCostPerToken": 1.95e-07,
+        "outputCostPerToken": 9.75e-07,
+        "inputCacheReadPerToken": 3.9e-08
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 65536,
@@ -4962,8 +4962,8 @@
       "name": "Qwen: Qwen3 Next 80B A3B Thinking",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 9.75e-8,
-        "outputCostPerToken": 7.8e-7
+        "inputCostPerToken": 9.75e-08,
+        "outputCostPerToken": 7.8e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -4993,7 +4993,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Qwen3-Next-80B-A3B-Thinking is a reasoning-first chat model in the Qwen3-Next line that outputs structured “thinking” traces by default. It’s designed for hard multi-step problems; math proofs, code synthesis/debugging, logic, and agentic planning, and reports strong results across knowledge, reasoning, coding, alignment, and multilingual evaluations. Compared with prior Qwen3 variants, it emphasizes stability under long chains of thought and efficient scaling during inference, and it is tuned to follow complex instructions while reducing repetitive or off-task behavior. The model is suitable for agent frameworks and tool use (function calling), retrieval-heavy workflows, and standardized benchmarking where step-by-step solutions are required. It supports long, detailed completions and leverages throughput-oriented techniques (e.g., multi-token prediction) for faster generation. Note that it operates in thinking-only mode.",
+      "description": "Qwen3-Next-80B-A3B-Thinking is a reasoning-first chat model in the Qwen3-Next line that outputs structured \u201cthinking\u201d traces by default. It\u2019s designed for hard multi-step problems; math proofs, code synthesis/debugging, logic, and agentic planning, and reports strong results across knowledge, reasoning, coding, alignment, and multilingual evaluations. Compared with prior Qwen3 variants, it emphasizes stability under long chains of thought and efficient scaling during inference, and it is tuned to follow complex instructions while reducing repetitive or off-task behavior. The model is suitable for agent frameworks and tool use (function calling), retrieval-heavy workflows, and standardized benchmarking where step-by-step solutions are required. It supports long, detailed completions and leverages throughput-oriented techniques (e.g., multi-token prediction) for faster generation. Note that it operates in thinking-only mode.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5004,8 +5004,8 @@
       "name": "Qwen: Qwen3 Next 80B A3B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 9e-8,
-        "outputCostPerToken": 0.0000011
+        "inputCostPerToken": 9e-08,
+        "outputCostPerToken": 1.1e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -5029,7 +5029,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Qwen3-Next-80B-A3B-Instruct is an instruction-tuned chat model in the Qwen3-Next series optimized for fast, stable responses without “thinking” traces. It targets complex tasks across reasoning, code generation, knowledge QA, and multilingual use, while remaining robust on alignment and formatting. Compared with prior Qwen3 instruct variants, it focuses on higher throughput and stability on ultra-long inputs and multi-turn dialogues, making it well-suited for RAG, tool use, and agentic workflows that require consistent final answers rather than visible chain-of-thought. The model employs scaling-efficient training and decoding to improve parameter efficiency and inference speed, and has been validated on a broad set of public benchmarks where it reaches or approaches larger Qwen3 systems in several categories while outperforming earlier mid-sized baselines. It is best used as a general assistant, code helper, and long-context task solver in production settings where deterministic, instruction-following outputs are preferred.",
+      "description": "Qwen3-Next-80B-A3B-Instruct is an instruction-tuned chat model in the Qwen3-Next series optimized for fast, stable responses without \u201cthinking\u201d traces. It targets complex tasks across reasoning, code generation, knowledge QA, and multilingual use, while remaining robust on alignment and formatting. Compared with prior Qwen3 instruct variants, it focuses on higher throughput and stability on ultra-long inputs and multi-turn dialogues, making it well-suited for RAG, tool use, and agentic workflows that require consistent final answers rather than visible chain-of-thought. The model employs scaling-efficient training and decoding to improve parameter efficiency and inference speed, and has been validated on a broad set of public benchmarks where it reaches or approaches larger Qwen3 systems in several categories while outperforming earlier mid-sized baselines. It is best used as a general assistant, code helper, and long-context task solver in production settings where deterministic, instruction-following outputs are preferred.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5040,9 +5040,9 @@
       "name": "Meituan: LongCat Flash Chat",
       "provider": "meituan",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 8e-7,
-        "inputCacheReadPerToken": 2e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 8e-07,
+        "inputCacheReadPerToken": 2e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 131072,
@@ -5066,7 +5066,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "LongCat-Flash-Chat is a large-scale Mixture-of-Experts (MoE) model with 560B total parameters, of which 18.6B–31.3B (≈27B on average) are dynamically activated per input. It introduces a shortcut-connected MoE design to reduce communication overhead and achieve high throughput while maintaining training stability through advanced scaling strategies such as hyperparameter transfer, deterministic computation, and multi-stage optimization. This release, LongCat-Flash-Chat, is a non-thinking foundation model optimized for conversational and agentic tasks. It supports long context windows up to 128K tokens and shows competitive performance across reasoning, coding, instruction following, and domain benchmarks, with particular strengths in tool use and complex multi-step interactions.",
+      "description": "LongCat-Flash-Chat is a large-scale Mixture-of-Experts (MoE) model with 560B total parameters, of which 18.6B\u201331.3B (\u224827B on average) are dynamically activated per input. It introduces a shortcut-connected MoE design to reduce communication overhead and achieve high throughput while maintaining training stability through advanced scaling strategies such as hyperparameter transfer, deterministic computation, and multi-stage optimization. This release, LongCat-Flash-Chat, is a non-thinking foundation model optimized for conversational and agentic tasks. It supports long context windows up to 128K tokens and shows competitive performance across reasoning, coding, instruction following, and domain benchmarks, with particular strengths in tool use and complex multi-step interactions.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5077,8 +5077,8 @@
       "name": "Qwen: Qwen Plus 0728",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2.6e-7,
-        "outputCostPerToken": 7.8e-7
+        "inputCostPerToken": 2.6e-07,
+        "outputCostPerToken": 7.8e-07
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 32768,
@@ -5111,8 +5111,8 @@
       "name": "NVIDIA: Nemotron Nano 9B V2",
       "provider": "nvidia",
       "pricing": {
-        "inputCostPerToken": 4e-8,
-        "outputCostPerToken": 1.6e-7
+        "inputCostPerToken": 4e-08,
+        "outputCostPerToken": 1.6e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -5151,9 +5151,9 @@
       "name": "MoonshotAI: Kimi K2 0905",
       "provider": "moonshotai",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.000002,
-        "inputCacheReadPerToken": 1.5e-7
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 2e-06,
+        "inputCacheReadPerToken": 1.5e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -5190,8 +5190,8 @@
       "name": "Qwen: Qwen3 30B A3B Thinking 2507",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 5.1e-8,
-        "outputCostPerToken": 3.4e-7
+        "inputCostPerToken": 5.1e-08,
+        "outputCostPerToken": 3.4e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -5217,7 +5217,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Qwen3-30B-A3B-Thinking-2507 is a 30B parameter Mixture-of-Experts reasoning model optimized for complex tasks requiring extended multi-step thinking. The model is designed specifically for “thinking mode,” where internal reasoning traces are separated from final answers. Compared to earlier Qwen3-30B releases, this version improves performance across logical reasoning, mathematics, science, coding, and multilingual benchmarks. It also demonstrates stronger instruction following, tool use, and alignment with human preferences. With higher reasoning efficiency and extended output budgets, it is best suited for advanced research, competitive problem solving, and agentic applications requiring structured long-context reasoning.",
+      "description": "Qwen3-30B-A3B-Thinking-2507 is a 30B parameter Mixture-of-Experts reasoning model optimized for complex tasks requiring extended multi-step thinking. The model is designed specifically for \u201cthinking mode,\u201d where internal reasoning traces are separated from final answers. Compared to earlier Qwen3-30B releases, this version improves performance across logical reasoning, mathematics, science, coding, and multilingual benchmarks. It also demonstrates stronger instruction following, tool use, and alignment with human preferences. With higher reasoning efficiency and extended output budgets, it is best suited for advanced research, competitive problem solving, and agentic applications requiring structured long-context reasoning.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5228,9 +5228,9 @@
       "name": "xAI: Grok Code Fast 1",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 0.0000015,
-        "inputCacheReadPerToken": 2e-8,
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 1.5e-06,
+        "inputCacheReadPerToken": 2e-08,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 256000,
@@ -5264,8 +5264,8 @@
       "name": "Nous: Hermes 4 70B",
       "provider": "nousresearch",
       "pricing": {
-        "inputCostPerToken": 1.3e-7,
-        "outputCostPerToken": 4e-7
+        "inputCostPerToken": 1.3e-07,
+        "outputCostPerToken": 4e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -5295,8 +5295,8 @@
       "name": "Nous: Hermes 4 405B",
       "provider": "nousresearch",
       "pricing": {
-        "inputCostPerToken": 0.000001,
-        "outputCostPerToken": 0.000003
+        "inputCostPerToken": 1e-06,
+        "outputCostPerToken": 3e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -5326,8 +5326,8 @@
       "name": "DeepSeek: DeepSeek V3.1",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 7.5e-7
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 7.5e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 7168,
@@ -5366,9 +5366,9 @@
       "name": "OpenAI: GPT-4o Audio",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001,
-        "audioCostPerToken": 0.00004
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05,
+        "audioCostPerToken": 4e-05
       },
       "contextLength": 128000,
       "maxCompletionTokens": 16384,
@@ -5406,8 +5406,8 @@
       "name": "Mistral: Mistral Medium 3.1",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.000002
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 2e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -5429,7 +5429,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Mistral Medium 3.1 is an updated version of Mistral Medium 3, which is a high-performance enterprise-grade language model designed to deliver frontier-level capabilities at significantly reduced operational cost. It balances state-of-the-art reasoning and multimodal performance with 8× lower cost compared to traditional large models, making it suitable for scalable deployments across professional and industrial use cases. The model excels in domains such as coding, STEM reasoning, and enterprise adaptation. It supports hybrid, on-prem, and in-VPC deployments and is optimized for integration into custom workflows. Mistral Medium 3.1 offers competitive accuracy relative to larger models like Claude Sonnet 3.5/3.7, Llama 4 Maverick, and Command R+, while maintaining broad compatibility across cloud environments.",
+      "description": "Mistral Medium 3.1 is an updated version of Mistral Medium 3, which is a high-performance enterprise-grade language model designed to deliver frontier-level capabilities at significantly reduced operational cost. It balances state-of-the-art reasoning and multimodal performance with 8\u00d7 lower cost compared to traditional large models, making it suitable for scalable deployments across professional and industrial use cases. The model excels in domains such as coding, STEM reasoning, and enterprise adaptation. It supports hybrid, on-prem, and in-VPC deployments and is optimized for integration into custom workflows. Mistral Medium 3.1 offers competitive accuracy relative to larger models like Claude Sonnet 3.5/3.7, Llama 4 Maverick, and Command R+, while maintaining broad compatibility across cloud environments.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5440,8 +5440,8 @@
       "name": "Baidu: ERNIE 4.5 21B A3B",
       "provider": "baidu",
       "pricing": {
-        "inputCostPerToken": 7e-8,
-        "outputCostPerToken": 2.8e-7
+        "inputCostPerToken": 7e-08,
+        "outputCostPerToken": 2.8e-07
       },
       "contextLength": 120000,
       "maxCompletionTokens": 8000,
@@ -5476,8 +5476,8 @@
       "name": "Baidu: ERNIE 4.5 VL 28B A3B",
       "provider": "baidu",
       "pricing": {
-        "inputCostPerToken": 1.4e-7,
-        "outputCostPerToken": 5.6e-7
+        "inputCostPerToken": 1.4e-07,
+        "outputCostPerToken": 5.6e-07
       },
       "contextLength": 30000,
       "maxCompletionTokens": 8000,
@@ -5510,9 +5510,9 @@
       "name": "Z.ai: GLM 4.5V",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 6e-7,
-        "outputCostPerToken": 0.0000018,
-        "inputCacheReadPerToken": 1.1e-7
+        "inputCostPerToken": 6e-07,
+        "outputCostPerToken": 1.8e-06,
+        "inputCacheReadPerToken": 1.1e-07
       },
       "contextLength": 65536,
       "maxCompletionTokens": 16384,
@@ -5551,8 +5551,8 @@
       "name": "AI21: Jamba Large 1.7",
       "provider": "ai21",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000008
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 8e-06
       },
       "contextLength": 256000,
       "maxCompletionTokens": 4096,
@@ -5579,9 +5579,9 @@
       "name": "OpenAI: GPT-5 Chat",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7,
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 128000,
@@ -5617,9 +5617,9 @@
       "name": "OpenAI: GPT-5",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7,
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -5641,7 +5641,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "GPT-5 is OpenAI’s most advanced model, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy in high-stakes use cases. It supports test-time routing features and advanced prompt understanding, including user-specified intent like \"think hard about this.\" Improvements include reductions in hallucination, sycophancy, and better performance in coding, writing, and health-related tasks.",
+      "description": "GPT-5 is OpenAI\u2019s most advanced model, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy in high-stakes use cases. It supports test-time routing features and advanced prompt understanding, including user-specified intent like \"think hard about this.\" Improvements include reductions in hallucination, sycophancy, and better performance in coding, writing, and health-related tasks.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5663,9 +5663,9 @@
       "name": "OpenAI: GPT-5 Mini",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 0.000002,
-        "inputCacheReadPerToken": 2.5e-8,
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 2e-06,
+        "inputCacheReadPerToken": 2.5e-08,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -5709,9 +5709,9 @@
       "name": "OpenAI: GPT-5 Nano",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 5e-8,
-        "outputCostPerToken": 4e-7,
-        "inputCacheReadPerToken": 5e-9,
+        "inputCostPerToken": 5e-08,
+        "outputCostPerToken": 4e-07,
+        "inputCacheReadPerToken": 5e-09,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 400000,
@@ -5755,8 +5755,8 @@
       "name": "OpenAI: gpt-oss-120b",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 3.9e-8,
-        "outputCostPerToken": 1.9e-7
+        "inputCostPerToken": 3.9e-08,
+        "outputCostPerToken": 1.9e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -5800,8 +5800,8 @@
       "name": "OpenAI: gpt-oss-20b",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 3e-8,
-        "outputCostPerToken": 1.4e-7
+        "inputCostPerToken": 3e-08,
+        "outputCostPerToken": 1.4e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -5832,7 +5832,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "gpt-oss-20b is an open-weight 21B parameter model released by OpenAI under the Apache 2.0 license. It uses a Mixture-of-Experts (MoE) architecture with 3.6B active parameters per forward pass, optimized for lower-latency inference and deployability on consumer or single-GPU hardware. The model is trained in OpenAI’s Harmony response format and supports reasoning level configuration, fine-tuning, and agentic capabilities including function calling, tool use, and structured outputs.",
+      "description": "gpt-oss-20b is an open-weight 21B parameter model released by OpenAI under the Apache 2.0 license. It uses a Mixture-of-Experts (MoE) architecture with 3.6B active parameters per forward pass, optimized for lower-latency inference and deployability on consumer or single-GPU hardware. The model is trained in OpenAI\u2019s Harmony response format and supports reasoning level configuration, fine-tuning, and agentic capabilities including function calling, tool use, and structured outputs.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5843,10 +5843,10 @@
       "name": "Anthropic: Claude Opus 4.1",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000015,
-        "outputCostPerToken": 0.000075,
-        "inputCacheReadPerToken": 0.0000015,
-        "inputCacheWritePerToken": 0.00001875,
+        "inputCostPerToken": 1.5e-05,
+        "outputCostPerToken": 7.5e-05,
+        "inputCacheReadPerToken": 1.5e-06,
+        "inputCacheWritePerToken": 1.875e-05,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -5871,7 +5871,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "Claude Opus 4.1 is an updated version of Anthropic’s flagship model, offering improved performance in coding, reasoning, and agentic tasks. It achieves 74.5% on SWE-bench Verified and shows notable gains in multi-file code refactoring, debugging precision, and detail-oriented reasoning. The model supports extended thinking up to 64K tokens and is optimized for tasks involving research, data analysis, and tool-assisted reasoning.",
+      "description": "Claude Opus 4.1 is an updated version of Anthropic\u2019s flagship model, offering improved performance in coding, reasoning, and agentic tasks. It achieves 74.5% on SWE-bench Verified and shows notable gains in multi-file code refactoring, debugging precision, and detail-oriented reasoning. The model supports extended thinking up to 64K tokens and is optimized for tasks involving research, data analysis, and tool-assisted reasoning.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5893,8 +5893,8 @@
       "name": "Mistral: Codestral 2508",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 9e-7
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 9e-07
       },
       "contextLength": 256000,
       "maxCompletionTokens": null,
@@ -5927,8 +5927,8 @@
       "name": "Qwen: Qwen3 Coder 30B A3B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 7e-8,
-        "outputCostPerToken": 2.7e-7
+        "inputCostPerToken": 7e-08,
+        "outputCostPerToken": 2.7e-07
       },
       "contextLength": 160000,
       "maxCompletionTokens": 32768,
@@ -5950,7 +5950,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Qwen3-Coder-30B-A3B-Instruct is a 30.5B parameter Mixture-of-Experts (MoE) model with 128 experts (8 active per forward pass), designed for advanced code generation, repository-scale understanding, and agentic tool use. Built on the Qwen3 architecture, it supports a native context length of 256K tokens (extendable to 1M with Yarn) and performs strongly in tasks involving function calls, browser use, and structured code completion. This model is optimized for instruction-following without “thinking mode”, and integrates well with OpenAI-compatible tool-use formats.",
+      "description": "Qwen3-Coder-30B-A3B-Instruct is a 30.5B parameter Mixture-of-Experts (MoE) model with 128 experts (8 active per forward pass), designed for advanced code generation, repository-scale understanding, and agentic tool use. Built on the Qwen3 architecture, it supports a native context length of 256K tokens (extendable to 1M with Yarn) and performs strongly in tasks involving function calls, browser use, and structured code completion. This model is optimized for instruction-following without \u201cthinking mode\u201d, and integrates well with OpenAI-compatible tool-use formats.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -5961,8 +5961,8 @@
       "name": "Qwen: Qwen3 30B A3B Instruct 2507",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 9e-8,
-        "outputCostPerToken": 3e-7
+        "inputCostPerToken": 9e-08,
+        "outputCostPerToken": 3e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": 262144,
@@ -5997,9 +5997,9 @@
       "name": "Z.ai: GLM 4.5",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 6e-7,
-        "outputCostPerToken": 0.0000022,
-        "inputCacheReadPerToken": 1.1e-7
+        "inputCostPerToken": 6e-07,
+        "outputCostPerToken": 2.2e-06,
+        "inputCacheReadPerToken": 1.1e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 98304,
@@ -6038,9 +6038,9 @@
       "name": "Z.ai: GLM 4.5 Air",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 1.3e-7,
-        "outputCostPerToken": 8.5e-7,
-        "inputCacheReadPerToken": 2.5e-8
+        "inputCostPerToken": 1.3e-07,
+        "outputCostPerToken": 8.5e-07,
+        "inputCacheReadPerToken": 2.5e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": 98304,
@@ -6079,9 +6079,9 @@
       "name": "Qwen: Qwen3 235B A22B Thinking 2507",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.1e-7,
-        "outputCostPerToken": 6e-7,
-        "inputCacheReadPerToken": 5.5e-8
+        "inputCostPerToken": 1.1e-07,
+        "outputCostPerToken": 6e-07,
+        "inputCacheReadPerToken": 5.5e-08
       },
       "contextLength": 262144,
       "maxCompletionTokens": 262144,
@@ -6122,8 +6122,8 @@
       "name": "Z.ai: GLM 4 32B ",
       "provider": "z-ai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 1e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 1e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": null,
@@ -6152,9 +6152,9 @@
       "name": "Qwen: Qwen3 Coder 480B A35B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2.2e-7,
-        "outputCostPerToken": 0.000001,
-        "inputCacheReadPerToken": 2.2e-8
+        "inputCostPerToken": 2.2e-07,
+        "outputCostPerToken": 1e-06,
+        "inputCacheReadPerToken": 2.2e-08
       },
       "contextLength": 262144,
       "maxCompletionTokens": null,
@@ -6189,8 +6189,8 @@
       "name": "ByteDance: UI-TARS 7B ",
       "provider": "bytedance",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 2e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 2e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": 2048,
@@ -6220,13 +6220,13 @@
       "name": "Google: Gemini 2.5 Flash Lite",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 4e-7,
-        "inputCacheReadPerToken": 1e-8,
-        "inputCacheWritePerToken": 8.333333333333334e-8,
-        "imageCostPerToken": 1e-7,
-        "audioCostPerToken": 3e-7,
-        "internalReasoningCostPerToken": 4e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 4e-07,
+        "inputCacheReadPerToken": 1e-08,
+        "inputCacheWritePerToken": 8.333333333333334e-08,
+        "imageCostPerToken": 1e-07,
+        "audioCostPerToken": 3e-07,
+        "internalReasoningCostPerToken": 4e-07
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65535,
@@ -6272,8 +6272,8 @@
       "name": "Qwen: Qwen3 235B A22B Instruct 2507",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 7.1e-8,
-        "outputCostPerToken": 1e-7
+        "inputCostPerToken": 7.1e-08,
+        "outputCostPerToken": 1e-07
       },
       "contextLength": 262144,
       "maxCompletionTokens": null,
@@ -6312,8 +6312,8 @@
       "name": "Switchpoint Router",
       "provider": "switchpoint",
       "pricing": {
-        "inputCostPerToken": 8.5e-7,
-        "outputCostPerToken": 0.0000034
+        "inputCostPerToken": 8.5e-07,
+        "outputCostPerToken": 3.4e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -6341,8 +6341,8 @@
       "name": "MoonshotAI: Kimi K2 0711",
       "provider": "moonshotai",
       "pricing": {
-        "inputCostPerToken": 5.5e-7,
-        "outputCostPerToken": 0.0000022
+        "inputCostPerToken": 5.5e-07,
+        "outputCostPerToken": 2.2e-06
       },
       "contextLength": 131000,
       "maxCompletionTokens": null,
@@ -6378,8 +6378,8 @@
       "name": "Mistral: Devstral Medium",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.000002
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 2e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -6412,8 +6412,8 @@
       "name": "Mistral: Devstral Small 1.1",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 3e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 3e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -6446,9 +6446,9 @@
       "name": "xAI: Grok 4",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
-        "inputCacheReadPerToken": 7.5e-7,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
+        "inputCacheReadPerToken": 7.5e-07,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 256000,
@@ -6481,8 +6481,8 @@
       "name": "Tencent: Hunyuan A13B Instruct",
       "provider": "tencent",
       "pricing": {
-        "inputCostPerToken": 1.4e-7,
-        "outputCostPerToken": 5.7e-7
+        "inputCostPerToken": 1.4e-07,
+        "outputCostPerToken": 5.7e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 131072,
@@ -6510,9 +6510,9 @@
       "name": "TNG: DeepSeek R1T2 Chimera",
       "provider": "tngtech",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 8.5e-7,
-        "inputCacheReadPerToken": 1.25e-7
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 8.5e-07,
+        "inputCacheReadPerToken": 1.25e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": 163840,
@@ -6536,7 +6536,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "DeepSeek-TNG-R1T2-Chimera is the second-generation Chimera model from TNG Tech. It is a 671 B-parameter mixture-of-experts text-generation model assembled from DeepSeek-AI’s R1-0528, R1, and V3-0324 checkpoints with an Assembly-of-Experts merge. The tri-parent design yields strong reasoning performance while running roughly 20 % faster than the original R1 and more than 2× faster than R1-0528 under vLLM, giving a favorable cost-to-intelligence trade-off. The checkpoint supports contexts up to 60 k tokens in standard use (tested to ~130 k) and maintains consistent <think> token behaviour, making it suitable for long-context analysis, dialogue and other open-ended generation tasks.",
+      "description": "DeepSeek-TNG-R1T2-Chimera is the second-generation Chimera model from TNG Tech. It is a 671 B-parameter mixture-of-experts text-generation model assembled from DeepSeek-AI\u2019s R1-0528, R1, and V3-0324 checkpoints with an Assembly-of-Experts merge. The tri-parent design yields strong reasoning performance while running roughly 20 % faster than the original R1 and more than 2\u00d7 faster than R1-0528 under vLLM, giving a favorable cost-to-intelligence trade-off. The checkpoint supports contexts up to 60 k tokens in standard use (tested to ~130 k) and maintains consistent <think> token behaviour, making it suitable for long-context analysis, dialogue and other open-ended generation tasks.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -6547,8 +6547,8 @@
       "name": "Morph: Morph V3 Large",
       "provider": "morph",
       "pricing": {
-        "inputCostPerToken": 9e-7,
-        "outputCostPerToken": 0.0000019
+        "inputCostPerToken": 9e-07,
+        "outputCostPerToken": 1.9e-06
       },
       "contextLength": 262144,
       "maxCompletionTokens": 131072,
@@ -6575,8 +6575,8 @@
       "name": "Morph: Morph V3 Fast",
       "provider": "morph",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 0.0000012
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 1.2e-06
       },
       "contextLength": 81920,
       "maxCompletionTokens": 38000,
@@ -6603,8 +6603,8 @@
       "name": "Baidu: ERNIE 4.5 VL 424B A47B ",
       "provider": "baidu",
       "pricing": {
-        "inputCostPerToken": 4.2e-7,
-        "outputCostPerToken": 0.00000125
+        "inputCostPerToken": 4.2e-07,
+        "outputCostPerToken": 1.25e-06
       },
       "contextLength": 123000,
       "maxCompletionTokens": 16000,
@@ -6624,7 +6624,7 @@
       "defaultParameters": {},
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "ERNIE-4.5-VL-424B-A47B is a multimodal Mixture-of-Experts (MoE) model from Baidu’s ERNIE 4.5 series, featuring 424B total parameters with 47B active per token. It is trained jointly on text and image data using a heterogeneous MoE architecture and modality-isolated routing to enable high-fidelity cross-modal reasoning, image understanding, and long-context generation (up to 131k tokens). Fine-tuned with techniques like SFT, DPO, UPO, and RLVR, this model supports both “thinking” and non-thinking inference modes. Designed for vision-language tasks in English and Chinese, it is optimized for efficient scaling and can operate under 4-bit/8-bit quantization.",
+      "description": "ERNIE-4.5-VL-424B-A47B is a multimodal Mixture-of-Experts (MoE) model from Baidu\u2019s ERNIE 4.5 series, featuring 424B total parameters with 47B active per token. It is trained jointly on text and image data using a heterogeneous MoE architecture and modality-isolated routing to enable high-fidelity cross-modal reasoning, image understanding, and long-context generation (up to 131k tokens). Fine-tuned with techniques like SFT, DPO, UPO, and RLVR, this model supports both \u201cthinking\u201d and non-thinking inference modes. Designed for vision-language tasks in English and Chinese, it is optimized for efficient scaling and can operate under 4-bit/8-bit quantization.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -6635,8 +6635,8 @@
       "name": "Baidu: ERNIE 4.5 300B A47B ",
       "provider": "baidu",
       "pricing": {
-        "inputCostPerToken": 2.8e-7,
-        "outputCostPerToken": 0.0000011
+        "inputCostPerToken": 2.8e-07,
+        "outputCostPerToken": 1.1e-06
       },
       "contextLength": 123000,
       "maxCompletionTokens": 12000,
@@ -6667,9 +6667,9 @@
       "name": "Inception: Mercury",
       "provider": "inception",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 7.5e-7,
-        "inputCacheReadPerToken": 2.5e-8
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 7.5e-07,
+        "inputCacheReadPerToken": 2.5e-08
       },
       "contextLength": 128000,
       "maxCompletionTokens": 32000,
@@ -6700,9 +6700,9 @@
       "name": "Mistral: Mistral Small 3.2 24B",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 6e-8,
-        "outputCostPerToken": 1.8e-7,
-        "inputCacheReadPerToken": 3e-8
+        "inputCostPerToken": 6e-08,
+        "outputCostPerToken": 1.8e-07,
+        "inputCacheReadPerToken": 3e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": 131072,
@@ -6739,8 +6739,8 @@
       "name": "MiniMax: MiniMax M1",
       "provider": "minimax",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.0000022
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 2.2e-06
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 40000,
@@ -6766,7 +6766,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "MiniMax-M1 is a large-scale, open-weight reasoning model designed for extended context and high-efficiency inference. It leverages a hybrid Mixture-of-Experts (MoE) architecture paired with a custom \"lightning attention\" mechanism, allowing it to process long sequences—up to 1 million tokens—while maintaining competitive FLOP efficiency. With 456 billion total parameters and 45.9B active per token, this variant is optimized for complex, multi-step reasoning tasks. Trained via a custom reinforcement learning pipeline (CISPO), M1 excels in long-context understanding, software engineering, agentic tool use, and mathematical reasoning. Benchmarks show strong performance across FullStackBench, SWE-bench, MATH, GPQA, and TAU-Bench, often outperforming other open models like DeepSeek R1 and Qwen3-235B.",
+      "description": "MiniMax-M1 is a large-scale, open-weight reasoning model designed for extended context and high-efficiency inference. It leverages a hybrid Mixture-of-Experts (MoE) architecture paired with a custom \"lightning attention\" mechanism, allowing it to process long sequences\u2014up to 1 million tokens\u2014while maintaining competitive FLOP efficiency. With 456 billion total parameters and 45.9B active per token, this variant is optimized for complex, multi-step reasoning tasks. Trained via a custom reinforcement learning pipeline (CISPO), M1 excels in long-context understanding, software engineering, agentic tool use, and mathematical reasoning. Benchmarks show strong performance across FullStackBench, SWE-bench, MATH, GPQA, and TAU-Bench, often outperforming other open models like DeepSeek R1 and Qwen3-235B.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -6777,13 +6777,13 @@
       "name": "Google: Gemini 2.5 Flash",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 0.0000025,
-        "inputCacheReadPerToken": 3e-8,
-        "inputCacheWritePerToken": 8.333333333333334e-8,
-        "imageCostPerToken": 3e-7,
-        "audioCostPerToken": 0.000001,
-        "internalReasoningCostPerToken": 0.0000025
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 2.5e-06,
+        "inputCacheReadPerToken": 3e-08,
+        "inputCacheWritePerToken": 8.333333333333334e-08,
+        "imageCostPerToken": 3e-07,
+        "audioCostPerToken": 1e-06,
+        "internalReasoningCostPerToken": 2.5e-06
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65535,
@@ -6829,13 +6829,13 @@
       "name": "Google: Gemini 2.5 Pro",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7,
-        "inputCacheWritePerToken": 3.75e-7,
-        "imageCostPerToken": 0.00000125,
-        "audioCostPerToken": 0.00000125,
-        "internalReasoningCostPerToken": 0.00001
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07,
+        "inputCacheWritePerToken": 3.75e-07,
+        "imageCostPerToken": 1.25e-06,
+        "audioCostPerToken": 1.25e-06,
+        "internalReasoningCostPerToken": 1e-05
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65536,
@@ -6859,7 +6859,7 @@
       },
       "modality": "text+image+file+audio+video->text",
       "mode": "chat",
-      "description": "Gemini 2.5 Pro is Google’s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs “thinking” capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
+      "description": "Gemini 2.5 Pro is Google\u2019s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs \u201cthinking\u201d capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
       "supportsImageInput": true,
       "supportsAudioInput": true,
       "supportsImageOutput": false,
@@ -6880,8 +6880,8 @@
       "name": "OpenAI: o3 Pro",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00002,
-        "outputCostPerToken": 0.00008,
+        "inputCostPerToken": 2e-05,
+        "outputCostPerToken": 8e-05,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -6925,9 +6925,9 @@
       "name": "xAI: Grok 3 Mini",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 5e-7,
-        "inputCacheReadPerToken": 7.5e-8,
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 5e-07,
+        "inputCacheReadPerToken": 7.5e-08,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 131072,
@@ -6975,9 +6975,9 @@
       "name": "xAI: Grok 3",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
-        "inputCacheReadPerToken": 7.5e-7,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
+        "inputCacheReadPerToken": 7.5e-07,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 131072,
@@ -7011,13 +7011,13 @@
       "name": "Google: Gemini 2.5 Pro Preview 06-05",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7,
-        "inputCacheWritePerToken": 3.75e-7,
-        "imageCostPerToken": 0.00000125,
-        "audioCostPerToken": 0.00000125,
-        "internalReasoningCostPerToken": 0.00001
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07,
+        "inputCacheWritePerToken": 3.75e-07,
+        "imageCostPerToken": 1.25e-06,
+        "audioCostPerToken": 1.25e-06,
+        "internalReasoningCostPerToken": 1e-05
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65536,
@@ -7037,7 +7037,7 @@
       "defaultParameters": {},
       "modality": "text+image+file+audio->text",
       "mode": "chat",
-      "description": "Gemini 2.5 Pro is Google’s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs “thinking” capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
+      "description": "Gemini 2.5 Pro is Google\u2019s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs \u201cthinking\u201d capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
       "supportsImageInput": true,
       "supportsAudioInput": true,
       "supportsImageOutput": false,
@@ -7058,9 +7058,9 @@
       "name": "DeepSeek: R1 0528",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 4.5e-7,
-        "outputCostPerToken": 0.00000215,
-        "inputCacheReadPerToken": 2.25e-7
+        "inputCostPerToken": 4.5e-07,
+        "outputCostPerToken": 2.15e-06,
+        "inputCacheReadPerToken": 2.25e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": 65536,
@@ -7112,10 +7112,10 @@
       "name": "Anthropic: Claude Opus 4",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000015,
-        "outputCostPerToken": 0.000075,
-        "inputCacheReadPerToken": 0.0000015,
-        "inputCacheWritePerToken": 0.00001875,
+        "inputCostPerToken": 1.5e-05,
+        "outputCostPerToken": 7.5e-05,
+        "inputCacheReadPerToken": 1.5e-06,
+        "inputCacheWritePerToken": 1.875e-05,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -7138,7 +7138,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "Claude Opus 4 is benchmarked as the world’s best coding model, at time of release, bringing sustained performance on complex, long-running tasks and agent workflows. It sets new benchmarks in software engineering, achieving leading results on SWE-bench (72.5%) and Terminal-bench (43.2%). Opus 4 supports extended, agentic workflows, handling thousands of task steps continuously for hours without degradation. Read more at the [blog post here](https://www.anthropic.com/news/claude-4)",
+      "description": "Claude Opus 4 is benchmarked as the world\u2019s best coding model, at time of release, bringing sustained performance on complex, long-running tasks and agent workflows. It sets new benchmarks in software engineering, achieving leading results on SWE-bench (72.5%) and Terminal-bench (43.2%). Opus 4 supports extended, agentic workflows, handling thousands of task steps continuously for hours without degradation. Read more at the [blog post here](https://www.anthropic.com/news/claude-4)",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7160,10 +7160,10 @@
       "name": "Anthropic: Claude Sonnet 4",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
-        "inputCacheReadPerToken": 3e-7,
-        "inputCacheWritePerToken": 0.00000375,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
+        "inputCacheReadPerToken": 3e-07,
+        "inputCacheWritePerToken": 3.75e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -7197,8 +7197,8 @@
       "name": "Google: Gemma 3n 4B",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 2e-8,
-        "outputCostPerToken": 4e-8
+        "inputCostPerToken": 2e-08,
+        "outputCostPerToken": 4e-08
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -7217,7 +7217,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Gemma 3n E4B-it is optimized for efficient execution on mobile and low-resource devices, such as phones, laptops, and tablets. It supports multimodal inputs—including text, visual data, and audio—enabling diverse tasks such as text generation, speech recognition, translation, and image analysis. Leveraging innovations like Per-Layer Embedding (PLE) caching and the MatFormer architecture, Gemma 3n dynamically manages memory usage and computational load by selectively activating model parameters, significantly reducing runtime resource requirements. This model supports a wide linguistic range (trained in over 140 languages) and features a flexible 32K token context window. Gemma 3n can selectively load parameters, optimizing memory and computational efficiency based on the task or device capabilities, making it well-suited for privacy-focused, offline-capable applications and on-device AI solutions. [Read more in the blog post](https://developers.googleblog.com/en/introducing-gemma-3n/)",
+      "description": "Gemma 3n E4B-it is optimized for efficient execution on mobile and low-resource devices, such as phones, laptops, and tablets. It supports multimodal inputs\u2014including text, visual data, and audio\u2014enabling diverse tasks such as text generation, speech recognition, translation, and image analysis. Leveraging innovations like Per-Layer Embedding (PLE) caching and the MatFormer architecture, Gemma 3n dynamically manages memory usage and computational load by selectively activating model parameters, significantly reducing runtime resource requirements. This model supports a wide linguistic range (trained in over 140 languages) and features a flexible 32K token context window. Gemma 3n can selectively load parameters, optimizing memory and computational efficiency based on the task or device capabilities, making it well-suited for privacy-focused, offline-capable applications and on-device AI solutions. [Read more in the blog post](https://developers.googleblog.com/en/introducing-gemma-3n/)",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7228,8 +7228,8 @@
       "name": "Mistral: Mistral Medium 3",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.000002
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 2e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -7251,7 +7251,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Mistral Medium 3 is a high-performance enterprise-grade language model designed to deliver frontier-level capabilities at significantly reduced operational cost. It balances state-of-the-art reasoning and multimodal performance with 8× lower cost compared to traditional large models, making it suitable for scalable deployments across professional and industrial use cases. The model excels in domains such as coding, STEM reasoning, and enterprise adaptation. It supports hybrid, on-prem, and in-VPC deployments and is optimized for integration into custom workflows. Mistral Medium 3 offers competitive accuracy relative to larger models like Claude Sonnet 3.5/3.7, Llama 4 Maverick, and Command R+, while maintaining broad compatibility across cloud environments.",
+      "description": "Mistral Medium 3 is a high-performance enterprise-grade language model designed to deliver frontier-level capabilities at significantly reduced operational cost. It balances state-of-the-art reasoning and multimodal performance with 8\u00d7 lower cost compared to traditional large models, making it suitable for scalable deployments across professional and industrial use cases. The model excels in domains such as coding, STEM reasoning, and enterprise adaptation. It supports hybrid, on-prem, and in-VPC deployments and is optimized for integration into custom workflows. Mistral Medium 3 offers competitive accuracy relative to larger models like Claude Sonnet 3.5/3.7, Llama 4 Maverick, and Command R+, while maintaining broad compatibility across cloud environments.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7262,13 +7262,13 @@
       "name": "Google: Gemini 2.5 Pro Preview 05-06",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 0.00000125,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 1.25e-7,
-        "inputCacheWritePerToken": 3.75e-7,
-        "imageCostPerToken": 0.00000125,
-        "audioCostPerToken": 0.00000125,
-        "internalReasoningCostPerToken": 0.00001
+        "inputCostPerToken": 1.25e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-07,
+        "inputCacheWritePerToken": 3.75e-07,
+        "imageCostPerToken": 1.25e-06,
+        "audioCostPerToken": 1.25e-06,
+        "internalReasoningCostPerToken": 1e-05
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 65535,
@@ -7292,7 +7292,7 @@
       },
       "modality": "text+image+file+audio+video->text",
       "mode": "chat",
-      "description": "Gemini 2.5 Pro is Google’s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs “thinking” capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
+      "description": "Gemini 2.5 Pro is Google\u2019s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs \u201cthinking\u201d capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
       "supportsImageInput": true,
       "supportsAudioInput": true,
       "supportsImageOutput": false,
@@ -7313,8 +7313,8 @@
       "name": "Arcee AI: Spotlight",
       "provider": "arcee-ai",
       "pricing": {
-        "inputCostPerToken": 1.8e-7,
-        "outputCostPerToken": 1.8e-7
+        "inputCostPerToken": 1.8e-07,
+        "outputCostPerToken": 1.8e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 65537,
@@ -7333,7 +7333,7 @@
       "defaultParameters": {},
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Spotlight is a 7‑billion‑parameter vision‑language model derived from Qwen 2.5‑VL and fine‑tuned by Arcee AI for tight image‑text grounding tasks. It offers a 32 k‑token context window, enabling rich multimodal conversations that combine lengthy documents with one or more images. Training emphasized fast inference on consumer GPUs while retaining strong captioning, visual‐question‑answering, and diagram‑analysis accuracy. As a result, Spotlight slots neatly into agent workflows where screenshots, charts or UI mock‑ups need to be interpreted on the fly. Early benchmarks show it matching or out‑scoring larger VLMs such as LLaVA‑1.6 13 B on popular VQA and POPE alignment tests.",
+      "description": "Spotlight is a 7\u2011billion\u2011parameter vision\u2011language model derived from Qwen 2.5\u2011VL and fine\u2011tuned by Arcee AI for tight image\u2011text grounding tasks. It offers a 32 k\u2011token context window, enabling rich multimodal conversations that combine lengthy documents with one or more images. Training emphasized fast inference on consumer GPUs while retaining strong captioning, visual\u2010question\u2011answering, and diagram\u2011analysis accuracy. As a result, Spotlight slots neatly into agent workflows where screenshots, charts or UI mock\u2011ups need to be interpreted on the fly. Early benchmarks show it matching or out\u2011scoring larger VLMs such as LLaVA\u20111.6 13 B on popular VQA and POPE alignment tests.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7344,8 +7344,8 @@
       "name": "Arcee AI: Maestro Reasoning",
       "provider": "arcee-ai",
       "pricing": {
-        "inputCostPerToken": 9e-7,
-        "outputCostPerToken": 0.0000033
+        "inputCostPerToken": 9e-07,
+        "outputCostPerToken": 3.3e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32000,
@@ -7364,7 +7364,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Maestro Reasoning is Arcee's flagship analysis model: a 32 B‑parameter derivative of Qwen 2.5‑32 B tuned with DPO and chain‑of‑thought RL for step‑by‑step logic. Compared to the earlier 7 B preview, the production 32 B release widens the context window to 128 k tokens and doubles pass‑rate on MATH and GSM‑8K, while also lifting code completion accuracy. Its instruction style encourages structured \"thought → answer\" traces that can be parsed or hidden according to user preference. That transparency pairs well with audit‑focused industries like finance or healthcare where seeing the reasoning path matters. In Arcee Conductor, Maestro is automatically selected for complex, multi‑constraint queries that smaller SLMs bounce.",
+      "description": "Maestro Reasoning is Arcee's flagship analysis model: a 32 B\u2011parameter derivative of Qwen 2.5\u201132 B tuned with DPO and chain\u2011of\u2011thought RL for step\u2011by\u2011step logic. Compared to the earlier 7 B preview, the production 32 B release widens the context window to 128 k tokens and doubles pass\u2011rate on MATH and GSM\u20118K, while also lifting code completion accuracy. Its instruction style encourages structured \"thought \u2192 answer\" traces that can be parsed or hidden according to user preference. That transparency pairs well with audit\u2011focused industries like finance or healthcare where seeing the reasoning path matters. In Arcee Conductor, Maestro is automatically selected for complex, multi\u2011constraint queries that smaller SLMs bounce.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7375,8 +7375,8 @@
       "name": "Arcee AI: Virtuoso Large",
       "provider": "arcee-ai",
       "pricing": {
-        "inputCostPerToken": 7.5e-7,
-        "outputCostPerToken": 0.0000012
+        "inputCostPerToken": 7.5e-07,
+        "outputCostPerToken": 1.2e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 64000,
@@ -7397,7 +7397,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Virtuoso‑Large is Arcee's top‑tier general‑purpose LLM at 72 B parameters, tuned to tackle cross‑domain reasoning, creative writing and enterprise QA. Unlike many 70 B peers, it retains the 128 k context inherited from Qwen 2.5, letting it ingest books, codebases or financial filings wholesale. Training blended DeepSeek R1 distillation, multi‑epoch supervised fine‑tuning and a final DPO/RLHF alignment stage, yielding strong performance on BIG‑Bench‑Hard, GSM‑8K and long‑context Needle‑In‑Haystack tests. Enterprises use Virtuoso‑Large as the \"fallback\" brain in Conductor pipelines when other SLMs flag low confidence. Despite its size, aggressive KV‑cache optimizations keep first‑token latency in the low‑second range on 8× H100 nodes, making it a practical production‑grade powerhouse.",
+      "description": "Virtuoso\u2011Large is Arcee's top\u2011tier general\u2011purpose LLM at 72 B parameters, tuned to tackle cross\u2011domain reasoning, creative writing and enterprise QA. Unlike many 70 B peers, it retains the 128 k context inherited from Qwen 2.5, letting it ingest books, codebases or financial filings wholesale. Training blended DeepSeek R1 distillation, multi\u2011epoch supervised fine\u2011tuning and a final DPO/RLHF alignment stage, yielding strong performance on BIG\u2011Bench\u2011Hard, GSM\u20118K and long\u2011context Needle\u2011In\u2011Haystack tests. Enterprises use Virtuoso\u2011Large as the \"fallback\" brain in Conductor pipelines when other SLMs flag low confidence. Despite its size, aggressive KV\u2011cache optimizations keep first\u2011token latency in the low\u2011second range on 8\u00d7 H100 nodes, making it a practical production\u2011grade powerhouse.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7408,8 +7408,8 @@
       "name": "Arcee AI: Coder Large",
       "provider": "arcee-ai",
       "pricing": {
-        "inputCostPerToken": 5e-7,
-        "outputCostPerToken": 8e-7
+        "inputCostPerToken": 5e-07,
+        "outputCostPerToken": 8e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -7428,7 +7428,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Coder‑Large is a 32 B‑parameter offspring of Qwen 2.5‑Instruct that has been further trained on permissively‑licensed GitHub, CodeSearchNet and synthetic bug‑fix corpora. It supports a 32k context window, enabling multi‑file refactoring or long diff review in a single call, and understands 30‑plus programming languages with special attention to TypeScript, Go and Terraform. Internal benchmarks show 5–8 pt gains over CodeLlama‑34 B‑Python on HumanEval and competitive BugFix scores thanks to a reinforcement pass that rewards compilable output. The model emits structured explanations alongside code blocks by default, making it suitable for educational tooling as well as production copilot scenarios. Cost‑wise, Together AI prices it well below proprietary incumbents, so teams can scale interactive coding without runaway spend.",
+      "description": "Coder\u2011Large is a 32 B\u2011parameter offspring of Qwen 2.5\u2011Instruct that has been further trained on permissively\u2011licensed GitHub, CodeSearchNet and synthetic bug\u2011fix corpora. It supports a 32k context window, enabling multi\u2011file refactoring or long diff review in a single call, and understands 30\u2011plus programming languages with special attention to TypeScript, Go and Terraform. Internal benchmarks show 5\u20138 pt gains over CodeLlama\u201134 B\u2011Python on HumanEval and competitive BugFix scores thanks to a reinforcement pass that rewards compilable output. The model emits structured explanations alongside code blocks by default, making it suitable for educational tooling as well as production copilot scenarios. Cost\u2011wise, Together AI prices it well below proprietary incumbents, so teams can scale interactive coding without runaway spend.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7439,9 +7439,9 @@
       "name": "Inception: Mercury Coder",
       "provider": "inception",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 7.5e-7,
-        "inputCacheReadPerToken": 2.5e-8
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 7.5e-07,
+        "inputCacheReadPerToken": 2.5e-08
       },
       "contextLength": 128000,
       "maxCompletionTokens": 32000,
@@ -7472,8 +7472,8 @@
       "name": "Meta: Llama Guard 4 12B",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 1.8e-7,
-        "outputCostPerToken": 1.8e-7
+        "inputCostPerToken": 1.8e-07,
+        "outputCostPerToken": 1.8e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": null,
@@ -7494,7 +7494,7 @@
       "defaultParameters": {},
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Llama Guard 4 is a Llama 4 Scout-derived multimodal pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM inputs (prompt classification) and in LLM responses (response classification). It acts as an LLM—generating text in its output that indicates whether a given prompt or response is safe or unsafe, and if unsafe, it also lists the content categories violated. Llama Guard 4 was aligned to safeguard against the standardized MLCommons hazards taxonomy and designed to support multimodal Llama 4 capabilities. Specifically, it combines features from previous Llama Guard models, providing content moderation for English and multiple supported languages, along with enhanced capabilities to handle mixed text-and-image prompts, including multiple images. Additionally, Llama Guard 4 is integrated into the Llama Moderations API, extending robust safety classification to text and images.",
+      "description": "Llama Guard 4 is a Llama 4 Scout-derived multimodal pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM inputs (prompt classification) and in LLM responses (response classification). It acts as an LLM\u2014generating text in its output that indicates whether a given prompt or response is safe or unsafe, and if unsafe, it also lists the content categories violated. Llama Guard 4 was aligned to safeguard against the standardized MLCommons hazards taxonomy and designed to support multimodal Llama 4 capabilities. Specifically, it combines features from previous Llama Guard models, providing content moderation for English and multiple supported languages, along with enhanced capabilities to handle mixed text-and-image prompts, including multiple images. Additionally, Llama Guard 4 is integrated into the Llama Moderations API, extending robust safety classification to text and images.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7505,8 +7505,8 @@
       "name": "Qwen: Qwen3 30B A3B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 8e-8,
-        "outputCostPerToken": 2.8e-7
+        "inputCostPerToken": 8e-08,
+        "outputCostPerToken": 2.8e-07
       },
       "contextLength": 40960,
       "maxCompletionTokens": 40960,
@@ -7546,9 +7546,9 @@
       "name": "Qwen: Qwen3 8B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 5e-8,
-        "outputCostPerToken": 4e-7,
-        "inputCacheReadPerToken": 5e-8
+        "inputCostPerToken": 5e-08,
+        "outputCostPerToken": 4e-07,
+        "inputCacheReadPerToken": 5e-08
       },
       "contextLength": 40960,
       "maxCompletionTokens": 8192,
@@ -7589,8 +7589,8 @@
       "name": "Qwen: Qwen3 14B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 6e-8,
-        "outputCostPerToken": 2.4e-7
+        "inputCostPerToken": 6e-08,
+        "outputCostPerToken": 2.4e-07
       },
       "contextLength": 40960,
       "maxCompletionTokens": 40960,
@@ -7628,9 +7628,9 @@
       "name": "Qwen: Qwen3 32B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 8e-8,
-        "outputCostPerToken": 2.4e-7,
-        "inputCacheReadPerToken": 4e-8
+        "inputCostPerToken": 8e-08,
+        "outputCostPerToken": 2.4e-07,
+        "inputCacheReadPerToken": 4e-08
       },
       "contextLength": 40960,
       "maxCompletionTokens": 40960,
@@ -7666,8 +7666,8 @@
       "name": "Qwen: Qwen3 235B A22B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 4.55e-7,
-        "outputCostPerToken": 0.00000182
+        "inputCostPerToken": 4.55e-07,
+        "outputCostPerToken": 1.82e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 8192,
@@ -7697,9 +7697,9 @@
       "name": "OpenAI: o4 Mini High",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000011,
-        "outputCostPerToken": 0.0000044,
-        "inputCacheReadPerToken": 2.75e-7,
+        "inputCostPerToken": 1.1e-06,
+        "outputCostPerToken": 4.4e-06,
+        "inputCacheReadPerToken": 2.75e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -7721,7 +7721,7 @@
       },
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "OpenAI o4-mini-high is the same model as [o4-mini](/openai/o4-mini) with reasoning_effort set to high. OpenAI o4-mini is a compact reasoning model in the o-series, optimized for fast, cost-efficient performance while retaining strong multimodal and agentic capabilities. It supports tool use and demonstrates competitive reasoning and coding performance across benchmarks like AIME (99.5% with Python) and SWE-bench, outperforming its predecessor o3-mini and even approaching o3 in some domains. Despite its smaller size, o4-mini exhibits high accuracy in STEM tasks, visual problem solving (e.g., MathVista, MMMU), and code editing. It is especially well-suited for high-throughput scenarios where latency or cost is critical. Thanks to its efficient architecture and refined reinforcement learning training, o4-mini can chain tools, generate structured outputs, and solve multi-step tasks with minimal delay—often in under a minute.",
+      "description": "OpenAI o4-mini-high is the same model as [o4-mini](/openai/o4-mini) with reasoning_effort set to high. OpenAI o4-mini is a compact reasoning model in the o-series, optimized for fast, cost-efficient performance while retaining strong multimodal and agentic capabilities. It supports tool use and demonstrates competitive reasoning and coding performance across benchmarks like AIME (99.5% with Python) and SWE-bench, outperforming its predecessor o3-mini and even approaching o3 in some domains. Despite its smaller size, o4-mini exhibits high accuracy in STEM tasks, visual problem solving (e.g., MathVista, MMMU), and code editing. It is especially well-suited for high-throughput scenarios where latency or cost is critical. Thanks to its efficient architecture and refined reinforcement learning training, o4-mini can chain tools, generate structured outputs, and solve multi-step tasks with minimal delay\u2014often in under a minute.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7732,9 +7732,9 @@
       "name": "OpenAI: o3",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000008,
-        "inputCacheReadPerToken": 5e-7,
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 8e-06,
+        "inputCacheReadPerToken": 5e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -7774,9 +7774,9 @@
       "name": "OpenAI: o4 Mini",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000011,
-        "outputCostPerToken": 0.0000044,
-        "inputCacheReadPerToken": 2.75e-7,
+        "inputCostPerToken": 1.1e-06,
+        "outputCostPerToken": 4.4e-06,
+        "inputCacheReadPerToken": 2.75e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -7794,7 +7794,7 @@
       "defaultParameters": {},
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "OpenAI o4-mini is a compact reasoning model in the o-series, optimized for fast, cost-efficient performance while retaining strong multimodal and agentic capabilities. It supports tool use and demonstrates competitive reasoning and coding performance across benchmarks like AIME (99.5% with Python) and SWE-bench, outperforming its predecessor o3-mini and even approaching o3 in some domains. Despite its smaller size, o4-mini exhibits high accuracy in STEM tasks, visual problem solving (e.g., MathVista, MMMU), and code editing. It is especially well-suited for high-throughput scenarios where latency or cost is critical. Thanks to its efficient architecture and refined reinforcement learning training, o4-mini can chain tools, generate structured outputs, and solve multi-step tasks with minimal delay—often in under a minute.",
+      "description": "OpenAI o4-mini is a compact reasoning model in the o-series, optimized for fast, cost-efficient performance while retaining strong multimodal and agentic capabilities. It supports tool use and demonstrates competitive reasoning and coding performance across benchmarks like AIME (99.5% with Python) and SWE-bench, outperforming its predecessor o3-mini and even approaching o3 in some domains. Despite its smaller size, o4-mini exhibits high accuracy in STEM tasks, visual problem solving (e.g., MathVista, MMMU), and code editing. It is especially well-suited for high-throughput scenarios where latency or cost is critical. Thanks to its efficient architecture and refined reinforcement learning training, o4-mini can chain tools, generate structured outputs, and solve multi-step tasks with minimal delay\u2014often in under a minute.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7805,8 +7805,8 @@
       "name": "Qwen: Qwen2.5 Coder 7B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 3e-8,
-        "outputCostPerToken": 9e-8
+        "inputCostPerToken": 3e-08,
+        "outputCostPerToken": 9e-08
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -7835,9 +7835,9 @@
       "name": "OpenAI: GPT-4.1",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000008,
-        "inputCacheReadPerToken": 5e-7,
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 8e-06,
+        "inputCacheReadPerToken": 5e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 1047576,
@@ -7866,9 +7866,9 @@
       "name": "OpenAI: GPT-4.1 Mini",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.0000016,
-        "inputCacheReadPerToken": 1e-7,
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 1.6e-06,
+        "inputCacheReadPerToken": 1e-07,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 1047576,
@@ -7886,7 +7886,7 @@
       "defaultParameters": {},
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "GPT-4.1 Mini is a mid-sized model delivering performance competitive with GPT-4o at substantially lower latency and cost. It retains a 1 million token context window and scores 45.1% on hard instruction evals, 35.8% on MultiChallenge, and 84.1% on IFEval. Mini also shows strong coding ability (e.g., 31.6% on Aider’s polyglot diff benchmark) and vision understanding, making it suitable for interactive applications with tight performance constraints.",
+      "description": "GPT-4.1 Mini is a mid-sized model delivering performance competitive with GPT-4o at substantially lower latency and cost. It retains a 1 million token context window and scores 45.1% on hard instruction evals, 35.8% on MultiChallenge, and 84.1% on IFEval. Mini also shows strong coding ability (e.g., 31.6% on Aider\u2019s polyglot diff benchmark) and vision understanding, making it suitable for interactive applications with tight performance constraints.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7897,9 +7897,9 @@
       "name": "OpenAI: GPT-4.1 Nano",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 4e-7,
-        "inputCacheReadPerToken": 2.5e-8,
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 4e-07,
+        "inputCacheReadPerToken": 2.5e-08,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 1047576,
@@ -7917,7 +7917,7 @@
       "defaultParameters": {},
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "For tasks that demand low latency, GPT‑4.1 nano is the fastest and cheapest model in the GPT-4.1 series. It delivers exceptional performance at a small size with its 1 million token context window, and scores 80.1% on MMLU, 50.3% on GPQA, and 9.8% on Aider polyglot coding – even higher than GPT‑4o mini. It’s ideal for tasks like classification or autocompletion.",
+      "description": "For tasks that demand low latency, GPT\u20114.1 nano is the fastest and cheapest model in the GPT-4.1 series. It delivers exceptional performance at a small size with its 1 million token context window, and scores 80.1% on MMLU, 50.3% on GPQA, and 9.8% on Aider polyglot coding \u2013 even higher than GPT\u20114o mini. It\u2019s ideal for tasks like classification or autocompletion.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -7928,8 +7928,8 @@
       "name": "EleutherAI: Llemma 7b",
       "provider": "eleutherai",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 0.0000012
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 1.2e-06
       },
       "contextLength": 4096,
       "maxCompletionTokens": 4096,
@@ -7959,8 +7959,8 @@
       "name": "AlfredPros: CodeLLaMa 7B Instruct Solidity",
       "provider": "alfredpros",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 0.0000012
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 1.2e-06
       },
       "contextLength": 4096,
       "maxCompletionTokens": 4096,
@@ -7990,9 +7990,9 @@
       "name": "xAI: Grok 3 Mini Beta",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 5e-7,
-        "inputCacheReadPerToken": 7.5e-8,
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 5e-07,
+        "inputCacheReadPerToken": 7.5e-08,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 131072,
@@ -8018,7 +8018,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Grok 3 Mini is a lightweight, smaller thinking model. Unlike traditional models that generate answers immediately, Grok 3 Mini thinks before responding. It’s ideal for reasoning-heavy tasks that don’t demand extensive domain knowledge, and shines in math-specific and quantitative use cases, such as solving challenging puzzles or math problems. Transparent \"thinking\" traces accessible. Defaults to low reasoning, can boost with setting `reasoning: { effort: \"high\" }` Note: That there are two xAI endpoints for this model. By default when using this model we will always route you to the base endpoint. If you want the fast endpoint you can add `provider: { sort: throughput}`, to sort by throughput instead.",
+      "description": "Grok 3 Mini is a lightweight, smaller thinking model. Unlike traditional models that generate answers immediately, Grok 3 Mini thinks before responding. It\u2019s ideal for reasoning-heavy tasks that don\u2019t demand extensive domain knowledge, and shines in math-specific and quantitative use cases, such as solving challenging puzzles or math problems. Transparent \"thinking\" traces accessible. Defaults to low reasoning, can boost with setting `reasoning: { effort: \"high\" }` Note: That there are two xAI endpoints for this model. By default when using this model we will always route you to the base endpoint. If you want the fast endpoint you can add `provider: { sort: throughput}`, to sort by throughput instead.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -8039,9 +8039,9 @@
       "name": "xAI: Grok 3 Beta",
       "provider": "xai",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
-        "inputCacheReadPerToken": 7.5e-7,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
+        "inputCacheReadPerToken": 7.5e-07,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 131072,
@@ -8074,8 +8074,8 @@
       "name": "Meta: Llama 4 Maverick",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 6e-7
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 6e-07
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 16384,
@@ -8110,8 +8110,8 @@
       "name": "Meta: Llama 4 Scout",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 8e-8,
-        "outputCostPerToken": 3e-7
+        "inputCostPerToken": 8e-08,
+        "outputCostPerToken": 3e-07
       },
       "contextLength": 327680,
       "maxCompletionTokens": 16384,
@@ -8145,8 +8145,8 @@
       "name": "Qwen: Qwen2.5 VL 32B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 6e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 6e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": null,
@@ -8177,9 +8177,9 @@
       "name": "DeepSeek: DeepSeek V3 0324",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 7.7e-7,
-        "inputCacheReadPerToken": 1.35e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 7.7e-07,
+        "inputCacheReadPerToken": 1.35e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": null,
@@ -8255,8 +8255,8 @@
       "name": "Mistral: Mistral Small 3.1 24B",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 3.5e-7,
-        "outputCostPerToken": 5.6e-7
+        "inputCostPerToken": 3.5e-07,
+        "outputCostPerToken": 5.6e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": null,
@@ -8286,8 +8286,8 @@
       "name": "AllenAI: Olmo 2 32B Instruct",
       "provider": "allenai",
       "pricing": {
-        "inputCostPerToken": 5e-8,
-        "outputCostPerToken": 2e-7
+        "inputCostPerToken": 5e-08,
+        "outputCostPerToken": 2e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": null,
@@ -8306,8 +8306,8 @@
       "name": "Google: Gemma 3 4B",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 4e-8,
-        "outputCostPerToken": 8e-8
+        "inputCostPerToken": 4e-08,
+        "outputCostPerToken": 8e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -8338,8 +8338,8 @@
       "name": "Google: Gemma 3 12B",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 4e-8,
-        "outputCostPerToken": 1.3e-7
+        "inputCostPerToken": 4e-08,
+        "outputCostPerToken": 1.3e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -8372,8 +8372,8 @@
       "name": "Cohere: Command A",
       "provider": "cohere",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05
       },
       "contextLength": 256000,
       "maxCompletionTokens": 8192,
@@ -8403,8 +8403,8 @@
       "name": "OpenAI: GPT-4o-mini Search Preview",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 6e-7,
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 6e-07,
         "webSearchCostPerQuery": 0.0275
       },
       "contextLength": 128000,
@@ -8429,8 +8429,8 @@
       "name": "OpenAI: GPT-4o Search Preview",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001,
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05,
         "webSearchCostPerQuery": 0.035
       },
       "contextLength": 128000,
@@ -8455,9 +8455,9 @@
       "name": "Google: Gemma 3 27B",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 3e-8,
-        "outputCostPerToken": 1.1e-7,
-        "inputCacheReadPerToken": 1.5e-8
+        "inputCostPerToken": 3e-08,
+        "outputCostPerToken": 1.1e-07,
+        "inputCacheReadPerToken": 1.5e-08
       },
       "contextLength": 128000,
       "maxCompletionTokens": 65536,
@@ -8496,8 +8496,8 @@
       "name": "TheDrummer: Skyfall 36B V2",
       "provider": "thedrummer",
       "pricing": {
-        "inputCostPerToken": 5.5e-7,
-        "outputCostPerToken": 8e-7
+        "inputCostPerToken": 5.5e-07,
+        "outputCostPerToken": 8e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -8527,8 +8527,8 @@
       "name": "Perplexity: Sonar Reasoning Pro",
       "provider": "perplexity",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000008,
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 8e-06,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 128000,
@@ -8558,8 +8558,8 @@
       "name": "Perplexity: Sonar Pro",
       "provider": "perplexity",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 200000,
@@ -8587,9 +8587,9 @@
       "name": "Perplexity: Sonar Deep Research",
       "provider": "perplexity",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000008,
-        "internalReasoningCostPerToken": 0.000003,
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 8e-06,
+        "internalReasoningCostPerToken": 3e-06,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 128000,
@@ -8619,8 +8619,8 @@
       "name": "Qwen: QwQ 32B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 4e-7
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 4e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -8655,11 +8655,11 @@
       "name": "Google: Gemini 2.0 Flash Lite",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 7.5e-8,
-        "outputCostPerToken": 3e-7,
-        "imageCostPerToken": 7.5e-8,
-        "audioCostPerToken": 7.5e-8,
-        "internalReasoningCostPerToken": 3e-7
+        "inputCostPerToken": 7.5e-08,
+        "outputCostPerToken": 3e-07,
+        "imageCostPerToken": 7.5e-08,
+        "audioCostPerToken": 7.5e-08,
+        "internalReasoningCostPerToken": 3e-07
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 8192,
@@ -8692,10 +8692,10 @@
       "name": "Anthropic: Claude 3.7 Sonnet",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000015,
-        "inputCacheReadPerToken": 3e-7,
-        "inputCacheWritePerToken": 0.00000375,
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 1.5e-05,
+        "inputCacheReadPerToken": 3e-07,
+        "inputCacheWritePerToken": 3.75e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -8729,8 +8729,8 @@
       "name": "Mistral: Saba",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 6e-7
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 6e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -8752,7 +8752,7 @@
       },
       "modality": "text->text",
       "mode": "chat",
-      "description": "Mistral Saba is a 24B-parameter language model specifically designed for the Middle East and South Asia, delivering accurate and contextually relevant responses while maintaining efficient performance. Trained on curated regional datasets, it supports multiple Indian-origin languages—including Tamil and Malayalam—alongside Arabic. This makes it a versatile option for a range of regional and multilingual applications. Read more at the blog post [here](https://mistral.ai/en/news/mistral-saba)",
+      "description": "Mistral Saba is a 24B-parameter language model specifically designed for the Middle East and South Asia, delivering accurate and contextually relevant responses while maintaining efficient performance. Trained on curated regional datasets, it supports multiple Indian-origin languages\u2014including Tamil and Malayalam\u2014alongside Arabic. This makes it a versatile option for a range of regional and multilingual applications. Read more at the blog post [here](https://mistral.ai/en/news/mistral-saba)",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -8763,8 +8763,8 @@
       "name": "Llama Guard 3 8B",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 2e-8,
-        "outputCostPerToken": 6e-8
+        "inputCostPerToken": 2e-08,
+        "outputCostPerToken": 6e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -8781,7 +8781,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Llama Guard 3 is a Llama-3.1-8B pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM inputs (prompt classification) and in LLM responses (response classification). It acts as an LLM – it generates text in its output that indicates whether a given prompt or response is safe or unsafe, and if unsafe, it also lists the content categories violated. Llama Guard 3 was aligned to safeguard against the MLCommons standardized hazards taxonomy and designed to support Llama 3.1 capabilities. Specifically, it provides content moderation in 8 languages, and was optimized to support safety and security for search and code interpreter tool calls.",
+      "description": "Llama Guard 3 is a Llama-3.1-8B pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM inputs (prompt classification) and in LLM responses (response classification). It acts as an LLM \u2013 it generates text in its output that indicates whether a given prompt or response is safe or unsafe, and if unsafe, it also lists the content categories violated. Llama Guard 3 was aligned to safeguard against the MLCommons standardized hazards taxonomy and designed to support Llama 3.1 capabilities. Specifically, it provides content moderation in 8 languages, and was optimized to support safety and security for search and code interpreter tool calls.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -8792,9 +8792,9 @@
       "name": "OpenAI: o3 Mini High",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000011,
-        "outputCostPerToken": 0.0000044,
-        "inputCacheReadPerToken": 5.5e-7
+        "inputCostPerToken": 1.1e-06,
+        "outputCostPerToken": 4.4e-06,
+        "inputCacheReadPerToken": 5.5e-07
       },
       "contextLength": 200000,
       "maxCompletionTokens": 100000,
@@ -8835,13 +8835,13 @@
       "name": "Google: Gemini 2.0 Flash",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 4e-7,
-        "inputCacheReadPerToken": 2.5e-8,
-        "inputCacheWritePerToken": 8.333333333333334e-8,
-        "imageCostPerToken": 1e-7,
-        "audioCostPerToken": 7e-7,
-        "internalReasoningCostPerToken": 4e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 4e-07,
+        "inputCacheReadPerToken": 2.5e-08,
+        "inputCacheWritePerToken": 8.333333333333334e-08,
+        "imageCostPerToken": 1e-07,
+        "audioCostPerToken": 7e-07,
+        "internalReasoningCostPerToken": 4e-07
       },
       "contextLength": 1048576,
       "maxCompletionTokens": 8192,
@@ -8874,9 +8874,9 @@
       "name": "Qwen: Qwen VL Plus",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.365e-7,
-        "outputCostPerToken": 4.095e-7,
-        "inputCacheReadPerToken": 2.73e-8
+        "inputCostPerToken": 1.365e-07,
+        "outputCostPerToken": 4.095e-07,
+        "inputCacheReadPerToken": 2.73e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": 8192,
@@ -8902,8 +8902,8 @@
       "name": "AionLabs: Aion-1.0",
       "provider": "aion-labs",
       "pricing": {
-        "inputCostPerToken": 0.000004,
-        "outputCostPerToken": 0.000008
+        "inputCostPerToken": 4e-06,
+        "outputCostPerToken": 8e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -8928,8 +8928,8 @@
       "name": "AionLabs: Aion-1.0-Mini",
       "provider": "aion-labs",
       "pricing": {
-        "inputCostPerToken": 7e-7,
-        "outputCostPerToken": 0.0000014
+        "inputCostPerToken": 7e-07,
+        "outputCostPerToken": 1.4e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -8954,8 +8954,8 @@
       "name": "AionLabs: Aion-RP 1.0 (8B)",
       "provider": "aion-labs",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 0.0000016
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 1.6e-06
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -8967,7 +8967,7 @@
       "defaultParameters": {},
       "modality": "text->text",
       "mode": "chat",
-      "description": "Aion-RP-Llama-3.1-8B ranks the highest in the character evaluation portion of the RPBench-Auto benchmark, a roleplaying-specific variant of Arena-Hard-Auto, where LLMs evaluate each other’s responses. It is a fine-tuned base model rather than an instruct model, designed to produce more natural and varied writing.",
+      "description": "Aion-RP-Llama-3.1-8B ranks the highest in the character evaluation portion of the RPBench-Auto benchmark, a roleplaying-specific variant of Arena-Hard-Auto, where LLMs evaluate each other\u2019s responses. It is a fine-tuned base model rather than an instruct model, designed to produce more natural and varied writing.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -8978,8 +8978,8 @@
       "name": "Qwen: Qwen VL Max",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 0.0000032
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 3.2e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 32768,
@@ -9011,9 +9011,9 @@
       "name": "Qwen: Qwen-Turbo",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 3.25e-8,
-        "outputCostPerToken": 1.3e-7,
-        "inputCacheReadPerToken": 6.5e-9
+        "inputCostPerToken": 3.25e-08,
+        "outputCostPerToken": 1.3e-07,
+        "inputCacheReadPerToken": 6.5e-09
       },
       "contextLength": 131072,
       "maxCompletionTokens": 8192,
@@ -9041,8 +9041,8 @@
       "name": "Qwen: Qwen2.5 VL 72B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 8e-7
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 8e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -9074,9 +9074,9 @@
       "name": "Qwen: Qwen-Plus",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 0.0000012,
-        "inputCacheReadPerToken": 8e-8
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 1.2e-06,
+        "inputCacheReadPerToken": 8e-08
       },
       "contextLength": 1000000,
       "maxCompletionTokens": 32768,
@@ -9104,9 +9104,9 @@
       "name": "Qwen: Qwen-Max ",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 0.00000104,
-        "outputCostPerToken": 0.00000416,
-        "inputCacheReadPerToken": 2.08e-7
+        "inputCostPerToken": 1.04e-06,
+        "outputCostPerToken": 4.16e-06,
+        "inputCacheReadPerToken": 2.08e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 8192,
@@ -9134,9 +9134,9 @@
       "name": "OpenAI: o3 Mini",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000011,
-        "outputCostPerToken": 0.0000044,
-        "inputCacheReadPerToken": 5.5e-7
+        "inputCostPerToken": 1.1e-06,
+        "outputCostPerToken": 4.4e-06,
+        "inputCacheReadPerToken": 5.5e-07
       },
       "contextLength": 200000,
       "maxCompletionTokens": 100000,
@@ -9173,8 +9173,8 @@
       "name": "Mistral: Mistral Small 3",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 5e-8,
-        "outputCostPerToken": 8e-8
+        "inputCostPerToken": 5e-08,
+        "outputCostPerToken": 8e-08
       },
       "contextLength": 32768,
       "maxCompletionTokens": 16384,
@@ -9212,8 +9212,8 @@
       "name": "DeepSeek: R1 Distill Qwen 32B",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 2.9e-7,
-        "outputCostPerToken": 2.9e-7
+        "inputCostPerToken": 2.9e-07,
+        "outputCostPerToken": 2.9e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -9259,8 +9259,8 @@
       "name": "Perplexity: Sonar",
       "provider": "perplexity",
       "pricing": {
-        "inputCostPerToken": 0.000001,
-        "outputCostPerToken": 0.000001,
+        "inputCostPerToken": 1e-06,
+        "outputCostPerToken": 1e-06,
         "webSearchCostPerQuery": 0.005
       },
       "contextLength": 127072,
@@ -9277,7 +9277,7 @@
       "defaultParameters": {},
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "Sonar is lightweight, affordable, fast, and simple to use — now featuring citations and the ability to customize sources. It is designed for companies seeking to integrate lightweight question-and-answer features optimized for speed.",
+      "description": "Sonar is lightweight, affordable, fast, and simple to use \u2014 now featuring citations and the ability to customize sources. It is designed for companies seeking to integrate lightweight question-and-answer features optimized for speed.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -9288,8 +9288,8 @@
       "name": "DeepSeek: R1 Distill Llama 70B",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 7e-7,
-        "outputCostPerToken": 8e-7
+        "inputCostPerToken": 7e-07,
+        "outputCostPerToken": 8e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 16384,
@@ -9334,8 +9334,8 @@
       "name": "DeepSeek: R1",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 7e-7,
-        "outputCostPerToken": 0.0000025
+        "inputCostPerToken": 7e-07,
+        "outputCostPerToken": 2.5e-06
       },
       "contextLength": 64000,
       "maxCompletionTokens": 16000,
@@ -9379,8 +9379,8 @@
       "name": "MiniMax: MiniMax-01",
       "provider": "minimax",
       "pricing": {
-        "inputCostPerToken": 2e-7,
-        "outputCostPerToken": 0.0000011
+        "inputCostPerToken": 2e-07,
+        "outputCostPerToken": 1.1e-06
       },
       "contextLength": 1000192,
       "maxCompletionTokens": 1000192,
@@ -9396,7 +9396,7 @@
       },
       "modality": "text+image->text",
       "mode": "chat",
-      "description": "MiniMax-01 is a combines MiniMax-Text-01 for text generation and MiniMax-VL-01 for image understanding. It has 456 billion parameters, with 45.9 billion parameters activated per inference, and can handle a context of up to 4 million tokens. The text model adopts a hybrid architecture that combines Lightning Attention, Softmax Attention, and Mixture-of-Experts (MoE). The image model adopts the “ViT-MLP-LLM” framework and is trained on top of the text model. To read more about the release, see: https://www.minimaxi.com/en/news/minimax-01-series-2",
+      "description": "MiniMax-01 is a combines MiniMax-Text-01 for text generation and MiniMax-VL-01 for image understanding. It has 456 billion parameters, with 45.9 billion parameters activated per inference, and can handle a context of up to 4 million tokens. The text model adopts a hybrid architecture that combines Lightning Attention, Softmax Attention, and Mixture-of-Experts (MoE). The image model adopts the \u201cViT-MLP-LLM\u201d framework and is trained on top of the text model. To read more about the release, see: https://www.minimaxi.com/en/news/minimax-01-series-2",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -9407,8 +9407,8 @@
       "name": "Microsoft: Phi 4",
       "provider": "microsoft",
       "pricing": {
-        "inputCostPerToken": 6e-8,
-        "outputCostPerToken": 1.4e-7
+        "inputCostPerToken": 6e-08,
+        "outputCostPerToken": 1.4e-07
       },
       "contextLength": 16384,
       "maxCompletionTokens": 16384,
@@ -9442,8 +9442,8 @@
       "name": "Sao10K: Llama 3.1 70B Hanami x1",
       "provider": "sao10k",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000003
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 3e-06
       },
       "contextLength": 16000,
       "maxCompletionTokens": null,
@@ -9474,8 +9474,8 @@
       "name": "DeepSeek: DeepSeek V3",
       "provider": "deepseek",
       "pricing": {
-        "inputCostPerToken": 3.2e-7,
-        "outputCostPerToken": 8.9e-7
+        "inputCostPerToken": 3.2e-07,
+        "outputCostPerToken": 8.9e-07
       },
       "contextLength": 163840,
       "maxCompletionTokens": 163840,
@@ -9508,8 +9508,8 @@
       "name": "Sao10K: Llama 3.3 Euryale 70B",
       "provider": "sao10k",
       "pricing": {
-        "inputCostPerToken": 6.5e-7,
-        "outputCostPerToken": 7.5e-7
+        "inputCostPerToken": 6.5e-07,
+        "outputCostPerToken": 7.5e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 16384,
@@ -9543,9 +9543,9 @@
       "name": "OpenAI: o1",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000015,
-        "outputCostPerToken": 0.00006,
-        "inputCacheReadPerToken": 0.0000075
+        "inputCostPerToken": 1.5e-05,
+        "outputCostPerToken": 6e-05,
+        "inputCacheReadPerToken": 7.5e-06
       },
       "contextLength": 200000,
       "maxCompletionTokens": 100000,
@@ -9582,8 +9582,8 @@
       "name": "Cohere: Command R7B (12-2024)",
       "provider": "cohere",
       "pricing": {
-        "inputCostPerToken": 3.75e-8,
-        "outputCostPerToken": 1.5e-7
+        "inputCostPerToken": 3.75e-08,
+        "outputCostPerToken": 1.5e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": 4000,
@@ -9613,8 +9613,8 @@
       "name": "Meta: Llama 3.3 70B Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 1e-7,
-        "outputCostPerToken": 3.2e-7
+        "inputCostPerToken": 1e-07,
+        "outputCostPerToken": 3.2e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 16384,
@@ -9651,8 +9651,8 @@
       "name": "Amazon: Nova Lite 1.0",
       "provider": "amazon",
       "pricing": {
-        "inputCostPerToken": 6e-8,
-        "outputCostPerToken": 2.4e-7
+        "inputCostPerToken": 6e-08,
+        "outputCostPerToken": 2.4e-07
       },
       "contextLength": 300000,
       "maxCompletionTokens": 5120,
@@ -9678,8 +9678,8 @@
       "name": "Amazon: Nova Micro 1.0",
       "provider": "amazon",
       "pricing": {
-        "inputCostPerToken": 3.5e-8,
-        "outputCostPerToken": 1.4e-7
+        "inputCostPerToken": 3.5e-08,
+        "outputCostPerToken": 1.4e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": 5120,
@@ -9705,8 +9705,8 @@
       "name": "Amazon: Nova Pro 1.0",
       "provider": "amazon",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 0.0000032
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 3.2e-06
       },
       "contextLength": 300000,
       "maxCompletionTokens": 5120,
@@ -9732,9 +9732,9 @@
       "name": "OpenAI: GPT-4o (2024-11-20)",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 0.00000125
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-06
       },
       "contextLength": 128000,
       "maxCompletionTokens": 16384,
@@ -9758,7 +9758,7 @@
       "defaultParameters": {},
       "modality": "text+image+file->text",
       "mode": "chat",
-      "description": "The 2024-11-20 version of GPT-4o offers a leveled-up creative writing ability with more natural, engaging, and tailored writing to improve relevance & readability. It’s also better at working with uploaded files, providing deeper insights & more thorough responses. GPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs. It maintains the intelligence level of [GPT-4 Turbo](/models/openai/gpt-4-turbo) while being twice as fast and 50% more cost-effective. GPT-4o also offers improved performance in processing non-English languages and enhanced visual capabilities.",
+      "description": "The 2024-11-20 version of GPT-4o offers a leveled-up creative writing ability with more natural, engaging, and tailored writing to improve relevance & readability. It\u2019s also better at working with uploaded files, providing deeper insights & more thorough responses. GPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs. It maintains the intelligence level of [GPT-4 Turbo](/models/openai/gpt-4-turbo) while being twice as fast and 50% more cost-effective. GPT-4o also offers improved performance in processing non-English languages and enhanced visual capabilities.",
       "supportsImageInput": true,
       "supportsAudioInput": false,
       "supportsImageOutput": false,
@@ -9769,8 +9769,8 @@
       "name": "Mistral Large 2411",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000006
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 6e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -9803,8 +9803,8 @@
       "name": "Mistral Large 2407",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000006
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 6e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -9837,8 +9837,8 @@
       "name": "Mistral: Pixtral Large 2411",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000006
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 6e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -9871,8 +9871,8 @@
       "name": "Qwen2.5 Coder 32B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2.0000000000000002e-7,
-        "outputCostPerToken": 2.0000000000000002e-7
+        "inputCostPerToken": 2.0000000000000002e-07,
+        "outputCostPerToken": 2.0000000000000002e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 8192,
@@ -9903,8 +9903,8 @@
       "name": "TheDrummer: UnslopNemo 12B",
       "provider": "thedrummer",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 4e-7
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 4e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -9938,10 +9938,10 @@
       "name": "Anthropic: Claude 3.5 Haiku",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 8e-7,
-        "outputCostPerToken": 0.000004,
-        "inputCacheReadPerToken": 8e-8,
-        "inputCacheWritePerToken": 0.000001,
+        "inputCostPerToken": 8e-07,
+        "outputCostPerToken": 4e-06,
+        "inputCacheReadPerToken": 8e-08,
+        "inputCacheWritePerToken": 1e-06,
         "webSearchCostPerQuery": 0.01
       },
       "contextLength": 200000,
@@ -9973,8 +9973,8 @@
       "name": "Magnum v4 72B",
       "provider": "anthracite-org",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000005
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 5e-06
       },
       "contextLength": 16384,
       "maxCompletionTokens": 2048,
@@ -10009,10 +10009,10 @@
       "name": "Anthropic: Claude 3.5 Sonnet",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 0.000006,
-        "outputCostPerToken": 0.00003,
-        "inputCacheReadPerToken": 6e-7,
-        "inputCacheWritePerToken": 0.0000075
+        "inputCostPerToken": 6e-06,
+        "outputCostPerToken": 3e-05,
+        "inputCacheReadPerToken": 6e-07,
+        "inputCacheWritePerToken": 7.5e-06
       },
       "contextLength": 200000,
       "maxCompletionTokens": 8192,
@@ -10039,8 +10039,8 @@
       "name": "Qwen: Qwen2.5 7B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 4e-8,
-        "outputCostPerToken": 1e-7
+        "inputCostPerToken": 4e-08,
+        "outputCostPerToken": 1e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -10078,8 +10078,8 @@
       "name": "NVIDIA: Llama 3.1 Nemotron 70B Instruct",
       "provider": "nvidia",
       "pricing": {
-        "inputCostPerToken": 0.0000012,
-        "outputCostPerToken": 0.0000012
+        "inputCostPerToken": 1.2e-06,
+        "outputCostPerToken": 1.2e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 16384,
@@ -10112,8 +10112,8 @@
       "name": "Inflection: Inflection 3 Pi",
       "provider": "inflection",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05
       },
       "contextLength": 8000,
       "maxCompletionTokens": 1024,
@@ -10137,8 +10137,8 @@
       "name": "Inflection: Inflection 3 Productivity",
       "provider": "inflection",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05
       },
       "contextLength": 8000,
       "maxCompletionTokens": 1024,
@@ -10162,8 +10162,8 @@
       "name": "TheDrummer: Rocinante 12B",
       "provider": "thedrummer",
       "pricing": {
-        "inputCostPerToken": 1.7e-7,
-        "outputCostPerToken": 4.3e-7
+        "inputCostPerToken": 1.7e-07,
+        "outputCostPerToken": 4.3e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -10200,8 +10200,8 @@
       "name": "Meta: Llama 3.2 3B Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 5.1e-8,
-        "outputCostPerToken": 3.4e-7
+        "inputCostPerToken": 5.1e-08,
+        "outputCostPerToken": 3.4e-07
       },
       "contextLength": 80000,
       "maxCompletionTokens": null,
@@ -10229,8 +10229,8 @@
       "name": "Meta: Llama 3.2 1B Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 2.7e-8,
-        "outputCostPerToken": 2e-7
+        "inputCostPerToken": 2.7e-08,
+        "outputCostPerToken": 2e-07
       },
       "contextLength": 60000,
       "maxCompletionTokens": null,
@@ -10258,8 +10258,8 @@
       "name": "Meta: Llama 3.2 11B Vision Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 4.9e-8,
-        "outputCostPerToken": 4.9e-8
+        "inputCostPerToken": 4.9e-08,
+        "outputCostPerToken": 4.9e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": 16384,
@@ -10290,8 +10290,8 @@
       "name": "Qwen2.5 72B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1.2e-7,
-        "outputCostPerToken": 3.9e-7
+        "inputCostPerToken": 1.2e-07,
+        "outputCostPerToken": 3.9e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 16384,
@@ -10325,8 +10325,8 @@
       "name": "Cohere: Command R (08-2024)",
       "provider": "cohere",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 6e-7
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 6e-07
       },
       "contextLength": 128000,
       "maxCompletionTokens": 4000,
@@ -10358,8 +10358,8 @@
       "name": "Cohere: Command R+ (08-2024)",
       "provider": "cohere",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05
       },
       "contextLength": 128000,
       "maxCompletionTokens": 4000,
@@ -10391,8 +10391,8 @@
       "name": "Sao10K: Llama 3.1 Euryale 70B v2.2",
       "provider": "sao10k",
       "pricing": {
-        "inputCostPerToken": 8.5e-7,
-        "outputCostPerToken": 8.5e-7
+        "inputCostPerToken": 8.5e-07,
+        "outputCostPerToken": 8.5e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": 16384,
@@ -10426,8 +10426,8 @@
       "name": "Qwen: Qwen2.5-VL 7B Instruct",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2.0000000000000002e-7,
-        "outputCostPerToken": 2.0000000000000002e-7
+        "inputCostPerToken": 2.0000000000000002e-07,
+        "outputCostPerToken": 2.0000000000000002e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": null,
@@ -10458,8 +10458,8 @@
       "name": "Nous: Hermes 3 70B Instruct",
       "provider": "nousresearch",
       "pricing": {
-        "inputCostPerToken": 3e-7,
-        "outputCostPerToken": 3e-7
+        "inputCostPerToken": 3e-07,
+        "outputCostPerToken": 3e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -10490,8 +10490,8 @@
       "name": "Nous: Hermes 3 405B Instruct",
       "provider": "nousresearch",
       "pricing": {
-        "inputCostPerToken": 0.000001,
-        "outputCostPerToken": 0.000001
+        "inputCostPerToken": 1e-06,
+        "outputCostPerToken": 1e-06
       },
       "contextLength": 131072,
       "maxCompletionTokens": 16384,
@@ -10522,8 +10522,8 @@
       "name": "Sao10K: Llama 3 8B Lunaris",
       "provider": "sao10k",
       "pricing": {
-        "inputCostPerToken": 4e-8,
-        "outputCostPerToken": 5e-8
+        "inputCostPerToken": 4e-08,
+        "outputCostPerToken": 5e-08
       },
       "contextLength": 8192,
       "maxCompletionTokens": null,
@@ -10555,9 +10555,9 @@
       "name": "OpenAI: GPT-4o (2024-08-06)",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 0.00000125
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-06
       },
       "contextLength": 128000,
       "maxCompletionTokens": 16384,
@@ -10592,8 +10592,8 @@
       "name": "Meta: Llama 3.1 405B (base)",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 0.000004,
-        "outputCostPerToken": 0.000004
+        "inputCostPerToken": 4e-06,
+        "outputCostPerToken": 4e-06
       },
       "contextLength": 32768,
       "maxCompletionTokens": 32768,
@@ -10624,8 +10624,8 @@
       "name": "Meta: Llama 3.1 8B Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 2e-8,
-        "outputCostPerToken": 5e-8
+        "inputCostPerToken": 2e-08,
+        "outputCostPerToken": 5e-08
       },
       "contextLength": 16384,
       "maxCompletionTokens": 16384,
@@ -10662,8 +10662,8 @@
       "name": "Meta: Llama 3.1 405B Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 0.000004,
-        "outputCostPerToken": 0.000004
+        "inputCostPerToken": 4e-06,
+        "outputCostPerToken": 4e-06
       },
       "contextLength": 131000,
       "maxCompletionTokens": null,
@@ -10694,8 +10694,8 @@
       "name": "Meta: Llama 3.1 70B Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 4e-7,
-        "outputCostPerToken": 4e-7
+        "inputCostPerToken": 4e-07,
+        "outputCostPerToken": 4e-07
       },
       "contextLength": 131072,
       "maxCompletionTokens": null,
@@ -10728,8 +10728,8 @@
       "name": "Mistral: Mistral Nemo",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 2e-8,
-        "outputCostPerToken": 4e-8
+        "inputCostPerToken": 2e-08,
+        "outputCostPerToken": 4e-08
       },
       "contextLength": 131072,
       "maxCompletionTokens": 16384,
@@ -10765,9 +10765,9 @@
       "name": "OpenAI: GPT-4o-mini (2024-07-18)",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 6e-7,
-        "inputCacheReadPerToken": 7.5e-8
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 6e-07,
+        "inputCacheReadPerToken": 7.5e-08
       },
       "contextLength": 128000,
       "maxCompletionTokens": 16384,
@@ -10802,9 +10802,9 @@
       "name": "OpenAI: GPT-4o-mini",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
-        "outputCostPerToken": 6e-7,
-        "inputCacheReadPerToken": 7.5e-8
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 6e-07,
+        "inputCacheReadPerToken": 7.5e-08
       },
       "contextLength": 128000,
       "maxCompletionTokens": 16384,
@@ -10839,8 +10839,8 @@
       "name": "Google: Gemma 2 27B",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 6.5e-7,
-        "outputCostPerToken": 6.5e-7
+        "inputCostPerToken": 6.5e-07,
+        "outputCostPerToken": 6.5e-07
       },
       "contextLength": 8192,
       "maxCompletionTokens": 2048,
@@ -10868,8 +10868,8 @@
       "name": "Google: Gemma 2 9B",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 3e-8,
-        "outputCostPerToken": 9e-8
+        "inputCostPerToken": 3e-08,
+        "outputCostPerToken": 9e-08
       },
       "contextLength": 8192,
       "maxCompletionTokens": null,
@@ -10896,8 +10896,8 @@
       "name": "Sao10k: Llama 3 Euryale 70B v2.1",
       "provider": "sao10k",
       "pricing": {
-        "inputCostPerToken": 0.00000148,
-        "outputCostPerToken": 0.00000148
+        "inputCostPerToken": 1.48e-06,
+        "outputCostPerToken": 1.48e-06
       },
       "contextLength": 8192,
       "maxCompletionTokens": 8192,
@@ -10928,8 +10928,8 @@
       "name": "NousResearch: Hermes 2 Pro - Llama-3 8B",
       "provider": "nousresearch",
       "pricing": {
-        "inputCostPerToken": 1.4e-7,
-        "outputCostPerToken": 1.4e-7
+        "inputCostPerToken": 1.4e-07,
+        "outputCostPerToken": 1.4e-07
       },
       "contextLength": 8192,
       "maxCompletionTokens": 8192,
@@ -10960,8 +10960,8 @@
       "name": "OpenAI: GPT-4o (2024-05-13)",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000005,
-        "outputCostPerToken": 0.000015
+        "inputCostPerToken": 5e-06,
+        "outputCostPerToken": 1.5e-05
       },
       "contextLength": 128000,
       "maxCompletionTokens": 4096,
@@ -10996,9 +10996,9 @@
       "name": "OpenAI: GPT-4o",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000025,
-        "outputCostPerToken": 0.00001,
-        "inputCacheReadPerToken": 0.00000125
+        "inputCostPerToken": 2.5e-06,
+        "outputCostPerToken": 1e-05,
+        "inputCacheReadPerToken": 1.25e-06
       },
       "contextLength": 128000,
       "maxCompletionTokens": 16384,
@@ -11033,8 +11033,8 @@
       "name": "Meta: Llama 3 70B Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 5.1e-7,
-        "outputCostPerToken": 7.4e-7
+        "inputCostPerToken": 5.1e-07,
+        "outputCostPerToken": 7.4e-07
       },
       "contextLength": 8192,
       "maxCompletionTokens": 8000,
@@ -11065,8 +11065,8 @@
       "name": "Meta: Llama 3 8B Instruct",
       "provider": "meta-llama",
       "pricing": {
-        "inputCostPerToken": 3e-8,
-        "outputCostPerToken": 4e-8
+        "inputCostPerToken": 3e-08,
+        "outputCostPerToken": 4e-08
       },
       "contextLength": 8192,
       "maxCompletionTokens": 16384,
@@ -11100,8 +11100,8 @@
       "name": "Mistral: Mixtral 8x22B Instruct",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000006
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 6e-06
       },
       "contextLength": 65536,
       "maxCompletionTokens": null,
@@ -11134,8 +11134,8 @@
       "name": "WizardLM-2 8x22B",
       "provider": "microsoft",
       "pricing": {
-        "inputCostPerToken": 6.2e-7,
-        "outputCostPerToken": 6.2e-7
+        "inputCostPerToken": 6.2e-07,
+        "outputCostPerToken": 6.2e-07
       },
       "contextLength": 65535,
       "maxCompletionTokens": 8000,
@@ -11164,8 +11164,8 @@
       "name": "OpenAI: GPT-4 Turbo",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00001,
-        "outputCostPerToken": 0.00003
+        "inputCostPerToken": 1e-05,
+        "outputCostPerToken": 3e-05
       },
       "contextLength": 128000,
       "maxCompletionTokens": 4096,
@@ -11199,10 +11199,10 @@
       "name": "Anthropic: Claude 3 Haiku",
       "provider": "anthropic",
       "pricing": {
-        "inputCostPerToken": 2.5e-7,
-        "outputCostPerToken": 0.00000125,
-        "inputCacheReadPerToken": 3e-8,
-        "inputCacheWritePerToken": 3e-7
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 1.25e-06,
+        "inputCacheReadPerToken": 3e-08,
+        "inputCacheWritePerToken": 3e-07
       },
       "contextLength": 200000,
       "maxCompletionTokens": 4096,
@@ -11229,8 +11229,8 @@
       "name": "Mistral Large",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 0.000002,
-        "outputCostPerToken": 0.000006
+        "inputCostPerToken": 2e-06,
+        "outputCostPerToken": 6e-06
       },
       "contextLength": 128000,
       "maxCompletionTokens": null,
@@ -11263,8 +11263,8 @@
       "name": "OpenAI: GPT-3.5 Turbo (older v0613)",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000001,
-        "outputCostPerToken": 0.000002
+        "inputCostPerToken": 1e-06,
+        "outputCostPerToken": 2e-06
       },
       "contextLength": 4095,
       "maxCompletionTokens": 4096,
@@ -11298,8 +11298,8 @@
       "name": "OpenAI: GPT-4 Turbo Preview",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00001,
-        "outputCostPerToken": 0.00003
+        "inputCostPerToken": 1e-05,
+        "outputCostPerToken": 3e-05
       },
       "contextLength": 128000,
       "maxCompletionTokens": 4096,
@@ -11333,8 +11333,8 @@
       "name": "Mistral: Mixtral 8x7B Instruct",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 5.4e-7,
-        "outputCostPerToken": 5.4e-7
+        "inputCostPerToken": 5.4e-07,
+        "outputCostPerToken": 5.4e-07
       },
       "contextLength": 32768,
       "maxCompletionTokens": 16384,
@@ -11370,8 +11370,8 @@
       "name": "Goliath 120B",
       "provider": "alpindale",
       "pricing": {
-        "inputCostPerToken": 0.00000375,
-        "outputCostPerToken": 0.0000075
+        "inputCostPerToken": 3.75e-06,
+        "outputCostPerToken": 7.5e-06
       },
       "contextLength": 6144,
       "maxCompletionTokens": 1024,
@@ -11452,8 +11452,8 @@
       "name": "OpenAI: GPT-4 Turbo (older v1106)",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00001,
-        "outputCostPerToken": 0.00003
+        "inputCostPerToken": 1e-05,
+        "outputCostPerToken": 3e-05
       },
       "contextLength": 128000,
       "maxCompletionTokens": 4096,
@@ -11487,8 +11487,8 @@
       "name": "OpenAI: GPT-3.5 Turbo Instruct",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.0000015,
-        "outputCostPerToken": 0.000002
+        "inputCostPerToken": 1.5e-06,
+        "outputCostPerToken": 2e-06
       },
       "contextLength": 4095,
       "maxCompletionTokens": 4096,
@@ -11520,8 +11520,8 @@
       "name": "Mistral: Mistral 7B Instruct v0.1",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 1.1e-7,
-        "outputCostPerToken": 1.9e-7
+        "inputCostPerToken": 1.1e-07,
+        "outputCostPerToken": 1.9e-07
       },
       "contextLength": 2824,
       "maxCompletionTokens": null,
@@ -11551,8 +11551,8 @@
       "name": "OpenAI: GPT-3.5 Turbo 16k",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.000003,
-        "outputCostPerToken": 0.000004
+        "inputCostPerToken": 3e-06,
+        "outputCostPerToken": 4e-06
       },
       "contextLength": 16385,
       "maxCompletionTokens": 4096,
@@ -11586,8 +11586,8 @@
       "name": "Mancer: Weaver (alpha)",
       "provider": "mancer",
       "pricing": {
-        "inputCostPerToken": 7.5e-7,
-        "outputCostPerToken": 0.000001
+        "inputCostPerToken": 7.5e-07,
+        "outputCostPerToken": 1e-06
       },
       "contextLength": 8000,
       "maxCompletionTokens": 2000,
@@ -11622,8 +11622,8 @@
       "name": "ReMM SLERP 13B",
       "provider": "undi95",
       "pricing": {
-        "inputCostPerToken": 4.5e-7,
-        "outputCostPerToken": 6.5e-7
+        "inputCostPerToken": 4.5e-07,
+        "outputCostPerToken": 6.5e-07
       },
       "contextLength": 6144,
       "maxCompletionTokens": 4096,
@@ -11659,8 +11659,8 @@
       "name": "MythoMax 13B",
       "provider": "gryphe",
       "pricing": {
-        "inputCostPerToken": 6e-8,
-        "outputCostPerToken": 6e-8
+        "inputCostPerToken": 6e-08,
+        "outputCostPerToken": 6e-08
       },
       "contextLength": 4096,
       "maxCompletionTokens": 4096,
@@ -11696,8 +11696,8 @@
       "name": "OpenAI: GPT-4 (older v0314)",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00003,
-        "outputCostPerToken": 0.00006
+        "inputCostPerToken": 3e-05,
+        "outputCostPerToken": 6e-05
       },
       "contextLength": 8191,
       "maxCompletionTokens": 4096,
@@ -11731,8 +11731,8 @@
       "name": "OpenAI: GPT-4",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 0.00003,
-        "outputCostPerToken": 0.00006
+        "inputCostPerToken": 3e-05,
+        "outputCostPerToken": 6e-05
       },
       "contextLength": 8191,
       "maxCompletionTokens": 4096,
@@ -11766,8 +11766,8 @@
       "name": "OpenAI: GPT-3.5 Turbo",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 5e-7,
-        "outputCostPerToken": 0.0000015
+        "inputCostPerToken": 5e-07,
+        "outputCostPerToken": 1.5e-06
       },
       "contextLength": 16385,
       "maxCompletionTokens": 4096,
@@ -11801,7 +11801,7 @@
       "name": "Thenlper: GTE-Base",
       "provider": "thenlper",
       "pricing": {
-        "inputCostPerToken": 5e-9,
+        "inputCostPerToken": 5e-09,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11821,7 +11821,7 @@
       "name": "Thenlper: GTE-Large",
       "provider": "thenlper",
       "pricing": {
-        "inputCostPerToken": 1e-8,
+        "inputCostPerToken": 1e-08,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11841,7 +11841,7 @@
       "name": "Intfloat: E5-Large-v2",
       "provider": "intfloat",
       "pricing": {
-        "inputCostPerToken": 1e-8,
+        "inputCostPerToken": 1e-08,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11861,7 +11861,7 @@
       "name": "Intfloat: E5-Base-v2",
       "provider": "intfloat",
       "pricing": {
-        "inputCostPerToken": 5e-9,
+        "inputCostPerToken": 5e-09,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11881,7 +11881,7 @@
       "name": "Intfloat: Multilingual-E5-Large",
       "provider": "intfloat",
       "pricing": {
-        "inputCostPerToken": 1e-8,
+        "inputCostPerToken": 1e-08,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11901,7 +11901,7 @@
       "name": "Sentence Transformers: paraphrase-MiniLM-L6-v2",
       "provider": "sentence-transformers",
       "pricing": {
-        "inputCostPerToken": 5e-9,
+        "inputCostPerToken": 5e-09,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11921,7 +11921,7 @@
       "name": "Sentence Transformers: all-MiniLM-L12-v2",
       "provider": "sentence-transformers",
       "pricing": {
-        "inputCostPerToken": 5e-9,
+        "inputCostPerToken": 5e-09,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11941,7 +11941,7 @@
       "name": "BAAI: bge-base-en-v1.5",
       "provider": "baai",
       "pricing": {
-        "inputCostPerToken": 5e-9,
+        "inputCostPerToken": 5e-09,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11961,7 +11961,7 @@
       "name": "Sentence Transformers: multi-qa-mpnet-base-dot-v1",
       "provider": "sentence-transformers",
       "pricing": {
-        "inputCostPerToken": 5e-9,
+        "inputCostPerToken": 5e-09,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -11981,7 +11981,7 @@
       "name": "BAAI: bge-large-en-v1.5",
       "provider": "baai",
       "pricing": {
-        "inputCostPerToken": 1e-8,
+        "inputCostPerToken": 1e-08,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12001,7 +12001,7 @@
       "name": "BAAI: bge-m3",
       "provider": "baai",
       "pricing": {
-        "inputCostPerToken": 1e-8,
+        "inputCostPerToken": 1e-08,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12021,7 +12021,7 @@
       "name": "Sentence Transformers: all-mpnet-base-v2",
       "provider": "sentence-transformers",
       "pricing": {
-        "inputCostPerToken": 5e-9,
+        "inputCostPerToken": 5e-09,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12041,7 +12041,7 @@
       "name": "Sentence Transformers: all-MiniLM-L6-v2",
       "provider": "sentence-transformers",
       "pricing": {
-        "inputCostPerToken": 5e-9,
+        "inputCostPerToken": 5e-09,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12061,7 +12061,7 @@
       "name": "Mistral: Mistral Embed 2312",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
+        "inputCostPerToken": 1e-07,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12081,7 +12081,7 @@
       "name": "Google: Gemini Embedding 001",
       "provider": "gemini",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
+        "inputCostPerToken": 1.5e-07,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12101,7 +12101,7 @@
       "name": "OpenAI: Text Embedding Ada 002",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 1e-7,
+        "inputCostPerToken": 1e-07,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12121,7 +12121,7 @@
       "name": "Mistral: Codestral Embed 2505",
       "provider": "mistralai",
       "pricing": {
-        "inputCostPerToken": 1.5e-7,
+        "inputCostPerToken": 1.5e-07,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12141,7 +12141,7 @@
       "name": "OpenAI: Text Embedding 3 Large",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 1.3e-7,
+        "inputCostPerToken": 1.3e-07,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12161,7 +12161,7 @@
       "name": "OpenAI: Text Embedding 3 Small",
       "provider": "openai",
       "pricing": {
-        "inputCostPerToken": 2e-8,
+        "inputCostPerToken": 2e-08,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12181,7 +12181,7 @@
       "name": "Qwen: Qwen3 Embedding 8B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 1e-8,
+        "inputCostPerToken": 1e-08,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12201,7 +12201,7 @@
       "name": "Qwen: Qwen3 Embedding 4B",
       "provider": "qwen",
       "pricing": {
-        "inputCostPerToken": 2e-8,
+        "inputCostPerToken": 2e-08,
         "outputCostPerToken": 0
       },
       "contextLength": 0,
@@ -12211,6 +12211,95 @@
       "modality": "text->embeddings",
       "mode": "embedding",
       "description": "The Qwen3 Embedding model series is the latest proprietary model of the Qwen family, specifically designed for text embedding and ranking tasks. This series inherits the exceptional multilingual capabilities, long-text understanding, and reasoning skills of its foundational model. The Qwen3 Embedding series represents significant advancements in multiple text embedding and ranking tasks, including text retrieval, code retrieval, text classification, text clustering, and bitext mining.",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": false
+    },
+    "minimax/minimax-m2.7": {
+      "id": "minimax/minimax-m2.7",
+      "name": "MiniMax: MiniMax M2.7",
+      "provider": "minimax",
+      "pricing": {
+        "inputCostPerToken": 2.5e-07,
+        "outputCostPerToken": 1.2e-06
+      },
+      "contextLength": 1000000,
+      "maxCompletionTokens": 1000000,
+      "supportedParameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "defaultParameters": {
+        "temperature": 1,
+        "topP": 0.95,
+        "frequencyPenalty": null
+      },
+      "modality": "text->text",
+      "mode": "chat",
+      "description": "MiniMax-M2.7 is the latest flagship large language model from MiniMax, featuring a 1M token context window and state-of-the-art performance across coding, reasoning, and agentic workflows. Built on a Mixture-of-Experts architecture, M2.7 delivers exceptional results on benchmarks including SWE-Bench, MATH, and GPQA while maintaining cost efficiency.",
+      "supportsImageInput": false,
+      "supportsAudioInput": false,
+      "supportsImageOutput": false,
+      "supportsAudioOutput": false
+    },
+    "minimax/minimax-m2.7-highspeed": {
+      "id": "minimax/minimax-m2.7-highspeed",
+      "name": "MiniMax: MiniMax M2.7 Highspeed",
+      "provider": "minimax",
+      "pricing": {
+        "inputCostPerToken": 1.5e-07,
+        "outputCostPerToken": 6e-07
+      },
+      "contextLength": 1000000,
+      "maxCompletionTokens": 1000000,
+      "supportedParameters": [
+        "frequency_penalty",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "defaultParameters": {
+        "temperature": 1,
+        "topP": 0.95,
+        "frequencyPenalty": null
+      },
+      "modality": "text->text",
+      "mode": "chat",
+      "description": "MiniMax-M2.7-highspeed is a fast, cost-efficient variant of MiniMax M2.7 optimized for low-latency inference. It maintains the same 1M token context window with reduced pricing, ideal for high-throughput agentic workflows and developer tools.",
       "supportsImageInput": false,
       "supportsAudioInput": false,
       "supportsImageOutput": false,

--- a/langwatch/src/server/modelProviders/registry.ts
+++ b/langwatch/src/server/modelProviders/registry.ts
@@ -282,6 +282,19 @@ export const modelProviders = {
     }),
     enabledSince: new Date("2023-01-01"),
   },
+  minimax: {
+    name: "MiniMax",
+    apiKey: "MINIMAX_API_KEY",
+    endpointKey: undefined,
+    keysSchema: z.object({
+      MINIMAX_API_KEY: z.string().min(1),
+    }),
+    enabledSince: new Date("2025-01-01"),
+    // MiniMax API requires temperature in (0, 1] range
+    parameterConstraints: {
+      temperature: { min: 0, max: 1 },
+    },
+  },
 } satisfies Record<string, ModelProviderDefinition>;
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds MiniMax as a first-class LLM provider in the model providers registry, enabling direct API key configuration alongside existing providers like OpenAI, Anthropic, and DeepSeek.

### Changes

- **Provider registration** (registry.ts): Added minimax provider definition with MINIMAX_API_KEY Zod schema validation and temperature constraint (0-1 range, matching MiniMax API limits)
- **New models** (llmModels.json): Added MiniMax M2.7 and M2.7-highspeed models with 1M token context window and current pricing
- **Provider icon** (MiniMax.tsx + iconsMap.tsx): SVG icon component for the provider selector UI
- **Unit tests** (registry.unit.test.ts): 22 new tests covering provider definition, keysSchema validation, model registry entries, parameter constraints, pricing, and allLitellmModels integration
- **Integration tests** (minimax.integration.test.ts): 8 tests covering registry consistency checks and live MiniMax API calls (skipped when MINIMAX_API_KEY is not set)

### Why

MiniMax already had 6 models in the llmModels.json registry (M2.5, M2.1, M2, M1, M2-her, MiniMax-01) accessible via LiteLLM proxy routing, but was not a configured provider in registry.ts. This meant users could not enter their MiniMax API key directly in the LangWatch settings UI. Adding it as a first-class provider:

1. Enables direct MiniMax API key configuration in the provider settings
2. Adds the latest M2.7 and M2.7-highspeed models (1M context, improved performance)
3. Applies proper temperature constraints (MiniMax API requires 0-1 range)
4. Provides a provider icon in the UI

### Files changed (6)

| File | Change |
|------|--------|
| langwatch/src/server/modelProviders/registry.ts | Added minimax provider definition |
| langwatch/src/server/modelProviders/llmModels.json | Added M2.7 + M2.7-highspeed models |
| langwatch/src/components/icons/MiniMax.tsx | New SVG icon component |
| langwatch/src/server/modelProviders/iconsMap.tsx | Added minimax icon mapping |
| langwatch/src/server/modelProviders/__tests__/registry.unit.test.ts | 22 new unit tests |
| langwatch/src/server/modelProviders/__tests__/minimax.integration.test.ts | 8 new integration tests |

## Test plan

- [x] All 88 existing unit tests pass
- [x] 22 new MiniMax-specific unit tests pass
- [x] 8 integration tests pass (including live API calls with MINIMAX_API_KEY)
- [x] No typecheck regressions in modified files