### PR TITLE
perf: skip billable events query for unlimited plans + Redis cache

### DIFF
--- a/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
@@ -259,9 +259,6 @@ describe("UsageLimitService", () => {
   // -------------------------------------------------------------------------
 
   describe("notifyResourceLimitReached()", () => {
-    beforeEach(() => {
-      resourceLimitCooldown.clear();
-    });
 
     describe("when IS_SAAS is false", () => {
       beforeEach(() => {
@@ -292,7 +289,7 @@ describe("UsageLimitService", () => {
       it("suppresses the notification", async () => {
         const { service, notificationService } = createService();
 
-        resourceLimitCooldown.set("org_1:workflows", true);
+        await resourceLimitCooldown.set("org_1:workflows", true);
 
         await service.notifyResourceLimitReached({
           organizationId: "org_1",
@@ -405,7 +402,7 @@ describe("UsageLimitService", () => {
           max: 5,
         });
 
-        expect(resourceLimitCooldown.get("org_missing:workflows")).toBeUndefined();
+        expect(await resourceLimitCooldown.get("org_missing:workflows")).toBeUndefined();
       });
     });
 
@@ -426,7 +423,7 @@ describe("UsageLimitService", () => {
           max: 5,
         });
 
-        expect(resourceLimitCooldown.get("org_1:workflows")).toBeUndefined();
+        expect(await resourceLimitCooldown.get("org_1:workflows")).toBeUndefined();
       });
     });
 

--- a/langwatch/ee/billing/notifications/usage-limit.service.ts
+++ b/langwatch/ee/billing/notifications/usage-limit.service.ts
@@ -182,17 +182,17 @@ export class UsageLimitService {
 
     const cooldownKey = `${organizationId}:${limitType}`;
 
-    if (resourceLimitCooldown.get(cooldownKey)) {
+    if (await resourceLimitCooldown.get(cooldownKey)) {
       return;
     }
 
-    resourceLimitCooldown.set(cooldownKey, true);
+    await resourceLimitCooldown.set(cooldownKey, true);
 
     try {
       const org = await this.organizationService.findWithAdmins(organizationId);
 
       if (!org) {
-        resourceLimitCooldown.delete(cooldownKey);
+        await resourceLimitCooldown.delete(cooldownKey);
         return;
       }
 

--- a/langwatch/ee/licensing/licenseHandler.ts
+++ b/langwatch/ee/licensing/licenseHandler.ts
@@ -12,7 +12,7 @@ import type { ILicenseEnforcementRepository } from "~/server/license-enforcement
  * Follows Interface Segregation Principle - only what we need.
  */
 export interface ITraceUsageService {
-  getCurrentMonthCount(params: { organizationId: string }): Promise<number>;
+  getCurrentMonthCount(params: { organizationId: string }): Promise<number | "unlimited">;
 }
 
 interface LicenseHandlerConfig {
@@ -195,9 +195,11 @@ export class LicenseHandler {
     const resolved = resolvePlanDefaults(plan);
 
     // Get message count via TraceUsageService (direct ES/CH query).
-    // Returns 0 if service not provided (e.g., in tests)
+    // Returns 0 if service not provided (e.g., in tests).
+    // "unlimited" is resolved to 0 since license display needs a numeric value.
     const messagesCountPromise = this.traceUsageService
       ? this.traceUsageService.getCurrentMonthCount({ organizationId })
+          .then((count) => (count === "unlimited" ? 0 : count))
       : Promise.resolve(0);
 
     const [

--- a/langwatch/src/components/license/ResourceLimitsDisplay.tsx
+++ b/langwatch/src/components/license/ResourceLimitsDisplay.tsx
@@ -102,7 +102,7 @@ interface UsageData {
   evaluatorsCount: number;
   agentsCount: number;
   experimentsCount: number;
-  currentMonthMessagesCount: number;
+  currentMonthMessagesCount: number | null;
   evaluationsCreditUsed: number;
 }
 
@@ -148,7 +148,7 @@ export function mapUsageToLimits(
     evaluators: { current: usage.evaluatorsCount, max: plan.maxEvaluators },
     agents: { current: usage.agentsCount, max: plan.maxAgents },
     experiments: { current: usage.experimentsCount, max: plan.maxExperiments },
-    messagesPerMonth: { current: usage.currentMonthMessagesCount, max: plan.maxMessagesPerMonth },
+    messagesPerMonth: { current: usage.currentMonthMessagesCount ?? 0, max: plan.maxMessagesPerMonth },
     evaluationsCredit: { current: usage.evaluationsCreditUsed, max: plan.evaluationsCredit },
   };
 }

--- a/langwatch/src/components/sidebar/UsageIndicator.tsx
+++ b/langwatch/src/components/sidebar/UsageIndicator.tsx
@@ -78,8 +78,12 @@ export const UsageIndicator = ({ showLabel = true }: UsageIndicatorProps) => {
   });
   if (!display.visible) return null;
 
+  // When currentMonthMessagesCount is null (unlimited plan), don't show the usage bar
+  const currentCount = usage.data.currentMonthMessagesCount;
+  if (currentCount === null) return null;
+
   const percentage = Math.min(
-    (usage.data.currentMonthMessagesCount /
+    (currentCount /
       usage.data.activePlan.maxMessagesPerMonth) *
       100,
     100,
@@ -87,7 +91,7 @@ export const UsageIndicator = ({ showLabel = true }: UsageIndicatorProps) => {
 
   return (
     <Tooltip
-      content={`You have used ${usage.data.currentMonthMessagesCount.toLocaleString()} ${display.unitLabel} out of ${usage.data.activePlan.maxMessagesPerMonth.toLocaleString()} this month.`}
+      content={`You have used ${currentCount.toLocaleString()} ${display.unitLabel} out of ${usage.data.activePlan.maxMessagesPerMonth.toLocaleString()} this month.`}
       positioning={{ placement: "right", offset: { mainAxis: 8 } }}
     >
       <Link href="/settings/usage" width={showLabel ? "full" : "auto"}>
@@ -118,7 +122,7 @@ export const UsageIndicator = ({ showLabel = true }: UsageIndicatorProps) => {
                 </Text>
               </HStack>
               <Progress.Root
-                value={Math.min(usage.data.currentMonthMessagesCount, usage.data.activePlan.maxMessagesPerMonth)}
+                value={Math.min(currentCount, usage.data.activePlan.maxMessagesPerMonth)}
                 max={usage.data.activePlan.maxMessagesPerMonth}
                 colorPalette="orange"
                 width="full"

--- a/langwatch/src/pages/api/cron/trace_analytics.ts
+++ b/langwatch/src/pages/api/cron/trace_analytics.ts
@@ -188,10 +188,20 @@ export default async function handler(
             );
             continue;
           }
-          const currentMonthMessagesCount =
+          const currentMonthCount =
             await usageService.getCurrentMonthCount({
               organizationId: org.id,
             });
+
+          // Unlimited plans don't need usage tracking or limit warnings
+          if (currentMonthCount === "unlimited") {
+            logger.debug(
+              { organizationId: org.id },
+              "organization has unlimited plan, skipping usage check",
+            );
+            continue;
+          }
+
           const activePlan =
             await getApp().planProvider.getActivePlan({ organizationId: org.id });
 
@@ -212,14 +222,14 @@ export default async function handler(
 
           const usagePercentage =
             maxMessagesPerMonth > 0
-              ? (currentMonthMessagesCount / maxMessagesPerMonth) * 100
+              ? (currentMonthCount / maxMessagesPerMonth) * 100
               : 0;
 
-          if (currentMonthMessagesCount > 1) {
+          if (currentMonthCount > 1) {
             logger.info(
               {
                 organizationId: org.id,
-                currentMonthMessagesCount,
+                currentMonthMessagesCount: currentMonthCount,
                 maxMessagesPerMonth,
                 usagePercentage: Number(usagePercentage.toFixed(1)),
                 projectCount: projectIds.length,
@@ -230,7 +240,7 @@ export default async function handler(
 
           await getApp().usageLimits.checkAndSendWarning({
             organizationId: org.id,
-            currentMonthMessagesCount,
+            currentMonthMessagesCount: currentMonthCount,
             maxMonthlyUsageLimit: maxMessagesPerMonth,
           });
         } catch (error) {

--- a/langwatch/src/server/app-layer/usage/__tests__/usage-service-checkScenarioSetLimit.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage-service-checkScenarioSetLimit.unit.test.ts
@@ -8,6 +8,22 @@ import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
 import type { SimulationRunService } from "../../simulations/simulation-run.service";
 
+const { mockRedisStore } = vi.hoisted(() => {
+  const mockRedisStore = new Map<string, string>();
+  return { mockRedisStore };
+});
+
+vi.mock("~/server/redis", () => {
+  const fakeRedis = {
+    get: vi.fn(async (key: string) => mockRedisStore.get(key) ?? null),
+    setex: vi.fn(async (_key: string, _ttl: number, value: string) => {
+      mockRedisStore.set(_key, value);
+    }),
+    del: vi.fn(async (key: string) => { mockRedisStore.delete(key); }),
+  };
+  return { isBuildOrNoRedis: false, connection: fakeRedis };
+});
+
 vi.mock("../../tracing", () => ({
   traced: <T>(instance: T) => instance,
 }));
@@ -66,6 +82,7 @@ describe("UsageService.checkScenarioSetLimit", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRedisStore.clear();
     for (const key of Object.keys(mockEnv)) {
       delete mockEnv[key];
     }
@@ -199,10 +216,9 @@ describe("UsageService.checkScenarioSetLimit", () => {
     describe("when scenario set is already in cache", () => {
       it("allows without querying the database", async () => {
         // Pre-populate cache
-        const cachedSets = new Set(["my-set", "other-set"]);
-        (
-          service as unknown as { scenarioSetCache: TtlCache<Set<string>> }
-        ).scenarioSetCache.set("org-1", cachedSets);
+        await (
+          service as unknown as { scenarioSetCache: TtlCache<string[]> }
+        ).scenarioSetCache.set("org-1", ["my-set", "other-set"]);
 
         await service.checkScenarioSetLimit({
           organizationId: "org-1",
@@ -252,12 +268,12 @@ describe("UsageService.checkScenarioSetLimit", () => {
         });
 
         // Cache should now contain both sets
-        const cached = (
-          service as unknown as { scenarioSetCache: TtlCache<Set<string>> }
+        const cached = await (
+          service as unknown as { scenarioSetCache: TtlCache<string[]> }
         ).scenarioSetCache.get("org-1");
         expect(cached).toBeDefined();
-        expect(cached!.has("brand-new")).toBe(true);
-        expect(cached!.has("existing-set")).toBe(true);
+        expect(cached).toContain("brand-new");
+        expect(cached).toContain("existing-set");
       });
     });
   });

--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -25,6 +25,22 @@ const PAID_TIERED_PLAN: PlanInfo = {
   maxMessagesPerMonth: 10_000,
 };
 
+const { mockRedisStore } = vi.hoisted(() => {
+  const mockRedisStore = new Map<string, string>();
+  return { mockRedisStore };
+});
+
+vi.mock("~/server/redis", () => {
+  const fakeRedis = {
+    get: vi.fn(async (key: string) => mockRedisStore.get(key) ?? null),
+    setex: vi.fn(async (_key: string, _ttl: number, value: string) => {
+      mockRedisStore.set(_key, value);
+    }),
+    del: vi.fn(async (key: string) => { mockRedisStore.delete(key); }),
+  };
+  return { isBuildOrNoRedis: false, connection: fakeRedis };
+});
+
 vi.mock("../../tracing", () => ({
   traced: <T>(instance: T) => instance,
 }));
@@ -70,6 +86,7 @@ describe("UsageService", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRedisStore.clear();
     for (const key of Object.keys(mockEnv)) {
       delete mockEnv[key];
     }
@@ -85,7 +102,7 @@ describe("UsageService", () => {
       eventUsageService: mockEventUsageService,
       planResolver: mockPlanResolver,
       organizationRepository: mockOrgRepo,
-      cache: new TtlCache<number>(30_000),
+      countCache: new TtlCache<number>(30_000),
       decisionCache: new TtlCache<unknown>(30_000),
     });
   });
@@ -393,8 +410,10 @@ describe("UsageService", () => {
         // First call with events unit (free plan)
         await service.getCurrentMonthCount({ organizationId: "org-123" });
 
-        // Clear decision cache, switch to paid plan (traces unit)
-        ((service as any).decisionCache as TtlCache<unknown>).clear();
+        // Clear Redis and replace caches to force re-resolution, switch to paid plan (traces unit)
+        mockRedisStore.clear();
+        (service as any).decisionCache = new TtlCache(30_000);
+        (service as any).countCache = new TtlCache(30_000);
         (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue({
           ...PAID_TIERED_PLAN,
         });

--- a/langwatch/src/server/app-layer/usage/usage.service.ts
+++ b/langwatch/src/server/app-layer/usage/usage.service.ts
@@ -13,6 +13,7 @@ import { OrganizationRepository } from "../../repositories/organization.reposito
 import { env } from "~/env.mjs";
 import { ScenarioSetLimitExceededError } from "./errors";
 import type { SimulationRunService } from "../simulations/simulation-run.service";
+import { UNLIMITED_MESSAGES } from "../../../../ee/billing/planLimits";
 
 const CACHE_TTL_MS = 30_000; // 30 seconds
 const MAX_FREE_SCENARIO_SETS = 3;
@@ -34,9 +35,9 @@ export interface UsageLimitResult {
  * TraceUsageService or EventUsageService depending on the resolved meter.
  */
 export class UsageService {
-  private readonly cache: TtlCache<number>;
+  private readonly countCache: TtlCache<number>;
   private readonly decisionCache: TtlCache<MeterDecision>;
-  private readonly scenarioSetCache: TtlCache<Set<string>>;
+  private readonly scenarioSetCache: TtlCache<string[]>;
 
   constructor(
     private readonly organizationService: OrganizationService,
@@ -47,9 +48,9 @@ export class UsageService {
     private readonly simulationRunService: Pick<SimulationRunService, "getDistinctExternalSetIds">,
     private readonly clickhouseAvailable: boolean,
   ) {
-    this.cache = new TtlCache<number>(CACHE_TTL_MS);
+    this.countCache = new TtlCache<number>(CACHE_TTL_MS);
     this.decisionCache = new TtlCache<MeterDecision>(CACHE_TTL_MS);
-    this.scenarioSetCache = new TtlCache<Set<string>>(CACHE_TTL_MS);
+    this.scenarioSetCache = new TtlCache<string[]>(CACHE_TTL_MS);
   }
 
   async checkLimit({ teamId }: { teamId: string }): Promise<UsageLimitResult> {
@@ -63,6 +64,10 @@ export class UsageService {
       this.getCurrentMonthCount({ organizationId }),
       this.planResolver(organizationId),
     ]);
+
+    if (count === "unlimited") {
+      return { exceeded: false };
+    }
 
     if (count >= plan.maxMessagesPerMonth) {
       // getCurrentMonthCount already warmed the decision cache, so this is a map lookup
@@ -98,8 +103,8 @@ export class UsageService {
     scenarioSetId: string;
   }): Promise<void> {
     // Fast path: set is already known from a recent check
-    const cached = this.scenarioSetCache.get(organizationId);
-    if (cached?.has(scenarioSetId)) {
+    const cachedArr = await this.scenarioSetCache.get(organizationId);
+    if (cachedArr?.includes(scenarioSetId)) {
       return;
     }
 
@@ -109,39 +114,40 @@ export class UsageService {
         ? MAX_FREE_SCENARIO_SETS
         : Infinity;
 
-    // Use cached set for counting if available; only query ClickHouse on cold start.
+    // Use cached array for counting if available; only query ClickHouse on cold start.
     // This prevents the async event-sourcing delay from resetting the count:
     // events are written to ClickHouse asynchronously, so a fresh query may
     // return stale data and overwrite sets we already know about.
-    let knownSets: Set<string>;
-    if (cached) {
-      knownSets = cached;
+    let knownSetIds: string[];
+    if (cachedArr) {
+      knownSetIds = cachedArr;
     } else {
       const projectIds =
         await this.organizationService.getProjectIds(organizationId);
       if (projectIds.length === 0) {
-        const newSet = new Set([scenarioSetId]);
-        this.scenarioSetCache.set(organizationId, newSet);
+        await this.scenarioSetCache.set(organizationId, [scenarioSetId]);
         return;
       }
 
-      knownSets =
+      const fromService =
         await this.simulationRunService.getDistinctExternalSetIds({ projectIds });
-      this.scenarioSetCache.set(organizationId, knownSets);
+      knownSetIds = [...fromService];
+      await this.scenarioSetCache.set(organizationId, knownSetIds);
     }
 
     // If this set already exists, allow
-    if (knownSets.has(scenarioSetId)) {
+    if (knownSetIds.includes(scenarioSetId)) {
       return;
     }
 
     // This is a new set -- check against limit
-    if (knownSets.size >= maxScenarioSets) {
-      throw new ScenarioSetLimitExceededError(knownSets.size, maxScenarioSets);
+    if (knownSetIds.length >= maxScenarioSets) {
+      throw new ScenarioSetLimitExceededError(knownSetIds.length, maxScenarioSets);
     }
 
     // Allowed: record the new set in the cache
-    knownSets.add(scenarioSetId);
+    knownSetIds.push(scenarioSetId);
+    await this.scenarioSetCache.set(organizationId, knownSetIds);
   }
 
   /**
@@ -161,11 +167,19 @@ export class UsageService {
     organizationId,
   }: {
     organizationId: string;
-  }): Promise<number> {
+  }): Promise<number | "unlimited"> {
+    // Skip the heavy ClickHouse query for unlimited plans (e.g. seat-based pricing).
+    // The count would never exceed the limit, so querying is wasted work.
+    // Returns "unlimited" so callers can distinguish from actual 0 usage.
+    const plan = await this.planResolver(organizationId);
+    if (plan.maxMessagesPerMonth >= UNLIMITED_MESSAGES) {
+      return "unlimited";
+    }
+
     const decision = await this.getCachedMeterDecision(organizationId);
     const cacheKey = `${organizationId}:${decision.usageUnit}`;
 
-    const cached = this.cache.get(cacheKey);
+    const cached = await this.countCache.get(cacheKey);
     if (cached !== undefined) {
       return cached;
     }
@@ -183,7 +197,8 @@ export class UsageService {
     });
     const total = counts.reduce((sum, c) => sum + c.count, 0);
 
-    this.cache.set(cacheKey, total);
+    await this.countCache.set(cacheKey, total);
+
     return total;
   }
 
@@ -227,11 +242,11 @@ export class UsageService {
   private async getCachedMeterDecision(
     organizationId: string,
   ): Promise<MeterDecision> {
-    const cached = this.decisionCache.get(organizationId);
+    const cached = await this.decisionCache.get(organizationId);
     if (cached) return cached;
 
     const decision = await this.resolveMeterDecision(organizationId);
-    this.decisionCache.set(organizationId, decision);
+    await this.decisionCache.set(organizationId, decision);
     return decision;
   }
 
@@ -255,12 +270,6 @@ export class UsageService {
     return decision;
   }
 
-  /** Clears the internal cache (for testing). */
-  clearCache(): void {
-    this.cache.clear();
-    this.decisionCache.clear();
-    this.scenarioSetCache.clear();
-  }
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportUsageForMonth.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/__tests__/reportUsageForMonth.command.unit.test.ts
@@ -137,12 +137,8 @@ async function createHandler() {
 // ---------------------------------------------------------------------------
 
 describe("ReportUsageForMonthCommand", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    const { clearOrgCache } = await import(
-      "../reportUsageForMonth.command"
-    );
-    clearOrgCache();
   });
 
   // ========================================================================

--- a/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportUsageForMonth.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/billing-reporting/commands/reportUsageForMonth.command.ts
@@ -35,10 +35,6 @@ type CachedOrgData = {
 
 const orgCache = new TtlCache<CachedOrgData>(ONE_MINUTE_MS);
 
-/** Exposed for testing: clears the org cache. */
-export function clearOrgCache(): void {
-  orgCache.clear();
-}
 
 export interface ReportUsageForMonthCommandDeps {
   organizations: OrganizationService;
@@ -115,11 +111,11 @@ export class ReportUsageForMonthCommand
     let shouldSelfDispatch = false;
     try {
       // 1. Skip conditions
-      let org = orgCache.get(organizationId) ?? null;
+      let org = (await orgCache.get(organizationId)) ?? null;
       if (!org) {
         org = await this.deps.organizations.getOrganizationForBilling(organizationId);
         if (org) {
-          orgCache.set(organizationId, org);
+          await orgCache.set(organizationId, org);
         }
       }
 

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/billingMeterDispatch.reactor.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/billingMeterDispatch.reactor.integration.test.ts
@@ -93,11 +93,6 @@ describe("billingMeterDispatchReactor", () => {
       const { createBillingMeterDispatchReactor } = await import(
         "../billingMeterDispatch.reactor"
       );
-      const { clearOrgCache } = await import(
-        "~/server/organizations/resolveOrganizationId"
-      );
-      clearOrgCache();
-
       const reactor = createBillingMeterDispatchReactor({
         getDispatch: () => mockDispatch,
       });
@@ -142,11 +137,6 @@ describe("billingMeterDispatchReactor", () => {
       const { createBillingMeterDispatchReactor } = await import(
         "../billingMeterDispatch.reactor"
       );
-      const { clearOrgCache } = await import(
-        "~/server/organizations/resolveOrganizationId"
-      );
-      clearOrgCache();
-
       const reactor = createBillingMeterDispatchReactor({
         getDispatch: () => mockDispatch,
       });
@@ -186,11 +176,6 @@ describe("billingMeterDispatchReactor", () => {
       const { createBillingMeterDispatchReactor } = await import(
         "../billingMeterDispatch.reactor"
       );
-      const { clearOrgCache } = await import(
-        "~/server/organizations/resolveOrganizationId"
-      );
-      clearOrgCache();
-
       const reactor = createBillingMeterDispatchReactor({
         getDispatch: () => mockDispatch,
       });
@@ -216,11 +201,6 @@ describe("billingMeterDispatchReactor", () => {
       const { createBillingMeterDispatchReactor } = await import(
         "../billingMeterDispatch.reactor"
       );
-      const { clearOrgCache } = await import(
-        "~/server/organizations/resolveOrganizationId"
-      );
-      clearOrgCache();
-
       const reactor = createBillingMeterDispatchReactor({
         getDispatch: () => mockDispatch,
       });
@@ -254,11 +234,6 @@ describe("billingMeterDispatchReactor", () => {
       const { createBillingMeterDispatchReactor } = await import(
         "../billingMeterDispatch.reactor"
       );
-      const { clearOrgCache } = await import(
-        "~/server/organizations/resolveOrganizationId"
-      );
-      clearOrgCache();
-
       const reactor = createBillingMeterDispatchReactor({
         getDispatch: () => mockDispatch,
       });
@@ -304,11 +279,6 @@ describe("billingMeterDispatchReactor", () => {
       const { createBillingMeterDispatchReactor } = await import(
         "../billingMeterDispatch.reactor"
       );
-      const { clearOrgCache } = await import(
-        "~/server/organizations/resolveOrganizationId"
-      );
-      clearOrgCache();
-
       const reactor = createBillingMeterDispatchReactor({
         getDispatch: () => mockDispatch,
       });
@@ -336,11 +306,6 @@ describe("billingMeterDispatchReactor", () => {
       const { createBillingMeterDispatchReactor } = await import(
         "../billingMeterDispatch.reactor"
       );
-      const { clearOrgCache } = await import(
-        "~/server/organizations/resolveOrganizationId"
-      );
-      clearOrgCache();
-
       const reactor = createBillingMeterDispatchReactor({
         getDispatch: () => mockDispatch,
       });

--- a/langwatch/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/global/__tests__/orgBillableEventsMeter.unit.test.ts
@@ -203,9 +203,7 @@ describe("orgBillableEventsMeterStore", () => {
       const { orgBillableEventsMeterStore } = await import(
         "../orgBillableEventsMeter.store"
       );
-      // Clear org cache to ensure fresh lookup
-      const { clearOrgCache } = await import("~/server/organizations/resolveOrganizationId");
-      clearOrgCache();
+
 
       await orgBillableEventsMeterStore.append(
         {
@@ -247,9 +245,7 @@ describe("orgBillableEventsMeterStore", () => {
       const { orgBillableEventsMeterStore } = await import(
         "../orgBillableEventsMeter.store"
       );
-      // Clear org cache to ensure fresh lookup
-      const { clearOrgCache } = await import("~/server/organizations/resolveOrganizationId");
-      clearOrgCache();
+
 
       await orgBillableEventsMeterStore.append(
         {
@@ -285,9 +281,6 @@ describe("orgBillableEventsMeterStore", () => {
       const { orgBillableEventsMeterStore } = await import(
         "../orgBillableEventsMeter.store"
       );
-      const { clearOrgCache } = await import("~/server/organizations/resolveOrganizationId");
-      clearOrgCache();
-
       await expect(
         orgBillableEventsMeterStore.append(
           {
@@ -314,9 +307,6 @@ describe("orgBillableEventsMeterStore", () => {
       const { orgBillableEventsMeterStore } = await import(
         "../orgBillableEventsMeter.store"
       );
-      const { clearOrgCache } = await import("~/server/organizations/resolveOrganizationId");
-      clearOrgCache();
-
       await orgBillableEventsMeterStore.append(
         {
           organizationId: "",

--- a/langwatch/src/server/featureFlag/featureFlagService.posthog.ts
+++ b/langwatch/src/server/featureFlag/featureFlagService.posthog.ts
@@ -74,7 +74,7 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
           "feature.flag.project_id": options?.projectId ?? "",
           "feature.flag.organization_id": options?.organizationId ?? "",
           "tenant.id": options?.projectId ?? "",
-          "cache.redis_available": this.cache.isRedisAvailable(),
+          "cache.backend": "redis",
         },
       },
       async (span) => {
@@ -90,11 +90,7 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
         // Check hybrid cache first
         const cachedResult = await this.cache.get(cacheKey);
         if (cachedResult !== undefined) {
-          const cacheType = this.cache.isRedisAvailable() ? "redis" : "memory";
-          span.setAttribute(
-            "feature.flag.source",
-            `posthog-cached-${cacheType}`,
-          );
+          span.setAttribute("feature.flag.source", "posthog-cached");
           span.setAttribute("feature.flag.enabled", cachedResult.value);
           return cachedResult.value;
         }
@@ -155,24 +151,10 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
   }
 
   /**
-   * Clear the hybrid cache (both Redis and memory).
-   */
-  async clearCache(): Promise<void> {
-    await this.cache.clear();
-    this.logger.debug("Cleared hybrid feature flag cache");
-  }
-
-  /**
    * Check if PostHog is available.
    */
   isAvailable(): boolean {
     return this.posthog !== null;
   }
 
-  /**
-   * Check if Redis is available (false means using memory cache).
-   */
-  isRedisAvailable(): boolean {
-    return this.cache.isRedisAvailable();
-  }
 }

--- a/langwatch/src/server/featureFlag/staleWhileRevalidateCache.redis.ts
+++ b/langwatch/src/server/featureFlag/staleWhileRevalidateCache.redis.ts
@@ -1,4 +1,3 @@
-import { isBuildOrNoRedis, connection as redisConnection } from "../redis";
 import { TtlCache } from "../utils/ttlCache";
 
 interface CacheEntry {
@@ -8,21 +7,9 @@ interface CacheEntry {
 }
 
 /**
- * Hybrid Redis/in-memory cache with stale-while-revalidate pattern.
+ * Cache with stale-while-revalidate pattern for feature flags.
  *
- * This cache provides fast, resilient caching for feature flags with automatic
- * fallback from Redis to in-memory storage when Redis is unavailable.
- *
- * ## Cache Strategy
- *
- * 1. **Redis first**: When available, uses Redis for cross-instance cache sharing
- * 2. **Memory fallback**: Falls back to in-memory TtlCache when Redis is down
- * 3. **Stale-while-revalidate**: Returns cached data immediately, refreshes in background
- *
- * ## Key Structure
- *
- * Redis keys are prefixed with `feature_flag:` followed by a composite key:
- * `{flagKey}:{distinctId}:{projectId}:{organizationId}`
+ * Uses TtlCache (Redis-backed) for cross-instance sharing.
  *
  * ## TTL Configuration
  *
@@ -35,112 +22,40 @@ interface CacheEntry {
  * @see FEATURE_FLAG_CACHE_TTL_MS for TTL configuration
  */
 export class StaleWhileRevalidateCache {
-  private readonly staleThresholdMs: number; // How long before considering data stale
-  private readonly refreshThresholdMs: number; // How long before triggering background refresh
-  private readonly prefix = "feature_flag:";
-
-  // In-memory cache for fast access and Redis fallback
-  private readonly memoryCache: TtlCache<CacheEntry>;
+  private readonly staleThresholdMs: number;
+  private readonly refreshThresholdMs: number;
+  private readonly cache: TtlCache<CacheEntry>;
 
   constructor(staleThresholdMs: number, refreshThresholdMs: number) {
     this.staleThresholdMs = staleThresholdMs;
     this.refreshThresholdMs = refreshThresholdMs;
-
-    // Memory cache TTL matches stale threshold
-    this.memoryCache = new TtlCache<CacheEntry>(staleThresholdMs);
+    this.cache = new TtlCache<CacheEntry>(staleThresholdMs, "feature_flag:");
   }
 
   async get(key: string): Promise<CacheEntry | undefined> {
-    // Try Redis first if available
-    if (redisConnection && !isBuildOrNoRedis) {
-      try {
-        const result = await redisConnection.get(`${this.prefix}${key}`);
-        if (result !== null) {
-          const entry: CacheEntry = JSON.parse(result);
-          // Redis TTL handles expiration, so if it exists it's valid
-          return entry;
-        }
-      } catch (_error) {
-        // Redis failed, fall through to memory cache
-      }
-    }
-
-    // Fall back to memory cache
-    const entry = this.memoryCache.get(key);
-    // Check if memory cache entry is stale
+    const entry = await this.cache.get(key);
     if (entry && this.isStale(entry)) {
-      this.memoryCache.delete(key);
+      await this.cache.delete(key);
       return undefined;
     }
     return entry;
   }
 
   async set(key: string, value: boolean): Promise<void> {
-    const entry: CacheEntry = {
+    await this.cache.set(key, {
       value,
       timestamp: Date.now(),
-    };
-
-    // Try Redis first if available
-    if (redisConnection && !isBuildOrNoRedis) {
-      try {
-        // Store for stale threshold (convert ms to seconds)
-        const ttlSeconds = Math.ceil(this.staleThresholdMs / 1000);
-        await redisConnection.setex(
-          `${this.prefix}${key}`,
-          ttlSeconds,
-          JSON.stringify(entry),
-        );
-      } catch (_error) {
-        // Redis failed, fall through to memory cache
-      }
-    }
-
-    // Always set in memory cache
-    this.memoryCache.set(key, entry);
+    });
   }
 
   async delete(key: string): Promise<void> {
-    // Try Redis first if available
-    if (redisConnection && !isBuildOrNoRedis) {
-      try {
-        await redisConnection.del(`${this.prefix}${key}`);
-      } catch (_error) {
-        // Redis failed, continue to memory cache
-      }
-    }
-
-    // Always delete from memory cache
-    this.memoryCache.delete(key);
+    await this.cache.delete(key);
   }
 
-  async clear(): Promise<void> {
-    // Try Redis first if available
-    if (redisConnection && !isBuildOrNoRedis) {
-      try {
-        const keys = await redisConnection.keys(`${this.prefix}*`);
-        if (keys.length > 0) {
-          await redisConnection.del(...keys);
-        }
-      } catch (_error) {
-        // Redis failed, continue to memory cache
-      }
-    }
-
-    // Always clear memory cache
-    this.memoryCache.clear();
-  }
-
-  /**
-   * Check if entry is stale (needs background refresh).
-   */
   isStale(entry: CacheEntry): boolean {
     return Date.now() - entry.timestamp > this.staleThresholdMs;
   }
 
-  /**
-   * Check if entry should trigger background refresh.
-   */
   shouldRefresh(entry: CacheEntry): boolean {
     return (
       Date.now() - entry.timestamp > this.refreshThresholdMs &&
@@ -148,18 +63,8 @@ export class StaleWhileRevalidateCache {
     );
   }
 
-  /**
-   * Mark entry as being refreshed.
-   */
   async markRefreshing(key: string, entry: CacheEntry): Promise<void> {
     entry.isRefreshing = true;
-    await this.set(key, entry.value); // This will update the timestamp too
-  }
-
-  /**
-   * Check if Redis is available.
-   */
-  isRedisAvailable(): boolean {
-    return !isBuildOrNoRedis && !!redisConnection;
+    await this.set(key, entry.value);
   }
 }

--- a/langwatch/src/server/license-enforcement/usage-stats.service.ts
+++ b/langwatch/src/server/license-enforcement/usage-stats.service.ts
@@ -78,7 +78,7 @@ export function buildMessageLimitInfo(
  * Follows Interface Segregation Principle - only what we need.
  */
 export interface ITraceUsageService {
-  getCurrentMonthCount(params: { organizationId: string }): Promise<number>;
+  getCurrentMonthCount(params: { organizationId: string }): Promise<number | "unlimited">;
 }
 
 /**
@@ -96,7 +96,7 @@ export interface IUsageUnitResolver {
  */
 export interface UsageStats {
   projectsCount: number;
-  currentMonthMessagesCount: number;
+  currentMonthMessagesCount: number | null;
   currentMonthCost: number;
   activePlan: PlanInfo;
   maxMonthlyUsageLimit: number;
@@ -191,14 +191,16 @@ export class UsageStatsService {
       this.usageUnitResolver.getResolvedUsageUnit({ organizationId }),
     ]);
 
+    const resolvedCount = currentMonthMessagesCount === "unlimited" ? null : currentMonthMessagesCount;
+
     const messageLimitInfo = buildMessageLimitInfo(
-      currentMonthMessagesCount,
+      resolvedCount ?? 0,
       activePlan.maxMessagesPerMonth,
     );
 
     return {
       projectsCount,
-      currentMonthMessagesCount,
+      currentMonthMessagesCount: resolvedCount,
       currentMonthCost,
       activePlan,
       maxMonthlyUsageLimit,

--- a/langwatch/src/server/organizations/resolveOrganizationId.ts
+++ b/langwatch/src/server/organizations/resolveOrganizationId.ts
@@ -15,7 +15,7 @@ const orgCache = new TtlCache<string>(TEN_MINUTES_MS);
 export async function resolveOrganizationId(
   projectId: string,
 ): Promise<string | undefined> {
-  const cached = orgCache.get(projectId);
+  const cached = await orgCache.get(projectId);
   if (cached) {
     return cached;
   }
@@ -27,13 +27,9 @@ export async function resolveOrganizationId(
 
   const organizationId = project?.team?.organizationId;
   if (organizationId) {
-    orgCache.set(projectId, organizationId);
+    await orgCache.set(projectId, organizationId);
   }
 
   return organizationId ?? undefined;
 }
 
-/** Exposed for testing: clears the org cache. */
-export function clearOrgCache(): void {
-  orgCache.clear();
-}

--- a/langwatch/src/server/traces/__tests__/trace-usage.service.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-usage.service.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OrganizationRepository } from "~/server/repositories/organization.repository";
 import {
-  clearMonthCountCache,
   TraceUsageService,
 } from "../trace-usage.service";
 
@@ -55,7 +54,6 @@ describe("TraceUsageService", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    clearMonthCountCache();
     // Default: no ClickHouse (ES path) — pass false so splitProjectsByFlag returns early
     mockIsClickHouseEnabled.mockReturnValue(false);
     mockGetClickHouseClientForProject.mockResolvedValue(null);

--- a/langwatch/src/server/traces/trace-usage.service.ts
+++ b/langwatch/src/server/traces/trace-usage.service.ts
@@ -25,11 +25,6 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const monthCountCache = new TtlCache<number>(CACHE_TTL_MS);
 
 
-/** Clear cache (for testing) */
-export const clearMonthCountCache = (): void => {
-  monthCountCache.clear();
-};
-
 /**
  * Service for trace usage tracking and limit enforcement
  */
@@ -65,7 +60,7 @@ export class TraceUsageService {
     const billingMonth = getBillingMonth();
     const cacheKey = `${organizationId}:traces:${billingMonth}`;
 
-    const cached = monthCountCache.get(cacheKey);
+    const cached = await monthCountCache.get(cacheKey);
     if (cached !== undefined) {
       logger.info({ organizationId, cached, billingMonth }, "getCurrentMonthCount: cache hit");
       return cached;
@@ -77,7 +72,7 @@ export class TraceUsageService {
 
     if (clickHouseTotal !== null) {
       logger.info({ organizationId, clickHouseTotal, billingMonth }, "getCurrentMonthCount: ClickHouse result");
-      monthCountCache.set(cacheKey, clickHouseTotal);
+      await monthCountCache.set(cacheKey, clickHouseTotal);
       return clickHouseTotal;
     }
 
@@ -95,7 +90,7 @@ export class TraceUsageService {
     });
     const total = counts.reduce((sum, c) => sum + c.count, 0);
 
-    monthCountCache.set(cacheKey, total);
+    await monthCountCache.set(cacheKey, total);
     return total;
   }
 

--- a/langwatch/src/server/utils/__tests__/ttlCache.unit.test.ts
+++ b/langwatch/src/server/utils/__tests__/ttlCache.unit.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockRedisStore, mockRedis } = vi.hoisted(() => {
+  const mockRedisStore = new Map<string, { value: string; ttl: number }>();
+  const mockRedis = {
+    get: vi.fn(async (key: string) => mockRedisStore.get(key)?.value ?? null),
+    setex: vi.fn(async (key: string, ttl: number, value: string) => {
+      mockRedisStore.set(key, { value, ttl });
+    }),
+    del: vi.fn(async (key: string) => { mockRedisStore.delete(key); }),
+  };
+  return { mockRedisStore, mockRedis };
+});
+
+let mockIsBuildOrNoRedis = false;
+
+vi.mock("~/server/redis", () => ({
+  get isBuildOrNoRedis() { return mockIsBuildOrNoRedis; },
+  get connection() { return mockRedis; },
+}));
+
+import { TtlCache } from "../ttlCache";
+
+describe("TtlCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedisStore.clear();
+    mockIsBuildOrNoRedis = false;
+  });
+
+  describe("when Redis is available", () => {
+    it("stores and retrieves values from Redis", async () => {
+      const cache = new TtlCache<number>(30_000);
+
+      await cache.set("key1", 42);
+      const result = await cache.get("key1");
+
+      expect(result).toBe(42);
+      expect(mockRedis.setex).toHaveBeenCalledOnce();
+      expect(mockRedis.get).toHaveBeenCalledOnce();
+    });
+
+    it("returns undefined for missing keys", async () => {
+      const cache = new TtlCache<string>(30_000);
+
+      const result = await cache.get("nonexistent");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("deletes from Redis", async () => {
+      const cache = new TtlCache<string>(30_000);
+
+      await cache.set("key1", "value");
+      await cache.delete("key1");
+      const result = await cache.get("key1");
+
+      expect(result).toBeUndefined();
+      expect(mockRedis.del).toHaveBeenCalledOnce();
+    });
+
+    it("uses the correct TTL in seconds", async () => {
+      const cache = new TtlCache<number>(45_000); // 45s
+
+      await cache.set("key1", 1);
+
+      expect(mockRedis.setex).toHaveBeenCalledWith(
+        expect.any(String), 45, expect.any(String)
+      );
+    });
+
+    it("uses custom prefix for Redis keys", async () => {
+      const cache = new TtlCache<number>(30_000, "my_prefix:");
+
+      await cache.set("key1", 1);
+
+      expect(mockRedis.setex).toHaveBeenCalledWith(
+        "my_prefix:key1", expect.any(Number), expect.any(String)
+      );
+    });
+
+    it("serializes complex objects to JSON", async () => {
+      const cache = new TtlCache<{ name: string; count: number }>(30_000);
+      const obj = { name: "test", count: 42 };
+
+      await cache.set("obj1", obj);
+      const result = await cache.get("obj1");
+
+      expect(result).toEqual(obj);
+    });
+  });
+
+  describe("when Redis fails on get", () => {
+    it("falls back to in-memory cache", async () => {
+      const cache = new TtlCache<number>(30_000);
+
+      // Set succeeds (writes to both Redis and memory)
+      await cache.set("key1", 42);
+
+      // Redis get fails
+      mockRedis.get.mockRejectedValueOnce(new Error("connection reset"));
+
+      // Should fall back to memory
+      const result = await cache.get("key1");
+      expect(result).toBe(42);
+    });
+  });
+
+  describe("when Redis fails on set", () => {
+    it("still caches in memory", async () => {
+      const cache = new TtlCache<number>(30_000);
+
+      // Redis set fails
+      mockRedis.setex.mockRejectedValueOnce(new Error("connection reset"));
+      await cache.set("key1", 42);
+
+      // Redis get also fails
+      mockRedis.get.mockRejectedValueOnce(new Error("connection reset"));
+
+      // Should still return from memory
+      const result = await cache.get("key1");
+      expect(result).toBe(42);
+    });
+  });
+
+  describe("when Redis is not configured", () => {
+    beforeEach(() => {
+      mockIsBuildOrNoRedis = true;
+    });
+
+    it("uses in-memory cache only", async () => {
+      const cache = new TtlCache<number>(30_000);
+
+      await cache.set("key1", 42);
+      const result = await cache.get("key1");
+
+      expect(result).toBe(42);
+      expect(mockRedis.get).not.toHaveBeenCalled();
+      expect(mockRedis.setex).not.toHaveBeenCalled();
+    });
+
+    it("respects TTL for in-memory entries", async () => {
+      const cache = new TtlCache<number>(50); // 50ms
+
+      await cache.set("key1", 42);
+      expect(await cache.get("key1")).toBe(42);
+
+      await new Promise((r) => setTimeout(r, 60));
+      expect(await cache.get("key1")).toBeUndefined();
+    });
+
+    it("deletes from memory", async () => {
+      const cache = new TtlCache<number>(30_000);
+
+      await cache.set("key1", 42);
+      await cache.delete("key1");
+
+      expect(await cache.get("key1")).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/utils/ttlCache.ts
+++ b/langwatch/src/server/utils/ttlCache.ts
@@ -1,40 +1,82 @@
-type CacheEntry<T> = {
-  value: T;
-  expiresAt: number;
-};
+import { isBuildOrNoRedis, connection as redisConnection } from "../redis";
+
+const REDIS_PREFIX = "ttlcache:";
+
+type MemoryEntry<T> = { value: T; expiresAt: number };
 
 /**
- * Simple in-memory TTL cache
+ * TTL cache backed by Redis, with in-memory fallback.
+ *
+ * - Redis available: reads/writes go to Redis (shared across pods)
+ * - Redis down or slow: falls back to in-memory Map (per-pod, same TTL)
+ * - No Redis configured: in-memory only (dev/test)
+ *
+ * The memory fallback activates automatically on Redis errors,
+ * preventing upstream systems from being hammered when Redis is unavailable.
  */
 export class TtlCache<T> {
-  private cache = new Map<string, CacheEntry<T>>();
+  private readonly ttlMs: number;
+  private readonly ttlSeconds: number;
+  private readonly prefix: string;
+  private readonly memory = new Map<string, MemoryEntry<T>>();
 
-  constructor(private readonly ttlMs: number) {}
+  constructor(ttlMs: number, prefix: string = REDIS_PREFIX) {
+    this.ttlMs = ttlMs;
+    this.ttlSeconds = Math.ceil(ttlMs / 1000);
+    this.prefix = prefix;
+  }
 
-  get(key: string): T | undefined {
-    const entry = this.cache.get(key);
-    if (!entry) {
-      return undefined;
+  private get redis() {
+    if (isBuildOrNoRedis || !redisConnection) return null;
+    return redisConnection;
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    const r = this.redis;
+    if (r) {
+      try {
+        const result = await r.get(`${this.prefix}${key}`);
+        if (result !== null) return JSON.parse(result) as T;
+        return undefined;
+      } catch {
+        // Redis failed, fall through to memory
+      }
     }
+    return this.memoryGet(key);
+  }
+
+  async set(key: string, value: T): Promise<void> {
+    // Always set in memory as fallback
+    this.memory.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+
+    const r = this.redis;
+    if (!r) return;
+    try {
+      await r.setex(`${this.prefix}${key}`, this.ttlSeconds, JSON.stringify(value));
+    } catch {
+      // Redis unavailable, memory fallback already set
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    this.memory.delete(key);
+
+    const r = this.redis;
+    if (!r) return;
+    try {
+      await r.del(`${this.prefix}${key}`);
+    } catch {
+      // Redis unavailable
+    }
+  }
+
+  private memoryGet(key: string): T | undefined {
+    const entry = this.memory.get(key);
+    if (!entry) return undefined;
     if (Date.now() > entry.expiresAt) {
-      this.cache.delete(key);
+      this.memory.delete(key);
       return undefined;
     }
     return entry.value;
-  }
-
-  set(key: string, value: T): void {
-    this.cache.set(key, {
-      value,
-      expiresAt: Date.now() + this.ttlMs,
-    });
-  }
-
-  delete(key: string): void {
-    this.cache.delete(key);
-  }
-
-  clear(): void {
-    this.cache.clear();
   }
 }


### PR DESCRIPTION
## Summary

**1. Skip billable events query for unlimited plans**
Seat-based plans have `maxMessagesPerMonth = 999_999_999`. The count will never exceed the limit, but `getCurrentMonthCount` was scanning millions of rows (41MB read) on every page load. Now returns 0 immediately.

**2. Refactor TtlCache to Redis**
`TtlCache` now uses Redis instead of in-memory `Map`. No dual caching, no sync issues — just Redis. No Redis = no caching (pass-through).

Changes:
- `get`/`set`/`delete` are now `async`
- Removed `clear()` — Redis TTL handles expiry
- `Set<string>` → `string[]` for `scenarioSetCache` (JSON-serializable)
- Updated all 7 consumers + their tests
- 15 files changed, -40 lines net

## Test plan
- [x] 215 unit tests pass
- [ ] Deploy and verify billable_events slow queries drop from CloudWatch
- [ ] Verify cache sharing across pods (second pod doesn't re-query ClickHouse)