### PR TITLE
docs: harden regression test instructions for test level matching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ specs/               # BDD feature specs
 | Describe blocks without "when" context | Inner describe blocks must use "when" conditions: `describe("when user clicks submit", () => ...)` not `describe("submit behavior", ...)` |
 | Flat test structure with GWT comments | Use nested `describe("given X")` and `describe("when Y")` blocks for BDD structure, not comments |
 | Naming tests as unit when they render components | Tests that render components and mock boundaries are integration tests (`.integration.test.ts`), not unit tests |
+| Writing string-assertion "regression tests" for runtime bugs | If the bug is a runtime crash/error, the regression test must execute the code path and observe the crash — not just assert the generated output string looks different. String checks are supplementary, not primary |
 | Code before tests | Outside-In TDD: spec → test → code |
 | Tests after TODO list | BDD specs come first |
 | Shared types in `types.ts` | Colocate unless truly shared |


### PR DESCRIPTION
## Summary

- Add common mistake to AGENTS.md: writing string-assertion regression tests for runtime crash bugs
- Local `.claude/` changes (not tracked in repo): hardened orchestrate skill, test-reviewer agent, and review skill to enforce test level matching and proper agent delegation

Closes #2663

## Context

During #2660, a string-output unit test was accepted as a "regression test" for a ClickHouse runtime planner crash. The test asserted generated SQL contained `IN` instead of `EXISTS` but never executed the query to prove it doesn't crash. Three instruction gaps allowed this:

1. **Orchestrate Step 2** didn't define what "reproduces the bug" means concretely
2. **Self-Check Step 9** didn't validate test level for bug fixes (only features)
3. **Review skill** role-played reviewers inline instead of spawning dedicated agents with their decision trees

## Test plan

- [x] Verify AGENTS.md common mistake table renders correctly
- [ ] Next bug fix implementation should be reviewed against the new test-level criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2663