### PR TITLE
fix(mcp): redis-backed sessions for multi-pod support + 30-day OAuth TTL

### DIFF
--- a/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
+++ b/langwatch/src/mcp/__tests__/mcp-handler.integration.test.ts
@@ -34,6 +34,11 @@ const mockRedis = {
   get: vi.fn(),
   set: vi.fn(),
   del: vi.fn(),
+  expire: vi.fn(),
+  sadd: vi.fn(),
+  srem: vi.fn(),
+  smembers: vi.fn(),
+  exists: vi.fn(),
 };
 
 vi.mock("~/server/db", () => ({
@@ -239,13 +244,17 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
     mockRedis.get.mockResolvedValue(null);
     mockRedis.set.mockResolvedValue("OK");
     mockRedis.del.mockResolvedValue(1);
+    mockRedis.expire.mockResolvedValue(1);
+    mockRedis.sadd.mockResolvedValue(1);
+    mockRedis.srem.mockResolvedValue(1);
+    mockRedis.smembers.mockResolvedValue([]);
+    mockRedis.exists.mockResolvedValue(0);
   });
 
   // --- Route Mounting ---
 
   describe("when Streamable HTTP transport is accessed at /mcp", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("responds with 200 and mcp-session-id header", async () => {
+    it("responds with 200 and mcp-session-id header", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const res = await sendRequest({
@@ -260,8 +269,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when GET /mcp/health is requested without credentials", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("responds with 200 and status ok", async () => {
+    it("responds with 200 and status ok", async () => {
       const res = await sendRequest({
         server,
         method: "GET",
@@ -275,8 +283,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when a non-MCP route is requested", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("is not intercepted by the MCP handler", async () => {
+    it("is not intercepted by the MCP handler", async () => {
       const res = await sendRequest({
         server,
         method: "GET",
@@ -290,8 +297,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when MCP POST request body is sent", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns a valid initialize result", async () => {
+    it("returns a valid initialize result", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const res = await sendRequest({
@@ -314,8 +320,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- OAuth authorization_code ---
 
   describe("when OAuth metadata is fetched", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("advertises authorization_code grant", async () => {
+    it("advertises authorization_code grant", async () => {
       const res = await sendRequest({
         server,
         method: "GET",
@@ -334,8 +339,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when authorization_code grant is used with a valid auth code and PKCE verifier", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("issues an access token", async () => {
+    it("issues an access token", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const code = randomUUID();
@@ -355,7 +359,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       const body = await res.json();
       expect(body.access_token).toBeDefined();
       expect(body.token_type).toBe("Bearer");
-      expect(body.expires_in).toBe(3600);
+      expect(body.expires_in).toBe(30 * 24 * 3600); // 30 days
 
       // Verify the auth code was deleted (one-time use)
       expect(mockRedis.del).toHaveBeenCalledWith(`mcp:auth_code:${code}`);
@@ -363,8 +367,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when authorization_code grant is used with an invalid code_verifier", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 400 with invalid_grant error", async () => {
+    it("returns 400 with invalid_grant error", async () => {
       const code = randomUUID();
       const { codeChallenge } = createPkceChallenge();
 
@@ -386,8 +389,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when authorization_code grant is missing the code parameter", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 400 with invalid_request error", async () => {
+    it("returns 400 with invalid_request error", async () => {
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
@@ -404,8 +406,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when authorization_code grant is missing the code_verifier parameter", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 400 with invalid_request error", async () => {
+    it("returns 400 with invalid_request error", async () => {
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
@@ -422,8 +423,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when an unsupported grant_type is used", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 400 with unsupported_grant_type error", async () => {
+    it("returns 400 with unsupported_grant_type error", async () => {
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;
       const res = await fetch(`http://127.0.0.1:${port}/oauth/token`, {
@@ -439,8 +439,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when an invalid authorization code is used", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 400 with invalid_grant error", async () => {
+    it("returns 400 with invalid_grant error", async () => {
       // Redis returns null for unknown codes (default mock behavior)
       const addr = server.address();
       const port = typeof addr === "object" && addr ? addr.port : 0;
@@ -459,8 +458,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- Bearer Token DB Validation ---
 
   describe("when a direct API key is used as Bearer token", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("validates against the database and accepts the connection", async () => {
+    it("validates against the database and accepts the connection", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const res = await sendRequest({
@@ -477,8 +475,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when an invalid Bearer token is used", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 401", async () => {
+    it("returns 401", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(null);
 
       const res = await sendRequest({
@@ -492,8 +489,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when an OAuth-issued access token is used", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("re-validates the API key against the database during MCP init", async () => {
+    it("re-validates the API key against the database during MCP init", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const code = randomUUID();
@@ -535,8 +531,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- Redis Token Storage ---
 
   describe("when OAuth token is looked up from Redis after in-memory cache miss", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("accepts the connection via Redis lookup", async () => {
+    it("accepts the connection via Redis lookup", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const code = randomUUID();
@@ -579,8 +574,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when an expired OAuth token is used", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 401", async () => {
+    it("returns 401", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(null);
 
       // Mock Redis returning an expired token (encrypted format)
@@ -601,11 +595,65 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
     });
   });
 
+  // --- Redis Session Recovery (multi-pod) ---
+
+  describe("when a session exists in Redis but not in local memory (different pod)", () => {
+    it("recovers the session from Redis and handles the request", async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(validProject());
+
+      // 1. Initialize a session normally
+      const initRes = await sendRequest({
+        server,
+        body: mcpInitializeBody(),
+        headers: { authorization: `Bearer ${VALID_API_KEY}` },
+      });
+      expect(initRes.status).toBe(200);
+      const sessionId = initRes.headers["mcp-session-id"];
+      expect(sessionId).toBeDefined();
+
+      // 2. Simulate pod switch: close all local sessions (as if this is a
+      //    different pod) but keep the Redis entry.
+      handler.closeAllSessions();
+
+      // 3. Mock Redis returning the session metadata
+      mockRedis.get.mockImplementation(async (key: string) => {
+        if (key === `mcp:session:${sessionId}`) {
+          return JSON.stringify({
+            encryptedApiKey: `encrypted:${VALID_API_KEY}`,
+            createdAt: Date.now(),
+          });
+        }
+        return null;
+      });
+      mockRedis.expire.mockResolvedValue(1);
+
+      // 4. Re-create the server+handler (simulating a different pod)
+      handler.closeAllSessions();
+
+      // 5. Send a tool list request with the old session ID — should recover
+      const toolsRes = await sendRequest({
+        server,
+        body: {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/list",
+          params: {},
+        },
+        headers: {
+          authorization: `Bearer ${VALID_API_KEY}`,
+          "mcp-session-id": sessionId!,
+        },
+      });
+      expect(toolsRes.status).toBe(200);
+      const toolsBody = toolsRes.json() as { result?: { tools?: unknown[] } };
+      expect(toolsBody.result?.tools).toBeDefined();
+    });
+  });
+
   // --- CORS ---
 
   describe("when a request to /mcp includes an Origin header", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("includes CORS headers in the response", async () => {
+    it("includes CORS headers in the response", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const res = await sendRequest({
@@ -631,8 +679,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when an OPTIONS preflight request is sent to /mcp", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("responds with 200 and CORS headers", async () => {
+    it("responds with 200 and CORS headers", async () => {
       const res = await sendRequest({
         server,
         method: "OPTIONS",
@@ -650,8 +697,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- Security: session re-auth ---
 
   describe("when an existing session request omits the Authorization header", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 401 on POST", async () => {
+    it("returns 401 on POST", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       // Initialize a session
@@ -672,8 +718,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       expect(res.status).toBe(401);
     });
 
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 401 on GET", async () => {
+    it("returns 401 on GET", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const initRes = await sendRequest({
@@ -693,8 +738,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
       expect(res.status).toBe(401);
     });
 
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 401 on DELETE", async () => {
+    it("returns 401 on DELETE", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const initRes = await sendRequest({
@@ -716,8 +760,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when an existing session request has a wrong Bearer token", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 401", async () => {
+    it("returns 401", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const initRes = await sendRequest({
@@ -745,8 +788,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- Security: rate limiting ---
 
   describe("when /oauth/token is called more than 10 times per minute", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns 429", async () => {
+    it("returns 429", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const addr = server.address();
@@ -775,8 +817,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- Standalone Package Isolation ---
 
   describe("when the standalone mcp-server package is checked for isolation", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("does not import any main app modules", async () => {
+    it("does not import any main app modules", async () => {
       // The mcp-server package's create-mcp-server.ts should not import
       // from the main app (~/server/db, ~/server/redis, etc.)
       const fs = await import("node:fs");
@@ -796,8 +837,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- Tool Availability ---
 
   describe("when a client lists available tools via /mcp", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("includes observability, platform, and documentation tools", async () => {
+    it("includes observability, platform, and documentation tools", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       // First, initialize a session
@@ -859,8 +899,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   //   - "LANGWATCH_API_KEY is required" (globalConfig has no apiKey)
 
   describe("when search_traces is called within an authenticated session", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("receives the API key from session config via AsyncLocalStorage", async () => {
+    it("receives the API key from session config via AsyncLocalStorage", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       // Initialize session
@@ -912,8 +951,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when search_traces is called via an OAuth-obtained access token", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("propagates the OAuth-resolved API key through to the tool handler", async () => {
+    it("propagates the OAuth-resolved API key through to the tool handler", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       // 1. Obtain an access token via OAuth authorization_code + PKCE
@@ -980,8 +1018,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when fetch_langwatch_docs is called with a specific URL", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("returns page content", async () => {
+    it("returns page content", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const initRes = await sendRequest({
@@ -1029,8 +1066,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   });
 
   describe("when fetch_langwatch_docs is called with a specific docs page URL", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("fetches the page and returns its content", async () => {
+    it("fetches the page and returns its content", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const initRes = await sendRequest({
@@ -1082,8 +1118,7 @@ describe("Feature: MCP HTTP Server In-App Integration", () => {
   // --- SSE Transport Tool Execution ---
 
   describe("when a tool is called via the SSE transport", () => {
-    // TODO(#3048): pre-existing failure unmasked by #3001
-    it.skip("propagates the API key to search_traces", async () => {
+    it("propagates the API key to search_traces", async () => {
       mockPrisma.project.findUnique.mockResolvedValue(validProject());
 
       const addr = server.address();

--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -46,6 +46,15 @@ const TOKEN_TTL_SECONDS = 30 * 24 * 3600;
 /** Max concurrent sessions per API key. */
 const MAX_SESSIONS_PER_KEY = 20;
 
+/**
+ * Derive an opaque key from an API key for use in Redis key names.
+ * Raw API keys must never appear in key names — they're visible in
+ * admin tools, MONITOR, key dumps, and metrics.
+ */
+function hashApiKey(apiKey: string): string {
+  return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+}
+
 // ---------------------------------------------------------------------------
 // Rate limiter — sliding window per IP
 // ---------------------------------------------------------------------------
@@ -497,9 +506,9 @@ export function createMcpHandler(): McpHandler {
         SESSION_REDIS_TTL_SECONDS,
       );
       // Track session ID in a per-key set for counting
-      await redis.sadd(`${REDIS_SESSION_SET_PREFIX}${apiKey}`, sessionId);
+      await redis.sadd(`${REDIS_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`, sessionId);
       await redis.expire(
-        `${REDIS_SESSION_SET_PREFIX}${apiKey}`,
+        `${REDIS_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`,
         SESSION_REDIS_TTL_SECONDS,
       );
     } catch (err) {
@@ -519,7 +528,7 @@ export function createMcpHandler(): McpHandler {
         SESSION_REDIS_TTL_SECONDS,
       );
       await redis.expire(
-        `${REDIS_SESSION_SET_PREFIX}${apiKey}`,
+        `${REDIS_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`,
         SESSION_REDIS_TTL_SECONDS,
       );
     } catch {
@@ -551,7 +560,7 @@ export function createMcpHandler(): McpHandler {
     if (!redis) return;
     try {
       await redis.del(`${REDIS_SESSION_PREFIX}${sessionId}`);
-      await redis.srem(`${REDIS_SESSION_SET_PREFIX}${apiKey}`, sessionId);
+      await redis.srem(`${REDIS_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`, sessionId);
     } catch {
       // Best-effort cleanup
     }
@@ -571,9 +580,9 @@ export function createMcpHandler(): McpHandler {
       return count;
     }
     try {
-      // Clean up stale entries: check each session ID in the set still exists
+      // Count Streamable HTTP sessions from Redis (cross-pod)
       const members = await redis.smembers(
-        `${REDIS_SESSION_SET_PREFIX}${apiKey}`,
+        `${REDIS_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`,
       );
       let liveCount = 0;
       for (const id of members) {
@@ -582,8 +591,12 @@ export function createMcpHandler(): McpHandler {
           liveCount++;
         } else {
           // Stale entry — session expired, clean it from the set
-          await redis.srem(`${REDIS_SESSION_SET_PREFIX}${apiKey}`, id);
+          await redis.srem(`${REDIS_SESSION_SET_PREFIX}${hashApiKey(apiKey)}`, id);
         }
+      }
+      // SSE sessions are connection-bound (not in Redis) — count local only
+      for (const session of sseSessions.values()) {
+        if (session.apiKey === apiKey) liveCount++;
       }
       return liveCount;
     } catch (err) {

--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -877,7 +877,7 @@ export function createMcpHandler(): McpHandler {
           });
 
           // Runtime assertion: verify the internal structure hasn't changed
-          const transportAny = transport as Record<string, unknown>;
+          const transportAny = transport as unknown as Record<string, unknown>;
           if (
             !transportAny._webStandardTransport ||
             typeof transportAny._webStandardTransport !== "object"
@@ -1007,7 +1007,7 @@ export function createMcpHandler(): McpHandler {
       }
 
       session.lastActivityAt = Date.now();
-      touchSessionInRedis(sessionId).catch(() => {});
+      touchSessionInRedis(sessionId, session.apiKey).catch(() => {});
       await handleWithSessionConfig(session.apiKey, () =>
         session.transport.handleRequest(req, res),
       );

--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -508,11 +508,18 @@ export function createMcpHandler(): McpHandler {
   }
 
   /** Refresh the Redis TTL when a session is active (called on each request). */
-  async function touchSessionInRedis(sessionId: string): Promise<void> {
+  async function touchSessionInRedis(
+    sessionId: string,
+    apiKey: string,
+  ): Promise<void> {
     if (!redis) return;
     try {
       await redis.expire(
         `${REDIS_SESSION_PREFIX}${sessionId}`,
+        SESSION_REDIS_TTL_SECONDS,
+      );
+      await redis.expire(
+        `${REDIS_SESSION_SET_PREFIX}${apiKey}`,
         SESSION_REDIS_TTL_SECONDS,
       );
     } catch {
@@ -858,19 +865,35 @@ export function createMcpHandler(): McpHandler {
         const redisApiKey = await getSessionFromRedis(sessionId);
         if (redisApiKey) {
           // Recreate transport locally for this pod.
-          // The SDK transport starts uninitialized — we patch its inner state
-          // so it accepts non-init requests with the existing session ID.
+          // WORKAROUND: The SDK transport starts uninitialized — we patch its
+          // inner state so it accepts non-init requests with the existing
+          // session ID. This accesses private fields of the SDK's
+          // StreamableHTTPServerTransport wrapper and the underlying
+          // WebStandardStreamableHTTPServerTransport.
+          // Tested against @modelcontextprotocol/sdk@1.26.0.
+          // See: https://github.com/modelcontextprotocol/typescript-sdk/issues/1658
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => sessionId,
           });
-          const inner = (
-            transport as unknown as {
-              _webStandardTransport: {
-                _initialized: boolean;
-                sessionId: string;
-              };
-            }
-          )._webStandardTransport;
+
+          // Runtime assertion: verify the internal structure hasn't changed
+          const transportAny = transport as Record<string, unknown>;
+          if (
+            !transportAny._webStandardTransport ||
+            typeof transportAny._webStandardTransport !== "object"
+          ) {
+            logger.error(
+              "StreamableHTTPServerTransport internal structure changed — " +
+                "Redis session recovery unavailable. Update the SDK workaround.",
+            );
+            sendJson(res, 500, { error: "Internal server error" });
+            return;
+          }
+
+          const inner = transportAny._webStandardTransport as Record<
+            string,
+            unknown
+          >;
           inner._initialized = true;
           inner.sessionId = sessionId;
 
@@ -905,7 +928,7 @@ export function createMcpHandler(): McpHandler {
         }
 
         session.lastActivityAt = Date.now();
-        touchSessionInRedis(sessionId).catch(() => {});
+        touchSessionInRedis(sessionId, session.apiKey).catch(() => {});
         await handleWithSessionConfig(session.apiKey, () =>
           session.transport.handleRequest(req, res, body),
         );

--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -34,8 +34,14 @@ const REDIS_TOKEN_PREFIX = "mcp:oauth:token:";
 /** Redis key prefix for MCP authorization codes. */
 const REDIS_AUTH_CODE_PREFIX = "mcp:auth_code:";
 
-/** OAuth token TTL in seconds. */
-const TOKEN_TTL_SECONDS = 3600;
+/** Redis key prefix for MCP transport sessions. */
+const REDIS_SESSION_PREFIX = "mcp:session:";
+
+/** Redis key for the set of session IDs belonging to an API key. */
+const REDIS_SESSION_SET_PREFIX = "mcp:sessions_by_key:";
+
+/** OAuth token TTL in seconds (30 days — matches cookie-based login duration). */
+const TOKEN_TTL_SECONDS = 30 * 24 * 3600;
 
 /** Max concurrent sessions per API key. */
 const MAX_SESSIONS_PER_KEY = 20;
@@ -161,21 +167,23 @@ export function createMcpHandler(): McpHandler {
   // and never-used OAuth tokens.
   // -------------------------------------------------------------------------
 
-  const SESSION_MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
+  const SESSION_MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes (local transport cleanup)
+  const SESSION_REDIS_TTL_SECONDS = 35 * 60; // 35 minutes (slightly longer than local, buffer for clock skew)
   const REAPER_INTERVAL_MS = 60 * 1000; // 60 seconds
 
   const reaper = setInterval(() => {
     const now = Date.now();
 
-    // Sweep idle sessions
+    // Sweep idle local transports (Redis entries expire via TTL)
     for (const [id, session] of sessions) {
       if (now - session.lastActivityAt > SESSION_MAX_AGE_MS) {
         session.transport.close().catch(() => {});
         sessions.delete(id);
+        removeSessionFromRedis(id, session.apiKey).catch(() => {});
       }
     }
 
-    // Sweep idle SSE sessions
+    // Sweep idle SSE sessions (SSE is connection-bound, no Redis needed)
     for (const [id, session] of sseSessions) {
       if (now - session.lastActivityAt > SESSION_MAX_AGE_MS) {
         session.transport.close().catch(() => {});
@@ -183,7 +191,7 @@ export function createMcpHandler(): McpHandler {
       }
     }
 
-    // Sweep expired OAuth tokens
+    // Sweep expired in-memory OAuth token cache (Redis is source of truth)
     for (const [token, entry] of oauthTokens) {
       if (now >= entry.expiresAt) {
         oauthTokens.delete(token);
@@ -468,18 +476,113 @@ export function createMcpHandler(): McpHandler {
   }
 
   // -------------------------------------------------------------------------
-  // Session helpers
+  // Redis session helpers
   // -------------------------------------------------------------------------
 
-  function sessionCountForKey(apiKey: string): number {
-    let count = 0;
-    for (const session of sessions.values()) {
-      if (session.apiKey === apiKey) count++;
+  /** Store session metadata in Redis so other pods can serve it. */
+  async function storeSessionInRedis(
+    sessionId: string,
+    apiKey: string,
+  ): Promise<void> {
+    if (!redis) return;
+    try {
+      const data = JSON.stringify({
+        encryptedApiKey: encrypt(apiKey),
+        createdAt: Date.now(),
+      });
+      await redis.set(
+        `${REDIS_SESSION_PREFIX}${sessionId}`,
+        data,
+        "EX",
+        SESSION_REDIS_TTL_SECONDS,
+      );
+      // Track session ID in a per-key set for counting
+      await redis.sadd(`${REDIS_SESSION_SET_PREFIX}${apiKey}`, sessionId);
+      await redis.expire(
+        `${REDIS_SESSION_SET_PREFIX}${apiKey}`,
+        SESSION_REDIS_TTL_SECONDS,
+      );
+    } catch (err) {
+      logger.error({ error: err }, "Failed to store session in Redis");
     }
-    for (const session of sseSessions.values()) {
-      if (session.apiKey === apiKey) count++;
+  }
+
+  /** Refresh the Redis TTL when a session is active (called on each request). */
+  async function touchSessionInRedis(sessionId: string): Promise<void> {
+    if (!redis) return;
+    try {
+      await redis.expire(
+        `${REDIS_SESSION_PREFIX}${sessionId}`,
+        SESSION_REDIS_TTL_SECONDS,
+      );
+    } catch {
+      // Non-critical — the session will still work until Redis TTL expires
     }
-    return count;
+  }
+
+  /** Look up session metadata from Redis (returns apiKey or null). */
+  async function getSessionFromRedis(
+    sessionId: string,
+  ): Promise<string | null> {
+    if (!redis) return null;
+    try {
+      const data = await redis.get(`${REDIS_SESSION_PREFIX}${sessionId}`);
+      if (!data) return null;
+      const stored = JSON.parse(data) as { encryptedApiKey: string };
+      return decrypt(stored.encryptedApiKey);
+    } catch (err) {
+      logger.error({ error: err }, "Redis session lookup failed");
+      return null;
+    }
+  }
+
+  /** Remove session from Redis. */
+  async function removeSessionFromRedis(
+    sessionId: string,
+    apiKey: string,
+  ): Promise<void> {
+    if (!redis) return;
+    try {
+      await redis.del(`${REDIS_SESSION_PREFIX}${sessionId}`);
+      await redis.srem(`${REDIS_SESSION_SET_PREFIX}${apiKey}`, sessionId);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
+  /** Count sessions for an API key across all pods via Redis. */
+  async function sessionCountForKey(apiKey: string): Promise<number> {
+    if (!redis) {
+      // Fallback to local count if Redis is down
+      let count = 0;
+      for (const session of sessions.values()) {
+        if (session.apiKey === apiKey) count++;
+      }
+      for (const session of sseSessions.values()) {
+        if (session.apiKey === apiKey) count++;
+      }
+      return count;
+    }
+    try {
+      // Clean up stale entries: check each session ID in the set still exists
+      const members = await redis.smembers(
+        `${REDIS_SESSION_SET_PREFIX}${apiKey}`,
+      );
+      let liveCount = 0;
+      for (const id of members) {
+        const exists = await redis.exists(`${REDIS_SESSION_PREFIX}${id}`);
+        if (exists) {
+          liveCount++;
+        } else {
+          // Stale entry — session expired, clean it from the set
+          await redis.srem(`${REDIS_SESSION_SET_PREFIX}${apiKey}`, id);
+        }
+      }
+      return liveCount;
+    } catch (err) {
+      logger.error({ error: err }, "Redis session count failed");
+      return 0; // Fail open to avoid blocking users
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -746,30 +849,72 @@ export function createMcpHandler(): McpHandler {
 
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
-    // Existing session — require Bearer token and verify it matches
-    if (sessionId && sessions.has(sessionId)) {
-      const session = sessions.get(sessionId)!;
+    // Existing session — check local Map first, then Redis
+    if (sessionId) {
+      let session = sessions.get(sessionId);
 
-      const token = extractBearerToken(req);
-      if (!token) {
-        send401(res, "Authorization header required");
+      // L2: Redis lookup — session may live on another pod
+      if (!session) {
+        const redisApiKey = await getSessionFromRedis(sessionId);
+        if (redisApiKey) {
+          // Recreate transport locally for this pod.
+          // The SDK transport starts uninitialized — we patch its inner state
+          // so it accepts non-init requests with the existing session ID.
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => sessionId,
+          });
+          const inner = (
+            transport as unknown as {
+              _webStandardTransport: {
+                _initialized: boolean;
+                sessionId: string;
+              };
+            }
+          )._webStandardTransport;
+          inner._initialized = true;
+          inner.sessionId = sessionId;
+
+          session = {
+            transport,
+            apiKey: redisApiKey,
+            lastActivityAt: Date.now(),
+          };
+          sessions.set(sessionId, session);
+
+          transport.onclose = () => {
+            sessions.delete(sessionId);
+          };
+
+          const sessionServer = createMcpServer();
+          await handleWithSessionConfig(redisApiKey, () =>
+            sessionServer.connect(transport),
+          );
+        }
+      }
+
+      if (session) {
+        const token = extractBearerToken(req);
+        if (!token) {
+          send401(res, "Authorization header required");
+          return;
+        }
+        const apiKey = await resolveApiKey(token);
+        if (apiKey !== session.apiKey) {
+          send401(res, "Bearer token does not match session");
+          return;
+        }
+
+        session.lastActivityAt = Date.now();
+        touchSessionInRedis(sessionId).catch(() => {});
+        await handleWithSessionConfig(session.apiKey, () =>
+          session.transport.handleRequest(req, res, body),
+        );
         return;
       }
-      const apiKey = await resolveApiKey(token);
-      if (apiKey !== session.apiKey) {
-        send401(res, "Bearer token does not match session");
-        return;
-      }
-
-      session.lastActivityAt = Date.now();
-      await handleWithSessionConfig(session.apiKey, () =>
-        session.transport.handleRequest(req, res, body),
-      );
-      return;
     }
 
     // New session — must be an initialize request
-    if (!sessionId && isInitializeRequest(body)) {
+    if ((!sessionId || !sessions.has(sessionId)) && isInitializeRequest(body)) {
       // Rate limit failed auth attempts (check only — track on failure in authenticateRequest)
       const ip = getClientIp(req);
       if (authFailRateLimiter.isBlocked(ip)) {
@@ -780,8 +925,8 @@ export function createMcpHandler(): McpHandler {
       const apiKey = await authenticateRequest(req, res);
       if (!apiKey) return; // 401 already sent
 
-      // Per-key session limit
-      if (sessionCountForKey(apiKey) >= MAX_SESSIONS_PER_KEY) {
+      // Per-key session limit (cross-pod via Redis)
+      if ((await sessionCountForKey(apiKey)) >= MAX_SESSIONS_PER_KEY) {
         sendJson(res, 429, {
           error: `Too many concurrent sessions (max ${MAX_SESSIONS_PER_KEY})`,
         });
@@ -792,12 +937,14 @@ export function createMcpHandler(): McpHandler {
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
           sessions.set(id, { transport, apiKey, lastActivityAt: Date.now() });
+          storeSessionInRedis(id, apiKey).catch(() => {});
         },
       });
 
       transport.onclose = () => {
         if (transport.sessionId) {
           sessions.delete(transport.sessionId);
+          removeSessionFromRedis(transport.sessionId, apiKey).catch(() => {});
         }
       };
 
@@ -822,10 +969,9 @@ export function createMcpHandler(): McpHandler {
     res: ServerResponse,
   ): Promise<void> {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
+    const session = sessionId ? sessions.get(sessionId) : undefined;
 
-    if (sessionId && sessions.has(sessionId)) {
-      const session = sessions.get(sessionId)!;
-
+    if (sessionId && session) {
       const token = extractBearerToken(req);
       if (!token) {
         send401(res, "Authorization header required");
@@ -838,6 +984,7 @@ export function createMcpHandler(): McpHandler {
       }
 
       session.lastActivityAt = Date.now();
+      touchSessionInRedis(sessionId).catch(() => {});
       await handleWithSessionConfig(session.apiKey, () =>
         session.transport.handleRequest(req, res),
       );
@@ -868,6 +1015,7 @@ export function createMcpHandler(): McpHandler {
 
       await session.transport.close();
       sessions.delete(sessionId);
+      removeSessionFromRedis(sessionId, session.apiKey).catch(() => {});
       sendJson(res, 200, { status: "session closed" });
     } else {
       sendJson(res, 404, { error: "Session not found" });
@@ -885,7 +1033,7 @@ export function createMcpHandler(): McpHandler {
     const apiKey = await authenticateRequest(req, res);
     if (!apiKey) return;
 
-    if (sessionCountForKey(apiKey) >= MAX_SESSIONS_PER_KEY) {
+    if ((await sessionCountForKey(apiKey)) >= MAX_SESSIONS_PER_KEY) {
       sendJson(res, 429, {
         error: `Too many concurrent sessions (max ${MAX_SESSIONS_PER_KEY})`,
       });


### PR DESCRIPTION
## Summary
- **Redis-backed sessions**: store session metadata (encrypted apiKey) in Redis so any pod can serve any MCP session. Local Map is L1 cache, Redis is L2. On cache miss (request routed to a different pod), the handler looks up Redis and recreates the transport on-the-fly.
- **30-day OAuth TTL**: bump `TOKEN_TTL_SECONDS` from 1 hour to 30 days, matching the web login cookie duration. Users no longer need to re-authenticate MCP frequently.
- **Unskipped all 30 MCP tests**: tests were bulk-skipped in #3001 when tee fix unmasked failures. Root cause was mcp-server dist not built — fixed by #3069 workspace auto-build.
- **New test**: verifies Redis session recovery across pods (init on pod A, tool call on pod B).

## Why
Production has 3 replicas behind an NLB with no session affinity. The `initialize` request creates a session on Pod A, but follow-up tool calls may route to Pod B/C which don't have the session in memory — causing 400 errors for `fetch_langwatch_docs`, `search_traces`, etc.

## Test plan
- [x] All 31 MCP integration tests pass locally (`pnpm exec vitest run -c vitest.mcp.config.ts`)
- [x] Typecheck passes
- [ ] CI green
- [ ] Deploy to prod, verify MCP tools work from Claude Chat across multiple requests