### PR TITLE
fix: use semantic tokens on subscription page for dark mode

### DIFF
--- a/langwatch/src/components/subscription/ContactSalesBlock.tsx
+++ b/langwatch/src/components/subscription/ContactSalesBlock.tsx
@@ -19,7 +19,7 @@ export function ContactSalesBlock() {
     <Card.Root
       data-testid="contact-sales-block"
       borderWidth={1}
-      borderColor="gray.200"
+      borderColor="border"
     >
       <Card.Body paddingY={5} paddingX={6}>
         <Text fontWeight="semibold" fontSize="lg">
@@ -33,8 +33,8 @@ export function ContactSalesBlock() {
         >
           {ENTERPRISE_PLAN_FEATURES.map((feature) => (
             <HStack key={feature} gap={2} alignItems="start">
-              <Check size={16} color="var(--chakra-colors-orange-500)" />
-              <Text fontSize="sm" color="gray.600">
+              <Check size={16} color="var(--chakra-colors-orange-solid)" />
+              <Text fontSize="sm" color="fg.muted">
                 {feature}
               </Text>
             </HStack>

--- a/langwatch/src/components/subscription/CurrentPlanBlock.tsx
+++ b/langwatch/src/components/subscription/CurrentPlanBlock.tsx
@@ -49,7 +49,7 @@ export function CurrentPlanBlock({
     <Card.Root
       data-testid="current-plan-block"
       borderWidth={1}
-      borderColor="gray.200"
+      borderColor="border"
     >
       <Card.Body paddingY={5} paddingX={6}>
         <VStack align="stretch" gap={5}>
@@ -91,7 +91,7 @@ export function CurrentPlanBlock({
               )}
             </VStack>
             <VStack align="end" gap={0}>
-              <Text color="gray.500" fontSize="sm">
+              <Text color="fg.muted" fontSize="sm">
                 Members / Seats
               </Text>
               {onUserCountClick ? (
@@ -99,8 +99,8 @@ export function CurrentPlanBlock({
                   as="button"
                   onClick={onUserCountClick}
                   textDecoration="underline"
-                  _hover={{ color: "blue.600", cursor: "pointer" }}
-                  color="gray.900"
+                  _hover={{ color: "blue.fg", cursor: "pointer" }}
+                  color="fg"
                 >
                   <Text
                     fontWeight="semibold"
@@ -114,7 +114,7 @@ export function CurrentPlanBlock({
                 <Text
                   fontWeight="semibold"
                   fontSize="lg"
-                  color="gray.900"
+                  color="fg"
                   data-testid="user-count-link"
                 >
                   {maxSeats != null ? `${userCount}/${maxSeats}` : userCount}
@@ -130,8 +130,8 @@ export function CurrentPlanBlock({
             >
               {features.map((feature, index) => (
                 <HStack key={index} gap={2}>
-                  <Check size={16} color="var(--chakra-colors-blue-500)" />
-                  <Text fontSize="sm" color="gray.600">
+                  <Check size={16} color="var(--chakra-colors-blue-solid)" />
+                  <Text fontSize="sm" color="fg.muted">
                     {feature}
                   </Text>
                 </HStack>
@@ -140,13 +140,13 @@ export function CurrentPlanBlock({
           )}
           {deprecatedNotice && (
             <Box data-testid="tiered-deprecated-notice" paddingTop={1}>
-              <Text fontSize="sm" color="gray.600">
+              <Text fontSize="sm" color="fg.muted">
                 You are on a legacy tiered pricing model.{" "}
                 <Link
                   href="/settings/plans"
                   fontWeight="semibold"
-                  color="gray.800"
-                  _hover={{ color: "gray.900" }}
+                  color="fg"
+                  _hover={{ color: "fg" }}
                 >
                   Update your plan
                 </Link>{" "}

--- a/langwatch/src/components/subscription/InvoicesBlock.tsx
+++ b/langwatch/src/components/subscription/InvoicesBlock.tsx
@@ -36,7 +36,7 @@ export function InvoicesBlock({
     <Card.Root
       data-testid="invoices-block"
       borderWidth={1}
-      borderColor="gray.200"
+      borderColor="border"
     >
       <Card.Body paddingY={5} paddingX={6}>
         <VStack align="stretch" gap={4}>
@@ -53,9 +53,9 @@ export function InvoicesBlock({
                   data-testid="view-all-invoices-link"
                   as="button"
                   fontSize="sm"
-                  color="gray.600"
+                  color="fg.muted"
                   cursor="pointer"
-                  _hover={{ color: "blue.500" }}
+                  _hover={{ color: "blue.fg" }}
                   onClick={onViewAllInStripe}
                 >
                   <HStack gap={1}>
@@ -75,7 +75,7 @@ export function InvoicesBlock({
           )}
 
           {invoices.isError && (
-            <Text color="red.500" fontSize="sm">
+            <Text color="red.fg" fontSize="sm">
               Failed to load invoices. Please try again later.
             </Text>
           )}
@@ -84,7 +84,7 @@ export function InvoicesBlock({
             !invoices.isError &&
             invoices.data?.length === 0 && (
               <Text
-                color="gray.500"
+                color="fg.muted"
                 fontSize="sm"
                 textAlign="center"
                 paddingY={4}
@@ -148,7 +148,7 @@ export function InvoicesBlock({
                             isExternal
                             aria-label={`Download PDF for invoice ${invoice.number ?? invoice.id}`}
                           >
-                            <HStack gap={1} color="blue.500" fontSize="sm">
+                            <HStack gap={1} color="blue.fg" fontSize="sm">
                               <Download size={14} />
                               <Text>PDF</Text>
                             </HStack>

--- a/langwatch/src/components/subscription/PricingSummary.tsx
+++ b/langwatch/src/components/subscription/PricingSummary.tsx
@@ -13,11 +13,11 @@ export function PricingSummary({
 }) {
   return (
     <VStack align="start" gap={0}>
-      <Text data-testid={totalTestId} fontSize="sm" color="gray.700">
+      <Text data-testid={totalTestId} fontSize="sm" color="fg">
         {totalPrice} for {seatCount} seat{seatCount !== 1 ? "s" : ""}
       </Text>
       {perSeatPrice && seatCount > 1 && (
-        <Text fontSize="xs" color="gray.500">
+        <Text fontSize="xs" color="fg.muted">
           {perSeatPrice}
         </Text>
       )}

--- a/langwatch/src/components/subscription/SubscriptionPage.tsx
+++ b/langwatch/src/components/subscription/SubscriptionPage.tsx
@@ -295,7 +295,7 @@ export function SubscriptionPage() {
     return (
       <SettingsLayout>
         <Flex justifyContent="center" padding={8}>
-          <Text color="red.500">
+          <Text color="red.fg">
             Failed to load subscription information. Please try again later.
           </Text>
         </Flex>
@@ -367,13 +367,13 @@ export function SubscriptionPage() {
         <Flex justifyContent="space-between" alignItems="flex-start">
           <VStack align="start" gap={1}>
             <Heading size="xl">Billing</Heading>
-            <Text color="gray.500">
+            <Text color="fg.muted">
               For questions about billing,{" "}
               <Link
                 href="mailto:sales@langwatch.ai"
                 fontWeight="semibold"
-                color="gray.700"
-                _hover={{ color: "gray.900" }}
+                color="fg"
+                _hover={{ color: "fg" }}
               >
                 contact us
               </Link>
@@ -416,7 +416,7 @@ export function SubscriptionPage() {
               </>
             )}
             <Link href="/settings/plans">
-              <Button variant="ghost" size="sm" color="gray.600">
+              <Button variant="ghost" size="sm" color="fg.muted">
                 All plans <ArrowRight size={14} />
               </Button>
             </Link>
@@ -426,21 +426,21 @@ export function SubscriptionPage() {
         {showSuccess && (
           <Box
             data-testid="subscription-success"
-            backgroundColor="green.50"
+            backgroundColor="green.subtle"
             borderWidth={1}
-            borderColor="green.200"
+            borderColor="green.muted"
             borderRadius="md"
             padding={4}
           >
             <VStack align="start" gap={1}>
               <HStack gap={2}>
-                <Check size={16} color="green" />
-                <Text fontWeight="semibold" color="green.800">
+                <Check size={16} color="var(--chakra-colors-green-solid)" />
+                <Text fontWeight="semibold" color="green.fg">
                   Subscription activated successfully!
                 </Text>
               </HStack>
               {showUpgradeCredit && (
-                <Text fontSize="sm" color="green.700" data-testid="credit-notice">
+                <Text fontSize="sm" color="green.fg" data-testid="credit-notice">
                   Your previous plan has been prorated. Any unused credit has been
                   applied to your account and will offset future invoices.
                 </Text>

--- a/langwatch/src/components/subscription/UpdateSeatsBlock.tsx
+++ b/langwatch/src/components/subscription/UpdateSeatsBlock.tsx
@@ -30,7 +30,7 @@ export function UpdateSeatsBlock({
     <Card.Root
       data-testid="update-seats-block"
       borderWidth={1}
-      borderColor="gray.200"
+      borderColor="border"
     >
       <Card.Body paddingY={5} paddingX={6}>
         <Flex justifyContent="space-between" alignItems="center">

--- a/langwatch/src/components/subscription/UpgradePlanBlock.tsx
+++ b/langwatch/src/components/subscription/UpgradePlanBlock.tsx
@@ -35,7 +35,7 @@ export function UpgradePlanBlock({
     <Card.Root
       data-testid="upgrade-plan-block"
       borderWidth={1}
-      borderColor="gray.200"
+      borderColor="border"
     >
       <Card.Body paddingY={5} paddingX={6}>
         <VStack align="stretch" gap={5}>
@@ -70,8 +70,8 @@ export function UpgradePlanBlock({
           >
             {features.map((feature, index) => (
               <HStack key={index} gap={2}>
-                <Check size={16} color="var(--chakra-colors-blue-500)" />
-                <Text fontSize="sm" color="gray.600">
+                <Check size={16} color="var(--chakra-colors-blue-solid)" />
+                <Text fontSize="sm" color="fg.muted">
                   {feature}
                 </Text>
               </HStack>

--- a/langwatch/src/components/subscription/UserManagementDrawer.tsx
+++ b/langwatch/src/components/subscription/UserManagementDrawer.tsx
@@ -189,7 +189,7 @@ export function UserManagementDrawer({
                     <Button
                       variant="ghost"
                       size="xs"
-                      color="gray.500"
+                      color="fg.muted"
                       fontSize="xs"
                     >
                       Show members ({editableUsers.length + pendingInvitesWithMemberType.length})
@@ -203,10 +203,10 @@ export function UserManagementDrawer({
                       {editableUsers.map((user) => (
                         <Box as="tr" key={user.id}>
                           <Box as="td" paddingY={2} verticalAlign="top">
-                            <Text fontSize="sm" fontWeight="medium" color="gray.600">
+                            <Text fontSize="sm" fontWeight="medium" color="fg">
                               {user.email}
                             </Text>
-                            <Text fontSize="xs" color="gray.500">
+                            <Text fontSize="xs" color="fg.muted">
                               Active
                             </Text>
                           </Box>
@@ -228,10 +228,10 @@ export function UserManagementDrawer({
                           data-testid={`pending-invite-${invite.email}`}
                         >
                           <Box as="td" paddingY={2} verticalAlign="top">
-                            <Text fontSize="sm" fontWeight="medium" color="gray.600">
+                            <Text fontSize="sm" fontWeight="medium" color="fg">
                               {invite.email}
                             </Text>
-                            <Text fontSize="xs" color="gray.500">
+                            <Text fontSize="xs" color="fg.muted">
                               Invited - Waiting for acceptance
                             </Text>
                           </Box>
@@ -253,7 +253,7 @@ export function UserManagementDrawer({
               {/* New Planned Seats section (editable) */}
               <VStack align="start" gap={3} width="full">
                 <HStack justify="space-between" width="full">
-                  <Text fontWeight="semibold" fontSize="sm" color="gray.500">
+                  <Text fontWeight="semibold" fontSize="sm" color="fg.muted">
                     Seats available
                   </Text>
                   <Button variant="outline" size="sm" onClick={handleAddSeat}>
@@ -270,7 +270,7 @@ export function UserManagementDrawer({
                       padding={3}
                       borderWidth={1}
                       borderRadius="md"
-                      borderColor={emailErrors[user.id] ? "red.300" : "gray.200"}
+                      borderColor={emailErrors[user.id] ? "red.emphasized" : "border"}
                     >
                       <Input
                         data-testid={`seat-email-${index}`}
@@ -300,7 +300,7 @@ export function UserManagementDrawer({
                       </Button>
                     </HStack>
                     {emailErrors[user.id] && (
-                      <Text fontSize="xs" color="red.500" paddingLeft={3}>
+                      <Text fontSize="xs" color="red.fg" paddingLeft={3}>
                         {emailErrors[user.id]}
                       </Text>
                     )}
@@ -319,7 +319,7 @@ export function UserManagementDrawer({
               gap={2}
               fontSize="sm"
               padding={4}
-              bg="gray.50"
+              bg="bg.subtle"
               borderRadius="md"
               width="full"
             >
@@ -335,7 +335,7 @@ export function UserManagementDrawer({
 
               <HStack justify="space-between">
                 <Text fontWeight="bold">{priceLabel}</Text>
-                <Text fontWeight="bold" color="blue.600" data-testid="monthly-price-footer">
+                <Text fontWeight="bold" color="blue.fg" data-testid="monthly-price-footer">
                   {formatPrice({ cents: totalPriceCentsInDrawer, currency })}{periodSuffix}
                 </Text>
               </HStack>


### PR DESCRIPTION
## Summary
- Replace hardcoded `gray.*` / `blue.*` / `green.*` / `red.*` palette values on the `/settings/subscription` page with the semantic tokens already defined in `_app.tsx` (`fg`, `fg.muted`, `border`, `bg.subtle`, `blue.fg`, `green.fg`, `red.fg`, etc.) so the page renders correctly in dark mode.
- Switch lucide check icons from `var(--chakra-colors-blue-500)` to `var(--chakra-colors-blue-solid)` (and similar for orange) so the icon color flips for dark mode too.
- No behavior changes — pure styling fix.

Files touched (all under `langwatch/src/components/subscription/`):
`SubscriptionPage.tsx`, `CurrentPlanBlock.tsx`, `PricingSummary.tsx`, `UpdateSeatsBlock.tsx`, `UpgradePlanBlock.tsx`, `ContactSalesBlock.tsx`, `InvoicesBlock.tsx`, `UserManagementDrawer.tsx`.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm vitest run src/components/subscription/__tests__/` — 99 passed / 5 skipped
- [x] Manually verified in Playwright against local dev server: `/settings/subscription` renders correctly in both light and dark modes (header, current plan card, invoices, upgrade card, contact sales, and the Manage Seats drawer including member rows, planned seat rows, and footer breakdown).