### PR TITLE
fix(tests): update 5 tests for source ID prefix in mapping tags

### DIFF
--- a/langwatch/src/components/variables/__tests__/VariableMappingInput.test.tsx
+++ b/langwatch/src/components/variables/__tests__/VariableMappingInput.test.tsx
@@ -73,17 +73,16 @@ describe("VariableMappingInput", () => {
       expect(screen.getByDisplayValue("Hello world")).toBeInTheDocument();
     });
 
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("displays source mapping as a closable tag", () => {
+    it("displays source mapping as a closable tag", () => {
       const mapping: FieldMapping = {
         type: "source",
         sourceId: "dataset-1",
         path: ["input"],
       };
       renderComponent({ mapping });
-      // Should show a tag with just the field name (no source name prefix)
+      // Should show a tag with the source prefix and field name
       expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-      expect(screen.getByText("input")).toBeInTheDocument();
+      expect(screen.getByText("dataset-1.input")).toBeInTheDocument();
       // Should have a close button
       expect(screen.getByTestId("clear-mapping-button")).toBeInTheDocument();
     });
@@ -545,8 +544,7 @@ describe("VariableMappingInput", () => {
   });
 
   describe("prop synchronization", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("updates display when mapping prop changes externally", async () => {
+    it("updates display when mapping prop changes externally", async () => {
       const onMappingChange = vi.fn();
 
       // Start with no mapping
@@ -584,12 +582,11 @@ describe("VariableMappingInput", () => {
       // Should immediately show the new mapping as a tag
       await waitFor(() => {
         expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-        expect(screen.getByText("input")).toBeInTheDocument();
+        expect(screen.getByText("dataset-1.input")).toBeInTheDocument();
       });
     });
 
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("reflects mapping immediately after selecting from dropdown", async () => {
+    it("reflects mapping immediately after selecting from dropdown", async () => {
       const user = userEvent.setup();
       let currentMapping: FieldMapping | undefined = undefined;
 
@@ -640,7 +637,7 @@ describe("VariableMappingInput", () => {
       // Should show the mapping immediately without needing to close/reopen
       await waitFor(() => {
         expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-        expect(screen.getByText("input")).toBeInTheDocument();
+        expect(screen.getByText("dataset-1.input")).toBeInTheDocument();
       });
     });
   });
@@ -1221,8 +1218,7 @@ describe("VariableMappingInput", () => {
         );
       });
 
-      // TODO(#3048): pre-existing failure unmasked by #3001
-      it.skip("shows 'Use all X' option when in nested view with complete parent", async () => {
+      it("shows 'Use all X' option when in nested view with complete parent", async () => {
         const user = userEvent.setup();
         const onMappingChange = vi.fn();
 
@@ -1289,7 +1285,7 @@ describe("VariableMappingInput", () => {
 
         // Should show the mapping tag
         expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-        expect(screen.getByText("traces")).toBeInTheDocument();
+        expect(screen.getByText("thread.traces")).toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/variables/__tests__/VariablesSection.test.tsx
+++ b/langwatch/src/components/variables/__tests__/VariablesSection.test.tsx
@@ -396,8 +396,7 @@ describe("VariablesSection", () => {
       expect(screen.getByRole("textbox")).toBeInTheDocument();
     });
 
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("displays mapping value when mapped", () => {
+    it("displays mapping value when mapped", () => {
       const variables: Variable[] = [{ identifier: "question", type: "str" }];
       const mappings: Record<string, FieldMapping> = {
         question: { type: "source", sourceId: "dataset-1", path: ["input"] },
@@ -410,9 +409,9 @@ describe("VariablesSection", () => {
         mappings,
       });
 
-      // Should show a tag with the field name
+      // Should show a tag with the source prefix and field name
       expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-      expect(screen.getByText("input")).toBeInTheDocument();
+      expect(screen.getByText("dataset-1.input")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- Unskip and fix 4 pre-existing test failures in `VariableMappingInput.test.tsx` that were masked before #3001 surfaced them
- Fix 1 additional test in `VariablesSection.test.tsx` with the same stale expectation (found by sweep)
- **Root cause:** The component now renders source mapping tags with a `sourceId` prefix (e.g., `dataset-1.input` instead of just `input`), but these 5 tests still expected the old plain field name format

### Changes
- `VariableMappingInput.test.tsx`: Update 4 test expectations from plain field names to prefixed format, remove `it.skip` and `TODO(#3048)` annotations
- `VariablesSection.test.tsx`: Update 1 test expectation, remove `it.skip` and `TODO(#3048)` annotation

## Test plan

- [x] All 41 tests in `VariableMappingInput.test.tsx` pass (including the 4 unskipped)
- [x] All 37 tests in `VariablesSection.test.tsx` pass (including the 1 unskipped)
- [x] Sweep confirmed no other test files have stale source-mapping-tag text expectations

Closes #3056

🤖 Generated with [Claude Code](https://claude.com/claude-code)