### PR TITLE
feat: add /code-review skill for project-level rule checks

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: "[diff, branch, or commit range]"
 
 Review code changes and sign off on each rule below.
 
-**What to diff:** Use the provided argument if given (a diff, branch, or commit range). Otherwise diff against `origin/main`, or the PR base branch if on a PR branch. If ambiguous, ask.
+**What to diff:** If `$ARGUMENTS` is provided, use it as the diff target (a branch, commit range, or raw diff). Otherwise diff against `origin/main`, or the PR base branch if on a PR branch. If ambiguous, ask.
 
 For each rule: **PASS** if no violations, or **FAIL** with every violation listed — one per line with `file:line`.
 


### PR DESCRIPTION
## Summary
- Adds a thin `/code-review` skill that greps changed files for LangWatch project conventions
- 10 binary pass/fail checks: KSUID usage, no FK in migrations, projectId in Prisma queries, TenantId in ClickHouse, no `any`, no hardcoded schema names, hooks don't return JSX, no backwards-compat re-exports, Hono routes use services, repo/service method naming
- Runs on Sonnet (cheap, binary checks don't need Opus

## Test plan
- [ ] Run  on a branch with known violations
- [ ] Verify pass/fail table output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)