### PR TITLE
fix(analytics): add date bounds to JOIN subqueries to prevent OOM

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -542,6 +542,76 @@ describe("aggregation-builder", () => {
         expect(result.params).not.toHaveProperty("groupByKey");
       });
     });
+
+    // @regression issue #2692: JOIN subqueries scanned full tenant history
+    // causing ClickHouse OOM. Date bounds must be pushed into JOIN subqueries.
+    describe("when query requires evaluation_runs JOIN", () => {
+      it("includes date bounds in evaluation_runs JOIN subquery", () => {
+        const input = {
+          ...baseInput,
+          series: [
+            {
+              metric: "evaluations.evaluation_score" as FlattenAnalyticsMetricsEnum,
+              aggregation: "avg" as const,
+              key: "my-evaluator",
+            },
+          ],
+        };
+        const result = buildTimeseriesQuery(input);
+
+        expect(result.sql).toContain(
+          "CreatedAt >= {joinDateStart:DateTime64(3)}"
+        );
+        expect(result.sql).toContain(
+          "CreatedAt < {joinDateEnd:DateTime64(3)}"
+        );
+        expect(result.params).toHaveProperty("joinDateStart");
+        expect(result.params).toHaveProperty("joinDateEnd");
+      });
+
+      it("uses previousPeriodStartDate as joinDateStart and endDate as joinDateEnd", () => {
+        const input = {
+          ...baseInput,
+          series: [
+            {
+              metric: "evaluations.evaluation_score" as FlattenAnalyticsMetricsEnum,
+              aggregation: "avg" as const,
+              key: "my-evaluator",
+            },
+          ],
+        };
+        const result = buildTimeseriesQuery(input);
+
+        expect(result.params.joinDateStart).toEqual(
+          baseInput.previousPeriodStartDate
+        );
+        expect(result.params.joinDateEnd).toEqual(baseInput.endDate);
+      });
+    });
+
+    describe("when query requires stored_spans JOIN", () => {
+      it("includes date bounds in stored_spans JOIN subquery", () => {
+        const input = {
+          ...baseInput,
+          series: [
+            {
+              metric: "metadata.span_type" as FlattenAnalyticsMetricsEnum,
+              aggregation: "cardinality" as const,
+            },
+          ],
+        };
+        const result = buildTimeseriesQuery(input);
+
+        expect(result.sql).toContain(
+          "StartTime >= {joinDateStart:DateTime64(3)}"
+        );
+        expect(result.sql).toContain(
+          "StartTime < {joinDateEnd:DateTime64(3)}"
+        );
+        expect(result.params).toHaveProperty("joinDateStart");
+        expect(result.params).toHaveProperty("joinDateEnd");
+      });
+    });
   });
 
   describe("buildDataForFilterQuery", () => {
@@ -682,6 +752,46 @@ describe("aggregation-builder", () => {
       );
 
       expect(result.sql).toContain("WHERE 1=0");
+    });
+
+    // @regression issue #2692: JOIN subqueries for filter queries must include
+    // date bounds to prevent scanning full tenant history.
+    describe("when JOIN subquery requires date bounds", () => {
+      it("includes StartTime date bounds in stored_spans JOIN for spans.model", () => {
+        const result = buildDataForFilterQuery(
+          projectId,
+          "spans.model",
+          startDate,
+          endDate
+        );
+
+        expect(result.sql).toContain(
+          "StartTime >= {joinDateStart:DateTime64(3)}"
+        );
+        expect(result.sql).toContain(
+          "StartTime < {joinDateEnd:DateTime64(3)}"
+        );
+        expect(result.params).toHaveProperty("joinDateStart", startDate);
+        expect(result.params).toHaveProperty("joinDateEnd", endDate);
+      });
+
+      it("includes CreatedAt date bounds in evaluation_runs JOIN", () => {
+        const result = buildDataForFilterQuery(
+          projectId,
+          "evaluations.evaluator_id",
+          startDate,
+          endDate
+        );
+
+        expect(result.sql).toContain(
+          "CreatedAt >= {joinDateStart:DateTime64(3)}"
+        );
+        expect(result.sql).toContain(
+          "CreatedAt < {joinDateEnd:DateTime64(3)}"
+        );
+        expect(result.params).toHaveProperty("joinDateStart", startDate);
+        expect(result.params).toHaveProperty("joinDateEnd", endDate);
+      });
     });
   });
 

