### PR TITLE
fix(skills): update MCP config schema for Claude Code compatibility

### DIFF
--- a/skills/_tests/helpers/claude-code-adapter.ts
+++ b/skills/_tests/helpers/claude-code-adapter.ts
@@ -83,12 +83,12 @@ export function createClaudeCodeAgent({
         const mcpConfig = {
           mcpServers: {
             LangWatch: {
+              type: "stdio",
               command: "node",
-              args: [
-                mcpServerDistPath,
-                "--apiKey",
-                process.env.LANGWATCH_API_KEY!,
-              ],
+              args: [mcpServerDistPath],
+              env: {
+                LANGWATCH_API_KEY: process.env.LANGWATCH_API_KEY!,
+              },
             },
           },
         };


### PR DESCRIPTION
## Summary
- Add `type: "stdio"` and `env` fields to the MCP server config in the skills test adapter
- Pass `LANGWATCH_API_KEY` via `env` instead of `--apiKey` CLI arg, matching the current Claude Code MCP config schema
- Without this fix, all scenario tests fail with `mcpServers.LangWatch: Does not adhere to MCP server configuration schema`

## Test plan
- [x] Verified MCP config validation passes (no more schema error)
- [ ] Run full tracing scenario test suite