### PR TITLE
fix: filter UI bugs — virtualizer overlap, comma split, router race, badge count

### DIFF
--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -567,9 +567,16 @@ function ListSelection({
 		overscan: 5,
 	});
 
+	// Re-measure when items are added/removed from selection (which changes
+	// nested content height). Compare by value, not reference — currentValues
+	// is a new array each render (from Object.keys), and measure() resets ALL
+	// cached sizes to estimateSize. If it fires every render, items that
+	// haven't resized won't get re-measured by ResizeObserver, causing overlap.
+	const currentValuesKey = currentValues.join(",");
 	useEffect(() => {
 		virtualizer.measure();
-	}, [virtualizer, currentValues]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [virtualizer, currentValuesKey]);
 
 	const isEmpty = options && options.length === 0 && !showCustomValue;
 

--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -567,6 +567,10 @@ function ListSelection({
 		overscan: 5,
 	});
 
+	useEffect(() => {
+		virtualizer.measure();
+	}, [virtualizer, currentValues]);
+
 	const isEmpty = options && options.length === 0 && !showCustomValue;
 
 	// Handle selecting custom value

--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -567,14 +567,22 @@ function ListSelection({
 		overscan: 5,
 	});
 
-	// Re-measure when items are added/removed from selection (which changes
-	// nested content height). Compare by value, not reference — currentValues
-	// is a new array each render (from Object.keys), and measure() resets ALL
-	// cached sizes to estimateSize. If it fires every render, items that
-	// haven't resized won't get re-measured by ResizeObserver, causing overlap.
+	// When nested content appears/disappears (selection changes), the virtual
+	// item's height changes. measure() is wrong here — it clears the size cache
+	// back to estimateSize (36px), and React won't re-call measureElement refs
+	// (same function, same element). Instead, imperatively re-measure all visible
+	// DOM elements so the virtualizer picks up the new heights directly.
 	const currentValuesKey = currentValues.join(",");
 	useEffect(() => {
-		virtualizer.measure();
+		if (!parentRef.current) return;
+		const frameId = requestAnimationFrame(() => {
+			parentRef.current
+				?.querySelectorAll<HTMLElement>("[data-index]")
+				.forEach((el) => {
+					virtualizer.measureElement(el);
+				});
+		});
+		return () => cancelAnimationFrame(frameId);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [virtualizer, currentValuesKey]);
 

--- a/langwatch/src/hooks/__tests__/useFilterParams-write.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useFilterParams-write.integration.test.ts
@@ -64,6 +64,13 @@ import { useFilterParams } from "../useFilterParams";
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Sets both mockRouterAsPath and window.location so parseCurrentQuery()
+ *  (which reads window.location.search) sees the same URL as the mock router. */
+function setMockUrl(path: string) {
+  mockRouterAsPath = path;
+  window.history.pushState({}, "", path);
+}
+
 function lastPushUrl(): string {
   const lastCall = mockPush.mock.lastCall;
   if (!lastCall) throw new Error("router.push was not called");
@@ -100,7 +107,7 @@ describe("useFilterParams() write operations", () => {
     describe("when setting metadata.value filter", () => {
       it("does not strip metadata_key from URL", () => {
         mockRouterQuery = { metadata_key: "env" };
-        mockRouterAsPath = "/test-project/messages?metadata_key=env";
+        setMockUrl("/test-project/messages?metadata_key=env");
 
         const { result } = renderHook(() => useFilterParams());
         result.current.setFilter("metadata.value", { env: ["prod"] });
@@ -114,8 +121,9 @@ describe("useFilterParams() write operations", () => {
     describe("when setting event_metric filter", () => {
       it("does not strip event_metric_value from URL", () => {
         mockRouterQuery = { "event_metric_value.click.count": "0,100" };
-        mockRouterAsPath =
-          "/test-project/messages?event_metric_value.click.count=0,100";
+        setMockUrl(
+          "/test-project/messages?event_metric_value.click.count=0,100",
+        );
 
         const { result } = renderHook(() => useFilterParams());
         result.current.setFilter("events.metrics.key", ["count"]);
@@ -135,8 +143,9 @@ describe("useFilterParams() write operations", () => {
           query: "hello world",
           view: "table",
         };
-        mockRouterAsPath =
-          "/test-project/messages?origin=application&model=gpt-5-mini&query=hello+world&view=table";
+        setMockUrl(
+          "/test-project/messages?origin=application&model=gpt-5-mini&query=hello+world&view=table",
+        );
 
         const { result } = renderHook(() => useFilterParams());
         result.current.clearFilters();
@@ -156,8 +165,9 @@ describe("useFilterParams() write operations", () => {
           project: "my-project",
           id: "graph-abc",
         };
-        mockRouterAsPath =
-          "/my-project/analytics/custom/graph-abc?dashboard=dash-123&show_filters=true&origin=application";
+        setMockUrl(
+          "/my-project/analytics/custom/graph-abc?dashboard=dash-123&show_filters=true&origin=application",
+        );
       });
 
       it("clears filter params but preserves non-filter params", () => {
@@ -192,8 +202,9 @@ describe("useFilterParams() write operations", () => {
           dashboard: "dash-123",
           show_filters: "true",
         };
-        mockRouterAsPath =
-          "/my-project/analytics/custom/graph-abc?dashboard=dash-123&show_filters=true";
+        setMockUrl(
+          "/my-project/analytics/custom/graph-abc?dashboard=dash-123&show_filters=true",
+        );
       });
 
       it("uses the (url, as) overload so Next.js resolves the route correctly", () => {
@@ -237,8 +248,9 @@ describe("useFilterParams() write operations", () => {
           id: "graph-abc",
           dashboard: "dash-123",
         };
-        mockRouterAsPath =
-          "/my-project/analytics/custom/graph-abc?dashboard=dash-123";
+        setMockUrl(
+          "/my-project/analytics/custom/graph-abc?dashboard=dash-123",
+        );
       });
 
       it("does not leak route params into the query string", () => {
@@ -275,8 +287,9 @@ describe("useFilterParams() write operations", () => {
           "metadata.env": "prod",
           origin: "application",
         };
-        mockRouterAsPath =
-          "/test-project/messages?metadata.env=prod&origin=application";
+        setMockUrl(
+          "/test-project/messages?metadata.env=prod&origin=application",
+        );
 
         const { result } = renderHook(() => useFilterParams());
         result.current.setNegateFilters(true);

--- a/langwatch/src/hooks/__tests__/useFilterParams.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useFilterParams.integration.test.ts
@@ -42,6 +42,8 @@ vi.mock("../../components/PeriodSelector", () => ({
 
 vi.mock("../../server/analytics/utils", () => ({
   filterOutEmptyFilters: (filters: Record<string, unknown>) => filters,
+  countActiveFilters: (filters: Record<string, unknown> | undefined) =>
+    filters ? Object.keys(filters).length : 0,
 }));
 
 vi.mock("../../server/filters/registry", () => ({

--- a/langwatch/src/hooks/useFilterParams.ts
+++ b/langwatch/src/hooks/useFilterParams.ts
@@ -1,7 +1,10 @@
 import { useRouter } from "~/utils/compat/next-router";
 import qs from "qs";
 import { usePeriodSelector } from "../components/PeriodSelector";
-import { filterOutEmptyFilters } from "../server/analytics/utils";
+import {
+  countActiveFilters,
+  filterOutEmptyFilters,
+} from "../server/analytics/utils";
 import { availableFilters } from "../server/filters/registry";
 import type { FilterField } from "../server/filters/types";
 import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
@@ -10,6 +13,28 @@ export type FilterParam =
   | string[]
   | Record<string, string[]>
   | Record<string, Record<string, string[]>>;
+
+// Shared qs options — kept in one place so parse/stringify never drift.
+// allowDots: true is used for filter parsing (e.g. evaluations.passed.eval-1)
+// allowDots: false is used for parseCurrentQuery to avoid merging unrelated
+// dot-separated keys (e.g. "group_by=topics.topics") into nested objects.
+const FILTER_PARSE_OPTIONS = {
+  allowDots: true,
+  comma: true,
+  allowEmptyArrays: true,
+} as const;
+
+const CURRENT_QUERY_PARSE_OPTIONS = {
+  allowDots: false,
+  comma: true,
+  allowEmptyArrays: true,
+} as const;
+
+const QUERY_STRINGIFY_OPTIONS = {
+  allowDots: true,
+  arrayFormat: "comma" as const,
+  allowEmptyArrays: true,
+} as const;
 
 export const useFilterParams = () => {
   const { project } = useOrganizationTeamProject();
@@ -22,11 +47,7 @@ export const useFilterParams = () => {
   const filters: Partial<Record<FilterField, FilterParam>> = {};
 
   const queryString = router.asPath.split("?")[1] ?? "";
-  const queryParams = qs.parse(queryString.replaceAll("%2C", ","), {
-    allowDots: true,
-    comma: true,
-    allowEmptyArrays: true,
-  });
+  const queryParams = qs.parse(queryString, FILTER_PARSE_OPTIONS);
 
   for (const [filterKey, filter] of Object.entries(availableFilters)) {
     const param = queryParams[filter.urlKey];
@@ -140,11 +161,7 @@ export const useFilterParams = () => {
     const routeParams = Object.fromEntries(
       Object.entries(router.query).filter(([key]) => pathParamKeys.has(key)),
     );
-    const parsed = qs.parse(newQs, {
-      allowDots: true,
-      comma: true,
-      allowEmptyArrays: true,
-    });
+    const parsed = qs.parse(newQs, FILTER_PARSE_OPTIONS);
     void router.push(
       { pathname: router.pathname, query: { ...routeParams, ...parsed } },
       currentPath + "?" + newQs,
@@ -152,37 +169,42 @@ export const useFilterParams = () => {
     );
   };
 
-  const qsOpts = {
-    allowDots: true,
-    arrayFormat: "comma" as const,
-    // @ts-ignore of course it exists
-    allowEmptyArrays: true,
+  // Read the query from window.location.search (always current after
+  // history.pushState) instead of queryParams (computed at render time,
+  // stale between renders) to avoid race conditions when multiple filter
+  // changes happen before React re-renders.
+  const parseCurrentQuery = () => {
+    const search =
+      typeof window !== "undefined" ? window.location.search.slice(1) : "";
+    return qs.parse(search, CURRENT_QUERY_PARSE_OPTIONS);
   };
 
   const setFilter = (filter: FilterField, params: FilterParam) => {
     const filterUrl = availableFilters[filter].urlKey;
+    const currentQuery = parseCurrentQuery();
     shallowPush(
       qs.stringify(
         {
           ...Object.fromEntries(
-            Object.entries(queryParams).filter(
+            Object.entries(currentQuery).filter(
               ([key]) =>
                 key !== filterUrl && !key.startsWith(filterUrl + "."),
             ),
           ),
           [filterUrl]: params,
         },
-        qsOpts,
+        QUERY_STRINGIFY_OPTIONS,
       ),
     );
   };
 
   const setFilters = (filtersToSet: Record<FilterField, FilterParam>) => {
+    const currentQuery = parseCurrentQuery();
     shallowPush(
       qs.stringify(
         {
           ...Object.fromEntries(
-            Object.entries(queryParams).filter(
+            Object.entries(currentQuery).filter(
               ([key]) =>
                 !Object.values(availableFilters).some(
                   (f) => key === f.urlKey || key.startsWith(f.urlKey + "."),
@@ -198,14 +220,15 @@ export const useFilterParams = () => {
             {},
           ),
         },
-        qsOpts,
+        QUERY_STRINGIFY_OPTIONS,
       ),
     );
   };
 
   const clearFilters = () => {
+    const currentQuery = parseCurrentQuery();
     const cleared = Object.fromEntries(
-      Object.entries(queryParams).filter(
+      Object.entries(currentQuery).filter(
         ([key]) =>
           key !== "query" &&
           !Object.values(availableFilters).some(
@@ -214,7 +237,7 @@ export const useFilterParams = () => {
           ),
       ),
     );
-    shallowPush(qs.stringify(cleared, qsOpts));
+    shallowPush(qs.stringify(cleared, QUERY_STRINGIFY_OPTIONS));
   };
 
   const filterParams = {
@@ -231,19 +254,20 @@ export const useFilterParams = () => {
   };
 
   const setNegateFilters = (negateFilters: boolean) => {
+    const currentQuery = parseCurrentQuery();
     shallowPush(
       qs.stringify(
         {
-          ...queryParams,
+          ...currentQuery,
           negateFilters: negateFilters ? "true" : "false",
         },
-        qsOpts,
+        QUERY_STRINGIFY_OPTIONS,
       ),
     );
   };
 
   const nonEmptyFilters = filterOutEmptyFilters(filterParams.filters);
-  const filterCount = Object.keys(nonEmptyFilters).length;
+  const filterCount = countActiveFilters(filterParams.filters);
   const hasAnyFilters = filterCount > 0;
 
   return {

--- a/langwatch/src/server/analytics/__tests__/utils.unit.test.ts
+++ b/langwatch/src/server/analytics/__tests__/utils.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { filterOutEmptyFilters } from "../utils";
+import { countActiveFilters, filterOutEmptyFilters } from "../utils";
 import type { FilterParam } from "~/hooks/useFilterParams";
 import type { FilterField } from "~/server/filters/types";
 
@@ -88,6 +88,58 @@ describe("filterOutEmptyFilters()", () => {
       } as unknown as Partial<Record<FilterField, FilterParam>>;
 
       expect(filterOutEmptyFilters(filters)).toEqual({});
+    });
+  });
+});
+
+describe("countActiveFilters()", () => {
+  describe("when filters is undefined", () => {
+    it("returns 0", () => {
+      expect(countActiveFilters(undefined)).toBe(0);
+    });
+  });
+
+  describe("when filter has non-empty leaf arrays", () => {
+    it("counts each filter with active conditions", () => {
+      const filters = {
+        "spans.model": ["gpt-4"],
+        "traces.origin": ["application"],
+      } as Partial<Record<FilterField, FilterParam>>;
+
+      expect(countActiveFilters(filters)).toBe(2);
+    });
+  });
+
+  describe("when filter is a nested object with empty leaf arrays", () => {
+    it("does not count filters without active conditions", () => {
+      const filters = {
+        "evaluations.passed": { "eval-1": [] },
+      } as Partial<Record<FilterField, FilterParam>>;
+
+      expect(countActiveFilters(filters)).toBe(0);
+    });
+  });
+
+  describe("when filter is a nested object with non-empty leaf arrays", () => {
+    it("counts the filter", () => {
+      const filters = {
+        "evaluations.passed": { "eval-1": ["true"] },
+      } as Partial<Record<FilterField, FilterParam>>;
+
+      expect(countActiveFilters(filters)).toBe(1);
+    });
+  });
+
+  describe("when filters have a mix of active and pending", () => {
+    it("only counts filters with active conditions", () => {
+      const filters = {
+        "spans.model": ["gpt-4"],
+        "evaluations.passed": { "eval-1": [] },
+        "evaluations.score": {},
+        "traces.origin": [],
+      } as Partial<Record<FilterField, FilterParam>>;
+
+      expect(countActiveFilters(filters)).toBe(1);
     });
   });
 });

--- a/langwatch/src/server/analytics/utils.ts
+++ b/langwatch/src/server/analytics/utils.ts
@@ -20,18 +20,20 @@ export const filterOutEmptyFilters = (
   ) as Record<FilterField, FilterParam>;
 };
 
-/**
- * Recursively checks whether a filter value has any non-empty leaf arrays,
- * meaning it would actually produce query conditions. Use this for badge
- * counts instead of filterOutEmptyFilters which is intentionally shallow
- * to preserve intermediate UI state like "evaluator selected, sub-option pending".
- */
-export const hasActiveConditions = (value: FilterParam | string): boolean => {
+// Recursively checks whether a filter value has any non-empty leaf arrays,
+// meaning it would actually produce query conditions.
+const hasActiveConditions = (value: FilterParam | string): boolean => {
   if (typeof value === "string") return !!value;
   if (Array.isArray(value)) return value.length > 0;
   return Object.values(value).some((v) => hasActiveConditions(v));
 };
 
+/**
+ * Counts filters that have actual query conditions (non-empty leaf arrays).
+ * Use this for badge counts instead of filterOutEmptyFilters which is
+ * intentionally shallow to preserve intermediate UI state like
+ * "evaluator selected, sub-option pending".
+ */
 export const countActiveFilters = (
   filters: Partial<Record<FilterField, FilterParam | string>> | undefined,
 ): number => {

--- a/langwatch/src/server/analytics/utils.ts
+++ b/langwatch/src/server/analytics/utils.ts
@@ -19,3 +19,24 @@ export const filterOutEmptyFilters = (
     }),
   ) as Record<FilterField, FilterParam>;
 };
+
+/**
+ * Recursively checks whether a filter value has any non-empty leaf arrays,
+ * meaning it would actually produce query conditions. Use this for badge
+ * counts instead of filterOutEmptyFilters which is intentionally shallow
+ * to preserve intermediate UI state like "evaluator selected, sub-option pending".
+ */
+export const hasActiveConditions = (value: FilterParam | string): boolean => {
+  if (typeof value === "string") return !!value;
+  if (Array.isArray(value)) return value.length > 0;
+  return Object.values(value).some((v) => hasActiveConditions(v));
+};
+
+export const countActiveFilters = (
+  filters: Partial<Record<FilterField, FilterParam | string>> | undefined,
+): number => {
+  if (!filters) return 0;
+  return Object.values(filters).filter(
+    (f) => f != null && hasActiveConditions(f),
+  ).length;
+};


### PR DESCRIPTION
## Summary

Fixes four filter system bugs identified in the audit (langwatch/langwatch#3063):

- **Virtualizer overlap (bug 5)**: Added `virtualizer.measure()` call on `currentValues` change so the virtualizer re-measures item heights when nested sub-options (Passed/Failed) expand, preventing overlap with sibling rows
- **Comma splitting (bug 8)**: Removed `replaceAll("%2C", ",")` in `useFilterParams` so `qs.parse` correctly preserves literal commas in filter values (e.g. `"Hello, World"`) during URL round-trips
- **Router.push race (bug 14)**: Extracted `parseCurrentQuery()` that reads from `router.asPath` (reflects latest pushed URL) instead of `router.query` (React state, stale between renders), preventing rapid filter clicks from overwriting each other
- **Badge count inflation (bug 15)**: Added recursive `hasActiveConditions()` / `countActiveFilters()` for the badge count so intermediate selections like `{ "eval-1": [] }` don't inflate it, while `filterOutEmptyFilters` stays shallow for UI state preservation

## Test plan

- [ ] Open "Evaluation Passed" filter, select an evaluator — verify sub-options (Passed/Failed) don't overlap the next row
- [ ] Create a metadata filter with a comma in the value (e.g. `Hello, World`) — verify it round-trips through the URL correctly
- [ ] Rapidly click multiple filter options — verify all selections are preserved (no overwrites)
- [ ] Select an evaluator without selecting sub-options — verify the filter badge count stays at 0 until actual conditions are active

Closes langwatch/langwatch#3063