### PR TITLE
fix: use composite key in EvaluationGroupList to prevent React key collisions

### DIFF
--- a/langwatch/src/components/traces/Evaluations.tsx
+++ b/langwatch/src/components/traces/Evaluations.tsx
@@ -20,6 +20,14 @@ interface TraceEval {
 /** Indentation matching the width of the evaluation status icon. */
 const EVALUATION_STATUS_INDENT = "22px";
 
+function getEvaluationGroupKey(group: EvaluationGroup, index: number) {
+  if (group.evaluatorId) {
+    return `${group.evaluatorId}::${group.latest.evaluation_id}`;
+  }
+
+  return `ungrouped::${group.latest.evaluation_id}::${index}`;
+}
+
 function EvaluationGroupEntry({ group }: { group: EvaluationGroup }) {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -71,7 +79,7 @@ function EvaluationGroupList({
   return (
     <VStack align="start" gap={0} width="full">
       {groups.map((group, index) => (
-        <Box key={`${group.evaluatorId}-${group.latest.evaluation_id}`} width="full">
+        <Box key={getEvaluationGroupKey(group, index)} width="full">
           {index > 0 && (
             <Box
               borderTopWidth="1px"

--- a/langwatch/src/components/traces/__tests__/Evaluations.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/Evaluations.integration.test.tsx
@@ -310,6 +310,65 @@ describe("<Evaluations/>", () => {
     });
   });
 
+  describe("when list keys would otherwise collide", () => {
+    it("renders grouped and ungrouped entries without duplicate key warnings", () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      const evaluations: ElasticSearchEvaluation[] = [
+        makeEvaluation({
+          evaluation_id: "shared",
+          evaluator_id: undefined as unknown as string,
+          name: "Ungrouped A",
+          timestamps: { finished_at: 4000 },
+        }),
+        makeEvaluation({
+          evaluation_id: "shared",
+          evaluator_id: undefined as unknown as string,
+          name: "Ungrouped B",
+          timestamps: { finished_at: 3000 },
+        }),
+        makeEvaluation({
+          evaluation_id: "c",
+          evaluator_id: "a-b",
+          name: "Grouped A-B",
+          timestamps: { finished_at: 2000 },
+        }),
+        makeEvaluation({
+          evaluation_id: "b-c",
+          evaluator_id: "a",
+          name: "Grouped A",
+          timestamps: { finished_at: 1000 },
+        }),
+      ];
+
+      render(
+        <Evaluations
+          {...traceBase}
+          evaluations={evaluations}
+          anyGuardrails={false}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByText("Ungrouped A")).toBeInTheDocument();
+      expect(screen.getByText("Ungrouped B")).toBeInTheDocument();
+      expect(screen.getByText("Grouped A-B")).toBeInTheDocument();
+      expect(screen.getByText("Grouped A")).toBeInTheDocument();
+
+      const hasDuplicateKeyWarning = consoleErrorSpy.mock.calls.some(
+        ([message]) =>
+          typeof message === "string" &&
+          message.includes("Encountered two children with the same key"),
+      );
+
+      expect(hasDuplicateKeyWarning).toBe(false);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
   describe("when expanding history", () => {
     const evaluations: ElasticSearchEvaluation[] = [
       makeEvaluation({


### PR DESCRIPTION
## Summary
- Uses `${group.evaluatorId}-${group.latest.evaluation_id}` as the React key instead of just `evaluation_id`, preventing silent element drops if two groups share the same latest evaluation_id.

Closes #1914

## Test plan
- [ ] Verify evaluations render correctly on trace detail view
- [ ] Confirm no React key warnings in console

# Related Issue

- Resolve #1914