### PR TITLE
fix(nurturing): first_prompt_created only on first prompt

### DIFF
--- a/langwatch/ee/billing/nurturing/hooks/promptCreation.ts
+++ b/langwatch/ee/billing/nurturing/hooks/promptCreation.ts
@@ -9,12 +9,7 @@ const logger = createLogger("ee:nurturing:prompt-creation");
  * Fires nurturing calls when a prompt is created.
  *
  * Always sends has_prompts: true + prompt_count on every call (idempotent).
- * This ensures recovery if a previous CIO call failed during an outage.
- *
- * Also always sends first_prompt_created event — Customer.io Journey
- * entry conditions fire once per person, so duplicates are harmless.
- * This avoids race conditions when prompts are created concurrently
- * (e.g., via CLI push scripts).
+ * Only sends first_prompt_created event when orgPromptCount === 1.
  *
  * All calls are fire-and-forget.
  *
@@ -34,7 +29,6 @@ export function firePromptCreatedNurturing({
   const nurturing = getApp().nurturing;
   if (!nurturing) return;
 
-  // Always send has_prompts: true — idempotent, recovers from prior failures
   void nurturing
     .identifyUser({
       userId,
@@ -42,14 +36,15 @@ export function firePromptCreatedNurturing({
     })
     .catch(captureException);
 
-  // Always send event — CIO Journey entry deduplicates per person
-  void nurturing
-    .trackEvent({
-      userId,
-      event: "first_prompt_created",
-      properties: { project_id: projectId },
-    })
-    .catch(captureException);
+  if (orgPromptCount === 1) {
+    void nurturing
+      .trackEvent({
+        userId,
+        event: "first_prompt_created",
+        properties: { project_id: projectId },
+      })
+      .catch(captureException);
+  }
 }
 
 /**

--- a/langwatch/ee/billing/nurturing/hooks/promptCreation.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/promptCreation.unit.test.ts
@@ -82,18 +82,14 @@ describe("firePromptCreatedNurturing()", () => {
         });
       });
 
-      it("sends first_prompt_created event (CIO Journey deduplicates per person)", async () => {
+      it("does not send first_prompt_created event", async () => {
         firePromptCreatedNurturing({
           userId: "user-1",
           projectId: "proj-1",
           orgPromptCount: 5,
         });
 
-        expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
-          userId: "user-1",
-          event: "first_prompt_created",
-          properties: { project_id: "proj-1" },
-        });
+        expect(mockNurturing.trackEvent).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## Summary
- `first_prompt_created` event was firing on every prompt creation instead of only the first
- Now only fires when `orgPromptCount === 1`

## Context
Epic: #1781

During manual CIO verification, existing user prompts triggered `first_prompt_created` even when the org already had prompts.

## Test plan
- [x] Unit tests pass (`promptCreation.unit.test.ts` updated: org with existing prompts no longer fires event)
- [ ] Deploy and verify `first_prompt_created` only appears once per org in CIO