### PR TITLE
feat(api): add a versioned Hono service builder

### DIFF
--- a/langwatch/packages/api/README.md
+++ b/langwatch/packages/api/README.md
@@ -60,14 +60,14 @@ export const app = createService({
   })
   .build();
 
-export const { GET, POST, PUT, DELETE } = routeHandlers(app);
+export const { GET, POST, PUT, PATCH, DELETE } = routeHandlers(app);
 ```
 
 The Next.js route file:
 
 ```ts
 // src/app/api/things/[[...route]]/route.ts
-export { GET, POST, PUT, DELETE } from "./things.service";
+export { GET, POST, PUT, PATCH, DELETE } from "./things.service";
 ```
 
 ## What it does for you
@@ -86,7 +86,7 @@ v.get("/path", config, async (c, { input, params, query, app }) => {
   // input    = parsed JSON body (from config.input schema)
   // params   = parsed path params (from config.params schema)
   // query    = parsed query string (from config.query schema)
-  // app      = { project, organization, prisma, ...providers }
+  // app      = { project, _legacy: { organization, prisma }, ...providers }
 
   return data; // framework validates against config.output and calls c.json()
 });
@@ -166,8 +166,8 @@ v.sse("/execute", {
     result: z.object({ score: z.number() }),
     error: z.object({ message: z.string() }),
   },
-  input: executeSchema,
-}, async (c, { input, app }, stream) => {
+  query: querySchema,
+}, async (c, { query, app }, stream) => {
   await stream.emit("result", { score: 0.95 }); // validated against schema
   stream.close();
 });
@@ -232,10 +232,10 @@ src/
 When creating a new API service using this framework:
 
 1. Create `src/app/api/{name}/[[...route]]/` with two files: `{name}.service.ts` and `route.ts`
-2. `route.ts` is always just `export { GET, POST, PUT, DELETE } from "./{name}.service"`
+2. `route.ts` is always just `export { GET, POST, PUT, PATCH, DELETE } from "./{name}.service"`
 3. Use `createService({ name })` with the service name matching the URL path segment
 4. Inject auth, organization, and resource limit middleware from `../../middleware/`
-5. Use `.provide()` for service-layer dependencies — factories get `{ project, organization, prisma }`
+5. Use `.provide()` for service-layer dependencies — factories get `{ project, _legacy: { organization, prisma } }`
 6. Define Zod schemas for input/output/params next to the service, not in a shared types file
 7. Handlers return raw data when `output` is set; the framework validates and serializes
 8. Throw `NotFoundError` / `DomainError` for error responses — don't return `c.json({ error }, 404)` manually

--- a/langwatch/packages/api/README.md
+++ b/langwatch/packages/api/README.md
@@ -1,0 +1,243 @@
+# @langwatch/api
+
+Builder for versioned Hono API services. Handles middleware stacking, input/output validation, OpenAPI docs, error formatting, and date-based versioning with forward-copying.
+
+Built on top of [Hono](https://hono.dev), [hono-openapi](https://github.com/rhinobase/hono-openapi), and Zod.
+
+## Quick start
+
+Two files per service. The service definition:
+
+```ts
+// src/app/api/things/[[...route]]/things.service.ts
+import { z } from "zod";
+import { createService, routeHandlers } from "@langwatch/api";
+import { authMiddleware } from "../../middleware/auth";
+import { organizationMiddleware } from "../../middleware/organization";
+import { ThingService } from "~/server/things/thing.service";
+import { prisma } from "~/server/db";
+
+const thingSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export const app = createService({
+  name: "things",
+  auth: authMiddleware,
+  _legacy: { organizationMiddleware },
+})
+  .provide({
+    thingService: () => ThingService.create(prisma),
+  })
+  .version("2025-03-15", (v) => {
+    v.get("/", { output: z.array(thingSchema) }, async (_c, { app }) => {
+      return app.thingService.getAll({ projectId: app.project.id });
+    });
+
+    v.post(
+      "/",
+      {
+        input: z.object({ name: z.string().min(1) }),
+        output: thingSchema,
+        status: 201,
+      },
+      async (_c, { input, app }) => {
+        return app.thingService.create({ projectId: app.project.id, ...input });
+      },
+    );
+
+    v.get(
+      "/:id",
+      {
+        params: z.object({ id: z.string() }),
+        output: thingSchema,
+      },
+      async (_c, { params, app }) => {
+        return app.thingService.getById({ id: params.id, projectId: app.project.id });
+      },
+    );
+  })
+  .build();
+
+export const { GET, POST, PUT, DELETE } = routeHandlers(app);
+```
+
+The Next.js route file:
+
+```ts
+// src/app/api/things/[[...route]]/route.ts
+export { GET, POST, PUT, DELETE } from "./things.service";
+```
+
+## What it does for you
+
+- **Tracing + logging** via `@langwatch/telemetry` (automatic, disable with `tracer: false` / `logger: false`)
+- **Auth, org, resource limits** applied in the right order per-endpoint
+- **Input/output/params/query validation** from Zod schemas, auto-wired to OpenAPI
+- **Error formatting** that duck-types `DomainError` (kind, meta, reasons, telemetry) and catches Zod errors
+- **Versioned routing** at `/api/{name}/{date}/...` with forward-copying from previous versions
+
+## Handler signature
+
+```ts
+v.get("/path", config, async (c, { input, params, query, app }) => {
+  // c        = Hono Context (escape hatch for headers, raw request)
+  // input    = parsed JSON body (from config.input schema)
+  // params   = parsed path params (from config.params schema)
+  // query    = parsed query string (from config.query schema)
+  // app      = { project, organization, prisma, ...providers }
+
+  return data; // framework validates against config.output and calls c.json()
+});
+```
+
+When `output` is defined, return raw data. The framework validates + serializes.
+When `output` is not defined, return a Hono `Response` directly.
+
+## Endpoint config
+
+Second argument to `v.get()`, `v.post()`, etc:
+
+```ts
+{
+  input: z.object({ ... }),         // JSON body schema
+  output: z.object({ ... }),        // Response schema (validates + OpenAPI)
+  params: z.object({ id: z.string() }), // Path params
+  query: z.object({ limit: z.number() }), // Query string
+  description: "...",               // OpenAPI description
+  status: 201,                      // HTTP status (default 200)
+  auth: "none",                     // Skip auth for this endpoint
+  resourceLimit: "scenarios",       // Enforce resource limits
+  middleware: [rateLimiter()],       // Extra per-endpoint middleware
+}
+```
+
+All fields optional. Pass `{}` for a bare endpoint.
+
+## Versioning
+
+Versions are dates. Each version inherits all endpoints from the previous one. Override or add endpoints, and use `withdraw()` to remove.
+
+```ts
+.version("2025-03-15", (v) => {
+  v.get("/", { output: listSchema }, handler);
+  v.post("/", { input: createSchema, output: itemSchema }, handler);
+})
+.version("2025-09-01", (v) => {
+  // Override POST with new input schema
+  v.post("/", { input: newCreateSchema, output: itemSchema }, newHandler);
+  // Remove GET /:id (returns 410 Gone)
+  v.withdraw("get", "/:id");
+  // GET / is inherited from 2025-03-15 automatically
+})
+```
+
+URL structure:
+
+| URL | Resolves to |
+|-----|-------------|
+| `/api/things/2025-03-15/` | Exact version |
+| `/api/things/2025-09-01/` | Exact version |
+| `/api/things/latest/` | Most recent dated version |
+| `/api/things/` | Same as latest (backwards compat) |
+| `/api/things/preview/` | Preview endpoints (never in latest) |
+
+Response headers: `X-API-Version` and `X-API-Version-Status` (stable/latest/preview/unversioned).
+
+## Providers
+
+`.provide()` injects services into handlers via `app.*`. Factories receive the base context. No cross-provider dependencies.
+
+```ts
+.provide({
+  thingService: () => ThingService.create(prisma),
+  cache: async (base) => CacheService.forProject(base.project.id),
+})
+```
+
+`app.thingService` and `app.cache` are fully typed from the factory return types.
+
+## SSE streaming
+
+```ts
+v.sse("/execute", {
+  events: {
+    result: z.object({ score: z.number() }),
+    error: z.object({ message: z.string() }),
+  },
+  input: executeSchema,
+}, async (c, { input, app }, stream) => {
+  await stream.emit("result", { score: 0.95 }); // validated against schema
+  stream.close();
+});
+```
+
+## Error handling
+
+Throw `DomainError` subclasses (from `~/server/app-layer/domain-error`). The framework:
+
+1. Catches and serializes them with `kind`, `meta`, `reasons`, `telemetry`
+2. Catches `ZodError` and maps each issue to a `schema_failure` reason (cher-style)
+3. Returns union format for unversioned requests (includes legacy `error` field)
+4. Returns clean format for versioned requests
+
+Validation error example:
+
+```json
+{
+  "kind": "validation_error",
+  "message": "Validation error",
+  "reasons": [
+    {
+      "code": "schema_failure",
+      "meta": { "field": "url", "type": "invalid_string", "message": "must be a valid URL" }
+    },
+    {
+      "code": "schema_failure",
+      "meta": { "field": "title", "type": "too_small", "message": "title is required" }
+    }
+  ]
+}
+```
+
+## Testing
+
+The `app` export is a standard Hono instance. Test with `app.request()`:
+
+```ts
+const res = await app.request("/api/things", {
+  headers: { "X-Auth-Token": apiKey },
+});
+expect(res.status).toBe(200);
+```
+
+Unit tests: `pnpm test:unit packages/api`
+
+## File structure
+
+```
+src/
+  builder.ts          # createService(), ServiceBuilder, VersionBuilder
+  versioning.ts       # Forward-copy algorithm + request-time resolution
+  middleware.ts       # Built-in tracer + logger (uses @langwatch/telemetry)
+  errors.ts           # Error handler (DomainError, ZodError, version-gated format)
+  sse.ts              # v.sse() with typed events
+  types.ts            # ServiceConfig, EndpointConfig, Handler, BaseApp
+  index.ts            # Public re-exports + routeHandlers()
+```
+
+## LLM instructions
+
+When creating a new API service using this framework:
+
+1. Create `src/app/api/{name}/[[...route]]/` with two files: `{name}.service.ts` and `route.ts`
+2. `route.ts` is always just `export { GET, POST, PUT, DELETE } from "./{name}.service"`
+3. Use `createService({ name })` with the service name matching the URL path segment
+4. Inject auth, organization, and resource limit middleware from `../../middleware/`
+5. Use `.provide()` for service-layer dependencies — factories get `{ project, organization, prisma }`
+6. Define Zod schemas for input/output/params next to the service, not in a shared types file
+7. Handlers return raw data when `output` is set; the framework validates and serializes
+8. Throw `NotFoundError` / `DomainError` for error responses — don't return `c.json({ error }, 404)` manually
+9. Use `status: 201` in endpoint config for creation endpoints
+10. Copy the scenarios service at `src/app/api/scenarios/[[...route]]/scenarios.service.ts` as a reference

--- a/langwatch/packages/api/README.md
+++ b/langwatch/packages/api/README.md
@@ -1,0 +1,243 @@
+# @langwatch/api
+
+Builder for versioned Hono API services. Handles middleware stacking, input/output validation, OpenAPI docs, error formatting, and date-based versioning with forward-copying.
+
+Built on top of [Hono](https://hono.dev), [hono-openapi](https://github.com/rhinobase/hono-openapi), and Zod.
+
+## Quick start
+
+Two files per service. The service definition:
+
+```ts
+// src/app/api/things/[[...route]]/things.service.ts
+import { z } from "zod";
+import { createService, routeHandlers } from "@langwatch/api";
+import { authMiddleware } from "../../middleware/auth";
+import { organizationMiddleware } from "../../middleware/organization";
+import { ThingService } from "~/server/things/thing.service";
+import { prisma } from "~/server/db";
+
+const thingSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export const app = createService({
+  name: "things",
+  auth: authMiddleware,
+  _legacy: { organizationMiddleware },
+})
+  .provide({
+    thingService: () => ThingService.create(prisma),
+  })
+  .version("2025-03-15", (v) => {
+    v.get("/", { output: z.array(thingSchema) }, async (_c, { app }) => {
+      return app.thingService.getAll({ projectId: app.project.id });
+    });
+
+    v.post(
+      "/",
+      {
+        input: z.object({ name: z.string().min(1) }),
+        output: thingSchema,
+        status: 201,
+      },
+      async (_c, { input, app }) => {
+        return app.thingService.create({ projectId: app.project.id, ...input });
+      },
+    );
+
+    v.get(
+      "/:id",
+      {
+        params: z.object({ id: z.string() }),
+        output: thingSchema,
+      },
+      async (_c, { params, app }) => {
+        return app.thingService.getById({ id: params.id, projectId: app.project.id });
+      },
+    );
+  })
+  .build();
+
+export const { GET, POST, PUT, DELETE } = routeHandlers(app);
+```
+
+The Next.js route file:
+
+```ts
+// src/app/api/things/[[...route]]/route.ts
+export { GET, POST, PUT, DELETE } from "./things.service";
+```
+
+## What it does for you
+
+- **Tracing + logging** via `@langwatch/observability` (automatic, disable with `tracer: false` / `logger: false`)
+- **Auth, org, resource limits** applied in the right order per-endpoint
+- **Input/output/params/query validation** from Zod schemas, auto-wired to OpenAPI
+- **Error formatting** that duck-types `DomainError` (kind, meta, reasons, telemetry) and catches Zod errors
+- **Versioned routing** at `/api/{name}/{date}/...` with forward-copying from previous versions
+
+## Handler signature
+
+```ts
+v.get("/path", config, async (c, { input, params, query, app }) => {
+  // c        = Hono Context (escape hatch for headers, raw request)
+  // input    = parsed JSON body (from config.input schema)
+  // params   = parsed path params (from config.params schema)
+  // query    = parsed query string (from config.query schema)
+  // app      = { project, organization, prisma, ...providers }
+
+  return data; // framework validates against config.output and calls c.json()
+});
+```
+
+When `output` is defined, return raw data. The framework validates + serializes.
+When `output` is not defined, return a Hono `Response` directly.
+
+## Endpoint config
+
+Second argument to `v.get()`, `v.post()`, etc:
+
+```ts
+{
+  input: z.object({ ... }),         // JSON body schema
+  output: z.object({ ... }),        // Response schema (validates + OpenAPI)
+  params: z.object({ id: z.string() }), // Path params
+  query: z.object({ limit: z.number() }), // Query string
+  description: "...",               // OpenAPI description
+  status: 201,                      // HTTP status (default 200)
+  auth: "none",                     // Skip auth for this endpoint
+  resourceLimit: "scenarios",       // Enforce resource limits
+  middleware: [rateLimiter()],       // Extra per-endpoint middleware
+}
+```
+
+All fields optional. Pass `{}` for a bare endpoint.
+
+## Versioning
+
+Versions are dates. Each version inherits all endpoints from the previous one. Override or add endpoints, and use `withdraw()` to remove.
+
+```ts
+.version("2025-03-15", (v) => {
+  v.get("/", { output: listSchema }, handler);
+  v.post("/", { input: createSchema, output: itemSchema }, handler);
+})
+.version("2025-09-01", (v) => {
+  // Override POST with new input schema
+  v.post("/", { input: newCreateSchema, output: itemSchema }, newHandler);
+  // Remove GET /:id (returns 410 Gone)
+  v.withdraw("get", "/:id");
+  // GET / is inherited from 2025-03-15 automatically
+})
+```
+
+URL structure:
+
+| URL | Resolves to |
+|-----|-------------|
+| `/api/things/2025-03-15/` | Exact version |
+| `/api/things/2025-09-01/` | Exact version |
+| `/api/things/latest/` | Most recent dated version |
+| `/api/things/` | Same as latest (backwards compat) |
+| `/api/things/preview/` | Preview endpoints (never in latest) |
+
+Response headers: `X-API-Version` and `X-API-Version-Status` (stable/latest/preview/unversioned).
+
+## Providers
+
+`.provide()` injects services into handlers via `app.*`. Factories receive the base context. No cross-provider dependencies.
+
+```ts
+.provide({
+  thingService: () => ThingService.create(prisma),
+  cache: async (base) => CacheService.forProject(base.project.id),
+})
+```
+
+`app.thingService` and `app.cache` are fully typed from the factory return types.
+
+## SSE streaming
+
+```ts
+v.sse("/execute", {
+  events: {
+    result: z.object({ score: z.number() }),
+    error: z.object({ message: z.string() }),
+  },
+  input: executeSchema,
+}, async (c, { input, app }, stream) => {
+  await stream.emit("result", { score: 0.95 }); // validated against schema
+  stream.close();
+});
+```
+
+## Error handling
+
+Throw `DomainError` subclasses (from `~/server/app-layer/domain-error`). The framework:
+
+1. Catches and serializes them with `kind`, `meta`, `reasons`, `telemetry`
+2. Catches `ZodError` and maps each issue to a `schema_failure` reason (cher-style)
+3. Returns union format for unversioned requests (includes legacy `error` field)
+4. Returns clean format for versioned requests
+
+Validation error example:
+
+```json
+{
+  "kind": "validation_error",
+  "message": "Validation error",
+  "reasons": [
+    {
+      "code": "schema_failure",
+      "meta": { "field": "url", "type": "invalid_string", "message": "must be a valid URL" }
+    },
+    {
+      "code": "schema_failure",
+      "meta": { "field": "title", "type": "too_small", "message": "title is required" }
+    }
+  ]
+}
+```
+
+## Testing
+
+The `app` export is a standard Hono instance. Test with `app.request()`:
+
+```ts
+const res = await app.request("/api/things", {
+  headers: { "X-Auth-Token": apiKey },
+});
+expect(res.status).toBe(200);
+```
+
+Unit tests: `pnpm test:unit packages/api`
+
+## File structure
+
+```
+src/
+  builder.ts          # createService(), ServiceBuilder, VersionBuilder
+  versioning.ts       # Forward-copy algorithm + request-time resolution
+  middleware.ts       # Built-in tracer + logger (uses @langwatch/observability)
+  errors.ts           # Error handler (DomainError, ZodError, version-gated format)
+  sse.ts              # v.sse() with typed events
+  types.ts            # ServiceConfig, EndpointConfig, Handler, BaseApp
+  index.ts            # Public re-exports + routeHandlers()
+```
+
+## LLM instructions
+
+When creating a new API service using this framework:
+
+1. Create `src/app/api/{name}/[[...route]]/` with two files: `{name}.service.ts` and `route.ts`
+2. `route.ts` is always just `export { GET, POST, PUT, DELETE } from "./{name}.service"`
+3. Use `createService({ name })` with the service name matching the URL path segment
+4. Inject auth, organization, and resource limit middleware from `../../middleware/`
+5. Use `.provide()` for service-layer dependencies — factories get `{ project, organization, prisma }`
+6. Define Zod schemas for input/output/params next to the service, not in a shared types file
+7. Handlers return raw data when `output` is set; the framework validates and serializes
+8. Throw `NotFoundError` / `DomainError` for error responses — don't return `c.json({ error }, 404)` manually
+9. Use `status: 201` in endpoint config for creation endpoints
+10. Copy the scenarios service at `src/app/api/scenarios/[[...route]]/scenarios.service.ts` as a reference

--- a/langwatch/packages/api/README.md
+++ b/langwatch/packages/api/README.md
@@ -110,7 +110,7 @@ Second argument to `v.get()`, `v.post()`, etc:
   query: z.object({ limit: z.number() }), // Query string
   description: "...",               // OpenAPI description
   status: 201,                      // HTTP status (default 200)
-  auth: "none",                     // Skip auth for this endpoint
+  auth: "none",                     // Skip auth and legacy org resolution
   resourceLimit: "scenarios",       // Enforce resource limits
   middleware: [rateLimiter()],       // Extra per-endpoint middleware
 }
@@ -152,7 +152,7 @@ The first path segment is reserved when it is `latest`, `preview`, or a date-sha
 
 ## Providers
 
-`.provide()` injects services into handlers via `app.*`. Factories receive the base context and resolve concurrently, so there are no cross-provider dependencies. Provider factories run after auth and organization middleware, with the resolved request context available to logging. The `project` and `_legacy` names are reserved for the base context.
+`.provide()` injects services into handlers via `app.*`. Factories receive the base context and resolve concurrently, so there are no cross-provider dependencies. Provider factories run after any enabled auth and organization middleware, with the resolved request context available to logging. Endpoints using `auth: "none"` skip both the service auth and legacy organization middleware. The `project` and `_legacy` names are reserved for the base context.
 
 ```ts
 .provide({

--- a/langwatch/packages/api/README.md
+++ b/langwatch/packages/api/README.md
@@ -54,7 +54,10 @@ export const app = createService({
         output: thingSchema,
       },
       async (_c, { params, app }) => {
-        return app.thingService.getById({ id: params.id, projectId: app.project.id });
+        return app.thingService.getById({
+          id: params.id,
+          projectId: app.project.id,
+        });
       },
     );
   })
@@ -92,7 +95,7 @@ v.get("/path", config, async (c, { input, params, query, app }) => {
 });
 ```
 
-When `output` is defined, return raw data. The framework validates + serializes.
+When `output` is defined, return raw data. The framework validates + serializes; a handler response that violates its output contract is reported as an internal server error.
 When `output` is not defined, return a Hono `Response` directly.
 
 ## Endpoint config
@@ -113,11 +116,11 @@ Second argument to `v.get()`, `v.post()`, etc:
 }
 ```
 
-All fields optional. Pass `{}` for a bare endpoint.
+All fields optional. Pass `{}` for a bare endpoint. Endpoint paths must be empty or begin with `/`. Declaring `resourceLimit` without a service-level `_legacy.resourceLimitMiddleware` fails the build rather than silently disabling the limit.
 
 ## Versioning
 
