### PR TITLE
feat: analytics fact tables with event sourcing projections

### DIFF
--- a/langwatch/src/server/analytics/__tests__/analytics.service.test.ts
+++ b/langwatch/src/server/analytics/__tests__/analytics.service.test.ts
@@ -394,6 +394,311 @@ describe("AnalyticsService", () => {
       expect(fakeES.getFeedbacksCalled).toBe(false);
     });
   });
+
+  describe("when projection service is provided", () => {
+    const input = {
+      projectId: "test-project",
+      startDate: Date.now() - 86400000,
+      endDate: Date.now(),
+      filters: {},
+      series: [
+        {
+          metric: "metadata.trace_id" as const,
+          aggregation: "cardinality" as const,
+        },
+      ],
+      timeZone: "UTC",
+    };
+
+    function createFakeFeatureFlagService(enabled: boolean) {
+      return {
+        isEnabled: vi.fn().mockResolvedValue(enabled),
+      };
+    }
+
+    describe("when projection feature flag is enabled", () => {
+      it("routes getTimeseries to projection service", async () => {
+        const fakeES = createFakeBackend();
+        const fakeCH = createFakeBackend({ available: true });
+        const fakeProjection = createFakeBackend({
+          available: true,
+          timeseriesResult: {
+            currentPeriod: [{ date: "2024-01-01", count: 200 }],
+            previousPeriod: [{ date: "2023-12-31", count: 180 }],
+          },
+        });
+        const fakePrisma = createFakePrisma({ clickhouseEnabled: true });
+        const fakeFlags = createFakeFeatureFlagService(true);
+
+        const service = new AnalyticsService({
+          esService: fakeES,
+          chService: fakeCH,
+          projectionService: fakeProjection,
+          prisma: fakePrisma,
+          featureFlagService: fakeFlags,
+        });
+
+        const result = await service.getTimeseries(input);
+
+        expect(result.currentPeriod[0]!.count).toBe(200);
+        expect(fakeProjection.getTimeseriesCalled).toBe(true);
+        expect(fakeCH.getTimeseriesCalled).toBe(false);
+        expect(fakeES.getTimeseriesCalled).toBe(false);
+      });
+
+      it("routes getDataForFilter to projection service", async () => {
+        const fakeES = createFakeBackend();
+        const fakeCH = createFakeBackend({ available: true });
+        const fakeProjection = createFakeBackend({
+          available: true,
+          filterDataResult: {
+            options: [{ field: "proj-1", label: "Proj 1", count: 99 }],
+          },
+        });
+        const fakePrisma = createFakePrisma({ clickhouseEnabled: true });
+        const fakeFlags = createFakeFeatureFlagService(true);
+
+        const service = new AnalyticsService({
+          esService: fakeES,
+          chService: fakeCH,
+          projectionService: fakeProjection,
+          prisma: fakePrisma,
+          featureFlagService: fakeFlags,
+        });
+
+        const result = await service.getDataForFilter(
+          "test-project",
+          "topics.topics",
+          Date.now() - 86400000,
+          Date.now(),
+          {},
+        );
+
+        expect(result.options[0]!.field).toBe("proj-1");
+        expect(fakeProjection.getDataForFilterCalled).toBe(true);
+        expect(fakeCH.getDataForFilterCalled).toBe(false);
+      });
+
+      it("routes getTopUsedDocuments to projection service", async () => {
+        const fakeES = createFakeBackend();
+        const fakeCH = createFakeBackend({ available: true });
+        const fakeProjection = createFakeBackend({
+          available: true,
+          topDocumentsResult: {
+            topDocuments: [
+              { documentId: "proj-doc-1", count: 5, traceId: "trace-p1" },
+            ],
+            totalUniqueDocuments: 42,
+          },
+        });
+        const fakePrisma = createFakePrisma({ clickhouseEnabled: true });
+        const fakeFlags = createFakeFeatureFlagService(true);
+
+        const service = new AnalyticsService({
+          esService: fakeES,
+          chService: fakeCH,
+          projectionService: fakeProjection,
+          prisma: fakePrisma,
+          featureFlagService: fakeFlags,
+        });
+
+        const result = await service.getTopUsedDocuments(
+          "test-project",
+          Date.now() - 86400000,
+          Date.now(),
+          {},
+        );
+
+        expect(result.topDocuments[0]!.documentId).toBe("proj-doc-1");
+        expect(fakeProjection.getTopUsedDocumentsCalled).toBe(true);
+        expect(fakeCH.getTopUsedDocumentsCalled).toBe(false);
+      });
+
+      it("routes getFeedbacks to projection service", async () => {
+        const fakeES = createFakeBackend();
+        const fakeCH = createFakeBackend({ available: true });
+        const fakeProjection = createFakeBackend({
+          available: true,
+          feedbacksResult: {
+            events: [
+              { event_id: "proj-ev-1", event_type: "thumbs_up_down" },
+            ],
+          },
+        });
+        const fakePrisma = createFakePrisma({ clickhouseEnabled: true });
+        const fakeFlags = createFakeFeatureFlagService(true);
+
+        const service = new AnalyticsService({
+          esService: fakeES,
+          chService: fakeCH,
+          projectionService: fakeProjection,
+          prisma: fakePrisma,
+          featureFlagService: fakeFlags,
+        });
+
+        const result = await service.getFeedbacks(
+          "test-project",
+          Date.now() - 86400000,
+          Date.now(),
+          {},
+        );
+
+        expect(result.events[0]!.event_id).toBe("proj-ev-1");
+        expect(fakeProjection.getFeedbacksCalled).toBe(true);
+        expect(fakeCH.getFeedbacksCalled).toBe(false);
+      });
+    });
+
+    describe("when projection feature flag is disabled", () => {
+      it("falls through to normal CH/ES routing", async () => {
+        const fakeES = createFakeBackend();
+        const fakeCH = createFakeBackend({ available: true });
+        const fakeProjection = createFakeBackend({ available: true });
+        const fakePrisma = createFakePrisma({ clickhouseEnabled: true });
+        const fakeFlags = createFakeFeatureFlagService(false);
+
+        const service = new AnalyticsService({
+          esService: fakeES,
+          chService: fakeCH,
+          projectionService: fakeProjection,
+          prisma: fakePrisma,
+          featureFlagService: fakeFlags,
+        });
+
+        const result = await service.getTimeseries(input);
+
+        expect(result.currentPeriod).toHaveLength(1);
+        expect(fakeProjection.getTimeseriesCalled).toBe(false);
+        expect(fakeCH.getTimeseriesCalled).toBe(true);
+      });
+    });
+
+    describe("when projection service is not available", () => {
+      it("skips feature flag check and falls through to normal routing", async () => {
+        const fakeES = createFakeBackend();
+        const fakeCH = createFakeBackend({ available: true });
+        const fakeProjection = createFakeBackend({ available: false });
+        const fakePrisma = createFakePrisma({ clickhouseEnabled: true });
+        const fakeFlags = createFakeFeatureFlagService(true);
+
+        const service = new AnalyticsService({
+          esService: fakeES,
+          chService: fakeCH,
+          projectionService: fakeProjection,
+          prisma: fakePrisma,
+          featureFlagService: fakeFlags,
+        });
+
+        const result = await service.getTimeseries(input);
+
+        expect(result.currentPeriod).toHaveLength(1);
+        expect(fakeProjection.getTimeseriesCalled).toBe(false);
+        expect(fakeCH.getTimeseriesCalled).toBe(true);
+        // Should not even call the feature flag service when projection is unavailable
+        expect(fakeFlags.isEnabled).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when projection service is not provided", () => {
+      it("falls through to normal CH/ES routing", async () => {
+        const fakeES = createFakeBackend();
+        const fakeCH = createFakeBackend({ available: true });
+        const fakePrisma = createFakePrisma({ clickhouseEnabled: true });
+
+        const service = new AnalyticsService({
+          esService: fakeES,
+          chService: fakeCH,
+          prisma: fakePrisma,
+        });
+
+        const result = await service.getTimeseries(input);
+
+        expect(result.currentPeriod).toHaveLength(1);
+        expect(fakeCH.getTimeseriesCalled).toBe(true);
+      });
+    });
+
+    describe("when comparison mode is enabled with projections", () => {
+      it("compares projection results against CH results", async () => {
+        const fakeES = createFakeBackend();
+        const fakeCH = createFakeBackend({
+          available: true,
+          timeseriesResult: {
+            currentPeriod: [{ date: "2024-01-01", count: 100 }],
+            previousPeriod: [{ date: "2023-12-31", count: 90 }],
+          },
+        });
+        const fakeProjection = createFakeBackend({
+          available: true,
+          timeseriesResult: {
+            currentPeriod: [{ date: "2024-01-01", count: 200 }],
+            previousPeriod: [{ date: "2023-12-31", count: 180 }],
+          },
+        });
+        const fakePrisma = createFakePrisma({ clickhouseEnabled: true });
+        const fakeFlags = createFakeFeatureFlagService(true);
+        const fakeComparator = {
+          compare: vi.fn(),
+        };
+
+        const service = new AnalyticsService({
+          esService: fakeES,
+          chService: fakeCH,
+          projectionService: fakeProjection,
+          prisma: fakePrisma,
+          featureFlagService: fakeFlags,
+          comparator: fakeComparator as any,
+          config: { comparisonModeEnabled: true },
+        });
+
+        const result = await service.getTimeseries(input);
+
+        // Projection is the primary result
+        expect(result.currentPeriod[0]!.count).toBe(200);
+        // Both CH and projection were called for comparison
+        expect(fakeCH.getTimeseriesCalled).toBe(true);
+        expect(fakeProjection.getTimeseriesCalled).toBe(true);
+        // ES was not called
+        expect(fakeES.getTimeseriesCalled).toBe(false);
+        // Comparator was invoked with CH as baseline and projection as experimental
+        expect(fakeComparator.compare).toHaveBeenCalledWith(
+          "getTimeseries",
+          expect.anything(),
+          expect.objectContaining({
+            currentPeriod: [{ date: "2024-01-01", count: 100 }],
+          }),
+          expect.objectContaining({
+            currentPeriod: [{ date: "2024-01-01", count: 200 }],
+          }),
+        );
+      });
+    });
+
+    it("passes correct flag key and projectId to feature flag service", async () => {
+      const fakeES = createFakeBackend();
+      const fakeCH = createFakeBackend({ available: true });
+      const fakeProjection = createFakeBackend({ available: true });
+      const fakePrisma = createFakePrisma({ clickhouseEnabled: false });
+      const fakeFlags = createFakeFeatureFlagService(false);
+
+      const service = new AnalyticsService({
+        esService: fakeES,
+        chService: fakeCH,
+        projectionService: fakeProjection,
+        prisma: fakePrisma,
+        featureFlagService: fakeFlags,
+      });
+
+      await service.getTimeseries(input);
+
+      expect(fakeFlags.isEnabled).toHaveBeenCalledWith(
+        "analytics_projections_enabled",
+        "test-project",
+        false,
+        { projectId: "test-project" },
+      );
+    });
+  });
 });
 
 describe("getAnalyticsService", () => {

--- a/langwatch/src/server/analytics/analytics.service.ts
+++ b/langwatch/src/server/analytics/analytics.service.ts
@@ -1,10 +1,12 @@
 /**
  * Analytics Service Facade
  *
- * Routes analytics queries to either Elasticsearch or ClickHouse based on
- * the project's featureClickHouseDataSourceTraces flag.
+ * Routes analytics queries to the appropriate backend based on feature flags:
+ * 1. Projection-based fact tables (PostHog flag: analytics_projections_enabled)
+ * 2. ClickHouse entity tables (Prisma flag: featureClickHouseDataSourceTraces)
+ * 3. Elasticsearch (default fallback)
  *
- * Supports comparison mode for verifying CH results against ES results.
+ * Supports comparison mode for verifying results between backends.
  */
 
 import type { PrismaClient } from "@prisma/client";
@@ -21,6 +23,8 @@ import type {
 import type { TimeseriesInputType } from "./registry";
 import { getElasticsearchAnalyticsService } from "./elasticsearch-analytics.service";
 import { getClickHouseAnalyticsService } from "./clickhouse/clickhouse-analytics.service";
+import { getProjectionAnalyticsService } from "./projection/index";
+import { featureFlagService } from "~/server/featureFlag";
 import {
   AnalyticsComparator,
   getAnalyticsComparator,
@@ -35,31 +39,53 @@ export interface AnalyticsServiceConfig {
 }
 
 /**
+ * Minimal interface for feature flag evaluation, allowing injection for testing.
+ */
+export interface AnalyticsFeatureFlagService {
+  isEnabled(
+    flagKey: string,
+    distinctId: string,
+    defaultValue: boolean,
+    options?: { projectId?: string },
+  ): Promise<boolean>;
+}
+
+/**
  * Dependencies required by AnalyticsService
  */
 export interface AnalyticsServiceDependencies {
   esService: AnalyticsBackend;
   chService: AnalyticsBackend;
+  projectionService?: AnalyticsBackend;
   prisma: PrismaClient;
   comparator?: AnalyticsComparator;
+  featureFlagService?: AnalyticsFeatureFlagService;
   config?: AnalyticsServiceConfig;
 }
 
 /**
  * Analytics Service Facade
  *
- * This facade routes analytics requests to either Elasticsearch or ClickHouse
- * based on the project's configuration. It supports:
+ * This facade routes analytics requests to the appropriate backend
+ * based on feature flags. Routing priority:
  *
- * - Feature flag based routing (featureClickHouseDataSourceTraces)
- * - Comparison mode for verifying ClickHouse results against Elasticsearch
- * - Logging of discrepancies for debugging
+ * 1. **Projection service** - PostHog flag `analytics_projections_enabled`
+ *    (or env var `ANALYTICS_PROJECTIONS_ENABLED=1`). Uses pre-built
+ *    denormalized fact tables for fast, JOIN-free queries.
+ * 2. **ClickHouse** - Prisma flag `featureClickHouseDataSourceTraces`.
+ *    Queries entity-oriented tables with JOINs.
+ * 3. **Elasticsearch** - Default fallback.
+ *
+ * In comparison mode, results from the experimental backend are compared
+ * against the baseline and discrepancies are logged.
  */
 export class AnalyticsService {
   private readonly prisma: PrismaClient;
   private readonly esService: AnalyticsBackend;
   private readonly chService: AnalyticsBackend;
+  private readonly projectionService?: AnalyticsBackend;
   private readonly comparator: AnalyticsComparator;
+  private readonly featureFlagService?: AnalyticsFeatureFlagService;
   private readonly config: AnalyticsServiceConfig;
   private readonly logger = createLogger("langwatch:analytics:service");
   private readonly tracer = getLangWatchTracer("langwatch.analytics.service");
@@ -67,8 +93,10 @@ export class AnalyticsService {
   constructor(deps: AnalyticsServiceDependencies) {
     this.esService = deps.esService;
     this.chService = deps.chService;
+    this.projectionService = deps.projectionService;
     this.prisma = deps.prisma;
     this.comparator = deps.comparator ?? getAnalyticsComparator();
+    this.featureFlagService = deps.featureFlagService;
     this.config = deps.config ?? {};
   }
 
@@ -122,11 +150,34 @@ export class AnalyticsService {
     input: unknown,
     esCall: () => Promise<TResult>,
     chCall: () => Promise<TResult>,
+    projectionCall?: () => Promise<TResult>,
   ): Promise<TResult> {
     return this.tracer.withActiveSpan(
       `AnalyticsService.${operationName}`,
       { attributes: { "tenant.id": projectId } },
       async (span) => {
+        // Check projection-based analytics before existing routing
+        const useProjections = await this.isProjectionsEnabled(projectId);
+
+        if (useProjections && projectionCall) {
+          span.setAttribute("backend", "projections");
+          const comparisonMode = this.isComparisonModeEnabled();
+          span.setAttribute("comparison.mode", comparisonMode);
+
+          if (comparisonMode && this.chService.isAvailable()) {
+            // In comparison mode, compare projection results against CH (baseline)
+            return this.runComparison(
+              operationName,
+              input,
+              chCall,
+              projectionCall,
+              true, // useClickHouse=true makes chCall the baseline, projectionCall the primary
+            );
+          }
+
+          return projectionCall();
+        }
+
         const useClickHouse = await this.isClickHouseEnabled(projectId);
         const comparisonMode = this.isComparisonModeEnabled();
 
@@ -149,6 +200,39 @@ export class AnalyticsService {
         return useClickHouse ? chCall() : esCall();
       },
     );
+  }
+
+  /**
+   * Check if projection-based analytics is enabled for the given project.
+   *
+   * Returns true only when:
+   * 1. A projection service is injected and reports itself as available
+   * 2. The PostHog feature flag `analytics_projections_enabled` is on for the project
+   *    (or force-enabled via ANALYTICS_PROJECTIONS_ENABLED=1 env var)
+   */
+  private async isProjectionsEnabled(projectId: string): Promise<boolean> {
+    if (!this.projectionService?.isAvailable()) {
+      return false;
+    }
+
+    if (!this.featureFlagService) {
+      return false;
+    }
+
+    try {
+      return await this.featureFlagService.isEnabled(
+        "analytics_projections_enabled",
+        projectId,
+        false,
+        { projectId },
+      );
+    } catch (error) {
+      this.logger.warn(
+        { projectId, error: error instanceof Error ? error.message : error },
+        "Failed to check projection feature flag, defaulting to off",
+      );
+      return false;
+    }
   }
 
   /**
@@ -214,6 +298,9 @@ export class AnalyticsService {
       input,
       () => this.esService.getTimeseries(input),
       () => this.chService.getTimeseries(input),
+      this.projectionService
+        ? () => this.projectionService!.getTimeseries(input)
+        : undefined,
     );
   }
 
@@ -263,6 +350,19 @@ export class AnalyticsService {
           subkey,
           searchQuery,
         ),
+      this.projectionService
+        ? () =>
+            this.projectionService!.getDataForFilter(
+              projectId,
+              field,
+              startDate,
+              endDate,
+              filters,
+              key,
+              subkey,
+              searchQuery,
+            )
+        : undefined,
     );
   }
 
@@ -300,6 +400,15 @@ export class AnalyticsService {
           endDate,
           filters,
         ),
+      this.projectionService
+        ? () =>
+            this.projectionService!.getTopUsedDocuments(
+              projectId,
+              startDate,
+              endDate,
+              filters,
+            )
+        : undefined,
     );
   }
 
@@ -325,6 +434,15 @@ export class AnalyticsService {
       { projectId, startDate, endDate },
       () => this.esService.getFeedbacks(projectId, startDate, endDate, filters),
       () => this.chService.getFeedbacks(projectId, startDate, endDate, filters),
+      this.projectionService
+        ? () =>
+            this.projectionService!.getFeedbacks(
+              projectId,
+              startDate,
+              endDate,
+              filters,
+            )
+        : undefined,
     );
   }
 }
@@ -339,7 +457,9 @@ export function createAnalyticsService(
   return new AnalyticsService({
     esService: getElasticsearchAnalyticsService(),
     chService: getClickHouseAnalyticsService(),
+    projectionService: getProjectionAnalyticsService(),
     prisma,
+    featureFlagService,
     config: {
       comparisonModeEnabled: process.env.ANALYTICS_COMPARISON_MODE === "true",
       ...config,

--- a/langwatch/src/server/analytics/projection/index.ts
+++ b/langwatch/src/server/analytics/projection/index.ts
@@ -1,0 +1,87 @@
+/**
+ * Adapter: wraps the clean app-layer AnalyticsService to implement
+ * the legacy AnalyticsBackend interface used by the analytics facade.
+ */
+
+import { getClickHouseClientForProject, isClickHouseEnabled } from "~/server/clickhouse/clickhouseClient";
+import { AnalyticsService } from "~/server/app-layer/analytics/analytics.service";
+import type { AnalyticsBackend, TimeseriesResult, FilterDataResult, TopDocumentsResult, FeedbacksResult } from "../types";
+import type { TimeseriesInputType } from "../registry";
+import type { FilterField } from "~/server/filters/types";
+
+class AnalyticsBackendAdapter implements AnalyticsBackend {
+  constructor(private readonly service: AnalyticsService) {}
+
+  isAvailable(): boolean {
+    return isClickHouseEnabled();
+  }
+
+  async getTimeseries(input: TimeseriesInputType): Promise<TimeseriesResult> {
+    return this.service.getTimeseries(input);
+  }
+
+  async getDataForFilter(
+    projectId: string,
+    field: FilterField,
+    startDate: number,
+    endDate: number,
+    filters?: Partial<Record<FilterField, string[] | Record<string, string[]> | Record<string, Record<string, string[]>>>>,
+    key?: string,
+    subkey?: string,
+    searchQuery?: string,
+  ): Promise<FilterDataResult> {
+    const options = await this.service.getFilterOptions({
+      projectId,
+      field,
+      startDate,
+      endDate,
+      key,
+      subkey,
+      searchQuery,
+    });
+    return { options };
+  }
+
+  async getTopUsedDocuments(
+    projectId: string,
+    startDate: number,
+    endDate: number,
+  ): Promise<TopDocumentsResult> {
+    const result = await this.service.getTopDocuments({
+      projectId,
+      startDate,
+      endDate,
+    });
+    return {
+      topDocuments: result.documents,
+      totalUniqueDocuments: result.totalUnique,
+    };
+  }
+
+  async getFeedbacks(
+    projectId: string,
+    startDate: number,
+    endDate: number,
+  ): Promise<FeedbacksResult> {
+    const events = await this.service.getFeedbacks({
+      projectId,
+      startDate,
+      endDate,
+    });
+    return { events };
+  }
+}
+
+let instance: AnalyticsBackend | null = null;
+
+export function getProjectionAnalyticsService(): AnalyticsBackend {
+  if (!instance) {
+    const service = new AnalyticsService(getClickHouseClientForProject);
+    instance = new AnalyticsBackendAdapter(service);
+  }
+  return instance;
+}
+
+export function resetProjectionAnalyticsService(): void {
+  instance = null;
+}

--- a/langwatch/src/server/app-layer/analytics/__tests__/metric-column-map.unit.test.ts
+++ b/langwatch/src/server/app-layer/analytics/__tests__/metric-column-map.unit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  metricColumnMap,
+  groupByColumnMap,
+  filterColumnMap,
+  factTableNames,
+} from "../metric-column-map";
+
+describe("metricColumnMap", () => {
+  describe("when looking up trace metrics", () => {
+    it("maps metadata.trace_id to TraceId with identity flag", () => {
+      const mapping = metricColumnMap["metadata.trace_id"];
+      expect(mapping).toEqual({
+        table: "trace",
+        column: "TraceId",
+        isIdentity: true,
+      });
+    });
+
+    it("maps performance.total_cost to TotalCost", () => {
+      const mapping = metricColumnMap["performance.total_cost"];
+      expect(mapping).toEqual({
+        table: "trace",
+        column: "TotalCost",
+      });
+    });
+
+    it("maps performance.total_tokens to a coalesce expression", () => {
+      const mapping = metricColumnMap["performance.total_tokens"];
+      expect(mapping?.column).toContain("coalesce");
+      expect(mapping?.table).toBe("trace");
+    });
+
+    it("maps sentiment.thumbs_up_down to ThumbsUpDownVote", () => {
+      const mapping = metricColumnMap["sentiment.thumbs_up_down"];
+      expect(mapping).toEqual({
+        table: "trace",
+        column: "ThumbsUpDownVote",
+      });
+    });
+  });
+
+  describe("when looking up evaluation metrics", () => {
+    it("maps evaluations.evaluation_score to Score", () => {
+      const mapping = metricColumnMap["evaluations.evaluation_score"];
+      expect(mapping).toEqual({
+        table: "evaluation",
+        column: "Score",
+      });
+    });
+
+    it("maps evaluations.evaluation_runs to EvaluationId with identity flag", () => {
+      const mapping = metricColumnMap["evaluations.evaluation_runs"];
+      expect(mapping).toEqual({
+        table: "evaluation",
+        column: "EvaluationId",
+        isIdentity: true,
+      });
+    });
+  });
+
+  describe("when looking up a nonexistent metric", () => {
+    it("returns undefined", () => {
+      const mapping = metricColumnMap["nonexistent.metric"];
+      expect(mapping).toBeUndefined();
+    });
+  });
+});
+
+describe("groupByColumnMap", () => {
+  it("maps topics.topics to TopicId on trace table", () => {
+    expect(groupByColumnMap["topics.topics"]).toEqual({
+      table: "trace",
+      column: "TopicId",
+    });
+  });
+
+  it("marks array columns with isArray flag", () => {
+    expect(groupByColumnMap["metadata.labels"]?.isArray).toBe(true);
+    expect(groupByColumnMap["metadata.model"]?.isArray).toBe(true);
+  });
+
+  it("maps evaluation group columns to evaluation table", () => {
+    expect(groupByColumnMap["evaluations.evaluation_passed"]?.table).toBe(
+      "evaluation",
+    );
+    expect(groupByColumnMap["evaluations.evaluation_label"]?.table).toBe(
+      "evaluation",
+    );
+  });
+});
+
+describe("filterColumnMap", () => {
+  it("maps metadata filters to trace table columns", () => {
+    expect(filterColumnMap["metadata.user_id"]).toEqual({
+      table: "trace",
+      column: "UserId",
+    });
+  });
+
+  it("maps evaluation filters to evaluation table columns", () => {
+    expect(filterColumnMap["evaluations.evaluator_id"]).toEqual({
+      table: "evaluation",
+      column: "EvaluatorId",
+    });
+  });
+
+  it("marks array filter columns with isArray flag", () => {
+    expect(filterColumnMap["metadata.labels"]?.isArray).toBe(true);
+    expect(filterColumnMap["spans.model"]?.isArray).toBe(true);
+  });
+});
+
+describe("factTableNames", () => {
+  it("maps trace to analytics_trace_facts", () => {
+    expect(factTableNames.trace).toBe("analytics_trace_facts");
+  });
+
+  it("maps evaluation to analytics_evaluation_facts", () => {
+    expect(factTableNames.evaluation).toBe("analytics_evaluation_facts");
+  });
+});

--- a/langwatch/src/server/app-layer/analytics/analytics.service.ts
+++ b/langwatch/src/server/app-layer/analytics/analytics.service.ts
@@ -1,0 +1,1174 @@
+/**
+ * AnalyticsService
+ *
+ * Clean app-layer service that queries the denormalized analytics fact tables
+ * (analytics_trace_facts, analytics_evaluation_facts) to produce timeseries,
+ * filter options, top documents, and feedback results.
+ *
+ * No legacy imports — this service is self-contained within the app-layer.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { addDays, differenceInCalendarDays } from "date-fns";
+import { getLangWatchTracer } from "langwatch";
+import { createLogger } from "~/utils/logger/server";
+import type {
+  AnalyticsTimeseriesInput,
+  AnalyticsSeriesInput,
+  TimeseriesBucket,
+  TimeseriesResult,
+  FilterOption,
+  TopDocument,
+  FeedbackEvent,
+} from "./analytics.types";
+import {
+  metricColumnMap,
+  groupByColumnMap,
+  filterColumnMap,
+  factTableNames,
+  type FactTable,
+} from "./metric-column-map";
+
+/** Resolver that returns the ClickHouse client for a project, or null if unavailable */
+export type ClickHouseClientResolver = (
+  projectId: string,
+) => Promise<ClickHouseClient | null>;
+
+/** ClickHouse query settings for analytics queries */
+const QUERY_SETTINGS: Record<string, number> = {
+  max_bytes_before_external_group_by: 500_000_000,
+};
+
+/** Maximum number of timeseries buckets before auto-adjusting to daily granularity */
+const MAX_TIMESERIES_BUCKETS = 1000;
+/** Minutes in a day */
+const MINUTES_PER_DAY = 24 * 60;
+/** Milliseconds per minute */
+const MS_PER_MINUTE = 1000 * 60;
+
+/** ClickHouse quantile values for percentile aggregations */
+const PERCENTILE_VALUES: Record<string, number> = {
+  median: 0.5,
+  p99: 0.99,
+  p95: 0.95,
+  p90: 0.9,
+};
+
+/**
+ * AnalyticsService queries denormalized analytics fact tables.
+ *
+ * Produces timeseries, filter options, top documents, and feedback results.
+ * All queries filter by TenantId and OccurredAt for partition pruning.
+ */
+export class AnalyticsService {
+  private readonly logger = createLogger("langwatch:analytics:app-layer");
+  private readonly tracer = getLangWatchTracer("langwatch.analytics.appLayer");
+
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
+
+  // ==========================================================================
+  // getTimeseries
+  // ==========================================================================
+
+  /**
+   * Query timeseries data for one or more metric series, split into
+   * current and previous periods for comparison.
+   */
+  async getTimeseries(
+    input: AnalyticsTimeseriesInput,
+  ): Promise<TimeseriesResult> {
+    return this.tracer.withActiveSpan(
+      "AnalyticsService.getTimeseries",
+      { attributes: { "tenant.id": input.projectId } },
+      async (span) => {
+        const client = await this.requireClient(input.projectId);
+
+        const { previousPeriodStartDate, startDate, endDate } =
+          this.computePeriodDates(input);
+
+        const adjustedTimeScale = this.adjustTimeScale(
+          input.timeScale,
+          startDate,
+          endDate,
+        );
+
+        const needsEvaluation = this.seriesNeedTable(
+          input.series,
+          "evaluation",
+        );
+        const needsTrace = this.seriesNeedTable(input.series, "trace");
+        const groupByNeedsEvaluation =
+          input.groupBy != null &&
+          groupByColumnMap[input.groupBy]?.table === "evaluation";
+
+        const { sql, params } = this.buildTimeseriesQuery({
+          projectId: input.projectId,
+          startDate,
+          endDate,
+          previousPeriodStartDate,
+          series: input.series,
+          filters: input.filters,
+          groupBy: input.groupBy,
+          groupByKey: input.groupByKey,
+          timeScale: adjustedTimeScale,
+          timeZone: input.timeZone,
+          needsEvaluation: needsEvaluation || groupByNeedsEvaluation,
+          needsTrace: needsTrace || !needsEvaluation,
+        });
+
+        this.logger.debug({ sql, params }, "Executing timeseries query");
+
+        try {
+          const result = await client.query({
+            query: sql,
+            query_params: params,
+            format: "JSONEachRow",
+            clickhouse_settings: QUERY_SETTINGS,
+          });
+
+          const rows = (await result.json()) as Array<Record<string, unknown>>;
+
+          const parsed = this.parseTimeseriesResults(
+            rows,
+            input.series,
+            input.groupBy,
+            input.timeScale,
+          );
+
+          span.setAttribute("bucket.count", parsed.currentPeriod.length);
+          return parsed;
+        } catch (error) {
+          this.logger.error(
+            { error: error instanceof Error ? error.message : error, sql },
+            "Failed to execute timeseries query",
+          );
+          throw error;
+        }
+      },
+    );
+  }
+
+  // ==========================================================================
+  // getFilterOptions
+  // ==========================================================================
+
+  /**
+   * Query distinct values for a filter field, with counts, for populating
+   * filter dropdowns in the UI.
+   */
+  async getFilterOptions(input: {
+    projectId: string;
+    field: string;
+    startDate: number;
+    endDate: number;
+    key?: string;
+    subkey?: string;
+    searchQuery?: string;
+  }): Promise<FilterOption[]> {
+    return this.tracer.withActiveSpan(
+      "AnalyticsService.getFilterOptions",
+      { attributes: { "tenant.id": input.projectId, "filter.field": input.field } },
+      async (span) => {
+        const client = await this.requireClient(input.projectId);
+
+        const mapping = filterColumnMap[input.field];
+        if (!mapping) {
+          this.logger.warn({ field: input.field }, "No filter column mapping found");
+          return [];
+        }
+
+        const tableName = factTableNames[mapping.table];
+        const alias = mapping.table === "trace" ? "tf" : "ef";
+        const params: Record<string, unknown> = {
+          tenantId: input.projectId,
+          startDate: this.formatDateParam(new Date(input.startDate)),
+          endDate: this.formatDateParam(new Date(input.endDate)),
+        };
+
+        let columnExpr: string;
+        let fromClause: string;
+
+        if (mapping.isArray) {
+          columnExpr = `${mapping.column}_item`;
+          fromClause = `${tableName} ${alias}\nARRAY JOIN ${alias}.${mapping.column} AS ${mapping.column}_item`;
+        } else {
+          columnExpr = `${alias}.${mapping.column}`;
+          fromClause = `${tableName} ${alias}`;
+        }
+
+        let whereExtra = "";
+        if (input.key && mapping.table === "evaluation") {
+          params.filterKey = input.key;
+          whereExtra += ` AND ${alias}.EvaluatorId = {filterKey:String}`;
+        }
+
+        if (input.searchQuery) {
+          params.searchQuery = `%${input.searchQuery}%`;
+          whereExtra += ` AND toString(${columnExpr}) ILIKE {searchQuery:String}`;
+        }
+
+        const sql = `
+          SELECT
+            toString(${columnExpr}) AS field,
+            toString(${columnExpr}) AS label,
+            count() AS count
+          FROM ${fromClause}
+          WHERE ${alias}.TenantId = {tenantId:String}
+            AND ${alias}.OccurredAt >= {startDate:DateTime64(3)}
+            AND ${alias}.OccurredAt <= {endDate:DateTime64(3)}
+            AND ${columnExpr} != ''
+            AND ${columnExpr} IS NOT NULL
+            ${whereExtra}
+          GROUP BY ${columnExpr}
+          ORDER BY count DESC
+          LIMIT 100
+        `;
+
+        try {
+          const result = await client.query({
+            query: sql,
+            query_params: params,
+            format: "JSONEachRow",
+            clickhouse_settings: QUERY_SETTINGS,
+          });
+
+          const rows = (await result.json()) as Array<{
+            field: string;
+            label: string;
+            count: string | number;
+          }>;
+
+          span.setAttribute("result.count", rows.length);
+
+          return rows.map((row) => ({
+            field: row.field,
+            label: row.label,
+            count:
+              typeof row.count === "string"
+                ? parseInt(row.count, 10)
+                : row.count,
+          }));
+        } catch (error) {
+          this.logger.error(
+            { error: error instanceof Error ? error.message : error, sql },
+            "Failed to execute filter options query",
+          );
+          throw error;
+        }
+      },
+    );
+  }
+
+  // ==========================================================================
+  // getTopDocuments
+  // ==========================================================================
+
+  /**
+   * Query the most frequently used RAG documents within the given time range.
+   */
+  async getTopDocuments(input: {
+    projectId: string;
+    startDate: number;
+    endDate: number;
+  }): Promise<{ documents: TopDocument[]; totalUnique: number }> {
+    return this.tracer.withActiveSpan(
+      "AnalyticsService.getTopDocuments",
+      { attributes: { "tenant.id": input.projectId } },
+      async (span) => {
+        const client = await this.requireClient(input.projectId);
+
+        const params: Record<string, unknown> = {
+          tenantId: input.projectId,
+          startDate: this.formatDateParam(new Date(input.startDate)),
+          endDate: this.formatDateParam(new Date(input.endDate)),
+        };
+
+        const topDocsSql = `
+          SELECT
+            doc_id AS documentId,
+            count() AS count,
+            any(tf.TraceId) AS traceId,
+            any(doc_content) AS content
+          FROM analytics_trace_facts tf
+          ARRAY JOIN tf.RAGDocumentIds AS doc_id, tf.RAGDocumentContents AS doc_content
+          WHERE tf.TenantId = {tenantId:String}
+            AND tf.OccurredAt >= {startDate:DateTime64(3)}
+            AND tf.OccurredAt <= {endDate:DateTime64(3)}
+            AND doc_id != ''
+          GROUP BY doc_id
+          ORDER BY count DESC
+          LIMIT 10
+        `;
+
+        const totalSql = `
+          SELECT uniq(doc_id) AS total
+          FROM analytics_trace_facts tf
+          ARRAY JOIN tf.RAGDocumentIds AS doc_id
+          WHERE tf.TenantId = {tenantId:String}
+            AND tf.OccurredAt >= {startDate:DateTime64(3)}
+            AND tf.OccurredAt <= {endDate:DateTime64(3)}
+            AND doc_id != ''
+        `;
+
+        try {
+          const [topDocsResult, totalResult] = await Promise.all([
+            client.query({
+              query: topDocsSql,
+              query_params: params,
+              format: "JSONEachRow",
+              clickhouse_settings: QUERY_SETTINGS,
+            }),
+            client.query({
+              query: totalSql,
+              query_params: params,
+              format: "JSONEachRow",
+              clickhouse_settings: QUERY_SETTINGS,
+            }),
+          ]);
+
+          const topDocs = (await topDocsResult.json()) as Array<{
+            documentId: string;
+            count: string | number;
+            traceId: string;
+            content?: string;
+          }>;
+
+          const totalRows = (await totalResult.json()) as Array<{
+            total: string | number;
+          }>;
+
+          const total = totalRows[0]?.total ?? 0;
+
+          span.setAttribute("document.count", topDocs.length);
+
+          return {
+            documents: topDocs.map((doc) => ({
+              documentId: doc.documentId,
+              count:
+                typeof doc.count === "string"
+                  ? parseInt(doc.count, 10)
+                  : doc.count,
+              traceId: doc.traceId,
+              content: doc.content,
+            })),
+            totalUnique:
+              typeof total === "string" ? parseInt(total, 10) : total,
+          };
+        } catch (error) {
+          this.logger.error(
+            { error: error instanceof Error ? error.message : error },
+            "Failed to execute top documents query",
+          );
+          throw error;
+        }
+      },
+    );
+  }
+
+  // ==========================================================================
+  // getFeedbacks
+  // ==========================================================================
+
+  /**
+   * Query feedback events (thumbs up/down) from trace facts.
+   */
+  async getFeedbacks(input: {
+    projectId: string;
+    startDate: number;
+    endDate: number;
+  }): Promise<FeedbackEvent[]> {
+    return this.tracer.withActiveSpan(
+      "AnalyticsService.getFeedbacks",
+      { attributes: { "tenant.id": input.projectId } },
+      async (span) => {
+        const client = await this.requireClient(input.projectId);
+
+        const params: Record<string, unknown> = {
+          tenantId: input.projectId,
+          startDate: this.formatDateParam(new Date(input.startDate)),
+          endDate: this.formatDateParam(new Date(input.endDate)),
+        };
+
+        const sql = `
+          SELECT
+            tf.TraceId AS trace_id,
+            concat(tf.TraceId, '-feedback') AS event_id,
+            toUnixTimestamp64Milli(tf.OccurredAt) AS started_at,
+            'thumbs_up_down' AS event_type,
+            tf.ThumbsUpDownVote AS vote
+          FROM analytics_trace_facts tf
+          WHERE tf.TenantId = {tenantId:String}
+            AND tf.OccurredAt >= {startDate:DateTime64(3)}
+            AND tf.OccurredAt <= {endDate:DateTime64(3)}
+            AND tf.ThumbsUpDownVote IS NOT NULL
+          ORDER BY tf.OccurredAt DESC
+          LIMIT 1000
+        `;
+
+        try {
+          const result = await client.query({
+            query: sql,
+            query_params: params,
+            format: "JSONEachRow",
+            clickhouse_settings: QUERY_SETTINGS,
+          });
+
+          const rows = (await result.json()) as Array<{
+            trace_id: string;
+            event_id: string;
+            started_at: string | number;
+            event_type: string;
+            vote: number | null;
+          }>;
+
+          const events = rows.map((row) => {
+            const startedAt =
+              typeof row.started_at === "string"
+                ? parseInt(row.started_at, 10)
+                : row.started_at;
+
+            const metrics: Array<{ key: string; value: number }> = [];
+            if (row.vote != null) {
+              metrics.push({ key: "vote", value: row.vote });
+            }
+
+            return {
+              event_id: row.event_id,
+              event_type: row.event_type,
+              project_id: input.projectId,
+              trace_id: row.trace_id,
+              timestamps: {
+                started_at: startedAt,
+                inserted_at: startedAt,
+                updated_at: startedAt,
+              },
+              metrics,
+              event_details: [] as Array<{ key: string; value: string }>,
+            };
+          });
+
+          span.setAttribute("event.count", events.length);
+          return events;
+        } catch (error) {
+          this.logger.error(
+            { error: error instanceof Error ? error.message : error },
+            "Failed to execute feedbacks query",
+          );
+          throw error;
+        }
+      },
+    );
+  }
+
+  // ==========================================================================
+  // Private: Period Date Computation
+  // ==========================================================================
+
+  /**
+   * Compute previous period start, current period start, and end dates
+   * for comparison charts. Mirrors the logic from the analytics common utils.
+   */
+  private computePeriodDates(input: {
+    startDate: number;
+    endDate: number;
+    timeScale?: number | "full";
+  }): {
+    previousPeriodStartDate: Date;
+    startDate: Date;
+    endDate: Date;
+  } {
+    const startDate = new Date(input.startDate);
+    const endDate = new Date(input.endDate);
+
+    const periodInDays =
+      typeof input.timeScale === "number"
+        ? input.timeScale / MINUTES_PER_DAY
+        : 1;
+
+    const daysDifference = Math.max(
+      periodInDays,
+      differenceInCalendarDays(endDate, startDate) + 1,
+    );
+    const previousPeriodStartDate = addDays(startDate, -daysDifference);
+
+    return { previousPeriodStartDate, startDate, endDate };
+  }
+
+  /**
+   * Adjust timeScale to avoid producing too many timeseries buckets.
+   * Falls back to daily granularity if the estimated bucket count exceeds the limit.
+   */
+  private adjustTimeScale(
+    timeScale: number | "full" | undefined,
+    startDate: Date,
+    endDate: Date,
+  ): number | "full" | undefined {
+    if (typeof timeScale === "number") {
+      const totalMinutes =
+        (endDate.getTime() - startDate.getTime()) / MS_PER_MINUTE;
+      const estimatedBuckets = totalMinutes / timeScale;
+      if (estimatedBuckets > MAX_TIMESERIES_BUCKETS) {
+        return MINUTES_PER_DAY;
+      }
+      return timeScale;
+    }
+    if (timeScale === undefined) {
+      return MINUTES_PER_DAY;
+    }
+    return timeScale;
+  }
+
+  // ==========================================================================
+  // Private: Timeseries Query Building
+  // ==========================================================================
+
+  /**
+   * Build the SQL query for getTimeseries.
+   *
+   * Handles:
+   * - Simple metrics (trace count, avg cost, etc.)
+   * - Metrics with key (evaluation score for specific evaluator)
+   * - GroupBy on simple columns
+   * - Previous/current period comparison
+   * - timeScale "full" mode
+   *
+   * TODO: Pipeline aggregations (per-user, per-thread subqueries)
+   * TODO: Array groupBy (ARRAY JOIN for labels, models, event types)
+   * TODO: Event score/details metrics (ARRAY JOIN on score arrays)
+   */
+  private buildTimeseriesQuery({
+    projectId,
+    startDate,
+    endDate,
+    previousPeriodStartDate,
+    series,
+    filters,
+    groupBy,
+    groupByKey,
+    timeScale,
+    timeZone,
+    needsEvaluation,
+    needsTrace,
+  }: {
+    projectId: string;
+    startDate: Date;
+    endDate: Date;
+    previousPeriodStartDate: Date;
+    series: AnalyticsSeriesInput[];
+    filters?: Record<string, unknown>;
+    groupBy?: string;
+    groupByKey?: string;
+    timeScale?: number | "full";
+    timeZone: string;
+    needsEvaluation: boolean;
+    needsTrace: boolean;
+  }): { sql: string; params: Record<string, unknown> } {
+    const params: Record<string, unknown> = {
+      tenantId: projectId,
+      startDate: this.formatDateParam(previousPeriodStartDate),
+      currentStartDate: this.formatDateParam(startDate),
+      endDate: this.formatDateParam(endDate),
+    };
+
+    // Determine primary table and alias
+    const usesJoin = needsEvaluation && needsTrace;
+    const primaryTable: FactTable =
+      needsEvaluation && !needsTrace ? "evaluation" : "trace";
+    const primaryAlias = primaryTable === "trace" ? "tf" : "ef";
+    const primaryTableName = factTableNames[primaryTable];
+
+    // Build SELECT expressions
+    const selectParts: string[] = [];
+
+    // Period column
+    if (timeScale === "full") {
+      selectParts.push(
+        `CASE WHEN ${primaryAlias}.OccurredAt < {currentStartDate:DateTime64(3)} THEN 'previous' ELSE 'current' END AS period`,
+      );
+    } else {
+      const intervalMinutes =
+        typeof timeScale === "number" ? timeScale : MINUTES_PER_DAY;
+      params.intervalMinutes = intervalMinutes;
+      selectParts.push(
+        `toStartOfInterval(${primaryAlias}.OccurredAt, INTERVAL {intervalMinutes:UInt32} MINUTE, {timeZone:String}) AS date`,
+      );
+      selectParts.push(
+        `CASE WHEN ${primaryAlias}.OccurredAt < {currentStartDate:DateTime64(3)} THEN 'previous' ELSE 'current' END AS period`,
+      );
+      params.timeZone = timeZone;
+    }
+
+    // GroupBy column
+    let groupByExpr: string | null = null;
+    if (groupBy) {
+      const groupMapping = groupByColumnMap[groupBy];
+      if (groupMapping) {
+        const groupAlias = groupMapping.table === "trace" ? "tf" : "ef";
+
+        if (groupMapping.isArray) {
+          // TODO: ARRAY JOIN for array groupBy columns
+          // For now, fall back to toString of the array
+          groupByExpr = `toString(${groupAlias}.${groupMapping.column})`;
+        } else {
+          groupByExpr = `toString(${groupAlias}.${groupMapping.column})`;
+        }
+
+        selectParts.push(`${groupByExpr} AS group_key`);
+      }
+    }
+
+    // Metric aggregation expressions
+    for (let i = 0; i < series.length; i++) {
+      const s = series[i]!;
+      const alias = this.buildMetricAlias(i, s);
+      const aggExpr = this.buildAggregationExpression({
+        series: s,
+        index: i,
+        params,
+        primaryAlias,
+        usesJoin,
+      });
+      selectParts.push(`${aggExpr} AS ${alias}`);
+    }
+
+    // Build FROM clause
+    let fromClause = `${primaryTableName} ${primaryAlias}`;
+    if (usesJoin) {
+      const secondaryTable: FactTable =
+        primaryTable === "trace" ? "evaluation" : "trace";
+      const secondaryAlias = secondaryTable === "trace" ? "tf" : "ef";
+      const secondaryTableName = factTableNames[secondaryTable];
+      fromClause += `\nJOIN ${secondaryTableName} ${secondaryAlias} ON ${primaryAlias}.TenantId = ${secondaryAlias}.TenantId AND ${primaryAlias}.TraceId = ${secondaryAlias}.TraceId`;
+    }
+
+    // Build WHERE clause
+    const whereParts: string[] = [
+      `${primaryAlias}.TenantId = {tenantId:String}`,
+      `${primaryAlias}.OccurredAt >= {startDate:DateTime64(3)}`,
+      `${primaryAlias}.OccurredAt <= {endDate:DateTime64(3)}`,
+    ];
+
+    // Apply shared filters
+    const filterClauses = this.buildFilterWhereClauses({
+      filters: (filters as Record<string, unknown>) ?? {},
+      params,
+      alias: primaryAlias,
+      primaryTable,
+    });
+    if (filterClauses) {
+      whereParts.push(filterClauses.replace(/^\s*AND\s*/, ""));
+    }
+
+    // Apply groupByKey filter (for evaluations with evaluator filter)
+    if (groupByKey && groupBy) {
+      const groupMapping = groupByColumnMap[groupBy];
+      if (groupMapping) {
+        const gAlias = groupMapping.table === "trace" ? "tf" : "ef";
+        if (
+          groupBy.startsWith("evaluations.") &&
+          groupMapping.table === "evaluation"
+        ) {
+          params.groupByKey = groupByKey;
+          whereParts.push(`${gAlias}.EvaluatorId = {groupByKey:String}`);
+        }
+      }
+    }
+
+    // Build GROUP BY
+    const groupByParts: string[] = [];
+    if (timeScale !== "full") {
+      groupByParts.push("date");
+    }
+    groupByParts.push("period");
+    if (groupByExpr) {
+      groupByParts.push("group_key");
+    }
+
+    const sql = `
+      SELECT
+        ${selectParts.join(",\n        ")}
+      FROM ${fromClause}
+      WHERE ${whereParts.join("\n        AND ")}
+      GROUP BY ${groupByParts.join(", ")}
+      ORDER BY ${timeScale === "full" ? "period" : "date, period"}
+    `;
+
+    return { sql, params };
+  }
+
+  // ==========================================================================
+  // Private: Aggregation Expression Building
+  // ==========================================================================
+
+  /**
+   * Build the aggregation expression for a single series metric.
+   *
+   * Maps aggregation types to ClickHouse functions:
+   * - avg, sum, min, max: direct aggregation
+   * - cardinality, terms: uniq()
+   * - median, p99, p95, p90: quantileExact()
+   *
+   * For evaluation metrics with a key (evaluatorId), applies conditional
+   * aggregation using the *If suffix pattern.
+   */
+  private buildAggregationExpression({
+    series,
+    index,
+    params,
+    primaryAlias,
+    usesJoin,
+  }: {
+    series: AnalyticsSeriesInput;
+    index: number;
+    params: Record<string, unknown>;
+    primaryAlias: string;
+    usesJoin: boolean;
+  }): string {
+    const mapping = metricColumnMap[series.metric];
+    if (!mapping) {
+      this.logger.warn(
+        { metric: series.metric },
+        "No metric column mapping found, defaulting to count",
+      );
+      return `count()`;
+    }
+
+    const tableAlias = mapping.table === "trace" ? "tf" : "ef";
+    if (tableAlias !== primaryAlias && !usesJoin) {
+      this.logger.warn(
+        { metric: series.metric, table: mapping.table, primaryAlias },
+        "Metric requires table not in query, falling back to count",
+      );
+      return `count()`;
+    }
+
+    const columnExpr = mapping.column.startsWith("(")
+      ? mapping.column
+      : `${tableAlias}.${mapping.column}`;
+
+    // Handle pipeline aggregations (per-user, per-thread)
+    if (series.pipeline) {
+      // TODO: Implement proper pipeline aggregations with subqueries.
+      // For now, fall back to simple aggregation as a reasonable approximation.
+      this.logger.debug(
+        { metric: series.metric, pipeline: series.pipeline },
+        "Pipeline aggregation not yet fully implemented, using simple fallback",
+      );
+      return this.buildSimpleAggregation(
+        columnExpr,
+        series.aggregation,
+        mapping.isIdentity,
+      );
+    }
+
+    // Handle key-filtered evaluation metrics (e.g., evaluation score for specific evaluator)
+    if (series.key && mapping.table === "evaluation") {
+      const keyParam = `metric_key_${index}`;
+      params[keyParam] = series.key;
+      return this.buildConditionalAggregation(
+        columnExpr,
+        series.aggregation,
+        `${tableAlias}.EvaluatorId = {${keyParam}:String}`,
+      );
+    }
+
+    // Handle key-filtered trace metrics (e.g., event_type with specific type)
+    if (series.key && series.metric === "events.event_type") {
+      const keyParam = `metric_key_${index}`;
+      params[keyParam] = series.key;
+      return this.buildConditionalAggregation(
+        `${tableAlias}.TraceId`,
+        "cardinality",
+        `has(${tableAlias}.EventTypes, {${keyParam}:String})`,
+      );
+    }
+
+    // Simple aggregation
+    return this.buildSimpleAggregation(
+      columnExpr,
+      series.aggregation,
+      mapping.isIdentity,
+    );
+  }
+
+  /**
+   * Build a simple aggregation expression (no condition).
+   */
+  private buildSimpleAggregation(
+    columnExpr: string,
+    aggregation: string,
+    isIdentity?: boolean,
+  ): string {
+    if (isIdentity) {
+      return `uniq(${columnExpr})`;
+    }
+
+    switch (aggregation) {
+      case "avg":
+        return `avg(${columnExpr})`;
+      case "sum":
+        return `coalesce(sum(${columnExpr}), 0)`;
+      case "min":
+        return `min(${columnExpr})`;
+      case "max":
+        return `max(${columnExpr})`;
+      case "cardinality":
+      case "terms":
+        return `uniq(${columnExpr})`;
+      default: {
+        const percentile = PERCENTILE_VALUES[aggregation];
+        if (percentile !== undefined) {
+          return `quantileExact(${percentile})(${columnExpr})`;
+        }
+        return `count(${columnExpr})`;
+      }
+    }
+  }
+
+  /**
+   * Build a conditional aggregation expression (with ClickHouse *If suffix).
+   */
+  private buildConditionalAggregation(
+    columnExpr: string,
+    aggregation: string,
+    condition: string,
+  ): string {
+    switch (aggregation) {
+      case "avg":
+        return `avgIf(${columnExpr}, ${condition})`;
+      case "sum":
+        return `coalesce(sumIf(${columnExpr}, ${condition}), 0)`;
+      case "min":
+        return `minIf(${columnExpr}, ${condition})`;
+      case "max":
+        return `maxIf(${columnExpr}, ${condition})`;
+      case "cardinality":
+      case "terms":
+        return `uniqIf(${columnExpr}, ${condition})`;
+      default: {
+        const percentile = PERCENTILE_VALUES[aggregation];
+        if (percentile !== undefined) {
+          return `quantileExactIf(${percentile})(${columnExpr}, ${condition})`;
+        }
+        return `countIf(${columnExpr}, ${condition})`;
+      }
+    }
+  }
+
+  // ==========================================================================
+  // Private: Timeseries Result Parsing
+  // ==========================================================================
+
+  /**
+   * Parse ClickHouse rows into the TimeseriesResult format expected by the frontend.
+   */
+  private parseTimeseriesResults(
+    rows: Array<Record<string, unknown>>,
+    series: AnalyticsSeriesInput[],
+    groupBy?: string,
+    timeScale?: number | "full",
+  ): TimeseriesResult {
+    const bucketMap = {
+      previous: new Map<string, TimeseriesBucket>(),
+      current: new Map<string, TimeseriesBucket>(),
+    };
+
+    for (const row of rows) {
+      const period = row.period as string;
+      const dateKey =
+        timeScale === "full"
+          ? "full"
+          : ((row.date as string) ?? new Date().toISOString());
+
+      const targetMap =
+        period === "current" ? bucketMap.current : bucketMap.previous;
+
+      let bucket = targetMap.get(dateKey);
+      if (!bucket) {
+        bucket = { date: dateKey };
+        targetMap.set(dateKey, bucket);
+      }
+
+      if (groupBy && row.group_key !== undefined && row.group_key !== null) {
+        const groupKey = String(row.group_key);
+        if (!bucket[groupBy]) {
+          bucket[groupBy] = {};
+        }
+        const groupData = bucket[groupBy] as Record<
+          string,
+          Record<string, number>
+        >;
+        if (!groupData[groupKey]) {
+          groupData[groupKey] = {};
+        }
+
+        for (let i = 0; i < series.length; i++) {
+          const s = series[i]!;
+          const alias = this.buildMetricAlias(i, s);
+          const seriesName = this.buildSeriesName(s, i);
+          const value = row[alias];
+          if (value !== undefined && value !== null) {
+            groupData[groupKey]![seriesName] = Number(value);
+          }
+        }
+      } else {
+        for (let i = 0; i < series.length; i++) {
+          const s = series[i]!;
+          const alias = this.buildMetricAlias(i, s);
+          const seriesName = this.buildSeriesName(s, i);
+          const value = row[alias];
+          if (value !== undefined && value !== null) {
+            bucket[seriesName] = Number(value);
+          }
+        }
+      }
+    }
+
+    // Convert maps to sorted arrays
+    const previousPeriod: TimeseriesBucket[] = [];
+    const currentPeriod: TimeseriesBucket[] = [];
+
+    for (const [, bucket] of Array.from(bucketMap.previous.entries()).sort(
+      ([a], [b]) => a.localeCompare(b),
+    )) {
+      previousPeriod.push(bucket);
+    }
+    for (const [, bucket] of Array.from(bucketMap.current.entries()).sort(
+      ([a], [b]) => a.localeCompare(b),
+    )) {
+      currentPeriod.push(bucket);
+    }
+
+    // Trim previous period to not exceed current period length
+    const correctedPrevious = previousPeriod.slice(
+      Math.max(0, previousPeriod.length - currentPeriod.length),
+    );
+
+    // Fill missing metric keys with 0 across both periods
+    this.normalizeMetricKeys(correctedPrevious, currentPeriod, groupBy);
+
+    return {
+      previousPeriod: correctedPrevious,
+      currentPeriod,
+    };
+  }
+
+  /**
+   * Build the series name key for result buckets.
+   * Format: "{index}/{metric}/{aggregation}" or with key/pipeline variants.
+   * Must match what the frontend expects.
+   */
+  buildSeriesName(series: AnalyticsSeriesInput, index: number): string {
+    const aggregation =
+      series.aggregation === "terms" ? "cardinality" : series.aggregation;
+
+    if (series.pipeline) {
+      return `${index}/${series.metric}/${aggregation}/${series.pipeline.field}/${series.pipeline.aggregation}`;
+    }
+
+    if (series.key) {
+      return `${index}/${series.metric}/${aggregation}/${series.key}`;
+    }
+
+    return `${index}/${series.metric}/${aggregation}`;
+  }
+
+  /**
+   * Build the metric alias used in SQL SELECT AS and result row keys.
+   * Must be a valid SQL identifier.
+   */
+  private buildMetricAlias(index: number, series: AnalyticsSeriesInput): string {
+    const parts = [
+      index.toString(),
+      series.metric.replace(/\./g, "_"),
+      series.aggregation,
+    ];
+    if (series.key) parts.push(series.key.replace(/[^a-zA-Z0-9]/g, "_"));
+    if (series.subkey) parts.push(series.subkey.replace(/[^a-zA-Z0-9]/g, "_"));
+    return parts.join("__");
+  }
+
+  /**
+   * Normalize metric keys across both periods so all buckets have all metrics.
+   * This ensures charts don't have gaps where data is missing from one period.
+   */
+  private normalizeMetricKeys(
+    previousPeriod: TimeseriesBucket[],
+    currentPeriod: TimeseriesBucket[],
+    groupBy?: string,
+  ): void {
+    const allMetricKeys = new Set<string>();
+    const allGroupedMetricSubKeys = new Set<string>();
+
+    for (const bucket of [...previousPeriod, ...currentPeriod]) {
+      for (const key of Object.keys(bucket)) {
+        if (key === "date") continue;
+
+        const value = bucket[key];
+
+        if (
+          groupBy &&
+          key === groupBy &&
+          typeof value === "object" &&
+          value !== null
+        ) {
+          const groupData = value as Record<string, Record<string, number>>;
+          for (const metrics of Object.values(groupData)) {
+            for (const metricKey of Object.keys(metrics)) {
+              allGroupedMetricSubKeys.add(metricKey);
+            }
+          }
+        } else {
+          allMetricKeys.add(key);
+        }
+      }
+    }
+
+    for (const bucket of [...previousPeriod, ...currentPeriod]) {
+      for (const key of allMetricKeys) {
+        if (bucket[key] === undefined) {
+          bucket[key] = 0;
+        }
+      }
+
+      if (groupBy && bucket[groupBy] && typeof bucket[groupBy] === "object") {
+        const groupData = bucket[groupBy] as Record<
+          string,
+          Record<string, number>
+        >;
+
+        for (const groupKey of Object.keys(groupData)) {
+          for (const metricKey of allGroupedMetricSubKeys) {
+            if (groupData[groupKey]![metricKey] === undefined) {
+              groupData[groupKey]![metricKey] = 0;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // ==========================================================================
+  // Private: Filter Building
+  // ==========================================================================
+
+  /**
+   * Build WHERE clause fragments from the shared filter input.
+   * Handles simple equality filters and array membership (has()) filters.
+   * Returns a string of " AND ..." clauses or empty string.
+   */
+  private buildFilterWhereClauses({
+    filters,
+    params,
+    alias,
+    primaryTable,
+  }: {
+    filters: Record<string, unknown>;
+    params: Record<string, unknown>;
+    alias: string;
+    primaryTable: FactTable;
+  }): string {
+    const clauses: string[] = [];
+    let paramIdx = 0;
+
+    for (const [field, value] of Object.entries(filters)) {
+      if (!value) continue;
+
+      const mapping = filterColumnMap[field];
+      if (!mapping) continue;
+
+      const values = this.flattenFilterValues(value);
+      if (values.length === 0) continue;
+
+      const filterAlias =
+        mapping.table === primaryTable
+          ? alias
+          : mapping.table === "trace"
+            ? "tf"
+            : "ef";
+
+      const paramName = `filter_${paramIdx++}`;
+      params[paramName] = values;
+
+      if (mapping.isArray) {
+        clauses.push(
+          `hasAny(${filterAlias}.${mapping.column}, {${paramName}:Array(String)})`,
+        );
+      } else {
+        if (values.length === 1) {
+          const singleParam = `${paramName}_single`;
+          params[singleParam] = values[0];
+          clauses.push(
+            `${filterAlias}.${mapping.column} = {${singleParam}:String}`,
+          );
+        } else {
+          clauses.push(
+            `${filterAlias}.${mapping.column} IN {${paramName}:Array(String)}`,
+          );
+        }
+      }
+    }
+
+    if (clauses.length === 0) return "";
+    return " AND " + clauses.join(" AND ");
+  }
+
+  /**
+   * Flatten nested filter value structures to a flat string array.
+   *
+   * Filters can be:
+   * - string[] — simple values
+   * - Record<string, string[]> — keyed values (e.g., evaluator_id -> [values])
+   * - Record<string, Record<string, string[]>> — double-keyed
+   */
+  private flattenFilterValues(value: unknown): string[] {
+    if (Array.isArray(value)) {
+      return value as string[];
+    }
+
+    if (typeof value === "object" && value !== null) {
+      const results: string[] = [];
+      for (const v of Object.values(value)) {
+        results.push(...this.flattenFilterValues(v));
+      }
+      return results;
+    }
+
+    return [];
+  }
+
+  // ==========================================================================
+  // Private: Helpers
+  // ==========================================================================
+
+  /**
+   * Check if any series in the input requires a specific fact table.
+   */
+  private seriesNeedTable(
+    series: AnalyticsSeriesInput[],
+    table: FactTable,
+  ): boolean {
+    return series.some((s) => {
+      const mapping = metricColumnMap[s.metric];
+      return mapping?.table === table;
+    });
+  }
+
+  /**
+   * Resolve the ClickHouse client or throw if unavailable.
+   */
+  private async requireClient(projectId: string): Promise<ClickHouseClient> {
+    const client = await this.resolveClient(projectId);
+    if (!client) {
+      throw new Error("ClickHouse client not available");
+    }
+    return client;
+  }
+
+  /**
+   * Format a Date as a ClickHouse DateTime64(3) parameter string.
+   */
+  private formatDateParam(date: Date): string {
+    return date.toISOString().replace("T", " ").replace("Z", "");
+  }
+}

--- a/langwatch/src/server/app-layer/analytics/analytics.types.ts
+++ b/langwatch/src/server/app-layer/analytics/analytics.types.ts
@@ -1,0 +1,83 @@
+/**
+ * Analytics Service Types
+ *
+ * Clean input/output types for the AnalyticsService.
+ * These are defined independently of the legacy analytics layer and match
+ * the shape needed by the tRPC API.
+ */
+
+/**
+ * Input for timeseries queries. Combines shared filter parameters
+ * with series-specific configuration.
+ */
+export interface AnalyticsTimeseriesInput {
+  projectId: string;
+  startDate: number;
+  endDate: number;
+  filters: Record<string, unknown>;
+  series: AnalyticsSeriesInput[];
+  groupBy?: string;
+  groupByKey?: string;
+  timeScale?: number | "full";
+  timeZone: string;
+}
+
+/**
+ * A single series within a timeseries request.
+ * Describes which metric to query, how to aggregate it,
+ * and optional key/pipeline filters.
+ */
+export interface AnalyticsSeriesInput {
+  metric: string;
+  aggregation: string;
+  key?: string;
+  subkey?: string;
+  pipeline?: { field: string; aggregation: string };
+  filters?: Record<string, unknown>;
+  asPercent?: boolean;
+}
+
+/**
+ * A single timeseries bucket — one time interval with metric values.
+ * Keys beyond "date" are series names (e.g., "0/metadata.trace_id/cardinality").
+ * When groupBy is used, the groupBy field name maps to nested group data.
+ */
+export interface TimeseriesBucket {
+  date: string;
+  [key: string]: number | string | Record<string, Record<string, number>>;
+}
+
+/**
+ * Timeseries result with previous and current period buckets
+ * for comparison charts.
+ */
+export interface TimeseriesResult {
+  previousPeriod: TimeseriesBucket[];
+  currentPeriod: TimeseriesBucket[];
+}
+
+/** A single option returned by filter queries */
+export interface FilterOption {
+  field: string;
+  label: string;
+  count: number;
+}
+
+/** A top-used RAG document with usage count */
+export interface TopDocument {
+  documentId: string;
+  count: number;
+  traceId: string;
+  content?: string;
+}
+
+/** A feedback event from trace facts */
+export interface FeedbackEvent {
+  event_id: string;
+  event_type: string;
+  project_id?: string;
+  trace_id: string;
+  timestamps: { started_at: number; inserted_at: number; updated_at: number };
+  metrics?: Array<{ key: string; value: number }>;
+  event_details?: Array<{ key: string; value: string }>;
+}

--- a/langwatch/src/server/app-layer/analytics/metric-column-map.ts
+++ b/langwatch/src/server/app-layer/analytics/metric-column-map.ts
@@ -1,0 +1,205 @@
+/**
+ * Metric Column Map
+ *
+ * Maps analytics metric names, groupBy fields, and filter fields to their
+ * corresponding columns in the denormalized analytics fact tables.
+ *
+ * This replaces the complex metric-translator.ts + field-mappings.ts from
+ * the existing ClickHouse analytics service. Because the fact tables are
+ * pre-denormalized, we only need a simple lookup — no JOINs, no Map access,
+ * no subqueries for basic metrics.
+ */
+
+/** Which analytics fact table contains the data */
+export type FactTable = "trace" | "evaluation";
+
+/** Mapping from a metric name to its fact table column */
+export interface MetricColumnMapping {
+  table: FactTable;
+  /** The ClickHouse column expression (may include SQL expressions like coalesce) */
+  column: string;
+  /**
+   * For identity/cardinality metrics where the column represents a unique ID.
+   * These use uniq() instead of count().
+   */
+  isIdentity?: boolean;
+}
+
+/**
+ * Maps SeriesInputType.metric values to fact table columns.
+ *
+ * The keys match the flattened metric enum values from registry.ts
+ * (e.g., "metadata.trace_id", "performance.total_cost").
+ */
+export const metricColumnMap: Record<string, MetricColumnMapping> = {
+  // -- metadata.* --
+  "metadata.trace_id": {
+    table: "trace",
+    column: "TraceId",
+    isIdentity: true,
+  },
+  "metadata.user_id": {
+    table: "trace",
+    column: "UserId",
+    isIdentity: true,
+  },
+  "metadata.thread_id": {
+    table: "trace",
+    column: "ThreadId",
+    isIdentity: true,
+  },
+  "metadata.span_type": {
+    table: "trace",
+    column: "TraceId",
+    isIdentity: true,
+  },
+
+  // -- performance.* --
+  "performance.completion_time": {
+    table: "trace",
+    column: "TotalDurationMs",
+  },
+  "performance.first_token": {
+    table: "trace",
+    column: "TimeToFirstTokenMs",
+  },
+  "performance.total_cost": {
+    table: "trace",
+    column: "TotalCost",
+  },
+  "performance.prompt_tokens": {
+    table: "trace",
+    column: "TotalPromptTokens",
+  },
+  "performance.completion_tokens": {
+    table: "trace",
+    column: "TotalCompletionTokens",
+  },
+  "performance.total_tokens": {
+    table: "trace",
+    column:
+      "(coalesce(TotalPromptTokens, 0) + coalesce(TotalCompletionTokens, 0))",
+  },
+  "performance.tokens_per_second": {
+    table: "trace",
+    column: "TokensPerSecond",
+  },
+
+  // -- evaluations.* --
+  "evaluations.evaluation_score": {
+    table: "evaluation",
+    column: "Score",
+  },
+  "evaluations.evaluation_pass_rate": {
+    table: "evaluation",
+    column: "toFloat64(Passed)",
+  },
+  "evaluations.evaluation_runs": {
+    table: "evaluation",
+    column: "EvaluationId",
+    isIdentity: true,
+  },
+
+  // -- sentiment.* --
+  "sentiment.thumbs_up_down": {
+    table: "trace",
+    column: "ThumbsUpDownVote",
+  },
+
+  // -- events.* --
+  // event_type counts traces that have specific event types
+  "events.event_type": {
+    table: "trace",
+    column: "TraceId",
+    isIdentity: true,
+  },
+  // TODO: events.event_score and events.event_details need ARRAY JOIN on
+  // EventScoreKeys/EventScoreValues — handle as special cases in the service
+  "events.event_score": {
+    table: "trace",
+    column: "TraceId",
+    isIdentity: true,
+  },
+  "events.event_details": {
+    table: "trace",
+    column: "TraceId",
+    isIdentity: true,
+  },
+
+  // -- threads.* --
+  // TODO: threads.average_duration_per_thread requires a subquery grouping
+  // by ThreadId first — handle as special case in the service
+  "threads.average_duration_per_thread": {
+    table: "trace",
+    column: "TotalDurationMs",
+  },
+};
+
+/**
+ * Maps groupBy field names to fact table columns.
+ *
+ * The keys match the flattened group enum values from registry.ts
+ * (e.g., "topics.topics", "metadata.user_id").
+ */
+export const groupByColumnMap: Record<
+  string,
+  { table: FactTable; column: string; isArray?: boolean }
+> = {
+  "topics.topics": { table: "trace", column: "TopicId" },
+  "metadata.user_id": { table: "trace", column: "UserId" },
+  "metadata.thread_id": { table: "trace", column: "ThreadId" },
+  "metadata.customer_id": { table: "trace", column: "CustomerId" },
+  "metadata.labels": { table: "trace", column: "Labels", isArray: true },
+  "metadata.model": { table: "trace", column: "ModelNames", isArray: true },
+  "metadata.span_type": { table: "trace", column: "EventTypes", isArray: true },
+  "error.has_error": { table: "trace", column: "ContainsError" },
+  "evaluations.evaluation_passed": { table: "evaluation", column: "Passed" },
+  "evaluations.evaluation_label": { table: "evaluation", column: "Label" },
+  "evaluations.evaluation_processing_state": {
+    table: "evaluation",
+    column: "Status",
+  },
+  "events.event_type": { table: "trace", column: "EventTypes", isArray: true },
+  "sentiment.thumbs_up_down": {
+    table: "trace",
+    column: "ThumbsUpDownVote",
+  },
+};
+
+/**
+ * Maps filter field names (from FilterField enum) to fact table columns.
+ *
+ * Used to build WHERE clauses from the shared filter input format.
+ */
+export const filterColumnMap: Record<
+  string,
+  { table: FactTable; column: string; isArray?: boolean }
+> = {
+  "metadata.user_id": { table: "trace", column: "UserId" },
+  "metadata.thread_id": { table: "trace", column: "ThreadId" },
+  "metadata.customer_id": { table: "trace", column: "CustomerId" },
+  "metadata.labels": { table: "trace", column: "Labels", isArray: true },
+  "topics.topics": { table: "trace", column: "TopicId" },
+  "metadata.topic_id": { table: "trace", column: "TopicId" },
+  "topics.subtopics": { table: "trace", column: "SubTopicId" },
+  "metadata.subtopic_id": { table: "trace", column: "SubTopicId" },
+  "spans.model": { table: "trace", column: "ModelNames", isArray: true },
+  "spans.type": { table: "trace", column: "EventTypes", isArray: true },
+  "evaluations.evaluator_id": { table: "evaluation", column: "EvaluatorId" },
+  "evaluations.type": { table: "evaluation", column: "EvaluatorType" },
+  "evaluations.passed": { table: "evaluation", column: "Passed" },
+  "evaluations.score": { table: "evaluation", column: "Score" },
+  "evaluations.state": { table: "evaluation", column: "Status" },
+  "evaluations.label": { table: "evaluation", column: "Label" },
+  "error.has_error": { table: "trace", column: "ContainsError" },
+  "events.event_type": { table: "trace", column: "EventTypes", isArray: true },
+  "traces.error": { table: "trace", column: "ContainsError" },
+};
+
+/**
+ * Fact table names used in SQL queries
+ */
+export const factTableNames: Record<FactTable, string> = {
+  trace: "analytics_trace_facts",
+  evaluation: "analytics_evaluation_facts",
+};

--- a/langwatch/src/server/app-layer/analytics/repositories/analytics-evaluation-facts.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/analytics/repositories/analytics-evaluation-facts.clickhouse.repository.ts
@@ -1,0 +1,183 @@
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import type { WithDateWrites } from "~/server/clickhouse/types";
+import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
+import { createLogger } from "~/utils/logger/server";
+import type { AnalyticsEvaluationFactData } from "../types";
+import type { AnalyticsEvaluationFactsRepository } from "./analytics-evaluation-facts.repository";
+
+const TABLE_NAME = "analytics_evaluation_facts" as const;
+
+const logger = createLogger(
+  "langwatch:app-layer:analytics:evaluation-facts-repository",
+);
+
+type ClickHouseEvaluationFactWriteRecord = WithDateWrites<
+  ClickHouseEvaluationFactRecord,
+  "OccurredAt" | "CreatedAt" | "UpdatedAt"
+>;
+
+interface ClickHouseEvaluationFactRecord {
+  TenantId: string;
+  EvaluationId: string;
+  TraceId: string | null;
+  OccurredAt: number;
+  EvaluatorId: string;
+  EvaluatorName: string | null;
+  EvaluatorType: string;
+  IsGuardrail: number;
+  Score: number | null;
+  Passed: number | null;
+  Label: string | null;
+  Status: string;
+  UserId: string | null;
+  ThreadId: string | null;
+  TopicId: string | null;
+  CustomerId: string | null;
+  CreatedAt: number;
+  UpdatedAt: number;
+}
+
+export class AnalyticsEvaluationFactsClickHouseRepository
+  implements AnalyticsEvaluationFactsRepository
+{
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
+
+  async upsert(
+    data: AnalyticsEvaluationFactData,
+    tenantId: string,
+  ): Promise<void> {
+    EventUtils.validateTenantId(
+      { tenantId },
+      "AnalyticsEvaluationFactsClickHouseRepository.upsert",
+    );
+
+    try {
+      const client = await this.resolveClient(tenantId);
+      const record = this.toClickHouseRecord(data, tenantId);
+
+      await client.insert({
+        table: TABLE_NAME,
+        values: [record],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 1, wait_for_async_insert: 0 },
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(
+        { tenantId, evaluationId: data.evaluationId, error: errorMessage },
+        "Failed to store analytics evaluation fact in ClickHouse",
+      );
+      throw error;
+    }
+  }
+
+  async getByEvaluationId(
+    tenantId: string,
+    evaluationId: string,
+  ): Promise<AnalyticsEvaluationFactData | null> {
+    EventUtils.validateTenantId(
+      { tenantId },
+      "AnalyticsEvaluationFactsClickHouseRepository.getByEvaluationId",
+    );
+
+    try {
+      const client = await this.resolveClient(tenantId);
+      const result = await client.query({
+        query: `
+          SELECT
+            TenantId,
+            EvaluationId,
+            TraceId,
+            toUnixTimestamp64Milli(OccurredAt) AS OccurredAt,
+            EvaluatorId,
+            EvaluatorName,
+            EvaluatorType,
+            IsGuardrail,
+            Score,
+            Passed,
+            Label,
+            Status,
+            UserId,
+            ThreadId,
+            TopicId,
+            CustomerId,
+            toUnixTimestamp64Milli(CreatedAt) AS CreatedAt,
+            toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAt
+          FROM ${TABLE_NAME}
+          WHERE TenantId = {tenantId:String}
+            AND EvaluationId = {evaluationId:String}
+          ORDER BY UpdatedAt DESC
+          LIMIT 1
+        `,
+        query_params: { tenantId, evaluationId },
+        format: "JSONEachRow",
+        clickhouse_settings: { select_sequential_consistency: "1" },
+      });
+
+      const rows = await result.json<ClickHouseEvaluationFactRecord>();
+      const row = rows[0];
+      if (!row) return null;
+
+      return this.fromClickHouseRecord(row);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(
+        { tenantId, evaluationId, error: errorMessage },
+        "Failed to get analytics evaluation fact from ClickHouse",
+      );
+      throw error;
+    }
+  }
+
+  private fromClickHouseRecord(
+    record: ClickHouseEvaluationFactRecord,
+  ): AnalyticsEvaluationFactData {
+    return {
+      evaluationId: record.EvaluationId,
+      traceId: record.TraceId,
+      occurredAt: record.OccurredAt,
+      evaluatorId: record.EvaluatorId,
+      evaluatorName: record.EvaluatorName,
+      evaluatorType: record.EvaluatorType,
+      isGuardrail: !!record.IsGuardrail,
+      score: record.Score,
+      passed: record.Passed != null ? !!record.Passed : null,
+      label: record.Label,
+      status: record.Status,
+      userId: record.UserId,
+      threadId: record.ThreadId,
+      topicId: record.TopicId,
+      customerId: record.CustomerId,
+      createdAt: record.CreatedAt,
+      updatedAt: record.UpdatedAt,
+    };
+  }
+
+  private toClickHouseRecord(
+    data: AnalyticsEvaluationFactData,
+    tenantId: string,
+  ): ClickHouseEvaluationFactWriteRecord {
+    return {
+      TenantId: tenantId,
+      EvaluationId: data.evaluationId,
+      TraceId: data.traceId,
+      OccurredAt: new Date(data.occurredAt),
+      EvaluatorId: data.evaluatorId,
+      EvaluatorName: data.evaluatorName,
+      EvaluatorType: data.evaluatorType,
+      IsGuardrail: data.isGuardrail ? 1 : 0,
+      Score: data.score,
+      Passed: data.passed != null ? (data.passed ? 1 : 0) : null,
+      Label: data.label,
+      Status: data.status,
+      UserId: data.userId,
+      ThreadId: data.threadId,
+      TopicId: data.topicId,
+      CustomerId: data.customerId,
+      CreatedAt: new Date(data.createdAt),
+      UpdatedAt: new Date(data.updatedAt),
+    };
+  }
+}

--- a/langwatch/src/server/app-layer/analytics/repositories/analytics-evaluation-facts.repository.ts
+++ b/langwatch/src/server/app-layer/analytics/repositories/analytics-evaluation-facts.repository.ts
@@ -1,0 +1,25 @@
+import type { AnalyticsEvaluationFactData } from "../types";
+
+export interface AnalyticsEvaluationFactsRepository {
+  upsert(data: AnalyticsEvaluationFactData, tenantId: string): Promise<void>;
+  getByEvaluationId(
+    tenantId: string,
+    evaluationId: string,
+  ): Promise<AnalyticsEvaluationFactData | null>;
+}
+
+export class NullAnalyticsEvaluationFactsRepository
+  implements AnalyticsEvaluationFactsRepository
+{
+  async upsert(
+    _data: AnalyticsEvaluationFactData,
+    _tenantId: string,
+  ): Promise<void> {}
+
+  async getByEvaluationId(
+    _tenantId: string,
+    _evaluationId: string,
+  ): Promise<AnalyticsEvaluationFactData | null> {
+    return null;
+  }
+}

--- a/langwatch/src/server/app-layer/analytics/repositories/analytics-trace-facts.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/analytics/repositories/analytics-trace-facts.clickhouse.repository.ts
@@ -1,0 +1,248 @@
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import type { WithDateWrites } from "~/server/clickhouse/types";
+import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
+import { createLogger } from "~/utils/logger/server";
+import type { AnalyticsTraceFactData } from "../types";
+import type { AnalyticsTraceFactsRepository } from "./analytics-trace-facts.repository";
+
+const TABLE_NAME = "analytics_trace_facts" as const;
+
+const logger = createLogger(
+  "langwatch:app-layer:analytics:trace-facts-repository",
+);
+
+type ClickHouseTraceFactWriteRecord = WithDateWrites<
+  ClickHouseTraceFactRecord,
+  "OccurredAt" | "CreatedAt" | "UpdatedAt"
+>;
+
+interface ClickHouseTraceFactRecord {
+  TenantId: string;
+  TraceId: string;
+  OccurredAt: number;
+  UserId: string;
+  ThreadId: string;
+  CustomerId: string;
+  Labels: string[];
+  TopicId: string | null;
+  SubTopicId: string | null;
+  Metadata: Record<string, string>;
+  TotalCost: number | null;
+  TotalDurationMs: number;
+  TotalPromptTokens: number | null;
+  TotalCompletionTokens: number | null;
+  TokensPerSecond: number | null;
+  TimeToFirstTokenMs: number | null;
+  ContainsError: number;
+  HasAnnotation: number | null;
+  SpanCount: number;
+  ModelNames: string[];
+  ModelPromptTokens: number[];
+  ModelCompletionTokens: number[];
+  ModelCosts: number[];
+  EventTypes: string[];
+  EventScoreKeys: string[];
+  EventScoreValues: number[];
+  EventDetailKeys: string[];
+  EventDetailValues: string[];
+  ThumbsUpDownVote: number | null;
+  RAGDocumentIds: string[];
+  RAGDocumentContents: string[];
+  CreatedAt: number;
+  UpdatedAt: number;
+}
+
+export class AnalyticsTraceFactsClickHouseRepository
+  implements AnalyticsTraceFactsRepository
+{
+  constructor(private readonly resolveClient: ClickHouseClientResolver) {}
+
+  async upsert(data: AnalyticsTraceFactData, tenantId: string): Promise<void> {
+    EventUtils.validateTenantId(
+      { tenantId },
+      "AnalyticsTraceFactsClickHouseRepository.upsert",
+    );
+
+    try {
+      const client = await this.resolveClient(tenantId);
+      const record = this.toClickHouseRecord(data, tenantId);
+
+      await client.insert({
+        table: TABLE_NAME,
+        values: [record],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 1, wait_for_async_insert: 0 },
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(
+        { tenantId, traceId: data.traceId, error: errorMessage },
+        "Failed to store analytics trace fact in ClickHouse",
+      );
+      throw error;
+    }
+  }
+
+  async getByTraceId(
+    tenantId: string,
+    traceId: string,
+  ): Promise<AnalyticsTraceFactData | null> {
+    EventUtils.validateTenantId(
+      { tenantId },
+      "AnalyticsTraceFactsClickHouseRepository.getByTraceId",
+    );
+
+    try {
+      const client = await this.resolveClient(tenantId);
+      const result = await client.query({
+        query: `
+          SELECT
+            TenantId,
+            TraceId,
+            toUnixTimestamp64Milli(OccurredAt) AS OccurredAt,
+            UserId,
+            ThreadId,
+            CustomerId,
+            Labels,
+            TopicId,
+            SubTopicId,
+            Metadata,
+            TotalCost,
+            TotalDurationMs,
+            TotalPromptTokens,
+            TotalCompletionTokens,
+            TokensPerSecond,
+            TimeToFirstTokenMs,
+            ContainsError,
+            HasAnnotation,
+            SpanCount,
+            ModelNames,
+            ModelPromptTokens,
+            ModelCompletionTokens,
+            ModelCosts,
+            EventTypes,
+            EventScoreKeys,
+            EventScoreValues,
+            EventDetailKeys,
+            EventDetailValues,
+            ThumbsUpDownVote,
+            RAGDocumentIds,
+            RAGDocumentContents,
+            toUnixTimestamp64Milli(CreatedAt) AS CreatedAt,
+            toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAt
+          FROM ${TABLE_NAME}
+          WHERE TenantId = {tenantId:String}
+            AND TraceId = {traceId:String}
+          ORDER BY UpdatedAt DESC
+          LIMIT 1
+        `,
+        query_params: { tenantId, traceId },
+        format: "JSONEachRow",
+        clickhouse_settings: { select_sequential_consistency: "1" },
+      });
+
+      const rows = await result.json<ClickHouseTraceFactRecord>();
+      const row = rows[0];
+      if (!row) return null;
+
+      return this.fromClickHouseRecord(row);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(
+        { tenantId, traceId, error: errorMessage },
+        "Failed to get analytics trace fact from ClickHouse",
+      );
+      throw error;
+    }
+  }
+
+  private fromClickHouseRecord(
+    record: ClickHouseTraceFactRecord,
+  ): AnalyticsTraceFactData {
+    return {
+      traceId: record.TraceId,
+      occurredAt: record.OccurredAt,
+      userId: record.UserId,
+      threadId: record.ThreadId,
+      customerId: record.CustomerId,
+      labels: record.Labels,
+      topicId: record.TopicId,
+      subTopicId: record.SubTopicId,
+      metadata: record.Metadata ?? {},
+      totalCost: record.TotalCost,
+      totalDurationMs: Number(record.TotalDurationMs),
+      totalPromptTokens: record.TotalPromptTokens,
+      totalCompletionTokens: record.TotalCompletionTokens,
+      tokensPerSecond: record.TokensPerSecond,
+      timeToFirstTokenMs: record.TimeToFirstTokenMs,
+      containsError: !!record.ContainsError,
+      hasAnnotation:
+        record.HasAnnotation != null ? !!record.HasAnnotation : null,
+      spanCount: record.SpanCount,
+      modelNames: record.ModelNames,
+      modelPromptTokens: record.ModelPromptTokens,
+      modelCompletionTokens: record.ModelCompletionTokens,
+      modelCosts: record.ModelCosts,
+      eventTypes: record.EventTypes,
+      eventScoreKeys: record.EventScoreKeys,
+      eventScoreValues: record.EventScoreValues,
+      eventDetailKeys: record.EventDetailKeys,
+      eventDetailValues: record.EventDetailValues,
+      thumbsUpDownVote: record.ThumbsUpDownVote,
+      ragDocumentIds: record.RAGDocumentIds,
+      ragDocumentContents: record.RAGDocumentContents,
+      createdAt: record.CreatedAt,
+      updatedAt: record.UpdatedAt,
+    };
+  }
+
+  private toClickHouseRecord(
+    data: AnalyticsTraceFactData,
+    tenantId: string,
+  ): ClickHouseTraceFactWriteRecord {
+    return {
+      TenantId: tenantId,
+      TraceId: data.traceId,
+      OccurredAt: new Date(data.occurredAt),
+      UserId: data.userId,
+      ThreadId: data.threadId,
+      CustomerId: data.customerId,
+      Labels: data.labels,
+      TopicId: data.topicId,
+      SubTopicId: data.subTopicId,
+      Metadata: data.metadata,
+      TotalCost: data.totalCost,
+      TotalDurationMs: Math.round(data.totalDurationMs),
+      TotalPromptTokens: data.totalPromptTokens,
+      TotalCompletionTokens: data.totalCompletionTokens,
+      TokensPerSecond:
+        data.tokensPerSecond != null
+          ? Math.round(data.tokensPerSecond)
+          : null,
+      TimeToFirstTokenMs:
+        data.timeToFirstTokenMs != null
+          ? Math.round(data.timeToFirstTokenMs)
+          : null,
+      ContainsError: data.containsError ? 1 : 0,
+      HasAnnotation:
+        data.hasAnnotation != null ? (data.hasAnnotation ? 1 : 0) : null,
+      SpanCount: data.spanCount,
+      ModelNames: data.modelNames,
+      ModelPromptTokens: data.modelPromptTokens,
+      ModelCompletionTokens: data.modelCompletionTokens,
+      ModelCosts: data.modelCosts,
+      EventTypes: data.eventTypes,
+      EventScoreKeys: data.eventScoreKeys,
+      EventScoreValues: data.eventScoreValues,
+      EventDetailKeys: data.eventDetailKeys,
+      EventDetailValues: data.eventDetailValues,
+      ThumbsUpDownVote: data.thumbsUpDownVote,
+      RAGDocumentIds: data.ragDocumentIds,
+      RAGDocumentContents: data.ragDocumentContents,
+      CreatedAt: new Date(data.createdAt),
+      UpdatedAt: new Date(data.updatedAt),
+    };
+  }
+}

--- a/langwatch/src/server/app-layer/analytics/repositories/analytics-trace-facts.repository.ts
+++ b/langwatch/src/server/app-layer/analytics/repositories/analytics-trace-facts.repository.ts
@@ -1,0 +1,25 @@
+import type { AnalyticsTraceFactData } from "../types";
+
+export interface AnalyticsTraceFactsRepository {
+  upsert(data: AnalyticsTraceFactData, tenantId: string): Promise<void>;
+  getByTraceId(
+    tenantId: string,
+    traceId: string,
+  ): Promise<AnalyticsTraceFactData | null>;
+}
+
+export class NullAnalyticsTraceFactsRepository
+  implements AnalyticsTraceFactsRepository
+{
+  async upsert(
+    _data: AnalyticsTraceFactData,
+    _tenantId: string,
+  ): Promise<void> {}
+
+  async getByTraceId(
+    _tenantId: string,
+    _traceId: string,
+  ): Promise<AnalyticsTraceFactData | null> {
+    return null;
+  }
+}

--- a/langwatch/src/server/app-layer/analytics/types.ts
+++ b/langwatch/src/server/app-layer/analytics/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Domain state for the analytics trace fact projection.
+ * Denormalized, pre-aggregated row representing one trace for analytics queries.
+ * Populated by fold projections from trace-processing pipeline events.
+ */
+export interface AnalyticsTraceFactData {
+  traceId: string;
+  occurredAt: number;
+
+  // Known metadata
+  userId: string;
+  threadId: string;
+  customerId: string;
+  labels: string[];
+  topicId: string | null;
+  subTopicId: string | null;
+
+  // Dynamic metadata (semconv keyed, values >256 chars omitted)
+  metadata: Record<string, string>;
+
+  // Performance
+  totalCost: number | null;
+  totalDurationMs: number;
+  totalPromptTokens: number | null;
+  totalCompletionTokens: number | null;
+  tokensPerSecond: number | null;
+  timeToFirstTokenMs: number | null;
+  containsError: boolean;
+  hasAnnotation: boolean | null;
+  spanCount: number;
+
+  // Per-model (parallel arrays)
+  modelNames: string[];
+  modelPromptTokens: number[];
+  modelCompletionTokens: number[];
+  modelCosts: number[];
+
+  // Events (parallel arrays)
+  eventTypes: string[];
+  eventScoreKeys: string[];
+  eventScoreValues: number[];
+  eventDetailKeys: string[];
+  eventDetailValues: string[];
+  thumbsUpDownVote: number | null;
+
+  // RAG
+  ragDocumentIds: string[];
+  ragDocumentContents: string[];
+
+  // Timestamps (auto-managed by fold)
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Domain state for the analytics evaluation fact projection.
+ * Denormalized row representing one evaluation run for analytics queries.
+ * Populated by fold projections from evaluation-processing pipeline events.
+ */
+export interface AnalyticsEvaluationFactData {
+  evaluationId: string;
+  traceId: string | null;
+  occurredAt: number;
+
+  // Evaluator
+  evaluatorId: string;
+  evaluatorName: string | null;
+  evaluatorType: string;
+  isGuardrail: boolean;
+
+  // Results
+  score: number | null;
+  passed: boolean | null;
+  label: string | null;
+  status: string;
+
+  // Best-effort trace context (nullable)
+  userId: string | null;
+  threadId: string | null;
+  topicId: string | null;
+  customerId: string | null;
+
+  // Timestamps
+  createdAt: number;
+  updatedAt: number;
+}

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -17,6 +17,8 @@ import type { AppDependencies } from "./dependencies";
 import { EvaluationExecutionService } from "./evaluations/evaluation-execution.service";
 import { createDefaultModelEnvResolver } from "./evaluations/evaluation-execution.factories";
 import { EvaluationRunService } from "./evaluations/evaluation-run.service";
+import { AnalyticsEvaluationFactsClickHouseRepository } from "./analytics/repositories/analytics-evaluation-facts.clickhouse.repository";
+import { AnalyticsTraceFactsClickHouseRepository } from "./analytics/repositories/analytics-trace-facts.clickhouse.repository";
 import { EvaluationRunClickHouseRepository } from "./evaluations/repositories/evaluation-run.clickhouse.repository";
 import { NullEvaluationRunRepository } from "./evaluations/repositories/evaluation-run.repository";
 import { MonitorService } from "./monitors/monitor.service";
@@ -278,6 +280,12 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     experimentRunItemStorage: createExperimentRunItemAppendStore(
       clickhouseEnabled ? resolveClickHouseClient : null,
     ),
+    analyticsTraceFacts: clickhouseEnabled
+      ? new AnalyticsTraceFactsClickHouseRepository(resolveClickHouseClient)
+      : undefined,
+    analyticsEvaluationFacts: clickhouseEnabled
+      ? new AnalyticsEvaluationFactsClickHouseRepository(resolveClickHouseClient)
+      : undefined,
   };
 
   const registry = new PipelineRegistry({

--- a/langwatch/src/server/clickhouse/migrations/00013_create_analytics_fact_tables.sql
+++ b/langwatch/src/server/clickhouse/migrations/00013_create_analytics_fact_tables.sql
@@ -1,0 +1,149 @@
+-- +goose Up
+-- +goose ENVSUB ON
+-- +goose StatementBegin
+
+-- ============================================================================
+-- Table: analytics_trace_facts
+-- ============================================================================
+-- Denormalized fact table for trace-level analytics.
+-- One row per trace, pre-aggregated from trace_summaries + stored_spans data.
+-- Eliminates JOINs and dedup at query time for analytics queries.
+--
+-- Populated by the analyticsTraceFacts fold projection in the trace-processing pipeline.
+--
+-- Engine: ReplacingMergeTree / ReplicatedReplacingMergeTree (based on CLICKHOUSE_CLUSTER)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS ${CLICKHOUSE_DATABASE}.analytics_trace_facts
+(
+    -- Identity
+    TenantId String CODEC(ZSTD(1)),
+    TraceId String CODEC(ZSTD(1)),
+    OccurredAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+
+    -- Known metadata as top-level columns (fast, indexed)
+    UserId LowCardinality(String) CODEC(ZSTD(1)),
+    ThreadId LowCardinality(String) CODEC(ZSTD(1)),
+    CustomerId LowCardinality(String) CODEC(ZSTD(1)),
+    Labels Array(String) CODEC(ZSTD(1)),
+    TopicId LowCardinality(Nullable(String)) CODEC(ZSTD(1)),
+    SubTopicId LowCardinality(Nullable(String)) CODEC(ZSTD(1)),
+
+    -- Dynamic/custom metadata (semconv keyed, values >256 chars omitted at projection time)
+    Metadata Map(String, String) CODEC(ZSTD(1)),
+
+    -- Performance metrics
+    TotalCost Nullable(Float64),
+    TotalDurationMs Int64,
+    TotalPromptTokens Nullable(UInt32),
+    TotalCompletionTokens Nullable(UInt32),
+    TokensPerSecond Nullable(UInt32),
+    TimeToFirstTokenMs Nullable(UInt32),
+    ContainsError UInt8,
+    HasAnnotation Nullable(UInt8),
+    SpanCount UInt32,
+
+    -- Per-model breakdown (parallel arrays, pre-aggregated per unique model)
+    ModelNames Array(LowCardinality(String)) CODEC(ZSTD(1)),
+    ModelPromptTokens Array(UInt32) CODEC(ZSTD(1)),
+    ModelCompletionTokens Array(UInt32) CODEC(ZSTD(1)),
+    ModelCosts Array(Float64) CODEC(ZSTD(1)),
+
+    -- Events (parallel arrays)
+    EventTypes Array(String) CODEC(ZSTD(1)),
+    EventScoreKeys Array(String) CODEC(ZSTD(1)),
+    EventScoreValues Array(Float64) CODEC(ZSTD(1)),
+    EventDetailKeys Array(String) CODEC(ZSTD(1)),
+    EventDetailValues Array(String) CODEC(ZSTD(1)),
+    ThumbsUpDownVote Nullable(Int8),
+
+    -- RAG documents
+    RAGDocumentIds Array(String) CODEC(ZSTD(1)),
+    RAGDocumentContents Array(String) CODEC(ZSTD(3)),
+
+    -- Timestamps
+    CreatedAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+    UpdatedAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+
+    -- Indexes
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_occurred_at OccurredAt TYPE minmax GRANULARITY 1,
+    INDEX idx_contains_error ContainsError TYPE set(2) GRANULARITY 4,
+    INDEX idx_user_id UserId TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_topic_id TopicId TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = ${CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree(}UpdatedAt)
+PARTITION BY toYearWeek(OccurredAt)
+ORDER BY (TenantId, OccurredAt, TraceId)
+SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+
+-- +goose StatementEnd
+-- +goose StatementBegin
+
+-- ============================================================================
+-- Table: analytics_evaluation_facts
+-- ============================================================================
+-- Denormalized fact table for evaluation-level analytics.
+-- One row per evaluation, with best-effort denormalized trace context.
+-- Eliminates JOINs to evaluation_runs and dedup at query time.
+--
+-- Populated by the analyticsEvaluationFacts fold projection in the evaluation-processing pipeline.
+--
+-- Engine: ReplacingMergeTree / ReplicatedReplacingMergeTree (based on CLICKHOUSE_CLUSTER)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS ${CLICKHOUSE_DATABASE}.analytics_evaluation_facts
+(
+    -- Identity
+    TenantId String CODEC(ZSTD(1)),
+    EvaluationId String CODEC(ZSTD(1)),
+    TraceId Nullable(String) CODEC(ZSTD(1)),
+    OccurredAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+
+    -- Evaluator info
+    EvaluatorId String CODEC(ZSTD(1)),
+    EvaluatorName Nullable(String) CODEC(ZSTD(1)),
+    EvaluatorType LowCardinality(String) CODEC(ZSTD(1)),
+    IsGuardrail UInt8,
+
+    -- Results
+    Score Nullable(Float64),
+    Passed Nullable(UInt8),
+    Label Nullable(String) CODEC(ZSTD(1)),
+    Status LowCardinality(String) CODEC(ZSTD(1)),
+
+    -- Best-effort denormalized trace context (nullable, populated when available)
+    UserId Nullable(String) CODEC(ZSTD(1)),
+    ThreadId Nullable(String) CODEC(ZSTD(1)),
+    TopicId Nullable(String) CODEC(ZSTD(1)),
+    CustomerId Nullable(String) CODEC(ZSTD(1)),
+
+    -- Timestamps
+    CreatedAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+    UpdatedAt DateTime64(3) CODEC(Delta(8), ZSTD(1)),
+
+    -- Indexes
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_evaluation_id EvaluationId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_occurred_at OccurredAt TYPE minmax GRANULARITY 1,
+    INDEX idx_evaluator_type EvaluatorType TYPE set(20) GRANULARITY 1,
+    INDEX idx_status Status TYPE set(10) GRANULARITY 1,
+    INDEX idx_evaluator_id EvaluatorId TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = ${CLICKHOUSE_ENGINE_REPLACING_PREFIX:-ReplacingMergeTree(}UpdatedAt)
+PARTITION BY toYearWeek(OccurredAt)
+ORDER BY (TenantId, OccurredAt, EvaluationId)
+SETTINGS index_granularity = 8192${CLICKHOUSE_STORAGE_POLICY_SETTING};
+
+-- +goose StatementEnd
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- +goose ENVSUB ON
+-- +goose StatementBegin
+
+-- DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.analytics_trace_facts SYNC;
+-- DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.analytics_evaluation_facts SYNC;
+
+-- +goose StatementEnd
+-- +goose ENVSUB OFF

--- a/langwatch/src/server/clickhouse/ttlReconciler.ts
+++ b/langwatch/src/server/clickhouse/ttlReconciler.ts
@@ -92,6 +92,18 @@ export const TABLE_TTL_CONFIG: readonly TableTTLEntry[] = [
     envVar: "TIERED_TRACE_SUMMARIES_TABLE_HOT_DAYS",
     hardcodedDefault: 30,
   },
+  {
+    table: "analytics_trace_facts",
+    ttlColumn: "OccurredAt",
+    envVar: "TIERED_ANALYTICS_TRACE_FACTS_TABLE_HOT_DAYS",
+    hardcodedDefault: 30,
+  },
+  {
+    table: "analytics_evaluation_facts",
+    ttlColumn: "OccurredAt",
+    envVar: "TIERED_ANALYTICS_EVALUATION_FACTS_TABLE_HOT_DAYS",
+    hardcodedDefault: 30,
+  },
 ] as const;
 
 function parseNonNegativeInt(value: string, label: string): number {

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -15,6 +15,8 @@ import type { MonitorService } from "../app-layer/monitors/monitor.service";
 import type { ProjectService } from "../app-layer/projects/project.service";
 import type { LogRecordStorageRepository } from "../app-layer/traces/repositories/log-record-storage.repository";
 import type { MetricRecordStorageRepository } from "../app-layer/traces/repositories/metric-record-storage.repository";
+import type { AnalyticsEvaluationFactsRepository } from "../app-layer/analytics/repositories/analytics-evaluation-facts.repository";
+import type { AnalyticsTraceFactsRepository } from "../app-layer/analytics/repositories/analytics-trace-facts.repository";
 import type { TraceSummaryRepository } from "../app-layer/traces/repositories/trace-summary.repository";
 import type { SpanStorageService } from "../app-layer/traces/span-storage.service";
 import type { TraceSummaryService } from "../app-layer/traces/trace-summary.service";
@@ -52,6 +54,7 @@ import {
   createBillingReportingPipeline,
 } from "./pipelines/billing-reporting/pipeline";
 import { ExecuteEvaluationCommand } from "./pipelines/evaluation-processing/commands/executeEvaluation.command";
+import { AnalyticsEvaluationFactsStore } from "./pipelines/evaluation-processing/projections/analyticsEvaluationFacts.store";
 import { EvaluationRunStore } from "./pipelines/evaluation-processing/projections/evaluationRun.store";
 import type { EvaluationEsSyncReactorDeps } from "./pipelines/evaluation-processing/reactors/evaluationEsSync.reactor";
 import { createEvaluationEsSyncReactor } from "./pipelines/evaluation-processing/reactors/evaluationEsSync.reactor";
@@ -62,6 +65,7 @@ import type { ExperimentRunStateRepository } from "./pipelines/experiment-run-pr
 import { LogRecordAppendStore } from "./pipelines/trace-processing/projections/logRecordStorage.store";
 import { MetricRecordAppendStore } from "./pipelines/trace-processing/projections/metricRecordStorage.store";
 import { SpanAppendStore } from "./pipelines/trace-processing/projections/spanStorage.store";
+import { AnalyticsTraceFactsStore } from "./pipelines/trace-processing/projections/analyticsTraceFacts.store";
 import { TraceSummaryStore } from "./pipelines/trace-processing/projections/traceSummary.store";
 import { createCustomEvaluationSyncReactor } from "./pipelines/trace-processing/reactors/customEvaluationSync.reactor";
 import { createProjectMetadataReactor } from "./pipelines/trace-processing/reactors/projectMetadata.reactor";
@@ -94,6 +98,8 @@ export interface PipelineRepositories {
   logRecordStorage: LogRecordStorageRepository;
   metricRecordStorage: MetricRecordStorageRepository;
   experimentRunItemStorage: AppendStore<ClickHouseExperimentRunResultRecord>;
+  analyticsTraceFacts?: AnalyticsTraceFactsRepository;
+  analyticsEvaluationFacts?: AnalyticsEvaluationFactsRepository;
 }
 
 export interface PipelineRegistryDeps {
@@ -175,11 +181,16 @@ export class PipelineRegistry {
 
     const esSyncReactor = createEvaluationEsSyncReactor(this.deps.esSync);
 
+    const analyticsEvaluationFactsStore = this.deps.repositories.analyticsEvaluationFacts
+      ? new AnalyticsEvaluationFactsStore(this.deps.repositories.analyticsEvaluationFacts)
+      : undefined;
+
     return this.deps.eventSourcing.register(
       createEvaluationProcessingPipeline({
         evalRunStore: new EvaluationRunStore(
           this.deps.evaluations.runs.repository,
         ),
+        analyticsEvaluationFactsStore,
         executeEvaluationCommand,
         esSyncReactor,
       }),
@@ -258,12 +269,17 @@ export class PipelineRegistry {
       },
     });
 
+    const analyticsTraceFactsStore = this.deps.repositories.analyticsTraceFacts
+      ? new AnalyticsTraceFactsStore(this.deps.repositories.analyticsTraceFacts)
+      : undefined;
+
     const tracePipeline = this.deps.eventSourcing.register(
       createTraceProcessingPipeline({
         spanAppendStore: new SpanAppendStore(this.deps.traces.spans.repository),
         logRecordAppendStore: new LogRecordAppendStore(this.deps.repositories.logRecordStorage),
         metricRecordAppendStore: new MetricRecordAppendStore(this.deps.repositories.metricRecordStorage),
         traceSummaryStore,
+        analyticsTraceFactsStore,
         evaluationTriggerReactor,
         customEvaluationSyncReactor,
         traceUpdateBroadcastReactor,

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
@@ -1,3 +1,4 @@
+import type { AnalyticsEvaluationFactData } from "~/server/app-layer/analytics/types";
 import type { EvaluationRunData } from "~/server/app-layer/evaluations/types";
 import { definePipeline } from "../../";
 import type { FoldProjectionStore } from "../../projections/foldProjection.types";
@@ -8,11 +9,13 @@ import {
   ReportEvaluationCommand,
 } from "./commands";
 import { ExecuteEvaluationCommand } from "./commands/executeEvaluation.command";
+import { AnalyticsEvaluationFactsFoldProjection } from "./projections/analyticsEvaluationFacts.foldProjection";
 import { EvaluationRunFoldProjection } from "./projections/evaluationRun.foldProjection";
 import type { EvaluationProcessingEvent } from "./schemas/events";
 
 export interface EvaluationProcessingPipelineDeps {
   evalRunStore: FoldProjectionStore<EvaluationRunData>;
+  analyticsEvaluationFactsStore?: FoldProjectionStore<AnalyticsEvaluationFactData>;
   executeEvaluationCommand: ExecuteEvaluationCommand;
   esSyncReactor: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
   customerIoEvaluationSyncReactor?: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
@@ -38,6 +41,15 @@ export function createEvaluationProcessingPipeline(deps: EvaluationProcessingPip
       store: deps.evalRunStore,
     }))
     .withReactor("evaluationRun", "evaluationEsSync", deps.esSyncReactor);
+
+  if (deps.analyticsEvaluationFactsStore) {
+    builder = builder.withFoldProjection(
+      "analyticsEvaluationFacts",
+      new AnalyticsEvaluationFactsFoldProjection({
+        store: deps.analyticsEvaluationFactsStore,
+      }),
+    );
+  }
 
   if (deps.customerIoEvaluationSyncReactor) {
     builder = builder.withReactor(

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/analyticsEvaluationFacts.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/analyticsEvaluationFacts.unit.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from "vitest";
+import type { AnalyticsEvaluationFactData } from "~/server/app-layer/analytics/types";
+import type { FoldProjectionStore } from "../../../../projections/foldProjection.types";
+import type {
+  EvaluationScheduledEvent,
+  EvaluationStartedEvent,
+  EvaluationCompletedEvent,
+  EvaluationReportedEvent,
+} from "../../schemas/events";
+import { AnalyticsEvaluationFactsFoldProjection } from "../analyticsEvaluationFacts.foldProjection";
+
+function createStubStore(): FoldProjectionStore<AnalyticsEvaluationFactData> {
+  return {
+    store: async () => {},
+    get: async () => null,
+  };
+}
+
+function createProjection() {
+  return new AnalyticsEvaluationFactsFoldProjection({
+    store: createStubStore(),
+  });
+}
+
+function createInitState(): AnalyticsEvaluationFactData {
+  return createProjection().init();
+}
+
+function createScheduledEvent(
+  overrides: Partial<EvaluationScheduledEvent> = {},
+): EvaluationScheduledEvent {
+  return {
+    id: "evt-1",
+    aggregateId: "eval-1",
+    aggregateType: "evaluation",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: 1700000000000,
+    type: "lw.evaluation.scheduled",
+    version: "2025-01-14",
+    data: {
+      evaluationId: "eval-1",
+      evaluatorId: "evaluator-1",
+      evaluatorType: "custom",
+      evaluatorName: "toxicity",
+      traceId: "trace-1",
+      isGuardrail: false,
+    },
+    ...overrides,
+  } as unknown as EvaluationScheduledEvent;
+}
+
+function createStartedEvent(
+  overrides: Partial<EvaluationStartedEvent> = {},
+): EvaluationStartedEvent {
+  return {
+    id: "evt-2",
+    aggregateId: "eval-1",
+    aggregateType: "evaluation",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.evaluation.started",
+    version: "2025-01-14",
+    data: {
+      evaluationId: "eval-1",
+      evaluatorId: "evaluator-1",
+      evaluatorType: "custom",
+      evaluatorName: "toxicity",
+      traceId: "trace-1",
+      isGuardrail: false,
+    },
+    ...overrides,
+  } as unknown as EvaluationStartedEvent;
+}
+
+function createCompletedEvent(
+  overrides: Partial<EvaluationCompletedEvent> = {},
+): EvaluationCompletedEvent {
+  return {
+    id: "evt-3",
+    aggregateId: "eval-1",
+    aggregateType: "evaluation",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.evaluation.completed",
+    version: "2025-01-14",
+    data: {
+      evaluationId: "eval-1",
+      status: "processed",
+      score: 0.9,
+      passed: true,
+      label: "positive",
+      details: null,
+      error: null,
+      errorDetails: null,
+      costId: null,
+    },
+    ...overrides,
+  } as unknown as EvaluationCompletedEvent;
+}
+
+function createReportedEvent(
+  overrides: Partial<EvaluationReportedEvent> = {},
+): EvaluationReportedEvent {
+  return {
+    id: "evt-4",
+    aggregateId: "eval-1",
+    aggregateType: "evaluation",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: 1700000000000,
+    type: "lw.evaluation.reported",
+    version: "2025-01-14",
+    data: {
+      evaluationId: "eval-1",
+      evaluatorId: "evaluator-1",
+      evaluatorType: "custom",
+      evaluatorName: "toxicity",
+      traceId: "trace-1",
+      isGuardrail: false,
+      status: "processed",
+      score: 0.85,
+      passed: true,
+      label: "safe",
+      details: null,
+      error: null,
+    },
+    ...overrides,
+  } as unknown as EvaluationReportedEvent;
+}
+
+describe("analyticsEvaluationFacts foldProjection", () => {
+  describe("init()", () => {
+    it("returns initial state with timestamps and empty defaults", () => {
+      const state = createInitState();
+
+      expect(state.evaluationId).toBe("");
+      expect(state.traceId).toBeNull();
+      expect(state.occurredAt).toBe(0);
+      expect(state.evaluatorId).toBe("");
+      expect(state.evaluatorName).toBeNull();
+      expect(state.evaluatorType).toBe("");
+      expect(state.isGuardrail).toBe(false);
+      expect(state.score).toBeNull();
+      expect(state.passed).toBeNull();
+      expect(state.label).toBeNull();
+      expect(state.status).toBe("scheduled");
+      expect(state.userId).toBeNull();
+      expect(state.threadId).toBeNull();
+      expect(state.topicId).toBeNull();
+      expect(state.customerId).toBeNull();
+      expect(state.createdAt).toBeGreaterThan(0);
+      expect(state.updatedAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe("apply()", () => {
+    describe("when EvaluationScheduledEvent arrives", () => {
+      it("sets evaluator identity and status to scheduled", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(state, createScheduledEvent());
+
+        expect(result.evaluationId).toBe("eval-1");
+        expect(result.evaluatorId).toBe("evaluator-1");
+        expect(result.evaluatorType).toBe("custom");
+        expect(result.evaluatorName).toBe("toxicity");
+        expect(result.traceId).toBe("trace-1");
+        expect(result.isGuardrail).toBe(false);
+        expect(result.status).toBe("scheduled");
+        expect(result.occurredAt).toBe(1700000000000);
+      });
+
+      it("defaults optional fields when not provided", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(
+          state,
+          createScheduledEvent({
+            data: {
+              evaluationId: "eval-2",
+              evaluatorId: "evaluator-2",
+              evaluatorType: "llm",
+            },
+          } as Partial<EvaluationScheduledEvent>),
+        );
+
+        expect(result.evaluatorName).toBeNull();
+        expect(result.traceId).toBeNull();
+        expect(result.isGuardrail).toBe(false);
+      });
+    });
+
+    describe("when EvaluationStartedEvent arrives after scheduled", () => {
+      it("updates status to in_progress, preserving identity from scheduled", () => {
+        const projection = createProjection();
+        let state = createInitState();
+
+        state = projection.apply(state, createScheduledEvent());
+        state = projection.apply(state, createStartedEvent());
+
+        expect(state.status).toBe("in_progress");
+        expect(state.evaluationId).toBe("eval-1");
+        expect(state.evaluatorId).toBe("evaluator-1");
+      });
+    });
+
+    describe("when EvaluationCompletedEvent arrives after started", () => {
+      it("sets results and status from completed event", () => {
+        const projection = createProjection();
+        let state = createInitState();
+
+        state = projection.apply(state, createScheduledEvent());
+        state = projection.apply(state, createStartedEvent());
+        state = projection.apply(state, createCompletedEvent());
+
+        expect(state.status).toBe("processed");
+        expect(state.score).toBe(0.9);
+        expect(state.passed).toBe(true);
+        expect(state.label).toBe("positive");
+      });
+    });
+
+    describe("when EvaluationCompletedEvent has error status", () => {
+      it("sets status to error", () => {
+        const projection = createProjection();
+        let state = createInitState();
+
+        state = projection.apply(state, createScheduledEvent());
+        state = projection.apply(state, createStartedEvent());
+        state = projection.apply(
+          state,
+          createCompletedEvent({
+            data: {
+              evaluationId: "eval-1",
+              status: "error",
+              score: null,
+              passed: null,
+              label: null,
+              details: null,
+              error: "timeout",
+              errorDetails: "evaluation timed out",
+              costId: null,
+            },
+          } as Partial<EvaluationCompletedEvent>),
+        );
+
+        expect(state.status).toBe("error");
+        expect(state.score).toBeNull();
+        expect(state.passed).toBeNull();
+      });
+    });
+
+    describe("when EvaluationReportedEvent is applied (SDK path)", () => {
+      it("sets all fields atomically in one shot", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(state, createReportedEvent());
+
+        expect(result.evaluationId).toBe("eval-1");
+        expect(result.evaluatorId).toBe("evaluator-1");
+        expect(result.evaluatorType).toBe("custom");
+        expect(result.evaluatorName).toBe("toxicity");
+        expect(result.traceId).toBe("trace-1");
+        expect(result.isGuardrail).toBe(false);
+        expect(result.status).toBe("processed");
+        expect(result.score).toBe(0.85);
+        expect(result.passed).toBe(true);
+        expect(result.label).toBe("safe");
+        expect(result.occurredAt).toBe(1700000000000);
+      });
+
+      it("does not require prior scheduled/started events", () => {
+        const projection = createProjection();
+        const emptyState = createInitState();
+
+        expect(() =>
+          projection.apply(emptyState, createReportedEvent()),
+        ).not.toThrow();
+      });
+
+      it("defaults optional fields to null or false", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(
+          state,
+          createReportedEvent({
+            data: {
+              evaluationId: "eval-1",
+              evaluatorId: "evaluator-1",
+              evaluatorType: "custom",
+              status: "processed",
+            },
+          } as Partial<EvaluationReportedEvent>),
+        );
+
+        expect(result.evaluatorName).toBeNull();
+        expect(result.traceId).toBeNull();
+        expect(result.isGuardrail).toBe(false);
+        expect(result.score).toBeNull();
+        expect(result.passed).toBeNull();
+        expect(result.label).toBeNull();
+      });
+    });
+
+    describe("when isGuardrail is true", () => {
+      it("sets isGuardrail from scheduled event", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(
+          state,
+          createScheduledEvent({
+            data: {
+              evaluationId: "eval-1",
+              evaluatorId: "evaluator-1",
+              evaluatorType: "guardrail",
+              isGuardrail: true,
+            },
+          } as Partial<EvaluationScheduledEvent>),
+        );
+
+        expect(result.isGuardrail).toBe(true);
+      });
+    });
+  });
+
+  describe("projection metadata", () => {
+    it("has correct name, version, and event count", () => {
+      const projection = createProjection();
+
+      expect(projection.name).toBe("analyticsEvaluationFacts");
+      expect(projection.version).toBe("2026-04-01");
+      expect(projection.eventTypes).toHaveLength(4);
+    });
+  });
+
+  describe("full lifecycle", () => {
+    describe("when scheduled -> started -> completed", () => {
+      it("tracks the full evaluation lifecycle", () => {
+        const projection = createProjection();
+        let state = createInitState();
+
+        state = projection.apply(state, createScheduledEvent());
+        expect(state.status).toBe("scheduled");
+
+        state = projection.apply(state, createStartedEvent());
+        expect(state.status).toBe("in_progress");
+
+        state = projection.apply(state, createCompletedEvent());
+        expect(state.status).toBe("processed");
+        expect(state.score).toBe(0.9);
+        expect(state.passed).toBe(true);
+        expect(state.evaluationId).toBe("eval-1");
+        expect(state.evaluatorId).toBe("evaluator-1");
+        expect(state.traceId).toBe("trace-1");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/analyticsEvaluationFacts.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/analyticsEvaluationFacts.foldProjection.ts
@@ -1,0 +1,156 @@
+import type { AnalyticsEvaluationFactData } from "~/server/app-layer/analytics/types";
+import {
+  AbstractFoldProjection,
+  type FoldEventHandlers,
+} from "../../../projections/abstractFoldProjection";
+import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
+import type {
+  EvaluationScheduledEvent,
+  EvaluationStartedEvent,
+  EvaluationCompletedEvent,
+  EvaluationReportedEvent,
+} from "../schemas/events";
+import {
+  evaluationScheduledEventSchema,
+  evaluationStartedEventSchema,
+  evaluationCompletedEventSchema,
+  evaluationReportedEventSchema,
+} from "../schemas/events";
+
+export type { AnalyticsEvaluationFactData };
+
+const analyticsEvaluationFactEvents = [
+  evaluationScheduledEventSchema,
+  evaluationStartedEventSchema,
+  evaluationCompletedEventSchema,
+  evaluationReportedEventSchema,
+] as const;
+
+/**
+ * Fold projection that populates the denormalized analytics_evaluation_facts table.
+ *
+ * Mirrors the EvaluationRunFoldProjection logic but maps to the flatter analytics
+ * schema with best-effort trace context fields.
+ *
+ * - `implements FoldEventHandlers` enforces a handler exists for every event schema
+ * - Handler names derived from event type strings
+ * - `updatedAt` is auto-managed by the base class after each handler call (camelCase)
+ */
+export class AnalyticsEvaluationFactsFoldProjection
+  extends AbstractFoldProjection<
+    AnalyticsEvaluationFactData,
+    typeof analyticsEvaluationFactEvents
+  >
+  implements
+    FoldEventHandlers<
+      typeof analyticsEvaluationFactEvents,
+      AnalyticsEvaluationFactData
+    >
+{
+  readonly name = "analyticsEvaluationFacts";
+  readonly version = "2026-04-01";
+  readonly store: FoldProjectionStore<AnalyticsEvaluationFactData>;
+  protected override readonly timestampStyle = "camel" as const;
+
+  protected readonly events = analyticsEvaluationFactEvents;
+
+  constructor(deps: {
+    store: FoldProjectionStore<AnalyticsEvaluationFactData>;
+  }) {
+    super();
+    this.store = deps.store;
+  }
+
+  protected initState() {
+    return {
+      evaluationId: "",
+      traceId: null as string | null,
+      occurredAt: 0,
+
+      // Evaluator
+      evaluatorId: "",
+      evaluatorName: null as string | null,
+      evaluatorType: "",
+      isGuardrail: false,
+
+      // Results
+      score: null as number | null,
+      passed: null as boolean | null,
+      label: null as string | null,
+      status: "scheduled" as string,
+
+      // Best-effort trace context
+      userId: null as string | null,
+      threadId: null as string | null,
+      topicId: null as string | null,
+      customerId: null as string | null,
+    };
+  }
+
+  handleEvaluationScheduled(
+    event: EvaluationScheduledEvent,
+    state: AnalyticsEvaluationFactData,
+  ): AnalyticsEvaluationFactData {
+    return {
+      ...state,
+      evaluationId: event.data.evaluationId,
+      evaluatorId: event.data.evaluatorId,
+      evaluatorType: event.data.evaluatorType,
+      evaluatorName: event.data.evaluatorName ?? null,
+      traceId: event.data.traceId ?? null,
+      isGuardrail: event.data.isGuardrail ?? false,
+      status: "scheduled",
+      occurredAt: event.occurredAt,
+    };
+  }
+
+  handleEvaluationStarted(
+    event: EvaluationStartedEvent,
+    state: AnalyticsEvaluationFactData,
+  ): AnalyticsEvaluationFactData {
+    return {
+      ...state,
+      evaluationId: state.evaluationId || event.data.evaluationId,
+      evaluatorId: state.evaluatorId || event.data.evaluatorId,
+      evaluatorType: state.evaluatorType || event.data.evaluatorType,
+      evaluatorName: state.evaluatorName ?? (event.data.evaluatorName ?? null),
+      traceId: state.traceId ?? (event.data.traceId ?? null),
+      isGuardrail: event.data.isGuardrail ?? state.isGuardrail,
+      status: "in_progress",
+    };
+  }
+
+  handleEvaluationCompleted(
+    event: EvaluationCompletedEvent,
+    state: AnalyticsEvaluationFactData,
+  ): AnalyticsEvaluationFactData {
+    return {
+      ...state,
+      evaluationId: state.evaluationId || event.data.evaluationId,
+      status: event.data.status,
+      score: typeof event.data.score === "number" ? event.data.score : null,
+      passed: event.data.passed ?? null,
+      label: event.data.label ?? null,
+    };
+  }
+
+  handleEvaluationReported(
+    event: EvaluationReportedEvent,
+    state: AnalyticsEvaluationFactData,
+  ): AnalyticsEvaluationFactData {
+    return {
+      ...state,
+      evaluationId: event.data.evaluationId,
+      evaluatorId: event.data.evaluatorId,
+      evaluatorType: event.data.evaluatorType,
+      evaluatorName: event.data.evaluatorName ?? null,
+      traceId: event.data.traceId ?? null,
+      isGuardrail: event.data.isGuardrail ?? false,
+      status: event.data.status,
+      score: typeof event.data.score === "number" ? event.data.score : null,
+      passed: event.data.passed ?? null,
+      label: event.data.label ?? null,
+      occurredAt: state.occurredAt || event.occurredAt,
+    };
+  }
+}

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/analyticsEvaluationFacts.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/analyticsEvaluationFacts.store.ts
@@ -1,0 +1,34 @@
+import type { AnalyticsEvaluationFactsRepository } from "~/server/app-layer/analytics/repositories/analytics-evaluation-facts.repository";
+import type { AnalyticsEvaluationFactData } from "~/server/app-layer/analytics/types";
+import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
+import type { ProjectionStoreContext } from "../../../projections/projectionStoreContext";
+
+/**
+ * Thin FoldProjectionStore adapter for analytics evaluation facts.
+ * Delegates directly to AnalyticsEvaluationFactsRepository.
+ */
+export class AnalyticsEvaluationFactsStore
+  implements FoldProjectionStore<AnalyticsEvaluationFactData>
+{
+  constructor(private readonly repo: AnalyticsEvaluationFactsRepository) {}
+
+  async store(
+    state: AnalyticsEvaluationFactData,
+    context: ProjectionStoreContext,
+  ): Promise<void> {
+    const stateWithId = state.evaluationId
+      ? state
+      : { ...state, evaluationId: String(context.aggregateId) };
+    await this.repo.upsert(stateWithId, String(context.tenantId));
+  }
+
+  async get(
+    aggregateId: string,
+    context: ProjectionStoreContext,
+  ): Promise<AnalyticsEvaluationFactData | null> {
+    return await this.repo.getByEvaluationId(
+      String(context.tenantId),
+      aggregateId,
+    );
+  }
+}

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -1,3 +1,4 @@
+import type { AnalyticsTraceFactData } from "~/server/app-layer/analytics/types";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import { definePipeline } from "../../";
 import type { FoldProjectionStore } from "../../projections/foldProjection.types";
@@ -8,6 +9,7 @@ import { RecordLogCommand } from "./commands/recordLogCommand";
 import { RecordMetricCommand } from "./commands/recordMetricCommand";
 import { RecordSpanCommand } from "./commands/recordSpanCommand";
 import { ResolveOriginCommand } from "./commands/resolveOriginCommand";
+import { AnalyticsTraceFactsFoldProjection } from "./projections/analyticsTraceFacts.foldProjection";
 import { LogRecordStorageMapProjection } from "./projections/logRecordStorage.mapProjection";
 import { MetricRecordStorageMapProjection } from "./projections/metricRecordStorage.mapProjection";
 import { SpanStorageMapProjection } from "./projections/spanStorage.mapProjection";
@@ -22,6 +24,7 @@ export interface TraceProcessingPipelineDeps {
   logRecordAppendStore: AppendStore<NormalizedLogRecord>;
   metricRecordAppendStore: AppendStore<NormalizedMetricRecord>;
   traceSummaryStore: FoldProjectionStore<TraceSummaryData>;
+  analyticsTraceFactsStore?: FoldProjectionStore<AnalyticsTraceFactData>;
   evaluationTriggerReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   customEvaluationSyncReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   traceUpdateBroadcastReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
@@ -60,6 +63,15 @@ export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps)
     .withReactor("traceSummary", "projectMetadata", deps.projectMetadataReactor)
     .withReactor("traceSummary", "simulationMetricsSync", deps.simulationMetricsSyncReactor)
     .withReactor("spanStorage", "spanStorageBroadcast", deps.spanStorageBroadcastReactor);
+
+  if (deps.analyticsTraceFactsStore) {
+    builder = builder.withFoldProjection(
+      "analyticsTraceFacts",
+      new AnalyticsTraceFactsFoldProjection({
+        store: deps.analyticsTraceFactsStore,
+      }),
+    );
+  }
 
   if (deps.customerIoTraceSyncReactor) {
     builder = builder.withReactor(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/analyticsTraceFacts.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/analyticsTraceFacts.unit.test.ts
@@ -1,0 +1,700 @@
+import { describe, expect, it } from "vitest";
+import type { AnalyticsTraceFactData } from "~/server/app-layer/analytics/types";
+import type { FoldProjectionStore } from "../../../../projections/foldProjection.types";
+import type {
+  MetricRecordReceivedEvent,
+  SpanReceivedEvent,
+  TopicAssignedEvent,
+  LogRecordReceivedEvent,
+  OriginResolvedEvent,
+} from "../../schemas/events";
+import { NormalizedSpanKind } from "../../schemas/spans";
+import {
+  AnalyticsTraceFactsFoldProjection,
+  applySpanToAnalyticsFacts,
+} from "../analyticsTraceFacts.foldProjection";
+import { createTestSpan } from "./fixtures/trace-summary-test.fixtures";
+
+function createStubStore(): FoldProjectionStore<AnalyticsTraceFactData> {
+  return {
+    store: async () => {},
+    get: async () => null,
+  };
+}
+
+function createProjection() {
+  return new AnalyticsTraceFactsFoldProjection({
+    store: createStubStore(),
+  });
+}
+
+function createInitState(): AnalyticsTraceFactData {
+  return createProjection().init();
+}
+
+function createSpanReceivedEvent(
+  overrides: Partial<SpanReceivedEvent> = {},
+): SpanReceivedEvent {
+  return {
+    id: "evt-1",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.span_received",
+    version: "2025-12-14",
+    data: {
+      span: {
+        traceId: "trace-1",
+        spanId: "span-1",
+        parentSpanId: null,
+        traceState: null,
+        name: "test-span",
+        kind: 1,
+        startTimeUnixNano: "1000000000000",
+        endTimeUnixNano: "2000000000000",
+        attributes: [],
+        events: [],
+        links: [],
+        status: { message: null, code: null },
+        flags: null,
+        droppedAttributesCount: 0,
+        droppedEventsCount: 0,
+        droppedLinksCount: 0,
+      },
+      resource: null,
+      instrumentationScope: null,
+      piiRedactionLevel: "disabled",
+    },
+    metadata: {
+      spanId: "span-1",
+      traceId: "trace-1",
+    },
+    ...overrides,
+  } as unknown as SpanReceivedEvent;
+}
+
+function createTopicAssignedEvent(
+  overrides: Partial<TopicAssignedEvent> = {},
+): TopicAssignedEvent {
+  return {
+    id: "evt-2",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.topic_assigned",
+    version: "2025-02-01",
+    data: {
+      topicId: "topic-1",
+      topicName: "Topic One",
+      subtopicId: "subtopic-1",
+      subtopicName: "Subtopic One",
+      isIncremental: false,
+    },
+    metadata: {},
+    ...overrides,
+  } as unknown as TopicAssignedEvent;
+}
+
+function createMetricRecordReceivedEvent(
+  overrides: Partial<MetricRecordReceivedEvent> = {},
+): MetricRecordReceivedEvent {
+  return {
+    id: "evt-3",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.metric_record_received",
+    version: "2026-03-08",
+    data: {
+      traceId: "trace-1",
+      spanId: "span-1",
+      metricName: "gen_ai.server.time_to_first_token",
+      metricUnit: "s",
+      metricType: "gauge",
+      value: 0.5,
+      timeUnixMs: 1000,
+      attributes: {},
+      resourceAttributes: {},
+    },
+    metadata: {},
+    ...overrides,
+  } as unknown as MetricRecordReceivedEvent;
+}
+
+function createLogRecordReceivedEvent(
+  overrides: Partial<LogRecordReceivedEvent> = {},
+): LogRecordReceivedEvent {
+  return {
+    id: "evt-4",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.log_record_received",
+    version: "2026-03-08",
+    data: {
+      traceId: "trace-1",
+      spanId: "span-1",
+      timeUnixMs: 1000,
+      severityNumber: 9,
+      severityText: "INFO",
+      body: "test log",
+      attributes: {},
+      resourceAttributes: {},
+      scopeName: "test",
+      scopeVersion: null,
+      piiRedactionLevel: "disabled",
+    },
+    metadata: {},
+    ...overrides,
+  } as unknown as LogRecordReceivedEvent;
+}
+
+function createOriginResolvedEvent(
+  overrides: Partial<OriginResolvedEvent> = {},
+): OriginResolvedEvent {
+  return {
+    id: "evt-5",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.origin_resolved",
+    version: "2026-03-13",
+    data: {
+      origin: "api",
+      reason: "inferred",
+    },
+    metadata: {},
+    ...overrides,
+  } as unknown as OriginResolvedEvent;
+}
+
+describe("analyticsTraceFacts foldProjection", () => {
+  describe("init()", () => {
+    it("returns initial state with timestamps and zero defaults", () => {
+      const state = createInitState();
+
+      expect(state.traceId).toBe("");
+      expect(state.spanCount).toBe(0);
+      expect(state.occurredAt).toBe(0);
+      expect(state.userId).toBe("");
+      expect(state.threadId).toBe("");
+      expect(state.customerId).toBe("");
+      expect(state.labels).toEqual([]);
+      expect(state.topicId).toBeNull();
+      expect(state.subTopicId).toBeNull();
+      expect(state.metadata).toEqual({});
+      expect(state.totalCost).toBeNull();
+      expect(state.totalDurationMs).toBe(0);
+      expect(state.totalPromptTokens).toBeNull();
+      expect(state.totalCompletionTokens).toBeNull();
+      expect(state.tokensPerSecond).toBeNull();
+      expect(state.timeToFirstTokenMs).toBeNull();
+      expect(state.containsError).toBe(false);
+      expect(state.hasAnnotation).toBeNull();
+      expect(state.modelNames).toEqual([]);
+      expect(state.modelPromptTokens).toEqual([]);
+      expect(state.modelCompletionTokens).toEqual([]);
+      expect(state.modelCosts).toEqual([]);
+      expect(state.eventTypes).toEqual([]);
+      expect(state.thumbsUpDownVote).toBeNull();
+      expect(state.ragDocumentIds).toEqual([]);
+      expect(state.ragDocumentContents).toEqual([]);
+      expect(state.createdAt).toBeGreaterThan(0);
+      expect(state.updatedAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe("applySpanToAnalyticsFacts()", () => {
+    describe("when processing a span with userId, threadId, and customerId", () => {
+      it("extracts known metadata fields into top-level columns", () => {
+        const state = createInitState();
+        const span = createTestSpan({
+          traceId: "trace-1",
+          spanAttributes: {
+            "langwatch.user.id": "user-42",
+            "gen_ai.conversation.id": "thread-abc",
+            "langwatch.customer.id": "cust-99",
+          },
+        });
+
+        const result = applySpanToAnalyticsFacts({ state, span });
+
+        expect(result.userId).toBe("user-42");
+        expect(result.threadId).toBe("thread-abc");
+        expect(result.customerId).toBe("cust-99");
+        expect(result.spanCount).toBe(1);
+        expect(result.traceId).toBe("trace-1");
+      });
+    });
+
+    describe("when processing a span with labels", () => {
+      it("extracts labels from JSON string array", () => {
+        const state = createInitState();
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.labels": '["important","urgent"]',
+          },
+        });
+
+        const result = applySpanToAnalyticsFacts({ state, span });
+
+        expect(result.labels).toEqual(["important", "urgent"]);
+      });
+
+      it("unions labels across multiple spans", () => {
+        let state = createInitState();
+        const span1 = createTestSpan({
+          spanAttributes: {
+            "langwatch.labels": '["important"]',
+          },
+        });
+        const span2 = createTestSpan({
+          spanAttributes: {
+            "langwatch.labels": '["important","urgent"]',
+          },
+        });
+
+        state = applySpanToAnalyticsFacts({ state, span: span1 });
+        state = applySpanToAnalyticsFacts({ state, span: span2 });
+
+        expect(state.labels).toEqual(["important", "urgent"]);
+      });
+    });
+
+    describe("when processing spans with model and tokens", () => {
+      it("accumulates per-model token counts", () => {
+        let state = createInitState();
+
+        const llmSpan = createTestSpan({
+          spanAttributes: {
+            "gen_ai.request.model": "gpt-5-mini",
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 50,
+          },
+        });
+
+        state = applySpanToAnalyticsFacts({ state, span: llmSpan });
+
+        expect(state.modelNames).toEqual(["gpt-5-mini"]);
+        expect(state.modelPromptTokens).toEqual([100]);
+        expect(state.modelCompletionTokens).toEqual([50]);
+        expect(state.totalPromptTokens).toBe(100);
+        expect(state.totalCompletionTokens).toBe(50);
+      });
+
+      it("accumulates tokens for the same model across multiple spans", () => {
+        let state = createInitState();
+
+        const span1 = createTestSpan({
+          spanAttributes: {
+            "gen_ai.request.model": "gpt-5-mini",
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 50,
+          },
+        });
+        const span2 = createTestSpan({
+          spanAttributes: {
+            "gen_ai.request.model": "gpt-5-mini",
+            "gen_ai.usage.input_tokens": 200,
+            "gen_ai.usage.output_tokens": 100,
+          },
+        });
+
+        state = applySpanToAnalyticsFacts({ state, span: span1 });
+        state = applySpanToAnalyticsFacts({ state, span: span2 });
+
+        expect(state.modelNames).toEqual(["gpt-5-mini"]);
+        expect(state.modelPromptTokens).toEqual([300]);
+        expect(state.modelCompletionTokens).toEqual([150]);
+        expect(state.totalPromptTokens).toBe(300);
+        expect(state.totalCompletionTokens).toBe(150);
+      });
+
+      it("tracks separate models in parallel arrays", () => {
+        let state = createInitState();
+
+        const span1 = createTestSpan({
+          spanAttributes: {
+            "gen_ai.request.model": "gpt-5-mini",
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 50,
+          },
+        });
+        const span2 = createTestSpan({
+          spanAttributes: {
+            "gen_ai.request.model": "claude-opus-4-6",
+            "gen_ai.usage.input_tokens": 200,
+            "gen_ai.usage.output_tokens": 80,
+          },
+        });
+
+        state = applySpanToAnalyticsFacts({ state, span: span1 });
+        state = applySpanToAnalyticsFacts({ state, span: span2 });
+
+        expect(state.modelNames).toEqual(["gpt-5-mini", "claude-opus-4-6"]);
+        expect(state.modelPromptTokens).toEqual([100, 200]);
+        expect(state.modelCompletionTokens).toEqual([50, 80]);
+        expect(state.totalPromptTokens).toBe(300);
+        expect(state.totalCompletionTokens).toBe(130);
+      });
+    });
+
+    describe("when processing spans with events", () => {
+      it("extracts event types and score metrics", () => {
+        const state = createInitState();
+        const span = createTestSpan({
+          events: [
+            {
+              name: "thumbs_up_down",
+              timeUnixMs: 1500,
+              attributes: { vote: 1 },
+            },
+            {
+              name: "feedback",
+              timeUnixMs: 1600,
+              attributes: {
+                feedback: "Great response!",
+                score: 0.95,
+              },
+            },
+          ],
+        });
+
+        const result = applySpanToAnalyticsFacts({ state, span });
+
+        expect(result.eventTypes).toEqual(["thumbs_up_down", "feedback"]);
+        expect(result.thumbsUpDownVote).toBe(1);
+        expect(result.eventScoreKeys).toContain("vote");
+        expect(result.eventScoreKeys).toContain("score");
+        expect(result.eventDetailKeys).toContain("feedback");
+        expect(result.eventDetailValues).toContain("Great response!");
+      });
+    });
+
+    describe("when processing a span with RAG contexts", () => {
+      it("extracts document IDs and contents", () => {
+        const state = createInitState();
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.rag.contexts": [
+              { document_id: "doc-1", content: "First document content" },
+              { document_id: "doc-2", content: "Second document content" },
+            ],
+          },
+        });
+
+        const result = applySpanToAnalyticsFacts({ state, span });
+
+        expect(result.ragDocumentIds).toEqual(["doc-1", "doc-2"]);
+        expect(result.ragDocumentContents).toEqual([
+          "First document content",
+          "Second document content",
+        ]);
+      });
+    });
+
+    describe("when processing a span with an error status", () => {
+      it("sets containsError to true", () => {
+        const state = createInitState();
+        const span = createTestSpan({
+          statusCode: 2, // ERROR
+          statusMessage: "Something went wrong",
+        });
+
+        const result = applySpanToAnalyticsFacts({ state, span });
+
+        expect(result.containsError).toBe(true);
+      });
+    });
+
+    describe("when processing spans with metadata attributes", () => {
+      it("extracts metadata.* attributes to the metadata map", () => {
+        const state = createInitState();
+        const span = createTestSpan({
+          spanAttributes: {
+            "metadata.environment": "production",
+            "metadata.version": "1.2.3",
+          },
+        });
+
+        const result = applySpanToAnalyticsFacts({ state, span });
+
+        expect(result.metadata["metadata.environment"]).toBe("production");
+        expect(result.metadata["metadata.version"]).toBe("1.2.3");
+      });
+
+      it("omits metadata values longer than 256 characters", () => {
+        const state = createInitState();
+        const longValue = "x".repeat(257);
+        const span = createTestSpan({
+          spanAttributes: {
+            "metadata.short": "ok",
+            "metadata.long": longValue,
+          },
+        });
+
+        const result = applySpanToAnalyticsFacts({ state, span });
+
+        expect(result.metadata["metadata.short"]).toBe("ok");
+        expect(result.metadata["metadata.long"]).toBeUndefined();
+      });
+    });
+
+    describe("when processing timing across spans", () => {
+      it("computes occurredAt as the earliest span start time", () => {
+        let state = createInitState();
+
+        const span1 = createTestSpan({
+          startTimeUnixMs: 5000,
+          endTimeUnixMs: 6000,
+        });
+        const span2 = createTestSpan({
+          startTimeUnixMs: 3000,
+          endTimeUnixMs: 8000,
+        });
+
+        state = applySpanToAnalyticsFacts({ state, span: span1 });
+        state = applySpanToAnalyticsFacts({ state, span: span2 });
+
+        expect(state.occurredAt).toBe(3000);
+        expect(state.totalDurationMs).toBe(5000); // 8000 - 3000
+      });
+    });
+  });
+
+  describe("apply()", () => {
+    describe("when TopicAssignedEvent arrives", () => {
+      it("sets topicId and subTopicId", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(state, createTopicAssignedEvent());
+
+        expect(result.topicId).toBe("topic-1");
+        expect(result.subTopicId).toBe("subtopic-1");
+      });
+    });
+
+    describe("when MetricRecordReceivedEvent arrives with time_to_first_token", () => {
+      it("sets timeToFirstTokenMs from the metric value in seconds", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(
+          state,
+          createMetricRecordReceivedEvent(),
+        );
+
+        expect(result.timeToFirstTokenMs).toBe(500);
+      });
+
+      it("takes the minimum when multiple TTFT metrics arrive", () => {
+        const projection = createProjection();
+        let state = createInitState();
+
+        state = projection.apply(
+          state,
+          createMetricRecordReceivedEvent({
+            data: {
+              traceId: "trace-1",
+              spanId: "span-1",
+              metricName: "gen_ai.server.time_to_first_token",
+              metricUnit: "s",
+              metricType: "gauge",
+              value: 0.8,
+              timeUnixMs: 1000,
+              attributes: {},
+              resourceAttributes: {},
+            },
+          } as Partial<MetricRecordReceivedEvent>),
+        );
+        state = projection.apply(
+          state,
+          createMetricRecordReceivedEvent({
+            data: {
+              traceId: "trace-1",
+              spanId: "span-2",
+              metricName: "gen_ai.server.time_to_first_token",
+              metricUnit: "s",
+              metricType: "gauge",
+              value: 0.3,
+              timeUnixMs: 2000,
+              attributes: {},
+              resourceAttributes: {},
+            },
+          } as Partial<MetricRecordReceivedEvent>),
+        );
+
+        expect(state.timeToFirstTokenMs).toBe(300);
+      });
+    });
+
+    describe("when LogRecordReceivedEvent arrives", () => {
+      it("returns state unchanged (no-op for analytics)", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(
+          state,
+          createLogRecordReceivedEvent(),
+        );
+
+        // State should be identical except for updatedAt
+        expect(result.spanCount).toBe(state.spanCount);
+        expect(result.traceId).toBe(state.traceId);
+      });
+    });
+
+    describe("when OriginResolvedEvent arrives", () => {
+      it("returns state unchanged (origin not in analytics schema)", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(
+          state,
+          createOriginResolvedEvent(),
+        );
+
+        expect(result.spanCount).toBe(state.spanCount);
+        expect(result.traceId).toBe(state.traceId);
+      });
+    });
+
+    describe("when a non-metric MetricRecordReceivedEvent arrives", () => {
+      it("returns state unchanged for unrecognized metric names", () => {
+        const projection = createProjection();
+        const state = createInitState();
+
+        const result = projection.apply(
+          state,
+          createMetricRecordReceivedEvent({
+            data: {
+              traceId: "trace-1",
+              spanId: "span-1",
+              metricName: "custom.metric",
+              metricUnit: "count",
+              metricType: "gauge",
+              value: 42,
+              timeUnixMs: 1000,
+              attributes: {},
+              resourceAttributes: {},
+            },
+          } as Partial<MetricRecordReceivedEvent>),
+        );
+
+        expect(result.timeToFirstTokenMs).toBeNull();
+      });
+    });
+  });
+
+  describe("projection metadata", () => {
+    it("has correct name, version, and timestampStyle", () => {
+      const projection = createProjection();
+
+      expect(projection.name).toBe("analyticsTraceFacts");
+      expect(projection.version).toBe("2026-04-01");
+      expect(projection.eventTypes).toHaveLength(5);
+    });
+  });
+
+  describe("full flow", () => {
+    describe("when processing multiple spans with models, events, and RAG", () => {
+      it("accumulates all analytics fields correctly", () => {
+        let state = createInitState();
+
+        const rootSpan = createTestSpan({
+          id: "root-1",
+          traceId: "trace-1",
+          spanId: "root-1",
+          parentSpanId: null,
+          startTimeUnixMs: 1000,
+          endTimeUnixMs: 5000,
+          durationMs: 4000,
+          name: "root",
+          kind: NormalizedSpanKind.SERVER,
+          spanAttributes: {
+            "langwatch.user.id": "user-1",
+            "gen_ai.conversation.id": "thread-1",
+            "langwatch.customer.id": "cust-1",
+            "langwatch.labels": '["production"]',
+            "metadata.env": "prod",
+          },
+        });
+
+        const llmSpan = createTestSpan({
+          id: "llm-1",
+          traceId: "trace-1",
+          spanId: "llm-1",
+          parentSpanId: "root-1",
+          startTimeUnixMs: 1100,
+          endTimeUnixMs: 4000,
+          durationMs: 2900,
+          name: "llm",
+          kind: NormalizedSpanKind.INTERNAL,
+          spanAttributes: {
+            "langwatch.span.type": "llm",
+            "gen_ai.request.model": "gpt-5-mini",
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 50,
+          },
+          events: [
+            {
+              name: "thumbs_up_down",
+              timeUnixMs: 2000,
+              attributes: { vote: 1 },
+            },
+          ],
+        });
+
+        const ragSpan = createTestSpan({
+          id: "rag-1",
+          traceId: "trace-1",
+          spanId: "rag-1",
+          parentSpanId: "root-1",
+          startTimeUnixMs: 4100,
+          endTimeUnixMs: 4500,
+          durationMs: 400,
+          name: "retrieval",
+          kind: NormalizedSpanKind.INTERNAL,
+          spanAttributes: {
+            "langwatch.rag.contexts": [
+              { document_id: "doc-1", content: "RAG content" },
+            ],
+          },
+        });
+
+        state = applySpanToAnalyticsFacts({ state, span: rootSpan });
+        state = applySpanToAnalyticsFacts({ state, span: llmSpan });
+        state = applySpanToAnalyticsFacts({ state, span: ragSpan });
+
+        expect(state.traceId).toBe("trace-1");
+        expect(state.spanCount).toBe(3);
+        expect(state.userId).toBe("user-1");
+        expect(state.threadId).toBe("thread-1");
+        expect(state.customerId).toBe("cust-1");
+        expect(state.labels).toEqual(["production"]);
+        expect(state.metadata["metadata.env"]).toBe("prod");
+        expect(state.modelNames).toEqual(["gpt-5-mini"]);
+        expect(state.modelPromptTokens).toEqual([100]);
+        expect(state.modelCompletionTokens).toEqual([50]);
+        expect(state.totalPromptTokens).toBe(100);
+        expect(state.totalCompletionTokens).toBe(50);
+        expect(state.thumbsUpDownVote).toBe(1);
+        expect(state.ragDocumentIds).toEqual(["doc-1"]);
+        expect(state.ragDocumentContents).toEqual(["RAG content"]);
+        expect(state.occurredAt).toBe(1000);
+        expect(state.totalDurationMs).toBe(4000); // 5000 - 1000 (root span end)
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/analyticsTraceFacts.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/analyticsTraceFacts.foldProjection.ts
@@ -1,0 +1,527 @@
+import { coerceToNumber } from "~/utils/coerceToNumber";
+import { CanonicalizeSpanAttributesService } from "~/server/app-layer/traces/canonicalisation";
+import {
+  enrichRagContextIds,
+  SpanNormalizationPipelineService,
+} from "~/server/app-layer/traces/span-normalization.service";
+import { ATTR_KEYS } from "~/server/app-layer/traces/canonicalisation/extractors/_constants";
+import type { AnalyticsTraceFactData } from "~/server/app-layer/analytics/types";
+import {
+  AbstractFoldProjection,
+  type FoldEventHandlers,
+} from "~/server/event-sourcing/projections/abstractFoldProjection";
+import type { FoldProjectionStore } from "~/server/event-sourcing/projections/foldProjection.types";
+import type {
+  LogRecordReceivedEvent,
+  MetricRecordReceivedEvent,
+  OriginResolvedEvent,
+  SpanReceivedEvent,
+  TopicAssignedEvent,
+} from "../schemas/events";
+import {
+  spanReceivedEventSchema,
+  topicAssignedEventSchema,
+  logRecordReceivedEventSchema,
+  metricRecordReceivedEventSchema,
+  originResolvedEventSchema,
+} from "../schemas/events";
+import type { NormalizedSpan } from "../schemas/spans";
+import {
+  extractSpanMetrics,
+  extractIdentityAttributes,
+} from "./services/spanMetricsExtractor";
+import { parseJsonStringArray } from "./services/trace-summary.utils";
+
+export type { AnalyticsTraceFactData };
+
+// ─── Composition root ────────────────────────────────────────────────
+
+const spanNormalizationPipelineService = new SpanNormalizationPipelineService(
+  new CanonicalizeSpanAttributesService(),
+);
+
+// ─── Known semconv keys to omit from metadata ───────────────────────
+
+/**
+ * Attribute keys that are already extracted as top-level columns or are
+ * internal/structural. These are omitted from the `metadata` Map to avoid
+ * duplication and keep the analytics table lean.
+ */
+const METADATA_OMIT_PREFIXES = [
+  "gen_ai.",
+  "langwatch.",
+  "error.",
+  "exception.",
+  "traceloop.",
+  "openinference.",
+  "ai.",
+  "llm.",
+  "span.",
+  "otel.",
+  "status.",
+  "output.",
+  "input.",
+  "mastra.",
+  "telemetry.",
+  "service.",
+  "host.",
+  "process.",
+  "os.",
+  "container.",
+  "k8s.",
+  "cloud.",
+  "deployment.",
+  "device.",
+  "faas.",
+  "webengine.",
+  "scenario.",
+  "type",
+  "operation.name",
+  "agent.name",
+  "system.name",
+  "retrieval.documents",
+  "raw_input",
+] as const;
+
+const MAX_METADATA_VALUE_LENGTH = 256;
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function shouldOmitMetadataKey(key: string): boolean {
+  for (const prefix of METADATA_OMIT_PREFIXES) {
+    if (key === prefix || key.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function extractMetadataFromSpan(span: NormalizedSpan): Record<string, string> {
+  const metadata: Record<string, string> = {};
+
+  // Include metadata.* attributes from span attributes (custom user metadata)
+  for (const [key, value] of Object.entries(span.spanAttributes)) {
+    if (!key.startsWith("metadata.")) continue;
+    const strValue = typeof value === "string" ? value : String(value ?? "");
+    if (strValue.length <= MAX_METADATA_VALUE_LENGTH) {
+      metadata[key] = strValue;
+    }
+  }
+
+  // Include non-standard resource attributes as metadata
+  for (const [key, value] of Object.entries(span.resourceAttributes)) {
+    if (shouldOmitMetadataKey(key)) continue;
+    const strValue = typeof value === "string" ? value : String(value ?? "");
+    if (strValue.length <= MAX_METADATA_VALUE_LENGTH) {
+      metadata[key] = strValue;
+    }
+  }
+
+  return metadata;
+}
+
+function extractLabelsFromSpan(span: NormalizedSpan): string[] {
+  const labels = span.spanAttributes[ATTR_KEYS.LANGWATCH_LABELS];
+  if (typeof labels === "string") {
+    return parseJsonStringArray(labels);
+  }
+  if (Array.isArray(labels)) {
+    return labels.filter((l): l is string => typeof l === "string");
+  }
+  return [];
+}
+
+function extractRagDocuments(span: NormalizedSpan): {
+  ragDocumentIds: string[];
+  ragDocumentContents: string[];
+} {
+  const raw =
+    span.spanAttributes[ATTR_KEYS.LANGWATCH_RAG_CONTEXTS] ??
+    span.spanAttributes[ATTR_KEYS.LANGWATCH_RAG_CONTEXTS_LEGACY];
+
+  if (!Array.isArray(raw)) return { ragDocumentIds: [], ragDocumentContents: [] };
+
+  const ids: string[] = [];
+  const contents: string[] = [];
+
+  for (const ctx of raw) {
+    if (!ctx || typeof ctx !== "object" || Array.isArray(ctx)) continue;
+    const ctxObj = ctx as Record<string, unknown>;
+    const docId = ctxObj.document_id;
+    const content = ctxObj.content;
+    if (typeof docId === "string") ids.push(docId);
+    else ids.push("");
+    if (typeof content === "string") contents.push(content);
+    else if (content !== undefined && content !== null)
+      contents.push(String(content));
+    else contents.push("");
+  }
+
+  return { ragDocumentIds: ids, ragDocumentContents: contents };
+}
+
+function extractSpanEvents(span: NormalizedSpan): {
+  eventTypes: string[];
+  eventScoreKeys: string[];
+  eventScoreValues: number[];
+  eventDetailKeys: string[];
+  eventDetailValues: string[];
+  thumbsUpDownVote: number | null;
+} {
+  const eventTypes: string[] = [];
+  const eventScoreKeys: string[] = [];
+  const eventScoreValues: number[] = [];
+  const eventDetailKeys: string[] = [];
+  const eventDetailValues: string[] = [];
+  let thumbsUpDownVote: number | null = null;
+
+  if (!span.events?.length) {
+    return {
+      eventTypes,
+      eventScoreKeys,
+      eventScoreValues,
+      eventDetailKeys,
+      eventDetailValues,
+      thumbsUpDownVote,
+    };
+  }
+
+  for (const event of span.events) {
+    eventTypes.push(event.name);
+
+    const attrs = event.attributes ?? {};
+
+    // Extract score metrics from event attributes
+    for (const [key, value] of Object.entries(attrs)) {
+      const numValue = coerceToNumber(value);
+      if (
+        numValue !== null &&
+        (key.startsWith("event.metrics.") ||
+          key === "vote" ||
+          key === "score" ||
+          key === "gen_ai.evaluation.score.value")
+      ) {
+        eventScoreKeys.push(key);
+        eventScoreValues.push(numValue);
+      }
+    }
+
+    // Extract detail values from event attributes
+    for (const [key, value] of Object.entries(attrs)) {
+      if (
+        typeof value === "string" &&
+        (key === "feedback" ||
+          key === "comment" ||
+          key === "gen_ai.evaluation.score.label")
+      ) {
+        eventDetailKeys.push(key);
+        eventDetailValues.push(value);
+      }
+    }
+
+    // Extract thumbs up/down vote
+    if (event.name === "thumbs_up_down") {
+      const vote = coerceToNumber(attrs["vote"]);
+      if (vote !== null) {
+        thumbsUpDownVote = vote;
+      }
+    }
+  }
+
+  return {
+    eventTypes,
+    eventScoreKeys,
+    eventScoreValues,
+    eventDetailKeys,
+    eventDetailValues,
+    thumbsUpDownVote,
+  };
+}
+
+/** @internal Exported for unit testing */
+export function applySpanToAnalyticsFacts({
+  state,
+  span,
+}: {
+  state: AnalyticsTraceFactData;
+  span: NormalizedSpan;
+}): AnalyticsTraceFactData {
+  // Use shared extractor for metrics consistency with traceSummary
+  const metrics = extractSpanMetrics({ timingState: state, span });
+
+  // Accumulate token totals
+  const totalPromptTokens =
+    (state.totalPromptTokens ?? 0) + metrics.tokens.promptTokens;
+  const totalCompletionTokens =
+    (state.totalCompletionTokens ?? 0) + metrics.tokens.completionTokens;
+  const totalCost = (state.totalCost ?? 0) + metrics.tokens.cost;
+
+  const tokensPerSecond =
+    totalCompletionTokens > 0 && metrics.timing.totalDurationMs > 0
+      ? Math.round(
+          (totalCompletionTokens / metrics.timing.totalDurationMs) * 1000,
+        )
+      : null;
+
+  let timeToFirstTokenMs = state.timeToFirstTokenMs;
+  if (metrics.tokenTiming.timeToFirstToken !== null) {
+    timeToFirstTokenMs =
+      timeToFirstTokenMs === null
+        ? metrics.tokenTiming.timeToFirstToken
+        : Math.min(timeToFirstTokenMs, metrics.tokenTiming.timeToFirstToken);
+  }
+
+  // Per-model accumulation using shared model extraction
+  const model = metrics.models[0];
+  let modelNames = [...state.modelNames];
+  let modelPromptTokens = [...state.modelPromptTokens];
+  let modelCompletionTokens = [...state.modelCompletionTokens];
+  let modelCosts = [...state.modelCosts];
+
+  if (
+    model &&
+    (metrics.tokens.promptTokens > 0 ||
+      metrics.tokens.completionTokens > 0 ||
+      metrics.tokens.cost > 0)
+  ) {
+    const existingIndex = modelNames.indexOf(model);
+    if (existingIndex >= 0) {
+      modelPromptTokens[existingIndex]! += metrics.tokens.promptTokens;
+      modelCompletionTokens[existingIndex]! += metrics.tokens.completionTokens;
+      modelCosts[existingIndex]! += metrics.tokens.cost;
+    } else {
+      modelNames = [...modelNames, model];
+      modelPromptTokens = [...modelPromptTokens, metrics.tokens.promptTokens];
+      modelCompletionTokens = [
+        ...modelCompletionTokens,
+        metrics.tokens.completionTokens,
+      ];
+      modelCosts = [...modelCosts, metrics.tokens.cost];
+    }
+  }
+
+  // Use shared identity extraction for consistency
+  const identity = extractIdentityAttributes(span);
+  const userId = state.userId || identity.userId;
+  const threadId = state.threadId || identity.threadId;
+  const customerId = state.customerId || identity.customerId;
+
+  // Labels: union across spans
+  const spanLabels = extractLabelsFromSpan(span);
+  const labels =
+    spanLabels.length > 0
+      ? [...new Set([...state.labels, ...spanLabels])]
+      : state.labels;
+
+  // Metadata: merge span metadata into existing
+  const spanMetadata = extractMetadataFromSpan(span);
+  const metadata =
+    Object.keys(spanMetadata).length > 0
+      ? { ...spanMetadata, ...state.metadata }
+      : state.metadata;
+
+  // Events
+  const spanEvents = extractSpanEvents(span);
+
+  // RAG documents
+  const rag = extractRagDocuments(span);
+
+  return {
+    ...state,
+    traceId: state.traceId || span.traceId,
+    spanCount: state.spanCount + 1,
+    occurredAt: metrics.timing.occurredAt,
+    totalDurationMs: metrics.timing.totalDurationMs,
+    containsError: state.containsError || metrics.status.hasError,
+
+    // Known metadata
+    userId,
+    threadId,
+    customerId,
+    labels,
+    metadata,
+
+    // Token totals
+    totalPromptTokens: totalPromptTokens > 0 ? totalPromptTokens : null,
+    totalCompletionTokens:
+      totalCompletionTokens > 0 ? totalCompletionTokens : null,
+    totalCost: totalCost > 0 ? Number(totalCost.toFixed(6)) : null,
+    tokensPerSecond,
+    timeToFirstTokenMs,
+
+    // Per-model
+    modelNames,
+    modelPromptTokens,
+    modelCompletionTokens,
+    modelCosts,
+
+    // Events: append from this span
+    eventTypes: [...state.eventTypes, ...spanEvents.eventTypes],
+    eventScoreKeys: [...state.eventScoreKeys, ...spanEvents.eventScoreKeys],
+    eventScoreValues: [
+      ...state.eventScoreValues,
+      ...spanEvents.eventScoreValues,
+    ],
+    eventDetailKeys: [...state.eventDetailKeys, ...spanEvents.eventDetailKeys],
+    eventDetailValues: [
+      ...state.eventDetailValues,
+      ...spanEvents.eventDetailValues,
+    ],
+    thumbsUpDownVote: spanEvents.thumbsUpDownVote ?? state.thumbsUpDownVote,
+
+    // RAG
+    ragDocumentIds: [...state.ragDocumentIds, ...rag.ragDocumentIds],
+    ragDocumentContents: [
+      ...state.ragDocumentContents,
+      ...rag.ragDocumentContents,
+    ],
+  };
+}
+
+// ─── Fold projection class ──────────────────────────────────────────
+
+const analyticsTraceFactEvents = [
+  spanReceivedEventSchema,
+  topicAssignedEventSchema,
+  logRecordReceivedEventSchema,
+  metricRecordReceivedEventSchema,
+  originResolvedEventSchema,
+] as const;
+
+/**
+ * Fold projection that populates the denormalized analytics_trace_facts table.
+ *
+ * Extracts analytics-relevant fields (userId, threadId, per-model tokens,
+ * events, RAG documents, metadata) from trace-processing events into a flat,
+ * pre-aggregated row optimized for analytics queries.
+ *
+ * - `implements FoldEventHandlers` enforces a handler exists for every event schema
+ * - Handler names derived from event type strings
+ * - `updatedAt` is auto-managed by the base class after each handler call (camelCase)
+ */
+export class AnalyticsTraceFactsFoldProjection
+  extends AbstractFoldProjection<
+    AnalyticsTraceFactData,
+    typeof analyticsTraceFactEvents
+  >
+  implements
+    FoldEventHandlers<typeof analyticsTraceFactEvents, AnalyticsTraceFactData>
+{
+  readonly name = "analyticsTraceFacts";
+  readonly version = "2026-04-01";
+  readonly store: FoldProjectionStore<AnalyticsTraceFactData>;
+  protected override readonly timestampStyle = "camel" as const;
+
+  protected readonly events = analyticsTraceFactEvents;
+
+  constructor(deps: { store: FoldProjectionStore<AnalyticsTraceFactData> }) {
+    super();
+    this.store = deps.store;
+  }
+
+  protected initState() {
+    return {
+      traceId: "",
+      occurredAt: 0,
+
+      // Known metadata
+      userId: "",
+      threadId: "",
+      customerId: "",
+      labels: [] as string[],
+      topicId: null as string | null,
+      subTopicId: null as string | null,
+
+      // Dynamic metadata
+      metadata: {} as Record<string, string>,
+
+      // Performance
+      totalCost: null as number | null,
+      totalDurationMs: 0,
+      totalPromptTokens: null as number | null,
+      totalCompletionTokens: null as number | null,
+      tokensPerSecond: null as number | null,
+      timeToFirstTokenMs: null as number | null,
+      containsError: false,
+      hasAnnotation: null as boolean | null,
+      spanCount: 0,
+
+      // Per-model (parallel arrays)
+      modelNames: [] as string[],
+      modelPromptTokens: [] as number[],
+      modelCompletionTokens: [] as number[],
+      modelCosts: [] as number[],
+
+      // Events (parallel arrays)
+      eventTypes: [] as string[],
+      eventScoreKeys: [] as string[],
+      eventScoreValues: [] as number[],
+      eventDetailKeys: [] as string[],
+      eventDetailValues: [] as string[],
+      thumbsUpDownVote: null as number | null,
+
+      // RAG
+      ragDocumentIds: [] as string[],
+      ragDocumentContents: [] as string[],
+    };
+  }
+
+  handleTraceSpanReceived(
+    event: SpanReceivedEvent,
+    state: AnalyticsTraceFactData,
+  ): AnalyticsTraceFactData {
+    const normalizedSpan =
+      spanNormalizationPipelineService.normalizeSpanReceived(
+        event.tenantId,
+        event.data.span,
+        event.data.resource,
+        event.data.instrumentationScope,
+      );
+    enrichRagContextIds(normalizedSpan);
+
+    return {
+      ...applySpanToAnalyticsFacts({ state, span: normalizedSpan }),
+      createdAt: state.createdAt,
+    };
+  }
+
+  handleTraceTopicAssigned(
+    event: TopicAssignedEvent,
+    state: AnalyticsTraceFactData,
+  ): AnalyticsTraceFactData {
+    return {
+      ...state,
+      topicId: event.data.topicId ?? state.topicId,
+      subTopicId: event.data.subtopicId ?? state.subTopicId,
+    };
+  }
+
+  handleTraceLogRecordReceived(
+    _event: LogRecordReceivedEvent,
+    state: AnalyticsTraceFactData,
+  ): AnalyticsTraceFactData {
+    // Logs don't affect analytics fact columns
+    return state;
+  }
+
+  handleTraceMetricRecordReceived(
+    event: MetricRecordReceivedEvent,
+    state: AnalyticsTraceFactData,
+  ): AnalyticsTraceFactData {
+    if (event.data.metricName === "gen_ai.server.time_to_first_token") {
+      const ttftMs = event.data.value * 1000;
+      const timeToFirstTokenMs =
+        state.timeToFirstTokenMs === null
+          ? ttftMs
+          : Math.min(state.timeToFirstTokenMs, ttftMs);
+      return { ...state, timeToFirstTokenMs };
+    }
+    return state;
+  }
+
+  handleTraceOriginResolved(
+    _event: OriginResolvedEvent,
+    state: AnalyticsTraceFactData,
+  ): AnalyticsTraceFactData {
+    // Origin is not in the analytics schema
+    return state;
+  }
+}

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/analyticsTraceFacts.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/analyticsTraceFacts.store.ts
@@ -1,0 +1,35 @@
+import type { AnalyticsTraceFactsRepository } from "~/server/app-layer/analytics/repositories/analytics-trace-facts.repository";
+import type { AnalyticsTraceFactData } from "~/server/app-layer/analytics/types";
+import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
+import type { ProjectionStoreContext } from "../../../projections/projectionStoreContext";
+
+/**
+ * Thin FoldProjectionStore adapter for analytics trace facts.
+ * Delegates directly to AnalyticsTraceFactsRepository.
+ */
+export class AnalyticsTraceFactsStore
+  implements FoldProjectionStore<AnalyticsTraceFactData>
+{
+  constructor(private readonly repo: AnalyticsTraceFactsRepository) {}
+
+  async store(
+    state: AnalyticsTraceFactData,
+    context: ProjectionStoreContext,
+  ): Promise<void> {
+    if (state.spanCount === 0) return;
+    const stateWithId = state.traceId
+      ? state
+      : { ...state, traceId: String(context.aggregateId) };
+    await this.repo.upsert(stateWithId, String(context.tenantId));
+  }
+
+  async get(
+    aggregateId: string,
+    context: ProjectionStoreContext,
+  ): Promise<AnalyticsTraceFactData | null> {
+    return await this.repo.getByTraceId(
+      String(context.tenantId),
+      aggregateId,
+    );
+  }
+}

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/spanMetricsExtractor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/spanMetricsExtractor.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared span metrics extraction used by BOTH traceSummary and analyticsTraceFacts
+ * fold projections. This ensures consistency between the two projections.
+ *
+ * Both projections call `extractSpanMetrics()` to get the same intermediate result,
+ * then map it into their respective state shapes.
+ */
+
+import { ATTR_KEYS } from "~/server/app-layer/traces/canonicalisation/extractors/_constants";
+import type { NormalizedSpan } from "../../schemas/spans";
+import { SpanCostService } from "./span-cost.service";
+import { SpanStatusService } from "./span-status.service";
+import { SpanTimingService } from "./span-timing.service";
+
+// Singleton service instances — shared across both projections
+const spanTimingService = new SpanTimingService();
+const spanStatusService = new SpanStatusService();
+const spanCostService = new SpanCostService();
+
+export { spanTimingService, spanStatusService, spanCostService };
+
+/**
+ * Minimal state interface accepted by the timing accumulation.
+ * Both TraceSummaryData and AnalyticsTraceFactData satisfy this.
+ */
+export interface TimingState {
+  occurredAt: number;
+  totalDurationMs: number;
+}
+
+/**
+ * Intermediate result from span metric extraction.
+ * State-shape independent — both projections consume this.
+ */
+export interface SpanMetricsResult {
+  timing: { occurredAt: number; totalDurationMs: number };
+  status: { hasError: boolean; hasOK: boolean; errorMessage: string | null };
+  tokens: {
+    promptTokens: number;
+    completionTokens: number;
+    cost: number;
+    estimated: boolean;
+  };
+  tokenTiming: {
+    timeToFirstToken: number | null;
+    timeToLastToken: number | null;
+  };
+  models: string[];
+}
+
+/**
+ * Extract all standard span metrics in one call.
+ * Both traceSummary and analyticsTraceFacts projections call this
+ * to ensure identical computation.
+ */
+export function extractSpanMetrics({
+  timingState,
+  span,
+}: {
+  timingState: TimingState;
+  span: NormalizedSpan;
+}): SpanMetricsResult {
+  // SpanTimingService.accumulateTiming expects TraceSummaryData, but only
+  // reads occurredAt and totalDurationMs. Cast through the minimal interface.
+  const timing = spanTimingService.accumulateTiming({
+    state: timingState as Parameters<
+      typeof spanTimingService.accumulateTiming
+    >[0]["state"],
+    span,
+  });
+
+  const status = spanStatusService.extractStatus(span);
+  const tokens = spanCostService.extractTokenMetrics(span);
+  const tokenTiming = spanCostService.extractTokenTiming(span);
+  const models = spanCostService.extractModelsFromSpan(span);
+
+  return { timing, status, tokens, tokenTiming, models };
+}
+
+/**
+ * Extract known identity attributes from a span.
+ * Used by analyticsTraceFacts to populate top-level userId/threadId/customerId.
+ * traceSummary stores these in an Attributes map instead.
+ */
+export function extractIdentityAttributes(span: NormalizedSpan): {
+  userId: string;
+  threadId: string;
+  customerId: string;
+} {
+  const attrs = span.spanAttributes;
+  const str = (key: string): string => {
+    const v = attrs[key];
+    return typeof v === "string" ? v : "";
+  };
+
+  return {
+    userId:
+      str(ATTR_KEYS.LANGWATCH_USER_ID) ||
+      str(ATTR_KEYS.LANGWATCH_USER_ID_LEGACY) ||
+      str(ATTR_KEYS.LANGWATCH_USER_ID_LEGACY_ROOT),
+    threadId:
+      str(ATTR_KEYS.GEN_AI_CONVERSATION_ID) ||
+      str(ATTR_KEYS.LANGWATCH_THREAD_ID) ||
+      str(ATTR_KEYS.LANGWATCH_THREAD_ID_LEGACY) ||
+      str(ATTR_KEYS.LANGWATCH_THREAD_ID_LEGACY_ROOT),
+    customerId:
+      str(ATTR_KEYS.LANGWATCH_CUSTOMER_ID) ||
+      str(ATTR_KEYS.LANGWATCH_CUSTOMER_ID_LEGACY) ||
+      str(ATTR_KEYS.LANGWATCH_CUSTOMER_ID_LEGACY_ROOT),
+  };
+}

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -27,9 +27,6 @@ import {
 } from "../schemas/events";
 import type { NormalizedSpan } from "../schemas/spans";
 import {
-  SpanTimingService,
-  SpanStatusService,
-  SpanCostService,
   TraceOriginService,
   TraceAttributeAccumulationService,
   TraceIOAccumulationService,
@@ -38,6 +35,10 @@ import {
   extractIOFromLogRecord,
   OUTPUT_SOURCE,
 } from "./services";
+import {
+  extractSpanMetrics,
+  spanCostService,
+} from "./services/spanMetricsExtractor";
 
 export type { TraceSummaryData };
 
@@ -49,9 +50,6 @@ const spanNormalizationPipelineService = new SpanNormalizationPipelineService(
   new CanonicalizeSpanAttributesService(),
 );
 
-const spanTimingService = new SpanTimingService();
-const spanStatusService = new SpanStatusService();
-const spanCostService = new SpanCostService();
 const traceOriginService = new TraceOriginService();
 const traceAttributeAccumulationService =
   new TraceAttributeAccumulationService(traceOriginService);
@@ -71,13 +69,15 @@ export function applySpanToSummary({
   state: TraceSummaryData;
   span: NormalizedSpan;
 }): TraceSummaryData {
-  const timing = spanTimingService.accumulateTiming({ state, span });
+  // Use shared extractor for metrics consistency with analyticsTraceFacts
+  const metrics = extractSpanMetrics({ timingState: state, span });
+
   const tokens = spanCostService.accumulateTokens({
     state,
     span,
-    totalDurationMs: timing.totalDurationMs,
+    totalDurationMs: metrics.timing.totalDurationMs,
   });
-  const status = spanStatusService.accumulateStatus({ state, span });
+
   const io = traceIOAccumulationService.accumulateIO({ state, span });
   const attributes = traceAttributeAccumulationService.accumulateAttributes({
     state,
@@ -85,10 +85,9 @@ export function applySpanToSummary({
     outputSource: io.outputSource,
   });
 
-  const newModels = spanCostService.extractModelsFromSpan(span);
   const models =
-    newModels.length > 0
-      ? [...new Set([...state.models, ...newModels])].sort()
+    metrics.models.length > 0
+      ? [...new Set([...state.models, ...metrics.models])].sort()
       : state.models;
 
   const roleAccumulation = scenarioRoleCostService.accumulateRoleCostLatency({
@@ -101,11 +100,13 @@ export function applySpanToSummary({
     traceId: state.traceId || span.traceId,
     spanCount: state.spanCount + 1,
     computedIOSchemaVersion: COMPUTED_IO_SCHEMA_VERSION,
-    occurredAt: timing.occurredAt,
-    totalDurationMs: timing.totalDurationMs,
+    occurredAt: metrics.timing.occurredAt,
+    totalDurationMs: metrics.timing.totalDurationMs,
     models,
     ...tokens,
-    ...status,
+    containsErrorStatus: state.containsErrorStatus || metrics.status.hasError,
+    containsOKStatus: state.containsOKStatus || metrics.status.hasOK,
+    errorMessage: state.errorMessage ?? metrics.status.errorMessage,
     computedInput: io.computedInput,
     computedOutput: io.computedOutput,
     outputFromRootSpan: io.outputFromRootSpan,


### PR DESCRIPTION
## Summary

- Replaces JOIN-heavy analytics queries against entity tables (`trace_summaries`, `stored_spans`, `evaluation_runs`) with purpose-built denormalized fact tables populated by event sourcing fold projections
- Adds two new ClickHouse tables: `analytics_trace_facts` (one row per trace) and `analytics_evaluation_facts` (one row per evaluation), both with `ORDER BY (TenantId, OccurredAt, ...)` optimized for time-range analytics
- Adds clean app-layer `AnalyticsService` with own types, gated behind PostHog feature flag `analytics_projections_enabled`
- Extracts shared `spanMetricsExtractor` to ensure consistency between `traceSummary` and `analyticsTraceFacts` fold projections

## Test plan

- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] 48 new unit tests pass (21 trace projection + 12 eval projection + 15 metric column map)
- [ ] 24 analytics facade tests pass (18 existing + 6 new routing tests)
- [ ] Enable flag locally with `ANALYTICS_PROJECTIONS_ENABLED=1`, verify timeseries queries route to projection service
- [ ] Enable comparison mode with `ANALYTICS_COMPARISON_MODE=true` to compare projection results against CH entity table results
- [ ] Run ClickHouse migration `00013_create_analytics_fact_tables.sql`
- [ ] Verify fold projections populate fact tables on trace/evaluation ingestion