### PR TITLE
fix(ci): trigger e2e tests on python-sdk changes

### DIFF
--- a/.github/workflows/e2e-ci-unmodified.yml
+++ b/.github/workflows/e2e-ci-unmodified.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - "langwatch/**"
+      - "python-sdk/**"
       - "agentic-e2e-tests/**"
       - ".github/workflows/e2e-ci.yml"
 

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - "langwatch/**"
+      - "python-sdk/**"
       - "agentic-e2e-tests/**"
       - ".github/workflows/e2e-ci.yml"
   workflow_dispatch:

--- a/specs/ci/path-filters.feature
+++ b/specs/ci/path-filters.feature
@@ -32,7 +32,7 @@ Feature: CI path filters skip unnecessary workflows on non-code changes
   # ============================================================================
 
   Scenario: e2e-ci has a complementary stub
-    Given e2e-ci.yml triggers on langwatch/ and agentic-e2e-tests/ changes
+    Given e2e-ci.yml triggers on langwatch/, python-sdk/, and agentic-e2e-tests/ changes
     When a PR does not touch those directories
     Then e2e-ci-unmodified.yml reports success for all e2e-ci job names
 


### PR DESCRIPTION
## Summary

- **Problem:** The e2e CI workflow path filters only included `langwatch/` and `agentic-e2e-tests/`, so PRs touching `python-sdk/` silently skipped all e2e tests. On PR #2843 both e2e checks passed in 2s with "no modifications, skipping e2e tests" — the Python SDK e2e tests never ran.
- **Fix:** Add `python-sdk/**` to both `e2e-ci.yml` (paths trigger) and `e2e-ci-unmodified.yml` (paths-ignore stub) so the complementary pair correctly routes python-sdk PRs to the real e2e workflow.
- Updated `specs/ci/path-filters.feature` to reflect the new trigger path.

Closes #2901

## Test plan
- [ ] Verify this PR itself triggers the e2e-ci workflow (since it touches `.github/workflows/e2e-ci.yml`)
- [ ] Verify a future python-sdk-only PR triggers e2e-ci instead of the stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2901