### PR TITLE
fix(prompts): include same-ms siblings and fix ClickHouse StartTime type

### DIFF
--- a/langwatch/src/server/traces/__tests__/findPromptReferenceInAncestors.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/findPromptReferenceInAncestors.unit.test.ts
@@ -506,7 +506,7 @@ describe("findPromptReferenceInAncestors()", () => {
   });
 
   describe("when sibling prompt ref has same startTime as target", () => {
-    it("ignores the sibling (must be strictly before)", () => {
+    it("finds the sibling (same-ms siblings are included)", () => {
       const spans = [
         {
           spanId: "parent-span",
@@ -535,10 +535,109 @@ describe("findPromptReferenceInAncestors()", () => {
         spans,
       });
 
-      // Same startTime should not be considered "before" -- but it's ambiguous.
-      // For safety, we include same-startTime siblings since they were likely
-      // created as part of the same prompt flow.
-      expect(result).toBeNull();
+      // Same startTime siblings are included because Prompt.compile and the
+      // LLM span often start at the exact same millisecond in practice.
+      expect(result).toEqual({
+        promptHandle: "team/same-time-prompt",
+        promptVersionNumber: 1,
+        promptVariables: null,
+      });
+    });
+  });
+
+  describe("when Prompt.compile has the same startTime as the LLM span", () => {
+    it("finds the Prompt.compile sibling (not skipped)", () => {
+      // Regression: Prompt.compile and the llm span often start at the
+      // exact same millisecond. The old `>=` guard skipped same-ms siblings.
+      const spans = [
+        {
+          spanId: "parent",
+          parentSpanId: null,
+          startTime: 1000,
+          attributes: {},
+        },
+        {
+          spanId: "prompt-compile",
+          parentSpanId: "parent",
+          startTime: 1050,
+          attributes: {
+            "langwatch.prompt.id": "tea-prompt:4",
+            "langwatch.prompt.handle": "tea-prompt",
+            "langwatch.prompt.version.number": "4",
+          },
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "parent",
+          startTime: 1050, // same millisecond as Prompt.compile
+          attributes: {},
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      expect(result).toEqual({
+        promptHandle: "tea-prompt",
+        promptVersionNumber: 4,
+        promptVariables: null,
+      });
+    });
+  });
+
+  describe("when PromptApiService.get starts first, then llm and Prompt.compile at same ms", () => {
+    it("prefers Prompt.compile because it has more detail", () => {
+      // Real trace pattern: PromptApiService.get started first (has prompt id),
+      // then Prompt.compile and llm span at the same millisecond.
+      // Prompt.compile has handle + version, so it should be preferred.
+      const spans = [
+        {
+          spanId: "parent",
+          parentSpanId: null,
+          startTime: 1000,
+          attributes: {},
+        },
+        {
+          spanId: "prompt-api-get",
+          parentSpanId: "parent",
+          startTime: 1010,
+          attributes: {
+            "langwatch.prompt.id": "tea-prompt:4",
+          },
+        },
+        {
+          spanId: "prompt-compile",
+          parentSpanId: "parent",
+          startTime: 1050,
+          attributes: {
+            "langwatch.prompt.id": "tea-prompt:4",
+            "langwatch.prompt.handle": "tea-prompt",
+            "langwatch.prompt.version.number": "4",
+          },
+        },
+        {
+          spanId: "llm-span",
+          parentSpanId: "parent",
+          startTime: 1050, // same as Prompt.compile
+          attributes: {},
+        },
+      ];
+
+      const result = findPromptReferenceInAncestors({
+        targetSpanId: "llm-span",
+        spans,
+      });
+
+      // Prompt.compile (startTime=1050) is at the same ms as llm (1050),
+      // but it's included now. PromptApiService.get (startTime=1010) also
+      // qualifies. The closest preceding (highest startTime) wins: Prompt.compile.
+      expect(result).toEqual({
+        promptHandle: "tea-prompt",
+        promptVersionNumber: 4,
+        promptVariables: null,
+      });
     });
   });
 

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -914,8 +914,8 @@ export class ClickHouseTraceService {
                 ParentSpanId,
                 SpanName,
                 SpanAttributes,
-                StartTime,
-                EndTime,
+                toUnixTimestamp64Milli(StartTime) AS StartTime,
+                toUnixTimestamp64Milli(EndTime) AS EndTime,
                 DurationMs,
                 StatusCode,
                 StatusMessage

--- a/langwatch/src/server/traces/findPromptReferenceInAncestors.ts
+++ b/langwatch/src/server/traces/findPromptReferenceInAncestors.ts
@@ -146,7 +146,10 @@ export function findPromptReferenceInAncestors({
 
 /**
  * Among the children of a given parent, finds the one with a prompt reference
- * that started most recently before the target span's startTime.
+ * that started at or most recently before the target span's startTime.
+ *
+ * Same-millisecond siblings are included because SDK patterns like
+ * `Prompt.compile` and the LLM span often start at the exact same ms.
  */
 function findClosestPrecedingSibling({
   parentId,
@@ -167,7 +170,7 @@ function findClosestPrecedingSibling({
 
   for (const child of children) {
     if (excludeSpanIds.has(child.spanId)) continue;
-    if (child.startTime >= targetStartTime) continue;
+    if (child.startTime > targetStartTime) continue;
 
     const ref = parsePromptReference(child.attributes);
     if (ref.promptHandle && child.startTime > bestStartTime) {


### PR DESCRIPTION
## Summary

Follow-up to #2842. Two bugs preventing "Open existing prompt" from working:

- **Same-millisecond siblings skipped**: `findClosestPrecedingSibling` used `>=` which excluded siblings starting at the same millisecond as the LLM span. In practice, `Prompt.compile` and `llm` often start at the same ms. Changed to `>`.
- **ClickHouse DateTime64 returned as strings**: `getSpanForPromptStudio` selected raw `StartTime`/`EndTime` columns, which ClickHouse returns as ISO datetime strings in JSON format. All time comparisons in `findPromptReferenceInAncestors` silently failed (string vs number), so the backend never found the prompt reference and `promptHandle` was always null. The frontend fell through to "create-new" instead of opening the existing prompt. Fixed by adding `toUnixTimestamp64Milli()` conversion, matching the pattern in `getTracesWithSpans`.

## Test plan

- [x] Same-ms sibling: `Prompt.compile` at same startTime as LLM span is now found
- [x] Same-ms preference: when `PromptApiService.get` starts first and `Prompt.compile` + `llm` at same ms, prefers `Prompt.compile`
- [x] All 26 findPromptReferenceInAncestors tests pass
- [x] All 35 useLoadSpanIntoPromptPlayground unit tests pass
- [x] Typecheck clean