### PR TITLE
fix: classify transient ClickHouse errors as recoverable to prevent group blocking

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
@@ -1,7 +1,7 @@
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import type { WithDateWrites } from "~/server/clickhouse/types";
 import {
-	ErrorCategory,
+	classifyClickHouseError,
 	SecurityError,
 	StoreError,
 	ValidationError,
@@ -197,7 +197,7 @@ export class ExperimentRunStateRepositoryClickHouse<
         "getProjection",
         "ExperimentRunStateRepositoryClickHouse",
         `Failed to get projection for run ${runId}: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { runId },
         error,
       );
@@ -262,7 +262,7 @@ export class ExperimentRunStateRepositoryClickHouse<
         "storeProjection",
         "ExperimentRunStateRepositoryClickHouse",
         `Failed to store projection ${projection.id} for run ${projection.aggregateId}: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { projectionId: projection.id, runId: String(projection.aggregateId) },
         error,
       );
@@ -323,7 +323,7 @@ export class ExperimentRunStateRepositoryClickHouse<
         "storeProjectionBatch",
         "ExperimentRunStateRepositoryClickHouse",
         `Failed to batch store ${projections.length} projections: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { count: projections.length },
         error,
       );

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
@@ -1,7 +1,7 @@
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import type { WithDateWrites } from "~/server/clickhouse/types";
 import {
-  ErrorCategory,
+  classifyClickHouseError,
   SecurityError,
   StoreError,
   ValidationError,
@@ -225,7 +225,7 @@ export class SimulationRunStateRepositoryClickHouse<
         "getProjection",
         "SimulationRunStateRepositoryClickHouse",
         `Failed to get projection for scenario run ${scenarioRunId}: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { scenarioRunId },
         error,
       );
@@ -292,7 +292,7 @@ export class SimulationRunStateRepositoryClickHouse<
         "storeProjection",
         "SimulationRunStateRepositoryClickHouse",
         `Failed to store projection ${projection.id} for scenario run ${projection.aggregateId}: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { projectionId: projection.id, scenarioRunId: String(projection.aggregateId) },
         error,
       );
@@ -352,7 +352,7 @@ export class SimulationRunStateRepositoryClickHouse<
         "storeProjectionBatch",
         "SimulationRunStateRepositoryClickHouse",
         `Failed to batch store ${projections.length} projections: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { count: projections.length },
         error,
       );

--- a/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/repositories/suiteRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/repositories/suiteRunState.clickhouse.repository.ts
@@ -1,7 +1,7 @@
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import type { WithDateWrites } from "~/server/clickhouse/types";
 import {
-  ErrorCategory,
+  classifyClickHouseError,
   SecurityError,
   StoreError,
   ValidationError,
@@ -172,7 +172,7 @@ export class SuiteRunStateRepositoryClickHouse<
         "getProjection",
         "SuiteRunStateRepositoryClickHouse",
         `Failed to get projection for batch run ${batchRunId}: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { batchRunId },
         error,
       );
@@ -234,7 +234,7 @@ export class SuiteRunStateRepositoryClickHouse<
         "storeProjection",
         "SuiteRunStateRepositoryClickHouse",
         `Failed to store projection ${projection.id} for batch run ${projection.aggregateId}: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { projectionId: projection.id, batchRunId: String(projection.aggregateId) },
         error,
       );
@@ -292,7 +292,7 @@ export class SuiteRunStateRepositoryClickHouse<
         "storeProjectionBatch",
         "SuiteRunStateRepositoryClickHouse",
         `Failed to batch store ${projections.length} projections: ${errorMessage}`,
-        ErrorCategory.CRITICAL,
+        classifyClickHouseError(error),
         { count: projections.length },
         error,
       );

