### PR TITLE
fix: include tenantId in Redis fold cache key for tenant isolation

### DIFF
--- a/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
@@ -59,7 +59,7 @@ describe("RedisCachedFoldStore", () => {
         });
 
         const state: TestState = { count: 5, name: "cached" };
-        redis.data.set("fold:test_table:agg-1", {
+        redis.data.set("fold:test_table:tenant-1:agg-1", {
           value: JSON.stringify(state),
           ttl: 30,
         });
@@ -67,7 +67,7 @@ describe("RedisCachedFoldStore", () => {
         const result = await store.get("agg-1", TEST_CONTEXT);
 
         expect(result).toEqual(state);
-        expect(redis.get).toHaveBeenCalledWith("fold:test_table:agg-1");
+        expect(redis.get).toHaveBeenCalledWith("fold:test_table:tenant-1:agg-1");
         expect(inner.getCalls).toHaveLength(0);
       });
     });
@@ -108,7 +108,7 @@ describe("RedisCachedFoldStore", () => {
 
         // Then Redis cached
         expect(redis.set).toHaveBeenCalledWith(
-          "fold:test_table:agg-1",
+          "fold:test_table:tenant-1:agg-1",
           JSON.stringify(state),
           "EX",
           30,
@@ -160,6 +160,37 @@ describe("RedisCachedFoldStore", () => {
       const state2 = await store.get("agg-1", TEST_CONTEXT);
       expect(state2).toEqual(newState);
       expect(inner.getCalls).toHaveLength(1);
+    });
+  });
+
+  describe("tenant isolation", () => {
+    it("different tenants with the same aggregateId get separate cache entries", async () => {
+      const redis = createMockRedis();
+      const inner = createMockInnerStore();
+      const store = new RedisCachedFoldStore<TestState>(inner, redis as any, {
+        keyPrefix: "test_table",
+      });
+
+      const tenantA: ProjectionStoreContext = {
+        aggregateId: "shared-trace-id",
+        tenantId: createTenantId("tenant-A"),
+      };
+      const tenantB: ProjectionStoreContext = {
+        aggregateId: "shared-trace-id",
+        tenantId: createTenantId("tenant-B"),
+      };
+
+      // Store state for tenant A
+      await store.store({ count: 10, name: "tenant-A-state" }, tenantA);
+      // Store state for tenant B (same aggregateId)
+      await store.store({ count: 20, name: "tenant-B-state" }, tenantB);
+
+      // Each tenant reads their own state
+      const stateA = await store.get("shared-trace-id", tenantA);
+      const stateB = await store.get("shared-trace-id", tenantB);
+
+      expect(stateA).toEqual({ count: 10, name: "tenant-A-state" });
+      expect(stateB).toEqual({ count: 20, name: "tenant-B-state" });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
+++ b/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
@@ -39,7 +39,7 @@ export class RedisCachedFoldStore<State>
     aggregateId: string,
     context: ProjectionStoreContext,
   ): Promise<State | null> {
-    const key = this.redisKey(aggregateId);
+    const key = this.redisKey(aggregateId, context);
     const cached = await this.redis.get(key);
     if (cached !== null) {
       return JSON.parse(cached) as State;
@@ -59,7 +59,7 @@ export class RedisCachedFoldStore<State>
 
     // 2. Redis second — cache for fast reads on next fold step
     try {
-      const key = this.redisKey(aggregateId);
+      const key = this.redisKey(aggregateId, context);
       await this.redis.set(key, JSON.stringify(state), "EX", this.ttlSeconds);
     } catch (error) {
       logger.warn(
@@ -69,7 +69,7 @@ export class RedisCachedFoldStore<State>
     }
   }
 
-  private redisKey(aggregateId: string): string {
-    return `fold:${this.keyPrefix}:${aggregateId}`;
+  private redisKey(aggregateId: string, context: ProjectionStoreContext): string {
+    return `fold:${this.keyPrefix}:${String(context.tenantId)}:${aggregateId}`;
   }
 }


### PR DESCRIPTION
## Summary

- Aggregate IDs (trace IDs, evaluation IDs) are NOT unique across tenants — customers can choose their own IDs
- Without tenantId in the Redis cache key, two tenants with the same trace ID would share a cache entry, reading each other's fold state
- Key format changed: `fold:{prefix}:{tenantId}:{aggregateId}` (was `fold:{prefix}:{aggregateId}`)

## Rollout

Safe to deploy immediately. Old keys (30s TTL) expire naturally. New code misses the old format and falls back to ClickHouse — no data loss, just brief cache misses during the 30s transition.

## Test plan

- [x] 6/6 unit tests pass (existing + new tenant isolation test)
- [x] New test proves two tenants with same aggregateId get separate cache entries