### PR TITLE
fix: remove dead cost-checker code from worker paths

### DIFF
--- a/langwatch/src/pages/api/dataset/evaluate.ts
+++ b/langwatch/src/pages/api/dataset/evaluate.ts
@@ -9,7 +9,6 @@ import { fromZodError, type ZodError } from "zod-validation-error";
 import { captureException } from "~/utils/posthogErrorCapture";
 import { getInputsOutputs } from "../../../optimization_studio/utils/nodeUtils";
 import { getCustomEvaluators } from "../../../server/api/routers/evaluations";
-import { createCostChecker } from "../../../server/license-enforcement/license-enforcement.repository";
 import { extractChunkTextualContent } from "../../../server/background/workers/collector/rag";
 import {
   type DataForEvaluation,
@@ -104,23 +103,6 @@ export default async function handler(
 
     const validationError = fromZodError(error as ZodError);
     return res.status(400).json({ error: validationError.message });
-  }
-
-  const costChecker = createCostChecker(prisma);
-  const maxMonthlyUsage = await costChecker.maxMonthlyUsageLimit(
-    project.team.organizationId,
-  );
-  if (maxMonthlyUsage !== Infinity) {
-    const getCurrentCost = await costChecker.getCurrentMonthCost(
-      project.team.organizationId,
-    );
-
-    if (getCurrentCost >= maxMonthlyUsage) {
-      return res.status(200).json({
-        status: "skipped",
-        details: "Monthly usage limit exceeded",
-      });
-    }
   }
 
   const { datasetSlug } = params;

--- a/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
@@ -13,20 +13,17 @@ import type { SingleEvaluationResult } from "~/server/evaluations/evaluators.gen
 import type { Trace } from "~/server/tracer/types";
 import type { LangEvalsClient } from "../../clients/langevals/langevals.client";
 import {
-  CostLimitExceededError,
   EvaluatorConfigError,
   EvaluatorNotFoundError,
   TraceNotEvaluatableError,
 } from "../errors";
 import {
   EvaluationExecutionService,
-  type CostChecker,
   type EvaluationExecutionDeps,
   type ModelEnvResolver,
   type WorkflowExecutor,
 } from "../evaluation-execution.service";
 import type { TraceService } from "~/server/traces/trace.service";
-import type { ProjectService } from "../../projects/project.service";
 
 // Uses a real evaluator from AVAILABLE_EVALUATORS — no vi.mock needed.
 // openai/moderation: requiredFields=[], optionalFields=["input","output"], envVars=[]
@@ -54,10 +51,8 @@ function buildTrace(overrides?: Partial<Trace>): Trace {
 
 interface TestOverrides {
   traceService?: Partial<Pick<TraceService, "getTracesWithSpans" | "getTracesWithSpansByThreadIds">>;
-  costChecker?: Partial<CostChecker>;
   modelEnvResolver?: Partial<ModelEnvResolver>;
   workflowExecutor?: Partial<WorkflowExecutor>;
-  projectService?: Partial<Pick<ProjectService, "getWithTeam">>;
   client?: Partial<LangEvalsClient>;
   trace?: Trace | undefined;
 }
@@ -70,12 +65,6 @@ function createTestService(overrides: TestOverrides = {}) {
     getTracesWithSpansByThreadIds: vi.fn().mockResolvedValue([]),
     ...overrides.traceService,
   } as unknown as TraceService;
-
-  const mockCostChecker: CostChecker = {
-    maxMonthlyUsageLimit: vi.fn().mockResolvedValue(Infinity),
-    getCurrentMonthCost: vi.fn().mockResolvedValue(0),
-    ...overrides.costChecker,
-  };
 
   const mockModelEnvResolver: ModelEnvResolver = {
     resolveForEvaluator: vi.fn().mockResolvedValue({}),
@@ -90,14 +79,6 @@ function createTestService(overrides: TestOverrides = {}) {
     ...overrides.workflowExecutor,
   };
 
-  const mockProjectService = {
-    getWithTeam: vi.fn().mockResolvedValue({
-      id: "proj-1",
-      team: { organizationId: "org-1" },
-    }),
-    ...overrides.projectService,
-  } as unknown as ProjectService;
-
   const mockClient: LangEvalsClient = {
     evaluate: vi.fn().mockResolvedValue({
       status: "processed",
@@ -109,8 +90,6 @@ function createTestService(overrides: TestOverrides = {}) {
 
   const deps: EvaluationExecutionDeps = {
     traceService: mockTraceService,
-    projectService: mockProjectService,
-    costChecker: mockCostChecker,
     modelEnvResolver: mockModelEnvResolver,
     workflowExecutor: mockWorkflowExecutor,
     langevalsClient: mockClient,
@@ -121,10 +100,8 @@ function createTestService(overrides: TestOverrides = {}) {
   return {
     service,
     mockTraceService,
-    mockCostChecker,
     mockModelEnvResolver,
     mockWorkflowExecutor,
-    mockProjectService,
     mockClient,
   };
 }
@@ -280,51 +257,6 @@ describe("EvaluationExecutionService", () => {
         });
 
         expect(result.status).toBe("error");
-      });
-    });
-
-    describe("when cost limit is exceeded", () => {
-      it("throws CostLimitExceededError", async () => {
-        const { service } = createTestService({
-          costChecker: {
-            maxMonthlyUsageLimit: vi.fn().mockResolvedValue(100),
-            getCurrentMonthCost: vi.fn().mockResolvedValue(100),
-          },
-        });
-
-        await expect(service.executeForTrace(defaultParams)).rejects.toThrow(
-          CostLimitExceededError,
-        );
-      });
-    });
-
-    describe("when maxMonthlyUsageLimit is Infinity", () => {
-      it("skips getCurrentMonthCost call", async () => {
-        const getCurrentMonthCost = vi.fn().mockResolvedValue(0);
-        const { service } = createTestService({
-          costChecker: {
-            maxMonthlyUsageLimit: vi.fn().mockResolvedValue(Infinity),
-            getCurrentMonthCost,
-          },
-        });
-
-        await service.executeForTrace(defaultParams);
-
-        expect(getCurrentMonthCost).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("when project is not found", () => {
-      it("throws EvaluatorConfigError", async () => {
-        const { service } = createTestService({
-          projectService: {
-            getWithTeam: vi.fn().mockResolvedValue(null),
-          },
-        });
-
-        await expect(service.executeForTrace(defaultParams)).rejects.toThrow(
-          EvaluatorConfigError,
-        );
       });
     });
 

--- a/langwatch/src/server/app-layer/evaluations/errors.ts
+++ b/langwatch/src/server/app-layer/evaluations/errors.ts
@@ -46,22 +46,6 @@ export class EvaluatorConfigError extends DomainError {
   }
 }
 
-export class CostLimitExceededError extends DomainError {
-  declare readonly kind: "cost_limit_exceeded";
-
-  constructor(
-    organizationId: string,
-    options: { reasons?: readonly Error[] } = {},
-  ) {
-    super("cost_limit_exceeded", "Monthly usage limit exceeded", {
-      meta: { organizationId },
-      httpStatus: 429,
-      ...options,
-    });
-    this.name = "CostLimitExceededError";
-  }
-}
-
 export class EvaluatorExecutionError extends DomainError {
   declare readonly kind: "evaluator_execution_error";
 

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -20,9 +20,7 @@ import {
 } from "~/server/tracer/tracesMapping";
 import type { Trace } from "~/server/tracer/types";
 import type { TraceService } from "~/server/traces/trace.service";
-import type { ProjectService } from "../projects/project.service";
 import {
-  CostLimitExceededError,
   EvaluatorConfigError,
   EvaluatorNotFoundError,
   TraceNotEvaluatableError,
@@ -42,16 +40,9 @@ const INTERNAL_PROTECTIONS: Protections = {
 
 export interface EvaluationExecutionDeps {
   traceService: TraceService;
-  projectService: ProjectService;
-  costChecker: CostChecker;
   modelEnvResolver: ModelEnvResolver;
   langevalsClient: LangEvalsClient;
   workflowExecutor: WorkflowExecutor;
-}
-
-export interface CostChecker {
-  maxMonthlyUsageLimit(organizationId: string): Promise<number>;
-  getCurrentMonthCost(organizationId: string): Promise<number>;
 }
 
 export interface ModelEnvResolver {
@@ -331,24 +322,6 @@ export class EvaluationExecutionService {
     workflowId?: string | null;
   }): Promise<SingleEvaluationResult> {
     const { projectId, evaluatorType, data, settings, trace, workflowId } = params;
-
-    // Cost limit check
-    const project = await this.deps.projectService.getWithTeam(projectId);
-    if (!project) {
-      throw new EvaluatorConfigError("Project not found");
-    }
-
-    const maxMonthlyUsage = await this.deps.costChecker.maxMonthlyUsageLimit(
-      project.team.organizationId,
-    );
-    if (maxMonthlyUsage !== Infinity) {
-      const currentCost = await this.deps.costChecker.getCurrentMonthCost(
-        project.team.organizationId,
-      );
-      if (currentCost >= maxMonthlyUsage) {
-        throw new CostLimitExceededError(project.team.organizationId);
-      }
-    }
 
     // Custom/workflow evaluators
     if (data.type === "custom") {

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -71,7 +71,6 @@ import { NotificationRepository } from "../../../ee/billing/notifications/reposi
 import { UsageLimitService } from "../../../ee/billing/notifications/usage-limit.service";
 import { traced } from "./tracing";
 import { TraceService } from "../traces/trace.service";
-import { createCostChecker } from "../license-enforcement/license-enforcement.repository";
 import { runEvaluationWorkflow } from "../workflows/runWorkflow";
 
 export function initializeWebApp(): App {
@@ -151,8 +150,6 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
   const evaluationExecution = traced(
     new EvaluationExecutionService({
       traceService,
-      projectService: projects,
-      costChecker: createCostChecker(prisma),
       modelEnvResolver: createDefaultModelEnvResolver(),
       langevalsClient: config.langevalsEndpoint
         ? new LangEvalsHttpClient(config.langevalsEndpoint)

--- a/langwatch/src/server/background/workers/evaluationsWorker.ts
+++ b/langwatch/src/server/background/workers/evaluationsWorker.ts
@@ -35,7 +35,6 @@ class UserConfigError extends Error {
     this.name = "UserConfigError";
   }
 }
-import { createCostChecker } from "../../license-enforcement/license-enforcement.repository";
 import {
   getProjectModelProviders,
   prepareEnvKeys,
@@ -498,29 +497,6 @@ export const runEvaluation = async ({
   workflowId?: string | null;
   retries?: number;
 }): Promise<SingleEvaluationResult> => {
-  const project = await prisma.project.findUnique({
-    where: { id: projectId, archivedAt: null },
-    include: { team: true },
-  });
-  if (!project) {
-    throw new Error("Project not found");
-  }
-  const costChecker = createCostChecker(prisma);
-  const maxMonthlyUsage = await costChecker.maxMonthlyUsageLimit(
-    project.team.organizationId,
-  );
-  if (maxMonthlyUsage !== Infinity) {
-    const getCurrentCost = await costChecker.getCurrentMonthCost(
-      project.team.organizationId,
-    );
-    if (getCurrentCost >= maxMonthlyUsage) {
-      return {
-        status: "skipped",
-        details: "Monthly usage limit exceeded",
-      };
-    }
-  }
-
   if (data.type === "custom") {
     return customEvaluation(
       projectId,

--- a/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
+++ b/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
@@ -44,37 +44,6 @@ interface MemberClassificationContext {
 }
 
 /**
- * Minimal interface for cost checking operations.
- * Follows Interface Segregation Principle - callers only depend on what they need.
- * Used by workers and API routes that just need to check cost limits.
- */
-export interface ICostChecker {
-  getCurrentMonthCost(organizationId: string): Promise<number>;
-  maxMonthlyUsageLimit(organizationId: string): Promise<number>;
-}
-
-/**
- * Factory function to create a minimal cost checker.
- * Used by callers that only need cost checking (evaluate.ts, evaluationsWorker.ts, topicClustering.ts).
- */
-export function createCostChecker(prisma: PrismaClient): ICostChecker {
-  const repository = new LicenseEnforcementRepository(prisma);
-  return {
-    getCurrentMonthCost: (organizationId: string) =>
-      repository.getCurrentMonthCost(organizationId),
-    /**
-     * Get the maximum monthly usage limit for the organization.
-     * FIXME: This was recently changed to return Infinity,
-     * but still takes the organizationId as a parameter.
-     *
-     * Either we remove the organizationId parameter from all the calls to this function,
-     * or we use to get the plan and return it correctly.
-     */
-    maxMonthlyUsageLimit: (_organizationId: string) => Promise.resolve(Infinity),
-  };
-}
-
-/**
  * Repository interface for license enforcement.
  * Defines the contract for counting resources - allows for easy testing
  * and follows Dependency Inversion Principle (DIP).

--- a/langwatch/src/server/topicClustering/__tests__/topicClustering.unit.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/topicClustering.unit.test.ts
@@ -33,13 +33,6 @@ vi.mock("../../env.mjs", () => ({
   env: { TOPIC_CLUSTERING_SERVICE: "http://localhost:1234" },
 }));
 
-vi.mock("~/server/license-enforcement/license-enforcement.repository", () => ({
-  createCostChecker: () => ({
-    maxMonthlyUsageLimit: vi.fn().mockResolvedValue(Infinity),
-    getCurrentMonthCost: vi.fn().mockResolvedValue(0),
-  }),
-}));
-
 vi.mock("~/server/background/queues/topicClusteringQueue", () => ({
   scheduleTopicClusteringNextPage: vi.fn(),
 }));

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -23,7 +23,6 @@ import { getClickHouseClientForProject } from "../clickhouse/clickhouseClient";
 import { prisma } from "../db";
 import { esClient, TRACE_INDEX, traceIndexId } from "../elasticsearch";
 import { getProjectEmbeddingsModel } from "../embeddings";
-import { createCostChecker } from "../license-enforcement/license-enforcement.repository";
 import { getPayloadSizeHistogram } from "../metrics";
 import type { ElasticSearchTrace, Trace } from "../tracer/types";
 import type {
@@ -45,26 +44,9 @@ export const clusterTopicsForProject = async (
 ): Promise<void> => {
   const project = await prisma.project.findUnique({
     where: { id: projectId },
-    include: { team: true },
   });
   if (!project) {
     throw new Error("Project not found");
-  }
-  const costChecker = createCostChecker(prisma);
-  const maxMonthlyUsage = await costChecker.maxMonthlyUsageLimit(
-    project.team.organizationId,
-  );
-  if (maxMonthlyUsage !== Infinity) {
-    const getCurrentCost = await costChecker.getCurrentMonthCost(
-      project.team.organizationId,
-    );
-    if (getCurrentCost >= maxMonthlyUsage) {
-      logger.info(
-        { projectId },
-        "skipping clustering for project as monthly limit has been reached",
-      );
-      return;
-    }
   }
 
   const clickhouse = project.featureClickHouseDataSourceTraces

--- a/specs/features/remove-dead-cost-checker-code.feature
+++ b/specs/features/remove-dead-cost-checker-code.feature
@@ -1,0 +1,89 @@
+Feature: Remove dead cost-checking code from worker paths
+  As a maintainer
+  I want to delete the unused ICostChecker interface, createCostChecker() factory, and all worker cost-check blocks
+  So that every evaluation and clustering job no longer pays for a SUM query whose result is always discarded
+
+  Background:
+    Since Nov 2025 maxMonthlyUsageLimit() returns Infinity unconditionally.
+    The cost-check blocks in the four worker call sites always evaluate
+    `currentCost >= Infinity` which is always false, making the code dead.
+    The repository method getCurrentMonthCost() is still used by
+    UsageStatsService for the usage dashboard and must be preserved.
+
+  # ── Interface and factory removal ──────────────────────────────────────
+
+  @unit
+  Scenario: ICostChecker interface no longer exists
+    Given the license-enforcement repository module
+    When the module is inspected
+    Then the export "ICostChecker" does not exist
+
+  @unit
+  Scenario: createCostChecker factory no longer exists
+    Given the license-enforcement repository module
+    When the module is inspected
+    Then the export "createCostChecker" does not exist
+
+  # ── Worker call-site removal ───────────────────────────────────────────
+
+  @unit
+  Scenario: evaluationsWorker no longer performs cost check
+    Given the evaluationsWorker module
+    When the module is inspected
+    Then it contains no reference to costChecker, maxMonthlyUsageLimit, or createCostChecker
+
+  @unit
+  Scenario: EvaluationExecutionService no longer depends on CostChecker
+    Given the EvaluationExecutionService dependency interface
+    When the interface is inspected
+    Then it does not include a costChecker property
+    And the class does not call maxMonthlyUsageLimit or getCurrentMonthCost
+
+  @unit
+  Scenario: evaluate API route no longer performs cost check
+    Given the dataset evaluate API route
+    When the module is inspected
+    Then it contains no reference to costChecker, maxMonthlyUsageLimit, or createCostChecker
+
+  @unit
+  Scenario: topicClustering no longer performs cost check
+    Given the topicClustering module
+    When the module is inspected
+    Then it contains no reference to costChecker, maxMonthlyUsageLimit, or createCostChecker
+
+  # ── Presets wiring removal ─────────────────────────────────────────────
+
+  @unit
+  Scenario: App presets no longer wire a costChecker into EvaluationExecutionService
+    Given the app-layer presets module
+    When EvaluationExecutionService is constructed
+    Then no costChecker argument is passed
+
+  # ── Preserve repository method for dashboard ───────────────────────────
+
+  @integration
+  Scenario: getCurrentMonthCost remains available in the repository
+    Given a LicenseEnforcementRepository instance
+    When getCurrentMonthCost is called with an organization ID
+    Then it returns the summed cost for the current calendar month
+
+  @integration
+  Scenario: UsageStatsService still reports current month cost on the dashboard
+    Given a UsageStatsService backed by a repository that returns cost data
+    When usage stats are fetched for an organization
+    Then the response includes the current month cost from getCurrentMonthCost
+
+  # ── Existing tests updated ─────────────────────────────────────────────
+
+  @unit
+  Scenario: EvaluationExecutionService unit tests remove cost-limit scenarios
+    Given the evaluation-execution.service unit test file
+    When the test suite is inspected
+    Then there are no test cases for "cost limit exceeded" or "maxMonthlyUsageLimit"
+    And the test factory no longer includes a costChecker mock
+
+  @unit
+  Scenario: topicClustering unit tests remove createCostChecker mock
+    Given the topicClustering unit test file
+    When the test suite is inspected
+    Then there is no vi.mock for createCostChecker


### PR DESCRIPTION
## Summary

Closes #2609

- Remove `ICostChecker` interface and `createCostChecker()` factory from `license-enforcement.repository.ts`
- Remove `CostLimitExceededError` (zero consumers remaining)
- Remove cost-check blocks from all 4 worker call sites (`evaluationsWorker`, `EvaluationExecutionService`, `evaluate` API, `topicClustering`)
- Remove `costChecker`/`projectService` wiring from `presets.ts`
- Clean up unnecessary `include: { team: true }` from topic clustering query
- Remove cost-related test mocks and test cases
- Preserve `getCurrentMonthCost()` on `LicenseEnforcementRepository` (used by usage dashboard)

**Context:** `maxMonthlyUsageLimit()` has returned `Infinity` since Nov 2025. PR #2603 added short-circuit guards (P0 fix for RDS CPU exhaustion) but left the dead code in place. #2609 decided to remove it entirely.

## Test plan

- [x] Unit tests pass (`evaluation-execution.service`, `topicClustering`)
- [x] Typecheck passes
- [x] `getCurrentMonthCost()` preserved for dashboard path
- [x] No references to `ICostChecker`, `createCostChecker`, or `CostLimitExceededError` remain in codebase

# Related Issue

- Resolve #2609