### PR TITLE
feat: add /postmortem skill for structured incident investigation and write-up

### DIFF
--- a/.claude/skills/postmortem/SKILL.md
+++ b/.claude/skills/postmortem/SKILL.md
@@ -47,7 +47,7 @@ Do not proceed until the content is clean.
 
 **Prerequisites:**
 - `NOTION_API_KEY` must be set in the environment. Never hardcode it.
-- Parent page ID: `32e5e165-d482-80e2-bf9b-ef42132f7424`
+- `NOTION_POSTMORTEM_PAGE_ID` must be set in the environment. This is the Notion page ID where post-mortems are created as children.
 
 ### 3a. Derive page title
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/postmortem/SKILL.md` — a new `/postmortem` skill that codifies the repeatable incident response process developed during the RDS CPU exhaustion incident
- Guides through five phases: investigate → PII check → Notion write-up → GitHub issue creation → verify and report
- Notion post-mortem page is created under the Post-Mortems parent (ID: `32e5e165-d482-80e2-bf9b-ef42132f7424`) with the full structured template (TL;DR callout, TOC, Summary, Impact, Root Causes, Investigated/Ruled Out, Remediation P0/P1/P2, Timeline, Detection Improvements)
- PII check is a mandatory gate before any content is published — no secrets or user data can leak into Notion or GitHub
- API key is read exclusively from `$NOTION_API_KEY` — never hardcoded

## Test plan

- [ ] Run `/postmortem <incident description>` in a Claude session and verify the five phases execute in order
- [ ] Confirm the skill refuses to proceed past Phase 2 if PII is detected in findings
- [ ] Confirm Notion page is created with all required sections under the correct parent page
- [ ] Confirm GitHub parent issue + sub-issues are created and cross-linked
- [ ] Confirm `NOTION_API_KEY` is read from env and never appears in any created content

Closes #2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2653