### PR TITLE
fix: forward scrollId in messages pagination to fix stuck navigation after page 2

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/traces.getAllForProject.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/traces.getAllForProject.unit.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { tracesRouter } from "../traces";
+import { createInnerTRPCContext } from "../../trpc";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const { mockGetAllTracesForProject } = vi.hoisted(() => ({
+  mockGetAllTracesForProject: vi.fn(),
+}));
+
+vi.mock("~/server/traces/trace.service", () => ({
+  TraceService: {
+    create: () => ({
+      getAllTracesForProject: mockGetAllTracesForProject,
+    }),
+  },
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    hasProjectPermission: vi.fn(() => Promise.resolve(true)),
+    checkProjectPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+    checkPermissionOrPubliclyShared:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+vi.mock("../../utils", () => ({
+  getUserProtectionsForProject: vi.fn().mockResolvedValue({
+    canSeeCosts: true,
+    canSeePiiData: true,
+    canSeeTopics: true,
+  }),
+}));
+
+vi.mock("~/server/evaluations/evaluators.zod.generated", () => ({
+  evaluatorsSchema: { keyof: () => ({ or: () => ({}) }) },
+}));
+
+vi.mock("~/server/evaluations/preconditions", () => ({
+  evaluatePreconditions: vi.fn(),
+  buildPreconditionTraceDataFromTrace: vi.fn(),
+  checkEvaluatorRequiredFields: vi.fn(),
+}));
+
+vi.mock("~/server/evaluations/types", () => ({
+  checkPreconditionSchema: {},
+}));
+
+describe("traces.getAllForProject", () => {
+  let caller: ReturnType<typeof tracesRouter.createCaller>;
+
+  const baseInput = {
+    projectId: "project_123",
+    startDate: Date.now() - 86400000,
+    endDate: Date.now(),
+    pageSize: 10,
+    pageOffset: 0,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const ctx = createInnerTRPCContext({
+      session: {
+        user: { id: "test-user-id" },
+        expires: "1",
+      },
+      req: undefined,
+      res: undefined,
+      permissionChecked: true,
+      publiclyShared: false,
+    });
+
+    ctx.prisma = {} as unknown as PrismaClient;
+    caller = tracesRouter.createCaller(ctx);
+  });
+
+  describe("when scrollId is provided in the input", () => {
+    it("forwards scrollId to the trace service options parameter", async () => {
+      const scrollId = "base64encodedcursordata";
+
+      mockGetAllTracesForProject.mockResolvedValueOnce({
+        groups: [],
+        totalHits: 0,
+        traceChecks: {},
+      });
+
+      await caller.getAllForProject({
+        ...baseInput,
+        scrollId,
+      });
+
+      expect(mockGetAllTracesForProject).toHaveBeenCalledWith(
+        expect.objectContaining({ scrollId }),
+        expect.any(Object),
+        { scrollId },
+      );
+    });
+  });
+
+  describe("when scrollId is not provided", () => {
+    it("forwards undefined scrollId in options", async () => {
+      mockGetAllTracesForProject.mockResolvedValueOnce({
+        groups: [],
+        totalHits: 0,
+        traceChecks: {},
+      });
+
+      await caller.getAllForProject(baseInput);
+
+      expect(mockGetAllTracesForProject).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        { scrollId: undefined },
+      );
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/traces.ts
+++ b/langwatch/src/server/api/routers/traces.ts
@@ -36,7 +36,9 @@ export const tracesRouter = createTRPCRouter({
       });
 
       const traceService = TraceService.create(ctx.prisma);
-      return traceService.getAllTracesForProject(input, protections);
+      return traceService.getAllTracesForProject(input, protections, {
+        scrollId: input.scrollId,
+      });
     }),
 
   getById: publicProcedure


### PR DESCRIPTION
## Summary

Fixes #2856

- **Bug:** Messages page pagination stops working after page 2 — clicking "next" returns the same page 1 data repeatedly
- **Root cause:** `getAllForProject` query handler in `traces.ts` was not forwarding `scrollId` from input to the `TraceService` options parameter, so the ClickHouse cursor-based pagination was never applied
- **Fix:** Pass `{ scrollId: input.scrollId }` as the third argument to `traceService.getAllTracesForProject()`, matching the existing pattern in `getAllForDownload`
<img width="983" height="320" alt="image" src="https://github.com/user-attachments/assets/5075ab03-0367-470d-b36d-a03671d293ae" />

<img width="821" height="353" alt="image" src="https://github.com/user-attachments/assets/cd28029f-7495-43cf-856e-fdefc206969f" />


## Test plan
- [x] Unit regression test verifies scrollId is forwarded to the service options parameter
- [ ] Manual verification: navigate through pages 1 → 2 → 3 → 4 on the messages page and confirm forward pagination works