### PR TITLE
fix: route trace fold store to primary replica for read-after-write consistency

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -18,6 +18,7 @@ import { LogRecordStorageClickHouseRepository } from "../app-layer/traces/reposi
 import { NullLogRecordStorageRepository } from "../app-layer/traces/repositories/log-record-storage.repository";
 import { MetricRecordStorageClickHouseRepository } from "../app-layer/traces/repositories/metric-record-storage.clickhouse.repository";
 import { NullMetricRecordStorageRepository } from "../app-layer/traces/repositories/metric-record-storage.repository";
+import { TraceSummaryClickHouseRepository } from "../app-layer/traces/repositories/trace-summary.clickhouse.repository";
 import type { SpanStorageService } from "../app-layer/traces/span-storage.service";
 import type { TraceSummaryService } from "../app-layer/traces/trace-summary.service";
 
@@ -167,9 +168,14 @@ export class PipelineRegistry {
   ) {
     const evalCommands = mapCommands(evalPipeline.commands);
 
-    const traceSummaryStore = new TraceSummaryStore(
-      this.deps.traces.summary.repository,
-    );
+    // Use primary replica for the fold store to avoid replication lag.
+    // The shared TraceSummaryService.repository goes through the NLB
+    // (random replica), which causes stale reads during fold processing.
+    const foldClientResolver = this.deps.resolvePrimaryReplicaClickHouseClient ?? this.deps.resolveClickHouseClient;
+    const traceSummaryFoldRepo = foldClientResolver
+      ? new TraceSummaryClickHouseRepository(foldClientResolver)
+      : this.deps.traces.summary.repository;
+    const traceSummaryStore = new TraceSummaryStore(traceSummaryFoldRepo);
 
     // Late-bound reference to the trace pipeline's resolveOrigin command.
     // The reactor deps closure captures this; the actual dispatcher is set


### PR DESCRIPTION
## Summary

- **Root cause:** The trace summary fold store used the shared `TraceSummaryService` repository, which routes through the NLB to random ClickHouse replicas. During fold processing (`store.get()` → `apply()` → `store.store()`), the read could hit a different replica than the previous write, getting stale state missing recently processed spans. The fold builds on incomplete data (e.g., spans with `scenario.role` not yet replicated), and with monotonic UpdatedAt, the incomplete row wins the merge permanently.
- **Evidence:** `scenariorun_3BZ7ZOf5uaXLz4Y19EpXRFmiKh6` — all 6 span events exist with correct `scenario.role` attributes, but the final `trace_summaries` row only has data from 4 spans. The Agent role span (`WeatherAgent.call`) was processed but its data was lost to a stale read.
- **Fix:** Create a separate `TraceSummaryClickHouseRepository` with the primary replica resolver for the fold store, same pattern as the simulation_runs fold (which already uses `resolvePrimaryReplicaClickHouseClient`). Regular query reads still go through the NLB.

## Test plan

- [x] Typecheck clean (pre-existing SCIM/auth errors only)
- [x] All trace fold projection tests pass (80/80, 3 pre-existing origin failures)
- [ ] Deploy and verify `ScenarioRoleCosts`/`ScenarioRoleLatencies` are populated for all new runs