### PR TITLE
fix: prevent completed experiment runs from showing as Interrupted

### DIFF
--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
@@ -145,7 +145,11 @@ export function BatchEvaluationResults({
   // Determine if selected run is finished
   const isFinished = useMemo(() => {
     if (!selectedRun) return false;
-    return isRunFinished(selectedRun.timestamps);
+    return isRunFinished({
+      ...selectedRun.timestamps,
+      progress: selectedRun.progress,
+      total: selectedRun.total,
+    });
   }, [selectedRun]);
 
   // Track when the run finished and reset when run changes or becomes not finished
@@ -193,7 +197,11 @@ export function BatchEvaluationResults({
   // Update isSomeRunning state
   useEffect(() => {
     const hasRunning = runsQuery.data?.runs.some(
-      (r) => !isRunFinished(r.timestamps),
+      (r) => !isRunFinished({
+        ...r.timestamps,
+        progress: r.progress,
+        total: r.total,
+      }),
     );
     setIsSomeRunning(!!hasRunning);
   }, [runsQuery.data?.runs]);

--- a/langwatch/src/components/batch-evaluation-results/BatchRunsSidebar.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchRunsSidebar.tsx
@@ -88,19 +88,33 @@ type BatchRunsSidebarProps = {
 };
 
 /**
- * Check if a run was interrupted (no explicit finish/stop but stale)
+ * Check if a run was interrupted (no explicit finish/stop but stale).
+ * A run is NOT interrupted if all work completed (progress >= total),
+ * even when FinishedAt is missing due to a failed completion event.
  */
-const isRunInterrupted = (
-  timestamps: BatchRunSummary["timestamps"],
-): boolean => {
+const isRunInterrupted = (run: {
+  timestamps: BatchRunSummary["timestamps"];
+  progress?: number | null;
+  total?: number | null;
+}): boolean => {
   // Has explicit finish or stop - not interrupted
-  if (timestamps.finishedAt ?? timestamps.stoppedAt) {
+  if (run.timestamps.finishedAt ?? run.timestamps.stoppedAt) {
+    return false;
+  }
+
+  // All work completed — not interrupted even without FinishedAt
+  if (
+    run.progress != null &&
+    run.total != null &&
+    run.total > 0 &&
+    run.progress >= run.total
+  ) {
     return false;
   }
 
   // No updates for 5 minutes - considered interrupted
-  if (timestamps.updatedAt) {
-    const timeSinceUpdate = Date.now() - timestamps.updatedAt;
+  if (run.timestamps.updatedAt) {
+    const timeSinceUpdate = Date.now() - run.timestamps.updatedAt;
     return timeSinceUpdate > INTERRUPTED_THRESHOLD_MS;
   }
 
@@ -288,7 +302,11 @@ export function BatchRunsSidebar({
           !error &&
           sortedRuns.map((run) => {
             const isSelected = selectedRunId === run.runId;
-            const isFinished = isRunFinished(run.timestamps);
+            const isFinished = isRunFinished({
+              ...run.timestamps,
+              progress: run.progress,
+              total: run.total,
+            });
             const _runCost =
               (run.summary.datasetCost ?? 0) +
               (run.summary.evaluationsCost ?? 0);
@@ -312,7 +330,7 @@ export function BatchRunsSidebar({
               });
 
             const isSelectedForComparison = selectedRunIds.includes(run.runId);
-            const interrupted = isRunInterrupted(run.timestamps);
+            const interrupted = isRunInterrupted(run);
 
             // Use stable color from parent (based on position in full runs list)
             // Override with red for stopped runs, orange for interrupted

--- a/langwatch/src/components/batch-evaluation-results/__tests__/isRunFinished.test.ts
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/isRunFinished.test.ts
@@ -82,6 +82,49 @@ describe("isRunFinished", () => {
     });
   });
 
+  describe("when progress equals total and total > 0 (all work completed)", () => {
+    describe("when finishedAt is missing and updatedAt is stale", () => {
+      it("returns true (run completed all work)", () => {
+        const tenMinutesAgo = Date.now() - 10 * 60 * 1000;
+        expect(
+          isRunFinished({
+            updatedAt: tenMinutesAgo,
+            progress: 50,
+            total: 50,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when finishedAt is missing and updatedAt is recent", () => {
+      it("returns true (all work completed)", () => {
+        const twoMinutesAgo = Date.now() - 2 * 60 * 1000;
+        expect(
+          isRunFinished({
+            updatedAt: twoMinutesAgo,
+            progress: 50,
+            total: 50,
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe("when progress is less than total", () => {
+    describe("when finishedAt is missing and updatedAt is stale", () => {
+      it("returns true (interrupted)", () => {
+        const tenMinutesAgo = Date.now() - 10 * 60 * 1000;
+        expect(
+          isRunFinished({
+            updatedAt: tenMinutesAgo,
+            progress: 25,
+            total: 50,
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+
   it("exports INTERRUPTED_THRESHOLD_MS as 5 minutes in milliseconds", () => {
     expect(INTERRUPTED_THRESHOLD_MS).toBe(5 * 60 * 1000);
   });

--- a/langwatch/src/components/batch-evaluation-results/isRunFinished.ts
+++ b/langwatch/src/components/batch-evaluation-results/isRunFinished.ts
@@ -2,17 +2,31 @@
 export const INTERRUPTED_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
- * Check if a run is finished based on timestamps.
+ * Check if a run is finished based on timestamps and optional progress.
  * A run is considered finished if it has finishedAt, stoppedAt,
- * or hasn't been updated in 5 minutes (interrupted).
+ * all work is completed (progress >= total), or hasn't been updated
+ * in 5 minutes (interrupted).
  */
 export const isRunFinished = (timestamps: {
   finishedAt?: number | null;
   stoppedAt?: number | null;
   updatedAt?: number | null;
+  progress?: number | null;
+  total?: number | null;
 }): boolean => {
   // Explicitly finished or stopped
   if (timestamps.finishedAt ?? timestamps.stoppedAt) {
+    return true;
+  }
+
+  // All work completed — the completion event may have failed to persist
+  // FinishedAt, but progress reaching total means the run is done.
+  if (
+    timestamps.progress != null &&
+    timestamps.total != null &&
+    timestamps.total > 0 &&
+    timestamps.progress >= timestamps.total
+  ) {
     return true;
   }
 

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -392,6 +392,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
         const hasFinished = r.FinishedAt != null && Number(r.FinishedAt) > 0;
         const resolvedStatus = resolveRunStatus({
           finishedStatus: hasFinished ? baseStatus : undefined,
+          storedStatus: baseStatus,
           lastEventTimestamp: perRunUpdatedAt,
           now,
         });

--- a/langwatch/src/server/evaluations-v3/execution/orchestrator.ts
+++ b/langwatch/src/server/evaluations-v3/execution/orchestrator.ts
@@ -1125,19 +1125,28 @@ export async function* runOrchestrator(
 
     // Dispatch completion event to ClickHouse — must fire regardless of
     // repository (which is null when featureEventSourcingEvaluationIngestion is ON).
+    // Retry once on failure to reduce the chance of FinishedAt staying NULL.
     if (experimentId) {
       chDispatchTotal++;
-      await commands.completeExperimentRun({
+      const completionPayload = {
         tenantId: projectId,
         runId,
         experimentId,
         finishedAt: aborted ? null : finishedAt,
         stoppedAt: aborted ? finishedAt : null,
         occurredAt: Date.now(),
-      }).catch((err) => {
-        chDispatchFailures++;
-        logger.warn({ err, runId }, "Failed to dispatch completeExperimentRun to CH");
-      });
+      };
+      try {
+        await commands.completeExperimentRun(completionPayload);
+      } catch (firstErr) {
+        logger.error({ err: firstErr, runId }, "Failed to dispatch completeExperimentRun to CH, retrying once");
+        try {
+          await commands.completeExperimentRun(completionPayload);
+        } catch (retryErr) {
+          chDispatchFailures++;
+          logger.error({ err: retryErr, runId }, "Retry of completeExperimentRun also failed");
+        }
+      }
     }
   }
 

--- a/langwatch/src/server/scenarios/__tests__/stall-detection.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/stall-detection.unit.test.ts
@@ -100,6 +100,86 @@ describe("resolveRunStatus()", () => {
     });
   });
 
+  describe("given a run with terminal storedStatus but no RUN_FINISHED event", () => {
+    describe("when storedStatus is SUCCESS and time exceeds threshold", () => {
+      it("returns SUCCESS instead of STALLED", () => {
+        const status = resolveRunStatus({
+          finishedStatus: undefined,
+          storedStatus: ScenarioRunStatus.SUCCESS,
+          lastEventTimestamp: minutesAgo(15),
+          now: NOW,
+        });
+
+        expect(status).toBe(ScenarioRunStatus.SUCCESS);
+      });
+    });
+
+    describe("when storedStatus is FAILED and time exceeds threshold", () => {
+      it("returns FAILED instead of STALLED", () => {
+        const status = resolveRunStatus({
+          finishedStatus: undefined,
+          storedStatus: ScenarioRunStatus.FAILED,
+          lastEventTimestamp: minutesAgo(15),
+          now: NOW,
+        });
+
+        expect(status).toBe(ScenarioRunStatus.FAILED);
+      });
+    });
+
+    describe("when storedStatus is ERROR and time exceeds threshold", () => {
+      it("returns ERROR instead of STALLED", () => {
+        const status = resolveRunStatus({
+          finishedStatus: undefined,
+          storedStatus: ScenarioRunStatus.ERROR,
+          lastEventTimestamp: minutesAgo(15),
+          now: NOW,
+        });
+
+        expect(status).toBe(ScenarioRunStatus.ERROR);
+      });
+    });
+
+    describe("when storedStatus is CANCELLED and time exceeds threshold", () => {
+      it("returns CANCELLED instead of STALLED", () => {
+        const status = resolveRunStatus({
+          finishedStatus: undefined,
+          storedStatus: ScenarioRunStatus.CANCELLED,
+          lastEventTimestamp: minutesAgo(15),
+          now: NOW,
+        });
+
+        expect(status).toBe(ScenarioRunStatus.CANCELLED);
+      });
+    });
+
+    describe("when storedStatus is IN_PROGRESS and time exceeds threshold", () => {
+      it("returns STALLED (non-terminal status is not protected)", () => {
+        const status = resolveRunStatus({
+          finishedStatus: undefined,
+          storedStatus: ScenarioRunStatus.IN_PROGRESS,
+          lastEventTimestamp: minutesAgo(15),
+          now: NOW,
+        });
+
+        expect(status).toBe(ScenarioRunStatus.STALLED);
+      });
+    });
+
+    describe("when storedStatus is undefined", () => {
+      it("falls through to stall detection as before", () => {
+        const status = resolveRunStatus({
+          finishedStatus: undefined,
+          storedStatus: undefined,
+          lastEventTimestamp: minutesAgo(15),
+          now: NOW,
+        });
+
+        expect(status).toBe(ScenarioRunStatus.STALLED);
+      });
+    });
+  });
+
   describe("given stall detection uses the last event timestamp", () => {
     describe("when a MESSAGE_SNAPSHOT event is recent but RUN_STARTED is old", () => {
       it("returns IN_PROGRESS based on the more recent event", () => {

--- a/langwatch/src/server/scenarios/stall-detection.ts
+++ b/langwatch/src/server/scenarios/stall-detection.ts
@@ -7,6 +7,14 @@ import { ScenarioRunStatus } from "./scenario-event.enums";
  */
 export const STALL_THRESHOLD_MS = 10 * 60 * 1000;
 
+/** Statuses that represent a completed run (no further work expected). */
+const TERMINAL_STATUSES = new Set<ScenarioRunStatus>([
+  ScenarioRunStatus.SUCCESS,
+  ScenarioRunStatus.FAILED,
+  ScenarioRunStatus.ERROR,
+  ScenarioRunStatus.CANCELLED,
+]);
+
 /**
  * Resolves the effective status of a scenario run, deriving STALLED
  * at read time when a run has no RUN_FINISHED event and enough time
@@ -16,22 +24,35 @@ export const STALL_THRESHOLD_MS = 10 * 60 * 1000;
  * any new events to ElasticSearch.
  *
  * @param params.finishedStatus - The status from RUN_FINISHED event, or undefined if none exists
+ * @param params.storedStatus - The persisted status from ClickHouse/ES (optional). When this
+ *   is a terminal status (SUCCESS, FAILED, ERROR, CANCELLED) it takes precedence over stall
+ *   detection, preventing completed runs from being retroactively marked as STALLED when the
+ *   completion event (which sets FinishedAt) failed to persist.
  * @param params.lastEventTimestamp - Timestamp (ms) of the most recent event of any type
  * @param params.now - Current time in ms (injectable for testing)
  * @returns The resolved ScenarioRunStatus
  */
 export function resolveRunStatus({
   finishedStatus,
+  storedStatus,
   lastEventTimestamp,
   now = Date.now(),
 }: {
   finishedStatus: ScenarioRunStatus | undefined;
+  storedStatus?: ScenarioRunStatus;
   lastEventTimestamp: number;
   now?: number;
 }): ScenarioRunStatus {
   // If a RUN_FINISHED event exists, use its status as-is
   if (finishedStatus !== undefined) {
     return finishedStatus;
+  }
+
+  // If the stored status is already terminal, trust it even without a
+  // RUN_FINISHED event. This handles the case where the completion event
+  // dispatch to ClickHouse failed but the status was set correctly.
+  if (storedStatus !== undefined && TERMINAL_STATUSES.has(storedStatus)) {
+    return storedStatus;
   }
 
   // No RUN_FINISHED: check if the run has stalled

--- a/langwatch/src/server/simulations/simulation-run.mappers.ts
+++ b/langwatch/src/server/simulations/simulation-run.mappers.ts
@@ -96,9 +96,12 @@ export function mapClickHouseRowToScenarioRunData(
   // Use StartedAt for duration calculation (CreatedAt is CH insertion time, which can be after FinishedAt)
   const startTimestamp = startedAt ?? createdAt;
 
-  // Apply stall detection: if run has no finished timestamp, check if it's stalled
+  // Apply stall detection: if run has no finished timestamp, check if it's stalled.
+  // Pass storedStatus so terminal statuses (SUCCESS, FAILED, etc.) are respected
+  // even when FinishedAt is NULL due to a failed completion event dispatch.
   const resolvedStatus = resolveRunStatus({
     finishedStatus: finishedAt != null ? baseStatus : undefined,
+    storedStatus: baseStatus,
     lastEventTimestamp: updatedAt,
     now,
   });


### PR DESCRIPTION
## Summary

Fixes #2566 — Completed experiment/simulation results get trimmed and show "Interrupted" status after ~1 day.

**Root cause:** The completion event dispatch to ClickHouse can silently fail, leaving `FinishedAt` as NULL. Stale-detection logic then overrides the status to STALLED/Interrupted — even for runs with terminal statuses (SUCCESS, FAILED, etc.).

**Fixes:**

- **`resolveRunStatus()` respects terminal stored statuses** — When `storedStatus` is SUCCESS/FAILED/ERROR/CANCELLED, return it as-is even without `FinishedAt`. This prevents completed runs from being retroactively marked as STALLED.
- **`isRunFinished()`/`isRunInterrupted()` use progress as secondary signal** — When `progress >= total` and `total > 0`, the run is considered complete even without `finishedAt`. This handles experiment runs (which lack a `Status` column in ClickHouse).
- **Orchestrator retries completion dispatch once** — The `.catch()` that silently swallowed `completeExperimentRun` failures now retries once and logs at ERROR level.

## Changed files

| File | Change |
|------|--------|
| `stall-detection.ts` | Added `storedStatus` param + `TERMINAL_STATUSES` set |
| `isRunFinished.ts` | Added `progress`/`total` fields for completion detection |
| `BatchRunsSidebar.tsx` | Updated `isRunInterrupted()` to accept progress/total |
| `BatchEvaluationResults.tsx` | Pass progress/total to `isRunFinished()` |
| `simulation-run.mappers.ts` | Pass `storedStatus` to `resolveRunStatus()` |
| `simulation.clickhouse.repository.ts` | Pass `storedStatus` to `resolveRunStatus()` |
| `orchestrator.ts` | Retry completion dispatch once + ERROR logging |

## Test plan

- [x] `stall-detection.unit.test.ts` — 6 new regression tests (terminal statuses respected, non-terminal still stalls)
- [x] `isRunFinished.test.ts` — 3 new regression tests (progress-based completion)
- [x] `BatchRunsSidebar.integration.test.tsx` — 4 existing tests pass
- [x] 163 tests pass across batch-evaluation-results suite

# Related Issue

- Resolve #2566