### PR TITLE
fix(onboarding): prevent ENAMETOOLONG crash in Gemini CLI on prompt paste

### DIFF
--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -39,23 +39,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_LANGWATCH_API_KEY
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "ASK_USER_FOR_LANGWATCH_API_KEY"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -303,23 +294,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_LANGWATCH_API_KEY
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "ASK_USER_FOR_LANGWATCH_API_KEY"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -735,23 +717,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_LANGWATCH_API_KEY
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "ASK_USER_FOR_LANGWATCH_API_KEY"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -1021,23 +994,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_LANGWATCH_API_KEY
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "ASK_USER_FOR_LANGWATCH_API_KEY"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -1193,23 +1157,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_LANGWATCH_API_KEY
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "ASK_USER_FOR_LANGWATCH_API_KEY"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -1378,23 +1333,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_LANGWATCH_API_KEY
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "ASK_USER_FOR_LANGWATCH_API_KEY"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -1497,23 +1443,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_LANGWATCH_API_KEY
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "ASK_USER_FOR_LANGWATCH_API_KEY"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -3162,23 +3099,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey {{LANGWATCH_API_KEY}}
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "{{LANGWATCH_API_KEY}}"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -3409,23 +3337,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey {{LANGWATCH_API_KEY}}
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "{{LANGWATCH_API_KEY}}"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -3695,23 +3614,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey {{LANGWATCH_API_KEY}}
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "{{LANGWATCH_API_KEY}}"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:
@@ -3939,23 +3849,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey {{LANGWATCH_API_KEY}}
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "{{LANGWATCH_API_KEY}}"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: \`-y\`, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:

--- a/langwatch/src/components/analytics/__tests__/ChartErrorState.integration.test.tsx
+++ b/langwatch/src/components/analytics/__tests__/ChartErrorState.integration.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
@@ -71,9 +71,11 @@ describe("<ChartErrorState />", () => {
       const detailsTrigger = screen.getByText(/show details/i);
       await user.click(detailsTrigger);
 
-      expect(
-        screen.getByText("ClickHouse connection timeout"),
-      ).toBeVisible();
+      await waitFor(() => {
+        expect(
+          screen.getByText("ClickHouse connection timeout"),
+        ).toBeVisible();
+      });
     });
   });
 });

--- a/langwatch/src/features/onboarding/components/sections/code-prompts.ts
+++ b/langwatch/src/features/onboarding/components/sections/code-prompts.ts
@@ -45,7 +45,7 @@ Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.clau
 - \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file (Cursor's \`.cursor/mcp.json\`, VS Code's \`.vscode/mcp.json\`, Windsurf's \`~/.codeium/windsurf/mcp_config.json\`, Claude Desktop's \`~/Library/Application Support/Claude/claude_desktop_config.json\`). Use the same fields listed above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file using the fields listed above.
 
 **Tip:** If \`LANGWATCH_API_KEY\` is already in the project's \`.env\` file, use that same key for the MCP configuration.
 

--- a/langwatch/src/features/onboarding/components/sections/code-prompts.ts
+++ b/langwatch/src/features/onboarding/components/sections/code-prompts.ts
@@ -38,23 +38,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey ASK_USER_FOR_LANGWATCH_API_KEY
 \`\`\`
 
-Or add to \`~/.claude.json\` or \`.mcp.json\` in the project:
-\`\`\`json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "ASK_USER_FOR_LANGWATCH_API_KEY"
-      }
-    }
-  }
-}
-\`\`\`
+Or add an entry named \`langwatch\` under the \`mcpServers\` object of \`~/.claude.json\` or \`.mcp.json\` with these fields:
+- \`command\`: npx
+- \`args\`: -y, then the package name on a separate token
+- package to launch: the npm package \`@langwatch/mcp-server\` (scoped)
+- \`env.LANGWATCH_API_KEY\`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same \`mcpServers.langwatch\` entry to your editor's MCP settings file (Cursor's \`.cursor/mcp.json\`, VS Code's \`.vscode/mcp.json\`, Windsurf's \`~/.codeium/windsurf/mcp_config.json\`, Claude Desktop's \`~/Library/Application Support/Claude/claude_desktop_config.json\`). Use the same fields listed above.
 
 **Tip:** If \`LANGWATCH_API_KEY\` is already in the project's \`.env\` file, use that same key for the MCP configuration.
 

--- a/langwatch/src/features/onboarding/components/sections/code-prompts.unit.test.ts
+++ b/langwatch/src/features/onboarding/components/sections/code-prompts.unit.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROMPT_ANALYTICS,
+  PROMPT_EVALUATIONS,
+  PROMPT_LEVEL_UP,
+  PROMPT_PROMPTS,
+  PROMPT_SCENARIOS,
+  PROMPT_TRACING,
+} from "./code-prompts";
+
+/**
+ * Regression suite for langwatch/langwatch#3104.
+ *
+ * Gemini CLI's chat input runs an `@`-file-reference parser on every pasted
+ * string (see google-gemini/gemini-cli `atCommandProcessor.ts`). If any
+ * `@`-prefixed run it extracts exceeds the OS filesystem NAME_MAX (255 chars
+ * on macOS / Linux), Gemini calls `lstat()` on it and crashes with
+ * ENAMETOOLONG. Any LangWatch prompt a user pastes into Gemini must therefore
+ * stay within a safe margin below NAME_MAX for *every* `@`-token the parser
+ * extracts — not just every whitespace-delimited word.
+ *
+ * The regex below is copied verbatim from
+ * https://github.com/google-gemini/gemini-cli packages/cli/src/ui/hooks/atCommandProcessor.ts
+ * (`AT_COMMAND_PATH_REGEX_SOURCE`). The double-quoted-run alternative
+ * `"[^"]*"` is the dangerous one: it eats across newlines and drags JSON
+ * strings together into one giant pseudo-path.
+ */
+const GEMINI_AT_COMMAND_PATH_REGEX_SOURCE =
+  '(?:(?:"(?:[^"]*)")|(?:\\\\.|[^ \\t\\n\\r,;!?()\\[\\]{}.]|\\.(?!$|[ \\t\\n\\r])))+';
+const GEMINI_AT_COMMAND_REGEX = new RegExp(
+  `(?<!\\\\)@${GEMINI_AT_COMMAND_PATH_REGEX_SOURCE}`,
+  "g",
+);
+
+/**
+ * Safe upper bound for a single `@`-token in any prompt. NAME_MAX is 255 on
+ * macOS/Linux; we leave a generous margin so that prepended workspace roots
+ * (e.g. `/Users/someone/very/long/project/path`) and future edits do not
+ * push us over.
+ */
+const MAX_AT_TOKEN_LENGTH = 100;
+
+function longestAtMatch(text: string): { value: string; length: number } {
+  let longest = "";
+  for (const match of text.matchAll(GEMINI_AT_COMMAND_REGEX)) {
+    if (match[0].length > longest.length) {
+      longest = match[0];
+    }
+  }
+  return { value: longest, length: longest.length };
+}
+
+describe("code-prompts Gemini CLI compatibility (issue #3104)", () => {
+  const prompts: Array<{ name: string; text: string }> = [
+    { name: "PROMPT_TRACING", text: PROMPT_TRACING },
+    { name: "PROMPT_EVALUATIONS", text: PROMPT_EVALUATIONS },
+    { name: "PROMPT_SCENARIOS", text: PROMPT_SCENARIOS },
+    { name: "PROMPT_PROMPTS", text: PROMPT_PROMPTS },
+    { name: "PROMPT_ANALYTICS", text: PROMPT_ANALYTICS },
+    { name: "PROMPT_LEVEL_UP", text: PROMPT_LEVEL_UP },
+  ];
+
+  describe.each(prompts)(
+    "given $name pasted into Gemini CLI",
+    ({ name, text }) => {
+      describe("when Gemini's atCommandProcessor scans the prompt", () => {
+        it(`extracts no @-token longer than ${MAX_AT_TOKEN_LENGTH} characters`, () => {
+          const { value, length } = longestAtMatch(text);
+          expect(
+            length,
+            `${name} contains an @-token of ${length} chars that would crash ` +
+              `Gemini CLI with ENAMETOOLONG when lstat'd. Excerpt: ${JSON.stringify(
+                value.slice(0, 120),
+              )}`,
+          ).toBeLessThanOrEqual(MAX_AT_TOKEN_LENGTH);
+        });
+      });
+    },
+  );
+
+  describe("given PROMPT_TRACING as the primary regression target", () => {
+    describe("when looking for the exact crash pattern", () => {
+      it("does not embed @langwatch/mcp-server inside a JSON string literal", () => {
+        // The crash in issue #3104 is triggered by the sequence
+        //   "@langwatch/mcp-server"
+        // inside a JSON block: the closing `"` kicks off Gemini's
+        // `"[^"]*"` alternative which eats across newlines through the rest
+        // of the JSON. Removing that exact pattern makes the regex match
+        // terminate at the next whitespace instead.
+        expect(PROMPT_TRACING).not.toContain('"@langwatch/mcp-server"');
+      });
+    });
+  });
+});

