### PR TITLE
fix: monotonic UpdatedAt to prevent merge collisions with identical timestamps

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
@@ -221,7 +221,8 @@ describe("simulationRunStateFoldProjection", () => {
       expect(state.Status).toBe("IN_PROGRESS");
       expect(state.StartedAt).toBe(1000);
       expect(state.CreatedAt).toBe(FAKE_NOW);
-      expect(state.UpdatedAt).toBe(1000); // event.occurredAt
+      // UpdatedAt is monotonic: max(event.occurredAt, state.UpdatedAt + 1)
+      expect(state.UpdatedAt).toBeGreaterThanOrEqual(1000);
     });
   });
 
@@ -240,7 +241,8 @@ describe("simulationRunStateFoldProjection", () => {
         { Id: "", Role: "assistant", Content: "hi", TraceId: "", Rest: "" },
       ]);
       expect(state.TraceIds).toEqual(["trace-1", "trace-2"]);
-      expect(state.UpdatedAt).toBe(2000); // MessageSnapshot occurredAt
+      // UpdatedAt is monotonic: always advances
+      expect(state.UpdatedAt).toBeGreaterThanOrEqual(2000);
     });
 
     it("updates Status when provided", () => {
@@ -279,7 +281,8 @@ describe("simulationRunStateFoldProjection", () => {
       expect(state.Messages).toEqual([
         { Id: "", Role: "user", Content: "second", TraceId: "", Rest: "" },
       ]);
-      expect(state.UpdatedAt).toBe(2000); // newer snapshot's occurredAt (older ignored)
+      // UpdatedAt stays at the newer snapshot's level (older was ignored)
+      expect(state.UpdatedAt).toBeGreaterThanOrEqual(2000);
     });
   });
 
@@ -372,7 +375,7 @@ describe("simulationRunStateFoldProjection", () => {
       ]);
 
       expect(state.ArchivedAt).toBe(4000); // RunDeleted occurredAt
-      expect(state.UpdatedAt).toBe(4000); // RunDeleted occurredAt
+      expect(state.UpdatedAt).toBeGreaterThanOrEqual(4000);
     });
   });
 
