### PR TITLE
fix: redirect pycache to /tmp for readonly filesystem compat

### DIFF
--- a/Dockerfile.langevals
+++ b/Dockerfile.langevals
@@ -26,6 +26,7 @@ RUN PYTHONPATH="." uv run python langevals/server.py --preload
 
 ENV RUNNING_IN_DOCKER=true
 ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPYCACHEPREFIX=/tmp/pycache
 ENV PATH="/usr/src/app/.venv/bin:$PATH"
 
 # Copy remaining project files (scripts, docs, etc.)

--- a/Dockerfile.langwatch_nlp
+++ b/Dockerfile.langwatch_nlp
@@ -26,6 +26,7 @@ RUN PYTHONPATH=. uv run --no-editable python langwatch_nlp/main.py
 
 ENV RUNNING_IN_DOCKER=true
 ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPYCACHEPREFIX=/tmp/pycache
 
 EXPOSE 5561
 


### PR DESCRIPTION
## Summary
- Add `PYTHONPYCACHEPREFIX=/tmp/pycache` to langevals and NLP Dockerfiles
- Gunicorn workers fork and re-import modules, bypassing `PYTHONDONTWRITEBYTECODE`
- This redirects `__pycache__` writes to `/tmp` (already an emptyDir mount in the helm chart)

## Verified locally
```
docker run --rm --read-only --tmpfs /tmp --tmpfs /.cache \
  -e PYTHONPYCACHEPREFIX=/tmp/pycache -p 5562:5562 \
  langevals-test:local
# healthcheck passes ✓
```

## Test plan
- [ ] Build `next` images, deploy to `lw-helm-v3-test` with `readOnlyRootFilesystem: true`
- [ ] Verify langevals and NLP pods start and pass health checks