### PR TITLE
fix: clean deferred origin resolution to follow CQRS

### DIFF
--- a/langwatch/src/optimization_studio/hooks/useComponentExecution.ts
+++ b/langwatch/src/optimization_studio/hooks/useComponentExecution.ts
@@ -131,6 +131,7 @@ export const useComponentExecution = () => {
           },
           node_id: node.id,
           inputs: inputs_,
+          origin: "workflow",
         },
       };
 

--- a/langwatch/src/optimization_studio/hooks/useEvaluationExecution.ts
+++ b/langwatch/src/optimization_studio/hooks/useEvaluationExecution.ts
@@ -121,6 +121,7 @@ export const useEvaluationExecution = () => {
           workflow_version_id,
           evaluate_on,
           dataset_entry,
+          origin: "evaluation",
         },
       };
       postEvent(payload);

--- a/langwatch/src/optimization_studio/hooks/useRunEvalution.ts
+++ b/langwatch/src/optimization_studio/hooks/useRunEvalution.ts
@@ -210,6 +210,7 @@ export const useRunEvalution = () => {
           workflow_version_id: versionId ?? "",
           evaluate_on: evaluate_on ?? "full",
           dataset_entry,
+          origin: "evaluation",
         },
       };
       postEvent(payload);

--- a/langwatch/src/optimization_studio/hooks/useWorkflowExecution.ts
+++ b/langwatch/src/optimization_studio/hooks/useWorkflowExecution.ts
@@ -109,6 +109,7 @@ export const useWorkflowExecution = () => {
           until_node_id: untilNodeId,
           inputs: inputs,
           manual_execution_mode: true,
+          origin: "workflow",
         },
       };
       postEvent(payload);

--- a/langwatch/src/optimization_studio/types/events.ts
+++ b/langwatch/src/optimization_studio/types/events.ts
@@ -43,6 +43,7 @@ export const studioClientEventSchema = z.discriminatedUnion("type", [
       workflow_version_id: z.string(),
       evaluate_on: z.enum(["full", "test", "train", "specific"]),
       dataset_entry: z.number().optional(),
+      origin: z.string().optional(),
     }),
   }),
   z.object({

--- a/langwatch/src/prompts/utils/invokeLLM.ts
+++ b/langwatch/src/prompts/utils/invokeLLM.ts
@@ -185,6 +185,7 @@ function createEventPayload(
       workflow,
       node_id: nodeId,
       inputs,
+      origin: "playground",
     },
   };
 }

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -73,10 +73,10 @@ import { createCustomEvaluationSyncReactor } from "./pipelines/trace-processing/
 import { createProjectMetadataReactor } from "./pipelines/trace-processing/reactors/projectMetadata.reactor";
 import {
   createEvaluationTriggerReactor,
-  createDeferredEvaluationHandler,
+  createDeferredOriginHandler,
   makeDeferredJobId,
   DEFERRED_CHECK_DELAY_MS,
-  type DeferredEvaluationPayload,
+  type DeferredOriginPayload,
 } from "./pipelines/trace-processing/reactors/evaluationTrigger.reactor";
 import { createSpanStorageBroadcastReactor } from "./pipelines/trace-processing/reactors/spanStorageBroadcast.reactor";
 import { createTraceUpdateBroadcastReactor } from "./pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor";
