### PR TITLE
fix: use python -c for langevals CMD to avoid path shadowing

### DIFF
--- a/Dockerfile.langevals
+++ b/Dockerfile.langevals
@@ -26,6 +26,7 @@ RUN PYTHONPATH="." uv run python langevals/server.py --preload
 
 ENV RUNNING_IN_DOCKER=true
 ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPYCACHEPREFIX=/tmp/pycache
 ENV PATH="/usr/src/app/.venv/bin:$PATH"
 
 # Copy remaining project files (scripts, docs, etc.)

--- a/Dockerfile.langevals
+++ b/Dockerfile.langevals
@@ -33,4 +33,4 @@ ENV PATH="/usr/src/app/.venv/bin:$PATH"
 COPY langevals/scripts/ scripts/
 COPY langevals/Makefile langevals/README.md langevals/LICENSE.md ./
 
-CMD ["python", "langevals/server.py"]
+CMD ["python", "-c", "from langevals.server import main; main()"]

--- a/Dockerfile.langwatch_nlp
+++ b/Dockerfile.langwatch_nlp
@@ -26,6 +26,7 @@ RUN PYTHONPATH=. uv run --no-editable python langwatch_nlp/main.py
 
 ENV RUNNING_IN_DOCKER=true
 ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPYCACHEPREFIX=/tmp/pycache
 
 EXPOSE 5561
 


### PR DESCRIPTION
## Summary
- `python langevals/server.py` adds `langevals/` dir to `sys.path`, shadowing the installed `langevals` package → `ModuleNotFoundError`
- Use `python -c "from langevals.server import main; main()"` instead, which resolves through the venv's site-packages correctly

## Verified locally
```
docker run --rm --read-only --tmpfs /tmp --tmpfs /.cache \
  -p 5562:5562 langevals-test:local2
# healthcheck passes after ~45s startup ✓
```