### PR TITLE
fix(sdk): extend timeout for agent span naming test (#3162)

### DIFF
--- a/typescript-sdk/src/observability-sdk/instrumentation/langchain/__tests__/integration/simple-agent-and-tool.integration.test.ts
+++ b/typescript-sdk/src/observability-sdk/instrumentation/langchain/__tests__/integration/simple-agent-and-tool.integration.test.ts
@@ -349,7 +349,7 @@ describe("LangChain Integration Tests", () => {
       expect(toolSpan?.attributes["langwatch.span.type"]).toBe("tool");
     });
 
-    it("should name agent spans as components", async () => {
+    it("should name agent spans as components", { timeout: 30_000 }, async () => {
       const tools = [
         new DynamicStructuredTool({
           name: "search",


### PR DESCRIPTION
## Summary
- `simple-agent-and-tool.integration.test.ts > 'should name agent spans as components'` was timing out at 15s on CI, blocking `sdk-javascript-ci` on every PR.
- The test runs a real agent execution (multi-turn LLM + tool invocation via `gpt-5-mini` with reasoning), which legitimately exceeds 15s on CI.
- Bump its timeout to `30_000` to match the sibling agent-execution test at line 103 in the same file, which uses the identical pattern.

## Root cause
Not a bug in instrumentation — a real network-bound agent call with reasoning can take 15–25s. The other agent test in this file (`should trace tool calling and agent execution`) already runs with `{ timeout: 30_000 }` for the same reason.

Fixes #3162

## Test plan
- [x] Local diff confirms single-line, scoped change
- [ ] CI: `sdk-javascript-ci` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3162