### PR TITLE
feat: make all NLP service timeouts env-configurable

### DIFF
--- a/Dockerfile.langwatch_nlp
+++ b/Dockerfile.langwatch_nlp
@@ -30,4 +30,4 @@ ENV PYTHONPYCACHEPREFIX=/tmp/pycache
 
 EXPOSE 5561
 
-CMD uv --no-cache run --no-sync --no-editable uvicorn langwatch_nlp.main:app --host 0.0.0.0 --port 5561 --timeout-keep-alive 4500 | tee /var/log/uvicorn.log
+CMD ["sh", "-c", "uv --no-cache run --no-sync --no-editable uvicorn langwatch_nlp.main:app --host 0.0.0.0 --port 5561 --timeout-keep-alive ${NLP_UVICORN_KEEP_ALIVE_SECONDS:-4500} | tee /var/log/uvicorn.log"]

--- a/Dockerfile.langwatch_nlp.lambda
+++ b/Dockerfile.langwatch_nlp.lambda
@@ -32,4 +32,4 @@ ENV RUNNING_IN_DOCKER=true
 
 EXPOSE 8080
 
-CMD uv --no-cache run --no-sync --no-editable uvicorn langwatch_nlp.main:app --host 0.0.0.0 --port 8080 --timeout-keep-alive 4500
+CMD ["sh", "-c", "uv --no-cache run --no-sync --no-editable uvicorn langwatch_nlp.main:app --host 0.0.0.0 --port 8080 --timeout-keep-alive ${NLP_UVICORN_KEEP_ALIVE_SECONDS:-4500}"]

--- a/Dockerfile.langwatch_nlp.lambda
+++ b/Dockerfile.langwatch_nlp.lambda
@@ -32,4 +32,4 @@ ENV RUNNING_IN_DOCKER=true
 
 EXPOSE 8080
 
-CMD ["sh", "-c", "uv --no-cache run --no-sync --no-editable uvicorn langwatch_nlp.main:app --host 0.0.0.0 --port 8080 --timeout-keep-alive ${NLP_UVICORN_KEEP_ALIVE_SECONDS:-4500}"]
+CMD ["sh", "-c", "exec uv --no-cache run --no-sync --no-editable uvicorn langwatch_nlp.main:app --host 0.0.0.0 --port 8080 --timeout-keep-alive \"${NLP_UVICORN_KEEP_ALIVE_SECONDS:-4500}\""]

--- a/langwatch_nlp/Makefile
+++ b/langwatch_nlp/Makefile
@@ -27,7 +27,7 @@ ensure-uv:
 start: install
 	@echo "Starting the server..."
 	@uv run --no-sync watchmedo auto-restart -p 'none' --signal SIGTERM -- \
-		uvicorn langwatch_nlp.main:app --host 0.0.0.0 --port 5561 --timeout-keep-alive 70 \
+		uvicorn langwatch_nlp.main:app --host 0.0.0.0 --port 5561 --timeout-keep-alive $${NLP_UVICORN_KEEP_ALIVE_SECONDS:-70} \
 		--reload --reload-dir . --reload-dir ../python-sdk $(filter-out $@,$(MAKECMDGOALS))
 
 licenses:

--- a/langwatch_nlp/langwatch_nlp/studio/app.py
+++ b/langwatch_nlp/langwatch_nlp/studio/app.py
@@ -173,10 +173,10 @@ async def execute_event_on_a_subprocess(
 
         process = cast(Any, process)
 
-        timeout_without_messages = 900  # seconds (match AWS Lambda max execution timeout)
+        timeout_without_messages = int(os.getenv("NLP_STREAM_IDLE_TIMEOUT_SECONDS", "900"))
         if isinstance(event, ExecuteOptimization):
             # TODO: temporary until we actually send events in the middle of optimization process
-            timeout_without_messages = 120 * 60  # 120 minutes
+            timeout_without_messages = int(os.getenv("NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS", "7200"))
 
         try:
             done = False

--- a/langwatch_nlp/langwatch_nlp/studio/dspy/custom_node.py
+++ b/langwatch_nlp/langwatch_nlp/studio/dspy/custom_node.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 from typing import Any, Optional
 
@@ -34,7 +35,7 @@ class CustomNode(dspy.Module):
             url,
             headers={"X-Auth-Token": self.api_key, "Content-Type": "application/json"},
             content=json.dumps(kwargs, cls=SerializableWithPydanticAndPredictEncoder, ensure_ascii=False),
-            timeout=600,  # 10 minutes
+            timeout=int(os.getenv("NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS", "600")),
         )
 
         result = response.json()

