### PR TITLE
fix(mcp): extend session TTL to 30 days, return 401 on expired sessions

### DIFF
--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -995,6 +995,13 @@ export function createMcpHandler(): McpHandler {
       return;
     }
 
+    // If a session ID was provided but not found, the session expired.
+    // Return 401 with WWW-Authenticate so OAuth clients re-authenticate.
+    if (sessionId) {
+      send401(res, "Session expired or not found");
+      return;
+    }
+
     sendJson(res, 400, {
       error: "Invalid request — no session ID or not an initialize request",
     });
@@ -1024,6 +1031,8 @@ export function createMcpHandler(): McpHandler {
       await handleWithSessionConfig(session.apiKey, () =>
         session.transport.handleRequest(req, res),
       );
+    } else if (sessionId) {
+      send401(res, "Session expired or not found");
     } else {
       sendJson(res, 400, { error: "Invalid request — no valid session ID" });
     }

--- a/langwatch/src/mcp/handler.ts
+++ b/langwatch/src/mcp/handler.ts
@@ -177,7 +177,7 @@ export function createMcpHandler(): McpHandler {
   // -------------------------------------------------------------------------
 
   const SESSION_MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes (local transport cleanup)
-  const SESSION_REDIS_TTL_SECONDS = 35 * 60; // 35 minutes (slightly longer than local, buffer for clock skew)
+  const SESSION_REDIS_TTL_SECONDS = TOKEN_TTL_SECONDS; // Match OAuth token TTL (30 days) — session metadata is tiny, no reason to expire it sooner
   const REAPER_INTERVAL_MS = 60 * 1000; // 60 seconds
 
   const reaper = setInterval(() => {


### PR DESCRIPTION
## Summary
- Extend Redis session TTL from 35 minutes to 30 days (matching OAuth token TTL)
- Return `401 + WWW-Authenticate` instead of `400` when a session ID is provided but not found

## Why
After ~35 minutes of inactivity, the session was gone from both local memory AND Redis. The client sent the old `mcp-session-id`, got a `400`, and had no recovery path. With this fix:
- Sessions survive in Redis for 30 days (same as the OAuth token), so any pod can recreate the transport
- If the session IS truly gone (Redis cleared, etc.), the `401` response with `WWW-Authenticate` header tells OAuth clients to re-authenticate instead of giving up

## Test plan
- [x] All 31 MCP tests pass locally
- [ ] CI green
- [ ] Deploy, verify sessions survive idle periods > 35 min