### PR TITLE
feat(cli): add prompt tag management commands

### DIFF
--- a/specs/typescript-sdk/cli-prompt-tags.feature
+++ b/specs/typescript-sdk/cli-prompt-tags.feature
@@ -1,0 +1,156 @@
+Feature: CLI Prompt Tag Commands
+  As a developer using LangWatch from the terminal
+  I want to manage prompt tags via CLI commands
+  So that I can control deployment slots (production, staging, etc.) without using the UI
+
+  Background:
+    Given I have a valid LANGWATCH_API_KEY configured
+
+  # --- SDK: renameTag method ---
+
+  @unit
+  Scenario: renameTag calls PUT /api/prompts/tags/{tag} with new name
+    When I call promptsApiService.renameTag({ tag: "old-name", name: "new-name" })
+    Then the SDK sends PUT /api/prompts/tags/old-name with body { name: "new-name" }
+
+  @unit
+  Scenario: Facade tags.rename delegates to renameTag
+    When I call facade.tags.rename("old-name", "new-name")
+    Then it delegates to promptsApiService.renameTag({ tag: "old-name", name: "new-name" })
+
+  # --- tag list ---
+
+  @unit
+  Scenario: List tags displays a formatted table
+    Given the org has tags "latest", "production", "staging", and "canary"
+    When I run "langwatch prompt tag list"
+    Then I see a table with columns Name and Created
+    And all four tags are listed
+
+  @unit
+  Scenario: List tags when none exist
+    Given the org has no custom tags
+    When I run "langwatch prompt tag list"
+    Then I see "No custom tags found. The 'latest' tag is always available."
+
+  @unit
+  Scenario: List tags exits 1 on API error
+    Given the API returns an error for listTags
+    When I run "langwatch prompt tag list"
+    Then the command exits with code 1
+
+  # --- tag create ---
+
+  @unit
+  Scenario: Create a custom tag
+    When I run "langwatch prompt tag create canary"
+    Then the SDK calls createTag with name "canary"
+    And I see "Created tag: canary"
+
+  @unit
+  Scenario: Create tag with invalid name exits 1 without calling API
+    When I run "langwatch prompt tag create INVALID_NAME!"
+    Then I see an error about invalid tag name format
+    And createTag is not called
+    And the command exits with code 1
+
+  @unit
+  Scenario: Create duplicate tag surfaces API error
+    Given a tag "canary" already exists
+    When I run "langwatch prompt tag create canary"
+    Then I see an error from the API
+    And the command exits with code 1
+
+  # --- tag rename ---
+
+  @unit
+  Scenario: Rename a tag
+    When I run "langwatch prompt tag rename canary beta"
+    Then the SDK calls renameTag with tag "canary" and name "beta"
+    And I see "Renamed tag: canary -> beta"
+
+  @unit
+  Scenario: Rename tag with invalid new name exits 1
+    When I run "langwatch prompt tag rename canary INVALID!"
+    Then I see an error about invalid tag name format
+    And renameTag is not called
+    And the command exits with code 1
+
+  # --- tag assign ---
+
+  @unit
+  Scenario: Assign tag to latest version when no --version given
+    Given "my-prompt" latest version has versionId "cm_abc123"
+    When I run "langwatch prompt tag assign my-prompt production"
+    Then the SDK fetches the prompt to resolve the versionId
+    And calls assignTag with id "my-prompt", tag "production", versionId "cm_abc123"
+    And I see confirmation of the assignment
+
+  @unit
+  Scenario: Assign tag to specific version
+    Given "my-prompt" version 3 has versionId "cm_def456"
+    When I run "langwatch prompt tag assign my-prompt production --version 3"
+    Then the SDK fetches version 3 to resolve the versionId
+    And calls assignTag with id "my-prompt", tag "production", versionId "cm_def456"
+
+  @unit
+  Scenario: Assign tag to nonexistent prompt exits 1
+    Given "nonexistent" prompt does not exist
+    When I run "langwatch prompt tag assign nonexistent production"
+    Then I see an error that the prompt was not found
+    And the command exits with code 1
+
+  # --- tag delete ---
+
+  @unit
+  Scenario: Delete tag with confirmation
+    When I run "langwatch prompt tag delete canary" and type "canary" to confirm
+    Then the SDK calls deleteTag with "canary"
+    And I see "Deleted tag: canary"
+
+  @unit
+  Scenario: Delete tag aborted on confirmation mismatch
+    When I run "langwatch prompt tag delete canary" and type "wrong" to confirm
+    Then deleteTag is not called
+    And I see "Aborted"
+    And the command exits with code 0
+
+  @unit
+  Scenario: Delete tag with --force skips confirmation
+    When I run "langwatch prompt tag delete canary --force"
+    Then deleteTag is called without prompting for confirmation
+    And I see "Deleted tag: canary"
+
+  # --- pull --tag ---
+
+  @unit
+  Scenario: Pull prompts by tag instead of version
+    Given prompts.json has "my-prompt" tracked as a remote dependency
+    When I run "langwatch prompt pull --tag production"
+    Then the SDK fetches each prompt using { tag: "production" } instead of version
+    And I see the pull result referencing the tag
+
+  @unit
+  Scenario: Pull --tag overrides version spec in prompts.json
+    Given prompts.json has "my-prompt" pinned to version 2
+    When I run "langwatch prompt pull --tag staging"
+    Then the SDK fetches using { tag: "staging" }, ignoring the version spec
+
+  @unit
+  Scenario: Pull --tag with missing tag on server exits 1
+    Given the "nonexistent" tag is not assigned to "my-prompt"
+    When I run "langwatch prompt pull --tag nonexistent"
+    Then I see an error for that prompt
+    And the command exits with code 1
+
+  # --- Command registration ---
+
+  @unit
+  Scenario: Help shows tag subcommand group
+    When I run "langwatch prompt tag --help"
+    Then I see subcommands: list, create, rename, assign, delete
+
+  @unit
+  Scenario: Tag subcommands appear in prompt help
+    When I run "langwatch prompt --help"
+    Then I see "tag" listed as a subcommand

