### PR TITLE
fix(mcp): resolve dual-module config bug in production

### DIFF
--- a/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
+++ b/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
@@ -822,4 +822,329 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       expect(toolNames).toContain("fetch_scenario_docs");
     });
   });
+
+  // --- Tool Execution: AsyncLocalStorage Propagation ---
+  //
+  // These tests verify that the session's API key is correctly propagated
+  // to tool handlers through AsyncLocalStorage. In production (HTTP mode),
+  // there is NO global LANGWATCH_API_KEY — each client provides their own
+  // via OAuth. If the AsyncLocalStorage context is lost during MCP SDK
+  // tool dispatch, requireApiKey() fails with:
+  //   - "Config not initialized" (globalConfig null)
+  //   - "LANGWATCH_API_KEY is required" (globalConfig has no apiKey)
+
+  describe("when search_traces is called within an authenticated session", () => {
+    it("receives the API key from session config via AsyncLocalStorage", async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(validProject());
+
+      // Initialize session
+      const initRes = await sendRequest({
+        server,
+        body: mcpInitializeBody(),
+        headers: { authorization: `Bearer ${VALID_API_KEY}` },
+      });
+      const sessionId = initRes.headers["mcp-session-id"]!;
+
+      // Send initialized notification
+      await sendRequest({
+        server,
+        body: { jsonrpc: "2.0", method: "notifications/initialized" },
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+
+      // Call search_traces — the API endpoint is real but the key is fake,
+      // so this will fail with an API error, NOT a config error
+      const toolRes = await sendRequest({
+        server,
+        body: {
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: {
+            name: "search_traces",
+            arguments: {},
+          },
+        },
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+
+      expect(toolRes.status).toBe(200);
+      const body = toolRes.json() as Record<string, unknown>;
+      const result = body.result as Record<string, unknown>;
+      const content = result.content as Array<{ type: string; text: string }>;
+
+      // These config errors indicate AsyncLocalStorage context loss
+      expect(content[0]?.text).not.toContain("Config not initialized");
+      expect(content[0]?.text).not.toContain("LANGWATCH_API_KEY is required");
+    });
+  });
+
+  describe("when search_traces is called via an OAuth-obtained access token", () => {
+    it("propagates the OAuth-resolved API key through to the tool handler", async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(validProject());
+
+      // 1. Obtain an access token via OAuth authorization_code + PKCE
+      const code = randomUUID();
+      const { codeVerifier, codeChallenge } = createPkceChallenge();
+      mockAuthCodeInRedis({ code, codeChallenge });
+
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const tokenRes = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: `grant_type=authorization_code&code=${code}&code_verifier=${codeVerifier}&redirect_uri=http://localhost/callback`,
+      });
+      const tokenBody = (await tokenRes.json()) as { access_token: string };
+      const accessToken = tokenBody.access_token;
+
+      // Reset redis mock (auth code was consumed)
+      mockRedis.get.mockResolvedValue(null);
+
+      // 2. Initialize MCP session with the OAuth token
+      mockPrisma.project.findUnique.mockResolvedValue(validProject());
+      const initRes = await sendRequest({
+        server,
+        body: mcpInitializeBody(),
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+      expect(initRes.status).toBe(200);
+      const sessionId = initRes.headers["mcp-session-id"]!;
+
+      // 3. Send initialized notification
+      await sendRequest({
+        server,
+        body: { jsonrpc: "2.0", method: "notifications/initialized" },
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+
+      // 4. Call search_traces — should reach the API, not fail on config
+      const toolRes = await sendRequest({
+        server,
+        body: {
+          jsonrpc: "2.0",
+          id: 4,
+          method: "tools/call",
+          params: { name: "search_traces", arguments: {} },
+        },
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+
+      expect(toolRes.status).toBe(200);
+      const body = toolRes.json() as Record<string, unknown>;
+      const result = body.result as Record<string, unknown>;
+      const content = result.content as Array<{ type: string; text: string }>;
+
+      expect(content[0]?.text).not.toContain("Config not initialized");
+      expect(content[0]?.text).not.toContain("LANGWATCH_API_KEY is required");
+    });
+  });
+
+  describe("when fetch_langwatch_docs is called with a specific URL", () => {
+    it("returns page content", async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(validProject());
+
+      const initRes = await sendRequest({
+        server,
+        body: mcpInitializeBody(),
+        headers: { authorization: `Bearer ${VALID_API_KEY}` },
+      });
+      const sessionId = initRes.headers["mcp-session-id"]!;
+
+      await sendRequest({
+        server,
+        body: { jsonrpc: "2.0", method: "notifications/initialized" },
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+
+      // Call with the index URL (known to work in production)
+      const toolRes = await sendRequest({
+        server,
+        body: {
+          jsonrpc: "2.0",
+          id: 5,
+          method: "tools/call",
+          params: {
+            name: "fetch_langwatch_docs",
+            arguments: { url: "https://langwatch.ai/docs/llms.txt" },
+          },
+        },
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+
+      expect(toolRes.status).toBe(200);
+      const body = toolRes.json() as Record<string, unknown>;
+      const result = body.result as Record<string, unknown>;
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content).toBeDefined();
+      expect(content[0]?.text.length).toBeGreaterThan(0);
+      expect(content[0]?.text.toLowerCase()).toContain("langwatch");
+    });
+  });
+
+  describe("when fetch_langwatch_docs is called with a specific docs page URL", () => {
+    it("fetches the page and returns its content", async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(validProject());
+
+      const initRes = await sendRequest({
+        server,
+        body: mcpInitializeBody(),
+        headers: { authorization: `Bearer ${VALID_API_KEY}` },
+      });
+      const sessionId = initRes.headers["mcp-session-id"]!;
+
+      await sendRequest({
+        server,
+        body: { jsonrpc: "2.0", method: "notifications/initialized" },
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+
+      // This is the exact URL pattern that fails in production
+      const toolRes = await sendRequest({
+        server,
+        body: {
+          jsonrpc: "2.0",
+          id: 6,
+          method: "tools/call",
+          params: {
+            name: "fetch_langwatch_docs",
+            arguments: { url: "https://langwatch.ai/docs/integration/overview.md" },
+          },
+        },
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId,
+        },
+      });
+
+      expect(toolRes.status).toBe(200);
+      const body = toolRes.json() as Record<string, unknown>;
+      const result = body.result as Record<string, unknown>;
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content).toBeDefined();
+      expect(content[0]?.text.length).toBeGreaterThan(100);
+      // The result should NOT be an error — in production this was returning
+      // "Error occurred during tool execution"
+      expect(result.isError).not.toBe(true);
+    });
+  });
+
+  // --- SSE Transport Tool Execution ---
+
+  describe("when a tool is called via the SSE transport", () => {
+    it("propagates the API key to search_traces", async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(validProject());
+
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://127.0.0.1:${port}`;
+
+      // 1. Connect via SSE — GET /sse with Bearer token
+      // Use AbortController since SSE is a long-lived stream
+      const abortController = new AbortController();
+      const sseChunks: string[] = [];
+
+      const ssePromise = fetch(`${baseUrl}/sse`, {
+        method: "GET",
+        headers: { authorization: `Bearer ${VALID_API_KEY}` },
+        signal: abortController.signal,
+      }).then(async (res) => {
+        expect(res.status).toBe(200);
+        const reader = res.body!.getReader();
+        const decoder = new TextDecoder();
+        // Read chunks until we have the endpoint event
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          sseChunks.push(decoder.decode(value, { stream: true }));
+          const joined = sseChunks.join("");
+          if (joined.includes("event: endpoint")) break;
+        }
+      });
+
+      // Wait for the endpoint event
+      await ssePromise;
+
+      // Parse SSE stream to get the endpoint event with session URL
+      const sseBody = sseChunks.join("");
+      const endpointMatch = sseBody.match(
+        /event:\s*endpoint\ndata:\s*(.+)/,
+      );
+      expect(endpointMatch).toBeTruthy();
+
+      const messagesPath = endpointMatch![1]!.trim();
+      expect(messagesPath).toContain("sessionId=");
+
+      // 2. Send initialize request via POST /messages
+      const initRes = await fetch(`${baseUrl}${messagesPath}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${VALID_API_KEY}`,
+        },
+        body: JSON.stringify(mcpInitializeBody()),
+      });
+      expect(initRes.status).toBe(202);
+
+      // 3. Send initialized notification
+      await fetch(`${baseUrl}${messagesPath}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${VALID_API_KEY}`,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        }),
+      });
+
+      // 4. Call search_traces via SSE transport
+      const toolRes = await fetch(`${baseUrl}${messagesPath}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${VALID_API_KEY}`,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 7,
+          method: "tools/call",
+          params: { name: "search_traces", arguments: {} },
+        }),
+      });
+      expect(toolRes.status).toBe(202);
+
+      // Wait for the tool to execute (response goes through SSE stream)
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // Verify the server is still healthy (tool didn't crash it)
+      const healthRes = await fetch(`${baseUrl}/mcp/health`);
+      expect(healthRes.status).toBe(200);
+
+      // Clean up the SSE connection
+      abortController.abort();
+    });
+  });
 });

