### PR TITLE
fix: prevent duplicate plan limit alerts from concurrent trace requests

### DIFF
--- a/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
@@ -297,21 +297,18 @@ describe("UsageLimitService", () => {
       });
     });
 
-    describe("when notification delivery fails", () => {
-      it("rolls back cooldown so next request can retry", async () => {
+    describe("when one notification channel fails", () => {
+      it("completes without throwing (fire-and-forget sends)", async () => {
         const { service, organizationService, notificationService } = createService();
         (organizationService.findWithAdmins as ReturnType<typeof vi.fn>).mockResolvedValue(ORG_WITH_ADMIN);
         (notificationService.sendSlackPlanLimitAlert as ReturnType<typeof vi.fn>)
-          .mockRejectedValueOnce(new Error("Slack down"))
-          .mockResolvedValue(undefined);
+          .mockRejectedValueOnce(new Error("Slack down"));
 
-        // First call: delivery fails, cooldown should be rolled back
+        // Should not throw — allSettled absorbs the rejection
         await service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" });
-        expect(await planLimitCooldown.get("org_1")).toBeUndefined();
 
-        // Second call: should retry successfully
-        await service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" });
-        expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalledTimes(2);
+        expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalledTimes(1);
+        expect(notificationService.sendHubspotPlanLimitForm).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
@@ -36,6 +36,8 @@ import { env } from "../../../src/env.mjs";
 import {
   UsageLimitService,
   resourceLimitCooldown,
+  planLimitCooldown,
+  planLimitInFlight,
 } from "../notifications/usage-limit.service";
 import type { NotificationService } from "../notifications/notification.service";
 import type { NotificationRepository } from "../notifications/repositories/notification.repository";
@@ -152,6 +154,13 @@ describe("UsageLimitService", () => {
   // -------------------------------------------------------------------------
 
   describe("notifyPlanLimitReached()", () => {
+    afterEach(async () => {
+      planLimitInFlight.delete("org_1");
+      planLimitInFlight.delete("org_missing");
+      await planLimitCooldown.delete("org_1");
+      await planLimitCooldown.delete("org_missing");
+    });
+
     describe("when IS_SAAS is false", () => {
       beforeEach(() => {
         vi.mocked(env).IS_SAAS = false;
@@ -250,6 +259,23 @@ describe("UsageLimitService", () => {
         });
 
         expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalled();
+      });
+    });
+
+    describe("when called concurrently for the same organization", () => {
+      it("sends only one notification", async () => {
+        const { service, organizationService, notificationService } = createService();
+        (organizationService.findWithAdmins as ReturnType<typeof vi.fn>).mockResolvedValue(ORG_WITH_ADMIN);
+
+        await Promise.all([
+          service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" }),
+          service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" }),
+          service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" }),
+          service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" }),
+          service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" }),
+        ]);
+
+        expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
@@ -278,6 +278,24 @@ describe("UsageLimitService", () => {
         expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe("when called again after cooldown expires", () => {
+      it("sends notification again", async () => {
+        const { service, organizationService, notificationService } = createService();
+        (organizationService.findWithAdmins as ReturnType<typeof vi.fn>).mockResolvedValue(ORG_WITH_ADMIN);
+
+        await service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" });
+        expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalledTimes(1);
+
+        // Simulate cooldown expiry
+        planLimitInFlight.delete("org_1");
+        await planLimitCooldown.delete("org_1");
+        vi.mocked(notificationService.sendSlackPlanLimitAlert as ReturnType<typeof vi.fn>).mockClear();
+
+        await service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" });
+        expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
@@ -296,6 +296,24 @@ describe("UsageLimitService", () => {
         expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe("when notification delivery fails", () => {
+      it("rolls back cooldown so next request can retry", async () => {
+        const { service, organizationService, notificationService } = createService();
+        (organizationService.findWithAdmins as ReturnType<typeof vi.fn>).mockResolvedValue(ORG_WITH_ADMIN);
+        (notificationService.sendSlackPlanLimitAlert as ReturnType<typeof vi.fn>)
+          .mockRejectedValueOnce(new Error("Slack down"))
+          .mockResolvedValue(undefined);
+
+        // First call: delivery fails, cooldown should be rolled back
+        await service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" });
+        expect(await planLimitCooldown.get("org_1")).toBeUndefined();
+
+        // Second call: should retry successfully
+        await service.notifyPlanLimitReached({ organizationId: "org_1", planName: "free" });
+        expect(notificationService.sendSlackPlanLimitAlert).toHaveBeenCalledTimes(2);
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/langwatch/ee/billing/notifications/usage-limit.service.ts
+++ b/langwatch/ee/billing/notifications/usage-limit.service.ts
@@ -138,14 +138,17 @@ export class UsageLimitService {
     planLimitInFlight.add(organizationId);
 
     try {
-      // Async guard: blocks subsequent ticks and cross-pod duplicates via Redis.
-      if (await planLimitCooldown.get(organizationId)) {
+      // Atomic cross-pod guard: SET NX EX claims the cooldown slot in a
+      // single Redis round-trip, closing the distributed TOCTOU window.
+      const claimed = await planLimitCooldown.claim(organizationId, true);
+      if (!claimed) {
         return;
       }
 
       const organization = await this.organizationService.findWithAdmins(organizationId);
 
       if (!organization) {
+        await planLimitCooldown.delete(organizationId);
         return;
       }
 
@@ -160,10 +163,6 @@ export class UsageLimitService {
           return;
         }
       }
-
-      // Claim the cooldown slot before sending so concurrent calls on other
-      // pods are blocked immediately, even if sending takes a few seconds.
-      await planLimitCooldown.set(organizationId, true);
 
       const admin = organization.members[0]?.user;
 

--- a/langwatch/ee/billing/notifications/usage-limit.service.ts
+++ b/langwatch/ee/billing/notifications/usage-limit.service.ts
@@ -139,6 +139,7 @@ export class UsageLimitService {
 
     // Async guard: blocks subsequent ticks and cross-pod duplicates via Redis.
     if (await planLimitCooldown.get(organizationId)) {
+      planLimitInFlight.delete(organizationId);
       return;
     }
 
@@ -159,6 +160,7 @@ export class UsageLimitService {
       if (daysSinceLastAlert < MIN_DAYS_BETWEEN_ALERTS) {
         // Seed the cache so subsequent ticks skip the DB round-trip too.
         await planLimitCooldown.set(organizationId, true);
+        planLimitInFlight.delete(organizationId);
         return;
       }
     }
@@ -166,6 +168,7 @@ export class UsageLimitService {
     // Claim the cooldown slot before sending so concurrent calls on other
     // pods are blocked immediately, even if sending takes a few seconds.
     await planLimitCooldown.set(organizationId, true);
+    planLimitInFlight.delete(organizationId);
 
     const admin = organization.members[0]?.user;
 

--- a/langwatch/ee/billing/notifications/usage-limit.service.ts
+++ b/langwatch/ee/billing/notifications/usage-limit.service.ts
@@ -157,8 +157,6 @@ export class UsageLimitService {
         );
 
         if (daysSinceLastAlert < MIN_DAYS_BETWEEN_ALERTS) {
-          // Seed the cache so subsequent ticks skip the DB round-trip too.
-          await planLimitCooldown.set(organizationId, true);
           return;
         }
       }
@@ -177,17 +175,12 @@ export class UsageLimitService {
         planName,
       };
 
-      try {
-        await Promise.all([
-          this.notificationService.sendSlackPlanLimitAlert(context),
-          this.notificationService.sendHubspotPlanLimitForm(context),
-        ]);
-      } catch {
-        // Roll back cooldown so the next request can retry delivery,
-        // matching the pattern in notifyResourceLimitReached.
-        await planLimitCooldown.delete(organizationId);
-        return;
-      }
+      // Both sends are fire-and-forget (errors swallowed internally),
+      // so use allSettled to await completion without short-circuiting.
+      await Promise.allSettled([
+        this.notificationService.sendSlackPlanLimitAlert(context),
+        this.notificationService.sendHubspotPlanLimitForm(context),
+      ]);
 
       try {
         await this.organizationService.updateSentPlanLimitAlert(organizationId, new Date());

--- a/langwatch/ee/billing/notifications/usage-limit.service.ts
+++ b/langwatch/ee/billing/notifications/usage-limit.service.ts
@@ -24,6 +24,17 @@ const MIN_DAYS_BETWEEN_ALERTS = 30;
 const resourceLimitCooldown = new TtlCache<true>(24 * 60 * 60 * 1000, "ttlcache:billing:limitCooldown:");
 export { resourceLimitCooldown };
 
+// Guards notifyPlanLimitReached against concurrent calls (burst of traces from
+// a single org hitting the limit middleware at the same time). Two layers:
+//
+// 1. planLimitInFlight (sync Set) — blocks same-tick races where multiple
+//    Promise.all callers interleave before any async operation resolves.
+// 2. planLimitCooldown (TtlCache) — blocks subsequent ticks and coordinates
+//    across pods via Redis. The DB 30-day window remains authoritative.
+const planLimitInFlight = new Set<string>();
+const planLimitCooldown = new TtlCache<true>(MIN_DAYS_BETWEEN_ALERTS * 24 * 60 * 60 * 1000, "ttlcache:billing:planLimitCooldown:");
+export { planLimitInFlight, planLimitCooldown };
+
 export interface UsageLimitData {
   organizationId: string;
   currentMonthMessagesCount: number;
@@ -119,9 +130,22 @@ export class UsageLimitService {
       return;
     }
 
+    // Synchronous guard: blocks same-tick concurrent calls (e.g. 5 trace
+    // requests hitting Promise.all) before any await yields execution.
+    if (planLimitInFlight.has(organizationId)) {
+      return;
+    }
+    planLimitInFlight.add(organizationId);
+
+    // Async guard: blocks subsequent ticks and cross-pod duplicates via Redis.
+    if (await planLimitCooldown.get(organizationId)) {
+      return;
+    }
+
     const organization = await this.organizationService.findWithAdmins(organizationId);
 
     if (!organization) {
+      planLimitInFlight.delete(organizationId);
       return;
     }
 
@@ -133,9 +157,15 @@ export class UsageLimitService {
       );
 
       if (daysSinceLastAlert < MIN_DAYS_BETWEEN_ALERTS) {
+        // Seed the cache so subsequent ticks skip the DB round-trip too.
+        await planLimitCooldown.set(organizationId, true);
         return;
       }
     }
+
+    // Claim the cooldown slot before sending so concurrent calls on other
+    // pods are blocked immediately, even if sending takes a few seconds.
+    await planLimitCooldown.set(organizationId, true);
 
     const admin = organization.members[0]?.user;
 

--- a/langwatch/ee/billing/notifications/usage-limit.service.ts
+++ b/langwatch/ee/billing/notifications/usage-limit.service.ts
@@ -137,63 +137,70 @@ export class UsageLimitService {
     }
     planLimitInFlight.add(organizationId);
 
-    // Async guard: blocks subsequent ticks and cross-pod duplicates via Redis.
-    if (await planLimitCooldown.get(organizationId)) {
-      planLimitInFlight.delete(organizationId);
-      return;
-    }
-
-    const organization = await this.organizationService.findWithAdmins(organizationId);
-
-    if (!organization) {
-      planLimitInFlight.delete(organizationId);
-      return;
-    }
-
-    if (organization.sentPlanLimitAlert) {
-      const timeSinceLastAlert =
-        Date.now() - organization.sentPlanLimitAlert.getTime();
-      const daysSinceLastAlert = Math.floor(
-        timeSinceLastAlert / (1000 * 60 * 60 * 24),
-      );
-
-      if (daysSinceLastAlert < MIN_DAYS_BETWEEN_ALERTS) {
-        // Seed the cache so subsequent ticks skip the DB round-trip too.
-        await planLimitCooldown.set(organizationId, true);
-        planLimitInFlight.delete(organizationId);
+    try {
+      // Async guard: blocks subsequent ticks and cross-pod duplicates via Redis.
+      if (await planLimitCooldown.get(organizationId)) {
         return;
       }
-    }
 
-    // Claim the cooldown slot before sending so concurrent calls on other
-    // pods are blocked immediately, even if sending takes a few seconds.
-    await planLimitCooldown.set(organizationId, true);
-    planLimitInFlight.delete(organizationId);
+      const organization = await this.organizationService.findWithAdmins(organizationId);
 
-    const admin = organization.members[0]?.user;
+      if (!organization) {
+        return;
+      }
 
-    const context = {
-      organizationId,
-      organizationName: organization.name,
-      adminName: admin?.name ?? undefined,
-      adminEmail: admin?.email ?? undefined,
-      planName,
-    };
+      if (organization.sentPlanLimitAlert) {
+        const timeSinceLastAlert =
+          Date.now() - organization.sentPlanLimitAlert.getTime();
+        const daysSinceLastAlert = Math.floor(
+          timeSinceLastAlert / (1000 * 60 * 60 * 24),
+        );
 
-    await Promise.all([
-      this.notificationService.sendSlackPlanLimitAlert(context),
-      this.notificationService.sendHubspotPlanLimitForm(context),
-    ]);
+        if (daysSinceLastAlert < MIN_DAYS_BETWEEN_ALERTS) {
+          // Seed the cache so subsequent ticks skip the DB round-trip too.
+          await planLimitCooldown.set(organizationId, true);
+          return;
+        }
+      }
 
-    try {
-      await this.organizationService.updateSentPlanLimitAlert(organizationId, new Date());
-    } catch (error) {
-      captureException(
-        new Error(
-          `Critical: plan limit notification sent but DB timestamp update failed for org ${organizationId} on plan ${planName}`,
-          { cause: error },
-        ),
-      );
+      // Claim the cooldown slot before sending so concurrent calls on other
+      // pods are blocked immediately, even if sending takes a few seconds.
+      await planLimitCooldown.set(organizationId, true);
+
+      const admin = organization.members[0]?.user;
+
+      const context = {
+        organizationId,
+        organizationName: organization.name,
+        adminName: admin?.name ?? undefined,
+        adminEmail: admin?.email ?? undefined,
+        planName,
+      };
+
+      try {
+        await Promise.all([
+          this.notificationService.sendSlackPlanLimitAlert(context),
+          this.notificationService.sendHubspotPlanLimitForm(context),
+        ]);
+      } catch {
+        // Roll back cooldown so the next request can retry delivery,
+        // matching the pattern in notifyResourceLimitReached.
+        await planLimitCooldown.delete(organizationId);
+        return;
+      }
+
+      try {
+        await this.organizationService.updateSentPlanLimitAlert(organizationId, new Date());
+      } catch (error) {
+        captureException(
+          new Error(
+            `Critical: plan limit notification sent but DB timestamp update failed for org ${organizationId} on plan ${planName}`,
+            { cause: error },
+          ),
+        );
+      }
+    } finally {
+      planLimitInFlight.delete(organizationId);
     }
   }
 

--- a/langwatch/src/server/utils/__tests__/ttlCache.unit.test.ts
+++ b/langwatch/src/server/utils/__tests__/ttlCache.unit.test.ts
@@ -125,6 +125,21 @@ describe("TtlCache", () => {
     });
   });
 
+  describe("when Redis fails on claim", () => {
+    it("falls back to in-memory claim", async () => {
+      const cache = new TtlCache<boolean>(30_000, "test:");
+      mockRedis.set.mockRejectedValueOnce(new Error("connection reset"));
+
+      const result = await cache.claim("lock1", true);
+
+      expect(result).toBe(true);
+
+      // Redis also fails on get, so memory fallback is used
+      mockRedis.get.mockRejectedValueOnce(new Error("connection reset"));
+      expect(await cache.get("lock1")).toBe(true);
+    });
+  });
+
   describe("when Redis fails on get", () => {
     it("falls back to in-memory cache", async () => {
       const cache = new TtlCache<number>(30_000, "test:");

--- a/langwatch/src/server/utils/__tests__/ttlCache.unit.test.ts
+++ b/langwatch/src/server/utils/__tests__/ttlCache.unit.test.ts
@@ -95,7 +95,7 @@ describe("TtlCache", () => {
     });
   });
 
-  describe("claim()", () => {
+  describe("when claiming a key", () => {
     it("returns true and stores value when key is absent", async () => {
       const cache = new TtlCache<boolean>(30_000, "test:");
 

--- a/langwatch/src/server/utils/__tests__/ttlCache.unit.test.ts
+++ b/langwatch/src/server/utils/__tests__/ttlCache.unit.test.ts
@@ -7,6 +7,11 @@ const { mockRedisStore, mockRedis } = vi.hoisted(() => {
     setex: vi.fn(async (key: string, ttl: number, value: string) => {
       mockRedisStore.set(key, { value, ttl });
     }),
+    set: vi.fn(async (key: string, value: string, ex: string, ttl: number, nx: string) => {
+      if (nx === "NX" && mockRedisStore.has(key)) return null;
+      mockRedisStore.set(key, { value, ttl });
+      return "OK";
+    }),
     del: vi.fn(async (key: string) => { mockRedisStore.delete(key); }),
   };
   return { mockRedisStore, mockRedis };
@@ -87,6 +92,36 @@ describe("TtlCache", () => {
       const result = await cache.get("obj1");
 
       expect(result).toEqual(obj);
+    });
+  });
+
+  describe("claim()", () => {
+    it("returns true and stores value when key is absent", async () => {
+      const cache = new TtlCache<boolean>(30_000, "test:");
+
+      const result = await cache.claim("lock1", true);
+
+      expect(result).toBe(true);
+      expect(await cache.get("lock1")).toBe(true);
+    });
+
+    it("returns false when key already exists", async () => {
+      const cache = new TtlCache<boolean>(30_000, "test:");
+
+      await cache.claim("lock1", true);
+      const second = await cache.claim("lock1", true);
+
+      expect(second).toBe(false);
+    });
+
+    it("uses SET NX EX on Redis", async () => {
+      const cache = new TtlCache<boolean>(60_000, "test:");
+
+      await cache.claim("lock1", true);
+
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        "test:lock1", JSON.stringify(true), "EX", 60, "NX",
+      );
     });
   });
 

--- a/langwatch/src/server/utils/ttlCache.ts
+++ b/langwatch/src/server/utils/ttlCache.ts
@@ -56,6 +56,36 @@ export class TtlCache<T> {
     }
   }
 
+  /**
+   * Atomically set `key` only if it does not already exist (Redis SET NX EX).
+   * Returns `true` if this call claimed the key, `false` if it was already taken.
+   */
+  async claim(key: string, value: T): Promise<boolean> {
+    const r = this.redis;
+    if (r) {
+      try {
+        const result = await r.set(
+          `${this.prefix}${key}`,
+          JSON.stringify(value),
+          "EX",
+          this.ttlSeconds,
+          "NX",
+        );
+        if (result === "OK") {
+          this.memory.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+          return true;
+        }
+        return false;
+      } catch {
+        // Redis failed, fall through to memory
+      }
+    }
+
+    if (this.memoryGet(key) !== undefined) return false;
+    this.memory.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+    return true;
+  }
+
   async delete(key: string): Promise<void> {
     this.memory.delete(key);
 


### PR DESCRIPTION
## Summary
- Add two-layer deduplication guard to `notifyPlanLimitReached` to prevent TOCTOU race that caused 5+ duplicate Slack/HubSpot alerts when concurrent trace requests hit the limit middleware simultaneously
- Synchronous `Set` guard blocks same-tick races; `TtlCache` (Redis-backed) blocks cross-tick and cross-pod duplicates
- Add concurrent-call regression test verifying only 1 notification is sent from 5 simultaneous calls

Closes #3153

## Test plan
- [x] Unit tests pass (`pnpm test:unit ee/billing/__tests__/usage-limit.service.unit.test.ts`)
- [x] New "sends only one notification" test covers the concurrent burst scenario
- [ ] Verify in staging that a burst of limit-exceeding traces produces exactly 1 Slack alert

# Related Issue

- Resolve #3153