@@ -215,7 +215,7 @@ export class PipelineRegistry {
 
     // Late-bound reference to the deferred evaluation queue.
     // Set after pipeline registration, same pattern as resolveOriginDispatcher.
-    let scheduleDeferredDispatcher: ((payload: DeferredEvaluationPayload) => Promise<void>) | null = null;
+    let scheduleDeferredDispatcher: ((payload: DeferredOriginPayload) => Promise<void>) | null = null;
 
     const evaluationTriggerReactorDeps = {
       monitors: this.deps.monitors,
@@ -226,8 +226,7 @@ export class PipelineRegistry {
         }
         return resolveOriginDispatcher(data);
       },
-      traceSummaryStore,
-      scheduleDeferred: async (payload: DeferredEvaluationPayload) => {
+      scheduleDeferred: async (payload: DeferredOriginPayload) => {
         if (!scheduleDeferredDispatcher) {
           throw new Error("scheduleDeferred dispatcher not yet initialized — pipeline registration order issue");
         }
@@ -289,32 +288,39 @@ export class PipelineRegistry {
     const traceCommands = mapCommands(tracePipeline.commands);
     resolveOriginDispatcher = traceCommands.resolveOrigin;
 
-    // Wire the deferred evaluation queue (BullMQ-backed, survives process restart)
-    const deferredHandler = createDeferredEvaluationHandler(evaluationTriggerReactorDeps);
-    const deferredEvalQueue = tracePipeline.service.registerJob<DeferredEvaluationPayload>({
-      name: "deferredEvaluation",
-      process: deferredHandler,
+    // Wire the deferred origin resolution queue (BullMQ-backed, survives process restart).
+    // After 5 min, dispatches resolveOrigin command → OriginResolvedEvent → fold → reactor.
+    const deferredOriginHandler = createDeferredOriginHandler(
+      evaluationTriggerReactorDeps.resolveOrigin,
+    );
+    const deferredOriginQueue = tracePipeline.service.registerJob<DeferredOriginPayload>({
+      name: "deferredOriginResolution",
+      process: deferredOriginHandler,
       delay: DEFERRED_CHECK_DELAY_MS,
       deduplication: {
         makeId: makeDeferredJobId,
+        ttlMs: DEFERRED_CHECK_DELAY_MS + 60_000, // 6 min — covers the 5-min delay + buffer
         extend: false,  // Don't reset the 5-min timer on new spans
-        replace: false,
+        replace: false,  // Don't update payload (same trace, same data)
       },
+      groupKeyFn: (p) => p.traceId,  // Per-trace parallelism (was per-project serial)
       spanAttributes: (payload) => ({
         "deferred.tenant_id": payload.tenantId,
         "deferred.trace_id": payload.traceId,
       }),
     });
 
-    if (deferredEvalQueue) {
-      scheduleDeferredDispatcher = (payload) => deferredEvalQueue.send(payload);
+    if (deferredOriginQueue) {
+      scheduleDeferredDispatcher = (payload) => deferredOriginQueue.send(payload);
     } else {
       // Fallback: event sourcing disabled, use in-memory setTimeout (best-effort)
       const pendingDeferredChecks = new Map<string, ReturnType<typeof setTimeout>>();
-      scheduleDeferredDispatcher = async (payload: DeferredEvaluationPayload) => {
+      scheduleDeferredDispatcher = async (payload: DeferredOriginPayload) => {
         const dedupKey = makeDeferredJobId(payload);
         if (pendingDeferredChecks.has(dedupKey)) return;
-        const handler = createDeferredEvaluationHandler(evaluationTriggerReactorDeps);
+        const handler = createDeferredOriginHandler(
+          evaluationTriggerReactorDeps.resolveOrigin,
+        );
         const timer = setTimeout(async () => {
           pendingDeferredChecks.delete(dedupKey);
           try {
@@ -322,7 +328,7 @@ export class PipelineRegistry {
           } catch (error) {
             logger.error(
               { tenantId: payload.tenantId, traceId: payload.traceId, error },
-              "Deferred evaluation check failed",
+              "Deferred origin resolution failed",
             );
           }
         }, DEFERRED_CHECK_DELAY_MS);

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -303,7 +303,7 @@ export class PipelineRegistry {
         extend: false,  // Don't reset the 5-min timer on new spans
         replace: false,  // Don't update payload (same trace, same data)
       },
-      groupKeyFn: (p) => p.traceId,  // Per-trace parallelism (was per-project serial)
+      groupKeyFn: (p) => p.traceId,  // Per-trace parallelism (framework prepends tenantId)
       spanAttributes: (payload) => ({
         "deferred.tenant_id": payload.tenantId,
         "deferred.trace_id": payload.traceId,

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -71,13 +71,14 @@ import { TraceSummaryFoldProjection } from "./pipelines/trace-processing/project
 import { TraceSummaryStore } from "./pipelines/trace-processing/projections/traceSummary.store";
 import { createCustomEvaluationSyncReactor } from "./pipelines/trace-processing/reactors/customEvaluationSync.reactor";
 import { createProjectMetadataReactor } from "./pipelines/trace-processing/reactors/projectMetadata.reactor";
+import { createEvaluationTriggerReactor } from "./pipelines/trace-processing/reactors/evaluationTrigger.reactor";
 import {
-  createEvaluationTriggerReactor,
+  createOriginGateReactor,
   createDeferredOriginHandler,
   makeDeferredJobId,
   DEFERRED_CHECK_DELAY_MS,
   type DeferredOriginPayload,
-} from "./pipelines/trace-processing/reactors/evaluationTrigger.reactor";
+} from "./pipelines/trace-processing/reactors/originGate.reactor";
 import { createSpanStorageBroadcastReactor } from "./pipelines/trace-processing/reactors/spanStorageBroadcast.reactor";
 import { createTraceUpdateBroadcastReactor } from "./pipelines/trace-processing/reactors/traceUpdateBroadcast.reactor";
 import type { AppendStore } from "./projections/mapProjection.types";
@@ -213,28 +214,23 @@ export class PipelineRegistry {
     // after pipeline registration (same pattern as billing self-dispatch).
     let resolveOriginDispatcher: ((data: any) => Promise<void>) | null = null;
 
-    // Late-bound reference to the deferred evaluation queue.
+    // Late-bound reference to the deferred origin resolution queue.
     // Set after pipeline registration, same pattern as resolveOriginDispatcher.
     let scheduleDeferredDispatcher: ((payload: DeferredOriginPayload) => Promise<void>) | null = null;
 
-    const evaluationTriggerReactorDeps = {
-      monitors: this.deps.monitors,
-      evaluation: evalCommands.executeEvaluation,
-      resolveOrigin: async (data: any) => {
-        if (!resolveOriginDispatcher) {
-          throw new Error("resolveOrigin dispatcher not yet initialized — pipeline registration order issue");
-        }
-        return resolveOriginDispatcher(data);
-      },
+    const originGateReactor = createOriginGateReactor({
       scheduleDeferred: async (payload: DeferredOriginPayload) => {
         if (!scheduleDeferredDispatcher) {
           throw new Error("scheduleDeferred dispatcher not yet initialized — pipeline registration order issue");
         }
         return scheduleDeferredDispatcher(payload);
       },
-    };
+    });
 
-    const evaluationTriggerReactor = createEvaluationTriggerReactor(evaluationTriggerReactorDeps);
+    const evaluationTriggerReactor = createEvaluationTriggerReactor({
+      monitors: this.deps.monitors,
+      evaluation: evalCommands.executeEvaluation,
+    });
 
     const customEvaluationSyncReactor = createCustomEvaluationSyncReactor({
       reportEvaluation: evalCommands.reportEvaluation,
@@ -275,6 +271,7 @@ export class PipelineRegistry {
         logRecordAppendStore: new LogRecordAppendStore(this.deps.repositories.logRecordStorage),
         metricRecordAppendStore: new MetricRecordAppendStore(this.deps.repositories.metricRecordStorage),
         traceSummaryStore,
+        originGateReactor,
         evaluationTriggerReactor,
         customEvaluationSyncReactor,
         traceUpdateBroadcastReactor,
@@ -290,9 +287,12 @@ export class PipelineRegistry {
 
     // Wire the deferred origin resolution queue (BullMQ-backed, survives process restart).
     // After 5 min, dispatches resolveOrigin command → OriginResolvedEvent → fold → reactor.
-    const deferredOriginHandler = createDeferredOriginHandler(
-      evaluationTriggerReactorDeps.resolveOrigin,
-    );
+    const deferredOriginHandler = createDeferredOriginHandler(async (data) => {
+      if (!resolveOriginDispatcher) {
+        throw new Error("resolveOrigin dispatcher not yet initialized — pipeline registration order issue");
+      }
+      return resolveOriginDispatcher(data);
+    });
     const deferredOriginQueue = tracePipeline.service.registerJob<DeferredOriginPayload>({
       name: "deferredOriginResolution",
       process: deferredOriginHandler,
@@ -318,9 +318,12 @@ export class PipelineRegistry {
       scheduleDeferredDispatcher = async (payload: DeferredOriginPayload) => {
         const dedupKey = makeDeferredJobId(payload);
         if (pendingDeferredChecks.has(dedupKey)) return;
-        const handler = createDeferredOriginHandler(
-          evaluationTriggerReactorDeps.resolveOrigin,
-        );
+        const handler = createDeferredOriginHandler(async (data) => {
+          if (!resolveOriginDispatcher) {
+            throw new Error("resolveOrigin dispatcher not yet initialized");
+          }
+          return resolveOriginDispatcher(data);
+        });
         const timer = setTimeout(async () => {
           pendingDeferredChecks.delete(dedupKey);
           try {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -23,6 +23,7 @@ export interface TraceProcessingPipelineDeps {
   logRecordAppendStore: AppendStore<NormalizedLogRecord>;
   metricRecordAppendStore: AppendStore<NormalizedMetricRecord>;
   traceSummaryStore: FoldProjectionStore<TraceSummaryData>;
+  originGateReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   evaluationTriggerReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   customEvaluationSyncReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   traceUpdateBroadcastReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
@@ -55,6 +56,7 @@ export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps)
     .withMapProjection("metricRecordStorage", new MetricRecordStorageMapProjection({
       store: deps.metricRecordAppendStore,
     }))
+    .withReactor("traceSummary", "originGate", deps.originGateReactor)
     .withReactor("traceSummary", "evaluationTrigger", deps.evaluationTriggerReactor)
     .withReactor("traceSummary", "customEvaluationSync", deps.customEvaluationSyncReactor)
     .withReactor("traceSummary", "traceUpdateBroadcast", deps.traceUpdateBroadcastReactor)

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
@@ -322,8 +322,9 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when sdk.name is present but no explicit origin or legacy markers (old SDK heuristic)", () => {
-    it("infers langwatch.origin = 'application'", () => {
+    it("infers langwatch.origin = 'application' on root span", () => {
       const span = createTestSpan({
+        parentSpanId: null, // root span — heuristic only fires here
         resourceAttributes: {
           "telemetry.sdk.name": "langwatch",
         },
@@ -335,8 +336,23 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
       expect(state.attributes["langwatch.origin"]).toBe("application");
     });
 
+    it("does not infer origin on child span (prevents race with explicit platform origin)", () => {
+      const span = createTestSpan({
+        parentSpanId: "root-1", // child span — heuristic must not fire
+        resourceAttributes: {
+          "telemetry.sdk.name": "langwatch",
+        },
+        spanAttributes: {},
+      });
+
+      const state = applySpanToSummary({ state: createInitState(), span: span });
+
+      expect(state.attributes["langwatch.origin"]).toBeUndefined();
+    });
+
     it("does not override legacy-inferred origin with SDK heuristic", () => {
       const span = createTestSpan({
+        parentSpanId: null, // root span
         resourceAttributes: {
           "telemetry.sdk.name": "langwatch",
         },
@@ -366,6 +382,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
 
     it("does not infer origin when sdk.name is absent (pure OTEL)", () => {
       const span = createTestSpan({
+        parentSpanId: null,
         resourceAttributes: {},
         spanAttributes: {},
       });
@@ -490,7 +507,7 @@ describe("applySpanToSummary() langwatch.source hoisting", () => {
 
   describe("when child with sdk.name arrives before root with legacy marker", () => {
     it("overrides provisional 'application' origin with root's inferred origin", () => {
-      // Child arrives first — sdk.name heuristic sets origin to "application"
+      // Child arrives first — sdk.name heuristic does NOT fire (child span)
       const childSpan = createTestSpan({
         id: "child-1",
         spanId: "child-1",
@@ -511,10 +528,75 @@ describe("applySpanToSummary() langwatch.source hoisting", () => {
       });
 
       let state = applySpanToSummary({ state: createInitState(), span: childSpan });
-      expect(state.attributes["langwatch.origin"]).toBe("application");
+      // SDK heuristic no longer fires on child spans — origin stays unset
+      expect(state.attributes["langwatch.origin"]).toBeUndefined();
 
       state = applySpanToSummary({ state, span: rootSpan });
       expect(state.attributes["langwatch.origin"]).toBe("simulation");
+    });
+  });
+
+  describe("when child span arrives before non-root span with explicit platform origin (distributed trace)", () => {
+    it("explicit origin wins over heuristic-inferred origin", () => {
+      // Child span arrives first — no explicit origin, sdk.name present
+      // but SDK heuristic does not fire on child spans
+      const childSpan = createTestSpan({
+        id: "child-1",
+        spanId: "child-1",
+        parentSpanId: "platform-root",
+        resourceAttributes: {
+          "telemetry.sdk.name": "opentelemetry",
+        },
+        spanAttributes: {},
+      });
+
+      // Platform span arrives — has explicit origin but is NOT a root span
+      // (parent comes from distributed trace context / HTTP propagation)
+      const platformSpan = createTestSpan({
+        id: "platform-root",
+        spanId: "platform-root",
+        parentSpanId: "external-parent", // NOT null — distributed trace
+        spanAttributes: {
+          "langwatch.origin": "playground",
+          "langwatch.origin.source": "platform",
+        },
+      });
+
+      let state = applySpanToSummary({ state: createInitState(), span: childSpan });
+      expect(state.attributes["langwatch.origin"]).toBeUndefined();
+
+      state = applySpanToSummary({ state, span: platformSpan });
+      expect(state.attributes["langwatch.origin"]).toBe("playground");
+    });
+
+    it("explicit origin overrides previously heuristic-inferred 'application'", () => {
+      // Root span arrives first with sdk.name — heuristic fires
+      const rootSpan = createTestSpan({
+        id: "root-1",
+        spanId: "root-1",
+        parentSpanId: null,
+        resourceAttributes: {
+          "telemetry.sdk.name": "langwatch",
+        },
+        spanAttributes: {},
+      });
+
+      // Platform child span arrives with explicit origin
+      const platformSpan = createTestSpan({
+        id: "platform-1",
+        spanId: "platform-1",
+        parentSpanId: "root-1",
+        spanAttributes: {
+          "langwatch.origin": "playground",
+          "langwatch.origin.source": "platform",
+        },
+      });
+
+      let state = applySpanToSummary({ state: createInitState(), span: rootSpan });
+      expect(state.attributes["langwatch.origin"]).toBe("application");
+
+      state = applySpanToSummary({ state, span: platformSpan });
+      expect(state.attributes["langwatch.origin"]).toBe("playground");
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-origin.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-origin.service.ts
@@ -99,14 +99,9 @@ export class TraceOriginService {
       typeof explicitOrigin === "string" && explicitOrigin !== "";
 
     if (hasExplicitOrigin) {
-      if (isRootSpan) {
-        mergedAttributes["langwatch.origin"] = explicitOrigin as string;
-      } else if (!state.attributes["langwatch.origin"]) {
-        mergedAttributes["langwatch.origin"] = explicitOrigin as string;
-      } else {
-        mergedAttributes["langwatch.origin"] =
-          state.attributes["langwatch.origin"];
-      }
+      // Explicit langwatch.origin on any span always wins — it's a
+      // deliberate, high-confidence signal (SDK or platform).
+      mergedAttributes["langwatch.origin"] = explicitOrigin as string;
     } else {
       // For root spans, always try legacy markers first — a root with a
       // legacy marker should override a provisional origin (e.g. "application")
@@ -119,11 +114,11 @@ export class TraceOriginService {
       } else if (state.attributes["langwatch.origin"]) {
         mergedAttributes["langwatch.origin"] =
           state.attributes["langwatch.origin"];
-      } else if (mergedAttributes["sdk.name"]) {
-        // SDK heuristic: sdk.name present but no explicit origin and no
-        // legacy markers -> old SDK that doesn't tag origin. Old SDK
-        // evaluations/simulations are already caught by legacy rules above,
-        // so what's left must be a regular application trace.
+      } else if (isRootSpan && mergedAttributes["sdk.name"]) {
+        // SDK heuristic: only on root spans. sdk.name is a resource
+        // attribute identical across ALL spans — inferring origin from it
+        // on child spans creates a race where origin flips from "application"
+        // to the real value when the platform span arrives.
         mergedAttributes["langwatch.origin"] = "application";
       }
     }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -4,12 +4,9 @@ import type { ReactorContext } from "../../../../reactors/reactor.types";
 import type { TraceProcessingEvent } from "../../schemas/events";
 import {
   createEvaluationTriggerReactor,
-  createDeferredOriginHandler,
-  resolveOrigin,
-  DEFERRED_CHECK_DELAY_MS,
   type EvaluationTriggerReactorDeps,
-  type DeferredOriginPayload,
 } from "../evaluationTrigger.reactor";
+import { DEFERRED_CHECK_DELAY_MS } from "../originGate.reactor";
 
 function createFoldState(
   overrides: Partial<TraceSummaryData> = {},
@@ -85,28 +82,9 @@ function createDeps(
       ]),
     } as unknown as EvaluationTriggerReactorDeps["monitors"],
     evaluation: vi.fn().mockResolvedValue(undefined),
-    resolveOrigin: vi.fn().mockResolvedValue(undefined),
-    scheduleDeferred: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
-
-describe("resolveOrigin()", () => {
-  describe("when langwatch.origin is set", () => {
-    it("returns the origin", () => {
-      expect(resolveOrigin({ "langwatch.origin": "application" })).toBe("application");
-      expect(resolveOrigin({ "langwatch.origin": "evaluation" })).toBe("evaluation");
-      expect(resolveOrigin({ "langwatch.origin": "simulation" })).toBe("simulation");
-    });
-  });
-
-  describe("when langwatch.origin is absent", () => {
-    it("returns null (fold projection handles all heuristics before reactor)", () => {
-      expect(resolveOrigin({})).toBeNull();
-      expect(resolveOrigin({ "sdk.name": "langwatch" })).toBeNull();
-    });
-  });
-});
 
 describe("evaluationTrigger reactor", () => {
   beforeEach(() => {
@@ -130,19 +108,6 @@ describe("evaluationTrigger reactor", () => {
 
       expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
-      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
-    });
-
-    it("does not dispatch resolveOrigin command (origin is explicit)", async () => {
-      const deps = createDeps();
-      const reactor = createEvaluationTriggerReactor(deps);
-      const state = createFoldState({
-        attributes: { "langwatch.origin": "application" },
-      });
-
-      await reactor.handle(createEvent(), createContext(state));
-
-      expect(deps.resolveOrigin).not.toHaveBeenCalled();
     });
   });
 
@@ -156,9 +121,7 @@ describe("evaluationTrigger reactor", () => {
 
       await reactor.handle(createEvent(), createContext(state));
 
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
-      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
     });
 
     it("dispatches for origin 'evaluation' (preconditions handle filtering)", async () => {
@@ -170,57 +133,12 @@ describe("evaluationTrigger reactor", () => {
 
       await reactor.handle(createEvent(), createContext(state));
 
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
-      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
-    });
-
-    it("dispatches for origin 'workflow' (preconditions handle filtering)", async () => {
-      const deps = createDeps();
-      const reactor = createEvaluationTriggerReactor(deps);
-      const state = createFoldState({
-        attributes: { "langwatch.origin": "workflow" },
-      });
-
-      await reactor.handle(createEvent(), createContext(state));
-
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
-      expect(deps.evaluation).toHaveBeenCalledTimes(1);
-      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
     });
   });
 
-  describe("when old SDK trace has origin inferred by fold projection", () => {
-    it("dispatches evaluation commands (fold projection already set origin)", async () => {
-      const deps = createDeps();
-      const reactor = createEvaluationTriggerReactor(deps);
-      // Fold projection already set langwatch.origin = "application" from sdk.name heuristic
-      const state = createFoldState({
-        attributes: { "sdk.name": "langwatch", "langwatch.origin": "application" },
-      });
-
-      await reactor.handle(createEvent(), createContext(state));
-
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
-      expect(deps.evaluation).toHaveBeenCalledTimes(1);
-      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
-    });
-
-    it("does not dispatch resolveOrigin command (fold projection handled it)", async () => {
-      const deps = createDeps();
-      const reactor = createEvaluationTriggerReactor(deps);
-      const state = createFoldState({
-        attributes: { "sdk.name": "langwatch", "langwatch.origin": "application" },
-      });
-
-      await reactor.handle(createEvent(), createContext(state));
-
-      expect(deps.resolveOrigin).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("when trace has no origin and no sdk.name (pure OTEL)", () => {
-    it("schedules deferred origin resolution with traceId as id", async () => {
+  describe("when trace has no origin", () => {
+    it("returns early without dispatching evaluations", async () => {
       const deps = createDeps();
       const reactor = createEvaluationTriggerReactor(deps);
       const state = createFoldState({ attributes: {} });
@@ -229,46 +147,6 @@ describe("evaluationTrigger reactor", () => {
 
       expect(deps.monitors.getEnabledOnMessageMonitors).not.toHaveBeenCalled();
       expect(deps.evaluation).not.toHaveBeenCalled();
-      expect(deps.scheduleDeferred).toHaveBeenCalledWith({
-        id: "trace-1",
-        tenantId: "tenant-1",
-        traceId: "trace-1",
-        occurredAt: expect.any(Number),
-      });
-    });
-  });
-
-  describe("when old SDK evaluation trace is tagged by legacy inference", () => {
-    it("dispatches with evaluation origin (preconditions handle filtering)", async () => {
-      const deps = createDeps();
-      const reactor = createEvaluationTriggerReactor(deps);
-      const state = createFoldState({
-        attributes: {
-          "sdk.name": "langwatch",
-          "langwatch.origin": "evaluation",
-        },
-      });
-
-      await reactor.handle(createEvent(), createContext(state));
-
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
-      expect(deps.evaluation).toHaveBeenCalledTimes(1);
-      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
-    });
-
-    it("does not dispatch resolveOrigin command (origin is already explicit)", async () => {
-      const deps = createDeps();
-      const reactor = createEvaluationTriggerReactor(deps);
-      const state = createFoldState({
-        attributes: {
-          "sdk.name": "langwatch",
-          "langwatch.origin": "evaluation",
-        },
-      });
-
-      await reactor.handle(createEvent(), createContext(state));
-
-      expect(deps.resolveOrigin).not.toHaveBeenCalled();
     });
   });
 
@@ -286,48 +164,23 @@ describe("evaluationTrigger reactor", () => {
       expect(options).toBeDefined();
       expect(options!.deduplication).toBeDefined();
       expect(options!.deduplication!.ttlMs).toBe(DEFERRED_CHECK_DELAY_MS + 60_000);
-      // No delay override — uses command default
       expect(options!.delay).toBeUndefined();
     });
   });
-});
 
-describe("createDeferredOriginHandler()", () => {
-  describe("when called", () => {
-    it("dispatches resolveOrigin command unconditionally", async () => {
-      const resolveOriginFn = vi.fn().mockResolvedValue(undefined);
-      const handler = createDeferredOriginHandler(resolveOriginFn);
-      const payload: DeferredOriginPayload = {
-        id: "trace-1",
-        tenantId: "tenant-1",
-        traceId: "trace-1",
-        occurredAt: 1234567890,
-      };
-
-      await handler(payload);
-
-      expect(resolveOriginFn).toHaveBeenCalledWith({
-        tenantId: "tenant-1",
-        traceId: "trace-1",
-        origin: "application",
-        reason: "deferred_fallback",
-        occurredAt: 1234567890,
+  describe("when trace is blocked by guardrail with no output", () => {
+    it("skips without dispatching", async () => {
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+        blockedByGuardrail: true,
+        computedOutput: null,
       });
-    });
-  });
 
-  describe("when resolveOrigin throws", () => {
-    it("propagates the error", async () => {
-      const resolveOriginFn = vi.fn().mockRejectedValue(new Error("command failed"));
-      const handler = createDeferredOriginHandler(resolveOriginFn);
-      const payload: DeferredOriginPayload = {
-        id: "trace-1",
-        tenantId: "tenant-1",
-        traceId: "trace-1",
-        occurredAt: 1234567890,
-      };
+      await reactor.handle(createEvent(), createContext(state));
 
-      await expect(handler(payload)).rejects.toThrow("command failed");
+      expect(deps.evaluation).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -4,10 +4,11 @@ import type { ReactorContext } from "../../../../reactors/reactor.types";
 import type { TraceProcessingEvent } from "../../schemas/events";
 import {
   createEvaluationTriggerReactor,
-  createDeferredEvaluationHandler,
+  createDeferredOriginHandler,
   resolveOrigin,
+  DEFERRED_CHECK_DELAY_MS,
   type EvaluationTriggerReactorDeps,
-  type DeferredEvaluationPayload,
+  type DeferredOriginPayload,
 } from "../evaluationTrigger.reactor";
 
 function createFoldState(
@@ -85,10 +86,6 @@ function createDeps(
     } as unknown as EvaluationTriggerReactorDeps["monitors"],
     evaluation: vi.fn().mockResolvedValue(undefined),
     resolveOrigin: vi.fn().mockResolvedValue(undefined),
-    traceSummaryStore: {
-      get: vi.fn().mockResolvedValue(null),
-      store: vi.fn().mockResolvedValue(undefined),
-    },
     scheduleDeferred: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
@@ -223,7 +220,7 @@ describe("evaluationTrigger reactor", () => {
   });
 
   describe("when trace has no origin and no sdk.name (pure OTEL)", () => {
-    it("schedules a deferred check and does not dispatch evaluations", async () => {
+    it("schedules deferred origin resolution with traceId as id", async () => {
       const deps = createDeps();
       const reactor = createEvaluationTriggerReactor(deps);
       const state = createFoldState({ attributes: {} });
@@ -233,6 +230,7 @@ describe("evaluationTrigger reactor", () => {
       expect(deps.monitors.getEnabledOnMessageMonitors).not.toHaveBeenCalled();
       expect(deps.evaluation).not.toHaveBeenCalled();
       expect(deps.scheduleDeferred).toHaveBeenCalledWith({
+        id: "trace-1",
         tenantId: "tenant-1",
         traceId: "trace-1",
         occurredAt: expect.any(Number),
@@ -273,116 +271,63 @@ describe("evaluationTrigger reactor", () => {
       expect(deps.resolveOrigin).not.toHaveBeenCalled();
     });
   });
+
+  describe("when trace-level eval is dispatched", () => {
+    it("uses 6-minute dedup TTL to outlast deferred origin window", async () => {
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+      });
+
+      await reactor.handle(createEvent(), createContext(state));
+
+      const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
+      expect(options).toBeDefined();
+      expect(options!.deduplication).toBeDefined();
+      expect(options!.deduplication!.ttlMs).toBe(DEFERRED_CHECK_DELAY_MS + 60_000);
+      // No delay override — uses command default
+      expect(options!.delay).toBeUndefined();
+    });
+  });
 });
 
-describe("createDeferredEvaluationHandler()", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(Date.now());
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  describe("when fold state still has no origin after 5 minutes", () => {
-    it("dispatches resolveOrigin command with reason 'deferred_fallback' and dispatches evaluations", async () => {
-      const deps = createDeps();
-      const foldState = createFoldState({ attributes: {} });
-      vi.mocked(deps.traceSummaryStore.get).mockResolvedValue(foldState);
-
-      const handler = createDeferredEvaluationHandler(deps);
-      const payload: DeferredEvaluationPayload = {
+describe("createDeferredOriginHandler()", () => {
+  describe("when called", () => {
+    it("dispatches resolveOrigin command unconditionally", async () => {
+      const resolveOriginFn = vi.fn().mockResolvedValue(undefined);
+      const handler = createDeferredOriginHandler(resolveOriginFn);
+      const payload: DeferredOriginPayload = {
+        id: "trace-1",
         tenantId: "tenant-1",
         traceId: "trace-1",
-        occurredAt: Date.now(),
+        occurredAt: 1234567890,
       };
 
       await handler(payload);
 
-      expect(deps.traceSummaryStore.get).toHaveBeenCalledWith(
-        "trace-1",
-        { tenantId: "tenant-1", aggregateId: "trace-1" },
-      );
-      // Verify origin is persisted via event sourcing (not direct store)
-      expect(deps.resolveOrigin).toHaveBeenCalledWith({
+      expect(resolveOriginFn).toHaveBeenCalledWith({
         tenantId: "tenant-1",
         traceId: "trace-1",
         origin: "application",
         reason: "deferred_fallback",
-        occurredAt: expect.any(Number),
+        occurredAt: 1234567890,
       });
-      expect(deps.traceSummaryStore.store).not.toHaveBeenCalled();
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
-      expect(deps.evaluation).toHaveBeenCalledTimes(1);
-      // Verify the evaluation payload has origin stamped as "application"
-      const callArgs = vi.mocked(deps.evaluation).mock.calls[0]!;
-      expect(callArgs[0]).toMatchObject({ origin: "application" });
     });
   });
 
-  describe("when fold state acquired non-application origin", () => {
-    it("dispatches with the acquired origin and does not call resolveOrigin", async () => {
-      const deps = createDeps();
-      const foldState = createFoldState({
-        attributes: { "langwatch.origin": "evaluation" },
-      });
-      vi.mocked(deps.traceSummaryStore.get).mockResolvedValue(foldState);
-
-      const handler = createDeferredEvaluationHandler(deps);
-      const payload: DeferredEvaluationPayload = {
+  describe("when resolveOrigin throws", () => {
+    it("propagates the error", async () => {
+      const resolveOriginFn = vi.fn().mockRejectedValue(new Error("command failed"));
+      const handler = createDeferredOriginHandler(resolveOriginFn);
+      const payload: DeferredOriginPayload = {
+        id: "trace-1",
         tenantId: "tenant-1",
         traceId: "trace-1",
-        occurredAt: Date.now(),
+        occurredAt: 1234567890,
       };
 
-      await handler(payload);
-
-      expect(deps.traceSummaryStore.get).toHaveBeenCalled();
-      expect(deps.resolveOrigin).not.toHaveBeenCalled();
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
-      expect(deps.evaluation).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("when fold state acquired explicit application origin", () => {
-    it("dispatches evaluations", async () => {
-      const deps = createDeps();
-      const foldState = createFoldState({
-        attributes: { "langwatch.origin": "application" },
-      });
-      vi.mocked(deps.traceSummaryStore.get).mockResolvedValue(foldState);
-
-      const handler = createDeferredEvaluationHandler(deps);
-      const payload: DeferredEvaluationPayload = {
-        tenantId: "tenant-1",
-        traceId: "trace-1",
-        occurredAt: Date.now(),
-      };
-
-      await handler(payload);
-
-      expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
-      expect(deps.evaluation).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("when fold state is not found", () => {
-    it("skips silently", async () => {
-      const deps = createDeps();
-      vi.mocked(deps.traceSummaryStore.get).mockResolvedValue(null);
-
-      const handler = createDeferredEvaluationHandler(deps);
-      const payload: DeferredEvaluationPayload = {
-        tenantId: "tenant-1",
-        traceId: "trace-1",
-        occurredAt: Date.now(),
-      };
-
-      await handler(payload);
-
-      expect(deps.monitors.getEnabledOnMessageMonitors).not.toHaveBeenCalled();
-      expect(deps.evaluation).not.toHaveBeenCalled();
+      await expect(handler(payload)).rejects.toThrow("command failed");
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.unit.test.ts
@@ -5,6 +5,7 @@ import type { ReactorContext } from "../../../../reactors/reactor.types";
 import type { TraceProcessingEvent } from "../../schemas/events";
 import {
   createEvaluationTriggerReactor,
+  DEFERRED_CHECK_DELAY_MS,
   type EvaluationTriggerReactorDeps,
 } from "../evaluationTrigger.reactor";
 
@@ -73,10 +74,6 @@ function createDeps(overrides: Partial<EvaluationTriggerReactorDeps> = {}): Eval
     } as any,
     evaluation: vi.fn().mockResolvedValue(undefined),
     resolveOrigin: vi.fn().mockResolvedValue(undefined),
-    traceSummaryStore: {
-      get: vi.fn().mockResolvedValue(null),
-      store: vi.fn().mockResolvedValue(undefined),
-    },
     scheduleDeferred: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
@@ -84,7 +81,7 @@ function createDeps(overrides: Partial<EvaluationTriggerReactorDeps> = {}): Eval
 
 describe("evaluationTrigger reactor", () => {
   describe("when monitor is trace-level (no threadIdleTimeout)", () => {
-    it("sends without per-send options", async () => {
+    it("sends with dedup TTL outlasting deferred origin window", async () => {
       const monitor = makeMonitor({ threadIdleTimeout: null });
       const deps = createDeps();
       vi.mocked(deps.monitors.getEnabledOnMessageMonitors).mockResolvedValue([monitor]);
@@ -97,7 +94,10 @@ describe("evaluationTrigger reactor", () => {
 
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
       const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
-      expect(options).toBeUndefined();
+      expect(options).toBeDefined();
+      expect(options!.deduplication).toBeDefined();
+      expect(options!.deduplication!.ttlMs).toBe(DEFERRED_CHECK_DELAY_MS + 60_000);
+      expect(options!.delay).toBeUndefined();
     });
   });
 
@@ -129,7 +129,7 @@ describe("evaluationTrigger reactor", () => {
   });
 
   describe("when monitor has threadIdleTimeout but no threadId on trace", () => {
-    it("sends without per-send options (falls back to trace-level)", async () => {
+    it("falls back to trace-level dedup (6-min TTL, no delay override)", async () => {
       const monitor = makeMonitor({ threadIdleTimeout: 300 });
       const deps = createDeps();
       vi.mocked(deps.monitors.getEnabledOnMessageMonitors).mockResolvedValue([monitor]);
@@ -142,12 +142,14 @@ describe("evaluationTrigger reactor", () => {
 
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
       const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
-      expect(options).toBeUndefined();
+      expect(options).toBeDefined();
+      expect(options!.deduplication!.ttlMs).toBe(DEFERRED_CHECK_DELAY_MS + 60_000);
+      expect(options!.delay).toBeUndefined();
     });
   });
 
   describe("when monitor has threadIdleTimeout of 0", () => {
-    it("sends without per-send options (trace-level default)", async () => {
+    it("falls back to trace-level dedup (6-min TTL, no delay override)", async () => {
       const monitor = makeMonitor({ threadIdleTimeout: 0 });
       const deps = createDeps();
       vi.mocked(deps.monitors.getEnabledOnMessageMonitors).mockResolvedValue([monitor]);
@@ -160,7 +162,9 @@ describe("evaluationTrigger reactor", () => {
 
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
       const [_payload, options] = vi.mocked(deps.evaluation).mock.calls[0]!;
-      expect(options).toBeUndefined();
+      expect(options).toBeDefined();
+      expect(options!.deduplication!.ttlMs).toBe(DEFERRED_CHECK_DELAY_MS + 60_000);
+      expect(options!.delay).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.unit.test.ts
@@ -5,9 +5,9 @@ import type { ReactorContext } from "../../../../reactors/reactor.types";
 import type { TraceProcessingEvent } from "../../schemas/events";
 import {
   createEvaluationTriggerReactor,
-  DEFERRED_CHECK_DELAY_MS,
   type EvaluationTriggerReactorDeps,
 } from "../evaluationTrigger.reactor";
+import { DEFERRED_CHECK_DELAY_MS } from "../originGate.reactor";
 
 function makeEvent(overrides: Partial<TraceProcessingEvent> = {}): TraceProcessingEvent {
   return {
@@ -73,8 +73,6 @@ function createDeps(overrides: Partial<EvaluationTriggerReactorDeps> = {}): Eval
       getEnabledOnMessageMonitors: vi.fn().mockResolvedValue([]),
     } as any,
     evaluation: vi.fn().mockResolvedValue(undefined),
-    resolveOrigin: vi.fn().mockResolvedValue(undefined),
-    scheduleDeferred: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
@@ -36,10 +36,11 @@ function createFoldState(
     blockedByGuardrail: false,
     topicId: null,
     subTopicId: null,
-    hasAnnotation: null,
+    annotationIds: [],
     occurredAt: Date.now(),
     createdAt: Date.now(),
     updatedAt: Date.now(),
+    lastEventOccurredAt: Date.now(),
     attributes: {},
     ...overrides,
   };

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import type { ReactorContext } from "../../../../reactors/reactor.types";
+import type { TraceProcessingEvent } from "../../schemas/events";
+import {
+  createOriginGateReactor,
+  createDeferredOriginHandler,
+  makeDeferredJobId,
+  type OriginGateReactorDeps,
+  type DeferredOriginPayload,
+} from "../originGate.reactor";
+
+function createFoldState(
+  overrides: Partial<TraceSummaryData> = {},
+): TraceSummaryData {
+  return {
+    traceId: "trace-1",
+    spanCount: 1,
+    totalDurationMs: 100,
+    computedIOSchemaVersion: "2025-12-18",
+    computedInput: "hello",
+    computedOutput: "world",
+    timeToFirstTokenMs: null,
+    timeToLastTokenMs: null,
+    tokensPerSecond: null,
+    containsErrorStatus: false,
+    containsOKStatus: true,
+    errorMessage: null,
+    models: [],
+    totalCost: null,
+    tokensEstimated: false,
+    totalPromptTokenCount: null,
+    totalCompletionTokenCount: null,
+    outputFromRootSpan: false,
+    outputSpanEndTimeMs: 0,
+    blockedByGuardrail: false,
+    topicId: null,
+    subTopicId: null,
+    hasAnnotation: null,
+    occurredAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    attributes: {},
+    ...overrides,
+  };
+}
+
+function createEvent(
+  overrides: Partial<TraceProcessingEvent> = {},
+): TraceProcessingEvent {
+  return {
+    id: "event-1",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.span_received",
+    version: 1,
+    data: {},
+    metadata: { spanId: "span-1", traceId: "trace-1" },
+    ...overrides,
+  } as TraceProcessingEvent;
+}
+
+function createContext(
+  foldState: TraceSummaryData,
+): ReactorContext<TraceSummaryData> {
+  return {
+    tenantId: "tenant-1",
+    aggregateId: "trace-1",
+    foldState,
+  };
+}
+
+function createDeps(
+  overrides: Partial<OriginGateReactorDeps> = {},
+): OriginGateReactorDeps {
+  return {
+    scheduleDeferred: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("originGate reactor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("reactor options", () => {
+    it("uses 5s debounce and dedup to settle initial span burst", () => {
+      const deps = createDeps();
+      const reactor = createOriginGateReactor(deps);
+
+      expect(reactor.options?.delay).toBe(5_000);
+      expect(reactor.options?.ttl).toBe(5_000);
+    });
+
+    it("generates dedup key from tenant and trace", () => {
+      const deps = createDeps();
+      const reactor = createOriginGateReactor(deps);
+
+      const jobId = reactor.options?.makeJobId?.({
+        event: { tenantId: "t1", aggregateId: "tr1" } as any,
+        foldState: {} as any,
+      });
+      expect(jobId).toBe("origin-gate:t1:tr1");
+    });
+  });
+
+  describe("when origin is already resolved", () => {
+    it("does not schedule deferred resolution", async () => {
+      const deps = createDeps();
+      const reactor = createOriginGateReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+      });
+
+      await reactor.handle(createEvent(), createContext(state));
+
+      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
+    });
+
+    it("skips for all origin types", async () => {
+      for (const origin of ["application", "evaluation", "simulation", "workflow"]) {
+        const deps = createDeps();
+        const reactor = createOriginGateReactor(deps);
+        const state = createFoldState({
+          attributes: { "langwatch.origin": origin },
+        });
+
+        await reactor.handle(createEvent(), createContext(state));
+
+        expect(deps.scheduleDeferred).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("when origin is absent (pure OTEL trace)", () => {
+    it("schedules deferred origin resolution with traceId as id", async () => {
+      const deps = createDeps();
+      const reactor = createOriginGateReactor(deps);
+      const state = createFoldState({ attributes: {} });
+
+      await reactor.handle(createEvent(), createContext(state));
+
+      expect(deps.scheduleDeferred).toHaveBeenCalledWith({
+        id: "trace-1",
+        tenantId: "tenant-1",
+        traceId: "trace-1",
+      });
+    });
+  });
+
+  describe("when trace is old (resyncing)", () => {
+    it("skips without scheduling", async () => {
+      const deps = createDeps();
+      const reactor = createOriginGateReactor(deps);
+      const state = createFoldState({ attributes: {} });
+      const oldEvent = createEvent({
+        occurredAt: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
+      });
+
+      await reactor.handle(oldEvent, createContext(state));
+
+      expect(deps.scheduleDeferred).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("createDeferredOriginHandler()", () => {
+  describe("when called", () => {
+    it("dispatches resolveOrigin command unconditionally", async () => {
+      const resolveOriginFn = vi.fn().mockResolvedValue(undefined);
+      const handler = createDeferredOriginHandler(resolveOriginFn);
+      const payload: DeferredOriginPayload = {
+        id: "trace-1",
+        tenantId: "tenant-1",
+        traceId: "trace-1",
+      };
+
+      await handler(payload);
+
+      expect(resolveOriginFn).toHaveBeenCalledWith({
+        tenantId: "tenant-1",
+        traceId: "trace-1",
+        origin: "application",
+        reason: "deferred_fallback",
+        occurredAt: expect.any(Number),
+      });
+      // occurredAt should be the dispatch time (now), not the original trace time
+      const calledOccurredAt = resolveOriginFn.mock.calls[0]![0].occurredAt;
+      expect(calledOccurredAt).toBeGreaterThanOrEqual(Date.now() - 1000);
+      expect(calledOccurredAt).toBeLessThanOrEqual(Date.now() + 1000);
+    });
+  });
+
+  describe("when resolveOrigin throws", () => {
+    it("propagates the error", async () => {
+      const resolveOriginFn = vi.fn().mockRejectedValue(new Error("command failed"));
+      const handler = createDeferredOriginHandler(resolveOriginFn);
+      const payload: DeferredOriginPayload = {
+        id: "trace-1",
+        tenantId: "tenant-1",
+        traceId: "trace-1",
+      };
+
+      await expect(handler(payload)).rejects.toThrow("command failed");
+    });
+  });
+});
+
+describe("makeDeferredJobId()", () => {
+  it("generates dedup key from tenant and trace", () => {
+    const payload: DeferredOriginPayload = {
+      id: "trace-1",
+      tenantId: "tenant-1",
+      traceId: "trace-1",
+    };
+    expect(makeDeferredJobId(payload)).toBe("deferred-origin:tenant-1:trace-1");
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -3,50 +3,30 @@ import type { MonitorService } from "~/server/app-layer/monitors/monitor.service
 import type { QueueSendOptions } from "../../../queues";
 import { ExecuteEvaluationCommand } from "../../evaluation-processing/commands/executeEvaluation.command";
 import type { ExecuteEvaluationCommandData } from "../../evaluation-processing/schemas/commands";
-import type { ResolveOriginCommandData } from "../schemas/commands";
 import { KSUID_RESOURCES } from "../../../../../utils/constants";
 import { createLogger } from "../../../../../utils/logger/server";
 import type { ReactorContext, ReactorDefinition } from "../../../reactors/reactor.types";
 import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
 import type { TraceProcessingEvent } from "../schemas/events";
+import { DEFERRED_CHECK_DELAY_MS } from "./originGate.reactor";
 
 const logger = createLogger(
   "langwatch:trace-processing:evaluation-trigger-reactor",
 );
 
-/** Delay (ms) before the deferred origin resolution fires */
-const DEFERRED_CHECK_DELAY_MS = 5 * 60 * 1000; // 5 minutes
-
-export type DeferredOriginPayload = {
-  id: string;       // traceId — used as staged job ID for debuggability
-  tenantId: string;
-  traceId: string;
-  occurredAt: number;
-};
-
 export interface EvaluationTriggerReactorDeps {
   monitors: MonitorService;
   evaluation: (data: ExecuteEvaluationCommandData, options?: QueueSendOptions<ExecuteEvaluationCommandData>) => Promise<void>;
-  resolveOrigin: (data: ResolveOriginCommandData) => Promise<void>;
-  scheduleDeferred: (payload: DeferredOriginPayload) => Promise<void>;
 }
 
 /**
- * Reads the resolved origin from the fold state attributes.
+ * Dispatches evaluation commands for traces that have a resolved origin.
  *
- * By the time the reactor fires, the fold projection has already resolved
- * origin from: explicit span attributes → legacy markers → SDK heuristic.
- * The only case where origin is still absent is pure OTEL traces with no
- * LangWatch SDK info — those need a 5-min deferred check.
- *
- * Returns:
- * - The origin string when `langwatch.origin` is set (explicit or inferred by fold)
- * - `null` when no origin could be determined (needs deferred check)
+ * Fires on every trace event (via traceSummary fold). If origin is absent,
+ * returns early — the originGate reactor handles deferred resolution.
+ * Once origin is present, iterates all enabled ON_MESSAGE monitors and
+ * sends an executeEvaluation command per monitor.
  */
-export function resolveOrigin(attrs: Record<string, string>): string | null {
-  return attrs["langwatch.origin"] ?? null;
-}
-
 export function createEvaluationTriggerReactor(
   deps: EvaluationTriggerReactorDeps,
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
@@ -73,68 +53,14 @@ export function createEvaluationTriggerReactor(
 
       const attrs = foldState.attributes ?? {};
 
-      // Phase 1: Origin resolution
-      const resolvedOrigin = resolveOrigin(attrs);
-
-      if (resolvedOrigin === null) {
-        // No origin even after fold projection ran all heuristics (explicit,
-        // legacy markers, SDK heuristic). This is a pure OTEL trace with no
-        // LangWatch SDK info — schedule a deferred check.
-        logger.debug(
-          { tenantId, traceId },
-          "No origin resolved, scheduling deferred origin resolution",
-        );
-        await deps.scheduleDeferred({
-          id: traceId,
-          tenantId,
-          traceId,
-          occurredAt: event.occurredAt,
-        });
-        return;
-      }
+      // Guard: origin not yet resolved — originGate reactor handles deferred resolution
+      if (!attrs["langwatch.origin"]) return;
 
       // Origin is known — dispatch to monitors, precondition matchers filter by origin.
       await dispatchEvaluations({ deps, tenantId, traceId, foldState, occurredAt: event.occurredAt });
     },
   };
 }
-
-/**
- * Creates the deferred origin resolution handler.
- *
- * Fires after a 5-minute delay for pure OTEL traces that had no origin
- * at normal debounce time. Unconditionally dispatches a resolveOrigin
- * command with origin="application" — the command's idempotency key
- * and the fold projection's no-override guard handle duplicates.
- *
- * The resulting OriginResolvedEvent flows through:
- *   fold (sets origin if absent) → evaluationTrigger reactor → dispatchEvaluations()
- */
-export function createDeferredOriginHandler(
-  resolveOrigin: (data: ResolveOriginCommandData) => Promise<void>,
-) {
-  return async (payload: DeferredOriginPayload): Promise<void> => {
-    logger.debug(
-      { tenantId: payload.tenantId, traceId: payload.traceId },
-      "Deferred origin resolution: dispatching resolveOrigin command",
-    );
-    await resolveOrigin({
-      tenantId: payload.tenantId,
-      traceId: payload.traceId,
-      origin: "application",
-      reason: "deferred_fallback",
-      occurredAt: payload.occurredAt,
-    });
-  };
-}
-
-/** Dedup key for deferred origin resolution jobs */
-export function makeDeferredJobId(payload: DeferredOriginPayload): string {
-  return `deferred-origin:${payload.tenantId}:${payload.traceId}`;
-}
-
-/** Delay for deferred origin resolution */
-export { DEFERRED_CHECK_DELAY_MS };
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -221,7 +147,7 @@ async function dispatchEvaluations({
             }
           : {
               deduplication: {
-                makeId: makeJobId,
+                makeId: ExecuteEvaluationCommand.makeJobId,
                 // 6 min — outlasts the 5-min deferred origin resolution window
                 // so that if the reactor fires twice (once from a late span,
                 // once from the deferred OriginResolvedEvent), the second

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -9,17 +9,16 @@ import { createLogger } from "../../../../../utils/logger/server";
 import type { ReactorContext, ReactorDefinition } from "../../../reactors/reactor.types";
 import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
 import type { TraceProcessingEvent } from "../schemas/events";
-import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
-import { createTenantId } from "../../../domain/tenantId";
 
 const logger = createLogger(
   "langwatch:trace-processing:evaluation-trigger-reactor",
 );
 
-/** Delay (ms) before the deferred evaluation check fires */
+/** Delay (ms) before the deferred origin resolution fires */
 const DEFERRED_CHECK_DELAY_MS = 5 * 60 * 1000; // 5 minutes
 
-export type DeferredEvaluationPayload = {
+export type DeferredOriginPayload = {
+  id: string;       // traceId — used as staged job ID for debuggability
   tenantId: string;
   traceId: string;
   occurredAt: number;
@@ -29,8 +28,7 @@ export interface EvaluationTriggerReactorDeps {
   monitors: MonitorService;
   evaluation: (data: ExecuteEvaluationCommandData, options?: QueueSendOptions<ExecuteEvaluationCommandData>) => Promise<void>;
   resolveOrigin: (data: ResolveOriginCommandData) => Promise<void>;
-  traceSummaryStore: FoldProjectionStore<TraceSummaryData>;
-  scheduleDeferred: (payload: DeferredEvaluationPayload) => Promise<void>;
+  scheduleDeferred: (payload: DeferredOriginPayload) => Promise<void>;
 }
 
 /**
@@ -84,9 +82,10 @@ export function createEvaluationTriggerReactor(
         // LangWatch SDK info — schedule a deferred check.
         logger.debug(
           { tenantId, traceId },
-          "No origin resolved, scheduling deferred evaluation check",
+          "No origin resolved, scheduling deferred origin resolution",
         );
         await deps.scheduleDeferred({
+          id: traceId,
           tenantId,
           traceId,
           occurredAt: event.occurredAt,
@@ -101,66 +100,40 @@ export function createEvaluationTriggerReactor(
 }
 
 /**
- * Creates the deferred evaluation check handler.
+ * Creates the deferred origin resolution handler.
  *
- * This handler is called after a 5-minute delay for traces that had no origin
- * and no SDK info at normal debounce time. It re-reads the fold state from
- * the projection store (not the captured state) to see if an origin was set
- * in the meantime.
+ * Fires after a 5-minute delay for pure OTEL traces that had no origin
+ * at normal debounce time. Unconditionally dispatches a resolveOrigin
+ * command with origin="application" — the command's idempotency key
+ * and the fold projection's no-override guard handle duplicates.
+ *
+ * The resulting OriginResolvedEvent flows through:
+ *   fold (sets origin if absent) → evaluationTrigger reactor → dispatchEvaluations()
  */
-export function createDeferredEvaluationHandler(deps: EvaluationTriggerReactorDeps) {
-  return async (payload: DeferredEvaluationPayload): Promise<void> => {
-    const { tenantId, traceId, occurredAt } = payload;
-
-    // Re-read fold state from the projection store (fresh, not captured)
-    const foldState = await deps.traceSummaryStore.get(traceId, { tenantId: createTenantId(tenantId), aggregateId: traceId });
-    if (!foldState) {
-      logger.debug(
-        { tenantId, traceId },
-        "Deferred check: fold state not found, skipping",
-      );
-      return;
-    }
-
-    const attrs = foldState.attributes ?? {};
-    const origin = attrs["langwatch.origin"];
-
-    // If origin is still empty after 5 min, persist "application" via event sourcing.
-    if (!origin) {
-      await deps.resolveOrigin({
-        tenantId,
-        traceId,
-        origin: "application",
-        reason: "deferred_fallback",
-        occurredAt,
-      });
-
-      // Update local copy so dispatchEvaluations sees the origin
-      attrs["langwatch.origin"] = "application";
-      foldState.attributes = attrs;
-
-      logger.debug(
-        { tenantId, traceId },
-        "Deferred check: no origin after 5 min, dispatched resolveOrigin command",
-      );
-    } else {
-      logger.debug(
-        { tenantId, traceId, origin },
-        "Deferred check: origin now set, dispatching with it",
-      );
-    }
-
-    // Dispatch — precondition matchers handle filtering by origin
-    await dispatchEvaluations({ deps, tenantId, traceId, foldState, occurredAt });
+export function createDeferredOriginHandler(
+  resolveOrigin: (data: ResolveOriginCommandData) => Promise<void>,
+) {
+  return async (payload: DeferredOriginPayload): Promise<void> => {
+    logger.debug(
+      { tenantId: payload.tenantId, traceId: payload.traceId },
+      "Deferred origin resolution: dispatching resolveOrigin command",
+    );
+    await resolveOrigin({
+      tenantId: payload.tenantId,
+      traceId: payload.traceId,
+      origin: "application",
+      reason: "deferred_fallback",
+      occurredAt: payload.occurredAt,
+    });
   };
 }
 
-/** Dedup key for deferred evaluation checks */
-export function makeDeferredJobId(payload: DeferredEvaluationPayload): string {
-  return `deferred-eval-trigger:${payload.tenantId}:${payload.traceId}`;
+/** Dedup key for deferred origin resolution jobs */
+export function makeDeferredJobId(payload: DeferredOriginPayload): string {
+  return `deferred-origin:${payload.tenantId}:${payload.traceId}`;
 }
 
-/** Delay for deferred evaluation checks */
+/** Delay for deferred origin resolution */
 export { DEFERRED_CHECK_DELAY_MS };
 
 // ---------------------------------------------------------------------------
@@ -246,7 +219,16 @@ async function dispatchEvaluations({
                 ttlMs: monitor.threadIdleTimeout! * 1000,
               },
             }
-          : undefined;
+          : {
+              deduplication: {
+                makeId: makeJobId,
+                // 6 min — outlasts the 5-min deferred origin resolution window
+                // so that if the reactor fires twice (once from a late span,
+                // once from the deferred OriginResolvedEvent), the second
+                // dispatch is squashed by the dedup key.
+                ttlMs: DEFERRED_CHECK_DELAY_MS + 60_000,
+              },
+            };
 
       await deps.evaluation(payload, sendOptions);
     } catch (error) {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/originGate.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/originGate.reactor.ts
@@ -1,0 +1,105 @@
+import type { ResolveOriginCommandData } from "../schemas/commands";
+import { createLogger } from "../../../../../utils/logger/server";
+import type { ReactorContext, ReactorDefinition } from "../../../reactors/reactor.types";
+import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
+import type { TraceProcessingEvent } from "../schemas/events";
+
+const logger = createLogger(
+  "langwatch:trace-processing:origin-gate-reactor",
+);
+
+/** Delay (ms) before the deferred origin resolution fires */
+export const DEFERRED_CHECK_DELAY_MS = 5 * 60 * 1000; // 5 minutes
+
+export type DeferredOriginPayload = {
+  id: string;       // traceId — used as staged job ID for debuggability
+  tenantId: string;
+  traceId: string;
+};
+
+export interface OriginGateReactorDeps {
+  scheduleDeferred: (payload: DeferredOriginPayload) => Promise<void>;
+}
+
+/**
+ * Ensures every trace gets an origin resolved.
+ *
+ * Fires on every trace event (via traceSummary fold). If origin is already
+ * set (explicit, legacy markers, or SDK heuristic), this is a no-op.
+ * If absent (pure OTEL traces), schedules a 5-minute deferred origin
+ * resolution job.
+ *
+ * Completely decoupled from evaluation dispatch — evaluationTrigger
+ * handles that independently.
+ */
+export function createOriginGateReactor(
+  deps: OriginGateReactorDeps,
+): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
+  return {
+    name: "originGate",
+    options: {
+      makeJobId: (payload) =>
+        `origin-gate:${payload.event.tenantId}:${payload.event.aggregateId}`,
+      ttl: 5_000,    // 5s dedup — debounce the initial span burst
+      delay: 5_000,  // 5s delay — settle before checking origin
+    },
+
+    async handle(
+      event: TraceProcessingEvent,
+      context: ReactorContext<TraceSummaryData>,
+    ): Promise<void> {
+      const { tenantId, aggregateId: traceId, foldState } = context;
+
+      // Guard: skip old traces (resyncing)
+      if (event.occurredAt < Date.now() - 60 * 60 * 1000) return;
+
+      const attrs = foldState.attributes ?? {};
+      if (attrs["langwatch.origin"]) return; // origin already resolved
+
+      // No origin — schedule deferred resolution (5-min delay)
+      logger.debug(
+        { tenantId, traceId },
+        "No origin resolved, scheduling deferred origin resolution",
+      );
+      await deps.scheduleDeferred({
+        id: traceId,
+        tenantId,
+        traceId,
+      });
+    },
+  };
+}
+
+/**
+ * Creates the deferred origin resolution handler.
+ *
+ * Fires after a 5-minute delay for pure OTEL traces that had no origin
+ * at normal debounce time. Unconditionally dispatches a resolveOrigin
+ * command with origin="application" — the command's idempotency key
+ * and the fold projection's no-override guard handle duplicates.
+ *
+ * The resulting OriginResolvedEvent flows through:
+ *   fold (sets origin if absent) → evaluationTrigger reactor → dispatchEvaluations()
+ */
+export function createDeferredOriginHandler(
+  resolveOrigin: (data: ResolveOriginCommandData) => Promise<void>,
+) {
+  return async (payload: DeferredOriginPayload): Promise<void> => {
+    logger.debug(
+      { tenantId: payload.tenantId, traceId: payload.traceId },
+      "Deferred origin resolution: dispatching resolveOrigin command",
+    );
+    await resolveOrigin({
+      tenantId: payload.tenantId,
+      traceId: payload.traceId,
+      origin: "application",
+      reason: "deferred_fallback",
+      occurredAt: Date.now(),
+    });
+  };
+}
+
+/** Dedup key for deferred origin resolution jobs */
+export function makeDeferredJobId(payload: DeferredOriginPayload): string {
+  return `deferred-origin:${payload.tenantId}:${payload.traceId}`;
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -464,7 +464,12 @@ export class GroupStagingScripts {
   /**
    * Stage a job into a group's pending queue.
    *
-   * @returns true if a new job was staged, false if an existing job was replaced (dedup)
+   * When dedup is active and the old job is still in staging, squashes in place
+   * (reuses the existing stagedJobId, conditionally updates score/data per
+   * shouldExtend/shouldReplace). When the old job was already dispatched, the
+   * stale dedup key is cleaned up and the new job is staged as genuinely new.
+   *
+   * @returns true if a new job was staged, false if squashed onto an existing job (dedup)
    */
   async stage({
     stagedJobId,

--- a/langwatch/src/server/event-sourcing/queues/memory.ts
+++ b/langwatch/src/server/event-sourcing/queues/memory.ts
@@ -155,12 +155,16 @@ export class EventSourcedQueueProcessorMemory<
       return;
     }
 
+    // Remove dedup entry when job leaves staging — new sends with the same
+    // dedup ID should create a genuinely new job, not squash onto a job
+    // that's already being processed (same TOCTOU fix as GroupQueue Lua).
+    if (job.deduplicationId) {
+      this.pendingJobsByDeduplicationId.delete(job.deduplicationId);
+    }
+
     this.activeCount++;
     void this.processJob(job).finally(() => {
       this.activeCount--;
-      if (job.deduplicationId) {
-        this.pendingJobsByDeduplicationId.delete(job.deduplicationId);
-      }
       // Try to process next job
       this.tryProcessNext();
     });

--- a/langwatch/src/server/workflows/runWorkflow.ts
+++ b/langwatch/src/server/workflows/runWorkflow.ts
@@ -209,6 +209,7 @@ export async function runWorkflow(
             ? inputs.do_not_trace
             : false,
       ...(typeof run_evaluations === "boolean" && { run_evaluations }),
+      origin: "workflow",
     },
   };
 

--- a/langwatch_nlp/langwatch_nlp/studio/execute/execute_evaluation.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/execute_evaluation.py
@@ -24,6 +24,7 @@ from langwatch_nlp.studio.types.events import (
 from langwatch_nlp.studio.utils import (
     disable_dsp_caching,
     get_input_keys,
+    optional_langwatch_trace,
     transpose_inline_dataset_to_object_list,
 )
 
@@ -67,6 +68,8 @@ async def execute_evaluation(
             module.prevent_crashes()
 
             langwatch.setup(workflow.api_key)
+
+            origin = event.origin or "evaluation"
 
             entry_node = cast(
                 EntryNode,
@@ -158,7 +161,12 @@ async def execute_evaluation(
             )
             # Send initial empty batch to create the experiment in LangWatch
             reporting.send_batch()
-            await asyncify(evaluator)(module, metric=reporting.evaluate_and_report)  # type: ignore
+            with optional_langwatch_trace(
+                name="execute_evaluation",
+                type="evaluation",
+                origin=origin,
+            ):
+                await asyncify(evaluator)(module, metric=reporting.evaluate_and_report)  # type: ignore
             eval_logger.info(
                 "Evaluation execution complete, waiting for batch sends: run_id=%s",
                 run_id,

--- a/langwatch_nlp/langwatch_nlp/studio/types/events.py
+++ b/langwatch_nlp/langwatch_nlp/studio/types/events.py
@@ -70,6 +70,7 @@ class ExecuteEvaluationPayload(BaseModel):
     workflow_version_id: str
     evaluate_on: Literal["full", "test", "train", "specific"]
     dataset_entry: Optional[int] = None
+    origin: Optional[str] = None
 
 
 class ExecuteEvaluation(BaseModel):


### PR DESCRIPTION
## Summary

Untangles origin resolution from evaluation dispatching into two separate reactors on the `traceSummary` fold projection:

- **`originGate` reactor** (NEW): Ensures every trace gets an origin. 5s debounce, schedules 5-min deferred origin resolution for pure OTEL traces. Dispatches `resolveOrigin` command via proper CQRS flow.
- **`evaluationTrigger` reactor** (simplified): Dispatches evaluations only. 30s debounce, returns early if no origin. No knowledge of deferred scheduling.
- **Deferred origin handler**: Simple command dispatch (`resolveOrigin`). No fold state reads or mutations. The `OriginResolvedEvent` flows through fold → both reactors fire → originGate is a no-op → evaluationTrigger dispatches evals.
- **Trace-level eval dedup TTL**: Extended to 6 min to outlast the 5-min deferred window, preventing double dispatch.
- **Deferred job config**: Per-trace groupKey, debuggable staged job ID, proper TTL. Renamed to `deferredOriginResolution`.
- **Memory queue TOCTOU**: Dedup entry cleared on dispatch, not on processing complete.
- Depends on #2735

## Test plan

- [x] 7 originGate reactor tests (origin present, absent, old trace, deferred handler, dedup key)
- [x] 10 evaluationTrigger reactor tests (dispatch, origin-absent guard, dedup TTL, guardrail)
- [x] 4 thread-level eval dispatch tests
- [x] Memory queue tests pass
- [x] `pnpm typecheck` passes