### PR TITLE
perf: add StartedAt partition pruning to simulation_runs queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ specs/               # BDD feature specs
 | Writing ClickHouse queries without TenantId filtering | Every ClickHouse query MUST include `WHERE TenantId = {tenantId:String}` — no other ID (ScenarioRunId, BatchRunId, etc.) is unique across tenants. Always make TenantId the first predicate |
 | Using `LIMIT 1 BY` with heavy columns in subqueries | Use the IN-tuple dedup pattern (`GROUP BY key + max(UpdatedAt)` in subquery). `LIMIT 1 BY` forces ClickHouse to materialize ALL selected columns for entire granules (~8K rows), causing OOM with heavy payloads (Messages, SpanAttributes, ComputedInput/Output) |
 | Using `max(column)` for pagination sort keys on deduped tables | Use `argMax(column, UpdatedAt)` to derive sort keys from the latest version only. `max()` may pick values from stale versions, causing cursor pagination to skip/duplicate rows |
+| Not filtering on the partition key column in WHERE | Always include `StartedAt`/`OccurredAt`/`StartTime` range in WHERE when a date range is available — this enables partition pruning. Without it, ClickHouse scans ALL partitions including cold storage on S3, turning 100ms queries into 1-2s |
 
 ## Orchestration Model
 

--- a/dev/docs/best_practices/clickhouse-queries.md
+++ b/dev/docs/best_practices/clickhouse-queries.md
@@ -104,6 +104,35 @@ SELECT TraceId, argMax(OccurredAt, UpdatedAt) AS _oa FROM trace_summaries GROUP 
 
 Using `max(column)` for sort keys can select values from stale versions, causing cursor pagination to skip or duplicate rows at page boundaries.
 
+## Always Filter on the Partition Key
+
+Tables use weekly partitions (e.g. `toYearWeek(StartedAt)`, `toYearWeek(OccurredAt)`). Without a WHERE filter on the partition column, ClickHouse scans ALL partitions — including cold storage on S3. This turns a 100ms query into a 1-2s query.
+
+When a date range is available, always add a WHERE filter on the partition column:
+
+```sql
+-- WRONG: HAVING on max(CreatedAt) doesn't help partition pruning
+WHERE TenantId = {tenantId:String}
+GROUP BY BatchRunId
+HAVING toUnixTimestamp64Milli(max(CreatedAt)) >= ...
+
+-- CORRECT: WHERE on StartedAt enables partition pruning (~12x faster)
+WHERE TenantId = {tenantId:String}
+  AND StartedAt >= fromUnixTimestamp64Milli(...)
+  AND StartedAt <= fromUnixTimestamp64Milli(...)
+GROUP BY BatchRunId
+HAVING toUnixTimestamp64Milli(max(CreatedAt)) >= ...
+```
+
+Keep both: the WHERE prunes partitions, the HAVING ensures exact filtering for the edge case where `StartedAt` and `CreatedAt` differ.
+
+| Table | Partition Key |
+|-------|--------------|
+| `simulation_runs` | `toYearWeek(StartedAt)` |
+| `trace_summaries` | `toYearWeek(OccurredAt)` |
+| `stored_spans` | `toYearWeek(StartTime)` |
+| `evaluation_runs` | `toYearWeek(UpdatedAt)` |
+
 ## TenantId is Always Required
 
 Every ClickHouse query MUST include `WHERE TenantId = {tenantId:String}`. No other ID (ScenarioRunId, BatchRunId, TraceId, etc.) is unique across tenants.

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -18,33 +18,51 @@ import type { SimulationRepository } from "./simulation.repository";
 const TABLE_NAME = "simulation_runs" as const;
 
 /**
- * Builds a HAVING clause fragment that filters batches by their max(CreatedAt)
- * falling within [startDate, endDate]. Returns both the SQL clause and the
- * parameterized values so they stay co-located. Filters atomically by the
- * batch's latest timestamp so entire batches are included or excluded together.
+ * Builds date filter clauses from startDate/endDate:
+ *
+ * - `havingClause`: Filters on max(CreatedAt) for exact batch-level filtering
+ *   (post-aggregation). Used in HAVING.
+ * - `whereClause`: Filters on StartedAt for partition pruning (pre-scan).
+ *   simulation_runs is partitioned by toYearWeek(StartedAt). Without this,
+ *   ClickHouse scans ALL partitions including cold storage.
+ *
+ * Both clauses use the same startDate/endDate range but on different columns.
+ * The WHERE on StartedAt enables partition pruning (~12x faster), the HAVING
+ * on max(CreatedAt) ensures exact filtering for edge cases where they differ.
  */
