### PR TITLE
fix: increase scenario execution timeout from 5 to 15 minutes

### DIFF
--- a/langwatch/src/server/scenarios/__tests__/stall-detection-batch.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/stall-detection-batch.unit.test.ts
@@ -52,7 +52,7 @@ describe("getScenarioRunDataBatch()", () => {
         const projectId = "test-project";
 
         // Run A: finished with SUCCESS 20 min ago
-        // Run B: started 15 min ago, no finish -> beyond 10-min threshold -> STALLED
+        // Run B: started 35 min ago, no finish -> beyond 30-min threshold -> STALLED
         // Run C: started 2 min ago, no finish -> within threshold -> IN_PROGRESS
         mockGetRunStartedEvents.mockResolvedValue(
           new Map([
@@ -71,7 +71,7 @@ describe("getScenarioRunDataBatch()", () => {
               "run-B",
               {
                 type: ScenarioEventType.RUN_STARTED,
-                timestamp: minutesAgo(15),
+                timestamp: minutesAgo(35),
                 batchRunId: "batch-1",
                 scenarioId: "scenario-2",
                 scenarioRunId: "run-B",

--- a/langwatch/src/server/scenarios/__tests__/stall-detection.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/stall-detection.unit.test.ts
@@ -29,7 +29,7 @@ describe("resolveRunStatus()", () => {
       it("returns STALLED", () => {
         const status = resolveRunStatus({
           finishedStatus: undefined,
-          lastEventTimestamp: minutesAgo(15),
+          lastEventTimestamp: minutesAgo(35),
           now: NOW,
         });
 

--- a/langwatch/src/server/scenarios/scenario.constants.ts
+++ b/langwatch/src/server/scenarios/scenario.constants.ts
@@ -35,5 +35,5 @@ export const SCENARIO_WORKER = {
 /** Child process configuration */
 export const CHILD_PROCESS = {
   /** Timeout for scenario child process execution (ms) */
-  TIMEOUT_MS: 5 * 60 * 1000, // 5 minutes
+  TIMEOUT_MS: 15 * 60 * 1000, // 15 minutes
 } as const;

--- a/langwatch/src/server/scenarios/stall-detection.ts
+++ b/langwatch/src/server/scenarios/stall-detection.ts
@@ -1,11 +1,12 @@
 import { ScenarioRunStatus } from "./scenario-event.enums";
+import { CHILD_PROCESS } from "./scenario.constants";
 
 /**
  * Threshold in milliseconds after which a run without RUN_FINISHED
- * is considered stalled. Set to 10 minutes (2x the 5-minute job timeout)
+ * is considered stalled. Set to 2x the child process timeout
  * to cover all reasonable completion scenarios.
  */
-export const STALL_THRESHOLD_MS = 10 * 60 * 1000;
+export const STALL_THRESHOLD_MS = CHILD_PROCESS.TIMEOUT_MS * 2;
 
 /**
  * Resolves the effective status of a scenario run, deriving STALLED


### PR DESCRIPTION
## Summary
- Increase `CHILD_PROCESS.TIMEOUT_MS` from 5 minutes to 15 minutes — platform scenarios were timing out at ~297s even when actively progressing through LLM turns
- Derive `STALL_THRESHOLD_MS` from `CHILD_PROCESS.TIMEOUT_MS * 2` instead of hardcoding 10 minutes, so the two values stay in sync automatically
- Update stall detection tests to use timestamps beyond the new 30-minute threshold

## Context
The SDK's `maxTurns` (default 10) handles normal scenario termination. The wall-clock timeout is just a safety net for genuinely stuck processes. With 10 turns and 3 agents per turn (agent + user simulator + judge), each making LLM calls at ~10-15s, complex scenarios easily exceed 5 minutes.

## Test plan
- [x] `stall-detection.unit.test.ts` — 8 tests pass
- [x] `stall-detection-batch.unit.test.ts` — 2 tests pass
- [x] Manual: run a platform scenario with a slow model that takes >5 min — should complete instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)