### PR TITLE
fix(ci): re-enable skipped e2e tests with NLP services and health checks

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -116,6 +116,22 @@ jobs:
           --health-timeout 30s
           --health-retries 3
 
+      langwatch_nlp:
+        image: langwatch/langwatch_nlp:latest
+        ports:
+          - 5563:5561
+        env:
+          LANGWATCH_ENDPOINT: http://172.17.0.1:5570
+        options: >-
+          --add-host host.docker.internal:host-gateway
+
+      langevals:
+        image: langwatch/langevals:latest
+        ports:
+          - 5564:5562
+        env:
+          DISABLE_EVALUATORS_PRELOAD: "true"
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -185,8 +201,21 @@ jobs:
           cd langwatch && PORT=5570 pnpm start &
           APP_PID=$!
 
-          # Wait for app to be ready (global-setup.ts also checks, but this ensures the process is up)
+          # Wait for app to be ready
           sleep 5
+
+          # Wait for NLP service to be ready
+          echo "Waiting for NLP service..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:5563/ > /dev/null 2>&1; then
+              echo "NLP service is ready"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "Warning: NLP service not responding, continuing anyway"
+            fi
+            sleep 2
+          done
 
           # Run tests from the self-contained e2e package
           cd agentic-e2e-tests && pnpm test

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -125,9 +125,10 @@ jobs:
         options: >-
           --add-host host.docker.internal:host-gateway
           --health-cmd "curl -sf http://localhost:5561/ || exit 1"
-          --health-interval 10s
+          --health-interval 15s
           --health-timeout 10s
-          --health-retries 6
+          --health-retries 12
+          --health-start-period 30s
 
       langevals:
         image: langwatch/langevals:latest
@@ -137,9 +138,10 @@ jobs:
           DISABLE_EVALUATORS_PRELOAD: "true"
         options: >-
           --health-cmd "curl -sf http://localhost:5562/ || exit 1"
-          --health-interval 10s
+          --health-interval 15s
           --health-timeout 10s
-          --health-retries 6
+          --health-retries 12
+          --health-start-period 30s
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -201,6 +201,10 @@ jobs:
         working-directory: langwatch
         run: NODE_ENV=test pnpm build
 
+      - name: Build MCP server
+        working-directory: mcp-server
+        run: pnpm install --frozen-lockfile && pnpm build
+
       - name: Run E2E tests
         env:
           # Migrations already ran in earlier steps; skip them during pnpm start
@@ -212,8 +216,7 @@ jobs:
           cd langwatch && PORT=5570 pnpm start &
           APP_PID=$!
 
-          # Wait for app to be ready (NLP/langevals services have health checks)
-          sleep 5
+          # The e2e test global-setup.ts handles waiting for the app to be ready
 
           # Run tests from the self-contained e2e package
           cd agentic-e2e-tests && pnpm test

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -124,7 +124,7 @@ jobs:
           LANGWATCH_ENDPOINT: http://host.docker.internal:5570
         options: >-
           --add-host host.docker.internal:host-gateway
-          --health-cmd "curl -sf http://localhost:5561/ || exit 1"
+          --health-cmd "curl -sf http://localhost:5561/health || exit 1"
           --health-interval 15s
           --health-timeout 10s
           --health-retries 12
@@ -137,7 +137,7 @@ jobs:
         env:
           DISABLE_EVALUATORS_PRELOAD: "true"
         options: >-
-          --health-cmd "curl -sf http://localhost:5562/ || exit 1"
+          --health-cmd "curl -sf http://localhost:5562/healthcheck || exit 1"
           --health-interval 15s
           --health-timeout 10s
           --health-retries 12

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -124,7 +124,7 @@ jobs:
           LANGWATCH_ENDPOINT: http://host.docker.internal:5570
         options: >-
           --add-host host.docker.internal:host-gateway
-          --health-cmd "curl -sf http://localhost:5561/health || exit 1"
+          --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5561/health')\" || exit 1"
           --health-interval 15s
           --health-timeout 10s
           --health-retries 12
@@ -137,7 +137,7 @@ jobs:
         env:
           DISABLE_EVALUATORS_PRELOAD: "true"
         options: >-
-          --health-cmd "curl -sf http://localhost:5562/healthcheck || exit 1"
+          --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5562/healthcheck')\" || exit 1"
           --health-interval 15s
           --health-timeout 10s
           --health-retries 12

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -201,10 +201,6 @@ jobs:
         working-directory: langwatch
         run: NODE_ENV=test pnpm build
 
-      - name: Build MCP server
-        working-directory: mcp-server
-        run: pnpm install --frozen-lockfile && pnpm build
-
       - name: Run E2E tests
         env:
           # Migrations already ran in earlier steps; skip them during pnpm start

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -121,9 +121,13 @@ jobs:
         ports:
           - 5563:5561
         env:
-          LANGWATCH_ENDPOINT: http://172.17.0.1:5570
+          LANGWATCH_ENDPOINT: http://host.docker.internal:5570
         options: >-
           --add-host host.docker.internal:host-gateway
+          --health-cmd "curl -sf http://localhost:5561/ || exit 1"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 6
 
       langevals:
         image: langwatch/langevals:latest
@@ -131,6 +135,11 @@ jobs:
           - 5564:5562
         env:
           DISABLE_EVALUATORS_PRELOAD: "true"
+        options: >-
+          --health-cmd "curl -sf http://localhost:5562/ || exit 1"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 6
 
     steps:
       - name: Checkout
@@ -201,21 +210,8 @@ jobs:
           cd langwatch && PORT=5570 pnpm start &
           APP_PID=$!
 
-          # Wait for app to be ready
+          # Wait for app to be ready (NLP/langevals services have health checks)
           sleep 5
-
-          # Wait for NLP service to be ready
-          echo "Waiting for NLP service..."
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:5563/ > /dev/null 2>&1; then
-              echo "NLP service is ready"
-              break
-            fi
-            if [ $i -eq 30 ]; then
-              echo "Warning: NLP service not responding, continuing anyway"
-            fi
-            sleep 2
-          done
 
           # Run tests from the self-contained e2e package
           cd agentic-e2e-tests && pnpm test

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -122,14 +122,13 @@ jobs:
           --health-timeout 30s
           --health-retries 3
 
-      langwatch_nlp:
-        image: langwatch/langwatch_nlp:latest
-        ports:
-          - 5563:5561
-        env:
-          LANGWATCH_ENDPOINT: http://host.docker.internal:5570
-        options: >-
-          --add-host host.docker.internal:host-gateway
+      # NOTE: langwatch_nlp is intentionally NOT a service container here.
+      # The langwatch app auto-starts its own nlpgo binary on :5563
+      # (visible as "✓ nlpgo: auto-start on :5563" in startup logs).
+      # Adding a Docker service container on port 5563 causes an
+      # "address already in use" conflict that crash-loops the app.
+      # LANGWATCH_NLP_SERVICE=http://localhost:5563 is set in the env
+      # section above and the app's own nlpgo binary satisfies it.
 
       langevals:
         image: langwatch/langevals:latest
@@ -213,21 +212,6 @@ jobs:
       - name: Build app
         working-directory: langwatch
         run: NODE_ENV=test pnpm build
-
-      # langwatch_nlp uses a distroless base image (no shell), so Docker
-      # --health-cmd cannot run. Poll from the runner instead.
-      - name: Wait for NLP service
-        run: |
-          echo "Waiting for langwatch_nlp on localhost:5563/healthz ..."
-          for i in $(seq 1 40); do
-            if curl -sf http://localhost:5563/healthz > /dev/null 2>&1; then
-              echo "NLP service is ready (attempt $i)"
-              break
-            fi
-            echo "Attempt $i/40: not ready, waiting 10s..."
-            sleep 10
-          done
-          curl -sf http://localhost:5563/healthz || (echo "NLP service failed to start" && exit 1)
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -130,11 +130,6 @@ jobs:
           LANGWATCH_ENDPOINT: http://host.docker.internal:5570
         options: >-
           --add-host host.docker.internal:host-gateway
-          --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5561/healthz')\" || exit 1"
-          --health-interval 15s
-          --health-timeout 10s
-          --health-retries 12
-          --health-start-period 30s
 
       langevals:
         image: langwatch/langevals:latest
@@ -218,6 +213,21 @@ jobs:
       - name: Build app
         working-directory: langwatch
         run: NODE_ENV=test pnpm build
+
+      # langwatch_nlp uses a distroless base image (no shell), so Docker
+      # --health-cmd cannot run. Poll from the runner instead.
+      - name: Wait for NLP service
+        run: |
+          echo "Waiting for langwatch_nlp on localhost:5563/healthz ..."
+          for i in $(seq 1 40); do
+            if curl -sf http://localhost:5563/healthz > /dev/null 2>&1; then
+              echo "NLP service is ready (attempt $i)"
+              break
+            fi
+            echo "Attempt $i/40: not ready, waiting 10s..."
+            sleep 10
+          done
+          curl -sf http://localhost:5563/healthz || (echo "NLP service failed to start" && exit 1)
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -52,6 +52,22 @@ jobs:
       NEXTAUTH_SECRET: "test-secret-for-e2e-testing"
       NEXTAUTH_URL: "http://localhost:5570"
       API_TOKEN_JWT_SECRET: "test-jwt-secret-for-e2e"
+      # Trust the in-repo TEST license keypair so auth.setup.ts can activate a
+      # test ENTERPRISE license and exercise member-invitation flows above the
+      # free-tier maxMembers=1 cap. Public key only (safe to commit) — matches
+      # TEST_PUBLIC_KEY in langwatch/ee/licensing/__tests__/fixtures/testKeys.ts.
+      # Must be on the app process env before `pnpm start` boots — constants.ts
+      # resolves PUBLIC_KEY from this var once at module load. gitleaks:allow
+      LANGWATCH_LICENSE_PUBLIC_KEY: |
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApmJ61eRR1wxrapjipSmN
+        IqYMJPmbonA1d6XV51kdnVs/MdNrrdoWIal6TDt2lHvbAbrEalqR7h+vQzBBZ4St
+        ZPqBzTIHQwu3Wjlj7Fj7IeVUiJnRg60W+u9DmYXUeFBlZFMHxV3nNVqedwDcFpV/
+        IrAMmSe3QeTqBztcDMBxu5luA4DMU5Hi6kp4qcHDoCCiEH4a6ZZkPdNC+xpFdW41
+        75BwdKBKnyOZrUvyPaKrxInra7z+9YQKiggRciQvCNxc76Ef4DLGkTIf36Cvm7XL
+        m0gqlJm89dYcRBaDVGFTnb98BM7SrAIg117yjuuw5o/RmSlKq9/Klkz0QsXYF9Zj
+        iQIDAQAB
+        -----END PUBLIC KEY-----
       # AI Gateway data-plane secrets (shared by control plane + Go gateway).
       # The gateway validates these as required; without them `make service
       # svc=aigateway` crash-loops. Test-only values, 32+ chars.

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -130,7 +130,7 @@ jobs:
           LANGWATCH_ENDPOINT: http://host.docker.internal:5570
         options: >-
           --add-host host.docker.internal:host-gateway
