### PR TITLE
fix(workflows): coerce boolean score to 0/1 in workflow evaluator results

### DIFF
--- a/langwatch/src/server/workflows/runWorkflow.ts
+++ b/langwatch/src/server/workflows/runWorkflow.ts
@@ -143,7 +143,10 @@ export async function runEvaluationWorkflow(
 
     // Process the result
     if (data.result) {
-      if (
+      if ("score" in data.result && typeof data.result.score === "boolean") {
+        // Boolean scores (true/false) are coerced to 1/0 to match the numeric score field
+        data.result.score = data.result.score ? 1 : 0;
+      } else if (
         "score" in data.result &&
         (typeof data.result.score === "number" ||
           typeof data.result.score === "string")


### PR DESCRIPTION
## Summary

- Adds a boolean-to-number coercion step in `runEvaluationWorkflow` in `runWorkflow.ts`
- Boolean `true` maps to `1`, `false` maps to `0`

When a workflow evaluator's output field is typed as `boolean`, the returned score (e.g. `false`) was not coerced to a number. Downstream, all ES write paths guard against non-number scores with `typeof score === "number"`, so the score would be silently dropped rather than indexed — but the boolean value could still reach Elasticsearch in edge cases causing a `document_parsing_exception` because the ES mapping hardcodes `score` as `float`.

Explicit coercion at the source (`runWorkflow.ts`) prevents the boolean from propagating through the pipeline entirely.

Fixes #1530

## Test plan
- [ ] Create a workflow evaluator with a `boolean` score output
- [ ] Run an evaluation — verify `score` is stored as `1` or `0` (not `true`/`false`)
- [ ] Verify existing evaluators with numeric scores continue to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #1530