### PR TITLE
fix: show LLM config validation errors when popover is closed

### DIFF
--- a/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
+++ b/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
@@ -108,7 +108,7 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
                   paddingX={3}
                   borderRadius="md"
                   border="1px solid"
-                  borderColor={hasErrors ? "red.500" : "border"}
+                  borderColor={hasErrors ? "border.error" : "border"}
                   cursor="pointer"
                   _hover={{ bg: "bg.subtle" }}
                   transition="background 0.15s"
@@ -124,7 +124,7 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
                   <Text
                     data-testid="model-select-error-text"
                     fontSize="xs"
-                    color="red.500"
+                    color="fg.error"
                     paddingTop={1}
                   >
                     {errorMessages.join(". ")}

--- a/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
+++ b/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
@@ -83,10 +83,14 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
       render={({ field }) => {
         const llmErrors = formState.errors.version?.configData?.llm;
         const hasErrors = !!llmErrors;
-        const errorMessages = [
-          llmErrors?.temperature?.message,
-          llmErrors?.maxTokens?.message,
-        ].filter(Boolean);
+        const errorMessages = llmErrors
+          ? Object.values(llmErrors)
+              .map(
+                (err) =>
+                  (err as { message?: string } | undefined)?.message,
+              )
+              .filter(Boolean)
+          : [];
 
         return (
           <Popover.Root

--- a/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
+++ b/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
@@ -1,4 +1,10 @@
-import { Box, HStack, Popover as ChakraPopover } from "@chakra-ui/react";
+import {
+  Box,
+  HStack,
+  Popover as ChakraPopover,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import React, { useCallback, useState } from "react";
 import { ChevronDown } from "react-feather";
 import {
@@ -76,6 +82,12 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
       control={control}
       render={({ field }) => {
         const llmErrors = formState.errors.version?.configData?.llm;
+        const hasErrors = !!llmErrors;
+        const errorMessages = [
+          llmErrors?.temperature?.message,
+          llmErrors?.maxTokens?.message,
+        ].filter(Boolean);
+
         return (
           <Popover.Root
             positioning={{ placement: "bottom-start" }}
@@ -84,23 +96,37 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
             onOpenChange={({ open }) => setPopoverOpen(open)}
           >
             <ChakraPopover.Anchor asChild>
-              <HStack
-                paddingY={2}
-                paddingX={3}
-                borderRadius="md"
-                border="1px solid"
-                borderColor="border"
-                cursor="pointer"
-                _hover={{ bg: "bg.subtle" }}
-                transition="background 0.15s"
-                justify="space-between"
-                onClick={() => setPopoverOpen((prev) => !prev)}
-              >
-                <LLMModelDisplay model={field.value?.model ?? ""} />
-                <Box color="fg.muted">
-                  <ChevronDown size={16} />
-                </Box>
-              </HStack>
+              <VStack gap={0} align="stretch">
+                <HStack
+                  data-testid="model-select-trigger"
+                  data-error={hasErrors ? "true" : undefined}
+                  paddingY={2}
+                  paddingX={3}
+                  borderRadius="md"
+                  border="1px solid"
+                  borderColor={hasErrors ? "red.500" : "border"}
+                  cursor="pointer"
+                  _hover={{ bg: "bg.subtle" }}
+                  transition="background 0.15s"
+                  justify="space-between"
+                  onClick={() => setPopoverOpen((prev) => !prev)}
+                >
+                  <LLMModelDisplay model={field.value?.model ?? ""} />
+                  <Box color="fg.muted">
+                    <ChevronDown size={16} />
+                  </Box>
+                </HStack>
+                {!popoverOpen && errorMessages.length > 0 && (
+                  <Text
+                    data-testid="model-select-error-text"
+                    fontSize="xs"
+                    color="red.500"
+                    paddingTop={1}
+                  >
+                    {errorMessages.join(". ")}
+                  </Text>
+                )}
+              </VStack>
             </ChakraPopover.Anchor>
             <LLMConfigPopover
               values={field.value}

--- a/langwatch/src/prompts/forms/fields/__tests__/ModelSelectFieldMini.integration.test.tsx
+++ b/langwatch/src/prompts/forms/fields/__tests__/ModelSelectFieldMini.integration.test.tsx
@@ -50,9 +50,9 @@ vi.mock("~/hooks/useModelProvidersSettings", () => ({
   useModelProvidersSettings: () => ({
     providers: {},
     modelMetadata: {
-      "openai/gpt-4.1": {
-        id: "openai/gpt-4.1",
-        name: "GPT-4.1",
+      "openai/gpt-5-mini": {
+        id: "openai/gpt-5-mini",
+        name: "GPT-5 Mini",
         provider: "openai",
         supportedParameters: ["temperature", "max_tokens"],
         contextLength: 128000,
@@ -70,14 +70,14 @@ vi.mock("~/hooks/useModelProvidersSettings", () => ({
 
 // Mock ModelSelector
 vi.mock("~/components/ModelSelector", () => ({
-  allModelOptions: ["openai/gpt-4.1"],
+  allModelOptions: ["openai/gpt-5-mini"],
   ModelSelector: ({ model }: { model: string }) => (
     <select
       data-testid="model-selector"
       value={model}
       onChange={() => {}}
     >
-      <option value="openai/gpt-4.1">GPT-4.1</option>
+      <option value="openai/gpt-5-mini">GPT-5 Mini</option>
     </select>
   ),
   useModelSelectionOptions: (
@@ -116,7 +116,7 @@ type TestFormValues = {
 let testFormMethods: ReturnType<typeof useForm<TestFormValues>> | null = null;
 
 const defaultLlmConfig = {
-  model: "openai/gpt-4.1",
+  model: "openai/gpt-5-mini",
   temperature: 0.7,
   maxTokens: 4096,
 };

--- a/langwatch/src/prompts/forms/fields/__tests__/ModelSelectFieldMini.integration.test.tsx
+++ b/langwatch/src/prompts/forms/fields/__tests__/ModelSelectFieldMini.integration.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * @regression Tests that LLM config validation errors are visible
+ * when the config popover is closed (issue #863).
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock @prisma/client (transitively imported via ~/prompts barrel export)
+vi.mock("@prisma/client", () => ({
+  PromptScope: { GLOBAL: "GLOBAL", LOCAL: "LOCAL" },
+}));
+
+// Mock deep transitive dependencies that don't exist in worktree env
+vi.mock("~/optimization_studio/types/dsl", () => ({
+  nodeDatasetSchema: { optional: () => ({}) },
+}));
+
+// Mock next/router
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    query: { project: "test-project" },
+    push: vi.fn(),
+  }),
+}));
+
+// Mock useOrganizationTeamProject
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project" },
+    organization: { id: "test-org" },
+    team: null,
+  }),
+}));
+
+// Mock next-auth
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { id: "test-user" } },
+    status: "authenticated",
+  }),
+}));
+
+// Mock useModelProvidersSettings
+vi.mock("~/hooks/useModelProvidersSettings", () => ({
+  useModelProvidersSettings: () => ({
+    providers: {},
+    modelMetadata: {
+      "openai/gpt-4.1": {
+        id: "openai/gpt-4.1",
+        name: "GPT-4.1",
+        provider: "openai",
+        supportedParameters: ["temperature", "max_tokens"],
+        contextLength: 128000,
+        maxCompletionTokens: 16384,
+      },
+    },
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+  useModelMetadata: () => ({
+    metadata: undefined,
+    isLoading: false,
+  }),
+}));
+
+// Mock ModelSelector
+vi.mock("~/components/ModelSelector", () => ({
+  allModelOptions: ["openai/gpt-4.1"],
+  ModelSelector: ({ model }: { model: string }) => (
+    <select
+      data-testid="model-selector"
+      value={model}
+      onChange={() => {}}
+    >
+      <option value="openai/gpt-4.1">GPT-4.1</option>
+    </select>
+  ),
+  useModelSelectionOptions: (
+    _options: string[],
+    model: string,
+    _mode: string,
+  ) => ({
+    modelOption: { label: model, icon: null, isDisabled: false },
+  }),
+}));
+
+// Mock CodeEditor
+vi.mock("~/optimization_studio/components/code/CodeEditorModal", () => ({
+  CodeEditor: () => null,
+}));
+
+import { ModelSelectFieldMini } from "../ModelSelectFieldMini";
+
+// Form values type matching the component's expected shape
+type TestFormValues = {
+  version: {
+    configData: {
+      inputs: { identifier: string; type: string }[];
+      outputs: { identifier: string; type: string }[];
+      messages: unknown[];
+      llm: {
+        model: string;
+        temperature: number;
+        maxTokens: number;
+      };
+    };
+  };
+};
+
+// Store form methods for programmatic error setting
+let testFormMethods: ReturnType<typeof useForm<TestFormValues>> | null = null;
+
+const defaultLlmConfig = {
+  model: "openai/gpt-4.1",
+  temperature: 0.7,
+  maxTokens: 4096,
+};
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => {
+  const methods = useForm<TestFormValues>({
+    defaultValues: {
+      version: {
+        configData: {
+          inputs: [],
+          outputs: [{ identifier: "output", type: "str" }],
+          messages: [],
+          llm: defaultLlmConfig,
+        },
+      },
+    },
+  });
+
+  testFormMethods = methods;
+
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <FormProvider {...methods}>{children}</FormProvider>
+    </ChakraProvider>
+  );
+};
+
+const renderComponent = () => {
+  return render(
+    <TestWrapper>
+      <ModelSelectFieldMini />
+    </TestWrapper>,
+  );
+};
+
+describe("<ModelSelectFieldMini/>", () => {
+  afterEach(() => {
+    cleanup();
+    testFormMethods = null;
+  });
+
+  describe("when LLM config has no validation errors", () => {
+    it("displays a normal border on the trigger", () => {
+      renderComponent();
+
+      const trigger = screen.getByTestId("model-select-trigger");
+      expect(trigger).not.toHaveAttribute("data-error");
+    });
+
+    it("does not show error text below the trigger", () => {
+      renderComponent();
+
+      expect(
+        screen.queryByTestId("model-select-error-text"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when LLM config has validation errors", () => {
+    const setTemperatureError = () => {
+      testFormMethods!.setError("version.configData.llm.temperature", {
+        type: "manual",
+        message: "Temperature must be between 0 and 2",
+      });
+    };
+
+    const setMaxTokensError = () => {
+      testFormMethods!.setError("version.configData.llm.maxTokens", {
+        type: "manual",
+        message: "Max tokens must be positive",
+      });
+    };
+
+    describe("when popover is closed", () => {
+      it("displays a red border on the trigger", async () => {
+        renderComponent();
+        setTemperatureError();
+
+        const trigger = await screen.findByTestId("model-select-trigger");
+        expect(trigger).toHaveAttribute("data-error", "true");
+      });
+
+      it("shows temperature error text below the trigger", async () => {
+        renderComponent();
+        setTemperatureError();
+
+        const errorText = await screen.findByTestId(
+          "model-select-error-text",
+        );
+        expect(errorText).toHaveTextContent(
+          "Temperature must be between 0 and 2",
+        );
+      });
+
+      it("shows maxTokens error text below the trigger", async () => {
+        renderComponent();
+        setMaxTokensError();
+
+        const errorText = await screen.findByTestId(
+          "model-select-error-text",
+        );
+        expect(errorText).toHaveTextContent("Max tokens must be positive");
+      });
+
+      it("shows both error messages when both fields have errors", async () => {
+        renderComponent();
+        setTemperatureError();
+        setMaxTokensError();
+
+        const errorText = await screen.findByTestId(
+          "model-select-error-text",
+        );
+        expect(errorText).toHaveTextContent(
+          "Temperature must be between 0 and 2",
+        );
+        expect(errorText).toHaveTextContent("Max tokens must be positive");
+      });
+    });
+  });
+});

--- a/langwatch/src/prompts/forms/fields/__tests__/ModelSelectFieldMini.integration.test.tsx
+++ b/langwatch/src/prompts/forms/fields/__tests__/ModelSelectFieldMini.integration.test.tsx
@@ -6,6 +6,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { FormProvider, useForm } from "react-hook-form";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -232,6 +233,26 @@ describe("<ModelSelectFieldMini/>", () => {
           "Temperature must be between 0 and 2",
         );
         expect(errorText).toHaveTextContent("Max tokens must be positive");
+      });
+    });
+
+    describe("when popover is open", () => {
+      it("hides error text below the trigger", async () => {
+        const user = userEvent.setup();
+        renderComponent();
+        setTemperatureError();
+
+        // Error text is visible before opening
+        await screen.findByTestId("model-select-error-text");
+
+        // Open popover by clicking the trigger
+        const trigger = screen.getByTestId("model-select-trigger");
+        await user.click(trigger);
+
+        // Error text is hidden when popover is open
+        expect(
+          screen.queryByTestId("model-select-error-text"),
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/specs/prompts/llm-config-error-visibility.feature
+++ b/specs/prompts/llm-config-error-visibility.feature
@@ -1,0 +1,27 @@
+@regression @integration
+Feature: LLM config validation errors visible when popover is closed
+
+  Background:
+    Given a prompt editor form with an LLM configuration field
+
+  Scenario: Error indicator shows on trigger when config has validation errors
+    Given the LLM configuration has a validation error
+    When the config popover is closed
+    Then the trigger element displays a red border
+
+  Scenario: Error text shows below trigger when popover is closed
+    Given the LLM configuration has a validation error
+    When the config popover is closed
+    Then the error message text is visible below the trigger element
+
+  Scenario: Error text hides when popover is open
+    Given the LLM configuration has a validation error
+    When the config popover is open
+    Then the error message text is not visible below the trigger element
+    And the error is shown inside the popover content instead
+
+  Scenario: No error indicator when config is valid
+    Given the LLM configuration has no validation errors
+    When the config popover is closed
+    Then the trigger element displays a normal border
+    And no error text is shown below the trigger


### PR DESCRIPTION
## Summary
- When the LLM config popover has validation errors (temperature, maxTokens) but is closed, users couldn't see them — errors were rendered only inside popover content which unmounts on close
- Added a red border on the trigger element and compact error text below it when errors exist and the popover is closed
- Error text is hidden when the popover is open to avoid duplication with the existing error display inside the popover
- Error messages are derived dynamically from form state (not hardcoded fields) so future validated fields surface automatically

Fixes #863

## Changes
- `ModelSelectFieldMini.tsx`: Added `borderColor` conditional (`red.500` when errors exist), `data-testid`/`data-error` attributes for testability, and error text below trigger when popover is closed
- `ModelSelectFieldMini.integration.test.tsx`: 7 regression tests covering error indicator visibility, error text display, and popover-open hiding behavior

## Test plan
- [x] 7 integration tests passing (error border, error text for temperature/maxTokens/both, no-error baseline, popover-open hides text)
- [x] Typecheck passes (no new errors)
- [x] Code reviewed by uncle-bob-reviewer and cupid-reviewer
- [ ] Browser verification limited — trigger element renders correctly but validation errors could not be triggered in dev instance (spinbutton clamps values; no model providers configured for model switching)