### PR TITLE
fix(auth): fix account_not_linked infinite redirect loop

### DIFF
--- a/langwatch/src/pages/auth/error.tsx
+++ b/langwatch/src/pages/auth/error.tsx
@@ -34,7 +34,11 @@ export const normalizeErrorCode = (
   ) {
     return "DIFFERENT_EMAIL_NOT_ALLOWED";
   }
-  if (error === "account_already_linked_to_different_user") {
+  if (
+    error === "account_already_linked_to_different_user" ||
+    error === "account_not_linked" ||
+    error === "OAuthAccountNotLinked"
+  ) {
     return "OAuthAccountNotLinked";
   }
   return error;
@@ -116,20 +120,26 @@ export function SignInError({ error: rawError }: { error: string }) {
           >
             <Alert.Indicator />
             <Alert.Content gap={4}>
-              <Alert.Title fontWeight="bold">{error}</Alert.Title>
+              <Alert.Title fontWeight="bold">
+                {error === "OAuthAccountNotLinked"
+                  ? "Account already exists"
+                  : error}
+              </Alert.Title>
               {error === "OAuthAccountNotLinked" ? (
                 <Alert.Description>
                   <VStack gap={1} align="start">
                     <Text>
-                      It might be that an account using this email already
-                      exists but it&apos;s not linked with this authentication
-                      method. <br />
-                      Please sign in with email/password or the other provider
-                      you used before and go to the <b>Settings</b> page to link
-                      this one.
+                      An account with this email already exists but was created
+                      with a different sign-in method (e.g. Google, GitHub).
+                      <br />
+                      <br />
+                      To link this method, sign in with the method you used
+                      originally, then go to{" "}
+                      <b>Settings &gt; Authentication</b> to link additional
+                      sign-in methods.
                     </Text>
                     <Button asChild marginTop={4} color="white">
-                      <Link href="/settings/authentication">
+                      <Link href="/auth/signin">
                         Sign in with another method
                       </Link>
                     </Button>

--- a/langwatch/src/pages/auth/signin.tsx
+++ b/langwatch/src/pages/auth/signin.tsx
@@ -23,11 +23,14 @@ import { HorizontalFormControl } from "../../components/HorizontalFormControl";
 import { LogoIcon } from "../../components/icons/LogoIcon";
 import { toaster } from "../../components/ui/toaster";
 import { usePublicEnv } from "../../hooks/usePublicEnv";
-import { SignInError } from "./error";
+import { normalizeErrorCode, SignInError } from "./error";
 
 export default function SignIn({ session }: { session: Session | null }) {
   const query = useSearchParams();
-  const error = query?.get("error");
+  const rawError = query?.get("error");
+  // Normalize BetterAuth error codes so the auto-redirect gate works.
+  // e.g. "account_already_linked_to_different_user" → "OAuthAccountNotLinked"
+  const error = normalizeErrorCode(rawError);
 
   const publicEnv = usePublicEnv();
   const isAuthProvider = publicEnv.data?.NEXTAUTH_PROVIDER;


### PR DESCRIPTION
## Summary

When a user signs in via Google, logs out, then tries to sign up via email/password on Auth0, they get an `account_not_linked` error that causes an infinite redirect loop. The error page briefly shows then auto-redirects back to Auth0.

### Root cause
`normalizeErrorCode` only handled `account_already_linked_to_different_user` (BetterAuth's code), but Auth0 sends `account_not_linked`. The error wasn't recognized, so:
- `signin.tsx` auto-redirect gate didn't catch it → redirect loop
- `error.tsx` redirect guard didn't catch it → auto-redirect away from error page

### Fix
- Added `account_not_linked` to `normalizeErrorCode` (all three variants now map to `OAuthAccountNotLinked`)
- `signin.tsx` now calls `normalizeErrorCode` before the auto-redirect gate
- Improved error page: "Account already exists" title with clear instructions

## QA Evidence
Tested end-to-end via real Auth0 flow in Chrome:
1. Signed in with Google (rogeriocfj@gmail.com)
2. Logged out via federated Auth0 logout
3. Signed up with same email via Auth0 database connection
4. Error page shows "Account already exists" — no redirect loop
5. Signin page with error param stays stable for 10+ seconds

### Error page screenshot
![Account already exists error page](https://i.img402.dev/7t6btjcep5.png)

## Test plan
- [x] `/auth/error?error=account_not_linked` → shows "Account already exists" page, no redirect
- [x] `/auth/signin?error=account_not_linked` → shows error, no auto-redirect to Auth0
- [x] `/auth/error?error=account_already_linked_to_different_user` → same behavior
- [x] Real Auth0 flow: Google sign-in → logout → email sign-up → error page renders correctly