### PR TITLE
fix: hide restricted settings sidebar items from lite members

### DIFF
--- a/langwatch/src/components/SettingsLayout.tsx
+++ b/langwatch/src/components/SettingsLayout.tsx
@@ -42,28 +42,34 @@ export default function SettingsLayout({
           )}
           <MenuLink href="/settings/model-providers">Model Providers</MenuLink>
           <MenuLink href="/settings/model-costs">Model Costs</MenuLink>
-          <MenuLink href="/settings/secrets">Secrets</MenuLink>
-          <MenuLink href={`/${project?.slug}/automations`}>Automations</MenuLink>
+          {!isLiteMember && (
+            <MenuLink href="/settings/secrets">Secrets</MenuLink>
+          )}
+          {!isLiteMember && (
+            <MenuLink href={`/${project?.slug}/automations`}>Automations</MenuLink>
+          )}
           <MenuLink href="/settings/projects">Projects</MenuLink>
           <MenuLink href="/settings/teams">Teams</MenuLink>
           <MenuLink href="/settings/members" includePath="members">
             Members
           </MenuLink>
-          {isEnterprise && (
+          {isEnterprise && !isLiteMember && (
             <MenuLink href="/settings/roles">Roles & Permissions</MenuLink>
           )}
-          {isEnterprise && hasPermission("organization:manage") && (
+          {isEnterprise && !isLiteMember && hasPermission("organization:manage") && (
             <MenuLink href="/settings/audit-log">Audit Log</MenuLink>
           )}
 
           <MenuLink href="/settings/annotation-scores">
             Annotation Scores
           </MenuLink>
-          <MenuLink href="/settings/topic-clustering">
-            Topic Clustering
-          </MenuLink>
+          {!isLiteMember && (
+            <MenuLink href="/settings/topic-clustering">
+              Topic Clustering
+            </MenuLink>
+          )}
           <MenuLink href="/settings/authentication">Authentication</MenuLink>
-          {isEnterprise && (
+          {isEnterprise && !isLiteMember && (
             <MenuLink href="/settings/scim">SCIM Provisioning</MenuLink>
           )}
           {!isLiteMember && (


### PR DESCRIPTION
## Summary
- Lite members (EXTERNAL role) could see settings sidebar links they shouldn't have access to
- Added `!isLiteMember` guards to: **Secrets**, **Automations**, **Topic Clustering**, **Roles & Permissions**, **Audit Log**, and **SCIM Provisioning**
- Roles & Permissions, Audit Log, and SCIM already had enterprise-only checks — now they also require full membership

## Test plan
- [ ] Log in as a lite member and verify the 6 items above are no longer visible in the settings sidebar
- [ ] Log in as a full member and verify all items still appear correctly
- [ ] On an enterprise plan, verify Roles & Permissions, Audit Log, and SCIM are visible for full members but not lite members