### PR TITLE
fix: restore setMaxListeners(128) for production

### DIFF
--- a/langwatch/src/server.ts
+++ b/langwatch/src/server.ts
@@ -1,8 +1,14 @@
 import { setEnvironment } from "@langwatch/ksuid";
 import dotenv from "dotenv";
+import events from "events";
 
 dotenv.config();
 setEnvironment(process.env.ENVIRONMENT ?? "local");
+
+if (process.env.NODE_ENV === "production") {
+  process.setMaxListeners(128);
+  events.EventEmitter.defaultMaxListeners = 128;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { startApp } = require("./start.js");


### PR DESCRIPTION
## Summary

- Restores `process.setMaxListeners(128)` and `EventEmitter.defaultMaxListeners = 128` in production
- This was previously set in the saas `server.ts` wrapper and got lost during the dependency injection migration (#2952)
- Without it, production instances emit `MaxListenersExceededWarning` under load

## Test plan

- [ ] No `MaxListenersExceededWarning` in production logs under normal load