### PR TITLE
fix: use pnpm -w flags in compose.dev.yml for pnpm v10 compat

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -131,8 +131,8 @@ services:
         pnpm config set store-dir /root/.local/share/pnpm/store &&
         mkdir -p /app/node_modules &&
         (cd /mcp-server && pnpm install --ignore-scripts && pnpm run build) &&
-        pnpm install &&
-        pnpm prisma generate &&
+        pnpm -w install &&
+        pnpm -w exec prisma generate &&
         pnpm run types:zod:generate
       "
     environment:
@@ -155,7 +155,7 @@ services:
     command: >
       sh -c "
         corepack enable &&
-        pnpm prisma generate &&
+        pnpm -w exec prisma generate &&
         pnpm run types:zod:generate &&
         SKIP_CLICKHOUSE_MIGRATE=true SKIP_ELASTIC_MIGRATE=true pnpm run start:prepare:db &&
         pnpm run start:app
@@ -204,7 +204,7 @@ services:
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - app_modules:/app/node_modules
-    command: sh -c "corepack enable && while true; do pnpm tsx --tsconfig tsconfig.workers.json src/workers.ts; sleep 1; done"
+    command: sh -c "corepack enable && while true; do pnpm -w exec tsx --tsconfig tsconfig.workers.json src/workers.ts; sleep 1; done"
     environment:
       <<: *common-env
       # Override BASE_HOST for Docker networking - scenario child processes post events here
@@ -292,7 +292,7 @@ services:
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - app_modules:/app/node_modules
-    command: sh -c "corepack enable && pnpm tsx scripts/ai-server.ts"
+    command: sh -c "corepack enable && pnpm -w exec tsx scripts/ai-server.ts"
     ports:
       - "${AI_SERVER_PORT:-3456}:3456"
     environment:


### PR DESCRIPTION
## Summary

- Fixes `pnpm install` producing empty `node_modules` in the init container by using `pnpm -w install`
- Fixes `pnpm <binary>` (prisma, tsx) being interpreted as recursive exec by using `pnpm -w exec`
- Applied to all containers: init, app, workers, ai-server

Closes #3140

## Test plan

- [ ] `make quickstart` (option 1) completes without init container errors
- [ ] `make dev` starts app successfully with populated `node_modules`
- [ ] `make dev-scenarios` starts workers and ai-server without "Command not found" errors

# Related Issue

- Resolve #3140