### PR TITLE
fix(datasets): prevent CSV upload dialog from closing on drag-over

### DIFF
--- a/langwatch/src/components/datasets/UploadCSVModal.tsx
+++ b/langwatch/src/components/datasets/UploadCSVModal.tsx
@@ -74,6 +74,7 @@ export function UploadCSVModal({
       <Dialog.Root
         open={localIsOpen}
         onOpenChange={({ open }) => !open && onClose()}
+        closeOnInteractOutside={false}
       >
         <Dialog.Content>
           <Dialog.Header>


### PR DESCRIPTION
## Summary

- Adds `closeOnInteractOutside={false}` to `Dialog.Root` in `UploadCSVModal`

When a user drags a CSV file into the upload dialog, pointer/drag events were being interpreted by Ark UI as "interact outside" the dialog, causing it to close before the user could drop the file. The fix disables the interact-outside-close behavior so the dialog stays open during drag operations. The dialog can still be closed via the X button or Cancel.

Fixes #1361

## Test plan
- [x] Open the experiments workbench dataset upload dialog
- [x] Drag a CSV file over the dialog — verify it stays open
- [x] Drop the CSV file — verify it is uploaded correctly
- [x] Verify the dialog still closes when clicking the X button or pressing Escape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1361