### PR TITLE
fix(ci): use synchronous ClickHouse insert for fold projection state

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
@@ -246,7 +246,6 @@ export class ExperimentRunStateRepositoryClickHouse<
         table: TABLE_NAME,
         values: [projectionRecord],
         format: "JSONEachRow",
-        clickhouse_settings: { async_insert: 1, wait_for_async_insert: 1 },
       });
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- Removes async_insert / wait_for_async_insert ClickHouse settings from the fold projection state insert in ExperimentRunStateRepositoryClickHouse, reverting to synchronous (default) inserts
- Fixes flaky integration test failures where async inserts had not flushed before the test read back the projection state

## Test plan
- [x] CI test-integration passes (previously flaky)
- [x] All other CI checks green

Generated with [Claude Code](https://claude.com/claude-code)