### PR TITLE
feat: log slow ClickHouse queries at warn level for CloudWatch monitoring

### DIFF
--- a/langwatch/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.integration.test.ts
+++ b/langwatch/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.integration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration test verifying the X-ClickHouse-Summary header is returned
+ * by a real ClickHouse instance and that extractReadBytes can read it.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createClient, type ClickHouseClient } from "@clickhouse/client";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { createResilientClickHouseClient } from "../../clickhouse/resilient-client";
+
+let ch: ClickHouseClient;
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = createClient({ url: containers.clickHouseUrl });
+});
+
+afterAll(async () => {
+  await ch?.close();
+  await stopTestContainers();
+});
+
+describe("ClickHouse X-ClickHouse-Summary header", () => {
+  describe("when querying a real ClickHouse instance", () => {
+    it("returns response_headers with x-clickhouse-summary containing read_bytes", async () => {
+      // Create and query a real table so read_bytes is non-zero
+      await ch.command({ query: "CREATE TABLE IF NOT EXISTS _test_summary (id UInt64, data String) ENGINE = MergeTree() ORDER BY id" });
+      await ch.insert({ table: "_test_summary", values: [{ id: 1, data: "hello world" }], format: "JSONEachRow" });
+
+      const result = await ch.query({
+        query: "SELECT * FROM _test_summary",
+        format: "JSONEachRow",
+      });
+
+      const summary = result.response_headers["x-clickhouse-summary"];
+      expect(summary).toBeDefined();
+      expect(typeof summary).toBe("string");
+
+      const parsed = JSON.parse(summary as string);
+      // read_bytes is present in the summary (may be 0 for small queries in some CH versions)
+      expect(parsed).toHaveProperty("read_bytes");
+      // read_bytes should be > 0 since we read from a real table
+      expect(Number(parsed.read_bytes)).toBeGreaterThan(0);
+
+      await ch.command({ query: "DROP TABLE IF EXISTS _test_summary" });
+    });
+  });
+
+  describe("when using the resilient client wrapper", () => {
+    it("preserves response_headers through the wrapper", async () => {
+      await ch.command({ query: "CREATE TABLE IF NOT EXISTS _test_summary2 (id UInt64, data String) ENGINE = MergeTree() ORDER BY id" });
+      await ch.insert({ table: "_test_summary2", values: [{ id: 1, data: "test data" }], format: "JSONEachRow" });
+
+      const resilient = createResilientClickHouseClient({ client: ch });
+
+      const result = await resilient.query({
+        query: "SELECT * FROM _test_summary2",
+        format: "JSONEachRow",
+      });
+
+      const summary = result.response_headers["x-clickhouse-summary"];
+      expect(summary).toBeDefined();
+
+      const parsed = JSON.parse(summary as string);
+      expect(parsed).toHaveProperty("read_bytes");
+      expect(Number(parsed.read_bytes)).toBeGreaterThan(0);
+
+      await ch.command({ query: "DROP TABLE IF EXISTS _test_summary2" });
+    });
+
+    it("strips langwatch_* settings before forwarding to ClickHouse", async () => {
+      const resilient = createResilientClickHouseClient({ client: ch });
+
+      // Should not throw — langwatch_* keys are stripped before reaching CH
+      const result = await resilient.query({
+        query: "SELECT 1",
+        format: "JSONEachRow",
+        clickhouse_settings: {
+          langwatch_expected_max_duration_ms: 5000,
+          langwatch_expected_max_read_bytes: 10_000_000,
+        },
+      } as any);
+
+      const rows = await result.json();
+      expect(rows).toHaveLength(1);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
@@ -38,14 +38,14 @@ function makeMockClient(overrides?: Partial<ClickHouseClient>) {
 describe("createResilientClickHouseClient()", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockQueryLogger.debug.mockClear();
-    mockQueryLogger.warn.mockClear();
-    mockQueryLogger.error.mockClear();
-    mockQueryLogger.fatal.mockClear();
-    mockLogger.debug.mockClear();
-    mockLogger.warn.mockClear();
-    mockLogger.error.mockClear();
-    mockLogger.fatal.mockClear();
+    mockQueryLogger.debug.mockReset();
+    mockQueryLogger.warn.mockReset();
+    mockQueryLogger.error.mockReset();
+    mockQueryLogger.fatal.mockReset();
+    mockLogger.debug.mockReset();
+    mockLogger.warn.mockReset();
+    mockLogger.error.mockReset();
+    mockLogger.fatal.mockReset();
   });
 
   describe("when insert fails with transient error then succeeds", () => {
@@ -336,6 +336,150 @@ describe("createResilientClickHouseClient()", () => {
 
       const qr = await client.query({ query: "SELECT 1" });
       expect(qr).toBe(queryResult);
+    });
+  });
+
+  describe("when query exceeds default duration threshold (1s)", () => {
+    it("logs at warn level with query preview", async () => {
+      const queryResult = { response_headers: {} };
+      const mock = makeMockClient({
+        query: vi.fn().mockImplementation(async () => {
+          await new Promise((r) => setTimeout(r, 1100));
+          return queryResult;
+        }),
+      });
+      const client = createResilientClickHouseClient({ client: mock });
+
+      await client.query({ query: "SELECT * FROM big_table WHERE x = 1" });
+
+      expect(mockQueryLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "clickhouse",
+          operation: "query",
+          query: expect.stringContaining("SELECT * FROM big_table"),
+        }),
+        expect.stringContaining("ClickHouse slow query")
+      );
+      expect(mockQueryLogger.debug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when query result exceeds default size threshold (3MB)", () => {
+    it("logs at warn level with readBytes", async () => {
+      const queryResult = {
+        response_headers: {
+          "x-clickhouse-summary": JSON.stringify({ read_bytes: "4000000" }),
+        },
+      };
+      const mock = makeMockClient({
+        query: vi.fn().mockResolvedValue(queryResult),
+      });
+      const client = createResilientClickHouseClient({ client: mock });
+
+      await client.query({ query: "SELECT messages FROM traces" });
+
+      expect(mockQueryLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "clickhouse",
+          operation: "query",
+          readBytes: 4000000,
+        }),
+        expect.stringContaining("3.0MB expected")
+      );
+    });
+  });
+
+  describe("when query is fast and light", () => {
+    it("logs at debug level only", async () => {
+      const queryResult = {
+        response_headers: {
+          "x-clickhouse-summary": JSON.stringify({ read_bytes: "500" }),
+        },
+      };
+      const mock = makeMockClient({
+        query: vi.fn().mockResolvedValue(queryResult),
+      });
+      const client = createResilientClickHouseClient({ client: mock });
+
+      await client.query({ query: "SELECT count() FROM t" });
+
+      expect(mockQueryLogger.debug).toHaveBeenCalled();
+      expect(mockQueryLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when per-query expectations override defaults", () => {
+    it("uses custom thresholds for slow query detection", async () => {
+      const queryResult = {
+        response_headers: {
+          "x-clickhouse-summary": JSON.stringify({ read_bytes: "4000000" }),
+        },
+      };
+      const mock = makeMockClient({
+        query: vi.fn().mockResolvedValue(queryResult),
+      });
+      const client = createResilientClickHouseClient({ client: mock });
+
+      // 4MB is over the default 3MB, but under the custom 5MB
+      await client.query({
+        query: "SELECT * FROM heavy_table",
+        clickhouse_settings: {
+          langwatch_expected_max_duration_ms: 5000,
+          langwatch_expected_max_read_bytes: 5_000_000,
+        },
+      } as any);
+
+      expect(mockQueryLogger.debug).toHaveBeenCalled();
+      expect(mockQueryLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when langwatch_* settings are passed", () => {
+    it("strips them before forwarding to ClickHouse", async () => {
+      const queryResult = { response_headers: {} };
+      const mock = makeMockClient({
+        query: vi.fn().mockResolvedValue(queryResult),
+      });
+      const client = createResilientClickHouseClient({ client: mock });
+
+      await client.query({
+        query: "SELECT 1",
+        clickhouse_settings: {
+          max_memory_usage: 1000000,
+          langwatch_expected_max_duration_ms: 5000,
+          langwatch_expected_max_read_bytes: 10_000_000,
+        },
+      } as any);
+
+      const forwarded = (mock.query as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(forwarded.clickhouse_settings).toEqual({
+        max_memory_usage: 1000000,
+      });
+      expect(forwarded.clickhouse_settings).not.toHaveProperty("langwatch_expected_max_duration_ms");
+      expect(forwarded.clickhouse_settings).not.toHaveProperty("langwatch_expected_max_read_bytes");
+    });
+  });
+
+  describe("when both duration and size exceed thresholds", () => {
+    it("includes both reasons in the warn message", async () => {
+      const queryResult = {
+        response_headers: {
+          "x-clickhouse-summary": JSON.stringify({ read_bytes: "5000000" }),
+        },
+      };
+      const mock = makeMockClient({
+        query: vi.fn().mockImplementation(async () => {
+          await new Promise((r) => setTimeout(r, 1100));
+          return queryResult;
+        }),
+      });
+      const client = createResilientClickHouseClient({ client: mock });
+
+      await client.query({ query: "SELECT * FROM huge" });
+
+      const msg = mockQueryLogger.warn.mock.calls[0]![1] as string;
+      expect(msg).toContain("ms >");
+      expect(msg).toContain("MB >");
     });
   });
 

--- a/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -69,6 +69,97 @@ function safeQueryMeta(params: unknown): {
   return meta;
 }
 
+/** Default threshold for slow query warnings. */
+const DEFAULT_SLOW_QUERY_MS = 1000;
+const DEFAULT_MAX_READ_BYTES = 3 * 1024 * 1024; // 3MB
+
+/**
+ * Per-query performance expectations, passed via `clickhouse_settings`.
+ * The resilient client reads and strips these before forwarding to ClickHouse.
+ *
+ * Usage in repositories:
+ * ```ts
+ * client.query({
+ *   query: "SELECT ...",
+ *   clickhouse_settings: {
+ *     langwatch_expected_max_duration_ms: 5000,    // allow up to 5s
+ *     langwatch_expected_max_read_bytes: 5000000, // allow up to 5MB response
+ *   },
+ * });
+ * ```
+ */
+const LANGWATCH_SETTING_KEYS = [
+  "langwatch_expected_max_duration_ms",
+  "langwatch_expected_max_read_bytes",
+] as const;
+
+interface QueryExpectations {
+  maxDurationMs: number;
+  maxReadBytes?: number;
+}
+
+const DEFAULT_EXPECTATIONS: QueryExpectations = {
+  maxDurationMs: DEFAULT_SLOW_QUERY_MS,
+  maxReadBytes: DEFAULT_MAX_READ_BYTES,
+};
+
+function extractExpectations(params: unknown): QueryExpectations {
+  if (!params || typeof params !== "object") return DEFAULT_EXPECTATIONS;
+  const settings = (params as Record<string, unknown>).clickhouse_settings;
+  if (!settings || typeof settings !== "object") return DEFAULT_EXPECTATIONS;
+
+  const s = settings as Record<string, unknown>;
+  return {
+    maxDurationMs: typeof s.langwatch_expected_max_duration_ms === "number"
+      ? s.langwatch_expected_max_duration_ms
+      : DEFAULT_SLOW_QUERY_MS,
+    maxReadBytes: typeof s.langwatch_expected_max_read_bytes === "number"
+      ? s.langwatch_expected_max_read_bytes
+      : DEFAULT_MAX_READ_BYTES,
+  };
+}
+
+/** Remove langwatch_* keys from clickhouse_settings before forwarding to ClickHouse. */
+function stripLangwatchSettings(params: Record<string, unknown>): Record<string, unknown> {
+  const settings = params.clickhouse_settings;
+  if (!settings || typeof settings !== "object") return params;
+
+  const s = settings as Record<string, unknown>;
+  const hasLangwatchKeys = LANGWATCH_SETTING_KEYS.some((k) => k in s);
+  if (!hasLangwatchKeys) return params;
+
+  const cleaned = { ...s };
+  for (const key of LANGWATCH_SETTING_KEYS) {
+    delete cleaned[key];
+  }
+  return { ...params, clickhouse_settings: cleaned };
+}
+
+/**
+ * Extracts read_bytes from the X-ClickHouse-Summary response header.
+ * This measures how many bytes ClickHouse read from disk to answer the query —
+ * a proxy for query weight. Available in all ClickHouse versions.
+ * (read_bytes is always 0 for streaming formats like JSONEachRow.)
+ */
+function extractReadBytes(result: unknown): number | undefined {
+  try {
+    const headers = (result as { response_headers?: Record<string, string | string[] | undefined> })?.response_headers;
+    const summary = headers?.["x-clickhouse-summary"];
+    if (typeof summary !== "string") return undefined;
+    const parsed = JSON.parse(summary) as { read_bytes?: string };
+    return parsed.read_bytes ? Number(parsed.read_bytes) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractQueryPreview(params: unknown): string | undefined {
+  if (!params || typeof params !== "object") return undefined;
+  const p = params as Record<string, unknown>;
+  if (typeof p.query !== "string") return undefined;
+  return p.query.length > 200 ? p.query.slice(0, 200) + "..." : p.query;
+}
+
 function logFailure({
   operation,
   error,
@@ -104,26 +195,63 @@ function logSuccess({
   operation,
   durationMs,
   params,
+  readBytes,
 }: {
   operation: "query" | "insert";
   durationMs: number;
   params: unknown;
+  readBytes?: number;
 }): void {
   try {
+    const roundedMs = Math.round(durationMs);
     const meta = safeQueryMeta(params);
+    const expectations = extractExpectations(params);
 
-    queryLogger.debug(
-      {
-        source: "clickhouse",
-        operation,
-        durationMs: Math.round(durationMs),
-        queryId: meta.queryId,
-      },
-      `ClickHouse ${operation} succeeded`
-    );
+    const isSlow = roundedMs >= expectations.maxDurationMs;
+    const isTooHeavy = expectations.maxReadBytes !== undefined
+      && readBytes !== undefined
+      && readBytes > expectations.maxReadBytes;
+
+    if (isSlow || isTooHeavy) {
+      const reasons: string[] = [];
+      if (isSlow) reasons.push(`${roundedMs}ms > ${expectations.maxDurationMs}ms`);
+      if (isTooHeavy) reasons.push(`${formatBytes(readBytes!)} > ${formatBytes(expectations.maxReadBytes!)} expected`);
+
+      queryLogger.warn(
+        {
+          source: "clickhouse",
+          operation,
+          durationMs: roundedMs,
+          readBytes,
+          expectedMaxDurationMs: expectations.maxDurationMs,
+          expectedMaxReadBytes: expectations.maxReadBytes,
+          queryId: meta.queryId,
+          table: meta.table,
+          paramKeys: meta.paramKeys,
+          query: extractQueryPreview(params),
+        },
+        `ClickHouse slow ${operation}: ${reasons.join(", ")}`
+      );
+    } else {
+      queryLogger.debug(
+        {
+          source: "clickhouse",
+          operation,
+          durationMs: roundedMs,
+          queryId: meta.queryId,
+        },
+        `ClickHouse ${operation} succeeded`
+      );
+    }
   } catch (loggingError) {
     logger.error({ loggingError }, "Failed to log ClickHouse query success");
   }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
 /**
@@ -143,11 +271,14 @@ export function createResilientClickHouseClient({
   const wrapper = Object.create(client) as ClickHouseClient;
 
   wrapper.query = async (params) => {
+    const cleanedParams = stripLangwatchSettings(params as Record<string, unknown>);
     const start = performance.now();
     try {
-      const result = await client.query(params);
+      const result = await client.query(cleanedParams as Parameters<typeof client.query>[0]);
       const durationMs = performance.now() - start;
-      logSuccess({ operation: "query", durationMs, params });
+      const readBytes = extractReadBytes(result);
+      // params (not cleanedParams) so extractExpectations can read langwatch_* keys
+      logSuccess({ operation: "query", durationMs, params, readBytes });
       return result;
     } catch (error) {
       const durationMs = performance.now() - start;

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -143,12 +143,24 @@ export class SimulationClickHouseRepository implements SimulationRepository {
   private async queryRows<T>(
     query: string,
     params: { tenantId: string } & Record<string, string | string[]>,
+    options?: {
+      expectedMaxDurationMs?: number;
+      expectedMaxReadBytes?: number;
+    },
   ): Promise<T[]> {
     const client = await this.getClient(params.tenantId);
     const result = await client.query({
       query,
       query_params: params,
       format: "JSONEachRow",
+      clickhouse_settings: {
+        ...(options?.expectedMaxDurationMs !== undefined && {
+          langwatch_expected_max_duration_ms: options.expectedMaxDurationMs,
+        }),
+        ...(options?.expectedMaxReadBytes !== undefined && {
+          langwatch_expected_max_read_bytes: options.expectedMaxReadBytes,
+        }),
+      },
     });
     return result.json<T>();
   }
@@ -942,6 +954,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
        ORDER BY CreatedAt ASC
        LIMIT 5000`,
       { tenantId: projectId, batchRunIds, ...(scenarioSetId ? { scenarioSetIds: expandSetIdFilter(scenarioSetId) } : {}) },
+      { expectedMaxDurationMs: 5000, expectedMaxReadBytes: 5_000_000 },
     );
 
     const now = Date.now();


### PR DESCRIPTION
## Summary
Adds slow/heavy query detection to the ClickHouse resilient client. Queries exceeding **duration** or **read_bytes** thresholds are logged at **warn** level (visible in CloudWatch).

**Two thresholds, both configurable per query:**
- `langwatch_expected_max_duration_ms` — default 1000ms
- `langwatch_expected_max_read_bytes` — default 3MB

**read_bytes comes from ClickHouse's `X-ClickHouse-Summary` response header** — zero CPU cost. It measures bytes read from disk, catching overfetching even on fast queries.

**Per-query overrides** via `clickhouse_settings` (stripped before forwarding to ClickHouse):
```ts
client.query({
  query: "SELECT ...",
  clickhouse_settings: {
    langwatch_expected_max_duration_ms: 5000,
    langwatch_expected_max_read_bytes: 5_000_000,
  },
});
```

Applied to `getRunsForBatchIds` (known-heavy, 5s/5MB thresholds).

**Verified against production ClickHouse:**

| Query | rows | elapsed | read_bytes |
|---|---|---|---|
| HEAVY (old sidebar, SELECT *, no prune) | 1708 | 6376ms | **6.09MB** |
| LIGHT (batch IDs + partition pruning) | 3 | 62ms | **0.21MB** |
| Count (no prune) | 1 | 422ms | 1.55MB |

The 3MB default correctly flags the heavy pattern while letting light queries through.

**Example CloudWatch log:**
```json
{
  "level": "WARN",
  "name": "langwatch:clickhouse:query",
  "durationMs": 6376,
  "readBytes": 6385434,
  "expectedMaxDurationMs": 1000,
  "expectedMaxReadBytes": 3145728,
  "query": "SELECT ScenarioRunId, Status, Name, TotalCost...",
  "msg": "ClickHouse slow query: 6376ms > 1000ms, 6.1MB > 3.0MB expected"
}
```

## Test plan
- [x] 20 unit tests pass (14 existing + 6 new: slow duration, heavy read_bytes, fast+light, custom thresholds, settings stripping, both violations)
- [x] 3 integration tests pass (real ClickHouse testcontainer: header present, wrapper preserves headers, settings stripped)
- [x] Verified read_bytes values against production ClickHouse