-          --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5561/health')\" || exit 1"
+          --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5561/healthz')\" || exit 1"
           --health-interval 15s
           --health-timeout 10s
           --health-retries 12

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -47,7 +47,6 @@ jobs:
       CLICKHOUSE_URL: "http://default:ci_password@localhost:8123/langwatch"
       IS_OPENSEARCH: "true"
       REDIS_URL: "redis://localhost:6380"
-      ELASTICSEARCH_NODE_URL: "http://localhost:9201"
       LANGWATCH_NLP_SERVICE: "http://localhost:5563"
       LANGEVALS_ENDPOINT: "http://localhost:5564"
       NEXTAUTH_SECRET: "test-secret-for-e2e-testing"

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -47,6 +47,7 @@ jobs:
       CLICKHOUSE_URL: "http://default:ci_password@localhost:8123/langwatch"
       IS_OPENSEARCH: "true"
       REDIS_URL: "redis://localhost:6380"
+      ELASTICSEARCH_NODE_URL: "http://localhost:9201"
       LANGWATCH_NLP_SERVICE: "http://localhost:5563"
       LANGEVALS_ENDPOINT: "http://localhost:5564"
       NEXTAUTH_SECRET: "test-secret-for-e2e-testing"
@@ -120,6 +121,33 @@ jobs:
           --health-interval 30s
           --health-timeout 30s
           --health-retries 3
+
+      langwatch_nlp:
+        image: langwatch/langwatch_nlp:latest
+        ports:
+          - 5563:5561
+        env:
+          LANGWATCH_ENDPOINT: http://host.docker.internal:5570
+        options: >-
+          --add-host host.docker.internal:host-gateway
+          --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5561/health')\" || exit 1"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 30s
+
+      langevals:
+        image: langwatch/langevals:latest
+        ports:
+          - 5564:5562
+        env:
+          DISABLE_EVALUATORS_PRELOAD: "true"
+        options: >-
+          --health-cmd "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5562/healthcheck')\" || exit 1"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 12
+          --health-start-period 30s
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -52,9 +52,10 @@ jobs:
       NEXTAUTH_SECRET: "test-secret-for-e2e-testing"
       NEXTAUTH_URL: "http://localhost:5570"
       API_TOKEN_JWT_SECRET: "test-jwt-secret-for-e2e"
-      # Trust the in-repo TEST license keypair so auth.setup.ts can activate a
-      # test ENTERPRISE license and exercise member-invitation flows above the
-      # free-tier maxMembers=1 cap. Public key only (safe to commit) — matches
+      # Trust the in-repo TEST license keypair so the members suite
+      # (agentic-e2e-tests/tests/members/steps.ts withEnterpriseLicense()) can
+      # activate a test ENTERPRISE license and exercise member-invitation flows
+      # above the free-tier maxMembers=1 cap. Public key only (safe to commit) — matches
       # TEST_PUBLIC_KEY in langwatch/ee/licensing/__tests__/fixtures/testKeys.ts.
       # Must be on the app process env before `pnpm start` boots — constants.ts
       # resolves PUBLIC_KEY from this var once at module load. gitleaks:allow

--- a/agentic-e2e-tests/tests/auth.setup.ts
+++ b/agentic-e2e-tests/tests/auth.setup.ts
@@ -2,6 +2,8 @@ import { test as setup, expect } from "@playwright/test";
 import path from "path";
 import fs from "fs";
 
+import { E2E_ENTERPRISE_LICENSE_KEY } from "./license.fixture";
+
 const AUTH_DIR = path.join(__dirname, "..", ".auth");
 const AUTH_FILE = path.join(AUTH_DIR, "user.json");
 
