### PR TITLE
fix: break trace boundaries at command/reactor jobs to prevent giant traces

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1,4 +1,4 @@
-import { context as otelContext, SpanKind, trace, TraceFlags } from "@opentelemetry/api";
+import { context as otelContext, ROOT_CONTEXT, SpanKind, trace, TraceFlags } from "@opentelemetry/api";
 import fastq from "fastq";
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
@@ -381,6 +381,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     const contextMetadata = jobData.__context as JobContextMetadata | undefined;
     const attempt = typeof jobData.__attempt === "number" ? jobData.__attempt : 1;
+    const jobType = jobData.__jobType as string | undefined;
     const payload = this.stripInternalFields(jobData);
 
     const heartbeat = this.startActiveKeyHeartbeat({ groupId, stagedJobId });
@@ -532,8 +533,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         );
       };
 
-      // Restore parent OTEL context if available
-      if (contextMetadata?.traceId && contextMetadata?.parentSpanId) {
+      // Trace boundary: commands and reactors start a NEW trace (linked to parent),
+      // while projections (fold/map) continue the parent trace for causal grouping.
+      const startsNewTrace = jobType === "command" || jobType === "reactor";
+
+      if (contextMetadata?.traceId && contextMetadata?.parentSpanId && !startsNewTrace) {
+        // Non-command/non-reactor jobs (projections, handlers): restore parent context so spans stay in the same trace
         const parentContext = trace.setSpanContext(otelContext.active(), {
           traceId: contextMetadata.traceId,
           spanId: contextMetadata.parentSpanId,
@@ -542,7 +547,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         });
         await otelContext.with(parentContext, executeWithSpan);
       } else {
-        await executeWithSpan();
+        // Commands & reactors: run with a fresh ROOT context → new traceId.
+        // The link to the parent trace is already added via span.addLink() above.
+        await otelContext.with(ROOT_CONTEXT, executeWithSpan);
       }
     } finally {
       clearInterval(heartbeat);


### PR DESCRIPTION
## Summary
- Commands and reactors now start a **fresh OTel trace** (with a link back to the parent), while projections (fold/map) continue the parent trace
- Previously every job in the event-sourcing pipeline inherited the original request's traceId, causing a single experiment run (100 rows × 5 evaluators) to produce one trace with **2000+ spans** — OOM-killing Tempo (804 restarts in 3 days, exit code 137)

## Trace boundaries

| Job type | Behavior |
|---|---|
| `projection` / `handler` (map) | **Continue** parent trace (same traceId) |
| `command` | **New** trace, linked to parent |
| `reactor` | **New** trace, linked to parent |

## Test plan
- [ ] Deploy and verify Tempo stops OOM crash-looping
- [ ] Check Grafana traces — commands and reactors should appear as separate traces with links, projections should stay grouped with their parent command
- [ ] Run an experiment and verify trace fan-out is bounded