### PR TITLE
feat(dashboards): add REST API for dashboard CRUD

### DIFF
--- a/langwatch/src/app/api/dashboards/[[...route]]/app.ts
+++ b/langwatch/src/app/api/dashboards/[[...route]]/app.ts
@@ -1,0 +1,236 @@
+import { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import { validator as zValidator } from "hono-openapi/zod";
+import { z } from "zod";
+import { patchZodOpenapi } from "../../../../utils/extend-zod-openapi";
+import {
+  type AuthMiddlewareVariables,
+  authMiddleware,
+  resourceLimitMiddleware,
+} from "../../middleware";
+import {
+  type DashboardServiceMiddlewareVariables,
+  dashboardServiceMiddleware,
+} from "../../middleware/dashboard-service";
+import { loggerMiddleware } from "../../middleware/logger";
+import { tracerMiddleware } from "../../middleware/tracer";
+import { BadRequestError, NotFoundError } from "../../shared/errors";
+import { handleDashboardError } from "./error-handler";
+
+patchZodOpenapi();
+
+type Variables = AuthMiddlewareVariables & DashboardServiceMiddlewareVariables;
+
+// -- Validation schemas --
+
+const createDashboardSchema = z.object({
+  name: z.string().min(1, "name is required").max(255),
+});
+
+const renameDashboardSchema = z.object({
+  name: z.string().min(1, "name is required").max(255),
+});
+
+const reorderDashboardsSchema = z.object({
+  dashboardIds: z
+    .array(z.string().min(1))
+    .min(1, "dashboardIds must not be empty"),
+});
+
+function validationHook(
+  result: {
+    success: boolean;
+    error?: {
+      issues: Array<{ message?: string; path?: (string | number)[] }>;
+    };
+  },
+  c: { json: (body: unknown, status: number) => Response },
+): Response | undefined {
+  if (!result.success) {
+    const issue = result.error?.issues?.[0];
+    return c.json(
+      {
+        error: "Unprocessable Entity",
+        message: issue?.message ?? "Validation failed",
+        path: issue?.path,
+      },
+      422,
+    );
+  }
+  return undefined;
+}
+
+function mapDashboardNotFoundError(error: unknown): never {
+  if (error instanceof Error && error.name === "DashboardNotFoundError") {
+    throw new NotFoundError("Dashboard not found");
+  }
+  throw error;
+}
+
+function mapDashboardReorderError(error: unknown): never {
+  if (error instanceof Error && error.name === "DashboardReorderError") {
+    throw new BadRequestError(error.message);
+  }
+  throw error;
+}
+
+export const app = new Hono<{ Variables: Variables }>()
+  .basePath("/api/dashboards")
+  .use(tracerMiddleware({ name: "dashboards" }))
+  .use(loggerMiddleware())
+  .use(authMiddleware)
+  .use(dashboardServiceMiddleware)
+  .onError(handleDashboardError)
+
+  // ── List Dashboards ───────────────────────────────────────────
+  .get(
+    "/",
+    describeRoute({
+      description: "List all dashboards for the project with graph counts",
+    }),
+    async (c) => {
+      const project = c.get("project");
+      const service = c.get("dashboardService");
+
+      const dashboards = await service.getAll(project.id);
+
+      return c.json({
+        data: dashboards.map((d) => ({
+          id: d.id,
+          name: d.name,
+          order: d.order,
+          graphCount: d._count.graphs,
+          createdAt: d.createdAt,
+          updatedAt: d.updatedAt,
+        })),
+      });
+    },
+  )
+
+  // ── Create Dashboard ──────────────────────────────────────────
+  .post(
+    "/",
+    describeRoute({
+      description: "Create a new dashboard",
+    }),
+    resourceLimitMiddleware("dashboards"),
+    zValidator("json", createDashboardSchema, validationHook),
+    async (c) => {
+      const project = c.get("project");
+      const { name } = c.req.valid("json");
+      const service = c.get("dashboardService");
+
+      const dashboard = await service.create(project.id, name);
+
+      return c.json(
+        {
+          id: dashboard.id,
+          name: dashboard.name,
+          order: dashboard.order,
+          createdAt: dashboard.createdAt,
+          updatedAt: dashboard.updatedAt,
+        },
+        201,
+      );
+    },
+  )
+
+  // ── Reorder Dashboards ────────────────────────────────────────
+  // Placed before /:id to avoid route conflict with "reorder" being treated as an id
+  .put(
+    "/reorder",
+    describeRoute({
+      description: "Reorder dashboards by providing an ordered list of IDs",
+    }),
+    zValidator("json", reorderDashboardsSchema, validationHook),
+    async (c) => {
+      const project = c.get("project");
+      const { dashboardIds } = c.req.valid("json");
+      const service = c.get("dashboardService");
+
+      try {
+        const result = await service.reorder(project.id, dashboardIds);
+        return c.json(result);
+      } catch (error) {
+        mapDashboardReorderError(error);
+      }
+    },
+  )
+
+  // ── Get Single Dashboard ──────────────────────────────────────
+  .get(
+    "/:id",
+    describeRoute({
+      description: "Get a dashboard by its id, including its graphs",
+    }),
+    async (c) => {
+      const { id } = c.req.param();
+      const project = c.get("project");
+      const service = c.get("dashboardService");
+
+      try {
+        const dashboard = await service.getById(project.id, id);
+        return c.json({
+          id: dashboard.id,
+          name: dashboard.name,
+          order: dashboard.order,
+          graphs: dashboard.graphs,
+          createdAt: dashboard.createdAt,
+          updatedAt: dashboard.updatedAt,
+        });
+      } catch (error) {
+        return mapDashboardNotFoundError(error);
+      }
+    },
+  )
+
+  // ── Rename Dashboard ──────────────────────────────────────────
+  .patch(
+    "/:id",
+    describeRoute({
+      description: "Rename a dashboard",
+    }),
+    zValidator("json", renameDashboardSchema, validationHook),
+    async (c) => {
+      const { id } = c.req.param();
+      const project = c.get("project");
+      const { name } = c.req.valid("json");
+      const service = c.get("dashboardService");
+
+      try {
+        const dashboard = await service.rename(project.id, id, name);
+        return c.json({
+          id: dashboard.id,
+          name: dashboard.name,
+          order: dashboard.order,
+          createdAt: dashboard.createdAt,
+          updatedAt: dashboard.updatedAt,
+        });
+      } catch (error) {
+        return mapDashboardNotFoundError(error);
+      }
+    },
+  )
+
+  // ── Delete Dashboard ──────────────────────────────────────────
+  .delete(
+    "/:id",
+    describeRoute({
+      description: "Delete a dashboard and its graphs (hard delete, cascade)",
+    }),
+    async (c) => {
+      const { id } = c.req.param();
+      const project = c.get("project");
+      const service = c.get("dashboardService");
+
+      try {
+        const dashboard = await service.delete(project.id, id);
+        return c.json({
+          id: dashboard.id,
+          name: dashboard.name,
+        });
+      } catch (error) {
+        return mapDashboardNotFoundError(error);
+      }
+    },
+  );

--- a/langwatch/src/app/api/dashboards/[[...route]]/error-handler.ts
+++ b/langwatch/src/app/api/dashboards/[[...route]]/error-handler.ts
@@ -1,0 +1,40 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { createLogger } from "../../../../utils/logger/server";
+import { HttpError, InternalServerError } from "../../shared/errors";
+import { errorSchema } from "../../shared/schemas";
+
+const logger = createLogger("langwatch:api:dashboards:errors");
+
+export const handleDashboardError = async (
+  error: Error & { status?: ContentfulStatusCode },
+  c: Context,
+): Promise<Response> => {
+  const path = c.req.path;
+  const method = c.req.method;
+  const routeParams = c.req.param();
+  const status =
+    error instanceof HttpError ? error.status : (error.status ?? 500);
+
+  logger.error(
+    {
+      path,
+      method,
+      routeParams,
+      status,
+      error: {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      },
+    },
+    `Dashboard API Error [${status}]: ${error.message || String(error)}`,
+  );
+
+  if (error instanceof HttpError) {
+    return c.json(errorSchema.parse(error), error.status);
+  }
+
+  const internalError = new InternalServerError();
+  return c.json(errorSchema.parse(internalError), internalError.status);
+};

--- a/langwatch/src/app/api/dashboards/[[...route]]/route.ts
+++ b/langwatch/src/app/api/dashboards/[[...route]]/route.ts
@@ -1,0 +1,8 @@
+import { handle } from "hono/vercel";
+import { app } from "./app";
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const PUT = handle(app);
+export const DELETE = handle(app);

--- a/langwatch/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
@@ -1,0 +1,408 @@
+import type { Organization, Project, Team } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { projectFactory } from "~/factories/project.factory";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import {
+  PlanProviderService,
+  type PlanProvider,
+} from "~/server/app-layer/subscription/plan-provider";
+import { prisma } from "~/server/db";
+import { FREE_PLAN } from "../../../../../ee/licensing/constants";
+import { app } from "../[[...route]]/app";
+
+describe("Feature: Dashboard REST API", () => {
+  let testApiKey: string;
+  let testProjectId: string;
+  let testOrganization: Organization;
+  let testTeam: Team;
+  let testProject: Project;
+  let mockGetActivePlan: ReturnType<typeof vi.fn>;
+  let helpers: {
+    api: {
+      get: (path: string) => Response | Promise<Response>;
+      post: (path: string, body: unknown) => Response | Promise<Response>;
+      patch: (path: string, body: unknown) => Response | Promise<Response>;
+      put: (path: string, body: unknown) => Response | Promise<Response>;
+      delete: (path: string) => Response | Promise<Response>;
+    };
+  };
+
+  const createAuthHeaders = (apiKey: string) => ({
+    "X-Auth-Token": apiKey,
+    "Content-Type": "application/json",
+  });
+
+  beforeEach(async () => {
+    resetApp();
+    mockGetActivePlan = vi.fn().mockResolvedValue(FREE_PLAN);
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
+      }),
+      usageLimits: {
+        notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
+        checkAndSendWarning: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    });
+
+    testOrganization = await prisma.organization.create({
+      data: {
+        name: "Test Organization",
+        slug: `test-org-${nanoid()}`,
+      },
+    });
+
+    testTeam = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `test-team-${nanoid()}`,
+        organizationId: testOrganization.id,
+      },
+    });
+
+    testProject = projectFactory.build({ slug: nanoid() });
+    testProject = await prisma.project.create({
+      data: {
+        ...testProject,
+        teamId: testTeam.id,
+      },
+    });
+
+    testApiKey = testProject.apiKey;
+    testProjectId = testProject.id;
+
+    helpers = {
+      api: {
+        get: (path: string) =>
+          app.request(path, { headers: { "X-Auth-Token": testApiKey } }),
+        post: (path: string, body: unknown) =>
+          app.request(path, {
+            method: "POST",
+            headers: createAuthHeaders(testApiKey),
+            body: JSON.stringify(body),
+          }),
+        patch: (path: string, body: unknown) =>
+          app.request(path, {
+            method: "PATCH",
+            headers: createAuthHeaders(testApiKey),
+            body: JSON.stringify(body),
+          }),
+        put: (path: string, body: unknown) =>
+          app.request(path, {
+            method: "PUT",
+            headers: createAuthHeaders(testApiKey),
+            body: JSON.stringify(body),
+          }),
+        delete: (path: string) =>
+          app.request(path, {
+            method: "DELETE",
+            headers: { "X-Auth-Token": testApiKey },
+          }),
+      },
+    };
+  });
+
+  afterEach(async () => {
+    if (!testProjectId) return;
+
+    await prisma.customGraph.deleteMany({
+      where: { projectId: testProjectId },
+    });
+    await prisma.dashboard.deleteMany({
+      where: { projectId: testProjectId },
+    });
+    await prisma.project.delete({
+      where: { id: testProjectId },
+    });
+    await prisma.team.delete({
+      where: { id: testTeam.id },
+    });
+    await prisma.organization.delete({
+      where: { id: testOrganization.id },
+    });
+    resetApp();
+  });
+
+  async function createDashboard(overrides: {
+    name: string;
+    order?: number;
+    id?: string;
+  }) {
+    return await prisma.dashboard.create({
+      data: {
+        id: overrides.id ?? nanoid(),
+        name: overrides.name,
+        projectId: testProjectId,
+        order: overrides.order ?? 0,
+      },
+    });
+  }
+
+  async function createGraph(dashboardId: string, overrides?: { gridRow?: number; gridColumn?: number }) {
+    return await prisma.customGraph.create({
+      data: {
+        id: nanoid(),
+        projectId: testProjectId,
+        dashboardId,
+        name: `Graph ${nanoid(6)}`,
+        graph: {},
+        gridRow: overrides?.gridRow ?? 0,
+        gridColumn: overrides?.gridColumn ?? 0,
+      },
+    });
+  }
+
+  // ── Authentication ─────────────────────────────────────────────
+
+  describe("Authentication", () => {
+    it("returns 401 without X-Auth-Token header", async () => {
+      const res = await app.request("/api/dashboards");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 with invalid X-Auth-Token", async () => {
+      const res = await app.request("/api/dashboards", {
+        headers: { "X-Auth-Token": "invalid-key-xyz" },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── List Dashboards ──────────────────────────────────────────
+
+  describe("GET /api/dashboards", () => {
+    describe("when the project has dashboards", () => {
+      beforeEach(async () => {
+        const d1 = await createDashboard({ name: "Dashboard A", order: 0 });
+        const d2 = await createDashboard({ name: "Dashboard B", order: 1 });
+        await createGraph(d1.id);
+        await createGraph(d1.id);
+        await createGraph(d2.id);
+      });
+
+      it("returns all dashboards ordered by position with graph counts", async () => {
+        const res = await helpers.api.get("/api/dashboards");
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.data).toHaveLength(2);
+        expect(body.data[0].name).toBe("Dashboard A");
+        expect(body.data[0].graphCount).toBe(2);
+        expect(body.data[1].name).toBe("Dashboard B");
+        expect(body.data[1].graphCount).toBe(1);
+      });
+
+      it("includes id, name, order, graphCount, createdAt, and updatedAt", async () => {
+        const res = await helpers.api.get("/api/dashboards");
+        const body = await res.json();
+
+        for (const dashboard of body.data) {
+          expect(dashboard).toHaveProperty("id");
+          expect(dashboard).toHaveProperty("name");
+          expect(dashboard).toHaveProperty("order");
+          expect(dashboard).toHaveProperty("graphCount");
+          expect(dashboard).toHaveProperty("createdAt");
+          expect(dashboard).toHaveProperty("updatedAt");
+        }
+      });
+    });
+
+    describe("when the project has no dashboards", () => {
+      it("returns empty data array", async () => {
+        const res = await helpers.api.get("/api/dashboards");
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.data).toHaveLength(0);
+      });
+    });
+  });
+
+  // ── Create Dashboard ─────────────────────────────────────────
+
+  describe("POST /api/dashboards", () => {
+    it("creates a dashboard and returns 201", async () => {
+      const res = await helpers.api.post("/api/dashboards", {
+        name: "My Dashboard",
+      });
+      expect(res.status).toBe(201);
+
+      const body = await res.json();
+      expect(body.id).toBeDefined();
+      expect(body.name).toBe("My Dashboard");
+      expect(body.order).toBe(0);
+      expect(body.createdAt).toBeDefined();
+    });
+
+    it("auto-increments order for subsequent dashboards", async () => {
+      await createDashboard({ name: "Existing", order: 2 });
+
+      const res = await helpers.api.post("/api/dashboards", {
+        name: "New Dashboard",
+      });
+      const body = await res.json();
+      expect(body.order).toBe(3);
+    });
+
+    it("returns 422 when name is missing", async () => {
+      const res = await helpers.api.post("/api/dashboards", {});
+      expect(res.status).toBe(422);
+    });
+
+    it("returns 422 when name is empty string", async () => {
+      const res = await helpers.api.post("/api/dashboards", { name: "" });
+      expect(res.status).toBe(422);
+    });
+
+    describe("when the project has reached its dashboard plan limit", () => {
+      beforeEach(async () => {
+        await createDashboard({ name: "Existing Dashboard" });
+        mockGetActivePlan.mockResolvedValue({
+          ...FREE_PLAN,
+          maxDashboards: 1,
+          overrideAddingLimitations: false,
+        });
+      });
+
+      it("returns 403 Forbidden", async () => {
+        const res = await helpers.api.post("/api/dashboards", {
+          name: "Over Limit",
+        });
+        expect(res.status).toBe(403);
+      });
+    });
+  });
+
+  // ── Get Single Dashboard ─────────────────────────────────────
+
+  describe("GET /api/dashboards/:id", () => {
+    it("returns dashboard with its graphs ordered by grid position", async () => {
+      const dashboard = await createDashboard({ name: "Detail Dashboard" });
+      await createGraph(dashboard.id, { gridRow: 1, gridColumn: 0 });
+      await createGraph(dashboard.id, { gridRow: 0, gridColumn: 1 });
+      await createGraph(dashboard.id, { gridRow: 0, gridColumn: 0 });
+
+      const res = await helpers.api.get(`/api/dashboards/${dashboard.id}`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.id).toBe(dashboard.id);
+      expect(body.name).toBe("Detail Dashboard");
+      expect(body.graphs).toHaveLength(3);
+      // Ordered by gridRow asc, gridColumn asc
+      expect(body.graphs[0].gridRow).toBe(0);
+      expect(body.graphs[0].gridColumn).toBe(0);
+      expect(body.graphs[1].gridRow).toBe(0);
+      expect(body.graphs[1].gridColumn).toBe(1);
+      expect(body.graphs[2].gridRow).toBe(1);
+    });
+
+    it("returns 404 for non-existent dashboard", async () => {
+      const res = await helpers.api.get("/api/dashboards/nonexistent-id");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ── Rename Dashboard ─────────────────────────────────────────
+
+  describe("PATCH /api/dashboards/:id", () => {
+    it("renames the dashboard", async () => {
+      const dashboard = await createDashboard({ name: "Original Name" });
+
+      const res = await helpers.api.patch(
+        `/api/dashboards/${dashboard.id}`,
+        { name: "Updated Name" },
+      );
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.name).toBe("Updated Name");
+    });
+
+    it("returns 404 for non-existent dashboard", async () => {
+      const res = await helpers.api.patch("/api/dashboards/nonexistent-id", {
+        name: "Whatever",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 422 when name is empty", async () => {
+      const dashboard = await createDashboard({ name: "Test" });
+
+      const res = await helpers.api.patch(
+        `/api/dashboards/${dashboard.id}`,
+        { name: "" },
+      );
+      expect(res.status).toBe(422);
+    });
+  });
+
+  // ── Delete Dashboard ─────────────────────────────────────────
+
+  describe("DELETE /api/dashboards/:id", () => {
+    it("deletes the dashboard and cascades to graphs", async () => {
+      const dashboard = await createDashboard({ name: "To Delete" });
+      await createGraph(dashboard.id);
+      await createGraph(dashboard.id);
+
+      const res = await helpers.api.delete(`/api/dashboards/${dashboard.id}`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.id).toBe(dashboard.id);
+      expect(body.name).toBe("To Delete");
+
+      // Verify it's gone
+      const getRes = await helpers.api.get(`/api/dashboards/${dashboard.id}`);
+      expect(getRes.status).toBe(404);
+    });
+
+    it("returns 404 for non-existent dashboard", async () => {
+      const res = await helpers.api.delete("/api/dashboards/nonexistent-id");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ── Reorder Dashboards ───────────────────────────────────────
+
+  describe("PUT /api/dashboards/reorder", () => {
+    it("reorders dashboards according to the provided ID order", async () => {
+      const d1 = await createDashboard({ name: "First", order: 0 });
+      const d2 = await createDashboard({ name: "Second", order: 1 });
+      const d3 = await createDashboard({ name: "Third", order: 2 });
+
+      const res = await helpers.api.put("/api/dashboards/reorder", {
+        dashboardIds: [d3.id, d1.id, d2.id],
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.success).toBe(true);
+
+      // Verify new order via list
+      const listRes = await helpers.api.get("/api/dashboards");
+      const listBody = await listRes.json();
+      expect(listBody.data[0].name).toBe("Third");
+      expect(listBody.data[1].name).toBe("First");
+      expect(listBody.data[2].name).toBe("Second");
+    });
+
+    it("returns 400 when dashboardIds references non-existent dashboards", async () => {
+      const d1 = await createDashboard({ name: "Existing", order: 0 });
+
+      const res = await helpers.api.put("/api/dashboards/reorder", {
+        dashboardIds: [d1.id, "nonexistent-id"],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 422 when dashboardIds is empty", async () => {
+      const res = await helpers.api.put("/api/dashboards/reorder", {
+        dashboardIds: [],
+      });
+      expect(res.status).toBe(422);
+    });
+  });
+});

--- a/langwatch/src/app/api/middleware/dashboard-service.ts
+++ b/langwatch/src/app/api/middleware/dashboard-service.ts
@@ -1,0 +1,16 @@
+import type { MiddlewareHandler } from "hono";
+
+import { prisma } from "~/server/db";
+import { DashboardService } from "~/server/dashboards/dashboard.service";
+
+export type DashboardServiceMiddlewareVariables = {
+  dashboardService: DashboardService;
+};
+
+export const dashboardServiceMiddleware: MiddlewareHandler = async (
+  c,
+  next,
+) => {
+  c.set("dashboardService", DashboardService.create(prisma));
+  await next();
+};

--- a/specs/analytics/dashboard-rest-api.feature
+++ b/specs/analytics/dashboard-rest-api.feature
@@ -1,0 +1,50 @@
+Feature: Dashboard REST API
+  External tools and AI agents can manage dashboards programmatically
+  via a REST API authenticated with project API keys.
+
+  Background:
+    Given I have a valid API key for a project
+
+  Scenario: List dashboards
+    Given the project has dashboards
+    When I call GET /api/dashboards
+    Then I receive all dashboards for the project ordered by position
+    And each dashboard includes its graph count
+
+  Scenario: Get a dashboard
+    Given the project has a dashboard with graphs
+    When I call GET /api/dashboards/:id
+    Then I receive the dashboard with its graphs ordered by grid position
+
+  Scenario: Create a dashboard
+    When I call POST /api/dashboards with a name
+    Then a new dashboard is created with auto-incremented order
+    And I receive 201 Created
+
+  Scenario: Rename a dashboard
+    Given the project has a dashboard
+    When I call PATCH /api/dashboards/:id with a new name
+    Then the dashboard is renamed
+
+  Scenario: Delete a dashboard
+    Given the project has a dashboard with graphs
+    When I call DELETE /api/dashboards/:id
+    Then the dashboard and its graphs are deleted
+
+  Scenario: Reorder dashboards
+    Given the project has multiple dashboards
+    When I call PUT /api/dashboards/reorder with an ordered list of IDs
+    Then the dashboards are reordered accordingly
+
+  Scenario: Plan limit enforcement on create
+    Given the project has reached its dashboard limit
+    When I call POST /api/dashboards
+    Then I receive 403 Forbidden
+
+  Scenario: Dashboard not found
+    When I call GET /api/dashboards/:id with a non-existent ID
+    Then I receive 404 Not Found
+
+  Scenario: Unauthenticated request
+    When I call GET /api/dashboards without an API key
+    Then I receive 401 Unauthorized


### PR DESCRIPTION
## Summary
- Add 6 REST API endpoints for dashboard CRUD operations (`GET`, `POST`, `PATCH`, `DELETE`, `PUT /reorder`) following the established agents/datasets Hono patterns
- Reuse existing `DashboardService` and `DashboardRepository` — no new business logic, just a thin HTTP layer
- Include plan limit enforcement on create (403), proper error mapping (404/400/422), and `dashboardServiceMiddleware`

## Files
| File | Purpose |
|------|---------|
| `langwatch/src/app/api/dashboards/[[...route]]/app.ts` | Hono routes (6 endpoints) |
| `langwatch/src/app/api/dashboards/[[...route]]/route.ts` | Next.js handler |
| `langwatch/src/app/api/dashboards/[[...route]]/error-handler.ts` | Domain error → HTTP error mapping |
| `langwatch/src/app/api/middleware/dashboard-service.ts` | Service middleware (DI) |
| `langwatch/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts` | 20 integration tests |
| `specs/analytics/dashboard-rest-api.feature` | BDD feature spec |

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/dashboards` | List dashboards (with graph counts) |
| `POST` | `/api/dashboards` | Create dashboard (plan limit enforced) |
| `GET` | `/api/dashboards/:id` | Get dashboard with graphs |
| `PATCH` | `/api/dashboards/:id` | Rename dashboard |
| `DELETE` | `/api/dashboards/:id` | Delete dashboard (cascade to graphs) |
| `PUT` | `/api/dashboards/reorder` | Reorder dashboards |

## Test plan
- [x] All 20 integration tests pass (`pnpm test:integration`)
- [x] Typecheck passes (`pnpm typecheck`)
- [ ] CI green

Closes #3136

# Related Issue

- Resolve #3136