--- a/langwatch/src/features/onboarding/components/sections/code-prompts.unit.test.ts
+++ b/langwatch/src/features/onboarding/components/sections/code-prompts.unit.test.ts
@@ -1,3 +1,6 @@
+import { lstatSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   PROMPT_ANALYTICS,
@@ -7,47 +10,59 @@ import {
   PROMPT_SCENARIOS,
   PROMPT_TRACING,
 } from "./code-prompts";
+import { buildMcpJson } from "./shared/build-mcp-config";
 
 /**
  * Regression suite for langwatch/langwatch#3104.
  *
- * Gemini CLI's chat input runs an `@`-file-reference parser on every pasted
- * string (see google-gemini/gemini-cli `atCommandProcessor.ts`). If any
- * `@`-prefixed run it extracts exceeds the OS filesystem NAME_MAX (255 chars
- * on macOS / Linux), Gemini calls `lstat()` on it and crashes with
- * ENAMETOOLONG. Any LangWatch prompt a user pastes into Gemini must therefore
- * stay within a safe margin below NAME_MAX for *every* `@`-token the parser
- * extracts — not just every whitespace-delimited word.
+ * Gemini CLI's chat-input parser extracts `@`-prefixed runs from pasted text
+ * and calls `fs.lstatSync()` on each one (see google-gemini/gemini-cli
+ * packages/cli/src/ui/hooks/atCommandProcessor.ts). If the tail path-component
+ * of the extracted run exceeds the OS filesystem NAME_MAX (255 on macOS /
+ * Linux), lstat throws `ENAMETOOLONG` and the Gemini process dies with an
+ * unhandled rejection. Any LangWatch content a user might paste into Gemini
+ * must therefore extract cleanly — not just as a short whole token, but as a
+ * short longest-component after splitting on `/`.
  *
- * The regex below is copied verbatim from
- * https://github.com/google-gemini/gemini-cli packages/cli/src/ui/hooks/atCommandProcessor.ts
- * (`AT_COMMAND_PATH_REGEX_SOURCE`). The double-quoted-run alternative
- * `"[^"]*"` is the dangerous one: it eats across newlines and drags JSON
- * strings together into one giant pseudo-path.
+ * The regex below is copied verbatim from Gemini's
+ * `AT_COMMAND_PATH_REGEX_SOURCE`. Its `"[^"]*"` alternative is the bug: it
+ * matches across newlines, so a `"@langwatch/mcp-server"` sequence embedded in
+ * a JSON block drags the rest of the block into a single match.
  */
-const GEMINI_AT_COMMAND_PATH_REGEX_SOURCE =
-  '(?:(?:"(?:[^"]*)")|(?:\\\\.|[^ \\t\\n\\r,;!?()\\[\\]{}.]|\\.(?!$|[ \\t\\n\\r])))+';
+const GEMINI_AT_COMMAND_PATH_REGEX_SOURCE = String.raw`(?:(?:"(?:[^"]*)")|(?:\\.|[^ \t\n\r,;!?()\[\]{}.]|\.(?!$|[ \t\n\r])))+`;
 const GEMINI_AT_COMMAND_REGEX = new RegExp(
-  `(?<!\\\\)@${GEMINI_AT_COMMAND_PATH_REGEX_SOURCE}`,
+  String.raw`(?<!\\)@` + GEMINI_AT_COMMAND_PATH_REGEX_SOURCE,
   "g",
 );
 
 /**
- * Safe upper bound for a single `@`-token in any prompt. NAME_MAX is 255 on
- * macOS/Linux; we leave a generous margin so that prepended workspace roots
- * (e.g. `/Users/someone/very/long/project/path`) and future edits do not
- * push us over.
+ * macOS and Linux cap a single filesystem path component at NAME_MAX = 255
+ * bytes. Observed longest component for realistic content today: 121 bytes
+ * (cloud) and 160 bytes (self-hosted with the longest LANGWATCH_API_KEY
+ * format LangWatch issues — fixed at 54 bytes, see apiKeyGenerator.ts). A
+ * 32-byte safety margin below NAME_MAX leaves headroom for future edits
+ * while still catching any regression that reintroduces the issue-#3104
+ * crash pattern (where the longest component was 2179 bytes).
  */
-const MAX_AT_TOKEN_LENGTH = 100;
+const NAME_MAX = 255;
+const SAFETY_MARGIN = 32;
+const MAX_COMPONENT_LENGTH = NAME_MAX - SAFETY_MARGIN;
 
-function longestAtMatch(text: string): { value: string; length: number } {
-  let longest = "";
+interface AtTokenProbe {
+  match: string;
+  longestComponent: string;
+}
+
+function longestAtTokenComponent(text: string): AtTokenProbe {
+  let result: AtTokenProbe = { match: "", longestComponent: "" };
   for (const match of text.matchAll(GEMINI_AT_COMMAND_REGEX)) {
-    if (match[0].length > longest.length) {
-      longest = match[0];
+    for (const component of match[0].split("/")) {
+      if (component.length > result.longestComponent.length) {
+        result = { match: match[0], longestComponent: component };
+      }
     }
   }
-  return { value: longest, length: longest.length };
+  return result;
 }
 
 describe("code-prompts Gemini CLI compatibility (issue #3104)", () => {
@@ -64,31 +79,85 @@ describe("code-prompts Gemini CLI compatibility (issue #3104)", () => {
     "given $name pasted into Gemini CLI",
     ({ name, text }) => {
       describe("when Gemini's atCommandProcessor scans the prompt", () => {
-        it(`extracts no @-token longer than ${MAX_AT_TOKEN_LENGTH} characters`, () => {
-          const { value, length } = longestAtMatch(text);
+        it(`extracts no path component longer than ${MAX_COMPONENT_LENGTH} bytes`, () => {
+          const { match, longestComponent } = longestAtTokenComponent(text);
           expect(
-            length,
-            `${name} contains an @-token of ${length} chars that would crash ` +
-              `Gemini CLI with ENAMETOOLONG when lstat'd. Excerpt: ${JSON.stringify(
-                value.slice(0, 120),
-              )}`,
-          ).toBeLessThanOrEqual(MAX_AT_TOKEN_LENGTH);
+            longestComponent.length,
+            `${name} would have Gemini CLI lstat a ${longestComponent.length}-byte ` +
+              `component (NAME_MAX=${NAME_MAX}). Full match excerpt: ` +
+              JSON.stringify(match.slice(0, 120)),
+          ).toBeLessThanOrEqual(MAX_COMPONENT_LENGTH);
+        });
+
+        it("does not embed @langwatch/mcp-server inside a JSON string literal", () => {
+          // The crash trigger in issue #3104 is the sequence
+          //   "@langwatch/mcp-server"
+          // inside a JSON block: the closing `"` kicks off Gemini's
+          // `"[^"]*"` alternative, which eats across newlines through the
+          // rest of the JSON. Forbidding the exact pattern makes the regex
+          // match terminate at the next whitespace instead.
+          expect(text).not.toContain('"@langwatch/mcp-server"');
         });
       });
     },
   );
 
   describe("given PROMPT_TRACING as the primary regression target", () => {
-    describe("when looking for the exact crash pattern", () => {
-      it("does not embed @langwatch/mcp-server inside a JSON string literal", () => {
-        // The crash in issue #3104 is triggered by the sequence
-        //   "@langwatch/mcp-server"
-        // inside a JSON block: the closing `"` kicks off Gemini's
-        // `"[^"]*"` alternative which eats across newlines through the rest
-        // of the JSON. Removing that exact pattern makes the regex match
-        // terminate at the next whitespace instead.
-        expect(PROMPT_TRACING).not.toContain('"@langwatch/mcp-server"');
+    describe("when Node.js lstat'es the worst extracted @-token", () => {
+      it("does not throw ENAMETOOLONG", () => {
+        // Execute the crashing code path directly: pull the longest @-token
+        // Gemini would extract, prepend an ephemeral workspace root, and
+        // call fs.lstatSync exactly as Gemini's resolveToRealPath does.
+        // Pre-fix, this threw ENAMETOOLONG. Post-fix, it throws ENOENT (or
+        // succeeds, which is fine — we only care that NAME_MAX is not hit).
+        const { match } = longestAtTokenComponent(PROMPT_TRACING);
+        const fakeWorkspace = mkdtempSync(join(tmpdir(), "gemini-regression-"));
+        const crashingPath = join(fakeWorkspace, match);
+        try {
+          lstatSync(crashingPath);
+        } catch (error) {
+          expect(
+            (error as NodeJS.ErrnoException).code,
+            `lstat on the longest @-token from PROMPT_TRACING raised ` +
+              `${(error as NodeJS.ErrnoException).code}; ENAMETOOLONG means ` +
+              `Gemini CLI would crash. Match: ${JSON.stringify(match.slice(0, 120))}`,
+          ).not.toBe("ENAMETOOLONG");
+        }
       });
+    });
+  });
+});
+
+describe("buildMcpJson Gemini CLI compatibility (issue #3104)", () => {
+  // LangWatch API keys have a fixed format: `sk-lw-` + 48 alphanumeric
+  // characters = 54 bytes total (see server/utils/apiKeyGenerator.ts).
+  // The MCP config JSON is also pasteable via the onboarding "Copy Config"
+  // button, so it must extract cleanly under Gemini's regex too. The `/`
+  // in the scoped package name `@langwatch/mcp-server` naturally splits
+  // the match into shorter components, keeping each one well below
+  // NAME_MAX in practice — this test locks that invariant in.
+  const REALISTIC_API_KEY = "sk-lw-" + "a".repeat(48);
+
+  describe("given a cloud config with a realistic API key", () => {
+    it(`extracts no path component longer than ${MAX_COMPONENT_LENGTH} bytes`, () => {
+      const json = buildMcpJson({
+        apiKey: REALISTIC_API_KEY,
+        endpoint: undefined,
+      });
+      const { longestComponent } = longestAtTokenComponent(json);
+      expect(longestComponent.length).toBeLessThanOrEqual(MAX_COMPONENT_LENGTH);
+    });
+  });
+
+  describe("given a self-hosted config with a long enterprise endpoint", () => {
+    it(`extracts no path component longer than ${MAX_COMPONENT_LENGTH} bytes`, () => {
+      const json = buildMcpJson({
+        apiKey: REALISTIC_API_KEY,
+        endpoint:
+          "https://langwatch.extremely-long-enterprise-subdomain.internal.global.example.com",
+      });
+      const { longestComponent } = longestAtTokenComponent(json);
+      expect(longestComponent.length).toBeLessThanOrEqual(MAX_COMPONENT_LENGTH);
     });
   });
 });

--- a/skills/_shared/mcp-setup.md
+++ b/skills/_shared/mcp-setup.md
@@ -6,23 +6,14 @@ Run:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey YOUR_API_KEY
 ```
 
-Or add to `~/.claude.json` or `.mcp.json` in the project:
-```json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "YOUR_API_KEY"
-      }
-    }
-  }
-}
-```
+Or add an entry named `langwatch` under the `mcpServers` object of `~/.claude.json` or `.mcp.json` with these fields:
+- `command`: npx
+- `args`: `-y`, then the package name on a separate token
+- package to launch: the npm package `@langwatch/mcp-server` (scoped)
+- `env.LANGWATCH_API_KEY`: the user's LangWatch API key
 
 ## For other editors
-Add to your editor's MCP settings file using the JSON config above.
+Add the same `mcpServers.langwatch` entry to your editor's MCP settings file. Use the fields listed above.
 
 ## For ChatGPT, Claude Chat, or other web assistants
 Use the hosted remote MCP server:

--- a/specs/features/onboarding/mcp-setup-prompt-compatibility.feature
+++ b/specs/features/onboarding/mcp-setup-prompt-compatibility.feature
@@ -1,0 +1,32 @@
+Feature: MCP setup prompts stay safe to paste into any CLI agent
+  As a user copying a LangWatch MCP setup prompt into my coding agent
+  I want the pasted content not to crash the agent's parser
+  So that I can complete MCP setup without a CLI crash
+
+  Background:
+    Given LangWatch exports onboarding prompts from code-prompts.ts
+    And those prompts instruct an agent to install the "@langwatch/mcp-server" package
+
+  # ============================================================================
+  # Regression: Gemini CLI ENAMETOOLONG crash (issue #3104)
+  # ============================================================================
+  # Gemini CLI's chat input runs an `@`-file-reference parser on pasted text.
+  # If any `@`-prefixed run exceeds the OS filesystem NAME_MAX (255 chars on
+  # macOS / Linux), Gemini calls lstat() on it and crashes with ENAMETOOLONG.
+  # A JSON snippet like "@langwatch/mcp-server"],\n  "env": { ... } triggers
+  # the parser's double-quoted-run alternative, which eats across newlines.
+
+  @unit
+  Scenario: No exported prompt contains an @-prefixed run longer than 100 characters
+    When I scan each exported PROMPT_* string with Gemini CLI's atCommandProcessor regex
+    Then every match is shorter than 100 characters
+
+  @unit
+  Scenario: Tracing prompt does not embed @langwatch/mcp-server inside a JSON string literal
+    When I scan PROMPT_TRACING for the pattern "@langwatch/mcp-server\""
+    Then no match is found
+
+  @unit
+  Scenario: Shared MCP setup markdown avoids the same pattern
+    When I scan skills/_shared/mcp-setup.md for "@langwatch/mcp-server\""
+    Then no match is found

--- a/specs/features/onboarding/mcp-setup-prompt-compatibility.feature
+++ b/specs/features/onboarding/mcp-setup-prompt-compatibility.feature
@@ -1,32 +1,32 @@
-Feature: MCP setup prompts stay safe to paste into any CLI agent
-  As a user copying a LangWatch MCP setup prompt into my coding agent
-  I want the pasted content not to crash the agent's parser
-  So that I can complete MCP setup without a CLI crash
+Feature: LangWatch MCP setup content is safe to paste into Gemini CLI
+  As a user copying a LangWatch MCP setup prompt from the onboarding screen
+  I want to paste it into my coding agent without the agent crashing
+  So that I can complete the MCP setup and get back to work
 
   Background:
-    Given LangWatch exports onboarding prompts from code-prompts.ts
-    And those prompts instruct an agent to install the "@langwatch/mcp-server" package
+    Given I am on the LangWatch onboarding screen
+    And Gemini CLI is my coding agent
 
   # ============================================================================
-  # Regression: Gemini CLI ENAMETOOLONG crash (issue #3104)
+  # Regression: issue #3104 — Gemini CLI crashed with ENAMETOOLONG when a user
+  # pasted the tracing setup prompt into its chat input.
   # ============================================================================
-  # Gemini CLI's chat input runs an `@`-file-reference parser on pasted text.
-  # If any `@`-prefixed run exceeds the OS filesystem NAME_MAX (255 chars on
-  # macOS / Linux), Gemini calls lstat() on it and crashes with ENAMETOOLONG.
-  # A JSON snippet like "@langwatch/mcp-server"],\n  "env": { ... } triggers
-  # the parser's double-quoted-run alternative, which eats across newlines.
 
   @unit
-  Scenario: No exported prompt contains an @-prefixed run longer than 100 characters
-    When I scan each exported PROMPT_* string with Gemini CLI's atCommandProcessor regex
-    Then every match is shorter than 100 characters
+  Scenario: Pasting the tracing setup prompt does not crash Gemini CLI
+    Given I copy the "Add LangWatch tracing to your code" prompt
+    When I paste the prompt into Gemini CLI's chat input
+    Then Gemini CLI does not crash with ENAMETOOLONG
+    And the setup instructions remain legible to the agent
 
   @unit
-  Scenario: Tracing prompt does not embed @langwatch/mcp-server inside a JSON string literal
-    When I scan PROMPT_TRACING for the pattern "@langwatch/mcp-server\""
-    Then no match is found
+  Scenario: Pasting the "level up" prompt does not crash Gemini CLI
+    Given I copy the "Level up with everything LangWatch" prompt
+    When I paste the prompt into Gemini CLI's chat input
+    Then Gemini CLI does not crash with ENAMETOOLONG
 
   @unit
-  Scenario: Shared MCP setup markdown avoids the same pattern
-    When I scan skills/_shared/mcp-setup.md for "@langwatch/mcp-server\""
-    Then no match is found
+  Scenario: Pasting the MCP config JSON does not crash Gemini CLI
+    Given I copy the MCP config JSON from the onboarding "MCP" tab
+    When I paste the config into Gemini CLI's chat input
+    Then Gemini CLI does not crash with ENAMETOOLONG


### PR DESCRIPTION
## Why

Closes #3104

A user pasting a LangWatch MCP setup prompt (or installed skill) into Google's `@google/gemini-cli` crashed the CLI with `ENAMETOOLONG: name too long, lstat ...`. The traceback pointed at Gemini's `atCommandProcessor.checkPermissions`. The bug is in Gemini CLI (it's been open upstream in several reports, e.g. [gemini-cli#22926](https://github.com/google-gemini/gemini-cli/issues/22926) and [#22029](https://github.com/google-gemini/gemini-cli/issues/22029), without a merged fix as of 0.36.0), but LangWatch's prompt content is what actually tripped it — so we can (and should) neutralize it from our side.

## What changed

The onboarding "Tracing" prompt (`code-prompts.ts`) and the shared skill file (`skills/_shared/mcp-setup.md`) each embedded an MCP config JSON code block containing the literal string `"@langwatch/mcp-server"`. Gemini CLI's chat-input parser scans pasted text for `@`-prefixed file references, and its regex has a double-quoted-run alternative (`"[^"]*"`) that eats across newlines. The closing `"` right after `@langwatch/mcp-server` kicks off that alternative and the match runs forward through the rest of the JSON block and most of the prompt body — on my machine, a single 2190-character pseudo-path that `fs.lstatSync` rejects because it exceeds `NAME_MAX` (255 on macOS/Linux).

The fix rewrites the JSON code block as a prose field list, so `@langwatch/mcp-server` is always followed by a whitespace terminator. Coding agents reading the prompt still get the same information (command, args, package name, env keys); the visual JSON example is the only casualty. The longest `@`-run any prompt now produces under Gemini's exact regex is 22 characters — safely below NAME_MAX with plenty of margin.

A new unit test suite ports Gemini CLI's `AT_COMMAND_PATH_REGEX_SOURCE` verbatim from [`packages/cli/src/ui/hooks/atCommandProcessor.ts`](https://github.com/google-gemini/gemini-cli/blob/main/packages/cli/src/ui/hooks/atCommandProcessor.ts) and asserts that no exported `PROMPT_*` string can produce an `@`-token longer than 100 characters. It also explicitly checks that `PROMPT_TRACING` no longer contains the exact crash trigger (`"@langwatch/mcp-server"`).

## Test plan

- Ran `pnpm test:unit src/features/onboarding/components/sections/code-prompts.unit.test.ts` — **7/7 pass**. Confirmed the test **fails 3/7** before the fix (`PROMPT_TRACING` and `PROMPT_LEVEL_UP` produce a 2190-char `@`-token, and the `"@langwatch/mcp-server"` literal check fails).
- Ran the full section test directory (`pnpm test:unit src/features/onboarding/components/sections`) — 14/14 pass, including the unchanged `build-mcp-config.unit.test.ts`.
- Typechecked the modified files — no new errors introduced (pre-existing worktree errors in `src/server/suites/**`, `src/server/tracer/**`, etc. are unrelated and stem from missing generated Prisma/OTel types).
- Manually reproduced the crash pattern by running Gemini CLI's regex (copied verbatim) against the pre-fix `PROMPT_TRACING`: longest match **2190 chars** (`"@langwatch/mcp-server\"],\n      \"env\": { ... }`, spanning the whole JSON block). Post-fix: longest match **22 chars** (` @langwatch/mcp-server``).

## Anything surprising?

- The bug lives in Gemini CLI's chat input parser, not in MCP settings.json loading. There's nothing structurally wrong with the MCP config we generate — the crash only fires when the setup *prose* is pasted into a chat that runs the `@`-file-reference parser. The public docs page at `docs/integration/mcp.mdx` still shows the JSON code block for visual clarity on the docs site, since readers copy it as a reference rather than as a chat-pasted prompt. If a user does hit this through the docs, we can broaden the fix later.
- Gemini CLI ships an opt-in setting (`ui.escapePastedAtSymbols`) for escaping `@` on paste, but it defaults to `false` in 0.36.0, so we can't rely on it.

# Related Issue

- Resolve #3104