### PR TITLE
feat: JSON syntax highlighting and dark mode border fixes for onboarding MCP screens

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -137,6 +137,7 @@ services:
       "
     environment:
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+      CI: "true"
 
   # =============================================================================
   # APP (mounted for hot reload)

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -40,7 +40,7 @@
     "prisma:generate:migration": "pnpm prisma migrate dev --create-only",
     "prisma:migrate": "sh -c 'if [ \"$SKIP_PRISMA_MIGRATE\" != \"true\" ]; then pnpm prisma migrate deploy; else echo \"Skipping Prisma migrations\"; fi'",
     "prisma:seed": "tsx prisma/seed.ts",
-    "elastic:migrate": "sh -c 'if [ \"$SKIP_ELASTIC_MIGRATE\" != \"true\" ]; then pnpm run task elasticMigrate; else echo \"Skipping Elasticsearch migrations\"; fi'",
+    "elastic:migrate": "sh -c 'set -a; [ -f .env ] && . ./.env; set +a; if [ \"$SKIP_ELASTIC_MIGRATE\" != \"true\" ]; then pnpm run task elasticMigrate; else echo \"Skipping Elasticsearch migrations\"; fi'",
     "clickhouse:migrate": "sh -c 'if [ \"$SKIP_CLICKHOUSE_MIGRATE\" != \"true\" ]; then pnpm run task clickhouseMigrate; else echo \"Skipping ClickHouse migrations\"; fi'",
     "types:zod:generate": "./scripts/generate-zod-types.sh",
     "copy:langevals-types": "cp ../langevals/ts-integration/evaluators.generated.ts src/server/evaluations/evaluators.generated.ts",

--- a/langwatch/src/components/scenarios/SaveAndRunMenu.tsx
+++ b/langwatch/src/components/scenarios/SaveAndRunMenu.tsx
@@ -99,7 +99,7 @@ export function SaveAndRunMenu({
           }, 0);
         }
       }}
-      positioning={{ placement: "top-end" }}
+      positioning={{ placement: "bottom-end" }}
     >
       <Popover.Trigger asChild>
         <Button colorPalette="blue" size="sm" loading={isLoading}>

