### PR TITLE
fix: quorum writes for simulation_runs fold to prevent replication lag stale reads

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
@@ -276,8 +276,11 @@ export class SimulationRunStateRepositoryClickHouse<
           // a subsequent store.get() on a replica may return stale state,
           // causing the fold to overwrite fields (e.g. ScenarioSetId lost,
           // Status reverted from SUCCESS to IN_PROGRESS).
+          // select_sequential_consistency on reads only works when writes
+          // use insert_quorum with insert_quorum_parallel disabled.
           async_insert: 0,
-          insert_quorum: "2",
+          insert_quorum: "auto",
+          insert_quorum_parallel: "0",
         },
       });
 


### PR DESCRIPTION
## Summary

On prod (ClickHouse with master + 2 replicas), the fold's store.get() can hit a replica that hasn't received the latest write, even with FINAL + select_sequential_consistency. This causes the fold to overwrite ScenarioSetId, BatchRunId, and Status with stale values from init().

This was NOT reproducible on dev (single ClickHouse node) where FINAL alone was sufficient.

## Fix

- Disable `async_insert` for simulation_runs fold store writes (sync inserts for immediate durability)
- Enable `insert_quorum: 2` (write must be acknowledged by 2 out of 3 nodes before returning)
- Combined with existing FINAL + select_sequential_consistency on reads, this guarantees read-after-write consistency across replicas

Only applied to the simulation_runs fold store. General trace ingestion is unaffected.

## Risk

If 2 out of 3 ClickHouse nodes are down simultaneously, fold writes will fail. With 1 node down, writes still succeed (2 out of 2 remaining).

## Test plan

- [ ] Deploy to prod, run a scenario from Python SDK with `set_id="python-examples"`
- [ ] Verify ScenarioSetId is preserved after all events are processed
- [ ] Verify Status transitions correctly (no green flash revert)