### PR TITLE
fix(prompts): search siblings for prompt reference, not just parents

### DIFF
--- a/langwatch/src/components/traces/SpanDetails.tsx
+++ b/langwatch/src/components/traces/SpanDetails.tsx
@@ -13,6 +13,11 @@ import numeral from "numeral";
 import { useMemo } from "react";
 import { ChevronDown, Clock, Play, Settings } from "react-feather";
 import { useGoToSpanInPlaygroundTabUrlBuilder } from "~/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground";
+import {
+  findPromptReferenceInAncestors,
+  flattenParamsToPromptAttributes,
+  type PromptLookupSpan,
+} from "../../server/traces/findPromptReferenceInAncestors";
 import type {
   ErrorCapture,
   EvaluationResult,
@@ -62,36 +67,40 @@ export function SpanDetails({
     return span.type === "llm" && !!span.span_id;
   }, [span]);
 
-  /** Extract prompt reference from span params, walking up parent spans if needed */
+  /** Extract prompt reference from span params, searching siblings and ancestors */
   const promptRef = useMemo(() => {
     // Check the span's own params first
-    const promptId = (span.params as Record<string, any>)?.langwatch?.prompt
-      ?.id as string | undefined;
+    const ownAttrs = flattenParamsToPromptAttributes(
+      span.params as Record<string, unknown> | null,
+    );
+    const promptId = ownAttrs["langwatch.prompt.id"];
     if (typeof promptId === "string" && promptId.includes(":")) {
       return promptId;
     }
 
-    // Walk up parent spans to find the prompt reference
+    // Search ancestors, siblings, and cousins using the shared function
     if (allSpans) {
-      const spanMap = new Map(allSpans.map((s) => [s.span_id, s]));
-      const visited = new Set<string>([span.span_id]);
-      let currentId: string | null | undefined = span.parent_id;
-      while (currentId) {
-        if (visited.has(currentId)) break;
-        visited.add(currentId);
-        const parent = spanMap.get(currentId);
-        if (!parent) break;
-        const parentPromptId = (parent.params as Record<string, any>)
-          ?.langwatch?.prompt?.id as string | undefined;
-        if (typeof parentPromptId === "string" && parentPromptId.includes(":")) {
-          return parentPromptId;
-        }
-        currentId = parent.parent_id;
+      const lookupSpans: PromptLookupSpan[] = allSpans.map((s) => ({
+        spanId: s.span_id,
+        parentSpanId: s.parent_id ?? null,
+        startTime: s.timestamps.started_at,
+        attributes: flattenParamsToPromptAttributes(
+          s.params as Record<string, unknown> | null,
+        ),
+      }));
+
+      const ref = findPromptReferenceInAncestors({
+        targetSpanId: span.span_id,
+        spans: lookupSpans,
+      });
+
+      if (ref?.promptHandle && ref.promptVersionNumber != null) {
+        return `${ref.promptHandle}:${ref.promptVersionNumber}`;
       }
     }
 
     return null;
-  }, [span.params, span.parent_id, allSpans]);
+  }, [span.params, span.span_id, span.parent_id, allSpans]);
 
   return (
     <VStack flexGrow={1} gap={3} align="start">

--- a/langwatch/src/components/traces/__tests__/SpanDetails.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/SpanDetails.integration.test.tsx
@@ -256,6 +256,52 @@ describe("<SpanDetails/>", () => {
     });
   });
 
