### PR TITLE
fix: misc UI fixes

### DIFF
--- a/langwatch/src/pages/settings/members.tsx
+++ b/langwatch/src/pages/settings/members.tsx
@@ -239,7 +239,9 @@ function MembersList({
   const sortedMembers = useMemo(
     () =>
       [...organization.members].sort((a, b) =>
-        b.user.id.localeCompare(a.user.id),
+        (a.user.name ?? a.user.email ?? "").localeCompare(
+          b.user.name ?? b.user.email ?? "",
+        ),
       ),
     [organization.members],
   );

--- a/langwatch/src/server/api/routers/team.ts
+++ b/langwatch/src/server/api/routers/team.ts
@@ -92,6 +92,7 @@ export const teamRouter = createTRPCRouter({
         },
         include: {
           members: {
+            orderBy: { user: { name: "asc" } },
             include: {
               user: true,
               assignedRole: true,
@@ -297,6 +298,7 @@ export const teamRouter = createTRPCRouter({
         },
         include: {
           members: {
+            orderBy: { user: { name: "asc" } },
             include: {
               user: true,
               assignedRole: true,

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -324,6 +324,7 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
           ...(!includeDeactivated
             ? { where: { user: { deactivatedAt: null } } }
             : {}),
+          orderBy: { user: { name: "asc" } },
           include: {
             user: {
               include: {


### PR DESCRIPTION
## Summary

- **`members.tsx`**: Sort by `user.name` (email fallback) instead of `user.id` descending
- **`organization.prisma.repository.ts`**: Add `orderBy: { user: { name: "asc" } }` to `getOrganizationWithMembers` so the DB returns members sorted
- **`team.ts`**: Same `orderBy` on `getTeamsWithMembers` and `getTeamWithMembers`

## Test plan
- [ ] Open Settings → Members — list is now A→Z by name
- [ ] Open Settings → Teams → team detail — members sorted A→Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)