### PR TITLE
fix(experiments): deduplicate slugs to prevent unique constraint violation

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
@@ -7,18 +7,26 @@
  * an existing experiment's slug in the same project, the upsert fails with a
  * unique constraint violation on (projectId, slug).
  *
- * These tests exercise the actual database to verify the fix prevents the
- * Prisma unique constraint error at runtime.
+ * These tests exercise the actual router mutations to verify the fix prevents
+ * the Prisma unique constraint error at runtime.
  */
 import { ExperimentType } from "@prisma/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { globalForApp } from "../../../app-layer/app";
+import { createTestApp } from "../../../app-layer/presets";
+import { getTestUser } from "../../../../utils/testUtils";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
 import { prisma } from "../../../db";
 import { generateUniqueExperimentSlug } from "../experiments";
+
+globalForApp.__langwatch_app = createTestApp();
 
 describe("Feature: Experiment slug deduplication", () => {
   const projectId = "test-project-id";
   const createdExperimentIds: string[] = [];
+  let caller: ReturnType<typeof appRouter.createCaller>;
 
   /**
    * Helper to create an experiment directly in the database with a specific slug.
@@ -37,6 +45,17 @@ describe("Feature: Experiment slug deduplication", () => {
     createdExperimentIds.push(id);
     return id;
   };
+
+  beforeAll(async () => {
+    const user = await getTestUser();
+    const ctx = createInnerTRPCContext({
+      session: {
+        user: { id: user.id },
+        expires: "1",
+      },
+    });
+    caller = appRouter.createCaller(ctx);
+  });
 
   afterAll(async () => {
     if (createdExperimentIds.length > 0) {
@@ -126,58 +145,56 @@ describe("Feature: Experiment slug deduplication", () => {
         });
       });
     });
+  });
 
-    describe("given the slug conflict triggers an actual database upsert", () => {
-      it("does not throw a unique constraint violation", async () => {
-        // This is the exact scenario from issue #977:
-        // 1. Create an experiment with a known slug
-        // 2. Try to create a second experiment that would generate the same slug
-        // 3. Without the fix, this would throw P2002 (unique constraint violation)
-        const sharedSlug = `regression-977-${nanoid(6)}`;
-        const firstId = await createExperimentWithSlug(sharedSlug);
+  describe("saveEvaluationsV3 router mutation", () => {
+    describe("given an experiment exists with a specific slug", () => {
+      const sharedName = `Regression 977 ${nanoid(6)}`;
+      let firstExperimentId: string;
 
-        // Generate a unique slug for the second experiment
-        const uniqueSlug = await generateUniqueExperimentSlug({
-          baseSlug: sharedSlug,
+      beforeAll(async () => {
+        // Create the first experiment via the real router mutation
+        const result = await caller.experiments.saveEvaluationsV3({
           projectId,
-          prisma,
+          state: {
+            name: sharedName,
+            datasets: [],
+            activeDatasetId: "dummy",
+            evaluators: [],
+            targets: [],
+          },
         });
+        firstExperimentId = result.id;
+        createdExperimentIds.push(firstExperimentId);
+      });
 
-        // Now create the second experiment with the deduplicated slug
-        const secondId = `experiment_${nanoid()}`;
-        createdExperimentIds.push(secondId);
-
-        // This upsert must NOT throw a unique constraint violation
-        await expect(
-          prisma.experiment.upsert({
-            where: { id: secondId, projectId },
-            update: {
-              name: "Second Experiment",
-              slug: uniqueSlug,
-              projectId,
-              type: ExperimentType.BATCH_EVALUATION_V2,
+      describe("when a new experiment is saved with the same name", () => {
+        it("deduplicates the slug without P2002 error", async () => {
+          const result = await caller.experiments.saveEvaluationsV3({
+            projectId,
+            state: {
+              name: sharedName,
+              experimentSlug: (
+                await prisma.experiment.findUnique({
+                  where: { id: firstExperimentId, projectId },
+                })
+              )!.slug,
+              datasets: [],
+              activeDatasetId: "dummy",
+              evaluators: [],
+              targets: [],
             },
-            create: {
-              id: secondId,
-              name: "Second Experiment",
-              slug: uniqueSlug,
-              projectId,
-              type: ExperimentType.BATCH_EVALUATION_V2,
-            },
-          })
-        ).resolves.toBeDefined();
+          });
 
-        // Verify both experiments exist with different slugs
-        const first = await prisma.experiment.findUnique({
-          where: { id: firstId, projectId },
-        });
-        const second = await prisma.experiment.findUnique({
-          where: { id: secondId, projectId },
-        });
+          createdExperimentIds.push(result.id);
 
-        expect(first!.slug).toBe(sharedSlug);
-        expect(second!.slug).toBe(`${sharedSlug}-2`);
-        expect(first!.slug).not.toBe(second!.slug);
+          const first = await prisma.experiment.findUnique({
+            where: { id: firstExperimentId, projectId },
+          });
+
+          expect(result.slug).toBe(`${first!.slug}-2`);
+          expect(result.slug).not.toBe(first!.slug);
+        });
       });
     });
   });

--- a/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
@@ -19,13 +19,14 @@ import { getTestUser } from "../../../../utils/testUtils";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 import { prisma } from "../../../db";
-import { generateUniqueExperimentSlug } from "../experiments";
+import { ExperimentService } from "../../../experiments/experiment.service";
 
 globalForApp.__langwatch_app = createTestApp();
 
 describe("Feature: Experiment slug deduplication", () => {
   const projectId = "test-project-id";
   const createdExperimentIds: string[] = [];
+  const service = ExperimentService.create(prisma);
   let caller: ReturnType<typeof appRouter.createCaller>;
 
   /**
@@ -65,14 +66,13 @@ describe("Feature: Experiment slug deduplication", () => {
     }
   });
 
-  describe("generateUniqueExperimentSlug()", () => {
+  describe("ExperimentService.generateUniqueSlug()", () => {
     describe("when no conflicting slug exists", () => {
       it("returns the base slug unchanged", async () => {
         const uniqueBase = `no-conflict-${nanoid(8)}`;
-        const result = await generateUniqueExperimentSlug({
+        const result = await service.generateUniqueSlug({
           baseSlug: uniqueBase,
           projectId,
-          prisma,
         });
 
         expect(result).toBe(uniqueBase);
@@ -90,10 +90,9 @@ describe("Feature: Experiment slug deduplication", () => {
 
       describe("when a new experiment generates the same slug", () => {
         it("gets deduplicated slug with -2 suffix", async () => {
-          const result = await generateUniqueExperimentSlug({
+          const result = await service.generateUniqueSlug({
             baseSlug: existingSlug,
             projectId,
-            prisma,
           });
 
           expect(result).toBe(`${existingSlug}-2`);
@@ -102,10 +101,9 @@ describe("Feature: Experiment slug deduplication", () => {
 
       describe("when the same experiment is updated with the same slug", () => {
         it("retains the original slug unchanged", async () => {
-          const result = await generateUniqueExperimentSlug({
+          const result = await service.generateUniqueSlug({
             baseSlug: existingSlug,
             projectId,
-            prisma,
             excludeExperimentId: existingExperimentId,
           });
 
@@ -124,10 +122,9 @@ describe("Feature: Experiment slug deduplication", () => {
 
       describe("when a new experiment generates the same base slug", () => {
         it("increments to -3 suffix", async () => {
-          const result = await generateUniqueExperimentSlug({
+          const result = await service.generateUniqueSlug({
             baseSlug,
             projectId,
-            prisma,
           });
 
           expect(result).toBe(`${baseSlug}-3`);
@@ -145,10 +142,9 @@ describe("Feature: Experiment slug deduplication", () => {
       });
 
       it("does not treat the unrelated slug as a conflict", async () => {
-        const result = await generateUniqueExperimentSlug({
+        const result = await service.generateUniqueSlug({
           baseSlug,
           projectId,
-          prisma,
         });
 
         expect(result).toBe(baseSlug);

--- a/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
@@ -80,47 +80,36 @@ describe("Feature: Experiment slug deduplication", () => {
     });
 
     describe("given an experiment exists with slug 'my-experiment'", () => {
+      let existingSlug: string;
       let existingExperimentId: string;
 
       beforeAll(async () => {
-        existingExperimentId = await createExperimentWithSlug(
-          `my-experiment-${nanoid(6)}`
-        );
+        existingSlug = `my-experiment-${nanoid(6)}`;
+        existingExperimentId = await createExperimentWithSlug(existingSlug);
       });
 
       describe("when a new experiment generates the same slug", () => {
-        it("appends -2 suffix to avoid the constraint violation", async () => {
-          // Use the exact slug of the existing experiment
-          const existingExperiment = await prisma.experiment.findUnique({
-            where: { id: existingExperimentId, projectId },
-          });
-          const conflictingSlug = existingExperiment!.slug;
-
+        it("gets deduplicated slug with -2 suffix", async () => {
           const result = await generateUniqueExperimentSlug({
-            baseSlug: conflictingSlug,
+            baseSlug: existingSlug,
             projectId,
             prisma,
           });
 
-          expect(result).toBe(`${conflictingSlug}-2`);
+          expect(result).toBe(`${existingSlug}-2`);
         });
       });
 
-      describe("when updating the same experiment with the same slug", () => {
-        it("returns the base slug unchanged (excludes self)", async () => {
-          const existingExperiment = await prisma.experiment.findUnique({
-            where: { id: existingExperimentId, projectId },
-          });
-          const slug = existingExperiment!.slug;
-
+      describe("when the same experiment is updated with the same slug", () => {
+        it("retains the original slug unchanged", async () => {
           const result = await generateUniqueExperimentSlug({
-            baseSlug: slug,
+            baseSlug: existingSlug,
             projectId,
             prisma,
             excludeExperimentId: existingExperimentId,
           });
 
-          expect(result).toBe(slug);
+          expect(result).toBe(existingSlug);
         });
       });
     });
@@ -134,7 +123,7 @@ describe("Feature: Experiment slug deduplication", () => {
       });
 
       describe("when a new experiment generates the same base slug", () => {
-        it("skips to -3 suffix", async () => {
+        it("increments to -3 suffix", async () => {
           const result = await generateUniqueExperimentSlug({
             baseSlug,
             projectId,
@@ -145,15 +134,35 @@ describe("Feature: Experiment slug deduplication", () => {
         });
       });
     });
+
+    describe("when an unrelated slug shares the same prefix", () => {
+      const baseSlug = `my-exp-${nanoid(6)}`;
+
+      beforeAll(async () => {
+        // Create an unrelated experiment whose slug starts with baseSlug
+        // but is a different word (e.g., "my-exp-abc123-extended")
+        await createExperimentWithSlug(`${baseSlug}-extended`);
+      });
+
+      it("does not treat the unrelated slug as a conflict", async () => {
+        const result = await generateUniqueExperimentSlug({
+          baseSlug,
+          projectId,
+          prisma,
+        });
+
+        expect(result).toBe(baseSlug);
+      });
+    });
   });
 
-  describe("saveEvaluationsV3 router mutation", () => {
+  describe("saveEvaluationsV3()", () => {
     describe("given an experiment exists with a specific slug", () => {
       const sharedName = `Regression 977 ${nanoid(6)}`;
       let firstExperimentId: string;
+      let firstSlug: string;
 
       beforeAll(async () => {
-        // Create the first experiment via the real router mutation
         const result = await caller.experiments.saveEvaluationsV3({
           projectId,
           state: {
@@ -166,19 +175,20 @@ describe("Feature: Experiment slug deduplication", () => {
         });
         firstExperimentId = result.id;
         createdExperimentIds.push(firstExperimentId);
+
+        const experiment = await prisma.experiment.findUnique({
+          where: { id: firstExperimentId, projectId },
+        });
+        firstSlug = experiment!.slug;
       });
 
       describe("when a new experiment is saved with the same name", () => {
-        it("deduplicates the slug without P2002 error", async () => {
+        it("gets deduplicated slug without P2002 error", async () => {
           const result = await caller.experiments.saveEvaluationsV3({
             projectId,
             state: {
               name: sharedName,
-              experimentSlug: (
-                await prisma.experiment.findUnique({
-                  where: { id: firstExperimentId, projectId },
-                })
-              )!.slug,
+              experimentSlug: firstSlug,
               datasets: [],
               activeDatasetId: "dummy",
               evaluators: [],
@@ -188,12 +198,26 @@ describe("Feature: Experiment slug deduplication", () => {
 
           createdExperimentIds.push(result.id);
 
-          const first = await prisma.experiment.findUnique({
-            where: { id: firstExperimentId, projectId },
+          expect(result.slug).toBe(`${firstSlug}-2`);
+        });
+      });
+
+      describe("when the same experiment is updated with the same name", () => {
+        it("retains the original slug unchanged", async () => {
+          const result = await caller.experiments.saveEvaluationsV3({
+            projectId,
+            experimentId: firstExperimentId,
+            state: {
+              name: sharedName,
+              experimentSlug: firstSlug,
+              datasets: [],
+              activeDatasetId: "dummy",
+              evaluators: [],
+              targets: [],
+            },
           });
 
-          expect(result.slug).toBe(`${first!.slug}-2`);
-          expect(result.slug).not.toBe(first!.slug);
+          expect(result.slug).toBe(firstSlug);
         });
       });
     });

--- a/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
@@ -53,6 +53,7 @@ describe("Feature: Experiment slug deduplication", () => {
         const result = await generateUniqueExperimentSlug({
           baseSlug: uniqueBase,
           projectId,
+          prisma,
         });
 
         expect(result).toBe(uniqueBase);
@@ -79,6 +80,7 @@ describe("Feature: Experiment slug deduplication", () => {
           const result = await generateUniqueExperimentSlug({
             baseSlug: conflictingSlug,
             projectId,
+            prisma,
           });
 
           expect(result).toBe(`${conflictingSlug}-2`);
@@ -95,6 +97,7 @@ describe("Feature: Experiment slug deduplication", () => {
           const result = await generateUniqueExperimentSlug({
             baseSlug: slug,
             projectId,
+            prisma,
             excludeExperimentId: existingExperimentId,
           });
 
@@ -116,6 +119,7 @@ describe("Feature: Experiment slug deduplication", () => {
           const result = await generateUniqueExperimentSlug({
             baseSlug,
             projectId,
+            prisma,
           });
 
           expect(result).toBe(`${baseSlug}-3`);
@@ -136,6 +140,7 @@ describe("Feature: Experiment slug deduplication", () => {
         const uniqueSlug = await generateUniqueExperimentSlug({
           baseSlug: sharedSlug,
           projectId,
+          prisma,
         });
 
         // Now create the second experiment with the deduplicated slug

--- a/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
@@ -13,20 +13,19 @@
 import { ExperimentType } from "@prisma/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { globalForApp } from "../../../app-layer/app";
+import { getApp, globalForApp } from "../../../app-layer/app";
 import { createTestApp } from "../../../app-layer/presets";
 import { getTestUser } from "../../../../utils/testUtils";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
 import { prisma } from "../../../db";
-import { ExperimentService } from "../../../experiments/experiment.service";
 
 globalForApp.__langwatch_app = createTestApp();
 
 describe("Feature: Experiment slug deduplication", () => {
   const projectId = "test-project-id";
   const createdExperimentIds: string[] = [];
-  const service = ExperimentService.create(prisma);
+  const service = getApp().experiments;
   let caller: ReturnType<typeof appRouter.createCaller>;
 
   /**

--- a/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression tests for experiment slug deduplication.
+ *
+ * Issue #977: When saving an experiment, if the generated slug conflicts with
+ * an existing experiment's slug in the same project, the upsert fails with a
+ * unique constraint violation on (projectId, slug).
+ *
+ * These tests exercise the actual database to verify the fix prevents the
+ * Prisma unique constraint error at runtime.
+ */
+import { ExperimentType } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "../../../db";
+import { generateUniqueExperimentSlug } from "../experiments";
+
+describe("Feature: Experiment slug deduplication", () => {
+  const projectId = "test-project-id";
+  const createdExperimentIds: string[] = [];
+
+  /**
+   * Helper to create an experiment directly in the database with a specific slug.
+   */
+  const createExperimentWithSlug = async (slug: string) => {
+    const id = `experiment_${nanoid()}`;
+    await prisma.experiment.create({
+      data: {
+        id,
+        name: slug,
+        slug,
+        projectId,
+        type: ExperimentType.BATCH_EVALUATION_V2,
+      },
+    });
+    createdExperimentIds.push(id);
+    return id;
+  };
+
+  afterAll(async () => {
+    if (createdExperimentIds.length > 0) {
+      await prisma.experiment.deleteMany({
+        where: { id: { in: createdExperimentIds }, projectId },
+      });
+    }
+  });
+
+  describe("generateUniqueExperimentSlug()", () => {
+    describe("when no conflicting slug exists", () => {
+      it("returns the base slug unchanged", async () => {
+        const uniqueBase = `no-conflict-${nanoid(8)}`;
+        const result = await generateUniqueExperimentSlug({
+          baseSlug: uniqueBase,
+          projectId,
+        });
+
+        expect(result).toBe(uniqueBase);
+      });
+    });
+
+    describe("given an experiment exists with slug 'my-experiment'", () => {
+      let existingExperimentId: string;
+
+      beforeAll(async () => {
+        existingExperimentId = await createExperimentWithSlug(
+          `my-experiment-${nanoid(6)}`
+        );
+      });
+
+      describe("when a new experiment generates the same slug", () => {
+        it("appends -2 suffix to avoid the constraint violation", async () => {
+          // Use the exact slug of the existing experiment
+          const existingExperiment = await prisma.experiment.findUnique({
+            where: { id: existingExperimentId, projectId },
+          });
+          const conflictingSlug = existingExperiment!.slug;
+
+          const result = await generateUniqueExperimentSlug({
+            baseSlug: conflictingSlug,
+            projectId,
+          });
+
+          expect(result).toBe(`${conflictingSlug}-2`);
+        });
+      });
+
+      describe("when updating the same experiment with the same slug", () => {
+        it("returns the base slug unchanged (excludes self)", async () => {
+          const existingExperiment = await prisma.experiment.findUnique({
+            where: { id: existingExperimentId, projectId },
+          });
+          const slug = existingExperiment!.slug;
+
+          const result = await generateUniqueExperimentSlug({
+            baseSlug: slug,
+            projectId,
+            excludeExperimentId: existingExperimentId,
+          });
+
+          expect(result).toBe(slug);
+        });
+      });
+    });
+
+    describe("given experiments exist with slugs 'test-slug' and 'test-slug-2'", () => {
+      const baseSlug = `test-slug-${nanoid(6)}`;
+
+      beforeAll(async () => {
+        await createExperimentWithSlug(baseSlug);
+        await createExperimentWithSlug(`${baseSlug}-2`);
+      });
+
+      describe("when a new experiment generates the same base slug", () => {
+        it("skips to -3 suffix", async () => {
+          const result = await generateUniqueExperimentSlug({
+            baseSlug,
+            projectId,
+          });
+
+          expect(result).toBe(`${baseSlug}-3`);
+        });
+      });
+    });
+
+    describe("given the slug conflict triggers an actual database upsert", () => {
+      it("does not throw a unique constraint violation", async () => {
+        // This is the exact scenario from issue #977:
+        // 1. Create an experiment with a known slug
+        // 2. Try to create a second experiment that would generate the same slug
+        // 3. Without the fix, this would throw P2002 (unique constraint violation)
+        const sharedSlug = `regression-977-${nanoid(6)}`;
+        const firstId = await createExperimentWithSlug(sharedSlug);
+
+        // Generate a unique slug for the second experiment
+        const uniqueSlug = await generateUniqueExperimentSlug({
+          baseSlug: sharedSlug,
+          projectId,
+        });
+
+        // Now create the second experiment with the deduplicated slug
+        const secondId = `experiment_${nanoid()}`;
+        createdExperimentIds.push(secondId);
+
+        // This upsert must NOT throw a unique constraint violation
+        await expect(
+          prisma.experiment.upsert({
+            where: { id: secondId, projectId },
+            update: {
+              name: "Second Experiment",
+              slug: uniqueSlug,
+              projectId,
+              type: ExperimentType.BATCH_EVALUATION_V2,
+            },
+            create: {
+              id: secondId,
+              name: "Second Experiment",
+              slug: uniqueSlug,
+              projectId,
+              type: ExperimentType.BATCH_EVALUATION_V2,
+            },
+          })
+        ).resolves.toBeDefined();
+
+        // Verify both experiments exist with different slugs
+        const first = await prisma.experiment.findUnique({
+          where: { id: firstId, projectId },
+        });
+        const second = await prisma.experiment.findUnique({
+          where: { id: secondId, projectId },
+        });
+
+        expect(first!.slug).toBe(sharedSlug);
+        expect(second!.slug).toBe(`${sharedSlug}-2`);
+        expect(first!.slug).not.toBe(second!.slug);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiment-slug-deduplication.integration.test.ts
@@ -28,9 +28,6 @@ describe("Feature: Experiment slug deduplication", () => {
   const service = getApp().experiments;
   let caller: ReturnType<typeof appRouter.createCaller>;
 
-  /**
-   * Helper to create an experiment directly in the database with a specific slug.
-   */
   const createExperimentWithSlug = async (slug: string) => {
     const id = `experiment_${nanoid()}`;
     await prisma.experiment.create({
@@ -65,81 +62,79 @@ describe("Feature: Experiment slug deduplication", () => {
     }
   });
 
-  describe("ExperimentService.generateUniqueSlug()", () => {
-    describe("when no conflicting slug exists", () => {
-      it("returns the base slug unchanged", async () => {
-        const uniqueBase = `no-conflict-${nanoid(8)}`;
+  describe("when slug has no conflict", () => {
+    it("returns slug unchanged without a numeric suffix", async () => {
+      const uniqueBase = `no-conflict-${nanoid(8)}`;
+      const result = await service.generateUniqueSlug({
+        baseSlug: uniqueBase,
+        projectId,
+      });
+
+      expect(result).toBe(uniqueBase);
+    });
+  });
+
+  describe("given an experiment exists with slug 'my-experiment'", () => {
+    let existingSlug: string;
+    let existingExperimentId: string;
+
+    beforeAll(async () => {
+      existingSlug = `my-experiment-${nanoid(6)}`;
+      existingExperimentId = await createExperimentWithSlug(existingSlug);
+    });
+
+    describe("when a new experiment generates the same slug", () => {
+      it("gets deduplicated slug when slug conflicts with existing experiment", async () => {
         const result = await service.generateUniqueSlug({
-          baseSlug: uniqueBase,
+          baseSlug: existingSlug,
           projectId,
         });
 
-        expect(result).toBe(uniqueBase);
+        expect(result).toBe(`${existingSlug}-2`);
       });
     });
 
-    describe("given an experiment exists with slug 'my-experiment'", () => {
-      let existingSlug: string;
-      let existingExperimentId: string;
-
-      beforeAll(async () => {
-        existingSlug = `my-experiment-${nanoid(6)}`;
-        existingExperimentId = await createExperimentWithSlug(existingSlug);
-      });
-
-      describe("when a new experiment generates the same slug", () => {
-        it("gets deduplicated slug with -2 suffix", async () => {
-          const result = await service.generateUniqueSlug({
-            baseSlug: existingSlug,
-            projectId,
-          });
-
-          expect(result).toBe(`${existingSlug}-2`);
+    describe("when that same experiment is updated with the same name", () => {
+      it("does not trigger slug deduplication against itself", async () => {
+        const result = await service.generateUniqueSlug({
+          baseSlug: existingSlug,
+          projectId,
+          excludeExperimentId: existingExperimentId,
         });
-      });
 
-      describe("when the same experiment is updated with the same slug", () => {
-        it("retains the original slug unchanged", async () => {
-          const result = await service.generateUniqueSlug({
-            baseSlug: existingSlug,
-            projectId,
-            excludeExperimentId: existingExperimentId,
-          });
-
-          expect(result).toBe(existingSlug);
-        });
+        expect(result).toBe(existingSlug);
       });
     });
+  });
 
-    describe("given experiments exist with slugs 'test-slug' and 'test-slug-2'", () => {
-      const baseSlug = `test-slug-${nanoid(6)}`;
+  describe("given experiments exist with slugs 'test-slug' and 'test-slug-2'", () => {
+    const baseSlug = `test-slug-${nanoid(6)}`;
 
-      beforeAll(async () => {
-        await createExperimentWithSlug(baseSlug);
-        await createExperimentWithSlug(`${baseSlug}-2`);
-      });
-
-      describe("when a new experiment generates the same base slug", () => {
-        it("increments to -3 suffix", async () => {
-          const result = await service.generateUniqueSlug({
-            baseSlug,
-            projectId,
-          });
-
-          expect(result).toBe(`${baseSlug}-3`);
-        });
-      });
+    beforeAll(async () => {
+      await createExperimentWithSlug(baseSlug);
+      await createExperimentWithSlug(`${baseSlug}-2`);
     });
 
-    describe("when an unrelated slug shares the same prefix", () => {
-      const baseSlug = `my-exp-${nanoid(6)}`;
+    describe("when a new experiment generates the same base slug", () => {
+      it("increments the suffix to -3", async () => {
+        const result = await service.generateUniqueSlug({
+          baseSlug,
+          projectId,
+        });
 
-      beforeAll(async () => {
-        // Create an unrelated experiment whose slug starts with baseSlug
-        // but is a different word (e.g., "my-exp-abc123-extended")
-        await createExperimentWithSlug(`${baseSlug}-extended`);
+        expect(result).toBe(`${baseSlug}-3`);
       });
+    });
+  });
 
+  describe("given an unrelated experiment shares the same slug prefix", () => {
+    const baseSlug = `my-exp-${nanoid(6)}`;
+
+    beforeAll(async () => {
+      await createExperimentWithSlug(`${baseSlug}-extended`);
+    });
+
+    describe("when a new experiment generates the shorter base slug", () => {
       it("does not treat the unrelated slug as a conflict", async () => {
         const result = await service.generateUniqueSlug({
           baseSlug,

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -449,7 +449,7 @@ export const experimentsRouter = createTRPCRouter({
           })
           .catch(mapExperimentError);
       } else if (input.experimentSlug) {
-        return await experimentService
+        return await experimentService()
           .getBySlug({
             projectId: input.projectId,
             slug: input.experimentSlug,
@@ -502,13 +502,9 @@ export const experimentsRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiments = await prisma.experiment.findMany({
-        where: {
-          projectId: input.projectId,
-        },
+      return await experimentService().getAll({
+        projectId: input.projectId,
       });
-
-      return experiments;
     }),
 
   getAllForEvaluationsList: protectedProcedure
@@ -762,7 +758,7 @@ export const experimentsRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string(), experimentId: z.string() }))
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await experimentService
+      const experiment = await experimentService()
         .getById({
           projectId: input.projectId,
           id: input.experimentId,
@@ -788,7 +784,7 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await experimentService
+      const experiment = await experimentService()
         .getById({
           projectId: input.projectId,
           id: input.experimentId,

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -5,10 +5,8 @@ import {
   ExperimentType,
   type Prisma,
 } from "@prisma/client";
-import {
-  PrismaClientKnownRequestError,
-  type JsonValue,
-} from "@prisma/client/runtime/library";
+import type { JsonValue } from "@prisma/client/runtime/library";
+import { isUniqueConstraintError } from "../../utils/prismaErrors";
 import { TRPCError } from "@trpc/server";
 import type { Node } from "@xyflow/react";
 import { nanoid } from "nanoid";
@@ -174,54 +172,33 @@ export const experimentsRouter = createTRPCRouter({
       });
 
       const experimentId = input.experimentId ?? `experiment_${nanoid()}`;
-      const experimentData = {
-        name,
-        slug,
-        projectId: input.projectId,
-        type: ExperimentType.BATCH_EVALUATION_V2,
-        workflowId,
-        workbenchState: input.workbenchState,
-      };
 
-      try {
-        await prisma.experiment.upsert({
-          where: {
-            id: experimentId,
+      const { slug: finalSlug } = await withSlugConflictRetry({
+        initialSlug: slug,
+        execute: (s) => {
+          const data = {
+            name,
+            slug: s,
             projectId: input.projectId,
-          },
-          update: experimentData,
-          create: {
-            ...experimentData,
-            id: experimentId,
-          },
-        });
-      } catch (error) {
-        if (
-          error instanceof PrismaClientKnownRequestError &&
-          error.code === "P2002"
-        ) {
-          slug = await generateUniqueExperimentSlug({
+            type: ExperimentType.BATCH_EVALUATION_V2,
+            workflowId,
+            workbenchState: input.workbenchState,
+          };
+          return prisma.experiment.upsert({
+            where: { id: experimentId, projectId: input.projectId },
+            update: data,
+            create: { ...data, id: experimentId },
+          });
+        },
+        regenerateSlug: () =>
+          generateUniqueExperimentSlug({
             baseSlug: slugify(name),
             projectId: input.projectId,
             prisma,
             excludeExperimentId: input.experimentId,
-          });
-          const retryData = { ...experimentData, slug };
-          await prisma.experiment.upsert({
-            where: {
-              id: experimentId,
-              projectId: input.projectId,
-            },
-            update: retryData,
-            create: {
-              ...retryData,
-              id: experimentId,
-            },
-          });
-        } else {
-          throw error;
-        }
-      }
+          }),
+      });
+      slug = finalSlug;
 
       // For some reason, prisma upsert sometimes return not an experiment but {count: 0}, so we need to refetch it
       const updatedExperiment = await prisma.experiment.findUnique({
@@ -287,54 +264,32 @@ export const experimentsRouter = createTRPCRouter({
 
       // Convert to plain JSON for Prisma storage
       const workbenchStateJson = JSON.parse(JSON.stringify(input.state));
-      const experimentData = {
-        name,
-        slug,
-        projectId: input.projectId,
-        type: ExperimentType.EVALUATIONS_V3,
-        workbenchState: workbenchStateJson,
-      };
 
-      try {
-        await prisma.experiment.upsert({
-          where: {
-            id: experimentId,
+      const rawSlug = input.state.experimentSlug ?? experimentId.slice(-8);
+      const { slug: finalSlug } = await withSlugConflictRetry({
+        initialSlug: slug,
+        execute: (s) => {
+          const data = {
+            name,
+            slug: s,
             projectId: input.projectId,
-          },
-          update: experimentData,
-          create: {
-            ...experimentData,
-            id: experimentId,
-          },
-        });
-      } catch (error) {
-        if (
-          error instanceof PrismaClientKnownRequestError &&
-          error.code === "P2002"
-        ) {
-          const rawSlug =
-            input.state.experimentSlug ?? experimentId.slice(-8);
-          slug = await generateUniqueExperimentSlug({
+            type: ExperimentType.EVALUATIONS_V3,
+            workbenchState: workbenchStateJson,
+          };
+          return prisma.experiment.upsert({
+            where: { id: experimentId, projectId: input.projectId },
+            update: data,
+            create: { ...data, id: experimentId },
+          });
+        },
+        regenerateSlug: () =>
+          generateUniqueExperimentSlug({
             baseSlug: rawSlug,
             projectId: input.projectId,
             prisma,
-          });
-          const retryData = { ...experimentData, slug };
-          await prisma.experiment.upsert({
-            where: {
-              id: experimentId,
-              projectId: input.projectId,
-            },
-            update: retryData,
-            create: {
-              ...retryData,
-              id: experimentId,
-            },
-          });
-        } else {
-          throw error;
-        }
-      }
+          }),
+      });
+      slug = finalSlug;
 
       const updatedExperiment = await prisma.experiment.findUnique({
         where: {
@@ -1094,50 +1049,36 @@ export const experimentsRouter = createTRPCRouter({
 
       // Create new experiment with unique slug
       const experimentName = experiment.name ?? experiment.slug;
-      let newSlug = await generateUniqueExperimentSlug({
+      const initialSlug = await generateUniqueExperimentSlug({
         baseSlug: slugify(experimentName),
         projectId: input.projectId,
         prisma: ctx.prisma,
       });
 
-      const experimentCreateData = {
-        id: `experiment_${nanoid()}`,
-        name: experimentName,
-        slug: newSlug,
-        projectId: input.projectId,
-        type: experiment.type,
-        workflowId,
-        ...(experiment.workbenchState && {
-          workbenchState: experiment.workbenchState as Prisma.InputJsonValue,
-        }),
-      };
-
-      let newExperiment;
-      try {
-        newExperiment = await ctx.prisma.experiment.create({
-          data: experimentCreateData,
-        });
-      } catch (error) {
-        if (
-          error instanceof PrismaClientKnownRequestError &&
-          error.code === "P2002"
-        ) {
-          newSlug = await generateUniqueExperimentSlug({
+      const { result: newExperiment } = await withSlugConflictRetry({
+        initialSlug,
+        execute: (s) =>
+          ctx.prisma.experiment.create({
+            data: {
+              id: `experiment_${nanoid()}`,
+              name: experimentName,
+              slug: s,
+              projectId: input.projectId,
+              type: experiment.type,
+              workflowId,
+              ...(experiment.workbenchState && {
+                workbenchState:
+                  experiment.workbenchState as Prisma.InputJsonValue,
+              }),
+            },
+          }),
+        regenerateSlug: () =>
+          generateUniqueExperimentSlug({
             baseSlug: slugify(experimentName),
             projectId: input.projectId,
             prisma: ctx.prisma,
-          });
-          newExperiment = await ctx.prisma.experiment.create({
-            data: {
-              ...experimentCreateData,
-              id: `experiment_${nanoid()}`,
-              slug: newSlug,
-            },
-          });
-        } else {
-          throw error;
-        }
-      }
+          }),
+      });
 
       return { experiment: newExperiment, workflow: newWorkflow };
     }),
@@ -1263,6 +1204,10 @@ export const generateUniqueExperimentSlug = async ({
   prisma: typeof prisma;
   excludeExperimentId?: string;
 }): Promise<string> => {
+  // Fetch candidates that match the base slug or its numbered variants (baseSlug-N).
+  // We use startsWith for the DB query, then filter in-memory with a regex
+  // to avoid false positives (e.g., "my-exp" matching "my-experiment").
+  const suffixPattern = new RegExp(`^${escapeRegExpChars(baseSlug)}(-\\d+)?$`);
   const existingSlugs = new Set(
     (
       await prismaClient.experiment.findMany({
@@ -1275,7 +1220,9 @@ export const generateUniqueExperimentSlug = async ({
             : {}),
         },
       })
-    ).map((e) => e.slug),
+    )
+      .map((e) => e.slug)
+      .filter((slug) => suffixPattern.test(slug)),
   );
 
   if (!existingSlugs.has(baseSlug)) {
@@ -1292,6 +1239,37 @@ export const generateUniqueExperimentSlug = async ({
   }
 
   return `${baseSlug}-${nanoid(8)}`;
+};
+
+/** Escapes special regex characters in a string for use in `new RegExp()`. */
+const escapeRegExpChars = (str: string): string =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Wraps an experiment write operation with P2002 slug-conflict retry.
+ *
+ * If the initial write fails with a unique constraint violation (P2002),
+ * regenerates the slug and retries once. This handles the TOCTOU race
+ * between `generateUniqueExperimentSlug` and the actual insert/upsert.
+ */
+const withSlugConflictRetry = async <T>({
+  initialSlug,
+  execute,
+  regenerateSlug,
+}: {
+  initialSlug: string;
+  execute: (slug: string) => Promise<T>;
+  regenerateSlug: () => Promise<string>;
+}): Promise<{ result: T; slug: string }> => {
+  try {
+    return { result: await execute(initialSlug), slug: initialSlug };
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      const newSlug = await regenerateSlug();
+      return { result: await execute(newSlug), slug: newSlug };
+    }
+    throw error;
+  }
 };
 
 /**
@@ -1370,48 +1348,32 @@ const copyEvaluationsV3Experiment = async ({
 
   // Generate unique slug for the new experiment
   const experimentName = experiment.name ?? experiment.slug;
-  let newSlug = await generateUniqueExperimentSlug({
+  const initialSlug = await generateUniqueExperimentSlug({
     baseSlug: slugify(experimentName),
     projectId: targetProjectId,
     prisma: ctx.prisma,
   });
 
-  // Create the new experiment
-  const experimentCreateData = {
-    id: generate("eval").toString(),
-    name: experimentName,
-    slug: newSlug,
-    projectId: targetProjectId,
-    type: ExperimentType.EVALUATIONS_V3,
-    workbenchState: workbenchState as Prisma.InputJsonValue,
-  };
-
-  let newExperiment;
-  try {
-    newExperiment = await ctx.prisma.experiment.create({
-      data: experimentCreateData,
-    });
-  } catch (error) {
-    if (
-      error instanceof PrismaClientKnownRequestError &&
-      error.code === "P2002"
-    ) {
-      newSlug = await generateUniqueExperimentSlug({
+  const { result: newExperiment } = await withSlugConflictRetry({
+    initialSlug,
+    execute: (s) =>
+      ctx.prisma.experiment.create({
+        data: {
+          id: generate("eval").toString(),
+          name: experimentName,
+          slug: s,
+          projectId: targetProjectId,
+          type: ExperimentType.EVALUATIONS_V3,
+          workbenchState: workbenchState as Prisma.InputJsonValue,
+        },
+      }),
+    regenerateSlug: () =>
+      generateUniqueExperimentSlug({
         baseSlug: slugify(experimentName),
         projectId: targetProjectId,
         prisma: ctx.prisma,
-      });
-      newExperiment = await ctx.prisma.experiment.create({
-        data: {
-          ...experimentCreateData,
-          id: generate("eval").toString(),
-          slug: newSlug,
-        },
-      });
-    } else {
-      throw error;
-    }
-  }
+      }),
+  });
 
   return { experiment: newExperiment, workflow: null };
 };

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -8,7 +8,6 @@ import {
 import type { JsonValue } from "@prisma/client/runtime/library";
 import { TRPCError } from "@trpc/server";
 import { ExperimentNotFoundError } from "../../experiments/errors";
-import { ExperimentService } from "../../experiments/experiment.service";
 import type { Node } from "@xyflow/react";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -64,8 +63,8 @@ const mapExperimentError = (error: unknown): never => {
   throw error;
 };
 
-/** Module-level service for query procedures that don't have ctx.prisma. */
-const experimentService = ExperimentService.create(prisma);
+/** Experiment service from app dependency container. */
+const experimentService = () => getApp().experiments;
 
 export const experimentsRouter = createTRPCRouter({
   saveExperiment: protectedProcedure
@@ -80,7 +79,7 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:create"))
     .mutation(async ({ ctx, input }) => {
-      const experimentService = ExperimentService.create(ctx.prisma);
+      const experiments = experimentService();
 
       // Enforce experiment limit only when creating new experiments
       if (!input.experimentId) {
@@ -90,10 +89,10 @@ export const experimentsRouter = createTRPCRouter({
       let workflowId = input.dsl.workflow_id;
       const name =
         input.workbenchState.name ??
-        (await experimentService.findNextDraftName({
+        (await experiments.findNextDraftName({
           projectId: input.projectId,
         }));
-      const slug = await experimentService.generateUniqueSlug({
+      const slug = await experiments.generateUniqueSlug({
         baseSlug: slugify(name),
         projectId: input.projectId,
         excludeExperimentId: input.experimentId,
@@ -189,7 +188,7 @@ export const experimentsRouter = createTRPCRouter({
 
       const experimentId = input.experimentId ?? `experiment_${nanoid()}`;
 
-      await experimentService.saveWithSlugRetry({
+      await experiments.saveWithSlugRetry({
         initialSlug: slug,
         execute: (s) => {
           const data = {
@@ -207,7 +206,7 @@ export const experimentsRouter = createTRPCRouter({
           });
         },
         regenerateSlug: () =>
-          experimentService.generateUniqueSlug({
+          experiments.generateUniqueSlug({
             baseSlug: slugify(name),
             projectId: input.projectId,
             excludeExperimentId: input.experimentId,
@@ -242,7 +241,7 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:create"))
     .mutation(async ({ ctx, input }) => {
-      const experimentService = ExperimentService.create(ctx.prisma);
+      const experiments = experimentService();
       const experimentId =
         input.experimentId ?? generate(KSUID_RESOURCES.EXPERIMENT).toString();
 
@@ -262,14 +261,14 @@ export const experimentsRouter = createTRPCRouter({
       // For existing experiments, keep the same slug to avoid breaking URLs
       const name =
         input.state.name ||
-        (await experimentService.findNextDraftName({
+        (await experiments.findNextDraftName({
           projectId: input.projectId,
         }));
 
       const rawSlug = input.state.experimentSlug ?? experimentId.slice(-8);
       let slug: string;
       if (isNewExperiment) {
-        slug = await experimentService.generateUniqueSlug({
+        slug = await experiments.generateUniqueSlug({
           baseSlug: rawSlug,
           projectId: input.projectId,
         });
@@ -280,7 +279,7 @@ export const experimentsRouter = createTRPCRouter({
       // Convert to plain JSON for Prisma storage
       const workbenchStateJson = JSON.parse(JSON.stringify(input.state));
 
-      await experimentService.saveWithSlugRetry({
+      await experiments.saveWithSlugRetry({
         initialSlug: slug,
         execute: (s) => {
           const data = {
@@ -297,7 +296,7 @@ export const experimentsRouter = createTRPCRouter({
           });
         },
         regenerateSlug: () =>
-          experimentService.generateUniqueSlug({
+          experiments.generateUniqueSlug({
             baseSlug: rawSlug,
             projectId: input.projectId,
           }),
@@ -329,7 +328,7 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await experimentService
+      const experiment = await experimentService()
         .getBySlug({
           projectId: input.projectId,
           slug: input.experimentSlug,
@@ -443,7 +442,7 @@ export const experimentsRouter = createTRPCRouter({
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
       if (input.experimentId) {
-        return await experimentService
+        return await experimentService()
           .getById({
             projectId: input.projectId,
             id: input.experimentId,
@@ -474,7 +473,7 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await experimentService
+      const experiment = await experimentService()
         .getBySlug({
           projectId: input.projectId,
           slug: input.experimentSlug,
@@ -640,7 +639,7 @@ export const experimentsRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string(), experimentSlug: z.string() }))
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await experimentService
+      const experiment = await experimentService()
         .getBySlug({
           projectId: input.projectId,
           slug: input.experimentSlug,
@@ -709,7 +708,7 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await experimentService
+      const experiment = await experimentService()
         .getBySlug({
           projectId: input.projectId,
           slug: input.experimentSlug,
@@ -1064,13 +1063,13 @@ export const experimentsRouter = createTRPCRouter({
 
       // Create new experiment with unique slug
       const experimentName = experiment.name ?? experiment.slug;
-      const copyService = ExperimentService.create(ctx.prisma);
-      const initialSlug = await copyService.generateUniqueSlug({
+      const experiments = experimentService();
+      const initialSlug = await experiments.generateUniqueSlug({
         baseSlug: slugify(experimentName),
         projectId: input.projectId,
       });
 
-      const { result: newExperiment } = await copyService.saveWithSlugRetry({
+      const { result: newExperiment } = await experiments.saveWithSlugRetry({
         initialSlug,
         execute: (s) =>
           ctx.prisma.experiment.create({
@@ -1088,7 +1087,7 @@ export const experimentsRouter = createTRPCRouter({
             },
           }),
         regenerateSlug: () =>
-          copyService.generateUniqueSlug({
+          experiments.generateUniqueSlug({
             baseSlug: slugify(experimentName),
             projectId: input.projectId,
           }),
@@ -1104,7 +1103,7 @@ export const experimentsRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      return await experimentService.getLatest({
+      return await experimentService().getLatest({
         projectId: input.projectId,
       });
     }),
@@ -1186,13 +1185,13 @@ const copyEvaluationsV3Experiment = async ({
 
   // Generate unique slug for the new experiment
   const experimentName = experiment.name ?? experiment.slug;
-  const copyService = ExperimentService.create(ctx.prisma);
-  const initialSlug = await copyService.generateUniqueSlug({
+  const experiments = experimentService();
+  const initialSlug = await experiments.generateUniqueSlug({
     baseSlug: slugify(experimentName),
     projectId: targetProjectId,
   });
 
-  const { result: newExperiment } = await copyService.saveWithSlugRetry({
+  const { result: newExperiment } = await experiments.saveWithSlugRetry({
     initialSlug,
     execute: (s) =>
       ctx.prisma.experiment.create({
@@ -1206,7 +1205,7 @@ const copyEvaluationsV3Experiment = async ({
         },
       }),
     regenerateSlug: () =>
-      copyService.generateUniqueSlug({
+      experiments.generateUniqueSlug({
         baseSlug: slugify(experimentName),
         projectId: targetProjectId,
       }),

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -78,6 +78,7 @@ export const experimentsRouter = createTRPCRouter({
       const slug = await generateUniqueExperimentSlug({
         baseSlug: slugify(name),
         projectId: input.projectId,
+        prisma,
         excludeExperimentId: input.experimentId,
       });
 
@@ -234,16 +235,20 @@ export const experimentsRouter = createTRPCRouter({
         await enforceLicenseLimit(ctx, input.projectId, "experiments");
       }
 
-      // For new experiments, use the ID as the slug (guaranteed unique)
+      // For new experiments, deduplicate the slug to avoid constraint violations
       // For existing experiments, keep the same slug to avoid breaking URLs
       const name =
         input.state.name || (await findNextDraftName(input.projectId));
 
       let slug: string;
       if (isNewExperiment) {
-        // New experiment: prefer the slug from state (set by frontend redirect),
-        // otherwise use last 8 chars of the ID for a shorter, cleaner URL
-        slug = input.state.experimentSlug ?? experimentId.slice(-8);
+        // New experiment: deduplicate the slug to avoid P2002 constraint violations
+        const rawSlug = input.state.experimentSlug ?? experimentId.slice(-8);
+        slug = await generateUniqueExperimentSlug({
+          baseSlug: rawSlug,
+          projectId: input.projectId,
+          prisma,
+        });
       } else {
         // Existing experiment: keep the same slug to avoid breaking URLs
         slug = existing.slug;
@@ -1173,46 +1178,58 @@ const findNextDraftName = async (projectId: string) => {
  *
  * If the base slug already exists (belonging to a different experiment),
  * appends an incrementing numeric suffix (-2, -3, ...) until a unique
- * slug is found. Falls back to a random nanoid suffix after 100 attempts.
+ * slug is found. Falls back to a random nanoid suffix after 100 candidates.
+ *
+ * NOTE: There is a TOCTOU race window between this slug check and the
+ * subsequent insert/upsert. If two concurrent requests generate the same
+ * slug, one will hit a P2002 constraint violation. Callers should catch
+ * P2002 and retry if needed.
  *
  * @param baseSlug - The initial slug derived from the experiment name
  * @param projectId - The project to check for uniqueness within
+ * @param prismaClient - The Prisma client to use for database queries
  * @param excludeExperimentId - Optional experiment ID to exclude from
  *   conflict checks (used when updating an existing experiment)
  */
 export const generateUniqueExperimentSlug = async ({
   baseSlug,
   projectId,
+  prisma: prismaClient,
   excludeExperimentId,
 }: {
   baseSlug: string;
   projectId: string;
+  prisma: typeof prisma;
   excludeExperimentId?: string;
 }): Promise<string> => {
-  const MAX_ATTEMPTS = 100;
-  let candidateSlug = baseSlug;
-  let index = 2;
-  let attempts = 0;
+  const existingSlugs = new Set(
+    (
+      await prismaClient.experiment.findMany({
+        select: { slug: true },
+        where: {
+          projectId,
+          slug: { startsWith: baseSlug },
+          ...(excludeExperimentId
+            ? { id: { not: excludeExperimentId } }
+            : {}),
+        },
+      })
+    ).map((e) => e.slug),
+  );
 
-  while (attempts < MAX_ATTEMPTS) {
-    const conflicting = await prisma.experiment.findFirst({
-      where: {
-        projectId,
-        slug: candidateSlug,
-        ...(excludeExperimentId ? { id: { not: excludeExperimentId } } : {}),
-      },
-    });
-
-    if (!conflicting) {
-      return candidateSlug;
-    }
-
-    candidateSlug = `${baseSlug}-${index}`;
-    index++;
-    attempts++;
+  if (!existingSlugs.has(baseSlug)) {
+    return baseSlug;
   }
 
-  // Fallback to random suffix if we hit the limit
+  let index = 2;
+  while (index <= 102) {
+    const candidate = `${baseSlug}-${index}`;
+    if (!existingSlugs.has(candidate)) {
+      return candidate;
+    }
+    index++;
+  }
+
   return `${baseSlug}-${nanoid(8)}`;
 };
 
@@ -1295,6 +1312,7 @@ const copyEvaluationsV3Experiment = async ({
   const newSlug = await generateUniqueExperimentSlug({
     baseSlug: slugify(experimentName),
     projectId: targetProjectId,
+    prisma: ctx.prisma,
   });
 
   // Create the new experiment

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -5,7 +5,10 @@ import {
   ExperimentType,
   type Prisma,
 } from "@prisma/client";
-import type { JsonValue } from "@prisma/client/runtime/library";
+import {
+  PrismaClientKnownRequestError,
+  type JsonValue,
+} from "@prisma/client/runtime/library";
 import { TRPCError } from "@trpc/server";
 import type { Node } from "@xyflow/react";
 import { nanoid } from "nanoid";
@@ -75,7 +78,7 @@ export const experimentsRouter = createTRPCRouter({
       let workflowId = input.dsl.workflow_id;
       const name =
         input.workbenchState.name ?? (await findNextDraftName(input.projectId));
-      const slug = await generateUniqueExperimentSlug({
+      let slug = await generateUniqueExperimentSlug({
         baseSlug: slugify(name),
         projectId: input.projectId,
         prisma,
@@ -180,17 +183,45 @@ export const experimentsRouter = createTRPCRouter({
         workbenchState: input.workbenchState,
       };
 
-      await prisma.experiment.upsert({
-        where: {
-          id: experimentId,
-          projectId: input.projectId,
-        },
-        update: experimentData,
-        create: {
-          ...experimentData,
-          id: experimentId,
-        },
-      });
+      try {
+        await prisma.experiment.upsert({
+          where: {
+            id: experimentId,
+            projectId: input.projectId,
+          },
+          update: experimentData,
+          create: {
+            ...experimentData,
+            id: experimentId,
+          },
+        });
+      } catch (error) {
+        if (
+          error instanceof PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        ) {
+          slug = await generateUniqueExperimentSlug({
+            baseSlug: slugify(name),
+            projectId: input.projectId,
+            prisma,
+            excludeExperimentId: input.experimentId,
+          });
+          const retryData = { ...experimentData, slug };
+          await prisma.experiment.upsert({
+            where: {
+              id: experimentId,
+              projectId: input.projectId,
+            },
+            update: retryData,
+            create: {
+              ...retryData,
+              id: experimentId,
+            },
+          });
+        } else {
+          throw error;
+        }
+      }
 
       // For some reason, prisma upsert sometimes return not an experiment but {count: 0}, so we need to refetch it
       const updatedExperiment = await prisma.experiment.findUnique({
@@ -264,17 +295,46 @@ export const experimentsRouter = createTRPCRouter({
         workbenchState: workbenchStateJson,
       };
 
-      await prisma.experiment.upsert({
-        where: {
-          id: experimentId,
-          projectId: input.projectId,
-        },
-        update: experimentData,
-        create: {
-          ...experimentData,
-          id: experimentId,
-        },
-      });
+      try {
+        await prisma.experiment.upsert({
+          where: {
+            id: experimentId,
+            projectId: input.projectId,
+          },
+          update: experimentData,
+          create: {
+            ...experimentData,
+            id: experimentId,
+          },
+        });
+      } catch (error) {
+        if (
+          error instanceof PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        ) {
+          const rawSlug =
+            input.state.experimentSlug ?? experimentId.slice(-8);
+          slug = await generateUniqueExperimentSlug({
+            baseSlug: rawSlug,
+            projectId: input.projectId,
+            prisma,
+          });
+          const retryData = { ...experimentData, slug };
+          await prisma.experiment.upsert({
+            where: {
+              id: experimentId,
+              projectId: input.projectId,
+            },
+            update: retryData,
+            create: {
+              ...retryData,
+              id: experimentId,
+            },
+          });
+        } else {
+          throw error;
+        }
+      }
 
       const updatedExperiment = await prisma.experiment.findUnique({
         where: {
@@ -1309,23 +1369,48 @@ const copyEvaluationsV3Experiment = async ({
 
   // Generate unique slug for the new experiment
   const experimentName = experiment.name ?? experiment.slug;
-  const newSlug = await generateUniqueExperimentSlug({
+  let newSlug = await generateUniqueExperimentSlug({
     baseSlug: slugify(experimentName),
     projectId: targetProjectId,
     prisma: ctx.prisma,
   });
 
   // Create the new experiment
-  const newExperiment = await ctx.prisma.experiment.create({
-    data: {
-      id: generate("eval").toString(),
-      name: experimentName,
-      slug: newSlug,
-      projectId: targetProjectId,
-      type: ExperimentType.EVALUATIONS_V3,
-      workbenchState: workbenchState as Prisma.InputJsonValue,
-    },
-  });
+  const experimentCreateData = {
+    id: generate("eval").toString(),
+    name: experimentName,
+    slug: newSlug,
+    projectId: targetProjectId,
+    type: ExperimentType.EVALUATIONS_V3,
+    workbenchState: workbenchState as Prisma.InputJsonValue,
+  };
+
+  let newExperiment;
+  try {
+    newExperiment = await ctx.prisma.experiment.create({
+      data: experimentCreateData,
+    });
+  } catch (error) {
+    if (
+      error instanceof PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      newSlug = await generateUniqueExperimentSlug({
+        baseSlug: slugify(experimentName),
+        projectId: targetProjectId,
+        prisma: ctx.prisma,
+      });
+      newExperiment = await ctx.prisma.experiment.create({
+        data: {
+          ...experimentCreateData,
+          id: generate("eval").toString(),
+          slug: newSlug,
+        },
+      });
+    } else {
+      throw error;
+    }
+  }
 
   return { experiment: newExperiment, workflow: null };
 };

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -1094,49 +1094,50 @@ export const experimentsRouter = createTRPCRouter({
 
       // Create new experiment with unique slug
       const experimentName = experiment.name ?? experiment.slug;
-      const baseSlug = slugify(experimentName);
-
-      // Find a unique slug by appending -2, -3, etc. if needed
-      const MAX_ATTEMPTS = 100;
-      let newSlug = baseSlug;
-      let index = 2;
-      let attempts = 0;
-
-      while (attempts < MAX_ATTEMPTS) {
-        const existingExperiment = await ctx.prisma.experiment.findFirst({
-          where: {
-            projectId: input.projectId,
-            slug: newSlug,
-          },
-        });
-
-        if (!existingExperiment) {
-          break;
-        }
-
-        newSlug = `${baseSlug}-${index}`;
-        index++;
-        attempts++;
-      }
-
-      // Fallback to random suffix if we hit the limit (should never happen in practice)
-      if (attempts >= MAX_ATTEMPTS) {
-        newSlug = `${baseSlug}-${nanoid(8)}`;
-      }
-
-      const newExperiment = await ctx.prisma.experiment.create({
-        data: {
-          id: `experiment_${nanoid()}`,
-          name: experimentName,
-          slug: newSlug,
-          projectId: input.projectId,
-          type: experiment.type,
-          workflowId,
-          ...(experiment.workbenchState && {
-            workbenchState: experiment.workbenchState as Prisma.InputJsonValue,
-          }),
-        },
+      let newSlug = await generateUniqueExperimentSlug({
+        baseSlug: slugify(experimentName),
+        projectId: input.projectId,
+        prisma: ctx.prisma,
       });
+
+      const experimentCreateData = {
+        id: `experiment_${nanoid()}`,
+        name: experimentName,
+        slug: newSlug,
+        projectId: input.projectId,
+        type: experiment.type,
+        workflowId,
+        ...(experiment.workbenchState && {
+          workbenchState: experiment.workbenchState as Prisma.InputJsonValue,
+        }),
+      };
+
+      let newExperiment;
+      try {
+        newExperiment = await ctx.prisma.experiment.create({
+          data: experimentCreateData,
+        });
+      } catch (error) {
+        if (
+          error instanceof PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        ) {
+          newSlug = await generateUniqueExperimentSlug({
+            baseSlug: slugify(experimentName),
+            projectId: input.projectId,
+            prisma: ctx.prisma,
+          });
+          newExperiment = await ctx.prisma.experiment.create({
+            data: {
+              ...experimentCreateData,
+              id: `experiment_${nanoid()}`,
+              slug: newSlug,
+            },
+          });
+        } else {
+          throw error;
+        }
+      }
 
       return { experiment: newExperiment, workflow: newWorkflow };
     }),

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -76,7 +76,7 @@ export const experimentsRouter = createTRPCRouter({
       let workflowId = input.dsl.workflow_id;
       const name =
         input.workbenchState.name ?? (await findNextDraftName(input.projectId));
-      let slug = await generateUniqueExperimentSlug({
+      const slug = await generateUniqueExperimentSlug({
         baseSlug: slugify(name),
         projectId: input.projectId,
         prisma,
@@ -173,7 +173,7 @@ export const experimentsRouter = createTRPCRouter({
 
       const experimentId = input.experimentId ?? `experiment_${nanoid()}`;
 
-      const { slug: finalSlug } = await withSlugConflictRetry({
+      await withSlugConflictRetry({
         initialSlug: slug,
         execute: (s) => {
           const data = {
@@ -198,7 +198,6 @@ export const experimentsRouter = createTRPCRouter({
             excludeExperimentId: input.experimentId,
           }),
       });
-      slug = finalSlug;
 
       // For some reason, prisma upsert sometimes return not an experiment but {count: 0}, so we need to refetch it
       const updatedExperiment = await prisma.experiment.findUnique({
@@ -248,10 +247,10 @@ export const experimentsRouter = createTRPCRouter({
       const name =
         input.state.name || (await findNextDraftName(input.projectId));
 
+      const rawSlug = input.state.experimentSlug ?? experimentId.slice(-8);
       let slug: string;
       if (isNewExperiment) {
         // New experiment: deduplicate the slug to avoid P2002 constraint violations
-        const rawSlug = input.state.experimentSlug ?? experimentId.slice(-8);
         slug = await generateUniqueExperimentSlug({
           baseSlug: rawSlug,
           projectId: input.projectId,
@@ -265,8 +264,7 @@ export const experimentsRouter = createTRPCRouter({
       // Convert to plain JSON for Prisma storage
       const workbenchStateJson = JSON.parse(JSON.stringify(input.state));
 
-      const rawSlug = input.state.experimentSlug ?? experimentId.slice(-8);
-      const { slug: finalSlug } = await withSlugConflictRetry({
+      await withSlugConflictRetry({
         initialSlug: slug,
         execute: (s) => {
           const data = {
@@ -289,7 +287,6 @@ export const experimentsRouter = createTRPCRouter({
             prisma,
           }),
       });
-      slug = finalSlug;
 
       const updatedExperiment = await prisma.experiment.findUnique({
         where: {

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -7,7 +7,7 @@ import {
 } from "@prisma/client";
 import type { JsonValue } from "@prisma/client/runtime/library";
 import { TRPCError } from "@trpc/server";
-import { ExperimentNotFoundError } from "../../experiments/errors";
+import { DomainError } from "../../app-layer/domain-error";
 import type { Node } from "@xyflow/react";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -55,9 +55,12 @@ import { enforceLicenseLimit } from "../../license-enforcement";
 
 type TRPCContext = ReturnType<typeof createInnerTRPCContext>;
 
-/** Maps experiment domain errors to TRPCError. */
+/** Maps experiment domain errors to TRPCError using kind discriminant. */
 const mapExperimentError = (error: unknown): never => {
-  if (error instanceof ExperimentNotFoundError) {
+  if (
+    error instanceof DomainError &&
+    error.kind === "experiment_not_found"
+  ) {
     throw new TRPCError({ code: "NOT_FOUND", message: error.message });
   }
   throw error;

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -75,7 +75,11 @@ export const experimentsRouter = createTRPCRouter({
       let workflowId = input.dsl.workflow_id;
       const name =
         input.workbenchState.name ?? (await findNextDraftName(input.projectId));
-      const slug = slugify(name);
+      const slug = await generateUniqueExperimentSlug({
+        baseSlug: slugify(name),
+        projectId: input.projectId,
+        excludeExperimentId: input.experimentId,
+      });
 
       if (input.experimentId) {
         const currentExperiment = await prisma.experiment.findUnique({
@@ -1165,6 +1169,54 @@ const findNextDraftName = async (projectId: string) => {
 };
 
 /**
+ * Generates a unique slug for an experiment within a project.
+ *
+ * If the base slug already exists (belonging to a different experiment),
+ * appends an incrementing numeric suffix (-2, -3, ...) until a unique
+ * slug is found. Falls back to a random nanoid suffix after 100 attempts.
+ *
+ * @param baseSlug - The initial slug derived from the experiment name
+ * @param projectId - The project to check for uniqueness within
+ * @param excludeExperimentId - Optional experiment ID to exclude from
+ *   conflict checks (used when updating an existing experiment)
+ */
+export const generateUniqueExperimentSlug = async ({
+  baseSlug,
+  projectId,
+  excludeExperimentId,
+}: {
+  baseSlug: string;
+  projectId: string;
+  excludeExperimentId?: string;
+}): Promise<string> => {
+  const MAX_ATTEMPTS = 100;
+  let candidateSlug = baseSlug;
+  let index = 2;
+  let attempts = 0;
+
+  while (attempts < MAX_ATTEMPTS) {
+    const conflicting = await prisma.experiment.findFirst({
+      where: {
+        projectId,
+        slug: candidateSlug,
+        ...(excludeExperimentId ? { id: { not: excludeExperimentId } } : {}),
+      },
+    });
+
+    if (!conflicting) {
+      return candidateSlug;
+    }
+
+    candidateSlug = `${baseSlug}-${index}`;
+    index++;
+    attempts++;
+  }
+
+  // Fallback to random suffix if we hit the limit
+  return `${baseSlug}-${nanoid(8)}`;
+};
+
+/**
  * Copies an EVALUATIONS_V3 experiment to another project.
  * V3 experiments store their state in workbenchState (no workflow).
  * Optionally copies saved datasets and updates references.
@@ -1240,34 +1292,10 @@ const copyEvaluationsV3Experiment = async ({
 
   // Generate unique slug for the new experiment
   const experimentName = experiment.name ?? experiment.slug;
-  const baseSlug = slugify(experimentName);
-
-  const MAX_ATTEMPTS = 100;
-  let newSlug = baseSlug;
-  let index = 2;
-  let attempts = 0;
-
-  while (attempts < MAX_ATTEMPTS) {
-    const existingExperiment = await ctx.prisma.experiment.findFirst({
-      where: {
-        projectId: targetProjectId,
-        slug: newSlug,
-      },
-    });
-
-    if (!existingExperiment) {
-      break;
-    }
-
-    newSlug = `${baseSlug}-${index}`;
-    index++;
-    attempts++;
-  }
-
-  // Fallback to random suffix if we hit the limit
-  if (attempts >= MAX_ATTEMPTS) {
-    newSlug = `${baseSlug}-${nanoid(8)}`;
-  }
+  const newSlug = await generateUniqueExperimentSlug({
+    baseSlug: slugify(experimentName),
+    projectId: targetProjectId,
+  });
 
   // Create the new experiment
   const newExperiment = await ctx.prisma.experiment.create({

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -6,8 +6,9 @@ import {
   type Prisma,
 } from "@prisma/client";
 import type { JsonValue } from "@prisma/client/runtime/library";
-import { isUniqueConstraintError } from "../../utils/prismaErrors";
 import { TRPCError } from "@trpc/server";
+import { ExperimentNotFoundError } from "../../experiments/errors";
+import { ExperimentService } from "../../experiments/experiment.service";
 import type { Node } from "@xyflow/react";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -55,6 +56,17 @@ import { enforceLicenseLimit } from "../../license-enforcement";
 
 type TRPCContext = ReturnType<typeof createInnerTRPCContext>;
 
+/** Maps experiment domain errors to TRPCError. */
+const mapExperimentError = (error: unknown): never => {
+  if (error instanceof ExperimentNotFoundError) {
+    throw new TRPCError({ code: "NOT_FOUND", message: error.message });
+  }
+  throw error;
+};
+
+/** Module-level service for query procedures that don't have ctx.prisma. */
+const experimentService = ExperimentService.create(prisma);
+
 export const experimentsRouter = createTRPCRouter({
   saveExperiment: protectedProcedure
     .input(
@@ -68,6 +80,8 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:create"))
     .mutation(async ({ ctx, input }) => {
+      const experimentService = ExperimentService.create(ctx.prisma);
+
       // Enforce experiment limit only when creating new experiments
       if (!input.experimentId) {
         await enforceLicenseLimit(ctx, input.projectId, "experiments");
@@ -75,11 +89,13 @@ export const experimentsRouter = createTRPCRouter({
 
       let workflowId = input.dsl.workflow_id;
       const name =
-        input.workbenchState.name ?? (await findNextDraftName(input.projectId));
-      const slug = await generateUniqueExperimentSlug({
+        input.workbenchState.name ??
+        (await experimentService.findNextDraftName({
+          projectId: input.projectId,
+        }));
+      const slug = await experimentService.generateUniqueSlug({
         baseSlug: slugify(name),
         projectId: input.projectId,
-        prisma,
         excludeExperimentId: input.experimentId,
       });
 
@@ -173,7 +189,7 @@ export const experimentsRouter = createTRPCRouter({
 
       const experimentId = input.experimentId ?? `experiment_${nanoid()}`;
 
-      await withSlugConflictRetry({
+      await experimentService.saveWithSlugRetry({
         initialSlug: slug,
         execute: (s) => {
           const data = {
@@ -191,10 +207,9 @@ export const experimentsRouter = createTRPCRouter({
           });
         },
         regenerateSlug: () =>
-          generateUniqueExperimentSlug({
+          experimentService.generateUniqueSlug({
             baseSlug: slugify(name),
             projectId: input.projectId,
-            prisma,
             excludeExperimentId: input.experimentId,
           }),
       });
@@ -227,6 +242,7 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:create"))
     .mutation(async ({ ctx, input }) => {
+      const experimentService = ExperimentService.create(ctx.prisma);
       const experimentId =
         input.experimentId ?? generate(KSUID_RESOURCES.EXPERIMENT).toString();
 
@@ -245,26 +261,26 @@ export const experimentsRouter = createTRPCRouter({
       // For new experiments, deduplicate the slug to avoid constraint violations
       // For existing experiments, keep the same slug to avoid breaking URLs
       const name =
-        input.state.name || (await findNextDraftName(input.projectId));
+        input.state.name ||
+        (await experimentService.findNextDraftName({
+          projectId: input.projectId,
+        }));
 
       const rawSlug = input.state.experimentSlug ?? experimentId.slice(-8);
       let slug: string;
       if (isNewExperiment) {
-        // New experiment: deduplicate the slug to avoid P2002 constraint violations
-        slug = await generateUniqueExperimentSlug({
+        slug = await experimentService.generateUniqueSlug({
           baseSlug: rawSlug,
           projectId: input.projectId,
-          prisma,
         });
       } else {
-        // Existing experiment: keep the same slug to avoid breaking URLs
         slug = existing.slug;
       }
 
       // Convert to plain JSON for Prisma storage
       const workbenchStateJson = JSON.parse(JSON.stringify(input.state));
 
-      await withSlugConflictRetry({
+      await experimentService.saveWithSlugRetry({
         initialSlug: slug,
         execute: (s) => {
           const data = {
@@ -281,10 +297,9 @@ export const experimentsRouter = createTRPCRouter({
           });
         },
         regenerateSlug: () =>
-          generateUniqueExperimentSlug({
+          experimentService.generateUniqueSlug({
             baseSlug: rawSlug,
             projectId: input.projectId,
-            prisma,
           }),
       });
 
@@ -314,10 +329,12 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await getExperimentBySlug(
-        input.projectId,
-        input.experimentSlug,
-      );
+      const experiment = await experimentService
+        .getBySlug({
+          projectId: input.projectId,
+          slug: input.experimentSlug,
+        })
+        .catch(mapExperimentError);
 
       if (experiment.type !== ExperimentType.EVALUATIONS_V3) {
         throw new TRPCError({
@@ -426,28 +443,19 @@ export const experimentsRouter = createTRPCRouter({
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
       if (input.experimentId) {
-        const experiment = await prisma.experiment.findFirst({
-          where: {
-            id: input.experimentId,
+        return await experimentService
+          .getById({
             projectId: input.projectId,
-          },
-        });
-
-        if (!experiment) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Experiment not found",
-          });
-        }
-
-        return experiment;
+            id: input.experimentId,
+          })
+          .catch(mapExperimentError);
       } else if (input.experimentSlug) {
-        const experiment = await getExperimentBySlug(
-          input.projectId,
-          input.experimentSlug,
-        );
-
-        return experiment;
+        return await experimentService
+          .getBySlug({
+            projectId: input.projectId,
+            slug: input.experimentSlug,
+          })
+          .catch(mapExperimentError);
       }
 
       throw new TRPCError({
@@ -466,10 +474,12 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await getExperimentBySlug(
-        input.projectId,
-        input.experimentSlug,
-      );
+      const experiment = await experimentService
+        .getBySlug({
+          projectId: input.projectId,
+          slug: input.experimentSlug,
+        })
+        .catch(mapExperimentError);
 
       const workflow = experiment.workflowId
         ? await prisma.workflow.findUnique({
@@ -630,10 +640,12 @@ export const experimentsRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string(), experimentSlug: z.string() }))
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await getExperimentBySlug(
-        input.projectId,
-        input.experimentSlug,
-      );
+      const experiment = await experimentService
+        .getBySlug({
+          projectId: input.projectId,
+          slug: input.experimentSlug,
+        })
+        .catch(mapExperimentError);
 
       const steps = await getApp().dspySteps.steps.getStepsByExperiment({
         tenantId: input.projectId,
@@ -697,10 +709,12 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await getExperimentBySlug(
-        input.projectId,
-        input.experimentSlug,
-      );
+      const experiment = await experimentService
+        .getBySlug({
+          projectId: input.projectId,
+          slug: input.experimentSlug,
+        })
+        .catch(mapExperimentError);
 
       try {
         const step = await getApp().dspySteps.steps.getStep({
@@ -749,10 +763,12 @@ export const experimentsRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string(), experimentId: z.string() }))
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await getExperimentById(
-        input.projectId,
-        input.experimentId,
-      );
+      const experiment = await experimentService
+        .getById({
+          projectId: input.projectId,
+          id: input.experimentId,
+        })
+        .catch(mapExperimentError);
 
       const experimentRunService = ExperimentRunService.create(prisma);
       const runsByExperimentId = await experimentRunService.listRuns({
@@ -773,10 +789,12 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await getExperimentById(
-        input.projectId,
-        input.experimentId,
-      );
+      const experiment = await experimentService
+        .getById({
+          projectId: input.projectId,
+          id: input.experimentId,
+        })
+        .catch(mapExperimentError);
 
       const experimentRunService = ExperimentRunService.create(prisma);
       return experimentRunService.getRun({
@@ -1046,13 +1064,13 @@ export const experimentsRouter = createTRPCRouter({
 
       // Create new experiment with unique slug
       const experimentName = experiment.name ?? experiment.slug;
-      const initialSlug = await generateUniqueExperimentSlug({
+      const copyService = ExperimentService.create(ctx.prisma);
+      const initialSlug = await copyService.generateUniqueSlug({
         baseSlug: slugify(experimentName),
         projectId: input.projectId,
-        prisma: ctx.prisma,
       });
 
-      const { result: newExperiment } = await withSlugConflictRetry({
+      const { result: newExperiment } = await copyService.saveWithSlugRetry({
         initialSlug,
         execute: (s) =>
           ctx.prisma.experiment.create({
@@ -1070,10 +1088,9 @@ export const experimentsRouter = createTRPCRouter({
             },
           }),
         regenerateSlug: () =>
-          generateUniqueExperimentSlug({
+          copyService.generateUniqueSlug({
             baseSlug: slugify(experimentName),
             projectId: input.projectId,
-            prisma: ctx.prisma,
           }),
       });
 
@@ -1087,187 +1104,11 @@ export const experimentsRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("workflows:view"))
     .query(async ({ input }) => {
-      const experiment = await prisma.experiment.findFirst({
-        where: { projectId: input.projectId },
-        orderBy: { createdAt: "desc" },
+      return await experimentService.getLatest({
+        projectId: input.projectId,
       });
-
-      return experiment;
     }),
 });
-
-const getExperimentBySlug = async (
-  projectId: string,
-  experimentSlug: string,
-) => {
-  const experiment = await prisma.experiment.findFirst({
-    where: {
-      projectId: projectId,
-      slug: experimentSlug,
-    },
-  });
-
-  if (!experiment) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Experiment not found",
-    });
-  }
-
-  return experiment;
-};
-
-const getExperimentById = async (projectId: string, experimentId: string) => {
-  const experiment = await prisma.experiment.findFirst({
-    where: {
-      projectId: projectId,
-      id: experimentId,
-    },
-  });
-
-  if (!experiment) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Experiment not found",
-    });
-  }
-
-  return experiment;
-};
-
-
-const findNextDraftName = async (projectId: string) => {
-  const experiments = await prisma.experiment.findMany({
-    select: {
-      name: true,
-      slug: true,
-    },
-    where: {
-      projectId: projectId,
-      name: {
-        startsWith: "Draft",
-      },
-    },
-  });
-
-  const slugs = new Set(
-    (
-      await prisma.experiment.findMany({
-        select: { slug: true },
-        where: { projectId: projectId },
-      })
-    ).map((e) => e.slug),
-  );
-
-  let draftName;
-  let index = experiments.length + 1;
-  while (true) {
-    draftName = `Draft Evaluation (${index})`;
-    if (!slugs.has(slugify(draftName))) {
-      break;
-    }
-    index++;
-  }
-
-  return draftName;
-};
-
-/**
- * Generates a unique slug for an experiment within a project.
- *
- * If the base slug already exists (belonging to a different experiment),
- * appends an incrementing numeric suffix (-2, -3, ...) until a unique
- * slug is found. Falls back to a random nanoid suffix after 100 candidates.
- *
- * NOTE: There is a TOCTOU race window between this slug check and the
- * subsequent insert/upsert. If two concurrent requests generate the same
- * slug, one will hit a P2002 constraint violation. Callers should catch
- * P2002 and retry if needed.
- *
- * @param baseSlug - The initial slug derived from the experiment name
- * @param projectId - The project to check for uniqueness within
- * @param prismaClient - The Prisma client to use for database queries
- * @param excludeExperimentId - Optional experiment ID to exclude from
- *   conflict checks (used when updating an existing experiment)
- */
-export const generateUniqueExperimentSlug = async ({
-  baseSlug,
-  projectId,
-  prisma: prismaClient,
-  excludeExperimentId,
-}: {
-  baseSlug: string;
-  projectId: string;
-  prisma: typeof prisma;
-  excludeExperimentId?: string;
-}): Promise<string> => {
-  // Fetch candidates that match the base slug or its numbered variants (baseSlug-N).
-  // We use startsWith for the DB query, then filter in-memory with a regex
-  // to avoid false positives (e.g., "my-exp" matching "my-experiment").
-  const suffixPattern = new RegExp(`^${escapeRegExpChars(baseSlug)}(-\\d+)?$`);
-  const existingSlugs = new Set(
-    (
-      await prismaClient.experiment.findMany({
-        select: { slug: true },
-        where: {
-          projectId,
-          slug: { startsWith: baseSlug },
-          ...(excludeExperimentId
-            ? { id: { not: excludeExperimentId } }
-            : {}),
-        },
-      })
-    )
-      .map((e) => e.slug)
-      .filter((slug) => suffixPattern.test(slug)),
-  );
-
-  if (!existingSlugs.has(baseSlug)) {
-    return baseSlug;
-  }
-
-  let index = 2;
-  while (index <= 102) {
-    const candidate = `${baseSlug}-${index}`;
-    if (!existingSlugs.has(candidate)) {
-      return candidate;
-    }
-    index++;
-  }
-
-  return `${baseSlug}-${nanoid(8)}`;
-};
-
-/** Escapes special regex characters in a string for use in `new RegExp()`. */
-const escapeRegExpChars = (str: string): string =>
-  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-/**
- * Wraps an experiment write operation with P2002 slug-conflict retry.
- *
- * If the initial write fails with a unique constraint violation (P2002),
- * regenerates the slug and retries once. This handles the TOCTOU race
- * between `generateUniqueExperimentSlug` and the actual insert/upsert.
- */
-const withSlugConflictRetry = async <T>({
-  initialSlug,
-  execute,
-  regenerateSlug,
-}: {
-  initialSlug: string;
-  execute: (slug: string) => Promise<T>;
-  regenerateSlug: () => Promise<string>;
-}): Promise<{ result: T; slug: string }> => {
-  try {
-    return { result: await execute(initialSlug), slug: initialSlug };
-  } catch (error) {
-    if (isUniqueConstraintError(error)) {
-      const newSlug = await regenerateSlug();
-      return { result: await execute(newSlug), slug: newSlug };
-    }
-    throw error;
-  }
-};
 
 /**
  * Copies an EVALUATIONS_V3 experiment to another project.
@@ -1345,13 +1186,13 @@ const copyEvaluationsV3Experiment = async ({
 
   // Generate unique slug for the new experiment
   const experimentName = experiment.name ?? experiment.slug;
-  const initialSlug = await generateUniqueExperimentSlug({
+  const copyService = ExperimentService.create(ctx.prisma);
+  const initialSlug = await copyService.generateUniqueSlug({
     baseSlug: slugify(experimentName),
     projectId: targetProjectId,
-    prisma: ctx.prisma,
   });
 
-  const { result: newExperiment } = await withSlugConflictRetry({
+  const { result: newExperiment } = await copyService.saveWithSlugRetry({
     initialSlug,
     execute: (s) =>
       ctx.prisma.experiment.create({
@@ -1365,10 +1206,9 @@ const copyEvaluationsV3Experiment = async ({
         },
       }),
     regenerateSlug: () =>
-      generateUniqueExperimentSlug({
+      copyService.generateUniqueSlug({
         baseSlug: slugify(experimentName),
         projectId: targetProjectId,
-        prisma: ctx.prisma,
       }),
   });
 

--- a/langwatch/src/server/app-layer/app.ts
+++ b/langwatch/src/server/app-layer/app.ts
@@ -17,6 +17,7 @@ export class App {
   readonly dspySteps: AppDependencies["dspySteps"];
   readonly simulations: AppDependencies["simulations"] & AppCommands["simulations"];
   readonly suiteRuns: AppDependencies["suiteRuns"] & AppCommands["suiteRuns"];
+  readonly experiments: AppDependencies["experiments"];
   readonly organizations: AppDependencies["organizations"];
   readonly projects: AppDependencies["projects"];
   readonly tokenizer: AppDependencies["tokenizer"];
@@ -41,6 +42,7 @@ export class App {
 
   constructor(deps: AppDependencies) {
     this.config = deps.config;
+    this.experiments = deps.experiments;
     this.organizations = deps.organizations;
     this.projects = deps.projects;
     this.tokenizer = deps.tokenizer;

--- a/langwatch/src/server/app-layer/dependencies.ts
+++ b/langwatch/src/server/app-layer/dependencies.ts
@@ -27,6 +27,7 @@ import type { EventExplorerService } from "./ops/event-explorer.service";
 import type { ReplayService } from "./ops/replay.service";
 import type { OpsMetricsCollector } from "./ops/metrics-collector";
 import type { UsageService } from "./usage/usage.service";
+import type { ExperimentService } from "../experiments/experiment.service";
 
 export interface OpsDependencies {
   queues: QueueService;
@@ -62,6 +63,7 @@ export interface AppDependencies {
   suiteRuns: {
     runs: SuiteRunService;
   };
+  experiments: ExperimentService;
   organizations: OrganizationService;
   projects: ProjectService;
   tokenizer: TokenizerService;

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -464,6 +464,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
 
 /** Tests — noop commands, null-backed services. */
 export function createTestApp(overrides?: Partial<AppDependencies>): App {
+  const { prisma: testPrisma } = require("../db") as { prisma: PrismaClient; };
   const noop = async () => { };
   const config: AppConfig = {
     nodeEnv: "test",
@@ -516,7 +517,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       execution: void 0 as unknown as AppDependencies["evaluations"]["execution"],
     },
     dspySteps: { steps: new DspyStepService(new NullDspyStepRepository()) },
-    experiments: ExperimentService.create(prisma),
+    experiments: ExperimentService.create(testPrisma),
     simulations: { runs: SimulationRunService.create(null) },
     suiteRuns: { runs: SuiteRunService.create({ resolveClickHouseClient: null, startSuiteRun: noop, queueSimulationRun: noop }) },
     organizations: nullOrganizations,

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -22,6 +22,7 @@ import { EvaluationRunClickHouseRepository } from "./evaluations/repositories/ev
 import { NullEvaluationRunRepository } from "./evaluations/repositories/evaluation-run.repository";
 import { MonitorService } from "./monitors/monitor.service";
 import { PrismaMonitorRepository } from "./monitors/repositories/monitor.prisma.repository";
+import { ExperimentService } from "../experiments/experiment.service";
 import { OrganizationService } from "./organizations/organization.service";
 import { PrismaOrganizationRepository } from "./organizations/repositories/organization.prisma.repository";
 import { NullOrganizationRepository } from "./organizations/repositories/organization.repository";
@@ -165,6 +166,10 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     "EvaluationRunService",
   );
 
+  const experiments = traced(
+    ExperimentService.create(prisma),
+    "ExperimentService",
+  );
   const organizations = traced(
     new OrganizationService(
       new PrismaOrganizationRepository(prisma),
@@ -437,6 +442,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     broadcast,
     traces,
     evaluations,
+    experiments,
     dspySteps: { steps: dspySteps },
     simulations: { runs: simulationReads },
     suiteRuns: { runs: suiteRunService },
@@ -510,6 +516,7 @@ export function createTestApp(overrides?: Partial<AppDependencies>): App {
       execution: void 0 as unknown as AppDependencies["evaluations"]["execution"],
     },
     dspySteps: { steps: new DspyStepService(new NullDspyStepRepository()) },
+    experiments: ExperimentService.create(prisma),
     simulations: { runs: SimulationRunService.create(null) },
     suiteRuns: { runs: SuiteRunService.create({ resolveClickHouseClient: null, startSuiteRun: noop, queueSimulationRun: noop }) },
     organizations: nullOrganizations,

--- a/langwatch/src/server/experiments/errors.ts
+++ b/langwatch/src/server/experiments/errors.ts
@@ -1,11 +1,16 @@
-/**
- * Custom error types for experiment domain.
- * These are framework-agnostic and can be mapped to tRPC/HTTP errors in the router layer.
- */
+import { NotFoundError } from "../app-layer/domain-error";
 
-export class ExperimentNotFoundError extends Error {
-  constructor(message = "Experiment not found") {
-    super(message);
+export class ExperimentNotFoundError extends NotFoundError {
+  declare readonly kind: "experiment_not_found";
+
+  constructor(
+    experimentId: string,
+    options: { reasons?: readonly Error[] } = {},
+  ) {
+    super("experiment_not_found", "Experiment", experimentId, {
+      meta: { experimentId },
+      ...options,
+    });
     this.name = "ExperimentNotFoundError";
   }
 }

--- a/langwatch/src/server/experiments/errors.ts
+++ b/langwatch/src/server/experiments/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Custom error types for experiment domain.
+ * These are framework-agnostic and can be mapped to tRPC/HTTP errors in the router layer.
+ */
+
+export class ExperimentNotFoundError extends Error {
+  constructor(message = "Experiment not found") {
+    super(message);
+    this.name = "ExperimentNotFoundError";
+  }
+}

--- a/langwatch/src/server/experiments/experiment.repository.ts
+++ b/langwatch/src/server/experiments/experiment.repository.ts
@@ -1,0 +1,120 @@
+import type { Experiment, Prisma, PrismaClient } from "@prisma/client";
+
+/**
+ * Repository layer for experiment data access.
+ * Single Responsibility: Database operations for experiments.
+ */
+export class ExperimentRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(
+    input: { id: string; projectId: string },
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Experiment | null> {
+    const client = options?.tx ?? this.prisma;
+    return await client.experiment.findFirst({
+      where: { id: input.id, projectId: input.projectId },
+    });
+  }
+
+  async findBySlug(
+    input: { slug: string; projectId: string },
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Experiment | null> {
+    const client = options?.tx ?? this.prisma;
+    return await client.experiment.findFirst({
+      where: { slug: input.slug, projectId: input.projectId },
+    });
+  }
+
+  async findAll(
+    input: { projectId: string },
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Experiment[]> {
+    const client = options?.tx ?? this.prisma;
+    return await client.experiment.findMany({
+      where: { projectId: input.projectId },
+    });
+  }
+
+  /**
+   * Finds slugs matching a prefix, used by slug deduplication.
+   * Returns only slug strings for efficient in-memory filtering.
+   */
+  async findBySlugPrefix(input: {
+    projectId: string;
+    slugPrefix: string;
+    excludeId?: string;
+  }): Promise<Array<{ slug: string }>> {
+    return await this.prisma.experiment.findMany({
+      select: { slug: true },
+      where: {
+        projectId: input.projectId,
+        slug: { startsWith: input.slugPrefix },
+        ...(input.excludeId ? { id: { not: input.excludeId } } : {}),
+      },
+    });
+  }
+
+  /**
+   * Finds experiment names starting with "Draft" for draft name generation.
+   */
+  async findDraftNames(input: {
+    projectId: string;
+  }): Promise<Array<{ name: string | null; slug: string }>> {
+    return await this.prisma.experiment.findMany({
+      select: { name: true, slug: true },
+      where: {
+        projectId: input.projectId,
+        name: { startsWith: "Draft" },
+      },
+    });
+  }
+
+  async findAllSlugs(input: {
+    projectId: string;
+  }): Promise<Array<{ slug: string }>> {
+    return await this.prisma.experiment.findMany({
+      select: { slug: true },
+      where: { projectId: input.projectId },
+    });
+  }
+
+  async findLatest(
+    input: { projectId: string },
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Experiment | null> {
+    const client = options?.tx ?? this.prisma;
+    return await client.experiment.findFirst({
+      where: { projectId: input.projectId },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async upsert(
+    input: {
+      id: string;
+      projectId: string;
+      data: Prisma.ExperimentUpdateInput;
+    },
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Experiment> {
+    const client = options?.tx ?? this.prisma;
+    return await client.experiment.upsert({
+      where: { id: input.id, projectId: input.projectId },
+      update: input.data,
+      create: {
+        ...(input.data as Prisma.ExperimentUncheckedCreateInput),
+        id: input.id,
+      },
+    });
+  }
+
+  async create(
+    input: { data: Prisma.ExperimentUncheckedCreateInput },
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Experiment> {
+    const client = options?.tx ?? this.prisma;
+    return await client.experiment.create({ data: input.data });
+  }
+}

--- a/langwatch/src/server/experiments/experiment.service.ts
+++ b/langwatch/src/server/experiments/experiment.service.ts
@@ -1,0 +1,181 @@
+import type { Experiment, PrismaClient } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { slugify } from "../../utils/slugify";
+import { isUniqueConstraintError } from "../utils/prismaErrors";
+import { ExperimentNotFoundError } from "./errors";
+import { ExperimentRepository } from "./experiment.repository";
+
+/**
+ * Service layer for experiment business logic.
+ * Owns slug generation, draft naming, lookups, and P2002 retry strategy.
+ */
+export class ExperimentService {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly repository: ExperimentRepository,
+  ) {}
+
+  static create(prisma: PrismaClient): ExperimentService {
+    return new ExperimentService(prisma, new ExperimentRepository(prisma));
+  }
+
+  async getBySlug({
+    projectId,
+    slug,
+  }: {
+    projectId: string;
+    slug: string;
+  }): Promise<Experiment> {
+    const experiment = await this.repository.findBySlug({
+      slug,
+      projectId,
+    });
+
+    if (!experiment) {
+      throw new ExperimentNotFoundError();
+    }
+
+    return experiment;
+  }
+
+  async getById({
+    projectId,
+    id,
+  }: {
+    projectId: string;
+    id: string;
+  }): Promise<Experiment> {
+    const experiment = await this.repository.findById({ id, projectId });
+
+    if (!experiment) {
+      throw new ExperimentNotFoundError();
+    }
+
+    return experiment;
+  }
+
+  async getAll({ projectId }: { projectId: string }): Promise<Experiment[]> {
+    return this.repository.findAll({ projectId });
+  }
+
+  async getLatest({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<Experiment | null> {
+    return this.repository.findLatest({ projectId });
+  }
+
+  /**
+   * Generates a unique slug for an experiment within a project.
+   *
+   * If the base slug already exists (belonging to a different experiment),
+   * appends an incrementing numeric suffix (-2, -3, ...) until a unique
+   * slug is found. Falls back to a random nanoid suffix after 100 candidates.
+   *
+   * NOTE: There is a TOCTOU race window between this slug check and the
+   * subsequent insert/upsert. If two concurrent requests generate the same
+   * slug, one will hit a P2002 constraint violation. Callers should use
+   * `saveWithSlugRetry` to handle this.
+   */
+  async generateUniqueSlug({
+    baseSlug,
+    projectId,
+    excludeExperimentId,
+  }: {
+    baseSlug: string;
+    projectId: string;
+    excludeExperimentId?: string;
+  }): Promise<string> {
+    // Fetch candidates that match the base slug or its numbered variants (baseSlug-N).
+    // We use startsWith for the DB query, then filter in-memory with a regex
+    // to avoid false positives (e.g., "my-exp" matching "my-experiment").
+    const suffixPattern = new RegExp(
+      `^${ExperimentService.escapeRegExpChars(baseSlug)}(-\\d+)?$`,
+    );
+    const existingSlugs = new Set(
+      (
+        await this.repository.findBySlugPrefix({
+          projectId,
+          slugPrefix: baseSlug,
+          excludeId: excludeExperimentId,
+        })
+      )
+        .map((e) => e.slug)
+        .filter((slug) => suffixPattern.test(slug)),
+    );
+
+    if (!existingSlugs.has(baseSlug)) {
+      return baseSlug;
+    }
+
+    let index = 2;
+    while (index <= 102) {
+      const candidate = `${baseSlug}-${index}`;
+      if (!existingSlugs.has(candidate)) {
+        return candidate;
+      }
+      index++;
+    }
+
+    return `${baseSlug}-${nanoid(8)}`;
+  }
+
+  /**
+   * Finds the next available "Draft Evaluation (N)" name for a project.
+   */
+  async findNextDraftName({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<string> {
+    const experiments = await this.repository.findDraftNames({ projectId });
+
+    const slugs = new Set(
+      (await this.repository.findAllSlugs({ projectId })).map((e) => e.slug),
+    );
+
+    let draftName;
+    let index = experiments.length + 1;
+    while (true) {
+      draftName = `Draft Evaluation (${index})`;
+      if (!slugs.has(slugify(draftName))) {
+        break;
+      }
+      index++;
+    }
+
+    return draftName;
+  }
+
+  /**
+   * Wraps an experiment write operation with P2002 slug-conflict retry.
+   *
+   * If the initial write fails with a unique constraint violation (P2002),
+   * regenerates the slug and retries once. This handles the TOCTOU race
+   * between `generateUniqueSlug` and the actual insert/upsert.
+   */
+  async saveWithSlugRetry<T>({
+    initialSlug,
+    execute,
+    regenerateSlug,
+  }: {
+    initialSlug: string;
+    execute: (slug: string) => Promise<T>;
+    regenerateSlug: () => Promise<string>;
+  }): Promise<{ result: T; slug: string }> {
+    try {
+      return { result: await execute(initialSlug), slug: initialSlug };
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        const newSlug = await regenerateSlug();
+        return { result: await execute(newSlug), slug: newSlug };
+      }
+      throw error;
+    }
+  }
+
+  private static escapeRegExpChars(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+}

--- a/langwatch/src/server/experiments/experiment.service.ts
+++ b/langwatch/src/server/experiments/experiment.service.ts
@@ -29,7 +29,7 @@ export class ExperimentService {
     });
 
     if (!experiment) {
-      throw new ExperimentNotFoundError();
+      throw new ExperimentNotFoundError(slug);
     }
 
     return experiment;
@@ -45,7 +45,7 @@ export class ExperimentService {
     const experiment = await this.repository.findById({ id, projectId });
 
     if (!experiment) {
-      throw new ExperimentNotFoundError();
+      throw new ExperimentNotFoundError(id);
     }
 
     return experiment;
@@ -132,17 +132,17 @@ export class ExperimentService {
       (await this.repository.findAllSlugs({ projectId })).map((e) => e.slug),
     );
 
-    let draftName;
     let index = experiments.length + 1;
-    while (true) {
-      draftName = `Draft Evaluation (${index})`;
+    const maxIndex = index + 1000;
+    while (index < maxIndex) {
+      const draftName = `Draft Evaluation (${index})`;
       if (!slugs.has(slugify(draftName))) {
-        break;
+        return draftName;
       }
       index++;
     }
 
-    return draftName;
+    return `Draft Evaluation (${nanoid(8)})`;
   }
 
   /**

--- a/langwatch/src/server/experiments/experiment.service.ts
+++ b/langwatch/src/server/experiments/experiment.service.ts
@@ -10,13 +10,10 @@ import { ExperimentRepository } from "./experiment.repository";
  * Owns slug generation, draft naming, lookups, and P2002 retry strategy.
  */
 export class ExperimentService {
-  constructor(
-    private readonly prisma: PrismaClient,
-    private readonly repository: ExperimentRepository,
-  ) {}
+  constructor(private readonly repository: ExperimentRepository) {}
 
   static create(prisma: PrismaClient): ExperimentService {
-    return new ExperimentService(prisma, new ExperimentRepository(prisma));
+    return new ExperimentService(new ExperimentRepository(prisma));
   }
 
   async getBySlug({

--- a/langwatch/src/server/prompt-config/prompt-tag.service.ts
+++ b/langwatch/src/server/prompt-config/prompt-tag.service.ts
@@ -4,6 +4,7 @@ import {
   PromptTagRepository,
   type ProtectedTag,
 } from "./repositories/prompt-tag.repository";
+import { isUniqueConstraintError } from "../utils/prismaErrors";
 
 const TAG_NAME_REGEX = /^[a-z][a-z0-9_-]*$/;
 const PURELY_NUMERIC_REGEX = /^\d+$/;
@@ -222,11 +223,3 @@ export class PromptTagService {
   }
 }
 
-function isUniqueConstraintError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code: string }).code === "P2002"
-  );
-}

--- a/langwatch/src/server/utils/prismaErrors.ts
+++ b/langwatch/src/server/utils/prismaErrors.ts
@@ -1,0 +1,15 @@
+/**
+ * Duck-type check for Prisma P2002 unique constraint violations.
+ *
+ * Uses duck-typing instead of `instanceof PrismaClientKnownRequestError`
+ * because turbopack/bundlers can create duplicate class copies, causing
+ * `instanceof` to return false even for the correct type.
+ */
+export function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code: string }).code === "P2002"
+  );
+}

--- a/specs/evaluations-v3/experiment-slug-deduplication.feature
+++ b/specs/evaluations-v3/experiment-slug-deduplication.feature
@@ -1,0 +1,24 @@
+Feature: Experiment slug deduplication
+
+  When saving experiments, the slug is derived from the experiment name.
+  If two experiments in the same project generate the same slug, the system
+  must deduplicate by appending a numeric suffix to avoid a unique constraint
+  violation on (projectId, slug).
+
+  @regression @integration
+  Scenario: New experiment gets deduplicated slug when slug conflicts with existing experiment
+    Given an experiment exists in the project with slug "my-experiment"
+    When a new experiment is saved with a name that generates slug "my-experiment"
+    Then the new experiment is created with slug "my-experiment-2"
+
+  @regression @integration
+  Scenario: Updating an existing experiment does not trigger slug deduplication against itself
+    Given an experiment exists in the project with slug "my-experiment"
+    When that same experiment is updated with the same name
+    Then the experiment retains slug "my-experiment"
+
+  @regression @integration
+  Scenario: Multiple slug conflicts increment the suffix
+    Given experiments exist in the project with slugs "my-experiment" and "my-experiment-2"
+    When a new experiment is saved with a name that generates slug "my-experiment"
+    Then the new experiment is created with slug "my-experiment-3"

--- a/specs/evaluations-v3/experiment-slug-deduplication.feature
+++ b/specs/evaluations-v3/experiment-slug-deduplication.feature
@@ -22,3 +22,15 @@ Feature: Experiment slug deduplication
     Given experiments exist in the project with slugs "my-experiment" and "my-experiment-2"
     When a new experiment is saved with a name that generates slug "my-experiment"
     Then the new experiment is created with slug "my-experiment-3"
+
+  @regression @integration
+  Scenario: Slug with no conflict returns unchanged
+    Given no experiment exists in the project with the target slug
+    When a new experiment is saved
+    Then the slug is used as-is without a numeric suffix
+
+  @regression @integration
+  Scenario: Unrelated slug sharing the same prefix is not treated as a conflict
+    Given an experiment exists with slug "my-exp-extended"
+    When a new experiment is saved with a name that generates slug "my-exp"
+    Then the new experiment is created with slug "my-exp" without a suffix


### PR DESCRIPTION
## Summary

Fixes #977

When saving an experiment, if the generated slug conflicts with an existing experiment's slug in the same project, the Prisma upsert fails with a unique constraint violation on `(projectId, slug)`.

### Changes

- **Extracted `generateUniqueExperimentSlug()`** — shared function that checks for slug conflicts and appends numeric suffixes (`-2`, `-3`, ...) until unique. Falls back to random nanoid suffix after 100 candidates. Uses a single `findMany` query (no N+1 loop).
- **Fixed `saveExperiment`** — now calls `generateUniqueExperimentSlug` before upsert
- **Fixed `saveEvaluationsV3`** — same protection applied for new experiments created via the V3 path
- **Refactored `copyEvaluationsV3Experiment`** — replaced 24 lines of inline dedup with shared function call
- **Dependency injection** — `prisma` is passed as a parameter (not imported globally) per project DIP standards

### Architecture

- Single query pattern (matching existing `findNextDraftName`) instead of N+1 loop
- TOCTOU race condition documented in JSDoc; callers advised to catch P2002 if needed

## Test plan

- [x] Typecheck passes
- [x] 5 integration tests: no-conflict, `-2` suffix, `-3` suffix, self-exclusion for updates, full upsert regression
- [x] BDD spec: `specs/evaluations-v3/experiment-slug-deduplication.feature`