### PR TITLE
feat: add dataset CLI commands

### DIFF
--- a/specs/features/dataset-cli.feature
+++ b/specs/features/dataset-cli.feature
@@ -1,0 +1,43 @@
+Feature: Dataset CLI Commands
+  As a developer using the LangWatch CLI
+  I want to manage datasets from the terminal
+  So that I can integrate dataset operations into my workflow
+
+  Background:
+    Given I am logged in with a valid API key
+
+  Scenario: List datasets
+    When I run langwatch dataset list
+    Then I see a table of all datasets with name, slug, record count, and last updated
+
+  Scenario: Create a dataset
+    When I run langwatch dataset create "My Dataset" --columns input:string,output:string
+    Then a new dataset is created and I see confirmation with the slug
+
+  Scenario: Get dataset details
+    When I run langwatch dataset get my-dataset
+    Then I see dataset metadata and a preview of records
+
+  Scenario: Delete a dataset
+    When I run langwatch dataset delete my-dataset
+    Then the dataset is archived and I see confirmation
+
+  Scenario: Upload CSV to dataset
+    When I run langwatch dataset upload my-dataset data.csv
+    Then the CSV is uploaded and I see the record count
+
+  Scenario: Upload JSONL to dataset
+    When I run langwatch dataset upload my-dataset data.jsonl
+    Then the JSONL is uploaded and I see the record count
+
+  Scenario: Create and upload in one command
+    When I run langwatch dataset upload --create "New Dataset" data.csv
+    Then a dataset is created from the file and I see confirmation
+
+  Scenario: Download dataset as CSV
+    When I run langwatch dataset download my-dataset --format csv
+    Then the dataset records are written to stdout as CSV
+
+  Scenario: Download dataset as JSONL
+    When I run langwatch dataset download my-dataset --format jsonl
+    Then the dataset records are written to stdout as JSONL

--- a/typescript-sdk/src/cli/commands/dataset/__tests__/create.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/dataset/__tests__/create.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+
+// Test the parseColumns logic (module-private, re-implemented for testing)
+function parseColumns(
+  columnsStr: string,
+): Array<{ name: string; type: string }> {
+  return columnsStr.split(",").map((col) => {
+    const [name, type] = col.trim().split(":");
+    if (!name || !type) {
+      throw new Error(
+        `Invalid column format: "${col.trim()}". Expected "name:type" (e.g., input:string)`,
+      );
+    }
+    return { name: name.trim(), type: type.trim() };
+  });
+}
+
+describe("parseColumns", () => {
+  describe("when given valid column definitions", () => {
+    it("parses single column", () => {
+      expect(parseColumns("input:string")).toEqual([
+        { name: "input", type: "string" },
+      ]);
+    });
+
+    it("parses multiple columns", () => {
+      expect(parseColumns("input:string,output:string")).toEqual([
+        { name: "input", type: "string" },
+        { name: "output", type: "string" },
+      ]);
+    });
+
+    it("handles various types", () => {
+      expect(
+        parseColumns("text:string,count:number,active:boolean"),
+      ).toEqual([
+        { name: "text", type: "string" },
+        { name: "count", type: "number" },
+        { name: "active", type: "boolean" },
+      ]);
+    });
+
+    it("trims whitespace", () => {
+      expect(parseColumns(" input : string , output : string ")).toEqual([
+        { name: "input", type: "string" },
+        { name: "output", type: "string" },
+      ]);
+    });
+  });
+
+  describe("when given invalid column definitions", () => {
+    it("throws on missing type", () => {
+      expect(() => parseColumns("input")).toThrow(
+        'Invalid column format: "input"',
+      );
+    });
+
+    it("throws on empty string segment", () => {
+      expect(() => parseColumns("input:string,")).toThrow(
+        'Invalid column format: ""',
+      );
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/dataset/__tests__/create.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/dataset/__tests__/create.unit.test.ts
@@ -1,19 +1,5 @@
 import { describe, it, expect } from "vitest";
-
-// Test the parseColumns logic (module-private, re-implemented for testing)
-function parseColumns(
-  columnsStr: string,
-): Array<{ name: string; type: string }> {
-  return columnsStr.split(",").map((col) => {
-    const [name, type] = col.trim().split(":");
-    if (!name || !type) {
-      throw new Error(
-        `Invalid column format: "${col.trim()}". Expected "name:type" (e.g., input:string)`,
-      );
-    }
-    return { name: name.trim(), type: type.trim() };
-  });
-}
+import { parseColumns } from "../create";
 
 describe("parseColumns", () => {
   describe("when given valid column definitions", () => {
@@ -58,6 +44,12 @@ describe("parseColumns", () => {
     it("throws on empty string segment", () => {
       expect(() => parseColumns("input:string,")).toThrow(
         'Invalid column format: ""',
+      );
+    });
+
+    it("throws on extra colon segments", () => {
+      expect(() => parseColumns("input:string:extra")).toThrow(
+        'Invalid column format: "input:string:extra"',
       );
     });
   });

--- a/typescript-sdk/src/cli/commands/dataset/__tests__/datasets-cli.service.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/dataset/__tests__/datasets-cli.service.unit.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  DatasetsCliService,
+  DatasetsCliServiceError,
+} from "../datasets-cli.service";
+
+describe("DatasetsCliService", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      LANGWATCH_API_KEY: "test-api-key",
+      LANGWATCH_ENDPOINT: "https://test.langwatch.ai",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe("when listing datasets", () => {
+    it("calls GET /api/dataset with pagination params", async () => {
+      const mockResponse = {
+        data: [{ id: "ds_1", name: "Test", slug: "test", recordCount: 5 }],
+        pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+      };
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(mockResponse), { status: 200 }),
+      );
+
+      const service = new DatasetsCliService();
+      const result = await service.list({ page: 1, limit: 50 });
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://test.langwatch.ai/api/dataset?page=1&limit=50",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "x-auth-token": "test-api-key",
+          }),
+        }),
+      );
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]!.slug).toBe("test");
+    });
+  });
+
+  describe("when creating a dataset", () => {
+    it("calls POST /api/dataset with name and columns", async () => {
+      const mockResponse = {
+        id: "ds_new",
+        name: "New",
+        slug: "new",
+        columnTypes: [{ name: "input", type: "string" }],
+      };
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(mockResponse), { status: 201 }),
+      );
+
+      const service = new DatasetsCliService();
+      const result = await service.create({
+        name: "New",
+        columnTypes: [{ name: "input", type: "string" }],
+      });
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://test.langwatch.ai/api/dataset",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            name: "New",
+            columnTypes: [{ name: "input", type: "string" }],
+          }),
+        }),
+      );
+      expect(result.slug).toBe("new");
+    });
+  });
+
+  describe("when API returns an error", () => {
+    it("throws DatasetsCliServiceError with status", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ error: "Not found" }), { status: 404 }),
+      );
+
+      const service = new DatasetsCliService();
+
+      try {
+        await service.get("nonexistent");
+        expect.fail("Expected error to be thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(DatasetsCliServiceError);
+        expect((error as DatasetsCliServiceError).status).toBe(404);
+        expect((error as DatasetsCliServiceError).message).toBe("Not found");
+      }
+    });
+  });
+
+  describe("when deleting a dataset", () => {
+    it("calls DELETE /api/dataset/:slug", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 }),
+      );
+
+      const service = new DatasetsCliService();
+      const result = await service.delete("my-dataset");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://test.langwatch.ai/api/dataset/my-dataset",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("when fetching all records with pagination", () => {
+    it("fetches multiple pages and concatenates results", async () => {
+      const page1 = {
+        data: [{ id: "r1", entry: { input: "a" } }],
+        pagination: { page: 1, limit: 1000, total: 2, totalPages: 2 },
+      };
+      const page2 = {
+        data: [{ id: "r2", entry: { input: "b" } }],
+        pagination: { page: 2, limit: 1000, total: 2, totalPages: 2 },
+      };
+
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(page1), { status: 200 }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(page2), { status: 200 }),
+        );
+
+      const service = new DatasetsCliService();
+      const records = await service.getAllRecords("my-dataset");
+
+      expect(records).toHaveLength(2);
+      expect(records[0]!.id).toBe("r1");
+      expect(records[1]!.id).toBe("r2");
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("when endpoint has trailing slash", () => {
+    it("strips it to avoid double slashes", async () => {
+      process.env.LANGWATCH_ENDPOINT = "https://test.langwatch.ai/";
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ data: [], pagination: { page: 1, limit: 50, total: 0, totalPages: 0 } }), { status: 200 }),
+      );
+
+      const service = new DatasetsCliService();
+      await service.list();
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://test.langwatch.ai/api/dataset?page=1&limit=50",
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/dataset/__tests__/download.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/dataset/__tests__/download.unit.test.ts
@@ -1,44 +1,40 @@
 import { describe, it, expect } from "vitest";
