### PR TITLE
fix(dev): mount mcp-server/langevals and build mcp-server in compose dev

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -121,6 +121,8 @@ services:
     working_dir: /app
     volumes:
       - ./langwatch:/app
+      - ./mcp-server:/mcp-server
+      - ./langevals:/langevals
       - app_modules:/app/node_modules
       - pnpm_store:/root/.local/share/pnpm/store
     command: >
@@ -128,15 +130,8 @@ services:
         corepack enable &&
         pnpm config set store-dir /root/.local/share/pnpm/store &&
         mkdir -p /app/node_modules &&
-        LOCK_HASH=$$(md5sum /app/pnpm-lock.yaml | cut -d' ' -f1) &&
-        if [ ! -f /app/node_modules/.install-hash ] ||
-           [ \"$$LOCK_HASH\" != \"$$(cat /app/node_modules/.install-hash)\" ]; then
-          echo 'Lockfile changed — running pnpm install...' &&
-          pnpm install &&
-          echo $$LOCK_HASH > /app/node_modules/.install-hash
-        else
-          echo 'Lockfile unchanged — skipping pnpm install'
-        fi &&
+        (cd /mcp-server && pnpm install --ignore-scripts && pnpm run build) &&
+        pnpm install &&
         pnpm prisma generate &&
         pnpm run types:zod:generate
       "
@@ -153,6 +148,8 @@ services:
     working_dir: /app
     volumes:
       - ./langwatch:/app
+      - ./mcp-server:/mcp-server
+      - ./langevals:/langevals
       - app_modules:/app/node_modules
     command: >
       sh -c "
@@ -199,6 +196,8 @@ services:
     profiles: [workers, scenarios, full]
     volumes:
       - ./langwatch:/app
+      - ./mcp-server:/mcp-server
+      - ./langevals:/langevals
       - app_modules:/app/node_modules
     command: sh -c "corepack enable && while true; do pnpm tsx --tsconfig tsconfig.workers.json src/workers.ts; sleep 1; done"
     environment:
@@ -284,6 +283,8 @@ services:
     profiles: [test, scenarios, full]
     volumes:
       - ./langwatch:/app
+      - ./mcp-server:/mcp-server
+      - ./langevals:/langevals
       - app_modules:/app/node_modules
     command: sh -c "corepack enable && pnpm tsx scripts/ai-server.ts"
     ports:


### PR DESCRIPTION
## Problem

`make dev` fails with `ENOENT: no such file or directory, scandir '/mcp-server'`, and after a partial fix with `Cannot find module '@langwatch/mcp-server/dist/create-mcp-server.js'`.

## Root cause

`langwatch/package.json` declares `"@langwatch/mcp-server": "file:../mcp-server"`, but `compose.dev.yml` only mounts `./langwatch:/app`. So `../mcp-server` resolves to `/mcp-server` which doesn't exist. mcp-server's build also imports from `langevals/ts-integration/evaluators.generated.ts`, so langevals must be mounted too. And nothing in dev ever runs `pnpm run build` inside mcp-server, so its `dist/` exports are missing.

A stale `.install-hash` short-circuit in the init container also caused broken installs to persist across rebuilds.

## Fix

- Mount `./mcp-server` and `./langevals` in every dev service that runs `pnpm install` or imports the package: `init`, `app`, `workers`, `ai-server`.
- In the `init` container, build mcp-server before running langwatch's `pnpm install`, so pnpm picks up the built `dist/` when it copies the `file:` dep into `node_modules`.
- Remove the `.install-hash` short-circuit. pnpm with a warm store is already fast and the cache caused stale broken installs.

Closes #3002

## Test plan
- [ ] `make dev` boots cleanly from a fresh checkout
- [ ] `docker compose -f compose.dev.yml config -q` passes
- [ ] App can import `@langwatch/mcp-server` at runtime

# Related Issue

- Resolve #3002