### PR TITLE
fix: avoid path shadowing in langevals CMD for readonly FS

### DIFF
--- a/Dockerfile.langevals
+++ b/Dockerfile.langevals
@@ -33,4 +33,4 @@ ENV PATH="/usr/src/app/.venv/bin:$PATH"
 COPY langevals/scripts/ scripts/
 COPY langevals/Makefile langevals/README.md langevals/LICENSE.md ./
 
-CMD ["python", "langevals/server.py"]
+CMD ["python", "-c", "from langevals.server import main; main()"]


### PR DESCRIPTION
## Summary
- Change langevals CMD from `python langevals/server.py` to `python -c "from langevals.server import main; main()"`
- `python langevals/server.py` adds the script's parent dir to `sys.path`, shadowing the installed `langevals` package → `ModuleNotFoundError`
- Verified locally with `docker run --read-only --tmpfs /tmp` — healthcheck passes after ~60s startup

1 file, 1 line.