### PR TITLE
fix: use ECR pull-through cache for aws-lambda-adapter image

### DIFF
--- a/Dockerfile.langwatch_nlp.lambda
+++ b/Dockerfile.langwatch_nlp.lambda
@@ -1,5 +1,8 @@
+ARG LAMBDA_ADAPTER_IMAGE=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1
+FROM ${LAMBDA_ADAPTER_IMAGE} AS lambda-adapter
+
 FROM python:3.12-slim-bookworm
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=lambda-adapter /lambda-adapter /opt/extensions/lambda-adapter
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsndfile1 \


### PR DESCRIPTION
## Summary
- Makes the `aws-lambda-adapter` image source configurable via `LAMBDA_ADAPTER_IMAGE` build arg
- Defaults to `public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1` for local/on-prem builds
- CI overrides this to use the ECR pull-through cache, avoiding 429 rate limit errors from public ECR

Companion PR: https://github.com/langwatch/langwatch-saas/pull/397

## Test plan
- [ ] Local `docker build` still works with default (public ECR)
- [ ] CI build uses the pull-through cache arg