--- a/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings.test.ts
@@ -178,7 +178,7 @@ describe("field-mappings", () => {
     });
   });
 
-  describe("buildJoinClause", () => {
+  describe("buildJoinClause()", () => {
     it("returns empty string for trace_summaries", () => {
       expect(buildJoinClause("trace_summaries")).toBe("");
     });
@@ -199,6 +199,56 @@ describe("field-mappings", () => {
       expect(join).toContain("LIMIT 1 BY TenantId, EvaluationId");
       expect(join).toContain("ts.TenantId = es.TenantId");
       expect(join).toContain("ts.TraceId = es.TraceId");
+    });
+
+    describe("when date bounds are provided", () => {
+      const dateBounds = {
+        start: new Date("2024-01-01T00:00:00Z"),
+        end: new Date("2024-02-01T00:00:00Z"),
+      };
+
+      it("includes StartTime date filter in stored_spans subquery", () => {
+        const join = buildJoinClause("stored_spans", undefined, dateBounds);
+        expect(join).toContain(
+          "StartTime >= {joinDateStart:DateTime64(3)}"
+        );
+        expect(join).toContain(
+          "StartTime < {joinDateEnd:DateTime64(3)}"
+        );
+      });
+
+      it("includes CreatedAt date filter in evaluation_runs subquery", () => {
+        const join = buildJoinClause("evaluation_runs", undefined, dateBounds);
+        expect(join).toContain(
+          "CreatedAt >= {joinDateStart:DateTime64(3)}"
+        );
+        expect(join).toContain(
+          "CreatedAt < {joinDateEnd:DateTime64(3)}"
+        );
+      });
+
+      it("preserves column pruning alongside date bounds", () => {
+        const columns = new Set(["SpanAttributes"]);
+        const join = buildJoinClause("stored_spans", columns, dateBounds);
+        expect(join).toContain("SpanAttributes");
+        expect(join).toContain("StartTime >= {joinDateStart:DateTime64(3)}");
+      });
+    });
+
+    describe("when date bounds are omitted", () => {
+      it("does not include date filters for stored_spans (backward compat)", () => {
+        const join = buildJoinClause("stored_spans");
+        expect(join).not.toContain("joinDateStart");
+        expect(join).not.toContain("joinDateEnd");
+        expect(join).not.toContain("StartTime >=");
+      });
+
+      it("does not include date filters for evaluation_runs (backward compat)", () => {
+        const join = buildJoinClause("evaluation_runs");
+        expect(join).not.toContain("joinDateStart");
+        expect(join).not.toContain("joinDateEnd");
+        expect(join).not.toContain("CreatedAt >=");
+      });
     });
   });
 

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -10,6 +10,7 @@ import type { SeriesInputType } from "../registry";
 import type { FilterField } from "../../filters/types";
 import {
   type CHTable,
+  type JoinDateBounds,
   buildJoinClause,
   tableAliases,
   TRACE_ANALYTICS_COLUMNS,
@@ -488,18 +489,24 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
     }
   }
 
-  // Build JOIN clauses with column pruning.
+  // Build JOIN clauses with column pruning and date bounds.
   // Collect all SQL expressions that reference columns from joined tables
   // so we only SELECT the columns actually needed in each JOIN subquery.
+  // Date bounds span both current and previous periods so the JOIN covers
+  // all rows the outer query might reference.
   const allExpressions = [
     ...metricTranslations.map((m) => m.selectExpression),
     filterTranslation.whereClause,
     groupByColumn ?? "",
   ];
+  const joinDateBounds: JoinDateBounds = {
+    start: input.previousPeriodStartDate,
+    end: input.endDate,
+  };
   const joinClauses = Array.from(allJoins)
     .map((table) => {
       const requiredColumns = resolveRequiredColumns(table, allExpressions);
-      return buildJoinClause(table, requiredColumns);
+      return buildJoinClause(table, requiredColumns, joinDateBounds);
     })
     .join("\n");
 
@@ -533,6 +540,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
       filterWhere,
       allTranslationParams,
       timeZone,
+      joinDateBounds,
     );
   }
 
