### PR TITLE
fix: make Docker images compatible with readOnlyRootFilesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,11 @@ COPY langevals/ts-integration/evaluators.generated.ts ./langevals/ts-integration
 COPY typescript-sdk/package.json ./typescript-sdk/package.json
 COPY python-sdk/pyproject.toml ./python-sdk/pyproject.toml
 COPY mcp-server ./mcp-server
+RUN cd mcp-server && pnpm install --frozen-lockfile
 COPY langwatch ./langwatch
 RUN cd langwatch && pnpm run build
+# Symlink mcp-server source for tsx runtime imports (pnpm file: only copies published files)
+RUN rm -rf /app/langwatch/node_modules/@langwatch/mcp-server && ln -s /app/mcp-server /app/langwatch/node_modules/@langwatch/mcp-server
 EXPOSE 5560
 
 ENV NODE_ENV=production

--- a/Dockerfile.langevals
+++ b/Dockerfile.langevals
@@ -25,9 +25,11 @@ COPY langevals/langevals/ langevals/
 RUN PYTHONPATH="." uv run python langevals/server.py --preload
 
 ENV RUNNING_IN_DOCKER=true
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPATH="/usr/src/app"
 
 # Copy remaining project files (scripts, docs, etc.)
 COPY langevals/scripts/ scripts/
 COPY langevals/Makefile langevals/README.md langevals/LICENSE.md ./
 
-CMD ["uv", "run", "python", "langevals/server.py"]
+CMD ["uv", "--no-cache", "run", "--no-sync", "python", "langevals/server.py"]

--- a/Dockerfile.langwatch_nlp
+++ b/Dockerfile.langwatch_nlp
@@ -25,6 +25,7 @@ COPY langwatch_nlp .
 RUN PYTHONPATH=. uv run --no-editable python langwatch_nlp/main.py
 
 ENV RUNNING_IN_DOCKER=true
+ENV PYTHONDONTWRITEBYTECODE=1
 
 EXPOSE 5561
 


### PR DESCRIPTION
## Summary
- **App**: Install mcp-server dependencies (`@modelcontextprotocol/sdk`) and symlink source into `node_modules` so `tsx` can resolve TypeScript imports at runtime (pnpm `file:` protocol only copies published files, not `src/`)
- **Langevals**: Use `uv --no-cache run --no-sync` in CMD (prevents venv writes on readonly FS). Add `PYTHONDONTWRITEBYTECODE=1` and `PYTHONPATH=/usr/src/app` for module resolution without sync.
- **NLP**: Add `PYTHONDONTWRITEBYTECODE=1` to prevent `.pyc` writes (CMD already uses `--no-cache --no-sync`)

## Context
The new helm chart v3 enables `readOnlyRootFilesystem: true` for security. These changes ensure all images work without needing to write to the filesystem at runtime.

Companion PR for SaaS: langwatch/langwatch-saas#432

## Test plan
- [ ] Build images with `next` tag via workflow_dispatch
- [ ] Deploy to `lw-helm-v3-test` namespace with `readOnlyRootFilesystem: true`
- [ ] Verify all pods start without filesystem errors
- [ ] Verify app can load mcp-server module
- [ ] Verify langevals can import its modules