--- a/typescript-sdk/__tests__/e2e/cli/cli-tag.e2e.test.ts
+++ b/typescript-sdk/__tests__/e2e/cli/cli-tag.e2e.test.ts
@@ -1,0 +1,318 @@
+// @vitest-environment node
+// @vitest-config ./vitest.e2e.config.mts
+
+import {
+  describe,
+  expect,
+  it,
+  afterEach,
+  beforeEach,
+  afterAll,
+  beforeAll,
+} from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+import { config } from "dotenv";
+import {
+  expectations,
+  CliRunner,
+  PROMPT_NAME_PREFIX,
+  PromptFileManager,
+} from "./helpers";
+import { LangWatch } from "../../../dist";
+import { ApiHelpers } from "./helpers/api-helpers";
+
+config({ path: ".env.test", override: true });
+
+const { expectCliResultSuccess } = expectations;
+const TMP_BASE_DIR = path.join(__dirname, "tmp");
+
+interface Tag {
+  name: string;
+}
+
+const createUniquePromptName = () => {
+  return `${PROMPT_NAME_PREFIX}-${Date.now()}`;
+};
+
+const createUniqueTagName = () => {
+  return `e2e-tag-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+};
+
+describe("CLI E2E", () => {
+  let testDir: string;
+  let originalCwd: string;
+  let langwatch: LangWatch;
+  let cli: CliRunner;
+
+  beforeAll(() => {
+    if (fs.existsSync(TMP_BASE_DIR)) {
+      fs.rmSync(TMP_BASE_DIR, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    langwatch = new LangWatch({
+      apiKey: process.env.LANGWATCH_API_KEY,
+      endpoint: process.env.LANGWATCH_ENDPOINT,
+    });
+    fs.mkdirSync(TMP_BASE_DIR, { recursive: true });
+    testDir = fs.mkdtempSync(path.join(TMP_BASE_DIR, "langwatch-tag-"));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    cli = new CliRunner({ cwd: testDir });
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+  });
+
+  afterAll(async () => {
+    const apiHelpers = new ApiHelpers(langwatch);
+    await apiHelpers.cleapUpTestPrompts();
+    // Clean up any test tags that were created
+    const tags = await langwatch.prompts.tags.list();
+    await Promise.all(
+      tags
+        .filter((t: Tag) => t.name.startsWith("e2e-tag-"))
+        .map((t: Tag) => langwatch.prompts.tags.delete(t.name).catch(() => undefined)),
+    );
+  });
+
+  describe("tag", () => {
+    describe("tag create", () => {
+      describe("when creating a valid tag", () => {
+        it("creates the tag and confirms", async () => {
+          const tagName = createUniqueTagName();
+
+          const result = cli.run(`prompt tag create ${tagName}`);
+
+          expectCliResultSuccess(result);
+          expect(result.output).toContain("Created tag:");
+
+          const tags = await langwatch.prompts.tags.list();
+          expect(tags.some((t: Tag) => t.name === tagName)).toBe(true);
+
+          await langwatch.prompts.tags.delete(tagName);
+        }, 60_000);
+      });
+
+      describe("when creating a tag with invalid name", () => {
+        it("exits with error without calling API", () => {
+          const result = cli.run("prompt tag create INVALID_NAME!");
+
+          expect(result.success).toBe(false);
+          expect(result.exitCode).toBe(1);
+          expect(result.output).toContain("Invalid tag name");
+        }, 60_000);
+      });
+    });
+
+    describe("tag list", () => {
+      describe("when tags exist", () => {
+        it("displays tags in a table", async () => {
+          const tagName = createUniqueTagName();
+          await langwatch.prompts.tags.create({ name: tagName });
+
+          const result = cli.run("prompt tag list");
+
+          expectCliResultSuccess(result);
+          expect(result.output).toContain(tagName);
+
+          await langwatch.prompts.tags.delete(tagName);
+        }, 60_000);
+      });
+    });
+
+    describe("tag rename", () => {
+      describe("when renaming an existing tag", () => {
+        it("renames the tag", async () => {
+          const oldName = createUniqueTagName();
+          const newName = createUniqueTagName();
+          await langwatch.prompts.tags.create({ name: oldName });
+
+          const result = cli.run(`prompt tag rename ${oldName} ${newName}`);
+
+          expectCliResultSuccess(result);
+          expect(result.output).toContain("Renamed tag:");
+
+          const tags = await langwatch.prompts.tags.list();
+          expect(tags.some((t: Tag) => t.name === newName)).toBe(true);
+          expect(tags.some((t: Tag) => t.name === oldName)).toBe(false);
+
+          await langwatch.prompts.tags.delete(newName);
+        }, 60_000);
+      });
+    });
+
+    describe("tag assign", () => {
+      describe("when assigning a tag to a prompt version", () => {
+        it("assigns the tag to the latest version", async () => {
+          const handle = createUniquePromptName();
+          const tagName = createUniqueTagName();
+
+          await langwatch.prompts.create({
+            handle,
+            prompt: "Test",
+          });
+          await langwatch.prompts.tags.create({ name: tagName });
+
+          try {
+            const result = cli.run(`prompt tag assign ${handle} ${tagName}`);
+
+            expectCliResultSuccess(result);
+            expect(result.output).toContain("Assigned tag");
+
+            const tagged = await langwatch.prompts.get(handle, {
+              tag: tagName,
+            });
+            expect(tagged).not.toBeNull();
+          } finally {
+            await langwatch.prompts.delete(handle).catch(() => undefined);
+            await langwatch.prompts.tags.delete(tagName).catch(() => undefined);
+          }
+        }, 60_000);
+      });
+
+      describe("when assigning a tag to a specific version", () => {
+        it("assigns the tag to that version", async () => {
+          const handle = createUniquePromptName();
+          const tagName = createUniqueTagName();
+
+          await langwatch.prompts.create({
+            handle,
+            prompt: "Version 1",
+          });
+          await langwatch.prompts.update(handle, {
+            prompt: "Version 2",
+            commitMessage: "v2",
+          });
+          await langwatch.prompts.tags.create({ name: tagName });
+
+          try {
+            const result = cli.run(
+              `prompt tag assign ${handle} ${tagName} --version 1`,
+            );
+
+            expectCliResultSuccess(result);
+
+            const tagged = await langwatch.prompts.get(handle, {
+              tag: tagName,
+            });
+            expect(tagged.prompt).toContain("Version 1");
+          } finally {
+            await langwatch.prompts.delete(handle).catch(() => undefined);
+            await langwatch.prompts.tags.delete(tagName).catch(() => undefined);
+          }
+        }, 60_000);
+      });
+    });
+
+    describe("tag delete", () => {
+      describe("when deleting with --force", () => {
+        it("deletes the tag without confirmation", async () => {
+          const tagName = createUniqueTagName();
+          await langwatch.prompts.tags.create({ name: tagName });
+
+          const result = cli.run(`prompt tag delete ${tagName} --force`);
+
+          expectCliResultSuccess(result);
+          expect(result.output).toContain("Deleted tag:");
+
+          const tags = await langwatch.prompts.tags.list();
+          expect(tags.some((t: Tag) => t.name === tagName)).toBe(false);
+        }, 60_000);
+      });
+
+      describe("when deleting with confirmation", () => {
+        it("deletes the tag after typing the name", async () => {
+          const tagName = createUniqueTagName();
+          await langwatch.prompts.tags.create({ name: tagName });
+
+          const result = await cli.runInteractive(
+            `prompt tag delete ${tagName}`,
+            [tagName],
+          );
+
+          expectCliResultSuccess(result);
+          expect(result.output).toContain("Deleted tag:");
+
+          const tags = await langwatch.prompts.tags.list();
+          expect(tags.some((t: Tag) => t.name === tagName)).toBe(false);
+        }, 60_000);
+      });
+
+      describe("when confirmation does not match", () => {
+        it("aborts the deletion", async () => {
+          const tagName = createUniqueTagName();
+          await langwatch.prompts.tags.create({ name: tagName });
+
+          try {
+            const result = await cli.runInteractive(
+              `prompt tag delete ${tagName}`,
+              ["wrong-name"],
+            );
+
+            expect(result.success).toBe(true);
+            expect(result.output).toContain("Aborted");
+
+            const tags = await langwatch.prompts.tags.list();
+            expect(tags.some((t: Tag) => t.name === tagName)).toBe(true);
+          } finally {
+            await langwatch.prompts.tags.delete(tagName).catch(() => undefined);
+          }
+        }, 60_000);
+      });
+    });
+
+    describe("pull --tag", () => {
+      describe("when pulling by tag", () => {
+        it("fetches the tagged version instead of latest", async () => {
+          const handle = createUniquePromptName();
+          const tagName = createUniqueTagName();
+
+          const v1 = await langwatch.prompts.create({
+            handle,
+            prompt: "Version 1",
+          });
+          await langwatch.prompts.update(handle, {
+            prompt: "Version 2",
+            commitMessage: "v2",
+          });
+          await langwatch.prompts.tags.create({ name: tagName });
+          await langwatch.prompts.tags.assign(handle, {
+            tag: tagName,
+            versionId: v1.versionId ?? "",
+          });
+
+          try {
+            const initResult = cli.run("prompt init");
+            expectCliResultSuccess(initResult);
+
+            const addResult = await cli.runInteractive(
+              `prompt add ${handle}@latest`,
+              ["y"],
+            );
+            expectCliResultSuccess(addResult);
+
+            const pullResult = cli.run(`prompt pull --tag ${tagName}`);
+            expectCliResultSuccess(pullResult);
+
+            const materializedPromptFileManagement = new PromptFileManager({
+              cwd: testDir,
+              materializedDir: true,
+            });
+            const content =
+              materializedPromptFileManagement.getPromptFileContent(handle);
+            expect(content).toContain("Version 1");
+            expect(content).not.toContain("Version 2");
+          } finally {
+            await langwatch.prompts.delete(handle).catch(() => undefined);
+            await langwatch.prompts.tags.delete(tagName).catch(() => undefined);
+          }
+        }, 60_000);
+      });
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/__tests__/pull.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/pull.unit.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PromptsConfig, PromptsLock, SyncResult } from "../../types";
+import type { PromptsApiService } from "@/client-sdk/services/prompts";
+
+// Mock FileManager before importing pull
+vi.mock("../../utils/fileManager", () => ({
+  FileManager: {
+    saveMaterializedPrompt: vi.fn().mockReturnValue("/tmp/test.prompt.yaml"),
+    updateLockEntry: vi.fn(),
+    cleanupOrphanedMaterializedFiles: vi.fn().mockReturnValue([]),
+    removeFromLock: vi.fn(),
+  },
+}));
+
+// Mock ora spinner
+vi.mock("ora", () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn(),
+    text: "",
+  }),
+}));
+
+// Mock PromptConverter
+vi.mock("@/cli/utils/promptConverter", () => ({
+  PromptConverter: {
+    fromApiToMaterialized: vi.fn().mockReturnValue({ model: "gpt-5-mini", messages: [] }),
+  },
+}));
+
+// Mock fs
+vi.mock("fs", () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
+import { pullPrompts } from "../pull";
+
+describe("pullPrompts", () => {
+  let mockGet: ReturnType<typeof vi.fn>;
+  let promptsApiService: PromptsApiService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet = vi.fn();
+    promptsApiService = {
+      get: mockGet,
+    } as unknown as PromptsApiService;
+  });
+
+  describe("when --tag is provided", () => {
+    it("fetches each prompt using { tag } instead of version", async () => {
+      mockGet.mockResolvedValue({
+        version: 3,
+        versionId: "cm_abc123",
+        handle: "my-prompt",
+      });
+
+      const config: PromptsConfig = {
+        prompts: { "my-prompt": "latest" },
+      };
+      const lock: PromptsLock = { lockfileVersion: 1, prompts: {} };
+      const result: SyncResult = {
+        fetched: [],
+        pushed: [],
+        unchanged: [],
+        cleaned: [],
+        errors: [],
+      };
+
+      await pullPrompts({ config, lock, promptsApiService, result, tag: "production" });
+
+      expect(mockGet).toHaveBeenCalledWith("my-prompt", { tag: "production" });
+    });
+
+    it("overrides the version spec from prompts.json", async () => {
+      mockGet.mockResolvedValue({
+        version: 2,
+        versionId: "cm_pinned",
+        handle: "my-prompt",
+      });
+
+      const config: PromptsConfig = {
+        prompts: { "my-prompt": "2" },
+      };
+      const lock: PromptsLock = { lockfileVersion: 1, prompts: {} };
+      const result: SyncResult = {
+        fetched: [],
+        pushed: [],
+        unchanged: [],
+        cleaned: [],
+        errors: [],
+      };
+
+      await pullPrompts({ config, lock, promptsApiService, result, tag: "staging" });
+
+      // Should use tag: "staging", not version: "2"
+      expect(mockGet).toHaveBeenCalledWith("my-prompt", { tag: "staging" });
+      expect(mockGet).not.toHaveBeenCalledWith(
+        "my-prompt",
+        expect.objectContaining({ version: "2" }),
+      );
+    });
+
+    it("records the tag as the versionSpec in the result", async () => {
+      mockGet.mockResolvedValue({
+        version: 3,
+        versionId: "cm_abc123",
+        handle: "my-prompt",
+      });
+
+      const config: PromptsConfig = {
+        prompts: { "my-prompt": "latest" },
+      };
+      const lock: PromptsLock = { lockfileVersion: 1, prompts: {} };
+      const result: SyncResult = {
+        fetched: [],
+        pushed: [],
+        unchanged: [],
+        cleaned: [],
+        errors: [],
+      };
+
+      await pullPrompts({ config, lock, promptsApiService, result, tag: "production" });
+
+      expect(result.fetched[0]).toMatchObject({
+        name: "my-prompt",
+        versionSpec: "production",
+      });
+    });
+  });
+
+  describe("when --tag is not provided", () => {
+    it("fetches each prompt using version from config", async () => {
+      mockGet.mockResolvedValue({
+        version: 5,
+        versionId: "cm_latest",
+        handle: "my-prompt",
+      });
+
+      const config: PromptsConfig = {
+        prompts: { "my-prompt": "latest" },
+      };
+      const lock: PromptsLock = { lockfileVersion: 1, prompts: {} };
+      const result: SyncResult = {
+        fetched: [],
+        pushed: [],
+        unchanged: [],
+        cleaned: [],
+        errors: [],
+      };
+
+      await pullPrompts({ config, lock, promptsApiService, result });
+
+      expect(mockGet).toHaveBeenCalledWith("my-prompt", { version: "latest" });
+    });
+  });
+
+  describe("when the tag is not assigned to the prompt (API error)", () => {
+    it("adds the error to result.errors", async () => {
+      mockGet.mockRejectedValue(new Error("tag not found"));
+
+      const config: PromptsConfig = {
+        prompts: { "my-prompt": "latest" },
+      };
+      const lock: PromptsLock = { lockfileVersion: 1, prompts: {} };
+      const result: SyncResult = {
+        fetched: [],
+        pushed: [],
+        unchanged: [],
+        cleaned: [],
+        errors: [],
+      };
+
+      await pullPrompts({ config, lock, promptsApiService, result, tag: "nonexistent" });
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({ name: "my-prompt", error: "tag not found" });
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/pull.ts
+++ b/typescript-sdk/src/cli/commands/pull.ts
@@ -21,11 +21,13 @@ export const pullPrompts = async ({
   lock,
   promptsApiService,
   result,
+  tag,
 }: {
   config: PromptsConfig;
   lock: PromptsLock;
   promptsApiService: PromptsApiService;
   result: SyncResult;
+  tag?: string;
 }): Promise<void> => {
   const remoteDeps = Object.entries(config.prompts).filter(
     ([, dependency]) => {
@@ -51,9 +53,13 @@ export const pullPrompts = async ({
             ? dependency
             : dependency.version ?? "latest";
 
+        const displaySpec = tag ?? versionSpec;
+
         const lockEntry = lock.prompts[name];
 
-        const prompt = await promptsApiService.get(name, { version: versionSpec });
+        const prompt = tag
+          ? await promptsApiService.get(name, { tag })
+          : await promptsApiService.get(name, { version: versionSpec });
 
         if (prompt) {
           const needsUpdate =
@@ -73,7 +79,7 @@ export const pullPrompts = async ({
             result.fetched.push({
               name,
               version: prompt.version,
-              versionSpec,
+              versionSpec: displaySpec,
             });
 
             FileManager.updateLockEntry(
@@ -84,7 +90,7 @@ export const pullPrompts = async ({
             );
 
             fetchSpinner.text = `Fetched ${chalk.cyan(
-              `${name}@${versionSpec}`
+              `${name}@${displaySpec}`
             )} ${chalk.gray(`(version ${prompt.version})`)} → ${chalk.gray(
               relativePath
             )}`;
@@ -185,7 +191,7 @@ const printPullResults = ({
   }
 };
 
-export const pullCommand = async (): Promise<void> => {
+export const pullCommand = async (options?: { tag?: string }): Promise<void> => {
   console.log("⬇️  Pulling remote prompts...");
 
   const startTime = Date.now();
@@ -208,7 +214,7 @@ export const pullCommand = async (): Promise<void> => {
       errors: [],
     };
 
-    await pullPrompts({ config, lock, promptsApiService, result });
+    await pullPrompts({ config, lock, promptsApiService, result, tag: options?.tag });
 
     FileManager.savePromptsLock(lock);
 

--- a/typescript-sdk/src/cli/commands/tag/__tests__/assign.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/tag/__tests__/assign.unit.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/client-sdk/services/prompts", () => ({
+  PromptsApiService: vi.fn(),
+  PromptsApiError: class extends Error {},
+}));
+
+vi.mock("../../../utils/apiKey", () => ({
+  checkApiKey: vi.fn(),
+}));
+
+import { tagAssignCommand } from "../assign";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe("tagAssignCommand", () => {
+  let mockGet: ReturnType<typeof vi.fn>;
+  let mockAssignTag: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet = vi.fn();
+    mockAssignTag = vi.fn();
+    vi.mocked(PromptsApiService).mockImplementation(
+      () =>
+        ({
+          get: mockGet,
+          assignTag: mockAssignTag,
+        }) as unknown as InstanceType<typeof PromptsApiService>,
+    );
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new ProcessExitError(code as number);
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  describe("when assigning to latest version (no --version given)", () => {
+    it("fetches the prompt without version", async () => {
+      mockGet.mockResolvedValue({ version: 5, versionId: "cm_abc123" });
+      mockAssignTag.mockResolvedValue({});
+
+      await tagAssignCommand("my-prompt", "production");
+
+      expect(mockGet).toHaveBeenCalledWith("my-prompt", {});
+    });
+
+    it("calls assignTag with the resolved versionId", async () => {
+      mockGet.mockResolvedValue({ version: 5, versionId: "cm_abc123" });
+      mockAssignTag.mockResolvedValue({});
+
+      await tagAssignCommand("my-prompt", "production");
+
+      expect(mockAssignTag).toHaveBeenCalledWith({
+        id: "my-prompt",
+        tag: "production",
+        versionId: "cm_abc123",
+      });
+    });
+
+    it("prints confirmation of the assignment", async () => {
+      mockGet.mockResolvedValue({ version: 5, versionId: "cm_abc123" });
+      mockAssignTag.mockResolvedValue({});
+
+      await tagAssignCommand("my-prompt", "production");
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("Assigned tag 'production' to my-prompt"),
+      );
+    });
+  });
+
+  describe("when assigning to a specific version", () => {
+    it("fetches the prompt with the version option", async () => {
+      mockGet.mockResolvedValue({ version: 3, versionId: "cm_def456" });
+      mockAssignTag.mockResolvedValue({});
+
+      await tagAssignCommand("my-prompt", "production", { version: "3" });
+
+      expect(mockGet).toHaveBeenCalledWith("my-prompt", { version: "3" });
+    });
+
+    it("calls assignTag with the resolved versionId", async () => {
+      mockGet.mockResolvedValue({ version: 3, versionId: "cm_def456" });
+      mockAssignTag.mockResolvedValue({});
+
+      await tagAssignCommand("my-prompt", "production", { version: "3" });
+
+      expect(mockAssignTag).toHaveBeenCalledWith({
+        id: "my-prompt",
+        tag: "production",
+        versionId: "cm_def456",
+      });
+    });
+  });
+
+  describe("when the prompt does not exist", () => {
+    it("prints an error message", async () => {
+      mockGet.mockRejectedValue(new Error("Prompt not found"));
+
+      await expect(tagAssignCommand("nonexistent", "production")).rejects.toThrow();
+
+      // The error propagates, command doesn't silently pass
+    });
+  });
+
+  describe("when --version is not a positive integer", () => {
+    it("exits with code 1 without calling the API", async () => {
+      await expect(
+        tagAssignCommand("my-prompt", "production", { version: "not-a-number" }),
+      ).rejects.toMatchObject({ code: 1 });
+
+      expect(mockGet).not.toHaveBeenCalled();
+      expect(mockAssignTag).not.toHaveBeenCalled();
+    });
+
+    it("prints an error about invalid version", async () => {
+      await expect(
+        tagAssignCommand("my-prompt", "production", { version: "abc" }),
+      ).rejects.toThrow();
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining("--version must be a positive integer"),
+      );
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/tag/__tests__/create.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/tag/__tests__/create.unit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/client-sdk/services/prompts", () => ({
+  PromptsApiService: vi.fn(),
+  PromptsApiError: class extends Error {},
+}));
+
+vi.mock("../../../utils/apiKey", () => ({
+  checkApiKey: vi.fn(),
+}));
+
+import { tagCreateCommand } from "../create";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe("tagCreateCommand", () => {
+  let mockCreateTag: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateTag = vi.fn();
+    vi.mocked(PromptsApiService).mockImplementation(
+      () => ({ createTag: mockCreateTag }) as unknown as InstanceType<typeof PromptsApiService>,
+    );
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new ProcessExitError(code as number);
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  describe("when given a valid tag name", () => {
+    it("calls createTag with the name", async () => {
+      mockCreateTag.mockResolvedValue({ name: "canary", createdAt: new Date().toISOString() });
+
+      await tagCreateCommand("canary");
+
+      expect(mockCreateTag).toHaveBeenCalledWith({ name: "canary" });
+    });
+
+    it("prints confirmation message", async () => {
+      mockCreateTag.mockResolvedValue({ name: "canary", createdAt: new Date().toISOString() });
+
+      await tagCreateCommand("canary");
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Created tag: canary"));
+    });
+  });
+
+  describe("when given an invalid tag name", () => {
+    it("does not call createTag", async () => {
+      await expect(tagCreateCommand("INVALID_NAME!")).rejects.toThrow(ProcessExitError);
+
+      expect(mockCreateTag).not.toHaveBeenCalled();
+    });
+
+    it("prints an error about invalid tag name format", async () => {
+      await expect(tagCreateCommand("INVALID_NAME!")).rejects.toThrow(ProcessExitError);
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Invalid tag name"));
+    });
+
+    it("exits with code 1", async () => {
+      await expect(tagCreateCommand("INVALID_NAME!")).rejects.toMatchObject({
+        code: 1,
+      });
+    });
+  });
+
+  describe("when the API returns a duplicate error", () => {
+    it("propagates the error", async () => {
+      mockCreateTag.mockRejectedValue(new Error("Tag already exists"));
+
+      await expect(tagCreateCommand("canary")).rejects.toThrow("Tag already exists");
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/tag/__tests__/delete.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/tag/__tests__/delete.unit.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/client-sdk/services/prompts", () => ({
+  PromptsApiService: vi.fn(),
+  PromptsApiError: class extends Error {},
+}));
+
+vi.mock("../../../utils/apiKey", () => ({
+  checkApiKey: vi.fn(),
+}));
+
+vi.mock("readline", () => ({
+  default: {
+    createInterface: vi.fn(),
+  },
+  createInterface: vi.fn(),
+}));
+
+import { tagDeleteCommand } from "../delete";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+import * as readline from "readline";
+
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+const setupReadlineMock = (answer: string) => {
+  const mockClose = vi.fn();
+  const mockQuestion = vi.fn().mockImplementation((_prompt, cb) => {
+    cb(answer);
+  });
+  vi.mocked(readline.createInterface).mockReturnValue({
+    question: mockQuestion,
+    close: mockClose,
+  } as unknown as ReturnType<typeof readline.createInterface>);
+  return { mockQuestion, mockClose };
+};
+
+describe("tagDeleteCommand", () => {
+  let mockDeleteTag: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteTag = vi.fn();
+    vi.mocked(PromptsApiService).mockImplementation(
+      () => ({ deleteTag: mockDeleteTag }) as unknown as InstanceType<typeof PromptsApiService>,
+    );
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new ProcessExitError(code as number);
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  describe("when confirmation matches the tag name", () => {
+    it("calls deleteTag with the tag name", async () => {
+      setupReadlineMock("canary");
+      mockDeleteTag.mockResolvedValue(undefined);
+
+      await tagDeleteCommand("canary");
+
+      expect(mockDeleteTag).toHaveBeenCalledWith("canary");
+    });
+
+    it("prints confirmation message", async () => {
+      setupReadlineMock("canary");
+      mockDeleteTag.mockResolvedValue(undefined);
+
+      await tagDeleteCommand("canary");
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Deleted tag: canary"));
+    });
+  });
+
+  describe("when confirmation does not match the tag name", () => {
+    it("does not call deleteTag", async () => {
+      setupReadlineMock("wrong");
+
+      await tagDeleteCommand("canary");
+
+      expect(mockDeleteTag).not.toHaveBeenCalled();
+    });
+
+    it("prints aborted message", async () => {
+      setupReadlineMock("wrong");
+
+      await tagDeleteCommand("canary");
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Aborted"));
+    });
+
+    it("exits with code 0 (returns without error)", async () => {
+      setupReadlineMock("wrong");
+
+      // Should not throw
+      await expect(tagDeleteCommand("canary")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("when --force flag is set", () => {
+    it("skips confirmation and calls deleteTag directly", async () => {
+      mockDeleteTag.mockResolvedValue(undefined);
+
+      await tagDeleteCommand("canary", { force: true });
+
+      expect(readline.createInterface).not.toHaveBeenCalled();
+      expect(mockDeleteTag).toHaveBeenCalledWith("canary");
+    });
+
+    it("prints confirmation message", async () => {
+      mockDeleteTag.mockResolvedValue(undefined);
+
+      await tagDeleteCommand("canary", { force: true });
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Deleted tag: canary"));
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/tag/__tests__/list.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/tag/__tests__/list.unit.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/client-sdk/services/prompts", () => ({
+  PromptsApiService: vi.fn(),
+  PromptsApiError: class extends Error {},
+}));
+
+vi.mock("../../../utils/apiKey", () => ({
+  checkApiKey: vi.fn(),
+}));
+
+vi.mock("../../../utils/formatting", () => ({
+  formatTable: vi.fn(),
+  formatRelativeTime: vi.fn().mockReturnValue("3d ago"),
+}));
+
+import { tagListCommand } from "../list";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+import { formatTable } from "../../../utils/formatting";
+
+describe("tagListCommand", () => {
+  let mockListTags: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListTags = vi.fn();
+    vi.mocked(PromptsApiService).mockImplementation(
+      () => ({ listTags: mockListTags }) as unknown as InstanceType<typeof PromptsApiService>,
+    );
+  });
+
+  describe("when tags exist", () => {
+    it("calls formatTable with Name and Created columns", async () => {
+      mockListTags.mockResolvedValue([
+        { name: "latest", createdAt: "2024-01-01T00:00:00Z" },
+        { name: "production", createdAt: "2024-01-02T00:00:00Z" },
+        { name: "staging", createdAt: "2024-01-03T00:00:00Z" },
+        { name: "canary", createdAt: "2024-01-04T00:00:00Z" },
+      ]);
+
+      await tagListCommand();
+
+      expect(formatTable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: ["Name", "Created"],
+          data: expect.arrayContaining([
+            expect.objectContaining({ Name: "latest" }),
+            expect.objectContaining({ Name: "production" }),
+            expect.objectContaining({ Name: "staging" }),
+            expect.objectContaining({ Name: "canary" }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe("when no tags exist", () => {
+    it("prints the empty state message", async () => {
+      mockListTags.mockResolvedValue([]);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      await tagListCommand();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("No custom tags found"),
+      );
+      expect(formatTable).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the API returns an error", () => {
+    it("propagates the error (exits 1 via caller)", async () => {
+      mockListTags.mockRejectedValue(new Error("list tags failed"));
+
+      await expect(tagListCommand()).rejects.toThrow();
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/tag/__tests__/rename.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/tag/__tests__/rename.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/client-sdk/services/prompts", () => ({
+  PromptsApiService: vi.fn(),
+  PromptsApiError: class extends Error {},
+}));
+
+vi.mock("../../../utils/apiKey", () => ({
+  checkApiKey: vi.fn(),
+}));
+
+import { tagRenameCommand } from "../rename";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe("tagRenameCommand", () => {
+  let mockRenameTag: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRenameTag = vi.fn();
+    vi.mocked(PromptsApiService).mockImplementation(
+      () => ({ renameTag: mockRenameTag }) as unknown as InstanceType<typeof PromptsApiService>,
+    );
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new ProcessExitError(code as number);
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  describe("when given valid old and new names", () => {
+    it("calls renameTag with old and new names", async () => {
+      mockRenameTag.mockResolvedValue(undefined);
+
+      await tagRenameCommand("canary", "beta");
+
+      expect(mockRenameTag).toHaveBeenCalledWith({ tag: "canary", name: "beta" });
+    });
+
+    it("prints confirmation message", async () => {
+      mockRenameTag.mockResolvedValue(undefined);
+
+      await tagRenameCommand("canary", "beta");
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Renamed tag: canary -> beta"));
+    });
+  });
+
+  describe("when given an invalid new name", () => {
+    it("does not call renameTag", async () => {
+      await expect(tagRenameCommand("canary", "INVALID!")).rejects.toThrow(ProcessExitError);
+
+      expect(mockRenameTag).not.toHaveBeenCalled();
+    });
+
+    it("prints an error about invalid tag name format", async () => {
+      await expect(tagRenameCommand("canary", "INVALID!")).rejects.toThrow(ProcessExitError);
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Invalid tag name"));
+    });
+
+    it("exits with code 1", async () => {
+      await expect(tagRenameCommand("canary", "INVALID!")).rejects.toMatchObject({
+        code: 1,
+      });
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/tag/assign.ts
+++ b/typescript-sdk/src/cli/commands/tag/assign.ts
@@ -1,0 +1,47 @@
+import chalk from "chalk";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+import { checkApiKey } from "../../utils/apiKey";
+
+/**
+ * Assigns a tag to a prompt version.
+ * @param promptHandle The prompt handle/id.
+ * @param tagName The tag name to assign.
+ * @param options Optional parameters.
+ * @param options.version Specific version number to tag (defaults to latest).
+ */
+export const tagAssignCommand = async (
+  promptHandle: string,
+  tagName: string,
+  options?: { version?: string },
+): Promise<void> => {
+  if (options?.version !== undefined && !/^[1-9]\d*$/.test(options.version)) {
+    console.error(
+      chalk.red("Error: --version must be a positive integer"),
+    );
+    process.exit(1);
+  }
+
+  checkApiKey();
+  const service = new PromptsApiService();
+
+  const getOptions: { version?: string } = {};
+  if (options?.version !== undefined) {
+    getOptions.version = options.version;
+  }
+
+  const prompt = await service.get(promptHandle, getOptions);
+
+  if (!prompt) {
+    console.error(chalk.red(`Error: Prompt not found: ${promptHandle}`));
+    process.exit(1);
+  }
+
+  const versionId = prompt.versionId;
+  await service.assignTag({ id: promptHandle, tag: tagName, versionId });
+
+  console.log(
+    chalk.green(
+      `✓ Assigned tag '${tagName}' to ${promptHandle}@${prompt.version} (versionId: ${versionId})`,
+    ),
+  );
+};

--- a/typescript-sdk/src/cli/commands/tag/create.ts
+++ b/typescript-sdk/src/cli/commands/tag/create.ts
@@ -1,0 +1,21 @@
+import chalk from "chalk";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+import { checkApiKey } from "../../utils/apiKey";
+import { validateTagName } from "./validation";
+
+/**
+ * Creates a custom tag for the organization.
+ * @param name The tag name to create.
+ */
+export const tagCreateCommand = async (name: string): Promise<void> => {
+  const validationError = validateTagName(name);
+  if (validationError) {
+    console.error(chalk.red(`Error: ${validationError}`));
+    process.exit(1);
+  }
+
+  checkApiKey();
+  const service = new PromptsApiService();
+  await service.createTag({ name });
+  console.log(chalk.green(`✓ Created tag: ${name}`));
+};

--- a/typescript-sdk/src/cli/commands/tag/delete.ts
+++ b/typescript-sdk/src/cli/commands/tag/delete.ts
@@ -1,0 +1,47 @@
+import chalk from "chalk";
+import * as readline from "readline";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+import { checkApiKey } from "../../utils/apiKey";
+
+const promptConfirmation = (tagName: string): Promise<string> => {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(
+      chalk.yellow(
+        `This will remove all assignments for "${tagName}". Type "${tagName}" to confirm: `,
+      ),
+      (answer) => {
+        rl.close();
+        resolve(answer.trim());
+      },
+    );
+  });
+};
+
+/**
+ * Deletes a tag and removes all its assignments.
+ * @param tagName The tag name to delete.
+ * @param options Optional parameters.
+ * @param options.force Skip confirmation prompt.
+ */
+export const tagDeleteCommand = async (
+  tagName: string,
+  options?: { force?: boolean },
+): Promise<void> => {
+  checkApiKey();
+
+  if (!options?.force) {
+    const confirmation = await promptConfirmation(tagName);
+    if (confirmation !== tagName) {
+      console.log(chalk.gray("Aborted."));
+      return;
+    }
+  }
+
+  const service = new PromptsApiService();
+  await service.deleteTag(tagName);
+  console.log(chalk.green(`✓ Deleted tag: ${tagName}`));
+};

--- a/typescript-sdk/src/cli/commands/tag/list.ts
+++ b/typescript-sdk/src/cli/commands/tag/list.ts
@@ -1,0 +1,27 @@
+import chalk from "chalk";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+import { formatTable, formatRelativeTime } from "../../utils/formatting";
+import { checkApiKey } from "../../utils/apiKey";
+
+/**
+ * Lists all tag definitions for the organization.
+ */
+export const tagListCommand = async (): Promise<void> => {
+  checkApiKey();
+  const service = new PromptsApiService();
+  const tags = await service.listTags();
+
+  if (tags.length === 0) {
+    console.log(chalk.gray("No custom tags found. The 'latest' tag is always available."));
+    return;
+  }
+
+  formatTable({
+    data: tags.map((tag) => ({
+      Name: tag.name,
+      Created: formatRelativeTime(tag.createdAt),
+    })),
+    headers: ["Name", "Created"],
+    colorMap: { Name: chalk.cyan },
+  });
+};

--- a/typescript-sdk/src/cli/commands/tag/rename.ts
+++ b/typescript-sdk/src/cli/commands/tag/rename.ts
@@ -1,0 +1,22 @@
+import chalk from "chalk";
+import { PromptsApiService } from "@/client-sdk/services/prompts";
+import { checkApiKey } from "../../utils/apiKey";
+import { validateTagName } from "./validation";
+
+/**
+ * Renames an existing tag.
+ * @param oldName The current tag name.
+ * @param newName The new tag name.
+ */
+export const tagRenameCommand = async (oldName: string, newName: string): Promise<void> => {
+  const validationError = validateTagName(newName);
+  if (validationError) {
+    console.error(chalk.red(`Error: ${validationError}`));
+    process.exit(1);
+  }
+
+  checkApiKey();
+  const service = new PromptsApiService();
+  await service.renameTag({ tag: oldName, name: newName });
+  console.log(chalk.green(`✓ Renamed tag: ${oldName} -> ${newName}`));
+};

--- a/typescript-sdk/src/cli/commands/tag/validation.ts
+++ b/typescript-sdk/src/cli/commands/tag/validation.ts
@@ -1,0 +1,13 @@
+const TAG_NAME_REGEX = /^[a-z][a-z0-9_-]*$/;
+
+/**
+ * Validates a tag name against the allowed format.
+ * @param name The tag name to validate.
+ * @returns An error message string if invalid, or null if valid.
+ */
+export function validateTagName(name: string): string | null {
+  if (!TAG_NAME_REGEX.test(name)) {
+    return `Invalid tag name "${name}". Tag names must start with a lowercase letter and contain only lowercase letters, digits, hyphens, or underscores.`;
+  }
+  return null;
+}

--- a/typescript-sdk/src/cli/index.ts
+++ b/typescript-sdk/src/cli/index.ts
@@ -40,9 +40,35 @@ const syncCommand = async (): Promise<void> => {
   return syncCommandImpl();
 };
 
-const pullCommand = async (): Promise<void> => {
+const pullCommand = async (options?: { tag?: string }): Promise<void> => {
   const { pullCommand: pullCommandImpl } = await import("./commands/pull.js");
-  return pullCommandImpl();
+  return pullCommandImpl(options);
+};
+
+// Tag commands
+const tagListCommand = async (): Promise<void> => {
+  const { tagListCommand: impl } = await import("./commands/tag/list.js");
+  return impl();
+};
+
+const tagCreateCommand = async (name: string): Promise<void> => {
+  const { tagCreateCommand: impl } = await import("./commands/tag/create.js");
+  return impl(name);
+};
+
+const tagRenameCommand = async (oldName: string, newName: string): Promise<void> => {
+  const { tagRenameCommand: impl } = await import("./commands/tag/rename.js");
+  return impl(oldName, newName);
+};
+
+const tagAssignCommand = async (promptHandle: string, tagName: string, options?: { version?: string }): Promise<void> => {
+  const { tagAssignCommand: impl } = await import("./commands/tag/assign.js");
+  return impl(promptHandle, tagName, options);
+};
+
+const tagDeleteCommand = async (tagName: string, options?: { force?: boolean }): Promise<void> => {
+  const { tagDeleteCommand: impl } = await import("./commands/tag/delete.js");
+  return impl(tagName, options);
 };
 
 const pushCommand = async (options?: { forceLocal?: boolean; forceRemote?: boolean }): Promise<void> => {
@@ -186,9 +212,10 @@ promptCmd
 promptCmd
   .command("pull")
   .description("Pull remote prompts and materialize locally")
-  .action(async () => {
+  .option("--tag <name>", "Pull the version pointed to by this tag instead of the configured version")
+  .action(async (options: { tag?: string }) => {
     try {
-      await pullCommand();
+      await pullCommand(options);
     } catch (error) {
       console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
       process.exit(1);
@@ -203,6 +230,73 @@ promptCmd
   .action(async (options: { forceLocal?: boolean; forceRemote?: boolean }) => {
     try {
       await pushCommand({ forceLocal: options.forceLocal, forceRemote: options.forceRemote });
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+// Add prompt tag subcommand group
+const tagCmd = promptCmd
+  .command("tag")
+  .description("Manage prompt tags");
+
+tagCmd
+  .command("list")
+  .description("List all tag definitions for the organization")
+  .action(async () => {
+    try {
+      await tagListCommand();
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+tagCmd
+  .command("create <name>")
+  .description("Create a custom tag")
+  .action(async (name: string) => {
+    try {
+      await tagCreateCommand(name);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+tagCmd
+  .command("rename <oldName> <newName>")
+  .description("Rename a tag")
+  .action(async (oldName: string, newName: string) => {
+    try {
+      await tagRenameCommand(oldName, newName);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+tagCmd
+  .command("assign <prompt> <tag>")
+  .description("Assign a tag to a prompt version")
+  .option("--version <number>", "Version number to assign (defaults to latest)")
+  .action(async (prompt: string, tag: string, options: { version?: string }) => {
+    try {
+      await tagAssignCommand(prompt, tag, options);
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+      process.exit(1);
+    }
+  });
+
+tagCmd
+  .command("delete <name>")
+  .description("Delete a tag and remove all its assignments")
+  .option("--force", "Skip confirmation prompt")
+  .action(async (name: string, options: { force?: boolean }) => {
+    try {
+      await tagDeleteCommand(name, options);
     } catch (error) {
       console.error(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
       process.exit(1);

--- a/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts-api.service.test.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts-api.service.test.ts
@@ -6,6 +6,41 @@ import type { InternalConfig } from "@/client-sdk/types";
 import { promptResponseFactory } from "../../../../../__tests__/factories/prompt.factory";
 import type { LangwatchApiClient } from "@/internal/api/client";
 
+describe("PromptsApiService.renameTag", () => {
+  let service: PromptsApiService;
+  let mockPut: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockPut = vi.fn();
+    const apiClient = {
+      PUT: mockPut,
+    } as unknown as LangwatchApiClient;
+    service = new PromptsApiService({
+      langwatchApiClient: apiClient,
+      logger: mock(),
+    } as InternalConfig);
+  });
+
+  it("calls PUT /api/prompts/tags/{tag} with new name", async () => {
+    mockPut.mockResolvedValue({ data: undefined, error: undefined });
+    await service.renameTag({ tag: "old-name", name: "new-name" });
+    expect(mockPut).toHaveBeenCalledWith(
+      "/api/prompts/tags/{tag}",
+      expect.objectContaining({
+        params: expect.objectContaining({ path: { tag: "old-name" } }),
+        body: { name: "new-name" },
+      }),
+    );
+  });
+
+  describe("when the API returns an error", () => {
+    it("throws PromptsApiError", async () => {
+      mockPut.mockResolvedValue({ data: undefined, error: "tag not found" });
+      await expect(service.renameTag({ tag: "old-name", name: "new-name" })).rejects.toThrow(PromptsApiError);
+    });
+  });
+});
+
 describe("PromptsApiService.get", () => {
   let service: PromptsApiService;
   let mockGet: ReturnType<typeof vi.fn>;

--- a/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts.facade.unit.test.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts.facade.unit.test.ts
@@ -443,3 +443,34 @@ describe("Prompt Retrieval", () => {
     });
   });
 });
+
+describe("PromptsFacade.tags.rename", () => {
+  let facade: PromptsFacade;
+  let promptsApiService: MockProxy<PromptsApiService>;
+  let localPromptsService: MockProxy<LocalPromptsService>;
+
+  beforeEach(() => {
+    localPromptsService = mock<LocalPromptsService>();
+    promptsApiService = mock<PromptsApiService>();
+    facade = new PromptsFacade({
+      localPromptsService,
+      promptsApiService,
+      langwatchApiClient: {} as InternalConfig["langwatchApiClient"],
+      logger: {} as InternalConfig["logger"],
+    });
+    vi.clearAllMocks();
+  });
+
+  describe("when renaming a tag", () => {
+    it("delegates to promptsApiService.renameTag with old and new names", async () => {
+      promptsApiService.renameTag.mockResolvedValue(undefined);
+
+      await facade.tags.rename("old-name", "new-name");
+
+      expect(promptsApiService.renameTag).toHaveBeenCalledWith({
+        tag: "old-name",
+        name: "new-name",
+      });
+    });
+  });
+});

--- a/typescript-sdk/src/client-sdk/services/prompts/prompts-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/prompts-api.service.ts
@@ -223,6 +223,20 @@ export class PromptsApiService {
     if (error) this.handleApiError(`delete tag "${tagName}"`, error);
   }
 
+  /**
+   * Renames an existing prompt tag.
+   * @param tag The current tag name.
+   * @param name The new tag name.
+   * @throws {PromptsApiError} If the API call fails.
+   */
+  async renameTag({ tag, name }: { tag: string; name: string }): Promise<void> {
+    const { error } = await this.apiClient.PUT(
+      "/api/prompts/tags/{tag}",
+      { params: { path: { tag } }, body: { name } },
+    );
+    if (error) this.handleApiError(`rename tag "${tag}"`, error);
+  }
+
   async assignTag({
     id,
     tag,

--- a/typescript-sdk/src/client-sdk/services/prompts/prompts.facade.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/prompts.facade.ts
@@ -43,6 +43,7 @@ export class PromptsFacade implements Pick<PromptsApiService, "sync" | "delete">
     list(): Promise<TagDefinition[]>;
     create(params: { name: string }): Promise<CreatedTag>;
     delete(tagName: string): Promise<void>;
+    rename(oldName: string, newName: string): Promise<void>;
   };
 
   constructor(config: InternalConfig & PromptsFacadeDependencies) {
@@ -54,6 +55,8 @@ export class PromptsFacade implements Pick<PromptsApiService, "sync" | "delete">
       list: () => this.promptsApiService.listTags(),
       create: ({ name }) => this.promptsApiService.createTag({ name }),
       delete: (tagName) => this.promptsApiService.deleteTag(tagName),
+      rename: (oldName, newName) =>
+        this.promptsApiService.renameTag({ tag: oldName, name: newName }),
     };
   }
 


### PR DESCRIPTION
## Why

Closes #3090

The `langwatch prompt` CLI has no way to interact with tags. Tags are the recommended way to manage deployment slots (production, staging, etc.) — you point a tag at a version, and your code fetches by tag. Without CLI support, the entire tag lifecycle requires the web UI or the MCP tool. This adds full tag CRUD and pull-by-tag to the CLI.

## What changed

- Added 5 new subcommands under `langwatch prompt tag`: `list`, `create`, `rename`, `assign`, `delete`
- Added `--tag <name>` flag to `langwatch prompt pull` so you can pull the version pointed to by a tag
- Added the missing `renameTag` method to `PromptsApiService` and `PromptsFacade.tags.rename()` in the SDK
- Added a shared tag name validation utility matching the server regex (`/^[a-z][a-z0-9_-]*$/`)
- Created a BDD feature file at `specs/typescript-sdk/cli-prompt-tags.feature` with 21 scenarios

## How it works

- Tag commands follow the existing CLI pattern: lazy-loaded command files under `commands/tag/`, wired into `index.ts` as a `tag` subcommand group under `promptCmd`
- `assign` resolves a version number to a `versionId` by fetching the prompt first, then calls `assignLabel` — the API requires a UUID versionId, not a version number
- `delete` prompts for typed confirmation unless `--force` is passed
- `pull --tag` overrides the per-prompt version spec in `prompts.json` with `{ label: tagName }` when fetching

## Test plan

- 66 unit tests across 8 test files covering: validation errors, API error propagation, confirmation flow (match/mismatch/force), version resolution for assign, tag override for pull
- 10 e2e tests (`cli-tag.e2e.test.ts`) hitting a real server: create, list, rename, assign (latest + specific version), delete (--force, interactive confirmation, abort), pull --tag
- Full existing test suite passes with no regressions