### PR TITLE
fix: monotonic UpdatedAt for trace_summaries fold to prevent span data loss

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -976,6 +976,12 @@ export function createTraceSummaryFoldProjection({
       state: TraceSummaryData,
       event: TraceProcessingEvent,
     ): TraceSummaryData {
+      // Monotonic UpdatedAt for ReplacingMergeTree correctness.
+      // Multiple spans can process within the same millisecond, producing
+      // rows with identical Date.now(). The merge then picks
+      // non-deterministically, potentially discarding rows with role data.
+      const nextUpdatedAt = Math.max(Date.now(), state.updatedAt + 1);
+
       if (isSpanReceivedEvent(event)) {
         const normalizedSpan =
           spanNormalizationPipelineService.normalizeSpanReceived(
@@ -989,7 +995,7 @@ export function createTraceSummaryFoldProjection({
         return {
           ...applySpanToSummary({ state, span: normalizedSpan }),
           createdAt: state.createdAt,
-          updatedAt: Date.now(),
+          updatedAt: nextUpdatedAt,
         };
       }
 
@@ -998,7 +1004,7 @@ export function createTraceSummaryFoldProjection({
           ...state,
           topicId: event.data.topicId ?? state.topicId,
           subTopicId: event.data.subtopicId ?? state.subTopicId,
-          updatedAt: Date.now(),
+          updatedAt: nextUpdatedAt,
         };
       }
 
@@ -1050,7 +1056,7 @@ export function createTraceSummaryFoldProjection({
           computedOutput,
           outputSpanEndTimeMs,
           attributes: mergedAttributes,
-          updatedAt: Date.now(),
+          updatedAt: nextUpdatedAt,
         };
       }
 
@@ -1078,7 +1084,7 @@ export function createTraceSummaryFoldProjection({
           traceId: state.traceId || event.data.traceId,
           timeToFirstTokenMs,
           attributes: mergedAttributes,
-          updatedAt: Date.now(),
+          updatedAt: nextUpdatedAt,
         };
       }
 
@@ -1094,7 +1100,7 @@ export function createTraceSummaryFoldProjection({
             ...state.attributes,
             "langwatch.origin": event.data.origin,
           },
-          updatedAt: Date.now(),
+          updatedAt: nextUpdatedAt,
         };
       }
 


### PR DESCRIPTION
## Summary

- Same ReplacingMergeTree merge collision as simulation_runs (fixed in #2731): multiple spans processing within the same millisecond produce rows with identical `Date.now()` UpdatedAt
- The merge picks non-deterministically, discarding rows that accumulated `scenario.role` costs and latencies — causing empty `RoleCosts`/`RoleLatencies` in metrics_computed events
- Fix: `Math.max(Date.now(), state.updatedAt + 1)` for all trace fold handlers

Builds on #2731 (simulation_runs fold fix, already merged).

## Test plan

- [x] Typecheck clean
- [x] All trace fold projection tests pass (3 pre-existing failures unrelated to this change)
- [ ] Deploy and verify roleCosts/roleLatencies are populated for new scenario runs