### PR TITLE
fix: fail fast on worker startup if database is unreachable

### DIFF
--- a/langwatch/src/server/background/worker.ts
+++ b/langwatch/src/server/background/worker.ts
@@ -126,7 +126,7 @@ export const start = async (
 ): Promise<Workers | undefined> => {
   // Fail fast if Prisma client can't connect (e.g. wrong engine binary, DB unreachable)
   const { prisma } = await import("../db");
-  await prisma.$queryRaw`SELECT 1`;
+  await prisma.organization.findFirst({ select: { id: true } });
   logger.info("database connection verified");
 
   // Reset state for restart scenarios - prevents duplicate closeables


### PR DESCRIPTION
## Summary

- Adds a `SELECT 1` health check at the start of the worker `start()` function
- Workers previously connected to Redis and appeared healthy to K8s even when Prisma couldn't load (e.g. wrong engine binary after `pnpm prune --prod`)
- Now crashes immediately on startup if the DB connection fails, so K8s sees the error right away

## Test plan

- [ ] Workers with valid DB config start normally (health check passes)
- [ ] Workers with broken Prisma (wrong binary) crash immediately instead of appearing healthy