-Versions are dates. Each version inherits all endpoints from the previous one. Override or add endpoints, and use `withdraw()` to remove.
+Versions are real `YYYY-MM-DD` calendar dates. Invalid or duplicate versions fail at registration instead of being silently ignored. Each version inherits all endpoints from the previous one. Override or add endpoints, and use `withdraw()` to remove.
 
 ```ts
 .version("2025-03-15", (v) => {
@@ -135,19 +138,21 @@ Versions are dates. Each version inherits all endpoints from the previous one. O
 
 URL structure:
 
-| URL | Resolves to |
-|-----|-------------|
-| `/api/things/2025-03-15/` | Exact version |
-| `/api/things/2025-09-01/` | Exact version |
-| `/api/things/latest/` | Most recent dated version |
-| `/api/things/` | Same as latest (backwards compat) |
-| `/api/things/preview/` | Preview endpoints (never in latest) |
+| URL                       | Resolves to                         |
+| ------------------------- | ----------------------------------- |
+| `/api/things/2025-03-15/` | Exact version                       |
+| `/api/things/2025-09-01/` | Exact version                       |
+| `/api/things/latest/`     | Most recent dated version           |
+| `/api/things/`            | Same as latest (backwards compat)   |
+| `/api/things/preview/`    | Preview endpoints (never in latest) |
 
 Response headers: `X-API-Version` and `X-API-Version-Status` (stable/latest/preview/unversioned).
 
+The first path segment is reserved when it is `latest`, `preview`, or a date-shaped version. This prevents a missing versioned route from falling through to a dynamic unversioned endpoint.
+
 ## Providers
 
-`.provide()` injects services into handlers via `app.*`. Factories receive the base context. No cross-provider dependencies.
+`.provide()` injects services into handlers via `app.*`. Factories receive the base context and resolve concurrently, so there are no cross-provider dependencies. Provider factories run after auth and organization middleware, with the resolved request context available to logging. The `project` and `_legacy` names are reserved for the base context.
 
 ```ts
 .provide({
@@ -160,17 +165,23 @@ Response headers: `X-API-Version` and `X-API-Version-Status` (stable/latest/prev
 
 ## SSE streaming
 
+SSE endpoints are GET routes. Use `query` for request data; JSON request bodies are intentionally unsupported. `stream.emit()` validates and serializes the parsed payload. On validation failure it emits an `error` event and rejects, so the handler must explicitly catch the error if it wants to continue streaming.
+
 ```ts
-v.sse("/execute", {
-  events: {
-    result: z.object({ score: z.number() }),
-    error: z.object({ message: z.string() }),
+v.sse(
+  "/execute",
+  {
+    events: {
+      result: z.object({ score: z.number() }),
+      error: z.object({ message: z.string() }),
+    },
+    query: querySchema,
   },
-  query: querySchema,
-}, async (c, { query, app }, stream) => {
-  await stream.emit("result", { score: 0.95 }); // validated against schema
-  stream.close();
-});
+  async (c, { query, app }, stream) => {
+    await stream.emit("result", { score: 0.95 }); // validated against schema
+    stream.close();
+  },
+);
 ```
 
 ## Error handling
@@ -191,11 +202,19 @@ Validation error example:
   "reasons": [
     {
       "code": "schema_failure",
-      "meta": { "field": "url", "type": "invalid_string", "message": "must be a valid URL" }
+      "meta": {
+        "field": "url",
+        "type": "invalid_string",
+        "message": "must be a valid URL"
+      }
     },
     {
       "code": "schema_failure",
-      "meta": { "field": "title", "type": "too_small", "message": "title is required" }
+      "meta": {
+        "field": "title",
+        "type": "too_small",
+        "message": "title is required"
+      }
     }
   ]
 }
@@ -212,7 +231,7 @@ const res = await app.request("/api/things", {
 expect(res.status).toBe(200);
 ```
 
-Unit tests: `pnpm test:unit packages/api`
+Unit tests: `pnpm --filter @langwatch/api test:unit`
 
 ## File structure
 
@@ -240,4 +259,4 @@ When creating a new API service using this framework:
 7. Handlers return raw data when `output` is set; the framework validates and serializes
 8. Throw `NotFoundError` / `DomainError` for error responses — don't return `c.json({ error }, 404)` manually
 9. Use `status: 201` in endpoint config for creation endpoints
-10. Copy the scenarios service at `src/app/api/scenarios/[[...route]]/scenarios.service.ts` as a reference
+10. Use the Quick start in this README as the reference until an existing service has been migrated to the package

--- a/langwatch/packages/api/package.json
+++ b/langwatch/packages/api/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@langwatch/api",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Service framework for building versioned, typed API services on Hono",
+  "type": "module",
+  "packageManager": "pnpm@10.26.0",
+  "main": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:unit": "vitest run"
+  },
+  "keywords": [
+    "langwatch",
+    "hono",
+    "api",
+    "service-framework"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@langwatch/telemetry": "workspace:*"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "hono": "^4.12.0",
+    "hono-openapi": "^0.4.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.0",
+    "@typescript/native-preview": "7.0.0-dev.20260316.1",
+    "vitest": "^4.1.0"
+  }
+}

--- a/langwatch/packages/api/package.json
+++ b/langwatch/packages/api/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "description": "Service framework for building versioned, typed API services on Hono",
   "type": "module",
-  "packageManager": "pnpm@10.26.0",
+  "packageManager": "pnpm@10.24.0",
   "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest",
@@ -23,13 +26,13 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "hono": "^4.12.0",
+    "hono": "^4.12.25",
     "hono-openapi": "^0.4.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "@types/node": "^24.12.0",
-    "@typescript/native-preview": "7.0.0-dev.20260316.1",
-    "vitest": "^4.1.0"
+    "@types/node": "^26.0.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
   }
 }

--- a/langwatch/packages/api/package.json
+++ b/langwatch/packages/api/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@langwatch/api",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Service framework for building versioned, typed API services on Hono",
+  "type": "module",
+  "packageManager": "pnpm@10.26.0",
+  "main": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:unit": "vitest run"
+  },
+  "keywords": [
+    "langwatch",
+    "hono",
+    "api",
+    "service-framework"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@langwatch/observability": "workspace:*"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "hono": "^4.12.0",
+    "hono-openapi": "^0.4.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.0",
+    "@typescript/native-preview": "7.0.0-dev.20260316.1",
+    "vitest": "^4.1.0"
+  }
+}

--- a/langwatch/packages/api/src/__tests__/builder.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/builder.unit.test.ts
@@ -1,0 +1,694 @@
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+import type { MiddlewareHandler } from "hono";
+
+import { createService } from "../builder.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildTestService() {
+  return createService({ name: "test", basePath: "/api/test" });
+}
+
+async function makeRequest(
+  app: ReturnType<ReturnType<typeof createService>["build"]>,
+  path: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  return app.request(path, options);
+}
+
+async function jsonBody(res: Response): Promise<unknown> {
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// createService + build
+// ---------------------------------------------------------------------------
+
+describe("createService", () => {
+  describe("when building a minimal service with one version", () => {
+    it("responds to versioned path", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.array(z.string()) }, async () => {
+            return ["a", "b"];
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/items");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual(["a", "b"]);
+    });
+
+    it("responds to latest path", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => {
+            return { ok: true };
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/latest/items");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ ok: true });
+    });
+
+    it("responds to bare path (no version) as latest alias", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => {
+            return { ok: true };
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/items");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ ok: true });
+    });
+  });
+
+  describe("when requesting an unknown version", () => {
+    it("returns 404", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", {}, async (c) => c.json({ ok: true }));
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2099-01-01/items");
+      expect(res.status).toBe(404);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// .provide() -- provider injection
+// ---------------------------------------------------------------------------
+
+describe("provide", () => {
+  describe("when providers are registered", () => {
+    it("makes them available in the handler via app context", async () => {
+      const app = buildTestService()
+        .provide({
+          greeting: () => "hello from provider",
+        })
+        .version("2025-03-15", (v) => {
+          v.get("/greet", { output: z.object({ message: z.string() }) }, async (_c, { app }) => {
+            return { message: app.greeting };
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/greet");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ message: "hello from provider" });
+    });
+  });
+
+  describe("when providers are async", () => {
+    it("resolves them before the handler runs", async () => {
+      const app = buildTestService()
+        .provide({
+          data: async () => {
+            return { loaded: true };
+          },
+        })
+        .version("2025-03-15", (v) => {
+          v.get("/data", { output: z.object({ loaded: z.boolean() }) }, async (_c, { app }) => {
+            return app.data;
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/data");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ loaded: true });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input / output validation
+// ---------------------------------------------------------------------------
+
+describe("input validation", () => {
+  describe("when valid input is provided", () => {
+    it("passes parsed input to the handler", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.post(
+            "/items",
+            {
+              input: z.object({ name: z.string() }),
+              output: z.object({ created: z.string() }),
+            },
+            async (_c, { input }) => {
+              return { created: input.name };
+            },
+          );
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/items", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "test-item" }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ created: "test-item" });
+    });
+  });
+
+  describe("when invalid input is provided", () => {
+    it("returns a validation error", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.post(
+            "/items",
+            {
+              input: z.object({ name: z.string().min(1) }),
+              output: z.object({ created: z.string() }),
+            },
+            async (_c, { input }) => {
+              return { created: input.name };
+            },
+          );
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/items", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "" }),
+      });
+
+      // hono-openapi/zod validator returns 400 by default
+      expect(res.status).toBeLessThan(500);
+    });
+  });
+});
+
+describe("output validation", () => {
+  describe("when handler returns data matching the output schema", () => {
+    it("serializes and returns the validated output", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/items",
+            { output: z.object({ id: z.number(), name: z.string() }) },
+            async () => {
+              return { id: 1, name: "item", extraField: "stripped" };
+            },
+          );
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/items");
+      expect(res.status).toBe(200);
+      // Zod .parse strips extra fields
+      expect(await jsonBody(res)).toEqual({ id: 1, name: "item" });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Params and query validation
+// ---------------------------------------------------------------------------
+
+describe("params validation", () => {
+  describe("when params schema is provided", () => {
+    it("passes parsed params to the handler", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/items/:id",
+            {
+              params: z.object({ id: z.string() }),
+              output: z.object({ id: z.string() }),
+            },
+            async (_c, { params }) => {
+              return { id: params.id };
+            },
+          );
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/items/abc");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ id: "abc" });
+    });
+  });
+});
+
+describe("query validation", () => {
+  describe("when query schema is provided", () => {
+    it("passes parsed query to the handler", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/items",
+            {
+              query: z.object({ page: z.string() }),
+              output: z.object({ page: z.string() }),
+            },
+            async (_c, { query }) => {
+              return { page: query.page };
+            },
+          );
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/items?page=2");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ page: "2" });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-endpoint options
+// ---------------------------------------------------------------------------
+
+describe("per-endpoint auth option", () => {
+  describe("when auth is 'none'", () => {
+    it("skips the auth middleware", async () => {
+      const authMiddleware: MiddlewareHandler = vi.fn(async (_c, next) => {
+        await next();
+      });
+
+      const app = createService({ name: "test", basePath: "/api/test", auth: authMiddleware })
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/public",
+            { auth: "none", output: z.object({ open: z.boolean() }) },
+            async () => ({ open: true }),
+          );
+          v.get(
+            "/private",
+            { output: z.object({ secret: z.boolean() }) },
+            async () => ({ secret: true }),
+          );
+        })
+        .build();
+
+      // Public endpoint -- auth should NOT be called
+      const publicRes = await makeRequest(app, "/api/test/2025-03-15/public");
+      expect(publicRes.status).toBe(200);
+
+      // Private endpoint -- auth SHOULD be called
+      await makeRequest(app, "/api/test/2025-03-15/private");
+      expect(authMiddleware).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("per-endpoint middleware", () => {
+  describe("when custom middleware is provided", () => {
+    it("runs the middleware before the handler", async () => {
+      const order: string[] = [];
+
+      const customMiddleware: MiddlewareHandler = async (_c, next) => {
+        order.push("custom-middleware");
+        await next();
+      };
+
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/items",
+            {
+              middleware: [customMiddleware],
+              output: z.object({ ok: z.boolean() }),
+            },
+            async () => {
+              order.push("handler");
+              return { ok: true };
+            },
+          );
+        })
+        .build();
+
+      await makeRequest(app, "/api/test/2025-03-15/items");
+      expect(order).toEqual(["custom-middleware", "handler"]);
+    });
+  });
+});
+
+describe("resource limit middleware", () => {
+  describe("when resourceLimit is set and factory is provided", () => {
+    it("applies the resource limit middleware", async () => {
+      const resourceLimitCalled = vi.fn();
+
+      const app = createService({
+        name: "test",
+        basePath: "/api/test",
+        _legacy: {
+          resourceLimitMiddleware: (limitType: string) => {
+            return async (_c: any, next: any) => {
+              resourceLimitCalled(limitType);
+              await next();
+            };
+          },
+        },
+      })
+        .version("2025-03-15", (v) => {
+          v.post(
+            "/items",
+            {
+              resourceLimit: "items",
+              output: z.object({ ok: z.boolean() }),
+            },
+            async () => ({ ok: true }),
+          );
+        })
+        .build();
+
+      await makeRequest(app, "/api/test/2025-03-15/items", { method: "POST" });
+      expect(resourceLimitCalled).toHaveBeenCalledWith("items");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Versioning behavior (via builder)
+// ---------------------------------------------------------------------------
+
+describe("version forward-copying via builder", () => {
+  describe("when v2 inherits endpoints from v1", () => {
+    it("makes v1 endpoints available in v2", async () => {
+      const app = buildTestService()
+        .version("2025-01-01", (v) => {
+          v.get("/items", { output: z.object({ from: z.string() }) }, async () => ({
+            from: "v1",
+          }));
+        })
+        .version("2025-06-01", (v) => {
+          v.get("/new", { output: z.object({ from: z.string() }) }, async () => ({
+            from: "v2",
+          }));
+        })
+        .build();
+
+      // v2 should have the inherited /items endpoint
+      const res = await makeRequest(app, "/api/test/2025-06-01/items");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ from: "v1" });
+
+      // v2 should have its own /new endpoint
+      const newRes = await makeRequest(app, "/api/test/2025-06-01/new");
+      expect(newRes.status).toBe(200);
+      expect(await jsonBody(newRes)).toEqual({ from: "v2" });
+    });
+  });
+
+  describe("when an endpoint is withdrawn", () => {
+    it("returns 410 Gone for the withdrawn endpoint", async () => {
+      const app = buildTestService()
+        .version("2025-01-01", (v) => {
+          v.get("/old", { output: z.object({ ok: z.boolean() }) }, async () => ({
+            ok: true,
+          }));
+          v.get("/kept", { output: z.object({ ok: z.boolean() }) }, async () => ({
+            ok: true,
+          }));
+        })
+        .version("2025-06-01", (v) => {
+          v.withdraw("get", "/old");
+        })
+        .build();
+
+      // /old should be 410 in v2
+      const oldRes = await makeRequest(app, "/api/test/2025-06-01/old");
+      expect(oldRes.status).toBe(410);
+      const oldBody = await jsonBody(oldRes);
+      expect((oldBody as { kind: string }).kind).toBe("endpoint_withdrawn");
+
+      // /old should still work in v1
+      const v1Res = await makeRequest(app, "/api/test/2025-01-01/old");
+      expect(v1Res.status).toBe(200);
+
+      // /kept should still work in v2
+      const keptRes = await makeRequest(app, "/api/test/2025-06-01/kept");
+      expect(keptRes.status).toBe(200);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response headers
+// ---------------------------------------------------------------------------
+
+describe("version response headers", () => {
+  describe("when a versioned request is made", () => {
+    it("sets X-API-Version and X-API-Version-Status headers", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => ({
+            ok: true,
+          }));
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/items");
+      expect(res.headers.get("X-API-Version")).toBe("2025-03-15");
+      expect(res.headers.get("X-API-Version-Status")).toBe("stable");
+    });
+  });
+
+  describe("when a latest request is made", () => {
+    it("sets status to latest", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => ({
+            ok: true,
+          }));
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/latest/items");
+      expect(res.headers.get("X-API-Version")).toBe("latest");
+      expect(res.headers.get("X-API-Version-Status")).toBe("latest");
+    });
+  });
+
+  describe("when a bare path request is made", () => {
+    it("sets status to unversioned", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => ({
+            ok: true,
+          }));
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/items");
+      expect(res.headers.get("X-API-Version-Status")).toBe("unversioned");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Preview endpoints
+// ---------------------------------------------------------------------------
+
+describe("preview", () => {
+  describe("when preview endpoints are registered", () => {
+    it("makes them available at /preview/ path", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.object({ stable: z.boolean() }) }, async () => ({
+            stable: true,
+          }));
+        })
+        .preview((v) => {
+          v.get("/beta", { output: z.object({ preview: z.boolean() }) }, async () => ({
+            preview: true,
+          }));
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/preview/beta");
+      expect(res.status).toBe(200);
+      expect(await jsonBody(res)).toEqual({ preview: true });
+    });
+
+    it("does not include preview endpoints in latest", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.object({ stable: z.boolean() }) }, async () => ({
+            stable: true,
+          }));
+        })
+        .preview((v) => {
+          v.get("/beta", { output: z.object({ preview: z.boolean() }) }, async () => ({
+            preview: true,
+          }));
+        })
+        .build();
+
+      // /beta should not exist under latest
+      const res = await makeRequest(app, "/api/test/latest/beta");
+      expect(res.status).toBe(404);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handler integration
+// ---------------------------------------------------------------------------
+
+describe("error handling", () => {
+  describe("when a handler throws an error", () => {
+    it("catches and formats the error", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/fail", {}, async () => {
+            throw new Error("something broke");
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/fail");
+      expect(res.status).toBe(500);
+      const body = (await jsonBody(res)) as { kind: string };
+      expect(body.kind).toBe("internal_error");
+    });
+  });
+
+  describe("when a handler throws a DomainError-like error", () => {
+    it("serializes it correctly", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/fail", {}, async () => {
+            const err = Object.assign(new Error("Not found"), {
+              kind: "thing_not_found",
+              httpStatus: 404,
+              meta: { id: "123" },
+              serialize() {
+                return {
+                  kind: "thing_not_found",
+                  meta: { id: "123" },
+                  telemetry: { traceId: undefined, spanId: undefined },
+                  httpStatus: 404,
+                  reasons: [],
+                };
+              },
+            });
+            throw err;
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/fail");
+      expect(res.status).toBe(404);
+      const body = (await jsonBody(res)) as { kind: string; meta: { id: string } };
+      expect(body.kind).toBe("thing_not_found");
+      expect(body.meta.id).toBe("123");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Global middleware
+// ---------------------------------------------------------------------------
+
+describe("global middleware", () => {
+  describe("when global middleware is provided", () => {
+    it("runs for every request", async () => {
+      const calls: string[] = [];
+
+      const app = createService({
+        name: "test",
+        basePath: "/api/test",
+        middleware: [
+          async (_c, next) => {
+            calls.push("global");
+            await next();
+          },
+        ],
+      })
+        .version("2025-03-15", (v) => {
+          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => {
+            calls.push("handler");
+            return { ok: true };
+          });
+        })
+        .build();
+
+      await makeRequest(app, "/api/test/2025-03-15/items");
+      expect(calls).toEqual(["global", "handler"]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP methods
+// ---------------------------------------------------------------------------
+
+describe("HTTP methods", () => {
+  function buildMethodApp() {
+    return buildTestService()
+      .version("2025-03-15", (v) => {
+        v.get("/r", { output: z.literal("get") }, async () => "get" as const);
+        v.post("/r", { output: z.literal("post") }, async () => "post" as const);
+        v.put("/r", { output: z.literal("put") }, async () => "put" as const);
+        v.delete("/r", { output: z.literal("del") }, async () => "del" as const);
+        v.patch("/r", { output: z.literal("patch") }, async () => "patch" as const);
+      })
+      .build();
+  }
+
+  it("handles GET", async () => {
+    const app = buildMethodApp();
+    expect(await (await makeRequest(app, "/api/test/2025-03-15/r")).json()).toBe("get");
+  });
+
+  it("handles POST", async () => {
+    const app = buildMethodApp();
+    expect(await (await makeRequest(app, "/api/test/2025-03-15/r", { method: "POST" })).json()).toBe("post");
+  });
+
+  it("handles PUT", async () => {
+    const app = buildMethodApp();
+    expect(await (await makeRequest(app, "/api/test/2025-03-15/r", { method: "PUT" })).json()).toBe("put");
+  });
+
+  it("handles DELETE", async () => {
+    const app = buildMethodApp();
+    expect(await (await makeRequest(app, "/api/test/2025-03-15/r", { method: "DELETE" })).json()).toBe("del");
+  });
+
+  it("handles PATCH", async () => {
+    const app = buildMethodApp();
+    expect(await (await makeRequest(app, "/api/test/2025-03-15/r", { method: "PATCH" })).json()).toBe("patch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler returning raw Response (no output schema)
+// ---------------------------------------------------------------------------
+
+describe("raw Response return", () => {
+  describe("when no output schema is set", () => {
+    it("allows the handler to return a raw Response", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/raw", {}, async (c) => {
+            return c.text("raw response", 201);
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/raw");
+      expect(res.status).toBe(201);
+      expect(await res.text()).toBe("raw response");
+    });
+  });
+});

--- a/langwatch/packages/api/src/__tests__/builder.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/builder.unit.test.ts
@@ -424,11 +424,13 @@ describe("version forward-copying via builder", () => {
         })
         .build();
 
-      // /old should be 410 in v2
+      // /old should be 410 in v2 with version headers
       const oldRes = await makeRequest(app, "/api/test/2025-06-01/old");
       expect(oldRes.status).toBe(410);
       const oldBody = await jsonBody(oldRes);
       expect((oldBody as { kind: string }).kind).toBe("endpoint_withdrawn");
+      expect(oldRes.headers.get("X-API-Version")).toBe("2025-06-01");
+      expect(oldRes.headers.get("X-API-Version-Status")).toBe("stable");
 
       // /old should still work in v1
       const v1Res = await makeRequest(app, "/api/test/2025-01-01/old");
@@ -689,6 +691,43 @@ describe("raw Response return", () => {
       const res = await makeRequest(app, "/api/test/2025-03-15/raw");
       expect(res.status).toBe(201);
       expect(await res.text()).toBe("raw response");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Null return (should serialize as JSON null, not 204)
+// ---------------------------------------------------------------------------
+
+describe("null return", () => {
+  describe("when handler returns null with an output schema", () => {
+    it("serializes as JSON null", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/nullable", { output: z.null() }, async () => {
+            return null;
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/nullable");
+      expect(res.status).toBe(200);
+      expect(await res.json()).toBeNull();
+    });
+  });
+
+  describe("when handler returns undefined", () => {
+    it("returns 204 No Content", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get("/void", {}, async (c) => {
+            return c.body(null, 204);
+          });
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/void");
+      expect(res.status).toBe(204);
     });
   });
 });

--- a/langwatch/packages/api/src/__tests__/builder.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/builder.unit.test.ts
@@ -123,6 +123,21 @@ describe("createService", () => {
         }),
       ).toThrow(/Endpoint path must start/);
     });
+
+    it("rejects endpoints in the reserved version namespace", () => {
+      for (const path of [
+        "/latest",
+        "/preview/items",
+        "/2025-03-15/items",
+        "/2025-02-30/items",
+      ]) {
+        expect(() =>
+          buildTestService().version("2025-03-15", (v) => {
+            v.get(path, {}, async (c) => c.body(null, 204));
+          }),
+        ).toThrow(/reserved API version namespace/);
+      }
+    });
   });
 
   describe("when a version namespace misses a route", () => {
@@ -477,6 +492,41 @@ describe("per-endpoint auth option", () => {
       // Private endpoint -- auth SHOULD be called
       await makeRequest(app, "/api/test/2025-03-15/private");
       expect(authMiddleware).toHaveBeenCalled();
+    });
+
+    it("skips legacy organization resolution that depends on auth", async () => {
+      const authMiddleware: MiddlewareHandler = vi.fn(async (c, next) => {
+        c.set("project", { id: "project-1" });
+        await next();
+      });
+      const organizationMiddleware: MiddlewareHandler = vi.fn(
+        async (c, next) => {
+          if (!c.get("project")) {
+            return c.json({ error: "without project" }, 500);
+          }
+          await next();
+        },
+      );
+
+      const app = createService({
+        name: "test",
+        basePath: "/api/test",
+        auth: authMiddleware,
+        _legacy: { organizationMiddleware },
+      })
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/public",
+            { auth: "none", output: z.object({ open: z.boolean() }) },
+            async () => ({ open: true }),
+          );
+        })
+        .build();
+
+      const response = await makeRequest(app, "/api/test/2025-03-15/public");
+      expect(response.status).toBe(200);
+      expect(authMiddleware).not.toHaveBeenCalled();
+      expect(organizationMiddleware).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/packages/api/src/__tests__/builder.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/builder.unit.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { z } from "zod";
 import type { MiddlewareHandler } from "hono";
+import { generateSpecs } from "hono-openapi";
+import { getCurrentContext } from "@langwatch/observability/context";
 
 import { createService } from "../builder.js";
 
@@ -47,9 +49,13 @@ describe("createService", () => {
     it("responds to latest path", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
-          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => {
-            return { ok: true };
-          });
+          v.get(
+            "/items",
+            { output: z.object({ ok: z.boolean() }) },
+            async () => {
+              return { ok: true };
+            },
+          );
         })
         .build();
 
@@ -61,9 +67,13 @@ describe("createService", () => {
     it("responds to bare path (no version) as latest alias", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
-          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => {
-            return { ok: true };
-          });
+          v.get(
+            "/items",
+            { output: z.object({ ok: z.boolean() }) },
+            async () => {
+              return { ok: true };
+            },
+          );
         })
         .build();
 
@@ -85,6 +95,59 @@ describe("createService", () => {
       expect(res.status).toBe(404);
     });
   });
+
+  describe("when registering an invalid or duplicate version", () => {
+    it("fails fast instead of silently dropping endpoints", () => {
+      const service = buildTestService();
+
+      expect(() => service.version("2025-02-30", () => {})).toThrow(
+        /Invalid API version/,
+      );
+
+      service.version("2025-02-28", () => {});
+      expect(() => service.version("2025-02-28", () => {})).toThrow(
+        /registered more than once/,
+      );
+    });
+  });
+
+  describe("when service or endpoint paths are malformed", () => {
+    it("fails fast with an actionable error", () => {
+      expect(() => createService({ name: " " })).toThrow(/must not be empty/);
+      expect(() =>
+        createService({ name: "test", basePath: "api/test" }).build(),
+      ).toThrow(/basePath must start/);
+      expect(() =>
+        buildTestService().version("2025-03-15", (v) => {
+          v.get("items", {}, async (c) => c.body(null, 204));
+        }),
+      ).toThrow(/Endpoint path must start/);
+    });
+  });
+
+  describe("when a version namespace misses a route", () => {
+    it("does not fall through to a dynamic unversioned endpoint", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/:id/:child",
+            { params: z.object({ id: z.string(), child: z.string() }) },
+            async (c, { params }) => c.json(params),
+          );
+        })
+        .build();
+
+      expect((await makeRequest(app, "/api/test/latest/missing")).status).toBe(
+        404,
+      );
+      expect(
+        (await makeRequest(app, "/api/test/2099-01-01/missing")).status,
+      ).toBe(404);
+
+      const bare = await makeRequest(app, "/api/test/item-1/detail");
+      expect(bare.status).toBe(200);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -99,9 +162,13 @@ describe("provide", () => {
           greeting: () => "hello from provider",
         })
         .version("2025-03-15", (v) => {
-          v.get("/greet", { output: z.object({ message: z.string() }) }, async (_c, { app }) => {
-            return { message: app.greeting };
-          });
+          v.get(
+            "/greet",
+            { output: z.object({ message: z.string() }) },
+            async (_c, { app }) => {
+              return { message: app.greeting };
+            },
+          );
         })
         .build();
 
@@ -120,15 +187,85 @@ describe("provide", () => {
           },
         })
         .version("2025-03-15", (v) => {
-          v.get("/data", { output: z.object({ loaded: z.boolean() }) }, async (_c, { app }) => {
-            return app.data;
-          });
+          v.get(
+            "/data",
+            { output: z.object({ loaded: z.boolean() }) },
+            async (_c, { app }) => {
+              return app.data;
+            },
+          );
         })
         .build();
 
       const res = await makeRequest(app, "/api/test/2025-03-15/data");
       expect(res.status).toBe(200);
       expect(await jsonBody(res)).toEqual({ loaded: true });
+    });
+  });
+
+  describe("when providers are added after a version", () => {
+    it("preserves the endpoints already registered on the fluent builder", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/health",
+            { output: z.literal("ok") },
+            async () => "ok" as const,
+          );
+        })
+        .provide({ dependency: () => "available" })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/health");
+      expect(res.status).toBe(200);
+      expect(await res.json()).toBe("ok");
+    });
+  });
+
+  describe("when a provider uses a reserved BaseApp key", () => {
+    it("rejects the provider instead of overwriting request context", () => {
+      expect(() =>
+        buildTestService().provide({ project: () => ({ id: "wrong" }) }),
+      ).toThrow(/reserved by BaseApp/);
+    });
+  });
+
+  describe("when auth resolves request context", () => {
+    it("makes that context available to providers before the handler runs", async () => {
+      const auth: MiddlewareHandler = async (c, next) => {
+        c.set("organization", { id: "org-1" });
+        c.set("project", { id: "project-1" });
+        c.set("user", { id: "user-1" });
+        await next();
+      };
+
+      const app = createService({ name: "test", basePath: "/api/test", auth })
+        .provide({ requestContext: () => getCurrentContext() })
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/context",
+            {
+              output: z.object({
+                organizationId: z.string(),
+                projectId: z.string(),
+                userId: z.string(),
+              }),
+            },
+            async (_c, { app }) => ({
+              organizationId: app.requestContext?.organizationId ?? "missing",
+              projectId: app.requestContext?.projectId ?? "missing",
+              userId: app.requestContext?.userId ?? "missing",
+            }),
+          );
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/context");
+      expect(await res.json()).toEqual({
+        organizationId: "org-1",
+        projectId: "project-1",
+        userId: "user-1",
+      });
     });
   });
 });
@@ -189,8 +326,17 @@ describe("input validation", () => {
         body: JSON.stringify({ name: "" }),
       });
 
-      // hono-openapi/zod validator returns 400 by default
-      expect(res.status).toBeLessThan(500);
+      expect(res.status).toBe(422);
+      expect(await jsonBody(res)).toMatchObject({
+        kind: "validation_error",
+        reasons: [
+          {
+            code: "schema_failure",
+            meta: { field: "name", type: "too_small" },
+          },
+        ],
+      });
+      expect(res.headers.get("X-API-Version")).toBe("2025-03-15");
     });
   });
 });
@@ -214,6 +360,28 @@ describe("output validation", () => {
       expect(res.status).toBe(200);
       // Zod .parse strips extra fields
       expect(await jsonBody(res)).toEqual({ id: 1, name: "item" });
+    });
+  });
+
+  describe("when handler output violates the declared schema", () => {
+    it("returns an internal error instead of blaming the client", async () => {
+      const app = buildTestService()
+        .version("2025-03-15", (v) => {
+          v.get(
+            "/items",
+            { output: z.object({ id: z.number() }) },
+            async () => ({ id: "not-a-number" }) as never,
+          );
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-03-15/items");
+
+      expect(res.status).toBe(500);
+      expect(await jsonBody(res)).toEqual({
+        kind: "internal_error",
+        message: "Internal server error",
+      });
     });
   });
 });
@@ -283,7 +451,11 @@ describe("per-endpoint auth option", () => {
         await next();
       });
 
-      const app = createService({ name: "test", basePath: "/api/test", auth: authMiddleware })
+      const app = createService({
+        name: "test",
+        basePath: "/api/test",
+        auth: authMiddleware,
+      })
         .version("2025-03-15", (v) => {
           v.get(
             "/public",
@@ -351,7 +523,7 @@ describe("resource limit middleware", () => {
         basePath: "/api/test",
         _legacy: {
           resourceLimitMiddleware: (limitType: string) => {
-            return async (_c: any, next: any) => {
+            return async (_c, next) => {
               resourceLimitCalled(limitType);
               await next();
             };
@@ -374,6 +546,18 @@ describe("resource limit middleware", () => {
       expect(resourceLimitCalled).toHaveBeenCalledWith("items");
     });
   });
+
+  describe("when a resource limit is declared without its middleware factory", () => {
+    it("fails closed while building the service", () => {
+      const service = buildTestService().version("2025-03-15", (v) => {
+        v.post("/items", { resourceLimit: "items" }, async (c) =>
+          c.body(null, 204),
+        );
+      });
+
+      expect(() => service.build()).toThrow(/has no resourceLimitMiddleware/);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -385,14 +569,22 @@ describe("version forward-copying via builder", () => {
     it("makes v1 endpoints available in v2", async () => {
       const app = buildTestService()
         .version("2025-01-01", (v) => {
-          v.get("/items", { output: z.object({ from: z.string() }) }, async () => ({
-            from: "v1",
-          }));
+          v.get(
+            "/items",
+            { output: z.object({ from: z.string() }) },
+            async () => ({
+              from: "v1",
+            }),
+          );
         })
         .version("2025-06-01", (v) => {
-          v.get("/new", { output: z.object({ from: z.string() }) }, async () => ({
-            from: "v2",
-          }));
+          v.get(
+            "/new",
+            { output: z.object({ from: z.string() }) },
+            async () => ({
+              from: "v2",
+            }),
+          );
         })
         .build();
 
@@ -412,12 +604,20 @@ describe("version forward-copying via builder", () => {
     it("returns 410 Gone for the withdrawn endpoint", async () => {
       const app = buildTestService()
         .version("2025-01-01", (v) => {
-          v.get("/old", { output: z.object({ ok: z.boolean() }) }, async () => ({
-            ok: true,
-          }));
-          v.get("/kept", { output: z.object({ ok: z.boolean() }) }, async () => ({
-            ok: true,
-          }));
+          v.get(
+            "/old",
+            { output: z.object({ ok: z.boolean() }) },
+            async () => ({
+              ok: true,
+            }),
+          );
+          v.get(
+            "/kept",
+            { output: z.object({ ok: z.boolean() }) },
+            async () => ({
+              ok: true,
+            }),
+          );
         })
         .version("2025-06-01", (v) => {
           v.withdraw("get", "/old");
@@ -440,6 +640,75 @@ describe("version forward-copying via builder", () => {
       const keptRes = await makeRequest(app, "/api/test/2025-06-01/kept");
       expect(keptRes.status).toBe(200);
     });
+
+    it("keeps inherited auth and endpoint middleware on the 410 response", async () => {
+      const calls: string[] = [];
+      const auth: MiddlewareHandler = async (_c, next) => {
+        calls.push("auth");
+        await next();
+      };
+      const endpointMiddleware: MiddlewareHandler = async (_c, next) => {
+        calls.push("endpoint");
+        await next();
+      };
+
+      const app = createService({ name: "test", basePath: "/api/test", auth })
+        .version("2025-01-01", (v) => {
+          v.get("/old", { middleware: [endpointMiddleware] }, async (c) =>
+            c.json({ ok: true }),
+          );
+        })
+        .version("2025-06-01", (v) => {
+          v.withdraw("get", "/old");
+        })
+        .build();
+
+      const res = await makeRequest(app, "/api/test/2025-06-01/old");
+      expect(res.status).toBe(410);
+      expect(calls).toEqual(["auth", "endpoint"]);
+      expect(res.headers.get("X-API-Version")).toBe("2025-06-01");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAPI metadata
+// ---------------------------------------------------------------------------
+
+describe("OpenAPI responses", () => {
+  it("documents the configured success status", async () => {
+    const app = buildTestService()
+      .version("2025-03-15", (v) => {
+        v.post(
+          "/items",
+          { output: z.object({ id: z.string() }), status: 201 },
+          async () => ({ id: "item-1" }),
+        );
+      })
+      .build();
+
+    const spec = await generateSpecs(app);
+    expect(
+      spec.paths["/api/test/2025-03-15/items"]?.post?.responses,
+    ).toHaveProperty("201");
+    expect(
+      spec.paths["/api/test/2025-03-15/items"]?.post?.responses,
+    ).not.toHaveProperty("200");
+  });
+
+  it("adds a default success response for description-only routes", async () => {
+    const app = buildTestService()
+      .version("2025-03-15", (v) => {
+        v.get("/health", { description: "Health check" }, async (c) =>
+          c.text("ok"),
+        );
+      })
+      .build();
+
+    const spec = await generateSpecs(app);
+    expect(
+      spec.paths["/api/test/2025-03-15/health"]?.get?.responses,
+    ).toHaveProperty("200");
   });
 });
 
@@ -452,9 +721,13 @@ describe("version response headers", () => {
     it("sets X-API-Version and X-API-Version-Status headers", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
-          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => ({
-            ok: true,
-          }));
+          v.get(
+            "/items",
+            { output: z.object({ ok: z.boolean() }) },
+            async () => ({
+              ok: true,
+            }),
+          );
         })
         .build();
 
@@ -468,9 +741,13 @@ describe("version response headers", () => {
     it("sets status to latest", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
-          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => ({
-            ok: true,
-          }));
+          v.get(
+            "/items",
+            { output: z.object({ ok: z.boolean() }) },
+            async () => ({
+              ok: true,
+            }),
+          );
         })
         .build();
 
@@ -484,9 +761,13 @@ describe("version response headers", () => {
     it("sets status to unversioned", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
-          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => ({
-            ok: true,
-          }));
+          v.get(
+            "/items",
+            { output: z.object({ ok: z.boolean() }) },
+            async () => ({
+              ok: true,
+            }),
+          );
         })
         .build();
 
@@ -505,14 +786,22 @@ describe("preview", () => {
     it("makes them available at /preview/ path", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
-          v.get("/items", { output: z.object({ stable: z.boolean() }) }, async () => ({
-            stable: true,
-          }));
+          v.get(
+            "/items",
+            { output: z.object({ stable: z.boolean() }) },
+            async () => ({
+              stable: true,
+            }),
+          );
         })
         .preview((v) => {
-          v.get("/beta", { output: z.object({ preview: z.boolean() }) }, async () => ({
-            preview: true,
-          }));
+          v.get(
+            "/beta",
+            { output: z.object({ preview: z.boolean() }) },
+            async () => ({
+              preview: true,
+            }),
+          );
         })
         .build();
 
@@ -524,14 +813,22 @@ describe("preview", () => {
     it("does not include preview endpoints in latest", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
-          v.get("/items", { output: z.object({ stable: z.boolean() }) }, async () => ({
-            stable: true,
-          }));
+          v.get(
+            "/items",
+            { output: z.object({ stable: z.boolean() }) },
+            async () => ({
+              stable: true,
+            }),
+          );
         })
         .preview((v) => {
-          v.get("/beta", { output: z.object({ preview: z.boolean() }) }, async () => ({
-            preview: true,
-          }));
+          v.get(
+            "/beta",
+            { output: z.object({ preview: z.boolean() }) },
+            async () => ({
+              preview: true,
+            }),
+          );
         })
         .build();
 
@@ -590,7 +887,10 @@ describe("error handling", () => {
 
       const res = await makeRequest(app, "/api/test/2025-03-15/fail");
       expect(res.status).toBe(404);
-      const body = (await jsonBody(res)) as { kind: string; meta: { id: string } };
+      const body = (await jsonBody(res)) as {
+        kind: string;
+        meta: { id: string };
+      };
       expect(body.kind).toBe("thing_not_found");
       expect(body.meta.id).toBe("123");
     });
@@ -617,10 +917,14 @@ describe("global middleware", () => {
         ],
       })
         .version("2025-03-15", (v) => {
-          v.get("/items", { output: z.object({ ok: z.boolean() }) }, async () => {
-            calls.push("handler");
-            return { ok: true };
-          });
+          v.get(
+            "/items",
+            { output: z.object({ ok: z.boolean() }) },
+            async () => {
+              calls.push("handler");
+              return { ok: true };
+            },
+          );
         })
         .build();
 
@@ -639,37 +943,67 @@ describe("HTTP methods", () => {
     return buildTestService()
       .version("2025-03-15", (v) => {
         v.get("/r", { output: z.literal("get") }, async () => "get" as const);
-        v.post("/r", { output: z.literal("post") }, async () => "post" as const);
+        v.post(
+          "/r",
+          { output: z.literal("post") },
+          async () => "post" as const,
+        );
         v.put("/r", { output: z.literal("put") }, async () => "put" as const);
-        v.delete("/r", { output: z.literal("del") }, async () => "del" as const);
-        v.patch("/r", { output: z.literal("patch") }, async () => "patch" as const);
+        v.delete(
+          "/r",
+          { output: z.literal("del") },
+          async () => "del" as const,
+        );
+        v.patch(
+          "/r",
+          { output: z.literal("patch") },
+          async () => "patch" as const,
+        );
       })
       .build();
   }
 
   it("handles GET", async () => {
     const app = buildMethodApp();
-    expect(await (await makeRequest(app, "/api/test/2025-03-15/r")).json()).toBe("get");
+    expect(
+      await (await makeRequest(app, "/api/test/2025-03-15/r")).json(),
+    ).toBe("get");
   });
 
   it("handles POST", async () => {
     const app = buildMethodApp();
-    expect(await (await makeRequest(app, "/api/test/2025-03-15/r", { method: "POST" })).json()).toBe("post");
+    expect(
+      await (
+        await makeRequest(app, "/api/test/2025-03-15/r", { method: "POST" })
+      ).json(),
+    ).toBe("post");
   });
 
   it("handles PUT", async () => {
     const app = buildMethodApp();
-    expect(await (await makeRequest(app, "/api/test/2025-03-15/r", { method: "PUT" })).json()).toBe("put");
+    expect(
+      await (
+        await makeRequest(app, "/api/test/2025-03-15/r", { method: "PUT" })
+      ).json(),
+    ).toBe("put");
   });
 
   it("handles DELETE", async () => {
     const app = buildMethodApp();
-    expect(await (await makeRequest(app, "/api/test/2025-03-15/r", { method: "DELETE" })).json()).toBe("del");
+    expect(
+      await (
+        await makeRequest(app, "/api/test/2025-03-15/r", { method: "DELETE" })
+      ).json(),
+    ).toBe("del");
   });
 
   it("handles PATCH", async () => {
     const app = buildMethodApp();
-    expect(await (await makeRequest(app, "/api/test/2025-03-15/r", { method: "PATCH" })).json()).toBe("patch");
+    expect(
+      await (
+        await makeRequest(app, "/api/test/2025-03-15/r", { method: "PATCH" })
+      ).json(),
+    ).toBe("patch");
   });
 });
 
@@ -720,9 +1054,7 @@ describe("null return", () => {
     it("returns 204 No Content", async () => {
       const app = buildTestService()
         .version("2025-03-15", (v) => {
-          v.get("/void", {}, async (c) => {
-            return c.body(null, 204);
-          });
+          v.get("/void", { output: z.undefined() }, async () => undefined);
         })
         .build();
 

--- a/langwatch/packages/api/src/__tests__/errors.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/errors.unit.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from "vitest";
+import { ZodError, z } from "zod";
+
+import { formatError, isDomainErrorLike } from "../errors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers -- fake DomainError-like object (duck-typed)
+// ---------------------------------------------------------------------------
+
+function makeDomainError(overrides: {
+  kind?: string;
+  message?: string;
+  httpStatus?: number;
+  meta?: Record<string, unknown>;
+} = {}): Error & {
+  kind: string;
+  httpStatus: number;
+  meta: Record<string, unknown>;
+  serialize: () => {
+    kind: string;
+    meta: Record<string, unknown>;
+    telemetry: { traceId: undefined; spanId: undefined };
+    httpStatus: number;
+    reasons: Array<{ kind: string }>;
+  };
+} {
+  const kind = overrides.kind ?? "test_error";
+  const httpStatus = overrides.httpStatus ?? 422;
+  const meta = overrides.meta ?? {};
+  const message = overrides.message ?? "Test error message";
+
+  const error = new Error(message) as Error & {
+    kind: string;
+    httpStatus: number;
+    meta: Record<string, unknown>;
+    serialize: () => {
+      kind: string;
+      meta: Record<string, unknown>;
+      telemetry: { traceId: undefined; spanId: undefined };
+      httpStatus: number;
+      reasons: Array<{ kind: string }>;
+    };
+  };
+  error.kind = kind;
+  error.httpStatus = httpStatus;
+  error.meta = meta;
+  error.serialize = () => ({
+    kind,
+    meta,
+    telemetry: { traceId: undefined, spanId: undefined },
+    httpStatus,
+    reasons: [],
+  });
+
+  return error;
+}
+
+// ---------------------------------------------------------------------------
+// isDomainErrorLike
+// ---------------------------------------------------------------------------
+
+describe("isDomainErrorLike", () => {
+  describe("when given a DomainError-like object", () => {
+    it("returns true", () => {
+      const err = makeDomainError();
+      expect(isDomainErrorLike(err)).toBe(true);
+    });
+  });
+
+  describe("when given a plain Error", () => {
+    it("returns false", () => {
+      expect(isDomainErrorLike(new Error("plain"))).toBe(false);
+    });
+  });
+
+  describe("when given null", () => {
+    it("returns false", () => {
+      expect(isDomainErrorLike(null)).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatError -- DomainError-like
+// ---------------------------------------------------------------------------
+
+describe("formatError", () => {
+  describe("when given a DomainError-like error", () => {
+    describe("when the request is versioned", () => {
+      it("returns the new format without the error field", () => {
+        const err = makeDomainError({
+          kind: "not_found",
+          message: "Resource not found",
+          httpStatus: 404,
+          meta: { id: "abc" },
+        });
+
+        const { status, body } = formatError(err, true);
+
+        expect(status).toBe(404);
+        expect(body.kind).toBe("not_found");
+        expect(body.message).toBe("Resource not found");
+        expect(body.meta).toEqual({ id: "abc" });
+        expect(body.error).toBeUndefined();
+      });
+    });
+
+    describe("when the request is unversioned", () => {
+      it("returns the union format with the error field", () => {
+        const err = makeDomainError({
+          kind: "not_found",
+          message: "Resource not found",
+          httpStatus: 404,
+        });
+
+        const { status, body } = formatError(err, false);
+
+        expect(status).toBe(404);
+        expect(body.kind).toBe("not_found");
+        expect(body.error).toBe("Not Found");
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ZodError
+  // -------------------------------------------------------------------------
+
+  describe("when given a ZodError", () => {
+    it("maps to validation_error with reasons per field", () => {
+      const schema = z.object({
+        name: z.string().min(1),
+        age: z.number(),
+      });
+
+      let zodError: ZodError;
+      try {
+        schema.parse({ name: "", age: "not-a-number" });
+        throw new Error("should not reach");
+      } catch (err) {
+        zodError = err as ZodError;
+      }
+
+      const { status, body } = formatError(zodError!, true);
+
+      expect(status).toBe(422);
+      expect(body.kind).toBe("validation_error");
+      expect(body.message).toBe("Validation error");
+      expect(body.reasons).toEqual(
+        expect.arrayContaining([
+          {
+            code: "schema_failure",
+            meta: expect.objectContaining({ field: "name", type: "too_small" }),
+          },
+          {
+            code: "schema_failure",
+            meta: expect.objectContaining({ field: "age", type: "invalid_type" }),
+          },
+        ]),
+      );
+    });
+
+    describe("when the request is unversioned", () => {
+      it("includes the error field", () => {
+        const schema = z.object({ name: z.string() });
+        let zodError: ZodError;
+        try {
+          schema.parse({});
+          throw new Error("should not reach");
+        } catch (err) {
+          zodError = err as ZodError;
+        }
+
+        const { body } = formatError(zodError!, false);
+        expect(body.error).toBe("Unprocessable Entity");
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error with status property
+  // -------------------------------------------------------------------------
+
+  describe("when given an Error with a status property", () => {
+    it("uses the status as the HTTP code", () => {
+      const err = Object.assign(new Error("Forbidden"), { status: 403 });
+      const { status, body } = formatError(err, true);
+
+      expect(status).toBe(403);
+      expect(body.kind).toBe("http_error");
+      expect(body.message).toBe("Forbidden");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown errors
+  // -------------------------------------------------------------------------
+
+  describe("when given an unknown error", () => {
+    it("returns 500 with a sanitized message in non-dev mode", () => {
+      const originalEnv = process.env["NODE_ENV"];
+      process.env["NODE_ENV"] = "production";
+      try {
+        const err = new Error("secret internal details");
+        const { status, body } = formatError(err, true);
+
+        expect(status).toBe(500);
+        expect(body.kind).toBe("internal_error");
+        expect(body.message).toBe("Internal server error");
+      } finally {
+        process.env["NODE_ENV"] = originalEnv;
+      }
+    });
+
+    it("exposes the error message in development mode", () => {
+      const originalEnv = process.env["NODE_ENV"];
+      process.env["NODE_ENV"] = "development";
+      try {
+        const err = new Error("secret internal details");
+        const { status, body } = formatError(err, true);
+
+        expect(status).toBe(500);
+        expect(body.kind).toBe("internal_error");
+        expect(body.message).toBe("secret internal details");
+      } finally {
+        process.env["NODE_ENV"] = originalEnv;
+      }
+    });
+
+    describe("when the request is unversioned", () => {
+      it("includes the error field", () => {
+        const err = new Error("oops");
+        const { body } = formatError(err, false);
+        expect(body.error).toBe("Internal Server Error");
+      });
+    });
+  });
+});

--- a/langwatch/packages/api/src/__tests__/errors.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/errors.unit.test.ts
@@ -7,12 +7,14 @@ import { formatError, isDomainErrorLike } from "../errors.js";
 // Helpers -- fake DomainError-like object (duck-typed)
 // ---------------------------------------------------------------------------
 
-function makeDomainError(overrides: {
-  kind?: string;
-  message?: string;
-  httpStatus?: number;
-  meta?: Record<string, unknown>;
-} = {}): Error & {
+function makeDomainError(
+  overrides: {
+    kind?: string;
+    message?: string;
+    httpStatus?: number;
+    meta?: Record<string, unknown>;
+  } = {},
+): Error & {
   kind: string;
   httpStatus: number;
   meta: Record<string, unknown>;
@@ -154,7 +156,10 @@ describe("formatError", () => {
           },
           {
             code: "schema_failure",
-            meta: expect.objectContaining({ field: "age", type: "invalid_type" }),
+            meta: expect.objectContaining({
+              field: "age",
+              type: "invalid_type",
+            }),
           },
         ]),
       );

--- a/langwatch/packages/api/src/__tests__/errors.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/errors.unit.test.ts
@@ -97,7 +97,7 @@ describe("formatError", () => {
           meta: { id: "abc" },
         });
 
-        const { status, body } = formatError(err, true);
+        const { status, body } = formatError({ err, isVersioned: true });
 
         expect(status).toBe(404);
         expect(body.kind).toBe("not_found");
@@ -115,7 +115,7 @@ describe("formatError", () => {
           httpStatus: 404,
         });
 
-        const { status, body } = formatError(err, false);
+        const { status, body } = formatError({ err, isVersioned: false });
 
         expect(status).toBe(404);
         expect(body.kind).toBe("not_found");
@@ -143,7 +143,10 @@ describe("formatError", () => {
         zodError = err as ZodError;
       }
 
-      const { status, body } = formatError(zodError!, true);
+      const { status, body } = formatError({
+        err: zodError!,
+        isVersioned: true,
+      });
 
       expect(status).toBe(422);
       expect(body.kind).toBe("validation_error");
@@ -176,7 +179,10 @@ describe("formatError", () => {
           zodError = err as ZodError;
         }
 
-        const { body } = formatError(zodError!, false);
+        const { body } = formatError({
+          err: zodError!,
+          isVersioned: false,
+        });
         expect(body.error).toBe("Unprocessable Entity");
       });
     });
@@ -189,7 +195,7 @@ describe("formatError", () => {
   describe("when given an Error with a status property", () => {
     it("uses the status as the HTTP code", () => {
       const err = Object.assign(new Error("Forbidden"), { status: 403 });
-      const { status, body } = formatError(err, true);
+      const { status, body } = formatError({ err, isVersioned: true });
 
       expect(status).toBe(403);
       expect(body.kind).toBe("http_error");
@@ -207,7 +213,7 @@ describe("formatError", () => {
       process.env["NODE_ENV"] = "production";
       try {
         const err = new Error("secret internal details");
-        const { status, body } = formatError(err, true);
+        const { status, body } = formatError({ err, isVersioned: true });
 
         expect(status).toBe(500);
         expect(body.kind).toBe("internal_error");
@@ -222,7 +228,7 @@ describe("formatError", () => {
       process.env["NODE_ENV"] = "development";
       try {
         const err = new Error("secret internal details");
-        const { status, body } = formatError(err, true);
+        const { status, body } = formatError({ err, isVersioned: true });
 
         expect(status).toBe(500);
         expect(body.kind).toBe("internal_error");
@@ -235,7 +241,7 @@ describe("formatError", () => {
     describe("when the request is unversioned", () => {
       it("includes the error field", () => {
         const err = new Error("oops");
-        const { body } = formatError(err, false);
+        const { body } = formatError({ err, isVersioned: false });
         expect(body.error).toBe("Internal Server Error");
       });
     });

--- a/langwatch/packages/api/src/__tests__/sse.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/sse.unit.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+import { createService } from "../builder.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectSSE(res: Response): Promise<string[]> {
+  const reader = res.body?.getReader();
+  if (!reader) return [];
+
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      if (result.value) {
+        chunks.push(decoder.decode(result.value, { stream: true }));
+      }
+    }
+  } catch {
+    // Stream closed
+  } finally {
+    reader.releaseLock();
+  }
+
+  return chunks;
+}
+
+function parseSSEEvents(chunks: string[]): Array<{ event: string; data: unknown }> {
+  const raw = chunks.join("");
+  const events: Array<{ event: string; data: unknown }> = [];
+
+  // Parse SSE format: "event: ...\ndata: ...\n\n"
+  const blocks = raw.split("\n\n").filter(Boolean);
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    let event = "";
+    let data = "";
+    for (const line of lines) {
+      if (line.startsWith("event: ")) {
+        event = line.slice(7);
+      } else if (line.startsWith("data: ")) {
+        data = line.slice(6);
+      }
+    }
+    if (event && data) {
+      try {
+        events.push({ event, data: JSON.parse(data) });
+      } catch {
+        events.push({ event, data });
+      }
+    }
+  }
+
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// SSE endpoint tests
+// ---------------------------------------------------------------------------
+
+describe("SSE endpoints", () => {
+  describe("when an SSE endpoint emits typed events", () => {
+    it("streams events in SSE format", async () => {
+      const app = createService({ name: "test", basePath: "/api/test" })
+        .version("2025-03-15", (v) => {
+          v.sse(
+            "/stream",
+            {
+              events: {
+                progress: z.object({ percent: z.number() }),
+                done: z.object({ total: z.number() }),
+              },
+            },
+            async (_c, _args, stream) => {
+              await stream.emit("progress", { percent: 50 });
+              await stream.emit("progress", { percent: 100 });
+              await stream.emit("done", { total: 2 });
+              stream.close();
+            },
+          );
+        })
+        .build();
+
+      const res = await app.request("/api/test/2025-03-15/stream");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+      const chunks = await collectSSE(res);
+      const events = parseSSEEvents(chunks);
+
+      expect(events).toHaveLength(3);
+      expect(events[0]).toEqual({ event: "progress", data: { percent: 50 } });
+      expect(events[1]).toEqual({ event: "progress", data: { percent: 100 } });
+      expect(events[2]).toEqual({ event: "done", data: { total: 2 } });
+    });
+  });
+
+  describe("when SSE event data fails schema validation", () => {
+    it("emits an error event instead of the invalid data", async () => {
+      const app = createService({ name: "test", basePath: "/api/test" })
+        .version("2025-03-15", (v) => {
+          v.sse(
+            "/stream",
+            {
+              events: {
+                result: z.object({ score: z.number() }),
+              },
+            },
+            async (_c, _args, stream) => {
+              // This should emit an error event, not throw
+              await stream.emit("result", { score: "invalid" as unknown as number });
+              // Valid event should still work after
+              await stream.emit("result", { score: 0.95 });
+              stream.close();
+            },
+          );
+        })
+        .build();
+
+      const res = await app.request("/api/test/2025-03-15/stream");
+      expect(res.status).toBe(200);
+
+      const chunks = await collectSSE(res);
+      const events = parseSSEEvents(chunks);
+
+      expect(events).toHaveLength(2);
+
+      // First event: validation error
+      expect(events[0]!.event).toBe("error");
+      const errorData = events[0]!.data as { message: string; issues: unknown[] };
+      expect(errorData.message).toContain("Validation failed");
+      expect(errorData.issues.length).toBeGreaterThan(0);
+
+      // Second event: valid data went through
+      expect(events[1]).toEqual({ event: "result", data: { score: 0.95 } });
+    });
+  });
+});

--- a/langwatch/packages/api/src/__tests__/sse.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/sse.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { z } from "zod";
+import { ZodError, z } from "zod";
 
 import { createService } from "../builder.js";
 
@@ -31,7 +31,9 @@ async function collectSSE(res: Response): Promise<string[]> {
   return chunks;
 }
 
-function parseSSEEvents(chunks: string[]): Array<{ event: string; data: unknown }> {
+function parseSSEEvents(
+  chunks: string[],
+): Array<{ event: string; data: unknown }> {
   const raw = chunks.join("");
   const events: Array<{ event: string; data: unknown }> = [];
 
@@ -102,7 +104,7 @@ describe("SSE endpoints", () => {
   });
 
   describe("when SSE event data fails schema validation", () => {
-    it("emits an error event instead of the invalid data", async () => {
+    it("emits an error event and rejects instead of silently continuing", async () => {
       const app = createService({ name: "test", basePath: "/api/test" })
         .version("2025-03-15", (v) => {
           v.sse(
@@ -113,9 +115,13 @@ describe("SSE endpoints", () => {
               },
             },
             async (_c, _args, stream) => {
-              // This should emit an error event, not throw
-              await stream.emit("result", { score: "invalid" as unknown as number });
-              // Valid event should still work after
+              await expect(
+                stream.emit("result", {
+                  score: "invalid" as unknown as number,
+                }),
+              ).rejects.toBeInstanceOf(ZodError);
+
+              // Callers may explicitly recover and continue the stream.
               await stream.emit("result", { score: 0.95 });
               stream.close();
             },
@@ -133,12 +139,43 @@ describe("SSE endpoints", () => {
 
       // First event: validation error
       expect(events[0]!.event).toBe("error");
-      const errorData = events[0]!.data as { message: string; issues: unknown[] };
+      const errorData = events[0]!.data as {
+        message: string;
+        issues: unknown[];
+      };
       expect(errorData.message).toContain("Validation failed");
       expect(errorData.issues.length).toBeGreaterThan(0);
 
       // Second event: valid data went through
       expect(events[1]).toEqual({ event: "result", data: { score: 0.95 } });
+    });
+  });
+
+  describe("when an SSE endpoint declares a query schema", () => {
+    it("parses query input on its GET route", async () => {
+      const app = createService({ name: "test", basePath: "/api/test" })
+        .version("2025-03-15", (v) => {
+          v.sse(
+            "/stream",
+            {
+              events: { ready: z.object({ channel: z.string() }) },
+              query: z.object({ channel: z.string() }),
+            },
+            async (_c, { query }, stream) => {
+              await stream.emit("ready", { channel: query.channel });
+            },
+          );
+        })
+        .build();
+
+      const res = await app.request(
+        "/api/test/2025-03-15/stream?channel=updates",
+      );
+      const events = parseSSEEvents(await collectSSE(res));
+
+      expect(events).toEqual([
+        { event: "ready", data: { channel: "updates" } },
+      ]);
     });
   });
 });

--- a/langwatch/packages/api/src/__tests__/sse.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/sse.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ZodError, z } from "zod";
 
 import { createService } from "../builder.js";
@@ -176,6 +176,40 @@ describe("SSE endpoints", () => {
       expect(events).toEqual([
         { event: "ready", data: { channel: "updates" } },
       ]);
+    });
+  });
+
+  describe("when an SSE handler throws", () => {
+    it("reports the error through the configured framework error handler", async () => {
+      const onError = vi.fn((error: Error, c) =>
+        c.json({ message: error.message }, 500),
+      );
+      const app = createService({
+        name: "test",
+        basePath: "/api/test",
+        logger: false,
+        tracer: false,
+        onError,
+      })
+        .version("2025-03-15", (v) => {
+          v.sse(
+            "/stream",
+            { events: { result: z.object({ score: z.number() }) } },
+            async () => {
+              throw new Error("stream failed");
+            },
+          );
+        })
+        .build();
+
+      const response = await app.request("/api/test/2025-03-15/stream");
+      const events = parseSSEEvents(await collectSSE(response));
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "stream failed" }),
+        expect.anything(),
+      );
+      expect(events).toContainEqual({ event: "error", data: "stream failed" });
     });
   });
 });

--- a/langwatch/packages/api/src/__tests__/sse.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/sse.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { ZodError, z } from "zod";
 
 import { createService } from "../builder.js";
+import { getSSECompletion } from "../sse.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -210,6 +211,37 @@ describe("SSE endpoints", () => {
         expect.anything(),
       );
       expect(events).toContainEqual({ event: "error", data: "stream failed" });
+    });
+  });
+
+  describe("when the client disconnects", () => {
+    it("settles the SSE lifecycle used by request instrumentation", async () => {
+      let requestContext: Parameters<typeof getSSECompletion>[0] | undefined;
+      const app = createService({
+        name: "test",
+        basePath: "/api/test",
+        logger: false,
+        tracer: false,
+      })
+        .version("2025-03-15", (v) => {
+          v.sse(
+            "/stream",
+            { events: { ready: z.object({ ok: z.boolean() }) } },
+            async (c) => {
+              requestContext = c;
+              await new Promise(() => {});
+            },
+          );
+        })
+        .build();
+
+      const response = await app.request("/api/test/2025-03-15/stream");
+      expect(requestContext).toBeDefined();
+      const completion = getSSECompletion(requestContext!);
+
+      await response.body?.cancel();
+
+      await expect(completion).resolves.toEqual({});
     });
   });
 });

--- a/langwatch/packages/api/src/__tests__/versioning.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/versioning.unit.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+
+import type { EndpointRegistration } from "../types.js";
+import {
+  resolveVersions,
+  resolveRequestVersion,
+  type VersionDefinition,
+} from "../versioning.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEndpoint(
+  overrides: Partial<EndpointRegistration> = {},
+): EndpointRegistration {
+  return {
+    method: "get",
+    path: "/items",
+    config: {} as EndpointRegistration["config"],
+    handler: () => ({ ok: true }),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveVersions
+// ---------------------------------------------------------------------------
+
+describe("resolveVersions", () => {
+  describe("when given a single version", () => {
+    it("resolves the version and creates a latest alias", () => {
+      const definitions: VersionDefinition[] = [
+        { version: "2025-03-15", endpoints: [makeEndpoint()] },
+      ];
+
+      const result = resolveVersions(definitions, []);
+
+      expect(result.has("2025-03-15")).toBe(true);
+      expect(result.has("latest")).toBe(true);
+      expect(result.get("2025-03-15")).toHaveLength(1);
+      expect(result.get("latest")).toEqual(result.get("2025-03-15"));
+    });
+  });
+
+  describe("when given multiple versions", () => {
+    it("forward-copies endpoints from v1 to v2", () => {
+      const getItems = makeEndpoint({ method: "get", path: "/items" });
+      const postItems = makeEndpoint({ method: "post", path: "/items" });
+      const getDetails = makeEndpoint({ method: "get", path: "/details" });
+
+      const definitions: VersionDefinition[] = [
+        { version: "2025-01-01", endpoints: [getItems, postItems] },
+        { version: "2025-06-01", endpoints: [getDetails] },
+      ];
+
+      const result = resolveVersions(definitions, []);
+
+      // v1 has 2 endpoints
+      expect(result.get("2025-01-01")).toHaveLength(2);
+
+      // v2 has 3 endpoints (2 inherited + 1 new)
+      expect(result.get("2025-06-01")).toHaveLength(3);
+
+      // latest points to v2
+      expect(result.get("latest")).toEqual(result.get("2025-06-01"));
+    });
+
+    it("overrides an endpoint when re-registered in a later version", () => {
+      const v1Handler = () => ({ version: 1 });
+      const v2Handler = () => ({ version: 2 });
+
+      const definitions: VersionDefinition[] = [
+        {
+          version: "2025-01-01",
+          endpoints: [makeEndpoint({ method: "get", path: "/items", handler: v1Handler })],
+        },
+        {
+          version: "2025-06-01",
+          endpoints: [makeEndpoint({ method: "get", path: "/items", handler: v2Handler })],
+        },
+      ];
+
+      const result = resolveVersions(definitions, []);
+
+      // v1 has the original handler
+      const v1Endpoints = result.get("2025-01-01")!;
+      expect(v1Endpoints).toHaveLength(1);
+      const v1Active = v1Endpoints[0]!;
+      expect(v1Active.withdrawn).not.toBe(true);
+      if (!v1Active.withdrawn) {
+        expect(v1Active.handler).toBe(v1Handler);
+      }
+
+      // v2 has the new handler
+      const v2Endpoints = result.get("2025-06-01")!;
+      expect(v2Endpoints).toHaveLength(1);
+      const v2Active = v2Endpoints[0]!;
+      expect(v2Active.withdrawn).not.toBe(true);
+      if (!v2Active.withdrawn) {
+        expect(v2Active.handler).toBe(v2Handler);
+      }
+    });
+  });
+
+  describe("when an endpoint is withdrawn", () => {
+    it("marks the endpoint as withdrawn in the version", () => {
+      const definitions: VersionDefinition[] = [
+        {
+          version: "2025-01-01",
+          endpoints: [makeEndpoint({ method: "get", path: "/items" })],
+        },
+        {
+          version: "2025-06-01",
+          endpoints: [
+            {
+              method: "get",
+              path: "/items",
+              config: {} as EndpointRegistration["config"],
+              handler: () => {},
+              withdrawn: true,
+            },
+          ],
+        },
+      ];
+
+      const result = resolveVersions(definitions, []);
+
+      // v1 is active
+      const v1Ep = result.get("2025-01-01")![0]!;
+      expect(v1Ep.withdrawn).not.toBe(true);
+
+      // v2 is withdrawn
+      const v2Ep = result.get("2025-06-01")![0]!;
+      expect(v2Ep.withdrawn).toBe(true);
+    });
+  });
+
+  describe("when preview endpoints are provided", () => {
+    it("stores them under the preview key", () => {
+      const definitions: VersionDefinition[] = [
+        { version: "2025-01-01", endpoints: [makeEndpoint()] },
+      ];
+      const previewEndpoints = [makeEndpoint({ method: "post", path: "/beta" })];
+
+      const result = resolveVersions(definitions, previewEndpoints);
+
+      expect(result.has("preview")).toBe(true);
+      expect(result.get("preview")).toHaveLength(1);
+    });
+
+    it("keeps preview endpoints separate from latest", () => {
+      const definitions: VersionDefinition[] = [
+        { version: "2025-01-01", endpoints: [makeEndpoint()] },
+      ];
+      const previewEndpoints = [makeEndpoint({ method: "post", path: "/beta" })];
+
+      const result = resolveVersions(definitions, previewEndpoints);
+
+      const latest = result.get("latest")!;
+      const preview = result.get("preview")!;
+
+      // Latest should only have the v1 endpoint
+      expect(latest).toHaveLength(1);
+      // Preview should only have the beta endpoint
+      expect(preview).toHaveLength(1);
+    });
+  });
+
+  describe("when versions are provided out of order", () => {
+    it("sorts them chronologically", () => {
+      const v2Handler = () => ({ latest: true });
+      const definitions: VersionDefinition[] = [
+        { version: "2025-06-01", endpoints: [makeEndpoint({ handler: v2Handler })] },
+        { version: "2025-01-01", endpoints: [makeEndpoint()] },
+      ];
+
+      const result = resolveVersions(definitions, []);
+
+      // Latest should be v2
+      const latestEp = result.get("latest")![0]!;
+      expect(latestEp.withdrawn).not.toBe(true);
+      if (!latestEp.withdrawn) {
+        expect(latestEp.handler).toBe(v2Handler);
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRequestVersion
+// ---------------------------------------------------------------------------
+
+describe("resolveRequestVersion", () => {
+  const definitions: VersionDefinition[] = [
+    { version: "2025-01-01", endpoints: [makeEndpoint()] },
+    { version: "2025-06-01", endpoints: [makeEndpoint({ method: "post", path: "/new" })] },
+  ];
+  const previewEndpoints = [makeEndpoint({ method: "get", path: "/beta" })];
+  const versionMap = resolveVersions(definitions, previewEndpoints);
+
+  describe("when an exact dated version is requested", () => {
+    it("returns the version with stable status", () => {
+      const result = resolveRequestVersion(versionMap, "2025-01-01");
+      expect(result.found).toBe(true);
+      if (result.found) {
+        expect(result.version).toBe("2025-01-01");
+        expect(result.status).toBe("stable");
+      }
+    });
+  });
+
+  describe("when latest is requested", () => {
+    it("returns the newest dated version with latest status", () => {
+      const result = resolveRequestVersion(versionMap, "latest");
+      expect(result.found).toBe(true);
+      if (result.found) {
+        expect(result.version).toBe("latest");
+        expect(result.status).toBe("latest");
+        // Should have endpoints from both versions (forward-copied)
+        expect(result.endpoints.length).toBeGreaterThanOrEqual(2);
+      }
+    });
+  });
+
+  describe("when preview is requested", () => {
+    it("returns preview endpoints with preview status", () => {
+      const result = resolveRequestVersion(versionMap, "preview");
+      expect(result.found).toBe(true);
+      if (result.found) {
+        expect(result.version).toBe("preview");
+        expect(result.status).toBe("preview");
+      }
+    });
+  });
+
+  describe("when no version is provided (bare path)", () => {
+    it("returns latest with unversioned status", () => {
+      const result = resolveRequestVersion(versionMap, undefined);
+      expect(result.found).toBe(true);
+      if (result.found) {
+        expect(result.status).toBe("unversioned");
+      }
+    });
+  });
+
+  describe("when an unknown version is requested", () => {
+    it("returns not found", () => {
+      const result = resolveRequestVersion(versionMap, "2099-01-01");
+      expect(result.found).toBe(false);
+    });
+  });
+
+  describe("when a non-date string is requested", () => {
+    it("returns not found", () => {
+      const result = resolveRequestVersion(versionMap, "v1");
+      expect(result.found).toBe(false);
+    });
+  });
+});

--- a/langwatch/packages/api/src/__tests__/versioning.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/versioning.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import type { EndpointRegistration } from "../types.js";
+import { isDateVersion } from "../types.js";
 import {
   resolveVersions,
   resolveRequestVersion,
@@ -28,6 +29,29 @@ function makeEndpoint(
 // ---------------------------------------------------------------------------
 
 describe("resolveVersions", () => {
+  describe("when a version is invalid or duplicated", () => {
+    it("rejects invalid calendar dates", () => {
+      expect(() =>
+        resolveVersions(
+          [{ version: "2025-02-30", endpoints: [makeEndpoint()] }],
+          [],
+        ),
+      ).toThrow(/Invalid API version/);
+    });
+
+    it("rejects duplicate version definitions", () => {
+      expect(() =>
+        resolveVersions(
+          [
+            { version: "2025-03-15", endpoints: [makeEndpoint()] },
+            { version: "2025-03-15", endpoints: [makeEndpoint()] },
+          ],
+          [],
+        ),
+      ).toThrow(/registered more than once/);
+    });
+  });
+
   describe("when given a single version", () => {
     it("resolves the version and creates a latest alias", () => {
       const definitions: VersionDefinition[] = [
@@ -73,11 +97,15 @@ describe("resolveVersions", () => {
       const definitions: VersionDefinition[] = [
         {
           version: "2025-01-01",
-          endpoints: [makeEndpoint({ method: "get", path: "/items", handler: v1Handler })],
+          endpoints: [
+            makeEndpoint({ method: "get", path: "/items", handler: v1Handler }),
+          ],
         },
         {
           version: "2025-06-01",
-          endpoints: [makeEndpoint({ method: "get", path: "/items", handler: v2Handler })],
+          endpoints: [
+            makeEndpoint({ method: "get", path: "/items", handler: v2Handler }),
+          ],
         },
       ];
 
@@ -99,6 +127,31 @@ describe("resolveVersions", () => {
       expect(v2Active.withdrawn).not.toBe(true);
       if (!v2Active.withdrawn) {
         expect(v2Active.handler).toBe(v2Handler);
+      }
+    });
+
+    it("treats an empty root path and slash root path as the same endpoint", () => {
+      const rootHandler = () => ({ version: 1 });
+      const replacementHandler = () => ({ version: 2 });
+      const definitions: VersionDefinition[] = [
+        {
+          version: "2025-01-01",
+          endpoints: [makeEndpoint({ path: "", handler: rootHandler })],
+        },
+        {
+          version: "2025-06-01",
+          endpoints: [makeEndpoint({ path: "/", handler: replacementHandler })],
+        },
+      ];
+
+      const result = resolveVersions(definitions, []);
+      const endpoints = result.get("2025-06-01")!;
+
+      expect(endpoints).toHaveLength(1);
+      const endpoint = endpoints[0]!;
+      expect(endpoint.withdrawn).not.toBe(true);
+      if (!endpoint.withdrawn) {
+        expect(endpoint.handler).toBe(replacementHandler);
       }
     });
   });
@@ -141,7 +194,9 @@ describe("resolveVersions", () => {
       const definitions: VersionDefinition[] = [
         { version: "2025-01-01", endpoints: [makeEndpoint()] },
       ];
-      const previewEndpoints = [makeEndpoint({ method: "post", path: "/beta" })];
+      const previewEndpoints = [
+        makeEndpoint({ method: "post", path: "/beta" }),
+      ];
 
       const result = resolveVersions(definitions, previewEndpoints);
 
@@ -153,7 +208,9 @@ describe("resolveVersions", () => {
       const definitions: VersionDefinition[] = [
         { version: "2025-01-01", endpoints: [makeEndpoint()] },
       ];
-      const previewEndpoints = [makeEndpoint({ method: "post", path: "/beta" })];
+      const previewEndpoints = [
+        makeEndpoint({ method: "post", path: "/beta" }),
+      ];
 
       const result = resolveVersions(definitions, previewEndpoints);
 
@@ -165,13 +222,45 @@ describe("resolveVersions", () => {
       // Preview should only have the beta endpoint
       expect(preview).toHaveLength(1);
     });
+
+    it("normalizes GET and SSE keys when de-duplicating preview endpoints", () => {
+      const previewEndpoints = [
+        makeEndpoint({ method: "get", path: "/stream" }),
+        makeEndpoint({ method: "sse", path: "/stream" }),
+      ];
+
+      const result = resolveVersions([], previewEndpoints);
+
+      expect(result.get("preview")).toHaveLength(1);
+      expect(result.get("preview")?.[0]?.method).toBe("sse");
+    });
+
+    it("preserves preview withdrawals as 410 markers", () => {
+      const previewEndpoints = [
+        makeEndpoint({ method: "get", path: "/beta" }),
+        makeEndpoint({
+          method: "get",
+          path: "/beta",
+          withdrawn: true,
+        }),
+      ];
+
+      const result = resolveVersions([], previewEndpoints);
+
+      expect(result.get("preview")).toEqual([
+        expect.objectContaining({ path: "/beta", withdrawn: true }),
+      ]);
+    });
   });
 
   describe("when versions are provided out of order", () => {
     it("sorts them chronologically", () => {
       const v2Handler = () => ({ latest: true });
       const definitions: VersionDefinition[] = [
-        { version: "2025-06-01", endpoints: [makeEndpoint({ handler: v2Handler })] },
+        {
+          version: "2025-06-01",
+          endpoints: [makeEndpoint({ handler: v2Handler })],
+        },
         { version: "2025-01-01", endpoints: [makeEndpoint()] },
       ];
 
@@ -187,6 +276,15 @@ describe("resolveVersions", () => {
   });
 });
 
+describe("isDateVersion", () => {
+  it("accepts real dates and rejects impossible calendar dates", () => {
+    expect(isDateVersion("2024-02-29")).toBe(true);
+    expect(isDateVersion("2025-02-29")).toBe(false);
+    expect(isDateVersion("2025-13-01")).toBe(false);
+    expect(isDateVersion("v1")).toBe(false);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // resolveRequestVersion
 // ---------------------------------------------------------------------------
@@ -194,7 +292,10 @@ describe("resolveVersions", () => {
 describe("resolveRequestVersion", () => {
   const definitions: VersionDefinition[] = [
     { version: "2025-01-01", endpoints: [makeEndpoint()] },
-    { version: "2025-06-01", endpoints: [makeEndpoint({ method: "post", path: "/new" })] },
+    {
+      version: "2025-06-01",
+      endpoints: [makeEndpoint({ method: "post", path: "/new" })],
+    },
   ];
   const previewEndpoints = [makeEndpoint({ method: "get", path: "/beta" })];
   const versionMap = resolveVersions(definitions, previewEndpoints);

--- a/langwatch/packages/api/src/__tests__/versioning.unit.test.ts
+++ b/langwatch/packages/api/src/__tests__/versioning.unit.test.ts
@@ -32,22 +32,22 @@ describe("resolveVersions", () => {
   describe("when a version is invalid or duplicated", () => {
     it("rejects invalid calendar dates", () => {
       expect(() =>
-        resolveVersions(
-          [{ version: "2025-02-30", endpoints: [makeEndpoint()] }],
-          [],
-        ),
+        resolveVersions({
+          definitions: [{ version: "2025-02-30", endpoints: [makeEndpoint()] }],
+          previewEndpoints: [],
+        }),
       ).toThrow(/Invalid API version/);
     });
 
     it("rejects duplicate version definitions", () => {
       expect(() =>
-        resolveVersions(
-          [
+        resolveVersions({
+          definitions: [
             { version: "2025-03-15", endpoints: [makeEndpoint()] },
             { version: "2025-03-15", endpoints: [makeEndpoint()] },
           ],
-          [],
-        ),
+          previewEndpoints: [],
+        }),
       ).toThrow(/registered more than once/);
     });
   });
@@ -58,7 +58,7 @@ describe("resolveVersions", () => {
         { version: "2025-03-15", endpoints: [makeEndpoint()] },
       ];
 
-      const result = resolveVersions(definitions, []);
+      const result = resolveVersions({ definitions, previewEndpoints: [] });
 
       expect(result.has("2025-03-15")).toBe(true);
       expect(result.has("latest")).toBe(true);
@@ -78,7 +78,7 @@ describe("resolveVersions", () => {
         { version: "2025-06-01", endpoints: [getDetails] },
       ];
 
-      const result = resolveVersions(definitions, []);
+      const result = resolveVersions({ definitions, previewEndpoints: [] });
 
       // v1 has 2 endpoints
       expect(result.get("2025-01-01")).toHaveLength(2);
@@ -109,7 +109,7 @@ describe("resolveVersions", () => {
         },
       ];
 
-      const result = resolveVersions(definitions, []);
+      const result = resolveVersions({ definitions, previewEndpoints: [] });
 
       // v1 has the original handler
       const v1Endpoints = result.get("2025-01-01")!;
@@ -144,7 +144,7 @@ describe("resolveVersions", () => {
         },
       ];
 
-      const result = resolveVersions(definitions, []);
+      const result = resolveVersions({ definitions, previewEndpoints: [] });
       const endpoints = result.get("2025-06-01")!;
 
       expect(endpoints).toHaveLength(1);
@@ -177,7 +177,7 @@ describe("resolveVersions", () => {
         },
       ];
 
-      const result = resolveVersions(definitions, []);
+      const result = resolveVersions({ definitions, previewEndpoints: [] });
 
       // v1 is active
       const v1Ep = result.get("2025-01-01")![0]!;
@@ -198,7 +198,7 @@ describe("resolveVersions", () => {
         makeEndpoint({ method: "post", path: "/beta" }),
       ];
 
-      const result = resolveVersions(definitions, previewEndpoints);
+      const result = resolveVersions({ definitions, previewEndpoints });
 
       expect(result.has("preview")).toBe(true);
       expect(result.get("preview")).toHaveLength(1);
@@ -212,7 +212,7 @@ describe("resolveVersions", () => {
         makeEndpoint({ method: "post", path: "/beta" }),
       ];
 
-      const result = resolveVersions(definitions, previewEndpoints);
+      const result = resolveVersions({ definitions, previewEndpoints });
 
       const latest = result.get("latest")!;
       const preview = result.get("preview")!;
@@ -229,7 +229,7 @@ describe("resolveVersions", () => {
         makeEndpoint({ method: "sse", path: "/stream" }),
       ];
 
-      const result = resolveVersions([], previewEndpoints);
+      const result = resolveVersions({ definitions: [], previewEndpoints });
 
       expect(result.get("preview")).toHaveLength(1);
       expect(result.get("preview")?.[0]?.method).toBe("sse");
@@ -245,7 +245,7 @@ describe("resolveVersions", () => {
         }),
       ];
 
-      const result = resolveVersions([], previewEndpoints);
+      const result = resolveVersions({ definitions: [], previewEndpoints });
 
       expect(result.get("preview")).toEqual([
         expect.objectContaining({ path: "/beta", withdrawn: true }),
@@ -264,7 +264,7 @@ describe("resolveVersions", () => {
         { version: "2025-01-01", endpoints: [makeEndpoint()] },
       ];
 
-      const result = resolveVersions(definitions, []);
+      const result = resolveVersions({ definitions, previewEndpoints: [] });
 
       // Latest should be v2
       const latestEp = result.get("latest")![0]!;
@@ -298,11 +298,14 @@ describe("resolveRequestVersion", () => {
     },
   ];
   const previewEndpoints = [makeEndpoint({ method: "get", path: "/beta" })];
-  const versionMap = resolveVersions(definitions, previewEndpoints);
+  const versionMap = resolveVersions({ definitions, previewEndpoints });
 
   describe("when an exact dated version is requested", () => {
     it("returns the version with stable status", () => {
-      const result = resolveRequestVersion(versionMap, "2025-01-01");
+      const result = resolveRequestVersion({
+        versionMap,
+        requestVersion: "2025-01-01",
+      });
       expect(result.found).toBe(true);
       if (result.found) {
         expect(result.version).toBe("2025-01-01");
@@ -313,7 +316,10 @@ describe("resolveRequestVersion", () => {
 
   describe("when latest is requested", () => {
     it("returns the newest dated version with latest status", () => {
-      const result = resolveRequestVersion(versionMap, "latest");
+      const result = resolveRequestVersion({
+        versionMap,
+        requestVersion: "latest",
+      });
       expect(result.found).toBe(true);
       if (result.found) {
         expect(result.version).toBe("latest");
@@ -326,7 +332,10 @@ describe("resolveRequestVersion", () => {
 
   describe("when preview is requested", () => {
     it("returns preview endpoints with preview status", () => {
-      const result = resolveRequestVersion(versionMap, "preview");
+      const result = resolveRequestVersion({
+        versionMap,
+        requestVersion: "preview",
+      });
       expect(result.found).toBe(true);
       if (result.found) {
         expect(result.version).toBe("preview");
@@ -337,7 +346,10 @@ describe("resolveRequestVersion", () => {
 
   describe("when no version is provided (bare path)", () => {
     it("returns latest with unversioned status", () => {
-      const result = resolveRequestVersion(versionMap, undefined);
+      const result = resolveRequestVersion({
+        versionMap,
+        requestVersion: undefined,
+      });
       expect(result.found).toBe(true);
       if (result.found) {
         expect(result.status).toBe("unversioned");
@@ -347,14 +359,20 @@ describe("resolveRequestVersion", () => {
 
   describe("when an unknown version is requested", () => {
     it("returns not found", () => {
-      const result = resolveRequestVersion(versionMap, "2099-01-01");
+      const result = resolveRequestVersion({
+        versionMap,
+        requestVersion: "2099-01-01",
+      });
       expect(result.found).toBe(false);
     });
   });
 
   describe("when a non-date string is requested", () => {
     it("returns not found", () => {
-      const result = resolveRequestVersion(versionMap, "v1");
+      const result = resolveRequestVersion({
+        versionMap,
+        requestVersion: "v1",
+      });
       expect(result.found).toBe(false);
     });
   });

--- a/langwatch/packages/api/src/builder.ts
+++ b/langwatch/packages/api/src/builder.ts
@@ -268,6 +268,10 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
       if (ep.withdrawn) {
         const method = ep.method === "sse" ? "get" : ep.method;
         app[method](fullPath, (c) => {
+          if (version) {
+            c.header("X-API-Version", version);
+          }
+          c.header("X-API-Version-Status", status);
           return c.json(
             { kind: "endpoint_withdrawn", message: "This endpoint has been removed" },
             410,
@@ -339,9 +343,10 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
 
     // 6. OpenAPI description (describeRoute) -- only when output or description exists
     if (config.output || config.description) {
-      const responses: Record<string, unknown> = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const responses: Record<string, any> = {};
       if (config.output) {
-        responses["200"] = {
+        responses[String(config.status ?? 200)] = {
           description: "Success",
           content: {
             "application/json": {
@@ -365,14 +370,15 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
     if (config.query) {
       stack.push(zValidator("query", config.query) as unknown as MiddlewareHandler);
     }
-    if (config.input) {
+    // SSE endpoints are GET-only — skip JSON body validation
+    if (config.input && ep.method !== "sse") {
       stack.push(zValidator("json", config.input) as unknown as MiddlewareHandler);
     }
 
     // 8. App context middleware (resolves providers)
     const providers = this._providers;
     stack.push(async (c, next) => {
-      const base: BaseApp = {
+      const base: BaseApp<TProject> = {
         project: c.get("project"),
         _legacy: {
           organization: c.get("organization"),
@@ -397,11 +403,10 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
       const sseConfig = ep.config as unknown as SSEConfig<Record<string, ZodType>>;
       stack.push(async (c) => {
         const appCtx = c.get("app");
-        const input = config.input ? c.req.valid("json" as never) : undefined;
         const query = config.query ? c.req.valid("query" as never) : undefined;
 
         return createSSEResponse(c, sseConfig.events, async (stream) => {
-          await ep.handler(c, { input, query, app: appCtx }, stream);
+          await ep.handler(c, { query, app: appCtx }, stream);
         });
       });
     } else {
@@ -420,7 +425,7 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
         }
 
         // void/undefined → 204 No Content
-        if (result === undefined || result === null) {
+        if (result === undefined) {
           return c.body(null, config.status ?? 204);
         }
 

--- a/langwatch/packages/api/src/builder.ts
+++ b/langwatch/packages/api/src/builder.ts
@@ -1,0 +1,476 @@
+import { Hono } from "hono";
+import type { MiddlewareHandler } from "hono";
+import { describeRoute } from "hono-openapi";
+import { resolver, validator as zValidator } from "hono-openapi/zod";
+import type { ZodType } from "zod";
+
+import { createErrorHandler } from "./errors.js";
+import { tracerMiddleware, loggerMiddleware } from "./middleware.js";
+import { createSSEResponse, type SSEConfig, type SSEHandler } from "./sse.js";
+import type {
+  BaseApp,
+  EndpointConfig,
+  EndpointRegistration,
+  Handler,
+  HttpMethod,
+  ServiceConfig,
+  VersionStatus,
+} from "./types.js";
+import {
+  resolveVersions,
+  type ResolvedEndpoint,
+  type VersionDefinition,
+} from "./versioning.js";
+
+// ---------------------------------------------------------------------------
+// VersionBuilder -- collects endpoint registrations for a single version
+// ---------------------------------------------------------------------------
+
+/**
+ * Builder used inside the `.version(date, (v) => { ... })` callback.
+ *
+ * Provides HTTP method helpers and `withdraw()` for removing inherited
+ * endpoints.
+ */
+class VersionBuilder<TApp> {
+  /** @internal */
+  readonly _endpoints: EndpointRegistration[] = [];
+
+  /** Register a GET endpoint. */
+  get<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("get", path, config, handler);
+  }
+
+  /** Register a POST endpoint. */
+  post<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("post", path, config, handler);
+  }
+
+  /** Register a PUT endpoint. */
+  put<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("put", path, config, handler);
+  }
+
+  /** Register a DELETE endpoint. */
+  delete<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("delete", path, config, handler);
+  }
+
+  /** Register a PATCH endpoint. */
+  patch<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("patch", path, config, handler);
+  }
+
+  /**
+   * Register an SSE streaming endpoint.
+   *
+   * The handler receives a `TypedSSEStream` whose `emit()` validates event
+   * data against the declared Zod schemas.
+   */
+  sse<TEvents extends Record<string, ZodType>, TConfig extends SSEConfig<TEvents>>(
+    path: string,
+    config: TConfig,
+    handler: SSEHandler<TApp, TEvents, TConfig>,
+  ): void {
+    this._endpoints.push({
+      method: "sse",
+      path,
+      config: config as unknown as EndpointConfig,
+      handler: handler as EndpointRegistration["handler"],
+    });
+  }
+
+  /**
+   * Withdraw (remove) an endpoint inherited from a previous version.
+   *
+   * Withdrawn endpoints return `410 Gone` in this and all subsequent versions.
+   */
+  withdraw(method: HttpMethod, path: string): void {
+    this._endpoints.push({
+      method,
+      path,
+      config: {} as EndpointConfig,
+      handler: () => {},
+      withdrawn: true,
+    });
+  }
+
+  private _register(
+    method: HttpMethod,
+    path: string,
+    config: EndpointConfig,
+    handler: Handler<TApp, EndpointConfig>,
+  ): void {
+    this._endpoints.push({
+      method,
+      path,
+      config,
+      handler: handler as EndpointRegistration["handler"],
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ServiceBuilder -- the fluent builder returned by createService()
+// ---------------------------------------------------------------------------
+
+/**
+ * Fluent builder for constructing a versioned Hono service.
+ *
+ * @typeParam TProject - The project type for `app.project`.
+ * @typeParam TProviders - The inferred provider map from `.provide()` calls.
+ */
+class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
+  private readonly _config: ServiceConfig;
+  private readonly _providers: Record<string, (base: BaseApp<TProject>) => unknown>;
+  private readonly _versions: VersionDefinition[] = [];
+  private readonly _previewEndpoints: EndpointRegistration[] = [];
+
+  constructor(
+    config: ServiceConfig,
+    providers: Record<string, (base: BaseApp<TProject>) => unknown> = {},
+  ) {
+    this._config = config;
+    this._providers = providers;
+  }
+
+  /**
+   * Register provider factories.
+   *
+   * Each factory receives the base app context (`{ project, _legacy }`)
+   * and returns a service instance. Providers are resolved per-request and
+   * available on `app.{key}` in handlers.
+   *
+   * No cross-provider dependencies -- factories only receive the base context.
+   */
+  provide<P extends Record<string, (base: BaseApp<TProject>) => unknown>>(
+    providers: P,
+  ): ServiceBuilder<TProject, TProviders & { [K in keyof P]: Awaited<ReturnType<P[K]>> }> {
+    return new ServiceBuilder<TProject, TProviders & { [K in keyof P]: Awaited<ReturnType<P[K]>> }>(
+      this._config,
+      { ...this._providers, ...providers },
+    );
+  }
+
+  /**
+   * Register endpoints for a dated version (e.g. `"2025-03-15"`).
+   *
+   * Versions are forward-copied: each version inherits the previous version's
+   * endpoints, and the callback can override, add, or withdraw endpoints.
+   */
+  version(
+    date: string,
+    define: (v: VersionBuilder<BaseApp<TProject> & TProviders>) => void,
+  ): this {
+    const builder = new VersionBuilder<BaseApp<TProject> & TProviders>();
+    define(builder);
+    this._versions.push({ version: date, endpoints: builder._endpoints });
+    return this;
+  }
+
+  /**
+   * Register preview-only endpoints.
+   *
+   * Preview endpoints are accessible at `/preview/...` but are never included
+   * in `latest`.
+   */
+  preview(define: (v: VersionBuilder<BaseApp<TProject> & TProviders>) => void): this {
+    const builder = new VersionBuilder<BaseApp<TProject> & TProviders>();
+    define(builder);
+    this._previewEndpoints.push(...builder._endpoints);
+    return this;
+  }
+
+  /**
+   * Build the final Hono application.
+   *
+   * Creates sub-routers for each resolved version, mounts them under
+   * `/{version}/`, and sets up `latest` + bare-path aliases.
+   */
+  build(): Hono {
+    const basePath = this._config.basePath ?? `/api/${this._config.name}`;
+    const app = new Hono().basePath(basePath);
+
+    // Apply built-in tracer + logger middleware (unless explicitly disabled)
+    if (this._config.tracer !== false) {
+      app.use("*", tracerMiddleware({ name: this._config.name }));
+    }
+    if (this._config.logger !== false) {
+      app.use("*", loggerMiddleware({ name: this._config.name }));
+    }
+
+    // Apply additional global middleware
+    if (this._config.middleware) {
+      for (const mw of this._config.middleware) {
+        app.use("*", mw);
+      }
+    }
+
+    // Resolve versions
+    const versionMap = resolveVersions(this._versions, this._previewEndpoints);
+
+    // Mount versioned sub-routers
+    for (const [version, endpoints] of versionMap) {
+      const status = resolveVersionStatus(version);
+      this._mountVersion(app, version, status, endpoints);
+    }
+
+    // Bare path (no version) = latest
+    const latestEndpoints = versionMap.get("latest");
+    if (latestEndpoints) {
+      this._mountVersion(app, null, "unversioned", latestEndpoints);
+    }
+
+    // Error handler
+    const onError = this._config.onError ?? createErrorHandler();
+    app.onError(onError);
+
+    return app;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private _mountVersion(
+    app: Hono,
+    version: string | null,
+    status: VersionStatus,
+    endpoints: ResolvedEndpoint[],
+  ): void {
+    const prefix = version ? `/${version}` : "";
+    const isVersioned = status !== "unversioned";
+
+    for (const ep of endpoints) {
+      const fullPath = `${prefix}${ep.path || "/"}`;
+
+      // Withdrawn endpoint -- return 410 Gone
+      if (ep.withdrawn) {
+        const method = ep.method === "sse" ? "get" : ep.method;
+        app[method](fullPath, (c) => {
+          return c.json(
+            { kind: "endpoint_withdrawn", message: "This endpoint has been removed" },
+            410,
+          );
+        });
+        continue;
+      }
+
+      // Active endpoint -- build middleware stack
+      const middlewareStack = this._buildMiddlewareStack({ ep, isVersioned, status, version });
+      const method = ep.method === "sse" ? "get" : ep.method;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (app[method] as any)(fullPath, ...middlewareStack);
+    }
+  }
+
+  private _buildMiddlewareStack({
+    ep,
+    isVersioned,
+    status,
+    version,
+  }: {
+    ep: EndpointRegistration;
+    isVersioned: boolean;
+    status: VersionStatus;
+    version: string | null;
+  }): MiddlewareHandler[] {
+    const stack: MiddlewareHandler[] = [];
+    const config = ep.config;
+
+    // 1. Version context middleware
+    stack.push(async (c, next) => {
+      c.set("isVersionedRequest", isVersioned);
+      if (version) {
+        c.set("apiVersion", version);
+      }
+      await next();
+      // Set response headers
+      if (version) {
+        c.header("X-API-Version", version);
+      }
+      c.header("X-API-Version-Status", status);
+    });
+
+    // 2. Auth middleware
+    const authSetting = config.auth ?? "default";
+    if (authSetting === "default" && this._config.auth) {
+      stack.push(this._config.auth);
+    } else if (typeof authSetting === "function") {
+      stack.push(authSetting);
+    }
+    // "none" -- skip auth
+
+    // 3. Legacy organization middleware
+    if (this._config._legacy?.organizationMiddleware) {
+      stack.push(this._config._legacy.organizationMiddleware);
+    }
+
+    // 4. Legacy resource limit middleware
+    if (config.resourceLimit && this._config._legacy?.resourceLimitMiddleware) {
+      stack.push(this._config._legacy.resourceLimitMiddleware(config.resourceLimit));
+    }
+
+    // 5. Per-endpoint middleware
+    if (config.middleware) {
+      stack.push(...config.middleware);
+    }
+
+    // 6. OpenAPI description (describeRoute) -- only when output or description exists
+    if (config.output || config.description) {
+      const responses: Record<string, unknown> = {};
+      if (config.output) {
+        responses["200"] = {
+          description: "Success",
+          content: {
+            "application/json": {
+              schema: resolver(config.output),
+            },
+          },
+        };
+      }
+      stack.push(
+        describeRoute({
+          description: config.description,
+          responses,
+        }) as unknown as MiddlewareHandler,
+      );
+    }
+
+    // 7. Validation middleware
+    if (config.params) {
+      stack.push(zValidator("param", config.params) as unknown as MiddlewareHandler);
+    }
+    if (config.query) {
+      stack.push(zValidator("query", config.query) as unknown as MiddlewareHandler);
+    }
+    if (config.input) {
+      stack.push(zValidator("json", config.input) as unknown as MiddlewareHandler);
+    }
+
+    // 8. App context middleware (resolves providers)
+    const providers = this._providers;
+    stack.push(async (c, next) => {
+      const base: BaseApp = {
+        project: c.get("project"),
+        _legacy: {
+          organization: c.get("organization"),
+          prisma: c.get("prisma"),
+        },
+      };
+
+      // Resolve providers
+      const resolved: Record<string, unknown> = {};
+      for (const [key, factory] of Object.entries(providers)) {
+        resolved[key] = await factory(base);
+      }
+
+      const appCtx = { ...base, ...resolved };
+      c.set("app", appCtx);
+      await next();
+    });
+
+    // 9. Handler wrapper
+    if (ep.method === "sse") {
+      // SSE handler
+      const sseConfig = ep.config as unknown as SSEConfig<Record<string, ZodType>>;
+      stack.push(async (c) => {
+        const appCtx = c.get("app");
+        const input = config.input ? c.req.valid("json" as never) : undefined;
+        const query = config.query ? c.req.valid("query" as never) : undefined;
+
+        return createSSEResponse(c, sseConfig.events, async (stream) => {
+          await ep.handler(c, { input, query, app: appCtx }, stream);
+        });
+      });
+    } else {
+      // Regular handler
+      stack.push(async (c) => {
+        const appCtx = c.get("app");
+        const input = config.input ? c.req.valid("json" as never) : undefined;
+        const params = config.params ? c.req.valid("param" as never) : undefined;
+        const query = config.query ? c.req.valid("query" as never) : undefined;
+
+        const result = await ep.handler(c, { input, params, query, app: appCtx });
+
+        // If handler returns a Response directly, use it
+        if (result instanceof Response) {
+          return result;
+        }
+
+        // void/undefined → 204 No Content
+        if (result === undefined || result === null) {
+          return c.body(null, config.status ?? 204);
+        }
+
+        // Validate output if schema is defined
+        const status = config.status ?? 200;
+        if (config.output) {
+          const validated = config.output.parse(result);
+          return c.json(validated, status);
+        }
+
+        // No output schema -- return as-is
+        return c.json(result, status);
+      });
+    }
+
+    return stack;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Version status resolver
+// ---------------------------------------------------------------------------
+
+function resolveVersionStatus(version: string): VersionStatus {
+  if (version === "latest") return "latest";
+  if (version === "preview") return "preview";
+  return "stable";
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a new service builder.
+ *
+ * ```ts
+ * const app = createService({ name: "scenarios" })
+ *   .provide({ scenarioService: () => ScenarioService.create(prisma) })
+ *   .version("2025-03-15", (v) => {
+ *     v.get("/", { output: listSchema }, async (c, { app }) => { ... });
+ *   })
+ *   .build();
+ * ```
+ */
+export function createService<TProject = unknown>(
+  config: ServiceConfig,
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+): ServiceBuilder<TProject, {}> {
+  return new ServiceBuilder(config);
+}
+
+export { ServiceBuilder, VersionBuilder };

--- a/langwatch/packages/api/src/builder.ts
+++ b/langwatch/packages/api/src/builder.ts
@@ -1,145 +1,12 @@
-import { updateCurrentContext } from "@langwatch/observability/context";
-import { Hono, type MiddlewareHandler } from "hono";
-import { describeRoute, type DescribeRouteOptions } from "hono-openapi";
-import { resolver, validator as zValidator } from "hono-openapi/zod";
-import type { ZodType } from "zod";
+import { Hono } from "hono";
 
 import { createErrorHandler } from "./errors.js";
-import { tracerMiddleware, loggerMiddleware } from "./middleware.js";
-import { createSSEResponse, type SSEConfig, type SSEHandler } from "./sse.js";
+import { loggerMiddleware, tracerMiddleware } from "./middleware.js";
+import { mountResolvedRoutes } from "./route-mounting.js";
 import { isDateVersion } from "./types.js";
-import type {
-  BaseApp,
-  EndpointConfig,
-  EndpointRegistration,
-  Handler,
-  HttpMethod,
-  ServiceConfig,
-  VersionStatus,
-} from "./types.js";
-import {
-  resolveVersions,
-  type ResolvedEndpoint,
-  type VersionDefinition,
-} from "./versioning.js";
-
-// ---------------------------------------------------------------------------
-// VersionBuilder -- collects endpoint registrations for a single version
-// ---------------------------------------------------------------------------
-
-/**
- * Builder used inside the `.version(date, (v) => { ... })` callback.
- *
- * Provides HTTP method helpers and `withdraw()` for removing inherited
- * endpoints.
- */
-class VersionBuilder<TApp> {
-  /** @internal */
-  readonly _endpoints: EndpointRegistration[] = [];
-
-  /** Register a GET endpoint. */
-  get<TConfig extends EndpointConfig>(
-    path: string,
-    config: TConfig,
-    handler: Handler<TApp, TConfig>,
-  ): void {
-    this._register("get", path, config, handler);
-  }
-
-  /** Register a POST endpoint. */
-  post<TConfig extends EndpointConfig>(
-    path: string,
-    config: TConfig,
-    handler: Handler<TApp, TConfig>,
-  ): void {
-    this._register("post", path, config, handler);
-  }
-
-  /** Register a PUT endpoint. */
-  put<TConfig extends EndpointConfig>(
-    path: string,
-    config: TConfig,
-    handler: Handler<TApp, TConfig>,
-  ): void {
-    this._register("put", path, config, handler);
-  }
-
-  /** Register a DELETE endpoint. */
-  delete<TConfig extends EndpointConfig>(
-    path: string,
-    config: TConfig,
-    handler: Handler<TApp, TConfig>,
-  ): void {
-    this._register("delete", path, config, handler);
-  }
-
-  /** Register a PATCH endpoint. */
-  patch<TConfig extends EndpointConfig>(
-    path: string,
-    config: TConfig,
-    handler: Handler<TApp, TConfig>,
-  ): void {
-    this._register("patch", path, config, handler);
-  }
-
-  /**
-   * Register an SSE streaming endpoint.
-   *
-   * The handler receives a `TypedSSEStream` whose `emit()` validates event
-   * data against the declared Zod schemas.
-   */
-  sse<
-    TEvents extends Record<string, ZodType>,
-    TConfig extends SSEConfig<TEvents>,
-  >(
-    path: string,
-    config: TConfig,
-    handler: SSEHandler<TApp, TEvents, TConfig>,
-  ): void {
-    assertEndpointPath(path);
-    this._endpoints.push({
-      method: "sse",
-      path,
-      config: config as unknown as EndpointConfig,
-      handler: handler as EndpointRegistration["handler"],
-    });
-  }
-
-  /**
-   * Withdraw (remove) an endpoint inherited from a previous version.
-   *
-   * Withdrawn endpoints return `410 Gone` in this and all subsequent versions.
-   */
-  withdraw(method: HttpMethod, path: string): void {
-    assertEndpointPath(path);
-    this._endpoints.push({
-      method,
-      path,
-      config: {} as EndpointConfig,
-      handler: () => {},
-      withdrawn: true,
-    });
-  }
-
-  private _register(
-    method: HttpMethod,
-    path: string,
-    config: EndpointConfig,
-    handler: Handler<TApp, EndpointConfig>,
-  ): void {
-    assertEndpointPath(path);
-    this._endpoints.push({
-      method,
-      path,
-      config,
-      handler: handler as EndpointRegistration["handler"],
-    });
-  }
-}
-
-// ---------------------------------------------------------------------------
-// ServiceBuilder -- the fluent builder returned by createService()
-// ---------------------------------------------------------------------------
+import type { BaseApp, EndpointRegistration, ServiceConfig } from "./types.js";
+import { VersionBuilder } from "./version-builder.js";
+import { resolveVersions, type VersionDefinition } from "./versioning.js";
 
 /**
  * Fluent builder for constructing a versioned Hono service.
@@ -172,13 +39,8 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
   }
 
   /**
-   * Register provider factories.
-   *
-   * Each factory receives the base app context (`{ project, _legacy }`)
-   * and returns a service instance. Providers are resolved per-request and
-   * available on `app.{key}` in handlers.
-   *
-   * No cross-provider dependencies -- factories only receive the base context.
+   * Register provider factories that resolve concurrently for each request.
+   * Factories receive the base app context and cannot depend on one another.
    */
   provide<P extends Record<string, (base: BaseApp<TProject>) => unknown>>(
     providers: P,
@@ -203,12 +65,7 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
     );
   }
 
-  /**
-   * Register endpoints for a dated version (e.g. `"2025-03-15"`).
-   *
-   * Versions are forward-copied: each version inherits the previous version's
-   * endpoints, and the callback can override, add, or withdraw endpoints.
-   */
+  /** Register a dated version whose endpoints inherit from earlier versions. */
   version(
     date: string,
     define: (v: VersionBuilder<BaseApp<TProject> & TProviders>) => void,
@@ -228,12 +85,7 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
     return this;
   }
 
-  /**
-   * Register preview-only endpoints.
-   *
-   * Preview endpoints are accessible at `/preview/...` but are never included
-   * in `latest`.
-   */
+  /** Register preview-only endpoints that are excluded from `latest`. */
   preview(
     define: (v: VersionBuilder<BaseApp<TProject> & TProviders>) => void,
   ): this {
@@ -243,12 +95,7 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
     return this;
   }
 
-  /**
-   * Build the final Hono application.
-   *
-   * Creates sub-routers for each resolved version, mounts them under
-   * `/{version}/`, and sets up `latest` + bare-path aliases.
-   */
+  /** Build the final Hono application and mount every resolved route. */
   build(): Hono {
     this._validateConfiguration();
 
@@ -258,365 +105,28 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
         `Service basePath must start with "/"; received "${basePath}"`,
       );
     }
-    const app = new Hono().basePath(basePath);
 
-    // Apply built-in tracer + logger middleware (unless explicitly disabled)
+    const app = new Hono().basePath(basePath);
     if (this._config.tracer !== false) {
       app.use("*", tracerMiddleware({ name: this._config.name }));
     }
     if (this._config.logger !== false) {
       app.use("*", loggerMiddleware({ name: this._config.name }));
     }
-
-    // Apply additional global middleware
-    if (this._config.middleware) {
-      for (const mw of this._config.middleware) {
-        app.use("*", mw);
-      }
+    for (const middleware of this._config.middleware ?? []) {
+      app.use("*", middleware);
     }
 
-    // Resolve versions
-    const versionMap = resolveVersions(this._versions, this._previewEndpoints);
-
-    // Mount versioned sub-routers
-    for (const [version, endpoints] of versionMap) {
-      const status = resolveVersionStatus(version);
-      this._mountVersion(app, version, status, endpoints);
-    }
-
-    // Keep reserved version-like path prefixes from falling through to a
-    // dynamic bare-path endpoint when the requested version/route is absent.
-    const versionNamespace =
-      "/:apiVersion{latest|preview|20\\d{2}-\\d{2}-\\d{2}}";
-    app.all(versionNamespace, (c) => c.notFound());
-    app.all(`${versionNamespace}/*`, (c) => c.notFound());
-
-    // Bare path (no version) = latest
-    const latestEndpoints = versionMap.get("latest");
-    if (latestEndpoints) {
-      this._mountVersion(app, null, "unversioned", latestEndpoints);
-    }
-
-    // Error handler
     const onError = this._config.onError ?? createErrorHandler();
+    mountResolvedRoutes({
+      app,
+      onError,
+      providers: this._providers,
+      serviceConfig: this._config,
+      versionMap: resolveVersions(this._versions, this._previewEndpoints),
+    });
     app.onError(onError);
-
     return app;
-  }
-
-  // -------------------------------------------------------------------------
-  // Private helpers
-  // -------------------------------------------------------------------------
-
-  private _mountVersion(
-    app: Hono,
-    version: string | null,
-    status: VersionStatus,
-    endpoints: ResolvedEndpoint[],
-  ): void {
-    const prefix = version ? `/${version}` : "";
-    const isVersioned = status !== "unversioned";
-
-    for (const ep of endpoints) {
-      const fullPath = `${prefix}${ep.path || "/"}`;
-      const method = ep.method === "sse" ? "get" : ep.method;
-
-      // Withdrawn endpoint -- return 410 Gone
-      if (ep.withdrawn) {
-        const middlewareStack = this._buildWithdrawnMiddlewareStack({
-          ep,
-          isVersioned,
-          status,
-          version,
-        });
-        this._mountRoute(app, method, fullPath, middlewareStack);
-        continue;
-      }
-
-      // Active endpoint -- build middleware stack
-      const middlewareStack = this._buildMiddlewareStack({
-        ep,
-        isVersioned,
-        status,
-        version,
-      });
-      this._mountRoute(app, method, fullPath, middlewareStack);
-    }
-  }
-
-  private _mountRoute(
-    app: Hono,
-    method: HttpMethod,
-    path: string,
-    stack: MiddlewareHandler[],
-  ): void {
-    const handlers = stack as [MiddlewareHandler, ...MiddlewareHandler[]];
-    switch (method) {
-      case "get":
-        app.get(path, ...handlers);
-        break;
-      case "post":
-        app.post(path, ...handlers);
-        break;
-      case "put":
-        app.put(path, ...handlers);
-        break;
-      case "delete":
-        app.delete(path, ...handlers);
-        break;
-      case "patch":
-        app.patch(path, ...handlers);
-        break;
-    }
-  }
-
-  private _versionContextMiddleware({
-    isVersioned,
-    status,
-    version,
-  }: {
-    isVersioned: boolean;
-    status: VersionStatus;
-    version: string | null;
-  }): MiddlewareHandler {
-    return async (c, next) => {
-      c.set("isVersionedRequest", isVersioned);
-      if (version) {
-        c.set("apiVersion", version);
-      }
-      try {
-        await next();
-      } finally {
-        if (version) {
-          c.header("X-API-Version", version);
-        }
-        c.header("X-API-Version-Status", status);
-      }
-    };
-  }
-
-  private _appendAccessMiddleware(
-    stack: MiddlewareHandler[],
-    config: EndpointConfig,
-    { includeResourceLimit }: { includeResourceLimit: boolean },
-  ): void {
-    const authSetting = config.auth ?? "default";
-    if (authSetting === "default" && this._config.auth) {
-      stack.push(this._config.auth);
-    } else if (typeof authSetting === "function") {
-      stack.push(authSetting);
-    }
-
-    if (this._config._legacy?.organizationMiddleware) {
-      stack.push(this._config._legacy.organizationMiddleware);
-    }
-
-    if (includeResourceLimit && config.resourceLimit) {
-      stack.push(
-        this._config._legacy!.resourceLimitMiddleware!(config.resourceLimit),
-      );
-    }
-
-    if (config.middleware) {
-      stack.push(...config.middleware);
-    }
-  }
-
-  private _buildWithdrawnMiddlewareStack({
-    ep,
-    isVersioned,
-    status,
-    version,
-  }: {
-    ep: ResolvedEndpoint & { withdrawn: true };
-    isVersioned: boolean;
-    status: VersionStatus;
-    version: string | null;
-  }): MiddlewareHandler[] {
-    const stack: MiddlewareHandler[] = [
-      this._versionContextMiddleware({ isVersioned, status, version }),
-    ];
-    this._appendAccessMiddleware(stack, ep.config, {
-      includeResourceLimit: false,
-    });
-    stack.push(async (c) =>
-      c.json(
-        {
-          kind: "endpoint_withdrawn",
-          message: "This endpoint has been removed",
-        },
-        410,
-      ),
-    );
-    return stack;
-  }
-
-  private _buildMiddlewareStack({
-    ep,
-    isVersioned,
-    status,
-    version,
-  }: {
-    ep: EndpointRegistration;
-    isVersioned: boolean;
-    status: VersionStatus;
-    version: string | null;
-  }): MiddlewareHandler[] {
-    const stack: MiddlewareHandler[] = [];
-    const config = ep.config;
-
-    // 1. Version context middleware
-    stack.push(
-      this._versionContextMiddleware({ isVersioned, status, version }),
-    );
-
-    // 2-5. Auth, legacy organization/resource-limit, endpoint middleware
-    this._appendAccessMiddleware(stack, config, { includeResourceLimit: true });
-
-    // 6. OpenAPI description (describeRoute) -- only when output or description exists
-    if (config.output || config.description) {
-      const successStatus = String(config.status ?? 200);
-      const responses: NonNullable<DescribeRouteOptions["responses"]> = {};
-      if (config.output) {
-        responses[successStatus] = {
-          description: "Success",
-          content: {
-            "application/json": {
-              schema: resolver(config.output),
-            },
-          },
-        };
-      } else {
-        responses[successStatus] = { description: "Success" };
-      }
-      stack.push(
-        describeRoute({
-          description: config.description,
-          responses,
-        }) as unknown as MiddlewareHandler,
-      );
-    }
-
-    // 7. Validation middleware
-    if (config.params) {
-      stack.push(
-        zValidator("param", config.params, (result) => {
-          if (!result.success) throw result.error;
-        }) as unknown as MiddlewareHandler,
-      );
-    }
-    if (config.query) {
-      stack.push(
-        zValidator("query", config.query, (result) => {
-          if (!result.success) throw result.error;
-        }) as unknown as MiddlewareHandler,
-      );
-    }
-    // SSE endpoints are GET-only — skip JSON body validation
-    if (config.input && ep.method !== "sse") {
-      stack.push(
-        zValidator("json", config.input, (result) => {
-          if (!result.success) throw result.error;
-        }) as unknown as MiddlewareHandler,
-      );
-    }
-
-    // 8. App context middleware (resolves providers)
-    const providers = this._providers;
-    stack.push(async (c, next) => {
-      const base: BaseApp<TProject> = {
-        project: c.get("project"),
-        _legacy: {
-          organization: c.get("organization"),
-          prisma: c.get("prisma"),
-        },
-      };
-
-      // Auth runs inside loggerMiddleware's AsyncLocalStorage scope. Sync the
-      // fields it resolved before providers and handlers emit any log entries.
-      updateCurrentContext({
-        organizationId: c.get("organization")?.id,
-        projectId: c.get("project")?.id,
-        userId: c.get("user")?.id,
-      });
-
-      // Resolve providers
-      const resolved = Object.fromEntries(
-        await Promise.all(
-          Object.entries(providers).map(async ([key, factory]) => [
-            key,
-            await factory(base),
-          ]),
-        ),
-      );
-
-      const appCtx = { ...base, ...resolved };
-      c.set("app", appCtx);
-      await next();
-    });
-
-    // 9. Handler wrapper
-    if (ep.method === "sse") {
-      // SSE handler
-      const sseConfig = ep.config as unknown as SSEConfig<
-        Record<string, ZodType>
-      >;
-      stack.push(async (c) => {
-        const appCtx = c.get("app");
-        const query = config.query ? c.req.valid("query" as never) : undefined;
-
-        return createSSEResponse(c, sseConfig.events, async (stream) => {
-          await ep.handler(c, { query, app: appCtx }, stream);
-        });
-      });
-    } else {
-      // Regular handler
-      stack.push(async (c) => {
-        const appCtx = c.get("app");
-        const input = config.input ? c.req.valid("json" as never) : undefined;
-        const params = config.params
-          ? c.req.valid("param" as never)
-          : undefined;
-        const query = config.query ? c.req.valid("query" as never) : undefined;
-
-        const result = await ep.handler(c, {
-          input,
-          params,
-          query,
-          app: appCtx,
-        });
-
-        // If handler returns a Response directly, use it
-        if (result instanceof Response) {
-          return result;
-        }
-
-        // Validate output if schema is defined
-        const status = config.status ?? 200;
-        if (config.output) {
-          const validation = config.output.safeParse(result);
-          if (!validation.success) {
-            throw new Error("Response failed output validation", {
-              cause: validation.error,
-            });
-          }
-          if (validation.data === undefined) {
-            return c.body(null, config.status ?? 204);
-          }
-          return c.json(validation.data, status);
-        }
-
-        // void/undefined → 204 No Content
-        if (result === undefined) {
-          return c.body(null, 204);
-        }
-
-        // No output schema -- return as-is
-        return c.json(result, status);
-      });
-    }
-
-    return stack;
   }
 
   private _validateConfiguration(): void {
@@ -638,32 +148,7 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Version status resolver
-// ---------------------------------------------------------------------------
-
-function resolveVersionStatus(version: string): VersionStatus {
-  if (version === "latest") return "latest";
-  if (version === "preview") return "preview";
-  return "stable";
-}
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-/**
- * Creates a new service builder.
- *
- * ```ts
- * const app = createService({ name: "scenarios" })
- *   .provide({ scenarioService: () => ScenarioService.create(prisma) })
- *   .version("2025-03-15", (v) => {
- *     v.get("/", { output: listSchema }, async (c, { app }) => { ... });
- *   })
- *   .build();
- * ```
- */
+/** Creates a new typed service builder. */
 export function createService<TProject = unknown>(
   config: ServiceConfig,
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -672,9 +157,3 @@ export function createService<TProject = unknown>(
 }
 
 export { ServiceBuilder, VersionBuilder };
-
-function assertEndpointPath(path: string): void {
-  if (path !== "" && !path.startsWith("/")) {
-    throw new Error(`Endpoint path must start with "/"; received "${path}"`);
-  }
-}

--- a/langwatch/packages/api/src/builder.ts
+++ b/langwatch/packages/api/src/builder.ts
@@ -1,12 +1,13 @@
-import { Hono } from "hono";
-import type { MiddlewareHandler } from "hono";
-import { describeRoute } from "hono-openapi";
+import { updateCurrentContext } from "@langwatch/observability/context";
+import { Hono, type MiddlewareHandler } from "hono";
+import { describeRoute, type DescribeRouteOptions } from "hono-openapi";
 import { resolver, validator as zValidator } from "hono-openapi/zod";
 import type { ZodType } from "zod";
 
 import { createErrorHandler } from "./errors.js";
 import { tracerMiddleware, loggerMiddleware } from "./middleware.js";
 import { createSSEResponse, type SSEConfig, type SSEHandler } from "./sse.js";
+import { isDateVersion } from "./types.js";
 import type {
   BaseApp,
   EndpointConfig,
@@ -87,11 +88,15 @@ class VersionBuilder<TApp> {
    * The handler receives a `TypedSSEStream` whose `emit()` validates event
    * data against the declared Zod schemas.
    */
-  sse<TEvents extends Record<string, ZodType>, TConfig extends SSEConfig<TEvents>>(
+  sse<
+    TEvents extends Record<string, ZodType>,
+    TConfig extends SSEConfig<TEvents>,
+  >(
     path: string,
     config: TConfig,
     handler: SSEHandler<TApp, TEvents, TConfig>,
   ): void {
+    assertEndpointPath(path);
     this._endpoints.push({
       method: "sse",
       path,
@@ -106,6 +111,7 @@ class VersionBuilder<TApp> {
    * Withdrawn endpoints return `410 Gone` in this and all subsequent versions.
    */
   withdraw(method: HttpMethod, path: string): void {
+    assertEndpointPath(path);
     this._endpoints.push({
       method,
       path,
@@ -121,6 +127,7 @@ class VersionBuilder<TApp> {
     config: EndpointConfig,
     handler: Handler<TApp, EndpointConfig>,
   ): void {
+    assertEndpointPath(path);
     this._endpoints.push({
       method,
       path,
@@ -142,16 +149,26 @@ class VersionBuilder<TApp> {
  */
 class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
   private readonly _config: ServiceConfig;
-  private readonly _providers: Record<string, (base: BaseApp<TProject>) => unknown>;
-  private readonly _versions: VersionDefinition[] = [];
-  private readonly _previewEndpoints: EndpointRegistration[] = [];
+  private readonly _providers: Record<
+    string,
+    (base: BaseApp<TProject>) => unknown
+  >;
+  private readonly _versions: VersionDefinition[];
+  private readonly _previewEndpoints: EndpointRegistration[];
 
   constructor(
     config: ServiceConfig,
     providers: Record<string, (base: BaseApp<TProject>) => unknown> = {},
+    versions: VersionDefinition[] = [],
+    previewEndpoints: EndpointRegistration[] = [],
   ) {
+    if (!config.name.trim()) {
+      throw new Error("Service name must not be empty");
+    }
     this._config = config;
     this._providers = providers;
+    this._versions = versions;
+    this._previewEndpoints = previewEndpoints;
   }
 
   /**
@@ -165,10 +182,24 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
    */
   provide<P extends Record<string, (base: BaseApp<TProject>) => unknown>>(
     providers: P,
-  ): ServiceBuilder<TProject, TProviders & { [K in keyof P]: Awaited<ReturnType<P[K]>> }> {
-    return new ServiceBuilder<TProject, TProviders & { [K in keyof P]: Awaited<ReturnType<P[K]>> }>(
+  ): ServiceBuilder<
+    TProject,
+    TProviders & { [K in keyof P]: Awaited<ReturnType<P[K]>> }
+  > {
+    for (const key of Object.keys(providers)) {
+      if (key === "project" || key === "_legacy") {
+        throw new Error(`Provider name "${key}" is reserved by BaseApp`);
+      }
+    }
+
+    return new ServiceBuilder<
+      TProject,
+      TProviders & { [K in keyof P]: Awaited<ReturnType<P[K]>> }
+    >(
       this._config,
       { ...this._providers, ...providers },
+      [...this._versions],
+      [...this._previewEndpoints],
     );
   }
 
@@ -182,6 +213,15 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
     date: string,
     define: (v: VersionBuilder<BaseApp<TProject> & TProviders>) => void,
   ): this {
+    if (!isDateVersion(date)) {
+      throw new RangeError(
+        `Invalid API version "${date}"; expected a real date in YYYY-MM-DD form`,
+      );
+    }
+    if (this._versions.some((definition) => definition.version === date)) {
+      throw new Error(`API version "${date}" is registered more than once`);
+    }
+
     const builder = new VersionBuilder<BaseApp<TProject> & TProviders>();
     define(builder);
     this._versions.push({ version: date, endpoints: builder._endpoints });
@@ -194,7 +234,9 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
    * Preview endpoints are accessible at `/preview/...` but are never included
    * in `latest`.
    */
-  preview(define: (v: VersionBuilder<BaseApp<TProject> & TProviders>) => void): this {
+  preview(
+    define: (v: VersionBuilder<BaseApp<TProject> & TProviders>) => void,
+  ): this {
     const builder = new VersionBuilder<BaseApp<TProject> & TProviders>();
     define(builder);
     this._previewEndpoints.push(...builder._endpoints);
@@ -208,7 +250,14 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
    * `/{version}/`, and sets up `latest` + bare-path aliases.
    */
   build(): Hono {
+    this._validateConfiguration();
+
     const basePath = this._config.basePath ?? `/api/${this._config.name}`;
+    if (!basePath.startsWith("/")) {
+      throw new Error(
+        `Service basePath must start with "/"; received "${basePath}"`,
+      );
+    }
     const app = new Hono().basePath(basePath);
 
     // Apply built-in tracer + logger middleware (unless explicitly disabled)
@@ -234,6 +283,13 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
       const status = resolveVersionStatus(version);
       this._mountVersion(app, version, status, endpoints);
     }
+
+    // Keep reserved version-like path prefixes from falling through to a
+    // dynamic bare-path endpoint when the requested version/route is absent.
+    const versionNamespace =
+      "/:apiVersion{latest|preview|20\\d{2}-\\d{2}-\\d{2}}";
+    app.all(versionNamespace, (c) => c.notFound());
+    app.all(`${versionNamespace}/*`, (c) => c.notFound());
 
     // Bare path (no version) = latest
     const latestEndpoints = versionMap.get("latest");
@@ -263,30 +319,136 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
 
     for (const ep of endpoints) {
       const fullPath = `${prefix}${ep.path || "/"}`;
+      const method = ep.method === "sse" ? "get" : ep.method;
 
       // Withdrawn endpoint -- return 410 Gone
       if (ep.withdrawn) {
-        const method = ep.method === "sse" ? "get" : ep.method;
-        app[method](fullPath, (c) => {
-          if (version) {
-            c.header("X-API-Version", version);
-          }
-          c.header("X-API-Version-Status", status);
-          return c.json(
-            { kind: "endpoint_withdrawn", message: "This endpoint has been removed" },
-            410,
-          );
+        const middlewareStack = this._buildWithdrawnMiddlewareStack({
+          ep,
+          isVersioned,
+          status,
+          version,
         });
+        this._mountRoute(app, method, fullPath, middlewareStack);
         continue;
       }
 
       // Active endpoint -- build middleware stack
-      const middlewareStack = this._buildMiddlewareStack({ ep, isVersioned, status, version });
-      const method = ep.method === "sse" ? "get" : ep.method;
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (app[method] as any)(fullPath, ...middlewareStack);
+      const middlewareStack = this._buildMiddlewareStack({
+        ep,
+        isVersioned,
+        status,
+        version,
+      });
+      this._mountRoute(app, method, fullPath, middlewareStack);
     }
+  }
+
+  private _mountRoute(
+    app: Hono,
+    method: HttpMethod,
+    path: string,
+    stack: MiddlewareHandler[],
+  ): void {
+    const handlers = stack as [MiddlewareHandler, ...MiddlewareHandler[]];
+    switch (method) {
+      case "get":
+        app.get(path, ...handlers);
+        break;
+      case "post":
+        app.post(path, ...handlers);
+        break;
+      case "put":
+        app.put(path, ...handlers);
+        break;
+      case "delete":
+        app.delete(path, ...handlers);
+        break;
+      case "patch":
+        app.patch(path, ...handlers);
+        break;
+    }
+  }
+
+  private _versionContextMiddleware({
+    isVersioned,
+    status,
+    version,
+  }: {
+    isVersioned: boolean;
+    status: VersionStatus;
+    version: string | null;
+  }): MiddlewareHandler {
+    return async (c, next) => {
+      c.set("isVersionedRequest", isVersioned);
+      if (version) {
+        c.set("apiVersion", version);
+      }
+      try {
+        await next();
+      } finally {
+        if (version) {
+          c.header("X-API-Version", version);
+        }
+        c.header("X-API-Version-Status", status);
+      }
+    };
+  }
+
+  private _appendAccessMiddleware(
+    stack: MiddlewareHandler[],
+    config: EndpointConfig,
+    { includeResourceLimit }: { includeResourceLimit: boolean },
+  ): void {
+    const authSetting = config.auth ?? "default";
+    if (authSetting === "default" && this._config.auth) {
+      stack.push(this._config.auth);
+    } else if (typeof authSetting === "function") {
+      stack.push(authSetting);
+    }
+
+    if (this._config._legacy?.organizationMiddleware) {
+      stack.push(this._config._legacy.organizationMiddleware);
+    }
+
+    if (includeResourceLimit && config.resourceLimit) {
+      stack.push(
+        this._config._legacy!.resourceLimitMiddleware!(config.resourceLimit),
+      );
+    }
+
+    if (config.middleware) {
+      stack.push(...config.middleware);
+    }
+  }
+
+  private _buildWithdrawnMiddlewareStack({
+    ep,
+    isVersioned,
+    status,
+    version,
+  }: {
+    ep: ResolvedEndpoint & { withdrawn: true };
+    isVersioned: boolean;
+    status: VersionStatus;
+    version: string | null;
+  }): MiddlewareHandler[] {
+    const stack: MiddlewareHandler[] = [
+      this._versionContextMiddleware({ isVersioned, status, version }),
+    ];
+    this._appendAccessMiddleware(stack, ep.config, {
+      includeResourceLimit: false,
+    });
+    stack.push(async (c) =>
+      c.json(
+        {
+          kind: "endpoint_withdrawn",
+          message: "This endpoint has been removed",
+        },
+        410,
+      ),
+    );
+    return stack;
   }
 
   private _buildMiddlewareStack({
@@ -304,49 +466,19 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
     const config = ep.config;
 
     // 1. Version context middleware
-    stack.push(async (c, next) => {
-      c.set("isVersionedRequest", isVersioned);
-      if (version) {
-        c.set("apiVersion", version);
-      }
-      await next();
-      // Set response headers
-      if (version) {
-        c.header("X-API-Version", version);
-      }
-      c.header("X-API-Version-Status", status);
-    });
+    stack.push(
+      this._versionContextMiddleware({ isVersioned, status, version }),
+    );
 
-    // 2. Auth middleware
-    const authSetting = config.auth ?? "default";
-    if (authSetting === "default" && this._config.auth) {
-      stack.push(this._config.auth);
-    } else if (typeof authSetting === "function") {
-      stack.push(authSetting);
-    }
-    // "none" -- skip auth
-
-    // 3. Legacy organization middleware
-    if (this._config._legacy?.organizationMiddleware) {
-      stack.push(this._config._legacy.organizationMiddleware);
-    }
-
-    // 4. Legacy resource limit middleware
-    if (config.resourceLimit && this._config._legacy?.resourceLimitMiddleware) {
-      stack.push(this._config._legacy.resourceLimitMiddleware(config.resourceLimit));
-    }
-
-    // 5. Per-endpoint middleware
-    if (config.middleware) {
-      stack.push(...config.middleware);
-    }
+    // 2-5. Auth, legacy organization/resource-limit, endpoint middleware
+    this._appendAccessMiddleware(stack, config, { includeResourceLimit: true });
 
     // 6. OpenAPI description (describeRoute) -- only when output or description exists
     if (config.output || config.description) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const responses: Record<string, any> = {};
+      const successStatus = String(config.status ?? 200);
+      const responses: NonNullable<DescribeRouteOptions["responses"]> = {};
       if (config.output) {
-        responses[String(config.status ?? 200)] = {
+        responses[successStatus] = {
           description: "Success",
           content: {
             "application/json": {
@@ -354,6 +486,8 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
             },
           },
         };
+      } else {
+        responses[successStatus] = { description: "Success" };
       }
       stack.push(
         describeRoute({
@@ -365,14 +499,26 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
 
     // 7. Validation middleware
     if (config.params) {
-      stack.push(zValidator("param", config.params) as unknown as MiddlewareHandler);
+      stack.push(
+        zValidator("param", config.params, (result) => {
+          if (!result.success) throw result.error;
+        }) as unknown as MiddlewareHandler,
+      );
     }
     if (config.query) {
-      stack.push(zValidator("query", config.query) as unknown as MiddlewareHandler);
+      stack.push(
+        zValidator("query", config.query, (result) => {
+          if (!result.success) throw result.error;
+        }) as unknown as MiddlewareHandler,
+      );
     }
     // SSE endpoints are GET-only — skip JSON body validation
     if (config.input && ep.method !== "sse") {
-      stack.push(zValidator("json", config.input) as unknown as MiddlewareHandler);
+      stack.push(
+        zValidator("json", config.input, (result) => {
+          if (!result.success) throw result.error;
+        }) as unknown as MiddlewareHandler,
+      );
     }
 
     // 8. App context middleware (resolves providers)
@@ -386,11 +532,23 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
         },
       };
 
+      // Auth runs inside loggerMiddleware's AsyncLocalStorage scope. Sync the
+      // fields it resolved before providers and handlers emit any log entries.
+      updateCurrentContext({
+        organizationId: c.get("organization")?.id,
+        projectId: c.get("project")?.id,
+        userId: c.get("user")?.id,
+      });
+
       // Resolve providers
-      const resolved: Record<string, unknown> = {};
-      for (const [key, factory] of Object.entries(providers)) {
-        resolved[key] = await factory(base);
-      }
+      const resolved = Object.fromEntries(
+        await Promise.all(
+          Object.entries(providers).map(async ([key, factory]) => [
+            key,
+            await factory(base),
+          ]),
+        ),
+      );
 
       const appCtx = { ...base, ...resolved };
       c.set("app", appCtx);
@@ -400,7 +558,9 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
     // 9. Handler wrapper
     if (ep.method === "sse") {
       // SSE handler
-      const sseConfig = ep.config as unknown as SSEConfig<Record<string, ZodType>>;
+      const sseConfig = ep.config as unknown as SSEConfig<
+        Record<string, ZodType>
+      >;
       stack.push(async (c) => {
         const appCtx = c.get("app");
         const query = config.query ? c.req.valid("query" as never) : undefined;
@@ -414,26 +574,41 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
       stack.push(async (c) => {
         const appCtx = c.get("app");
         const input = config.input ? c.req.valid("json" as never) : undefined;
-        const params = config.params ? c.req.valid("param" as never) : undefined;
+        const params = config.params
+          ? c.req.valid("param" as never)
+          : undefined;
         const query = config.query ? c.req.valid("query" as never) : undefined;
 
-        const result = await ep.handler(c, { input, params, query, app: appCtx });
+        const result = await ep.handler(c, {
+          input,
+          params,
+          query,
+          app: appCtx,
+        });
 
         // If handler returns a Response directly, use it
         if (result instanceof Response) {
           return result;
         }
 
-        // void/undefined → 204 No Content
-        if (result === undefined) {
-          return c.body(null, config.status ?? 204);
-        }
-
         // Validate output if schema is defined
         const status = config.status ?? 200;
         if (config.output) {
-          const validated = config.output.parse(result);
-          return c.json(validated, status);
+          const validation = config.output.safeParse(result);
+          if (!validation.success) {
+            throw new Error("Response failed output validation", {
+              cause: validation.error,
+            });
+          }
+          if (validation.data === undefined) {
+            return c.body(null, config.status ?? 204);
+          }
+          return c.json(validation.data, status);
+        }
+
+        // void/undefined → 204 No Content
+        if (result === undefined) {
+          return c.body(null, 204);
         }
 
         // No output schema -- return as-is
@@ -442,6 +617,24 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
     }
 
     return stack;
+  }
+
+  private _validateConfiguration(): void {
+    const endpoints = [
+      ...this._versions.flatMap((definition) => definition.endpoints),
+      ...this._previewEndpoints,
+    ];
+    for (const endpoint of endpoints) {
+      if (
+        endpoint.config.resourceLimit &&
+        !this._config._legacy?.resourceLimitMiddleware
+      ) {
+        throw new Error(
+          `Endpoint ${endpoint.method.toUpperCase()} ${endpoint.path} declares resourceLimit ` +
+            `"${endpoint.config.resourceLimit}" but the service has no resourceLimitMiddleware`,
+        );
+      }
+    }
   }
 }
 
@@ -479,3 +672,9 @@ export function createService<TProject = unknown>(
 }
 
 export { ServiceBuilder, VersionBuilder };
+
+function assertEndpointPath(path: string): void {
+  if (path !== "" && !path.startsWith("/")) {
+    throw new Error(`Endpoint path must start with "/"; received "${path}"`);
+  }
+}

--- a/langwatch/packages/api/src/builder.ts
+++ b/langwatch/packages/api/src/builder.ts
@@ -123,7 +123,10 @@ class ServiceBuilder<TProject, TProviders extends Record<string, unknown>> {
       onError,
       providers: this._providers,
       serviceConfig: this._config,
-      versionMap: resolveVersions(this._versions, this._previewEndpoints),
+      versionMap: resolveVersions({
+        definitions: this._versions,
+        previewEndpoints: this._previewEndpoints,
+      }),
     });
     app.onError(onError);
     return app;

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -1,0 +1,179 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { ZodError } from "zod";
+
+import { httpStatusText } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Duck-typed interfaces for DomainError (no imports from langwatch app)
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape that a DomainError-like object must satisfy for the framework error
+ * handler to use its `serialize()` output.
+ *
+ * We duck-type rather than import so this package stays standalone.
+ */
+interface DomainErrorLike {
+  kind: string;
+  message: string;
+  httpStatus: number;
+  meta: Record<string, unknown>;
+  serialize(): {
+    kind: string;
+    meta: Record<string, unknown>;
+    telemetry?: { traceId?: string; spanId?: string };
+    httpStatus: number;
+    reasons: Array<{ kind: string; meta?: Record<string, unknown>; reasons?: unknown[] }>;
+  };
+}
+
+function isDomainErrorLike(err: unknown): err is DomainErrorLike {
+  if (typeof err !== "object" || err === null) return false;
+  const obj = err as Record<string, unknown>;
+  return (
+    typeof obj["kind"] === "string" &&
+    typeof obj["httpStatus"] === "number" &&
+    typeof obj["serialize"] === "function"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Zod error mapping
+// ---------------------------------------------------------------------------
+
+interface ValidationReason {
+  code: "schema_failure";
+  meta: {
+    field: string;
+    type: string;
+    message: string;
+  };
+}
+
+interface ValidationErrorPayload {
+  kind: "validation_error";
+  message: string;
+  reasons: ValidationReason[];
+  httpStatus: 422;
+}
+
+function zodErrorToPayload(err: ZodError): ValidationErrorPayload {
+  return {
+    kind: "validation_error",
+    message: "Validation error",
+    reasons: err.issues.map((issue) => ({
+      code: "schema_failure" as const,
+      meta: {
+        field: issue.path.join(".") || "(root)",
+        type: issue.code,
+        message: issue.message,
+      },
+    })),
+    httpStatus: 422,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error response formatting
+// ---------------------------------------------------------------------------
+
+interface ErrorResponseBody {
+  /** Present only for unversioned (backwards-compat) responses. */
+  error?: string;
+  kind: string;
+  message: string;
+  meta?: Record<string, unknown>;
+  reasons?: unknown[];
+  telemetry?: { traceId?: string; spanId?: string };
+}
+
+/**
+ * Formats an error into a JSON response body + status code.
+ *
+ * @param isVersioned - Whether the request was made through a versioned path.
+ *   Versioned requests get the new format only; unversioned get a union
+ *   format that includes the legacy `error` field.
+ */
+function formatError(
+  err: unknown,
+  isVersioned: boolean,
+): { status: ContentfulStatusCode; body: ErrorResponseBody } {
+  // 1. DomainError-like errors
+  if (isDomainErrorLike(err)) {
+    const serialized = err.serialize();
+    const status = serialized.httpStatus as ContentfulStatusCode;
+    const body: ErrorResponseBody = {
+      kind: serialized.kind,
+      message: err.message ?? serialized.kind,
+      meta: serialized.meta,
+      reasons: serialized.reasons,
+      telemetry: serialized.telemetry,
+    };
+    if (!isVersioned) {
+      body.error = httpStatusText(status);
+    }
+    return { status, body };
+  }
+
+  // 2. ZodError
+  if (err instanceof ZodError) {
+    const payload = zodErrorToPayload(err);
+    const status: ContentfulStatusCode = 422;
+    const body: ErrorResponseBody = {
+      kind: payload.kind,
+      message: payload.message,
+      reasons: payload.reasons,
+    };
+    if (!isVersioned) {
+      body.error = httpStatusText(status);
+    }
+    return { status, body };
+  }
+
+  // 3. Error with `status` property (e.g. Hono HTTPException)
+  const errObj = err as Record<string, unknown>;
+  if (err instanceof Error && typeof errObj["status"] === "number") {
+    const status = errObj["status"] as ContentfulStatusCode;
+    const body: ErrorResponseBody = {
+      kind: "http_error",
+      message: err.message,
+    };
+    if (!isVersioned) {
+      body.error = httpStatusText(status);
+    }
+    return { status, body };
+  }
+
+  // 4. Unknown errors -- 500
+  const isDev = typeof process !== "undefined" && process.env?.["NODE_ENV"] === "development";
+  const message = isDev && err instanceof Error ? err.message : "Internal server error";
+  const status: ContentfulStatusCode = 500;
+  const body: ErrorResponseBody = {
+    kind: "internal_error",
+    message,
+  };
+  if (!isVersioned) {
+    body.error = httpStatusText(status);
+  }
+  return { status, body };
+}
+
+// ---------------------------------------------------------------------------
+// Hono onError handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the `app.onError(...)` handler for the service framework.
+ *
+ * Reads `c.get("isVersionedRequest")` to decide the response format.
+ */
+export function createErrorHandler(): (err: Error, c: Context) => Response | Promise<Response> {
+  return (err: Error, c: Context) => {
+    const isVersioned = c.get("isVersionedRequest") === true;
+    const { status, body } = formatError(err, isVersioned);
+    return c.json(body, status);
+  };
+}
+
+export { formatError, isDomainErrorLike, zodErrorToPayload };

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -99,10 +99,13 @@ interface ErrorResponseBody {
  *   Versioned requests get the new format only; unversioned get a union
  *   format that includes the legacy `error` field.
  */
-function formatError(
-  err: unknown,
-  isVersioned: boolean,
-): { status: ContentfulStatusCode; body: ErrorResponseBody } {
+function formatError({
+  err,
+  isVersioned,
+}: {
+  err: unknown;
+  isVersioned: boolean;
+}): { status: ContentfulStatusCode; body: ErrorResponseBody } {
   // 1. DomainError-like errors
   if (isDomainErrorLike(err)) {
     const serialized = err.serialize();
@@ -181,7 +184,7 @@ export function createErrorHandler(): (
 ) => Response | Promise<Response> {
   return (err: Error, c: Context) => {
     const isVersioned = c.get("isVersionedRequest") === true;
-    const { status, body } = formatError(err, isVersioned);
+    const { status, body } = formatError({ err, isVersioned });
     return c.json(body, status);
   };
 }

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -24,7 +24,11 @@ interface DomainErrorLike {
     meta: Record<string, unknown>;
     telemetry?: { traceId?: string; spanId?: string };
     httpStatus: number;
-    reasons: Array<{ kind: string; meta?: Record<string, unknown>; reasons?: unknown[] }>;
+    reasons: Array<{
+      kind: string;
+      meta?: Record<string, unknown>;
+      reasons?: unknown[];
+    }>;
   };
 }
 
@@ -146,8 +150,11 @@ function formatError(
   }
 
   // 4. Unknown errors -- 500
-  const isDev = typeof process !== "undefined" && process.env?.["NODE_ENV"] === "development";
-  const message = isDev && err instanceof Error ? err.message : "Internal server error";
+  const isDev =
+    typeof process !== "undefined" &&
+    process.env?.["NODE_ENV"] === "development";
+  const message =
+    isDev && err instanceof Error ? err.message : "Internal server error";
   const status: ContentfulStatusCode = 500;
   const body: ErrorResponseBody = {
     kind: "internal_error",
@@ -168,7 +175,10 @@ function formatError(
  *
  * Reads `c.get("isVersionedRequest")` to decide the response format.
  */
-export function createErrorHandler(): (err: Error, c: Context) => Response | Promise<Response> {
+export function createErrorHandler(): (
+  err: Error,
+  c: Context,
+) => Response | Promise<Response> {
   return (err: Error, c: Context) => {
     const isVersioned = c.get("isVersionedRequest") === true;
     const { status, body } = formatError(err, isVersioned);

--- a/langwatch/packages/api/src/errors.ts
+++ b/langwatch/packages/api/src/errors.ts
@@ -92,6 +92,19 @@ interface ErrorResponseBody {
   telemetry?: { traceId?: string; spanId?: string };
 }
 
+function finalizeErrorResponse({
+  status,
+  body,
+  isVersioned,
+}: {
+  status: ContentfulStatusCode;
+  body: ErrorResponseBody;
+  isVersioned: boolean;
+}): { status: ContentfulStatusCode; body: ErrorResponseBody } {
+  if (!isVersioned) body.error = httpStatusText(status);
+  return { status, body };
+}
+
 /**
  * Formats an error into a JSON response body + status code.
  *
@@ -110,46 +123,43 @@ function formatError({
   if (isDomainErrorLike(err)) {
     const serialized = err.serialize();
     const status = serialized.httpStatus as ContentfulStatusCode;
-    const body: ErrorResponseBody = {
-      kind: serialized.kind,
-      message: err.message ?? serialized.kind,
-      meta: serialized.meta,
-      reasons: serialized.reasons,
-      telemetry: serialized.telemetry,
-    };
-    if (!isVersioned) {
-      body.error = httpStatusText(status);
-    }
-    return { status, body };
+    return finalizeErrorResponse({
+      status,
+      isVersioned,
+      body: {
+        kind: serialized.kind,
+        message: err.message ?? serialized.kind,
+        meta: serialized.meta,
+        reasons: serialized.reasons,
+        telemetry: serialized.telemetry,
+      },
+    });
   }
 
   // 2. ZodError
   if (err instanceof ZodError) {
     const payload = zodErrorToPayload(err);
     const status: ContentfulStatusCode = 422;
-    const body: ErrorResponseBody = {
-      kind: payload.kind,
-      message: payload.message,
-      reasons: payload.reasons,
-    };
-    if (!isVersioned) {
-      body.error = httpStatusText(status);
-    }
-    return { status, body };
+    return finalizeErrorResponse({
+      status,
+      isVersioned,
+      body: {
+        kind: payload.kind,
+        message: payload.message,
+        reasons: payload.reasons,
+      },
+    });
   }
 
   // 3. Error with `status` property (e.g. Hono HTTPException)
   const errObj = err as Record<string, unknown>;
   if (err instanceof Error && typeof errObj["status"] === "number") {
     const status = errObj["status"] as ContentfulStatusCode;
-    const body: ErrorResponseBody = {
-      kind: "http_error",
-      message: err.message,
-    };
-    if (!isVersioned) {
-      body.error = httpStatusText(status);
-    }
-    return { status, body };
+    return finalizeErrorResponse({
+      status,
+      isVersioned,
+      body: { kind: "http_error", message: err.message },
+    });
   }
 
   // 4. Unknown errors -- 500
@@ -159,14 +169,11 @@ function formatError({
   const message =
     isDev && err instanceof Error ? err.message : "Internal server error";
   const status: ContentfulStatusCode = 500;
-  const body: ErrorResponseBody = {
-    kind: "internal_error",
-    message,
-  };
-  if (!isVersioned) {
-    body.error = httpStatusText(status);
-  }
-  return { status, body };
+  return finalizeErrorResponse({
+    status,
+    isVersioned,
+    body: { kind: "internal_error", message },
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/langwatch/packages/api/src/index.ts
+++ b/langwatch/packages/api/src/index.ts
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------
+// @langwatch/api -- Public API
+// ---------------------------------------------------------------------------
+
+export { createService, ServiceBuilder, VersionBuilder } from "./builder.js";
+export { createErrorHandler, formatError } from "./errors.js";
+export { tracerMiddleware, loggerMiddleware } from "./middleware.js";
+import type { Hono } from "hono";
+import { handle } from "hono/vercel";
+
+export function routeHandlers(app: Hono) {
+  const h = handle(app);
+  return { GET: h, POST: h, PUT: h, DELETE: h, PATCH: h } as const;
+}
+export {
+  createSSEResponse,
+  type SSEConfig,
+  type SSEHandler,
+  type TypedSSEStream,
+} from "./sse.js";
+export {
+  VERSION_LATEST,
+  VERSION_PREVIEW,
+  isDateVersion,
+  httpStatusText,
+  type BaseApp,
+  type DateVersion,
+  type EndpointConfig,
+  type EndpointRegistration,
+  type Handler,
+  type HttpMethod,
+  type ServiceConfig,
+  type VersionStatus,
+} from "./types.js";
+export {
+  resolveVersions,
+  resolveRequestVersion,
+  type ResolvedEndpoint,
+  type ResolvedVersion,
+  type VersionDefinition,
+} from "./versioning.js";

--- a/langwatch/packages/api/src/middleware.ts
+++ b/langwatch/packages/api/src/middleware.ts
@@ -1,0 +1,154 @@
+import {
+  context as otContext,
+  propagation,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+} from "@opentelemetry/api";
+import type { Context, Next } from "hono";
+import {
+  createLogger,
+  runWithContext,
+  updateCurrentContext,
+  logHttpRequest,
+  getStatusCodeFromError,
+} from "@langwatch/telemetry";
+
+// ---------------------------------------------------------------------------
+// Tracer middleware
+// ---------------------------------------------------------------------------
+
+const headersGetter = {
+  keys: (carrier: Headers): string[] => Array.from(carrier.keys()),
+  get: (carrier: Headers, key: string): string | string[] | undefined =>
+    carrier.get(key) ?? void 0,
+};
+
+/**
+ * Creates a Hono middleware that wraps each request in an OTel span.
+ *
+ * Sets `traceId` and `spanId` on the Hono context for downstream use.
+ * After the handler runs, adds org/project/user attributes to the span.
+ */
+export function tracerMiddleware(options?: { name?: string }) {
+  return async (c: Context, next: Next): Promise<void> => {
+    const tracer = trace.getTracer("langwatch:api:hono");
+
+    const incomingHeaders = c.req.raw.headers;
+    const parentCtx = propagation.extract(
+      otContext.active(),
+      incomingHeaders,
+      headersGetter,
+    );
+
+    const method = c.req.method;
+    const spanName = `${method} ${options?.name ?? c.req.path}`;
+
+    return otContext.with(parentCtx, async () => {
+      return tracer.startActiveSpan(
+        spanName,
+        {
+          kind: SpanKind.SERVER,
+          attributes: options?.name
+            ? { "service.name": options.name }
+            : undefined,
+        },
+        async (span) => {
+          try {
+            const spanCtx = span.spanContext();
+            c.set("traceId", spanCtx.traceId);
+            c.set("spanId", spanCtx.spanId);
+
+            await next();
+
+            const organizationId = c.get("organization")?.id;
+            const projectId = c.get("project")?.id;
+            const userId = c.get("user")?.id;
+
+            if (organizationId) {
+              span.setAttribute("organization.id", organizationId);
+            }
+            if (projectId) {
+              span.setAttribute("tenant.id", projectId);
+            }
+            if (userId) {
+              span.setAttribute("user.id", userId);
+            }
+          } catch (err) {
+            span.recordException(err as Error);
+            span.setStatus({ code: SpanStatusCode.ERROR });
+            throw err;
+          } finally {
+            const carrier: Record<string, string> = {};
+            propagation.inject(otContext.active(), carrier);
+            for (const [key, value] of Object.entries(carrier)) {
+              try {
+                c.res.headers.set(key, value);
+              } catch {
+                // ignore if response headers are not available
+              }
+            }
+            span.end();
+          }
+        },
+      );
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Logger middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Hono middleware that logs each request using `@langwatch/telemetry`.
+ *
+ * Sets up async context propagation so that downstream code can access
+ * org/project/user context via `getCurrentContext()`.
+ */
+export function loggerMiddleware(options?: { name?: string }) {
+  const logger = createLogger(
+    `langwatch:api:${options?.name ?? "hono"}`,
+  );
+
+  return async (c: Context, next: Next): Promise<void> => {
+    const ctx = {
+      organizationId: c.get("organization")?.id,
+      projectId: c.get("project")?.id,
+      userId: c.get("user")?.id,
+    };
+
+    return runWithContext(ctx, async () => {
+      const start = Date.now();
+      let error: unknown = c.error;
+
+      try {
+        await next();
+
+        // Update context after auth resolves org/project/user
+        updateCurrentContext({
+          organizationId: c.get("organization")?.id,
+          projectId: c.get("project")?.id,
+          userId: c.get("user")?.id,
+        });
+      } catch (err) {
+        error = err;
+        throw err;
+      } finally {
+        const duration = Date.now() - start;
+        const statusCode = error
+          ? getStatusCodeFromError(error)
+          : c.res.status;
+
+        logHttpRequest(logger, {
+          method: c.req.method,
+          url: c.req.url,
+          statusCode,
+          duration,
+          userAgent: c.req.header("user-agent") ?? null,
+          error: error || c.error,
+        });
+      }
+    });
+  };
+}

--- a/langwatch/packages/api/src/middleware.ts
+++ b/langwatch/packages/api/src/middleware.ts
@@ -16,6 +16,8 @@ import {
   updateCurrentContext,
 } from "@langwatch/observability/context";
 
+import { getSSECompletion } from "./sse.js";
+
 // ---------------------------------------------------------------------------
 // Tracer middleware
 // ---------------------------------------------------------------------------
@@ -56,17 +58,15 @@ export function tracerMiddleware(options?: { name?: string }) {
             : undefined,
         },
         async (span) => {
-          try {
-            const spanCtx = span.spanContext();
-            c.set("traceId", spanCtx.traceId);
-            c.set("spanId", spanCtx.spanId);
-
-            await next();
+          let requestError: unknown;
+          let finished = false;
+          const finishSpan = () => {
+            if (finished) return;
+            finished = true;
 
             const organizationId = c.get("organization")?.id;
             const projectId = c.get("project")?.id;
             const userId = c.get("user")?.id;
-
             if (organizationId) {
               span.setAttribute("organization.id", organizationId);
             }
@@ -76,9 +76,23 @@ export function tracerMiddleware(options?: { name?: string }) {
             if (userId) {
               span.setAttribute("user.id", userId);
             }
+
+            const error = requestError ?? c.error;
+            if (error) {
+              span.recordException(error as Error);
+              span.setStatus({ code: SpanStatusCode.ERROR });
+            }
+            span.end();
+          };
+
+          try {
+            const spanCtx = span.spanContext();
+            c.set("traceId", spanCtx.traceId);
+            c.set("spanId", spanCtx.spanId);
+
+            await next();
           } catch (err) {
-            span.recordException(err as Error);
-            span.setStatus({ code: SpanStatusCode.ERROR });
+            requestError = err;
             throw err;
           } finally {
             const carrier: Record<string, string> = {};
@@ -90,7 +104,16 @@ export function tracerMiddleware(options?: { name?: string }) {
                 // ignore if response headers are not available
               }
             }
-            span.end();
+
+            const streamCompletion = getSSECompletion(c);
+            if (streamCompletion) {
+              void streamCompletion.then(finishSpan, (error) => {
+                requestError = error;
+                finishSpan();
+              });
+            } else {
+              finishSpan();
+            }
           }
         },
       );
@@ -135,17 +158,32 @@ export function loggerMiddleware(options?: { name?: string }) {
         error = err;
         throw err;
       } finally {
-        const duration = Date.now() - start;
-        const statusCode = error ? getStatusCodeFromError(error) : c.res.status;
+        const logRequest = () => {
+          const requestError = error || c.error;
+          const duration = Date.now() - start;
+          const statusCode = requestError
+            ? getStatusCodeFromError(requestError)
+            : c.res.status;
 
-        logHttpRequest(logger, {
-          method: c.req.method,
-          url: c.req.url,
-          statusCode,
-          duration,
-          userAgent: c.req.header("user-agent") ?? null,
-          error: error || c.error,
-        });
+          logHttpRequest(logger, {
+            method: c.req.method,
+            url: c.req.path,
+            statusCode,
+            duration,
+            userAgent: c.req.header("user-agent") ?? null,
+            error: requestError,
+          });
+        };
+
+        const streamCompletion = getSSECompletion(c);
+        if (streamCompletion) {
+          void streamCompletion.then(logRequest, (streamError) => {
+            error = streamError;
+            logRequest();
+          });
+        } else {
+          logRequest();
+        }
       }
     });
   };

--- a/langwatch/packages/api/src/middleware.ts
+++ b/langwatch/packages/api/src/middleware.ts
@@ -109,9 +109,7 @@ export function tracerMiddleware(options?: { name?: string }) {
  * org/project/user context via `getCurrentContext()`.
  */
 export function loggerMiddleware(options?: { name?: string }) {
-  const logger = createLogger(
-    `langwatch:api:${options?.name ?? "hono"}`,
-  );
+  const logger = createLogger(`langwatch:api:${options?.name ?? "hono"}`);
 
   return async (c: Context, next: Next): Promise<void> => {
     const ctx = {
@@ -138,9 +136,7 @@ export function loggerMiddleware(options?: { name?: string }) {
         throw err;
       } finally {
         const duration = Date.now() - start;
-        const statusCode = error
-          ? getStatusCodeFromError(error)
-          : c.res.status;
+        const statusCode = error ? getStatusCodeFromError(error) : c.res.status;
 
         logHttpRequest(logger, {
           method: c.req.method,

--- a/langwatch/packages/api/src/middleware.ts
+++ b/langwatch/packages/api/src/middleware.ts
@@ -59,10 +59,10 @@ export function tracerMiddleware(options?: { name?: string }) {
         },
         async (span) => {
           let requestError: unknown;
-          let finished = false;
+          let isFinished = false;
           const finishSpan = () => {
-            if (finished) return;
-            finished = true;
+            if (isFinished) return;
+            isFinished = true;
 
             const organizationId = c.get("organization")?.id;
             const projectId = c.get("project")?.id;
@@ -105,15 +105,13 @@ export function tracerMiddleware(options?: { name?: string }) {
               }
             }
 
-            const streamCompletion = getSSECompletion(c);
-            if (streamCompletion) {
-              void streamCompletion.then(finishSpan, (error) => {
+            runAfterSSECompletion({
+              c,
+              onSettled: finishSpan,
+              onStreamError: (error) => {
                 requestError = error;
-                finishSpan();
-              });
-            } else {
-              finishSpan();
-            }
+              },
+            });
           }
         },
       );
@@ -175,16 +173,35 @@ export function loggerMiddleware(options?: { name?: string }) {
           });
         };
 
-        const streamCompletion = getSSECompletion(c);
-        if (streamCompletion) {
-          void streamCompletion.then(logRequest, (streamError) => {
+        runAfterSSECompletion({
+          c,
+          onSettled: logRequest,
+          onStreamError: (streamError) => {
             error = streamError;
-            logRequest();
-          });
-        } else {
-          logRequest();
-        }
+          },
+        });
       }
     });
   };
+}
+
+function runAfterSSECompletion({
+  c,
+  onSettled,
+  onStreamError,
+}: {
+  c: Context;
+  onSettled: () => void;
+  onStreamError: (error: Error) => void;
+}): void {
+  const streamCompletion = getSSECompletion(c);
+  if (!streamCompletion) {
+    onSettled();
+    return;
+  }
+
+  void streamCompletion.then(({ error }) => {
+    if (error) onStreamError(error);
+    onSettled();
+  });
 }

--- a/langwatch/packages/api/src/middleware.ts
+++ b/langwatch/packages/api/src/middleware.ts
@@ -1,0 +1,156 @@
+import {
+  context as otContext,
+  propagation,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+} from "@opentelemetry/api";
+import type { Context, Next } from "hono";
+import {
+  createLogger,
+  logHttpRequest,
+  getStatusCodeFromError,
+} from "@langwatch/observability";
+import {
+  runWithContext,
+  updateCurrentContext,
+} from "@langwatch/observability/context";
+
+// ---------------------------------------------------------------------------
+// Tracer middleware
+// ---------------------------------------------------------------------------
+
+const headersGetter = {
+  keys: (carrier: Headers): string[] => Array.from(carrier.keys()),
+  get: (carrier: Headers, key: string): string | string[] | undefined =>
+    carrier.get(key) ?? void 0,
+};
+
+/**
+ * Creates a Hono middleware that wraps each request in an OTel span.
+ *
+ * Sets `traceId` and `spanId` on the Hono context for downstream use.
+ * After the handler runs, adds org/project/user attributes to the span.
+ */
+export function tracerMiddleware(options?: { name?: string }) {
+  return async (c: Context, next: Next): Promise<void> => {
+    const tracer = trace.getTracer("langwatch:api:hono");
+
+    const incomingHeaders = c.req.raw.headers;
+    const parentCtx = propagation.extract(
+      otContext.active(),
+      incomingHeaders,
+      headersGetter,
+    );
+
+    const method = c.req.method;
+    const spanName = `${method} ${options?.name ?? c.req.path}`;
+
+    return otContext.with(parentCtx, async () => {
+      return tracer.startActiveSpan(
+        spanName,
+        {
+          kind: SpanKind.SERVER,
+          attributes: options?.name
+            ? { "service.name": options.name }
+            : undefined,
+        },
+        async (span) => {
+          try {
+            const spanCtx = span.spanContext();
+            c.set("traceId", spanCtx.traceId);
+            c.set("spanId", spanCtx.spanId);
+
+            await next();
+
+            const organizationId = c.get("organization")?.id;
+            const projectId = c.get("project")?.id;
+            const userId = c.get("user")?.id;
+
+            if (organizationId) {
+              span.setAttribute("organization.id", organizationId);
+            }
+            if (projectId) {
+              span.setAttribute("tenant.id", projectId);
+            }
+            if (userId) {
+              span.setAttribute("user.id", userId);
+            }
+          } catch (err) {
+            span.recordException(err as Error);
+            span.setStatus({ code: SpanStatusCode.ERROR });
+            throw err;
+          } finally {
+            const carrier: Record<string, string> = {};
+            propagation.inject(otContext.active(), carrier);
+            for (const [key, value] of Object.entries(carrier)) {
+              try {
+                c.res.headers.set(key, value);
+              } catch {
+                // ignore if response headers are not available
+              }
+            }
+            span.end();
+          }
+        },
+      );
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Logger middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Hono middleware that logs each request using `@langwatch/observability`.
+ *
+ * Sets up async context propagation so that downstream code can access
+ * org/project/user context via `getCurrentContext()`.
+ */
+export function loggerMiddleware(options?: { name?: string }) {
+  const logger = createLogger(
+    `langwatch:api:${options?.name ?? "hono"}`,
+  );
+
+  return async (c: Context, next: Next): Promise<void> => {
+    const ctx = {
+      organizationId: c.get("organization")?.id,
+      projectId: c.get("project")?.id,
+      userId: c.get("user")?.id,
+    };
+
+    return runWithContext(ctx, async () => {
+      const start = Date.now();
+      let error: unknown = c.error;
+
+      try {
+        await next();
+
+        // Update context after auth resolves org/project/user
+        updateCurrentContext({
+          organizationId: c.get("organization")?.id,
+          projectId: c.get("project")?.id,
+          userId: c.get("user")?.id,
+        });
+      } catch (err) {
+        error = err;
+        throw err;
+      } finally {
+        const duration = Date.now() - start;
+        const statusCode = error
+          ? getStatusCodeFromError(error)
+          : c.res.status;
+
+        logHttpRequest(logger, {
+          method: c.req.method,
+          url: c.req.url,
+          statusCode,
+          duration,
+          userAgent: c.req.header("user-agent") ?? null,
+          error: error || c.error,
+        });
+      }
+    });
+  };
+}

--- a/langwatch/packages/api/src/middleware.ts
+++ b/langwatch/packages/api/src/middleware.ts
@@ -28,6 +28,18 @@ const headersGetter = {
     carrier.get(key) ?? void 0,
 };
 
+function injectTraceHeaders(c: Context): void {
+  const carrier: Record<string, string> = {};
+  propagation.inject(otContext.active(), carrier);
+  for (const [key, value] of Object.entries(carrier)) {
+    try {
+      c.res.headers.set(key, value);
+    } catch {
+      // ignore if response headers are not available
+    }
+  }
+}
+
 /**
  * Creates a Hono middleware that wraps each request in an OTel span.
  *
@@ -95,16 +107,7 @@ export function tracerMiddleware(options?: { name?: string }) {
             requestError = err;
             throw err;
           } finally {
-            const carrier: Record<string, string> = {};
-            propagation.inject(otContext.active(), carrier);
-            for (const [key, value] of Object.entries(carrier)) {
-              try {
-                c.res.headers.set(key, value);
-              } catch {
-                // ignore if response headers are not available
-              }
-            }
-
+            injectTraceHeaders(c);
             runAfterSSECompletion({
               c,
               onSettled: finishSpan,

--- a/langwatch/packages/api/src/middleware.ts
+++ b/langwatch/packages/api/src/middleware.ts
@@ -202,8 +202,11 @@ function runAfterSSECompletion({
 
   void streamCompletion
     .then(({ error }) => {
-      if (error) onStreamError(error);
-      onSettled();
+      try {
+        if (error) onStreamError(error);
+      } finally {
+        onSettled();
+      }
     })
     .catch(() => {
       // Instrumentation finalizers run after the response has started and must

--- a/langwatch/packages/api/src/middleware.ts
+++ b/langwatch/packages/api/src/middleware.ts
@@ -200,8 +200,13 @@ function runAfterSSECompletion({
     return;
   }
 
-  void streamCompletion.then(({ error }) => {
-    if (error) onStreamError(error);
-    onSettled();
-  });
+  void streamCompletion
+    .then(({ error }) => {
+      if (error) onStreamError(error);
+      onSettled();
+    })
+    .catch(() => {
+      // Instrumentation finalizers run after the response has started and must
+      // never surface as an unhandled rejection in the application process.
+    });
 }

--- a/langwatch/packages/api/src/pipeline.ts
+++ b/langwatch/packages/api/src/pipeline.ts
@@ -121,9 +121,14 @@ function appendAccessMiddleware({
   }
 
   if (includeResourceLimit && config.resourceLimit) {
-    stack.push(
-      serviceConfig._legacy!.resourceLimitMiddleware!(config.resourceLimit),
-    );
+    const createResourceLimitMiddleware =
+      serviceConfig._legacy?.resourceLimitMiddleware;
+    if (!createResourceLimitMiddleware) {
+      throw new Error(
+        `Endpoint resource limit "${config.resourceLimit}" requires resourceLimitMiddleware`,
+      );
+    }
+    stack.push(createResourceLimitMiddleware(config.resourceLimit));
   }
   if (config.middleware) stack.push(...config.middleware);
 }

--- a/langwatch/packages/api/src/pipeline.ts
+++ b/langwatch/packages/api/src/pipeline.ts
@@ -1,0 +1,239 @@
+import { updateCurrentContext } from "@langwatch/observability/context";
+import type { Context, MiddlewareHandler } from "hono";
+import { describeRoute, type DescribeRouteOptions } from "hono-openapi";
+import { resolver, validator as zValidator } from "hono-openapi/zod";
+import type { ZodType } from "zod";
+
+import { serializeEndpointResult } from "./response.js";
+import { createSSEResponse, type SSEConfig } from "./sse.js";
+import type {
+  BaseApp,
+  EndpointConfig,
+  EndpointRegistration,
+  ServiceConfig,
+  VersionStatus,
+} from "./types.js";
+import type { ResolvedEndpoint } from "./versioning.js";
+
+type ProviderMap<TProject> = Record<
+  string,
+  (base: BaseApp<TProject>) => unknown
+>;
+type ErrorHandler = NonNullable<ServiceConfig["onError"]>;
+
+interface StackOptions<TProject> {
+  ep: EndpointRegistration;
+  isVersioned: boolean;
+  onError: ErrorHandler;
+  providers: ProviderMap<TProject>;
+  serviceConfig: ServiceConfig;
+  status: VersionStatus;
+  version: string | null;
+}
+
+/** Composes the complete middleware pipeline for an active endpoint. */
+export function buildEndpointMiddlewareStack<TProject>(
+  options: StackOptions<TProject>,
+): MiddlewareHandler[] {
+  const { ep } = options;
+  const stack = [versionContextMiddleware(options)];
+
+  appendAccessMiddleware({
+    stack,
+    config: ep.config,
+    includeResourceLimit: true,
+    serviceConfig: options.serviceConfig,
+  });
+  appendOpenApiMiddleware(stack, ep.config);
+  appendValidationMiddleware(stack, ep);
+  stack.push(providerMiddleware(options.providers));
+  stack.push(handlerMiddleware(options));
+
+  return stack;
+}
+
+/** Composes the inherited access pipeline and 410 response for a withdrawal. */
+export function buildWithdrawnMiddlewareStack({
+  ep,
+  ...options
+}: Omit<StackOptions<unknown>, "ep" | "providers" | "onError"> & {
+  ep: ResolvedEndpoint & { withdrawn: true };
+}): MiddlewareHandler[] {
+  const stack = [versionContextMiddleware(options)];
+  appendAccessMiddleware({
+    stack,
+    config: ep.config,
+    includeResourceLimit: false,
+    serviceConfig: options.serviceConfig,
+  });
+  stack.push(async (c) =>
+    c.json(
+      {
+        kind: "endpoint_withdrawn",
+        message: "This endpoint has been removed",
+      },
+      410,
+    ),
+  );
+  return stack;
+}
+
+function versionContextMiddleware({
+  isVersioned,
+  status,
+  version,
+}: Pick<
+  StackOptions<unknown>,
+  "isVersioned" | "status" | "version"
+>): MiddlewareHandler {
+  return async (c, next) => {
+    c.set("isVersionedRequest", isVersioned);
+    if (version) c.set("apiVersion", version);
+    try {
+      await next();
+    } finally {
+      if (version) c.header("X-API-Version", version);
+      c.header("X-API-Version-Status", status);
+    }
+  };
+}
+
+function appendAccessMiddleware({
+  stack,
+  config,
+  includeResourceLimit,
+  serviceConfig,
+}: {
+  stack: MiddlewareHandler[];
+  config: EndpointConfig;
+  includeResourceLimit: boolean;
+  serviceConfig: ServiceConfig;
+}): void {
+  const authSetting = config.auth ?? "default";
+  if (authSetting === "default" && serviceConfig.auth) {
+    stack.push(serviceConfig.auth);
+  } else if (typeof authSetting === "function") {
+    stack.push(authSetting);
+  }
+
+  if (authSetting !== "none" && serviceConfig._legacy?.organizationMiddleware) {
+    stack.push(serviceConfig._legacy.organizationMiddleware);
+  }
+
+  if (includeResourceLimit && config.resourceLimit) {
+    stack.push(
+      serviceConfig._legacy!.resourceLimitMiddleware!(config.resourceLimit),
+    );
+  }
+  if (config.middleware) stack.push(...config.middleware);
+}
+
+function appendOpenApiMiddleware(
+  stack: MiddlewareHandler[],
+  config: EndpointConfig,
+): void {
+  if (!config.output && !config.description) return;
+
+  const successStatus = String(config.status ?? 200);
+  const responses: NonNullable<DescribeRouteOptions["responses"]> = {};
+  responses[successStatus] = config.output
+    ? {
+        description: "Success",
+        content: {
+          "application/json": { schema: resolver(config.output) },
+        },
+      }
+    : { description: "Success" };
+
+  stack.push(
+    describeRoute({
+      description: config.description,
+      responses,
+    }) as unknown as MiddlewareHandler,
+  );
+}
+
+function appendValidationMiddleware(
+  stack: MiddlewareHandler[],
+  ep: EndpointRegistration,
+): void {
+  const addValidator = (
+    target: "param" | "query" | "json",
+    schema: ZodType | undefined,
+  ) => {
+    if (!schema) return;
+    stack.push(
+      zValidator(target, schema, (result) => {
+        if (!result.success) throw result.error;
+      }) as unknown as MiddlewareHandler,
+    );
+  };
+
+  addValidator("param", ep.config.params);
+  addValidator("query", ep.config.query);
+  if (ep.method !== "sse") addValidator("json", ep.config.input);
+}
+
+function providerMiddleware<TProject>(
+  providers: ProviderMap<TProject>,
+): MiddlewareHandler {
+  return async (c, next) => {
+    const base: BaseApp<TProject> = {
+      project: c.get("project"),
+      _legacy: {
+        organization: c.get("organization"),
+        prisma: c.get("prisma"),
+      },
+    };
+
+    updateCurrentContext({
+      organizationId: c.get("organization")?.id,
+      projectId: c.get("project")?.id,
+      userId: c.get("user")?.id,
+    });
+
+    const resolved = Object.fromEntries(
+      await Promise.all(
+        Object.entries(providers).map(async ([key, factory]) => [
+          key,
+          await factory(base),
+        ]),
+      ),
+    );
+    c.set("app", { ...base, ...resolved });
+    await next();
+  };
+}
+
+function handlerMiddleware<TProject>({
+  ep,
+  onError,
+}: StackOptions<TProject>): MiddlewareHandler {
+  const { config } = ep;
+  if (ep.method === "sse") {
+    const sseConfig = config as unknown as SSEConfig<Record<string, ZodType>>;
+    return async (c) => {
+      const query = config.query ? c.req.valid("query" as never) : undefined;
+      return createSSEResponse({
+        c,
+        events: sseConfig.events,
+        handler: async (stream) => {
+          await ep.handler(c, { query, app: c.get("app") }, stream);
+        },
+        onError: async (error) => {
+          await onError(error, c);
+        },
+      });
+    };
+  }
+
+  return async (c: Context) => {
+    const result = await ep.handler(c, {
+      input: config.input ? c.req.valid("json" as never) : undefined,
+      params: config.params ? c.req.valid("param" as never) : undefined,
+      query: config.query ? c.req.valid("query" as never) : undefined,
+      app: c.get("app"),
+    });
+    return serializeEndpointResult({ c, config, result });
+  };
+}

--- a/langwatch/packages/api/src/pipeline.ts
+++ b/langwatch/packages/api/src/pipeline.ts
@@ -44,8 +44,8 @@ export function buildEndpointMiddlewareStack<TProject>(
     includeResourceLimit: true,
     serviceConfig: options.serviceConfig,
   });
-  appendOpenApiMiddleware(stack, ep.config);
-  appendValidationMiddleware(stack, ep);
+  appendOpenApiMiddleware({ stack, config: ep.config });
+  appendValidationMiddleware({ stack, ep });
   stack.push(providerMiddleware(options.providers));
   stack.push(handlerMiddleware(options));
 
@@ -128,10 +128,13 @@ function appendAccessMiddleware({
   if (config.middleware) stack.push(...config.middleware);
 }
 
-function appendOpenApiMiddleware(
-  stack: MiddlewareHandler[],
-  config: EndpointConfig,
-): void {
+function appendOpenApiMiddleware({
+  stack,
+  config,
+}: {
+  stack: MiddlewareHandler[];
+  config: EndpointConfig;
+}): void {
   if (!config.output && !config.description) return;
 
   const successStatus = String(config.status ?? 200);
@@ -153,10 +156,13 @@ function appendOpenApiMiddleware(
   );
 }
 
-function appendValidationMiddleware(
-  stack: MiddlewareHandler[],
-  ep: EndpointRegistration,
-): void {
+function appendValidationMiddleware({
+  stack,
+  ep,
+}: {
+  stack: MiddlewareHandler[];
+  ep: EndpointRegistration;
+}): void {
   const addValidator = (
     target: "param" | "query" | "json",
     schema: ZodType | undefined,
@@ -214,6 +220,10 @@ function handlerMiddleware<TProject>({
     const sseConfig = config as unknown as SSEConfig<Record<string, ZodType>>;
     return async (c) => {
       const query = config.query ? c.req.valid("query" as never) : undefined;
+
+      // The streaming response must reach the client before the producer can
+      // safely write. createSSEResponse registers its lifecycle synchronously;
+      // request logging and tracing defer finalization against that lifecycle.
       return createSSEResponse({
         c,
         events: sseConfig.events,

--- a/langwatch/packages/api/src/response.ts
+++ b/langwatch/packages/api/src/response.ts
@@ -1,0 +1,38 @@
+import type { Context } from "hono";
+
+import type { EndpointConfig } from "./types.js";
+
+/** Validates and serializes the value returned by a regular endpoint handler. */
+export function serializeEndpointResult({
+  c,
+  config,
+  result,
+}: {
+  c: Context;
+  config: EndpointConfig;
+  result: unknown;
+}): Response {
+  if (result instanceof Response) {
+    return result;
+  }
+
+  const status = config.status ?? 200;
+  if (config.output) {
+    const validation = config.output.safeParse(result);
+    if (!validation.success) {
+      throw new Error("Response failed output validation", {
+        cause: validation.error,
+      });
+    }
+    if (validation.data === undefined) {
+      return c.body(null, config.status ?? 204);
+    }
+    return c.json(validation.data, status);
+  }
+
+  if (result === undefined) {
+    return c.body(null, 204);
+  }
+
+  return c.json(result, status);
+}

--- a/langwatch/packages/api/src/route-mounting.ts
+++ b/langwatch/packages/api/src/route-mounting.ts
@@ -1,0 +1,140 @@
+import { Hono, type MiddlewareHandler } from "hono";
+
+import {
+  buildEndpointMiddlewareStack,
+  buildWithdrawnMiddlewareStack,
+} from "./pipeline.js";
+import type {
+  BaseApp,
+  HttpMethod,
+  ServiceConfig,
+  VersionStatus,
+} from "./types.js";
+import {
+  VERSION_LATEST,
+  VERSION_PREVIEW,
+  type ResolvedEndpoint,
+} from "./versioning.js";
+
+type ProviderMap<TProject> = Record<
+  string,
+  (base: BaseApp<TProject>) => unknown
+>;
+type ErrorHandler = NonNullable<ServiceConfig["onError"]>;
+
+/** Mounts all resolved versions, namespace guards, and the bare latest alias. */
+export function mountResolvedRoutes<TProject>({
+  app,
+  onError,
+  providers,
+  serviceConfig,
+  versionMap,
+}: {
+  app: Hono;
+  onError: ErrorHandler;
+  providers: ProviderMap<TProject>;
+  serviceConfig: ServiceConfig;
+  versionMap: Map<string, ResolvedEndpoint[]>;
+}): void {
+  for (const [version, endpoints] of versionMap) {
+    mountVersion({
+      app,
+      endpoints,
+      onError,
+      providers,
+      serviceConfig,
+      status: resolveVersionStatus(version),
+      version,
+    });
+  }
+
+  const versionNamespace =
+    "/:apiVersion{latest|preview|20\\d{2}-\\d{2}-\\d{2}}";
+  app.all(versionNamespace, (c) => c.notFound());
+  app.all(`${versionNamespace}/*`, (c) => c.notFound());
+
+  const latestEndpoints = versionMap.get(VERSION_LATEST);
+  if (latestEndpoints) {
+    mountVersion({
+      app,
+      endpoints: latestEndpoints,
+      onError,
+      providers,
+      serviceConfig,
+      status: "unversioned",
+      version: null,
+    });
+  }
+}
+
+function mountVersion<TProject>({
+  app,
+  endpoints,
+  onError,
+  providers,
+  serviceConfig,
+  status,
+  version,
+}: {
+  app: Hono;
+  endpoints: ResolvedEndpoint[];
+  onError: ErrorHandler;
+  providers: ProviderMap<TProject>;
+  serviceConfig: ServiceConfig;
+  status: VersionStatus;
+  version: string | null;
+}): void {
+  const prefix = version ? `/${version}` : "";
+  const isVersioned = status !== "unversioned";
+
+  for (const ep of endpoints) {
+    const path = `${prefix}${ep.path || "/"}`;
+    const method = ep.method === "sse" ? "get" : ep.method;
+    const stack = ep.withdrawn
+      ? buildWithdrawnMiddlewareStack({
+          ep,
+          isVersioned,
+          serviceConfig,
+          status,
+          version,
+        })
+      : buildEndpointMiddlewareStack({
+          ep,
+          isVersioned,
+          onError,
+          providers,
+          serviceConfig,
+          status,
+          version,
+        });
+    mountRoute({ app, method, path, stack });
+  }
+}
+
+function mountRoute({
+  app,
+  method,
+  path,
+  stack,
+}: {
+  app: Hono;
+  method: HttpMethod;
+  path: string;
+  stack: MiddlewareHandler[];
+}): void {
+  const handlers = stack as [MiddlewareHandler, ...MiddlewareHandler[]];
+  const register: Record<HttpMethod, () => void> = {
+    get: () => void app.get(path, ...handlers),
+    post: () => void app.post(path, ...handlers),
+    put: () => void app.put(path, ...handlers),
+    delete: () => void app.delete(path, ...handlers),
+    patch: () => void app.patch(path, ...handlers),
+  };
+  register[method]();
+}
+
+function resolveVersionStatus(version: string): VersionStatus {
+  if (version === VERSION_LATEST) return "latest";
+  if (version === VERSION_PREVIEW) return "preview";
+  return "stable";
+}

--- a/langwatch/packages/api/src/sse.ts
+++ b/langwatch/packages/api/src/sse.ts
@@ -1,0 +1,120 @@
+import type { Context } from "hono";
+import { streamSSE } from "hono/streaming";
+import type { ZodType, z } from "zod";
+
+// ---------------------------------------------------------------------------
+// SSE configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration object for SSE endpoints registered via `v.sse()`.
+ *
+ * Each event type is declared with a Zod schema. The framework validates
+ * event data against the schema before sending.
+ */
+export interface SSEConfig<
+  TEvents extends Record<string, ZodType>,
+  TInput extends ZodType = ZodType,
+  TQuery extends ZodType = ZodType,
+> {
+  /** Map of event names to their payload schemas. */
+  events: TEvents;
+  /** Optional JSON body schema (for POST-based SSE). */
+  input?: TInput;
+  /** Optional query string schema. */
+  query?: TQuery;
+  /** OpenAPI description. */
+  description?: string;
+
+  // -- per-endpoint options (same as EndpointConfig) -------------------------
+  auth?: "default" | "none";
+  resourceLimit?: string;
+  middleware?: Array<(c: Context, next: () => Promise<void>) => Promise<void | Response>>;
+}
+
+// ---------------------------------------------------------------------------
+// Typed SSE stream
+// ---------------------------------------------------------------------------
+
+/**
+ * A typed wrapper around Hono's SSE streaming API.
+ *
+ * The `emit` method validates data against the declared event schema before
+ * writing to the stream.
+ */
+export interface TypedSSEStream<TEvents extends Record<string, ZodType>> {
+  /** Emit a typed event. Data is validated against the event's Zod schema. */
+  emit<K extends string & keyof TEvents>(
+    event: K,
+    data: z.infer<TEvents[K]>,
+  ): Promise<void>;
+  /** Close the SSE stream. */
+  close(): void;
+}
+
+// ---------------------------------------------------------------------------
+// SSE handler type
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler function for SSE endpoints.
+ *
+ * Receives the Hono context, parsed arguments, and a typed SSE stream.
+ */
+export type SSEHandler<TApp, TEvents extends Record<string, ZodType>, TConfig> = (
+  c: Context,
+  args: {
+    input: TConfig extends { input: ZodType } ? z.infer<TConfig["input"]> : never;
+    query: TConfig extends { query: ZodType } ? z.infer<TConfig["query"]> : never;
+    app: TApp;
+  },
+  stream: TypedSSEStream<TEvents>,
+) => void | Promise<void>;
+
+// ---------------------------------------------------------------------------
+// SSE stream factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Hono response that streams SSE events with typed validation.
+ *
+ * @param c       - Hono context
+ * @param events  - Map of event names to Zod schemas (for validation)
+ * @param handler - Callback that receives the typed stream
+ * @returns A streaming Response
+ */
+export function createSSEResponse<TEvents extends Record<string, ZodType>>(
+  c: Context,
+  events: TEvents,
+  handler: (stream: TypedSSEStream<TEvents>) => void | Promise<void>,
+): Response {
+  return streamSSE(c, async (sseStream) => {
+    const typedStream: TypedSSEStream<TEvents> = {
+      async emit(event, data) {
+        const schema = events[event];
+        if (schema) {
+          const result = schema.safeParse(data);
+          if (!result.success) {
+            await sseStream.writeSSE({
+              event: "error",
+              data: JSON.stringify({
+                message: `Validation failed for event "${String(event)}"`,
+                issues: result.error.issues,
+              }),
+            });
+            return;
+          }
+        }
+        await sseStream.writeSSE({
+          event: String(event),
+          data: JSON.stringify(data),
+        });
+      },
+      close() {
+        sseStream.close();
+      },
+    };
+
+    await handler(typedStream);
+  }) as unknown as Response;
+}

--- a/langwatch/packages/api/src/sse.ts
+++ b/langwatch/packages/api/src/sse.ts
@@ -14,13 +14,10 @@ import type { ZodType, z } from "zod";
  */
 export interface SSEConfig<
   TEvents extends Record<string, ZodType>,
-  TInput extends ZodType = ZodType,
   TQuery extends ZodType = ZodType,
 > {
   /** Map of event names to their payload schemas. */
   events: TEvents;
-  /** Optional JSON body schema (for POST-based SSE). */
-  input?: TInput;
   /** Optional query string schema. */
   query?: TQuery;
   /** OpenAPI description. */
@@ -64,8 +61,7 @@ export interface TypedSSEStream<TEvents extends Record<string, ZodType>> {
 export type SSEHandler<TApp, TEvents extends Record<string, ZodType>, TConfig> = (
   c: Context,
   args: {
-    input: TConfig extends { input: ZodType } ? z.infer<TConfig["input"]> : never;
-    query: TConfig extends { query: ZodType } ? z.infer<TConfig["query"]> : never;
+    query: TConfig extends { query: ZodType } ? z.infer<TConfig["query"]> : undefined;
     app: TApp;
   },
   stream: TypedSSEStream<TEvents>,

--- a/langwatch/packages/api/src/sse.ts
+++ b/langwatch/packages/api/src/sse.ts
@@ -1,6 +1,8 @@
-import type { Context } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ZodType, z } from "zod";
+
+import type { EndpointConfig } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // SSE configuration
@@ -8,6 +10,9 @@ import type { ZodType, z } from "zod";
 
 /**
  * Configuration object for SSE endpoints registered via `v.sse()`.
+ *
+ * SSE endpoints are mounted as GET routes and therefore accept query-string
+ * input only, not a JSON request body.
  *
  * Each event type is declared with a Zod schema. The framework validates
  * event data against the schema before sending.
@@ -24,9 +29,9 @@ export interface SSEConfig<
   description?: string;
 
   // -- per-endpoint options (same as EndpointConfig) -------------------------
-  auth?: "default" | "none";
+  auth?: EndpointConfig["auth"];
   resourceLimit?: string;
-  middleware?: Array<(c: Context, next: () => Promise<void>) => Promise<void | Response>>;
+  middleware?: MiddlewareHandler[];
 }
 
 // ---------------------------------------------------------------------------
@@ -58,10 +63,16 @@ export interface TypedSSEStream<TEvents extends Record<string, ZodType>> {
  *
  * Receives the Hono context, parsed arguments, and a typed SSE stream.
  */
-export type SSEHandler<TApp, TEvents extends Record<string, ZodType>, TConfig> = (
+export type SSEHandler<
+  TApp,
+  TEvents extends Record<string, ZodType>,
+  TConfig,
+> = (
   c: Context,
   args: {
-    query: TConfig extends { query: ZodType } ? z.infer<TConfig["query"]> : undefined;
+    query: TConfig extends { query: ZodType }
+      ? z.infer<TConfig["query"]>
+      : undefined;
     app: TApp;
   },
   stream: TypedSSEStream<TEvents>,
@@ -98,8 +109,10 @@ export function createSSEResponse<TEvents extends Record<string, ZodType>>(
                 issues: result.error.issues,
               }),
             });
-            return;
+            throw result.error;
           }
+
+          data = result.data;
         }
         await sseStream.writeSSE({
           event: String(event),

--- a/langwatch/packages/api/src/sse.ts
+++ b/langwatch/packages/api/src/sse.ts
@@ -4,6 +4,8 @@ import type { ZodType, z } from "zod";
 
 import type { EndpointConfig } from "./types.js";
 
+const completions = new WeakMap<Context, Promise<void>>();
+
 // ---------------------------------------------------------------------------
 // SSE configuration
 // ---------------------------------------------------------------------------
@@ -85,45 +87,77 @@ export type SSEHandler<
 /**
  * Creates a Hono response that streams SSE events with typed validation.
  *
- * @param c       - Hono context
- * @param events  - Map of event names to Zod schemas (for validation)
- * @param handler - Callback that receives the typed stream
  * @returns A streaming Response
  */
-export function createSSEResponse<TEvents extends Record<string, ZodType>>(
-  c: Context,
-  events: TEvents,
-  handler: (stream: TypedSSEStream<TEvents>) => void | Promise<void>,
-): Response {
-  return streamSSE(c, async (sseStream) => {
-    const typedStream: TypedSSEStream<TEvents> = {
-      async emit(event, data) {
-        const schema = events[event];
-        if (schema) {
-          const result = schema.safeParse(data);
-          if (!result.success) {
-            await sseStream.writeSSE({
-              event: "error",
-              data: JSON.stringify({
-                message: `Validation failed for event "${String(event)}"`,
-                issues: result.error.issues,
-              }),
-            });
-            throw result.error;
+export function createSSEResponse<TEvents extends Record<string, ZodType>>({
+  c,
+  events,
+  handler,
+  onError,
+}: {
+  c: Context;
+  events: TEvents;
+  handler: (stream: TypedSSEStream<TEvents>) => void | Promise<void>;
+  onError?: (error: Error) => void | Promise<void>;
+}): Response {
+  let finish!: () => void;
+  const completion = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  completions.set(c, completion);
+
+  return streamSSE(
+    c,
+    async (sseStream) => {
+      const typedStream: TypedSSEStream<TEvents> = {
+        async emit(event, data) {
+          const schema = events[event];
+          if (schema) {
+            const result = schema.safeParse(data);
+            if (!result.success) {
+              await sseStream.writeSSE({
+                event: "error",
+                data: JSON.stringify({
+                  message: `Validation failed for event "${String(event)}"`,
+                  issues: result.error.issues,
+                }),
+              });
+              throw result.error;
+            }
+
+            data = result.data;
           }
+          await sseStream.writeSSE({
+            event: String(event),
+            data: JSON.stringify(data),
+          });
+        },
+        close() {
+          sseStream.close();
+        },
+      };
 
-          data = result.data;
-        }
-        await sseStream.writeSSE({
-          event: String(event),
-          data: JSON.stringify(data),
-        });
-      },
-      close() {
-        sseStream.close();
-      },
-    };
+      try {
+        await handler(typedStream);
+        finish();
+      } catch (error) {
+        throw error instanceof Error
+          ? error
+          : new Error("SSE handler failed", { cause: error });
+      }
+    },
+    async (error) => {
+      c.error = error;
+      try {
+        await onError?.(error);
+      } finally {
+        finish();
+      }
+    },
+  ) as unknown as Response;
+}
 
-    await handler(typedStream);
-  }) as unknown as Response;
+/** Returns the current SSE handler lifecycle for request instrumentation. */
+export function getSSECompletion(c: Context): Promise<void> | undefined {
+  return completions.get(c);
 }

--- a/langwatch/packages/api/src/sse.ts
+++ b/langwatch/packages/api/src/sse.ts
@@ -4,7 +4,11 @@ import type { ZodType, z } from "zod";
 
 import type { EndpointConfig } from "./types.js";
 
-const completions = new WeakMap<Context, Promise<void>>();
+export interface SSECompletion {
+  error?: Error;
+}
+
+const completions = new WeakMap<Context, Promise<SSECompletion>>();
 
 // ---------------------------------------------------------------------------
 // SSE configuration
@@ -100,8 +104,8 @@ export function createSSEResponse<TEvents extends Record<string, ZodType>>({
   handler: (stream: TypedSSEStream<TEvents>) => void | Promise<void>;
   onError?: (error: Error) => void | Promise<void>;
 }): Response {
-  let finish!: () => void;
-  const completion = new Promise<void>((resolve) => {
+  let finish!: (result: SSECompletion) => void;
+  const completion = new Promise<SSECompletion>((resolve) => {
     finish = resolve;
   });
   completions.set(c, completion);
@@ -139,7 +143,7 @@ export function createSSEResponse<TEvents extends Record<string, ZodType>>({
 
       try {
         await handler(typedStream);
-        finish();
+        finish({});
       } catch (error) {
         throw error instanceof Error
           ? error
@@ -151,13 +155,15 @@ export function createSSEResponse<TEvents extends Record<string, ZodType>>({
       try {
         await onError?.(error);
       } finally {
-        finish();
+        finish({ error });
       }
     },
   ) as unknown as Response;
 }
 
 /** Returns the current SSE handler lifecycle for request instrumentation. */
-export function getSSECompletion(c: Context): Promise<void> | undefined {
+export function getSSECompletion(
+  c: Context,
+): Promise<SSECompletion> | undefined {
   return completions.get(c);
 }

--- a/langwatch/packages/api/src/sse.ts
+++ b/langwatch/packages/api/src/sse.ts
@@ -1,5 +1,5 @@
 import type { Context, MiddlewareHandler } from "hono";
-import { streamSSE } from "hono/streaming";
+import { streamSSE, type SSEStreamingApi } from "hono/streaming";
 import type { ZodType, z } from "zod";
 
 import type { EndpointConfig } from "./types.js";
@@ -9,6 +9,41 @@ export interface SSECompletion {
 }
 
 const completions = new WeakMap<Context, Promise<SSECompletion>>();
+
+function createTypedStream<TEvents extends Record<string, ZodType>>({
+  sseStream,
+  events,
+}: {
+  sseStream: SSEStreamingApi;
+  events: TEvents;
+}): TypedSSEStream<TEvents> {
+  return {
+    async emit(event, data) {
+      const schema = events[event];
+      if (schema) {
+        const result = schema.safeParse(data);
+        if (!result.success) {
+          await sseStream.writeSSE({
+            event: "error",
+            data: JSON.stringify({
+              message: `Validation failed for event "${String(event)}"`,
+              issues: result.error.issues,
+            }),
+          });
+          throw result.error;
+        }
+        data = result.data;
+      }
+      await sseStream.writeSSE({
+        event: String(event),
+        data: JSON.stringify(data),
+      });
+    },
+    close() {
+      sseStream.close();
+    },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // SSE configuration
@@ -113,33 +148,8 @@ export function createSSEResponse<TEvents extends Record<string, ZodType>>({
   return streamSSE(
     c,
     async (sseStream) => {
-      const typedStream: TypedSSEStream<TEvents> = {
-        async emit(event, data) {
-          const schema = events[event];
-          if (schema) {
-            const result = schema.safeParse(data);
-            if (!result.success) {
-              await sseStream.writeSSE({
-                event: "error",
-                data: JSON.stringify({
-                  message: `Validation failed for event "${String(event)}"`,
-                  issues: result.error.issues,
-                }),
-              });
-              throw result.error;
-            }
-
-            data = result.data;
-          }
-          await sseStream.writeSSE({
-            event: String(event),
-            data: JSON.stringify(data),
-          });
-        },
-        close() {
-          sseStream.close();
-        },
-      };
+      sseStream.onAbort(() => finish({}));
+      const typedStream = createTypedStream({ sseStream, events });
 
       try {
         await handler(typedStream);

--- a/langwatch/packages/api/src/types.ts
+++ b/langwatch/packages/api/src/types.ts
@@ -1,0 +1,194 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { ZodType, z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Version primitives
+// ---------------------------------------------------------------------------
+
+/** A date-based API version string, e.g. `"2025-03-15"`. Validated at runtime. */
+export type DateVersion = string;
+
+export const VERSION_LATEST = "latest" as const;
+export const VERSION_PREVIEW = "preview" as const;
+
+const DATE_VERSION_RE = /^20\d{2}-\d{2}-\d{2}$/;
+
+/** Returns true when `value` matches the `YYYY-MM-DD` date-version pattern. */
+export function isDateVersion(value: string): value is DateVersion {
+  return DATE_VERSION_RE.test(value);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP method
+// ---------------------------------------------------------------------------
+
+export type HttpMethod = "get" | "post" | "put" | "delete" | "patch";
+
+// ---------------------------------------------------------------------------
+// Base app context
+// ---------------------------------------------------------------------------
+
+/**
+ * The base application context available to every handler.
+ *
+ * Generic `TProject` lets consumers type `app.project` downstream:
+ *
+ * ```ts
+ * createService<{ project: Project }>({ name: "things" })
+ * ```
+ */
+export interface BaseApp<TProject = unknown> {
+  project: TProject;
+  _legacy: {
+    organization: unknown;
+    prisma: unknown;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-endpoint configuration object -- the second argument to
+ * `v.get(path, config, handler)`.
+ *
+ * Merges schema declarations (input, output, params, query) with per-endpoint
+ * options (auth, resourceLimit, middleware, etc.).
+ */
+export interface EndpointConfig<
+  TInput extends ZodType = ZodType,
+  TOutput extends ZodType = ZodType,
+  TParams extends ZodType = ZodType,
+  TQuery extends ZodType = ZodType,
+> {
+  /** JSON body schema. */
+  input?: TInput;
+  /** Response body schema -- validated before serialization. */
+  output?: TOutput;
+  /** Path parameter schema. */
+  params?: TParams;
+  /** Query string schema. */
+  query?: TQuery;
+  /** OpenAPI description for the endpoint. */
+  description?: string;
+  /** HTTP status code for successful responses (default: 200). */
+  status?: ContentfulStatusCode;
+
+  // -- per-endpoint options --------------------------------------------------
+
+  /**
+   * Auth behaviour for this endpoint.
+   * - `"default"` -- use the service-level auth middleware (default).
+   * - `"none"` -- skip authentication entirely.
+   * - A `MiddlewareHandler` -- use a custom auth middleware for this endpoint.
+   */
+  auth?: "default" | "none" | MiddlewareHandler;
+  /** Resource limit type — requires `_legacy.resourceLimitMiddleware` on the service. */
+  resourceLimit?: string;
+  /** Additional middleware to run for this endpoint (after auth, before handler). */
+  middleware?: MiddlewareHandler[];
+}
+
+// ---------------------------------------------------------------------------
+// Service configuration (top-level)
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level configuration for `createService()`.
+ */
+export interface ServiceConfig {
+  /** Service name, used in the default base path (`/api/${name}`). */
+  name: string;
+  /** Override the default base path. */
+  basePath?: string;
+  /** Default auth middleware applied to every endpoint (unless overridden). */
+  auth?: MiddlewareHandler;
+  /** Disable the built-in tracer middleware. Set to `false` to opt out. */
+  tracer?: false;
+  /** Disable the built-in logger middleware. Set to `false` to opt out. */
+  logger?: false;
+  /** Additional global middleware applied to every request. */
+  middleware?: MiddlewareHandler[];
+  /** Custom error handler. If omitted the framework default is used. */
+  onError?: (err: Error, c: Context) => Response | Promise<Response>;
+  /** Middleware that will be removed once services are fully migrated. */
+  _legacy?: {
+    /** Organization-resolution middleware. */
+    organizationMiddleware?: MiddlewareHandler;
+    /** Factory for resource-limit middleware, called per-endpoint. */
+    resourceLimitMiddleware?: (limitType: string) => MiddlewareHandler;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler types
+// ---------------------------------------------------------------------------
+
+/** Extract inferred input type from config, defaulting to undefined. */
+type InferInput<TConfig> = TConfig extends { input: infer I extends ZodType } ? z.infer<I> : undefined;
+
+/** Extract inferred params type from config, defaulting to undefined. */
+type InferParams<TConfig> = TConfig extends { params: infer P extends ZodType } ? z.infer<P> : undefined;
+
+/** Extract inferred query type from config, defaulting to undefined. */
+type InferQuery<TConfig> = TConfig extends { query: infer Q extends ZodType } ? z.infer<Q> : undefined;
+
+/** Extract inferred output type from config. */
+type InferOutput<TConfig> = TConfig extends { output: infer O extends ZodType } ? z.infer<O> : never;
+
+/**
+ * The handler function signature.
+ *
+ * When `output` is defined the handler returns raw data (framework validates
+ * and serializes). When `output` is *not* defined the handler returns a raw
+ * Hono `Response`.
+ */
+export type Handler<TApp, TConfig> = (
+  c: Context,
+  args: {
+    input: InferInput<TConfig>;
+    params: InferParams<TConfig>;
+    query: InferQuery<TConfig>;
+    app: TApp;
+  },
+) => TConfig extends { output: ZodType }
+  ? InferOutput<TConfig> | Promise<InferOutput<TConfig>>
+  : Response | Promise<Response>;
+
+// ---------------------------------------------------------------------------
+// Internal endpoint registration record
+// ---------------------------------------------------------------------------
+
+/** @internal Stored by the version builder when registering an endpoint. */
+export interface EndpointRegistration {
+  method: HttpMethod | "sse";
+  path: string;
+  config: EndpointConfig;
+  handler: (...args: unknown[]) => unknown;
+  withdrawn?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Version status (set as response header)
+// ---------------------------------------------------------------------------
+
+export type VersionStatus = "stable" | "latest" | "preview" | "unversioned";
+
+/** HTTP status text lookup for error responses. */
+export function httpStatusText(status: ContentfulStatusCode): string {
+  const map: Record<number, string> = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    409: "Conflict",
+    410: "Gone",
+    422: "Unprocessable Entity",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+  };
+  return map[status] ?? "Error";
+}

--- a/langwatch/packages/api/src/types.ts
+++ b/langwatch/packages/api/src/types.ts
@@ -14,9 +14,18 @@ export const VERSION_PREVIEW = "preview" as const;
 
 const DATE_VERSION_RE = /^20\d{2}-\d{2}-\d{2}$/;
 
-/** Returns true when `value` matches the `YYYY-MM-DD` date-version pattern. */
+/** Returns true when `value` is a real calendar date in `YYYY-MM-DD` form. */
 export function isDateVersion(value: string): value is DateVersion {
-  return DATE_VERSION_RE.test(value);
+  if (!DATE_VERSION_RE.test(value)) return false;
+
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year!, month! - 1, day!));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month! - 1 &&
+    date.getUTCDate() === day
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -35,7 +44,7 @@ export type HttpMethod = "get" | "post" | "put" | "delete" | "patch";
  * Generic `TProject` lets consumers type `app.project` downstream:
  *
  * ```ts
- * createService<{ project: Project }>({ name: "things" })
+ * createService<Project>({ name: "things" })
  * ```
  */
 export interface BaseApp<TProject = unknown> {
@@ -127,16 +136,30 @@ export interface ServiceConfig {
 // ---------------------------------------------------------------------------
 
 /** Extract inferred input type from config, defaulting to undefined. */
-type InferInput<TConfig> = TConfig extends { input: infer I extends ZodType } ? z.infer<I> : undefined;
+type InferInput<TConfig> = TConfig extends {
+  input: infer I extends ZodType;
+}
+  ? z.infer<I>
+  : undefined;
 
 /** Extract inferred params type from config, defaulting to undefined. */
-type InferParams<TConfig> = TConfig extends { params: infer P extends ZodType } ? z.infer<P> : undefined;
+type InferParams<TConfig> = TConfig extends {
+  params: infer P extends ZodType;
+}
+  ? z.infer<P>
+  : undefined;
 
 /** Extract inferred query type from config, defaulting to undefined. */
-type InferQuery<TConfig> = TConfig extends { query: infer Q extends ZodType } ? z.infer<Q> : undefined;
+type InferQuery<TConfig> = TConfig extends {
+  query: infer Q extends ZodType;
+}
+  ? z.infer<Q>
+  : undefined;
 
 /** Extract inferred output type from config. */
-type InferOutput<TConfig> = TConfig extends { output: infer O extends ZodType } ? z.infer<O> : never;
+type InferOutput<TConfig> = TConfig extends { output: infer O extends ZodType }
+  ? z.infer<O>
+  : never;
 
 /**
  * The handler function signature.

--- a/langwatch/packages/api/src/version-builder.ts
+++ b/langwatch/packages/api/src/version-builder.ts
@@ -1,0 +1,131 @@
+import type { ZodType } from "zod";
+
+import {
+  VERSION_LATEST,
+  VERSION_PREVIEW,
+  type EndpointConfig,
+  type EndpointRegistration,
+  type Handler,
+  type HttpMethod,
+} from "./types.js";
+import type { SSEConfig, SSEHandler } from "./sse.js";
+
+const DATE_VERSION_SEGMENT_RE = /^20\d{2}-\d{2}-\d{2}$/;
+
+/**
+ * Builder used inside the `.version(date, (v) => { ... })` callback.
+ *
+ * Provides HTTP method helpers and `withdraw()` for removing inherited
+ * endpoints.
+ */
+export class VersionBuilder<TApp> {
+  /** @internal */
+  readonly _endpoints: EndpointRegistration[] = [];
+
+  /** Register a GET endpoint. */
+  get<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("get", path, config, handler);
+  }
+
+  /** Register a POST endpoint. */
+  post<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("post", path, config, handler);
+  }
+
+  /** Register a PUT endpoint. */
+  put<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("put", path, config, handler);
+  }
+
+  /** Register a DELETE endpoint. */
+  delete<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("delete", path, config, handler);
+  }
+
+  /** Register a PATCH endpoint. */
+  patch<TConfig extends EndpointConfig>(
+    path: string,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
+  ): void {
+    this._register("patch", path, config, handler);
+  }
+
+  /** Register a typed GET-only SSE endpoint. */
+  sse<
+    TEvents extends Record<string, ZodType>,
+    TConfig extends SSEConfig<TEvents>,
+  >(
+    path: string,
+    config: TConfig,
+    handler: SSEHandler<TApp, TEvents, TConfig>,
+  ): void {
+    assertEndpointPath(path);
+    this._endpoints.push({
+      method: "sse",
+      path,
+      config: config as unknown as EndpointConfig,
+      handler: handler as EndpointRegistration["handler"],
+    });
+  }
+
+  /** Withdraw an endpoint inherited from a previous version. */
+  withdraw(method: HttpMethod, path: string): void {
+    assertEndpointPath(path);
+    this._endpoints.push({
+      method,
+      path,
+      config: {} as EndpointConfig,
+      handler: () => {},
+      withdrawn: true,
+    });
+  }
+
+  private _register(
+    method: HttpMethod,
+    path: string,
+    config: EndpointConfig,
+    handler: Handler<TApp, EndpointConfig>,
+  ): void {
+    assertEndpointPath(path);
+    this._endpoints.push({
+      method,
+      path,
+      config,
+      handler: handler as EndpointRegistration["handler"],
+    });
+  }
+}
+
+function assertEndpointPath(path: string): void {
+  if (path !== "" && !path.startsWith("/")) {
+    throw new Error(`Endpoint path must start with "/"; received "${path}"`);
+  }
+
+  const firstSegment = path.split("/").find(Boolean);
+  if (
+    firstSegment === VERSION_LATEST ||
+    firstSegment === VERSION_PREVIEW ||
+    (firstSegment !== undefined && DATE_VERSION_SEGMENT_RE.test(firstSegment))
+  ) {
+    throw new Error(
+      `Endpoint path "${path}" collides with the reserved API version namespace`,
+    );
+  }
+}

--- a/langwatch/packages/api/src/version-builder.ts
+++ b/langwatch/packages/api/src/version-builder.ts
@@ -97,11 +97,11 @@ export class VersionBuilder<TApp> {
     });
   }
 
-  private _register(
+  private _register<TConfig extends EndpointConfig>(
     method: HttpMethod,
     path: string,
-    config: EndpointConfig,
-    handler: Handler<TApp, EndpointConfig>,
+    config: TConfig,
+    handler: Handler<TApp, TConfig>,
   ): void {
     assertEndpointPath(path);
     this._endpoints.push({

--- a/langwatch/packages/api/src/versioning.ts
+++ b/langwatch/packages/api/src/versioning.ts
@@ -26,7 +26,8 @@ export type ResolvedEndpoint =
 
 /** A composite key for de-duplicating endpoints within a version. */
 function endpointKey(method: string, path: string): string {
-  return `${method}:${path}`;
+  const normalized = method === "sse" ? "get" : method;
+  return `${normalized}:${path}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/langwatch/packages/api/src/versioning.ts
+++ b/langwatch/packages/api/src/versioning.ts
@@ -1,0 +1,143 @@
+import type { EndpointRegistration, HttpMethod } from "./types.js";
+import { isDateVersion, VERSION_LATEST, VERSION_PREVIEW } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Version registration input (collected by the builder)
+// ---------------------------------------------------------------------------
+
+export interface VersionDefinition {
+  /** The dated version label, e.g. `"2025-03-15"`. */
+  version: string;
+  /** Endpoints registered in this version (including withdrawals). */
+  endpoints: EndpointRegistration[];
+}
+
+// ---------------------------------------------------------------------------
+// Resolved endpoint map (after forward-copying)
+// ---------------------------------------------------------------------------
+
+/**
+ * A fully resolved endpoint: either active (has a handler) or withdrawn
+ * (returns 410 Gone).
+ */
+export type ResolvedEndpoint =
+  | (EndpointRegistration & { withdrawn?: false })
+  | { method: HttpMethod | "sse"; path: string; withdrawn: true };
+
+/** A composite key for de-duplicating endpoints within a version. */
+function endpointKey(method: string, path: string): string {
+  return `${method}:${path}`;
+}
+
+// ---------------------------------------------------------------------------
+// Forward-copy algorithm
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves all version definitions into concrete endpoint maps per version.
+ *
+ * Algorithm:
+ * 1. Sort dated versions chronologically.
+ * 2. For each version, start with a **copy** of the previous version's map.
+ * 3. Apply the current version's registrations (overrides / additions).
+ * 4. Withdrawn endpoints are kept as `{ withdrawn: true }` markers.
+ * 5. The final dated version is aliased as `latest`.
+ * 6. `preview` endpoints are separate and never included in `latest`.
+ *
+ * @returns A map from version label to its resolved endpoint array.
+ */
+export function resolveVersions(
+  definitions: VersionDefinition[],
+  previewEndpoints: EndpointRegistration[],
+): Map<string, ResolvedEndpoint[]> {
+  const dated = definitions
+    .filter((d) => isDateVersion(d.version))
+    .sort((a, b) => a.version.localeCompare(b.version));
+
+  const result = new Map<string, ResolvedEndpoint[]>();
+  let previousMap = new Map<string, ResolvedEndpoint>();
+
+  for (const def of dated) {
+    // Start with a copy of the previous version
+    const currentMap = new Map(previousMap);
+
+    for (const ep of def.endpoints) {
+      const key = endpointKey(ep.method, ep.path);
+
+      if (ep.withdrawn) {
+        currentMap.set(key, { method: ep.method, path: ep.path, withdrawn: true });
+      } else {
+        currentMap.set(key, { ...ep, withdrawn: false });
+      }
+    }
+
+    result.set(def.version, Array.from(currentMap.values()));
+    previousMap = currentMap;
+  }
+
+  // `latest` = final dated version
+  if (dated.length > 0) {
+    const latestVersion = dated[dated.length - 1]!.version;
+    const latestEndpoints = result.get(latestVersion)!;
+    result.set(VERSION_LATEST, latestEndpoints);
+  }
+
+  // `preview` endpoints are separate
+  if (previewEndpoints.length > 0) {
+    result.set(
+      VERSION_PREVIEW,
+      previewEndpoints.map((ep) => ({ ...ep, withdrawn: false as const })),
+    );
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Request-time version resolution
+// ---------------------------------------------------------------------------
+
+export type ResolvedVersion =
+  | { found: true; version: string; status: "stable" | "latest" | "preview" | "unversioned"; endpoints: ResolvedEndpoint[] }
+  | { found: false };
+
+/**
+ * Resolves a version string from the request path to a set of endpoints.
+ *
+ * - Exact dated version match (e.g. `"2025-03-15"`) -- status `"stable"`.
+ * - `"latest"` -- resolves to newest dated version, status `"latest"`.
+ * - `"preview"` -- resolves to preview endpoints, status `"preview"`.
+ * - `undefined` (bare path, no version segment) -- resolves to latest, status `"unversioned"`.
+ * - Anything else -- `{ found: false }`.
+ */
+export function resolveRequestVersion(
+  versionMap: Map<string, ResolvedEndpoint[]>,
+  requestVersion: string | undefined,
+): ResolvedVersion {
+  if (requestVersion === undefined) {
+    // Bare path -- alias for latest
+    const latest = versionMap.get(VERSION_LATEST);
+    if (!latest) return { found: false };
+    return { found: true, version: VERSION_LATEST, status: "unversioned", endpoints: latest };
+  }
+
+  if (requestVersion === VERSION_LATEST) {
+    const latest = versionMap.get(VERSION_LATEST);
+    if (!latest) return { found: false };
+    return { found: true, version: VERSION_LATEST, status: "latest", endpoints: latest };
+  }
+
+  if (requestVersion === VERSION_PREVIEW) {
+    const preview = versionMap.get(VERSION_PREVIEW);
+    if (!preview) return { found: false };
+    return { found: true, version: VERSION_PREVIEW, status: "preview", endpoints: preview };
+  }
+
+  if (isDateVersion(requestVersion)) {
+    const endpoints = versionMap.get(requestVersion);
+    if (!endpoints) return { found: false };
+    return { found: true, version: requestVersion, status: "stable", endpoints };
+  }
+
+  return { found: false };
+}

--- a/langwatch/packages/api/src/versioning.ts
+++ b/langwatch/packages/api/src/versioning.ts
@@ -1,5 +1,11 @@
-import type { EndpointRegistration, HttpMethod } from "./types.js";
+import type {
+  EndpointRegistration,
+  HttpMethod,
+  VersionStatus,
+} from "./types.js";
 import { isDateVersion, VERSION_LATEST, VERSION_PREVIEW } from "./types.js";
+
+export { VERSION_LATEST, VERSION_PREVIEW } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Version registration input (collected by the builder)
@@ -34,6 +40,26 @@ function endpointKey(method: string, path: string): string {
   const normalized = method === "sse" ? "get" : method;
   const normalizedPath = path === "" ? "/" : path;
   return `${normalized}:${normalizedPath}`;
+}
+
+function applyRegistrations(
+  target: Map<string, ResolvedEndpoint>,
+  endpoints: EndpointRegistration[],
+): void {
+  for (const ep of endpoints) {
+    const key = endpointKey(ep.method, ep.path);
+    if (ep.withdrawn) {
+      const inherited = target.get(key);
+      target.set(key, {
+        method: ep.method,
+        path: ep.path,
+        config: inherited?.config ?? ep.config,
+        withdrawn: true,
+      });
+    } else {
+      target.set(key, { ...ep, withdrawn: false });
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -82,22 +108,7 @@ export function resolveVersions(
   for (const def of dated) {
     // Start with a copy of the previous version
     const currentMap = new Map(previousMap);
-
-    for (const ep of def.endpoints) {
-      const key = endpointKey(ep.method, ep.path);
-
-      if (ep.withdrawn) {
-        const inherited = currentMap.get(key);
-        currentMap.set(key, {
-          method: ep.method,
-          path: ep.path,
-          config: inherited?.config ?? ep.config,
-          withdrawn: true,
-        });
-      } else {
-        currentMap.set(key, { ...ep, withdrawn: false });
-      }
-    }
+    applyRegistrations(currentMap, def.endpoints);
 
     result.set(def.version, Array.from(currentMap.values()));
     previousMap = currentMap;
@@ -113,20 +124,7 @@ export function resolveVersions(
   // `preview` endpoints are separate
   if (previewEndpoints.length > 0) {
     const previewMap = new Map<string, ResolvedEndpoint>();
-    for (const ep of previewEndpoints) {
-      const key = endpointKey(ep.method, ep.path);
-      if (ep.withdrawn) {
-        const inherited = previewMap.get(key);
-        previewMap.set(key, {
-          method: ep.method,
-          path: ep.path,
-          config: inherited?.config ?? ep.config,
-          withdrawn: true,
-        });
-      } else {
-        previewMap.set(key, { ...ep, withdrawn: false });
-      }
-    }
+    applyRegistrations(previewMap, previewEndpoints);
     result.set(VERSION_PREVIEW, Array.from(previewMap.values()));
   }
 
@@ -141,7 +139,7 @@ export type ResolvedVersion =
   | {
       found: true;
       version: string;
-      status: "stable" | "latest" | "preview" | "unversioned";
+      status: VersionStatus;
       endpoints: ResolvedEndpoint[];
     }
   | { found: false };

--- a/langwatch/packages/api/src/versioning.ts
+++ b/langwatch/packages/api/src/versioning.ts
@@ -22,12 +22,18 @@ export interface VersionDefinition {
  */
 export type ResolvedEndpoint =
   | (EndpointRegistration & { withdrawn?: false })
-  | { method: HttpMethod | "sse"; path: string; withdrawn: true };
+  | {
+      method: HttpMethod | "sse";
+      path: string;
+      config: EndpointRegistration["config"];
+      withdrawn: true;
+    };
 
 /** A composite key for de-duplicating endpoints within a version. */
 function endpointKey(method: string, path: string): string {
   const normalized = method === "sse" ? "get" : method;
-  return `${normalized}:${path}`;
+  const normalizedPath = path === "" ? "/" : path;
+  return `${normalized}:${normalizedPath}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -51,9 +57,24 @@ export function resolveVersions(
   definitions: VersionDefinition[],
   previewEndpoints: EndpointRegistration[],
 ): Map<string, ResolvedEndpoint[]> {
-  const dated = definitions
-    .filter((d) => isDateVersion(d.version))
-    .sort((a, b) => a.version.localeCompare(b.version));
+  const seenVersions = new Set<string>();
+  for (const definition of definitions) {
+    if (!isDateVersion(definition.version)) {
+      throw new RangeError(
+        `Invalid API version "${definition.version}"; expected a real date in YYYY-MM-DD form`,
+      );
+    }
+    if (seenVersions.has(definition.version)) {
+      throw new Error(
+        `API version "${definition.version}" is registered more than once`,
+      );
+    }
+    seenVersions.add(definition.version);
+  }
+
+  const dated = [...definitions].sort((a, b) =>
+    a.version.localeCompare(b.version),
+  );
 
   const result = new Map<string, ResolvedEndpoint[]>();
   let previousMap = new Map<string, ResolvedEndpoint>();
@@ -66,7 +87,13 @@ export function resolveVersions(
       const key = endpointKey(ep.method, ep.path);
 
       if (ep.withdrawn) {
-        currentMap.set(key, { method: ep.method, path: ep.path, withdrawn: true });
+        const inherited = currentMap.get(key);
+        currentMap.set(key, {
+          method: ep.method,
+          path: ep.path,
+          config: inherited?.config ?? ep.config,
+          withdrawn: true,
+        });
       } else {
         currentMap.set(key, { ...ep, withdrawn: false });
       }
@@ -85,10 +112,22 @@ export function resolveVersions(
 
   // `preview` endpoints are separate
   if (previewEndpoints.length > 0) {
-    result.set(
-      VERSION_PREVIEW,
-      previewEndpoints.map((ep) => ({ ...ep, withdrawn: false as const })),
-    );
+    const previewMap = new Map<string, ResolvedEndpoint>();
+    for (const ep of previewEndpoints) {
+      const key = endpointKey(ep.method, ep.path);
+      if (ep.withdrawn) {
+        const inherited = previewMap.get(key);
+        previewMap.set(key, {
+          method: ep.method,
+          path: ep.path,
+          config: inherited?.config ?? ep.config,
+          withdrawn: true,
+        });
+      } else {
+        previewMap.set(key, { ...ep, withdrawn: false });
+      }
+    }
+    result.set(VERSION_PREVIEW, Array.from(previewMap.values()));
   }
 
   return result;
@@ -99,7 +138,12 @@ export function resolveVersions(
 // ---------------------------------------------------------------------------
 
 export type ResolvedVersion =
-  | { found: true; version: string; status: "stable" | "latest" | "preview" | "unversioned"; endpoints: ResolvedEndpoint[] }
+  | {
+      found: true;
+      version: string;
+      status: "stable" | "latest" | "preview" | "unversioned";
+      endpoints: ResolvedEndpoint[];
+    }
   | { found: false };
 
 /**
@@ -119,25 +163,45 @@ export function resolveRequestVersion(
     // Bare path -- alias for latest
     const latest = versionMap.get(VERSION_LATEST);
     if (!latest) return { found: false };
-    return { found: true, version: VERSION_LATEST, status: "unversioned", endpoints: latest };
+    return {
+      found: true,
+      version: VERSION_LATEST,
+      status: "unversioned",
+      endpoints: latest,
+    };
   }
 
   if (requestVersion === VERSION_LATEST) {
     const latest = versionMap.get(VERSION_LATEST);
     if (!latest) return { found: false };
-    return { found: true, version: VERSION_LATEST, status: "latest", endpoints: latest };
+    return {
+      found: true,
+      version: VERSION_LATEST,
+      status: "latest",
+      endpoints: latest,
+    };
   }
 
   if (requestVersion === VERSION_PREVIEW) {
     const preview = versionMap.get(VERSION_PREVIEW);
     if (!preview) return { found: false };
-    return { found: true, version: VERSION_PREVIEW, status: "preview", endpoints: preview };
+    return {
+      found: true,
+      version: VERSION_PREVIEW,
+      status: "preview",
+      endpoints: preview,
+    };
   }
 
   if (isDateVersion(requestVersion)) {
     const endpoints = versionMap.get(requestVersion);
     if (!endpoints) return { found: false };
-    return { found: true, version: requestVersion, status: "stable", endpoints };
+    return {
+      found: true,
+      version: requestVersion,
+      status: "stable",
+      endpoints,
+    };
   }
 
   return { found: false };

--- a/langwatch/packages/api/src/versioning.ts
+++ b/langwatch/packages/api/src/versioning.ts
@@ -36,18 +36,27 @@ export type ResolvedEndpoint =
     };
 
 /** A composite key for de-duplicating endpoints within a version. */
-function endpointKey(method: string, path: string): string {
+function endpointKey({
+  method,
+  path,
+}: {
+  method: string;
+  path: string;
+}): string {
   const normalized = method === "sse" ? "get" : method;
   const normalizedPath = path === "" ? "/" : path;
   return `${normalized}:${normalizedPath}`;
 }
 
-function applyRegistrations(
-  target: Map<string, ResolvedEndpoint>,
-  endpoints: EndpointRegistration[],
-): void {
+function applyRegistrations({
+  target,
+  endpoints,
+}: {
+  target: Map<string, ResolvedEndpoint>;
+  endpoints: EndpointRegistration[];
+}): void {
   for (const ep of endpoints) {
-    const key = endpointKey(ep.method, ep.path);
+    const key = endpointKey({ method: ep.method, path: ep.path });
     if (ep.withdrawn) {
       const inherited = target.get(key);
       target.set(key, {
@@ -79,10 +88,13 @@ function applyRegistrations(
  *
  * @returns A map from version label to its resolved endpoint array.
  */
-export function resolveVersions(
-  definitions: VersionDefinition[],
-  previewEndpoints: EndpointRegistration[],
-): Map<string, ResolvedEndpoint[]> {
+export function resolveVersions({
+  definitions,
+  previewEndpoints,
+}: {
+  definitions: VersionDefinition[];
+  previewEndpoints: EndpointRegistration[];
+}): Map<string, ResolvedEndpoint[]> {
   const seenVersions = new Set<string>();
   for (const definition of definitions) {
     if (!isDateVersion(definition.version)) {
@@ -108,7 +120,7 @@ export function resolveVersions(
   for (const def of dated) {
     // Start with a copy of the previous version
     const currentMap = new Map(previousMap);
-    applyRegistrations(currentMap, def.endpoints);
+    applyRegistrations({ target: currentMap, endpoints: def.endpoints });
 
     result.set(def.version, Array.from(currentMap.values()));
     previousMap = currentMap;
@@ -124,7 +136,7 @@ export function resolveVersions(
   // `preview` endpoints are separate
   if (previewEndpoints.length > 0) {
     const previewMap = new Map<string, ResolvedEndpoint>();
-    applyRegistrations(previewMap, previewEndpoints);
+    applyRegistrations({ target: previewMap, endpoints: previewEndpoints });
     result.set(VERSION_PREVIEW, Array.from(previewMap.values()));
   }
 
@@ -153,10 +165,13 @@ export type ResolvedVersion =
  * - `undefined` (bare path, no version segment) -- resolves to latest, status `"unversioned"`.
  * - Anything else -- `{ found: false }`.
  */
-export function resolveRequestVersion(
-  versionMap: Map<string, ResolvedEndpoint[]>,
-  requestVersion: string | undefined,
-): ResolvedVersion {
+export function resolveRequestVersion({
+  versionMap,
+  requestVersion,
+}: {
+  versionMap: Map<string, ResolvedEndpoint[]>;
+  requestVersion: string | undefined;
+}): ResolvedVersion {
   if (requestVersion === undefined) {
     // Bare path -- alias for latest
     const latest = versionMap.get(VERSION_LATEST);

--- a/langwatch/packages/api/tsconfig.json
+++ b/langwatch/packages/api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"resolveJsonModule": true,
+		"rootDir": "src",
+		"types": ["node"],
+		"noEmit": true
+	},
+	"include": ["src/**/*"]
+}

--- a/langwatch/packages/api/tsconfig.json
+++ b/langwatch/packages/api/tsconfig.json
@@ -1,16 +1,16 @@
 {
-	"compilerOptions": {
-		"target": "ES2022",
-		"module": "ESNext",
-		"moduleResolution": "Bundler",
-		"lib": ["ES2022", "DOM", "DOM.Iterable"],
-		"strict": true,
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"resolveJsonModule": true,
-		"rootDir": "src",
-		"types": ["node"],
-		"noEmit": true
-	},
-	"include": ["src/**/*"]
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
 }

--- a/langwatch/packages/api/vitest.config.ts
+++ b/langwatch/packages/api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    watch: false,
+    testTimeout: 10000,
+  },
+});

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -835,7 +835,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.55.0
-        version: 8.58.2(eslint@8.57.1)(typescript@5.9.3)
+        version: 8.58.1(eslint@8.57.1)(typescript@5.9.3)
 
   packages/analytics-parity-check:
     dependencies:
@@ -873,6 +873,34 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+
+  packages/api:
+    dependencies:
+      '@langwatch/telemetry':
+        specifier: workspace:*
+        version: link:../telemetry
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      hono:
+        specifier: ^4.12.0
+        version: 4.12.4
+      hono-openapi:
+        specifier: ^0.4.0
+        version: 0.4.8(@hono/zod-validator@0.4.3(hono@4.12.4)(zod@3.25.76))(hono@4.12.4)(openapi-types@12.1.3)(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76)
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.12.2
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260316.1
+        version: 7.0.0-dev.20260316.1
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/coverage-v8@4.0.18(vitest@4.0.18))(@vitest/ui@4.0.18)(jsdom@27.3.0(bufferutil@4.0.9))(vite@7.2.4(@types/node@24.12.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
 
   packages/deja-view:
     dependencies:
@@ -934,6 +962,31 @@ importers:
       vitest:
         specifier: ^4.0.16
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/ui@4.0.18)(jsdom@27.3.0(bufferutil@4.0.9))(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+
+  packages/insanity-check:
+    dependencies:
+      '@langwatch/scenario-npm':
+        specifier: npm:@langwatch/scenario@^0.4.9
+        version: '@langwatch/scenario@0.4.10(c742dd90ef100b2d03937715778502b1)'
+      commander:
+        specifier: ^14.0.2
+        version: 14.0.2
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+      langwatch:
+        specifier: ^0.16.0
+        version: 0.16.1(3d86cdbb290c11e871573ccc43e3efb3)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.19.27
+        version: 20.19.27
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/projection-replay:
     dependencies:
@@ -3978,6 +4031,13 @@ packages:
   '@langwatch/ksuid@2.0.2':
     resolution: {integrity: sha512-h9zbd+nfnxmCoSitXDwr0xpW9Ij62ZoYN8SxZlkddlBzZh0v2lwZI5lFmqMyrhUPlHnRJqCoqUFnZGRO3dvORA==}
     engines: {node: '>=16.0.0'}
+
+  '@langwatch/scenario@0.4.10':
+    resolution: {integrity: sha512-/rBTXHZLCgLICsb8zT8gLmgyAVY3hxS73tW7lnkt/qW3TOMCTs+aMR+4NhRa/v6C5ZUPjdrIvol0mg0AGvpXuA==}
+    engines: {node: '>=20', pnpm: '>=8'}
+    peerDependencies:
+      ai: '>=6.0.0'
+      vitest: '>=3.2.4'
 
   '@langwatch/scenario@0.4.7':
     resolution: {integrity: sha512-eTujqAKb9kCBIXIlmN7Zo98SXibf0ymd9ZPRu0cLDWLwB0hrv4Zso1MzYuPAT9+cOFQ11m3RAZZQVV40yf4k0Q==}
@@ -7040,6 +7100,9 @@ packages:
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
 
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
   '@types/nprogress@0.2.1':
     resolution: {integrity: sha512-TYuyVnp+nOnimgdOydDIDYIxv2kSeuJZw4tF0p/KG7hpzcMF1WkHaREwM8O4blqfT1F7rq0nht6Ko2KVUfWzBA==}
 
@@ -7155,63 +7218,63 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@typescript-eslint/eslint-plugin@8.58.2':
-    resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
+  '@typescript-eslint/eslint-plugin@8.58.1':
+    resolution: {integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.58.2
+      '@typescript-eslint/parser': ^8.58.1
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.58.2':
-    resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.58.2':
-    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.58.2':
-    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.58.2':
-    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.58.2':
-    resolution: {integrity: sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==}
+  '@typescript-eslint/parser@8.58.1':
+    resolution: {integrity: sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.58.2':
-    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.58.2':
-    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
+  '@typescript-eslint/project-service@8.58.1':
+    resolution: {integrity: sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.58.2':
-    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
+  '@typescript-eslint/scope-manager@8.58.1':
+    resolution: {integrity: sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.58.1':
+    resolution: {integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.58.1':
+    resolution: {integrity: sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.58.2':
-    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
+  '@typescript-eslint/types@8.58.1':
+    resolution: {integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.58.1':
+    resolution: {integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.58.1':
+    resolution: {integrity: sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.58.1':
+    resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20250911.1':
@@ -7222,6 +7285,11 @@ packages:
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251222.1':
     resolution: {integrity: sha512-wq2sTeZzexOrGYKKsMODvL/9+HF4nqyHt/h7hW55ikHU5gscby5xkhG4/oA8KECLTYVdDfAQM+Yfnku76SQBPw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260316.1':
+    resolution: {integrity: sha512-TjeMEMabLsc5VNYy8WVlu1oHBVqibwSbkIRSyqANFxyD6iWnCFquDvliwErVo8TFIu0c8C+C+tgFSvYkhVZMMw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -7236,6 +7304,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260316.1':
+    resolution: {integrity: sha512-Lv/JmtMfNbMJiIEZlByQ5zSR1t9WoE8rFuZxU0vpiyfUEjSbuBMG8pt+Ryqj6uiylR3XThlV3EaVYsJ7Um6n8w==}
+    cpu: [x64]
+    os: [darwin]
+
   '@typescript/native-preview-linux-arm64@7.0.0-dev.20250911.1':
     resolution: {integrity: sha512-qtNel8vs2pqnHtSGL46T17SNcPe0kSXhMPzRolNUJi60+RMA2X2AG5TC8GLHql6zEACtJDfYFCSvvma29KlS8Q==}
     engines: {node: '>=20.6.0'}
@@ -7244,6 +7317,11 @@ packages:
 
   '@typescript/native-preview-linux-arm64@7.0.0-dev.20251222.1':
     resolution: {integrity: sha512-wN+IfT/KZfsq1g3Imd50+3k4qCgAwD8N7qU82tJDa9BNj6GtXE/za05N8LBFFq624FBiiqabazsTdE2e/m4OKw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260316.1':
+    resolution: {integrity: sha512-xA4DekkAesjnWyp8p0iF79Rf0q2NVszxedd9M2Ztb0WBSDQFiECVYJSQMFd4+FKNiSq9DnadPy68Dly+B1r17A==}
     cpu: [arm64]
     os: [linux]
 
@@ -7258,6 +7336,11 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260316.1':
+    resolution: {integrity: sha512-vItkqjOuVY9OfqdovSyEjnAbNMM+QGM9AqzGRknX1nZjGlWXsUTL3IPuv5by69SOqw5TLi8ddx82cyu6F3ZRVQ==}
+    cpu: [arm]
+    os: [linux]
+
   '@typescript/native-preview-linux-x64@7.0.0-dev.20250911.1':
     resolution: {integrity: sha512-bqr2A77jNRuVSes0kyTCW47x8Iz9AjNjJxALVPJBGRXeFt/2q0ma3zpbuwIIQNLVcdlpseTFmLZsw8cXzCJIyA==}
     engines: {node: '>=20.6.0'}
@@ -7266,6 +7349,11 @@ packages:
 
   '@typescript/native-preview-linux-x64@7.0.0-dev.20251222.1':
     resolution: {integrity: sha512-yra1TDTzBEI8DjV2BPuQR6PbLJJZPAMWvfCWOxETEbJfKRsz4kBKBG9cPgALeUdjvM6I8ah/CwvJtVc+9oVDGw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260316.1':
+    resolution: {integrity: sha512-osY+4HCIpi9Bu4jNz49k8BVOB9A04BG6mWF7WltmAQWBIAeosa4n/qtKokfAZDTD5/moHSn20p7hZAlGI8JWjw==}
     cpu: [x64]
     os: [linux]
 
@@ -7280,6 +7368,11 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260316.1':
+    resolution: {integrity: sha512-DcWceiTXClIakJhk0+8KjQ+pBp435HaA6uw9EtDTo75uWUEPVf9D489KKbylRChci/paYX8uPKlROo9+6N8M9g==}
+    cpu: [arm64]
+    os: [win32]
+
   '@typescript/native-preview-win32-x64@7.0.0-dev.20250911.1':
     resolution: {integrity: sha512-TqTkbWQlj0khZaivLuUAlPQwyKUcODgG9vD4RTzalGm09mXfp1viJMMAS1sDblLiUUrGupU/M0/eI414wqk/+g==}
     engines: {node: '>=20.6.0'}
@@ -7288,6 +7381,11 @@ packages:
 
   '@typescript/native-preview-win32-x64@7.0.0-dev.20251222.1':
     resolution: {integrity: sha512-9wRuExH/aJq0sWm20DVhg1Ciu3M8jgegOfjSGqweaREp1toMEmVkyhXp7xH1y69LMuXZFmzjy2kmHiUZgOE6lQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260316.1':
+    resolution: {integrity: sha512-LvpV1hyQS0U9yMLHgWexhC7oSeBpcNbIJtYC6Iyvu63Mb6J/cP0k2fQmnAVB2yesMMQFtuY6v2YIx17vE0Ymfw==}
     cpu: [x64]
     os: [win32]
 
@@ -7300,8 +7398,15 @@ packages:
     resolution: {integrity: sha512-/9Xrcwb1vkJX+Wdj57ckixQBgF+I1DwEi1PEwgu13i/q5gs1AWVxOGg318sibuZu/33ZfvxRZZXOS24UzqDwWw==}
     hasBin: true
 
+  '@typescript/native-preview@7.0.0-dev.20260316.1':
+    resolution: {integrity: sha512-s+QGNx+3zxTZBuZw3oNOFlHqpbmg0cTgBd/b6SRZ5mo3vFChkhflYqRW2IvTvU9a3PPX3bQAkQ/gWbDZCmNC3Q==}
+    hasBin: true
+
   '@typescript/vfs@1.5.0':
     resolution: {integrity: sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==}
+
+  '@ungap/structured-clone@1.2.0':
+    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -7330,6 +7435,9 @@ packages:
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -7364,6 +7472,17 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
@@ -7372,6 +7491,9 @@ packages:
 
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
@@ -7382,6 +7504,9 @@ packages:
   '@vitest/runner@4.0.18':
     resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
@@ -7391,6 +7516,9 @@ packages:
   '@vitest/snapshot@4.0.18':
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
@@ -7399,6 +7527,9 @@ packages:
 
   '@vitest/spy@4.0.18':
     resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/ui@4.0.18':
     resolution: {integrity: sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==}
@@ -7413,6 +7544,9 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -9165,6 +9299,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -12841,6 +12978,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
   stream-events@1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
 
@@ -13119,6 +13259,10 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
@@ -13345,8 +13489,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript-eslint@8.58.2:
-    resolution: {integrity: sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==}
+  typescript-eslint@8.58.1:
+    resolution: {integrity: sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -13370,6 +13514,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
@@ -13725,6 +13872,47 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -14212,9 +14400,9 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
-      eventsource-parser: 3.0.5
+      eventsource-parser: 3.0.6
       zod: 3.25.76
-      zod-to-json-schema: 3.24.5(zod@3.25.76)
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
 
   '@ai-sdk/provider-utils@3.0.8(zod@3.25.76)':
     dependencies:
@@ -14792,41 +14980,41 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.9
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.9
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/middleware-host-header': 3.972.7
+      '@aws-sdk/middleware-logger': 3.972.7
+      '@aws-sdk/middleware-recursion-detection': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.20
+      '@aws-sdk/region-config-resolver': 3.972.7
+      '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-endpoints': 3.985.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.7
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/util-user-agent-browser': 3.972.7
+      '@aws-sdk/util-user-agent-node': 3.973.5
+      '@smithy/config-resolver': 4.4.10
+      '@smithy/core': 3.23.9
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/hash-node': 4.2.11
+      '@smithy/invalid-dependency': 4.2.11
+      '@smithy/middleware-content-length': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.23
+      '@smithy/middleware-retry': 4.4.40
+      '@smithy/middleware-serde': 4.2.12
+      '@smithy/middleware-stack': 4.2.11
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.3
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.39
+      '@smithy/util-defaults-mode-node': 4.2.42
+      '@smithy/util-endpoints': 3.3.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-retry': 4.2.11
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -14835,41 +15023,41 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.9
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.9
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/middleware-host-header': 3.972.7
+      '@aws-sdk/middleware-logger': 3.972.7
+      '@aws-sdk/middleware-recursion-detection': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.20
+      '@aws-sdk/region-config-resolver': 3.972.7
+      '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-endpoints': 3.989.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.7
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/util-user-agent-browser': 3.972.7
+      '@aws-sdk/util-user-agent-node': 3.973.5
+      '@smithy/config-resolver': 4.4.10
+      '@smithy/core': 3.23.9
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/hash-node': 4.2.11
+      '@smithy/invalid-dependency': 4.2.11
+      '@smithy/middleware-content-length': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.23
+      '@smithy/middleware-retry': 4.4.40
+      '@smithy/middleware-serde': 4.2.12
+      '@smithy/middleware-stack': 4.2.11
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.3
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.39
+      '@smithy/util-defaults-mode-node': 4.2.42
+      '@smithy/util-endpoints': 3.3.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-retry': 4.2.11
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -15244,26 +15432,26 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.5':
     dependencies:
-      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.985.0
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.5
       '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
+      '@smithy/protocol-http': 5.3.11
       '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
   '@aws-sdk/credential-provider-login@3.972.7':
     dependencies:
-      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.989.0
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.5
       '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
+      '@smithy/protocol-http': 5.3.11
       '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -15798,41 +15986,41 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.9
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.9
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/middleware-host-header': 3.972.7
+      '@aws-sdk/middleware-logger': 3.972.7
+      '@aws-sdk/middleware-recursion-detection': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.20
+      '@aws-sdk/region-config-resolver': 3.972.7
+      '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-endpoints': 3.985.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.7
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/util-user-agent-browser': 3.972.7
+      '@aws-sdk/util-user-agent-node': 3.973.5
+      '@smithy/config-resolver': 4.4.10
+      '@smithy/core': 3.23.9
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/hash-node': 4.2.11
+      '@smithy/invalid-dependency': 4.2.11
+      '@smithy/middleware-content-length': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.23
+      '@smithy/middleware-retry': 4.4.40
+      '@smithy/middleware-serde': 4.2.12
+      '@smithy/middleware-stack': 4.2.11
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.3
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.39
+      '@smithy/util-defaults-mode-node': 4.2.42
+      '@smithy/util-endpoints': 3.3.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-retry': 4.2.11
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -15841,41 +16029,41 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.9
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.9
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/core': 3.973.19
+      '@aws-sdk/middleware-host-header': 3.972.7
+      '@aws-sdk/middleware-logger': 3.972.7
+      '@aws-sdk/middleware-recursion-detection': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.20
+      '@aws-sdk/region-config-resolver': 3.972.7
+      '@aws-sdk/types': 3.973.5
       '@aws-sdk/util-endpoints': 3.989.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.7
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.0
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.14
-      '@smithy/middleware-retry': 4.4.31
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.10
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.3
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.30
-      '@smithy/util-defaults-mode-node': 4.2.33
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/util-user-agent-browser': 3.972.7
+      '@aws-sdk/util-user-agent-node': 3.973.5
+      '@smithy/config-resolver': 4.4.10
+      '@smithy/core': 3.23.9
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/hash-node': 4.2.11
+      '@smithy/invalid-dependency': 4.2.11
+      '@smithy/middleware-content-length': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.23
+      '@smithy/middleware-retry': 4.4.40
+      '@smithy/middleware-serde': 4.2.12
+      '@smithy/middleware-stack': 4.2.11
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.3
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.39
+      '@smithy/util-defaults-mode-node': 4.2.42
+      '@smithy/util-endpoints': 3.3.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-retry': 4.2.11
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -16057,24 +16245,24 @@ snapshots:
 
   '@aws-sdk/token-providers@3.985.0':
     dependencies:
-      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.985.0
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.5
       '@smithy/property-provider': 4.2.8
       '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
   '@aws-sdk/token-providers@3.989.0':
     dependencies:
-      '@aws-sdk/core': 3.973.9
+      '@aws-sdk/core': 3.973.19
       '@aws-sdk/nested-clients': 3.989.0
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.5
       '@smithy/property-provider': 4.2.8
       '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18108,6 +18296,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.20
+      langsmith: 0.3.67(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+
   '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
@@ -18156,6 +18364,11 @@ snapshots:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))
       uuid: 10.0.0
 
+  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
+      uuid: 10.0.0
+
   '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6)))':
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))
@@ -18180,6 +18393,17 @@ snapshots:
       uuid: 9.0.1
     optionalDependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))
+      react: 19.2.3
+      react-dom: 19.1.0(react@19.2.3)
+
+  '@langchain/langgraph-sdk@0.0.112(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(react-dom@19.1.0(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+    optionalDependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
       react: 19.2.3
       react-dom: 19.1.0(react@19.2.3)
 
@@ -18230,6 +18454,19 @@ snapshots:
       - react
       - react-dom
 
+  '@langchain/langgraph@0.4.6(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(react-dom@19.1.0(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 0.0.112(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(react-dom@19.1.0(react@19.2.3))(react@19.2.3)
+      uuid: 10.0.0
+      zod: 3.25.76
+    optionalDependencies:
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@langchain/langgraph@0.4.6(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6)))(react-dom@19.1.0(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@4.3.6))':
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))
@@ -18272,6 +18509,15 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
+  '@langchain/openai@0.6.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.0.9))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
+      js-tiktoken: 1.0.20
+      openai: 5.12.2(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - ws
+
   '@langchain/openai@0.6.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6)))(ws@8.19.0(bufferutil@4.0.9))':
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))
@@ -18291,6 +18537,11 @@ snapshots:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))
       js-tiktoken: 1.0.20
 
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
+      js-tiktoken: 1.0.20
+
   '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6)))':
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))
@@ -18305,6 +18556,35 @@ snapshots:
       - encoding
 
   '@langwatch/ksuid@2.0.2': {}
+
+  '@langwatch/scenario@0.4.10(c742dd90ef100b2d03937715778502b1)':
+    dependencies:
+      '@ag-ui/core': 0.0.28
+      '@ai-sdk/openai': 3.0.41(zod@3.25.76)
+      '@openai/agents': 0.3.9(@cfworker/json-schema@4.1.1)(bufferutil@4.0.9)(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)
+      '@opentelemetry/sdk-node': 0.212.0(@opentelemetry/api@1.9.0)
+      ai: 6.0.116(zod@3.25.76)
+      chalk: 5.6.2
+      langwatch: 0.16.1(3d86cdbb290c11e871573ccc43e3efb3)
+      open: 11.0.0
+      rxjs: 7.8.2
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.0.18(vitest@4.0.18))(@vitest/ui@4.0.18)(jsdom@27.3.0(bufferutil@4.0.9))(vite@7.2.4(@types/node@20.19.27)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      xksuid: 0.0.4
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@langchain/core'
+      - '@langchain/langgraph'
+      - '@langchain/openai'
+      - '@opentelemetry/api'
+      - '@opentelemetry/context-async-hooks'
+      - '@opentelemetry/context-zone'
+      - '@opentelemetry/sdk-trace-web'
+      - bufferutil
+      - langchain
+      - supports-color
+      - utf-8-validate
+      - ws
 
   '@langwatch/scenario@0.4.7(b06db1dee4dd5d0ad4edcf5973f729f1)':
     dependencies:
@@ -20926,7 +21206,7 @@ snapshots:
   '@smithy/eventstream-codec@4.2.8':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       '@smithy/util-hex-encoding': 4.2.0
       tslib: 2.8.1
 
@@ -22346,6 +22626,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/nprogress@0.2.1': {}
 
   '@types/numeral@2.0.5': {}
@@ -22463,14 +22747,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/type-utils': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/type-utils': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.1
       eslint: 8.57.1
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -22479,41 +22763,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.2(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.58.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.1
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.58.2':
+  '@typescript-eslint/scope-manager@8.58.1':
     dependencies:
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/visitor-keys': 8.58.1
 
-  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.58.2(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.58.1(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -22521,14 +22805,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.58.2': {}
+  '@typescript-eslint/types@8.58.1': {}
 
-  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.2(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/project-service': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.4
       semver: 7.7.4
@@ -22538,20 +22822,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.2(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.58.1(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       eslint: 8.57.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.58.2':
+  '@typescript-eslint/visitor-keys@8.58.1':
     dependencies:
-      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20250911.1':
@@ -22560,10 +22844,16 @@ snapshots:
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251222.1':
     optional: true
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260316.1':
+    optional: true
+
   '@typescript/native-preview-darwin-x64@7.0.0-dev.20250911.1':
     optional: true
 
   '@typescript/native-preview-darwin-x64@7.0.0-dev.20251222.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260316.1':
     optional: true
 
   '@typescript/native-preview-linux-arm64@7.0.0-dev.20250911.1':
@@ -22572,10 +22862,16 @@ snapshots:
   '@typescript/native-preview-linux-arm64@7.0.0-dev.20251222.1':
     optional: true
 
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260316.1':
+    optional: true
+
   '@typescript/native-preview-linux-arm@7.0.0-dev.20250911.1':
     optional: true
 
   '@typescript/native-preview-linux-arm@7.0.0-dev.20251222.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260316.1':
     optional: true
 
   '@typescript/native-preview-linux-x64@7.0.0-dev.20250911.1':
@@ -22584,16 +22880,25 @@ snapshots:
   '@typescript/native-preview-linux-x64@7.0.0-dev.20251222.1':
     optional: true
 
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260316.1':
+    optional: true
+
   '@typescript/native-preview-win32-arm64@7.0.0-dev.20250911.1':
     optional: true
 
   '@typescript/native-preview-win32-arm64@7.0.0-dev.20251222.1':
     optional: true
 
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260316.1':
+    optional: true
+
   '@typescript/native-preview-win32-x64@7.0.0-dev.20250911.1':
     optional: true
 
   '@typescript/native-preview-win32-x64@7.0.0-dev.20251222.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260316.1':
     optional: true
 
   '@typescript/native-preview@7.0.0-dev.20250911.1':
@@ -22616,11 +22921,23 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20251222.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20251222.1
 
+  '@typescript/native-preview@7.0.0-dev.20260316.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260316.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260316.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260316.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260316.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260316.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260316.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260316.1
+
   '@typescript/vfs@1.5.0':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@ungap/structured-clone@1.2.0': {}
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -22673,6 +22990,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@3.2.4(vite@7.2.4(@types/node@16.18.126)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -22705,6 +23031,22 @@ snapshots:
     optionalDependencies:
       vite: 7.2.4(@types/node@20.19.27)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
 
+  '@vitest/mocker@4.1.4(vite@7.2.4(@types/node@20.19.27)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.4(@types/node@20.19.27)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@vitest/mocker@4.1.4(vite@7.2.4(@types/node@24.12.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.4(@types/node@24.12.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -22716,6 +23058,10 @@ snapshots:
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -22731,6 +23077,11 @@ snapshots:
   '@vitest/runner@4.0.18':
     dependencies:
       '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
   '@vitest/snapshot@3.2.4':
@@ -22751,6 +23102,13 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
@@ -22758,6 +23116,8 @@ snapshots:
   '@vitest/spy@4.0.16': {}
 
   '@vitest/spy@4.0.18': {}
+
+  '@vitest/spy@4.1.4': {}
 
   '@vitest/ui@4.0.18(vitest@4.0.18)':
     dependencies:
@@ -22785,6 +23145,12 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -24899,6 +25265,8 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -26936,6 +27304,30 @@ snapshots:
       - openai
       - ws
 
+  langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(axios@1.13.6(debug@4.4.1))(handlebars@4.7.8)(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)):
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
+      '@langchain/openai': 0.6.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.0.9))
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))
+      js-tiktoken: 1.0.20
+      js-yaml: 4.1.0
+      jsonpointer: 5.0.1
+      langsmith: 0.3.67(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
+      openapi-types: 12.1.3
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      yaml: 2.8.1
+      zod: 3.25.76
+    optionalDependencies:
+      axios: 1.13.6(debug@4.4.1)
+      handlebars: 4.7.8
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
   langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(axios@1.13.6(debug@4.4.1))(handlebars@4.7.8)(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))(ws@8.19.0(bufferutil@4.0.9)):
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6))
@@ -27013,6 +27405,21 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.5.0(@opentelemetry/api@1.9.0)
       openai: 6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6)
 
+  langsmith@0.3.67(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.13.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      semver: 7.7.4
+      uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/exporter-trace-otlp-proto': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      openai: 6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)
+
   langsmith@0.3.67(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@4.3.6)):
     dependencies:
       '@types/uuid': 10.0.0
@@ -27061,7 +27468,7 @@ snapshots:
       ora: 5.4.1
       prompts: 2.4.2
       xksuid: 0.0.4
-      zod: 4.2.1
+      zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -27099,6 +27506,43 @@ snapshots:
       prompts: 2.4.2
       xksuid: 0.0.4
       zod: 4.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  langwatch@0.16.1(3d86cdbb290c11e871573ccc43e3efb3):
+    dependencies:
+      '@ai-sdk/openai': 3.0.41(zod@3.25.76)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))
+      '@langchain/langgraph': 0.4.6(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(react-dom@19.1.0(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      '@langchain/openai': 0.6.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.0.9))
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/context-zone': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.212.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-web': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/prompts': 2.4.9
+      chalk: 4.1.2
+      commander: 12.1.0
+      dotenv: 17.3.1
+      js-yaml: 4.1.0
+      langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(axios@1.13.6(debug@4.4.1))(handlebars@4.7.8)(openai@6.15.0(ws@8.19.0(bufferutil@4.0.9))(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9))
+      liquidjs: 10.25.0
+      open: 11.0.0
+      openapi-fetch: 0.16.0
+      ora: 5.4.1
+      prompts: 2.4.2
+      xksuid: 0.0.4
+      zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -27564,7 +28008,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.2.0
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -29926,6 +30370,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  std-env@4.0.0: {}
+
   stream-events@1.0.5:
     dependencies:
       stubs: 3.0.0
@@ -30280,6 +30726,8 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tinyrainbow@3.1.0: {}
+
   tinyspy@4.0.4: {}
 
   tldts-core@7.0.19: {}
@@ -30498,12 +30946,12 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.58.2(eslint@8.57.1)(typescript@5.9.3):
+  typescript-eslint@8.58.1(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -30519,6 +30967,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.16.0: {}
 
   undici@5.29.0:
     dependencies:
@@ -30837,6 +31287,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.1
 
+  vite@7.2.4(@types/node@24.12.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+      sass: 1.97.3
+      terser: 5.46.0
+      tsx: 4.21.0
+      yaml: 2.8.1
+
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@16.18.126)(@vitest/ui@4.0.18)(jsdom@27.3.0(bufferutil@4.0.9))(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.3
@@ -31000,6 +31466,68 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(@vitest/coverage-v8@4.0.18(vitest@4.0.18))(@vitest/ui@4.0.18)(jsdom@27.3.0(bufferutil@4.0.9))(vite@7.2.4(@types/node@20.19.27)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.2.4(@types/node@20.19.27)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.2.4(@types/node@20.19.27)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 20.19.27
+      '@vitest/coverage-v8': 4.0.18(vitest@4.0.18)
+      '@vitest/ui': 4.0.18(vitest@4.0.18)
+      jsdom: 27.3.0(bufferutil@4.0.9)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/coverage-v8@4.0.18(vitest@4.0.18))(@vitest/ui@4.0.18)(jsdom@27.3.0(bufferutil@4.0.9))(vite@7.2.4(@types/node@24.12.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.2.4(@types/node@24.12.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.2.4(@types/node@24.12.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.12.2
+      '@vitest/coverage-v8': 4.0.18(vitest@4.0.18)
+      '@vitest/ui': 4.0.18(vitest@4.0.18)
+      jsdom: 27.3.0(bufferutil@4.0.9)
+    transitivePeerDependencies:
+      - msw
 
   vscode-jsonrpc@8.2.0: {}
 

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -920,6 +920,34 @@ importers:
         specifier: ^8.55.0
         version: 8.58.1(eslint@10.2.1)(typescript@5.9.3)
 
+  packages/api:
+    dependencies:
+      '@langwatch/observability':
+        specifier: workspace:*
+        version: link:../observability
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      hono:
+        specifier: ^4.12.25
+        version: 4.12.27
+      hono-openapi:
+        specifier: ^0.4.0
+        version: 0.4.8(@hono/zod-validator@0.4.3(hono@4.12.27)(zod@3.25.76))(hono@4.12.27)(openapi-types@12.1.3)(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76)
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^26.0.1
+        version: 26.1.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/observability:
     dependencies:
       pino:

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -946,7 +946,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/observability:
     dependencies:


### PR DESCRIPTION
## Summary

- add a private `@langwatch/api` package for building typed, versioned Hono services
- provide date-based forward-copying, `latest`/bare aliases, isolated preview routes, and explicit endpoint withdrawal
- compose tracing, logging, auth, organization, resource-limit, endpoint middleware, providers, validation, OpenAPI metadata, and consistent error responses
- add typed SSE helpers and Next.js route-handler adapters
- include package documentation and comprehensive unit coverage

## Review follow-up

- rebased onto the latest `main`
- removed the obsolete observability/telemetry extraction history that is already present on `main`, leaving this PR focused on `@langwatch/api`
- addressed the review feedback around GET/SSE collisions, SSE request semantics, null/undefined responses, OpenAPI status codes, withdrawn-route middleware, README accuracy, and lockfile integration
- hardened version/path validation, provider preservation, context propagation, output validation, reserved namespaces, and fail-closed resource-limit configuration
- no existing API service is migrated to the package in this PR

## Validation

- `pnpm --filter @langwatch/api typecheck`
- `pnpm --filter @langwatch/api test:unit` (80 tests)
- `pnpm --filter @langwatch/observability typecheck`
- `pnpm --filter @langwatch/observability test:unit` (56 tests)
- `pnpm typecheck`
- `pnpm run typecheck:tests`
- frozen pnpm 10.24.0 install and Prettier check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fluent builder for typed, versioned API services with preview support and endpoint inheritance/withdrawal semantics.
  * Introduced Zod-driven request/response validation, OpenAPI metadata, and standardized result/error serialization.
  * Added typed SSE endpoints with validated query/events and streamed validation/error handling.
  * Added request-scoped tracing and logging middleware, plus provider injection per request.
* **Documentation**
  * Added a comprehensive `@langwatch/api` README covering versioning, SSE, validation, and migration.
* **Tests**
  * Expanded Vitest coverage for versioning, routing/middleware, errors, SSE, and OpenAPI behavior.
* **Chores**
  * Added API package TypeScript and Vitest configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