--- a/langwatch_nlp/langwatch_nlp/studio/dspy/evaluation.py
+++ b/langwatch_nlp/langwatch_nlp/studio/dspy/evaluation.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 import threading
 import time
 from typing import List, Optional, Any, Literal
@@ -325,7 +326,7 @@ class EvaluationReporting:
                 "Content-Type": "application/json",
             },
             data=json.dumps(body, cls=SerializableWithStringFallback, ensure_ascii=False),  # type: ignore
-            timeout=60,
+            timeout=int(os.getenv("NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS", "60")),
         )
         if response.status_code != 200:
             logger.error(

--- a/langwatch_nlp/langwatch_nlp/studio/execute/http_node.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/http_node.py
@@ -10,6 +10,7 @@ Supports making HTTP requests with:
 - Timeout configuration
 """
 
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional
@@ -246,7 +247,7 @@ async def execute_http_node(
     headers = build_headers(config)
 
     # Configure timeout (default 5 minutes)
-    timeout_seconds = (config.timeout_ms / 1000) if config.timeout_ms else 300.0
+    timeout_seconds = (config.timeout_ms / 1000) if config.timeout_ms else float(os.getenv("NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS", "300"))
 
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:

--- a/langwatch_nlp/tests/test_timeout_config.py
+++ b/langwatch_nlp/tests/test_timeout_config.py
@@ -1,42 +1,15 @@
 """
-Unit tests for env-configurable NLP timeouts.
+Integration tests for env-configurable NLP timeouts.
 
-Each timeout reads from an env var with os.getenv() and falls back to a default.
-Tests verify:
-  1. Without the env var set, the default value is used
-  2. With the env var set, the custom value is used
+These tests exercise actual production code paths to verify that timeout
+env vars are read and passed through to the underlying HTTP clients.
 """
 
 import os
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
-
-
-class TestStreamIdleTimeout:
-    """NLP_STREAM_IDLE_TIMEOUT_SECONDS controls idle timeout for streaming events."""
-
-    def test_defaults_to_120_seconds(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("NLP_STREAM_IDLE_TIMEOUT_SECONDS", None)
-            assert int(os.getenv("NLP_STREAM_IDLE_TIMEOUT_SECONDS", "120")) == 120
-
-    def test_reads_custom_value_from_env(self):
-        with patch.dict(os.environ, {"NLP_STREAM_IDLE_TIMEOUT_SECONDS": "300"}):
-            assert int(os.getenv("NLP_STREAM_IDLE_TIMEOUT_SECONDS", "120")) == 300
-
-
-class TestOptimizationIdleTimeout:
-    """NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS controls idle timeout for optimization events."""
-
-    def test_defaults_to_7200_seconds(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS", None)
-            assert int(os.getenv("NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS", "7200")) == 7200
-
-    def test_reads_custom_value_from_env(self):
-        with patch.dict(os.environ, {"NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS": "3600"}):
-            assert int(os.getenv("NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS", "7200")) == 3600
 
 
 class TestHttpNodeDefaultTimeout:
@@ -76,7 +49,7 @@ class TestHttpNodeDefaultTimeout:
 
         captured_timeout = []
 
-        original_async_client = __import__("httpx").AsyncClient
+        original_async_client = httpx.AsyncClient
 
         class CapturingAsyncClient:
             def __init__(self, **kwargs):
@@ -110,7 +83,7 @@ class TestHttpNodeDefaultTimeout:
 
         captured_timeout = []
 
-        original_async_client = __import__("httpx").AsyncClient
+        original_async_client = httpx.AsyncClient
 
         class CapturingAsyncClient:
             def __init__(self, **kwargs):
@@ -134,15 +107,6 @@ class TestHttpNodeDefaultTimeout:
 
 class TestDspyCustomNodeTimeout:
     """NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS controls timeout for DSPy custom node HTTP calls."""
-
-    def test_defaults_to_600_seconds(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS", None)
-            assert int(os.getenv("NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS", "600")) == 600
-
-    def test_reads_custom_value_from_env(self):
-        with patch.dict(os.environ, {"NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS": "120"}):
-            assert int(os.getenv("NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS", "600")) == 120
 
     def test_passes_default_timeout_to_httpx_post(self):
         from langwatch_nlp.studio.dspy.custom_node import CustomNode
@@ -190,15 +154,6 @@ class TestDspyCustomNodeTimeout:
 
 class TestDspyEvalLogTimeout:
     """NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS controls timeout for evaluation batch log HTTP calls."""
-
-    def test_defaults_to_60_seconds(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS", None)
-            assert int(os.getenv("NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS", "60")) == 60
-
-    def test_reads_custom_value_from_env(self):
-        with patch.dict(os.environ, {"NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS": "120"}):
-            assert int(os.getenv("NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS", "60")) == 120
 
     def test_passes_default_timeout_to_httpx_post(self):
         from langwatch_nlp.studio.dspy.evaluation import EvaluationReporting

--- a/langwatch_nlp/tests/test_timeout_config.py
+++ b/langwatch_nlp/tests/test_timeout_config.py
@@ -65,7 +65,7 @@ class TestHttpNodeDefaultTimeout:
 
         with patch.dict(os.environ, {"NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS": "45"}):
             with patch("langwatch_nlp.studio.execute.http_node.httpx.AsyncClient", CapturingAsyncClient):
-                result = await execute_http_node(config=config, inputs={})
+                await execute_http_node(config=config, inputs={})
 
         assert captured_timeout == [45.0]
 
@@ -99,7 +99,7 @@ class TestHttpNodeDefaultTimeout:
 
         with patch.dict(os.environ, {"NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS": "999"}):
             with patch("langwatch_nlp.studio.execute.http_node.httpx.AsyncClient", CapturingAsyncClient):
-                result = await execute_http_node(config=config, inputs={})
+                await execute_http_node(config=config, inputs={})
 
         # 5000ms / 1000 = 5.0 seconds — env var is ignored when timeout_ms is set
         assert captured_timeout == [5.0]

--- a/langwatch_nlp/tests/test_timeout_config.py
+++ b/langwatch_nlp/tests/test_timeout_config.py
@@ -27,13 +27,31 @@ class TestHttpNodeDefaultTimeout:
             timeout_ms=None,
         )
 
+        captured_timeout = []
+
+        original_async_client = httpx.AsyncClient
+
+        class CapturingAsyncClient:
+            def __init__(self, **kwargs):
+                captured_timeout.append(kwargs.get("timeout"))
+                self._client = original_async_client(**kwargs)
+
+            async def __aenter__(self):
+                await self._client.__aenter__()
+                return self._client
+
+            async def __aexit__(self, *args):
+                return await self._client.__aexit__(*args)
+
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS", None)
-            result = await execute_http_node(config=config, inputs={})
+            with patch("langwatch_nlp.studio.execute.http_node.httpx.AsyncClient", CapturingAsyncClient):
+                result = await execute_http_node(config=config, inputs={})
 
         assert result.success is True
         requests = httpx_mock.get_requests()
         assert len(requests) == 1
+        assert captured_timeout == [300.0]
 
     @pytest.mark.asyncio
     async def test_uses_env_var_when_timeout_ms_is_none(self, httpx_mock):

--- a/langwatch_nlp/tests/test_timeout_config.py
+++ b/langwatch_nlp/tests/test_timeout_config.py
@@ -1,0 +1,238 @@
+"""
+Unit tests for env-configurable NLP timeouts.
+
+Each timeout reads from an env var with os.getenv() and falls back to a default.
+Tests verify:
+  1. Without the env var set, the default value is used
+  2. With the env var set, the custom value is used
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestStreamIdleTimeout:
+    """NLP_STREAM_IDLE_TIMEOUT_SECONDS controls idle timeout for streaming events."""
+
+    def test_defaults_to_120_seconds(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NLP_STREAM_IDLE_TIMEOUT_SECONDS", None)
+            assert int(os.getenv("NLP_STREAM_IDLE_TIMEOUT_SECONDS", "120")) == 120
+
+    def test_reads_custom_value_from_env(self):
+        with patch.dict(os.environ, {"NLP_STREAM_IDLE_TIMEOUT_SECONDS": "300"}):
+            assert int(os.getenv("NLP_STREAM_IDLE_TIMEOUT_SECONDS", "120")) == 300
+
+
+class TestOptimizationIdleTimeout:
+    """NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS controls idle timeout for optimization events."""
+
+    def test_defaults_to_7200_seconds(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS", None)
+            assert int(os.getenv("NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS", "7200")) == 7200
+
+    def test_reads_custom_value_from_env(self):
+        with patch.dict(os.environ, {"NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS": "3600"}):
+            assert int(os.getenv("NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS", "7200")) == 3600
+
+
+class TestHttpNodeDefaultTimeout:
+    """NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS is used when timeout_ms is not set."""
+
+    @pytest.mark.asyncio
+    async def test_uses_default_300_when_timeout_ms_is_none(self, httpx_mock):
+        from langwatch_nlp.studio.execute.http_node import HttpNodeConfig, execute_http_node
+
+        httpx_mock.add_response(url="https://example.com/api", json={"result": "ok"})
+
+        config = HttpNodeConfig(
+            url="https://example.com/api",
+            method="POST",
+            timeout_ms=None,
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS", None)
+            result = await execute_http_node(config=config, inputs={})
+
+        assert result.success is True
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_uses_env_var_when_timeout_ms_is_none(self, httpx_mock):
+        from langwatch_nlp.studio.execute.http_node import HttpNodeConfig, execute_http_node
+
+        httpx_mock.add_response(url="https://example.com/api", json={"result": "ok"})
+
+        config = HttpNodeConfig(
+            url="https://example.com/api",
+            method="POST",
+            timeout_ms=None,
+        )
+
+        captured_timeout = []
+
+        original_async_client = __import__("httpx").AsyncClient
+
+        class CapturingAsyncClient:
+            def __init__(self, **kwargs):
+                captured_timeout.append(kwargs.get("timeout"))
+                self._client = original_async_client(**kwargs)
+
+            async def __aenter__(self):
+                await self._client.__aenter__()
+                return self._client
+
+            async def __aexit__(self, *args):
+                return await self._client.__aexit__(*args)
+
+        with patch.dict(os.environ, {"NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS": "45"}):
+            with patch("langwatch_nlp.studio.execute.http_node.httpx.AsyncClient", CapturingAsyncClient):
+                result = await execute_http_node(config=config, inputs={})
+
+        assert captured_timeout == [45.0]
+
+    @pytest.mark.asyncio
+    async def test_explicit_timeout_ms_overrides_env_default(self, httpx_mock):
+        from langwatch_nlp.studio.execute.http_node import HttpNodeConfig, execute_http_node
+
+        httpx_mock.add_response(url="https://example.com/api", json={"result": "ok"})
+
+        config = HttpNodeConfig(
+            url="https://example.com/api",
+            method="POST",
+            timeout_ms=5000,  # 5 seconds explicit
+        )
+
+        captured_timeout = []
+
+        original_async_client = __import__("httpx").AsyncClient
+
+        class CapturingAsyncClient:
+            def __init__(self, **kwargs):
+                captured_timeout.append(kwargs.get("timeout"))
+                self._client = original_async_client(**kwargs)
+
+            async def __aenter__(self):
+                await self._client.__aenter__()
+                return self._client
+
+            async def __aexit__(self, *args):
+                return await self._client.__aexit__(*args)
+
+        with patch.dict(os.environ, {"NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS": "999"}):
+            with patch("langwatch_nlp.studio.execute.http_node.httpx.AsyncClient", CapturingAsyncClient):
+                result = await execute_http_node(config=config, inputs={})
+
+        # 5000ms / 1000 = 5.0 seconds — env var is ignored when timeout_ms is set
+        assert captured_timeout == [5.0]
+
+
+class TestDspyCustomNodeTimeout:
+    """NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS controls timeout for DSPy custom node HTTP calls."""
+
+    def test_defaults_to_600_seconds(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS", None)
+            assert int(os.getenv("NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS", "600")) == 600
+
+    def test_reads_custom_value_from_env(self):
+        with patch.dict(os.environ, {"NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS": "120"}):
+            assert int(os.getenv("NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS", "600")) == 120
+
+    def test_passes_default_timeout_to_httpx_post(self):
+        from langwatch_nlp.studio.dspy.custom_node import CustomNode
+
+        node = CustomNode(
+            api_key="test-key",
+            endpoint="https://example.com",
+            workflow_id="wf-123",
+            version_id=None,
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": "output-value"}
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS", None)
+            with patch("langwatch_nlp.studio.dspy.custom_node.httpx.post", return_value=mock_response) as mock_post:
+                node.forward(input="hello")
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["timeout"] == 600
+
+    def test_passes_custom_timeout_to_httpx_post(self):
+        from langwatch_nlp.studio.dspy.custom_node import CustomNode
+
+        node = CustomNode(
+            api_key="test-key",
+            endpoint="https://example.com",
+            workflow_id="wf-123",
+            version_id=None,
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": "output-value"}
+
+        with patch.dict(os.environ, {"NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS": "30"}):
+            with patch("langwatch_nlp.studio.dspy.custom_node.httpx.post", return_value=mock_response) as mock_post:
+                node.forward(input="hello")
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["timeout"] == 30
+
+
+class TestDspyEvalLogTimeout:
+    """NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS controls timeout for evaluation batch log HTTP calls."""
+
+    def test_defaults_to_60_seconds(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS", None)
+            assert int(os.getenv("NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS", "60")) == 60
+
+    def test_reads_custom_value_from_env(self):
+        with patch.dict(os.environ, {"NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS": "120"}):
+            assert int(os.getenv("NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS", "60")) == 120
+
+    def test_passes_default_timeout_to_httpx_post(self):
+        from langwatch_nlp.studio.dspy.evaluation import EvaluationReporting
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        body = {"experiment_id": "exp-1", "dataset": [], "evaluations": []}
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS", None)
+            with patch("langwatch_nlp.studio.dspy.evaluation.httpx.post", return_value=mock_response) as mock_post:
+                with patch("langwatch_nlp.studio.dspy.evaluation.langwatch.get_endpoint", return_value="https://app.langwatch.ai"):
+                    EvaluationReporting.post_results(api_key="test-api-key", body=body)
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["timeout"] == 60
+
+    def test_passes_custom_timeout_to_httpx_post(self):
+        from langwatch_nlp.studio.dspy.evaluation import EvaluationReporting
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        body = {"experiment_id": "exp-1", "dataset": [], "evaluations": []}
+
+        with patch.dict(os.environ, {"NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS": "15"}):
+            with patch("langwatch_nlp.studio.dspy.evaluation.httpx.post", return_value=mock_response) as mock_post:
+                with patch("langwatch_nlp.studio.dspy.evaluation.langwatch.get_endpoint", return_value="https://app.langwatch.ai"):
+                    EvaluationReporting.post_results(api_key="test-api-key", body=body)
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["timeout"] == 15


### PR DESCRIPTION
## Why

Closes #3074

All NLP service timeouts were hardcoded magic numbers scattered across multiple files. In production, different deployment environments (Lambda vs ECS, high-latency networks) need different timeout values, but changing them required code changes and redeployment.

## What changed

Replaced 6 hardcoded timeout values with environment variables that fall back to the original defaults:

| Env Var | Default | Where |
|---------|---------|-------|
| `NLP_UVICORN_KEEP_ALIVE_SECONDS` | 4500 (prod) / 70 (dev) | Dockerfiles + Makefile |
| `NLP_STREAM_IDLE_TIMEOUT_SECONDS` | 900 | Studio subprocess stream idle timeout |
| `NLP_OPTIMIZATION_IDLE_TIMEOUT_SECONDS` | 7200 | Optimization execution idle timeout |
| `NLP_HTTP_NODE_DEFAULT_TIMEOUT_SECONDS` | 300 | HTTP node default when `timeout_ms` unset |
| `NLP_DSPY_CUSTOM_NODE_TIMEOUT_SECONDS` | 600 | DSPy custom node HTTP calls |
| `NLP_DSPY_EVAL_LOG_TIMEOUT_SECONDS` | 60 | Evaluation batch log HTTP calls |

The Lambda Dockerfile also gained `exec` for proper signal handling and quoted env var expansion.

## Test plan

7 integration tests in `langwatch_nlp/tests/test_timeout_config.py` covering:
- Default timeout values are used when env vars are absent
- Custom env var values override defaults
- Explicit `timeout_ms` config takes precedence over env defaults
- Timeout values are captured and asserted via `CapturingAsyncClient` pattern for httpx and mock inspection for synchronous httpx.post calls

All tests pass locally via `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)