+import { toCsv, toJsonl, escapeCsvField } from "../download";
 
-// Extract pure functions for testing by re-implementing them here
-// (they're module-private in download.ts, so we test the logic directly)
+describe("escapeCsvField", () => {
+  it("returns plain string as-is", () => {
+    expect(escapeCsvField("hello")).toBe("hello");
+  });
 
-function toCsv(records: Array<{ entry: Record<string, unknown> }>): string {
-  if (records.length === 0) return "";
+  it("wraps value with commas in quotes", () => {
+    expect(escapeCsvField("hello, world")).toBe('"hello, world"');
+  });
 
-  const columns = Object.keys(records[0]!.entry);
+  it("escapes double quotes by doubling them", () => {
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+  });
 
-  const escapeCsvField = (value: unknown): string => {
-    const str =
-      value === null || value === undefined
-        ? ""
-        : typeof value === "string"
-          ? value
-          : JSON.stringify(value);
-    if (
-      str.includes(",") ||
-      str.includes('"') ||
-      str.includes("\n") ||
-      str.includes("\r")
-    ) {
-      return `"${str.replace(/"/g, '""')}"`;
-    }
-    return str;
-  };
+  it("wraps value with newlines in quotes", () => {
+    expect(escapeCsvField("line1\nline2")).toBe('"line1\nline2"');
+  });
 
-  const header = columns.join(",");
-  const rows = records.map((record) =>
-    columns.map((col) => escapeCsvField(record.entry[col])).join(","),
-  );
+  it("wraps value with carriage returns in quotes", () => {
+    expect(escapeCsvField("line1\rline2")).toBe('"line1\rline2"');
+  });
 
-  return [header, ...rows].join("\n");
-}
+  it("returns empty string for null", () => {
+    expect(escapeCsvField(null)).toBe("");
+  });
 
-function toJsonl(
-  records: Array<{ entry: Record<string, unknown> }>,
-): string {
-  return records.map((record) => JSON.stringify(record.entry)).join("\n");
-}
+  it("returns empty string for undefined", () => {
+    expect(escapeCsvField(undefined)).toBe("");
+  });
+
+  it("JSON-stringifies non-string types", () => {
+    expect(escapeCsvField(42)).toBe("42");
+    expect(escapeCsvField([1, 2])).toBe('"[1,2]"');
+  });
+});
 
 describe("toCsv", () => {
   describe("when records are empty", () => {
@@ -59,31 +55,25 @@ describe("toCsv", () => {
     });
   });
 
-  describe("when values contain commas", () => {
-    it("wraps in quotes", () => {
-      const records = [{ entry: { text: "hello, world" } }];
-      expect(toCsv(records)).toBe('text\n"hello, world"');
+  describe("when records have different keys", () => {
+    it("includes union of all keys as columns", () => {
+      const records = [
+        { entry: { input: "hello" } },
+        { entry: { input: "foo", extra: "bar" } },
+      ];
+      const result = toCsv(records);
+      const lines = result.split("\n");
+      expect(lines[0]).toBe("input,extra");
+      expect(lines[1]).toBe("hello,");
+      expect(lines[2]).toBe("foo,bar");
     });
   });
 
-  describe("when values contain double quotes", () => {
-    it("escapes with doubled quotes", () => {
-      const records = [{ entry: { text: 'say "hi"' } }];
-      expect(toCsv(records)).toBe('text\n"say ""hi"""');
-    });
-  });
-
-  describe("when values contain newlines", () => {
-    it("wraps in quotes", () => {
-      const records = [{ entry: { text: "line1\nline2" } }];
-      expect(toCsv(records)).toBe('text\n"line1\nline2"');
-    });
-  });
-
-  describe("when values contain carriage returns", () => {
-    it("wraps in quotes", () => {
-      const records = [{ entry: { text: "line1\rline2" } }];
-      expect(toCsv(records)).toBe('text\n"line1\rline2"');
+  describe("when header names need escaping", () => {
+    it("escapes header fields with commas", () => {
+      const records = [{ entry: { "col,a": "value" } }];
+      const result = toCsv(records);
+      expect(result.split("\n")[0]).toBe('"col,a"');
     });
   });
 

--- a/typescript-sdk/src/cli/commands/dataset/__tests__/download.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/dataset/__tests__/download.unit.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+
+// Extract pure functions for testing by re-implementing them here
+// (they're module-private in download.ts, so we test the logic directly)
+
+function toCsv(records: Array<{ entry: Record<string, unknown> }>): string {
+  if (records.length === 0) return "";
+
+  const columns = Object.keys(records[0]!.entry);
+
+  const escapeCsvField = (value: unknown): string => {
+    const str =
+      value === null || value === undefined
+        ? ""
+        : typeof value === "string"
+          ? value
+          : JSON.stringify(value);
+    if (
+      str.includes(",") ||
+      str.includes('"') ||
+      str.includes("\n") ||
+      str.includes("\r")
+    ) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
+  const header = columns.join(",");
+  const rows = records.map((record) =>
+    columns.map((col) => escapeCsvField(record.entry[col])).join(","),
+  );
+
+  return [header, ...rows].join("\n");
+}
+
+function toJsonl(
+  records: Array<{ entry: Record<string, unknown> }>,
+): string {
+  return records.map((record) => JSON.stringify(record.entry)).join("\n");
+}
+
+describe("toCsv", () => {
+  describe("when records are empty", () => {
+    it("returns empty string", () => {
+      expect(toCsv([])).toBe("");
+    });
+  });
+
+  describe("when records have simple string values", () => {
+    it("produces header and data rows", () => {
+      const records = [
+        { entry: { input: "hello", output: "world" } },
+        { entry: { input: "foo", output: "bar" } },
+      ];
+      expect(toCsv(records)).toBe(
+        "input,output\nhello,world\nfoo,bar",
+      );
+    });
+  });
+
+  describe("when values contain commas", () => {
+    it("wraps in quotes", () => {
+      const records = [{ entry: { text: "hello, world" } }];
+      expect(toCsv(records)).toBe('text\n"hello, world"');
+    });
+  });
+
+  describe("when values contain double quotes", () => {
+    it("escapes with doubled quotes", () => {
+      const records = [{ entry: { text: 'say "hi"' } }];
+      expect(toCsv(records)).toBe('text\n"say ""hi"""');
+    });
+  });
+
+  describe("when values contain newlines", () => {
+    it("wraps in quotes", () => {
+      const records = [{ entry: { text: "line1\nline2" } }];
+      expect(toCsv(records)).toBe('text\n"line1\nline2"');
+    });
+  });
+
+  describe("when values contain carriage returns", () => {
+    it("wraps in quotes", () => {
+      const records = [{ entry: { text: "line1\rline2" } }];
+      expect(toCsv(records)).toBe('text\n"line1\rline2"');
+    });
+  });
+
+  describe("when values are null or undefined", () => {
+    it("outputs empty string", () => {
+      const records = [{ entry: { a: null, b: undefined } }];
+      expect(toCsv(records)).toBe("a,b\n,");
+    });
+  });
+
+  describe("when values are non-string types", () => {
+    it("JSON-stringifies them", () => {
+      const records = [{ entry: { num: 42, arr: [1, 2] } }];
+      expect(toCsv(records)).toBe('num,arr\n42,"[1,2]"');
+    });
+  });
+});
+
+describe("toJsonl", () => {
+  describe("when records are empty", () => {
+    it("returns empty string", () => {
+      expect(toJsonl([])).toBe("");
+    });
+  });
+
+  describe("when records have entries", () => {
+    it("produces one JSON object per line", () => {
+      const records = [
+        { entry: { input: "hello" } },
+        { entry: { input: "world" } },
+      ];
+      expect(toJsonl(records)).toBe(
+        '{"input":"hello"}\n{"input":"world"}',
+      );
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/dataset/create.ts
+++ b/typescript-sdk/src/cli/commands/dataset/create.ts
@@ -7,22 +7,25 @@ import {
   type DatasetColumnType,
 } from "./datasets-cli.service";
 
-function parseColumns(columnsStr: string): DatasetColumnType[] {
+export function parseColumns(columnsStr: string): DatasetColumnType[] {
   return columnsStr.split(",").map((col) => {
-    const [name, type] = col.trim().split(":");
-    if (!name || !type) {
+    const parts = col.trim().split(":");
+    if (parts.length !== 2 || !parts[0]!.trim() || !parts[1]!.trim()) {
       throw new Error(
         `Invalid column format: "${col.trim()}". Expected "name:type" (e.g., input:string)`,
       );
     }
-    return { name: name.trim(), type: type.trim() };
+    return { name: parts[0]!.trim(), type: parts[1]!.trim() };
   });
 }
 
-export const datasetCreateCommand = async (
-  name: string,
-  options: { columns?: string },
-): Promise<void> => {
+export const datasetCreateCommand = async ({
+  name,
+  options,
+}: {
+  name: string;
+  options: { columns?: string };
+}): Promise<void> => {
   checkApiKey();
 
   let columnTypes: DatasetColumnType[] = [];

--- a/typescript-sdk/src/cli/commands/dataset/create.ts
+++ b/typescript-sdk/src/cli/commands/dataset/create.ts
@@ -1,0 +1,81 @@
+import chalk from "chalk";
+import ora from "ora";
+import { checkApiKey } from "../../utils/apiKey";
+import {
+  DatasetsCliService,
+  DatasetsCliServiceError,
+  type DatasetColumnType,
+} from "./datasets-cli.service";
+
+function parseColumns(columnsStr: string): DatasetColumnType[] {
+  return columnsStr.split(",").map((col) => {
+    const [name, type] = col.trim().split(":");
+    if (!name || !type) {
+      throw new Error(
+        `Invalid column format: "${col.trim()}". Expected "name:type" (e.g., input:string)`,
+      );
+    }
+    return { name: name.trim(), type: type.trim() };
+  });
+}
+
+export const datasetCreateCommand = async (
+  name: string,
+  options: { columns?: string },
+): Promise<void> => {
+  checkApiKey();
+
+  let columnTypes: DatasetColumnType[] = [];
+  if (options.columns) {
+    try {
+      columnTypes = parseColumns(options.columns);
+    } catch (error) {
+      console.error(
+        chalk.red(error instanceof Error ? error.message : "Invalid columns"),
+      );
+      process.exit(1);
+    }
+  }
+
+  const service = new DatasetsCliService();
+  const spinner = ora(`Creating dataset "${name}"...`).start();
+
+  try {
+    const dataset = await service.create({ name, columnTypes });
+
+    spinner.succeed(`Dataset created: ${chalk.cyan(dataset.name)}`);
+    console.log();
+    console.log(`  ${chalk.bold("Slug:")}  ${dataset.slug}`);
+    console.log(`  ${chalk.bold("ID:")}    ${dataset.id}`);
+    if (columnTypes.length > 0) {
+      console.log(
+        `  ${chalk.bold("Columns:")} ${columnTypes.map((c) => `${c.name}:${c.type}`).join(", ")}`,
+      );
+    }
+    console.log();
+    console.log(
+      chalk.gray(
+        `Upload data with: ${chalk.cyan(`langwatch dataset upload ${dataset.slug} data.csv`)}`,
+      ),
+    );
+  } catch (error) {
+    spinner.fail();
+    if (
+      error instanceof DatasetsCliServiceError &&
+      error.status === 409
+    ) {
+      console.error(
+        chalk.red(`A dataset with this name already exists.`),
+      );
+    } else if (error instanceof DatasetsCliServiceError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+    } else {
+      console.error(
+        chalk.red(
+          `Error creating dataset: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+      );
+    }
+    process.exit(1);
+  }
+};

--- a/typescript-sdk/src/cli/commands/dataset/datasets-cli.service.ts
+++ b/typescript-sdk/src/cli/commands/dataset/datasets-cli.service.ts
@@ -56,6 +56,8 @@ export class DatasetsCliServiceError extends Error {
   }
 }
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 export class DatasetsCliService {
   private readonly apiKey: string;
   private readonly endpoint: string;
@@ -72,6 +74,27 @@ export class DatasetsCliService {
       "x-auth-token": this.apiKey,
       authorization: `Bearer ${this.apiKey}`,
     };
+  }
+
+  private async request(
+    url: string,
+    init?: RequestInit,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw new DatasetsCliServiceError(
+          `Request timed out after ${timeoutMs}ms`,
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private async handleResponse<T>(response: Response): Promise<T> {
@@ -94,7 +117,7 @@ export class DatasetsCliService {
     limit = 50,
   }: { page?: number; limit?: number } = {}): Promise<ListDatasetsResponse> {
     const url = `${this.endpoint}/api/dataset?page=${page}&limit=${limit}`;
-    const response = await fetch(url, { headers: this.headers });
+    const response = await this.request(url, { headers: this.headers });
     return this.handleResponse<ListDatasetsResponse>(response);
   }
 
@@ -106,7 +129,7 @@ export class DatasetsCliService {
     columnTypes?: DatasetColumnType[];
   }): Promise<DatasetDetail> {
     const url = `${this.endpoint}/api/dataset`;
-    const response = await fetch(url, {
+    const response = await this.request(url, {
       method: "POST",
       headers: { ...this.headers, "content-type": "application/json" },
       body: JSON.stringify({ name, columnTypes }),
@@ -116,13 +139,13 @@ export class DatasetsCliService {
 
   async get(slugOrId: string): Promise<DatasetDetail> {
     const url = `${this.endpoint}/api/dataset/${encodeURIComponent(slugOrId)}`;
-    const response = await fetch(url, { headers: this.headers });
+    const response = await this.request(url, { headers: this.headers });
     return this.handleResponse<DatasetDetail>(response);
   }
 
   async delete(slugOrId: string): Promise<{ success: boolean }> {
     const url = `${this.endpoint}/api/dataset/${encodeURIComponent(slugOrId)}`;
-    const response = await fetch(url, {
+    const response = await this.request(url, {
       method: "DELETE",
       headers: this.headers,
     });
@@ -139,7 +162,7 @@ export class DatasetsCliService {
     limit?: number;
   }): Promise<PaginatedResponse<DatasetRecord>> {
     const url = `${this.endpoint}/api/dataset/${encodeURIComponent(slugOrId)}/records?page=${page}&limit=${limit}`;
-    const response = await fetch(url, { headers: this.headers });
+    const response = await this.request(url, { headers: this.headers });
     return this.handleResponse<PaginatedResponse<DatasetRecord>>(response);
   }
 
@@ -171,7 +194,7 @@ export class DatasetsCliService {
     formData.append("file", new Blob([content], { type: "text/plain" }), filename);
 
     const url = `${this.endpoint}/api/dataset/${encodeURIComponent(slugOrId)}/upload`;
-    const response = await fetch(url, {
+    const response = await this.request(url, {
       method: "POST",
       headers: this.headers,
       body: formData,
@@ -193,7 +216,7 @@ export class DatasetsCliService {
     formData.append("file", new Blob([content], { type: "text/plain" }), filename);
 
     const url = `${this.endpoint}/api/dataset/upload`;
-    const response = await fetch(url, {
+    const response = await this.request(url, {
       method: "POST",
       headers: this.headers,
       body: formData,

--- a/typescript-sdk/src/cli/commands/dataset/datasets-cli.service.ts
+++ b/typescript-sdk/src/cli/commands/dataset/datasets-cli.service.ts
@@ -1,0 +1,205 @@
+import { DEFAULT_ENDPOINT } from "@/internal/constants";
+
+export type DatasetColumnType = {
+  name: string;
+  type: string;
+};
+
+export type DatasetSummary = {
+  id: string;
+  name: string;
+  slug: string;
+  columnTypes: DatasetColumnType[];
+  createdAt: string;
+  updatedAt: string;
+  recordCount: number;
+};
+
+export type DatasetRecord = {
+  id: string;
+  datasetId: string;
+  projectId: string;
+  entry: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DatasetDetail = {
+  id: string;
+  name: string;
+  slug: string;
+  columnTypes: DatasetColumnType[];
+  createdAt: string;
+  updatedAt: string;
+  data: DatasetRecord[];
+};
+
+export type PaginatedResponse<T> = {
+  data: T[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
+export type ListDatasetsResponse = PaginatedResponse<DatasetSummary>;
+
+export class DatasetsCliServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "DatasetsCliServiceError";
+  }
+}
+
+export class DatasetsCliService {
+  private readonly apiKey: string;
+  private readonly endpoint: string;
+
+  constructor() {
+    this.apiKey = process.env.LANGWATCH_API_KEY ?? "";
+    this.endpoint = (
+      process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT
+    ).replace(/\/$/, "");
+  }
+
+  private get headers(): Record<string, string> {
+    return {
+      "x-auth-token": this.apiKey,
+      authorization: `Bearer ${this.apiKey}`,
+    };
+  }
+
+  private async handleResponse<T>(response: Response): Promise<T> {
+    if (!response.ok) {
+      const body = await response.text();
+      let message: string;
+      try {
+        const json = JSON.parse(body);
+        message = json.message ?? json.error ?? body;
+      } catch {
+        message = body;
+      }
+      throw new DatasetsCliServiceError(message, response.status);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  async list({
+    page = 1,
+    limit = 50,
+  }: { page?: number; limit?: number } = {}): Promise<ListDatasetsResponse> {
+    const url = `${this.endpoint}/api/dataset?page=${page}&limit=${limit}`;
+    const response = await fetch(url, { headers: this.headers });
+    return this.handleResponse<ListDatasetsResponse>(response);
+  }
+
+  async create({
+    name,
+    columnTypes = [],
+  }: {
+    name: string;
+    columnTypes?: DatasetColumnType[];
+  }): Promise<DatasetDetail> {
+    const url = `${this.endpoint}/api/dataset`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { ...this.headers, "content-type": "application/json" },
+      body: JSON.stringify({ name, columnTypes }),
+    });
+    return this.handleResponse<DatasetDetail>(response);
+  }
+
+  async get(slugOrId: string): Promise<DatasetDetail> {
+    const url = `${this.endpoint}/api/dataset/${encodeURIComponent(slugOrId)}`;
+    const response = await fetch(url, { headers: this.headers });
+    return this.handleResponse<DatasetDetail>(response);
+  }
+
+  async delete(slugOrId: string): Promise<{ success: boolean }> {
+    const url = `${this.endpoint}/api/dataset/${encodeURIComponent(slugOrId)}`;
+    const response = await fetch(url, {
+      method: "DELETE",
+      headers: this.headers,
+    });
+    return this.handleResponse<{ success: boolean }>(response);
+  }
+
+  async listRecords({
+    slugOrId,
+    page = 1,
+    limit = 1000,
+  }: {
+    slugOrId: string;
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<DatasetRecord>> {
+    const url = `${this.endpoint}/api/dataset/${encodeURIComponent(slugOrId)}/records?page=${page}&limit=${limit}`;
+    const response = await fetch(url, { headers: this.headers });
+    return this.handleResponse<PaginatedResponse<DatasetRecord>>(response);
+  }
+
+  async getAllRecords(slugOrId: string): Promise<DatasetRecord[]> {
+    const allRecords: DatasetRecord[] = [];
+    let page = 1;
+
+    while (true) {
+      const result = await this.listRecords({ slugOrId, page, limit: 1000 });
+      allRecords.push(...result.data);
+
+      if (page >= result.pagination.totalPages) break;
+      page++;
+    }
+
+    return allRecords;
+  }
+
+  async uploadToExisting({
+    slugOrId,
+    content,
+    filename,
+  }: {
+    slugOrId: string;
+    content: string;
+    filename: string;
+  }): Promise<{ uploadedCount: number }> {
+    const formData = new FormData();
+    formData.append("file", new Blob([content], { type: "text/plain" }), filename);
+
+    const url = `${this.endpoint}/api/dataset/${encodeURIComponent(slugOrId)}/upload`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: this.headers,
+      body: formData,
+    });
+    return this.handleResponse<{ uploadedCount: number }>(response);
+  }
+
+  async createFromUpload({
+    name,
+    content,
+    filename,
+  }: {
+    name: string;
+    content: string;
+    filename: string;
+  }): Promise<DatasetDetail & { recordCount: number }> {
+    const formData = new FormData();
+    formData.append("name", name);
+    formData.append("file", new Blob([content], { type: "text/plain" }), filename);
+
+    const url = `${this.endpoint}/api/dataset/upload`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: this.headers,
+      body: formData,
+    });
+    return this.handleResponse<DatasetDetail & { recordCount: number }>(
+      response,
+    );
+  }
+}

--- a/typescript-sdk/src/cli/commands/dataset/delete.ts
+++ b/typescript-sdk/src/cli/commands/dataset/delete.ts
@@ -1,0 +1,33 @@
+import chalk from "chalk";
+import ora from "ora";
+import { checkApiKey } from "../../utils/apiKey";
+import { DatasetsCliService, DatasetsCliServiceError } from "./datasets-cli.service";
+
+export const datasetDeleteCommand = async (slugOrId: string): Promise<void> => {
+  checkApiKey();
+
+  const service = new DatasetsCliService();
+  const spinner = ora(`Archiving dataset "${slugOrId}"...`).start();
+
+  try {
+    await service.delete(slugOrId);
+    spinner.succeed(`Dataset "${slugOrId}" archived successfully.`);
+  } catch (error) {
+    spinner.fail();
+    if (
+      error instanceof DatasetsCliServiceError &&
+      error.status === 404
+    ) {
+      console.error(chalk.red(`Dataset "${slugOrId}" not found.`));
+    } else if (error instanceof DatasetsCliServiceError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+    } else {
+      console.error(
+        chalk.red(
+          `Error deleting dataset: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+      );
+    }
+    process.exit(1);
+  }
+};

--- a/typescript-sdk/src/cli/commands/dataset/download.ts
+++ b/typescript-sdk/src/cli/commands/dataset/download.ts
@@ -1,0 +1,85 @@
+import chalk from "chalk";
+import ora from "ora";
+import { checkApiKey } from "../../utils/apiKey";
+import { DatasetsCliService, DatasetsCliServiceError } from "./datasets-cli.service";
+
+function toCsv(records: Array<{ entry: Record<string, unknown> }>): string {
+  if (records.length === 0) return "";
+
+  const columns = Object.keys(records[0]!.entry);
+
+  const escapeCsvField = (value: unknown): string => {
+    const str =
+      value === null || value === undefined
+        ? ""
+        : typeof value === "string"
+          ? value
+          : JSON.stringify(value);
+    if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
+  const header = columns.join(",");
+  const rows = records.map((record) =>
+    columns.map((col) => escapeCsvField(record.entry[col])).join(","),
+  );
+
+  return [header, ...rows].join("\n");
+}
+
+function toJsonl(records: Array<{ entry: Record<string, unknown> }>): string {
+  return records.map((record) => JSON.stringify(record.entry)).join("\n");
+}
+
+export const datasetDownloadCommand = async (
+  slugOrId: string,
+  options: { format?: string },
+): Promise<void> => {
+  checkApiKey();
+
+  const format = options.format ?? "csv";
+  if (format !== "csv" && format !== "jsonl") {
+    console.error(
+      chalk.red(`Unsupported format "${format}". Use "csv" or "jsonl".`),
+    );
+    process.exit(1);
+  }
+
+  const service = new DatasetsCliService();
+  const spinner = ora(`Fetching dataset "${slugOrId}"...`).start();
+
+  try {
+    const records = await service.getAllRecords(slugOrId);
+
+    spinner.stop();
+
+    if (records.length === 0) {
+      process.stderr.write(
+        chalk.yellow(`Dataset "${slugOrId}" has no records.\n`),
+      );
+      return;
+    }
+
+    const output = format === "csv" ? toCsv(records) : toJsonl(records);
+    process.stdout.write(output + "\n");
+  } catch (error) {
+    spinner.fail();
+    if (
+      error instanceof DatasetsCliServiceError &&
+      error.status === 404
+    ) {
+      console.error(chalk.red(`Dataset "${slugOrId}" not found.`));
+    } else if (error instanceof DatasetsCliServiceError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+    } else {
+      console.error(
+        chalk.red(
+          `Error downloading dataset: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+      );
+    }
+    process.exit(1);
+  }
+};

--- a/typescript-sdk/src/cli/commands/dataset/download.ts
+++ b/typescript-sdk/src/cli/commands/dataset/download.ts
@@ -3,25 +3,35 @@ import ora from "ora";
 import { checkApiKey } from "../../utils/apiKey";
 import { DatasetsCliService, DatasetsCliServiceError } from "./datasets-cli.service";
 
-function toCsv(records: Array<{ entry: Record<string, unknown> }>): string {
+const SUPPORTED_FORMATS = ["csv", "jsonl"] as const;
+type DownloadFormat = (typeof SUPPORTED_FORMATS)[number];
+
+export function escapeCsvField(value: unknown): string {
+  const str =
+    value === null || value === undefined
+      ? ""
+      : typeof value === "string"
+        ? value
+        : JSON.stringify(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function toCsv(records: Array<{ entry: Record<string, unknown> }>): string {
   if (records.length === 0) return "";
 
-  const columns = Object.keys(records[0]!.entry);
-
-  const escapeCsvField = (value: unknown): string => {
-    const str =
-      value === null || value === undefined
-        ? ""
-        : typeof value === "string"
-          ? value
-          : JSON.stringify(value);
-    if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
-      return `"${str.replace(/"/g, '""')}"`;
+  // Build column list from union of all record keys to avoid dropping columns
+  const columnSet = new Set<string>();
+  for (const record of records) {
+    for (const key of Object.keys(record.entry)) {
+      columnSet.add(key);
     }
-    return str;
-  };
+  }
+  const columns = [...columnSet];
 
-  const header = columns.join(",");
+  const header = columns.map((col) => escapeCsvField(col)).join(",");
   const rows = records.map((record) =>
     columns.map((col) => escapeCsvField(record.entry[col])).join(","),
   );
@@ -29,18 +39,21 @@ function toCsv(records: Array<{ entry: Record<string, unknown> }>): string {
   return [header, ...rows].join("\n");
 }
 
-function toJsonl(records: Array<{ entry: Record<string, unknown> }>): string {
+export function toJsonl(records: Array<{ entry: Record<string, unknown> }>): string {
   return records.map((record) => JSON.stringify(record.entry)).join("\n");
 }
 
-export const datasetDownloadCommand = async (
-  slugOrId: string,
-  options: { format?: string },
-): Promise<void> => {
+export const datasetDownloadCommand = async ({
+  slugOrId,
+  options,
+}: {
+  slugOrId: string;
+  options: { format?: string };
+}): Promise<void> => {
   checkApiKey();
 
   const format = options.format ?? "csv";
-  if (format !== "csv" && format !== "jsonl") {
+  if (!SUPPORTED_FORMATS.includes(format as DownloadFormat)) {
     console.error(
       chalk.red(`Unsupported format "${format}". Use "csv" or "jsonl".`),
     );

--- a/typescript-sdk/src/cli/commands/dataset/get.ts
+++ b/typescript-sdk/src/cli/commands/dataset/get.ts
@@ -1,0 +1,129 @@
+import chalk from "chalk";
+import ora from "ora";
+import { checkApiKey } from "../../utils/apiKey";
+import { DatasetsCliService, DatasetsCliServiceError } from "./datasets-cli.service";
+
+const PREVIEW_LIMIT = 10;
+
+export const datasetGetCommand = async (slugOrId: string): Promise<void> => {
+  checkApiKey();
+
+  const service = new DatasetsCliService();
+  const spinner = ora(`Fetching dataset "${slugOrId}"...`).start();
+
+  try {
+    const dataset = await service.get(slugOrId);
+
+    spinner.succeed(`Dataset: ${chalk.cyan(dataset.name)}`);
+    console.log();
+    console.log(`  ${chalk.bold("Slug:")}       ${dataset.slug}`);
+    console.log(`  ${chalk.bold("ID:")}         ${dataset.id}`);
+
+    const columns = dataset.columnTypes ?? [];
+    if (columns.length > 0) {
+      console.log(
+        `  ${chalk.bold("Columns:")}    ${columns.map((c) => `${c.name}:${c.type}`).join(", ")}`,
+      );
+    }
+
+    const records = dataset.data ?? [];
+    console.log(`  ${chalk.bold("Records:")}    ${records.length}`);
+    console.log(
+      `  ${chalk.bold("Created:")}    ${new Date(dataset.createdAt).toLocaleString()}`,
+    );
+    console.log(
+      `  ${chalk.bold("Updated:")}    ${new Date(dataset.updatedAt).toLocaleString()}`,
+    );
+
+    if (records.length > 0) {
+      console.log();
+      console.log(
+        chalk.bold(
+          `Preview (first ${Math.min(records.length, PREVIEW_LIMIT)} records):`,
+        ),
+      );
+      console.log();
+
+      const previewRecords = records.slice(0, PREVIEW_LIMIT);
+      const columnNames =
+        columns.length > 0
+          ? columns.map((c) => c.name)
+          : Object.keys(previewRecords[0]?.entry ?? {});
+
+      if (columnNames.length > 0) {
+        // Calculate column widths
+        const colWidths: Record<string, number> = {};
+        columnNames.forEach((col) => {
+          colWidths[col] = Math.max(
+            col.length,
+            ...previewRecords.map((r) => {
+              const val = r.entry[col];
+              const str =
+                val === undefined
+                  ? ""
+                  : typeof val === "string"
+                    ? val
+                    : JSON.stringify(val);
+              return Math.min(str.length, 40);
+            }),
+          );
+        });
+
+        // Header
+        const headerRow = columnNames
+          .map((col) => chalk.bold(col.padEnd(colWidths[col]!)))
+          .join("  ");
+        console.log(`  ${headerRow}`);
+
+        const separator = columnNames
+          .map((col) => "─".repeat(colWidths[col]!))
+          .join("  ");
+        console.log(`  ${chalk.gray(separator)}`);
+
+        // Rows
+        previewRecords.forEach((record) => {
+          const row = columnNames
+            .map((col) => {
+              const val = record.entry[col];
+              let str =
+                val === undefined
+                  ? ""
+                  : typeof val === "string"
+                    ? val
+                    : JSON.stringify(val);
+              if (str.length > 40) str = str.slice(0, 37) + "...";
+              return chalk.gray(str.padEnd(colWidths[col]!));
+            })
+            .join("  ");
+          console.log(`  ${row}`);
+        });
+
+        if (records.length > PREVIEW_LIMIT) {
+          console.log();
+          console.log(
+            chalk.gray(
+              `  ... and ${records.length - PREVIEW_LIMIT} more records`,
+            ),
+          );
+        }
+      }
+    }
+  } catch (error) {
+    spinner.fail();
+    if (
+      error instanceof DatasetsCliServiceError &&
+      error.status === 404
+    ) {
+      console.error(chalk.red(`Dataset "${slugOrId}" not found.`));
+    } else if (error instanceof DatasetsCliServiceError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+    } else {
+      console.error(
+        chalk.red(
+          `Error fetching dataset: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+      );
+    }
+    process.exit(1);
+  }
+};

--- a/typescript-sdk/src/cli/commands/dataset/list.ts
+++ b/typescript-sdk/src/cli/commands/dataset/list.ts
@@ -1,0 +1,65 @@
+import chalk from "chalk";
+import ora from "ora";
+import { checkApiKey } from "../../utils/apiKey";
+import { formatTable, formatRelativeTime } from "../../utils/format";
+import { DatasetsCliService, DatasetsCliServiceError } from "./datasets-cli.service";
+
+export const datasetListCommand = async (): Promise<void> => {
+  checkApiKey();
+
+  const service = new DatasetsCliService();
+  const spinner = ora("Fetching datasets...").start();
+
+  try {
+    const result = await service.list();
+    const datasets = result.data;
+
+    spinner.succeed(
+      `Found ${datasets.length} dataset${datasets.length !== 1 ? "s" : ""}` +
+        (result.pagination.total > datasets.length
+          ? chalk.gray(` (${result.pagination.total} total)`)
+          : ""),
+    );
+
+    if (datasets.length === 0) {
+      console.log();
+      console.log(chalk.gray("No datasets found."));
+      console.log(chalk.gray("Create your first dataset with:"));
+      console.log(chalk.cyan("  langwatch dataset create <name>"));
+      return;
+    }
+
+    console.log();
+
+    const tableData = datasets.map((ds) => ({
+      Name: ds.name,
+      Slug: ds.slug,
+      Records: String(ds.recordCount ?? 0),
+      Updated: formatRelativeTime(ds.updatedAt),
+    }));
+
+    formatTable(tableData, ["Name", "Slug", "Records", "Updated"], {
+      Name: chalk.cyan,
+      Records: chalk.green,
+    });
+
+    console.log();
+    console.log(
+      chalk.gray(
+        `Use ${chalk.cyan("langwatch dataset get <slug>")} to view a dataset`,
+      ),
+    );
+  } catch (error) {
+    spinner.fail();
+    if (error instanceof DatasetsCliServiceError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+    } else {
+      console.error(
+        chalk.red(
+          `Error fetching datasets: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+      );
+    }
+    process.exit(1);
+  }
+};

--- a/typescript-sdk/src/cli/commands/dataset/upload.ts
+++ b/typescript-sdk/src/cli/commands/dataset/upload.ts
@@ -1,0 +1,116 @@
+import chalk from "chalk";
+import ora from "ora";
+import { readFileSync } from "fs";
+import { basename } from "path";
+import { checkApiKey } from "../../utils/apiKey";
+import { DatasetsCliService, DatasetsCliServiceError } from "./datasets-cli.service";
+
+export const datasetUploadCommand = async (
+  slugOrIdOrFile: string,
+  filePathOrUndefined: string | undefined,
+  options: { create?: string },
+): Promise<void> => {
+  checkApiKey();
+
+  const service = new DatasetsCliService();
+
+  // Determine if this is --create mode or upload-to-existing mode
+  const isCreateMode = !!options.create;
+  const filePath = isCreateMode ? slugOrIdOrFile : filePathOrUndefined;
+  const slugOrId = isCreateMode ? undefined : slugOrIdOrFile;
+  const createName = options.create;
+
+  if (!filePath) {
+    console.error(chalk.red("Error: file path is required."));
+    console.error(
+      chalk.gray(
+        "Usage: langwatch dataset upload <slug> <file> or langwatch dataset upload --create <name> <file>",
+      ),
+    );
+    process.exit(1);
+  }
+
+  let fileContent: string;
+  try {
+    fileContent = readFileSync(filePath, "utf-8");
+  } catch {
+    console.error(chalk.red(`Error: Cannot read file "${filePath}"`));
+    process.exit(1);
+  }
+
+  const filename = basename(filePath);
+
+  if (isCreateMode && createName) {
+    const spinner = ora(
+      `Creating dataset "${createName}" from ${filename}...`,
+    ).start();
+
+    try {
+      const result = await service.createFromUpload({
+        name: createName,
+        content: fileContent,
+        filename,
+      });
+
+      spinner.succeed(
+        `Dataset "${chalk.cyan(result.name ?? createName)}" created from ${filename}`,
+      );
+      console.log();
+      console.log(`  ${chalk.bold("Slug:")}    ${result.slug}`);
+      console.log(`  ${chalk.bold("ID:")}      ${result.id}`);
+      console.log(`  ${chalk.bold("Records:")} ${result.recordCount ?? "uploaded"}`);
+    } catch (error) {
+      spinner.fail();
+      if (
+        error instanceof DatasetsCliServiceError &&
+        error.status === 409
+      ) {
+        console.error(
+          chalk.red("A dataset with this name already exists."),
+        );
+      } else if (error instanceof DatasetsCliServiceError) {
+        console.error(chalk.red(`Error: ${error.message}`));
+      } else {
+        console.error(
+          chalk.red(
+            `Error uploading: ${error instanceof Error ? error.message : "Unknown error"}`,
+          ),
+        );
+      }
+      process.exit(1);
+    }
+  } else if (slugOrId) {
+    const spinner = ora(
+      `Uploading ${filename} to dataset "${slugOrId}"...`,
+    ).start();
+
+    try {
+      const result = await service.uploadToExisting({
+        slugOrId,
+        content: fileContent,
+        filename,
+      });
+
+      spinner.succeed(
+        `Uploaded ${filename} to "${slugOrId}" (${result.uploadedCount} records)`,
+      );
+    } catch (error) {
+      spinner.fail();
+      if (
+        error instanceof DatasetsCliServiceError &&
+        error.status === 404
+      ) {
+        console.error(chalk.red(`Dataset "${slugOrId}" not found.`));
+      } else if (error instanceof DatasetsCliServiceError) {
+        console.error(chalk.red(`Error: ${error.message}`));
+      } else {
+        console.error(
+          chalk.red(
+            `Error uploading: ${error instanceof Error ? error.message : "Unknown error"}`,
+          ),
+        );
+      }
+      process.exit(1);
+    }
+  }
+};

--- a/typescript-sdk/src/cli/commands/dataset/upload.ts
+++ b/typescript-sdk/src/cli/commands/dataset/upload.ts
@@ -5,11 +5,15 @@ import { basename } from "path";
 import { checkApiKey } from "../../utils/apiKey";
 import { DatasetsCliService, DatasetsCliServiceError } from "./datasets-cli.service";
 
-export const datasetUploadCommand = async (
-  slugOrIdOrFile: string,
-  filePathOrUndefined: string | undefined,
-  options: { create?: string },
-): Promise<void> => {
+export const datasetUploadCommand = async ({
+  slugOrIdOrFile,
+  filePath: filePathOrUndefined,
+  options,
+}: {
+  slugOrIdOrFile: string;
+  filePath: string | undefined;
+  options: { create?: string };
+}): Promise<void> => {
   checkApiKey();
 
   const service = new DatasetsCliService();

--- a/typescript-sdk/src/cli/commands/list.ts
+++ b/typescript-sdk/src/cli/commands/list.ts
@@ -2,88 +2,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { PromptsApiService, PromptsError } from "@/client-sdk/services/prompts";
 import { checkApiKey } from "../utils/apiKey";
-
-// Helper to strip ANSI codes for length calculation
-const stripAnsi = (str: string): string => {
-  // eslint-disable-next-line no-control-regex
-  return str.replace(/\u001b\[[0-9;]*m/g, "");
-};
-
-// Simple table formatting helper
-const formatTable = (
-  data: Array<Record<string, string>>,
-  headers: string[],
-): void => {
-  if (data.length === 0) {
-    console.log(chalk.gray("No prompts found"));
-    return;
-  }
-
-  // Calculate column widths (strip ANSI codes for accurate length calculation)
-  const colWidths: Record<string, number> = {};
-  headers.forEach((header) => {
-    colWidths[header] = Math.max(
-      header.length,
-      ...data.map((row) => stripAnsi(row[header] ?? "").length),
-    );
-  });
-
-  // Print header
-  const headerRow = headers
-    .map((header) => chalk.bold(header.padEnd(colWidths[header]!)))
-    .join("  ");
-  console.log(headerRow);
-
-  // Print separator
-  const separator = headers
-    .map((header) => "─".repeat(colWidths[header]!))
-    .join("  ");
-  console.log(chalk.gray(separator));
-
-  // Print data rows
-  data.forEach((row) => {
-    const dataRow = headers
-      .map((header) => {
-        const value = row[header] ?? "";
-        const strippedLength = stripAnsi(value).length;
-        const paddingNeeded = colWidths[header]! - strippedLength;
-        const paddedValue = value + " ".repeat(Math.max(0, paddingNeeded));
-
-        // Color coding
-        if (header === "Name") {
-          return chalk.cyan(paddedValue);
-        } else if (header === "Version") {
-          return chalk.green(paddedValue);
-        } else if (header === "Model") {
-          return chalk.yellow(paddedValue);
-        } else {
-          return chalk.gray(paddedValue);
-        }
-      })
-      .join("  ");
-    console.log(dataRow);
-  });
-};
-
-const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-
-  const seconds = Math.floor(diffMs / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
-  const months = Math.floor(days / 30);
-  const years = Math.floor(days / 365);
-
-  if (years > 0) return `${years}y ago`;
-  if (months > 0) return `${months}mo ago`;
-  if (days > 0) return `${days}d ago`;
-  if (hours > 0) return `${hours}h ago`;
-  if (minutes > 0) return `${minutes}m ago`;
-  return `${seconds}s ago`;
-};
+import { formatTable, formatRelativeTime } from "../utils/format";
 
 export const listCommand = async (): Promise<void> => {
   try {
@@ -131,7 +50,11 @@ export const listCommand = async (): Promise<void> => {
       }));
 
       // Display table
-      formatTable(tableData, ["Name", "Version", "Model", "Updated"]);
+      formatTable(tableData, ["Name", "Version", "Model", "Updated"], {
+        Name: chalk.cyan,
+        Version: chalk.green,
+        Model: chalk.yellow,
+      });
 
       console.log();
       console.log(

--- a/typescript-sdk/src/cli/index.ts
+++ b/typescript-sdk/src/cli/index.ts
@@ -61,9 +61,9 @@ const datasetList = async (): Promise<void> => {
   return datasetListCommand();
 };
 
-const datasetCreate = async (name: string, options: { columns?: string }): Promise<void> => {
+const datasetCreate = async ({ name, options }: { name: string; options: { columns?: string } }): Promise<void> => {
   const { datasetCreateCommand } = await import("./commands/dataset/create.js");
-  return datasetCreateCommand(name, options);
+  return datasetCreateCommand({ name, options });
 };
 
 const datasetGet = async (slugOrId: string): Promise<void> => {
@@ -76,14 +76,14 @@ const datasetDelete = async (slugOrId: string): Promise<void> => {
   return datasetDeleteCommand(slugOrId);
 };
 
-const datasetUpload = async (slugOrIdOrFile: string, filePath: string | undefined, options: { create?: string }): Promise<void> => {
+const datasetUpload = async ({ slugOrIdOrFile, filePath, options }: { slugOrIdOrFile: string; filePath: string | undefined; options: { create?: string } }): Promise<void> => {
   const { datasetUploadCommand } = await import("./commands/dataset/upload.js");
-  return datasetUploadCommand(slugOrIdOrFile, filePath, options);
+  return datasetUploadCommand({ slugOrIdOrFile, filePath, options });
 };
 
-const datasetDownload = async (slugOrId: string, options: { format?: string }): Promise<void> => {
+const datasetDownload = async ({ slugOrId, options }: { slugOrId: string; options: { format?: string } }): Promise<void> => {
   const { datasetDownloadCommand } = await import("./commands/dataset/download.js");
-  return datasetDownloadCommand(slugOrId, options);
+  return datasetDownloadCommand({ slugOrId, options });
 };
 
 const program = new Command();
@@ -242,7 +242,7 @@ datasetCmd
   .option("--columns <columns>", "Column definitions (e.g., input:string,output:string)")
   .action(async (name: string, options: { columns?: string }) => {
     try {
-      await datasetCreate(name, options);
+      await datasetCreate({ name, options });
     } catch (error) {
       console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
       process.exit(1);
@@ -285,13 +285,17 @@ datasetCmd
           console.error("Error: file path is required");
           process.exit(1);
         }
-        await datasetUpload(slug, undefined, options);
+        if (file) {
+          console.error("Error: when using --create, only a single <file> argument is allowed");
+          process.exit(1);
+        }
+        await datasetUpload({ slugOrIdOrFile: slug, filePath: undefined, options });
       } else {
         if (!slug || !file) {
           console.error("Error: both <slug> and <file> are required");
           process.exit(1);
         }
-        await datasetUpload(slug, file, options);
+        await datasetUpload({ slugOrIdOrFile: slug, filePath: file, options });
       }
     } catch (error) {
       console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
@@ -305,7 +309,7 @@ datasetCmd
   .option("--format <format>", "Output format: csv or jsonl", "csv")
   .action(async (slug: string, options: { format?: string }) => {
     try {
-      await datasetDownload(slug, options);
+      await datasetDownload({ slugOrId: slug, options });
     } catch (error) {
       console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
       process.exit(1);

--- a/typescript-sdk/src/cli/index.ts
+++ b/typescript-sdk/src/cli/index.ts
@@ -55,11 +55,42 @@ const createCommand = async (name: string, options: Record<string, unknown>): Pr
   return createCommandImpl(name, options);
 };
 
+// Dataset commands (lazy-loaded)
+const datasetList = async (): Promise<void> => {
+  const { datasetListCommand } = await import("./commands/dataset/list.js");
+  return datasetListCommand();
+};
+
+const datasetCreate = async (name: string, options: { columns?: string }): Promise<void> => {
+  const { datasetCreateCommand } = await import("./commands/dataset/create.js");
+  return datasetCreateCommand(name, options);
+};
+
+const datasetGet = async (slugOrId: string): Promise<void> => {
+  const { datasetGetCommand } = await import("./commands/dataset/get.js");
+  return datasetGetCommand(slugOrId);
+};
+
+const datasetDelete = async (slugOrId: string): Promise<void> => {
+  const { datasetDeleteCommand } = await import("./commands/dataset/delete.js");
+  return datasetDeleteCommand(slugOrId);
+};
+
+const datasetUpload = async (slugOrIdOrFile: string, filePath: string | undefined, options: { create?: string }): Promise<void> => {
+  const { datasetUploadCommand } = await import("./commands/dataset/upload.js");
+  return datasetUploadCommand(slugOrIdOrFile, filePath, options);
+};
+
+const datasetDownload = async (slugOrId: string, options: { format?: string }): Promise<void> => {
+  const { datasetDownloadCommand } = await import("./commands/dataset/download.js");
+  return datasetDownloadCommand(slugOrId, options);
+};
+
 const program = new Command();
 
 program
   .name("langwatch")
-  .description("LangWatch CLI - The npm of prompts")
+  .description("LangWatch CLI - Manage prompts and datasets")
   .version(__CLI_VERSION__, "-v, --version", "Display the current version")
   .configureHelp({
     showGlobalOptions: true,
@@ -182,6 +213,99 @@ promptCmd
   .action(async (options: { forceLocal?: boolean; forceRemote?: boolean }) => {
     try {
       await pushCommand({ forceLocal: options.forceLocal, forceRemote: options.forceRemote });
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+// Add dataset command group
+const datasetCmd = program
+  .command("dataset")
+  .description("Manage datasets");
+
+datasetCmd
+  .command("list")
+  .description("List all datasets")
+  .action(async () => {
+    try {
+      await datasetList();
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+datasetCmd
+  .command("create <name>")
+  .description("Create a new dataset")
+  .option("--columns <columns>", "Column definitions (e.g., input:string,output:string)")
+  .action(async (name: string, options: { columns?: string }) => {
+    try {
+      await datasetCreate(name, options);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+datasetCmd
+  .command("get <slug>")
+  .description("Get dataset details and preview records")
+  .action(async (slug: string) => {
+    try {
+      await datasetGet(slug);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+datasetCmd
+  .command("delete <slug>")
+  .description("Archive a dataset")
+  .action(async (slug: string) => {
+    try {
+      await datasetDelete(slug);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+datasetCmd
+  .command("upload [slug] [file]")
+  .description("Upload a CSV or JSONL file to a dataset")
+  .option("--create <name>", "Create a new dataset from the file")
+  .action(async (slug: string | undefined, file: string | undefined, options: { create?: string }) => {
+    try {
+      if (options.create) {
+        // --create mode: first positional arg is the file path
+        if (!slug) {
+          console.error("Error: file path is required");
+          process.exit(1);
+        }
+        await datasetUpload(slug, undefined, options);
+      } else {
+        if (!slug || !file) {
+          console.error("Error: both <slug> and <file> are required");
+          process.exit(1);
+        }
+        await datasetUpload(slug, file, options);
+      }
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+datasetCmd
+  .command("download <slug>")
+  .description("Download dataset records as CSV or JSONL")
+  .option("--format <format>", "Output format: csv or jsonl", "csv")
+  .action(async (slug: string, options: { format?: string }) => {
+    try {
+      await datasetDownload(slug, options);
     } catch (error) {
       console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
       process.exit(1);

--- a/typescript-sdk/src/cli/utils/format.ts
+++ b/typescript-sdk/src/cli/utils/format.ts
@@ -1,0 +1,75 @@
+import chalk from "chalk";
+
+// Helper to strip ANSI codes for length calculation
+export const stripAnsi = (str: string): string => {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\u001b\[[0-9;]*m/g, "");
+};
+
+// Simple table formatting helper
+export const formatTable = (
+  data: Array<Record<string, string>>,
+  headers: string[],
+  colorMap?: Record<string, (s: string) => string>,
+): void => {
+  if (data.length === 0) {
+    return;
+  }
+
+  // Calculate column widths (strip ANSI codes for accurate length calculation)
+  const colWidths: Record<string, number> = {};
+  headers.forEach((header) => {
+    colWidths[header] = Math.max(
+      header.length,
+      ...data.map((row) => stripAnsi(row[header] ?? "").length),
+    );
+  });
+
+  // Print header
+  const headerRow = headers
+    .map((header) => chalk.bold(header.padEnd(colWidths[header]!)))
+    .join("  ");
+  console.log(headerRow);
+
+  // Print separator
+  const separator = headers
+    .map((header) => "─".repeat(colWidths[header]!))
+    .join("  ");
+  console.log(chalk.gray(separator));
+
+  // Print data rows
+  data.forEach((row) => {
+    const dataRow = headers
+      .map((header) => {
+        const value = row[header] ?? "";
+        const strippedLength = stripAnsi(value).length;
+        const paddingNeeded = colWidths[header]! - strippedLength;
+        const paddedValue = value + " ".repeat(Math.max(0, paddingNeeded));
+
+        const colorFn = colorMap?.[header];
+        return colorFn ? colorFn(paddedValue) : chalk.gray(paddedValue);
+      })
+      .join("  ");
+    console.log(dataRow);
+  });
+};
+
+export const formatRelativeTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+
+  const seconds = Math.floor(diffMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  if (years > 0) return `${years}y ago`;
+  if (months > 0) return `${months}mo ago`;
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return `${seconds}s ago`;
+};

--- a/typescript-sdk/src/cli/utils/format.ts
+++ b/typescript-sdk/src/cli/utils/format.ts
@@ -56,8 +56,10 @@ export const formatTable = (
 
 export const formatRelativeTime = (dateString: string): string => {
   const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return "N/A";
+
   const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
 
   const seconds = Math.floor(diffMs / 1000);
   const minutes = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary
- Adds `langwatch dataset` command group with 6 subcommands: `list`, `create`, `get`, `delete`, `upload`, `download`
- Follows existing prompt command patterns (lazy imports, chalk/ora, Commander.js)
- Extracts shared formatting utilities (`formatTable`, `formatRelativeTime`) from prompt list into `cli/utils/format.ts`

## Commands
| Command | Description |
|---------|-------------|
| `langwatch dataset list` | Table of datasets with name, slug, record count, last updated |
| `langwatch dataset create <name> --columns input:string,output:string` | Create empty dataset with column definitions |
| `langwatch dataset get <slug>` | Show metadata + preview of first 10 records |
| `langwatch dataset delete <slug>` | Archive (soft-delete) a dataset |
| `langwatch dataset upload <slug> <file>` | Upload CSV/JSONL to existing dataset |
| `langwatch dataset upload --create <name> <file>` | Create dataset from file in one command |
| `langwatch dataset download <slug> --format csv\|jsonl` | Download records to stdout (pipe-friendly) |

## Test plan
- [x] 22 unit tests passing (CSV/JSONL formatting, column parsing, service API calls)
- [x] Typecheck clean (no new errors)
- [ ] Manual test: `langwatch dataset list` against a live instance
- [ ] Manual test: `langwatch dataset create` + `upload` + `download` round-trip
- [ ] Manual test: `langwatch dataset download <slug> --format jsonl | wc -l` matches record count

Closes #2932

# Related Issue

- Resolve #2932