### PR TITLE
fix: exclude synthetic spans from trace timing calculation

### DIFF
--- a/langwatch/src/pages/api/track_event.ts
+++ b/langwatch/src/pages/api/track_event.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { type ZodError, z } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { getApp } from "~/server/app-layer/app";
+import { TRACK_EVENT_SPAN_NAME } from "~/server/tracer/constants";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { normalizeHeaderValue } from "~/utils/headers";
 import { captureException } from "~/utils/posthogErrorCapture";
@@ -168,7 +169,7 @@ export default async function handler(
         spanId: spanId,
         traceState: null,
         parentSpanId: null,
-        name: "langwatch.track_event",
+        name: TRACK_EVENT_SPAN_NAME,
         kind: ESpanKind.SPAN_KIND_INTERNAL,
         startTimeUnixNano: timestampNano,
         endTimeUnixNano: timestampNano,
@@ -192,7 +193,7 @@ export default async function handler(
         attributes: [],
       },
       instrumentationScope: {
-        name: "langwatch.track_event",
+        name: TRACK_EVENT_SPAN_NAME,
       },
       piiRedactionLevel: project.piiRedactionLevel,
       occurredAt: Date.now(),

--- a/langwatch/src/server/background/workers/collector/metrics.test.ts
+++ b/langwatch/src/server/background/workers/collector/metrics.test.ts
@@ -260,11 +260,11 @@ describe("Trace metrics", () => {
         expect(metrics!.total_time_ms).toBe(1600);
       });
 
-      it("still counts tokens from synthetic spans", () => {
+      it("excludes synthetic span from token calculation", () => {
         const metrics = computeTraceMetrics(spans);
 
-        expect(metrics!.prompt_tokens).toBe(110);
-        expect(metrics!.completion_tokens).toBe(55);
+        expect(metrics!.prompt_tokens).toBe(100);
+        expect(metrics!.completion_tokens).toBe(50);
       });
     });
 

--- a/langwatch/src/server/background/workers/collector/metrics.test.ts
+++ b/langwatch/src/server/background/workers/collector/metrics.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TRACK_EVENT_SPAN_NAME } from "../../../tracer/constants";
 import type { Span } from "../../../tracer/types";
 import {
   addGuardrailCosts,
@@ -221,7 +222,7 @@ describe("Trace metrics", () => {
       expect(metrics!.total_cost).toBe(0.0001);
     });
 
-    it("excludes langwatch.track_event spans from timing calculation", () => {
+    describe("when a langwatch.track_event span is present", () => {
       const spans: Span[] = [
         {
           trace_id: "trace_1",
@@ -232,23 +233,39 @@ describe("Trace metrics", () => {
             started_at: 1000,
             finished_at: 2600,
           },
+          metrics: {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+          },
         },
         {
           trace_id: "trace_1",
           span_id: "span_2",
           type: "span",
-          name: "langwatch.track_event",
+          name: TRACK_EVENT_SPAN_NAME,
           timestamps: {
             started_at: 19000,
             finished_at: 19000,
           },
+          metrics: {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+          },
         },
       ];
 
-      const metrics = computeTraceMetrics(spans);
+      it("excludes synthetic span from timing calculation", () => {
+        const metrics = computeTraceMetrics(spans);
 
-      expect(metrics!.total_time_ms).toBe(1600);
-      expect(metrics!.first_token_ms).toBeNull();
+        expect(metrics!.total_time_ms).toBe(1600);
+      });
+
+      it("still counts tokens from synthetic spans", () => {
+        const metrics = computeTraceMetrics(spans);
+
+        expect(metrics!.prompt_tokens).toBe(110);
+        expect(metrics!.completion_tokens).toBe(55);
+      });
     });
 
     it("should set tokens_estimated to true when any span has tokens_estimated", () => {

--- a/langwatch/src/server/background/workers/collector/metrics.test.ts
+++ b/langwatch/src/server/background/workers/collector/metrics.test.ts
@@ -221,6 +221,36 @@ describe("Trace metrics", () => {
       expect(metrics!.total_cost).toBe(0.0001);
     });
 
+    it("excludes langwatch.track_event spans from timing calculation", () => {
+      const spans: Span[] = [
+        {
+          trace_id: "trace_1",
+          span_id: "span_1",
+          type: "span",
+          name: "agent-chat",
+          timestamps: {
+            started_at: 1000,
+            finished_at: 2600,
+          },
+        },
+        {
+          trace_id: "trace_1",
+          span_id: "span_2",
+          type: "span",
+          name: "langwatch.track_event",
+          timestamps: {
+            started_at: 19000,
+            finished_at: 19000,
+          },
+        },
+      ];
+
+      const metrics = computeTraceMetrics(spans);
+
+      expect(metrics!.total_time_ms).toBe(1600);
+      expect(metrics!.first_token_ms).toBeNull();
+    });
+
     it("should set tokens_estimated to true when any span has tokens_estimated", () => {
       const spans: Span[] = [
         {

--- a/langwatch/src/server/background/workers/collector/metrics.ts
+++ b/langwatch/src/server/background/workers/collector/metrics.ts
@@ -29,18 +29,18 @@ export const computeTraceMetrics = (spans: Span[]): Trace["metrics"] => {
   let totalCost: number | null = null;
 
   (spans ?? []).forEach((span) => {
-    const isSynthetic = span.name != null && SYNTHETIC_SPAN_NAMES.has(span.name);
+    if (span.name != null && SYNTHETIC_SPAN_NAMES.has(span.name)) {
+      return;
+    }
 
     if (
-      !isSynthetic &&
-      (earliestStartedAt === null ||
-        span.timestamps.started_at < earliestStartedAt)
+      earliestStartedAt === null ||
+      span.timestamps.started_at < earliestStartedAt
     ) {
       earliestStartedAt = span.timestamps.started_at;
     }
 
     if (
-      !isSynthetic &&
       span.timestamps.first_token_at &&
       (latestFirstTokenAt === null ||
         span.timestamps.first_token_at > latestFirstTokenAt)
@@ -49,9 +49,8 @@ export const computeTraceMetrics = (spans: Span[]): Trace["metrics"] => {
     }
 
     if (
-      !isSynthetic &&
-      (latestFinishedAt === null ||
-        span.timestamps.finished_at > latestFinishedAt)
+      latestFinishedAt === null ||
+      span.timestamps.finished_at > latestFinishedAt
     ) {
       latestFinishedAt = span.timestamps.finished_at;
     }

--- a/langwatch/src/server/background/workers/collector/metrics.ts
+++ b/langwatch/src/server/background/workers/collector/metrics.ts
@@ -13,6 +13,9 @@ import {
 
 const logger = createLogger("langwatch:workers:collector:metrics");
 
+/** Span names that represent synthetic events, not real execution, and must be excluded from timing. */
+const SYNTHETIC_SPAN_NAMES = new Set(["langwatch.track_event"]);
+
 // TODO: test
 export const computeTraceMetrics = (spans: Span[]): Trace["metrics"] => {
   let earliestStartedAt: number | null = null;
@@ -28,14 +31,18 @@ export const computeTraceMetrics = (spans: Span[]): Trace["metrics"] => {
   let totalCost: number | null = null;
 
   (spans ?? []).forEach((span) => {
+    const isSynthetic = span.name != null && SYNTHETIC_SPAN_NAMES.has(span.name);
+
     if (
-      earliestStartedAt === null ||
-      span.timestamps.started_at < earliestStartedAt
+      !isSynthetic &&
+      (earliestStartedAt === null ||
+        span.timestamps.started_at < earliestStartedAt)
     ) {
       earliestStartedAt = span.timestamps.started_at;
     }
 
     if (
+      !isSynthetic &&
       span.timestamps.first_token_at &&
       (latestFirstTokenAt === null ||
         span.timestamps.first_token_at > latestFirstTokenAt)
@@ -44,8 +51,9 @@ export const computeTraceMetrics = (spans: Span[]): Trace["metrics"] => {
     }
 
     if (
-      latestFinishedAt === null ||
-      span.timestamps.finished_at > latestFinishedAt
+      !isSynthetic &&
+      (latestFinishedAt === null ||
+        span.timestamps.finished_at > latestFinishedAt)
     ) {
       latestFinishedAt = span.timestamps.finished_at;
     }

--- a/langwatch/src/server/background/workers/collector/metrics.ts
+++ b/langwatch/src/server/background/workers/collector/metrics.ts
@@ -3,6 +3,7 @@ import {
   getLLMModelCosts,
   type MaybeStoredLLMModelCost,
 } from "../../../modelProviders/llmModelCost";
+import { SYNTHETIC_SPAN_NAMES } from "../../../tracer/constants";
 import type { LLMSpan, Span, Trace } from "../../../tracer/types";
 import { typedValueToText } from "./common";
 import {
@@ -12,9 +13,6 @@ import {
 } from "./cost";
 
 const logger = createLogger("langwatch:workers:collector:metrics");
-
-/** Span names that represent synthetic events, not real execution, and must be excluded from timing. */
-const SYNTHETIC_SPAN_NAMES = new Set(["langwatch.track_event"]);
 
 // TODO: test
 export const computeTraceMetrics = (spans: Span[]): Trace["metrics"] => {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-timing.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-timing.service.ts
@@ -7,6 +7,9 @@ import type { NormalizedSpan } from "../../schemas/spans";
 export const isValidTimestamp = (ts: number | undefined | null): ts is number =>
   typeof ts === "number" && ts > 0 && Number.isFinite(ts);
 
+/** Span names that represent synthetic events, not real execution, and must be excluded from timing. */
+const SYNTHETIC_SPAN_NAMES = new Set(["langwatch.track_event"]);
+
 /**
  * Accumulates trace-level timing from individual spans.
  *
@@ -22,6 +25,7 @@ export class SpanTimingService {
     span: NormalizedSpan;
   }): { occurredAt: number; totalDurationMs: number } {
     if (
+      SYNTHETIC_SPAN_NAMES.has(span.name) ||
       !isValidTimestamp(span.startTimeUnixMs) ||
       !isValidTimestamp(span.endTimeUnixMs)
     ) {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-timing.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-timing.service.ts
@@ -1,4 +1,5 @@
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import { SYNTHETIC_SPAN_NAMES } from "~/server/tracer/constants";
 import type { NormalizedSpan } from "../../schemas/spans";
 
 /**
@@ -6,9 +7,6 @@ import type { NormalizedSpan } from "../../schemas/spans";
  */
 export const isValidTimestamp = (ts: number | undefined | null): ts is number =>
   typeof ts === "number" && ts > 0 && Number.isFinite(ts);
-
-/** Span names that represent synthetic events, not real execution, and must be excluded from timing. */
-const SYNTHETIC_SPAN_NAMES = new Set(["langwatch.track_event"]);
 
 /**
  * Accumulates trace-level timing from individual spans.

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-timing.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-timing.service.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import { TRACK_EVENT_SPAN_NAME } from "~/server/tracer/constants";
 import type { NormalizedSpan } from "../../schemas/spans";
 import { NormalizedSpanKind, NormalizedStatusCode } from "../../schemas/spans";
 import { SpanTimingService, isValidTimestamp } from "./span-timing.service";
@@ -76,7 +77,7 @@ function makeState(
 describe("SpanTimingService", () => {
   const service = new SpanTimingService();
 
-  describe("accumulateTiming", () => {
+  describe("accumulateTiming()", () => {
     describe("when processing a single real span", () => {
       it("computes timing from the span timestamps", () => {
         const result = service.accumulateTiming({
@@ -97,7 +98,10 @@ describe("SpanTimingService", () => {
           state,
           span: makeSpan({ startTimeUnixMs: 1000, endTimeUnixMs: 2000 }),
         });
-        state = makeState({ occurredAt: first.occurredAt, totalDurationMs: first.totalDurationMs });
+        state = makeState({
+          occurredAt: first.occurredAt,
+          totalDurationMs: first.totalDurationMs,
+        });
 
         const result = service.accumulateTiming({
           state,
@@ -117,12 +121,15 @@ describe("SpanTimingService", () => {
           state,
           span: makeSpan({ startTimeUnixMs: 1000, endTimeUnixMs: 2600 }),
         });
-        state = makeState({ occurredAt: first.occurredAt, totalDurationMs: first.totalDurationMs });
+        state = makeState({
+          occurredAt: first.occurredAt,
+          totalDurationMs: first.totalDurationMs,
+        });
 
         const result = service.accumulateTiming({
           state,
           span: makeSpan({
-            name: "langwatch.track_event",
+            name: TRACK_EVENT_SPAN_NAME,
             startTimeUnixMs: 19000,
             endTimeUnixMs: 19000,
           }),
@@ -136,7 +143,7 @@ describe("SpanTimingService", () => {
         const result = service.accumulateTiming({
           state: makeState(),
           span: makeSpan({
-            name: "langwatch.track_event",
+            name: TRACK_EVENT_SPAN_NAME,
             startTimeUnixMs: 50000,
             endTimeUnixMs: 50000,
           }),
@@ -162,19 +169,18 @@ describe("SpanTimingService", () => {
     });
   });
 
-  describe("isValidTimestamp", () => {
-    it("rejects null, undefined, zero, negative, and non-finite values", () => {
-      expect(isValidTimestamp(null)).toBe(false);
-      expect(isValidTimestamp(undefined)).toBe(false);
-      expect(isValidTimestamp(0)).toBe(false);
-      expect(isValidTimestamp(-1)).toBe(false);
-      expect(isValidTimestamp(Infinity)).toBe(false);
-      expect(isValidTimestamp(NaN)).toBe(false);
-    });
+  describe("isValidTimestamp()", () => {
+    it.each([null, undefined, 0, -1, Infinity, NaN])(
+      "rejects %s",
+      (value) => {
+        expect(isValidTimestamp(value as number | null | undefined)).toBe(
+          false,
+        );
+      },
+    );
 
-    it("accepts positive finite numbers", () => {
-      expect(isValidTimestamp(1)).toBe(true);
-      expect(isValidTimestamp(1713000000000)).toBe(true);
+    it.each([1, 1713000000000])("accepts %d", (value) => {
+      expect(isValidTimestamp(value)).toBe(true);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-timing.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-timing.service.unit.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import type { NormalizedSpan } from "../../schemas/spans";
+import { NormalizedSpanKind, NormalizedStatusCode } from "../../schemas/spans";
+import { SpanTimingService, isValidTimestamp } from "./span-timing.service";
+
+function makeSpan(overrides: Partial<NormalizedSpan> = {}): NormalizedSpan {
+  return {
+    id: "span-1",
+    traceId: "trace-1",
+    spanId: "span-1",
+    tenantId: "tenant-1",
+    parentSpanId: null,
+    parentTraceId: null,
+    parentIsRemote: null,
+    sampled: true,
+    startTimeUnixMs: 1000,
+    endTimeUnixMs: 2000,
+    durationMs: 1000,
+    name: "test-span",
+    kind: NormalizedSpanKind.INTERNAL,
+    resourceAttributes: {},
+    spanAttributes: {},
+    events: [],
+    links: [],
+    statusMessage: null,
+    statusCode: NormalizedStatusCode.OK,
+    instrumentationScope: { name: "test", version: null },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    ...overrides,
+  };
+}
+
+function makeState(
+  overrides: Partial<TraceSummaryData> = {},
+): TraceSummaryData {
+  return {
+    traceId: "trace-1",
+    spanCount: 0,
+    totalDurationMs: 0,
+    computedIOSchemaVersion: "2025-12-18",
+    computedInput: null,
+    computedOutput: null,
+    timeToFirstTokenMs: null,
+    timeToLastTokenMs: null,
+    tokensPerSecond: null,
+    containsErrorStatus: false,
+    containsOKStatus: false,
+    errorMessage: null,
+    models: [],
+    totalCost: null,
+    tokensEstimated: false,
+    totalPromptTokenCount: null,
+    totalCompletionTokenCount: null,
+    outputFromRootSpan: false,
+    outputSpanEndTimeMs: 0,
+    blockedByGuardrail: false,
+    topicId: null,
+    subTopicId: null,
+    annotationIds: [],
+    attributes: {},
+    scenarioRoleCosts: {},
+    scenarioRoleLatencies: {},
+    scenarioRoleSpans: {},
+    spanCosts: {},
+    occurredAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    lastEventOccurredAt: 0,
+    ...overrides,
+  };
+}
+
+describe("SpanTimingService", () => {
+  const service = new SpanTimingService();
+
+  describe("accumulateTiming", () => {
+    describe("when processing a single real span", () => {
+      it("computes timing from the span timestamps", () => {
+        const result = service.accumulateTiming({
+          state: makeState(),
+          span: makeSpan({ startTimeUnixMs: 5000, endTimeUnixMs: 7000 }),
+        });
+
+        expect(result.occurredAt).toBe(5000);
+        expect(result.totalDurationMs).toBe(2000);
+      });
+    });
+
+    describe("when processing multiple sequential spans", () => {
+      it("computes wall-clock time from earliest start to latest end", () => {
+        let state = makeState();
+
+        const first = service.accumulateTiming({
+          state,
+          span: makeSpan({ startTimeUnixMs: 1000, endTimeUnixMs: 2000 }),
+        });
+        state = makeState({ occurredAt: first.occurredAt, totalDurationMs: first.totalDurationMs });
+
+        const result = service.accumulateTiming({
+          state,
+          span: makeSpan({ startTimeUnixMs: 3000, endTimeUnixMs: 5000 }),
+        });
+
+        expect(result.occurredAt).toBe(1000);
+        expect(result.totalDurationMs).toBe(4000);
+      });
+    });
+
+    describe("when a langwatch.track_event span is present", () => {
+      it("excludes synthetic span from timing calculation", () => {
+        let state = makeState();
+
+        const first = service.accumulateTiming({
+          state,
+          span: makeSpan({ startTimeUnixMs: 1000, endTimeUnixMs: 2600 }),
+        });
+        state = makeState({ occurredAt: first.occurredAt, totalDurationMs: first.totalDurationMs });
+
+        const result = service.accumulateTiming({
+          state,
+          span: makeSpan({
+            name: "langwatch.track_event",
+            startTimeUnixMs: 19000,
+            endTimeUnixMs: 19000,
+          }),
+        });
+
+        expect(result.occurredAt).toBe(1000);
+        expect(result.totalDurationMs).toBe(1600);
+      });
+
+      it("does not inflate timing when track_event is the only span", () => {
+        const result = service.accumulateTiming({
+          state: makeState(),
+          span: makeSpan({
+            name: "langwatch.track_event",
+            startTimeUnixMs: 50000,
+            endTimeUnixMs: 50000,
+          }),
+        });
+
+        expect(result.occurredAt).toBe(0);
+        expect(result.totalDurationMs).toBe(0);
+      });
+    });
+
+    describe("when span has invalid timestamps", () => {
+      it("returns unchanged state", () => {
+        const state = makeState({ occurredAt: 1000, totalDurationMs: 500 });
+
+        const result = service.accumulateTiming({
+          state,
+          span: makeSpan({ startTimeUnixMs: 0, endTimeUnixMs: 0 }),
+        });
+
+        expect(result.occurredAt).toBe(1000);
+        expect(result.totalDurationMs).toBe(500);
+      });
+    });
+  });
+
+  describe("isValidTimestamp", () => {
+    it("rejects null, undefined, zero, negative, and non-finite values", () => {
+      expect(isValidTimestamp(null)).toBe(false);
+      expect(isValidTimestamp(undefined)).toBe(false);
+      expect(isValidTimestamp(0)).toBe(false);
+      expect(isValidTimestamp(-1)).toBe(false);
+      expect(isValidTimestamp(Infinity)).toBe(false);
+      expect(isValidTimestamp(NaN)).toBe(false);
+    });
+
+    it("accepts positive finite numbers", () => {
+      expect(isValidTimestamp(1)).toBe(true);
+      expect(isValidTimestamp(1713000000000)).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -5,6 +5,7 @@ import {
 } from "~/server/app-layer/traces/span-normalization.service";
 import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import { SYNTHETIC_SPAN_NAMES } from "~/server/tracer/constants";
 import {
   AbstractFoldProjection,
   type FoldEventHandlers,
@@ -77,6 +78,10 @@ export function applySpanToSummary({
   state: TraceSummaryData;
   span: NormalizedSpan;
 }): TraceSummaryData {
+  if (SYNTHETIC_SPAN_NAMES.has(span.name)) {
+    return state;
+  }
+
   const timing = spanTimingService.accumulateTiming({ state, span });
   const tokens = spanCostService.accumulateTokens({
     state,

--- a/langwatch/src/server/tracer/constants.ts
+++ b/langwatch/src/server/tracer/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Span name used by the `/api/track_event` endpoint for synthetic event spans.
+ *
+ * These spans represent user-tracked events (e.g. thumbs-up), not actual
+ * execution, and must be excluded from trace timing calculations.
+ */
+export const TRACK_EVENT_SPAN_NAME = "langwatch.track_event";
+
+/** Span names that represent synthetic events, not real execution. */
+export const SYNTHETIC_SPAN_NAMES: ReadonlySet<string> = new Set([
+  TRACK_EVENT_SPAN_NAME,
+]);


### PR DESCRIPTION
## Summary

Excludes `langwatch.track_event` synthetic spans from **all** trace-level calculations — timing, tokens, cost, status, IO, and attributes. These spans represent user-tracked events (e.g. thumbs-up), not actual execution.

Previously, these spans used `Date.now()` as their timestamp when no explicit timestamp was provided, which could be seconds after the real trace completed — inflating reported duration (e.g. 1.6s real → 18s reported) and polluting token/cost metrics.

Fixes #3144

**Note:** Existing traces with inflated metrics in ClickHouse will not self-heal — only new or re-ingested traces will benefit.

## Changes

- `tracer/constants.ts` — new shared module with `TRACK_EVENT_SPAN_NAME` and `SYNTHETIC_SPAN_NAMES`
- `traceSummary.foldProjection.ts` — `applySpanToSummary()` returns early for synthetic spans (skips all accumulation)
- `span-timing.service.ts` — defense-in-depth guard for timing specifically
- `metrics.ts` — early return skips entire span in legacy path
- `track_event.ts` — uses `TRACK_EVENT_SPAN_NAME` constant instead of magic string
- Unit tests for both paths covering timing exclusion and token exclusion

## Verified: no other calculation paths

Searched all references to `total_time_ms`/`totalDurationMs` — every other usage reads the pre-computed value. The only two places that compute it are the two we fixed.

## Test plan

- [x] `span-timing.service.unit.test.ts` — 13 tests pass
- [x] `metrics.test.ts` — 14 tests pass (timing + token exclusion)
- [x] No new typecheck errors introduced
- [ ] Verify on staging with trace `fa05838ad813f798ee3f694bb91f77f7`