### PR TITLE
fix(analytics): map NULL evaluation labels to 'unknown' bucket

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -541,6 +541,44 @@ describe("aggregation-builder", () => {
         expect(result.sql).not.toContain("{groupByKey:String}");
         expect(result.params).not.toHaveProperty("groupByKey");
       });
+
+      it("maps NULL labels to 'unknown' bucket when groupByKey is set", () => {
+        const input = {
+          ...baseInput,
+          groupBy: "evaluations.evaluation_label",
+          groupByKey: "evaluatorA",
+          series: [
+            {
+              metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+              aggregation: "cardinality" as const,
+            },
+          ],
+        };
+        const result = buildTimeseriesQuery(input);
+
+        // COALESCE must appear inside the conditional to map NULL labels → 'unknown'
+        // so that score-only evaluators (Passed=NULL) are not silently dropped by HAVING
+        expect(result.sql).toContain("COALESCE");
+        expect(result.sql).toMatch(/COALESCE\(.*Label.*'unknown'\)/s);
+      });
+
+      it("maps NULL labels to 'unknown' bucket when no groupByKey", () => {
+        const input = {
+          ...baseInput,
+          groupBy: "evaluations.evaluation_label",
+          series: [
+            {
+              metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+              aggregation: "cardinality" as const,
+            },
+          ],
+        };
+        const result = buildTimeseriesQuery(input);
+
+        // Without groupByKey, the group_key expression must still COALESCE NULL labels
+        expect(result.sql).toContain("COALESCE");
+        expect(result.sql).toMatch(/COALESCE\(.*Label.*'unknown'\)/s);
+      });
     });
   });
 

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -542,42 +542,45 @@ describe("aggregation-builder", () => {
         expect(result.params).not.toHaveProperty("groupByKey");
       });
 
-      it("maps NULL labels to 'unknown' bucket when groupByKey is set", () => {
-        const input = {
-          ...baseInput,
-          groupBy: "evaluations.evaluation_label",
-          groupByKey: "evaluatorA",
-          series: [
-            {
-              metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
-              aggregation: "cardinality" as const,
-            },
-          ],
-        };
-        const result = buildTimeseriesQuery(input);
+      describe("when Label IS NULL (score-only evaluator) with groupByKey", () => {
+        it("maps NULL labels to 'unknown' bucket so rows are not silently dropped by HAVING", () => {
+          const input = {
+            ...baseInput,
+            groupBy: "evaluations.evaluation_label",
+            groupByKey: "evaluatorA",
+            series: [
+              {
+                metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+                aggregation: "cardinality" as const,
+              },
+            ],
+          };
+          const result = buildTimeseriesQuery(input);
 
-        // COALESCE must appear inside the conditional to map NULL labels → 'unknown'
-        // so that score-only evaluators (Passed=NULL) are not silently dropped by HAVING
-        expect(result.sql).toContain("COALESCE");
-        expect(result.sql).toMatch(/COALESCE\(.*Label.*'unknown'\)/s);
+          // COALESCE must appear inside the IF to map NULL labels → 'unknown'.
+          // Without COALESCE, if(match, NULL, '') returns NULL; HAVING group_key != ''
+          // evaluates NULL != '' as NULL (not TRUE) and silently drops the row.
+          expect(result.sql).toMatch(/COALESCE\(.*Label.*'unknown'\)/s);
+        });
       });
 
-      it("maps NULL labels to 'unknown' bucket when no groupByKey", () => {
-        const input = {
-          ...baseInput,
-          groupBy: "evaluations.evaluation_label",
-          series: [
-            {
-              metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
-              aggregation: "cardinality" as const,
-            },
-          ],
-        };
-        const result = buildTimeseriesQuery(input);
+      describe("when Label IS NULL (score-only evaluator) without groupByKey", () => {
+        it("maps NULL labels to 'unknown' bucket so rows are not silently dropped by HAVING", () => {
+          const input = {
+            ...baseInput,
+            groupBy: "evaluations.evaluation_label",
+            series: [
+              {
+                metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+                aggregation: "cardinality" as const,
+              },
+            ],
+          };
+          const result = buildTimeseriesQuery(input);
 
-        // Without groupByKey, the group_key expression must still COALESCE NULL labels
-        expect(result.sql).toContain("COALESCE");
-        expect(result.sql).toMatch(/COALESCE\(.*Label.*'unknown'\)/s);
+          // COALESCE must appear in the bare column expression to map NULL labels → 'unknown'.
+          expect(result.sql).toMatch(/COALESCE\(.*Label.*'unknown'\)/s);
+        });
       });
     });
   });

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -238,6 +238,11 @@ const groupByExpressions: Partial<
     handlesUnknown: true,
   }),
 
+  // NOTE: handlesUnknown is intentionally NOT set here.
+  // When groupByKey is present the IF expression uses '' as the sentinel for
+  // non-matching rows, which must be filtered by HAVING group_key != ''.
+  // Setting handlesUnknown: true would suppress that HAVING clause and leak
+  // non-matching '' rows into results.
   "evaluations.evaluation_label": (groupByKey) => ({
     column: groupByKey
       ? `if(${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed', COALESCE(${tableAliases.evaluation_runs}.Label, 'unknown'), '')`

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -240,8 +240,8 @@ const groupByExpressions: Partial<
 
   "evaluations.evaluation_label": (groupByKey) => ({
     column: groupByKey
-      ? `if(${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed', ${tableAliases.evaluation_runs}.Label, '')`
-      : `${tableAliases.evaluation_runs}.Label`,
+      ? `if(${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed', COALESCE(${tableAliases.evaluation_runs}.Label, 'unknown'), '')`
+      : `COALESCE(${tableAliases.evaluation_runs}.Label, 'unknown')`,
     requiredJoins: ["evaluation_runs"],
   }),
 


### PR DESCRIPTION
## Summary

Fixes #2673

### Root cause

In `aggregation-builder.ts`, the `evaluation_label` groupBy column expression is:

```sql
-- with groupByKey:
if(er.EvaluatorId = {groupByKey} AND er.Status = 'processed', er.Label, '')

-- without groupByKey:
er.Label
```

When `er.Label IS NULL` (score-only evaluators that produce no label), ClickHouse evaluates:
- `if(true, NULL, '')` → `NULL`
- `NULL != ''` → `NULL` (not `TRUE`) in ClickHouse

The `HAVING group_key != ''` clause silently drops these rows, causing score-only evaluators to vanish from analytics when grouping by label.

### Fix

Wrap `er.Label` with `COALESCE(er.Label, 'unknown')` in both paths:

```sql
-- with groupByKey:
if(er.EvaluatorId = {groupByKey} AND er.Status = 'processed', COALESCE(er.Label, 'unknown'), '')

-- without groupByKey:
COALESCE(er.Label, 'unknown')
```

This maps NULL labels to `'unknown'` — consistent with how `evaluation_passed` handles `Passed IS NULL` rows via its `ELSE 'unknown'` branch.

## Test plan

- [x] Added regression test: "maps NULL labels to 'unknown' bucket when groupByKey is set"
- [x] Added regression test: "maps NULL labels to 'unknown' bucket when no groupByKey"
- [x] All 51 existing passing tests continue to pass (2 pre-existing failures on `main` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2673