### PR TITLE
fix: checkbox groups in Add Custom Model dialog only toggle first item

### DIFF
--- a/langwatch/src/components/settings/AddCustomModelDialog.tsx
+++ b/langwatch/src/components/settings/AddCustomModelDialog.tsx
@@ -1,7 +1,9 @@
 import {
+  Box,
   Button,
   HStack,
   Input,
+  Spacer,
   Text,
   VStack,
   Wrap,
@@ -223,41 +225,74 @@ export function AddCustomModelDialog({
               />
             </HorizontalFormControl>
 
-            <HorizontalFormControl
-              label="Supported Parameters"
-              helper="Which sampling parameters this model accepts"
+            <Box
+              role="group"
+              aria-label="Supported Parameters"
+              borderBottomWidth="1px"
+              paddingY={5}
             >
-              <Wrap gap={3}>
-                {DIALOG_PARAMETERS.map((param) => (
-                  <Checkbox
-                    key={param.value}
-                    checked={supportedParameters.includes(param.value)}
-                    onCheckedChange={() => toggleParameter(param.value)}
-                    size="sm"
-                  >
-                    <Text fontSize="sm">{param.label}</Text>
-                  </Checkbox>
-                ))}
-              </Wrap>
-            </HorizontalFormControl>
+              <HStack
+                width="full"
+                flexDirection={["column", "column", "row"]}
+                gap={4}
+              >
+                <VStack align="start" gap={1} width="full">
+                  <Text fontWeight="medium">Supported Parameters</Text>
+                  <Text fontSize="13px" color="fg.muted">
+                    Which sampling parameters this model accepts
+                  </Text>
+                </VStack>
+                <Spacer />
+                <Box minWidth={["full", "full", "50%"]}>
+                  <Wrap gap={3}>
+                    {DIALOG_PARAMETERS.map((param) => (
+                      <Checkbox
+                        key={param.value}
+                        checked={supportedParameters.includes(param.value)}
+                        onCheckedChange={() => toggleParameter(param.value)}
+                        size="sm"
+                      >
+                        <Text fontSize="sm">{param.label}</Text>
+                      </Checkbox>
+                    ))}
+                  </Wrap>
+                </Box>
+              </HStack>
+            </Box>
 
-            <HorizontalFormControl
-              label="Multimodal Support"
-              helper="Input types this model can process besides text"
+            <Box
+              role="group"
+              aria-label="Multimodal Support"
+              paddingY={5}
             >
-              <Wrap gap={3}>
-                {multimodalInputValues.map((input) => (
-                  <Checkbox
-                    key={input}
-                    checked={multimodalInputs.includes(input)}
-                    onCheckedChange={() => toggleMultimodal(input)}
-                    size="sm"
-                  >
-                    <Text fontSize="sm">{MULTIMODAL_LABELS[input]}</Text>
-                  </Checkbox>
-                ))}
-              </Wrap>
-            </HorizontalFormControl>
+              <HStack
+                width="full"
+                flexDirection={["column", "column", "row"]}
+                gap={4}
+              >
+                <VStack align="start" gap={1} width="full">
+                  <Text fontWeight="medium">Multimodal Support</Text>
+                  <Text fontSize="13px" color="fg.muted">
+                    Input types this model can process besides text
+                  </Text>
+                </VStack>
+                <Spacer />
+                <Box minWidth={["full", "full", "50%"]}>
+                  <Wrap gap={3}>
+                    {multimodalInputValues.map((input) => (
+                      <Checkbox
+                        key={input}
+                        checked={multimodalInputs.includes(input)}
+                        onCheckedChange={() => toggleMultimodal(input)}
+                        size="sm"
+                      >
+                        <Text fontSize="sm">{MULTIMODAL_LABELS[input]}</Text>
+                      </Checkbox>
+                    ))}
+                  </Wrap>
+                </Box>
+              </HStack>
+            </Box>
           </VStack>
         </DialogBody>
         <DialogFooter>


### PR DESCRIPTION
## Summary
- **Bug:** In the "Add Custom Model" dialog, clicking any checkbox in "Supported Parameters" (Top P, Top K, Reasoning) or "Multimodal Support" (Files, Audio) only toggles the first item (Temperature / Images)
- **Root cause:** `HorizontalFormControl` uses Chakra v3's `Field.Root` + `Field.Label`, which assigns a single `id` to the first form control descendant. Multiple checkboxes inside one `Field.Root` all compete for that ID, so clicks always route to the first checkbox
- **Fix:** Replace `HorizontalFormControl` with plain `Box` layout (using `role="group"` + `aria-label` for accessibility) for the two checkbox group sections. Text input fields remain in `HorizontalFormControl` since they each have exactly one input

## Test plan
- [ ] Open Model Provider settings → Add Custom Model dialog
- [ ] Click each "Supported Parameters" checkbox (Temperature, Top P, Top K, Reasoning) — each should toggle independently
- [ ] Click each "Multimodal Support" checkbox (Images, Files, Audio) — each should toggle independently
- [ ] Verify visual layout matches the previous design (labels, helper text, spacing)