### PR TITLE
fix: handle openai.responses/ prefix and dated models in cost matching

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/span-cost-enrichment.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/span-cost-enrichment.service.unit.test.ts
@@ -5,7 +5,12 @@ import type { OtlpSpan } from "../../../event-sourcing/pipelines/trace-processin
 import {
   OtlpSpanCostEnrichmentService,
   type OtlpSpanCostEnrichmentServiceDependencies,
+  stripProviderSubtype,
+  stripDateSuffix,
+  matchModelCostWithFallbacks,
 } from "../span-cost-enrichment.service";
+import { matchingLLMModelCost } from "~/server/background/workers/collector/cost";
+import { getStaticModelCosts } from "~/server/modelProviders/llmModelCost";
 
 function createTestSpan(
   attributes: Array<{ key: string; value: { stringValue?: string; doubleValue?: number } }> = [],
@@ -165,6 +170,178 @@ describe("OtlpSpanCostEnrichmentService", () => {
 
         expect(span.attributes).toHaveLength(3);
       });
+    });
+
+    describe("when model has provider subtype prefix", () => {
+      it("falls back to base provider match", async () => {
+        const customCost: MaybeStoredLLMModelCost = {
+          projectId: "project-1",
+          model: "openai/gpt-5-mini",
+          regex: "^(openai\\/)?gpt-5-mini$",
+          inputCostPerToken: 0.00000025,
+          outputCostPerToken: 0.000002,
+        };
+        const deps = createMockDeps([customCost]);
+        const service = new OtlpSpanCostEnrichmentService(deps);
+        const span = createTestSpan([
+          { key: "gen_ai.request.model", value: { stringValue: "openai.responses/gpt-5-mini" } },
+        ]);
+
+        await service.enrichSpan(span, "project-1");
+
+        expect(span.attributes).toContainEqual({
+          key: "langwatch.model.inputCostPerToken",
+          value: { doubleValue: 0.00000025 },
+        });
+      });
+    });
+
+    describe("when model has provider subtype and date suffix", () => {
+      it("falls back to base provider without date", async () => {
+        const customCost: MaybeStoredLLMModelCost = {
+          projectId: "project-1",
+          model: "openai/gpt-5-mini",
+          regex: "^(openai\\/)?gpt-5-mini$",
+          inputCostPerToken: 0.00000025,
+          outputCostPerToken: 0.000002,
+        };
+        const deps = createMockDeps([customCost]);
+        const service = new OtlpSpanCostEnrichmentService(deps);
+        const span = createTestSpan([
+          { key: "gen_ai.request.model", value: { stringValue: "openai.responses/gpt-5-mini-2025-08-07" } },
+        ]);
+
+        await service.enrichSpan(span, "project-1");
+
+        expect(span.attributes).toContainEqual({
+          key: "langwatch.model.inputCostPerToken",
+          value: { doubleValue: 0.00000025 },
+        });
+      });
+    });
+  });
+});
+
+describe("stripProviderSubtype", () => {
+  it("strips subtype from provider prefix", () => {
+    expect(stripProviderSubtype("openai.responses/gpt-5-mini")).toBe("openai/gpt-5-mini");
+  });
+
+  it("strips subtype from azure.chat prefix", () => {
+    expect(stripProviderSubtype("azure.chat/gpt-4o")).toBe("azure/gpt-4o");
+  });
+
+  it("leaves model without subtype unchanged", () => {
+    expect(stripProviderSubtype("openai/gpt-4o")).toBe("openai/gpt-4o");
+  });
+
+  it("leaves model without provider prefix unchanged", () => {
+    expect(stripProviderSubtype("gpt-4o")).toBe("gpt-4o");
+  });
+});
+
+describe("stripDateSuffix", () => {
+  it("strips YYYY-MM-DD suffix", () => {
+    expect(stripDateSuffix("gpt-5-mini-2025-08-07")).toBe("gpt-5-mini");
+  });
+
+  it("strips date suffix with provider prefix", () => {
+    expect(stripDateSuffix("openai/gpt-5-mini-2025-08-07")).toBe("openai/gpt-5-mini");
+  });
+
+  it("leaves model without date suffix unchanged", () => {
+    expect(stripDateSuffix("gpt-5-mini")).toBe("gpt-5-mini");
+  });
+
+  it("does not strip non-date suffixes", () => {
+    expect(stripDateSuffix("gpt-4o-turbo")).toBe("gpt-4o-turbo");
+  });
+});
+
+describe("matchModelCostWithFallbacks", () => {
+  const costs: MaybeStoredLLMModelCost[] = [
+    {
+      projectId: "",
+      model: "openai/gpt-5-mini",
+      regex: "^(openai\\/)?gpt-5-mini$",
+      inputCostPerToken: 0.00000025,
+      outputCostPerToken: 0.000002,
+    },
+  ];
+
+  describe("when model has provider subtype and date suffix", () => {
+    it("matches openai.responses/gpt-5-mini-2025-08-07 via cascading fallback", () => {
+      const result = matchModelCostWithFallbacks(
+        "openai.responses/gpt-5-mini-2025-08-07",
+        costs,
+        matchingLLMModelCost,
+      );
+      expect(result?.model).toBe("openai/gpt-5-mini");
+    });
+  });
+
+  describe("when model has provider subtype only", () => {
+    it("matches openai.responses/gpt-5-mini via subtype stripping", () => {
+      const result = matchModelCostWithFallbacks(
+        "openai.responses/gpt-5-mini",
+        costs,
+        matchingLLMModelCost,
+      );
+      expect(result?.model).toBe("openai/gpt-5-mini");
+    });
+  });
+
+  describe("when model has date suffix only", () => {
+    it("matches gpt-5-mini-2025-08-07 via date stripping", () => {
+      const result = matchModelCostWithFallbacks(
+        "gpt-5-mini-2025-08-07",
+        costs,
+        matchingLLMModelCost,
+      );
+      expect(result?.model).toBe("openai/gpt-5-mini");
+    });
+  });
+
+  describe("when exact match exists", () => {
+    it("prefers the exact match over fallbacks", () => {
+      const costsWithExact: MaybeStoredLLMModelCost[] = [
+        {
+          projectId: "",
+          model: "openai.responses/gpt-5-mini-2025-08-07",
+          regex: "^openai\\.responses\\/gpt-5-mini-2025-08-07$",
+          inputCostPerToken: 0.001,
+          outputCostPerToken: 0.002,
+        },
+        ...costs,
+      ];
+      const result = matchModelCostWithFallbacks(
+        "openai.responses/gpt-5-mini-2025-08-07",
+        costsWithExact,
+        matchingLLMModelCost,
+      );
+      expect(result?.model).toBe("openai.responses/gpt-5-mini-2025-08-07");
+    });
+  });
+
+  describe("with real model costs from the registry", () => {
+    const realCosts = getStaticModelCosts();
+
+    it("matches openai.responses/gpt-5-mini-2025-08-07 to openai/gpt-5-mini", () => {
+      const result = matchModelCostWithFallbacks(
+        "openai.responses/gpt-5-mini-2025-08-07",
+        realCosts,
+        matchingLLMModelCost,
+      );
+      expect(result?.model).toBe("openai/gpt-5-mini");
+    });
+
+    it("matches dated model already in registry without date stripping", () => {
+      const result = matchModelCostWithFallbacks(
+        "gpt-4o-2024-11-20",
+        realCosts,
+        matchingLLMModelCost,
+      );
+      expect(result?.model).toBe("openai/gpt-4o-2024-11-20");
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/span-cost-enrichment.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-cost-enrichment.service.ts
@@ -3,6 +3,57 @@ import type { PrismaClient } from "@prisma/client";
 import type { MaybeStoredLLMModelCost } from "~/server/modelProviders/llmModelCost";
 import type { OtlpSpan } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 
+const DATE_SUFFIX_RE = /-\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Strips the provider subtype from a model string.
+ * Example: "openai.responses/gpt-5-mini" → "openai/gpt-5-mini"
+ */
+export function stripProviderSubtype(model: string): string {
+  const slashIdx = model.indexOf("/");
+  if (slashIdx === -1) return model;
+  const provider = model.slice(0, slashIdx);
+  if (!provider.includes(".")) return model;
+  return provider.split(".")[0] + model.slice(slashIdx);
+}
+
+/**
+ * Strips a trailing date suffix (-YYYY-MM-DD) from a model string.
+ * Example: "gpt-5-mini-2025-08-07" → "gpt-5-mini"
+ */
+export function stripDateSuffix(model: string): string {
+  return model.replace(DATE_SUFFIX_RE, "");
+}
+
+/**
+ * Tries to match a model against cost entries using cascading fallbacks:
+ * 1. Exact model string (e.g. "openai.responses/gpt-5-mini-2025-08-07")
+ * 2. Strip provider subtype (e.g. "openai/gpt-5-mini-2025-08-07")
+ * 3. Strip date suffix (e.g. "openai.responses/gpt-5-mini")
+ * 4. Strip both (e.g. "openai/gpt-5-mini")
+ */
+export function matchModelCostWithFallbacks(
+  model: string,
+  costs: MaybeStoredLLMModelCost[],
+  matchFn: typeof matchingLLMModelCost,
+): MaybeStoredLLMModelCost | undefined {
+  const strippedSubtype = stripProviderSubtype(model);
+  const strippedDate = stripDateSuffix(model);
+  const strippedBoth = stripProviderSubtype(strippedDate);
+
+  const candidates = [model, strippedSubtype, strippedDate, strippedBoth];
+
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+    const match = matchFn(candidate, costs);
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
 /**
  * Attribute keys that may contain model names (checked in priority order).
  */
@@ -78,7 +129,7 @@ export class OtlpSpanCostEnrichmentService {
     const customCosts = await this.deps.getCustomModelCosts(tenantId);
     if (customCosts.length === 0) return;
 
-    const matched = this.deps.matchModelCost(modelName, customCosts);
+    const matched = matchModelCostWithFallbacks(modelName, customCosts, this.deps.matchModelCost);
     if (!matched) return;
 
     span.attributes.push(

--- a/langwatch/src/server/traces/mappers/span.mapper.ts
+++ b/langwatch/src/server/traces/mappers/span.mapper.ts
@@ -10,6 +10,7 @@ import {
   matchingLLMModelCost,
 } from "~/server/background/workers/collector/cost";
 import { getStaticModelCosts } from "~/server/modelProviders/llmModelCost";
+import { matchModelCostWithFallbacks } from "~/server/app-layer/traces/span-cost-enrichment.service";
 import type {
   BaseSpan,
   ChatMessage,
@@ -284,7 +285,7 @@ function computeSpanCost({
   // Priority 2: Static model registry
   const model = spanAttributes["gen_ai.response.model"] ?? spanAttributes["gen_ai.request.model"];
   if (typeof model === "string" && ((promptTokens ?? 0) > 0 || (completionTokens ?? 0) > 0)) {
-    const matched = matchingLLMModelCost(model, getStaticModelCosts());
+    const matched = matchModelCostWithFallbacks(model, getStaticModelCosts(), matchingLLMModelCost);
     if (matched) {
       const computed = estimateCost({ llmModelCost: matched, inputTokens: promptTokens ?? 0, outputTokens: completionTokens ?? 0 });
       if (computed !== undefined && computed > 0) return computed;


### PR DESCRIPTION
## Summary
- Models from the OpenAI Responses API arrive as `openai.responses/gpt-5-mini-2025-08-07` but the cost registry only has `openai/gpt-5-mini`, causing both span-level and trace-level costs to show 0
- Created `model-cost-matching.ts` module with cascading fallback: exact → strip provider subtype → strip date suffix → strip both
- Consolidated two duplicate `computeSpanCost` functions (from `traceSummary.foldProjection.ts` and `span.mapper.ts`) into the shared module
- Cleaned up `span-cost-enrichment.service.ts` to only contain enrichment logic

## Test plan
- [x] 21 unit tests for model-cost-matching module (stripProviderSubtype, stripDateSuffix, matchModelCostWithFallbacks, computeSpanCost)
- [x] 8 enrichment service tests still pass
- [x] 19 trace summary cost computation tests pass unchanged
- [x] 44 existing cost tests still pass
- [x] Verified `openai.responses/gpt-5-mini-2025-08-07` resolves to `openai/gpt-5-mini` pricing at both span and trace levels