### PR TITLE
feat: enforce at-least-one search backend, gate migrations by active mode

### DIFF
--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -42,7 +42,7 @@ export function createEnvConfig() {
       AUTH0_CLIENT_SECRET: z.string().optional(),
       AUTH0_ISSUER: z.string().optional(),
       API_TOKEN_JWT_SECRET: optionalIfBuildTime(z.string().min(1)),
-      ELASTICSEARCH_NODE_URL: optionalIfBuildTime(z.string().min(1)),
+      ELASTICSEARCH_NODE_URL: z.string().min(1).optional(),
       ELASTICSEARCH_API_KEY: z.string().optional(),
       REDIS_URL: z.string().optional(),
       REDIS_CLUSTER_ENDPOINTS: z.string().optional(),
@@ -259,5 +259,19 @@ export function createEnvConfig() {
      */
     skipValidation: !!process.env.SKIP_ENV_VALIDATION,
   });
+
+  if (!process.env.BUILD_TIME && !process.env.SKIP_ENV_VALIDATION) {
+    const isClickhouseMode =
+      _env.ENABLE_CLICKHOUSE && _env.ENABLE_EVENT_SOURCING && !!_env.CLICKHOUSE_URL;
+    const isElasticsearchMode = !!_env.ELASTICSEARCH_NODE_URL;
+
+    if (!isClickhouseMode && !isElasticsearchMode) {
+      throw new Error(
+        "Missing search backend configuration: set either ELASTICSEARCH_NODE_URL " +
+          "or all three of ENABLE_CLICKHOUSE=true, ENABLE_EVENT_SOURCING=true, and CLICKHOUSE_URL.",
+      );
+    }
+  }
+
   return _env;
 }

--- a/langwatch/src/tasks/elasticMigrate.ts
+++ b/langwatch/src/tasks/elasticMigrate.ts
@@ -24,6 +24,16 @@ import {
 const migrations: Record<string, any> = importedMigrations;
 
 export default async function execute() {
+  const isClickhouseMode =
+    process.env.ENABLE_CLICKHOUSE === "true" &&
+    process.env.ENABLE_EVENT_SOURCING === "true" &&
+    !!process.env.CLICKHOUSE_URL;
+
+  if (isClickhouseMode) {
+    console.log("ClickHouse mode is active; Elasticsearch migrations are disabled.");
+    return;
+  }
+
   if (env.IS_QUICKWIT) {
     return quickwitMigrate();
   }


### PR DESCRIPTION
## Summary

- `ELASTICSEARCH_NODE_URL` is now unconditionally optional in the Zod schema (was required unless `BUILD_TIME`)
- Added a cross-field startup guard: if neither Elasticsearch nor full ClickHouse mode (`ENABLE_CLICKHOUSE` + `ENABLE_EVENT_SOURCING` + `CLICKHOUSE_URL`) is configured, the app throws a clear error. Both backends can coexist during the transition period.
- `elasticMigrate` exits early when ClickHouse mode is fully active, preventing accidental Elasticsearch index migrations when the stack has moved to ClickHouse.

## Test plan

- [ ] Start app with only `ELASTICSEARCH_NODE_URL` set → starts normally
- [ ] Start app with `ENABLE_CLICKHOUSE=true`, `ENABLE_EVENT_SOURCING=true`, `CLICKHOUSE_URL` set (no `ELASTICSEARCH_NODE_URL`) → starts normally
- [ ] Start app with both sets of vars → starts normally (transition mode)
- [ ] Start app with neither → fails at startup with `"Missing search backend configuration"` error
- [ ] `BUILD_TIME=1` with neither set → no error thrown (existing Docker build behaviour)
- [ ] Run `elasticMigrate` in ClickHouse mode → logs skip message and returns early