### PR TITLE
fix: use (url, as) router.push overload for filters on dynamic route pages

### DIFF
--- a/langwatch/src/hooks/__tests__/useFilterParams-write.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useFilterParams-write.integration.test.ts
@@ -67,8 +67,13 @@ import { useFilterParams } from "../useFilterParams";
 function lastPushUrl(): string {
   const lastCall = mockPush.mock.lastCall;
   if (!lastCall) throw new Error("router.push was not called");
-  // First arg can be a string (URL) or an object ({ pathname, query })
-  return typeof lastCall[0] === "string" ? lastCall[0] : "";
+  // With the (url, as) overload, the display URL is the second arg.
+  // Fall back to first arg for string-form or object-form pushes.
+  if (typeof lastCall[1] === "string") return lastCall[1];
+  if (typeof lastCall[0] === "string") return lastCall[0];
+  throw new Error(
+    "router.push did not receive a string URL in either `url` or `as`",
+  );
 }
 
 function lastPushQuery(): Record<string, unknown> {
@@ -159,7 +164,19 @@ describe("useFilterParams() write operations", () => {
           "/my-project/analytics/custom/graph-abc?dashboard=dash-123&show_filters=true";
       });
 
-      it("does not leak route params into the query string", () => {
+      it("uses the (url, as) overload so Next.js resolves the route correctly", () => {
+        const { result } = renderHook(() => useFilterParams());
+        result.current.setFilter("traces.origin", ["application"]);
+
+        const [routeArg, asArg] = mockPush.mock.lastCall!;
+        // First arg must be an object (tells Next.js "same page")
+        expect(typeof routeArg).toBe("object");
+        expect(routeArg).toHaveProperty("pathname");
+        // Second arg is the display URL string
+        expect(typeof asArg).toBe("string");
+      });
+
+      it("does not leak route params into the display URL", () => {
         const { result } = renderHook(() => useFilterParams());
         result.current.setFilter("traces.origin", ["application"]);
 

--- a/langwatch/src/hooks/useFilterParams.ts
+++ b/langwatch/src/hooks/useFilterParams.ts
@@ -117,70 +117,73 @@ export const useFilterParams = () => {
     }
   }
 
-  // Use queryParams (parsed from router.asPath) instead of router.query to
-  // avoid leaking dynamic route params (e.g. [id]) into the query string.
-  // router.query merges route params with query params, so on pages like
-  // /[project]/analytics/custom/[id], it includes `id` which breaks shallow
-  // navigation when serialised back into a "?" string URL.
-
-  const setFilter = (filter: FilterField, params: FilterParam) => {
-    const filterUrl = availableFilters[filter].urlKey;
+  // Shallow-push helper that works on every page, including those with
+  // dynamic route params beyond [project] (e.g. /[project]/analytics/custom/[id]).
+  //
+  // The string form router.push("?" + qs) fails on dynamic-route pages in
+  // Next.js 15 Pages Router — the relative "?" URL isn't resolved correctly
+  // for shallow navigation, so the push silently does nothing.
+  //
+  // The (url, as) overload avoids this:
+  //   url  = { pathname, query: router.query }  →  tells Next.js "same page"
+  //   as   = currentPath + "?" + newQs           →  what the browser shows
+  const shallowPush = (newQs: string) => {
+    const currentPath = router.asPath.split("?")[0] ?? router.asPath;
     void router.push(
-      "?" +
-        qs.stringify(
-          {
-            ...Object.fromEntries(
-              Object.entries(queryParams).filter(
-                ([key]) =>
-                  key !== filterUrl &&
-                  !key.startsWith(filterUrl + "."),
-              ),
-            ),
-            [filterUrl]: params,
-          },
-          {
-            allowDots: true,
-            arrayFormat: "comma",
-            // @ts-ignore of course it exists
-            allowEmptyArrays: true,
-          },
-        ),
-      undefined,
+      { pathname: router.pathname, query: router.query },
+      currentPath + "?" + newQs,
       { shallow: true, scroll: false },
     );
   };
 
+  const qsOpts = {
+    allowDots: true,
+    arrayFormat: "comma" as const,
+    // @ts-ignore of course it exists
+    allowEmptyArrays: true,
+  };
+
+  const setFilter = (filter: FilterField, params: FilterParam) => {
+    const filterUrl = availableFilters[filter].urlKey;
+    shallowPush(
+      qs.stringify(
+        {
+          ...Object.fromEntries(
+            Object.entries(queryParams).filter(
+              ([key]) =>
+                key !== filterUrl && !key.startsWith(filterUrl + "."),
+            ),
+          ),
+          [filterUrl]: params,
+        },
+        qsOpts,
+      ),
+    );
+  };
+
   const setFilters = (filtersToSet: Record<FilterField, FilterParam>) => {
-    void router.push(
-      "?" +
-        qs.stringify(
-          {
-            ...Object.fromEntries(
-              Object.entries(queryParams).filter(
-                ([key]) =>
-                  !Object.values(availableFilters).some(
-                    (f) => key === f.urlKey || key.startsWith(f.urlKey + "."),
-                  ),
-              ),
+    shallowPush(
+      qs.stringify(
+        {
+          ...Object.fromEntries(
+            Object.entries(queryParams).filter(
+              ([key]) =>
+                !Object.values(availableFilters).some(
+                  (f) => key === f.urlKey || key.startsWith(f.urlKey + "."),
+                ),
             ),
-            ...Object.entries(filtersToSet).reduce(
-              (acc, [filter, params]) => ({
-                ...acc,
-                [availableFilters[filter as keyof typeof availableFilters]
-                  .urlKey]: params,
-              }),
-              {},
-            ),
-          },
-          {
-            allowDots: true,
-            arrayFormat: "comma",
-            // @ts-ignore of course it exists
-            allowEmptyArrays: true,
-          },
-        ),
-      undefined,
-      { shallow: true, scroll: false },
+          ),
+          ...Object.entries(filtersToSet).reduce(
+            (acc, [filter, params]) => ({
+              ...acc,
+              [availableFilters[filter as keyof typeof availableFilters]
+                .urlKey]: params,
+            }),
+            {},
+          ),
+        },
+        qsOpts,
+      ),
     );
   };
 
@@ -218,22 +221,14 @@ export const useFilterParams = () => {
   };
 
   const setNegateFilters = (negateFilters: boolean) => {
-    void router.push(
-      "?" +
-        qs.stringify(
-          {
-            ...queryParams,
-            negateFilters: negateFilters ? "true" : "false",
-          },
-          {
-            allowDots: true,
-            arrayFormat: "comma",
-            // @ts-ignore of course it exists
-            allowEmptyArrays: true,
-          },
-        ),
-      undefined,
-      { shallow: true, scroll: false },
+    shallowPush(
+      qs.stringify(
+        {
+          ...queryParams,
+          negateFilters: negateFilters ? "true" : "false",
+        },
+        qsOpts,
+      ),
     );
   };
 


### PR DESCRIPTION
## Summary

- Follow-up to #3146 which didn't fully fix the bug — filter checkboxes on the custom graph edit page still didn't respond to clicks
- **Root cause:** `router.push("?" + qs)` — the **string form** — silently fails on Next.js 15 Pages Router pages with dynamic route params beyond `[project]` (e.g. `[id]`). The relative `"?"` URL isn't resolved correctly for shallow navigation, so the push does nothing
- **Evidence:** Per-series "Edit Filters" drawer (React state, no router) works fine on the same page. `clearFilters()` and `setShowFilters()` also work — they use the **object form** of `router.push`
- **Fix:** Switch `setFilter`/`setFilters`/`setNegateFilters` to the `(url, as)` overload:
  - `url` = `{ pathname: router.pathname, query: router.query }` — tells Next.js "same page"  
  - `as` = `currentPath + "?" + newQs` — controls the browser URL with full qs encoding

Closes #3149
Refs #3063 (bug #14), #3017

## Test plan

- [x] 9 integration tests pass (including `(url, as)` overload verification)
- [x] Typecheck clean
- [ ] Manual: click filter checkboxes on custom graph edit page → selections persist
- [ ] Manual: verify per-series "Edit Filters" drawer still works
- [ ] Manual: verify filters on creation page and messages page (no regression)