-function buildDateHavingFilter({
+function buildDateFilter({
   startDate,
   endDate,
 }: {
   startDate?: number;
   endDate?: number;
-}): { clause: string | null; params: Record<string, string> } {
-  const parts: string[] = [];
+}): { havingClause: string | null; whereClause: string; params: Record<string, string> } {
+  const havingParts: string[] = [];
+  const whereParts: string[] = [];
   const params: Record<string, string> = {};
   if (startDate !== undefined) {
-    parts.push(
+    havingParts.push(
       "toUnixTimestamp64Milli(max(CreatedAt)) >= toUInt64({startDateMs:String})",
+    );
+    whereParts.push(
+      "StartedAt >= fromUnixTimestamp64Milli(toUInt64({startDateMs:String}))",
     );
     params.startDateMs = String(startDate);
   }
   if (endDate !== undefined) {
-    parts.push(
+    havingParts.push(
       "toUnixTimestamp64Milli(max(CreatedAt)) <= toUInt64({endDateMs:String})",
+    );
+    whereParts.push(
+      "StartedAt <= fromUnixTimestamp64Milli(toUInt64({endDateMs:String}))",
     );
     params.endDateMs = String(endDate);
   }
-  return { clause: parts.length > 0 ? parts.join(" AND ") : null, params };
+  return {
+    havingClause: havingParts.length > 0 ? havingParts.join(" AND ") : null,
+    whereClause: whereParts.length > 0 ? `AND ${whereParts.join(" AND ")}` : "",
+    params,
+  };
 }
 
 const RUN_COLUMNS = `
@@ -567,8 +585,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
         )`
       : "1 = 1";
 
-    const dateFilter = buildDateHavingFilter({ startDate, endDate });
-    const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.clause].filter(Boolean).join(" AND ")}`;
+    const dateFilter = buildDateFilter({ startDate, endDate });
+    
+    const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.havingClause].filter(Boolean).join(" AND ")}`;
 
     const batchRows = await this.queryRows<{
       BatchRunId: string;
@@ -582,6 +601,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          FROM ${TABLE_NAME}
          WHERE TenantId = {tenantId:String}
            AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
+           ${dateFilter.whereClause}
          ORDER BY ScenarioRunId, UpdatedAt DESC
          LIMIT 1 BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
        )
@@ -668,8 +688,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
         )`
       : "1 = 1";
 
-    const dateFilter = buildDateHavingFilter({ startDate, endDate });
-    const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.clause].filter(Boolean).join(" AND ")}`;
+    const dateFilter = buildDateFilter({ startDate, endDate });
+    
+    const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.havingClause].filter(Boolean).join(" AND ")}`;
 
     const batchRows = await this.queryRows<{
       BatchRunId: string;
@@ -684,6 +705,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          SELECT ${DEDUP_COLUMNS}
          FROM ${TABLE_NAME}
          WHERE TenantId = {tenantId:String}
+           ${dateFilter.whereClause}
          ORDER BY ScenarioRunId, UpdatedAt DESC
          LIMIT 1 BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
        )
@@ -754,8 +776,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     endDate?: number;
     filter: "external" | "internal-suites";
   }): Promise<ExternalSetSummary[]> {
-    const dateFilter = buildDateHavingFilter({ startDate, endDate });
-    const havingClause = dateFilter.clause ? `HAVING ${dateFilter.clause}` : "";
+    const dateFilter = buildDateFilter({ startDate, endDate });
+    
+    const havingClause = dateFilter.havingClause ? `HAVING ${dateFilter.havingClause}` : "";
 
     const wherePredicate = filter === "external"
       ? "AND NOT startsWith(ScenarioSetId, '__internal__')"
@@ -794,6 +817,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
              FROM ${TABLE_NAME}
              WHERE TenantId = {tenantId:String}
                ${wherePredicate}
+               ${dateFilter.whereClause}
              ORDER BY ScenarioRunId, UpdatedAt DESC
              LIMIT 1 BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
            )


### PR DESCRIPTION
## Summary
`getSuiteRunData` was taking ~2s on production for a lightweight query (34 rows, 4 batches). Root cause: `simulation_runs` is partitioned by `toYearWeek(StartedAt)` but date filters were only in the HAVING clause on `max(CreatedAt)` — post-aggregation, no partition pruning. ClickHouse scanned ALL 90 partitions (950K rows across all tenants) including cold storage on S3.

**Fix:** Added `StartedAt` range to WHERE clause for partition pruning. Unified `buildDateHavingFilter` + `buildStartedAtWhereFilter` into a single `buildDateFilter()` that returns both `havingClause` and `whereClause` from the same `startDate`/`endDate`.

Applied to all 3 methods using date filters: `getRunDataForScenarioSet`, `getRunDataForAllSuites`, `getSetSummaries`.

**Measured on production:** 1013ms → 84ms (~12x faster)

Also added partition pruning to the ClickHouse best practices doc.

## Test plan
- [x] 21 unit tests pass
- [x] 17 integration tests pass
- [x] Verified on production ClickHouse: 84ms with StartedAt filter vs 1013ms without