### PR TITLE
feat: add custom tag input to publish-docker-app workflow

### DIFF
--- a/.github/workflows/publish-docker-app.yml
+++ b/.github/workflows/publish-docker-app.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Custom image tag (default: "next")'
+        required: false
+        default: 'next'
 
 jobs:
   extract-version:
@@ -124,12 +129,14 @@ jobs:
               langwatch/${IMAGE}:${HASH}-arm64
           done
 
-      - name: Create multi-arch manifests (next)
+      - name: Create multi-arch manifests (custom tag)
         if: needs.extract-version.outputs.is_release != 'true'
+        env:
+          TAG: ${{ inputs.tag || 'next' }}
+          HASH: ${{ needs.extract-version.outputs.short_hash }}
         run: |
-          HASH="${{ needs.extract-version.outputs.short_hash }}"
           for IMAGE in langwatch langwatch_nlp langevals; do
-            docker buildx imagetools create -t langwatch/${IMAGE}:next \
+            docker buildx imagetools create -t langwatch/${IMAGE}:${TAG} \
               langwatch/${IMAGE}:${HASH}-amd64 \
               langwatch/${IMAGE}:${HASH}-arm64
           done

--- a/.github/workflows/release-langwatch-chart.yml
+++ b/.github/workflows/release-langwatch-chart.yml
@@ -13,7 +13,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event == 'release')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `tag` input to `publish-docker-app` workflow_dispatch (default: `next`)
- Allows custom tags like `my-custom-in-dev-preview` for testing
- Release flow untouched — custom tag only applies to manual dispatch

## Usage
```bash
gh workflow run publish-docker-app --ref main -f tag=my-preview
```