### PR TITLE
fix: don't spread class instances in buildServiceOptions — loses prototype getters

### DIFF
--- a/langwatch/src/server/event-sourcing/__tests__/buildServiceOptions.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/buildServiceOptions.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { AbstractFoldProjection, type FoldEventHandlers } from "../projections/abstractFoldProjection";
+import { AbstractMapProjection, type MapEventHandlers } from "../projections/abstractMapProjection";
+import type { FoldProjectionStore } from "../projections/foldProjection.types";
+import type { AppendStore } from "../projections/mapProjection.types";
+
+const testEventSchema = z.object({
+  id: z.string(),
+  aggregateId: z.string(),
+  aggregateType: z.literal("test_aggregate"),
+  tenantId: z.string(),
+  createdAt: z.number(),
+  occurredAt: z.number(),
+  type: z.literal("lw.test.item_added"),
+  version: z.string(),
+  data: z.object({ item: z.string() }),
+});
+
+const testEvents = [testEventSchema] as const;
+type TestEvent = z.infer<typeof testEventSchema>;
+
+interface TestFoldState {
+  count: number;
+  CreatedAt: number;
+  UpdatedAt: number;
+}
+
+class TestFoldProjection
+  extends AbstractFoldProjection<TestFoldState, typeof testEvents>
+  implements FoldEventHandlers<typeof testEvents, TestFoldState>
+{
+  readonly name = "testFold";
+  readonly version = "2026-03-29";
+  readonly store: FoldProjectionStore<TestFoldState> = {
+    get: async () => null,
+    store: async () => {},
+  };
+  protected readonly events = testEvents;
+
+  protected initState() {
+    return { count: 0 };
+  }
+
+  handleTestItemAdded(state: TestFoldState, _event: TestEvent): TestFoldState {
+    return { ...state, count: state.count + 1 };
+  }
+}
+
+class TestMapProjection
+  extends AbstractMapProjection<{ id: string }, typeof testEvents>
+  implements MapEventHandlers<typeof testEvents, { id: string }>
+{
+  readonly name = "testMap";
+  readonly store: AppendStore<{ id: string }> = { append: async () => {} };
+  protected readonly events = testEvents;
+
+  mapTestItemAdded(): { id: string }[] {
+    return [{ id: "1" }];
+  }
+}
+
+describe("AbstractFoldProjection and AbstractMapProjection getter preservation", () => {
+  describe("when class instance is used directly", () => {
+    it("eventTypes getter works on fold projection", () => {
+      const fold = new TestFoldProjection();
+      expect(fold.eventTypes).toEqual(["lw.test.item_added"]);
+    });
+
+    it("eventTypes getter works on map projection", () => {
+      const map = new TestMapProjection();
+      expect(map.eventTypes).toEqual(["lw.test.item_added"]);
+    });
+  });
+
+  describe("when class instance is spread into a plain object", () => {
+    it("eventTypes getter is lost on fold projection", () => {
+      const fold = new TestFoldProjection();
+      const spread = { ...fold };
+
+      // This is the bug: spreading loses the prototype getter
+      expect(spread.eventTypes).toBeUndefined();
+    });
+
+    it("eventTypes getter is lost on map projection", () => {
+      const map = new TestMapProjection();
+      const spread = { ...map };
+
+      expect(spread.eventTypes).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -523,18 +523,14 @@ function buildServiceOptions<
   EventType extends Event,
   ProjectionTypes extends Record<string, Projection>,
 >(definition: StaticPipelineDefinition<EventType, ProjectionTypes, any>) {
+  // Pass class instances directly — do NOT spread.
+  // Getters like `eventTypes` live on the prototype and are lost by `{...obj}`.
   const foldProjections = Array.from(definition.foldProjections.values()).map(
-    ({ definition: fold, options }) => ({
-      ...fold,
-      options: options ?? fold.options,
-    }),
+    ({ definition: fold }) => fold,
   );
 
   const mapProjections = Array.from(definition.mapProjections.values()).map(
-    ({ definition: mapProj, options }) => ({
-      ...mapProj,
-      options: options ?? mapProj.options,
-    }),
+    ({ definition: mapProj }) => mapProj,
   );
 
   const commandRegistrations =

--- a/langwatch/src/server/event-sourcing/services/eventSourcingService.ts
+++ b/langwatch/src/server/event-sourcing/services/eventSourcingService.ts
@@ -239,11 +239,15 @@ export class EventSourcingService<
                 error instanceof Error ? error.message : String(error),
             });
             if (this.logger) {
+              const subErrors = error instanceof AggregateError
+                ? error.errors.map((e: unknown) => e instanceof Error ? { message: e.message, stack: e.stack?.split("\n").slice(0, 3).join("\n") } : String(e))
+                : [];
               this.logger.error(
                 {
                   aggregateType: this.aggregateType,
                   eventCount: enrichedEvents.length,
                   error: error instanceof Error ? error.message : String(error),
+                  subErrors,
                 },
                 "Failed to dispatch events to projections",
               );


### PR DESCRIPTION
## Summary

`buildServiceOptions()` was spreading fold/map projection class instances (`{...fold}`) before passing them to the router. Object spread copies only own enumerable properties — getters like `eventTypes` (defined on `AbstractFoldProjection`/`AbstractMapProjection` prototype) are silently lost.

At runtime, the router accesses `fold.eventTypes.length` → `undefined.length` → crash:
```
TypeError: Cannot read properties of undefined (reading 'length')
    at ProjectionRouter.dispatchToFoldProjections
```

TypeScript can't catch this — structural typing sees the getter as satisfying the interface both before and after the spread.

**Fix:** Pass class instances directly instead of spreading. No options override is used by any pipeline (verified by grep).

## Test plan
- [x] Unit test proves: spreading class instance loses `eventTypes` getter
- [x] Unit test proves: direct reference preserves `eventTypes` getter
- [x] Manual: experiment runs dispatch without errors on dev