--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -420,6 +420,10 @@ export function createMcpHandler(): McpHandler {
     fn: () => Promise<T>,
   ): Promise<T> {
     const baseConfig = getConfig();
+    logger.debug(
+      { hasApiKey: !!apiKey, endpoint: baseConfig.endpoint },
+      "Running with session config",
+    );
     return runWithConfig({ ...baseConfig, apiKey }, fn);
   }
 

--- a/mcp-server/src/config.ts
+++ b/mcp-server/src/config.ts
@@ -37,18 +37,32 @@ export function initConfig(args: { apiKey?: string; endpoint?: string }): void {
 export function getConfig(): McpConfig {
   const scoped = configStorage.getStore();
   if (scoped) return scoped;
-  if (!globalConfig) throw new Error("Config not initialized");
+  if (!globalConfig) {
+    console.error(
+      "[MCP config] getConfig() failed: globalConfig is null, no scoped config active. " +
+        "Was initConfig() called? Stack:",
+      new Error().stack,
+    );
+    throw new Error("Config not initialized");
+  }
   return globalConfig;
 }
 
 export function requireApiKey(): string {
-  const { apiKey } = getConfig();
-  if (!apiKey) {
+  const config = getConfig();
+  if (!config.apiKey) {
+    const hasScoped = !!configStorage.getStore();
+    console.error(
+      "[MCP config] requireApiKey() failed: apiKey is undefined. " +
+        `scopedConfig=${hasScoped}, endpoint=${config.endpoint}. ` +
+        "In HTTP mode, the API key should be set per-session via runWithConfig(). Stack:",
+      new Error().stack,
+    );
     throw new Error(
       "LANGWATCH_API_KEY is required. Set it via --apiKey flag or LANGWATCH_API_KEY environment variable."
     );
   }
-  return apiKey;
+  return config.apiKey;
 }
 
 /**

--- a/mcp-server/src/create-mcp-server.ts
+++ b/mcp-server/src/create-mcp-server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import packageJson from "../package.json" assert { type: "json" };
+import { requireApiKey } from "./config.js";
 
 const modelSchema = z
   .string()
@@ -25,6 +26,29 @@ export function createMcpServer(): McpServer {
   return server;
 }
 
+/**
+ * Wraps a tool handler with error logging. In HTTP mode (production),
+ * tool errors are caught by the MCP SDK and returned to the client as
+ * error responses — but without server-side logs we can't diagnose them.
+ */
+function withToolLogging<T extends unknown[], R>(
+  toolName: string,
+  fn: (...args: T) => Promise<R>,
+): (...args: T) => Promise<R> {
+  return async (...args: T) => {
+    try {
+      return await fn(...args);
+    } catch (error) {
+      console.error(
+        `[MCP tool] ${toolName} failed:`,
+        error instanceof Error ? error.message : error,
+        error instanceof Error ? error.stack : "",
+      );
+      throw error;
+    }
+  };
+}
+
 function registerTools(server: McpServer): void {
   server.tool(
     "fetch_langwatch_docs",
@@ -37,7 +61,7 @@ function registerTools(server: McpServer): void {
           "The full url of the specific doc page. If not provided, the docs index will be fetched."
         ),
     },
-    async ({ url }) => {
+    withToolLogging("fetch_langwatch_docs", async ({ url }) => {
       let urlToFetch = url || "https://langwatch.ai/docs/llms.txt";
       if (url && !urlToFetch.endsWith(".md") && !urlToFetch.endsWith(".txt")) {
         urlToFetch += ".md";
@@ -53,7 +77,7 @@ function registerTools(server: McpServer): void {
       return {
         content: [{ type: "text", text: await response.text() }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -67,7 +91,7 @@ function registerTools(server: McpServer): void {
           "The full url of the specific doc page. If not provided, the docs index will be fetched."
         ),
     },
-    async ({ url }) => {
+    withToolLogging("fetch_scenario_docs", async ({ url }) => {
       let urlToFetch = url || "https://langwatch.ai/scenario/llms.txt";
       if (url && !urlToFetch.endsWith(".md") && !urlToFetch.endsWith(".txt")) {
         urlToFetch += ".md";
@@ -83,7 +107,7 @@ function registerTools(server: McpServer): void {
       return {
         content: [{ type: "text", text: await response.text() }],
       };
-    }
+    })
   );
 
   // --- Observability Tools (require API key) ---
@@ -181,14 +205,13 @@ function registerTools(server: McpServer): void {
           "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)"
         ),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("search_traces", async (params) => {
       requireApiKey();
       const { handleSearchTraces } = await import("./tools/search-traces.js");
       return {
         content: [{ type: "text", text: await handleSearchTraces(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -203,14 +226,13 @@ function registerTools(server: McpServer): void {
           "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)"
         ),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("get_trace", async (params) => {
       requireApiKey();
       const { handleGetTrace } = await import("./tools/get-trace.js");
       return {
         content: [{ type: "text", text: await handleGetTrace(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -245,14 +267,13 @@ function registerTools(server: McpServer): void {
         .optional()
         .describe("Filters to apply"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("get_analytics", async (params) => {
       requireApiKey();
       const { handleGetAnalytics } = await import("./tools/get-analytics.js");
       return {
         content: [{ type: "text", text: await handleGetAnalytics(params) }],
       };
-    }
+    })
   );
 
   // --- Platform Prompt Tools (require API key) ---
@@ -293,28 +314,26 @@ NOTE: Prompts can be managed two ways. Determine which approach the user needs:
         'Built-in tags: "latest" (auto-assigned), "production", "staging". Custom tags must be created first.'
       ),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_create_prompt", async (params) => {
       requireApiKey();
       const { handleCreatePrompt } = await import("./tools/create-prompt.js");
       return {
         content: [{ type: "text", text: await handleCreatePrompt(params) }],
       };
-    }
+    })
   );
 
   server.tool(
     "platform_list_prompts",
     "List all prompts configured on the LangWatch platform.",
     {},
-    async () => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_list_prompts", async () => {
       requireApiKey();
       const { handleListPrompts } = await import("./tools/list-prompts.js");
       return {
         content: [{ type: "text", text: await handleListPrompts() }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -331,20 +350,19 @@ NOTE: Prompts can be managed two ways. Determine which approach the user needs:
         'Alternatively, use shorthand in idOrHandle: "pizza-prompt:production"'
       ),
     },
-    async (params) => {
+    withToolLogging("platform_get_prompt", async (params) => {
       if (params.version != null && params.tag) {
         return {
           content: [{ type: "text", text: "Error: Provide either 'version' or 'tag', not both." }],
           isError: true,
         };
       }
-      const { requireApiKey } = await import("./config.js");
       requireApiKey();
       const { handleGetPrompt } = await import("./tools/get-prompt.js");
       return {
         content: [{ type: "text", text: await handleGetPrompt(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -369,14 +387,13 @@ NOTE: Prompts can be managed two ways. Determine which approach the user needs:
         'Tags to assign to the new version created by this update.'
       ),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_update_prompt", async (params) => {
       requireApiKey();
       const { handleUpdatePrompt } = await import("./tools/update-prompt.js");
       return {
         content: [{ type: "text", text: await handleUpdatePrompt(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -388,14 +405,13 @@ NOTE: Prompts can be managed two ways. Determine which approach the user needs:
       tag: z.string().describe('Tag name (e.g., "production", "staging")'),
       versionId: z.string().describe("The version ID to assign the tag to"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_assign_prompt_tag", async (params) => {
       requireApiKey();
       const { handleAssignPromptTag } = await import("./tools/assign-prompt-tag.js");
       return {
         content: [{ type: "text", text: await handleAssignPromptTag(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -403,14 +419,13 @@ NOTE: Prompts can be managed two ways. Determine which approach the user needs:
     "List all prompt tag definitions for the organization. " +
     "Shows built-in tags (latest, production, staging) and any custom tags.",
     {},
-    async () => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_list_prompt_tags", async () => {
       requireApiKey();
       const { handleListPromptTags } = await import("./tools/list-prompt-tags.js");
       return {
         content: [{ type: "text", text: await handleListPromptTags() }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -420,14 +435,13 @@ NOTE: Prompts can be managed two ways. Determine which approach the user needs:
     {
       name: z.string().describe("Tag name to create"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_create_prompt_tag", async (params) => {
       requireApiKey();
       const { handleCreatePromptTag } = await import("./tools/create-prompt-tag.js");
       return {
         content: [{ type: "text", text: await handleCreatePromptTag(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -437,14 +451,13 @@ NOTE: Prompts can be managed two ways. Determine which approach the user needs:
       tag: z.string().describe("Current tag name to rename"),
       name: z.string().describe("New tag name"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_rename_prompt_tag", async (params) => {
       requireApiKey();
       const { handleRenamePromptTag } = await import("./tools/rename-prompt-tag.js");
       return {
         content: [{ type: "text", text: await handleRenamePromptTag(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -453,14 +466,13 @@ NOTE: Prompts can be managed two ways. Determine which approach the user needs:
     {
       tag: z.string().describe("Tag name to delete"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_delete_prompt_tag", async (params) => {
       requireApiKey();
       const { handleDeletePromptTag } = await import("./tools/delete-prompt-tag.js");
       return {
         content: [{ type: "text", text: await handleDeletePromptTag(params) }],
       };
-    }
+    })
   );
 
   // --- Platform Scenario Tools (require API key) ---
@@ -495,8 +507,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
         .optional()
         .describe("Tags for organizing and filtering scenarios"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_create_scenario", async (params) => {
       requireApiKey();
       const { handleCreateScenario } = await import(
         "./tools/create-scenario.js"
@@ -506,7 +517,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           { type: "text", text: await handleCreateScenario(params) },
         ],
       };
-    }
+    })
   );
 
   server.tool(
@@ -520,8 +531,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)"
         ),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_list_scenarios", async (params) => {
       requireApiKey();
       const { handleListScenarios } = await import(
         "./tools/list-scenarios.js"
@@ -531,7 +541,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           { type: "text", text: await handleListScenarios(params) },
         ],
       };
-    }
+    })
   );
 
   server.tool(
@@ -546,14 +556,13 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)"
         ),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_get_scenario", async (params) => {
       requireApiKey();
       const { handleGetScenario } = await import("./tools/get-scenario.js");
       return {
         content: [{ type: "text", text: await handleGetScenario(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -572,8 +581,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
         .optional()
         .describe("Updated labels"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_update_scenario", async (params) => {
       requireApiKey();
       const { handleUpdateScenario } = await import(
         "./tools/update-scenario.js"
@@ -583,7 +591,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           { type: "text", text: await handleUpdateScenario(params) },
         ],
       };
-    }
+    })
   );
 
   server.tool(
@@ -592,8 +600,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
     {
       scenarioId: z.string().describe("The scenario ID to archive"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_archive_scenario", async (params) => {
       requireApiKey();
       const { handleArchiveScenario } = await import(
         "./tools/archive-scenario.js"
@@ -603,7 +610,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           { type: "text", text: await handleArchiveScenario(params) },
         ],
       };
-    }
+    })
   );
 
   // --- Platform Evaluator Tools (require API key) ---
@@ -620,8 +627,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           'Evaluator config object. Must include "evaluatorType" (e.g. "langevals/llm_boolean") and optional "settings" overrides.'
         ),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_create_evaluator", async (params) => {
       requireApiKey();
       const { handleCreateEvaluator } = await import(
         "./tools/create-evaluator.js"
@@ -631,15 +637,14 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           { type: "text", text: await handleCreateEvaluator(params) },
         ],
       };
-    }
+    })
   );
 
   server.tool(
     "platform_list_evaluators",
     "List all evaluators configured on the LangWatch platform.",
     {},
-    async () => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_list_evaluators", async () => {
       requireApiKey();
       const { handleListEvaluators } = await import(
         "./tools/list-evaluators.js"
@@ -647,7 +652,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
       return {
         content: [{ type: "text", text: await handleListEvaluators() }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -658,8 +663,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
         .string()
         .describe("The evaluator ID or slug to retrieve"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_get_evaluator", async (params) => {
       requireApiKey();
       const { handleGetEvaluator } = await import(
         "./tools/get-evaluator.js"
@@ -667,7 +671,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
       return {
         content: [{ type: "text", text: await handleGetEvaluator(params) }],
       };
-    }
+    })
   );
 
   server.tool(
@@ -683,8 +687,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           "Updated config settings. Note: evaluatorType cannot be changed after creation."
         ),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_update_evaluator", async (params) => {
       requireApiKey();
       const { handleUpdateEvaluator } = await import(
         "./tools/update-evaluator.js"
@@ -694,7 +697,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           { type: "text", text: await handleUpdateEvaluator(params) },
         ],
       };
-    }
+    })
   );
 
   // --- Platform Model Provider Tools (require API key) ---
@@ -721,8 +724,7 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
         .optional()
         .describe("Set as project default model"),
     },
-    async (params) => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_set_model_provider", async (params) => {
       requireApiKey();
       const { handleSetModelProvider } = await import(
         "./tools/set-model-provider.js"
@@ -732,15 +734,14 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
           { type: "text", text: await handleSetModelProvider(params) },
         ],
       };
-    }
+    })
   );
 
   server.tool(
     "platform_list_model_providers",
     "List all model providers configured on the LangWatch platform. API keys are masked in the response.",
     {},
-    async () => {
-      const { requireApiKey } = await import("./config.js");
+    withToolLogging("platform_list_model_providers", async () => {
       requireApiKey();
       const { handleListModelProviders } = await import(
         "./tools/list-model-providers.js"
@@ -748,6 +749,6 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
       return {
         content: [{ type: "text", text: await handleListModelProviders() }],
       };
-    }
+    })
   );
 }


### PR DESCRIPTION
## Summary
- **Root cause found and fixed**: In the Docker production image, tsx's dynamic `import("./config.js")` inside tool handlers resolved to a separate module instance from the static `import from "@langwatch/mcp-server/config"` in `handler.ts`. When `handler.ts` called `initConfig()`, it set `globalConfig` on instance A. When tool handlers called `requireApiKey()` via the dynamic import, they read from instance B (where `globalConfig` was null) → "Config not initialized".
- **Fix**: Replaced all 23 dynamic `await import("./config.js")` calls in `create-mcp-server.ts` with a single static `import { requireApiKey } from "./config.js"` at the top of the file.
- Adds `withToolLogging()` wrapper on all tool handlers for server-side error visibility
- Adds 5 integration tests covering tool execution through MCP sessions (search_traces, fetch_langwatch_docs, OAuth flow, SSE transport)

## Diagnosis
Reproduced by `kubectl exec` into a production pod:
- `curl /mcp` → initialized session successfully
- `tools/call search_traces` → returned `"Config not initialized"` (confirmed the bug)
- `curl https://langwatch.ai/docs/skills/directory.md` → 200 (not a firewall issue)
- Node module identity test: `import("./config.js")` from within the package failed with "Cannot find module config.js", and `import("./config.ts")` created a fresh module instance with its own `globalConfig = undefined`

## Deploy together with
- langwatch/langwatch-saas#427 (adds `COPY langwatch/mcp-server/` to Dockerfile.runtime)

## Test plan
- [x] 30 integration tests pass (including 5 new tool execution tests)
- [x] Typecheck passes
- [ ] After merge + saas PR merge, verify `search_traces` works via Claude Chat connector