### PR TITLE
fix(analytics): use actual vote values for sentiment.thumbs_up_down aggregations

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/metric-translator.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/metric-translator.test.ts
@@ -228,7 +228,14 @@ describe("metric-translator", () => {
             0
           );
           expect(result.selectExpression).toContain("countIf");
-          expect(result.selectExpression).toContain("thumbs_up_down");
+          expect(result.selectExpression).toMatch(
+            /\{m_sentimentEventType_[a-f0-9]+:String\}/
+          );
+          const eventTypeParam = Object.keys(result.params).find((k) =>
+            k.startsWith("m_sentimentEventType_")
+          );
+          expect(eventTypeParam).toBeDefined();
+          expect(result.params[eventTypeParam!]).toBe("thumbs_up_down");
           expect(result.requiredJoins).toContain("stored_spans");
         });
       });
@@ -277,6 +284,7 @@ describe("metric-translator", () => {
             0
           );
           expect(result.selectExpression).toContain("avgArray");
+          expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
         });
       });
@@ -289,6 +297,7 @@ describe("metric-translator", () => {
             0
           );
           expect(result.selectExpression).toContain("minArray");
+          expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
         });
       });
@@ -301,6 +310,7 @@ describe("metric-translator", () => {
             0
           );
           expect(result.selectExpression).toContain("maxArray");
+          expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
         });
       });
@@ -313,6 +323,7 @@ describe("metric-translator", () => {
             0
           );
           expect(result.selectExpression).toContain("quantileExactArray(0.95)");
+          expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
         });
       });

--- a/langwatch/src/server/analytics/clickhouse/metric-translator.ts
+++ b/langwatch/src/server/analytics/clickhouse/metric-translator.ts
@@ -701,21 +701,22 @@ function translateSentimentMetric(
     case "sentiment.thumbs_up_down": {
       requiredJoins.push("stored_spans");
 
+      const params: Record<string, unknown> = {};
+      const eventTypeParam = genMetricParamName("sentimentEventType");
+      params[eventTypeParam] = "thumbs_up_down";
+
       // For cardinality, count traces that have thumbs_up_down events
       if (aggregation === "cardinality") {
         return {
-          selectExpression: `countIf(has(${ss}."Events.Name", 'thumbs_up_down')) AS ${alias}`,
+          selectExpression: `countIf(has(${ss}."Events.Name", {${eventTypeParam}:String})) AS ${alias}`,
           alias,
           requiredJoins,
-          params: {},
+          params,
         };
       }
 
       // For all other aggregations, extract vote values and aggregate
-      const params: Record<string, unknown> = {};
-      const eventTypeParam = genMetricParamName("sentimentEventType");
       const voteKeyParam = genMetricParamName("sentimentVoteKey");
-      params[eventTypeParam] = "thumbs_up_down";
       params[voteKeyParam] = "event.metrics.vote";
 
       // Extract vote values from Events.Attributes for thumbs_up_down events,


### PR DESCRIPTION
## Summary
- **Bug:** `sentiment.thumbs_up_down` returned the same trace count for all aggregation types (sum, avg, min, max, cardinality) because `translateSentimentMetric` hardcoded `countIf(has(...))` ignoring the aggregation parameter
- **Fix:** For non-cardinality aggregations, extract actual vote values (-1, 0, 1) from `Events.Attributes` using `arrayMap`/`arrayFilter` (same pattern as `events.event_score`), filter out zeros, and delegate to `translateArrayAggregation` for proper `sumArray`/`avgArray`/`minArray`/`maxArray`
- **Cardinality** still counts traces with thumbs_up_down events (unchanged)

Closes #2908

## Test plan

### Unit tests
- [x] Regression tests for each aggregation type (sum, avg, min, max, cardinality, p95)
- [x] Parameterized query params verified (SQL injection prevention)
- [x] Zero-value exclusion verified across all non-cardinality aggregation types
- [x] All 240 analytics/clickhouse unit tests pass

### Manual verification against local instance
Populated a local instance with 10 traces with thumbs_up_down events (5× vote=1, 2× vote=0, 3× vote=-1) and queried `POST /api/analytics/timeseries` with all 5 aggregation types in a single request:

```json
{
  "currentPeriod": [
    {
      "date": "full",
      "0/sentiment.thumbs_up_down/sum": 2,
      "1/sentiment.thumbs_up_down/avg": 0.25,
      "2/sentiment.thumbs_up_down/min": -1,
      "3/sentiment.thumbs_up_down/max": 1,
      "4/sentiment.thumbs_up_down/cardinality": 10
    }
  ]
}
```

| Aggregation | Result | Expected | Status |
|---|---|---|---|
| **sum** | 2 | 2 (5−3, zeros excluded) | ✅ |
| **avg** | 0.25 | 0.25 (2/8 non-zero votes) | ✅ |
| **min** | -1 | -1 | ✅ |
| **max** | 1 | 1 | ✅ |
| **cardinality** | 10 | 10 (all traces counted) | ✅ |

Before the fix, all 5 aggregations would return `10` (trace count). Now each returns the correct distinct value.