@@ -555,6 +563,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
       allTranslationParams,
       groupByColumn,
       groupByHandlesUnknown,
+      joinDateBounds,
     );
   }
 
@@ -566,6 +575,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
       groupByColumn,
       groupByHandlesUnknown,
       joinClauses,
+      joinDateBounds,
       baseWhere,
       filterWhere,
       filterParams: allTranslationParams,
@@ -647,6 +657,8 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
       currentEnd: input.endDate,
       previousStart: input.previousPeriodStartDate,
       previousEnd: input.startDate,
+      joinDateStart: joinDateBounds.start,
+      joinDateEnd: joinDateBounds.end,
       ...allTranslationParams,
       ...(input.groupByKey ? { groupByKey: input.groupByKey } : {}),
     },
@@ -668,6 +680,7 @@ function buildArrayJoinTimeseriesQuery(
   filterWhere: string,
   filterParams: Record<string, unknown>,
   timeZone: string,
+  joinDateBounds: JoinDateBounds,
 ): BuiltQuery {
   const ts = tableAliases.trace_summaries;
 
@@ -769,6 +782,8 @@ function buildArrayJoinTimeseriesQuery(
       currentEnd: input.endDate,
       previousStart: input.previousPeriodStartDate,
       previousEnd: input.startDate,
+      joinDateStart: joinDateBounds.start,
+      joinDateEnd: joinDateBounds.end,
       ...filterParams,
       ...(input.groupByKey ? { groupByKey: input.groupByKey } : {}),
     },
@@ -790,12 +805,14 @@ function buildGroupByUnionAllQuery({
   simpleMetrics,
   subqueryMetrics,
   filterParams,
+  joinDateBounds,
 }: {
   input: TimeseriesQueryInput;
   ctes: string[];
   simpleMetrics: MetricTranslation[];
   subqueryMetrics: MetricTranslation[];
   filterParams: Record<string, unknown>;
+  joinDateBounds?: JoinDateBounds;
 }): BuiltQuery {
   const simpleAliases = simpleMetrics.map((m) => quoteIdentifier(m.alias));
   const subqueryAliasExprs = subqueryMetrics.map(
@@ -884,6 +901,9 @@ function buildGroupByUnionAllQuery({
       currentEnd: input.endDate,
       previousStart: input.previousPeriodStartDate,
       previousEnd: input.startDate,
+      ...(joinDateBounds
+        ? { joinDateStart: joinDateBounds.start, joinDateEnd: joinDateBounds.end }
+        : {}),
       ...filterParams,
       ...(input.groupByKey ? { groupByKey: input.groupByKey } : {}),
     },
@@ -904,6 +924,7 @@ function buildSubqueryTimeseriesQuery(
   filterParams: Record<string, unknown>,
   groupByColumn: string | null = null,
   groupByHandlesUnknown = false,
+  joinDateBounds?: JoinDateBounds,
 ): BuiltQuery {
   const ts = tableAliases.trace_summaries;
   const ctes: string[] = [];
@@ -1073,6 +1094,7 @@ function buildSubqueryTimeseriesQuery(
       simpleMetrics,
       subqueryMetrics,
       filterParams,
+      joinDateBounds,
     });
   }
 
@@ -1124,6 +1146,9 @@ function buildSubqueryTimeseriesQuery(
       currentEnd: input.endDate,
       previousStart: input.previousPeriodStartDate,
       previousEnd: input.startDate,
+      ...(joinDateBounds
+        ? { joinDateStart: joinDateBounds.start, joinDateEnd: joinDateBounds.end }
+        : {}),
       ...filterParams,
       ...(input.groupByKey ? { groupByKey: input.groupByKey } : {}),
     },
@@ -1152,6 +1177,7 @@ function buildDateBucketedPipelineQuery({
   groupByColumn,
   groupByHandlesUnknown,
   joinClauses,
+  joinDateBounds,
   baseWhere,
   filterWhere,
   filterParams,
@@ -1162,6 +1188,7 @@ function buildDateBucketedPipelineQuery({
   groupByColumn: string | null;
   groupByHandlesUnknown: boolean;
   joinClauses: string;
+  joinDateBounds: JoinDateBounds;
   baseWhere: string;
   filterWhere: string;
   filterParams: Record<string, unknown>;
@@ -1252,6 +1279,8 @@ function buildDateBucketedPipelineQuery({
       currentEnd: input.endDate,
       previousStart: input.previousPeriodStartDate,
       previousEnd: input.startDate,
+      joinDateStart: joinDateBounds.start,
+      joinDateEnd: joinDateBounds.end,
       ...filterParams,
       ...(input.groupByKey ? { groupByKey: input.groupByKey } : {}),
     },
@@ -1483,10 +1512,11 @@ export function buildDataForFilterQuery(
       ? `AND ${filterTranslation.whereClause}`
       : "";
   const filterExpressions = [filterTranslation.whereClause];
+  const filterDateBounds: JoinDateBounds = { start: startDate, end: endDate };
   const filterJoins = Array.from(filterTranslation.requiredJoins)
     .map((table) => {
       const requiredColumns = resolveRequiredColumns(table, filterExpressions);
-      return buildJoinClause(table, requiredColumns);
+      return buildJoinClause(table, requiredColumns, filterDateBounds);
     })
     .join("\n");
 
@@ -1578,7 +1608,7 @@ export function buildDataForFilterQuery(
       break;
 
     case "spans.model":
-      joins = buildJoinClause("stored_spans", new Set(["SpanAttributes"]));
+      joins = buildJoinClause("stored_spans", new Set(["SpanAttributes"]), filterDateBounds);
       sql = `
         SELECT
           ${ss}.SpanAttributes['gen_ai.request.model'] AS field,
@@ -1600,7 +1630,7 @@ export function buildDataForFilterQuery(
       break;
 
     case "spans.type":
-      joins = buildJoinClause("stored_spans", new Set(["SpanAttributes"]));
+      joins = buildJoinClause("stored_spans", new Set(["SpanAttributes"]), filterDateBounds);
       sql = `
         SELECT
           ${ss}.SpanAttributes['langwatch.span.type'] AS field,
@@ -1623,7 +1653,7 @@ export function buildDataForFilterQuery(
 
     case "evaluations.evaluator_id":
     case "evaluations.evaluator_id.guardrails_only":
-      joins = buildJoinClause("evaluation_runs");
+      joins = buildJoinClause("evaluation_runs", undefined, filterDateBounds);
       sql = `
         SELECT
           ${es}.EvaluatorId AS field,
@@ -1672,6 +1702,8 @@ export function buildDataForFilterQuery(
       tenantId: projectId,
       startDate,
       endDate,
+      joinDateStart: filterDateBounds.start,
+      joinDateEnd: filterDateBounds.end,
       searchQuery: searchQuery ? `%${searchQuery}%` : undefined,
       ...filterTranslation.params,
     },

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -473,26 +473,44 @@ export function getTableAlias(table: CHTable): string {
 }
 
 /**
+ * Optional date range for pruning JOIN subqueries.
+ *
+ * WHY: Without date bounds, JOIN subqueries scan ALL data for the tenant,
+ * causing ClickHouse OOM on large tenants. Pushing date bounds into the
+ * subquery lets ClickHouse prune partitions early.
+ */
+export interface JoinDateBounds {
+  start: Date;
+  end: Date;
+}
+
+/**
  * Build JOIN clause for a table, selecting only the columns needed.
  *
  * @param table - The table to JOIN
  * @param requiredColumns - Optional set of columns needed by the query.
  *   When provided, only these columns (plus identity columns) are selected.
  *   When omitted, all analytics columns for the table are selected.
+ * @param dateBounds - Optional date range to push into the JOIN subquery.
+ *   When provided, adds date predicates so ClickHouse can prune partitions.
+ *   When omitted, no date filtering is applied (backward compat for callers
+ *   like filter queries that may not have date context).
  */
 export function buildJoinClause(
   table: CHTable,
   requiredColumns?: ReadonlySet<string>,
+  dateBounds?: JoinDateBounds,
 ): string {
   const alias = tableAliases[table];
   const baseAlias = tableAliases.trace_summaries;
+  const dateFilter = buildJoinDateFilter(table, dateBounds);
 
   switch (table) {
     case "stored_spans": {
       const columns = requiredColumns
         ? mergeWithIdentity(requiredColumns, SPAN_IDENTITY_COLUMNS)
         : SPAN_ANALYTICS_COLUMNS;
-      return `JOIN (SELECT ${Array.from(columns).join(", ")} FROM stored_spans WHERE TenantId = {tenantId:String}) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;
+      return `JOIN (SELECT ${Array.from(columns).join(", ")} FROM stored_spans WHERE TenantId = {tenantId:String}${dateFilter}) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;
     }
     case "evaluation_runs": {
       const columns = requiredColumns
@@ -500,13 +518,49 @@ export function buildJoinClause(
         : EVALUATION_ANALYTICS_COLUMNS;
       return `JOIN (
         SELECT ${Array.from(columns).join(", ")} FROM evaluation_runs
-        WHERE TenantId = {tenantId:String}
+        WHERE TenantId = {tenantId:String}${dateFilter}
         ORDER BY EvaluationId, UpdatedAt DESC
         LIMIT 1 BY TenantId, EvaluationId
       ) ${alias} ON ${baseAlias}.TenantId = ${alias}.TenantId AND ${baseAlias}.TraceId = ${alias}.TraceId`;
     }
     default:
       return "";
+  }
+}
+
+/**
+ * Build the date filter fragment for a JOIN subquery.
+ *
+ * Each table uses a different timestamp column:
+ * - stored_spans: StartTime (when the span began)
+ * - evaluation_runs: CreatedAt (when the evaluation was created)
+ *
+ * Returns an empty string when no date bounds are provided,
+ * preserving backward compatibility for callers without date context.
+ */
+function buildJoinDateFilter(
+  table: CHTable,
+  dateBounds?: JoinDateBounds,
+): string {
+  if (!dateBounds) return "";
+
+  const timestampColumn = getJoinTimestampColumn(table);
+  if (!timestampColumn) return "";
+
+  return ` AND ${timestampColumn} >= {joinDateStart:DateTime64(3)} AND ${timestampColumn} < {joinDateEnd:DateTime64(3)}`;
+}
+
+/**
+ * Map each joinable table to its appropriate timestamp column for date pruning.
+ */
+function getJoinTimestampColumn(table: CHTable): string | null {
+  switch (table) {
+    case "stored_spans":
+      return "StartTime";
+    case "evaluation_runs":
+      return "CreatedAt";
+    default:
+      return null;
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds date range filters to `evaluation_runs` and `stored_spans` JOIN subqueries in `buildJoinClause`, preventing ClickHouse from scanning full tenant history
- Uses `CreatedAt` for evaluation_runs and `StartTime` for stored_spans, covering the full query window (`previousStart` → `currentEnd`)
- Updates all 5 call sites in `aggregation-builder.ts` to pass date bounds

## Root Cause

The JOIN subqueries only filtered by `TenantId`, materializing millions of rows in memory for dedup (`LIMIT 1 BY`) and hash JOINs. Combined with pipeline metrics and `groupBy: "evaluations.evaluation_label"`, this caused ClickHouse OOM at 3.40 GiB.

## Test plan

- [x] Regression tests verify date bounds appear in generated SQL for both tables
- [x] Backward compatibility: bounds are optional, existing callers without date context still work
- [x] All 33 field-mappings tests pass
- [x] All 5 new aggregation-builder regression tests pass
- [x] Typecheck clean (pre-existing Prisma issues only)

Closes #2692

# Related Issue

- Resolve #2692