### PR TITLE
fix: remove redundant _parent: zero entries from SpanCosts Map column

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -812,11 +812,10 @@ function accumulateRoleCostLatency({
     spanCosts[span.spanId] = spanCost;
   }
 
-  // Record parent relationship for all spans (even if role unknown yet)
+  // Record parent relationship for retroactive role propagation.
+  // Only stored in scenarioRoleSpans — not in spanCosts (which would
+  // bloat the Map column with zero-value entries for every span).
   if (span.parentSpanId) {
-    // Store parent mapping as negative-prefixed entry (hack to avoid another Map column)
-    // "_parent:childId" -> parentId
-    spanCosts[`_parent:${span.spanId}`] = 0; // placeholder
     scenarioRoleSpans[`_parent:${span.spanId}`] = span.parentSpanId;
   }
 


### PR DESCRIPTION
## Summary

- Every span with a parent was adding `_parent:spanId → 0` to the SpanCosts Map column — pure dead weight
- For traces with 22k+ spans (observed in prod), this bloats the column with thousands of useless zero entries
- Contributes to OOM: "Amount of memory requested to allocate is more than allowed: (while reading column SpanCosts)"
- The parent relationship is already tracked in `ScenarioRoleSpans` — the SpanCosts `_parent:` entries were never read (recompute loop skips them at line 849, propagation loop uses ScenarioRoleSpans)

## Test plan

- [x] 20/20 cost computation tests pass (out-of-order spans, retroactive role assignment all covered)
- [x] 80/80 trace fold tests pass (3 pre-existing origin failures, verified on clean main)
- [x] Verified on clean main: same 3 failures exist without this change