### PR TITLE
fix: remove select_sequential_consistency from CH reads

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -139,7 +139,6 @@ export class EvaluationRunClickHouseRepository
         `,
         query_params: { tenantId, evaluationId },
         format: "JSONEachRow",
-        clickhouse_settings: { select_sequential_consistency: "1" },
       });
 
       const rows = await result.json<ClickHouseEvaluationRunRecord>();

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -155,7 +155,6 @@ export class TraceSummaryClickHouseRepository implements TraceSummaryRepository 
         `,
         query_params: { tenantId, traceId },
         format: "JSONEachRow",
-        clickhouse_settings: { select_sequential_consistency: "1" },
       });
 
       const rows = await result.json<ClickHouseSummaryRecord>();

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
@@ -169,7 +169,6 @@ export class ExperimentRunStateRepositoryClickHouse<
         `,
         query_params: { tenantId: context.tenantId, runId, experimentId },
         format: "JSONEachRow",
-        clickhouse_settings: { select_sequential_consistency: "1" },
       });
 
       const rows = await result.json<ClickHouseExperimentRunRecord>();


### PR DESCRIPTION
## Summary
- Removes `select_sequential_consistency: "1"` from all three ClickHouse repository reads (trace summaries, evaluation runs, experiment run state)
- This setting forces CH to synchronize with the Keeper before every SELECT, waiting for **all** pending async inserts to flush — causing 10-14s read latency on Redis cache misses in the fold projection path
- Safe because writes already use `async_insert` with `wait_for_async_insert=0` (eventual consistency accepted at write time), and fold projections have a Redis write-through cache that makes CH reads rare

## Test plan
- [x] Existing unit tests pass (`redisCachedFoldStore.unit.test.ts`)
- [ ] Monitor `es_fold_cache_get_duration` metric after deploy to confirm CH fallback reads drop from ~14s to <100ms
- [ ] Verify trace/evaluation data appears correctly in UI (may show ~1-2s staleness vs previous behavior)