### PR TITLE
ci: replace postgres pg_isready with real psql healthcheck

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -173,7 +173,7 @@ jobs:
           POSTGRES_PASSWORD: ci_password
           POSTGRES_DB: langwatch_test
         options: >-
-          --health-cmd "pg_isready -U langwatch_ci"
+          --health-cmd "PGPASSWORD=ci_password psql -U langwatch_ci -d langwatch_test -c 'select 1'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -129,7 +129,7 @@ jobs:
           POSTGRES_PASSWORD: ci_password
           POSTGRES_DB: langwatch_test
         options: >-
-          --health-cmd "pg_isready -U langwatch_ci"
+          --health-cmd "PGPASSWORD=ci_password psql -U langwatch_ci -d langwatch_test -c 'select 1'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
## Why

Closes #2998

`pg_isready` only checks whether the Postgres server is accepting connections — it exits 0 even when the target database doesn't exist. CI workflows were reporting postgres "healthy" before `langwatch_test` was actually queryable, causing sporadic failures in downstream steps (migrations, e2e) that assumed the database was ready.

## What changed

Replaced `pg_isready -U langwatch_ci` with a real `psql -c 'select 1'` healthcheck against the `langwatch_test` database in both CI workflows:

- `.github/workflows/langwatch-app-ci.yml`
- `.github/workflows/sdk-javascript-ci.yml`

The container now only reports healthy once the specific database is connectable and queryable.

## Test plan

- CI runs confirm postgres service starts successfully and prisma migrations run without connection errors
- The `langwatch-app-ci` workflow's postgres-dependent jobs (test-integration, build) pass with the new healthcheck

## Anything surprising?

The `sdk-javascript-ci` e2e job is failing, but with an unrelated `Cannot find module '@langwatch/mcp-server/dist/create-mcp-server.js'` error — this is a pre-existing breakage also present on `main` (latest 3 runs on main all fail identically). The postgres healthcheck itself works correctly.