### PR TITLE
fix(ci): ensure approval check runs on fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/approval-or-hotfix.yml
+++ b/.github/workflows/approval-or-hotfix.yml
@@ -12,6 +12,11 @@ concurrency:
 
 jobs:
   check-approval-or-label:
+    # Skip pull_request_review for fork PRs — the read-only token would 403
+    # and the concurrency group could cancel a passing pull_request_target run.
+    if: >-
+      github.event_name != 'pull_request_review' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
## Summary
- Add `opened`, `synchronize`, `reopened` types to the `pull_request_target` trigger in `approval-or-hotfix.yml`
- Previously only `labeled`/`unlabeled` used `pull_request_target`, so the check never ran with write permissions on fork PR creation/updates
- The `pull_request_review` trigger remains for internal PRs; for fork PRs where it lacks write permissions, the reviewer can re-run the check from the Actions tab after approving

Follows up on #2973 which switched from `pull_request` to `pull_request_target` but missed the PR lifecycle types.

## Test plan
- [ ] Internal PR: approval check triggers on open, push, and review submission
- [ ] Fork PR (e.g. #2953): approval check triggers on open/push with write permissions