### PR TITLE
fix: run prisma generate at container startup

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -26,7 +26,7 @@
     "start:quickwit": "cd quickwit && ./quickwit run",
     "start:prepare:files": "pnpm run generate:sdk-versions && pnpm run copy:langevals-types && pnpm run types:zod:generate && pnpm run prisma:generate:typescript",
     "generate:sdk-versions": "bash scripts/generate-sdk-versions.sh",
-    "start:prepare:db": "pnpm run prisma:migrate && pnpm run elastic:migrate && pnpm run clickhouse:migrate",
+    "start:prepare:db": "pnpm run prisma:generate:typescript && pnpm run prisma:migrate && pnpm run elastic:migrate && pnpm run clickhouse:migrate",
     "start:workers": "tsx --tsconfig tsconfig.workers.json src/workers.ts",
     "typecheck:legacy": "./node_modules/.bin/tsc --noEmit --project ./tsconfig.json",
     "typecheck": "./node_modules/.bin/tsgo --noEmit --project ./tsconfig.tsgo.json",


### PR DESCRIPTION
## Summary

- Adds `prisma generate` to `start:prepare:db` before migrations
- The CI runner generates the Prisma client for `linux-arm64-openssl-3.0.x`, but the Alpine Docker image needs `linux-musl-arm64-openssl-3.0.x`
- The old saas `prepare:production` script ran `prisma generate` at every boot — this was lost in the DI migration
- Running it at startup is fast and always gets the correct engine binary for the runtime

## Test plan

- [ ] Container starts without `Prisma Client could not locate the Query Engine` error