### PR TITLE
fix: update tracemessage error state

### DIFF
--- a/langwatch/src/components/copilot-kit/TraceMessage.tsx
+++ b/langwatch/src/components/copilot-kit/TraceMessage.tsx
@@ -2,15 +2,16 @@ import {
   Alert,
   Button,
   HStack,
-  Spinner,
   type StackProps,
   Text,
 } from "@chakra-ui/react";
+import type { TRPCClientErrorLike } from "@trpc/client";
 import { LuListTree, LuRefreshCw } from "react-icons/lu";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
 import { easyCatchToast } from "../../utils/easyCatchToast";
+import { getTraceErrorMessage } from "./getTraceErrorMessage";
 
 // Constants
 const TRACE_QUERY_CONFIG = {
@@ -36,11 +37,64 @@ export function TraceMessage({ traceId, ...props }: TraceMessageProps) {
     },
   );
 
-  if (traceQuery.isLoading || traceQuery.isError || !traceQuery.data) {
+  if (traceQuery.isError) {
+    return (
+      <TraceErrorState
+        {...props}
+        traceId={traceId}
+        error={traceQuery.error}
+        isRefetching={traceQuery.isRefetching}
+        onRetry={() =>
+          void traceQuery
+            .refetch()
+            .catch((err) => easyCatchToast(err, "TraceMessage refetch"))
+        }
+      />
+    );
+  }
+
+  if (traceQuery.isLoading || !traceQuery.data) {
     return null;
   }
 
   return <TraceSuccessState {...props} traceId={traceId} />;
+}
+
+// Error state component
+function TraceErrorState({
+  traceId,
+  error,
+  isRefetching,
+  onRetry,
+  ...props
+}: {
+  traceId: string;
+  error: TRPCClientErrorLike<any> | null;
+  isRefetching: boolean;
+  onRetry: () => void;
+} & StackProps) {
+  const message = getTraceErrorMessage({ error, traceId });
+
+  return (
+    <HStack paddingBottom={4} {...props}>
+      <Alert.Root status="error" borderRadius="md">
+        <Alert.Indicator />
+        <Alert.Content>
+          <Text>{message}</Text>
+        </Alert.Content>
+      </Alert.Root>
+      <Button
+        colorPalette="gray"
+        size="sm"
+        onClick={onRetry}
+        disabled={isRefetching}
+        loading={isRefetching}
+      >
+        <LuRefreshCw />
+        Retry
+      </Button>
+    </HStack>
+  );
 }
 
 // Success state component

--- a/langwatch/src/components/copilot-kit/TraceMessage.tsx
+++ b/langwatch/src/components/copilot-kit/TraceMessage.tsx
@@ -10,7 +10,6 @@ import { LuListTree, LuRefreshCw } from "react-icons/lu";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
-import { easyCatchToast } from "../../utils/easyCatchToast";
 import { getTraceErrorMessage } from "./getTraceErrorMessage";
 
 // Constants
@@ -44,13 +43,7 @@ export function TraceMessage({ traceId, ...props }: TraceMessageProps) {
         traceId={traceId}
         error={traceQuery.error}
         isRefetching={traceQuery.isRefetching}
-        onRetry={() =>
-          void traceQuery.refetch().then((result) => {
-            if (result.error) {
-              easyCatchToast(result.error, "TraceMessage refetch");
-            }
-          })
-        }
+        onRetry={() => void traceQuery.refetch()}
       />
     );
   }

--- a/langwatch/src/components/copilot-kit/TraceMessage.tsx
+++ b/langwatch/src/components/copilot-kit/TraceMessage.tsx
@@ -45,9 +45,11 @@ export function TraceMessage({ traceId, ...props }: TraceMessageProps) {
         error={traceQuery.error}
         isRefetching={traceQuery.isRefetching}
         onRetry={() =>
-          void traceQuery
-            .refetch()
-            .catch((err) => easyCatchToast(err, "TraceMessage refetch"))
+          void traceQuery.refetch().then((result) => {
+            if (result.error) {
+              easyCatchToast(result.error, "TraceMessage refetch");
+            }
+          })
         }
       />
     );