--- a/langwatch/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
@@ -10,6 +10,7 @@ import {
   ProjectionError,
   handleError,
   categorizeError,
+  classifyClickHouseError,
 } from "../errorHandling";
 
 const createMockLogger = () => ({
@@ -341,5 +342,49 @@ describe("categorizeError", () => {
 
   it("returns RECOVERABLE for non-Error value", () => {
     expect(categorizeError("not an error")).toBe(ErrorCategory.RECOVERABLE);
+  });
+});
+
+describe("classifyClickHouseError", () => {
+  describe("when error has a transient ClickHouse error code", () => {
+    it("returns RECOVERABLE for code 202 (TOO_MANY_SIMULTANEOUS_QUERIES)", () => {
+      const err = Object.assign(new Error("Too many simultaneous queries"), { code: "202" });
+      expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for code 159 (TIMEOUT_EXCEEDED)", () => {
+      const err = Object.assign(new Error("timeout"), { code: "159" });
+      expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for code 241 (MEMORY_LIMIT_EXCEEDED)", () => {
+      const err = Object.assign(new Error("memory"), { code: "241" });
+      expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
+    });
+  });
+
+  describe("when error message matches transient patterns", () => {
+    it("returns RECOVERABLE for 'Too many simultaneous queries' message", () => {
+      expect(classifyClickHouseError(new Error("Too many simultaneous queries. Maximum: 100. "))).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for connection refused", () => {
+      expect(classifyClickHouseError(new Error("connect ECONNREFUSED 127.0.0.1:8123"))).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for connection timeout", () => {
+      expect(classifyClickHouseError(new Error("connect ETIMEDOUT"))).toBe(ErrorCategory.RECOVERABLE);
+    });
+  });
+
+  describe("when error is not transient", () => {
+    it("returns CRITICAL for unknown ClickHouse errors", () => {
+      expect(classifyClickHouseError(new Error("Syntax error in SQL"))).toBe(ErrorCategory.CRITICAL);
+    });
+
+    it("returns CRITICAL for null/undefined", () => {
+      expect(classifyClickHouseError(null)).toBe(ErrorCategory.CRITICAL);
+      expect(classifyClickHouseError(undefined)).toBe(ErrorCategory.CRITICAL);
+    });
   });
 });

--- a/langwatch/src/server/event-sourcing/services/errorHandling.ts
+++ b/langwatch/src/server/event-sourcing/services/errorHandling.ts
@@ -402,3 +402,51 @@ export function categorizeError(error: unknown): ErrorCategory {
   // Callers can override based on context
   return ErrorCategory.RECOVERABLE;
 }
+
+/**
+ * ClickHouse error codes that indicate transient/overload conditions.
+ * These should be retried rather than treated as fatal.
+ *
+ * - 159: TIMEOUT_EXCEEDED
+ * - 160: TOO_SLOW
+ * - 202: TOO_MANY_SIMULTANEOUS_QUERIES
+ * - 203: NO_FREE_CONNECTION
+ * - 209: SOCKET_TIMEOUT
+ * - 210: NETWORK_ERROR
+ * - 241: MEMORY_LIMIT_EXCEEDED
+ * - 252: TOO_MANY_PARTS
+ */
+const CLICKHOUSE_TRANSIENT_CODES = new Set([
+  "159", "160", "202", "203", "209", "210", "241", "252",
+]);
+
+/**
+ * Classifies a ClickHouse error as RECOVERABLE (transient) or CRITICAL.
+ *
+ * Transient errors (overload, timeouts, connection issues) should be retried
+ * by the group queue. Only true data-integrity errors are CRITICAL.
+ */
+export function classifyClickHouseError(error: unknown): ErrorCategory {
+  if (
+    error != null &&
+    typeof error === "object" &&
+    "code" in error &&
+    CLICKHOUSE_TRANSIENT_CODES.has(String((error as { code: unknown }).code))
+  ) {
+    return ErrorCategory.RECOVERABLE;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    message.includes("Too many simultaneous queries") ||
+    message.includes("TIMEOUT_EXCEEDED") ||
+    message.includes("SOCKET_TIMEOUT") ||
+    message.includes("NETWORK_ERROR") ||
+    message.includes("connect ECONNREFUSED") ||
+    message.includes("connect ETIMEDOUT")
+  ) {
+    return ErrorCategory.RECOVERABLE;
+  }
+
+  return ErrorCategory.CRITICAL;
+}


### PR DESCRIPTION
## Summary

- **Root cause**: All ClickHouse repository catch blocks wrapped errors as `ErrorCategory.CRITICAL`, which the group queue treats as non-retryable — immediately blocking the group on the first failure
- **Impact**: Transient ClickHouse errors like "Too many simultaneous queries" (code 202) caused groups to block instantly instead of retrying with backoff. This triggered the `Blocked Groups` alert after deployment when all 8 workers restarted simultaneously and overwhelmed ClickHouse
- **Fix**: Added `classifyClickHouseError()` that inspects the error code/message to distinguish transient ClickHouse errors (RECOVERABLE → retried with backoff) from real data integrity issues (CRITICAL → blocks group)

### Transient error codes now classified as RECOVERABLE:
| Code | Name |
|------|------|
| 159 | TIMEOUT_EXCEEDED |
| 160 | TOO_SLOW |
| 202 | TOO_MANY_SIMULTANEOUS_QUERIES |
| 203 | NO_FREE_CONNECTION |
| 209 | SOCKET_TIMEOUT |
| 210 | NETWORK_ERROR |
| 241 | MEMORY_LIMIT_EXCEEDED |
| 252 | TOO_MANY_PARTS |

Also matches by message patterns: `connect ECONNREFUSED`, `connect ETIMEDOUT`.

### Files changed:
- `errorHandling.ts`: Added `classifyClickHouseError()` helper
- 3 repositories updated: simulation, experiment, suite run — `ErrorCategory.CRITICAL` → `classifyClickHouseError(error)`
- 8 new unit tests for the classifier

## Test plan

- [x] 43 error handling unit tests pass (35 existing + 8 new)
- [x] 9 group queue retry tests pass
- [x] Typecheck passes