### PR TITLE
fix: exclude ScenarioRole Map columns from trace_summaries SELECT to prevent OOM

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary-clickhouse-repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-summary-clickhouse-repository.unit.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { TraceSummaryClickHouseRepository } from "../trace-summary.clickhouse.repository";
+
+function makeMockClient() {
+  const insertFn = vi.fn().mockResolvedValue(undefined);
+  const jsonFn = vi.fn().mockResolvedValue([]);
+  const queryFn = vi.fn().mockResolvedValue({ json: jsonFn });
+  return { client: { query: queryFn, insert: insertFn } as unknown as ClickHouseClient, queryFn, jsonFn, insertFn };
+}
+
+describe("TraceSummaryClickHouseRepository", () => {
+  describe("getByTraceId()", () => {
+    describe("when querying for a trace summary", () => {
+      it("excludes ScenarioRole Map columns from SELECT to avoid OOM on old merged parts", async () => {
+        const { client, queryFn } = makeMockClient();
+        const resolver = vi.fn().mockResolvedValue(client);
+        const repo = new TraceSummaryClickHouseRepository(resolver);
+
+        await repo.getByTraceId("tenant-1", "trace-1");
+
+        const query = queryFn.mock.calls[0]![0].query as string;
+        expect(query).not.toContain("ScenarioRoleCosts");
+        expect(query).not.toContain("ScenarioRoleLatencies");
+        expect(query).not.toContain("ScenarioRoleSpans");
+      });
+
+      it("returns empty objects for scenarioRole fields", async () => {
+        const { client, jsonFn } = makeMockClient();
+        jsonFn.mockResolvedValue([
+          {
+            ProjectionId: "proj-1",
+            TenantId: "tenant-1",
+            TraceId: "trace-1",
+            Version: "1",
+            Attributes: {},
+            OccurredAt: 1000,
+            CreatedAt: 1000,
+            UpdatedAt: 1000,
+            ComputedIOSchemaVersion: "v1",
+            ComputedInput: null,
+            ComputedOutput: null,
+            TimeToFirstTokenMs: null,
+            TimeToLastTokenMs: null,
+            TotalDurationMs: 100,
+            TokensPerSecond: null,
+            SpanCount: 1,
+            ContainsErrorStatus: 0,
+            ContainsOKStatus: 1,
+            ErrorMessage: null,
+            Models: [],
+            TotalCost: null,
+            TokensEstimated: false,
+            TotalPromptTokenCount: null,
+            TotalCompletionTokenCount: null,
+            OutputFromRootSpan: 1,
+            OutputSpanEndTimeMs: 1100,
+            BlockedByGuardrail: 0,
+            TopicId: null,
+            SubTopicId: null,
+            HasAnnotation: null,
+          },
+        ]);
+        const resolver = vi.fn().mockResolvedValue(client);
+        const repo = new TraceSummaryClickHouseRepository(resolver);
+
+        const result = await repo.getByTraceId("tenant-1", "trace-1");
+
+        expect(result).not.toBeNull();
+        expect(result!.scenarioRoleCosts).toEqual({});
+        expect(result!.scenarioRoleLatencies).toEqual({});
+        expect(result!.scenarioRoleSpans).toEqual({});
+      });
+    });
+  });
+
+  describe("upsert()", () => {
+    describe("when writing a trace summary", () => {
+      it("includes ScenarioRole Map columns in the insert values", async () => {
+        const { client, insertFn } = makeMockClient();
+        const resolver = vi.fn().mockResolvedValue(client);
+        const repo = new TraceSummaryClickHouseRepository(resolver);
+
+        await repo.upsert(
+          {
+            traceId: "trace-1",
+            spanCount: 1,
+            totalDurationMs: 100,
+            computedIOSchemaVersion: "v1",
+            computedInput: null,
+            computedOutput: null,
+            timeToFirstTokenMs: null,
+            timeToLastTokenMs: null,
+            tokensPerSecond: null,
+            containsErrorStatus: false,
+            containsOKStatus: true,
+            errorMessage: null,
+            models: [],
+            totalCost: null,
+            tokensEstimated: false,
+            totalPromptTokenCount: null,
+            totalCompletionTokenCount: null,
+            outputFromRootSpan: true,
+            outputSpanEndTimeMs: 1100,
+            blockedByGuardrail: false,
+            topicId: null,
+            subTopicId: null,
+            hasAnnotation: null,
+            attributes: {},
+            scenarioRoleCosts: { agent: 0.05 },
+            scenarioRoleLatencies: { agent: 200 },
+            scenarioRoleSpans: { agent: "span-1" },
+            occurredAt: 1000,
+            createdAt: 1000,
+            updatedAt: 1000,
+          },
+          "tenant-1",
+        );
+
+        const insertedValues = insertFn.mock.calls[0]![0].values[0];
+        expect(insertedValues.ScenarioRoleCosts).toEqual({ agent: 0.05 });
+        expect(insertedValues.ScenarioRoleLatencies).toEqual({ agent: 200 });
+        expect(insertedValues.ScenarioRoleSpans).toEqual({ agent: "span-1" });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -13,11 +13,15 @@ const logger = createLogger(
   "langwatch:app-layer:traces:trace-summary-repository",
 );
 
-type ClickHouseSummaryWriteRecord = WithDateWrites<
-  ClickHouseSummaryRecord,
-  "OccurredAt" | "CreatedAt" | "UpdatedAt"
->;
-
+/**
+ * Read-side record type — intentionally excludes ScenarioRoleCosts,
+ * ScenarioRoleLatencies, and ScenarioRoleSpans.
+ *
+ * WHY: These Map(String, ...) columns were added after millions of rows already
+ * existed. When ClickHouse reads old merged parts it materializes default empty
+ * maps for every row in the granule, causing OOM kills. The trace-side reactor
+ * uses fold state instead, so these values are never needed on the read path.
+ */
 interface ClickHouseSummaryRecord {
   ProjectionId: string;
   TenantId: string;
@@ -49,10 +53,20 @@ interface ClickHouseSummaryRecord {
   TopicId: string | null;
   SubTopicId: string | null;
   HasAnnotation: number | null;
+}
+
+/** Write-side record extends the read type with ScenarioRole Map columns.
+ *  Single-row inserts are fine — only reads across old merged parts OOM. */
+interface ClickHouseSummaryWriteExtended extends ClickHouseSummaryRecord {
   ScenarioRoleCosts: Record<string, number>;
   ScenarioRoleLatencies: Record<string, number>;
   ScenarioRoleSpans: Record<string, string>;
 }
+
+type ClickHouseSummaryWriteRecord = WithDateWrites<
+  ClickHouseSummaryWriteExtended,
+  "OccurredAt" | "CreatedAt" | "UpdatedAt"
+>;
 
 export class TraceSummaryClickHouseRepository implements TraceSummaryRepository {
   constructor(private readonly resolveClient: ClickHouseClientResolver) {}
@@ -139,10 +153,7 @@ export class TraceSummaryClickHouseRepository implements TraceSummaryRepository 
             BlockedByGuardrail,
             TopicId,
             SubTopicId,
-            HasAnnotation,
-            ScenarioRoleCosts,
-            ScenarioRoleLatencies,
-            ScenarioRoleSpans
+            HasAnnotation
           FROM ${TABLE_NAME}
           WHERE TenantId = {tenantId:String}
             AND TraceId = {traceId:String}
@@ -199,9 +210,10 @@ export class TraceSummaryClickHouseRepository implements TraceSummaryRepository 
       hasAnnotation:
         record.HasAnnotation != null ? record.HasAnnotation === 1 : null,
       attributes: record.Attributes ?? {},
-      scenarioRoleCosts: record.ScenarioRoleCosts ?? {},
-      scenarioRoleLatencies: record.ScenarioRoleLatencies ?? {},
-      scenarioRoleSpans: record.ScenarioRoleSpans ?? {},
+      // Hardcoded to empty — see ClickHouseSummaryRecord comment for OOM rationale.
+      scenarioRoleCosts: {},
+      scenarioRoleLatencies: {},
+      scenarioRoleSpans: {},
       occurredAt: record.OccurredAt,
       createdAt: record.CreatedAt,
       updatedAt: record.UpdatedAt,


### PR DESCRIPTION
## Summary
Map(String, Float64) columns (ScenarioRoleCosts, ScenarioRoleLatencies, ScenarioRoleSpans) added to `trace_summaries` cause ClickHouse OOM when reading old merged parts. ClickHouse materializes default empty maps for every row in the granule, exceeding memory limits on parts with millions of rows.

This caused 201 BLOCKED traceSummary projections in production and hundreds of pending jobs accumulating.

## Fix
- Remove the 3 Map columns from the `SELECT` query in `getByTraceId()`
- Return empty `{}` for scenarioRoleCosts/Latencies/Spans on reads
- Keep writing them on `upsert()` (single-row inserts don't OOM)
- Separate read type (`ClickHouseSummaryRecord`) from write type (`ClickHouseSummaryWriteExtended`)

The trace-side reactor uses fold state (not the store) so role metrics propagation is unaffected.

## Root cause analysis
The issue is NOT an infinite loop — it's cascading failures:
1. Each OOM failure retries 15 times with exponential backoff
2. After 15 attempts, the group becomes BLOCKED permanently
3. 201 trace aggregates hit the OOM = 201 BLOCKED groups
4. Reactor dispatches queue up behind blocked folds = growing PENDING count

## Test plan
- [x] 3 regression tests: SELECT excludes Map columns, reads return empty, writes include them
- [x] `pnpm typecheck` passes

# Related Issue

- Resolve #2602