### PR TITLE
fix: reduce NLP CI OpenAI spend by scoping triggers and using gpt-5-mini

### DIFF
--- a/.github/workflows/langwatch-nlp-ci.yml
+++ b/.github/workflows/langwatch-nlp-ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "langwatch_nlp/**"
+      - "python-sdk/**"
+      - ".github/workflows/langwatch-nlp-ci.yml"
   pull_request:
     paths:
       - "langwatch_nlp/**"

--- a/langwatch_nlp/tests/studio/test_parse.py
+++ b/langwatch_nlp/tests/studio/test_parse.py
@@ -220,7 +220,7 @@ def test_parse_signature_with_default_workflow_llm():
         type="signature",
     )
     workflow = copy.deepcopy(basic_workflow)
-    workflow.default_llm = LLMConfig(model="gpt-4o", temperature=0.0, max_tokens=100)
+    workflow.default_llm = LLMConfig(model="gpt-5-mini", temperature=0.0, max_tokens=100)
 
     code, class_name, _ = parse_component(node, workflow)
     with materialized_component_class(code, class_name) as Module:

--- a/langwatch_nlp/tests/studio/test_workflow_parse_and_execution.py
+++ b/langwatch_nlp/tests/studio/test_workflow_parse_and_execution.py
@@ -38,7 +38,7 @@ llm_field = Field(
     type=FieldType.llm,
     optional=None,
     value=LLMConfig(
-        model="gpt-4o",
+        model="gpt-5-mini",
         temperature=0.0,
         max_tokens=100,
     ),
@@ -859,7 +859,7 @@ def test_langwatch_evaluator_llm_boolean_with_multiline_prompt():
                         identifier="model",
                         type=FieldType.str,
                         optional=None,
-                        value="openai/gpt-4o-mini",
+                        value="openai/gpt-5-mini",
                         desc=None,
                         prefix=None,
                         hidden=None,
@@ -983,7 +983,7 @@ def test_parse_workflow_with_default_llm():
 
     workflow = copy.deepcopy(simple_workflow)
     workflow.default_llm = LLMConfig(
-        model="gpt-4o", temperature=0.0, max_tokens=100
+        model="gpt-5-mini", temperature=0.0, max_tokens=100
     )
 
     generate_query_node = next(
@@ -1303,7 +1303,7 @@ def test_proposes_instructions_with_grounded_proposer():
         from dspy.propose.grounded_proposer import GroundedProposer
 
         proposer = GroundedProposer(
-            prompt_model=dspy.LM(model="openai/gpt-4o"),
+            prompt_model=dspy.LM(model="openai/gpt-5-mini"),
             program=instance,
             trainset=[],
         )

--- a/langwatch_nlp/tests/topic_clustering/test_topic_clustering.py
+++ b/langwatch_nlp/tests/topic_clustering/test_topic_clustering.py
@@ -82,7 +82,7 @@ class TestTopicClusteringIntegration:
         response = client.post(
             "/topics/batch_clustering",
             json={
-                "model": "openai/gpt-4o",
+                "model": "openai/gpt-5-mini",
                 "litellm_params": {},
                 "embeddings_litellm_params": {
                     "model": "openai/text-embedding-3-small",
@@ -103,7 +103,7 @@ class TestTopicClusteringIntegration:
         response = client.post(
             "/topics/incremental_clustering",
             json={
-                "model": "openai/gpt-4o",
+                "model": "openai/gpt-5-mini",
                 "litellm_params": {},
                 "embeddings_litellm_params": {
                     "model": "openai/text-embedding-3-small",
@@ -186,7 +186,7 @@ class TestTopicClusteringIntegration:
         response = client.post(
             "/topics/batch_clustering",
             json={
-                "model": "openai/gpt-4o",
+                "model": "openai/gpt-5-mini",
                 "litellm_params": {},
                 "embeddings_litellm_params": {
                     "model": "openai/text-embedding-3-small",


### PR DESCRIPTION
## Summary
- **Add path filters to `push` trigger on `langwatch-nlp-ci.yml`** — previously it ran on every push to main (even pure `langwatch/` changes), now it only runs when `langwatch_nlp/`, `python-sdk/`, or the workflow file itself changes
- **Replace `gpt-4o` with `gpt-5-mini`** in all NLP integration tests (`test_workflow_parse_and_execution.py`, `test_parse.py`, `test_topic_clustering.py`)
- Left `test_utils.py` unchanged as those tests verify model-specific behavior (reasoning model detection, parameter handling) where the model name is semantically meaningful

## Test plan
- [ ] Verify NLP CI still triggers on PRs touching `langwatch_nlp/`
- [ ] Verify NLP CI no longer triggers on pushes to main that only touch `langwatch/`
- [ ] Verify NLP integration tests pass with `gpt-5-mini`