### PR TITLE
feat(collection): drop spans outside the accepted time window

### DIFF
--- a/langwatch/src/server/app-layer/traces/trace-request-collection.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-request-collection.service.ts
@@ -13,8 +13,7 @@ import {
 import { TraceRequestUtils } from "../../event-sourcing/pipelines/trace-processing/utils/traceRequest.utils";
 import type { SpanDedupService } from "./span-dedupe.service";
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-const SPAN_MAX_FUTURE_MS = 7 * ONE_DAY_MS;
-const SPAN_MAX_PAST_MS = 15 * ONE_DAY_MS;
+const SPAN_MAX_PAST_MS = 31 * ONE_DAY_MS;
 
 /** An OtlpSpan whose ID fields have been normalized to hex strings. */
 type NormalizedIdSpan = OtlpSpan & { traceId: string; spanId: string };
@@ -184,11 +183,8 @@ export class TraceRequestCollectionService {
     );
     const now = Date.now();
 
-    if (startTimeUnixMs > now + SPAN_MAX_FUTURE_MS) {
-      return { status: "dropped", error: "span start time is more than 7 days in the future" };
-    }
     if (startTimeUnixMs < now - SPAN_MAX_PAST_MS) {
-      return { status: "dropped", error: "span start time is more than 15 days in the past" };
+      return { status: "dropped", error: "span start time is more than 31 days in the past" };
     }
 
     const normalizedSpan = normalizeSpanIds(spanParseResult.data);


### PR DESCRIPTION
## Summary
- Drops spans whose `startTimeUnixNano` is more than **31 days in the past**
- Returns dropped count and reason via the existing `partialSuccess` response (`rejectedSpans` + `errorMessage`)
- Window bounds extracted to module-level constants (`SPAN_MAX_PAST_MS`)