### PR TITLE
fix: require tag-based fetch pattern in scenario assertion

### DIFF
--- a/skills/_tests/prompts.scenario.test.ts
+++ b/skills/_tests/prompts.scenario.test.ts
@@ -413,11 +413,10 @@ describe("Prompts Skill", () => {
 
             // Code should reference tag-based fetching
             const usesTagFetch = /tag\s*=\s*["']production["']|tag\s*=\s*["']staging["']|{\s*tag:/.test(mainPy);
-            const usesLangwatch = /langwatch/.test(mainPy);
 
             expect(
-              usesTagFetch || usesLangwatch,
-              "Expected code to use tag-based prompt fetching or langwatch integration"
+              usesTagFetch,
+              "Expected code to fetch prompts by tag (e.g., tag='production' or tag='staging')"
             ).toBe(true);
           },
           scenario.judge(),


### PR DESCRIPTION
## Why

Closes #2939

The scenario test for tag-based deployment workflow had a loose assertion that accepted code merely mentioning `langwatch` without actually fetching prompts by tag. This weakened the regression signal — it could pass without the core behavior being implemented. Flagged by CodeRabbit in PR #2934.

## What changed

Removed the `usesLangwatch` fallback from the assertion in `skills/_tests/prompts.scenario.test.ts`. The test now requires the `usesTagFetch` regex to match (detecting patterns like `tag="production"`, `tag="staging"`, or `{ tag:`), rather than accepting a bare `langwatch` mention as a substitute.

## Test plan

- The scenario test will now fail if the generated code only mentions `langwatch` without setting up tag-based fetching
- The assertion error message now specifically describes the expected tag patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #2939