### PR TITLE
perf: add OccurredAt partition pruning to trace_summaries queries

### DIFF
--- a/langwatch/src/server/filters/__tests__/query-helpers.test.ts
+++ b/langwatch/src/server/filters/__tests__/query-helpers.test.ts
@@ -35,18 +35,19 @@ describe("buildTraceSummariesConditions", () => {
     expect(result).toContain("TenantId = {tenantId:String}");
   });
 
-  it("returns CreatedAt start condition", () => {
+  it("returns OccurredAt conditions for partition pruning", () => {
     const result = buildTraceSummariesConditions(baseParams);
     expect(result).toContain(
-      "CreatedAt >= fromUnixTimestamp64Milli({startDate:UInt64})"
+      "OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})"
+    );
+    expect(result).toContain(
+      "OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})"
     );
   });
 
-  it("returns CreatedAt end condition", () => {
+  it("does not filter on CreatedAt (OccurredAt is the user-facing timestamp)", () => {
     const result = buildTraceSummariesConditions(baseParams);
-    expect(result).toContain(
-      "CreatedAt <= fromUnixTimestamp64Milli({endDate:UInt64})"
-    );
+    expect(result).not.toContain("CreatedAt");
   });
 
   it("joins conditions with AND", () => {

--- a/langwatch/src/server/filters/clickhouse/query-helpers.ts
+++ b/langwatch/src/server/filters/clickhouse/query-helpers.ts
@@ -21,8 +21,8 @@ export function buildTraceSummariesConditions(
 ): string {
   const conditions: string[] = [
     "TenantId = {tenantId:String}",
-    "CreatedAt >= fromUnixTimestamp64Milli({startDate:UInt64})",
-    "CreatedAt <= fromUnixTimestamp64Milli({endDate:UInt64})",
+    "OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})",
+    "OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})",
   ];
   return conditions.join(" AND ");
 }


### PR DESCRIPTION
## Summary
Follow-up to #2817 (simulation_runs partition pruning). Found the same issue in trace_summaries queries:

**`query-helpers.ts` (`buildTraceSummariesConditions`):** Was filtering on `CreatedAt` (ClickHouse insertion time) but `trace_summaries` is partitioned by `toYearWeek(OccurredAt)`. Replaced `CreatedAt` with `OccurredAt` — this is both the partition key (enables pruning) and the correct semantic filter (when the trace occurred). This helper is used by ALL analytics/filter queries on `trace_summaries`.

**`trace-usage.service.ts`:** Added `OccurredAt` filter alongside `CreatedAt` for the usage counting query.

### What was NOT changed:
- **evaluation_runs**: Already filters on `ScheduledAt` which IS the partition key
- **topicClustering.ts**: Already has `OccurredAt >= 12monthsAgo` in WHERE — intentional for building clusters across a year. The 30-day count is a `countDistinctIf` aggregate within that window.
- **collectUsageStats.ts**: Legitimately scans all data for total counts

## Test plan
- [x] 17 query-helpers unit tests pass
- [x] No typecheck errors in modified files
- [x] 2 pre-existing failures in aggregation-builder.test.ts (not related)