### PR TITLE
chore: add pull request description template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Why
+
+<!-- What problem does this solve? Link the issue. A reviewer who hasn't seen the issue should understand the motivation after reading this section. -->
+
+Closes #
+
+## What changed
+
+<!-- Plain-English summary of what you did. Focus on the approach and key decisions, not a line-by-line diff. A non-technical teammate should be able to follow this. -->
+
+## How it works
+
+<!-- Only if the "what" isn't obvious. Explain the mechanism, trade-offs, or why you chose this approach over alternatives. Skip this section for straightforward changes. -->
+
+## Test plan
+
+<!-- How did you verify this works? List the key test scenarios. For bug fixes: what regression test did you add, and does it fail without the fix? -->
+
+## Anything surprising?
+
+<!-- Optional. Call out: known limitations, follow-up work needed, things a reviewer should pay extra attention to, or edge cases you deliberately chose not to handle. Delete this section if there's nothing to flag. -->


### PR DESCRIPTION
## Why

We had no PR template. PR descriptions were inconsistent — some were bullet dumps of code changes, others were missing context entirely. Reviewers had to read the diff to understand why a change was made.

## What changed

Added `.github/PULL_REQUEST_TEMPLATE.md` with five sections that tell a story:

- **Why** — the problem and issue link
- **What changed** — plain-English summary
- **How it works** — mechanism and trade-offs (optional, for non-obvious changes)
- **Test plan** — verification approach
- **Anything surprising?** — limitations, follow-ups, heads-up for reviewers (optional)

The structure mirrors the existing issue templates (bug report → describe/reproduce/expected; feature → problem/solution/alternatives) so the PR naturally answers the questions the issue raised.

## How it works

GitHub auto-populates this template when creating a PR via the web UI or `gh pr create`. The HTML comments guide authors without cluttering the rendered description — they disappear once replaced with real content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)