### PR TITLE
fix: increase WebSocket idle timeout from 120s to 900s

### DIFF
--- a/langwatch_nlp/langwatch_nlp/studio/app.py
+++ b/langwatch_nlp/langwatch_nlp/studio/app.py
@@ -173,7 +173,7 @@ async def execute_event_on_a_subprocess(
 
         process = cast(Any, process)
 
-        timeout_without_messages = 120  # seconds
+        timeout_without_messages = 900  # seconds (match AWS Lambda max execution timeout)
         if isinstance(event, ExecuteOptimization):
             # TODO: temporary until we actually send events in the middle of optimization process
             timeout_without_messages = 120 * 60  # 120 minutes


### PR DESCRIPTION
## Why

Closes #3073

Code nodes in the NLP studio that make long-running calls (e.g. external agent calls taking 8+ minutes) get killed before they complete because the WebSocket idle timeout is hardcoded to 120 seconds.

## What changed

Bumped the default `timeout_without_messages` in `langwatch_nlp/langwatch_nlp/studio/app.py` from 120s to 900s (15 minutes) to match the AWS Lambda maximum execution timeout. There is no benefit to a shorter timeout than the runtime's own cutoff.

## Test plan

- Verified the change is a single constant bump with no behavioral side effects
- The optimization timeout (120 minutes) is unaffected — it has its own override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3073