### PR TITLE
fix(mcp): copy langevals file before mcp-server build in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,13 @@ ENV PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1
 # Build mcp-server first — it's a file: dependency of langwatch, so dist/ must
 # exist before pnpm install copies it into the langwatch node_modules store
 COPY mcp-server ./mcp-server
+COPY langevals/ts-integration/evaluators.generated.ts ./langevals/ts-integration/evaluators.generated.ts
 RUN cd mcp-server && pnpm install --frozen-lockfile && pnpm run build
 
 COPY langwatch/package.json langwatch/pnpm-lock.yaml langwatch/pnpm-workspace.yaml ./langwatch/
 COPY langwatch/vendor ./langwatch/vendor
 # https://stackoverflow.com/questions/70154568/pnpm-equivalent-command-for-npm-ci
 RUN cd langwatch && CI=true pnpm install --frozen-lockfile
-COPY langevals/ts-integration/evaluators.generated.ts ./langevals/ts-integration/evaluators.generated.ts
 # SDK package files needed by generate-sdk-versions.sh during build
 COPY typescript-sdk/package.json ./typescript-sdk/package.json
 COPY python-sdk/pyproject.toml ./python-sdk/pyproject.toml


### PR DESCRIPTION
## Summary
Move `COPY langevals/ts-integration/evaluators.generated.ts` before the mcp-server build step. The `discover-evaluator-schema.ts` tool imports this file, so tsup needs it during the build.

## Test plan
- [ ] Docker build succeeds