### PR TITLE
fix(projection-replay): use dynamic imports for CJS/ESM interop on Node 24

### DIFF
--- a/langwatch/packages/projection-replay/src/cli.tsx
+++ b/langwatch/packages/projection-replay/src/cli.tsx
@@ -18,8 +18,11 @@ import type {
   BatchCompleteInfo,
 } from "../../../src/server/event-sourcing/replay";
 
-import { createReplayRuntime } from "../../../src/server/event-sourcing/replay/replayPreset";
-import { prisma } from "../../../src/server/db";
+// Dynamic imports: the parent langwatch package is CJS (no "type": "module")
+// while this package is ESM. Static named imports across the CJS→ESM boundary
+// fail on Node 24 + tsx. Dynamic import handles the interop correctly.
+const { createReplayRuntime } = await import("../../../src/server/event-sourcing/replay/replayPreset");
+const { prisma } = await import("../../../src/server/db");
 import { ReplayLog } from "./replayLog";
 import {
   ReplayWizard,


### PR DESCRIPTION
## Summary
- Static named imports from the parent `langwatch` package (CJS, no `"type": "module"`) into `projection-replay` (ESM, required by `ink`/`yoga-layout`) fail during ESM module linking on Node 24 + tsx
- Converts `createReplayRuntime` and `prisma` imports to dynamic `await import(...)`, which handles the CJS→ESM interop correctly

## Test plan
- [x] `pnpm run dev -- --help` runs without error
- [x] `pnpm run dev -- replay --help` shows options correctly