### PR TITLE
perf: replace LIMIT 1 BY with IN-tuple dedup in stored_spans queries

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -243,14 +243,16 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
             \`Links.TraceId\` AS Links_TraceId,
             \`Links.SpanId\` AS Links_SpanId,
             \`Links.Attributes\` AS Links_Attributes
-          FROM (
-            SELECT *
-            FROM ${TABLE_NAME}
-            WHERE TenantId = {tenantId:String}
-              AND TraceId = {traceId:String}
-            ORDER BY SpanId ASC, StartTime DESC
-            LIMIT 1 BY TenantId, TraceId, SpanId
-          )
+          FROM ${TABLE_NAME}
+          WHERE TenantId = {tenantId:String}
+            AND TraceId = {traceId:String}
+            AND (TenantId, TraceId, SpanId, StartTime) IN (
+              SELECT TenantId, TraceId, SpanId, max(StartTime)
+              FROM ${TABLE_NAME}
+              WHERE TenantId = {tenantId:String}
+                AND TraceId = {traceId:String}
+              GROUP BY TenantId, TraceId, SpanId
+            )
           ORDER BY StartTime ASC
         `,
         query_params: { tenantId, traceId },
@@ -354,14 +356,16 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
             toUnixTimestamp64Milli(event_timestamp) AS started_at,
             event_name AS event_type,
             event_attrs AS attributes
-          FROM (
-            SELECT *
-            FROM ${TABLE_NAME}
-            WHERE TenantId = {tenantId:String}
-              AND TraceId = {traceId:String}
-            ORDER BY SpanId ASC, StartTime DESC
-            LIMIT 1 BY TenantId, TraceId, SpanId
-          )
+          FROM ${TABLE_NAME}
+          WHERE TenantId = {tenantId:String}
+            AND TraceId = {traceId:String}
+            AND (TenantId, TraceId, SpanId, StartTime) IN (
+              SELECT TenantId, TraceId, SpanId, max(StartTime)
+              FROM ${TABLE_NAME}
+              WHERE TenantId = {tenantId:String}
+                AND TraceId = {traceId:String}
+              GROUP BY TenantId, TraceId, SpanId
+            )
           ARRAY JOIN
             "Events.Timestamp" AS event_timestamp,
             "Events.Name" AS event_name,

--- a/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
@@ -138,6 +138,66 @@ describe("trace dedup OOM safety", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // span-storage.clickhouse.repository.ts (app-layer): getSpansByTraceId
+  // ---------------------------------------------------------------------------
+  describe("SpanStorageClickHouseRepository.getSpansByTraceId() (app-layer)", () => {
+    const spanStoragePath = path.resolve(
+      __dirname,
+      "..",
+      "..",
+      "app-layer",
+      "traces",
+      "repositories",
+      "span-storage.clickhouse.repository.ts",
+    );
+    const spanStorageSource = fs.readFileSync(spanStoragePath, "utf-8");
+    const body = extractMethodBody(spanStorageSource, "getSpansByTraceId");
+
+    describe("when the stored_spans query SQL is inspected", () => {
+      it("does not use LIMIT 1 BY for deduplication", () => {
+        expect(body).not.toContain("LIMIT 1 BY");
+      });
+
+      it("uses max(StartTime) GROUP BY for span dedup", () => {
+        expect(body).toContain("max(StartTime)");
+        expect(body).toMatch(
+          /GROUP BY\s+TenantId,\s*TraceId,\s*SpanId/,
+        );
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // span-storage.clickhouse.repository.ts (app-layer): getEventsByTraceId
+  // ---------------------------------------------------------------------------
+  describe("SpanStorageClickHouseRepository.getEventsByTraceId() (app-layer)", () => {
+    const spanStoragePath = path.resolve(
+      __dirname,
+      "..",
+      "..",
+      "app-layer",
+      "traces",
+      "repositories",
+      "span-storage.clickhouse.repository.ts",
+    );
+    const spanStorageSource = fs.readFileSync(spanStoragePath, "utf-8");
+    const body = extractMethodBody(spanStorageSource, "getEventsByTraceId");
+
+    describe("when the stored_spans query SQL is inspected", () => {
+      it("does not use LIMIT 1 BY for deduplication", () => {
+        expect(body).not.toContain("LIMIT 1 BY");
+      });
+
+      it("uses max(StartTime) GROUP BY for span dedup", () => {
+        expect(body).toContain("max(StartTime)");
+        expect(body).toMatch(
+          /GROUP BY\s+TenantId,\s*TraceId,\s*SpanId/,
+        );
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // collectUsageStats.ts: getChScenariosCount
   // ---------------------------------------------------------------------------
   describe("getChScenariosCount()", () => {

--- a/langwatch/src/server/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/traces/repositories/span-storage.clickhouse.repository.ts
@@ -45,6 +45,13 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         FROM stored_spans
         WHERE TenantId = {tenantId:String}
           AND TraceId = {traceId:String}
+          AND (TenantId, TraceId, SpanId, StartTime) IN (
+            SELECT TenantId, TraceId, SpanId, max(StartTime)
+            FROM stored_spans
+            WHERE TenantId = {tenantId:String}
+              AND TraceId = {traceId:String}
+            GROUP BY TenantId, TraceId, SpanId
+          )
         ORDER BY StartTime ASC
       `,
       query_params: { tenantId, traceId },


### PR DESCRIPTION
## Summary

- Replace `LIMIT 1 BY` with IN-tuple dedup pattern (`GROUP BY key + max(StartTime)` subquery) in both `getSpansByTraceId` and `getEventsByTraceId` in the app-layer span storage repository
- Also fix the legacy `traces/repositories/span-storage.clickhouse.repository.ts` which had no dedup at all
- Add 4 new structural regression tests to `trace-dedup-oom-safety.unit.test.ts`

### Why

`LIMIT 1 BY` forces ClickHouse to materialize ALL columns (SpanAttributes, ResourceAttributes, Events.*, Links.*) for entire granules (~8K rows) before deduplicating. CloudWatch slow query logs show stored_spans queries are the **#1 offender by volume**: 240 calls/4h, averaging 4.2MB read per call (~1GB total).

The IN-tuple subquery resolves dedup using only lightweight key columns (TenantId, TraceId, SpanId, StartTime), avoiding the OOM-prone full materialization.

### Benchmarks (prod ClickHouse)

| Trace | Spans | Before (`LIMIT 1 BY`) | After (IN-tuple) | Reduction |
|-------|-------|-----------------------|-------------------|-----------|
| 70-span trace (biggest tenant) | 70 | 1.6MB / 12ms | 37KB / 9ms | **43x** less read |
| 226-span trace | 226 | 3.9MB / 20ms | 86KB / 9ms | **46x** less read |
| 152-span trace (heavy attrs) | 152 | 25.9MB / 41ms | 118KB / 9ms | **225x** less read |

### CloudWatch evidence (before)

```
[125x] avg=29ms/4.2MB max=100ms/9.1MB  params=['tenantId', 'traceId']
[115x] avg=25ms/4.2MB max=75ms/9.2MB   params=['tenantId', 'traceIds']
```

## Test plan

- [x] All 16 `trace-dedup-oom-safety.unit.test.ts` tests pass (4 new)
- [ ] Verify read_bytes drops in CloudWatch after deploy