### PR TITLE
fix: use non-nullable UpdatedAt for evaluation_runs TTL column

### DIFF
--- a/langwatch/src/server/clickhouse/ttlReconciler.ts
+++ b/langwatch/src/server/clickhouse/ttlReconciler.ts
@@ -39,7 +39,7 @@ export const TABLE_TTL_CONFIG: readonly TableTTLEntry[] = [
   },
   {
     table: "evaluation_runs",
-    ttlColumn: "ScheduledAt",
+    ttlColumn: "UpdatedAt",
     envVar: "TIERED_EVALUATION_RUNS_TABLE_HOT_DAYS",
     hardcodedDefault: 30,
   },


### PR DESCRIPTION
## Summary

- **Problem:** The `evaluation_runs` TTL config referenced `ScheduledAt`, which is `Nullable(DateTime64(3))`. ClickHouse rejects nullable columns in TTL expressions, causing the TTL reconciler to crash on every startup/deploy.
- **Fix:** Switch the TTL column from `ScheduledAt` to `UpdatedAt`, which is non-nullable (`DateTime64(3)`).
- **Prod alignment:** Production already uses `UpdatedAt` with a 1461-day TTL on this table, so this change brings the config in line with what's actually deployed.

## Changes

One-line change in `langwatch/src/server/clickhouse/ttlReconciler.ts`: `ScheduledAt` → `UpdatedAt` for the `evaluation_runs` table entry in `TABLE_TTL_CONFIG`.

## Test plan

- [ ] Verify `pnpm typecheck` passes
- [ ] Confirm the TTL reconciler no longer errors on startup when processing `evaluation_runs`