### PR TITLE
fix(mcp): add files field so pnpm copies dist/ into node_modules

### DIFF
--- a/langwatch/src/server.ts
+++ b/langwatch/src/server.ts
@@ -10,7 +10,5 @@ if (process.env.NODE_ENV === "production") {
   events.EventEmitter.defaultMaxListeners = 128;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { startApp } = require("./start.js");
-
+const { startApp } = await import("./start");
 void startApp();

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -60,7 +60,7 @@ const isMetricsAuthorized = (req: IncomingMessage): boolean => {
   );
 };
 
-module.exports.startApp = async (dir = path.dirname(__dirname)) => {
+export const startApp = async (dir = path.dirname(__dirname)) => {
   const dev = process.env.NODE_ENV !== "production";
 
   const hostname = "0.0.0.0";


### PR DESCRIPTION
## Root cause
`server.ts` loads start.ts via CJS `require("./start.js")`. This means handler.ts and all MCP config imports go through the CJS module cache. But the tsup-built `dist/` chunks are ESM modules — they load through the ESM module cache. **CJS and ESM maintain separate module caches**, so `initConfig()` via CJS sets `globalConfig` on one instance while the built tool handlers read from another (uninitialized) ESM instance → "Config not initialized".

Confirmed in production pod:
```
Same getConfig? false
Same initConfig? false
ESM FAILS: Config not initialized
```

## Fix
- Change `server.ts` from `require("./start.js")` to `import("./start.js")` so the entire import chain uses ESM, sharing the same module cache as the built dist/ chunks
- Also add `files` field to mcp-server package.json (ensures dist/ is included in pnpm copies)

## Test plan
- [ ] Docker build succeeds
- [ ] After deploy, `search_traces` and `fetch_langwatch_docs` work via Claude Chat