--- a/langwatch/src/components/copilot-kit/__tests__/getTraceErrorMessage.unit.test.ts
+++ b/langwatch/src/components/copilot-kit/__tests__/getTraceErrorMessage.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { TRPCClientError, type TRPCClientErrorLike } from "@trpc/client";
+import { getTraceErrorMessage } from "../getTraceErrorMessage";
+
+describe("getTraceErrorMessage()", () => {
+  const traceId = "trace_abc123";
+
+  describe("when the error is a 404 NOT_FOUND", () => {
+    it("returns 'Trace not found' with the trace_id", () => {
+      const error = new TRPCClientError("Not found", {
+        result: {
+          error: {
+            data: { code: "NOT_FOUND", httpStatus: 404 },
+          },
+        },
+      });
+
+      expect(getTraceErrorMessage({ error, traceId })).toBe(
+        "Trace not found [trace_abc123]",
+      );
+    });
+  });
+
+  describe("when the error is a 500 INTERNAL_SERVER_ERROR", () => {
+    it("returns 'Couldn't load trace' with the trace_id", () => {
+      const error = new TRPCClientError("Internal server error", {
+        result: {
+          error: {
+            data: { code: "INTERNAL_SERVER_ERROR", httpStatus: 500 },
+          },
+        },
+      });
+
+      expect(getTraceErrorMessage({ error, traceId })).toBe(
+        "Couldn't load trace [trace_abc123]",
+      );
+    });
+  });
+
+  describe("when the error is a non-TRPCClientError", () => {
+    it("returns 'Couldn't load trace' with the trace_id", () => {
+      // Cast to simulate a non-TRPC error reaching the function at runtime
+      const error = new Error(
+        "Network failure",
+      ) as unknown as TRPCClientErrorLike<any>;
+
+      expect(getTraceErrorMessage({ error, traceId })).toBe(
+        "Couldn't load trace [trace_abc123]",
+      );
+    });
+  });
+
+  describe("when the error is null", () => {
+    it("returns 'Couldn't load trace' with the trace_id", () => {
+      expect(getTraceErrorMessage({ error: null, traceId })).toBe(
+        "Couldn't load trace [trace_abc123]",
+      );
+    });
+  });
+});

--- a/langwatch/src/components/copilot-kit/getTraceErrorMessage.ts
+++ b/langwatch/src/components/copilot-kit/getTraceErrorMessage.ts
@@ -1,0 +1,19 @@
+import type { TRPCClientErrorLike } from "@trpc/client";
+import { isNotFound } from "../../utils/trpcError";
+
+/**
+ * Derives a user-facing error message for trace loading failures.
+ *
+ * - 404/NOT_FOUND errors produce "Trace not found [<traceId>]"
+ * - All other errors produce "Couldn't load trace [<traceId>]"
+ */
+export function getTraceErrorMessage({
+  error,
+  traceId,
+}: {
+  error: TRPCClientErrorLike<any> | null;
+  traceId: string;
+}): string {
+  const prefix = isNotFound(error) ? "Trace not found" : "Couldn't load trace";
+  return `${prefix} [${traceId}]`;
+}

--- a/specs/components/trace-message-error-state.feature
+++ b/specs/components/trace-message-error-state.feature
@@ -1,0 +1,27 @@
+@regression @integration
+Feature: TraceMessage error state UX
+
+  The TraceMessage component displays trace loading status and error states.
+  Error messages must differentiate between "not found" and generic errors,
+  and the retry button must remain accessible during refetch.
+
+  Scenario: displays "Trace not found" for 404 errors
+    Given the trace query fails with a 404 NOT_FOUND error
+    When the error state renders
+    Then the alert shows "Trace not found [<trace_id>]"
+
+  Scenario: displays "Couldn't load trace" for non-404 errors
+    Given the trace query fails with a 500 INTERNAL_SERVER_ERROR
+    When the error state renders
+    Then the alert shows "Couldn't load trace [<trace_id>]"
+
+  Scenario: retry button remains visible but disabled during refetch
+    Given the trace query has errored
+    When the user clicks the retry button and refetch is in progress
+    Then the button remains rendered with disabled state
+    And the button shows a loading indicator
+
+  Scenario: retry button passes context to error handler
+    Given the trace query has errored
+    When the user clicks the retry button and it fails
+    Then easyCatchToast receives the error with context "TraceMessage refetch"

--- a/specs/components/trace-message-error-state.feature
+++ b/specs/components/trace-message-error-state.feature
@@ -21,7 +21,7 @@ Feature: TraceMessage error state UX
     Then the button remains rendered with disabled state
     And the button shows a loading indicator
 
-  Scenario: retry button passes context to error handler
+  Scenario: retry failure shows an error toast
     Given the trace query has errored
-    When the user clicks the retry button and it fails
-    Then easyCatchToast receives the error with context "TraceMessage refetch"
+    When the user clicks the retry button and the retry also fails
+    Then an error toast notification is shown to the user

--- a/specs/components/trace-message-error-state.feature
+++ b/specs/components/trace-message-error-state.feature
@@ -21,7 +21,7 @@ Feature: TraceMessage error state UX
     Then the button remains rendered with disabled state
     And the button shows a loading indicator
 
-  Scenario: retry failure shows an error toast
+  Scenario: retry failure keeps the error alert visible with updated message
     Given the trace query has errored
     When the user clicks the retry button and the retry also fails
-    Then an error toast notification is shown to the user
+    Then the error alert remains visible with the appropriate error message


### PR DESCRIPTION
## Summary
- Distinguish 404 "Trace not found" from generic "Couldn't load trace" errors using `isNotFound()` utility
- Keep retry button visible but disabled with spinner during refetch (was previously hidden entirely)
- Simplify retry handler to `void traceQuery.refetch()` — when retry fails, the error alert remains visible (no redundant toast needed)

Closes #854

## Test plan
- [x] Unit tests for `getTraceErrorMessage` (4 tests covering 404, 500, non-TRPC, null errors)
- [x] Typecheck passes (no new errors)