### PR TITLE
docs: add Liquid Template Syntax to docs nav and improve discoverability

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -165,14 +165,15 @@
             "pages": [
               "prompt-management/overview",
               "prompt-management/getting-started",
-              "prompt-management/data-model",
-              "prompt-management/scope",
               "prompt-management/cli",
               "prompt-management/prompt-playground",
               {
                 "group": "Features",
                 "pages": [
                   "prompt-management/features/essential/version-control",
+                  "prompts/template-syntax",
+                  "prompt-management/data-model",
+                  "prompt-management/scope",
                   "prompt-management/features/essential/analytics",
                   "prompt-management/features/essential/github-integration",
                   "prompt-management/features/advanced/link-to-traces",

--- a/docs/integration/python/reference.mdx
+++ b/docs/integration/python/reference.mdx
@@ -1081,7 +1081,7 @@ Examples include:
 
 ### `Prompt`
 
-Represents a prompt configuration that can be used with OpenAI's API. Handles formatting messages with variables using Liquid templating.
+Represents a prompt configuration that can be used with OpenAI's API. Handles formatting messages with variables using [Liquid templating](/prompts/template-syntax).
 
 <ResponseField name="id" type="str">
   Unique identifier for the prompt.

--- a/docs/prompts/template-syntax.mdx
+++ b/docs/prompts/template-syntax.mdx
@@ -1,9 +1,11 @@
 ---
-title: "Template Syntax"
+title: "Liquid Template Syntax"
 description: "Reference for the Liquid template syntax supported in LangWatch prompts: variables, conditionals, loops, filters, and more."
 ---
 
-LangWatch prompts use [Liquid](https://liquidjs.com/) as their template language. Liquid gives you variables, conditionals, loops, and filters so you can build dynamic prompts without custom code.
+LangWatch prompts use [Liquid](https://liquidjs.com/) as their template language — a more powerful alternative to Jinja-style templating with a cleaner syntax. If you're coming from Jinja2, you'll find Liquid familiar but with better support for filters, strict compilation modes, and safe rendering out of the box.
+
+Liquid gives you variables, conditionals, loops, and filters so you can build dynamic prompts without custom code.
 
 Templates are rendered when you call `compile()` in the Python or TypeScript SDK, or when the platform executes a prompt on your behalf.
 


### PR DESCRIPTION
## Summary
- Add `template-syntax` page to the docs sidebar under Prompt Management > Features (after Version Control)
- Move Data Model and Scope into the Features group to reduce root-level clutter
- Rename page title to "Liquid Template Syntax"
- Add Jinja/Jinja2 mention in intro for SEO discoverability
- Link to template-syntax page from Python SDK reference where Liquid is mentioned

## Test plan
- [ ] Verify the docs sidebar shows "Liquid Template Syntax" under Prompt Management > Features
- [ ] Verify the page title renders as "Liquid Template Syntax"
- [ ] Verify the Jinja mention appears in the intro paragraph
- [ ] Verify the link in Python SDK reference navigates correctly