### PR TITLE
fix(ci): build mcp-server before app install in all CI workflows

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -114,6 +114,7 @@ jobs:
           cache-dependency-path: |
             langwatch/pnpm-lock.yaml
             agentic-e2e-tests/pnpm-lock.yaml
+            mcp-server/pnpm-lock.yaml
 
       - name: Install app dependencies
         working-directory: langwatch
@@ -151,6 +152,10 @@ jobs:
       - name: Setup Elasticsearch
         working-directory: langwatch
         run: pnpm elastic:migrate
+
+      - name: Build mcp-server
+        working-directory: mcp-server
+        run: pnpm install --frozen-lockfile && pnpm run build
 
       - name: Build app
         working-directory: langwatch

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -162,6 +162,11 @@ jobs:
         run: NODE_ENV=test pnpm build
 
       - name: Run E2E tests
+        env:
+          # Migrations already ran in earlier steps; skip them during pnpm start
+          SKIP_PRISMA_MIGRATE: "true"
+          SKIP_ELASTIC_MIGRATE: "true"
+          SKIP_CLICKHOUSE_MIGRATE: "true"
         run: |
           # Start the app in background
           cd langwatch && PORT=5570 pnpm start &

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -116,6 +116,10 @@ jobs:
             agentic-e2e-tests/pnpm-lock.yaml
             mcp-server/pnpm-lock.yaml
 
+      - name: Build mcp-server
+        working-directory: mcp-server
+        run: pnpm install --frozen-lockfile && pnpm run build
+
       - name: Install app dependencies
         working-directory: langwatch
         run: CI=true pnpm install --frozen-lockfile
@@ -152,10 +156,6 @@ jobs:
       - name: Setup Elasticsearch
         working-directory: langwatch
         run: pnpm elastic:migrate
-
-      - name: Build mcp-server
-        working-directory: mcp-server
-        run: pnpm install --frozen-lockfile && pnpm run build
 
       - name: Build app
         working-directory: langwatch

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -399,13 +399,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - name: Install dependencies
-        working-directory: langwatch
-        run: CI=true pnpm install --frozen-lockfile
-
       - name: Build mcp-server
         working-directory: mcp-server
         run: pnpm install --frozen-lockfile && pnpm run build
+
+      - name: Install dependencies
+        working-directory: langwatch
+        run: CI=true pnpm install --frozen-lockfile
 
       - name: Build
         working-directory: langwatch

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -403,6 +403,10 @@ jobs:
         working-directory: langwatch
         run: CI=true pnpm install --frozen-lockfile
 
+      - name: Build mcp-server
+        working-directory: mcp-server
+        run: pnpm install --frozen-lockfile && pnpm run build
+
       - name: Build
         working-directory: langwatch
         run: pnpm build

--- a/.github/workflows/langwatch-server-publish.yml
+++ b/.github/workflows/langwatch-server-publish.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build mcp-server
         working-directory: mcp-server
-        run: pnpm install && pnpm run build
+        run: pnpm install --frozen-lockfile && pnpm run build
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/langwatch-server-publish.yml
+++ b/.github/workflows/langwatch-server-publish.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           version: 10.24.0
 
+      - name: Build mcp-server
+        working-directory: mcp-server
+        run: pnpm install && pnpm run build
+
       - name: Install dependencies
         run: |
           cd langwatch

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -162,7 +162,9 @@ jobs:
         with:
           node-version: 24
           cache: "pnpm"
-          cache-dependency-path: "langwatch/pnpm-lock.yaml"
+          cache-dependency-path: |
+            langwatch/pnpm-lock.yaml
+            mcp-server/pnpm-lock.yaml
 
       - name: Install LangWatch app dependencies
         working-directory: langwatch
@@ -192,6 +194,10 @@ jobs:
       - name: Setup ClickHouse
         working-directory: langwatch
         run: pnpm clickhouse:migrate
+
+      - name: Build mcp-server
+        working-directory: mcp-server
+        run: pnpm install --frozen-lockfile && pnpm run build
 
       # Build the app so we can run a production server (dev mode is
       # unreliable in CI — turbopack JIT compilation can hang under

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -166,6 +166,10 @@ jobs:
             langwatch/pnpm-lock.yaml
             mcp-server/pnpm-lock.yaml
 
+      - name: Build mcp-server
+        working-directory: mcp-server
+        run: pnpm install --frozen-lockfile && pnpm run build
+
       - name: Install LangWatch app dependencies
         working-directory: langwatch
         run: CI=true pnpm install --frozen-lockfile
@@ -194,10 +198,6 @@ jobs:
       - name: Setup ClickHouse
         working-directory: langwatch
         run: pnpm clickhouse:migrate
-
-      - name: Build mcp-server
-        working-directory: mcp-server
-        run: pnpm install --frozen-lockfile && pnpm run build
 
       # Build the app so we can run a production server (dev mode is
       # unreliable in CI — turbopack JIT compilation can hang under


### PR DESCRIPTION
## Why

Closes #2995
Closes #3049

The mcp-server package is a workspace dependency of langwatch. When CI runs pnpm install for the app, it expects mcp-server/dist/ to already exist. Without a prior build step, pnpm install fails or produces broken installs.

Additionally, e2e tests were failing because the app re-ran migrations during pnpm start, which raced with the test setup.

## What changed

- Added Build mcp-server step before app install in: e2e-ci.yml, langwatch-app-ci.yml, langwatch-server-publish.yml, sdk-javascript-ci.yml
- Added mcp-server/pnpm-lock.yaml to pnpm cache keys
- Added SKIP_PRISMA_MIGRATE, SKIP_ELASTIC_MIGRATE, SKIP_CLICKHOUSE_MIGRATE env vars to e2e test run step

## Test plan

- CI passes on all 4 affected workflows
- e2e tests no longer fail with Cannot find module mcp-server/dist
- e2e tests no longer race on migrations during app startup