### PR TITLE
feat: add playwright-headed MCP server for interactive browser testing

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,9 +10,10 @@
     },
     "playwright-headed": {
       "type": "stdio",
-      "command": "npx",
+      "command": "bash",
       "args": [
-        "@playwright/mcp@latest"
+        "scripts/playwright-mcp.sh",
+        "--headed"
       ],
       "env": {}
     }

--- a/scripts/playwright-mcp.sh
+++ b/scripts/playwright-mcp.sh
@@ -15,4 +15,10 @@ if [ -n "$CHROMIUM_PATH" ]; then
   EXTRA_ARGS+=(--executable-path "$CHROMIUM_PATH")
 fi
 
-exec npx @playwright/mcp@latest --headless "${EXTRA_ARGS[@]}" "$@"
+HEADLESS_FLAG="--headless"
+if [ "$1" = "--headed" ]; then
+  HEADLESS_FLAG=""
+  shift
+fi
+
+exec npx @playwright/mcp@latest $HEADLESS_FLAG "${EXTRA_ARGS[@]}" "$@"


### PR DESCRIPTION
Adds a headed (visible browser) Playwright MCP server alongside the existing test server. This enables interactive browser verification during development, complementing the headless test server for automated testing scenarios.