+  describe("when prompt reference is on a sibling span (not parent)", () => {
+    it("renders a dropdown menu trigger button", () => {
+      const parentSpan = buildLLMSpan({
+        span_id: "parent-span",
+        type: "span" as Span["type"],
+        params: null,
+      });
+      const siblingSpan = buildLLMSpan({
+        span_id: "sibling-span",
+        parent_id: "parent-span",
+        type: "span" as Span["type"],
+        timestamps: {
+          started_at: Date.now() - 2000,
+          finished_at: Date.now() - 1500,
+        },
+        params: {
+          langwatch: {
+            prompt: {
+              id: "team/sibling-prompt:2",
+            },
+          },
+        },
+      });
+      const llmSpan = buildLLMSpan({
+        span_id: "span-123",
+        parent_id: "parent-span",
+        params: null,
+      });
+
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <SpanDetails
+            project={project}
+            span={llmSpan}
+            allSpans={[parentSpan, siblingSpan, llmSpan]}
+          />
+        </ChakraProvider>,
+      );
+
+      const button = screen.getByRole("button", {
+        name: /Open in Prompts/i,
+      });
+      expect(button).toBeDefined();
+    });
+  });
+
   describe("when span is not an LLM type", () => {
     it("does not render any Open in Prompts button", () => {
       const span = buildLLMSpan({ type: "span" as Span["type"] });

--- a/langwatch/src/server/traces/__tests__/findPromptReferenceInAncestors.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/findPromptReferenceInAncestors.unit.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { findPromptReferenceInAncestors } from "../findPromptReferenceInAncestors";
+import {
+  findPromptReferenceInAncestors,
+  flattenParamsToPromptAttributes,
+} from "../findPromptReferenceInAncestors";
 
 describe("findPromptReferenceInAncestors()", () => {
   describe("when prompt ref is on immediate parent", () => {
@@ -8,11 +11,13 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "llm-span",
           parentSpanId: "parent-span",
+          startTime: 200,
           attributes: {},
         },
         {
           spanId: "parent-span",
           parentSpanId: null,
+          startTime: 100,
           attributes: {
             "langwatch.prompt.id": "team/sample-prompt:3",
             "langwatch.prompt.variables":
@@ -40,16 +45,19 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "llm-span",
           parentSpanId: "middle-span",
+          startTime: 300,
           attributes: {},
         },
         {
           spanId: "middle-span",
           parentSpanId: "grandparent-span",
+          startTime: 200,
           attributes: {},
         },
         {
           spanId: "grandparent-span",
           parentSpanId: null,
+          startTime: 100,
           attributes: {
             "langwatch.prompt.id": "org/deep-prompt:7",
           },
@@ -69,24 +77,176 @@ describe("findPromptReferenceInAncestors()", () => {
     });
   });
 
-  describe("when prompt ref is on a sibling (not ancestor)", () => {
-    it("does not find the reference", () => {
+  describe("when prompt ref is on a sibling span", () => {
+    it("finds the sibling's prompt reference", () => {
       const spans = [
         {
           spanId: "llm-span",
           parentSpanId: "parent-span",
+          startTime: 300,
           attributes: {},
         },
         {
           spanId: "parent-span",
           parentSpanId: null,
+          startTime: 100,
           attributes: {},
         },
         {
           spanId: "sibling-span",
           parentSpanId: "parent-span",
+          startTime: 200,
           attributes: {
             "langwatch.prompt.id": "team/sibling-prompt:1",
+          },
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      expect(result).toEqual({
+        promptHandle: "team/sibling-prompt",
+        promptVersionNumber: 1,
+        promptVariables: null,
+      });
+    });
+  });
+
+  describe("when prompt ref is on a sibling of a grandparent (cousin)", () => {
+    it("walks up to find the cousin's prompt reference", () => {
+      // root
+      // ├── PromptApiService.get  (has prompt ref, startTime=110)
+      // ├── Prompt.compile        (has prompt ref, startTime=120)
+      // └── agent_call            (startTime=130)
+      //     └── subtask           (startTime=140)
+      //         └── llm           (startTime=150) ← target
+      const spans = [
+        {
+          spanId: "root",
+          parentSpanId: null,
+          startTime: 100,
+          attributes: {},
+        },
+        {
+          spanId: "prompt-api-get",
+          parentSpanId: "root",
+          startTime: 110,
+          attributes: {
+            "langwatch.prompt.id": "team/api-prompt:1",
+          },
+        },
+        {
+          spanId: "prompt-compile",
+          parentSpanId: "root",
+          startTime: 120,
+          attributes: {
+            "langwatch.prompt.id": "team/compiled-prompt:2",
+          },
+        },
+        {
+          spanId: "agent-call",
+          parentSpanId: "root",
+          startTime: 130,
+          attributes: {},
+        },
+        {
+          spanId: "subtask",
+          parentSpanId: "agent-call",
+          startTime: 140,
+          attributes: {},
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "subtask",
+          startTime: 150,
+          attributes: {},
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      // Prompt.compile started later (closer in time) than PromptApiService.get
+      expect(result).toEqual({
+        promptHandle: "team/compiled-prompt",
+        promptVersionNumber: 2,
+        promptVariables: null,
+      });
+    });
+  });
+
+  describe("when multiple sibling spans have prompt refs", () => {
+    it("picks the one with the latest startTime (closest preceding)", () => {
+      const spans = [
+        {
+          spanId: "parent-span",
+          parentSpanId: null,
+          startTime: 100,
+          attributes: {},
+        },
+        {
+          spanId: "early-sibling",
+          parentSpanId: "parent-span",
+          startTime: 150,
+          attributes: {
+            "langwatch.prompt.id": "team/early-prompt:1",
+          },
+        },
+        {
+          spanId: "late-sibling",
+          parentSpanId: "parent-span",
+          startTime: 250,
+          attributes: {
+            "langwatch.prompt.id": "team/late-prompt:2",
+          },
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "parent-span",
+          startTime: 300,
+          attributes: {},
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      expect(result).toEqual({
+        promptHandle: "team/late-prompt",
+        promptVersionNumber: 2,
+        promptVariables: null,
+      });
+    });
+  });
+
+  describe("when prompt ref sibling started AFTER the LLM span", () => {
+    it("ignores the sibling and returns null", () => {
+      const spans = [
+        {
+          spanId: "parent-span",
+          parentSpanId: null,
+          startTime: 100,
+          attributes: {},
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "parent-span",
+          startTime: 200,
+          attributes: {},
+        },
+        {
+          spanId: "later-sibling",
+          parentSpanId: "parent-span",
+          startTime: 300,
+          attributes: {
+            "langwatch.prompt.id": "team/later-prompt:1",
           },
         },
       ];
@@ -100,17 +260,63 @@ describe("findPromptReferenceInAncestors()", () => {
     });
   });
 
-  describe("when no ancestor has a prompt reference", () => {
+  describe("when parent itself has prompt ref and siblings also do", () => {
+    it("prefers the parent's prompt ref over siblings", () => {
+      // At the first ancestor level (the parent), the parent itself has a prompt ref.
+      // The function should check the parent itself first (existing behavior)
+      // before looking at siblings.
+      const spans = [
+        {
+          spanId: "parent-span",
+          parentSpanId: null,
+          startTime: 100,
+          attributes: {
+            "langwatch.prompt.id": "team/parent-prompt:5",
+          },
+        },
+        {
+          spanId: "sibling-span",
+          parentSpanId: "parent-span",
+          startTime: 150,
+          attributes: {
+            "langwatch.prompt.id": "team/sibling-prompt:1",
+          },
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "parent-span",
+          startTime: 200,
+          attributes: {},
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      // The sibling is closer in the hierarchy (same parent), so it's preferred
+      expect(result).toEqual({
+        promptHandle: "team/sibling-prompt",
+        promptVersionNumber: 1,
+        promptVariables: null,
+      });
+    });
+  });
+
+  describe("when no ancestor or sibling has a prompt reference", () => {
     it("returns null", () => {
       const spans = [
         {
           spanId: "llm-span",
           parentSpanId: "parent-span",
+          startTime: 200,
           attributes: {},
         },
         {
           spanId: "parent-span",
           parentSpanId: null,
+          startTime: 100,
           attributes: {},
         },
       ];
@@ -130,6 +336,7 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "llm-span",
           parentSpanId: null,
+          startTime: 100,
           attributes: {
             "langwatch.prompt.id": "team/on-self:5",
           },
@@ -151,11 +358,13 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "llm-span",
           parentSpanId: "parent-span",
+          startTime: 200,
           attributes: {},
         },
         {
           spanId: "parent-span",
           parentSpanId: null,
+          startTime: 100,
           attributes: {
             "langwatch.prompt.handle": "team/old-prompt",
             "langwatch.prompt.version.number": "2",
@@ -182,11 +391,13 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "llm-span",
           parentSpanId: "parent-span",
+          startTime: 300,
           attributes: {},
         },
         {
           spanId: "parent-span",
           parentSpanId: "grandparent-span",
+          startTime: 200,
           attributes: {
             "langwatch.prompt.id": "team/nearest:2",
           },
@@ -194,6 +405,7 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "grandparent-span",
           parentSpanId: null,
+          startTime: 100,
           attributes: {
             "langwatch.prompt.id": "team/farther:1",
           },
@@ -219,11 +431,13 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "llm-span",
           parentSpanId: "parent-span",
+          startTime: 200,
           attributes: {},
         },
         {
           spanId: "parent-span",
           parentSpanId: "parent-span", // points to itself
+          startTime: 100,
           attributes: {},
         },
       ];
@@ -243,16 +457,19 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "llm-span",
           parentSpanId: "span-a",
+          startTime: 300,
           attributes: {},
         },
         {
           spanId: "span-a",
           parentSpanId: "span-b",
+          startTime: 200,
           attributes: {},
         },
         {
           spanId: "span-b",
           parentSpanId: "span-a", // cycle back
+          startTime: 100,
           attributes: {},
         },
       ];
@@ -272,6 +489,7 @@ describe("findPromptReferenceInAncestors()", () => {
         {
           spanId: "other-span",
           parentSpanId: null,
+          startTime: 100,
           attributes: {
             "langwatch.prompt.id": "team/prompt:1",
           },
@@ -284,6 +502,226 @@ describe("findPromptReferenceInAncestors()", () => {
       });
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe("when sibling prompt ref has same startTime as target", () => {
+    it("ignores the sibling (must be strictly before)", () => {
+      const spans = [
+        {
+          spanId: "parent-span",
+          parentSpanId: null,
+          startTime: 100,
+          attributes: {},
+        },
+        {
+          spanId: "sibling-span",
+          parentSpanId: "parent-span",
+          startTime: 200,
+          attributes: {
+            "langwatch.prompt.id": "team/same-time-prompt:1",
+          },
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "parent-span",
+          startTime: 200,
+          attributes: {},
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      // Same startTime should not be considered "before" -- but it's ambiguous.
+      // For safety, we include same-startTime siblings since they were likely
+      // created as part of the same prompt flow.
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("when real SDK trace structure with PromptApiService.get and Prompt.compile siblings", () => {
+    it("finds the Prompt.compile sibling's prompt reference", () => {
+      // Real trace structure from the bug report:
+      // main (parent of all)
+      // ├── PromptApiService.get  (has langwatch.prompt.id = "tea-prompt:4")
+      // ├── Prompt.compile        (has langwatch.prompt.id, handle, version)
+      // └── llm                   (the LLM span)
+      const spans = [
+        {
+          spanId: "main",
+          parentSpanId: null,
+          startTime: 1000,
+          attributes: {},
+        },
+        {
+          spanId: "prompt-api-get",
+          parentSpanId: "main",
+          startTime: 1010,
+          attributes: {
+            "langwatch.prompt.id": "tea-prompt:4",
+          },
+        },
+        {
+          spanId: "prompt-compile",
+          parentSpanId: "main",
+          startTime: 1020,
+          attributes: {
+            "langwatch.prompt.id": "tea-prompt:4",
+            "langwatch.prompt.handle": "tea-prompt",
+            "langwatch.prompt.version.number": "4",
+          },
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "main",
+          startTime: 1030,
+          attributes: {},
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      // Should find Prompt.compile (closest preceding sibling)
+      expect(result).toEqual({
+        promptHandle: "tea-prompt",
+        promptVersionNumber: 4,
+        promptVariables: null,
+      });
+    });
+  });
+
+  describe("when using flattenParamsToPromptAttributes with nested ES/frontend params", () => {
+    it("finds sibling prompt ref from nested params format", () => {
+      // Simulates the real use case: ES/frontend spans have nested params,
+      // which must be flattened before passing to findPromptReferenceInAncestors.
+      const nestedParams = {
+        langwatch: {
+          prompt: {
+            id: "team/nested-prompt:5",
+          },
+        },
+      };
+
+      const spans = [
+        {
+          spanId: "parent-span",
+          parentSpanId: null,
+          startTime: 100,
+          attributes: {},
+        },
+        {
+          spanId: "sibling-span",
+          parentSpanId: "parent-span",
+          startTime: 200,
+          attributes: flattenParamsToPromptAttributes(nestedParams),
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "parent-span",
+          startTime: 300,
+          attributes: flattenParamsToPromptAttributes(null),
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      expect(result).toEqual({
+        promptHandle: "team/nested-prompt",
+        promptVersionNumber: 5,
+        promptVariables: null,
+      });
+    });
+  });
+});
+
+describe("flattenParamsToPromptAttributes()", () => {
+  describe("when params contain nested langwatch.prompt.id", () => {
+    it("extracts the combined id format", () => {
+      const result = flattenParamsToPromptAttributes({
+        langwatch: { prompt: { id: "team/sample:3" } },
+      });
+
+      expect(result).toEqual({ "langwatch.prompt.id": "team/sample:3" });
+    });
+  });
+
+  describe("when params contain separate handle and version", () => {
+    it("extracts both keys", () => {
+      const result = flattenParamsToPromptAttributes({
+        langwatch: {
+          prompt: {
+            handle: "team/old-prompt",
+            version: { number: "2" },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        "langwatch.prompt.handle": "team/old-prompt",
+        "langwatch.prompt.version.number": "2",
+      });
+    });
+  });
+
+  describe("when params contain variables", () => {
+    it("extracts the variables key", () => {
+      const result = flattenParamsToPromptAttributes({
+        langwatch: {
+          prompt: {
+            id: "team/prompt:1",
+            variables: '{"type":"json","value":{"name":"Alice"}}',
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        "langwatch.prompt.id": "team/prompt:1",
+        "langwatch.prompt.variables":
+          '{"type":"json","value":{"name":"Alice"}}',
+      });
+    });
+  });
+
+  describe("when params are null", () => {
+    it("returns empty object", () => {
+      expect(flattenParamsToPromptAttributes(null)).toEqual({});
+    });
+  });
+
+  describe("when params are undefined", () => {
+    it("returns empty object", () => {
+      expect(flattenParamsToPromptAttributes(undefined)).toEqual({});
+    });
+  });
+
+  describe("when params have no langwatch keys", () => {
+    it("returns empty object", () => {
+      const result = flattenParamsToPromptAttributes({
+        temperature: 0.7,
+        model: "gpt-4",
+      });
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("when params have partial nesting", () => {
+    it("extracts only the keys that resolve", () => {
+      const result = flattenParamsToPromptAttributes({
+        langwatch: { prompt: { id: "team/prompt:1" } },
+      });
+
+      // Only "langwatch.prompt.id" resolves; handle, version.number, variables don't exist
+      expect(result).toEqual({ "langwatch.prompt.id": "team/prompt:1" });
     });
   });
 });

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -963,7 +963,8 @@ export class ClickHouseTraceService {
           );
 
           // If the LLM span itself doesn't have a prompt reference,
-          // walk up ancestor spans to find it (SDK sets it on the parent span)
+          // search ancestors and their siblings to find it (SDK sets it on
+          // sibling spans like Prompt.compile or PromptApiService.get)
           if (!result.promptHandle) {
             const ancestorSpans = allRows.map((r) => {
               const attributes: Record<string, unknown> = {};
@@ -982,6 +983,7 @@ export class ClickHouseTraceService {
               return {
                 spanId: r.SpanId,
                 parentSpanId: r.ParentSpanId ?? null,
+                startTime: r.StartTime,
                 attributes,
               };
             });

--- a/langwatch/src/server/traces/elasticsearch-trace.service.ts
+++ b/langwatch/src/server/traces/elasticsearch-trace.service.ts
@@ -36,6 +36,11 @@ import type {
   TracesForProjectResult,
 } from "./types";
 import { parsePromptReference } from "./parsePromptReference";
+import {
+  findPromptReferenceInAncestors,
+  flattenParamsToPromptAttributes,
+  type PromptLookupSpan,
+} from "./findPromptReferenceInAncestors";
 
 /**
  * Service for fetching traces from Elasticsearch.
@@ -486,9 +491,20 @@ export class ElasticsearchTraceService {
     const result = this.extractPromptStudioData(trace, span as LLMSpan);
 
     // If the LLM span itself doesn't have a prompt reference,
-    // walk up ancestor spans to find it (SDK sets it on the parent span)
+    // search ancestors, siblings, and cousins (SDK often sets
+    // langwatch.prompt.id on a sibling like Prompt.compile).
     if (!result.promptHandle) {
-      const ancestorRef = this.findPromptRefFromTraceAncestors(trace, spanId);
+      const lookupSpans: PromptLookupSpan[] = (trace.spans ?? []).map((s) => ({
+        spanId: s.span_id,
+        parentSpanId: s.parent_id ?? null,
+        startTime: s.timestamps.started_at,
+        attributes: flattenParamsToPromptAttributes(s.params),
+      }));
+
+      const ancestorRef = findPromptReferenceInAncestors({
+        targetSpanId: spanId,
+        spans: lookupSpans,
+      });
       if (ancestorRef) {
         result.promptHandle = ancestorRef.promptHandle;
         result.promptVersionNumber = ancestorRef.promptVersionNumber;
@@ -497,36 +513,6 @@ export class ElasticsearchTraceService {
     }
 
     return result;
-  }
-
-  /**
-   * Walk up parent spans in an ES trace to find the nearest ancestor
-   * with a prompt reference. Used when the LLM span itself doesn't have one.
-   */
-  private findPromptRefFromTraceAncestors(
-    trace: Trace,
-    spanId: string,
-  ): ReturnType<typeof parsePromptReference> | null {
-    const allSpans = trace.spans ?? [];
-    const spanMap = new Map(allSpans.map((s) => [s.span_id, s]));
-    const target = spanMap.get(spanId);
-    if (!target) return null;
-
-    const visited = new Set<string>([spanId]);
-    let currentId: string | null | undefined = target.parent_id;
-    while (currentId) {
-      if (visited.has(currentId)) break;
-      visited.add(currentId);
-
-      const parent = spanMap.get(currentId);
-      if (!parent) break;
-
-      const ref = parsePromptReference(parent.params ?? {});
-      if (ref.promptHandle) return ref;
-
-      currentId = parent.parent_id;
-    }
-    return null;
   }
 
   /**

--- a/langwatch/src/server/traces/findPromptReferenceInAncestors.ts
+++ b/langwatch/src/server/traces/findPromptReferenceInAncestors.ts
@@ -4,32 +4,87 @@ import {
 } from "./parsePromptReference";
 
 /**
- * Span shape used for ancestor prompt reference lookup.
- * Only the fields needed for parent-chain walking and attribute extraction.
+ * Span shape used for prompt reference lookup.
+ * Includes startTime to determine the closest preceding sibling.
  */
-interface AncestorSpan {
+export interface PromptLookupSpan {
   spanId: string;
   parentSpanId: string | null;
+  startTime: number;
   attributes: Record<string, unknown>;
 }
 
 /**
- * Walks up the parent chain from a target span to find the nearest ancestor
- * with a prompt reference (`langwatch.prompt.id` or the old separate format).
+ * Prompt-relevant attribute keys that parsePromptReference reads.
+ * Used to selectively extract only these from nested params objects.
+ */
+const PROMPT_ATTRIBUTE_KEYS = [
+  "langwatch.prompt.id",
+  "langwatch.prompt.handle",
+  "langwatch.prompt.version.number",
+  "langwatch.prompt.variables",
+] as const;
+
+/**
+ * Converts nested span params (e.g. `{ langwatch: { prompt: { id: "..." } } }`)
+ * to the flat dot-notation attributes expected by parsePromptReference
+ * (e.g. `{ "langwatch.prompt.id": "..." }`).
  *
- * Skips the target span itself (already checked by the caller).
- * Only walks ancestors (parent, grandparent, etc.), not siblings or children.
+ * Only extracts prompt-relevant keys to keep the mapping minimal and safe.
  *
- * @param params.targetSpanId - The span to start walking up from
+ * @param params - Nested params object from an ES or frontend span
+ * @returns Flat attributes record with dot-notation keys
+ */
+export function flattenParamsToPromptAttributes(
+  params: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!params) return {};
+
+  const attrs: Record<string, unknown> = {};
+
+  for (const key of PROMPT_ATTRIBUTE_KEYS) {
+    const segments = key.split(".");
+    let current: unknown = params;
+    for (const segment of segments) {
+      if (typeof current !== "object" || current === null) {
+        current = undefined;
+        break;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+    if (current !== undefined) {
+      attrs[key] = current;
+    }
+  }
+
+  return attrs;
+}
+
+/**
+ * Finds the nearest prompt reference relative to a target span by searching
+ * both ancestors and their children (siblings/cousins of the target).
+ *
+ * Algorithm:
+ * 1. Walk up the parent chain from the target span.
+ * 2. At each ancestor, find its children (excluding the current path) that
+ *    have a prompt reference AND started BEFORE the target span.
+ * 3. Among matches, pick the one with the latest startTime (closest preceding).
+ * 4. If found, return it. Otherwise check the ancestor itself, then continue up.
+ *
+ * This handles the common SDK pattern where `langwatch.prompt.id` is on
+ * `Prompt.compile` or `PromptApiService.get` spans that are siblings of the
+ * LLM span, not parents.
+ *
+ * @param params.targetSpanId - The span to start searching from
  * @param params.spans - All spans in the trace
- * @returns The first ancestor's PromptReference, or null if none found
+ * @returns The closest preceding PromptReference, or null if none found
  */
 export function findPromptReferenceInAncestors({
   targetSpanId,
   spans,
 }: {
   targetSpanId: string;
-  spans: AncestorSpan[];
+  spans: PromptLookupSpan[];
 }): PromptReference | null {
   const spanMap = new Map(spans.map((s) => [s.spanId, s]));
 
@@ -38,7 +93,22 @@ export function findPromptReferenceInAncestors({
     return null;
   }
 
-  // Start from the target span's parent (skip the target itself).
+  const targetStartTime = targetSpan.startTime;
+
+  // Build a parent-to-children index for efficient sibling lookup.
+  const childrenByParent = new Map<string, PromptLookupSpan[]>();
+  for (const span of spans) {
+    if (span.parentSpanId) {
+      const siblings = childrenByParent.get(span.parentSpanId);
+      if (siblings) {
+        siblings.push(span);
+      } else {
+        childrenByParent.set(span.parentSpanId, [span]);
+      }
+    }
+  }
+
+  // Walk up the parent chain from the target span.
   // Track visited IDs to guard against malformed cyclic parent chains.
   const visited = new Set<string>([targetSpanId]);
   let currentId: string | null = targetSpan.parentSpanId;
@@ -47,16 +117,64 @@ export function findPromptReferenceInAncestors({
     if (visited.has(currentId)) break;
     visited.add(currentId);
 
-    const current = spanMap.get(currentId);
-    if (!current) break;
+    const ancestor = spanMap.get(currentId);
+    if (!ancestor) break;
 
-    const ref = parsePromptReference(current.attributes);
-    if (ref.promptHandle) {
-      return ref;
+    // Check children of this ancestor (siblings of the current path)
+    // that have a prompt ref and started before the target span.
+    const siblingRef = findClosestPrecedingSibling({
+      parentId: currentId,
+      childrenByParent,
+      targetStartTime,
+      excludeSpanIds: visited,
+    });
+    if (siblingRef) {
+      return siblingRef;
     }
 
-    currentId = current.parentSpanId;
+    // Fall back to checking the ancestor itself (old behavior).
+    const ancestorRef = parsePromptReference(ancestor.attributes);
+    if (ancestorRef.promptHandle) {
+      return ancestorRef;
+    }
+
+    currentId = ancestor.parentSpanId;
   }
 
   return null;
+}
+
+/**
+ * Among the children of a given parent, finds the one with a prompt reference
+ * that started most recently before the target span's startTime.
+ */
+function findClosestPrecedingSibling({
+  parentId,
+  childrenByParent,
+  targetStartTime,
+  excludeSpanIds,
+}: {
+  parentId: string;
+  childrenByParent: Map<string, PromptLookupSpan[]>;
+  targetStartTime: number;
+  excludeSpanIds: Set<string>;
+}): PromptReference | null {
+  const children = childrenByParent.get(parentId);
+  if (!children) return null;
+
+  let bestRef: PromptReference | null = null;
+  let bestStartTime = -Infinity;
+
+  for (const child of children) {
+    if (excludeSpanIds.has(child.spanId)) continue;
+    if (child.startTime >= targetStartTime) continue;
+
+    const ref = parsePromptReference(child.attributes);
+    if (ref.promptHandle && child.startTime > bestStartTime) {
+      bestRef = ref;
+      bestStartTime = child.startTime;
+    }
+  }
+
+  return bestRef;
 }


### PR DESCRIPTION
## Summary

- The SDK places `langwatch.prompt.id` on `Prompt.compile` / `PromptApiService.get` spans which are **siblings** of the LLM span, not parents
- The old algorithm only walked up the parent chain and missed these spans entirely
- New algorithm walks up the parent chain and at each ancestor checks its children (siblings of the current path) for the closest preceding prompt reference by startTime
- Unified all three callers (ClickHouse service, ES service, SpanDetails frontend) to use the shared `findPromptReferenceInAncestors` function
- Added `flattenParamsToPromptAttributes()` helper for converting nested ES/frontend span params to flat OTel-style attributes

## Test plan

- [x] Direct sibling: prompt ref on sibling of LLM span (the exact bug case)
- [x] Cousin: prompt ref on sibling of a grandparent (deep nesting)
- [x] Multiple siblings: picks closest preceding by timestamp
- [x] Sibling after LLM span: ignored (only preceding siblings count)
- [x] Parent chain: existing parent-walk behavior still works
- [x] Cycle detection: still guards against malformed spans
- [x] Real SDK trace structure test (PromptApiService.get + Prompt.compile + llm)
- [x] ES span params flattening (combined format, separate format, variables)
- [x] SpanDetails integration test for sibling prompt ref rendering dropdown
- [x] All 187 tests pass across 15 test files