### PR TITLE
fix(ci): build mcp-server before app start in e2e workflow

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -115,6 +115,10 @@ jobs:
             agentic-e2e-tests/pnpm-lock.yaml
             mcp-server/pnpm-lock.yaml
 
+      - name: Build MCP server
+        working-directory: mcp-server
+        run: pnpm install --frozen-lockfile && pnpm build
+
       - name: Install app dependencies
         working-directory: langwatch
         run: CI=true pnpm install --frozen-lockfile
@@ -126,10 +130,6 @@ jobs:
       - name: Install Playwright browsers
         working-directory: agentic-e2e-tests
         run: pnpm exec playwright install --with-deps chromium
-
-      - name: Build MCP server
-        working-directory: mcp-server
-        run: pnpm install --frozen-lockfile && pnpm build
 
       - name: Prepare files
         working-directory: langwatch

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -113,6 +113,7 @@ jobs:
           cache-dependency-path: |
             langwatch/pnpm-lock.yaml
             agentic-e2e-tests/pnpm-lock.yaml
+            mcp-server/pnpm-lock.yaml
 
       - name: Install app dependencies
         working-directory: langwatch
@@ -125,6 +126,10 @@ jobs:
       - name: Install Playwright browsers
         working-directory: agentic-e2e-tests
         run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build MCP server
+        working-directory: mcp-server
+        run: pnpm install --frozen-lockfile && pnpm build
 
       - name: Prepare files
         working-directory: langwatch
@@ -156,6 +161,11 @@ jobs:
         run: NODE_ENV=test pnpm build
 
       - name: Run E2E tests
+        env:
+          # Migrations already ran in earlier steps; skip them during pnpm start
+          SKIP_PRISMA_MIGRATE: "true"
+          SKIP_ELASTIC_MIGRATE: "true"
+          SKIP_CLICKHOUSE_MIGRATE: "true"
         run: |
           # Start the app in background
           cd langwatch && PORT=5570 pnpm start &


### PR DESCRIPTION
## Summary

- **Problem:** The e2e CI job fails because the Next.js app crashes on startup with `Cannot find module '@langwatch/mcp-server/dist/create-mcp-server.js'`. The `@langwatch/mcp-server` workspace package (linked via `file:../mcp-server`) was never built in CI, so its `dist/` directory didn't exist.
- **Root cause:** `langwatch/src/mcp/handler.ts` imports from `@langwatch/mcp-server/create-mcp-server`, which resolves to `dist/create-mcp-server.js`. The mcp-server needs `pnpm build` (tsup) to produce these files.
- **Fix:** Add a "Build MCP server" step to the e2e-ci workflow that installs deps and builds the package before the app starts. Also skip redundant migration re-runs during `pnpm start` since they already ran in earlier workflow steps.

Closes #3049

## Test plan

- [ ] e2e-ci workflow passes on this PR (app starts successfully on port 5570)
- [ ] Migrations are skipped during `pnpm start` (log shows "Skipping" messages instead of re-running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3049