### PR TITLE
fix: normalize scenarioSetId in SSE filter

### DIFF
--- a/langwatch/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useSimulationUpdateListener.unit.test.ts
@@ -101,6 +101,27 @@ describe("useSimulationUpdateListener()", () => {
     });
   });
 
+  describe("when filter is 'default' and payload has empty scenarioSetId", () => {
+    it("accepts the update by normalizing empty string to default", () => {
+      renderHook(() =>
+        useSimulationUpdateListener({
+          projectId: "proj_1",
+          refetch: refetchSpy,
+          filter: { scenarioSetId: "default" },
+        }),
+      );
+
+      act(() => {
+        simulateSSEEvent({
+          event: "simulation_updated",
+          scenarioSetId: "",
+        });
+      });
+
+      expect(refetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("when an SSE event fires for a different scenarioSetId", () => {
     it("does not trigger refetch", () => {
       renderHook(() =>

--- a/langwatch/src/hooks/useSimulationUpdateListener.ts
+++ b/langwatch/src/hooks/useSimulationUpdateListener.ts
@@ -4,11 +4,15 @@ import {
   type CompactStreamingEvent,
 } from "~/utils/streaming-event-codec";
 import { api } from "~/utils/api";
+import { DEFAULT_SET_ID } from "~/server/scenarios/internal-set-id";
 import { createLogger } from "~/utils/logger";
 import { usePageVisibility } from "./usePageVisibility";
 import { useSSESubscription } from "./useSSESubscription";
 
 const logger = createLogger("useSimulationUpdateListener");
+
+const normalizeSetId = (id: string | undefined): string =>
+  !id ? DEFAULT_SET_ID : id;
 
 interface SimulationUpdateFilter {
   scenarioRunId?: string;
@@ -55,7 +59,7 @@ export function useSimulationUpdateListener({
       if (!filter) return true;
       if (filter.scenarioRunId && payload.scenarioRunId !== filter.scenarioRunId) return false;
       if (filter.batchRunId && payload.batchRunId !== filter.batchRunId) return false;
-      if (filter.scenarioSetId && payload.scenarioSetId !== filter.scenarioSetId) return false;
+      if (filter.scenarioSetId && normalizeSetId(payload.scenarioSetId) !== normalizeSetId(filter.scenarioSetId)) return false;
       return true;
     },
     [filter],


### PR DESCRIPTION
## Summary

- Normalizes `scenarioSetId` in the SSE filter comparison so `""` (empty string from old data) matches `"default"` — fixes silent update drops in real-time UI
- Adds regression test covering the empty-string-to-default normalization case

## Problem

The `matchesFilter` callback in `useSimulationUpdateListener` used strict equality to compare `payload.scenarioSetId` with the client filter. When the SSE broadcast contained `scenarioSetId: ""` (from old fold state) but the client filtered for `"default"`, updates were silently dropped.

## Root cause

The backend Zod schema normalizes empty strings to `"default"`, but old rows in the database may still have `""`. The SSE broadcast sends the raw value, and the frontend filter didn't account for this mismatch.

## Fix

Added a `normalizeSetId` helper that coerces `""` and `undefined` to `DEFAULT_SET_ID` (`"default"`), applied to both sides of the comparison.

Closes #2720

## Test plan

- [x] Regression test: filter `"default"` accepts payload with `scenarioSetId: ""`
- [x] All 13 existing tests pass
- [x] No typecheck errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2720