### PR TITLE
fix: use venv python directly for langevals readonly FS compat

### DIFF
--- a/Dockerfile.langevals
+++ b/Dockerfile.langevals
@@ -26,10 +26,10 @@ RUN PYTHONPATH="." uv run python langevals/server.py --preload
 
 ENV RUNNING_IN_DOCKER=true
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONPATH="/usr/src/app"
+ENV PATH="/usr/src/app/.venv/bin:$PATH"
 
 # Copy remaining project files (scripts, docs, etc.)
 COPY langevals/scripts/ scripts/
 COPY langevals/Makefile langevals/README.md langevals/LICENSE.md ./
 
-CMD ["uv", "--no-cache", "run", "--no-sync", "python", "langevals/server.py"]
+CMD ["python", "langevals/server.py"]


### PR DESCRIPTION
## Summary
- Use venv's python directly (`PATH=.venv/bin`) instead of `uv run --no-sync` for langevals CMD
- `uv run --no-sync` doesn't activate editable workspace members (`.pth` files), causing `ModuleNotFoundError: langevals_core`
- All deps are still managed by uv at build time — only the runtime invocation changes

## Test plan
- [ ] Build `next` image, deploy to `lw-helm-v3-test` with `readOnlyRootFilesystem: true`
- [ ] Verify langevals pod starts and passes health check