### PR TITLE
fix: preserve monitor card structure when no evaluation data

### DIFF
--- a/langwatch/src/components/analytics/CustomGraph.tsx
+++ b/langwatch/src/components/analytics/CustomGraph.tsx
@@ -593,7 +593,7 @@ const CustomGraph_ = React.memo(
                   </Badge>
                 </button>
               )}
-              {allEmpty ? (
+              {allEmpty && input.graphType !== "monitor_graph" ? (
                 <Box
                   position="absolute"
                   top="50%"
@@ -1296,6 +1296,7 @@ function MonitorGraph({
     : currentAndPreviousData
       ?.map((entry) => entry[firstKey]!)
       .filter((x) => x !== undefined && x !== null);
+  const hasData = allValues !== undefined && allValues.length > 0;
   const total =
     allValues?.reduce((acc, curr) => {
       return acc + curr;
@@ -1307,7 +1308,7 @@ function MonitorGraph({
   // TODO: allow user to define the thresholds instead of hardcoded amounts
   const colorSet: RotatingColorSet = input.monitorGraph?.disabled
     ? "grayTones"
-    : average > 0.8 || !hasLoaded
+    : !hasData || average > 0.8 || !hasLoaded
       ? "greenTones"
       : average < 0.4
         ? "redTones"
@@ -1376,7 +1377,11 @@ function MonitorGraph({
         <HStack gap={2}>
           <Text fontSize="2xl" fontWeight="bold">
             {hasLoaded ? (
-              numeral(average).format(isPassRate ? "0%" : "0.[00]")
+              hasData ? (
+                numeral(average).format(isPassRate ? "0%" : "0.[00]")
+              ) : (
+                "-"
+              )
             ) : (
               <Skeleton
                 width="56px"
@@ -1386,7 +1391,11 @@ function MonitorGraph({
             )}
           </Text>
           <Text fontSize="xs">
-            {isPassRate ? "Pass Rate" : "Average Score"}
+            {hasData
+              ? isPassRate
+                ? "Pass Rate"
+                : "Average Score"
+              : "No data yet"}
           </Text>
         </HStack>
         <Text fontSize="xs">


### PR DESCRIPTION
## Summary
- When online evaluation monitors had no data, the card showed plain "No data" text without any card structure (no border, name, or score)
- Now MonitorGraph renders even when empty, showing the evaluator name with "-" score and "No data yet" label in neutral green tones
- Only affects `monitor_graph` type — other chart types unchanged

<img width="1135" height="217" alt="image" src="https://github.com/user-attachments/assets/25c42848-1864-4815-85b0-b91fa4ebe4c0" />


## Test plan
- [ ] Verify monitor cards with no data show evaluator name, "-" score, and "No data yet"
- [ ] Verify monitor cards with data still work normally
- [ ] Verify other chart types still show "No data" when empty