--- a/langwatch/src/components/scenarios/TargetSelector.tsx
+++ b/langwatch/src/components/scenarios/TargetSelector.tsx
@@ -111,11 +111,11 @@ export function TargetSelector({
     const next = !open;
     setOpen(next);
     if (next) {
-      // Cap dropdown height to available space above the trigger
+      // Cap dropdown height to available space below the trigger
       const triggerRect = triggerRef.current?.getBoundingClientRect();
       if (triggerRect) {
-        const spaceAbove = triggerRect.top - 8; // 8px padding from viewport edge
-        setMaxDropdownHeight(Math.min(400, Math.max(150, spaceAbove)));
+        const spaceBelow = window.innerHeight - triggerRect.bottom - 8; // 8px padding from viewport edge
+        setMaxDropdownHeight(Math.min(400, Math.max(150, spaceBelow)));
       }
       setTimeout(() => {
         inputRef.current?.focus();
@@ -149,11 +149,11 @@ export function TargetSelector({
       {open && (
         <Box
           position="absolute"
-          bottom="100%"
+          top="100%"
           left={0}
           width="300px"
           maxHeight={`${maxDropdownHeight}px`}
-          marginBottom={1}
+          marginTop={1}
           borderRadius="lg"
           borderWidth="1px"
           borderColor="border"

--- a/langwatch/src/components/scenarios/TargetSelector.tsx
+++ b/langwatch/src/components/scenarios/TargetSelector.tsx
@@ -115,7 +115,7 @@ export function TargetSelector({
       const triggerRect = triggerRef.current?.getBoundingClientRect();
       if (triggerRect) {
         const spaceBelow = window.innerHeight - triggerRect.bottom - 8; // 8px padding from viewport edge
-        setMaxDropdownHeight(Math.min(400, Math.max(150, spaceBelow)));
+        setMaxDropdownHeight(Math.min(400, Math.max(40, spaceBelow)));
       }
       setTimeout(() => {
         inputRef.current?.focus();

--- a/langwatch/src/features/onboarding/components/sections/ProductSelectionScreen.tsx
+++ b/langwatch/src/features/onboarding/components/sections/ProductSelectionScreen.tsx
@@ -72,7 +72,7 @@ export const ProductSelectionScreen: React.FC<ProductSelectionScreenProps> = ({
           borderRadius="2xl"
           bg="bg.panel/80"
           border="1px solid"
-          borderColor="border.subtle"
+          borderColor={{ base: "orange.200", _dark: "orange.800" }}
           boxShadow="sm"
           backdropFilter="blur(20px) saturate(1.3)"
           px={6}
@@ -87,12 +87,12 @@ export const ProductSelectionScreen: React.FC<ProductSelectionScreenProps> = ({
           textAlign="left"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.32, delay: i * 0.064, ease: "easeOut" }}
+          transition={{ duration: 0.27, delay: i * 0.054, ease: "easeOut" }}
           whileHover={{
             y: -3,
             boxShadow:
               "0 12px 40px rgba(0,0,0,0.08), 0 2px 6px rgba(0,0,0,0.04)",
-            borderColor: "var(--chakra-colors-orange-200)",
+            borderColor: "var(--chakra-colors-orange-emphasized)",
             transition: { duration: 0.25, ease: "easeOut" },
           }}
           whileTap={{ scale: 0.98, transition: { duration: 0.1 } }}

--- a/langwatch/src/features/onboarding/components/sections/ViaClaudeCodeScreen.tsx
+++ b/langwatch/src/features/onboarding/components/sections/ViaClaudeCodeScreen.tsx
@@ -20,6 +20,7 @@ import { maskApiKey } from "./shared/api-key-utils";
 import { buildMcpJson, CLOUD_ENDPOINT } from "./shared/build-mcp-config";
 import { copyToClipboard } from "./shared/copy-to-clipboard";
 import { InlineCopyButton } from "./shared/InlineCopyButton";
+import { JsonHighlight } from "./shared/JsonHighlight";
 import { TabButton } from "./shared/TabButton";
 
 type TabKey = "prompt" | "skill" | "mcp";
@@ -103,7 +104,7 @@ function glassCard({
   return {
     borderRadius: "xl",
     border: "1px solid",
-    borderColor: highlight ? "orange.200" : "border.subtle",
+    borderColor: highlight ? { base: "orange.200", _dark: "orange.800" } : "border.subtle",
     bg: highlight ? "orange.subtle" : "bg.panel/70",
     backdropFilter: "blur(20px) saturate(1.3)",
     boxShadow: highlight
@@ -111,7 +112,7 @@ function glassCard({
       : "sm",
     transition: "all 0.17s ease",
     _hover: {
-      borderColor: highlight ? "orange.300" : "border.emphasized",
+      borderColor: highlight ? "orange.emphasized" : "border.emphasized",
       boxShadow: highlight
         ? "0 0 0 1px var(--chakra-colors-orange-200)"
         : "md",
@@ -311,27 +312,11 @@ function McpTab({
         boxShadow="0 1px 3px rgba(0,0,0,0.04)"
         transition="all 0.17s ease"
         _hover={{
-          borderColor: "orange.200",
+          borderColor: "orange.emphasized",
           boxShadow: "0 6px 28px rgba(237,137,38,0.06)",
         }}
       >
-        <Box
-          as="pre"
-          px={5}
-          py={4}
-          pr={12}
-          fontSize="12.5px"
-          fontFamily="'Geist Mono', 'IBM Plex Mono', 'Source Code Pro', Menlo, monospace"
-          color="fg.DEFAULT"
-          lineHeight="1.8"
-          overflowX="hidden"
-          whiteSpace="pre-wrap"
-          wordBreak="break-all"
-          letterSpacing="0.01em"
-          fontWeight="500"
-        >
-          {displayConfigJson}
-        </Box>
+        <JsonHighlight code={displayConfigJson} />
         <Box position="absolute" top={2.5} right={2.5}>
           <InlineCopyButton text={mcpJson} label="Config" />
         </Box>
@@ -355,7 +340,7 @@ function McpTab({
               borderColor="border.subtle"
               cursor="pointer"
               transition="all 0.15s ease"
-              _hover={{ borderColor: "orange.200", bg: "bg.panel" }}
+              _hover={{ borderColor: "orange.emphasized", bg: "bg.panel" }}
               onClick={() => {
                 void copyToClipboard({
                   text: ep.path,

--- a/langwatch/src/features/onboarding/components/sections/ViaClaudeDesktopScreen.tsx
+++ b/langwatch/src/features/onboarding/components/sections/ViaClaudeDesktopScreen.tsx
@@ -9,6 +9,7 @@ import { useActiveProject } from "../../contexts/ActiveProjectContext";
 import { maskApiKey } from "./shared/api-key-utils";
 import { buildMcpConfig } from "./shared/build-mcp-config";
 import { InlineCopyButton } from "./shared/InlineCopyButton";
+import { JsonHighlight } from "./shared/JsonHighlight";
 import { TabButton } from "./shared/TabButton";
 
 const MotionVStack = motion(VStack);
@@ -237,27 +238,11 @@ export function ViaMcpClientScreen(): React.ReactElement {
           boxShadow="sm"
           transition="all 0.17s ease"
           _hover={{
-            borderColor: "orange.200",
+            borderColor: "orange.emphasized",
             boxShadow: "md",
           }}
         >
-          <Box
-            as="pre"
-            px={5}
-            py={4}
-            pr={12}
-            fontSize="12.5px"
-            fontFamily="'Geist Mono', 'IBM Plex Mono', 'Source Code Pro', Menlo, monospace"
-            color="fg.DEFAULT"
-            lineHeight="1.8"
-            overflowX="hidden"
-            whiteSpace="pre-wrap"
-            wordBreak="break-all"
-            letterSpacing="0.01em"
-            fontWeight="500"
-          >
-            {displayConfigJson ?? "Loading config…"}
-          </Box>
+          <JsonHighlight code={displayConfigJson ?? "Loading config…"} />
           {configJson && (
             <Box position="absolute" top={2.5} right={2.5}>
               <InlineCopyButton text={configJson} label="Config" />

--- a/langwatch/src/features/onboarding/components/sections/ViaPlatformScreen.tsx
+++ b/langwatch/src/features/onboarding/components/sections/ViaPlatformScreen.tsx
@@ -78,14 +78,14 @@ function CapabilityCard({
       flex={1}
       borderRadius="xl"
       border="1px solid"
-      borderColor="gray.200"
+      borderColor={{ base: "orange.200", _dark: "orange.800" }}
       bg="bg.panel/70"
       backdropFilter="blur(20px) saturate(1.3)"
       boxShadow="0 1px 3px rgba(0,0,0,0.04)"
       transition="all 0.2s ease"
       cursor="pointer"
       _hover={{
-        borderColor: "orange.200",
+        borderColor: "orange.emphasized",
         boxShadow:
           "0 6px 28px rgba(237,137,38,0.06)",
         transform: "translateY(-2px)",

--- a/langwatch/src/features/onboarding/components/sections/ViaPlatformScreen.tsx
+++ b/langwatch/src/features/onboarding/components/sections/ViaPlatformScreen.tsx
@@ -157,7 +157,7 @@ export function ViaPlatformScreen(): React.ReactElement {
             alignItems="center"
             gap="4px"
             fontSize="13px"
-            color="#51676C"
+            color={{ base: "#51676C", _dark: "white" }}
             textDecoration="none"
           >
             Read the docs

--- a/langwatch/src/features/onboarding/components/sections/shared/JsonHighlight.tsx
+++ b/langwatch/src/features/onboarding/components/sections/shared/JsonHighlight.tsx
@@ -1,0 +1,85 @@
+import { ClientOnly, CodeBlock, createShikiAdapter } from "@chakra-ui/react";
+import type React from "react";
+import { useMemo } from "react";
+import type { HighlighterGeneric } from "shiki";
+import { useColorMode } from "~/components/ui/color-mode";
+
+export function JsonHighlight({
+  code,
+}: {
+  code: string;
+}): React.ReactElement {
+  const { colorMode } = useColorMode();
+
+  const shikiAdapter = useMemo(
+    () =>
+      createShikiAdapter<HighlighterGeneric<any, any>>({
+        async load() {
+          const { createHighlighter } = await import("shiki");
+          return createHighlighter({
+            langs: ["json"],
+            themes: ["github-dark", "github-light"],
+          });
+        },
+        theme: colorMode === "dark" ? "github-dark" : "github-light",
+      }),
+    [colorMode],
+  );
+
+  return (
+    <CodeBlock.AdapterProvider value={shikiAdapter}>
+      <ClientOnly
+        fallback={
+          <pre
+            style={{
+              padding: "16px 48px 16px 20px",
+              fontSize: "12.5px",
+              fontFamily:
+                "'Geist Mono', 'IBM Plex Mono', 'Source Code Pro', Menlo, monospace",
+              lineHeight: "1.8",
+              overflowX: "hidden",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-all",
+              letterSpacing: "0.01em",
+              fontWeight: "500",
+            }}
+          >
+            {code}
+          </pre>
+        }
+      >
+        {() => (
+          <CodeBlock.Root
+            code={code}
+            language="json"
+            size="sm"
+            bg="transparent"
+            border="none"
+            borderRadius="0"
+          >
+            <CodeBlock.Content
+              overflowX="hidden"
+              css={{
+                "& pre": {
+                  padding: "16px 48px 16px 20px",
+                  fontSize: "12.5px",
+                  fontFamily:
+                    "'Geist Mono', 'IBM Plex Mono', 'Source Code Pro', Menlo, monospace",
+                  lineHeight: "1.8",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-all",
+                  letterSpacing: "0.01em",
+                  background: "transparent",
+                },
+              }}
+            >
+              <CodeBlock.Code>
+                <CodeBlock.CodeText />
+              </CodeBlock.Code>
+            </CodeBlock.Content>
+          </CodeBlock.Root>
+        )}
+      </ClientOnly>
+    </CodeBlock.AdapterProvider>
+  );
+}

--- a/langwatch/src/features/onboarding/components/sections/shared/TabButton.tsx
+++ b/langwatch/src/features/onboarding/components/sections/shared/TabButton.tsx
@@ -20,7 +20,7 @@ export function TabButton({
       py={1.5}
       fontSize="sm"
       fontWeight={active ? "semibold" : "medium"}
-      color={active ? "fg.DEFAULT" : "fg.muted"}
+      color={active ? "orange.500" : "fg.muted"}
       bg={active ? "bg.panel" : "transparent"}
       backdropFilter={active ? "blur(20px) saturate(1.3)" : undefined}
       boxShadow={
@@ -29,7 +29,7 @@ export function TabButton({
           : undefined
       }
       border="1px solid"
-      borderColor={active ? "gray.200" : "transparent"}
+      borderColor={active ? { base: "orange.200", _dark: "orange.800" } : "transparent"}
       transition="all 0.17s ease"
       _hover={{ bg: active ? "bg.panel" : "bg.muted" }}
       letterSpacing="-0.01em"


### PR DESCRIPTION
## Summary

- Add `JsonHighlight` component using Chakra `CodeBlock` + Shiki adapter (adapts to light/dark mode)
- Apply JSON highlighting to MCP config blocks in the coding agent MCP tab and the MCP client screen
- Fix hardcoded `orange.200`/`orange.300` hover borders → `orange.emphasized` across all onboarding screens for proper dark mode contrast
- Fix default card borders to use `{ base: orange.200, _dark: orange.800 }` in `ProductSelectionScreen` and `ViaPlatformScreen`
- Minor dev environment fixes: load `.env` in `elastic:migrate`, set `CI=true` in dev compose

## Test plan

- [ ] Open onboarding → Via Coding Agent → MCP tab: config JSON is syntax-highlighted
- [ ] Open onboarding → Via MCP: config JSON is syntax-highlighted
- [ ] Toggle dark mode: highlighting and borders look correct in both modes
- [ ] Copy button still copies the real (unmasked) API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)