### PR TITLE
fix: remove dead _parent: entries from SpanCosts to prevent OOM

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryCostComputation.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryCostComputation.unit.test.ts
@@ -632,4 +632,37 @@ describe("applySpanToSummary per-role cost/latency accumulation", () => {
       });
     });
   });
+
+  describe("given spans with parent relationships", () => {
+    describe("when the fold processes spans with costs and parents", () => {
+      it("does not store _parent: entries in spanCosts", () => {
+        const agentSpan = createTestSpan({
+          spanId: "agent-1",
+          parentSpanId: null,
+          spanAttributes: { "scenario.role": "Agent" },
+        });
+
+        const llmSpan = createTestSpan({
+          spanId: "llm-1",
+          parentSpanId: "agent-1",
+          spanAttributes: {
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 50,
+            "langwatch.model.inputCostPerToken": 0.000005,
+            "langwatch.model.outputCostPerToken": 0.000015,
+          },
+        });
+
+        let state = createInitState();
+        state = applySpanToSummary({ state, span: agentSpan });
+        state = applySpanToSummary({ state, span: llmSpan });
+
+        const parentKeys = Object.keys(state.spanCosts ?? {}).filter(k => k.startsWith("_parent:"));
+        expect(parentKeys).toHaveLength(0);
+
+        // Parent mappings belong in scenarioRoleSpans, not spanCosts
+        expect(state.scenarioRoleSpans?.["_parent:llm-1"]).toBe("agent-1");
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -816,7 +816,6 @@ function accumulateRoleCostLatency({
   if (span.parentSpanId) {
     // Store parent mapping as negative-prefixed entry (hack to avoid another Map column)
     // "_parent:childId" -> parentId
-    spanCosts[`_parent:${span.spanId}`] = 0; // placeholder
     scenarioRoleSpans[`_parent:${span.spanId}`] = span.parentSpanId;
   }
 


### PR DESCRIPTION
## Summary

- Remove `_parent:` placeholder entries from the `SpanCosts` map in the trace summary fold projection
- These entries were dead data (always value 0, always skipped during cost computation) that doubled the map size per row
- The parent chain info already lives in `ScenarioRoleSpans` where it's actually used for role propagation
- Add regression test asserting `_parent:` keys never appear in `spanCosts`

## Context

The `SpanCosts` column on `trace_summaries` was causing ClickHouse OOM errors ("Amount of memory requested to allocate is more than allowed") even for single-row reads. The `_parent:` entries bloated the `Map(String, Float64)` column, and when ClickHouse read 8192-row granules, decompressing the column exceeded the per-query memory limit.

Operational fix (DROP+ADD column, OPTIMIZE) was applied to clean existing data. This code change prevents re-bloat.

## Test plan

- [x] Existing 20 cost computation unit tests pass
- [x] New regression test verifies `_parent:` keys don't appear in `spanCosts`
- [x] `scenarioRoleSpans` parent mappings are preserved (role propagation unaffected)