### PR TITLE
feat: bring-your-own-key for Azure Content Safety evaluators (azure_safety provider)

### DIFF
--- a/langwatch/src/components/evaluators/EvaluatorTypeSelectorDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorTypeSelectorDrawer.tsx
@@ -1,9 +1,13 @@
 import { Box, Button, Heading, HStack, Text, VStack } from "@chakra-ui/react";
-import { LuArrowLeft } from "react-icons/lu";
+import { useRouter } from "next/router";
+import { LuArrowLeft, LuExternalLink } from "react-icons/lu";
 
+import { Tooltip } from "~/components/ui/tooltip";
 import { Drawer } from "~/components/ui/drawer";
 import { getComplexProps, useDrawer, useDrawerParams } from "~/hooks/useDrawer";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { AVAILABLE_EVALUATORS } from "~/server/evaluations/evaluators.generated";
+import { api } from "~/utils/api";
 import type { EvaluatorCategoryId } from "./EvaluatorCategorySelectorDrawer";
 
 export type EvaluatorTypeSelectorDrawerProps = {
@@ -118,6 +122,8 @@ export function EvaluatorTypeSelectorDrawer(
   const { closeDrawer, openDrawer, canGoBack, goBack } = useDrawer();
   const complexProps = getComplexProps();
   const drawerParams = useDrawerParams();
+  const router = useRouter();
+  const { project } = useOrganizationTeamProject();
 
   const onClose = props.onClose ?? closeDrawer;
   const onSelect =
@@ -132,9 +138,23 @@ export function EvaluatorTypeSelectorDrawer(
 
   const evaluatorTypes = category ? (categoryEvaluators[category] ?? []) : [];
 
+  // Query availableEvaluators to get project-aware missingEnvVars so we can
+  // gate Azure evaluator cards behind a configured azure_safety provider.
+  const availableEvaluatorsQuery = api.evaluations.availableEvaluators.useQuery(
+    { projectId: project?.id ?? "" },
+    { enabled: !!project?.id && isOpen },
+  );
+
   const handleSelectEvaluator = (evaluatorType: string) => {
     onSelect?.(evaluatorType);
     openDrawer("evaluatorEditor", { evaluatorType, category });
+  };
+
+  const handleConfigureAzureSafety = () => {
+    onClose();
+    if (project?.slug) {
+      void router.push(`/settings/model-providers?provider=azure_safety`);
+    }
   };
 
   return (
@@ -188,12 +208,33 @@ export function EvaluatorTypeSelectorDrawer(
                 const evaluator = AVAILABLE_EVALUATORS[evaluatorType];
                 if (!evaluator) return null;
 
+                const availableEntry =
+                  availableEvaluatorsQuery.data?.[evaluatorType];
+                const missingEnvVars = availableEntry?.missingEnvVars ?? [];
+                const isAzureEvaluator = evaluatorType.startsWith("azure/");
+                const isDisabled =
+                  isAzureEvaluator && missingEnvVars.length > 0;
+
                 return (
                   <EvaluatorCard
                     key={evaluatorType}
                     evaluatorType={evaluatorType}
                     name={evaluator.name}
                     description={evaluator.description}
+                    disabled={isDisabled}
+                    disabledTooltip={
+                      isDisabled
+                        ? "Configure Azure Safety provider in Settings → Model Providers"
+                        : undefined
+                    }
+                    disabledCta={
+                      isDisabled
+                        ? {
+                            label: "Configure Azure Safety",
+                            onClick: handleConfigureAzureSafety,
+                          }
+                        : undefined
+                    }
                     onClick={() => handleSelectEvaluator(evaluatorType)}
                   />
                 );
@@ -219,6 +260,9 @@ type EvaluatorCardProps = {
   evaluatorType: string;
   name: string;
   description: string;
+  disabled?: boolean;
+  disabledTooltip?: string;
+  disabledCta?: { label: string; onClick: () => void };
   onClick: () => void;
 };
 
@@ -226,31 +270,71 @@ function EvaluatorCard({
   evaluatorType,
   name,
   description,
+  disabled,
+  disabledTooltip,
+  disabledCta,
   onClick,
 }: EvaluatorCardProps) {
-  return (
+  const testId = `evaluator-type-${evaluatorType.replace("/", "-")}`;
+
+  const card = (
     <Box
       as="button"
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
       padding={4}
       borderRadius="lg"
       border="1px solid"
       borderColor="border"
-      bg="bg.panel"
+      bg={disabled ? "gray.50" : "bg.panel"}
+      color={disabled ? "gray.400" : undefined}
+      cursor={disabled ? "default" : "pointer"}
       textAlign="left"
       width="full"
-      _hover={{ borderColor: "green.muted", bg: "green.subtle" }}
+      _hover={
+        disabled
+          ? undefined
+          : { borderColor: "green.muted", bg: "green.subtle" }
+      }
       transition="all 0.15s"
-      data-testid={`evaluator-type-${evaluatorType.replace("/", "-")}`}
+      data-testid={testId}
+      data-disabled={disabled ? "true" : undefined}
     >
-      <VStack align="start" gap={1}>
+      <VStack align="start" gap={2}>
         <Text fontWeight="500" fontSize="sm">
           {name}
         </Text>
-        <Text fontSize="xs" color="fg.muted" lineClamp={2}>
+        <Text fontSize="xs" color={disabled ? "gray.400" : "fg.muted"} lineClamp={2}>
           {description}
         </Text>
+        {disabled && disabledCta && (
+          <HStack
+            as="span"
+            gap={1}
+            color="orange.600"
+            fontSize="xs"
+            fontWeight="500"
+            onClick={(e) => {
+              e.stopPropagation();
+              disabledCta.onClick();
+            }}
+            data-testid={`${testId}-cta`}
+            cursor="pointer"
+          >
+            <Text>{disabledCta.label}</Text>
+            <LuExternalLink size={12} />
+          </HStack>
+        )}
       </VStack>
     </Box>
   );
+
+  if (disabled && disabledTooltip) {
+    return (
+      <Tooltip content={disabledTooltip} positioning={{ placement: "top" }}>
+        {card}
+      </Tooltip>
+    );
+  }
+
+  return card;
 }

--- a/langwatch/src/components/evaluators/__tests__/EvaluatorTypeSelectorDrawer.azure-byok.integration.test.tsx
+++ b/langwatch/src/components/evaluators/__tests__/EvaluatorTypeSelectorDrawer.azure-byok.integration.test.tsx
@@ -1,0 +1,340 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for EvaluatorTypeSelectorDrawer — Azure Safety BYOK gating.
+ *
+ * Covers @integration scenarios from specs/evaluators/azure-safety-byok-gating.feature:
+ * - "Azure evaluators are disabled when no Azure Safety provider is configured"
+ * - "Disabled Azure card shows CTA to configure the provider"
+ * - "Configuring Azure Safety enables all three Azure evaluators"
+ * - "Non-Azure safety evaluators are unaffected by Azure Safety config"
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EvaluatorTypeSelectorDrawer } from "../EvaluatorTypeSelectorDrawer";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("~/server/evaluations/evaluators.generated", () => ({
+  AVAILABLE_EVALUATORS: {
+    "presidio/pii_detection": {
+      name: "PII Detection",
+      description: "Detect PII in text",
+    },
+    "azure/content_safety": {
+      name: "Azure Content Safety",
+      description: "Moderate content with Azure Content Safety",
+    },
+    "azure/prompt_injection": {
+      name: "Azure Prompt Injection",
+      description: "Detect prompt injection with Azure Prompt Shield",
+    },
+    "azure/jailbreak": {
+      name: "Azure Jailbreak Detection",
+      description: "Detect jailbreak attempts with Azure",
+    },
+    "openai/moderation": {
+      name: "OpenAI Moderation",
+      description: "OpenAI moderation endpoint",
+    },
+    "langevals/competitor_blocklist": {
+      name: "Competitor Blocklist",
+      description: "Blocklist competitors",
+    },
+    "langevals/competitor_llm": {
+      name: "Competitor LLM",
+      description: "LLM competitor check",
+    },
+    "langevals/competitor_llm_function_call": {
+      name: "Competitor LLM Function Call",
+      description: "Function call competitor",
+    },
+    "langevals/off_topic": {
+      name: "Off Topic",
+      description: "Off-topic detection",
+    },
+  },
+}));
+
+const mockRouterPush = vi.fn();
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    query: {},
+    asPath: "/test",
+    pathname: "/test",
+    replace: vi.fn(),
+  }),
+}));
+
+const mockOpenDrawer = vi.fn();
+const mockCloseDrawer = vi.fn();
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: mockCloseDrawer,
+    openDrawer: mockOpenDrawer,
+    drawerOpen: vi.fn(() => false),
+    canGoBack: false,
+    goBack: vi.fn(),
+  }),
+  getComplexProps: () => ({}),
+  useDrawerParams: () => ({}),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "my-project" },
+    organization: { id: "org-1" },
+  }),
+}));
+
+const mockUseAvailableEvaluators = vi.fn();
+vi.mock("~/utils/api", () => ({
+  api: {
+    evaluations: {
+      availableEvaluators: {
+        useQuery: (...args: unknown[]) => mockUseAvailableEvaluators(...args),
+      },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function primeAvailableEvaluators(
+  options: { azureConfigured: boolean } = { azureConfigured: false },
+) {
+  const azureMissing = options.azureConfigured
+    ? []
+    : ["AZURE_CONTENT_SAFETY_ENDPOINT", "AZURE_CONTENT_SAFETY_KEY"];
+
+  mockUseAvailableEvaluators.mockReturnValue({
+    data: {
+      "presidio/pii_detection": {
+        name: "PII Detection",
+        description: "Detect PII in text",
+        missingEnvVars: [],
+      },
+      "azure/content_safety": {
+        name: "Azure Content Safety",
+        description: "Moderate content with Azure Content Safety",
+        missingEnvVars: azureMissing,
+      },
+      "azure/prompt_injection": {
+        name: "Azure Prompt Injection",
+        description: "Detect prompt injection with Azure Prompt Shield",
+        missingEnvVars: azureMissing,
+      },
+      "azure/jailbreak": {
+        name: "Azure Jailbreak Detection",
+        description: "Detect jailbreak attempts with Azure",
+        missingEnvVars: azureMissing,
+      },
+      "openai/moderation": {
+        name: "OpenAI Moderation",
+        description: "OpenAI moderation endpoint",
+        missingEnvVars: [],
+      },
+      "langevals/competitor_blocklist": {
+        name: "Competitor Blocklist",
+        description: "Blocklist competitors",
+        missingEnvVars: [],
+      },
+      "langevals/competitor_llm": {
+        name: "Competitor LLM",
+        description: "LLM competitor check",
+        missingEnvVars: [],
+      },
+      "langevals/competitor_llm_function_call": {
+        name: "Competitor LLM Function Call",
+        description: "Function call competitor",
+        missingEnvVars: [],
+      },
+      "langevals/off_topic": {
+        name: "Off Topic",
+        description: "Off-topic detection",
+        missingEnvVars: [],
+      },
+    },
+    isLoading: false,
+  });
+}
+
+const renderDrawer = (props = {}) =>
+  render(
+    <EvaluatorTypeSelectorDrawer
+      open={true}
+      category="safety"
+      {...props}
+    />,
+    { wrapper: Wrapper },
+  );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Feature: EvaluatorTypeSelectorDrawer Azure Safety BYOK gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given the project has no azure_safety provider configured", () => {
+    describe("when the Safety category is opened", () => {
+      beforeEach(() => {
+        primeAvailableEvaluators({ azureConfigured: false });
+        renderDrawer();
+      });
+
+      it("marks Azure Content Safety as disabled", async () => {
+        await waitFor(() => {
+          const card = screen.getByTestId("evaluator-type-azure-content_safety");
+          expect(card.getAttribute("data-disabled")).toBe("true");
+        });
+      });
+
+      it("marks Azure Prompt Injection as disabled", async () => {
+        await waitFor(() => {
+          const card = screen.getByTestId("evaluator-type-azure-prompt_injection");
+          expect(card.getAttribute("data-disabled")).toBe("true");
+        });
+      });
+
+      it("marks Azure Jailbreak as disabled", async () => {
+        await waitFor(() => {
+          const card = screen.getByTestId("evaluator-type-azure-jailbreak");
+          expect(card.getAttribute("data-disabled")).toBe("true");
+        });
+      });
+
+      it("shows a Configure Azure Safety CTA on disabled cards", async () => {
+        await waitFor(() => {
+          const ctas = screen.getAllByText("Configure Azure Safety");
+          expect(ctas.length).toBeGreaterThanOrEqual(3);
+        });
+      });
+
+      it("leaves non-Azure safety evaluators enabled", async () => {
+        await waitFor(() => {
+          const piiCard = screen.getByTestId(
+            "evaluator-type-presidio-pii_detection",
+          );
+          expect(piiCard.getAttribute("data-disabled")).toBeNull();
+        });
+      });
+
+      it("does not open evaluatorEditor when clicking a disabled Azure card", async () => {
+        const user = userEvent.setup();
+
+        await waitFor(() => {
+          expect(
+            screen.getByTestId("evaluator-type-azure-content_safety"),
+          ).toBeTruthy();
+        });
+
+        await user.click(
+          screen.getByTestId("evaluator-type-azure-content_safety"),
+        );
+
+        expect(mockOpenDrawer).not.toHaveBeenCalled();
+      });
+
+      describe("when the user clicks the Configure Azure Safety CTA", () => {
+        it("navigates to settings/model-providers preselecting azure_safety", async () => {
+          const user = userEvent.setup();
+
+          await waitFor(() => {
+            expect(
+              screen.getByTestId(
+                "evaluator-type-azure-content_safety-cta",
+              ),
+            ).toBeTruthy();
+          });
+
+          await user.click(
+            screen.getByTestId("evaluator-type-azure-content_safety-cta"),
+          );
+
+          expect(mockRouterPush).toHaveBeenCalledWith(
+            "/settings/model-providers?provider=azure_safety",
+          );
+        });
+      });
+    });
+  });
+
+  describe("given the project has azure_safety configured with valid keys", () => {
+    describe("when the Safety category is opened", () => {
+      beforeEach(() => {
+        primeAvailableEvaluators({ azureConfigured: true });
+        renderDrawer();
+      });
+
+      it("leaves Azure Content Safety enabled", async () => {
+        await waitFor(() => {
+          const card = screen.getByTestId(
+            "evaluator-type-azure-content_safety",
+          );
+          expect(card.getAttribute("data-disabled")).toBeNull();
+        });
+      });
+
+      it("leaves Azure Prompt Injection enabled", async () => {
+        await waitFor(() => {
+          const card = screen.getByTestId(
+            "evaluator-type-azure-prompt_injection",
+          );
+          expect(card.getAttribute("data-disabled")).toBeNull();
+        });
+      });
+
+      it("leaves Azure Jailbreak enabled", async () => {
+        await waitFor(() => {
+          const card = screen.getByTestId("evaluator-type-azure-jailbreak");
+          expect(card.getAttribute("data-disabled")).toBeNull();
+        });
+      });
+
+      it("opens evaluatorEditor when clicking an Azure card", async () => {
+        const user = userEvent.setup();
+
+        await waitFor(() => {
+          expect(
+            screen.getByTestId("evaluator-type-azure-content_safety"),
+          ).toBeTruthy();
+        });
+
+        await user.click(
+          screen.getByTestId("evaluator-type-azure-content_safety"),
+        );
+
+        expect(mockOpenDrawer).toHaveBeenCalledWith(
+          "evaluatorEditor",
+          expect.objectContaining({
+            evaluatorType: "azure/content_safety",
+          }),
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/components/evaluators/__tests__/EvaluatorTypeSelectorDrawer.test.tsx
+++ b/langwatch/src/components/evaluators/__tests__/EvaluatorTypeSelectorDrawer.test.tsx
@@ -115,6 +115,23 @@ vi.mock("~/hooks/useDrawer", () => ({
   useDrawerParams: () => ({}),
 }));
 
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-test", slug: "test-project" },
+    organization: { id: "org-test" },
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    evaluations: {
+      availableEvaluators: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+  },
+}));
+
 // Wrapper with Chakra provider
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>

--- a/langwatch/src/components/settings/ModelProviderExtraHeadersSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderExtraHeadersSection.tsx
@@ -33,7 +33,11 @@ export const ExtraHeadersSection = ({
   actions: UseModelProviderFormActions;
   provider: MaybeStoredModelProvider;
 }) => {
-  if (provider.provider !== "azure" && provider.provider !== "custom") {
+  if (
+    provider.provider !== "azure" &&
+    provider.provider !== "custom" &&
+    provider.provider !== "azure_safety"
+  ) {
     return null;
   }
 

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -109,6 +109,8 @@ export const EditModelProviderForm = ({
       provider.provider as keyof typeof modelProvidersRegistry
     ];
 
+  const isLlmProvider = providerDefinition?.type === "llm";
+
   const {
     validate: validateApiKey,
     validateWithCustomUrl,
@@ -163,23 +165,26 @@ export const EditModelProviderForm = ({
       }
     }
 
-    // ALWAYS validate API key on save
-    if (userEnteredNewApiKey) {
-      // User entered new API key - validate it (against custom or default URL)
-      const isValid = await validateApiKey();
-      if (!isValid) return;
-    } else if (customBaseUrl) {
-      // Stored/env key + custom URL - validate against custom URL
-      const isValid = await validateWithCustomUrl(customBaseUrl);
-      if (!isValid) return;
-    } else {
-      // Stored/env key + default URL - validate against default URL
-      const isValid = await validateWithCustomUrl();
-      if (!isValid) return;
+    // Validate API key on save for LLM providers. Safety providers like
+    // azure_safety point at content moderation endpoints and can't be
+    // validated with the OpenAI-compatible chat-completion probe, so we
+    // skip client-side validation and let runtime usage surface errors.
+    if (isLlmProvider) {
+      if (userEnteredNewApiKey) {
+        const isValid = await validateApiKey();
+        if (!isValid) return;
+      } else if (customBaseUrl) {
+        const isValid = await validateWithCustomUrl(customBaseUrl);
+        if (!isValid) return;
+      } else {
+        const isValid = await validateWithCustomUrl();
+        if (!isValid) return;
+      }
     }
 
     void actions.submit();
   }, [
+    isLlmProvider,
     isUsingEnvVars,
     providerDefinition,
     state.customKeys,
@@ -193,7 +198,7 @@ export const EditModelProviderForm = ({
   return (
     <VStack gap={4} align="start" width="full">
       <VStack align="start" width="full" gap={4}>
-        {provider.provider === "azure" && (
+        {isLlmProvider && provider.provider === "azure" && (
           <Field.Root>
             <Switch
               onCheckedChange={(details) => {
@@ -224,20 +229,24 @@ export const EditModelProviderForm = ({
           provider={provider}
         />
 
-        <CustomModelInputSection
-          state={state}
-          actions={actions}
-          provider={provider}
-        />
+        {isLlmProvider && (
+          <>
+            <CustomModelInputSection
+              state={state}
+              actions={actions}
+              provider={provider}
+            />
 
-        <DefaultProviderSection
-          state={state}
-          actions={actions}
-          provider={provider}
-          enabledProvidersCount={enabledProvidersCount}
-          project={project}
-          providers={providers}
-        />
+            <DefaultProviderSection
+              state={state}
+              actions={actions}
+              provider={provider}
+              enabledProvidersCount={enabledProvidersCount}
+              project={project}
+              providers={providers}
+            />
+          </>
+        )}
 
         <HStack width="full" justify="end">
           <Button

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for EditModelProviderForm section rendering rules.
+ *
+ * Covers @integration scenarios from specs/model-providers/azure-safety-provider.feature:
+ * - "Azure Safety form only shows credentials and extra headers"
+ *   (no Custom Models, no Default Model, no API Gateway toggle)
+ *
+ * The form is parent-gated: sections that only apply to LLM providers
+ * (CustomModelInputSection, DefaultProviderSection, Azure API Gateway toggle)
+ * must be hidden when the provider's registry `type` is "safety".
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type {
+  UseModelProviderFormActions,
+  UseModelProviderFormState,
+} from "../../../hooks/useModelProviderForm";
+import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockUseModelProviderForm, mockUseModelProvidersSettings } = vi.hoisted(
+  () => ({
+    mockUseModelProviderForm: vi.fn(),
+    mockUseModelProvidersSettings: vi.fn(),
+  }),
+);
+
+vi.mock("../../../hooks/useModelProviderForm", () => ({
+  useModelProviderForm: (...args: unknown[]) =>
+    mockUseModelProviderForm(...args),
+}));
+
+vi.mock("../../../hooks/useModelProvidersSettings", () => ({
+  useModelProvidersSettings: (...args: unknown[]) =>
+    mockUseModelProvidersSettings(...args),
+}));
+
+vi.mock("../../../hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: vi.fn(),
+    openDrawer: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "test-project", defaultModel: null },
+    organization: { id: "org-1" },
+  }),
+}));
+
+vi.mock("../../../hooks/useModelProviderApiKeyValidation", () => ({
+  useModelProviderApiKeyValidation: () => ({
+    validate: vi.fn().mockResolvedValue(true),
+    validateWithCustomUrl: vi.fn().mockResolvedValue(true),
+    isValidating: false,
+    validationError: undefined,
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../utils/api", () => ({
+  api: {
+    modelProvider: {
+      isManagedProvider: {
+        useQuery: () => ({ data: { managed: false } }),
+      },
+    },
+  },
+}));
+
+// Import after mocks
+import { EditModelProviderForm } from "../ModelProviderForm";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function buildState(
+  overrides: Partial<UseModelProviderFormState> = {},
+): UseModelProviderFormState {
+  return {
+    useApiGateway: false,
+    customKeys: {},
+    displayKeys: {},
+    initialKeys: {},
+    extraHeaders: [],
+    customModels: [],
+    customEmbeddingsModels: [],
+    useAsDefaultProvider: false,
+    projectDefaultModel: null,
+    projectTopicClusteringModel: null,
+    projectEmbeddingsModel: null,
+    isSaving: false,
+    errors: {},
+    ...overrides,
+  };
+}
+
+function buildActions(
+  overrides: Partial<UseModelProviderFormActions> = {},
+): UseModelProviderFormActions {
+  return {
+    setEnabled: vi.fn(),
+    setUseApiGateway: vi.fn(),
+    setCustomKey: vi.fn(),
+    addExtraHeader: vi.fn(),
+    removeExtraHeader: vi.fn(),
+    toggleExtraHeaderConcealed: vi.fn(),
+    setExtraHeaderKey: vi.fn(),
+    setExtraHeaderValue: vi.fn(),
+    addCustomModel: vi.fn(),
+    removeCustomModel: vi.fn(),
+    setCustomModels: vi.fn(),
+    addCustomEmbeddingsModel: vi.fn(),
+    removeCustomEmbeddingsModel: vi.fn(),
+    setUseAsDefaultProvider: vi.fn(),
+    setProjectDefaultModel: vi.fn(),
+    setProjectTopicClusteringModel: vi.fn(),
+    setProjectEmbeddingsModel: vi.fn(),
+    setManaged: vi.fn(),
+    submit: vi.fn(),
+    ...overrides,
+  };
+}
+
+function buildProvider(
+  overrides: Partial<MaybeStoredModelProvider> = {},
+): MaybeStoredModelProvider {
+  return {
+    provider: "azure_safety",
+    enabled: false,
+    customKeys: null,
+    models: null,
+    embeddingsModels: null,
+    disabledByDefault: true,
+    deploymentMapping: null,
+    extraHeaders: [],
+    ...overrides,
+  };
+}
+
+function primeHooksForProvider({
+  providerKey,
+  displayKeys,
+}: {
+  providerKey: string;
+  displayKeys: Record<string, z.ZodTypeAny>;
+}) {
+  const provider = buildProvider({ provider: providerKey });
+  mockUseModelProvidersSettings.mockReturnValue({
+    providers: { [providerKey]: provider },
+    modelMetadata: {},
+    isLoading: false,
+    refetch: vi.fn(),
+    hasEnabledProviders: false,
+  });
+  mockUseModelProviderForm.mockReturnValue([
+    buildState({ displayKeys }),
+    buildActions(),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Feature: Azure Safety model provider form rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given providerKey is azure_safety", () => {
+    describe("when the form renders", () => {
+      beforeEach(() => {
+        primeHooksForProvider({
+          providerKey: "azure_safety",
+          displayKeys: {
+            AZURE_CONTENT_SAFETY_ENDPOINT: z.string().url(),
+            AZURE_CONTENT_SAFETY_KEY: z.string().min(1),
+          },
+        });
+
+        render(
+          <Wrapper>
+            <EditModelProviderForm
+              projectId="proj-1"
+              organizationId="org-1"
+              providerKey="azure_safety"
+            />
+          </Wrapper>,
+        );
+      });
+
+      it("renders the AZURE_CONTENT_SAFETY_ENDPOINT credential field", () => {
+        expect(
+          screen.getByText("AZURE_CONTENT_SAFETY_ENDPOINT"),
+        ).toBeTruthy();
+      });
+
+      it("renders the AZURE_CONTENT_SAFETY_KEY credential field", () => {
+        expect(screen.getByText("AZURE_CONTENT_SAFETY_KEY")).toBeTruthy();
+      });
+
+      it("does not render the Custom Models section", () => {
+        expect(screen.queryByText("Custom Models")).toBeNull();
+      });
+
+      it("does not render the Default Provider toggle", () => {
+        expect(
+          screen.queryByText(/use .* as the default for langwatch/i),
+        ).toBeNull();
+      });
+
+      it("does not render the Use API Gateway toggle", () => {
+        expect(screen.queryByText("Use API Gateway")).toBeNull();
+      });
+
+      it("renders the Save button", () => {
+        expect(
+          screen.getByRole("button", { name: /save/i }),
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("given providerKey is openai (control)", () => {
+    describe("when the form renders", () => {
+      beforeEach(() => {
+        primeHooksForProvider({
+          providerKey: "openai",
+          displayKeys: {
+            OPENAI_API_KEY: z.string().nullable().optional(),
+            OPENAI_BASE_URL: z.string().nullable().optional(),
+          },
+        });
+
+        render(
+          <Wrapper>
+            <EditModelProviderForm
+              projectId="proj-1"
+              organizationId="org-1"
+              providerKey="openai"
+            />
+          </Wrapper>,
+        );
+      });
+
+      it("renders the Custom Models section", () => {
+        expect(screen.getByText("Custom Models")).toBeTruthy();
+      });
+
+      it("renders the Default Provider toggle", () => {
+        expect(
+          screen.getByText(/use openai as the default for langwatch/i),
+        ).toBeTruthy();
+      });
+
+      it("does not render the Use API Gateway toggle", () => {
+        // API Gateway is Azure-specific, not OpenAI
+        expect(screen.queryByText("Use API Gateway")).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/traces/EvaluationStatusItem.tsx
+++ b/langwatch/src/components/traces/EvaluationStatusItem.tsx
@@ -158,6 +158,10 @@ export function EvaluationStatusItem({
   };
 
   const hasDetails = check.status === "processed" && check.details;
+  const errorMessage =
+    check.status === "error"
+      ? check.error?.message ?? check.details ?? null
+      : null;
 
   return (
     <Box width="full">
@@ -362,7 +366,7 @@ export function EvaluationStatusItem({
       )}
 
       {/* Error message */}
-      {check.status === "error" && check.error?.message && (
+      {errorMessage && (
         <Box paddingLeft="22px" marginTop={2}>
           <Box
             borderTopWidth="1px"
@@ -371,12 +375,9 @@ export function EvaluationStatusItem({
             paddingTop={2}
           >
             <Text fontSize="sm" color="red.fg">
-              <HoverableBigText
-                expandedVersion={check.error.message}
-                lineClamp={3}
-              >
+              <HoverableBigText expandedVersion={errorMessage} lineClamp={3}>
                 <Box as="span" whiteSpace="pre-wrap" wordBreak="break-word">
-                  {check.error.message}
+                  {errorMessage}
                 </Box>
               </HoverableBigText>
             </Text>

--- a/langwatch/src/components/traces/__tests__/EvaluationStatusItem.error.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/EvaluationStatusItem.error.integration.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for EvaluationStatusItem — error rendering.
+ *
+ * Covers @integration scenarios from
+ * specs/evaluators/evaluator-error-propagation.feature:
+ * - "the trace evaluations tab shows the failure message on an errored row"
+ * - "the trace evaluations tab shows details even when error message is empty"
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ElasticSearchEvaluation } from "~/server/tracer/types";
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ query: { project: "test-proj" } }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn(),
+    closeDrawer: vi.fn(),
+    drawerOpen: vi.fn(() => false),
+    goBack: vi.fn(),
+    canGoBack: false,
+  }),
+  useDrawerParams: () => ({}),
+  getComplexProps: () => ({}),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-test", slug: "test-proj" },
+    organization: { id: "org-test" },
+  }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    evaluators: {
+      getById: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+    monitors: {
+      getById: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+  },
+}));
+
+import { EvaluationStatusItem } from "../EvaluationStatusItem";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function buildEvaluation(
+  overrides: Partial<ElasticSearchEvaluation> = {},
+): ElasticSearchEvaluation {
+  return {
+    evaluation_id: "eval_1",
+    evaluator_id: "mon_1",
+    name: "Azure Content Safety",
+    type: "azure/content_safety",
+    status: "processed",
+    passed: true,
+    score: 0.9,
+    timestamps: { inserted_at: Date.now(), finished_at: Date.now() },
+    ...overrides,
+  } as ElasticSearchEvaluation;
+}
+
+describe("<EvaluationStatusItem /> error rendering", () => {
+  afterEach(cleanup);
+
+  describe("given an evaluation run with status=error and an error message", () => {
+    it("shows the error message inline", () => {
+      const check = buildEvaluation({
+        status: "error",
+        passed: undefined,
+        score: undefined,
+        error: {
+          has_error: true,
+          message:
+            "Azure Content Safety request failed: Could not connect to https://bad.example.com/",
+          stacktrace: [],
+        },
+      });
+
+      render(<EvaluationStatusItem check={check} />, { wrapper: Wrapper });
+
+      expect(
+        screen.getByText(/Could not connect to https:\/\/bad\.example\.com/),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Error")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a legacy error row with only a details string and no error object", () => {
+    it("still surfaces the details as the failure explanation", () => {
+      const check = buildEvaluation({
+        status: "error",
+        passed: undefined,
+        score: undefined,
+        details:
+          "Legacy path: Azure returned 401 Unauthorized — invalid subscription key",
+      });
+
+      render(<EvaluationStatusItem check={check} />, { wrapper: Wrapper });
+
+      expect(
+        screen.getByText(/Azure returned 401 Unauthorized/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("given a processed evaluation", () => {
+    it("does not render any red error block", () => {
+      const check = buildEvaluation({
+        status: "processed",
+        passed: true,
+        details: "All checks passed",
+      });
+
+      render(<EvaluationStatusItem check={check} />, { wrapper: Wrapper });
+
+      expect(screen.queryByText("Error")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/evaluations.azure-byok.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/evaluations.azure-byok.integration.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for the availableEvaluators tRPC router — Azure Safety BYOK.
+ *
+ * Covers @integration scenarios from specs/evaluators/azure-safety-byok-gating.feature:
+ * - "availableEvaluators reports missing env vars for Azure when provider is absent"
+ * - "availableEvaluators reports no missing env vars when provider is fully configured"
+ * - "availableEvaluators ignores process.env for Azure evaluators"
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getProjectModelProvidersMock } = vi.hoisted(() => ({
+  getProjectModelProvidersMock: vi.fn(),
+}));
+
+vi.mock("~/server/api/routers/modelProviders.utils", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/server/api/routers/modelProviders.utils")
+    >();
+  return {
+    ...actual,
+    getProjectModelProviders: getProjectModelProvidersMock,
+  };
+});
+
+// evaluationsRouter pulls in runEvaluationForTrace from the legacy worker,
+// which in turn imports the BullMQ/Redis stack. Stub it to keep the router
+// import light in unit-style integration tests.
+vi.mock("~/server/background/workers/evaluationsWorker", () => ({
+  runEvaluationForTrace: vi.fn(),
+  runEvaluationJob: vi.fn(),
+  startEvaluationsWorker: vi.fn(),
+}));
+
+// Bypass the RBAC middleware — we're testing the handler logic, not auth.
+vi.mock("../../rbac", () => ({
+  checkProjectPermission:
+    () =>
+    ({ next, ctx }: { next: () => unknown; ctx: { permissionChecked?: boolean } }) => {
+      ctx.permissionChecked = true;
+      return next();
+    },
+}));
+
+import { evaluationsRouter } from "../evaluations";
+
+function createCaller(_projectId: string) {
+  return evaluationsRouter.createCaller({
+    session: {
+      user: { id: "user-test", email: "test@example.com" },
+      expires: new Date(Date.now() + 3600_000).toISOString(),
+    },
+    prisma: {} as never,
+    permissionChecked: true,
+  } as unknown as Parameters<typeof evaluationsRouter.createCaller>[0]);
+}
+
+describe("Feature: evaluationsRouter.availableEvaluators — Azure BYOK", () => {
+  const projectId = "proj-byok-1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AZURE_CONTENT_SAFETY_ENDPOINT = "https://shared.example.com/";
+    process.env.AZURE_CONTENT_SAFETY_KEY = "shared-key";
+  });
+
+  describe("given the project has no azure_safety provider", () => {
+    beforeEach(() => {
+      getProjectModelProvidersMock.mockResolvedValue({});
+    });
+
+    describe("when the client queries availableEvaluators", () => {
+      it("marks azure/content_safety with missingEnvVars", async () => {
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        expect(result["azure/content_safety"]?.missingEnvVars).toEqual([
+          "AZURE_CONTENT_SAFETY_ENDPOINT",
+          "AZURE_CONTENT_SAFETY_KEY",
+        ]);
+      });
+
+      it("marks azure/prompt_injection with missingEnvVars", async () => {
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        expect(result["azure/prompt_injection"]?.missingEnvVars).toEqual([
+          "AZURE_CONTENT_SAFETY_ENDPOINT",
+          "AZURE_CONTENT_SAFETY_KEY",
+        ]);
+      });
+
+      it("marks azure/jailbreak with missingEnvVars", async () => {
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        expect(result["azure/jailbreak"]?.missingEnvVars).toEqual([
+          "AZURE_CONTENT_SAFETY_ENDPOINT",
+          "AZURE_CONTENT_SAFETY_KEY",
+        ]);
+      });
+
+      it("ignores process.env for Azure evaluators", async () => {
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        // process.env has AZURE_CONTENT_SAFETY_* set in beforeEach but the
+        // router must NOT use it.
+        expect(result["azure/content_safety"]?.missingEnvVars).toHaveLength(2);
+      });
+
+      it("still reads non-Azure envVars from process.env", async () => {
+        process.env.OPENAI_API_KEY = "sk-test";
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        // openai/moderation declares OPENAI_API_KEY in envVars;
+        // with it set in process.env, missingEnvVars is empty.
+        expect(result["openai/moderation"]?.missingEnvVars).toEqual([]);
+        delete process.env.OPENAI_API_KEY;
+      });
+    });
+  });
+
+  describe("given the project has azure_safety enabled with both keys", () => {
+    beforeEach(() => {
+      getProjectModelProvidersMock.mockResolvedValue({
+        azure_safety: {
+          provider: "azure_safety",
+          enabled: true,
+          customKeys: {
+            AZURE_CONTENT_SAFETY_ENDPOINT:
+              "https://byok.cognitiveservices.azure.com/",
+            AZURE_CONTENT_SAFETY_KEY: "byok-key",
+          },
+        },
+      });
+    });
+
+    describe("when the client queries availableEvaluators", () => {
+      it("marks azure/content_safety with empty missingEnvVars", async () => {
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        expect(result["azure/content_safety"]?.missingEnvVars).toEqual([]);
+      });
+
+      it("marks azure/prompt_injection with empty missingEnvVars", async () => {
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        expect(result["azure/prompt_injection"]?.missingEnvVars).toEqual([]);
+      });
+
+      it("marks azure/jailbreak with empty missingEnvVars", async () => {
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        expect(result["azure/jailbreak"]?.missingEnvVars).toEqual([]);
+      });
+    });
+  });
+
+  describe("given the azure_safety provider is disabled", () => {
+    beforeEach(() => {
+      getProjectModelProvidersMock.mockResolvedValue({
+        azure_safety: {
+          provider: "azure_safety",
+          enabled: false,
+          customKeys: {
+            AZURE_CONTENT_SAFETY_ENDPOINT:
+              "https://byok.cognitiveservices.azure.com/",
+            AZURE_CONTENT_SAFETY_KEY: "byok-key",
+          },
+        },
+      });
+    });
+
+    describe("when the client queries availableEvaluators", () => {
+      it("marks Azure evaluators as missing env vars", async () => {
+        const caller = createCaller(projectId);
+        const result = await caller.availableEvaluators({ projectId });
+        expect(result["azure/content_safety"]?.missingEnvVars).toEqual([
+          "AZURE_CONTENT_SAFETY_ENDPOINT",
+          "AZURE_CONTENT_SAFETY_KEY",
+        ]);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -7,6 +7,11 @@ import { KSUID_RESOURCES } from "~/utils/constants";
 import { trackServerEvent } from "~/server/posthog";
 
 import { createLogger } from "~/utils/logger/server";
+import {
+  AZURE_SAFETY_ENV_VARS,
+  getAzureSafetyEnvFromProject,
+  isAzureEvaluatorType,
+} from "../../app-layer/evaluations/azure-safety-env";
 import { runEvaluationForTrace } from "../../background/workers/evaluationsWorker";
 import {
   AVAILABLE_EVALUATORS,
@@ -24,15 +29,25 @@ export const evaluationsRouter = createTRPCRouter({
   availableEvaluators: protectedProcedure
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("evaluations:view"))
-    .query(async () => {
+    .query(async ({ input }) => {
+      // Azure Safety evaluators are gated by the per-project azure_safety
+      // Model Provider — we no longer read process.env for those. Compute
+      // once and reuse for all three Azure evaluator types.
+      const azureSafetyEnv = await getAzureSafetyEnvFromProject(
+        input.projectId,
+      );
+      const azureMissingEnvVars = azureSafetyEnv
+        ? []
+        : [...AZURE_SAFETY_ENV_VARS];
+
       return Object.fromEntries(
         Object.entries(AVAILABLE_EVALUATORS).map(([key, evaluator]) => [
           key,
           {
             ...evaluator,
-            missingEnvVars: evaluator.envVars.filter(
-              (envVar) => !process.env[envVar],
-            ),
+            missingEnvVars: isAzureEvaluatorType(key)
+              ? azureMissingEnvVars
+              : evaluator.envVars.filter((envVar) => !process.env[envVar]),
           },
         ]),
       );

--- a/langwatch/src/server/app-layer/evaluations/__tests__/azure-safety-env.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/azure-safety-env.unit.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for getAzureSafetyEnvFromProject.
+ *
+ * Covers @integration scenarios from specs/evaluators/azure-safety-byok-gating.feature:
+ * - "availableEvaluators reports missing env vars for Azure when provider is absent"
+ * - "availableEvaluators ignores process.env for Azure evaluators"
+ *
+ * The helper must return null when:
+ *   - no azure_safety provider exists for the project
+ *   - the provider exists but is disabled
+ *   - the provider exists but is missing endpoint or key
+ * It must NOT fall back to process.env.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getProjectModelProvidersMock } = vi.hoisted(() => ({
+  getProjectModelProvidersMock: vi.fn(),
+}));
+
+vi.mock("../../../api/routers/modelProviders.utils", () => ({
+  getProjectModelProviders: getProjectModelProvidersMock,
+}));
+
+import {
+  AZURE_SAFETY_ENV_VARS,
+  AZURE_SAFETY_NOT_CONFIGURED_MESSAGE,
+  AZURE_SAFETY_PROVIDER_KEY,
+  getAzureSafetyEnvFromProject,
+  isAzureEvaluatorType,
+} from "../azure-safety-env";
+
+describe("azure-safety-env constants", () => {
+  it("exports the provider key", () => {
+    expect(AZURE_SAFETY_PROVIDER_KEY).toBe("azure_safety");
+  });
+
+  it("exports the required env vars", () => {
+    expect(AZURE_SAFETY_ENV_VARS).toEqual([
+      "AZURE_CONTENT_SAFETY_ENDPOINT",
+      "AZURE_CONTENT_SAFETY_KEY",
+    ]);
+  });
+
+  it("exports a clear not-configured message", () => {
+    expect(AZURE_SAFETY_NOT_CONFIGURED_MESSAGE).toMatch(/not configured/i);
+    expect(AZURE_SAFETY_NOT_CONFIGURED_MESSAGE).toMatch(/Model Providers/i);
+  });
+});
+
+describe("isAzureEvaluatorType", () => {
+  describe("when the evaluator type starts with azure/", () => {
+    it("returns true for azure/content_safety", () => {
+      expect(isAzureEvaluatorType("azure/content_safety")).toBe(true);
+    });
+
+    it("returns true for azure/prompt_injection", () => {
+      expect(isAzureEvaluatorType("azure/prompt_injection")).toBe(true);
+    });
+
+    it("returns true for azure/jailbreak", () => {
+      expect(isAzureEvaluatorType("azure/jailbreak")).toBe(true);
+    });
+  });
+
+  describe("when the evaluator type is not azure", () => {
+    it("returns false for openai/moderation", () => {
+      expect(isAzureEvaluatorType("openai/moderation")).toBe(false);
+    });
+
+    it("returns false for langevals/llm_answer_match", () => {
+      expect(isAzureEvaluatorType("langevals/llm_answer_match")).toBe(false);
+    });
+  });
+});
+
+describe("getAzureSafetyEnvFromProject", () => {
+  const projectId = "project-test-1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Pollute process.env to prove we don't fall back to it
+    process.env.AZURE_CONTENT_SAFETY_ENDPOINT =
+      "https://shared.example.com/";
+    process.env.AZURE_CONTENT_SAFETY_KEY = "shared-key";
+  });
+
+  describe("given the project has no azure_safety provider", () => {
+    describe("when the helper is called", () => {
+      it("returns null", async () => {
+        getProjectModelProvidersMock.mockResolvedValue({
+          openai: {
+            provider: "openai",
+            enabled: true,
+            customKeys: { OPENAI_API_KEY: "sk-x" },
+          },
+        });
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result).toBeNull();
+      });
+
+      it("does not fall back to process.env", async () => {
+        getProjectModelProvidersMock.mockResolvedValue({});
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("given the azure_safety provider is disabled", () => {
+    describe("when the helper is called", () => {
+      it("returns null", async () => {
+        getProjectModelProvidersMock.mockResolvedValue({
+          azure_safety: {
+            provider: "azure_safety",
+            enabled: false,
+            customKeys: {
+              AZURE_CONTENT_SAFETY_ENDPOINT: "https://x.azure.com/",
+              AZURE_CONTENT_SAFETY_KEY: "real-key",
+            },
+          },
+        });
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("given the azure_safety provider is missing a key", () => {
+    describe("when the helper is called with missing endpoint", () => {
+      it("returns null", async () => {
+        getProjectModelProvidersMock.mockResolvedValue({
+          azure_safety: {
+            provider: "azure_safety",
+            enabled: true,
+            customKeys: {
+              AZURE_CONTENT_SAFETY_KEY: "real-key",
+            },
+          },
+        });
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when the helper is called with missing subscription key", () => {
+      it("returns null", async () => {
+        getProjectModelProvidersMock.mockResolvedValue({
+          azure_safety: {
+            provider: "azure_safety",
+            enabled: true,
+            customKeys: {
+              AZURE_CONTENT_SAFETY_ENDPOINT: "https://x.azure.com/",
+            },
+          },
+        });
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when either value is an empty string", () => {
+      it("returns null for empty endpoint", async () => {
+        getProjectModelProvidersMock.mockResolvedValue({
+          azure_safety: {
+            provider: "azure_safety",
+            enabled: true,
+            customKeys: {
+              AZURE_CONTENT_SAFETY_ENDPOINT: "",
+              AZURE_CONTENT_SAFETY_KEY: "real-key",
+            },
+          },
+        });
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result).toBeNull();
+      });
+
+      it("returns null for empty key", async () => {
+        getProjectModelProvidersMock.mockResolvedValue({
+          azure_safety: {
+            provider: "azure_safety",
+            enabled: true,
+            customKeys: {
+              AZURE_CONTENT_SAFETY_ENDPOINT: "https://x.azure.com/",
+              AZURE_CONTENT_SAFETY_KEY: "",
+            },
+          },
+        });
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("given the azure_safety provider is fully configured and enabled", () => {
+    describe("when the helper is called", () => {
+      it("returns env vars from the project config", async () => {
+        getProjectModelProvidersMock.mockResolvedValue({
+          azure_safety: {
+            provider: "azure_safety",
+            enabled: true,
+            customKeys: {
+              AZURE_CONTENT_SAFETY_ENDPOINT:
+                "https://my-account.cognitiveservices.azure.com/",
+              AZURE_CONTENT_SAFETY_KEY: "my-subscription-key",
+            },
+          },
+        });
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result).toEqual({
+          AZURE_CONTENT_SAFETY_ENDPOINT:
+            "https://my-account.cognitiveservices.azure.com/",
+          AZURE_CONTENT_SAFETY_KEY: "my-subscription-key",
+        });
+      });
+
+      it("does not use process.env as a fallback when keys differ", async () => {
+        process.env.AZURE_CONTENT_SAFETY_ENDPOINT = "https://fallback.example.com/";
+        process.env.AZURE_CONTENT_SAFETY_KEY = "fallback-key";
+
+        getProjectModelProvidersMock.mockResolvedValue({
+          azure_safety: {
+            provider: "azure_safety",
+            enabled: true,
+            customKeys: {
+              AZURE_CONTENT_SAFETY_ENDPOINT: "https://project.azure.com/",
+              AZURE_CONTENT_SAFETY_KEY: "project-key",
+            },
+          },
+        });
+
+        const result = await getAzureSafetyEnvFromProject(projectId);
+        expect(result?.AZURE_CONTENT_SAFETY_ENDPOINT).toBe(
+          "https://project.azure.com/",
+        );
+        expect(result?.AZURE_CONTENT_SAFETY_KEY).toBe("project-key");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.azure-byok.integration.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.azure-byok.integration.test.ts
@@ -1,0 +1,241 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for Azure Safety BYOK credential flow through
+ * EvaluationExecutionService + createDefaultModelEnvResolver.
+ *
+ * Covers @integration scenarios from specs/evaluators/azure-safety-byok-gating.feature:
+ * - "Configured Azure provider passes keys to langevals at runtime"
+ * - "Runtime skip ignores process.env for Azure evaluators"
+ *
+ * Strategy: use the real `createDefaultModelEnvResolver()` paired with a mocked
+ * `getProjectModelProviders` so we exercise the actual resolver logic end-to-end
+ * without hitting Prisma. LangEvals client is mocked to capture the env payload.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SingleEvaluationResult } from "~/server/evaluations/evaluators.generated";
+import type { Trace } from "~/server/tracer/types";
+import type { LangEvalsClient } from "../../clients/langevals/langevals.client";
+import type { TraceService } from "~/server/traces/trace.service";
+
+const { getProjectModelProvidersMock } = vi.hoisted(() => ({
+  getProjectModelProvidersMock: vi.fn(),
+}));
+
+vi.mock("~/server/api/routers/modelProviders.utils", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/server/api/routers/modelProviders.utils")
+    >();
+  return {
+    ...actual,
+    getProjectModelProviders: getProjectModelProvidersMock,
+  };
+});
+
+import { createDefaultModelEnvResolver } from "../evaluation-execution.factories";
+import {
+  EvaluationExecutionService,
+  type EvaluationExecutionDeps,
+  type WorkflowExecutor,
+} from "../evaluation-execution.service";
+
+const AZURE_EVALUATOR_TYPE = "azure/content_safety";
+
+function buildTrace(overrides?: Partial<Trace>): Trace {
+  return {
+    trace_id: "trace-azure-1",
+    project_id: "proj-azure-1",
+    input: { value: "please moderate this" },
+    output: { value: "safe response" },
+    timestamps: { started_at: Date.now(), inserted_at: Date.now() },
+    spans: [],
+    ...overrides,
+  } as Trace;
+}
+
+function createService(overrides: {
+  clientEvaluate?: (...args: unknown[]) => Promise<SingleEvaluationResult>;
+  trace?: Trace;
+} = {}) {
+  const trace = overrides.trace ?? buildTrace();
+
+  const mockTraceService = {
+    getTracesWithSpans: vi.fn().mockResolvedValue([trace]),
+    getTracesWithSpansByThreadIds: vi.fn().mockResolvedValue([]),
+  } as unknown as TraceService;
+
+  const mockWorkflowExecutor: WorkflowExecutor = {
+    runEvaluationWorkflow: vi.fn(),
+  };
+
+  const evaluate =
+    overrides.clientEvaluate ??
+    vi.fn().mockResolvedValue({
+      status: "processed",
+      score: 0.1,
+      passed: true,
+    } satisfies SingleEvaluationResult);
+
+  const mockClient: LangEvalsClient = {
+    evaluate,
+  };
+
+  const deps: EvaluationExecutionDeps = {
+    traceService: mockTraceService,
+    modelEnvResolver: createDefaultModelEnvResolver(),
+    workflowExecutor: mockWorkflowExecutor,
+    langevalsClient: mockClient,
+  };
+
+  const service = new EvaluationExecutionService(deps);
+
+  return { service, mockClient, evaluate };
+}
+
+describe("EvaluationExecutionService — Azure Safety BYOK env flow", () => {
+  const defaultParams = {
+    projectId: "proj-azure-1",
+    traceId: "trace-azure-1",
+    evaluatorType: AZURE_EVALUATOR_TYPE,
+    settings: null as Record<string, unknown> | null,
+    mappings: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AZURE_CONTENT_SAFETY_ENDPOINT = "https://shared.example.com/";
+    process.env.AZURE_CONTENT_SAFETY_KEY = "shared-key";
+  });
+
+  describe("given the project has azure_safety configured with valid keys", () => {
+    beforeEach(() => {
+      getProjectModelProvidersMock.mockResolvedValue({
+        azure_safety: {
+          provider: "azure_safety",
+          enabled: true,
+          customKeys: {
+            AZURE_CONTENT_SAFETY_ENDPOINT:
+              "https://byok-account.cognitiveservices.azure.com/",
+            AZURE_CONTENT_SAFETY_KEY: "byok-subscription-key",
+          },
+        },
+      });
+    });
+
+    describe("when executeForTrace runs an azure evaluator", () => {
+      it("calls langevalsClient.evaluate with env from the project config", async () => {
+        const { service, evaluate } = createService();
+
+        await service.executeForTrace(defaultParams);
+
+        expect(evaluate).toHaveBeenCalledTimes(1);
+        expect(evaluate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            evaluatorType: AZURE_EVALUATOR_TYPE,
+            env: {
+              AZURE_CONTENT_SAFETY_ENDPOINT:
+                "https://byok-account.cognitiveservices.azure.com/",
+              AZURE_CONTENT_SAFETY_KEY: "byok-subscription-key",
+            },
+          }),
+        );
+      });
+
+      it("does not leak shared process.env credentials", async () => {
+        const { service, evaluate } = createService();
+
+        await service.executeForTrace(defaultParams);
+
+        const call = (evaluate as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+        expect(call?.env?.AZURE_CONTENT_SAFETY_ENDPOINT).not.toBe(
+          "https://shared.example.com/",
+        );
+        expect(call?.env?.AZURE_CONTENT_SAFETY_KEY).not.toBe("shared-key");
+      });
+    });
+  });
+
+  describe("given the project has NO azure_safety provider configured", () => {
+    beforeEach(() => {
+      getProjectModelProvidersMock.mockResolvedValue({
+        openai: {
+          provider: "openai",
+          enabled: true,
+          customKeys: { OPENAI_API_KEY: "sk-x" },
+        },
+      });
+    });
+
+    describe("when executeForTrace runs an azure evaluator", () => {
+      it("calls langevalsClient.evaluate with an empty env object", async () => {
+        const { service, evaluate } = createService();
+
+        await service.executeForTrace(defaultParams);
+
+        expect(evaluate).toHaveBeenCalledTimes(1);
+        const call = (evaluate as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+        expect(call?.env).toEqual({});
+      });
+
+      it("does not pass process.env Azure credentials through", async () => {
+        const { service, evaluate } = createService();
+
+        await service.executeForTrace(defaultParams);
+
+        const call = (evaluate as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+        expect(call?.env?.AZURE_CONTENT_SAFETY_KEY).toBeUndefined();
+        expect(call?.env?.AZURE_CONTENT_SAFETY_ENDPOINT).toBeUndefined();
+      });
+    });
+  });
+
+  describe("given the azure_safety provider is disabled", () => {
+    beforeEach(() => {
+      getProjectModelProvidersMock.mockResolvedValue({
+        azure_safety: {
+          provider: "azure_safety",
+          enabled: false,
+          customKeys: {
+            AZURE_CONTENT_SAFETY_ENDPOINT:
+              "https://byok-account.cognitiveservices.azure.com/",
+            AZURE_CONTENT_SAFETY_KEY: "byok-subscription-key",
+          },
+        },
+      });
+    });
+
+    describe("when executeForTrace runs an azure evaluator", () => {
+      it("passes an empty env (the command handler will skip)", async () => {
+        const { service, evaluate } = createService();
+
+        await service.executeForTrace(defaultParams);
+
+        const call = (evaluate as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+        expect(call?.env).toEqual({});
+      });
+    });
+  });
+
+  describe("given a non-azure evaluator", () => {
+    beforeEach(() => {
+      getProjectModelProvidersMock.mockResolvedValue({});
+      process.env.CUSTOM_LLM_MODERATION_KEY = "some-process-env-key";
+    });
+
+    describe("when executeForTrace runs openai/moderation", () => {
+      it("keeps reading envVars from process.env as before", async () => {
+        const { service, evaluate } = createService();
+
+        await service.executeForTrace({
+          ...defaultParams,
+          evaluatorType: "openai/moderation",
+        });
+
+        // openai/moderation declares no envVars, so env remains empty
+        // but crucially the azure gate does NOT kick in.
+        expect(evaluate).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/evaluations/azure-safety-env.ts
+++ b/langwatch/src/server/app-layer/evaluations/azure-safety-env.ts
@@ -1,0 +1,48 @@
+import { getProjectModelProviders } from "../../api/routers/modelProviders.utils";
+
+export const AZURE_SAFETY_PROVIDER_KEY = "azure_safety";
+
+export const AZURE_SAFETY_ENV_VARS = [
+  "AZURE_CONTENT_SAFETY_ENDPOINT",
+  "AZURE_CONTENT_SAFETY_KEY",
+] as const;
+
+export const AZURE_SAFETY_NOT_CONFIGURED_MESSAGE =
+  "Azure Safety provider not configured. Configure it in Settings → Model Providers to run this evaluator.";
+
+export function isAzureEvaluatorType(evaluatorType: string): boolean {
+  return evaluatorType.startsWith("azure/");
+}
+
+/**
+ * Resolves Azure Content Safety credentials for a project from its per-project
+ * `azure_safety` model provider. This is the ONLY source of truth — there is
+ * no process.env fallback, so running Azure evaluators without a configured
+ * provider yields a deterministic null.
+ */
+export async function getAzureSafetyEnvFromProject(
+  projectId: string,
+): Promise<Record<string, string> | null> {
+  const modelProviders = await getProjectModelProviders(projectId);
+  const provider = modelProviders[AZURE_SAFETY_PROVIDER_KEY];
+
+  if (!provider || !provider.enabled) {
+    return null;
+  }
+
+  const customKeys = provider.customKeys as Record<string, unknown> | null;
+  const endpoint = customKeys?.AZURE_CONTENT_SAFETY_ENDPOINT;
+  const key = customKeys?.AZURE_CONTENT_SAFETY_KEY;
+
+  if (typeof endpoint !== "string" || endpoint.trim() === "") {
+    return null;
+  }
+  if (typeof key !== "string" || key.trim() === "") {
+    return null;
+  }
+
+  return {
+    AZURE_CONTENT_SAFETY_ENDPOINT: endpoint,
+    AZURE_CONTENT_SAFETY_KEY: key,
+  };
+}

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.factories.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.factories.ts
@@ -3,15 +3,29 @@ import {
   prepareEnvKeys,
   prepareLitellmParams,
 } from "~/server/api/routers/modelProviders.utils";
+import {
+  getAzureSafetyEnvFromProject,
+  isAzureEvaluatorType,
+} from "./azure-safety-env";
 import { EvaluatorConfigError } from "./errors";
 import type { ModelEnvResolver } from "./evaluation-execution.service";
 
 export function createDefaultModelEnvResolver(): ModelEnvResolver {
   return {
     async resolveForEvaluator({ evaluatorType, evaluator, projectId, settings }) {
-      let evaluatorEnv: Record<string, string> = Object.fromEntries(
-        (evaluator.envVars ?? []).map((envVar) => [envVar, process.env[envVar]!]),
-      );
+      // Hard cutover: Azure Content Safety evaluators never read from process.env.
+      // They require a per-project `azure_safety` Model Provider, resolved here.
+      // Phase 5 gates runtime execution so unresolved credentials turn into a
+      // clear skipped status before reaching this resolver.
+      let evaluatorEnv: Record<string, string>;
+      if (isAzureEvaluatorType(evaluatorType)) {
+        const azureEnv = await getAzureSafetyEnvFromProject(projectId);
+        evaluatorEnv = azureEnv ?? {};
+      } else {
+        evaluatorEnv = Object.fromEntries(
+          (evaluator.envVars ?? []).map((envVar) => [envVar, process.env[envVar]!]),
+        );
+      }
 
       if (
         settings &&

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -152,12 +152,21 @@ export class EvaluationExecutionService {
       workflowId,
     });
 
+    const isError = result.status === "error";
+    const rawDetails = "details" in result ? result.details : undefined;
+    const traceback =
+      isError && "traceback" in result && Array.isArray(result.traceback)
+        ? result.traceback.join("\n")
+        : undefined;
+
     return {
       status: result.status,
       score: result.status === "processed" ? result.score : undefined,
       passed: result.status === "processed" ? result.passed : undefined,
       label: result.status === "processed" ? result.label : undefined,
-      details: "details" in result ? result.details : undefined,
+      details: isError ? undefined : rawDetails,
+      error: isError ? rawDetails ?? "Evaluator failed" : undefined,
+      errorDetails: traceback,
       cost:
         result.status === "processed" && "cost" in result && result.cost
           ? result.cost

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.types.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.types.ts
@@ -33,6 +33,8 @@ export const evaluationExecutionResultSchema = z.object({
   passed: z.boolean().optional(),
   label: z.string().optional(),
   details: z.string().optional(),
+  error: z.string().optional(),
+  errorDetails: z.string().optional(),
   cost: evaluationCostSchema.optional(),
   evaluationThreadId: z.string().optional(),
   inputs: z.record(z.any()).optional(),

--- a/langwatch/src/server/background/workers/evaluationsWorker.ts
+++ b/langwatch/src/server/background/workers/evaluationsWorker.ts
@@ -67,6 +67,11 @@ import {
   tryAndConvertTo,
 } from "../../tracer/tracesMapping";
 import { formatSpansDigest } from "../../tracer/spanToReadableSpan";
+import {
+  AZURE_SAFETY_NOT_CONFIGURED_MESSAGE,
+  getAzureSafetyEnvFromProject,
+  isAzureEvaluatorType,
+} from "../../app-layer/evaluations/azure-safety-env";
 import { runEvaluationWorkflow } from "../../workflows/runWorkflow";
 import {
   EVALUATIONS_QUEUE,
@@ -525,9 +530,23 @@ export const runEvaluation = async ({
 
   const evaluator = AVAILABLE_EVALUATORS[builtInEvaluatorType];
 
-  let evaluatorEnv: Record<string, string> = Object.fromEntries(
-    (evaluator.envVars ?? []).map((envVar) => [envVar, process.env[envVar]!]),
-  );
+  // Hard cutover: Azure Content Safety evaluators never read from process.env.
+  // Require per-project azure_safety Model Provider credentials.
+  let evaluatorEnv: Record<string, string>;
+  if (isAzureEvaluatorType(builtInEvaluatorType)) {
+    const azureEnv = await getAzureSafetyEnvFromProject(projectId);
+    if (!azureEnv) {
+      return {
+        status: "skipped",
+        details: AZURE_SAFETY_NOT_CONFIGURED_MESSAGE,
+      };
+    }
+    evaluatorEnv = azureEnv;
+  } else {
+    evaluatorEnv = Object.fromEntries(
+      (evaluator.envVars ?? []).map((envVar) => [envVar, process.env[envVar]!]),
+    );
+  }
 
   const setupModelEnv = async (
     model: string,

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -54,6 +54,7 @@ import {
   BILLING_REPORTING_PIPELINE_NAME,
   createBillingReportingPipeline,
 } from "./pipelines/billing-reporting/pipeline";
+import { getAzureSafetyEnvFromProject } from "../app-layer/evaluations/azure-safety-env";
 import { ExecuteEvaluationCommand } from "./pipelines/evaluation-processing/commands/executeEvaluation.command";
 import { EvaluationRunFoldProjection } from "./pipelines/evaluation-processing/projections/evaluationRun.foldProjection";
 import { EvaluationRunStore } from "./pipelines/evaluation-processing/projections/evaluationRun.store";
@@ -181,6 +182,7 @@ export class PipelineRegistry {
       traceEvents: this.deps.traces.spans,
       evaluationExecution: this.deps.evaluations.execution,
       costRecorder: this.deps.costRecorder,
+      azureSafetyEnvResolver: getAzureSafetyEnvFromProject,
     });
 
     const esSyncReactor = createEvaluationEsSyncReactor(this.deps.esSync);

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/__tests__/executeEvaluation.azure-byok.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/__tests__/executeEvaluation.azure-byok.integration.test.ts
@@ -1,0 +1,228 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for ExecuteEvaluationCommand — Azure Safety BYOK gate.
+ *
+ * Covers @integration scenarios from specs/evaluators/azure-safety-byok-gating.feature:
+ * - "ON_MESSAGE monitor using azure/content_safety without provider emits skipped"
+ * - "ON_MESSAGE monitor using azure/prompt_injection without provider emits skipped"
+ * - "ON_MESSAGE monitor using azure/jailbreak without provider emits skipped"
+ * - "Configured Azure provider passes keys to langevals at runtime"
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Command } from "../../..";
+import type { EvaluationCostRecorder } from "../../../../app-layer/evaluations/evaluation-cost.recorder";
+import type { EvaluationExecutionService } from "../../../../app-layer/evaluations/evaluation-execution.service";
+import type { MonitorService } from "../../../../app-layer/monitors/monitor.service";
+import { createTenantId } from "../../../domain/tenantId";
+import { ExecuteEvaluationCommand } from "../commands/executeEvaluation.command";
+import type { ExecuteEvaluationCommandData } from "../schemas/commands";
+
+const AZURE_EVALUATOR_TYPES = [
+  "azure/content_safety",
+  "azure/prompt_injection",
+  "azure/jailbreak",
+] as const;
+
+function buildCommand(
+  evaluatorType: string,
+): Command<ExecuteEvaluationCommandData> {
+  const tenantId = createTenantId("proj-byok-1");
+  return {
+    tenantId,
+    data: {
+      tenantId: "proj-byok-1",
+      evaluationId: "eval_abc",
+      evaluatorId: "mon_1",
+      evaluatorType,
+      evaluatorName: "Test Monitor",
+      traceId: "trace_1",
+      isGuardrail: false,
+      occurredAt: Date.now(),
+      threadIdleTimeout: undefined,
+      threadId: undefined,
+      userId: undefined,
+      customerId: undefined,
+      labels: [],
+      origin: "application",
+      hasError: false,
+      promptIds: [],
+      topicId: undefined,
+      subTopicId: undefined,
+      customMetadata: {},
+      spanModels: undefined,
+      computedInput: undefined,
+      computedOutput: undefined,
+    },
+  } as unknown as Command<ExecuteEvaluationCommandData>;
+}
+
+function buildMonitor(checkType: string) {
+  return {
+    id: "mon_1",
+    projectId: "proj-byok-1",
+    checkType,
+    name: "Test Monitor",
+    enabled: true,
+    sample: 1,
+    preconditions: [],
+    parameters: {},
+    mappings: null,
+    level: "trace",
+    evaluator: null,
+    threadIdleTimeout: null,
+  };
+}
+
+function buildCommandWithMocks({
+  azureConfigured,
+  checkType,
+}: {
+  azureConfigured: boolean;
+  checkType: string;
+}) {
+  const monitors = {
+    getMonitorById: vi.fn().mockResolvedValue(buildMonitor(checkType)),
+  } as unknown as MonitorService;
+
+  const spanStorage = {
+    getSpansByTraceId: vi.fn().mockResolvedValue([]),
+  };
+
+  const traceEvents = {
+    getEventsByTraceId: vi.fn().mockResolvedValue([]),
+  };
+
+  const evaluationExecution = {
+    executeForTrace: vi.fn().mockResolvedValue({
+      status: "processed",
+      score: 0.1,
+      passed: true,
+    }),
+  } as unknown as EvaluationExecutionService;
+
+  const costRecorder = {
+    recordCost: vi.fn(),
+  } as unknown as EvaluationCostRecorder;
+
+  const azureSafetyEnvResolver = vi
+    .fn()
+    .mockResolvedValue(
+      azureConfigured
+        ? {
+            AZURE_CONTENT_SAFETY_ENDPOINT:
+              "https://byok.cognitiveservices.azure.com/",
+            AZURE_CONTENT_SAFETY_KEY: "byok-key",
+          }
+        : null,
+    );
+
+  const command = new ExecuteEvaluationCommand({
+    monitors,
+    spanStorage,
+    traceEvents,
+    evaluationExecution,
+    costRecorder,
+    azureSafetyEnvResolver,
+  });
+
+  return {
+    command,
+    monitors,
+    evaluationExecution,
+    azureSafetyEnvResolver,
+  };
+}
+
+describe("Feature: ExecuteEvaluationCommand — Azure Safety BYOK gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe.each(AZURE_EVALUATOR_TYPES)(
+    "given a monitor for %s",
+    (evaluatorType) => {
+      describe("and the project has NO azure_safety provider configured", () => {
+        describe("when the command handles the evaluation", () => {
+          it("emits a skipped event with the configure message", async () => {
+            const { command } = buildCommandWithMocks({
+              azureConfigured: false,
+              checkType: evaluatorType,
+            });
+
+            const events = await command.handle(buildCommand(evaluatorType));
+
+            expect(events).toHaveLength(1);
+            const eventData = events[0]?.data as unknown as {
+              status: string;
+              details?: string;
+            };
+            expect(eventData.status).toBe("skipped");
+            expect(eventData.details).toMatch(/not configured/i);
+            expect(eventData.details).toMatch(/Model Providers/i);
+          });
+
+          it("does not call evaluationExecution.executeForTrace", async () => {
+            const { command, evaluationExecution } = buildCommandWithMocks({
+              azureConfigured: false,
+              checkType: evaluatorType,
+            });
+
+            await command.handle(buildCommand(evaluatorType));
+
+            expect(
+              evaluationExecution.executeForTrace,
+            ).not.toHaveBeenCalled();
+          });
+
+          it("resolves azure safety env only once", async () => {
+            const { command, azureSafetyEnvResolver } = buildCommandWithMocks({
+              azureConfigured: false,
+              checkType: evaluatorType,
+            });
+
+            await command.handle(buildCommand(evaluatorType));
+
+            expect(azureSafetyEnvResolver).toHaveBeenCalledTimes(1);
+            expect(azureSafetyEnvResolver).toHaveBeenCalledWith(
+              "proj-byok-1",
+            );
+          });
+        });
+      });
+
+      describe("and the project has azure_safety configured", () => {
+        describe("when the command handles the evaluation", () => {
+          it("calls evaluationExecution.executeForTrace", async () => {
+            const { command, evaluationExecution } = buildCommandWithMocks({
+              azureConfigured: true,
+              checkType: evaluatorType,
+            });
+
+            await command.handle(buildCommand(evaluatorType));
+
+            expect(evaluationExecution.executeForTrace).toHaveBeenCalledTimes(
+              1,
+            );
+          });
+        });
+      });
+    },
+  );
+
+  describe("given a non-azure monitor", () => {
+    describe("when the command handles the evaluation", () => {
+      it("does not call the azure env resolver", async () => {
+        const { command, azureSafetyEnvResolver } = buildCommandWithMocks({
+          azureConfigured: false,
+          checkType: "openai/moderation",
+        });
+
+        await command.handle(buildCommand("openai/moderation"));
+
+        expect(azureSafetyEnvResolver).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/__tests__/executeEvaluation.error-propagation.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/__tests__/executeEvaluation.error-propagation.integration.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for ExecuteEvaluationCommand — error propagation.
+ *
+ * Covers @integration scenarios from
+ * specs/evaluators/evaluator-error-propagation.feature:
+ * - "langevals returns status=error with a detail message"
+ * - "evaluator throws an exception mid-execution"
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Command } from "../../..";
+import type { EvaluationCostRecorder } from "../../../../app-layer/evaluations/evaluation-cost.recorder";
+import type { EvaluationExecutionService } from "../../../../app-layer/evaluations/evaluation-execution.service";
+import type { MonitorService } from "../../../../app-layer/monitors/monitor.service";
+import { createTenantId } from "../../../domain/tenantId";
+import { ExecuteEvaluationCommand } from "../commands/executeEvaluation.command";
+import type { ExecuteEvaluationCommandData } from "../schemas/commands";
+
+function buildCommand(
+  evaluatorType: string,
+): Command<ExecuteEvaluationCommandData> {
+  const tenantId = createTenantId("proj-err-1");
+  return {
+    tenantId,
+    data: {
+      tenantId: "proj-err-1",
+      evaluationId: "eval_err",
+      evaluatorId: "mon_err",
+      evaluatorType,
+      evaluatorName: "Test Monitor",
+      traceId: "trace_err",
+      isGuardrail: false,
+      occurredAt: Date.now(),
+      threadIdleTimeout: undefined,
+      threadId: undefined,
+      userId: undefined,
+      customerId: undefined,
+      labels: [],
+      origin: "application",
+      hasError: false,
+      promptIds: [],
+      topicId: undefined,
+      subTopicId: undefined,
+      customMetadata: {},
+      spanModels: undefined,
+      computedInput: undefined,
+      computedOutput: undefined,
+    },
+  } as unknown as Command<ExecuteEvaluationCommandData>;
+}
+
+function buildMonitor(checkType: string) {
+  return {
+    id: "mon_err",
+    projectId: "proj-err-1",
+    checkType,
+    name: "Test Monitor",
+    enabled: true,
+    sample: 1,
+    preconditions: [],
+    parameters: {},
+    mappings: null,
+    level: "trace",
+    evaluator: null,
+    threadIdleTimeout: null,
+  };
+}
+
+function buildCommandWithMocks({
+  executionResult,
+  executionError,
+}: {
+  executionResult?: Record<string, unknown>;
+  executionError?: Error;
+}) {
+  const monitors = {
+    getMonitorById: vi
+      .fn()
+      .mockResolvedValue(buildMonitor("azure/content_safety")),
+  } as unknown as MonitorService;
+
+  const spanStorage = {
+    getSpansByTraceId: vi.fn().mockResolvedValue([]),
+  };
+
+  const traceEvents = {
+    getEventsByTraceId: vi.fn().mockResolvedValue([]),
+  };
+
+  const executeForTrace = executionError
+    ? vi.fn().mockRejectedValue(executionError)
+    : vi.fn().mockResolvedValue(executionResult);
+
+  const evaluationExecution = {
+    executeForTrace,
+  } as unknown as EvaluationExecutionService;
+
+  const costRecorder = {
+    recordCost: vi.fn(),
+  } as unknown as EvaluationCostRecorder;
+
+  const azureSafetyEnvResolver = vi.fn().mockResolvedValue({
+    AZURE_CONTENT_SAFETY_ENDPOINT: "https://byok.cognitiveservices.azure.com/",
+    AZURE_CONTENT_SAFETY_KEY: "byok-key",
+  });
+
+  const command = new ExecuteEvaluationCommand({
+    monitors,
+    spanStorage,
+    traceEvents,
+    evaluationExecution,
+    costRecorder,
+    azureSafetyEnvResolver,
+  });
+
+  return { command };
+}
+
+describe("Feature: ExecuteEvaluationCommand — error propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given langevals returns status=error with a detail message", () => {
+    describe("when the command handles the evaluation", () => {
+      it("emits status=error with the failure message in the event error field", async () => {
+        const failureMessage =
+          "Azure Content Safety request failed: Could not connect to https://invalid.cognitiveservices.azure.com/ (ENOTFOUND)";
+
+        const { command } = buildCommandWithMocks({
+          executionResult: {
+            status: "error",
+            details: failureMessage,
+          },
+        });
+
+        const events = await command.handle(buildCommand("azure/content_safety"));
+
+        expect(events).toHaveLength(1);
+        const eventData = events[0]?.data as unknown as {
+          status: string;
+          error?: string | null;
+          details?: string | null;
+        };
+
+        expect(eventData.status).toBe("error");
+        expect(eventData.error).toBe(failureMessage);
+      });
+
+      it("does not lose the failure message when both details and error could carry it", async () => {
+        const failureMessage = "Invalid subscription key";
+
+        const { command } = buildCommandWithMocks({
+          executionResult: {
+            status: "error",
+            details: failureMessage,
+          },
+        });
+
+        const events = await command.handle(buildCommand("azure/content_safety"));
+
+        const eventData = events[0]?.data as unknown as {
+          error?: string | null;
+          details?: string | null;
+        };
+
+        const errorText = eventData.error ?? eventData.details ?? "";
+        expect(errorText).toContain("Invalid subscription key");
+      });
+    });
+  });
+
+  describe("given the evaluator throws an exception mid-execution", () => {
+    describe("when the command handles the evaluation", () => {
+      it("emits status=error with the exception message and stack", async () => {
+        const { command } = buildCommandWithMocks({
+          executionError: new Error("boom"),
+        });
+
+        const events = await command.handle(buildCommand("azure/content_safety"));
+
+        const eventData = events[0]?.data as unknown as {
+          status: string;
+          error?: string | null;
+          errorDetails?: string | null;
+        };
+
+        expect(eventData.status).toBe("error");
+        expect(eventData.error).toContain("boom");
+        expect(eventData.errorDetails).toBeTruthy();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -8,6 +8,11 @@ import {
 import { extractErrorMessage } from "../../../../../utils/captureError";
 import { KSUID_RESOURCES } from "../../../../../utils/constants";
 import { createLogger } from "../../../../../utils/logger/server";
+import {
+  AZURE_SAFETY_NOT_CONFIGURED_MESSAGE,
+  getAzureSafetyEnvFromProject,
+  isAzureEvaluatorType,
+} from "../../../../app-layer/evaluations/azure-safety-env";
 import type { EvaluationCostRecorder } from "../../../../app-layer/evaluations/evaluation-cost.recorder";
 import type { EvaluationExecutionService } from "../../../../app-layer/evaluations/evaluation-execution.service";
 import type { MonitorService } from "../../../../app-layer/monitors/monitor.service";
@@ -43,6 +48,15 @@ export interface ExecuteEvaluationCommandDeps {
   traceEvents: { getEventsByTraceId(params: { tenantId: string; traceId: string }): Promise<ElasticSearchEvent[]> };
   evaluationExecution: EvaluationExecutionService;
   costRecorder: EvaluationCostRecorder;
+  /**
+   * Resolves Azure Content Safety credentials from the per-project
+   * `azure_safety` model provider. Returns null when no credentials are
+   * configured — the command then emits a "skipped" status instead of
+   * running the evaluator. Injected for testability.
+   */
+  azureSafetyEnvResolver?: (
+    projectId: string,
+  ) => Promise<Record<string, string> | null>;
 }
 
 const SCHEMA = defineCommandSchema(
@@ -123,6 +137,30 @@ export class ExecuteEvaluationCommand implements CommandHandler<
         status: "skipped",
         details: "Monitor not found",
       });
+    }
+
+    // 1a. Azure Safety BYOK gate — hard cutover to per-project credentials.
+    // If the monitor uses an Azure evaluator and the project has no
+    // azure_safety provider configured, skip with a clear configure message
+    // so the customer can self-serve the fix from the UI.
+    if (isAzureEvaluatorType(monitor.checkType)) {
+      const azureEnvResolver =
+        this.deps.azureSafetyEnvResolver ?? getAzureSafetyEnvFromProject;
+      const azureEnv = await azureEnvResolver(tenantId);
+      if (!azureEnv) {
+        logger.warn(
+          {
+            tenantId,
+            evaluatorId: data.evaluatorId,
+            evaluatorType: monitor.checkType,
+          },
+          "Azure Safety provider not configured — skipping evaluation",
+        );
+        return emitReported(data, tenantId, {
+          status: "skipped",
+          details: AZURE_SAFETY_NOT_CONFIGURED_MESSAGE,
+        });
+      }
     }
 
     // 2. Sampling

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -267,13 +267,23 @@ export class ExecuteEvaluationCommand implements CommandHandler<
         });
       }
 
-      // 6. Emit single reported event — fold projection persists to CH
+      // 6. Emit single reported event — fold projection persists to CH.
+      // For error results, lift `details` into `error` if the service didn't
+      // already set it, so the real failure message always lands in the
+      // event's error field where the UI reads from.
+      const isError = result.status === "error";
+      const errorField = isError
+        ? result.error ?? result.details ?? "Evaluator failed"
+        : result.error;
+
       return emitReported(data, tenantId, {
         status: result.status,
         score: result.score,
         passed: result.passed,
         label: result.label,
-        details: result.details,
+        details: isError ? undefined : result.details,
+        error: errorField,
+        errorDetails: result.errorDetails ?? null,
         inputs: result.inputs ?? null,
         costId,
       });

--- a/langwatch/src/server/modelProviders/__tests__/registry.azure-safety.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/registry.azure-safety.unit.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the azure_safety provider definition.
+ *
+ * Covers @integration scenarios from specs/model-providers/azure-safety-provider.feature:
+ * - "Azure Safety appears in the Add Model Provider list"
+ * - "Azure Safety validates endpoint is a URL"
+ * - "Azure Safety validates subscription key is non-empty"
+ *
+ * The azure_safety provider is a non-LLM provider; its registry entry must use
+ * `type: "safety"` so the form can hide LLM-only sections (Custom Models,
+ * Default Model, API Gateway).
+ */
+import { describe, expect, it } from "vitest";
+import { modelProviders } from "../registry";
+
+describe("Feature: azure_safety model provider registry entry", () => {
+  describe("given the registry is imported", () => {
+    describe("when accessing the azure_safety entry", () => {
+      const entry = modelProviders.azure_safety;
+
+      it("exposes the azure_safety provider", () => {
+        expect(entry).toBeDefined();
+      });
+
+      it("names the provider Azure Safety", () => {
+        expect(entry.name).toBe("Azure Safety");
+      });
+
+      it("marks the provider as type safety", () => {
+        expect(entry.type).toBe("safety");
+      });
+
+      it("uses AZURE_CONTENT_SAFETY_KEY as the apiKey field", () => {
+        expect(entry.apiKey).toBe("AZURE_CONTENT_SAFETY_KEY");
+      });
+
+      it("uses AZURE_CONTENT_SAFETY_ENDPOINT as the endpointKey field", () => {
+        expect(entry.endpointKey).toBe("AZURE_CONTENT_SAFETY_ENDPOINT");
+      });
+
+      it("declares a blurb describing content safety coverage", () => {
+        expect(entry.blurb).toBeDefined();
+        expect(entry.blurb).toMatch(/content moderation/i);
+        expect(entry.blurb).toMatch(/prompt injection/i);
+        expect(entry.blurb).toMatch(/jailbreak/i);
+      });
+    });
+  });
+
+  describe("given the azure_safety keysSchema", () => {
+    const schema = modelProviders.azure_safety.keysSchema;
+
+    describe("when validating a valid endpoint URL and non-empty key", () => {
+      it("passes validation", () => {
+        const result = schema.safeParse({
+          AZURE_CONTENT_SAFETY_ENDPOINT:
+            "https://my-account.cognitiveservices.azure.com/",
+          AZURE_CONTENT_SAFETY_KEY: "my-subscription-key",
+        });
+        expect(result.success).toBe(true);
+      });
+    });
+
+    describe("when the endpoint is not a URL", () => {
+      it("fails validation", () => {
+        const result = schema.safeParse({
+          AZURE_CONTENT_SAFETY_ENDPOINT: "not-a-url",
+          AZURE_CONTENT_SAFETY_KEY: "key",
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe("when the subscription key is missing", () => {
+      it("fails validation", () => {
+        const result = schema.safeParse({
+          AZURE_CONTENT_SAFETY_ENDPOINT:
+            "https://my-account.cognitiveservices.azure.com/",
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe("when the subscription key is empty string", () => {
+      it("fails validation", () => {
+        const result = schema.safeParse({
+          AZURE_CONTENT_SAFETY_ENDPOINT:
+            "https://my-account.cognitiveservices.azure.com/",
+          AZURE_CONTENT_SAFETY_KEY: "",
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe("when the endpoint is missing", () => {
+      it("fails validation", () => {
+        const result = schema.safeParse({
+          AZURE_CONTENT_SAFETY_KEY: "key",
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe("given the broader registry", () => {
+    describe("when checking existing LLM providers", () => {
+      it("marks openai as type llm", () => {
+        expect(modelProviders.openai.type).toBe("llm");
+      });
+
+      it("marks anthropic as type llm", () => {
+        expect(modelProviders.anthropic.type).toBe("llm");
+      });
+
+      it("marks azure as type llm", () => {
+        expect(modelProviders.azure.type).toBe("llm");
+      });
+
+      it("marks every entry with a type field", () => {
+        for (const [key, provider] of Object.entries(modelProviders)) {
+          expect(
+            (provider as { type?: "llm" | "safety" }).type,
+            `provider ${key} should have a type`,
+          ).toMatch(/^(llm|safety)$/);
+        }
+      });
+    });
+  });
+});

--- a/langwatch/src/server/modelProviders/iconsMap.tsx
+++ b/langwatch/src/server/modelProviders/iconsMap.tsx
@@ -28,4 +28,5 @@ export const modelProviderIcons: Record<
   custom: <Custom />,
   xai: <Xai />,
   cerebras: <Cerebras />,
+  azure_safety: <Azure />,
 };

--- a/langwatch/src/server/modelProviders/registry.ts
+++ b/langwatch/src/server/modelProviders/registry.ts
@@ -27,6 +27,14 @@ export type ParameterConstraints = Record<string, ParameterConstraint>;
 
 type ModelProviderDefinition = {
   name: string;
+  /**
+   * Category of provider. "llm" providers offer chat/embedding models and
+   * power the LangWatch app features (default model, topic clustering, etc).
+   * "safety" providers are non-LLM credential containers for services like
+   * Azure Content Safety — they only expose credentials + extra headers
+   * and never appear in model selectors or default-model settings.
+   */
+  type: "llm" | "safety";
   apiKey: string;
   endpointKey: string | undefined;
   keysSchema: z.ZodTypeAny;
@@ -154,6 +162,7 @@ export const getRegistryMetadata = () => ({
 export const modelProviders = {
   custom: {
     name: "Custom (OpenAI-compatible)",
+    type: "llm",
     apiKey: "CUSTOM_API_KEY",
     endpointKey: "CUSTOM_BASE_URL",
     keysSchema: z.object({
@@ -166,6 +175,7 @@ export const modelProviders = {
   },
   openai: {
     name: "OpenAI",
+    type: "llm",
     apiKey: "OPENAI_API_KEY",
     endpointKey: "OPENAI_BASE_URL",
     keysSchema: z
@@ -189,6 +199,7 @@ export const modelProviders = {
   },
   anthropic: {
     name: "Anthropic",
+    type: "llm",
     apiKey: "ANTHROPIC_API_KEY",
     endpointKey: "ANTHROPIC_BASE_URL",
     keysSchema: z.object({
@@ -203,6 +214,7 @@ export const modelProviders = {
   },
   gemini: {
     name: "Gemini",
+    type: "llm",
     apiKey: "GEMINI_API_KEY",
     endpointKey: undefined,
     keysSchema: z.object({
@@ -212,6 +224,7 @@ export const modelProviders = {
   },
   azure: {
     name: "Azure OpenAI",
+    type: "llm",
     apiKey: "AZURE_OPENAI_API_KEY",
     endpointKey: "AZURE_OPENAI_ENDPOINT",
     keysSchema: z
@@ -226,6 +239,7 @@ export const modelProviders = {
   },
   bedrock: {
     name: "Bedrock",
+    type: "llm",
     apiKey: "AWS_ACCESS_KEY_ID",
     endpointKey: undefined,
     keysSchema: z.object({
@@ -237,6 +251,7 @@ export const modelProviders = {
   },
   vertex_ai: {
     name: "Vertex AI",
+    type: "llm",
     apiKey: "GOOGLE_APPLICATION_CREDENTIALS",
     endpointKey: undefined,
     keysSchema: z.object({
@@ -248,6 +263,7 @@ export const modelProviders = {
   },
   deepseek: {
     name: "DeepSeek",
+    type: "llm",
     apiKey: "DEEPSEEK_API_KEY",
     endpointKey: undefined,
     keysSchema: z.object({
@@ -257,6 +273,7 @@ export const modelProviders = {
   },
   xai: {
     name: "xAI",
+    type: "llm",
     apiKey: "XAI_API_KEY",
     endpointKey: undefined,
     keysSchema: z.object({
@@ -266,6 +283,7 @@ export const modelProviders = {
   },
   cerebras: {
     name: "Cerebras",
+    type: "llm",
     apiKey: "CEREBRAS_API_KEY",
     endpointKey: undefined,
     keysSchema: z.object({
@@ -275,12 +293,26 @@ export const modelProviders = {
   },
   groq: {
     name: "Groq",
+    type: "llm",
     apiKey: "GROQ_API_KEY",
     endpointKey: undefined,
     keysSchema: z.object({
       GROQ_API_KEY: z.string().min(1),
     }),
     enabledSince: new Date("2023-01-01"),
+  },
+  azure_safety: {
+    name: "Azure Safety",
+    type: "safety",
+    apiKey: "AZURE_CONTENT_SAFETY_KEY",
+    endpointKey: "AZURE_CONTENT_SAFETY_ENDPOINT",
+    keysSchema: z.object({
+      AZURE_CONTENT_SAFETY_ENDPOINT: z.string().url(),
+      AZURE_CONTENT_SAFETY_KEY: z.string().min(1),
+    }),
+    enabledSince: new Date("2026-04-10"),
+    blurb:
+      "Azure Content Safety for content moderation, prompt injection, and jailbreak detection. Your subscription is billed directly by Microsoft.",
   },
 } satisfies Record<string, ModelProviderDefinition>;
 

--- a/specs/evaluators/azure-safety-byok-gating.feature
+++ b/specs/evaluators/azure-safety-byok-gating.feature
@@ -1,0 +1,141 @@
+Feature: Azure safety evaluators require BYOK provider
+  As a platform operator
+  I want Azure Content Safety, Prompt Injection, and Jailbreak evaluators to require a project-level Azure Safety provider
+  So that customers pay Microsoft directly for their own Azure Content Safety usage
+
+  Background:
+    Given I am logged in
+    And I have access to a project
+    And I have "project:manage" permission
+
+  # ============================================================================
+  # Evaluator Type Selector Drawer gating
+  # ============================================================================
+
+  @integration
+  Scenario: Azure evaluators are disabled when no Azure Safety provider is configured
+    Given the project has no "azure_safety" model provider configured
+    When I open the evaluator type selector for the "Safety" category
+    Then the "Azure Content Safety" card is disabled
+    And the "Azure Prompt Injection" card is disabled
+    And the "Azure Jailbreak Detection" card is disabled
+    And each disabled card shows a tooltip saying "Configure Azure Safety provider in Settings → Model Providers"
+
+  @integration
+  Scenario: Disabled Azure card shows CTA to configure the provider
+    Given the project has no "azure_safety" model provider configured
+    When I open the evaluator type selector for the "Safety" category
+    And I click the "Configure Azure Safety" link on the "Azure Content Safety" card
+    Then I navigate to the model providers settings page
+    And the Azure Safety provider configuration drawer opens
+
+  @integration
+  Scenario: Configuring Azure Safety enables all three Azure evaluators
+    Given the project has no "azure_safety" model provider configured
+    And the evaluator type selector is open on the "Safety" category
+    When I configure the "azure_safety" provider with valid credentials
+    And I re-open the evaluator type selector for the "Safety" category
+    Then the "Azure Content Safety" card is enabled
+    And the "Azure Prompt Injection" card is enabled
+    And the "Azure Jailbreak Detection" card is enabled
+
+  @integration
+  Scenario: Disabled Azure provider counts as not configured
+    Given the project has an "azure_safety" model provider with disabled=true
+    When I open the evaluator type selector for the "Safety" category
+    Then the "Azure Content Safety" card is disabled
+
+  @integration
+  Scenario: Non-Azure safety evaluators are unaffected by Azure Safety config
+    Given the project has no "azure_safety" model provider configured
+    When I open the evaluator type selector for the "Safety" category
+    Then non-Azure safety evaluators remain enabled
+    And I can select them to create a monitor
+
+  # ============================================================================
+  # availableEvaluators router
+  # ============================================================================
+
+  @integration
+  Scenario: availableEvaluators reports missing env vars for Azure when provider is absent
+    Given the project has no "azure_safety" model provider configured
+    When the client queries availableEvaluators for the project
+    Then the response marks the following evaluators with missingEnvVars:
+      | evaluator              | missingEnvVars                                            |
+      | azure/content_safety   | AZURE_CONTENT_SAFETY_ENDPOINT, AZURE_CONTENT_SAFETY_KEY   |
+      | azure/prompt_injection | AZURE_CONTENT_SAFETY_ENDPOINT, AZURE_CONTENT_SAFETY_KEY   |
+      | azure/jailbreak        | AZURE_CONTENT_SAFETY_ENDPOINT, AZURE_CONTENT_SAFETY_KEY   |
+
+  @integration
+  Scenario: availableEvaluators reports no missing env vars when provider is fully configured
+    Given the project has an enabled "azure_safety" model provider with both keys set
+    When the client queries availableEvaluators for the project
+    Then the response marks the Azure evaluators with an empty missingEnvVars list
+
+  @integration
+  Scenario: availableEvaluators ignores process.env for Azure evaluators
+    Given the process environment has AZURE_CONTENT_SAFETY_ENDPOINT and AZURE_CONTENT_SAFETY_KEY set
+    And the project has no "azure_safety" model provider configured
+    When the client queries availableEvaluators for the project
+    Then the response still marks Azure evaluators as missing both env vars
+
+  # ============================================================================
+  # Runtime skip for ON_MESSAGE monitors
+  # ============================================================================
+
+  @integration
+  Scenario: ON_MESSAGE monitor using azure/content_safety without provider emits skipped
+    Given a monitor with checkType "azure/content_safety" enabled ON_MESSAGE
+    And the project has no "azure_safety" model provider configured
+    When a trace is processed that matches the monitor
+    Then the evaluation is reported with status "skipped"
+    And the details say "Azure Safety provider not configured. Configure it in Settings → Model Providers to run this evaluator."
+    And the langevals client is not called
+
+  @integration
+  Scenario: ON_MESSAGE monitor using azure/prompt_injection without provider emits skipped
+    Given a monitor with checkType "azure/prompt_injection" enabled ON_MESSAGE
+    And the project has no "azure_safety" model provider configured
+    When a trace is processed that matches the monitor
+    Then the evaluation is reported with status "skipped"
+    And the details say "Azure Safety provider not configured. Configure it in Settings → Model Providers to run this evaluator."
+    And the langevals client is not called
+
+  @integration
+  Scenario: ON_MESSAGE monitor using azure/jailbreak without provider emits skipped
+    Given a monitor with checkType "azure/jailbreak" enabled ON_MESSAGE
+    And the project has no "azure_safety" model provider configured
+    When a trace is processed that matches the monitor
+    Then the evaluation is reported with status "skipped"
+    And the details say "Azure Safety provider not configured. Configure it in Settings → Model Providers to run this evaluator."
+    And the langevals client is not called
+
+  @integration
+  Scenario: Configured Azure provider passes keys to langevals at runtime
+    Given a monitor with checkType "azure/content_safety" enabled ON_MESSAGE
+    And the project has an enabled "azure_safety" provider with:
+      | key                              | value                                              |
+      | AZURE_CONTENT_SAFETY_ENDPOINT    | https://my-account.cognitiveservices.azure.com/   |
+      | AZURE_CONTENT_SAFETY_KEY         | my-subscription-key                                |
+    When a trace is processed that matches the monitor
+    Then the langevals client is called with env containing both keys
+    And the evaluation is reported with status "processed"
+
+  @integration
+  Scenario: Existing disabled monitors start succeeding after provider is configured
+    Given a monitor with checkType "azure/content_safety" enabled ON_MESSAGE
+    And the project has no "azure_safety" model provider configured
+    And a previous trace produced a "skipped" evaluation
+    When the user configures the "azure_safety" provider with valid credentials
+    And a new trace is processed that matches the monitor
+    Then the new evaluation is reported with status "processed"
+    And the monitor did not need to be re-enabled
+
+  @integration
+  Scenario: Runtime skip ignores process.env for Azure evaluators
+    Given the process environment has AZURE_CONTENT_SAFETY_ENDPOINT and AZURE_CONTENT_SAFETY_KEY set
+    And the project has no "azure_safety" model provider configured
+    And a monitor with checkType "azure/content_safety" enabled ON_MESSAGE
+    When a trace is processed that matches the monitor
+    Then the evaluation is reported with status "skipped"
+    And the langevals client is not called

--- a/specs/evaluators/evaluator-error-propagation.feature
+++ b/specs/evaluators/evaluator-error-propagation.feature
@@ -1,0 +1,46 @@
+Feature: Evaluator error details reach the UI
+  As a user debugging a failed monitor
+  I want to see the actual error message when an evaluator fails
+  So that I can fix the underlying problem (bad credentials, unreachable endpoint, bad settings) without guessing
+
+  Background:
+    Given I am logged in
+    And I have access to a project
+
+  # ============================================================================
+  # Backend error propagation
+  # ============================================================================
+
+  @integration
+  Scenario: langevals returns status=error with a detail message
+    Given a monitor configured for azure/content_safety
+    And the Azure Safety provider is configured with an endpoint that rejects the request
+    When the pipeline executes the monitor for a trace
+    Then the emitted EvaluationReportedEvent has status "error"
+    And the emitted event carries the real failure message in the error field
+    And the emitted event does not lose the failure message
+
+  @integration
+  Scenario: evaluator throws an exception mid-execution
+    Given a monitor that will raise an unexpected exception during execution
+    When the pipeline executes the monitor
+    Then the emitted EvaluationReportedEvent has status "error"
+    And the emitted event carries the exception message in the error field
+    And the emitted event carries the stack trace in the errorDetails field
+
+  # ============================================================================
+  # Frontend visibility
+  # ============================================================================
+
+  @integration
+  Scenario: the trace evaluations tab shows the failure message on an errored row
+    Given an evaluation run has been persisted with status "error" and an error message
+    When I open the Trace Details drawer and switch to the Evaluations tab
+    Then the errored evaluator row shows the error message inline
+    And the error message is visually distinct from a passing row
+
+  @integration
+  Scenario: the trace evaluations tab shows details even when error message is empty
+    Given a legacy evaluation run row has status "error" with only a details string and no error field
+    When I open the Trace Details drawer and switch to the Evaluations tab
+    Then the errored evaluator row still shows the details string as the failure explanation

--- a/specs/model-providers/azure-safety-provider.feature
+++ b/specs/model-providers/azure-safety-provider.feature
@@ -1,0 +1,81 @@
+Feature: Azure Safety model provider
+  As a user who wants to run Azure Content Safety, Prompt Injection, or Jailbreak evaluators
+  I want to configure my own Azure Content Safety subscription
+  So that safety evaluations run against my Azure account and I'm billed directly by Microsoft
+
+  Background:
+    Given I am logged in
+    And I have access to a project
+    And I have "project:manage" permission
+
+  @integration
+  Scenario: Azure Safety appears in the Add Model Provider list
+    When I open the model providers settings page
+    And I click "Add Model Provider"
+    Then I see "Azure Safety" in the provider list
+    And "Azure Safety" is described as "Azure Content Safety for content moderation, prompt injection, and jailbreak detection"
+
+  @integration
+  Scenario: Configure Azure Safety saves endpoint and subscription key
+    Given I open the model provider configuration drawer for "azure_safety"
+    When I enter "https://my-account.cognitiveservices.azure.com/" in the "AZURE_CONTENT_SAFETY_ENDPOINT" field
+    And I enter "my-subscription-key" in the "AZURE_CONTENT_SAFETY_KEY" field
+    And I click "Save"
+    Then the Azure Safety provider is saved for the project
+    And the drawer closes
+
+  @integration
+  Scenario: Azure Safety form only shows credentials and extra headers
+    When I open the model provider configuration drawer for "azure_safety"
+    Then I see the following fields:
+      | field                            | type         |
+      | AZURE_CONTENT_SAFETY_ENDPOINT    | text input   |
+      | AZURE_CONTENT_SAFETY_KEY         | password     |
+    And I see an "Extra Headers" section
+    And I do not see a "Custom Models" section
+    And I do not see a "Default Model" section
+    And I do not see a "Use API Gateway" toggle
+
+  @integration
+  Scenario: Azure Safety validates endpoint is a URL
+    Given I open the model provider configuration drawer for "azure_safety"
+    When I enter "not-a-url" in the "AZURE_CONTENT_SAFETY_ENDPOINT" field
+    And I enter "key" in the "AZURE_CONTENT_SAFETY_KEY" field
+    And I click "Save"
+    Then I see a validation error for "AZURE_CONTENT_SAFETY_ENDPOINT"
+    And the provider is not saved
+
+  @integration
+  Scenario: Azure Safety validates subscription key is non-empty
+    Given I open the model provider configuration drawer for "azure_safety"
+    When I enter "https://my-account.cognitiveservices.azure.com/" in the "AZURE_CONTENT_SAFETY_ENDPOINT" field
+    And I leave the "AZURE_CONTENT_SAFETY_KEY" field empty
+    And I click "Save"
+    Then I see a validation error for "AZURE_CONTENT_SAFETY_KEY"
+    And the provider is not saved
+
+  @integration
+  Scenario: Subscription key is masked when editing existing Azure Safety provider
+    Given I have "azure_safety" provider configured with key "real-subscription-key"
+    When I open the model provider configuration drawer for "azure_safety"
+    Then the "AZURE_CONTENT_SAFETY_KEY" field shows "HAS_KEY••••••••••••••••••••••••"
+    And the actual subscription key value is not displayed
+
+  @integration
+  Scenario: Preserve original subscription key when saving with masked placeholder
+    Given I have "azure_safety" provider configured with key "real-subscription-key"
+    When I open the model provider configuration drawer for "azure_safety"
+    And I see "HAS_KEY••••••••••••••••••••••••" in the subscription key field
+    And I change the endpoint to "https://new-account.cognitiveservices.azure.com/"
+    And I click "Save"
+    Then the original subscription key "real-subscription-key" is preserved
+    And the endpoint is updated to "https://new-account.cognitiveservices.azure.com/"
+
+  @integration
+  Scenario: Disable Azure Safety provider
+    Given I have "azure_safety" provider enabled with valid credentials
+    When I open the model provider configuration drawer for "azure_safety"
+    And I toggle the provider to disabled
+    And I click "Save"
+    Then the Azure Safety provider is disabled for the project
+    And the stored credentials are preserved


### PR DESCRIPTION
## Summary

Hard cutover to bring-your-own-key for the three Azure Content Safety evaluators (`azure/content_safety`, `azure/prompt_injection`, `azure/jailbreak`). All three now read credentials exclusively from a per-project `azure_safety` Model Provider — the shared `AZURE_CONTENT_SAFETY_*` env vars are no longer consulted, stopping the unintended cost socialization that surfaced last month (~\$500 unexpected Azure bill, 628k calls from Intergamma/Klusadviezen alone).

## Context

Investigation (ClickHouse + Postgres) showed all three Azure evaluators share the single subscription key shipped in `langwatch/.env`:
- `azure/content_safety` → `POST /contentsafety/text:analyze`
- `azure/prompt_injection` → `POST /contentsafety/text:shieldPrompt`
- `azure/jailbreak` → `POST /contentsafety/text:detectJailbreak` (deprecated by MS, still billed)

Top offender: **Intergamma / Klusadviezen** (`project_yv_gLnh5DP5SebYuCjdw4`) running both `prompt_injection` + `jailbreak` at `sample: 1.0` `ON_MESSAGE` — 628k evaluations in ~36 days.

## What changed

- **Registry**: `type: "llm" | "safety"` discriminator on `ModelProviderDefinition`, all existing entries backfilled as `"llm"`, new `azure_safety` entry (URL-validated endpoint + min-1 key, Azure icon).
- **Form** (`ModelProviderForm.tsx`): hides `CustomModelInputSection`, `DefaultProviderSection`, and Azure API Gateway toggle when `provider.type === "safety"`. Skips OpenAI-style `validateApiKey()` for safety providers (they don't speak chat-completions). `ExtraHeadersSection` now renders for `azure_safety` too.
- **Env resolution** (hard cutover): new `azure-safety-env.ts` helper with `getAzureSafetyEnvFromProject`, `isAzureEvaluatorType`, and `AZURE_SAFETY_NOT_CONFIGURED_MESSAGE`. `createDefaultModelEnvResolver` and the legacy `evaluationsWorker.runEvaluation` path read `azure/*` env **only** from the project provider — no `process.env` fallback.
- **`availableEvaluators` tRPC router**: derives `missingEnvVars` for `azure/*` from the project's `azure_safety` provider, ignoring `process.env`.
- **`EvaluatorTypeSelectorDrawer`**: queries `availableEvaluators`; for any `azure/*` evaluator with `missingEnvVars`, renders a disabled card with a "Configure Azure Safety" CTA that navigates to `/settings/model-providers?provider=azure_safety`.
- **`ExecuteEvaluationCommand`**: new pre-execution gate — if the monitor uses `azure/*` and `getAzureSafetyEnvFromProject(tenantId)` returns null, emits `status="skipped"` with `AZURE_SAFETY_NOT_CONFIGURED_MESSAGE` and never calls `evaluationExecution.executeForTrace`. Mirrored in the legacy `runEvaluation` path. Dep injected via `ExecuteEvaluationCommandDeps.azureSafetyEnvResolver`, wired in `pipelineRegistry.ts`.

## Out of scope (follow-up PRs)

- `azure/jailbreak` deprecation UX (deprecated badge, migration nudge to `prompt_injection`)
- `azure/jailbreak` 1000-char chunking bug in `langevals/evaluators/azure/langevals_azure/jailbreak.py:57`
- Customer migration emails / in-app notifications (product)
- Removing `AZURE_CONTENT_SAFETY_*` from the shared prod `.env` (deploy-side step after merge)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 455 passing (32 new: 15 registry + 17 env helper)
- [x] `pnpm test:integration` — 229 passing (48 new: 9 form, 6 resolver, 9 router, 11 drawer, 13 command)
- [x] BDD specs: 2 feature files, 21 scenarios
- [x] Manual QA via Playwright on `http://localhost:5560`, authenticated session:
  - [x] Settings → Model Providers → Add Model Provider → "Azure Safety" appears in list
  - [x] Clicking "Azure Safety" opens drawer with only credentials + Add Header, no Custom Models / Default Model / API Gateway
  - [x] Saving with endpoint + key creates enabled row in the providers table
  - [x] Evaluations → Safety category, with provider configured: all 3 Azure cards enabled, clickable
  - [x] Same page, with provider deleted: all 3 Azure cards `data-disabled="true"` with "Configure Azure Safety" CTA; non-Azure safety evaluators remain enabled
  - [x] Caught a real bug in manual QA: form `validateApiKey()` was hitting the wrong Azure endpoint shape — fixed by gating API-key validation on `isLlmProvider`
- [ ] Post-merge: remove `AZURE_CONTENT_SAFETY_*` from prod shared `.env` (deploy-side)