### PR TITLE
perf: eliminate duplicate spans query in trace details drawer

### DIFF
--- a/langwatch/src/components/traces/SequenceDiagram.tsx
+++ b/langwatch/src/components/traces/SequenceDiagram.tsx
@@ -7,10 +7,10 @@ import {
 } from "@chakra-ui/react";
 import { intervalToDuration } from "date-fns";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+
 import { useTraceDetailsState } from "../../hooks/useTraceDetailsState";
 import type { Span, SpanTypes } from "../../server/tracer/types";
-import { api } from "../../utils/api";
+
 import { useColorMode } from "../ui/color-mode";
 import { Select } from "../ui/select";
 
@@ -609,29 +609,21 @@ const countParticipants = (
  * Single Responsibility: Manage data fetching and state for the sequence diagram
  */
 export function SequenceDiagramContainer(props: SequenceDiagramProps) {
-  const { traceId, trace } = useTraceDetailsState(props.traceId);
-  const { project } = useOrganizationTeamProject();
+  const { trace } = useTraceDetailsState(props.traceId);
   const [selectedSpanTypes, setSelectedSpanTypes] = useState<SpanTypes[]>(
     defaultSelectedSpanTypes,
   );
 
-  const [keepRefetching, setKeepRefetching] = useState(false);
-  const spans = api.spans.getAllForTrace.useQuery(
-    { projectId: project?.id ?? "", traceId: traceId ?? "" },
-    {
-      enabled: !!project && !!traceId,
-      refetchOnWindowFocus: false,
-      refetchInterval: keepRefetching ? 1_000 : undefined,
-    },
-  );
+  // Use spans from trace.data directly — avoids a duplicate ClickHouse query.
+  const spans = trace.data?.spans;
 
   // Auto-include "span" types if there are too few participants
   useEffect(() => {
-    if (!spans.data || spans.data.length === 0) return;
+    if (!spans || spans.length === 0) return;
 
     // Count participants with default selection (without "span")
     const participantCount = countParticipants(
-      spans.data,
+      spans,
       defaultSelectedSpanTypes,
     );
 
@@ -639,21 +631,9 @@ export function SequenceDiagramContainer(props: SequenceDiagramProps) {
     if (participantCount <= 2 && !selectedSpanTypes.includes("span")) {
       setSelectedSpanTypes([...defaultSelectedSpanTypes, "span"]);
     }
-  }, [spans.data]);
+  }, [spans]);
 
-  useEffect(() => {
-    if ((trace.data?.timestamps.inserted_at ?? 0) < Date.now() - 10 * 1000) {
-      return;
-    }
-
-    setKeepRefetching(true);
-    const timeout = setTimeout(() => {
-      setKeepRefetching(false);
-    }, 10_000);
-    return () => clearTimeout(timeout);
-  }, [trace.data?.timestamps.inserted_at]);
-
-  if (!trace.data || !spans.data) {
+  if (!trace.data || !spans) {
     return null;
   }
 
@@ -691,7 +671,7 @@ export function SequenceDiagramContainer(props: SequenceDiagramProps) {
       </Select.Root>
 
       <SequenceDiagram
-        spans={spans.data}
+        spans={spans}
         selectedSpanTypes={selectedSpanTypes}
       />
     </VStack>

--- a/langwatch/src/components/traces/SpanTree.tsx
+++ b/langwatch/src/components/traces/SpanTree.tsx
@@ -1,12 +1,12 @@
 import { Alert, Box, HStack, Text, VStack } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import numeral from "numeral";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { useTraceDetailsState } from "../../hooks/useTraceDetailsState";
 import { useTraceUpdateListener } from "../../hooks/useTraceUpdateListener";
 import type { Span } from "../../server/tracer/types";
-import { api } from "../../utils/api";
+
 import {
   CheckStatusIcon,
   evaluationStatusColor,
@@ -266,60 +266,54 @@ export function SpanTree(props: SpanTreeProps) {
   const router = useRouter();
   const { project } = useOrganizationTeamProject();
 
-  const [keepRefetching, setKeepRefetching] = useState(false);
-  const spans = api.spans.getAllForTrace.useQuery(
-    { projectId: project?.id ?? "", traceId: traceId ?? "" },
-    {
-      enabled: !!project && !!traceId,
-      refetchOnWindowFocus: false,
-      refetchInterval: keepRefetching ? 5_000 : undefined,
-    },
-  );
-
-  useEffect(() => {
-    if ((trace.data?.timestamps.inserted_at ?? 0) < Date.now() - 10 * 1000) {
-      return;
-    }
-
-    setKeepRefetching(true);
-    const timeout = setTimeout(() => {
-      setKeepRefetching(false);
-    }, 10_000);
-    return () => clearTimeout(timeout);
-  }, [trace.data?.timestamps.inserted_at]);
+  // Use spans from trace.data directly — avoids a duplicate ClickHouse query.
+  // traces.getById already fetches spans via getTracesWithSpans.
+  const sortedSpans = useMemo(() => {
+    if (!trace.data?.spans) return undefined;
+    return [...trace.data.spans].sort((a, b) => {
+      const startDiff =
+        (a.timestamps?.started_at ?? 0) - (b.timestamps?.started_at ?? 0);
+      if (startDiff === 0) {
+        return (
+          (b.timestamps?.finished_at ?? 0) - (a.timestamps?.finished_at ?? 0)
+        );
+      }
+      return startDiff;
+    });
+  }, [trace.data?.spans]);
 
   useTraceUpdateListener({
     projectId: project?.id ?? "",
     traceId,
-    onSpanStored: (_traceIds) => void spans.refetch(),
+    onSpanStored: (_traceIds) => void trace.refetch(),
     onTraceSummaryUpdated: (_traceIds) => void trace.refetch(),
     enabled: !!project && !!traceId,
   });
 
   const span = spanId
-    ? spans.data?.find((span) => span.span_id === spanId)
-    : spans.data?.[0];
+    ? sortedSpans?.find((span) => span.span_id === spanId)
+    : sortedSpans?.[0];
 
   useEffect(() => {
     if (
       (!spanId || spanId !== span?.span_id) &&
       project &&
       traceId &&
-      spans.data &&
-      spans.data[0]
+      sortedSpans &&
+      sortedSpans[0]
     ) {
       void router.replace(
         {
           query: {
             ...router.query,
-            span: spans.data[0].span_id,
+            span: sortedSpans[0].span_id,
           },
         },
         undefined,
         { shallow: true },
       );
     }
-  }, [project, router, span?.span_id, spanId, spans.data, traceId]);
+  }, [project, router, span?.span_id, spanId, sortedSpans, traceId]);
 
   if (!trace.data) {
     return null;
@@ -327,7 +321,7 @@ export function SpanTree(props: SpanTreeProps) {
 
   return (
     <VStack width="full">
-      {spans.data ? (
+      {sortedSpans ? (
         <HStack
           align="start"
           width="full"
@@ -335,16 +329,16 @@ export function SpanTree(props: SpanTreeProps) {
           paddingX={6}
           flexDirection={{ base: "column", xl: "row" }}
         >
-          <TreeRenderer spans={spans.data} />
+          <TreeRenderer spans={sortedSpans} />
           {project && span && (
             <SpanDetails
               project={project}
               span={span}
-              allSpans={spans.data}
+              allSpans={sortedSpans}
             />
           )}
         </HStack>
-      ) : spans.isError ? (
+      ) : trace.isError ? (
         <Alert.Root status="error">
           <Alert.Indicator />
           <Alert.Content>


### PR DESCRIPTION
## Summary

- Remove separate `spans.getAllForTrace` tRPC call from `SpanTree` and `SequenceDiagramContainer`
- Both components now use `trace.data.spans` from the already-fetched `traces.getById` response
- Net deletion: 26 lines removed

### Why

When opening the trace details drawer, two tRPC queries fired in a batch:
1. `traces.getById` → calls `clickHouseService.getTracesWithSpans` → returns trace **with spans**
2. `spans.getAllForTrace` → calls `traceService.getTracesWithSpans` → returns the **same spans**

Both endpoints execute the exact same ClickHouse query under the hood, doubling the load on every drawer open. For traces with heavy spans (large SpanAttributes), this was reading 4-10MB twice.

### What changed

- **`SpanTree`**: Uses `trace.data.spans` (sorted via `useMemo`) instead of a separate query. The `useTraceUpdateListener` now refetches `trace` on both `onSpanStored` and `onTraceSummaryUpdated` events.
- **`SequenceDiagramContainer`**: Uses `trace.data.spans` directly. Removed the `keepRefetching` polling (trace already handles refetch for recent traces via `useTraceDetailsState`).

## Test plan

- [ ] Open trace details drawer — SpanTree and SequenceDiagram render correctly
- [ ] Verify only one `traces.getById` call fires (no `spans.getAllForTrace`)
- [ ] Click different spans in the tree — selection works
- [ ] Open a freshly-created trace — spans appear after refetch