### PR TITLE
fix(experiment-runs): scope ClickHouse queries by ExperimentId

### DIFF
--- a/langwatch/src/server/clickhouse/dateTime.ts
+++ b/langwatch/src/server/clickhouse/dateTime.ts
@@ -1,0 +1,34 @@
+/**
+ * Canonical helpers for serializing and parsing ClickHouse DateTime64(3)
+ * values across the codebase.
+ *
+ * ClickHouse returns DateTime64(3) as space-separated strings without a
+ * timezone suffix (e.g. "2024-01-15 10:30:00.000"); they should be treated
+ * as UTC. Two parse variants exist for caller convenience but share the same
+ * underlying parsing logic — there is exactly one definition of "what does
+ * ClickHouse mean by a DateTime64 string" in the codebase.
+ *
+ * Use `parseClickHouseDateTime` when you need a `Date` (e.g. arithmetic
+ * before round-tripping back to ClickHouse). Use `parseClickHouseDateTimeMs`
+ * when the canonical domain type is `number` (Unix epoch ms).
+ */
+
+/** Format a Date as a ClickHouse DateTime64(3) string (no timezone). */
+export function formatClickHouseDateTime(d: Date): string {
+  return d.toISOString().replace("T", " ").replace("Z", "");
+}
+
+/** Parse a ClickHouse DateTime64(3) string into a JS Date (UTC). */
+export function parseClickHouseDateTime(s: string): Date {
+  return new Date(s.replace(" ", "T") + "Z");
+}
+
+/**
+ * Parse a ClickHouse DateTime64(3) string into Unix epoch milliseconds.
+ * Returns 0 on parse failure, matching the prior behavior of the inline
+ * implementation in `evaluations-v3/services/mappers.ts`.
+ */
+export function parseClickHouseDateTimeMs(s: string): number {
+  const ms = parseClickHouseDateTime(s).getTime();
+  return isNaN(ms) ? 0 : ms;
+}

