### PR TITLE
fix(studio): remove sticky details output from evaluator results

### DIFF
--- a/langwatch/src/optimization_studio/components/properties/EndPropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/EndPropertiesPanel.tsx
@@ -16,11 +16,6 @@ export const evaluatorInputs: Field[] = [
     identifier: "passed",
     optional: true,
   },
-  {
-    type: "str",
-    identifier: "details",
-    optional: true,
-  },
 ];
 
 export function EndPropertiesPanel({ node: initialNode }: { node: Node<End> }) {

--- a/langwatch/src/optimization_studio/templates/custom_evaluator.ts
+++ b/langwatch/src/optimization_studio/templates/custom_evaluator.ts
@@ -245,7 +245,6 @@ Return your judgment as either TRUE (no significant cognitive biases) or FALSE (
         behave_as: "evaluator",
         inputs: [
           { identifier: "passed", type: "bool" },
-          { identifier: "details", type: "str" },
         ],
       } satisfies End,
     },
@@ -257,14 +256,6 @@ Return your judgment as either TRUE (no significant cognitive biases) or FALSE (
       sourceHandle: "outputs.answer",
       target: "llm_call",
       targetHandle: "inputs.llm_output",
-      type: "default",
-    },
-    {
-      id: "e1-2",
-      source: "llm_call",
-      sourceHandle: "outputs.reasoning",
-      target: "end",
-      targetHandle: "inputs.details",
       type: "default",
     },
     {

--- a/langwatch/src/server/evaluations-v3/execution/__tests__/resultMapper.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/resultMapper.test.ts
@@ -88,6 +88,56 @@ describe("resultMapper", () => {
     it("handles null output value", () => {
       expect(extractTargetOutput({ output: null })).toBeNull();
     });
+
+    describe("when outputs are evaluator-as-target (regression: sticky details)", () => {
+      it("excludes details when it is null", () => {
+        const result = extractTargetOutput({
+          passed: true,
+          score: 0.9,
+          details: null,
+        });
+        expect(result).toEqual({ passed: true, score: 0.9 });
+        expect(result).not.toHaveProperty("details");
+      });
+
+      it("excludes details when it is undefined", () => {
+        const result = extractTargetOutput({
+          passed: true,
+          score: 0.9,
+          details: undefined,
+        });
+        expect(result).toEqual({ passed: true, score: 0.9 });
+        expect(result).not.toHaveProperty("details");
+      });
+
+      it("includes details when it is a non-empty string", () => {
+        const result = extractTargetOutput({
+          passed: true,
+          score: 0.9,
+          details: "The output matched expectations",
+        });
+        expect(result).toEqual({
+          passed: true,
+          score: 0.9,
+          details: "The output matched expectations",
+        });
+      });
+
+      it("passes through all non-null output fields dynamically", () => {
+        const result = extractTargetOutput({
+          passed: false,
+          score: 0.3,
+          label: "negative",
+          custom_field: "extra data",
+        });
+        expect(result).toEqual({
+          passed: false,
+          score: 0.3,
+          label: "negative",
+          custom_field: "extra data",
+        });
+      });
+    });
   });
 
   describe("coerceScore", () => {
@@ -436,6 +486,44 @@ describe("resultMapper", () => {
           passed: true,
         });
       }
+    });
+
+    describe("when details is null (regression: sticky details)", () => {
+      it("does not include details in the result", () => {
+        const result = mapEvaluatorResult("target-1.eval-1", 0, {
+          status: "success",
+          outputs: { passed: true, score: 1.0, details: null },
+        });
+
+        expect(result.type).toBe("evaluator_result");
+        if (result.type === "evaluator_result") {
+          expect(result.result).toMatchObject({
+            status: "processed",
+            details: undefined,
+          });
+        }
+      });
+    });
+
+    describe("when details is a non-empty string", () => {
+      it("includes details in the result", () => {
+        const result = mapEvaluatorResult("target-1.eval-1", 0, {
+          status: "success",
+          outputs: {
+            passed: true,
+            score: 1.0,
+            details: "Output matched exactly",
+          },
+        });
+
+        expect(result.type).toBe("evaluator_result");
+        if (result.type === "evaluator_result") {
+          expect(result.result).toMatchObject({
+            status: "processed",
+            details: "Output matched exactly",
+          });
+        }
+      });
     });
 
     it("does not affect error results when stripScore is true", () => {

--- a/langwatch/src/server/evaluations-v3/execution/__tests__/resultMapper.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/resultMapper.test.ts
@@ -91,31 +91,32 @@ describe("resultMapper", () => {
 
     describe("when outputs are evaluator-as-target (regression: sticky details)", () => {
       it("excludes details when it is null", () => {
-        const result = extractTargetOutput({
-          passed: true,
-          score: 0.9,
-          details: null,
-        });
+        const result = extractTargetOutput(
+          { passed: true, score: 0.9, details: null },
+          { isEvaluatorAsTarget: true },
+        );
         expect(result).toEqual({ passed: true, score: 0.9 });
         expect(result).not.toHaveProperty("details");
       });
 
       it("excludes details when it is undefined", () => {
-        const result = extractTargetOutput({
-          passed: true,
-          score: 0.9,
-          details: undefined,
-        });
+        const result = extractTargetOutput(
+          { passed: true, score: 0.9, details: undefined },
+          { isEvaluatorAsTarget: true },
+        );
         expect(result).toEqual({ passed: true, score: 0.9 });
         expect(result).not.toHaveProperty("details");
       });
 
       it("includes details when it is a non-empty string", () => {
-        const result = extractTargetOutput({
-          passed: true,
-          score: 0.9,
-          details: "The output matched expectations",
-        });
+        const result = extractTargetOutput(
+          {
+            passed: true,
+            score: 0.9,
+            details: "The output matched expectations",
+          },
+          { isEvaluatorAsTarget: true },
+        );
         expect(result).toEqual({
           passed: true,
           score: 0.9,
@@ -124,18 +125,40 @@ describe("resultMapper", () => {
       });
 
       it("passes through all non-null output fields dynamically", () => {
-        const result = extractTargetOutput({
-          passed: false,
-          score: 0.3,
-          label: "negative",
-          custom_field: "extra data",
-        });
+        const result = extractTargetOutput(
+          {
+            passed: false,
+            score: 0.3,
+            label: "negative",
+            custom_field: "extra data",
+          },
+          { isEvaluatorAsTarget: true },
+        );
         expect(result).toEqual({
           passed: false,
           score: 0.3,
           label: "negative",
           custom_field: "extra data",
         });
+      });
+
+      it("detects evaluator with only custom output fields (no passed/score/label)", () => {
+        const result = extractTargetOutput(
+          { custom_metric: 0.8, reasoning: "good quality" },
+          { isEvaluatorAsTarget: true },
+        );
+        expect(result).toEqual({
+          custom_metric: 0.8,
+          reasoning: "good quality",
+        });
+      });
+
+      it("returns undefined when all values are null/undefined", () => {
+        const result = extractTargetOutput(
+          { details: null, custom_field: undefined },
+          { isEvaluatorAsTarget: true },
+        );
+        expect(result).toBeUndefined();
       });
     });
   });

--- a/langwatch/src/server/evaluations-v3/execution/__tests__/resultMapper.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/resultMapper.test.ts
@@ -505,6 +505,23 @@ describe("resultMapper", () => {
       });
     });
 
+    describe("when details is an empty string", () => {
+      it("does not include details in the result", () => {
+        const result = mapEvaluatorResult("target-1.eval-1", 0, {
+          status: "success",
+          outputs: { passed: true, score: 1.0, details: "" },
+        });
+
+        expect(result.type).toBe("evaluator_result");
+        if (result.type === "evaluator_result") {
+          expect(result.result).toMatchObject({
+            status: "processed",
+            details: undefined,
+          });
+        }
+      });
+    });
+
     describe("when details is a non-empty string", () => {
       it("includes details in the result", () => {
         const result = mapEvaluatorResult("target-1.eval-1", 0, {

--- a/langwatch/src/server/evaluations-v3/execution/orchestrator.ts
+++ b/langwatch/src/server/evaluations-v3/execution/orchestrator.ts
@@ -246,6 +246,15 @@ export async function* executeCell(
     // Create set of target nodes for the result mapper
     const targetNodes = new Set([cell.targetId]);
 
+    // Build evaluator target node IDs for explicit evaluator-as-target detection
+    const cellConfig: ResultMapperConfig = {
+      ...resultMapperConfig,
+      evaluatorTargetNodeIds:
+        cell.targetConfig.type === "evaluator"
+          ? new Set([cell.targetId])
+          : undefined,
+    };
+
     // Generate OTEL-compliant trace ID for this cell execution
     // Reuse existing traceId if provided (for evaluator reruns to append to existing trace)
     const traceId = cell.traceId ?? generateOtelTraceId();
@@ -328,7 +337,7 @@ export async function* executeCell(
           event,
           cell.rowIndex,
           targetNodes,
-          resultMapperConfig,
+          cellConfig,
         );
         if (mappedEvent) {
           yield mappedEvent;
@@ -408,7 +417,7 @@ export async function* executeCell(
               event,
               cell.rowIndex,
               targetNodes,
-              resultMapperConfig,
+              cellConfig,
             );
             if (mappedEvent) {
               yield mappedEvent;

--- a/langwatch/src/server/evaluations-v3/execution/resultMapper.ts
+++ b/langwatch/src/server/evaluations-v3/execution/resultMapper.ts
@@ -84,12 +84,7 @@ export const coercePassed = (value: unknown): boolean | undefined => {
  */
 const isEvaluatorOutput = (
   outputs: Record<string, unknown>,
-): outputs is {
-  passed?: boolean;
-  score?: number;
-  label?: string;
-  details?: string;
-} => {
+): boolean => {
   return "passed" in outputs || "score" in outputs || "label" in outputs;
 };
 
@@ -110,18 +105,16 @@ export const extractTargetOutput = (
 ): unknown => {
   if (!outputs) return undefined;
 
-  // Evaluator-as-target: return the full evaluator result object
-  // Only include keys that have non-null/undefined values
+  // Evaluator-as-target: return all non-null/undefined output fields dynamically.
+  // This avoids hardcoding specific field names (like `details`) which can cause
+  // "sticky" fields that persist even after removal from the End node.
   if (isEvaluatorOutput(outputs)) {
     const result: Record<string, unknown> = {};
-    if (outputs.passed !== undefined && outputs.passed !== null)
-      result.passed = outputs.passed;
-    if (outputs.score !== undefined && outputs.score !== null)
-      result.score = outputs.score;
-    if (outputs.label !== undefined && outputs.label !== null)
-      result.label = outputs.label;
-    if (outputs.details !== undefined && outputs.details !== null)
-      result.details = outputs.details;
+    for (const [key, value] of Object.entries(outputs)) {
+      if (value !== undefined && value !== null) {
+        result[key] = value;
+      }
+    }
     return result;
   }
 

--- a/langwatch/src/server/evaluations-v3/execution/resultMapper.ts
+++ b/langwatch/src/server/evaluations-v3/execution/resultMapper.ts
@@ -23,6 +23,11 @@ export type ResultMapperConfig = {
    * and doesn't provide meaningful information beyond the pass/fail status.
    */
   stripScoreEvaluatorIds?: Set<string>;
+  /**
+   * Set of target node IDs that are evaluator-as-target.
+   * Used to detect evaluator outputs without relying on a heuristic.
+   */
+  evaluatorTargetNodeIds?: Set<string>;
 };
 
 /**
@@ -80,20 +85,12 @@ export const coercePassed = (value: unknown): boolean | undefined => {
 };
 
 /**
- * Checks if outputs are from an evaluator (has passed/score/label fields).
- */
-const isEvaluatorOutput = (
-  outputs: Record<string, unknown>,
-): boolean => {
-  return "passed" in outputs || "score" in outputs || "label" in outputs;
-};
-
-/**
  * Extracts target output from execution outputs.
  *
- * Strategy (OCP-compliant - handles new output formats without modification):
- * 1. If outputs look like evaluator output (has passed/score/label) -> return as-is
- *    This handles evaluator-as-target where the evaluator outputs become target output
+ * Strategy:
+ * 1. If isEvaluatorAsTarget -> filter null/undefined values, return undefined if empty
+ *    This handles evaluator-as-target where the evaluator outputs become target output.
+ *    Uses an explicit marker instead of a heuristic so custom-only evaluators are detected.
  * 2. If outputs has exactly one key named "output" -> return its value (backward compatible)
  * 3. Otherwise -> return full outputs object (preserves structure for custom fields)
  *
@@ -102,20 +99,21 @@ const isEvaluatorOutput = (
  */
 export const extractTargetOutput = (
   outputs: Record<string, unknown> | undefined,
+  options?: { isEvaluatorAsTarget?: boolean },
 ): unknown => {
   if (!outputs) return undefined;
 
   // Evaluator-as-target: return all non-null/undefined output fields dynamically.
   // This avoids hardcoding specific field names (like `details`) which can cause
   // "sticky" fields that persist even after removal from the End node.
-  if (isEvaluatorOutput(outputs)) {
+  if (options?.isEvaluatorAsTarget) {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(outputs)) {
       if (value !== undefined && value !== null) {
         result[key] = value;
       }
     }
-    return result;
+    return Object.keys(result).length > 0 ? result : undefined;
   }
 
   // Empty outputs
@@ -148,6 +146,7 @@ export const mapTargetResult = (
     trace_id?: string;
     error?: string;
   },
+  options?: { isEvaluatorAsTarget?: boolean },
 ): EvaluationV3Event => {
   const { targetId } = parseNodeId(nodeId);
 
@@ -163,7 +162,9 @@ export const mapTargetResult = (
     type: "target_result",
     rowIndex,
     targetId,
-    output: extractTargetOutput(executionState.outputs),
+    output: extractTargetOutput(executionState.outputs, {
+      isEvaluatorAsTarget: options?.isEvaluatorAsTarget,
+    }),
     cost: executionState.cost,
     duration,
     traceId: executionState.trace_id,
@@ -293,13 +294,20 @@ export const mapNlpEvent = (
   // Determine if this is a target or evaluator node
   if (targetNodes.has(component_id)) {
     // Target node
-    return mapTargetResult(component_id, rowIndex, {
-      outputs: execution_state.outputs,
-      cost: execution_state.cost,
-      timestamps: execution_state.timestamps,
-      trace_id: execution_state.trace_id,
-      error: isError ? execution_state.error : undefined,
-    });
+    const isEvaluatorAsTarget =
+      config?.evaluatorTargetNodeIds?.has(component_id) ?? false;
+    return mapTargetResult(
+      component_id,
+      rowIndex,
+      {
+        outputs: execution_state.outputs,
+        cost: execution_state.cost,
+        timestamps: execution_state.timestamps,
+        trace_id: execution_state.trace_id,
+        error: isError ? execution_state.error : undefined,
+      },
+      { isEvaluatorAsTarget },
+    );
   } else if (isEvaluatorNode(component_id)) {
     // Evaluator node - check if score should be stripped
     const { evaluatorId } = parseNodeId(component_id);

--- a/langwatch/src/server/evaluators/__tests__/evaluator.service.test.ts
+++ b/langwatch/src/server/evaluators/__tests__/evaluator.service.test.ts
@@ -7,7 +7,11 @@
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Evaluator, PrismaClient } from "@prisma/client";
-import { EvaluatorService, type EvaluatorField } from "../evaluator.service";
+import {
+  EvaluatorService,
+  STANDARD_EVALUATOR_OUTPUT_FIELDS,
+  type EvaluatorField,
+} from "../evaluator.service";
 import type { EvaluatorRepository } from "../evaluator.repository";
 
 // Mock AVAILABLE_EVALUATORS
@@ -49,6 +53,23 @@ vi.mock("~/server/evaluations/evaluators.generated", () => ({
     },
   },
 }));
+
+describe("STANDARD_EVALUATOR_OUTPUT_FIELDS", () => {
+  it("does not include details (regression: sticky details bug #2514)", () => {
+    const identifiers = STANDARD_EVALUATOR_OUTPUT_FIELDS.map(
+      (f) => f.identifier,
+    );
+    expect(identifiers).not.toContain("details");
+  });
+
+  it("includes passed, score, and label only", () => {
+    expect(STANDARD_EVALUATOR_OUTPUT_FIELDS).toEqual([
+      { identifier: "passed", type: "bool" },
+      { identifier: "score", type: "float" },
+      { identifier: "label", type: "str" },
+    ]);
+  });
+});
 
 describe("EvaluatorService", () => {
   describe("field computation for built-in evaluators", () => {
@@ -253,7 +274,6 @@ describe("EvaluatorService", () => {
         { identifier: "passed", type: "bool" },
         { identifier: "score", type: "float" },
         { identifier: "label", type: "str" },
-        { identifier: "details", type: "str" },
       ]);
     });
 

--- a/langwatch/src/server/evaluators/evaluator.service.ts
+++ b/langwatch/src/server/evaluators/evaluator.service.ts
@@ -48,11 +48,10 @@ export type EvaluatorWithFields = Evaluator & {
  * Standard output fields for built-in evaluators.
  * All built-in evaluators produce these fields.
  */
-const STANDARD_EVALUATOR_OUTPUT_FIELDS: EvaluatorField[] = [
+export const STANDARD_EVALUATOR_OUTPUT_FIELDS: EvaluatorField[] = [
   { identifier: "passed", type: "bool" },
   { identifier: "score", type: "float" },
   { identifier: "label", type: "str" },
-  { identifier: "details", type: "str" },
 ];
 
 // ============================================================================

--- a/langwatch/src/server/evaluators/evaluator.service.ts
+++ b/langwatch/src/server/evaluators/evaluator.service.ts
@@ -48,11 +48,11 @@ export type EvaluatorWithFields = Evaluator & {
  * Standard output fields for built-in evaluators.
  * All built-in evaluators produce these fields.
  */
-export const STANDARD_EVALUATOR_OUTPUT_FIELDS: EvaluatorField[] = [
+export const STANDARD_EVALUATOR_OUTPUT_FIELDS = [
   { identifier: "passed", type: "bool" },
   { identifier: "score", type: "float" },
   { identifier: "label", type: "str" },
-];
+] as const satisfies readonly EvaluatorField[];
 
 // ============================================================================
 // Field Type Mapping
@@ -136,7 +136,7 @@ export class EvaluatorService {
     if (!workflow?.currentVersion?.dsl) {
       return {
         fields: [],
-        outputFields: STANDARD_EVALUATOR_OUTPUT_FIELDS,
+        outputFields: [...STANDARD_EVALUATOR_OUTPUT_FIELDS],
         workflowName: workflow?.name,
       };
     }
@@ -159,7 +159,7 @@ export class EvaluatorService {
             identifier: input.identifier,
             type: input.type,
           }))
-        : STANDARD_EVALUATOR_OUTPUT_FIELDS;
+        : [...STANDARD_EVALUATOR_OUTPUT_FIELDS];
 
     return {
       fields,
@@ -178,14 +178,14 @@ export class EvaluatorService {
    */
   private computeBuiltInOutputFields(evaluatorType: string): EvaluatorField[] {
     const def = AVAILABLE_EVALUATORS[evaluatorType as EvaluatorTypes];
-    if (!def) return STANDARD_EVALUATOR_OUTPUT_FIELDS;
+    if (!def) return [...STANDARD_EVALUATOR_OUTPUT_FIELDS];
 
     const fields: EvaluatorField[] = [];
     if (def.result.score) fields.push({ identifier: "score", type: "float" });
     if (def.result.passed) fields.push({ identifier: "passed", type: "bool" });
     if (def.result.label) fields.push({ identifier: "label", type: "str" });
 
-    return fields.length > 0 ? fields : STANDARD_EVALUATOR_OUTPUT_FIELDS;
+    return fields.length > 0 ? fields : [...STANDARD_EVALUATOR_OUTPUT_FIELDS];
   }
 
   /**
@@ -203,7 +203,7 @@ export class EvaluatorService {
     const fields = evaluatorType ? this.computeBuiltInFields(evaluatorType) : [];
     const outputFields = evaluatorType
       ? this.computeBuiltInOutputFields(evaluatorType)
-      : STANDARD_EVALUATOR_OUTPUT_FIELDS;
+      : [...STANDARD_EVALUATOR_OUTPUT_FIELDS];
 
     return {
       ...evaluator,

--- a/langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py
@@ -22,6 +22,12 @@ async def execute_component(event: ExecuteComponentPayload):
     yield Debug(payload=DebugPayload(message="executing component"))
 
     node = [node for node in event.workflow.nodes if node.id == event.node_id][0]
+
+    if node.type in ("entry", "end"):
+        raise ValueError(
+            f"{node.type.capitalize()} nodes cannot be executed as standalone components"
+        )
+
     disable_dsp_caching()
 
     started_at = int(time.time() * 1000)

--- a/langwatch_nlp/langwatch_nlp/studio/parser.py
+++ b/langwatch_nlp/langwatch_nlp/studio/parser.py
@@ -113,7 +113,9 @@ def parse_workflow(
         node.data.name = normalize_name_to_class_name(node.data.name or "")
 
     node_templates = {
-        node.id: parse_component(node, workflow, format) for node in nodes
+        node.id: parse_component(node, workflow, format)
+        for node in nodes
+        if node.type not in ("entry", "end")
     }
 
     inputs = workflow_inputs(workflow)
@@ -363,9 +365,9 @@ def parse_component(
                         f"Unknown agent_type '{agent_type}' for agent {node.data.name}"
                     )
         case "entry":
-            return "", "None", {}
+            raise ValueError("Entry nodes cannot be executed as standalone components")
         case "end":
-            return "", "None", {}
+            raise ValueError("End nodes cannot be executed as standalone components")
         case _:
             raise ValueError(f"Unknown node type: {node.type}")
 

--- a/langwatch_nlp/tests/studio/test_parse.py
+++ b/langwatch_nlp/tests/studio/test_parse.py
@@ -3,10 +3,15 @@ import dspy
 from langwatch_nlp.studio.dspy.llm_node import LLMNode
 from langwatch_nlp.studio.parser import parse_component, materialized_component_class
 from langwatch_nlp.studio.types.dataset import DatasetColumn, DatasetColumnType
+import pytest
 from langwatch_nlp.studio.types.dsl import (
     Code,
     CodeNode,
     DatasetInline,
+    End,
+    EndNode,
+    Entry,
+    EntryNode,
     Field,
     FieldType,
     LLMConfig,
@@ -254,3 +259,50 @@ class GenerateAnswer(dspy.Module):
     code, class_name, _ = parse_component(node, basic_workflow, format=True)
     with materialized_component_class(code, class_name) as Module:
         assert issubclass(Module, dspy.Module)
+
+
+class TestParseComponentEntryAndEndNodes:
+    """Regression tests for entry/end nodes returning 'None' as class name.
+
+    Entry and end nodes are structural workflow nodes that cannot be executed
+    as standalone components. Previously, parse_component returned the string
+    "None" as the class_name, which caused an AttributeError when
+    materialized_component_class tried getattr(module, "None").
+    """
+
+    def test_parse_component_raises_for_entry_node(self):
+        node = EntryNode(
+            id="entry",
+            data=Entry(
+                name="Entry",
+                outputs=[
+                    Field(
+                        identifier="question",
+                        type=FieldType.str,
+                    ),
+                ],
+                train_size=0.5,
+                test_size=0.5,
+                seed=42,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="Entry nodes cannot be executed as standalone components"):
+            parse_component(node, basic_workflow)
+
+    def test_parse_component_raises_for_end_node(self):
+        node = EndNode(
+            id="end",
+            data=End(
+                name="End",
+                inputs=[
+                    Field(
+                        identifier="output",
+                        type=FieldType.str,
+                    ),
+                ],
+            ),
+        )
+
+        with pytest.raises(ValueError, match="End nodes cannot be executed as standalone components"):
+            parse_component(node, basic_workflow)


### PR DESCRIPTION
## Summary
- Remove hardcoded `details` field from `evaluatorInputs` default (End node), `STANDARD_EVALUATOR_OUTPUT_FIELDS` fallback, `custom_evaluator.ts` template, and `extractTargetOutput` evaluator-as-target logic
- **Replace `isEvaluatorOutput` heuristic** (passed/score/label check) with explicit `isEvaluatorAsTarget` marker threaded from orchestrator via `ResultMapperConfig.evaluatorTargetNodeIds` — correctly detects workflow evaluators with only custom output fields
- **Return `undefined` from `extractTargetOutput`** when null-filtering removes all keys — prevents sticky nulls from leaking through
- **Make `STANDARD_EVALUATOR_OUTPUT_FIELDS` readonly** via `as const satisfies readonly EvaluatorField[]`; clone at mutable usage sites
- Fix `parser.py` returning string `"None"` as class name for entry/end nodes

Closes #2514

## Changes

| File | What |
|------|------|
| `EndPropertiesPanel.tsx` | Remove `details` from hardcoded `evaluatorInputs` |
| `evaluator.service.ts` | Remove `details` from `STANDARD_EVALUATOR_OUTPUT_FIELDS`; make it `as const` with spread at usage sites |
| `resultMapper.ts` | Replace heuristic with explicit `isEvaluatorAsTarget` flag; return `undefined` on empty result |
| `orchestrator.ts` | Build `evaluatorTargetNodeIds` from `cell.targetConfig.type` and pass via `cellConfig` |
| `custom_evaluator.ts` | Remove `details` from custom evaluator template End node |
| `parser.py` | Raise `ValueError` for entry/end nodes instead of returning `"None"` class name |
| `execute_component.py` | Early guard rejecting entry/end node execution |

## Test plan
- [x] `extractTargetOutput` excludes null/undefined fields when `isEvaluatorAsTarget: true`
- [x] `extractTargetOutput` returns `undefined` when all values are null/undefined
- [x] `extractTargetOutput` detects evaluator with only custom output fields (no passed/score/label)
- [x] `extractTargetOutput` passes through non-null fields dynamically
- [x] `mapEvaluatorResult` excludes `details` when null or empty string
- [x] `mapEvaluatorResult` includes `details` when non-empty string
- [x] `STANDARD_EVALUATOR_OUTPUT_FIELDS` is readonly, does not include `details`
- [x] `parse_component` raises ValueError for entry/end nodes
- [x] All 158 evaluation TS unit tests pass
- [x] All 8 Python parser tests pass
- [x] Typecheck passes (no new errors in changed files)

## Browser verification

**Studio — End node with only `passed: bool` (no details):**
![Studio End node](https://i.img402.dev/vcczxvo9sn.png)

**Evaluation results — `details` field does NOT appear in output:**
![Evaluation results](https://i.img402.dev/cg6g66pc0c.png)

Target output shows `status`, `score`, `passed`, `duration` — no `details` field leaks through.