### PR TITLE
fix: lite member UI restrictions and minor UI fixes

### DIFF
--- a/langwatch/src/components/AnnotationExpectedOutputs.tsx
+++ b/langwatch/src/components/AnnotationExpectedOutputs.tsx
@@ -36,7 +36,6 @@ export const AnnotationExpectedOutputs = ({
             <Text fontWeight="500">Suggest output:</Text>
             <Textarea
               width="full"
-              backgroundColor="white"
               value={expectedOutput ?? ""}
               placeholder="Enter your expected output here..."
               onClick={(e) => {
@@ -80,7 +79,6 @@ export const AnnotationExpectedOutputs = ({
                     {commentState.expectedOutputAction === "edit" &&
                     annotationId === annotation.id ? (
                       <Textarea
-                        backgroundColor="white"
                         value={
                           commentState.expectedOutputAction === "edit"
                             ? (expectedOutput ?? "")

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -20,6 +20,7 @@ import { signIn, signOut } from "next-auth/react";
 import numeral from "numeral";
 import React, { useState } from "react";
 import { useDrawer } from "../hooks/useDrawer";
+import { useLiteMemberGuard } from "../hooks/useLiteMemberGuard";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
 import { useUpgradeModalStore } from "../stores/upgradeModalStore";
 import { UpgradeModal } from "./UpgradeModal";
@@ -286,6 +287,7 @@ export const DashboardLayout = ({
 
   const { isLoading, organization, organizations, team, project } =
     useOrganizationTeamProject();
+  const { isLiteMember } = useLiteMemberGuard();
   const usage = api.limits.getUsage.useQuery(
     { organizationId: organization?.id ?? "" },
     {
@@ -475,11 +477,13 @@ export const DashboardLayout = ({
                   <Menu.ItemGroup
                     title={`${session.user.name} (${session.user.email})`}
                   >
-                    <Menu.Item value="setup" asChild>
-                      <Link href={`/${project?.slug}/setup`}>
-                        API Key & Setup
-                      </Link>
-                    </Menu.Item>
+                    {!isLiteMember && (
+                      <Menu.Item value="setup" asChild>
+                        <Link href={`/${project?.slug}/setup`}>
+                          API Key & Setup
+                        </Link>
+                      </Menu.Item>
+                    )}
                     <Menu.Item value="settings" asChild>
                       <Link href="/settings">Settings</Link>
                     </Menu.Item>

--- a/langwatch/src/components/SettingsLayout.tsx
+++ b/langwatch/src/components/SettingsLayout.tsx
@@ -3,6 +3,7 @@ import type { PropsWithChildren } from "react";
 import { DashboardLayout } from "~/components/DashboardLayout";
 import { MenuLink } from "~/components/MenuLink";
 import { useActivePlan } from "~/hooks/useActivePlan";
+import { useLiteMemberGuard } from "~/hooks/useLiteMemberGuard";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { usePublicEnv } from "~/hooks/usePublicEnv";
 import { PageLayout } from "./ui/layouts/PageLayout";
@@ -17,6 +18,7 @@ export default function SettingsLayout({
   const publicEnv = usePublicEnv();
   const isSaaS = publicEnv.data?.IS_SAAS ?? false;
   const { isEnterprise } = useActivePlan();
+  const { isLiteMember } = useLiteMemberGuard();
 
   return (
     <DashboardLayout compactMenu>
@@ -35,7 +37,9 @@ export default function SettingsLayout({
           display={isSubscription ? "none" : "flex"}
         >
           <MenuLink href="/settings">General Settings</MenuLink>
-          <MenuLink href={`/${project?.slug}/setup`}>API Key & Setup</MenuLink>
+          {!isLiteMember && (
+            <MenuLink href={`/${project?.slug}/setup`}>API Key & Setup</MenuLink>
+          )}
           <MenuLink href="/settings/model-providers">Model Providers</MenuLink>
           <MenuLink href="/settings/model-costs">Model Costs</MenuLink>
           <MenuLink href="/settings/secrets">Secrets</MenuLink>
@@ -62,9 +66,11 @@ export default function SettingsLayout({
           {isEnterprise && (
             <MenuLink href="/settings/scim">SCIM Provisioning</MenuLink>
           )}
-          <MenuLink href="/settings/usage">Usage & Billing</MenuLink>
-          {isSaaS && <MenuLink href="/settings/subscription">Subscription</MenuLink>}
-          {!isSaaS && <MenuLink href="/settings/license">License</MenuLink>}
+          {!isLiteMember && (
+            <MenuLink href="/settings/usage">Usage & Billing</MenuLink>
+          )}
+          {isSaaS && !isLiteMember && <MenuLink href="/settings/subscription">Subscription</MenuLink>}
+          {!isSaaS && !isLiteMember && <MenuLink href="/settings/license">License</MenuLink>}
         </VStack>
         <Container maxWidth="1280px" padding={4} paddingBottom={16}>
           {children}

--- a/langwatch/src/components/settings/LLMModelCostDrawer.tsx
+++ b/langwatch/src/components/settings/LLMModelCostDrawer.tsx
@@ -7,6 +7,7 @@ import { toaster } from "../../components/ui/toaster";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import type { MaybeStoredLLMModelCost } from "../../server/modelProviders/llmModelCost";
 import { api } from "../../utils/api";
+import { isHandledByGlobalHandler } from "../../utils/trpcError";
 import { HorizontalFormControl } from "../HorizontalFormControl";
 
 export function LLMModelCostDrawer({
@@ -127,6 +128,7 @@ function LLMModelCostForm({
           void llmModelCostsQuery.refetch();
         },
         onError: (error) => {
+          if (isHandledByGlobalHandler(error)) return;
           toaster.create({
             title: "Error",
             description: error.message || "Error creating LLM model cost",

--- a/langwatch/src/pages/settings.tsx
+++ b/langwatch/src/pages/settings.tsx
@@ -37,6 +37,7 @@ import { Switch } from "../components/ui/switch";
 import { toaster } from "../components/ui/toaster";
 import { withPermissionGuard } from "../components/WithPermissionGuard";
 import { useActivePlan } from "../hooks/useActivePlan";
+import { useLiteMemberGuard } from "../hooks/useLiteMemberGuard";
 import { useOrganizationTeamProject } from "../hooks/useOrganizationTeamProject";
 import { usePublicEnv } from "../hooks/usePublicEnv";
 import type { FullyLoadedOrganization } from "../server/api/routers/organization";
@@ -72,6 +73,7 @@ function SettingsForm({
   project: Project;
 }) {
   const { hasPermission } = useOrganizationTeamProject();
+  const { isLiteMember } = useLiteMemberGuard();
   const [defaultValues, setDefaultValues] = useState<OrganizationFormData>({
     name: organization.name,
     s3Endpoint: organization.s3Endpoint ?? "",
@@ -254,15 +256,17 @@ function SettingsForm({
               )}
             </VStack>
 
-            <HStack width="full" justify="flex-end" paddingTop={4}>
-              <Button
-                type="submit"
-                colorPalette="blue"
-                loading={updateOrganization.isLoading}
-              >
-                Save Changes
-              </Button>
-            </HStack>
+            {!isLiteMember && (
+              <HStack width="full" justify="flex-end" paddingTop={4}>
+                <Button
+                  type="submit"
+                  colorPalette="blue"
+                  loading={updateOrganization.isLoading}
+                >
+                  Save Changes
+                </Button>
+              </HStack>
+            )}
           </VStack>
         </form>
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `backgroundColor="white"` from annotation "Suggest output" textareas so they respect dark mode theme tokens
- Hide "API Key & Setup" from settings sidebar and profile dropdown menu for lite members
- Hide "Usage & Billing", "Subscription", and "License" settings links for lite members
- Hide organization "Save Changes" button for lite members (fields were already read-only)
- Fix double error display (toast + modal) when saving model costs fails due to role restriction — now checks `isHandledByGlobalHandler` before showing toast

## Test plan
- [ ] Verify "Suggest output" textarea in trace drawer matches dark mode theme (no white background)
- [ ] Log in as lite member (EXTERNAL role) and verify "API Key & Setup" is hidden in settings sidebar and profile menu
- [ ] Verify "Usage & Billing", "Subscription"/"License" links are hidden for lite members
- [ ] Verify "Save Changes" button is hidden on org settings for lite members
- [ ] Clone a model cost as lite member and verify only the modal appears (no duplicate toast)