--- a/langwatch/src/server/evaluations-v3/services/__tests__/mappers.test.ts
+++ b/langwatch/src/server/evaluations-v3/services/__tests__/mappers.test.ts
@@ -49,6 +49,7 @@ const workflowVersion: ExperimentRunWorkflowVersion = {
 
 const evaluatorBreakdown: ClickHouseEvaluatorBreakdownRow[] = [
   {
+    ExperimentId: "exp-1",
     RunId: "run-1",
     EvaluatorId: "eval-1",
     EvaluatorName: "Accuracy",
@@ -57,6 +58,7 @@ const evaluatorBreakdown: ClickHouseEvaluatorBreakdownRow[] = [
     hasPassedCount: 4,
   },
   {
+    ExperimentId: "exp-1",
     RunId: "run-1",
     EvaluatorId: "eval-2",
     EvaluatorName: null,

--- a/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.queries.ts
+++ b/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.queries.ts
@@ -1,0 +1,82 @@
+/**
+ * Query-construction helpers for `ClickHouseExperimentRunService`.
+ *
+ * Kept separate from the service so the service file can stay focused on
+ * orchestration (call query, map result, return) rather than mixing in
+ * partition-bound math and SQL parameter derivation.
+ */
+
+import {
+  formatClickHouseDateTime,
+  parseClickHouseDateTime,
+} from "~/server/clickhouse/dateTime";
+import type { ClickHouseExperimentRunRow } from "./mappers";
+
+/**
+ * Buffer applied to OccurredAt range filters, in milliseconds.
+ *
+ * `experiment_runs.UpdatedAt` is server wall-clock (`Date.now()` on the API
+ * node), but `experiment_run_items.OccurredAt` is sourced from the SDK's
+ * `event.occurredAt` — i.e. the wall-clock of whatever machine ran the
+ * BatchEvaluation, which in practice is often a developer laptop. Client
+ * clock drift (not inter-node ClickHouse skew) is the dominant source of
+ * skew here and can realistically reach several hours.
+ *
+ * 24h is wide enough to absorb everyday client drift while still pruning
+ * the vast majority of weekly partitions. If specific users start seeing
+ * phantom-missing items in the breakdown / cost summary, widen further or
+ * watch for `WARN_OLD_RUN_AGE_MS` log entries paired with user reports.
+ *
+ * Tunable: lift to a config module / env var if we ever need to vary it
+ * per environment.
+ */
+export const OCCURRED_AT_BUFFER_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * If any run being queried has a `CreatedAt` older than this, the service
+ * emits a warning. Lets us re-tune `OCCURRED_AT_BUFFER_MS` empirically: if
+ * old-run warnings coincide with user reports of missing breakdown rows,
+ * the buffer is too tight for the client-clock drift in that environment.
+ */
+export const WARN_OLD_RUN_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Derive a tight OccurredAt range for `experiment_run_items` queries from
+ * the runs being queried. Items can't be older than the earliest run's
+ * CreatedAt or newer than the latest run's UpdatedAt (modulo clock skew /
+ * late writes, absorbed by `OCCURRED_AT_BUFFER_MS`). This bound lets
+ * ClickHouse prune the weekly partitions that don't overlap the run window.
+ *
+ * Returns ClickHouse-formatted DateTime64(3) strings ready to pass as query
+ * parameters, plus the raw `minMs` so the caller can decide whether to emit
+ * an old-runs warning without reparsing the timestamps.
+ *
+ * Throws if `runs` is empty — callers must guard. Without this check the
+ * function would silently return `Invalid Date` strings (from
+ * `Math.min(...[])` → `Infinity`) which ClickHouse would reject with an
+ * opaque parse error.
+ */
+export function computeOccurredAtRangeForRuns(
+  runs: Pick<ClickHouseExperimentRunRow, "CreatedAt" | "UpdatedAt">[],
+): { minOccurredAt: string; maxOccurredAt: string; minMs: number } {
+  if (runs.length === 0) {
+    throw new Error(
+      "computeOccurredAtRangeForRuns called with no runs; caller must guard",
+    );
+  }
+  let minMs = Infinity;
+  let maxMs = -Infinity;
+  for (const r of runs) {
+    minMs = Math.min(minMs, parseClickHouseDateTime(r.CreatedAt).getTime());
+    maxMs = Math.max(maxMs, parseClickHouseDateTime(r.UpdatedAt).getTime());
+  }
+  return {
+    minOccurredAt: formatClickHouseDateTime(
+      new Date(minMs - OCCURRED_AT_BUFFER_MS),
+    ),
+    maxOccurredAt: formatClickHouseDateTime(
+      new Date(maxMs + OCCURRED_AT_BUFFER_MS),
+    ),
+    minMs,
+  };
+}

--- a/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts
+++ b/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts
@@ -6,6 +6,11 @@ import { prisma as defaultPrisma } from "~/server/db";
 import { createLogger } from "~/utils/logger/server";
 import { getVersionMap } from "./getVersionMap";
 
+import {
+  computeOccurredAtRangeForRuns,
+  OCCURRED_AT_BUFFER_MS,
+  WARN_OLD_RUN_AGE_MS,
+} from "./clickhouse-experiment-run.queries";
 import type {
   ClickHouseCostSummaryRow,
   ClickHouseEvaluatorBreakdownRow,
@@ -17,61 +22,6 @@ import {
   mapClickHouseRunToExperimentRun,
 } from "./mappers";
 import type { ExperimentRun, ExperimentRunWithItems } from "./types";
-
-/**
- * Format a Date as a ClickHouse DateTime64(3) string (no timezone).
- * ClickHouse parses this in the table's column timezone (UTC by default).
- */
-function formatClickHouseDateTime(d: Date): string {
-  return d.toISOString().replace("T", " ").replace("Z", "");
-}
-
-/**
- * Parse a ClickHouse DateTime64(3) string (e.g. "2024-01-15 10:30:00.000")
- * into a JS Date. ClickHouse returns these as space-separated strings without
- * a timezone suffix; treat them as UTC.
- */
-function parseClickHouseDateTime(s: string): Date {
-  return new Date(s.replace(" ", "T") + "Z");
-}
-
-/**
- * Buffer applied to OccurredAt range filters, in milliseconds. Items can
- * legitimately land slightly before the run's CreatedAt (clock skew between
- * ClickHouse nodes / SDK clients) and slightly after FinishedAt (late writes
- * from background workers). One hour is generous and still prunes the vast
- * majority of historical partitions (which are weekly).
- */
-const OCCURRED_AT_BUFFER_MS = 60 * 60 * 1000;
-
-/**
- * Derive a tight OccurredAt range for `experiment_run_items` queries from the
- * runs being queried. Items can't be older than the earliest run's CreatedAt
- * or newer than the latest run's UpdatedAt (modulo clock skew / late writes,
- * absorbed by `OCCURRED_AT_BUFFER_MS`). This bound lets ClickHouse prune the
- * weekly partitions that don't overlap the run window.
- *
- * Returns ClickHouse-formatted DateTime64(3) strings ready to pass as query
- * parameters.
- */
-function computeOccurredAtRangeForRuns(
-  runs: Pick<ClickHouseExperimentRunRow, "CreatedAt" | "UpdatedAt">[],
-): { minOccurredAt: string; maxOccurredAt: string } {
-  let minMs = Infinity;
-  let maxMs = -Infinity;
-  for (const r of runs) {
-    minMs = Math.min(minMs, parseClickHouseDateTime(r.CreatedAt).getTime());
-    maxMs = Math.max(maxMs, parseClickHouseDateTime(r.UpdatedAt).getTime());
-  }
-  return {
-    minOccurredAt: formatClickHouseDateTime(
-      new Date(minMs - OCCURRED_AT_BUFFER_MS),
-    ),
-    maxOccurredAt: formatClickHouseDateTime(
-      new Date(maxMs + OCCURRED_AT_BUFFER_MS),
-    ),
-  };
-}
 
 /**
  * ClickHouse backend for experiment run queries.
@@ -98,6 +48,36 @@ export class ClickHouseExperimentRunService {
     prisma: PrismaClient = defaultPrisma,
   ): ClickHouseExperimentRunService {
     return new ClickHouseExperimentRunService(prisma);
+  }
+
+  /**
+   * Emit a warning when the oldest run being queried is older than
+   * `WARN_OLD_RUN_AGE_MS`. Pairs with `OCCURRED_AT_BUFFER_MS`: if old-run
+   * warnings start showing up alongside reports of missing breakdown / cost
+   * rows, the buffer is too tight for the SDK client clock drift in that
+   * environment and should be widened.
+   */
+  private warnIfRunsAreOld({
+    projectId,
+    minMs,
+    runCount,
+  }: {
+    projectId: string;
+    minMs: number;
+    runCount: number;
+  }): void {
+    const ageMs = Date.now() - minMs;
+    if (ageMs > WARN_OLD_RUN_AGE_MS) {
+      this.logger.warn(
+        {
+          projectId,
+          oldestRunAgeDays: Math.floor(ageMs / (24 * 60 * 60 * 1000)),
+          runCount,
+          occurredAtBufferHours: OCCURRED_AT_BUFFER_MS / (60 * 60 * 1000),
+        },
+        "Querying experiment runs with very old CreatedAt; if users report missing items, OCCURRED_AT_BUFFER_MS may need to widen",
+      );
+    }
   }
 
   /**
@@ -186,6 +166,11 @@ export class ClickHouseExperimentRunService {
             (r) => new TupleParam([r.ExperimentId, r.RunId]),
           );
           const occurredAtRange = computeOccurredAtRangeForRuns(runRows);
+          this.warnIfRunsAreOld({
+            projectId,
+            minMs: occurredAtRange.minMs,
+            runCount: runRows.length,
+          });
 
           // Fetch per-evaluator breakdown for all runs.
           //
@@ -436,6 +421,11 @@ export class ClickHouseExperimentRunService {
           // `toYearWeek(OccurredAt)`, so without this bound a query against an
           // older run would scan every partition since the table was created.
           const occurredAtRange = computeOccurredAtRangeForRuns([runRecord]);
+          this.warnIfRunsAreOld({
+            projectId,
+            minMs: occurredAtRange.minMs,
+            runCount: 1,
+          });
 
           // Fetch all items for this run.
           //

--- a/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts
+++ b/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts
@@ -111,7 +111,15 @@ export class ClickHouseExperimentRunService {
             return {};
           }
 
-          // Fetch per-evaluator breakdown for all runs
+          // Fetch per-evaluator breakdown for all runs.
+          //
+          // Dedup uses an IN-tuple subquery on (key columns, OccurredAt) instead
+          // of LIMIT 1 BY. ClickHouse's LIMIT 1 BY reads every selected column
+          // (including heavy payloads like EvaluationDetails / EvaluationInputs)
+          // before deduplicating, which can OOM on large parts. The IN-tuple
+          // pattern resolves dedup using only lightweight key columns and the
+          // ReplacingMergeTree version column (OccurredAt). See
+          // trace-dedup-oom-safety.unit.test.ts for the rationale.
           const runIds = runRows.map((r) => r.RunId);
           const breakdownResult = await clickHouseClient.query({
             query: `
@@ -123,22 +131,28 @@ export class ClickHouseExperimentRunService {
                 avg(Score) AS avgScore,
                 if(countIf(Passed IS NOT NULL) > 0, countIf(Passed = 1) / countIf(Passed IS NOT NULL), NULL) AS passRate,
                 countIf(Passed IS NOT NULL) AS hasPassedCount
-              FROM (
-                SELECT *
-                FROM (
-                  SELECT *
+              FROM experiment_run_items
+              WHERE TenantId = {tenantId:String}
+                AND ExperimentId IN ({experimentIds:Array(String)})
+                AND RunId IN ({runIds:Array(String)})
+                AND ResultType = 'evaluator'
+                AND EvaluationStatus = 'processed'
+                AND (TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, ''), OccurredAt) IN (
+                  SELECT
+                    TenantId,
+                    ExperimentId,
+                    RunId,
+                    RowIndex,
+                    TargetId,
+                    ResultType,
+                    coalesce(EvaluatorId, ''),
+                    max(OccurredAt)
                   FROM experiment_run_items
                   WHERE TenantId = {tenantId:String}
                     AND ExperimentId IN ({experimentIds:Array(String)})
                     AND RunId IN ({runIds:Array(String)})
-                  ORDER BY ProjectionId, CreatedAt DESC
-                  LIMIT 1 BY TenantId, ExperimentId, RunId, ProjectionId
+                  GROUP BY TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
                 )
-                ORDER BY CreatedAt DESC
-                LIMIT 1 BY ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
-              )
-              WHERE ResultType = 'evaluator'
-                AND EvaluationStatus = 'processed'
               GROUP BY ExperimentId, RunId, EvaluatorId
               LIMIT 10000
             `,
@@ -167,7 +181,9 @@ export class ClickHouseExperimentRunService {
             breakdownByExperimentRun.set(key, existing);
           }
 
-          // Fetch cost/duration summary per run
+          // Fetch cost/duration summary per run.
+          // Dedup uses the same IN-tuple pattern as the breakdown query above —
+          // see comment there for the rationale (LIMIT 1 BY OOM safety).
           const costResult = await clickHouseClient.query({
             query: `
               SELECT
@@ -179,20 +195,26 @@ export class ClickHouseExperimentRunService {
                 avgIf(TargetDurationMs, ResultType = 'target' AND TargetDurationMs IS NOT NULL) AS datasetAverageDuration,
                 avgIf(EvaluationCost, ResultType = 'evaluator' AND EvaluationCost IS NOT NULL) AS evaluationsAverageCost,
                 avgIf(EvaluationDurationMs, ResultType = 'evaluator' AND EvaluationDurationMs IS NOT NULL) AS evaluationsAverageDuration
-              FROM (
-                SELECT *
-                FROM (
-                  SELECT *
+              FROM experiment_run_items
+              WHERE TenantId = {tenantId:String}
+                AND ExperimentId IN ({experimentIds:Array(String)})
+                AND RunId IN ({runIds:Array(String)})
+                AND (TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, ''), OccurredAt) IN (
+                  SELECT
+                    TenantId,
+                    ExperimentId,
+                    RunId,
+                    RowIndex,
+                    TargetId,
+                    ResultType,
+                    coalesce(EvaluatorId, ''),
+                    max(OccurredAt)
                   FROM experiment_run_items
                   WHERE TenantId = {tenantId:String}
                     AND ExperimentId IN ({experimentIds:Array(String)})
                     AND RunId IN ({runIds:Array(String)})
-                  ORDER BY ProjectionId, CreatedAt DESC
-                  LIMIT 1 BY TenantId, ExperimentId, RunId, ProjectionId
+                  GROUP BY TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
                 )
-                ORDER BY CreatedAt DESC
-                LIMIT 1 BY ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
-              )
               GROUP BY ExperimentId, RunId
               LIMIT 10000
             `,
@@ -328,32 +350,44 @@ export class ClickHouseExperimentRunService {
             return null;
           }
 
-          // Fetch all items for this run
-          // Two-level dedup: first by ProjectionId (handles un-merged ReplacingMergeTree parts),
-          // then by business key (handles duplicate writes from SDK progress updates that
-          // produce different ProjectionIds due to timestamp in the KSUID).
+          // Fetch all items for this run.
           //
-          // ExperimentId is included in the WHERE clause and both LIMIT 1 BY clauses
-          // because runId is not unique across experiments — without this filter,
-          // results from one experiment leak into another's view whenever they share
-          // the same runId (a common pattern when SDK callers reuse a stable run_id
-          // across BatchEvaluation invocations).
+          // ExperimentId is part of the WHERE filter and the dedup key tuple
+          // because runId is not unique across experiments — without it, rows
+          // from one experiment leak into another's view whenever they share
+          // the same runId (e.g. when SDK callers reuse a stable run_id across
+          // BatchEvaluation invocations).
+          //
+          // Dedup uses an IN-tuple subquery on (key columns, OccurredAt) rather
+          // than LIMIT 1 BY: ClickHouse's LIMIT 1 BY reads every selected column
+          // (including heavy payloads like DatasetEntry / EvaluationDetails)
+          // before deduplicating, which can OOM on large parts. The IN-tuple
+          // pattern resolves dedup using only lightweight key columns and the
+          // ReplacingMergeTree version column (OccurredAt). See
+          // trace-dedup-oom-safety.unit.test.ts for the rationale.
           const itemsResult = await clickHouseClient.query({
             query: `
-              SELECT * FROM (
-                SELECT *
-                FROM (
-                  SELECT *
+              SELECT *
+              FROM experiment_run_items
+              WHERE TenantId = {tenantId:String}
+                AND ExperimentId = {experimentId:String}
+                AND RunId = {runId:String}
+                AND (TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, ''), OccurredAt) IN (
+                  SELECT
+                    TenantId,
+                    ExperimentId,
+                    RunId,
+                    RowIndex,
+                    TargetId,
+                    ResultType,
+                    coalesce(EvaluatorId, ''),
+                    max(OccurredAt)
                   FROM experiment_run_items
                   WHERE TenantId = {tenantId:String}
                     AND ExperimentId = {experimentId:String}
                     AND RunId = {runId:String}
-                  ORDER BY ProjectionId, CreatedAt DESC
-                  LIMIT 1 BY TenantId, ExperimentId, RunId, ProjectionId
+                  GROUP BY TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
                 )
-                ORDER BY CreatedAt DESC
-                LIMIT 1 BY ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
-              )
               ORDER BY RowIndex ASC, ResultType ASC
             `,
             query_params: {

--- a/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts
+++ b/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts
@@ -1,3 +1,4 @@
+import { TupleParam } from "@clickhouse/client";
 import type { PrismaClient } from "@prisma/client";
 import { getLangWatchTracer } from "langwatch";
 import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
@@ -16,6 +17,61 @@ import {
   mapClickHouseRunToExperimentRun,
 } from "./mappers";
 import type { ExperimentRun, ExperimentRunWithItems } from "./types";
+
+/**
+ * Format a Date as a ClickHouse DateTime64(3) string (no timezone).
+ * ClickHouse parses this in the table's column timezone (UTC by default).
+ */
+function formatClickHouseDateTime(d: Date): string {
+  return d.toISOString().replace("T", " ").replace("Z", "");
+}
+
+/**
+ * Parse a ClickHouse DateTime64(3) string (e.g. "2024-01-15 10:30:00.000")
+ * into a JS Date. ClickHouse returns these as space-separated strings without
+ * a timezone suffix; treat them as UTC.
+ */
+function parseClickHouseDateTime(s: string): Date {
+  return new Date(s.replace(" ", "T") + "Z");
+}
+
+/**
+ * Buffer applied to OccurredAt range filters, in milliseconds. Items can
+ * legitimately land slightly before the run's CreatedAt (clock skew between
+ * ClickHouse nodes / SDK clients) and slightly after FinishedAt (late writes
+ * from background workers). One hour is generous and still prunes the vast
+ * majority of historical partitions (which are weekly).
+ */
+const OCCURRED_AT_BUFFER_MS = 60 * 60 * 1000;
+
+/**
+ * Derive a tight OccurredAt range for `experiment_run_items` queries from the
+ * runs being queried. Items can't be older than the earliest run's CreatedAt
+ * or newer than the latest run's UpdatedAt (modulo clock skew / late writes,
+ * absorbed by `OCCURRED_AT_BUFFER_MS`). This bound lets ClickHouse prune the
+ * weekly partitions that don't overlap the run window.
+ *
+ * Returns ClickHouse-formatted DateTime64(3) strings ready to pass as query
+ * parameters.
+ */
+function computeOccurredAtRangeForRuns(
+  runs: Pick<ClickHouseExperimentRunRow, "CreatedAt" | "UpdatedAt">[],
+): { minOccurredAt: string; maxOccurredAt: string } {
+  let minMs = Infinity;
+  let maxMs = -Infinity;
+  for (const r of runs) {
+    minMs = Math.min(minMs, parseClickHouseDateTime(r.CreatedAt).getTime());
+    maxMs = Math.max(maxMs, parseClickHouseDateTime(r.UpdatedAt).getTime());
+  }
+  return {
+    minOccurredAt: formatClickHouseDateTime(
+      new Date(minMs - OCCURRED_AT_BUFFER_MS),
+    ),
+    maxOccurredAt: formatClickHouseDateTime(
+      new Date(maxMs + OCCURRED_AT_BUFFER_MS),
+    ),
+  };
+}
 
 /**
  * ClickHouse backend for experiment run queries.
@@ -111,6 +167,26 @@ export class ClickHouseExperimentRunService {
             return {};
           }
 
+          // Build the exact (ExperimentId, RunId) tuple list and an OccurredAt
+          // bound from the runs we just fetched. Two reasons:
+          //
+          //   1. `ExperimentId IN (...) AND RunId IN (...)` would match the
+          //      cartesian product of those sets, pulling in unrelated rows
+          //      whenever a runId happens to be reused across experiments.
+          //      Filtering by exact pairs eliminates that overfetching and
+          //      avoids wasting LIMIT slots on rows that get discarded.
+          //
+          //   2. `experiment_run_items` is partitioned by `toYearWeek(OccurredAt)`.
+          //      Without an OccurredAt range in the WHERE clause, ClickHouse
+          //      cannot prune historical partitions and ends up scanning the
+          //      whole table. Bounds derived from the runs' lifecycle
+          //      (CreatedAt..UpdatedAt with a buffer for clock skew / late
+          //      writes) keep this cheap.
+          const runPairs = runRows.map(
+            (r) => new TupleParam([r.ExperimentId, r.RunId]),
+          );
+          const occurredAtRange = computeOccurredAtRangeForRuns(runRows);
+
           // Fetch per-evaluator breakdown for all runs.
           //
           // Dedup uses an IN-tuple subquery on (key columns, OccurredAt) instead
@@ -120,7 +196,6 @@ export class ClickHouseExperimentRunService {
           // pattern resolves dedup using only lightweight key columns and the
           // ReplacingMergeTree version column (OccurredAt). See
           // trace-dedup-oom-safety.unit.test.ts for the rationale.
-          const runIds = runRows.map((r) => r.RunId);
           const breakdownResult = await clickHouseClient.query({
             query: `
               SELECT
@@ -133,8 +208,9 @@ export class ClickHouseExperimentRunService {
                 countIf(Passed IS NOT NULL) AS hasPassedCount
               FROM experiment_run_items
               WHERE TenantId = {tenantId:String}
-                AND ExperimentId IN ({experimentIds:Array(String)})
-                AND RunId IN ({runIds:Array(String)})
+                AND OccurredAt >= {minOccurredAt:DateTime64(3)}
+                AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
+                AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}
                 AND ResultType = 'evaluator'
                 AND EvaluationStatus = 'processed'
                 AND (TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, ''), OccurredAt) IN (
@@ -149,8 +225,9 @@ export class ClickHouseExperimentRunService {
                     max(OccurredAt)
                   FROM experiment_run_items
                   WHERE TenantId = {tenantId:String}
-                    AND ExperimentId IN ({experimentIds:Array(String)})
-                    AND RunId IN ({runIds:Array(String)})
+                    AND OccurredAt >= {minOccurredAt:DateTime64(3)}
+                    AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
+                    AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}
                   GROUP BY TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
                 )
               GROUP BY ExperimentId, RunId, EvaluatorId
@@ -158,8 +235,9 @@ export class ClickHouseExperimentRunService {
             `,
             query_params: {
               tenantId: projectId,
-              experimentIds,
-              runIds,
+              runPairs,
+              minOccurredAt: occurredAtRange.minOccurredAt,
+              maxOccurredAt: occurredAtRange.maxOccurredAt,
             },
             format: "JSONEachRow",
           });
@@ -182,8 +260,8 @@ export class ClickHouseExperimentRunService {
           }
 
           // Fetch cost/duration summary per run.
-          // Dedup uses the same IN-tuple pattern as the breakdown query above —
-          // see comment there for the rationale (LIMIT 1 BY OOM safety).
+          // Same exact-pair + OccurredAt-bounded + IN-tuple-dedup pattern as
+          // the breakdown query above — see comment there for the rationale.
           const costResult = await clickHouseClient.query({
             query: `
               SELECT
@@ -197,8 +275,9 @@ export class ClickHouseExperimentRunService {
                 avgIf(EvaluationDurationMs, ResultType = 'evaluator' AND EvaluationDurationMs IS NOT NULL) AS evaluationsAverageDuration
               FROM experiment_run_items
               WHERE TenantId = {tenantId:String}
-                AND ExperimentId IN ({experimentIds:Array(String)})
-                AND RunId IN ({runIds:Array(String)})
+                AND OccurredAt >= {minOccurredAt:DateTime64(3)}
+                AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
+                AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}
                 AND (TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, ''), OccurredAt) IN (
                   SELECT
                     TenantId,
@@ -211,8 +290,9 @@ export class ClickHouseExperimentRunService {
                     max(OccurredAt)
                   FROM experiment_run_items
                   WHERE TenantId = {tenantId:String}
-                    AND ExperimentId IN ({experimentIds:Array(String)})
-                    AND RunId IN ({runIds:Array(String)})
+                    AND OccurredAt >= {minOccurredAt:DateTime64(3)}
+                    AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
+                    AND (ExperimentId, RunId) IN {runPairs:Array(Tuple(String, String))}
                   GROUP BY TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
                 )
               GROUP BY ExperimentId, RunId
@@ -220,8 +300,9 @@ export class ClickHouseExperimentRunService {
             `,
             query_params: {
               tenantId: projectId,
-              experimentIds,
-              runIds,
+              runPairs,
+              minOccurredAt: occurredAtRange.minOccurredAt,
+              maxOccurredAt: occurredAtRange.maxOccurredAt,
             },
             format: "JSONEachRow",
           });
@@ -350,6 +431,12 @@ export class ClickHouseExperimentRunService {
             return null;
           }
 
+          // Bound OccurredAt by the run's lifecycle so ClickHouse can prune
+          // historical partitions. `experiment_run_items` is partitioned by
+          // `toYearWeek(OccurredAt)`, so without this bound a query against an
+          // older run would scan every partition since the table was created.
+          const occurredAtRange = computeOccurredAtRangeForRuns([runRecord]);
+
           // Fetch all items for this run.
           //
           // ExperimentId is part of the WHERE filter and the dedup key tuple
@@ -372,6 +459,8 @@ export class ClickHouseExperimentRunService {
               WHERE TenantId = {tenantId:String}
                 AND ExperimentId = {experimentId:String}
                 AND RunId = {runId:String}
+                AND OccurredAt >= {minOccurredAt:DateTime64(3)}
+                AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
                 AND (TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, ''), OccurredAt) IN (
                   SELECT
                     TenantId,
@@ -386,6 +475,8 @@ export class ClickHouseExperimentRunService {
                   WHERE TenantId = {tenantId:String}
                     AND ExperimentId = {experimentId:String}
                     AND RunId = {runId:String}
+                    AND OccurredAt >= {minOccurredAt:DateTime64(3)}
+                    AND OccurredAt <= {maxOccurredAt:DateTime64(3)}
                   GROUP BY TenantId, ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
                 )
               ORDER BY RowIndex ASC, ResultType ASC
@@ -394,6 +485,8 @@ export class ClickHouseExperimentRunService {
               tenantId: projectId,
               experimentId,
               runId,
+              minOccurredAt: occurredAtRange.minOccurredAt,
+              maxOccurredAt: occurredAtRange.maxOccurredAt,
             },
             format: "JSONEachRow",
           });

--- a/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts
+++ b/langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts
@@ -116,6 +116,7 @@ export class ClickHouseExperimentRunService {
           const breakdownResult = await clickHouseClient.query({
             query: `
               SELECT
+                ExperimentId,
                 RunId,
                 EvaluatorId,
                 max(EvaluatorName) AS EvaluatorName,
@@ -128,20 +129,22 @@ export class ClickHouseExperimentRunService {
                   SELECT *
                   FROM experiment_run_items
                   WHERE TenantId = {tenantId:String}
+                    AND ExperimentId IN ({experimentIds:Array(String)})
                     AND RunId IN ({runIds:Array(String)})
                   ORDER BY ProjectionId, CreatedAt DESC
-                  LIMIT 1 BY TenantId, RunId, ProjectionId
+                  LIMIT 1 BY TenantId, ExperimentId, RunId, ProjectionId
                 )
                 ORDER BY CreatedAt DESC
-                LIMIT 1 BY RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
+                LIMIT 1 BY ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
               )
               WHERE ResultType = 'evaluator'
                 AND EvaluationStatus = 'processed'
-              GROUP BY RunId, EvaluatorId
+              GROUP BY ExperimentId, RunId, EvaluatorId
               LIMIT 10000
             `,
             query_params: {
               tenantId: projectId,
+              experimentIds,
               runIds,
             },
             format: "JSONEachRow",
@@ -150,21 +153,25 @@ export class ClickHouseExperimentRunService {
           const breakdownRows =
             (await breakdownResult.json()) as ClickHouseEvaluatorBreakdownRow[];
 
-          // Group breakdown by RunId
-          const breakdownByRunId = new Map<
+          // Group breakdown by (ExperimentId, RunId) — runIds are not unique
+          // across experiments, so a composite key is required to avoid mixing
+          // results between experiments that happen to share a runId.
+          const breakdownByExperimentRun = new Map<
             string,
             ClickHouseEvaluatorBreakdownRow[]
           >();
           for (const row of breakdownRows) {
-            const existing = breakdownByRunId.get(row.RunId) ?? [];
+            const key = `${row.ExperimentId}:${row.RunId}`;
+            const existing = breakdownByExperimentRun.get(key) ?? [];
             existing.push(row);
-            breakdownByRunId.set(row.RunId, existing);
+            breakdownByExperimentRun.set(key, existing);
           }
 
           // Fetch cost/duration summary per run
           const costResult = await clickHouseClient.query({
             query: `
               SELECT
+                ExperimentId,
                 RunId,
                 sumIf(TargetCost, ResultType = 'target') AS datasetCost,
                 sumIf(EvaluationCost, ResultType = 'evaluator') AS evaluationsCost,
@@ -178,18 +185,20 @@ export class ClickHouseExperimentRunService {
                   SELECT *
                   FROM experiment_run_items
                   WHERE TenantId = {tenantId:String}
+                    AND ExperimentId IN ({experimentIds:Array(String)})
                     AND RunId IN ({runIds:Array(String)})
                   ORDER BY ProjectionId, CreatedAt DESC
-                  LIMIT 1 BY TenantId, RunId, ProjectionId
+                  LIMIT 1 BY TenantId, ExperimentId, RunId, ProjectionId
                 )
                 ORDER BY CreatedAt DESC
-                LIMIT 1 BY RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
+                LIMIT 1 BY ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
               )
-              GROUP BY RunId
+              GROUP BY ExperimentId, RunId
               LIMIT 10000
             `,
             query_params: {
               tenantId: projectId,
+              experimentIds,
               runIds,
             },
             format: "JSONEachRow",
@@ -198,9 +207,10 @@ export class ClickHouseExperimentRunService {
           const costRows =
             (await costResult.json()) as ClickHouseCostSummaryRow[];
 
-          const costByRunId = new Map<string, ClickHouseCostSummaryRow>();
+          // Same composite key as breakdownByExperimentRun.
+          const costByExperimentRun = new Map<string, ClickHouseCostSummaryRow>();
           for (const row of costRows) {
-            costByRunId.set(row.RunId, row);
+            costByExperimentRun.set(`${row.ExperimentId}:${row.RunId}`, row);
           }
 
           // Fetch workflow version metadata from Prisma
@@ -222,11 +232,12 @@ export class ClickHouseExperimentRunService {
               ? (versionsMap[row.WorkflowVersionId] ?? null)
               : null;
 
+            const compositeKey = `${row.ExperimentId}:${row.RunId}`;
             const run = mapClickHouseRunToExperimentRun({
               record: row,
               workflowVersion,
-              evaluatorBreakdown: breakdownByRunId.get(row.RunId),
-              costSummary: costByRunId.get(row.RunId),
+              evaluatorBreakdown: breakdownByExperimentRun.get(compositeKey),
+              costSummary: costByExperimentRun.get(compositeKey),
             });
 
             if (!(run.experimentId in result)) {
@@ -321,6 +332,12 @@ export class ClickHouseExperimentRunService {
           // Two-level dedup: first by ProjectionId (handles un-merged ReplacingMergeTree parts),
           // then by business key (handles duplicate writes from SDK progress updates that
           // produce different ProjectionIds due to timestamp in the KSUID).
+          //
+          // ExperimentId is included in the WHERE clause and both LIMIT 1 BY clauses
+          // because runId is not unique across experiments — without this filter,
+          // results from one experiment leak into another's view whenever they share
+          // the same runId (a common pattern when SDK callers reuse a stable run_id
+          // across BatchEvaluation invocations).
           const itemsResult = await clickHouseClient.query({
             query: `
               SELECT * FROM (
@@ -329,17 +346,19 @@ export class ClickHouseExperimentRunService {
                   SELECT *
                   FROM experiment_run_items
                   WHERE TenantId = {tenantId:String}
+                    AND ExperimentId = {experimentId:String}
                     AND RunId = {runId:String}
                   ORDER BY ProjectionId, CreatedAt DESC
-                  LIMIT 1 BY TenantId, RunId, ProjectionId
+                  LIMIT 1 BY TenantId, ExperimentId, RunId, ProjectionId
                 )
                 ORDER BY CreatedAt DESC
-                LIMIT 1 BY RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
+                LIMIT 1 BY ExperimentId, RunId, RowIndex, TargetId, ResultType, coalesce(EvaluatorId, '')
               )
               ORDER BY RowIndex ASC, ResultType ASC
             `,
             query_params: {
               tenantId: projectId,
+              experimentId,
               runId,
             },
             format: "JSONEachRow",

--- a/langwatch/src/server/evaluations-v3/services/mappers.ts
+++ b/langwatch/src/server/evaluations-v3/services/mappers.ts
@@ -4,7 +4,7 @@
  * canonical camelCase service types.
  */
 
-import { parse } from "date-fns";
+import { parseClickHouseDateTimeMs } from "~/server/clickhouse/dateTime";
 import type {
   ESBatchEvaluation,
   ESBatchEvaluationTarget,
@@ -152,13 +152,13 @@ export function mapClickHouseRunToExperimentRun({
     runId: record.RunId,
     workflowVersion: workflowVersion ?? null,
     timestamps: {
-      createdAt: parseClickHouseDateTime(record.CreatedAt),
-      updatedAt: parseClickHouseDateTime(record.UpdatedAt),
+      createdAt: parseClickHouseDateTimeMs(record.CreatedAt),
+      updatedAt: parseClickHouseDateTimeMs(record.UpdatedAt),
       finishedAt: record.FinishedAt
-        ? parseClickHouseDateTime(record.FinishedAt)
+        ? parseClickHouseDateTimeMs(record.FinishedAt)
         : null,
       stoppedAt: record.StoppedAt
-        ? parseClickHouseDateTime(record.StoppedAt)
+        ? parseClickHouseDateTimeMs(record.StoppedAt)
         : null,
     },
     progress: record.Progress,
@@ -264,13 +264,13 @@ export function mapClickHouseItemsToRunWithItems({
     dataset,
     evaluations,
     timestamps: {
-      createdAt: parseClickHouseDateTime(runRecord.CreatedAt),
-      updatedAt: parseClickHouseDateTime(runRecord.UpdatedAt),
+      createdAt: parseClickHouseDateTimeMs(runRecord.CreatedAt),
+      updatedAt: parseClickHouseDateTimeMs(runRecord.UpdatedAt),
       finishedAt: runRecord.FinishedAt
-        ? parseClickHouseDateTime(runRecord.FinishedAt)
+        ? parseClickHouseDateTimeMs(runRecord.FinishedAt)
         : null,
       stoppedAt: runRecord.StoppedAt
-        ? parseClickHouseDateTime(runRecord.StoppedAt)
+        ? parseClickHouseDateTimeMs(runRecord.StoppedAt)
         : null,
     },
   };
@@ -457,17 +457,3 @@ export function mapEsTargetsToTargets(
   }));
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Parses a ClickHouse DateTime64(3) string into a Unix timestamp in milliseconds.
- * ClickHouse returns DateTime64(3) as strings like "2024-01-15 10:30:00.000".
- */
-const CLICKHOUSE_DATETIME64_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSX";
-
-function parseClickHouseDateTime(value: string): number {
-  const ms = parse(`${value}Z`, CLICKHOUSE_DATETIME64_FORMAT, new Date(0)).getTime();
-  return isNaN(ms) ? 0 : ms;
-}

--- a/langwatch/src/server/evaluations-v3/services/mappers.ts
+++ b/langwatch/src/server/evaluations-v3/services/mappers.ts
@@ -77,6 +77,7 @@ export interface ClickHouseExperimentRunItemRow {
 
 /** Per-evaluator aggregation row from ClickHouse GROUP BY query. */
 export interface ClickHouseEvaluatorBreakdownRow {
+  ExperimentId: string;
   RunId: string;
   EvaluatorId: string;
   EvaluatorName: string | null;
@@ -87,6 +88,7 @@ export interface ClickHouseEvaluatorBreakdownRow {
 
 /** Per-run cost/duration summary from ClickHouse aggregate query. */
 export interface ClickHouseCostSummaryRow {
+  ExperimentId: string;
   RunId: string;
   datasetCost: number | null;
   evaluationsCost: number | null;


### PR DESCRIPTION
## Summary
The read queries in \`ClickHouseExperimentRunService\` filter \`experiment_run_items\` by \`(TenantId, RunId)\` only — no \`ExperimentId\` filter. Because \`runId\` is **not** unique across experiments (SDK callers commonly reuse a stable \`run_id\` across \`BatchEvaluation\` invocations, each invocation creating a fresh experiment), rows from one experiment leak into every other experiment view that shares the same \`runId\`, producing phantom evaluator badges in the experiment results page.

## Symptom
Reported by users running \`langwatch.batch_evaluation.BatchEvaluation\` repeatedly with code like:

\`\`\`python
experiment_name = "QA_TEST_" + datetime.now().strftime("%Y-%m-%d_%H:%M:%S")  # fresh per invocation
...
BatchEvaluation(
    experiment=experiment_name,
    dataset=dataset_name,
    run_id=dataset_name,                    # ← stable across invocations
    evaluations=["llm-answer-match"],       # ← single evaluator
    callback=...,
)
\`\`\`

After 4 script invocations, the experiment results page shows **4 evaluator badges per row** (visible in user screenshot below) instead of the expected 1.

## Root cause walkthrough
1. Each invocation creates a new \`Experiment\` row (different \`experimentId\`) but writes \`experiment_run_items\` with the same \`RunId\`.
2. The read query in \`getRun\` (and \`listRuns\` breakdown/cost queries) filters only on \`(TenantId, RunId)\`, so it returns rows from **all** experiments that share that \`RunId\`.
3. When evaluator slugs differ across runs (different \`ProjectionId\`), both rows survive the \`LIMIT 1 BY\` dedup → multiple badges per row.
4. When evaluator slugs match (same \`ProjectionId\`), the dedup masks the leak — but Experiment A's row gets silently overwritten by Experiment B's during \`ReplacingMergeTree\` merges. Same data corruption, different presentation.

Reproducer (verified against \`app.langwatch.ai\`):
- One \`BatchEvaluation.run()\` with fresh \`run_id\` and one evaluator → 1 badge per row ✅
- Second \`BatchEvaluation.run()\` against a **new** experiment but reusing the same \`run_id\` and a **different** evaluator slug → first experiment's results page now shows **2 badges** per row ❌ — proving cross-experiment contamination.

## Fix
- Add \`AND ExperimentId = {experimentId:String}\` (or \`IN (...)\`) to the \`WHERE\` clauses of \`getRun\` items query, and \`listRuns\` breakdown + cost queries.
- Add \`ExperimentId\` to the \`LIMIT 1 BY\` dedup clauses so cross-experiment rows that share \`(RunId, RowIndex, EvaluatorId)\` don't collapse if (defensively) the \`WHERE\` filter is bypassed.
- Thread \`ExperimentId\` through \`ClickHouseEvaluatorBreakdownRow\` and \`ClickHouseCostSummaryRow\`, and switch the in-memory grouping maps in \`listRuns\` from \`RunId\`-keyed to \`(ExperimentId, RunId)\`-keyed so a single \`runId\` appearing under multiple experiments is no longer ambiguous in the consumer.

No SDK or write-path changes — purely tightens the read query to match the actual ownership semantics (each \`experiment_run_items\` row belongs to exactly one experiment via its \`ExperimentId\` column).

## Follow-up worth considering (not in this PR)
\`generateDeterministicResultId\` in \`experimentRunResultStorage.mapProjection.ts\` does **not** include \`experimentId\` in the key. Combined with the read fix, the WHERE filter prevents cross-experiment leakage at read time, but writes from two experiments with colliding \`(runId, rowIndex, evaluatorId)\` still produce identical \`ProjectionId\`s and one will overwrite the other during ClickHouse merges. Consider adding \`experimentId\` to the \`ProjectionId\` key in a follow-up.

## Test plan
- [x] CI integration tests in \`experimentRunProcessing.integration.test.ts\` pass against real ClickHouse
- [x] Manual: reproduce the cross-experiment leak on staging, apply patch, confirm each experiment view shows only its own evaluator badges
- [x] Manual: verify \`listRuns\` for projects with overlapping run_ids returns disjoint per-experiment results

🤖 Generated with [Claude Code](https://claude.com/claude-code)