### PR TITLE
fix: change AvgScoreBps to Int32 to support negative scores

### DIFF
--- a/langwatch/src/server/clickhouse/migrations/00012_fix_experiment_runs_score_signed.sql
+++ b/langwatch/src/server/clickhouse/migrations/00012_fix_experiment_runs_score_signed.sql
@@ -12,8 +12,8 @@ ALTER TABLE ${CLICKHOUSE_DATABASE}.experiment_runs
 -- +goose ENVSUB ON
 -- +goose StatementBegin
 
-ALTER TABLE ${CLICKHOUSE_DATABASE}.experiment_runs
-    MODIFY COLUMN AvgScoreBps Nullable(UInt32);
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.experiment_runs
+ --   MODIFY COLUMN AvgScoreBps Nullable(UInt32);
 
 -- +goose StatementEnd
 -- +goose ENVSUB OFF


### PR DESCRIPTION
## Summary

- Adds migration `00012` to change `AvgScoreBps` in the `experiment_runs` ClickHouse table from `Nullable(UInt32)` to `Nullable(Int32)`
- Fixes a crash when inserting experiment run projections where evaluator scores are negative (e.g. -0.5 → -5000 bps)

## Blocked by

#2780

## Test plan

- [ ] Run migration against ClickHouse
- [ ] Trigger an experiment run with a negative evaluator score and confirm projection stores without error