@@ -127,6 +129,50 @@ setup("authenticate", async ({ page, request }) => {
   } else {
     console.log("Org/project already exists, skipping setup.");
   }
+
+  // Step 3b: Activate a test ENTERPRISE license for the org so the
+  // member-invitation specs can invite past the free-tier maxMembers=1 cap.
+  // A no-license self-hosted deployment resolves to FREE_PLAN (maxMembers=1),
+  // so the owner alone is already at the cap and createInviteRequest 403s. The
+  // app trusts this test-signed license because e2e-ci sets
+  // LANGWATCH_LICENSE_PUBLIC_KEY to the matching TEST_PUBLIC_KEY;
+  // getActivePlan re-reads the license from Postgres on every call, so
+  // activating here (before the specs run) takes effect with no app restart.
+  console.log("Activating test enterprise license...");
+  const licenseOrgsResponse = await page.request.get(
+    "/api/trpc/organization.getAll?batch=1&input=" +
+      encodeURIComponent(JSON.stringify({ "0": { json: {} } })),
+  );
+  const licenseOrgsData = await licenseOrgsResponse.json().catch(() => null);
+  const licenseOrgs: Array<{ id: string }> =
+    licenseOrgsData?.["0"]?.result?.data?.json ?? [];
+  const organizationId = licenseOrgs[0]?.id;
+  if (!organizationId) {
+    throw new Error(
+      `Cannot activate license: no organization found (${JSON.stringify(
+        licenseOrgsData,
+      ).slice(0, 300)})`,
+    );
+  }
+  const licenseResponse = await page.request.post(
+    "/api/trpc/license.upload?batch=1",
+    {
+      data: {
+        "0": {
+          json: { organizationId, licenseKey: E2E_ENTERPRISE_LICENSE_KEY },
+        },
+      },
+    },
+  );
+  const licenseResult = await licenseResponse.json().catch(() => null);
+  if (!licenseResponse.ok() || licenseResult?.["0"]?.error) {
+    throw new Error(
+      `license.upload failed: ${licenseResponse.status()} ${JSON.stringify(
+        licenseResult,
+      ).slice(0, 500)}`,
+    );
+  }
+  console.log("Enterprise license activated (maxMembers=100).");
 
   // Step 4: Confirm the authenticated shell on a settings page. We use
   // /settings rather than the app root because root redirects to the

--- a/agentic-e2e-tests/tests/auth.setup.ts
+++ b/agentic-e2e-tests/tests/auth.setup.ts
@@ -2,8 +2,6 @@ import { test as setup, expect } from "@playwright/test";
 import path from "path";
 import fs from "fs";
 
-import { E2E_ENTERPRISE_LICENSE_KEY } from "./license.fixture";
-
 const AUTH_DIR = path.join(__dirname, "..", ".auth");
 const AUTH_FILE = path.join(AUTH_DIR, "user.json");
 
@@ -129,50 +127,6 @@ setup("authenticate", async ({ page, request }) => {
   } else {
     console.log("Org/project already exists, skipping setup.");
   }
-
-  // Step 3b: Activate a test ENTERPRISE license for the org so the
-  // member-invitation specs can invite past the free-tier maxMembers=1 cap.
-  // A no-license self-hosted deployment resolves to FREE_PLAN (maxMembers=1),
-  // so the owner alone is already at the cap and createInviteRequest 403s. The
-  // app trusts this test-signed license because e2e-ci sets
-  // LANGWATCH_LICENSE_PUBLIC_KEY to the matching TEST_PUBLIC_KEY;
-  // getActivePlan re-reads the license from Postgres on every call, so
-  // activating here (before the specs run) takes effect with no app restart.
-  console.log("Activating test enterprise license...");
-  const licenseOrgsResponse = await page.request.get(
-    "/api/trpc/organization.getAll?batch=1&input=" +
-      encodeURIComponent(JSON.stringify({ "0": { json: {} } })),
-  );
-  const licenseOrgsData = await licenseOrgsResponse.json().catch(() => null);
-  const licenseOrgs: Array<{ id: string }> =
-    licenseOrgsData?.["0"]?.result?.data?.json ?? [];
-  const organizationId = licenseOrgs[0]?.id;
-  if (!organizationId) {
-    throw new Error(
-      `Cannot activate license: no organization found (${JSON.stringify(
-        licenseOrgsData,
-      ).slice(0, 300)})`,
-    );
-  }
-  const licenseResponse = await page.request.post(
-    "/api/trpc/license.upload?batch=1",
-    {
-      data: {
-        "0": {
-          json: { organizationId, licenseKey: E2E_ENTERPRISE_LICENSE_KEY },
-        },
-      },
-    },
-  );
-  const licenseResult = await licenseResponse.json().catch(() => null);
-  if (!licenseResponse.ok() || licenseResult?.["0"]?.error) {
-    throw new Error(
-      `license.upload failed: ${licenseResponse.status()} ${JSON.stringify(
-        licenseResult,
-      ).slice(0, 500)}`,
-    );
-  }
-  console.log("Enterprise license activated (maxMembers=100).");
 
   // Step 4: Confirm the authenticated shell on a settings page. We use
   // /settings rather than the app root because root redirects to the

--- a/agentic-e2e-tests/tests/evaluations-v3/http-agent-cell-rerun.spec.ts
+++ b/agentic-e2e-tests/tests/evaluations-v3/http-agent-cell-rerun.spec.ts
@@ -31,8 +31,7 @@ import {
  * So that I can test modifications without re-running the entire evaluation
  */
 test.describe("Single Cell Re-execution", () => {
-  // fixme(#1811): flaky — Lambda warmup failures in CI cause timeouts
-  test.fixme();
+  test.slow();
   /**
    * Scenario: Single cell re-execution for HTTP agent
    * Source: http-agent-support.feature lines 233-238

--- a/agentic-e2e-tests/tests/evaluations-v3/http-agent-cell-rerun.spec.ts
+++ b/agentic-e2e-tests/tests/evaluations-v3/http-agent-cell-rerun.spec.ts
@@ -31,7 +31,10 @@ import {
  * So that I can test modifications without re-running the entire evaluation
  */
 test.describe("Single Cell Re-execution", () => {
-  test.slow();
+  // fixme: blocked on missing testids — spreadsheet-cell, cell-play-button, save-agent-button
+  // are not yet present in the app source. Re-enable when testids are added to the evaluations
+  // workbench spreadsheet component. Tracked in #1811.
+  test.fixme();
   /**
    * Scenario: Single cell re-execution for HTTP agent
    * Source: http-agent-support.feature lines 233-238

--- a/agentic-e2e-tests/tests/evaluations-v3/http-agent-full-evaluation.spec.ts
+++ b/agentic-e2e-tests/tests/evaluations-v3/http-agent-full-evaluation.spec.ts
@@ -27,8 +27,7 @@ import {
  * So that I can evaluate external APIs that expose my agent via HTTP endpoints
  */
 test.describe("Full Evaluation Run with HTTP Agent Target", () => {
-  // fixme(#1811): flaky — Lambda warmup failures in CI cause timeouts
-  test.fixme();
+  test.slow();
   /**
    * Scenario: Full evaluation run with HTTP agent target
    * Source: http-agent-support.feature lines 222-231

--- a/agentic-e2e-tests/tests/evaluations-v3/http-agent-full-evaluation.spec.ts
+++ b/agentic-e2e-tests/tests/evaluations-v3/http-agent-full-evaluation.spec.ts
@@ -27,7 +27,10 @@ import {
  * So that I can evaluate external APIs that expose my agent via HTTP endpoints
  */
 test.describe("Full Evaluation Run with HTTP Agent Target", () => {
-  test.slow();
+  // fixme: blocked on missing testids — spreadsheet-cell, cell-play-button, save-agent-button
+  // are not yet present in the app source. Re-enable when testids are added to the evaluations
+  // workbench spreadsheet component. Tracked in #1811.
+  test.fixme();
   /**
    * Scenario: Full evaluation run with HTTP agent target
    * Source: http-agent-support.feature lines 222-231

--- a/agentic-e2e-tests/tests/license.fixture.ts
+++ b/agentic-e2e-tests/tests/license.fixture.ts
@@ -1,0 +1,25 @@
+/**
+ * Test-only ENTERPRISE license for the member-invitation e2e tests.
+ *
+ * A no-license self-hosted deployment resolves to FREE_PLAN (maxMembers=1), so
+ * the org owner alone is at the cap and inviting anyone 403s. Activating this
+ * license (see auth.setup.ts) raises the org to ENTERPRISE (maxMembers=100) so
+ * the invitation flows can be exercised.
+ *
+ * This is the pre-signed `ENTERPRISE_LICENSE_KEY` fixture from
+ * `langwatch/ee/licensing/__tests__/fixtures/testLicenses.ts`, signed with the
+ * in-repo TEST keypair (`.../fixtures/testKeys.ts` `TEST_PRIVATE_KEY`), plan
+ * ENTERPRISE, maxMembers=100, expires 2030-12-31. It is copied here as a literal
+ * because agentic-e2e-tests is a standalone pnpm project (installed with
+ * `--ignore-workspace`) and cannot import across the workspace boundary.
+ *
+ * The app trusts it only because the e2e-ci workflow sets
+ * `LANGWATCH_LICENSE_PUBLIC_KEY` to the matching `TEST_PUBLIC_KEY`. If the
+ * in-repo test keypair is ever rotated, update BOTH this string and the
+ * workflow's public key — a mismatch makes the license fail validation, the org
+ * falls back to FREE_PLAN, and these specs fail loudly (invite 403s).
+ *
+ * gitleaks:allow — test-only signed license, not a real secret
+ */
+export const E2E_ENTERPRISE_LICENSE_KEY =
+  "eyJkYXRhIjp7ImxpY2Vuc2VJZCI6ImxpYy0wMDEiLCJ2ZXJzaW9uIjoxLCJvcmdhbml6YXRpb25OYW1lIjoiQWNtZSBDb3JwIiwiZW1haWwiOiJhZG1pbkBhY21lLmNvcnAiLCJpc3N1ZWRBdCI6IjIwMjQtMDEtMDFUMDA6MDA6MDBaIiwiZXhwaXJlc0F0IjoiMjAzMC0xMi0zMVQyMzo1OTo1OVoiLCJwbGFuIjp7InR5cGUiOiJFTlRFUlBSSVNFIiwibmFtZSI6IkVudGVycHJpc2UiLCJtYXhNZW1iZXJzIjoxMDAsIm1heFByb2plY3RzIjo1MDAsIm1heE1lc3NhZ2VzUGVyTW9udGgiOjEwMDAwMDAwLCJldmFsdWF0aW9uc0NyZWRpdCI6MTAwMDAsIm1heFdvcmtmbG93cyI6MTAwMCwibWF4UHJvbXB0cyI6MTAwMCwibWF4RXZhbHVhdG9ycyI6MTAwMCwibWF4U2NlbmFyaW9zIjoxMDAwLCJtYXhBZ2VudHMiOjEwMDAsIm1heEV4cGVyaW1lbnRzIjoxMDAwLCJtYXhPbmxpbmVFdmFsdWF0aW9ucyI6MTAwMCwiY2FuUHVibGlzaCI6dHJ1ZX19LCJzaWduYXR1cmUiOiJhRDlLVkx0V2JOT3pGc3JrOUxHQzdhWEZRdk41MDVBR1VHSWVpcXN5S0tYM1IzK3o1aXIrV01lTS9tQVovOVBOeGRDalUrODVLS3A4TFAweDhIcWl0YnRubVprNVhqQ29uNWQ3S1Q3WFhwOWtsd2tEV0VocnNuL2F5ZWlYcWw0eElzUWZMNG92QitaZEt3TFVQUVFucWFGUVhFU093WEt2akp4QzU0VFp6bUk4THBXbSthYk10Qm50VFNxaFVaamRMdkJJWTlVbHR6LzU2T3pvUmgvdlJuSXhleUdlVkJCK3pWaVQ3LzF6YkpGMG5QZ1ZhVW9GUHI1dFRGYzRvS1VPdXRJSjRyWVJPSkFQNUlUbjZ4OHJLSDBXNi9QSmNVeWlHUE9TL085UXhCVXhGWml0Y3R6UDlwZURGeGhxcm5wbGxUdE1iVER6SVprS3gyMWFadDJMRUE9PSJ9";

--- a/agentic-e2e-tests/tests/license.fixture.ts
+++ b/agentic-e2e-tests/tests/license.fixture.ts
@@ -3,8 +3,9 @@
  *
  * A no-license self-hosted deployment resolves to FREE_PLAN (maxMembers=1), so
  * the org owner alone is at the cap and inviting anyone 403s. Activating this
- * license (see auth.setup.ts) raises the org to ENTERPRISE (maxMembers=100) so
- * the invitation flows can be exercised.
+ * license (see members/steps.ts `withEnterpriseLicense()`, which activates it
+ * before each members test and removes it after) raises the org to ENTERPRISE
+ * (maxMembers=100) so the invitation flows can be exercised.
  *
  * This is the pre-signed `ENTERPRISE_LICENSE_KEY` fixture from
  * `langwatch/ee/licensing/__tests__/fixtures/testLicenses.ts`, signed with the

--- a/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
@@ -17,8 +17,7 @@ import {
  * Scenario: Admin approves an invitation request (lines 27-33)
  */
 test.describe("Invitation Approval - Admin Approves Request", () => {
-  // fixme(#1811): flaky — fails consistently in CI environment
-  test.fixme();
+  test.slow();
   /**
    * Scenario: Admin approves an invitation request
    * Source: update-pending-invitation.feature lines 27-33

--- a/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
@@ -17,13 +17,11 @@ import {
  * Scenario: Admin approves an invitation request (lines 27-33)
  */
 test.describe("Invitation Approval - Admin Approves Request", () => {
-  // fixme(#1811): the member-invitation flow needs an org plan with maxMembers>=2,
-  // but free-tier self-hosted CI has no license, so the plan resolves to FREE_PLAN
-  // (maxMembers=1) — the org owner alone is already at the cap and
-  // createInviteRequest 403s "maximum number of team members" (verified via
-  // licenseEnforcement.checkLimit: current=1, max=1). Re-enable once the CI test
-  // org is provisioned a license/subscription that raises the member cap.
-  test.fixme();
+  // Member-invitation requires an org plan with maxMembers>=2. auth.setup.ts
+  // activates a test ENTERPRISE license (maxMembers=100) for the org so these
+  // run in self-hosted CI, where a no-license org otherwise resolves to
+  // FREE_PLAN (maxMembers=1) and createInviteRequest 403s. See
+  // tests/license.fixture.ts. (#1811)
   /**
    * Scenario: Admin approves an invitation request
    * Source: update-pending-invitation.feature lines 27-33

--- a/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
@@ -8,6 +8,7 @@ import {
   seedWaitingApprovalInvite,
   getOrgAndTeamIds,
   generateUniqueEmail,
+  withEnterpriseLicense,
 } from "./steps";
 
 /**
@@ -17,11 +18,12 @@ import {
  * Scenario: Admin approves an invitation request (lines 27-33)
  */
 test.describe("Invitation Approval - Admin Approves Request", () => {
-  // Member-invitation requires an org plan with maxMembers>=2. auth.setup.ts
-  // activates a test ENTERPRISE license (maxMembers=100) for the org so these
-  // run in self-hosted CI, where a no-license org otherwise resolves to
-  // FREE_PLAN (maxMembers=1) and createInviteRequest 403s. See
-  // tests/license.fixture.ts. (#1811)
+  // Member-invitation requires an org plan with maxMembers>=2. A no-license
+  // self-hosted org resolves to FREE_PLAN (maxMembers=1), so createInviteRequest
+  // 403s. withEnterpriseLicense() activates a test ENTERPRISE license
+  // (maxMembers=100) before each test and removes it after, scoping the raised
+  // cap to this suite. See tests/license.fixture.ts. (#1802)
+  withEnterpriseLicense();
   /**
    * Scenario: Admin approves an invitation request
    * Source: update-pending-invitation.feature lines 27-33

--- a/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-approves-invitation.spec.ts
@@ -17,7 +17,13 @@ import {
  * Scenario: Admin approves an invitation request (lines 27-33)
  */
 test.describe("Invitation Approval - Admin Approves Request", () => {
-  test.slow();
+  // fixme(#1811): the member-invitation flow needs an org plan with maxMembers>=2,
+  // but free-tier self-hosted CI has no license, so the plan resolves to FREE_PLAN
+  // (maxMembers=1) — the org owner alone is already at the cap and
+  // createInviteRequest 403s "maximum number of team members" (verified via
+  // licenseEnforcement.checkLimit: current=1, max=1). Re-enable once the CI test
+  // org is provisioned a license/subscription that raises the member cap.
+  test.fixme();
   /**
    * Scenario: Admin approves an invitation request
    * Source: update-pending-invitation.feature lines 27-33

--- a/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
@@ -17,8 +17,7 @@ import {
  * Scenario: Admin creates an immediate invite (lines 19-24)
  */
 test.describe("Invitation Approval - Admin Creates Immediate Invite", () => {
-  // fixme(#1811): flaky — fails consistently in CI environment
-  test.fixme();
+  test.slow();
   /**
    * Scenario: Admin creates an immediate invite
    * Source: update-pending-invitation.feature lines 19-24

--- a/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
@@ -8,6 +8,7 @@ import {
   thenISeeSentInviteFor,
   thenISeeSuccessToast,
   generateUniqueEmail,
+  withEnterpriseLicense,
 } from "./steps";
 
 /**
@@ -17,11 +18,12 @@ import {
  * Scenario: Admin creates an immediate invite (lines 19-24)
  */
 test.describe("Invitation Approval - Admin Creates Immediate Invite", () => {
-  // Member-invitation requires an org plan with maxMembers>=2. auth.setup.ts
-  // activates a test ENTERPRISE license (maxMembers=100) for the org so these
-  // run in self-hosted CI, where a no-license org otherwise resolves to
-  // FREE_PLAN (maxMembers=1) and createInviteRequest 403s. See
-  // tests/license.fixture.ts. (#1811)
+  // Member-invitation requires an org plan with maxMembers>=2. A no-license
+  // self-hosted org resolves to FREE_PLAN (maxMembers=1), so createInviteRequest
+  // 403s. withEnterpriseLicense() activates a test ENTERPRISE license
+  // (maxMembers=100) before each test and removes it after, scoping the raised
+  // cap to this suite. See tests/license.fixture.ts. (#1802)
+  withEnterpriseLicense();
   /**
    * Scenario: Admin creates an immediate invite
    * Source: update-pending-invitation.feature lines 19-24

--- a/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
@@ -17,7 +17,13 @@ import {
  * Scenario: Admin creates an immediate invite (lines 19-24)
  */
 test.describe("Invitation Approval - Admin Creates Immediate Invite", () => {
-  test.slow();
+  // fixme(#1811): the member-invitation flow needs an org plan with maxMembers>=2,
+  // but free-tier self-hosted CI has no license, so the plan resolves to FREE_PLAN
+  // (maxMembers=1) — the org owner alone is already at the cap and
+  // createInviteRequest 403s "maximum number of team members" (verified via
+  // licenseEnforcement.checkLimit: current=1, max=1). Re-enable once the CI test
+  // org is provisioned a license/subscription that raises the member cap.
+  test.fixme();
   /**
    * Scenario: Admin creates an immediate invite
    * Source: update-pending-invitation.feature lines 19-24

--- a/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-creates-immediate-invite.spec.ts
@@ -17,13 +17,11 @@ import {
  * Scenario: Admin creates an immediate invite (lines 19-24)
  */
 test.describe("Invitation Approval - Admin Creates Immediate Invite", () => {
-  // fixme(#1811): the member-invitation flow needs an org plan with maxMembers>=2,
-  // but free-tier self-hosted CI has no license, so the plan resolves to FREE_PLAN
-  // (maxMembers=1) — the org owner alone is already at the cap and
-  // createInviteRequest 403s "maximum number of team members" (verified via
-  // licenseEnforcement.checkLimit: current=1, max=1). Re-enable once the CI test
-  // org is provisioned a license/subscription that raises the member cap.
-  test.fixme();
+  // Member-invitation requires an org plan with maxMembers>=2. auth.setup.ts
+  // activates a test ENTERPRISE license (maxMembers=100) for the org so these
+  // run in self-hosted CI, where a no-license org otherwise resolves to
+  // FREE_PLAN (maxMembers=1) and createInviteRequest 403s. See
+  // tests/license.fixture.ts. (#1811)
   /**
    * Scenario: Admin creates an immediate invite
    * Source: update-pending-invitation.feature lines 19-24

--- a/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
@@ -17,8 +17,7 @@ import {
  * Scenario: Admin rejects an invitation request (lines 36-42)
  */
 test.describe("Invitation Approval - Admin Rejects Request", () => {
-  // fixme(#1811): flaky — fails consistently in CI environment
-  test.fixme();
+  test.slow();
   /**
    * Scenario: Admin rejects an invitation request
    * Source: update-pending-invitation.feature lines 36-42

--- a/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
@@ -17,13 +17,11 @@ import {
  * Scenario: Admin rejects an invitation request (lines 36-42)
  */
 test.describe("Invitation Approval - Admin Rejects Request", () => {
-  // fixme(#1811): the member-invitation flow needs an org plan with maxMembers>=2,
-  // but free-tier self-hosted CI has no license, so the plan resolves to FREE_PLAN
-  // (maxMembers=1) — the org owner alone is already at the cap and
-  // createInviteRequest 403s "maximum number of team members" (verified via
-  // licenseEnforcement.checkLimit: current=1, max=1). Re-enable once the CI test
-  // org is provisioned a license/subscription that raises the member cap.
-  test.fixme();
+  // Member-invitation requires an org plan with maxMembers>=2. auth.setup.ts
+  // activates a test ENTERPRISE license (maxMembers=100) for the org so these
+  // run in self-hosted CI, where a no-license org otherwise resolves to
+  // FREE_PLAN (maxMembers=1) and createInviteRequest 403s. See
+  // tests/license.fixture.ts. (#1811)
   /**
    * Scenario: Admin rejects an invitation request
    * Source: update-pending-invitation.feature lines 36-42

--- a/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
@@ -17,7 +17,13 @@ import {
  * Scenario: Admin rejects an invitation request (lines 36-42)
  */
 test.describe("Invitation Approval - Admin Rejects Request", () => {
-  test.slow();
+  // fixme(#1811): the member-invitation flow needs an org plan with maxMembers>=2,
+  // but free-tier self-hosted CI has no license, so the plan resolves to FREE_PLAN
+  // (maxMembers=1) — the org owner alone is already at the cap and
+  // createInviteRequest 403s "maximum number of team members" (verified via
+  // licenseEnforcement.checkLimit: current=1, max=1). Re-enable once the CI test
+  // org is provisioned a license/subscription that raises the member cap.
+  test.fixme();
   /**
    * Scenario: Admin rejects an invitation request
    * Source: update-pending-invitation.feature lines 36-42

--- a/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
+++ b/agentic-e2e-tests/tests/members/admin-rejects-invitation.spec.ts
@@ -8,6 +8,7 @@ import {
   seedWaitingApprovalInvite,
   getOrgAndTeamIds,
   generateUniqueEmail,
+  withEnterpriseLicense,
 } from "./steps";
 
 /**
@@ -17,11 +18,12 @@ import {
  * Scenario: Admin rejects an invitation request (lines 36-42)
  */
 test.describe("Invitation Approval - Admin Rejects Request", () => {
-  // Member-invitation requires an org plan with maxMembers>=2. auth.setup.ts
-  // activates a test ENTERPRISE license (maxMembers=100) for the org so these
-  // run in self-hosted CI, where a no-license org otherwise resolves to
-  // FREE_PLAN (maxMembers=1) and createInviteRequest 403s. See
-  // tests/license.fixture.ts. (#1811)
+  // Member-invitation requires an org plan with maxMembers>=2. A no-license
+  // self-hosted org resolves to FREE_PLAN (maxMembers=1), so createInviteRequest
+  // 403s. withEnterpriseLicense() activates a test ENTERPRISE license
+  // (maxMembers=100) before each test and removes it after, scoping the raised
+  // cap to this suite. See tests/license.fixture.ts. (#1802)
+  withEnterpriseLicense();
   /**
    * Scenario: Admin rejects an invitation request
    * Source: update-pending-invitation.feature lines 36-42

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -70,7 +70,7 @@ export async function whenIClickAddMembers(page: Page) {
   // Wait for dialog - use last() for Chakra UI duplicate rendering
   await expect(
     page.getByRole("heading", { name: "Add members" }).last()
-  ).toBeVisible({ timeout: 5000 });
+  ).toBeVisible({ timeout: 10000 });
 }
 
 /**
@@ -165,8 +165,8 @@ export async function thenISeeSentInviteFor(page: Page, email: string) {
   const invitesSection = invitesHeading.locator("..");
   const row = invitesSection.getByRole("row").filter({ hasText: email });
 
-  await expect(row).toBeVisible({ timeout: 5000 });
-  await expect(row.getByText("Invited")).toBeVisible({ timeout: 5000 });
+  await expect(row).toBeVisible({ timeout: 15000 });
+  await expect(row.getByText("Invited")).toBeVisible({ timeout: 10000 });
 }
 
 /**
@@ -179,9 +179,9 @@ export async function thenISeePendingApprovalFor(page: Page, email: string) {
   const invitesSection = invitesHeading.locator("..");
   const row = invitesSection.getByRole("row").filter({ hasText: email });
 
-  await expect(row).toBeVisible({ timeout: 5000 });
+  await expect(row).toBeVisible({ timeout: 15000 });
   await expect(row.getByText("Pending Approval")).toBeVisible({
-    timeout: 5000,
+    timeout: 10000,
   });
 }
 
@@ -197,7 +197,7 @@ export async function thenEmailIsNotVisible(page: Page, email: string) {
  */
 export async function thenISeeSuccessToast(page: Page, titleText: string) {
   await expect(page.getByText(titleText, { exact: false })).toBeVisible({
-    timeout: 5000,
+    timeout: 10000,
   });
 }
 

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -8,28 +8,23 @@
  */
 import { Page, expect } from "@playwright/test";
 
-import { getProjectSlug } from "../helpers";
 
 /**
- * Typed shape of a tRPC response from organization.getAll.
- * tRPC wraps results in a nested `result.data` structure,
- * with the actual payload under `result.data.json`.
+ * Typed shape of the batched tRPC response from organization.getAll.
+ * The batch API wraps results under a numeric string key ("0").
  */
-interface TrpcOrganizationResponse {
-  result?: {
-    data?:
-      | {
-          json?: Array<{
-            id: string;
-            teams?: Array<{ id: string }>;
-          }>;
-        }
-      | Array<{
+type OrgGetAllBatchResponse = {
+  "0"?: {
+    result?: {
+      data?: {
+        json?: Array<{
           id: string;
           teams?: Array<{ id: string }>;
         }>;
+      };
+    };
   };
-}
+};
 
 // =============================================================================
 // Navigation Steps
@@ -40,10 +35,9 @@ interface TrpcOrganizationResponse {
  * Extracts the org slug from the Home link to build the URL.
  */
 export async function givenIAmOnTheMembersPage(page: Page) {
-  const projectSlug = await getProjectSlug(page);
-
-  // Navigate to settings/members using the org context
-  await page.goto(`/${projectSlug}/settings/members`);
+  // The members page lives at /settings/members (src/pages/settings/members.tsx),
+  // NOT under /{project}/settings/members — it has no [project] path segment.
+  await page.goto(`/settings/members`);
   await expect(
     page.getByRole("heading", { name: "Organization Members" })
   ).toBeVisible({ timeout: 15000 });
@@ -213,33 +207,34 @@ export async function getOrgAndTeamIds(page: Page): Promise<{
   organizationId: string;
   teamId: string;
 }> {
-  // Confirm the authenticated app loaded before calling the org API.
-  await getProjectSlug(page);
+  // Use page.request (same as getProjectSlug in helpers.ts) so this works
+  // even before the browser has navigated anywhere — page.evaluate with a
+  // relative URL fails on about:blank because there is no base URL.
+  const response = await page.request.get(
+    "/api/trpc/organization.getAll?batch=1&input=" +
+      encodeURIComponent(JSON.stringify({ "0": { json: {} } })),
+  );
 
-  // Use the settings API to get org data
-  const orgData = await page.evaluate(async () => {
-    const response = await fetch("/api/trpc/organization.getAll");
-    const json = (await response.json()) as TrpcOrganizationResponse;
-    // tRPC wraps the result; data may be {json: [...]} or directly [...]
-    const data = json.result?.data;
-    const orgs = (data && !Array.isArray(data) ? data.json : data) ?? [];
-    if (!Array.isArray(orgs) || orgs.length === 0) {
-      throw new Error("No organizations found");
-    }
-    const org = orgs[0]!;
-    return {
-      organizationId: org.id,
-      teamId: org.teams?.[0]?.id ?? "",
-    };
-  });
+  const data = (await response.json().catch(() => null)) as OrgGetAllBatchResponse | null;
+  const orgs = data?.["0"]?.result?.data?.json ?? [];
 
-  if (!orgData.organizationId || !orgData.teamId) {
+  if (!Array.isArray(orgs) || orgs.length === 0) {
     throw new Error(
-      `Could not extract org/team IDs: ${JSON.stringify(orgData)}`
+      `No organizations found in organization.getAll (status ${response.status()})`,
     );
   }
 
-  return orgData;
+  const org = orgs[0]!;
+  const organizationId = org.id;
+  const teamId = org.teams?.[0]?.id ?? "";
+
+  if (!organizationId || !teamId) {
+    throw new Error(
+      `Could not extract org/team IDs: ${JSON.stringify(org)}`,
+    );
+  }
+
+  return { organizationId, teamId };
 }
 
 /**

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -79,25 +79,16 @@ export async function whenIClickCreateInvites(page: Page) {
  * Shows when no email provider is configured after admin invite.
  */
 export async function whenICloseInviteLinkDialog(page: Page) {
-  const inviteLinkHeading = page.getByRole("heading", {
-    name: "Invite Link",
-  });
-  let isVisible = false;
-  try {
-    await expect(inviteLinkHeading).toBeVisible({ timeout: 3000 });
-    isVisible = true;
-  } catch {
-    isVisible = false;
-  }
-
-  if (isVisible) {
-    // Close the dialog
-    await page
-      .locator('[role="dialog"]')
-      .last()
-      .getByRole("button", { name: /close/i })
-      .click();
-    await expect(inviteLinkHeading).not.toBeVisible({ timeout: 3000 });
+  // The invite-link dialog appears when no email provider is configured. Match
+  // it by role+name (a single element) rather than by heading: the title
+  // renders two nested "Invite Link" headings (Dialog.Title > Heading), so a
+  // heading locator is a strict-mode multiple match that throws. Closing it is
+  // required — while open, the modal makes the underlying Invites table inert,
+  // so the "Invited" row is not visible to later assertions.
+  const dialog = page.getByRole("dialog", { name: "Invite Link" });
+  if (await dialog.isVisible().catch(() => false)) {
+    await dialog.getByRole("button", { name: /close/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
   }
 }
 

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -181,8 +181,10 @@ export async function thenEmailIsNotVisible(page: Page, email: string) {
  * Assert that a success toast with the given title text appears.
  */
 export async function thenISeeSuccessToast(page: Page, titleText: string) {
+  // 15 s: CI mutation round-trips can be slow; toast appears only after the
+  // server responds, and the default 5 s is too tight under load.
   await expect(page.getByText(titleText, { exact: false })).toBeVisible({
-    timeout: 5000,
+    timeout: 15000,
   });
 }
 
@@ -265,7 +267,7 @@ export async function seedWaitingApprovalInvite({
                 {
                   teamId,
                   role: "MEMBER",
-                  customRoleId: null,
+                  // customRoleId omitted — z.string().optional() accepts undefined, not null
                 },
               ],
             },

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -240,6 +240,39 @@ export async function getOrgAndTeamIds(page: Page): Promise<{
 }
 
 /**
+ * Purge all PENDING/WAITING_APPROVAL invites for the org before seeding.
+ * Required because the CI DB persists across runs (SKIP_PRISMA_MIGRATE=true),
+ * so accumulated invites count toward the free plan maxMembers=2 cap and
+ * cause 403 FORBIDDEN on subsequent seeding calls.
+ */
+async function purgeExistingInvites({
+  page,
+  organizationId,
+}: {
+  page: Page;
+  organizationId: string;
+}) {
+  const listResponse = await page.request.get(
+    "/api/trpc/organization.getOrganizationPendingInvites?batch=1&input=" +
+      encodeURIComponent(
+        JSON.stringify({ "0": { json: { organizationId } } }),
+      ),
+  );
+  if (!listResponse.ok()) return; // best-effort
+
+  const data = (await listResponse.json().catch(() => null)) as
+    | { "0": { result: { data: { json: { id: string }[] } } } }
+    | null;
+  const invites = data?.["0"]?.result?.data?.json ?? [];
+
+  for (const invite of invites) {
+    await page.request.post("/api/trpc/organization.deleteInvite", {
+      data: { json: { inviteId: invite.id, organizationId } },
+    });
+  }
+}
+
+/**
  * Create a WAITING_APPROVAL invitation via tRPC API.
  */
 export async function seedWaitingApprovalInvite({
@@ -253,6 +286,9 @@ export async function seedWaitingApprovalInvite({
   organizationId: string;
   teamId: string;
 }) {
+  // Purge accumulated invites first so we don't hit the free plan member cap.
+  await purgeExistingInvites({ page, organizationId });
+
   const response = await page.request.post(
     "/api/trpc/organization.createInviteRequest",
     {

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -48,7 +48,10 @@ export async function whenIClickAddMembers(page: Page) {
  * Fill the email input field in the Add Members dialog.
  */
 export async function whenIFillEmailWith(page: Page, email: string) {
-  await page.getByPlaceholder("Enter email address").last().fill(email);
+  // The Add-members dialog uses a single comma/space-separated email input whose
+  // placeholder is an example list ("alice@example.com, bob@example.com") — see
+  // langwatch/src/components/AddMembersForm.tsx. Match it by a stable substring.
+  await page.getByPlaceholder(/alice@example\.com/i).last().fill(email);
 }
 
 /**
@@ -245,11 +248,13 @@ export async function seedWaitingApprovalInvite({
             {
               email: email.toLowerCase(),
               role: "MEMBER",
+              // Omit customRoleId entirely: the createInviteRequest schema types
+              // it as z.string().optional() (organization.ts), so a literal null
+              // fails validation with "Expected string, received null".
               teams: [
                 {
                   teamId,
                   role: "MEMBER",
-                  customRoleId: null,
                 },
               ],
             },

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -8,23 +8,28 @@
  */
 import { Page, expect } from "@playwright/test";
 
+import { getProjectSlug } from "../helpers";
 
 /**
- * Typed shape of the batched tRPC response from organization.getAll.
- * The batch API wraps results under a numeric string key ("0").
+ * Typed shape of a tRPC response from organization.getAll.
+ * tRPC wraps results in a nested `result.data` structure,
+ * with the actual payload under `result.data.json`.
  */
-type OrgGetAllBatchResponse = {
-  "0"?: {
-    result?: {
-      data?: {
-        json?: Array<{
+interface TrpcOrganizationResponse {
+  result?: {
+    data?:
+      | {
+          json?: Array<{
+            id: string;
+            teams?: Array<{ id: string }>;
+          }>;
+        }
+      | Array<{
           id: string;
           teams?: Array<{ id: string }>;
         }>;
-      };
-    };
   };
-};
+}
 
 // =============================================================================
 // Navigation Steps
@@ -35,9 +40,10 @@ type OrgGetAllBatchResponse = {
  * Extracts the org slug from the Home link to build the URL.
  */
 export async function givenIAmOnTheMembersPage(page: Page) {
-  // The members page lives at /settings/members (src/pages/settings/members.tsx),
-  // NOT under /{project}/settings/members — it has no [project] path segment.
-  await page.goto(`/settings/members`);
+  const projectSlug = await getProjectSlug(page);
+
+  // Navigate to settings/members using the org context
+  await page.goto(`/${projectSlug}/settings/members`);
   await expect(
     page.getByRole("heading", { name: "Organization Members" })
   ).toBeVisible({ timeout: 15000 });
@@ -62,7 +68,7 @@ export async function whenIClickAddMembers(page: Page) {
  * Fill the email input field in the Add Members dialog.
  */
 export async function whenIFillEmailWith(page: Page, email: string) {
-  await page.getByPlaceholder("alice@example.com, bob@example.com").last().fill(email);
+  await page.getByPlaceholder("Enter email address").last().fill(email);
 }
 
 /**
@@ -181,10 +187,8 @@ export async function thenEmailIsNotVisible(page: Page, email: string) {
  * Assert that a success toast with the given title text appears.
  */
 export async function thenISeeSuccessToast(page: Page, titleText: string) {
-  // 15 s: CI mutation round-trips can be slow; toast appears only after the
-  // server responds, and the default 5 s is too tight under load.
   await expect(page.getByText(titleText, { exact: false })).toBeVisible({
-    timeout: 15000,
+    timeout: 5000,
   });
 }
 
@@ -209,67 +213,33 @@ export async function getOrgAndTeamIds(page: Page): Promise<{
   organizationId: string;
   teamId: string;
 }> {
-  // Use page.request (same as getProjectSlug in helpers.ts) so this works
-  // even before the browser has navigated anywhere — page.evaluate with a
-  // relative URL fails on about:blank because there is no base URL.
-  const response = await page.request.get(
-    "/api/trpc/organization.getAll?batch=1&input=" +
-      encodeURIComponent(JSON.stringify({ "0": { json: {} } })),
-  );
+  // Confirm the authenticated app loaded before calling the org API.
+  await getProjectSlug(page);
 
-  const data = (await response.json().catch(() => null)) as OrgGetAllBatchResponse | null;
-  const orgs = data?.["0"]?.result?.data?.json ?? [];
+  // Use the settings API to get org data
+  const orgData = await page.evaluate(async () => {
+    const response = await fetch("/api/trpc/organization.getAll");
+    const json = (await response.json()) as TrpcOrganizationResponse;
+    // tRPC wraps the result; data may be {json: [...]} or directly [...]
+    const data = json.result?.data;
+    const orgs = (data && !Array.isArray(data) ? data.json : data) ?? [];
+    if (!Array.isArray(orgs) || orgs.length === 0) {
+      throw new Error("No organizations found");
+    }
+    const org = orgs[0]!;
+    return {
+      organizationId: org.id,
+      teamId: org.teams?.[0]?.id ?? "",
+    };
+  });
 
-  if (!Array.isArray(orgs) || orgs.length === 0) {
+  if (!orgData.organizationId || !orgData.teamId) {
     throw new Error(
-      `No organizations found in organization.getAll (status ${response.status()})`,
+      `Could not extract org/team IDs: ${JSON.stringify(orgData)}`
     );
   }
 
-  const org = orgs[0]!;
-  const organizationId = org.id;
-  const teamId = org.teams?.[0]?.id ?? "";
-
-  if (!organizationId || !teamId) {
-    throw new Error(
-      `Could not extract org/team IDs: ${JSON.stringify(org)}`,
-    );
-  }
-
-  return { organizationId, teamId };
-}
-
-/**
- * Purge all PENDING/WAITING_APPROVAL invites for the org before seeding.
- * Required because the CI DB persists across runs (SKIP_PRISMA_MIGRATE=true),
- * so accumulated invites count toward the free plan maxMembers=2 cap and
- * cause 403 FORBIDDEN on subsequent seeding calls.
- */
-async function purgeExistingInvites({
-  page,
-  organizationId,
-}: {
-  page: Page;
-  organizationId: string;
-}) {
-  const listResponse = await page.request.get(
-    "/api/trpc/organization.getOrganizationPendingInvites?batch=1&input=" +
-      encodeURIComponent(
-        JSON.stringify({ "0": { json: { organizationId } } }),
-      ),
-  );
-  if (!listResponse.ok()) return; // best-effort
-
-  const data = (await listResponse.json().catch(() => null)) as
-    | { "0": { result: { data: { json: { id: string }[] } } } }
-    | null;
-  const invites = data?.["0"]?.result?.data?.json ?? [];
-
-  for (const invite of invites) {
-    await page.request.post("/api/trpc/organization.deleteInvite", {
-      data: { json: { inviteId: invite.id, organizationId } },
-    });
-  }
+  return orgData;
 }
 
 /**
@@ -286,9 +256,6 @@ export async function seedWaitingApprovalInvite({
   organizationId: string;
   teamId: string;
 }) {
-  // Purge accumulated invites first so we don't hit the free plan member cap.
-  await purgeExistingInvites({ page, organizationId });
-
   const response = await page.request.post(
     "/api/trpc/organization.createInviteRequest",
     {
@@ -303,7 +270,7 @@ export async function seedWaitingApprovalInvite({
                 {
                   teamId,
                   role: "MEMBER",
-                  // customRoleId omitted — z.string().optional() accepts undefined, not null
+                  customRoleId: null,
                 },
               ],
             },

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -68,7 +68,7 @@ export async function whenIClickAddMembers(page: Page) {
  * Fill the email input field in the Add Members dialog.
  */
 export async function whenIFillEmailWith(page: Page, email: string) {
-  await page.getByPlaceholder("Enter email address").last().fill(email);
+  await page.getByPlaceholder("alice@example.com, bob@example.com").last().fill(email);
 }
 
 /**

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -301,21 +301,43 @@ export async function activateEnterpriseLicense(page: Page): Promise<void> {
 }
 
 /**
- * Remove the org's license, restoring FREE_PLAN. Called after each members test
- * so the shared org does not leak an ENTERPRISE plan into other suites (e.g.
- * settings/plans-comparison asserts the Free plan is current).
+ * Remove the org's license, restoring the plan to FREE_PLAN so the shared org
+ * does not leak an ENTERPRISE cap into other suites (e.g.
+ * settings/plans-comparison asserts the Free plan is current). Mirrors
+ * activateEnterpriseLicense's error handling: under sequential execution a
+ * SILENT failure here would strand the shared singleton org on ENTERPRISE for
+ * the rest of the run and surface as a far-removed flake, so we throw at the
+ * point of cause.
+ *
+ * NOTE: activation also create-if-absent provisions org-level retention-policy
+ * rows (provisionMissingRetentionPolicies); removeLicense does not revert those.
+ * Harmless today (no e2e spec asserts retention state) — it's the plan/cap that
+ * is scoped, not every activation side effect.
  */
 export async function removeEnterpriseLicense(page: Page): Promise<void> {
   const { organizationId } = await getOrgAndTeamIds(page);
-  await page.request.post("/api/trpc/license.remove?batch=1", {
+  const response = await page.request.post("/api/trpc/license.remove?batch=1", {
     data: { "0": { json: { organizationId } } },
   });
+  const result = await response.json().catch(() => null);
+  if (!response.ok() || result?.["0"]?.error) {
+    throw new Error(
+      `license.remove failed: ${response.status()} ${JSON.stringify(
+        result,
+      ).slice(0, 500)}`,
+    );
+  }
 }
 
 /**
  * Registers per-test hooks that activate an ENTERPRISE license before each test
  * and remove it after — scoping the raised member cap to the members suite so
  * the shared test org returns to FREE_PLAN for every other suite.
+ *
+ * SAFE ONLY under sequential execution (playwright.config.ts:
+ * fullyParallel:false, workers:1). The test org is a shared singleton, so with
+ * parallel workers a concurrent test could observe it mid-ENTERPRISE-window;
+ * raising CI parallelism would require moving this to an isolated per-test org.
  */
 export function withEnterpriseLicense(): void {
   test.beforeEach(async ({ page }) => {

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -6,30 +6,9 @@
  * Usage: Import and compose these steps in test files to create
  * readable tests that map directly to feature specifications.
  */
-import { Page, expect } from "@playwright/test";
+import { Page, expect, test } from "@playwright/test";
 
-import { getProjectSlug } from "../helpers";
-
-/**
- * Typed shape of a tRPC response from organization.getAll.
- * tRPC wraps results in a nested `result.data` structure,
- * with the actual payload under `result.data.json`.
- */
-interface TrpcOrganizationResponse {
-  result?: {
-    data?:
-      | {
-          json?: Array<{
-            id: string;
-            teams?: Array<{ id: string }>;
-          }>;
-        }
-      | Array<{
-          id: string;
-          teams?: Array<{ id: string }>;
-        }>;
-  };
-}
+import { E2E_ENTERPRISE_LICENSE_KEY } from "../license.fixture";
 
 // =============================================================================
 // Navigation Steps
@@ -40,10 +19,11 @@ interface TrpcOrganizationResponse {
  * Extracts the org slug from the Home link to build the URL.
  */
 export async function givenIAmOnTheMembersPage(page: Page) {
-  const projectSlug = await getProjectSlug(page);
-
-  // Navigate to settings/members using the org context
-  await page.goto(`/${projectSlug}/settings/members`);
+  // Members settings is org-scoped at /settings/members (resolved via the
+  // session's active org), not project-prefixed — every app nav link uses this
+  // exact href (see langwatch/src/routes.tsx). The org context comes from the
+  // authenticated session, not the URL.
+  await page.goto(`/settings/members`);
   await expect(
     page.getByRole("heading", { name: "Organization Members" })
   ).toBeVisible({ timeout: 15000 });
@@ -213,33 +193,32 @@ export async function getOrgAndTeamIds(page: Page): Promise<{
   organizationId: string;
   teamId: string;
 }> {
-  // Confirm the authenticated app loaded before calling the org API.
-  await getProjectSlug(page);
-
-  // Use the settings API to get org data
-  const orgData = await page.evaluate(async () => {
-    const response = await fetch("/api/trpc/organization.getAll");
-    const json = (await response.json()) as TrpcOrganizationResponse;
-    // tRPC wraps the result; data may be {json: [...]} or directly [...]
-    const data = json.result?.data;
-    const orgs = (data && !Array.isArray(data) ? data.json : data) ?? [];
-    if (!Array.isArray(orgs) || orgs.length === 0) {
-      throw new Error("No organizations found");
-    }
-    const org = orgs[0]!;
-    return {
-      organizationId: org.id,
-      teamId: org.teams?.[0]?.id ?? "",
+  // Use page.request (not page.evaluate(fetch(...))): the Playwright request
+  // context resolves this relative URL against baseURL and carries the auth
+  // cookies, whereas an in-page fetch on a blank/unnavigated page throws
+  // "Failed to parse URL". Mirrors getProjectSlug and the batched tRPC shape.
+  const response = await page.request.get(
+    "/api/trpc/organization.getAll?batch=1&input=" +
+      encodeURIComponent(JSON.stringify({ "0": { json: {} } })),
+  );
+  const json = (await response.json().catch(() => null)) as {
+    "0"?: {
+      result?: {
+        data?: {
+          json?: Array<{ id: string; teams?: Array<{ id: string }> }>;
+        };
+      };
     };
-  });
-
-  if (!orgData.organizationId || !orgData.teamId) {
+  } | null;
+  const org = (json?.["0"]?.result?.data?.json ?? [])[0];
+  if (!org?.id || !org.teams?.[0]?.id) {
     throw new Error(
-      `Could not extract org/team IDs: ${JSON.stringify(orgData)}`
+      `Could not extract org/team IDs (status ${response.status()}): ${JSON.stringify(
+        json,
+      ).slice(0, 300)}`,
     );
   }
-
-  return orgData;
+  return { organizationId: org.id, teamId: org.teams[0].id };
 }
 
 /**
@@ -293,4 +272,60 @@ export function generateUniqueEmail(prefix: string): string {
   const timestamp = Date.now();
   const random = Math.floor(Math.random() * 1000);
   return `${prefix}-${timestamp}-${random}@example.com`;
+}
+
+// =============================================================================
+// License Scoping
+// =============================================================================
+
+/**
+ * Activate a test ENTERPRISE license (maxMembers=100) for the current org.
+ *
+ * A no-license self-hosted deployment resolves to FREE_PLAN (maxMembers=1), so
+ * the owner alone is at the cap and createInviteRequest 403s. The app trusts
+ * this test-signed license because e2e-ci sets LANGWATCH_LICENSE_PUBLIC_KEY to
+ * the matching TEST_PUBLIC_KEY; getActivePlan re-reads the org's license from
+ * Postgres on every call, so activation takes effect with no app restart.
+ */
+export async function activateEnterpriseLicense(page: Page): Promise<void> {
+  const { organizationId } = await getOrgAndTeamIds(page);
+  const response = await page.request.post("/api/trpc/license.upload?batch=1", {
+    data: {
+      "0": { json: { organizationId, licenseKey: E2E_ENTERPRISE_LICENSE_KEY } },
+    },
+  });
+  const result = await response.json().catch(() => null);
+  if (!response.ok() || result?.["0"]?.error) {
+    throw new Error(
+      `license.upload failed: ${response.status()} ${JSON.stringify(
+        result,
+      ).slice(0, 500)}`,
+    );
+  }
+}
+
+/**
+ * Remove the org's license, restoring FREE_PLAN. Called after each members test
+ * so the shared org does not leak an ENTERPRISE plan into other suites (e.g.
+ * settings/plans-comparison asserts the Free plan is current).
+ */
+export async function removeEnterpriseLicense(page: Page): Promise<void> {
+  const { organizationId } = await getOrgAndTeamIds(page);
+  await page.request.post("/api/trpc/license.remove?batch=1", {
+    data: { "0": { json: { organizationId } } },
+  });
+}
+
+/**
+ * Registers per-test hooks that activate an ENTERPRISE license before each test
+ * and remove it after — scoping the raised member cap to the members suite so
+ * the shared test org returns to FREE_PLAN for every other suite.
+ */
+export function withEnterpriseLicense(): void {
+  test.beforeEach(async ({ page }) => {
+    await activateEnterpriseLicense(page);
+  });
+  test.afterEach(async ({ page }) => {
+    await removeEnterpriseLicense(page);
+  });
 }

--- a/agentic-e2e-tests/tests/scenarios/scenario-editor.spec.ts
+++ b/agentic-e2e-tests/tests/scenarios/scenario-editor.spec.ts
@@ -25,8 +25,7 @@ import {
  * So that I can define behavioral test cases for my agents
  */
 test.describe("Scenario Editor", () => {
-  // fixme(#1811): flaky — timeouts in CI environment
-  test.fixme();
+  test.slow();
   // Background: Given I am logged into project
   test.beforeEach(async ({ page }) => {
     await givenIAmLoggedIntoProject(page);

--- a/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
+++ b/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
@@ -54,8 +54,8 @@ test.describe("Scenario Execution", () => {
    * Workflow test: creates scenario, runs it, and verifies results appear.
    * Requires NLP service to be running.
    */
-  // fixme(#1811): flaky — toBeVisible fails consistently in CI
-  test.fixme("executes scenario and displays run results", async ({ page }) => {
+  test("executes scenario and displays run results", async ({ page }) => {
+    test.slow();
     // Create a scenario first
     await givenIAmOnTheScenariosListPage(page);
     await whenIClickNewScenario(page);

--- a/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
+++ b/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
@@ -26,6 +26,10 @@ import {
  * Note: These tests require NLP service to be running for execution.
  */
 test.describe("Scenario Execution", () => {
+  // Describe-level slow() applies to every test in the suite (Playwright pushes
+  // it onto the suite's static annotations) — the execution test drives an NLP
+  // round-trip; the others are cheap but the longer budget is harmless.
+  test.slow();
   test.beforeEach(async ({ page }) => {
     await givenIAmLoggedIntoProject(page);
   });
@@ -54,7 +58,6 @@ test.describe("Scenario Execution", () => {
    * Workflow test: creates scenario, runs it, and verifies results appear.
    * Requires NLP service to be running.
    */
-  test.slow();
   test("executes scenario and displays run results", async ({ page }) => {
     // Create a scenario first
     await givenIAmOnTheScenariosListPage(page);

--- a/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
+++ b/agentic-e2e-tests/tests/scenarios/scenario-execution.spec.ts
@@ -54,8 +54,8 @@ test.describe("Scenario Execution", () => {
    * Workflow test: creates scenario, runs it, and verifies results appear.
    * Requires NLP service to be running.
    */
-  // fixme(#1811): flaky — toBeVisible fails consistently in CI
-  test.fixme("executes scenario and displays run results", async ({ page }) => {
+  test.slow();
+  test("executes scenario and displays run results", async ({ page }) => {
     // Create a scenario first
     await givenIAmOnTheScenariosListPage(page);
     await whenIClickNewScenario(page);

--- a/agentic-e2e-tests/tests/scenarios/steps.ts
+++ b/agentic-e2e-tests/tests/scenarios/steps.ts
@@ -186,7 +186,7 @@ export async function whenIClickSave(page: Page) {
 
   // Popover opens - click "Save without running"
   const saveWithoutRunning = page.getByText("Save without running").last();
-  await expect(saveWithoutRunning).toBeVisible({ timeout: 5000 });
+  await expect(saveWithoutRunning).toBeVisible({ timeout: 10000 });
   await saveWithoutRunning.click();
 
   // Wait for save to complete by checking dialog closes or list updates

--- a/agentic-e2e-tests/tests/scenarios/steps.ts
+++ b/agentic-e2e-tests/tests/scenarios/steps.ts
@@ -79,11 +79,31 @@ export async function thenISeeNewScenarioButton(page: Page) {
  */
 export async function whenIClickNewScenario(page: Page) {
   await page.getByRole("button", { name: /new scenario/i }).click();
-  // An AI-assist modal opens first; skip it to go straight to the form.
-  const skipButton = page.getByRole("button", { name: /i'll write it myself/i });
-  if (await skipButton.isVisible({ timeout: 5000 }).catch(() => false)) {
-    await skipButton.click();
+
+  // Two interstitial modals may appear before the scenario form drawer:
+  //   1. ModelProviderRequiredModal ("Proceed anyway") — shown when no model
+  //      provider is configured (typical in CI).
+  //   2. AICreateModal ("I'll write it myself") — shown when a provider exists.
+  // Race both locators; whichever becomes visible first wins.
+  const dismissed = await Promise.race([
+    page
+      .getByRole("button", { name: /proceed anyway/i })
+      .waitFor({ state: "visible", timeout: 5000 })
+      .then(() => "proceed" as const)
+      .catch(() => null),
+    page
+      .getByRole("button", { name: /i'll write it myself/i })
+      .waitFor({ state: "visible", timeout: 5000 })
+      .then(() => "skip" as const)
+      .catch(() => null),
+  ]);
+
+  if (dismissed === "proceed") {
+    await page.getByRole("button", { name: /proceed anyway/i }).click();
+  } else if (dismissed === "skip") {
+    await page.getByRole("button", { name: /i'll write it myself/i }).click();
   }
+  // If neither modal appeared the form drawer opened directly — no action needed.
 }
 
 /**

--- a/agentic-e2e-tests/tests/scenarios/steps.ts
+++ b/agentic-e2e-tests/tests/scenarios/steps.ts
@@ -135,17 +135,18 @@ export async function thenISeeTheScenarioEditor(page: Page) {
  * Then I see the scenario form fields (Name, Situation, Criteria, Labels)
  */
 export async function thenISeeScenarioFormFields(page: Page) {
-  // Name field
+  // Name field — SectionHeader renders as <p> not <label>, so there is no
+  // ARIA name association; match by placeholder instead.
   await expect(
-    page.getByRole("textbox", { name: "Name", exact: true }).first()
+    page.getByPlaceholder(/angry refund request/i).first()
   ).toBeVisible();
 
-  // Situation field (using placeholder as fallback - no label available)
+  // Situation field
   await expect(
     page.getByPlaceholder(/a frustrated premium subscriber/i).first()
   ).toBeVisible();
 
-  // Criteria field (using placeholder as fallback - no label available)
+  // Criteria field
   await expect(
     page.getByPlaceholder(/must apologize for the inconvenience/i).first()
   ).toBeVisible();
@@ -155,8 +156,9 @@ export async function thenISeeScenarioFormFields(page: Page) {
  * When I fill in "Name" with "<name>"
  */
 export async function whenIFillInNameWith(page: Page, name: string) {
+  // SectionHeader is a <p> not <label> — no accessible name; use placeholder.
   await page
-    .getByRole("textbox", { name: "Name", exact: true })
+    .getByPlaceholder(/angry refund request/i)
     .last()
     .fill(name);
 }
@@ -245,8 +247,9 @@ export async function whenIClickOnScenarioInList(page: Page, name: string) {
  * Then the form is populated with the existing data
  */
 export async function thenFormIsPopulatedWithName(page: Page, name: string) {
+  // SectionHeader is a <p> not <label> — no accessible name; use placeholder.
   const nameField = page
-    .getByRole("textbox", { name: "Name", exact: true })
+    .getByPlaceholder(/angry refund request/i)
     .last();
   await expect(nameField).toHaveValue(name);
 }
@@ -255,8 +258,9 @@ export async function thenFormIsPopulatedWithName(page: Page, name: string) {
  * When I change the name to "<name>"
  */
 export async function whenIChangeNameTo(page: Page, name: string) {
+  // SectionHeader is a <p> not <label> — no accessible name; use placeholder.
   const nameField = page
-    .getByRole("textbox", { name: "Name", exact: true })
+    .getByPlaceholder(/angry refund request/i)
     .last();
   await nameField.clear();
   await nameField.fill(name);

--- a/agentic-e2e-tests/tests/scenarios/steps.ts
+++ b/agentic-e2e-tests/tests/scenarios/steps.ts
@@ -136,19 +136,23 @@ export async function thenISeeTheScenarioEditor(page: Page) {
  */
 export async function thenISeeScenarioFormFields(page: Page) {
   // Name field — SectionHeader renders as <p> not <label>, so there is no
-  // ARIA name association; match by placeholder instead.
+  // ARIA name association; match by placeholder instead. .last() picks the
+  // visible dialog when Chakra renders duplicates (same reason as the sibling
+  // fill/assert helpers in this file).
   await expect(
-    page.getByPlaceholder(/angry refund request/i).first()
+    page.getByPlaceholder(/angry refund request/i).last()
   ).toBeVisible();
 
   // Situation field
   await expect(
-    page.getByPlaceholder(/a frustrated premium subscriber/i).first()
+    page.getByPlaceholder(/a frustrated premium subscriber/i).last()
   ).toBeVisible();
 
-  // Criteria field
+  // Criteria field — CriteriaInput mounts the entry textarea only after the
+  // add button is clicked (isAddingNew), so assert the reveal control instead
+  // of the not-yet-rendered placeholder textarea.
   await expect(
-    page.getByPlaceholder(/must apologize for the inconvenience/i).first()
+    page.getByRole("button", { name: /add.*criteria/i }).last()
   ).toBeVisible();
 }
 
@@ -177,21 +181,27 @@ export async function whenIFillInSituationWith(page: Page, situation: string) {
  * When I add criterion "<criterion>"
  */
 export async function whenIAddCriterion(page: Page, criterion: string) {
-  await page
+  // CriteriaInput hides the entry textarea behind an "Add ... criteria" button
+  // (label is "Add the first criteria" when empty, "Add criteria" otherwise);
+  // the textarea only mounts once adding starts (isAddingNew).
+  await page.getByRole("button", { name: /add.*criteria/i }).last().click();
+  const input = page
     .getByPlaceholder(/must apologize for the inconvenience/i)
-    .last()
-    .fill(criterion);
-  await page.getByRole("button", { name: "Add" }).last().click();
+    .last();
+  await input.fill(criterion);
+  // Enter commits the new criterion (handleAddKeyDown → handleSaveNew).
+  await input.press("Enter");
 }
 
 /**
  * Then the criterion appears in the criteria list
  */
 export async function thenCriterionAppearsInList(page: Page, criterion: string) {
-  // Scope to the criteria list container so we only match rendered criteria items.
-  // Saved criteria render as plain text (not inputs), so we assert visibility of
-  // the criterion text within the container rather than an input value.
-  const criteriaList = page.getByTestId("criteria-list");
+  // Committed criteria render as plain text within the criteria-list container
+  // (not as inputs). Scope to that container so we don't match the criterion
+  // text elsewhere on the page; .last() picks the visible Chakra dialog when
+  // duplicate dialogs are rendered.
+  const criteriaList = page.getByTestId("criteria-list").last();
   await expect(criteriaList.getByText(criterion)).toBeVisible({ timeout: 5000 });
 }
 

--- a/agentic-e2e-tests/tests/scenarios/steps.ts
+++ b/agentic-e2e-tests/tests/scenarios/steps.ts
@@ -75,9 +75,15 @@ export async function thenISeeNewScenarioButton(page: Page) {
 
 /**
  * When I click "New Scenario"
+ * Dismisses the AI-assist modal that now appears first.
  */
 export async function whenIClickNewScenario(page: Page) {
   await page.getByRole("button", { name: /new scenario/i }).click();
+  // An AI-assist modal opens first; skip it to go straight to the form.
+  const skipButton = page.getByRole("button", { name: /i'll write it myself/i });
+  if (await skipButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await skipButton.click();
+  }
 }
 
 /**

--- a/agentic-e2e-tests/tests/scenarios/steps.ts
+++ b/agentic-e2e-tests/tests/scenarios/steps.ts
@@ -80,7 +80,21 @@ export async function thenISeeNewScenarioButton(page: Page) {
 export async function whenIClickNewScenario(page: Page) {
   await page.getByRole("button", { name: /new scenario/i }).click();
 
-  // Two interstitial modals may appear before the scenario form drawer:
+  // Step 1: Handle ScenarioWelcomeModal — shown when user has zero scenarios
+  // and has not previously dismissed the welcome screen (localStorage flag).
+  // This modal appears BEFORE the scenario creation modals in step 2.
+  const welcomeButton = page.getByRole("button", {
+    name: /create your first scenario/i,
+  });
+  const welcomeVisible = await welcomeButton
+    .waitFor({ state: "visible", timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  if (welcomeVisible) {
+    await welcomeButton.click();
+  }
+
+  // Step 2: Handle interstitial modals before the scenario form drawer opens.
   //   1. ModelProviderRequiredModal ("Proceed anyway") — shown when no model
   //      provider is configured (typical in CI).
   //   2. AICreateModal ("I'll write it myself") — shown when a provider exists.

--- a/specs/members/update-pending-invitation.feature
+++ b/specs/members/update-pending-invitation.feature
@@ -18,11 +18,15 @@ Feature: Invitation Approval Workflow
   # batch / non-admin / email-failure edge cases.
   #
   # The Playwright e2e specs under
-  # `agentic-e2e-tests/tests/members/*.spec.ts` remain `test.fixme()`
-  # for CI-flakiness reasons (#1811), so the four `@e2e` scenarios
-  # below are still `@unimplemented`. The display-list scenarios
-  # (admin/non-admin visibility, badges) need a JSDOM render harness
-  # over the members page that does not yet exist.
+  # `agentic-e2e-tests/tests/members/*.spec.ts` now RUN and PASS in CI
+  # (#1802): the three ADMIN `@e2e` scenarios below (immediate invite,
+  # approve, reject) are live tests. They keep the `@unimplemented` tag
+  # only because `check-feature-parity.ts` does not scan
+  # `agentic-e2e-tests/` and these specs carry no `@scenario` binding,
+  # so parity cannot map them (extending the checker is a follow-up).
+  # The remaining `@e2e` scenario (a non-admin MEMBER creating a
+  # request) and the display-list scenarios (admin/non-admin
+  # visibility, badges) need a harness that does not yet exist.
 
   # ============================================================================
   # E2E: Happy Paths - Full User Workflows


### PR DESCRIPTION
<!-- no-ui-surface -->
<!-- Backend/test-infra only — no product UI changed. Proof is the before/after CI in "How I can prove I was successful". -->

> **Low risk** — test-infrastructure + CI only, no product code touched. **Start here:** `agentic-e2e-tests/tests/members/steps.ts` `withEnterpriseLicense()` — the load-bearing change is scoping a test ENTERPRISE license to the members suite (activate before each test, remove after) so the shared org stays Free for every other suite.

## Why

Closes #1802

Seven e2e tests were skipped in CI because they failed consistently. This PR re-enables **all seven** — the 4 scenario tests and the 3 member-invitation tests — and pins down the remaining 2 (evaluations-v3) so they aren't silently lost.

## What changed

- **Re-enable the 3 member-invitation tests with a scoped test license** → provisioning a real license/subscription for the CI org (heavier, security-adjacent) → the org has no license so its plan is FREE_PLAN (`maxMembers=1`) and `createInviteRequest` 403s. `withEnterpriseLicense()` activates the repo's **already-committed, pre-signed** test ENTERPRISE license (`ENTERPRISE_LICENSE_KEY`, `maxMembers=100`, expires 2030) before each members test and **removes it after**, so the raised cap never leaks into other suites. The app trusts it because `e2e-ci.yml` sets `LANGWATCH_LICENSE_PUBLIC_KEY` to the matching in-repo `TEST_PUBLIC_KEY`. **No new secret** — only a public key + an already-signed test license, both from `ee/licensing/__tests__/fixtures`.
- **Fix latent invite-test bugs the 403 had masked** → they only surfaced once the cap was lifted: `getOrgAndTeamIds` used `page.evaluate(fetch("/api/trpc/…"))` (relative URL, throws "Failed to parse URL") → switched to `page.request.get`; the members URL was `/${slug}/settings/members` → corrected to `/settings/members` (org-scoped, per `routes.tsx`); the seed sent `customRoleId: null` → omitted (schema is `z.string().optional()`); the email placeholder had drifted → matched to the real one; and the "Invite Link" modal was left open (two nested title headings → strict-mode throw skipped the close) → closed by role+name.
- **Re-enable the 4 scenario tests by driving `CriteriaInput` correctly** → the criteria textarea only mounts after an "Add … criteria" click and commits to plain text; the helpers click-reveal, fill, commit with Enter, and assert within the `criteria-list` container.
- **CI services for scenario execution** → the app auto-starts its own `nlpgo` on :5563, so only a `langevals` container (:5564) + `ELASTICSEARCH_NODE_URL` are added.
- **evaluations-v3 (2)** remain skipped (missing test-ids) — unchanged intent, tracked for a follow-up.

## How it works

```
.github/workflows/e2e-ci.yml
  + LANGWATCH_LICENSE_PUBLIC_KEY  (job env = in-repo TEST_PUBLIC_KEY, reaches the pnpm-start app)
  + langevals service, + ELASTICSEARCH_NODE_URL

agentic-e2e-tests/tests/
  license.fixture.ts                 → E2E_ENTERPRISE_LICENSE_KEY (pre-signed test license)
  members/steps.ts
    withEnterpriseLicense()          → beforeEach: license.upload (ENTERPRISE) · afterEach: license.remove
    getOrgAndTeamIds()               → page.request.get (batch tRPC), not page.evaluate(fetch)
    givenIAmOnTheMembersPage()       → /settings/members
    whenIFillEmailWith()             → real Add-members placeholder
    whenICloseInviteLinkDialog()     → getByRole("dialog", {name:"Invite Link"})
    seedWaitingApprovalInvite()      → omit customRoleId
  scenarios/steps.ts                 → CriteriaInput reveal→fill→commit
```

## Human verification

1. Open the green `e2e-ci` run for the head commit and confirm the `e2e` job is **Success** with all 3 members tests (`admin-approves`, `admin-creates-immediate-invite`, `admin-rejects`), the 4 scenario tests, and `settings/plans-comparison` **passing**, and only the 2 evaluations-v3 tests **skipped**.
2. Reproduce the scoping rationale: `settings/plans-comparison.spec.ts` asserts the **Free** plan is current for the shared org — so the members license must be removed after each members test, which `withEnterpriseLicense()`'s `afterEach` does.
3. Reproduce the licensing path yourself: `ee/licensing/licenseHandler.ts` `getActivePlan` reads `organization.license` from Postgres on every call (no boot cache), and `validateLicense` checks the signature against `LANGWATCH_LICENSE_PUBLIC_KEY` — so activating in `auth`/`beforeEach` takes effect with no app restart.

## How I can prove I was successful

**Claim: all 7 previously-skipped e2e tests now pass in CI, with no regression and no new flakes.** — **proven**

- **Green run** — [`e2e-ci` run 29182232679](https://github.com/langwatch/langwatch/actions/runs/29182232679) at `aa2198391`: **Success** (5.1m), tally **14 passed, 3 skipped**. All 3 members tests pass **first-try (no retries → not flaky)**: `admin-approves` ✓ 28.5s, `admin-creates-immediate-invite` ✓ 21.6s, `admin-rejects` ✓ 6.0s. The 4 scenario tests ✓, `settings/plans-comparison` ✓, `smoke` ✓.
- **Regression caught and fixed mid-drive**: an earlier iteration activated the license globally in `auth.setup.ts`, which flipped the shared org to ENTERPRISE and regressed `settings/plans-comparison` (it asserts Free-is-current). Scoping the license to the members suite restored it — `plans-comparison` ✓ in the green run above.
- **Falsifiability (before → after)**: the members tests failed deterministically at each masked bug in turn across the prior runs — the 403 cap ([run 29180882574](https://github.com/langwatch/langwatch/actions/runs/29180882574)), then the relative-fetch / URL bugs, then `customRoleId`, then the unclosed invite-link modal ([run 29181871351](https://github.com/langwatch/langwatch/actions/runs/29181871351)) — each fix advanced them to the next real failure, ending green above. No step passed by luck.

## Anything surprising?

- **The 403 masked a stack of latent test bugs.** Once the member cap was lifted, the invitation tests failed at successive real bugs (relative fetch, wrong URL, `customRoleId: null`, an unclosed modal) — none visible while seeding 403'd. Each was fixed against the app source, not guessed.
- **Re-enabling members did NOT require provisioning a real CI license** (the earlier assumption). The repo already ships a test keypair and a pre-signed enterprise license for licensing unit tests; reusing them as scoped test infra is secret-free and sufficient.
