### PR TITLE
fix: restore event-sourcing infrastructure regressed by #2734

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/evaluation-cost.recorder.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-cost.recorder.ts
@@ -1,7 +1,23 @@
 import { generate } from "@langwatch/ksuid";
 import { CostReferenceType, CostType, type PrismaClient } from "@prisma/client";
 import { KSUID_RESOURCES } from "../../../utils/constants";
-import type { EvaluationCostRecorder } from "../../event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command";
+
+/**
+ * Interface for recording evaluation costs.
+ * Consumers (command handlers) depend on this interface; the Prisma
+ * implementation lives alongside it in the app-layer.
+ */
+export interface EvaluationCostRecorder {
+  recordCost(params: {
+    projectId: string;
+    isGuardrail: boolean;
+    evaluatorName: string;
+    evaluatorId: string;
+    traceId: string;
+    amount: number;
+    currency: string;
+  }): Promise<string>;
+}
 
 /**
  * Records evaluation costs in the database via Prisma.

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -283,6 +283,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
   const registry = new PipelineRegistry({
     eventSourcing: es,
     repositories,
+    redis: redis!,
     broadcast,
     projects,
     monitors,

--- a/langwatch/src/server/event-sourcing/commands/defineCommand.ts
+++ b/langwatch/src/server/event-sourcing/commands/defineCommand.ts
@@ -58,6 +58,7 @@ export function defineCommand<
   schema,
   aggregateId,
   idempotencyKey,
+  groupKey,
   spanAttributes,
   makeJobId,
 }: {
@@ -68,6 +69,7 @@ export function defineCommand<
   schema: TEventDataSchema;
   aggregateId: (data: z.infer<TEventDataSchema> & CommandEnvelope) => string;
   idempotencyKey: (data: z.infer<TEventDataSchema> & CommandEnvelope) => string;
+  groupKey?: (data: z.infer<TEventDataSchema> & CommandEnvelope) => string;
   spanAttributes?: (data: z.infer<TEventDataSchema> & CommandEnvelope) => Record<string, string | number | boolean>;
   makeJobId?: (data: z.infer<TEventDataSchema> & CommandEnvelope) => string;
 }): DefinedCommandClass<z.infer<TEventDataSchema> & CommandEnvelope, TCmdType> {
@@ -86,6 +88,9 @@ export function defineCommand<
     static getAggregateId(payload: CommandData): string {
       return aggregateId(payload);
     }
+
+    static getGroupKey: ((payload: CommandData) => string) | undefined =
+      groupKey;
 
     static getSpanAttributes: ((payload: CommandData) => Record<string, string | number | boolean>) | undefined =
       spanAttributes;

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -1,8 +1,9 @@
+import type { Redis, Cluster } from "ioredis";
 import { createLogger } from "~/utils/logger/server";
 import { queryBillableEventsTotal } from "../../../ee/billing/services/billableEventsQuery";
 import type { UsageReportingService } from "../../../ee/billing/services/usageReportingService";
 import type { BillingCheckpointService } from "../app-layer/billing/billingCheckpoint.service";
-import type { EvaluationCostRecorder } from "./pipelines/evaluation-processing/commands/executeEvaluation.command";
+import type { EvaluationCostRecorder } from "../app-layer/evaluations/evaluation-cost.recorder";
 import type { OrganizationService } from "../app-layer/organizations/organization.service";
 
 import type { TraceSummaryData } from "../app-layer/traces/types";
@@ -35,6 +36,7 @@ import type { ComputeRunMetricsCommandData } from "./pipelines/simulation-proces
 import type { SimulationRunStateRepository } from "./pipelines/simulation-processing/repositories/simulationRunState.repository";
 import { createSuiteRunProcessingPipeline } from "./pipelines/suite-run-processing/pipeline";
 import type { SuiteRunStateData } from "./pipelines/suite-run-processing/projections/suiteRunState.foldProjection";
+import { RedisCachedFoldStore } from "./projections/redisCachedFoldStore";
 import { RepositoryFoldStore } from "./projections/repositoryFoldStore";
 import { SUITE_RUN_PROJECTION_VERSIONS } from "./pipelines/suite-run-processing/schemas/constants";
 import type { SuiteRunStateRepository } from "./pipelines/suite-run-processing/repositories/suiteRunState.repository";
@@ -55,6 +57,7 @@ import type { EvaluationEsSyncReactorDeps } from "./pipelines/evaluation-process
 import { createEvaluationEsSyncReactor } from "./pipelines/evaluation-processing/reactors/evaluationEsSync.reactor";
 import { createExperimentRunItemAppendStore } from "./pipelines/experiment-run-processing/projections/experimentRunResultStorage.store";
 import { createExperimentRunStateFoldStore } from "./pipelines/experiment-run-processing/projections/experimentRunState.store";
+import type { ExperimentRunStateData } from "./pipelines/experiment-run-processing/projections/experimentRunState.foldProjection";
 import type { ExperimentRunStateRepository } from "./pipelines/experiment-run-processing/repositories/experimentRunState.repository";
 import { LogRecordAppendStore } from "./pipelines/trace-processing/projections/logRecordStorage.store";
 import { MetricRecordAppendStore } from "./pipelines/trace-processing/projections/metricRecordStorage.store";
@@ -96,6 +99,7 @@ export interface PipelineRepositories {
 export interface PipelineRegistryDeps {
   eventSourcing: EventSourcing;
   repositories: PipelineRepositories;
+  redis: Redis | Cluster;
   broadcast: BroadcastService;
   projects: ProjectService;
   monitors: MonitorService;
@@ -123,6 +127,15 @@ export interface PipelineRegistryDeps {
  */
 export class PipelineRegistry {
   constructor(private readonly deps: PipelineRegistryDeps) {}
+
+  private cached<State>(
+    inner: FoldProjectionStore<State>,
+    keyPrefix: string,
+  ): FoldProjectionStore<State> {
+    return new RedisCachedFoldStore<State>(inner, this.deps.redis as Redis, {
+      keyPrefix,
+    });
+  }
 
   registerAll() {
     // TODO: Customer.io reactors are implemented but not yet registered.
@@ -178,7 +191,10 @@ export class PipelineRegistry {
   ) {
     const evalCommands = mapCommands(evalPipeline.commands);
 
-    const traceSummaryStore = new TraceSummaryStore(this.deps.repositories.traceSummaryFold);
+    const traceSummaryStore = this.cached<TraceSummaryData>(
+      new TraceSummaryStore(this.deps.repositories.traceSummaryFold),
+      "trace_summaries",
+    );
 
     // Late-bound reference to the trace pipeline's resolveOrigin command.
     // The reactor deps closure captures this; the actual dispatcher is set
@@ -324,9 +340,12 @@ export class PipelineRegistry {
   private registerSuiteRunPipeline() {
     return this.deps.eventSourcing.register(
       createSuiteRunProcessingPipeline({
-        suiteRunStateFoldStore: new RepositoryFoldStore<SuiteRunStateData>(
-          this.deps.repositories.suiteRunState,
-          SUITE_RUN_PROJECTION_VERSIONS.RUN_STATE,
+        suiteRunStateFoldStore: this.cached<SuiteRunStateData>(
+          new RepositoryFoldStore<SuiteRunStateData>(
+            this.deps.repositories.suiteRunState,
+            SUITE_RUN_PROJECTION_VERSIONS.RUN_STATE,
+          ),
+          "suite_runs",
         ),
       }),
     );
@@ -337,9 +356,12 @@ export class PipelineRegistry {
     traceSummaryStore: FoldProjectionStore<TraceSummaryData>;
     wireSimulationDeps: ReturnType<PipelineRegistry["registerTracePipeline"]>["wireSimulationDeps"];
   }) {
-    const simulationRunStore = new RepositoryFoldStore<SimulationRunStateData>(
-      this.deps.repositories.simulationRunState,
-      SIMULATION_PROJECTION_VERSIONS.RUN_STATE,
+    const simulationRunStore = this.cached<SimulationRunStateData>(
+      new RepositoryFoldStore<SimulationRunStateData>(
+        this.deps.repositories.simulationRunState,
+        SIMULATION_PROJECTION_VERSIONS.RUN_STATE,
+      ),
+      "simulation_runs",
     );
     const snapshotUpdateBroadcastReactor = createSnapshotUpdateBroadcastReactor(
       {
@@ -469,10 +491,14 @@ export class PipelineRegistry {
   }
 
   private registerExperimentRunPipeline() {
+    const experimentRunStore = this.cached<ExperimentRunStateData>(
+      createExperimentRunStateFoldStore(this.deps.repositories.experimentRunState),
+      "experiment_runs",
+    );
+
     return this.deps.eventSourcing.register(
       createExperimentRunProcessingPipeline({
-        experimentRunStateFoldStore:
-          createExperimentRunStateFoldStore(this.deps.repositories.experimentRunState),
+        experimentRunStateFoldStore: experimentRunStore,
         experimentRunItemAppendStore: this.deps.repositories.experimentRunItemStorage,
         esSync: createExperimentRunEsSyncReactor({
           project: this.deps.projects,

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands.ts
@@ -13,8 +13,8 @@ import {
  */
 
 export const StartEvaluationCommand = defineCommand({
-  commandType: "lw.evaluation.start" as const,
-  eventType: "lw.evaluation.started" as const,
+  commandType: "lw.evaluation.start",
+  eventType: "lw.evaluation.started",
   eventVersion: "2025-01-14",
   aggregateType: "evaluation",
   schema: evaluationStartedEventDataSchema,
@@ -30,8 +30,8 @@ export const StartEvaluationCommand = defineCommand({
 });
 
 export const CompleteEvaluationCommand = defineCommand({
-  commandType: "lw.evaluation.complete" as const,
-  eventType: "lw.evaluation.completed" as const,
+  commandType: "lw.evaluation.complete",
+  eventType: "lw.evaluation.completed",
   eventVersion: "2025-01-14",
   aggregateType: "evaluation",
   schema: evaluationCompletedEventDataSchema,
@@ -45,8 +45,8 @@ export const CompleteEvaluationCommand = defineCommand({
 });
 
 export const ReportEvaluationCommand = defineCommand({
-  commandType: "lw.evaluation.report" as const,
-  eventType: "lw.evaluation.reported" as const,
+  commandType: "lw.evaluation.report",
+  eventType: "lw.evaluation.reported",
   eventVersion: "2025-01-14",
   aggregateType: "evaluation",
   schema: evaluationReportedEventDataSchema,

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -8,6 +8,7 @@ import {
 import { extractErrorMessage } from "../../../../../utils/captureError";
 import { KSUID_RESOURCES } from "../../../../../utils/constants";
 import { createLogger } from "../../../../../utils/logger/server";
+import type { EvaluationCostRecorder } from "../../../../app-layer/evaluations/evaluation-cost.recorder";
 import type { EvaluationExecutionService } from "../../../../app-layer/evaluations/evaluation-execution.service";
 import type { MonitorService } from "../../../../app-layer/monitors/monitor.service";
 import {
@@ -35,22 +36,6 @@ import type {
 const logger = createLogger(
   "langwatch:evaluation-processing:execute-evaluation",
 );
-
-/**
- * Interface for recording evaluation costs.
- * Extracted from the command to remove the direct Prisma dependency.
- */
-export interface EvaluationCostRecorder {
-  recordCost(params: {
-    projectId: string;
-    isGuardrail: boolean;
-    evaluatorName: string;
-    evaluatorId: string;
-    traceId: string;
-    amount: number;
-    currency: string;
-  }): Promise<string>;
-}
 
 export interface ExecuteEvaluationCommandDeps {
   monitors: MonitorService;
@@ -319,6 +304,3 @@ function emitReported(
 
   return [event];
 }
-
-/** Re-export makeJobId for backward compatibility with existing tests. */
-export const makeJobId = ExecuteEvaluationCommand.makeJobId;

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/evaluationRun.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/__tests__/evaluationRun.foldProjection.unit.test.ts
@@ -124,17 +124,15 @@ describe("evaluationRun foldProjection", () => {
     });
 
     describe("when EvaluationCompletedEvent arrives with empty evaluationId in state", () => {
-      it("throws an error to trigger retry", () => {
+      it("falls back to evaluationId from the event", () => {
         const projection = new EvaluationRunFoldProjection({
           store: createStubStore(),
         });
         const emptyState = createInitState();
 
-        expect(() =>
-          projection.apply(emptyState, createCompletedEvent()),
-        ).toThrow(
-          /Received EvaluationCompletedEvent for evaluation eval-1 but state has no evaluationId/,
-        );
+        const result = projection.apply(emptyState, createCompletedEvent());
+
+        expect(result.evaluationId).toBe("eval-1");
       });
     });
 

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationRun.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/projections/evaluationRun.foldProjection.ts
@@ -125,13 +125,9 @@ export class EvaluationRunFoldProjection
     event: EvaluationCompletedEvent,
     state: EvaluationRunData,
   ): EvaluationRunData {
-    if (!state.evaluationId) {
-      throw new Error(
-        `Received EvaluationCompletedEvent for evaluation ${event.data.evaluationId} but state has no evaluationId — likely a replica lag issue, retrying`,
-      );
-    }
     return {
       ...state,
+      evaluationId: state.evaluationId || event.data.evaluationId,
       status: event.data.status,
       score: typeof event.data.score === 'number' ? event.data.score : null,
       passed: event.data.passed ?? null,

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/commands.ts
@@ -15,8 +15,8 @@ import { makeExperimentRunKey } from "./utils/compositeKey";
  */
 
 export const StartExperimentRunCommand = defineCommand({
-  commandType: "lw.experiment_run.start" as const,
-  eventType: "lw.experiment_run.started" as const,
+  commandType: "lw.experiment_run.start",
+  eventType: "lw.experiment_run.started",
   eventVersion: "2025-02-01",
   aggregateType: "experiment_run",
   schema: experimentRunStartedEventDataSchema,
@@ -31,12 +31,13 @@ export const StartExperimentRunCommand = defineCommand({
 });
 
 export const RecordTargetResultCommand = defineCommand({
-  commandType: "lw.experiment_run.record_target_result" as const,
-  eventType: "lw.experiment_run.target_result" as const,
+  commandType: "lw.experiment_run.record_target_result",
+  eventType: "lw.experiment_run.target_result",
   eventVersion: "2025-02-01",
   aggregateType: "experiment_run",
   schema: targetResultEventDataSchema,
   aggregateId: (d) => makeExperimentRunKey(d.experimentId, d.runId),
+  groupKey: (d) => `${d.experimentId}:${d.runId}:item:${d.index}`,
   idempotencyKey: (d) => `${d.tenantId}:${d.runId}:target:${d.targetId}:${d.index}`,
   spanAttributes: (d) => ({
     "payload.run.id": d.runId,
@@ -48,12 +49,13 @@ export const RecordTargetResultCommand = defineCommand({
 });
 
 export const RecordEvaluatorResultCommand = defineCommand({
-  commandType: "lw.experiment_run.record_evaluator_result" as const,
-  eventType: "lw.experiment_run.evaluator_result" as const,
+  commandType: "lw.experiment_run.record_evaluator_result",
+  eventType: "lw.experiment_run.evaluator_result",
   eventVersion: "2025-02-01",
   aggregateType: "experiment_run",
   schema: evaluatorResultEventDataSchema,
   aggregateId: (d) => makeExperimentRunKey(d.experimentId, d.runId),
+  groupKey: (d) => `${d.experimentId}:${d.runId}:item:${d.index}`,
   idempotencyKey: (d) => `${d.tenantId}:${d.runId}:evaluator:${d.evaluatorId}:${d.index}`,
   spanAttributes: (d) => ({
     "payload.run.id": d.runId,
@@ -65,8 +67,8 @@ export const RecordEvaluatorResultCommand = defineCommand({
 });
 
 export const CompleteExperimentRunCommand = defineCommand({
-  commandType: "lw.experiment_run.complete" as const,
-  eventType: "lw.experiment_run.completed" as const,
+  commandType: "lw.experiment_run.complete",
+  eventType: "lw.experiment_run.completed",
   eventVersion: "2025-02-01",
   aggregateType: "experiment_run",
   schema: experimentRunCompletedEventDataSchema,

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands.ts
@@ -17,8 +17,8 @@ import {
  */
 
 export const QueueRunCommand = defineCommand({
-  commandType: "lw.simulation_run.queue" as const,
-  eventType: "lw.simulation_run.queued" as const,
+  commandType: "lw.simulation_run.queue",
+  eventType: "lw.simulation_run.queued",
   eventVersion: "2026-03-08",
   aggregateType: "simulation_run",
   schema: simulationRunQueuedEventDataSchema,
@@ -33,8 +33,8 @@ export const QueueRunCommand = defineCommand({
 });
 
 export const StartRunCommand = defineCommand({
-  commandType: "lw.simulation_run.start" as const,
-  eventType: "lw.simulation_run.started" as const,
+  commandType: "lw.simulation_run.start",
+  eventType: "lw.simulation_run.started",
   eventVersion: "2026-02-01",
   aggregateType: "simulation_run",
   schema: simulationRunStartedEventDataSchema,
@@ -49,8 +49,8 @@ export const StartRunCommand = defineCommand({
 });
 
 export const MessageSnapshotCommand = defineCommand({
-  commandType: "lw.simulation_run.message_snapshot" as const,
-  eventType: "lw.simulation_run.message_snapshot" as const,
+  commandType: "lw.simulation_run.message_snapshot",
+  eventType: "lw.simulation_run.message_snapshot",
   eventVersion: "2026-02-01",
   aggregateType: "simulation_run",
   schema: simulationMessageSnapshotEventDataSchema,
@@ -64,8 +64,8 @@ export const MessageSnapshotCommand = defineCommand({
 });
 
 export const TextMessageStartCommand = defineCommand({
-  commandType: "lw.simulation_run.text_message_start" as const,
-  eventType: "lw.simulation_run.text_message_start" as const,
+  commandType: "lw.simulation_run.text_message_start",
+  eventType: "lw.simulation_run.text_message_start",
   eventVersion: "2026-02-01",
   aggregateType: "simulation_run",
   schema: simulationTextMessageStartEventDataSchema,
@@ -80,8 +80,8 @@ export const TextMessageStartCommand = defineCommand({
 });
 
 export const TextMessageEndCommand = defineCommand({
-  commandType: "lw.simulation_run.text_message_end" as const,
-  eventType: "lw.simulation_run.text_message_end" as const,
+  commandType: "lw.simulation_run.text_message_end",
+  eventType: "lw.simulation_run.text_message_end",
   eventVersion: "2026-02-01",
   aggregateType: "simulation_run",
   schema: simulationTextMessageEndEventDataSchema,
@@ -96,8 +96,8 @@ export const TextMessageEndCommand = defineCommand({
 });
 
 export const FinishRunCommand = defineCommand({
-  commandType: "lw.simulation_run.finish" as const,
-  eventType: "lw.simulation_run.finished" as const,
+  commandType: "lw.simulation_run.finish",
+  eventType: "lw.simulation_run.finished",
   eventVersion: "2026-02-01",
   aggregateType: "simulation_run",
   schema: simulationRunFinishedEventDataSchema,
@@ -110,8 +110,8 @@ export const FinishRunCommand = defineCommand({
 });
 
 export const DeleteRunCommand = defineCommand({
-  commandType: "lw.simulation_run.delete" as const,
-  eventType: "lw.simulation_run.deleted" as const,
+  commandType: "lw.simulation_run.delete",
+  eventType: "lw.simulation_run.deleted",
   eventVersion: "2026-02-01",
   aggregateType: "simulation_run",
   schema: simulationRunDeletedEventDataSchema,

--- a/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/commands.ts
@@ -14,8 +14,8 @@ import {
  */
 
 export const StartSuiteRunCommand = defineCommand({
-  commandType: "lw.suite_run.start" as const,
-  eventType: "lw.suite_run.started" as const,
+  commandType: "lw.suite_run.start",
+  eventType: "lw.suite_run.started",
   eventVersion: "2026-03-01",
   aggregateType: "suite_run",
   schema: suiteRunStartedEventDataSchema,
@@ -30,8 +30,8 @@ export const StartSuiteRunCommand = defineCommand({
 });
 
 export const RecordSuiteRunItemStartedCommand = defineCommand({
-  commandType: "lw.suite_run.record_item_started" as const,
-  eventType: "lw.suite_run.item_started" as const,
+  commandType: "lw.suite_run.record_item_started",
+  eventType: "lw.suite_run.item_started",
   eventVersion: "2026-03-01",
   aggregateType: "suite_run",
   schema: suiteRunItemStartedEventDataSchema,
@@ -45,8 +45,8 @@ export const RecordSuiteRunItemStartedCommand = defineCommand({
 });
 
 export const CompleteSuiteRunItemCommand = defineCommand({
-  commandType: "lw.suite_run.complete_item" as const,
-  eventType: "lw.suite_run.item_completed" as const,
+  commandType: "lw.suite_run.complete_item",
+  eventType: "lw.suite_run.item_completed",
   eventVersion: "2026-03-01",
   aggregateType: "suite_run",
   schema: suiteRunItemCompletedEventDataSchema,

--- a/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/redisCachedFoldStore.unit.test.ts
@@ -59,7 +59,7 @@ describe("RedisCachedFoldStore", () => {
         });
 
         const state: TestState = { count: 5, name: "cached" };
-        redis.data.set("fold:test_table:agg-1", {
+        redis.data.set("fold:test_table:tenant-1:agg-1", {
           value: JSON.stringify(state),
           ttl: 30,
         });
@@ -67,7 +67,7 @@ describe("RedisCachedFoldStore", () => {
         const result = await store.get("agg-1", TEST_CONTEXT);
 
         expect(result).toEqual(state);
-        expect(redis.get).toHaveBeenCalledWith("fold:test_table:agg-1");
+        expect(redis.get).toHaveBeenCalledWith("fold:test_table:tenant-1:agg-1");
         expect(inner.getCalls).toHaveLength(0);
       });
     });
@@ -108,7 +108,7 @@ describe("RedisCachedFoldStore", () => {
 
         // Then Redis cached
         expect(redis.set).toHaveBeenCalledWith(
-          "fold:test_table:agg-1",
+          "fold:test_table:tenant-1:agg-1",
           JSON.stringify(state),
           "EX",
           30,

--- a/langwatch/src/server/event-sourcing/projections/abstractFoldProjection.ts
+++ b/langwatch/src/server/event-sourcing/projections/abstractFoldProjection.ts
@@ -138,7 +138,15 @@ export abstract class AbstractFoldProjection<
       this._dispatchMap = {};
       for (const schema of this.events) {
         const eventType = schema.shape.type.value;
-        this._dispatchMap[eventType] = eventTypeToHandlerName(eventType);
+        const handlerName = eventTypeToHandlerName(eventType);
+
+        if (typeof this[handlerName as keyof this] !== "function") {
+          throw new Error(
+            `${this.name}: event "${eventType}" requires method ${handlerName}() but it does not exist`,
+          );
+        }
+
+        this._dispatchMap[eventType] = handlerName;
       }
     }
     return this._dispatchMap;

--- a/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
+++ b/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
@@ -39,7 +39,7 @@ export class RedisCachedFoldStore<State>
     aggregateId: string,
     context: ProjectionStoreContext,
   ): Promise<State | null> {
-    const key = this.redisKey(aggregateId);
+    const key = this.redisKey(aggregateId, context);
     const cached = await this.redis.get(key);
     if (cached !== null) {
       return JSON.parse(cached) as State;
@@ -59,7 +59,7 @@ export class RedisCachedFoldStore<State>
 
     // 2. Redis second — cache for fast reads on next fold step
     try {
-      const key = this.redisKey(aggregateId);
+      const key = this.redisKey(aggregateId, context);
       await this.redis.set(key, JSON.stringify(state), "EX", this.ttlSeconds);
     } catch (error) {
       logger.warn(
@@ -69,7 +69,7 @@ export class RedisCachedFoldStore<State>
     }
   }
 
-  private redisKey(aggregateId: string): string {
-    return `fold:${this.keyPrefix}:${aggregateId}`;
+  private redisKey(aggregateId: string, context: ProjectionStoreContext): string {
+    return `fold:${this.keyPrefix}:${String(context.tenantId)}:${aggregateId}`;
   }
 }


### PR DESCRIPTION
## Summary

The annotation sync PR (#2734) was branched before several infrastructure improvements landed on main and reverted them on merge:

- **Redis write-through cache** for all 4 fold projection stores (trace, suite-run, simulation, experiment-run) — removed by #2734, originally added in #2751
- **`groupKey` on `defineCommand`** for queue routing — removed by #2734, originally added in #2748
- **Handler existence check** in `AbstractFoldProjection.dispatchMap` — runtime guard that validates handler methods exist for each registered event type
- **`EvaluationCostRecorder` interface** moved back to its proper domain module (`evaluation-cost.recorder.ts`) instead of inlined in the command file
- **`evaluationId` fallback** in evaluation completed handler — graceful fallback vs hard throw on replica lag
- **Removed unnecessary `as const`** on all command/event type string literals (redundant with `defineCommand`'s generic type inference)

Also fixes tenant isolation in Redis fold cache keys: `fold:{prefix}:{tenantId}:{aggregateId}` — aggregate IDs are NOT globally unique, so without tenantId two tenants with the same trace ID would share a cache entry.

## Test plan

- [x] All event-sourcing unit tests pass (same baseline: 65 passed, 19 pre-existing failures from missing Prisma client)
- [x] Redis cache key tests updated for new tenant-isolated format
- [x] Typecheck clean (no new errors)