### PR TITLE
feat(agents): wire HTTP agent editor scenario mappings (#3064)

### DIFF
--- a/langwatch/src/components/agents/AgentHttpEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentHttpEditorDrawer.tsx
@@ -50,6 +50,8 @@ import {
   OutputPathInput,
   useHttpTest,
 } from "./http";
+import { ScenarioInputMappingSection } from "~/components/suites/ScenarioInputMappingSection";
+import { computeBestMatchMappings } from "~/server/scenarios/execution/resolve-field-mappings";
 
 // ============================================================================
 // Constants
@@ -93,6 +95,7 @@ function buildHttpConfig(
   outputPath: string,
   headers: HttpHeader[],
   auth: HttpAuth | undefined,
+  scenarioMappings: Record<string, FieldMapping>,
 ): HttpComponentConfig {
   return {
     name: "HTTP",
@@ -103,6 +106,8 @@ function buildHttpConfig(
     outputPath,
     headers: headers.length > 0 ? headers : undefined,
     auth: auth?.type === "none" ? undefined : auth,
+    scenarioMappings:
+      Object.keys(scenarioMappings).length > 0 ? scenarioMappings : undefined,
   };
 }
 
@@ -210,6 +215,8 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   // Custom variables (in addition to fixed ones)
   const [customVariables, setCustomVariables] = useState<Variable[]>([]);
+  // Scenario mappings persisted on the agent config
+  const [scenarioMappings, setScenarioMappings] = useState<Record<string, FieldMapping>>({});
   // Default to variables tab when in evaluations context (has availableSources)
   const [activeTab, setActiveTab] = useState(showVariablesTab ? "variables" : "body");
 
@@ -283,6 +290,12 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
       setOutputPath(config.outputPath || DEFAULT_OUTPUT_PATH);
       setHeaders(config.headers ?? []);
       setAuth(config.auth ?? { type: "none" });
+      const savedMappings = config.scenarioMappings ?? {};
+      setScenarioMappings(
+        Object.keys(savedMappings).length > 0
+          ? savedMappings
+          : computeBestMatchMappings({ inputs: FIXED_VARIABLES }),
+      );
       setHasUnsavedChanges(false);
       formInitializedRef.current = true;
     } else if (!agentId && isOpen) {
@@ -294,6 +307,7 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
       setOutputPath(DEFAULT_OUTPUT_PATH);
       setHeaders([]);
       setAuth({ type: "none" });
+      setScenarioMappings(computeBestMatchMappings({ inputs: FIXED_VARIABLES }));
       setHasUnsavedChanges(false);
       formInitializedRef.current = true;
     }
@@ -346,8 +360,35 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
   });
 
   const isSaving = createMutation.isPending || updateMutation.isPending;
+
+  const hasRequiredInputMapping = useMemo(() => {
+    // The HTTP adapter falls back to legacy body-template behavior when no
+    // scenarioMappings are present, so empty mappings are allowed.
+    if (Object.keys(scenarioMappings).length === 0) return true;
+    return Object.values(scenarioMappings).some(
+      (m) => m.type === "source" && (m.path[0] === "input" || m.path[0] === "messages"),
+    );
+  }, [scenarioMappings]);
+
   const isValid =
-    (name?.trim().length ?? 0) > 0 && (url?.trim().length ?? 0) > 0;
+    (name?.trim().length ?? 0) > 0 &&
+    (url?.trim().length ?? 0) > 0 &&
+    hasRequiredInputMapping;
+
+  const handleScenarioMappingChange = useCallback(
+    (identifier: string, mapping: FieldMapping | undefined) => {
+      setScenarioMappings((prev) => {
+        if (!mapping) {
+          const next = { ...prev };
+          delete next[identifier];
+          return next;
+        }
+        return { ...prev, [identifier]: mapping };
+      });
+      setHasUnsavedChanges(true);
+    },
+    [],
+  );
 
   const handleSave = useCallback(() => {
     if (!project?.id || !isValid) return;
@@ -359,6 +400,7 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
       outputPath,
       headers,
       auth,
+      scenarioMappings,
     );
 
     if (agentId) {
@@ -390,6 +432,7 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
     outputPath,
     headers,
     auth,
+    scenarioMappings,
     isValid,
     createMutation,
     updateMutation,
@@ -551,7 +594,11 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
                         }}
                       />
                     </Field.Root>
