### PR TITLE
fix(ci): use pull_request_target for fork-compatible PR checks

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -1,7 +1,7 @@
 name: Approval or Exception Required
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled]
   pull_request_review:
     types: [submitted, dismissed]

--- a/.github/workflows/pr-conventional-commits-title.yml
+++ b/.github/workflows/pr-conventional-commits-title.yml
@@ -1,7 +1,7 @@
 name: pr-conventions
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Summary
- Switch `approval-or-hotfix.yml` and `pr-conventional-commits-title.yml` from `pull_request` to `pull_request_target`
- Fork PRs get a read-only `GITHUB_TOKEN`, so these workflows fail with 403 when trying to write check-runs/statuses
- `pull_request_target` runs the workflow from the base branch with write permissions — safe here since neither workflow checks out or executes fork code

## Test plan
- [ ] Verify existing PRs from repo collaborators still get title validation and approval checks
- [ ] Verify a fork PR (e.g. #2953) gets passing checks after re-triggering