### PR TITLE
fix: reject unknown automation filter fields and fail-closed in evaluation

### DIFF
--- a/langwatch/src/server/api/routers/analytics/__tests__/common.unit.test.ts
+++ b/langwatch/src/server/api/routers/analytics/__tests__/common.unit.test.ts
@@ -1,13 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
 import type { QueryDslBoolQuery } from "@elastic/elasticsearch/lib/api/types";
+import type { FilterField } from "~/server/filters/types";
 
-// Mock the filter registry to avoid generated-file dependency chain
+// Mock the filter registry with one real-looking filter for testing
 vi.mock("~/server/filters/registry", () => ({
-  availableFilters: {},
+  availableFilters: {
+    "spans.model": {
+      name: "Model",
+      urlKey: "model",
+      query: (values: string[]) => ({ terms: { "spans.model": values } }),
+      listMatch: {
+        aggregation: () => ({}),
+        extract: () => [],
+      },
+    },
+  },
 }));
 
 // Dynamic import after mocks are set
-const { generateTracesPivotQueryConditions } = await import("../common");
+const { generateTracesPivotQueryConditions, generateFilterConditions } =
+  await import("../common");
 
 describe("generateTracesPivotQueryConditions()", () => {
   const baseInput = {
@@ -75,6 +87,42 @@ describe("generateTracesPivotQueryConditions()", () => {
       );
 
       expect(termsFilter).toBeUndefined();
+    });
+  });
+});
+
+describe("generateFilterConditions()", () => {
+  describe("when filter field is unknown", () => {
+    it("returns a match_none condition so the trigger never fires", () => {
+      const conditions = generateFilterConditions({
+        ["service.name" as FilterField]: ["chat"],
+      });
+
+      expect(conditions).toEqual([{ match_none: {} }]);
+    });
+  });
+
+  describe("when filter field is known", () => {
+    it("returns real query conditions", () => {
+      const conditions = generateFilterConditions({
+        "spans.model": ["gpt-4"],
+      });
+
+      expect(conditions).toHaveLength(1);
+      expect(conditions[0]).toEqual({ terms: { "spans.model": ["gpt-4"] } });
+    });
+  });
+
+  describe("when mixing known and unknown fields", () => {
+    it("includes match_none for the unknown field", () => {
+      const conditions = generateFilterConditions({
+        "spans.model": ["gpt-4"],
+        ["service.name" as FilterField]: ["chat"],
+      });
+
+      expect(conditions).toHaveLength(2);
+      expect(conditions).toContainEqual({ terms: { "spans.model": ["gpt-4"] } });
+      expect(conditions).toContainEqual({ match_none: {} });
     });
   });
 });

--- a/langwatch/src/server/api/routers/analytics/common.ts
+++ b/langwatch/src/server/api/routers/analytics/common.ts
@@ -97,6 +97,13 @@ export const generateFilterConditions = (
       continue;
     }
 
+    // Fail-closed: unknown filter fields must produce a "match nothing"
+    // condition so triggers don't silently fire on all traces.
+    if (!(field in availableFilters)) {
+      filterConditions.push({ match_none: {} });
+      continue;
+    }
+
     const col = collectConditions(field as FilterField, params);
     filterConditions = filterConditions.concat(col);
   }

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { enforceLicenseLimit } from "../../license-enforcement";
+import { triggerFiltersSchema } from "../../filters/types";
 import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { extractCheckKeys } from "../utils";
@@ -14,7 +15,7 @@ export const automationRouter = createTRPCRouter({
         projectId: z.string(),
         name: z.string(),
         action: z.nativeEnum(TriggerAction),
-        filters: z.any(),
+        filters: triggerFiltersSchema,
         actionParams: z.object({
           createdByUserId: z.string().optional(),
           members: z.string().array().optional(),
@@ -240,7 +241,7 @@ export const automationRouter = createTRPCRouter({
       z.object({
         triggerId: z.string(),
         projectId: z.string(),
-        filters: z.any(),
+        filters: triggerFiltersSchema,
       }),
     )
     .use(checkProjectPermission("triggers:update"))

--- a/langwatch/src/server/filters/__tests__/trigger-filters-schema.unit.test.ts
+++ b/langwatch/src/server/filters/__tests__/trigger-filters-schema.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { triggerFiltersSchema } from "../types";
+
+describe("triggerFiltersSchema", () => {
+  describe("when filter field is known", () => {
+    it("accepts spans.model with string array", () => {
+      const result = triggerFiltersSchema.safeParse({
+        "spans.model": ["gpt-4"],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts nested filter values", () => {
+      const result = triggerFiltersSchema.safeParse({
+        "evaluations.score": { evaluator_1: ["0.5", "1.0"] },
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("when filter field is unknown", () => {
+    it("rejects service.name", () => {
+      const result = triggerFiltersSchema.safeParse({
+        "service.name": ["chat"],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects arbitrary field names", () => {
+      const result = triggerFiltersSchema.safeParse({
+        "some.random.field": ["value"],
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("when mixing known and unknown fields", () => {
+    it("rejects the entire input", () => {
+      const result = triggerFiltersSchema.safeParse({
+        "spans.model": ["gpt-4"],
+        "service.name": ["chat"],
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Unknown filter fields (e.g., `service.name`) were silently ignored** in `generateFilterConditions()`, producing zero query conditions. This caused triggers to match ALL traces instead of none — firing evaluations on non-matching traces.
- **Two-pronged fix:**
  1. **Fail-closed**: `generateFilterConditions()` now returns `{ match_none: {} }` for filter fields not in `availableFilters`, blocking the trigger instead of passing everything through
  2. **API validation**: Replace `z.any()` with `triggerFiltersSchema` on `create` and `updateTriggerFilters` mutations, rejecting unknown fields before they reach the database

Fixes #2786

## Customer impact

Customer had `service.name` filters on automations to only run evals on chat traces. Batch agent traces (`service.name: unknown_service`) were triggering evaluations — all evaluations skipped/errored because the traces had no relevant content.

## Test plan

- [x] Regression test: `generateFilterConditions` with unknown field returns `match_none` (not empty)
- [x] Regression test: `generateFilterConditions` with known field returns real conditions
- [x] Regression test: `triggerFiltersSchema` rejects unknown fields like `service.name`
- [x] Regression test: `triggerFiltersSchema` accepts known fields like `spans.model`
- [x] Typecheck passes
- [x] All 11 regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