-                    {/* TODO: Wire HTTP agent adapter to use fieldMappings (see GitHub issue) */}
+                    <ScenarioInputMappingSection
+                      inputs={variables}
+                      mappings={scenarioMappings}
+                      onMappingChange={handleScenarioMappingChange}
+                    />
                   </VStack>
                 </Tabs.Content>
 

--- a/langwatch/src/components/agents/__tests__/AgentHttpEditorDrawer.integration.test.tsx
+++ b/langwatch/src/components/agents/__tests__/AgentHttpEditorDrawer.integration.test.tsx
@@ -147,5 +147,19 @@ describe("AgentHttpEditorDrawer", () => {
         });
       });
     });
+
+    // ========================================================================
+    // Scenario Mappings section (issue #3064)
+    // ========================================================================
+
+    describe("when the editor renders the Body tab", () => {
+      it("renders the Scenario Mappings section below the body template", async () => {
+        renderHttpDrawer();
+
+        await waitFor(() => {
+          expect(screen.getByText("Scenario Mappings")).toBeInTheDocument();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Why

Closes #3064.

The scenario input mapping backend (#2783) already threads `scenarioMappings` through the HTTP serialized adapter, data prefetcher, and type schemas — but the HTTP editor UI was pulled during cleanup so users had no way to configure or persist mappings on an HTTP agent. This PR wires `ScenarioInputMappingSection` back into `AgentHttpEditorDrawer` so HTTP agents get the same scenario-mapping experience as code agents. Companion to #3075 (workflow agents).

## What changed

`langwatch/src/components/agents/AgentHttpEditorDrawer.tsx`:

- Imports `ScenarioInputMappingSection` and `computeBestMatchMappings`
- Renders the section in the Body tab (below the Output Path field)
- Adds `scenarioMappings` form state, initialized from `config.scenarioMappings` (edit path) or from `computeBestMatchMappings({ inputs: FIXED_VARIABLES })` (new-agent path). Because the HTTP drawer's fixed variables (`input`, `messages`, `threadId`) match the canonical scenario field names, best-match reproduces the legacy implicit mapping explicitly
- Threads `scenarioMappings` through `buildHttpConfig` on save (omits the key when the map is empty, keeping existing agent configs clean)
- Adds `hasRequiredInputMapping` derived check — when `scenarioMappings` is non-empty, at least one entry must map `input` or `messages`. When it is empty, the adapter falls back to legacy body-template substitution so validation stays permissive (backwards-compat for existing HTTP agents)
- Removes the `TODO` comment referencing #3064

## How it works

- **Output validation does NOT apply.** `isScenarioMappingValid` from the shared section requires a declared outputs list; HTTP has no declared outputs (response is extracted via JSONPath `outputPath`), so we use an input-only inline check instead of the shared helper
- **No `outputs` prop passed to `ScenarioInputMappingSection`.** The section skips rendering the output sub-section when `outputs === undefined`, which is the desired behavior for HTTP

## Test plan

- `src/components/agents/__tests__/AgentHttpEditorDrawer.integration.test.tsx` — new test `"renders the Scenario Mappings section below the body template"` verifies the section mounts in the Body tab (fails before the edits, passes after)
- `src/server/scenarios/execution/serialized-adapters/__tests__/http-agent.adapter.unit.test.ts` — 21 existing tests still green, including the `scenarioMappings` coverage added in #2783
- `src/components/suites/__tests__/ScenarioInputMapping.integration.test.tsx`, `AgentCodeEditorDrawer.test.tsx`, `resolve-field-mappings.unit.test.ts` — 33 adjacent tests still green
- `pnpm typecheck` — clean

## Anything surprising?

- **Base branch is `issue2783/scenario-input-mapping-ui-backend`, not `main`.** This PR depends on #2809 (parent PR for #2783), which hasn't landed yet. Rebase/retarget to `main` once #2809 merges
- HTTP has no declared outputs, so the output sub-section of `ScenarioInputMappingSection` is intentionally hidden. If HTTP ever grows a structured-output concept, the validation path will need to mirror the code-agent `isScenarioMappingValid` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3064