### PR TITLE
fix: run prisma generate before workers start

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -27,7 +27,7 @@
     "start:prepare:files": "pnpm run generate:sdk-versions && pnpm run copy:langevals-types && pnpm run types:zod:generate && pnpm run prisma:generate:typescript",
     "generate:sdk-versions": "bash scripts/generate-sdk-versions.sh",
     "start:prepare:db": "pnpm run prisma:generate:typescript && pnpm run prisma:migrate && pnpm run elastic:migrate && pnpm run clickhouse:migrate",
-    "start:workers": "tsx --tsconfig tsconfig.workers.json src/workers.ts",
+    "start:workers": "pnpm run prisma:generate:typescript && tsx --tsconfig tsconfig.workers.json src/workers.ts",
     "typecheck:legacy": "./node_modules/.bin/tsc --noEmit --project ./tsconfig.json",
     "typecheck": "./node_modules/.bin/tsgo --noEmit --project ./tsconfig.tsgo.json",
     "test:unit": "NODE_ENV=test PINO_LOG_LEVEL=warn vitest",


### PR DESCRIPTION
## Summary

- Workers also need `prisma generate` at startup for the same reason as #2967 — the Prisma client is generated for the CI runner's architecture, not Alpine musl
- Workers run `pnpm run start:workers` directly without going through `start.sh` / `start:prepare:db`

## Test plan

- [ ] Workers start without `Prisma Client could not locate the Query Engine` error