### PR TITLE
fix(analytics): apply cardinality integer format per-series, not globally

### DIFF
--- a/langwatch/src/components/analytics/CustomGraph.tsx
+++ b/langwatch/src/components/analytics/CustomGraph.tsx
@@ -547,8 +547,10 @@ const CustomGraph_ = React.memo(
         payload.payload?.key ?? (payload.dataKey as string),
       );
       const metric = series?.metric && getMetric(series.metric);
+      const effectiveFormat =
+        series?.aggregation === "cardinality" ? "0a" : metric?.format;
 
-      return formatWith(metric?.format, value as number);
+      return formatWith(effectiveFormat, value as number);
     };
 
     const container = (child: React.ReactNode) => {


### PR DESCRIPTION
Closes #2868

## Summary

- When a chart has mixed series (e.g., one cardinality + one avg), the integer format override (`"0a"`) was applied to ALL series via `input.series.some()`. Now checks per-series so only cardinality aggregations use integer format, preserving decimal precision for value-based metrics.

## Test plan

- [ ] Create a mixed chart with one "count" series and one "avg" series — counts show integers, averages keep decimals