### PR TITLE
fix(scenarios): clear stale flow callbacks when AgentTypeSelectorDrawer closes

### DIFF
--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "~/utils/compat/next-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { KSUID_RESOURCES } from "../../utils/constants";
 import { type UseFormReturn, useWatch } from "react-hook-form";
-import { getComplexProps, setFlowCallbacks, useDrawer, useDrawerParams } from "../../hooks/useDrawer";
+import { clearFlowCallbacks, getComplexProps, setFlowCallbacks, useDrawer, useDrawerParams } from "../../hooks/useDrawer";
 import { AgentTypeSelectorDrawer } from "../agents/AgentTypeSelectorDrawer";
 import { checkCompoundLimits } from "../../hooks/useCompoundLicenseCheck";
 import { useLicenseEnforcement } from "../../hooks/useLicenseEnforcement";
@@ -492,7 +492,10 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
       {/* Agent Type Selector Drawer */}
       <AgentTypeSelectorDrawer
         open={agentTypeSelectorOpen}
-        onClose={() => setAgentTypeSelectorOpen(false)}
+        onClose={() => {
+          setAgentTypeSelectorOpen(false);
+          clearFlowCallbacks();
+        }}
       />
 
       {/* Prompt Creation Drawer */}

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.integration.test.tsx
@@ -88,6 +88,7 @@ const mocks = vi.hoisted(() => ({
   mockOpenDrawer: vi.fn(),
   mockCloseDrawer: vi.fn(),
   mockSetFlowCallbacks: vi.fn(),
+  mockClearFlowCallbacks: vi.fn(),
   mockRunScenario: vi.fn(),
   mockRouterPush: vi.fn(),
   mockGetByIdData: null as { id: string; name: string; situation: string; criteria: string[]; labels: string[] } | null,
@@ -174,6 +175,7 @@ vi.mock("~/hooks/useDrawer", () => ({
   useDrawerParams: () => mocks.mockDrawerParams,
   getComplexProps: () => mocks.mockComplexProps,
   setFlowCallbacks: mocks.mockSetFlowCallbacks,
+  clearFlowCallbacks: mocks.mockClearFlowCallbacks,
 }));
 
 vi.mock("~/hooks/useOrganizationTeamProject", () => ({
@@ -631,6 +633,22 @@ describe("<ScenarioFormDrawer/>", () => {
           type: "success",
         }),
       );
+    });
+
+    describe("when agent type selector is closed without completing the flow", () => {
+      it("clears flow callbacks to prevent stale callbacks in other contexts", async () => {
+        const user = userEvent.setup();
+        render(<ScenarioFormDrawer open={true} />, { wrapper: Wrapper });
+
+        // Open agent type selector
+        await user.click(screen.getByTestId("create-agent-button"));
+        expect(screen.getByTestId("agent-type-selector-drawer")).toBeInTheDocument();
+
+        // Close without completing (cancellation path)
+        await user.click(screen.getByTestId("close-agent-selector"));
+
+        expect(mocks.mockClearFlowCallbacks).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Imports `clearFlowCallbacks` from `useDrawer` in `ScenarioFormDrawer`
- Calls `clearFlowCallbacks()` in the `AgentTypeSelectorDrawer` `onClose` handler alongside `setAgentTypeSelectorOpen(false)`

`setFlowCallbacks` writes to a module-level store that persists until `closeDrawer()` runs. When the user opens the agent type selector, cancels, and another drawer context later opens the same agent editor drawers, the stale callbacks registered by `ScenarioFormDrawer` could fire unexpectedly.

Clearing callbacks when the selector closes ensures the stale references are removed immediately.

Fixes #1909

## Test plan
- [ ] Open a Scenario form drawer
- [ ] Click "Create Agent" to open the agent type selector
- [ ] Close the agent type selector without completing the flow
- [ ] Open another drawer that uses agent editor callbacks — verify stale callbacks do NOT fire
- [ ] Happy path: create an agent through the full flow — verify the scenario target is set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1909