@@ -386,7 +389,7 @@ describe("simulationRunStateFoldProjection", () => {
       expect(state.Messages).toEqual([
         { Id: "msg-1", Role: "user", Content: "", TraceId: "", Rest: "" },
       ]);
-      expect(state.UpdatedAt).toBe(1500); // TextMessageStart occurredAt
+      expect(state.UpdatedAt).toBeGreaterThanOrEqual(1500);
     });
 
     it("transitions PENDING to IN_PROGRESS", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.ordering.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.ordering.unit.test.ts
@@ -191,21 +191,6 @@ describe("simulation run fold — event ordering invariants", () => {
   const store = createReplacingMergeTreeStore();
   const projection = createSimulationRunStateFoldProjection({ store });
 
-  // Events that can be reordered after started.
-  // In production: started is always first, finished always after snapshot.
-  // metrics_computed can interleave anywhere.
-  const afterStarted: SimulationProcessingEvent[] = [
-    createMessageSnapshotEvent(5000),
-    createFinishedEvent(5200),
-    createMetricsComputedEvent("trace-1", 65000),
-    createMetricsComputedEvent("trace-2", 65100),
-  ];
-
-  const started = createStartedEvent(1000);
-
-  // Generate all permutations of the post-started events, prepend started
-  const allPerms = permutations(afterStarted).map(perm => [started, ...perm]);
-
   function assertCorrectFinalState(state: SimulationRunStateData, label: string) {
     expect(state.Status, `${label}: Status must be SUCCESS`).toBe("SUCCESS");
     expect(state.FinishedAt, `${label}: FinishedAt must be set`).not.toBeNull();
@@ -213,15 +198,57 @@ describe("simulation run fold — event ordering invariants", () => {
     expect(state.BatchRunId, `${label}: BatchRunId must be preserved`).toBe("batch-1");
     expect(state.ScenarioId, `${label}: ScenarioId must be preserved`).toBe("scenario-1");
     expect(state.Verdict, `${label}: Verdict must be set`).toBe("success");
+    // Metrics must always be preserved regardless of ordering
+    expect(state.TotalCost, `${label}: TotalCost must be computed`).toBeGreaterThan(0);
+    expect(Object.keys(state.RoleCosts).length, `${label}: RoleCosts must have entries`).toBeGreaterThan(0);
+    expect(Object.keys(state.RoleLatencies).length, `${label}: RoleLatencies must have entries`).toBeGreaterThan(0);
   }
 
-  describe(`when started is first, then ${afterStarted.length} events in all ${allPerms.length} orderings`, () => {
-    it.each(allPerms.map((perm, i) => ({
-      name: `[${i}] ${perm.map(eventLabel).join(" → ")}`,
-      perm,
-    })))("$name → final state is correct", async ({ name, perm }) => {
-      const state = await processFold(perm, store, projection);
-      assertCorrectFinalState(state, name);
+  // --- Distinct timestamps (finished > snapshot) ---
+  describe("when snapshot and finished have distinct timestamps", () => {
+    const started = createStartedEvent(1000);
+    const afterStarted: SimulationProcessingEvent[] = [
+      createMessageSnapshotEvent(5000),
+      createFinishedEvent(5200),
+      createMetricsComputedEvent("trace-1", 65000),
+      createMetricsComputedEvent("trace-2", 65100),
+    ];
+
+    const allPerms = permutations(afterStarted).map(perm => [started, ...perm]);
+
+    describe(`when started is first, then ${afterStarted.length} events in all ${allPerms.length} orderings`, () => {
+      it.each(allPerms.map((perm, i) => ({
+        name: `[${i}] ${perm.map(eventLabel).join(" → ")}`,
+        perm,
+      })))("$name → final state is correct", async ({ name, perm }) => {
+        const state = await processFold(perm, store, projection);
+        assertCorrectFinalState(state, name);
+      });
+    });
+  });
+
+  // --- Identical timestamps (production pattern: SDK sends snapshot and
+  // finished with the same occurredAt) ---
+  describe("when snapshot and finished have identical occurredAt (production SDK pattern)", () => {
+    const SAME_TS = 5000;
+    const started = createStartedEvent(1000);
+    const afterStarted: SimulationProcessingEvent[] = [
+      createMessageSnapshotEvent(SAME_TS),
+      createFinishedEvent(SAME_TS),
+      createMetricsComputedEvent("trace-1", 65000),
+      createMetricsComputedEvent("trace-2", 65100),
+    ];
+
+    const allPerms = permutations(afterStarted).map(perm => [started, ...perm]);
+
+    describe(`when started is first, then ${afterStarted.length} events in all ${allPerms.length} orderings`, () => {
+      it.each(allPerms.map((perm, i) => ({
+        name: `[${i}] ${perm.map(eventLabel).join(" → ")}`,
+        perm,
+      })))("$name → final state is correct", async ({ name, perm }) => {
+        const state = await processFold(perm, store, projection);
+        assertCorrectFinalState(state, name);
+      });
     });
   });
 
@@ -229,20 +256,19 @@ describe("simulation run fold — event ordering invariants", () => {
   describe("when processing in production-observed orderings", () => {
     it("started → snapshot → finished → metrics × 2 (happy path)", async () => {
       const state = await processFold([
-        started,
+        createStartedEvent(1000),
         createMessageSnapshotEvent(5000),
-        createFinishedEvent(5200),
+        createFinishedEvent(5000),
         createMetricsComputedEvent("trace-1", 65000),
         createMetricsComputedEvent("trace-2", 65100),
       ], store, projection);
       assertCorrectFinalState(state, "happy path");
-      expect(state.TotalCost).toBeGreaterThan(0);
     });
 
     it("started → finished → snapshot → metrics × 2 (finished before snapshot)", async () => {
       const state = await processFold([
-        started,
-        createFinishedEvent(5200),
+        createStartedEvent(1000),
+        createFinishedEvent(5000),
         createMessageSnapshotEvent(5000),
         createMetricsComputedEvent("trace-1", 65000),
         createMetricsComputedEvent("trace-2", 65100),
@@ -252,10 +278,10 @@ describe("simulation run fold — event ordering invariants", () => {
 
     it("started → metrics → snapshot → finished → metrics (metrics interleaved)", async () => {
       const state = await processFold([
-        started,
+        createStartedEvent(1000),
         createMetricsComputedEvent("trace-1", 65000),
         createMessageSnapshotEvent(5000),
-        createFinishedEvent(5200),
+        createFinishedEvent(5000),
         createMetricsComputedEvent("trace-2", 65100),
       ], store, projection);
       assertCorrectFinalState(state, "metrics interleaved");
@@ -266,9 +292,9 @@ describe("simulation run fold — event ordering invariants", () => {
   describe("when duplicate delayed metrics arrive after finished", () => {
     it("preserves SUCCESS with all metrics applied", async () => {
       const state = await processFold([
-        started,
+        createStartedEvent(1000),
         createMessageSnapshotEvent(5000),
-        createFinishedEvent(5200),
+        createFinishedEvent(5000),
         createMetricsComputedEvent("trace-1", 65000),
         createMetricsComputedEvent("trace-2", 65100),
         // Duplicate ECST fire
@@ -276,7 +302,6 @@ describe("simulation run fold — event ordering invariants", () => {
         createMetricsComputedEvent("trace-2", 125100),
       ], store, projection);
       assertCorrectFinalState(state, "duplicate delayed metrics");
-      expect(state.TotalCost).toBeGreaterThan(0);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -111,6 +111,28 @@ function init(): SimulationRunStateData {
   };
 }
 
+/**
+ * Monotonic UpdatedAt for ReplacingMergeTree correctness.
+ *
+ * Each new row MUST have a strictly higher UpdatedAt than the previous
+ * state so it always wins the merge. Without this, two events with the
+ * same occurredAt (e.g. SDK sends message_snapshot and finished with
+ * identical timestamps) produce rows with equal UpdatedAt, and the
+ * merge picks non-deterministically — potentially discarding the
+ * finished row.
+ *
+ * For most handlers: use the event's natural timestamp when it's
+ * already higher, otherwise advance by +1.
+ *
+ * For metrics_computed: ALWAYS use +1 because its occurredAt is
+ * server-generated (ECST reactor, 60s delay) and would jump far
+ * ahead of the finished event's timestamp, causing the stale
+ * metrics row to permanently win.
+ */
+function nextUpdatedAt(state: SimulationRunStateData, event: SimulationProcessingEvent): number {
+  return Math.max(event.occurredAt, state.UpdatedAt + 1);
+}
+
 function apply(
   state: SimulationRunStateData,
   event: SimulationProcessingEvent,
@@ -127,7 +149,7 @@ function apply(
       Description: event.data.description ?? null,
       Metadata: event.data.metadata ? JSON.stringify(event.data.metadata) : null,
       QueuedAt: event.occurredAt,
-      UpdatedAt: event.occurredAt,
+      UpdatedAt: nextUpdatedAt(state, event),
     };
   }
 
@@ -143,7 +165,7 @@ function apply(
       Metadata: state.Metadata ?? (event.data.metadata ? JSON.stringify(event.data.metadata) : null),
       Status: "IN_PROGRESS",
       StartedAt: event.occurredAt,
-      UpdatedAt: event.occurredAt,
+      UpdatedAt: nextUpdatedAt(state, event),
     };
   }
 
@@ -172,7 +194,7 @@ function apply(
       }),
       TraceIds: Array.isArray(event.data.traceIds) ? event.data.traceIds : [],
       Status: event.data.status ?? state.Status,
-      UpdatedAt: event.occurredAt,
+      UpdatedAt: nextUpdatedAt(state, event),
     };
   }
 
@@ -207,7 +229,7 @@ function apply(
       Status: state.Status === "PENDING" ? "IN_PROGRESS" : state.Status,
       StartedAt: state.StartedAt ?? event.occurredAt,
       Messages: messages,
-      UpdatedAt: event.occurredAt,
+      UpdatedAt: nextUpdatedAt(state, event),
     };
   }
 
@@ -261,7 +283,7 @@ function apply(
       StartedAt: state.StartedAt ?? event.occurredAt,
       Messages: updatedMessages,
       TraceIds: traceIds,
-      UpdatedAt: event.occurredAt,
+      UpdatedAt: nextUpdatedAt(state, event),
     };
   }
 
@@ -292,7 +314,7 @@ function apply(
       Error: results?.error ?? null,
       DurationMs: event.data.durationMs ?? null,
       FinishedAt: event.occurredAt,
-      UpdatedAt: event.occurredAt,
+      UpdatedAt: nextUpdatedAt(state, event),
     };
   }
 
@@ -328,14 +350,8 @@ function apply(
       TotalCost: totalCost > 0 ? Number(totalCost.toFixed(6)) : null,
       RoleCosts: roleCosts,
       RoleLatencies: roleLatencies,
-      // Use state.UpdatedAt + 1 instead of event.occurredAt.
-      // metrics_computed events are generated server-side (ECST reactor,
-      // 60s delay) with occurredAt = Date.now(), which is much higher than
-      // the user-sent finished event's occurredAt. In ReplacingMergeTree,
-      // the row with highest UpdatedAt wins the merge — if metrics has
-      // higher UpdatedAt, it permanently overwrites the finished row.
-      // Incrementing from state ensures monotonic ordering without jumping
-      // ahead of the finished event's timestamp.
+      // Always +1 for metrics_computed — its occurredAt is server-generated
+      // (ECST reactor, 60s delay) and would jump far ahead of finished.
       UpdatedAt: state.UpdatedAt + 1,
     };
   }
@@ -345,7 +361,7 @@ function apply(
       ...state,
       ScenarioRunId: state.ScenarioRunId || event.data.scenarioRunId,
       ArchivedAt: event.occurredAt,
-      UpdatedAt: event.occurredAt,
+      UpdatedAt: nextUpdatedAt(state, event),
     };
   }
 


### PR DESCRIPTION
## Summary

- **Root cause:** SDK sends `message_snapshot` and `finished` with identical `occurredAt`. Both rows get the same `UpdatedAt`, so ReplacingMergeTree picks non-deterministically — potentially discarding the finished row. All subsequent `metrics_computed` events then inherit `IN_PROGRESS`.
- **Fix:** `nextUpdatedAt()` = `Math.max(event.occurredAt, state.UpdatedAt + 1)` for all handlers. `metrics_computed` keeps `state.UpdatedAt + 1` (its `occurredAt` is 60s ahead from ECST reactor). This guarantees strictly monotonic UpdatedAt so the merge always keeps the latest state.
- **Safe because:** `apply()` spreads `...state`, so each row is a superset — no fields (Status, metrics, costs) are lost when a later event wins the merge.

Builds on #2730 (already merged).

## Test plan

- [x] 52 combinatorial orderings pass (24 distinct + 24 identical timestamps + 4 production-observed)
- [x] All assert Status=SUCCESS, FinishedAt set, TotalCost > 0, RoleCosts non-empty, RoleLatencies non-empty
- [x] 24 existing fold unit tests pass (updated to assert monotonic UpdatedAt)
- [x] Typecheck clean
- [ ] Deploy and verify no stuck IN_PROGRESS runs in production