### PR TITLE
fix(sdk): throw PromptsError instead of Error in fetch-policy branches

### DIFF
--- a/typescript-sdk/src/client-sdk/services/prompts/prompts.facade.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/prompts.facade.ts
@@ -4,6 +4,7 @@ import type { CreatePromptBody, UpdatePromptBody, PromptData } from "./types";
 import { FetchPolicy } from "./types";
 import { type InternalConfig } from "@/client-sdk/types";
 import { LocalPromptsService } from "./local-prompts.service";
+import { PromptsError } from "./errors";
 
 /**
  * Options for fetching a prompt.
@@ -105,7 +106,7 @@ export class PromptsFacade implements Pick<PromptsApiService, "sync" | "delete">
       if (localPrompt) {
         return new Prompt(localPrompt);
       }
-      throw new Error(`Prompt "${handleOrId}" not found locally or on server`);
+      throw new PromptsError(`Prompt "${handleOrId}" not found locally or on server`);
     }
   }
 
@@ -114,7 +115,7 @@ export class PromptsFacade implements Pick<PromptsApiService, "sync" | "delete">
     if (localPrompt) {
       return new Prompt(localPrompt);
     }
-    throw new Error(`Prompt "${handleOrId}" not found in materialized files`);
+    throw new PromptsError(`Prompt "${handleOrId}" not found in materialized files`);
   }
 
   /**
@@ -146,7 +147,7 @@ export class PromptsFacade implements Pick<PromptsApiService, "sync" | "delete">
       if (localPrompt) {
         return new Prompt(localPrompt);
       }
-      throw new Error(`Prompt "${handleOrId}" not found locally or on server`);
+      throw new PromptsError(`Prompt "${handleOrId}" not found locally or on server`);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #976

The public `get` method on `PromptsFacade` documents `@throws {PromptsError}`, but three private fetch-policy methods threw plain `Error` instances instead:

| Method | Before | After |
|--------|--------|-------|
| `getAlwaysFetch` | `throw new Error(...)` | `throw new PromptsError(...)` |
| `getMaterializedOnly` | `throw new Error(...)` | `throw new PromptsError(...)` |
| `getCacheTtl` | `throw new Error(...)` | `throw new PromptsError(...)` |

**Problem:** Callers that `catch (e) { if (e instanceof PromptsError) ... }` would miss these errors depending on the active fetch policy — a silent, policy-dependent behavior difference.

**Changes:**
- Added `import { PromptsError } from "./errors"` to `prompts.facade.ts`
- Replaced all three `new Error(...)` throws with `new PromptsError(...)` to satisfy the documented contract

## Test plan

- [x] All three error paths now throw `PromptsError` (which extends `Error`, so existing `catch (e)` blocks still work)
- [x] `PromptsError` is a simple `extends Error` class — no constructor shape changes needed
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #976