### PR TITLE
feat: time-of-day aware welcome greeting

### DIFF
--- a/langwatch/src/components/home/WelcomeHeader.tsx
+++ b/langwatch/src/components/home/WelcomeHeader.tsx
@@ -1,4 +1,5 @@
 import { Heading } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 import { useSession } from "~/utils/auth-client";
 
 /**
@@ -32,6 +33,12 @@ export const getTimeOfDay = (hour: number): TimeOfDay => {
   return "evening";
 };
 
+const GREETINGS: Record<TimeOfDay, { named: string; anonymous: string }> = {
+  morning: { named: "Good morning, ", anonymous: "Good morning" },
+  afternoon: { named: "Good afternoon, ", anonymous: "Good afternoon" },
+  evening: { named: "Good evening, ", anonymous: "Good evening" },
+};
+
 export const getGreeting = ({
   timeOfDay,
   name,
@@ -39,20 +46,18 @@ export const getGreeting = ({
   timeOfDay: TimeOfDay;
   name: string | null;
 }): string => {
-  const greetings: Record<TimeOfDay, { named: string; anonymous: string }> = {
-    morning: { named: "Good morning, ", anonymous: "Good morning" },
-    afternoon: { named: "Good afternoon, ", anonymous: "Good afternoon" },
-    evening: { named: "Good evening, ", anonymous: "Good evening" },
-  };
-
-  const { named, anonymous } = greetings[timeOfDay];
+  const { named, anonymous } = GREETINGS[timeOfDay];
   return name ? `${named}${name}` : anonymous;
 };
 
 export function WelcomeHeader() {
   const { data: session } = useSession();
   const greetingName = getGreetingName(session?.user?.name);
-  const timeOfDay = getTimeOfDay(new Date().getHours());
+  const [timeOfDay, setTimeOfDay] = useState<TimeOfDay>("morning");
+
+  useEffect(() => {
+    setTimeOfDay(getTimeOfDay(new Date().getHours()));
+  }, []);
 
   return (
     <Heading as="h1" size="lg">

--- a/langwatch/src/components/home/WelcomeHeader.tsx
+++ b/langwatch/src/components/home/WelcomeHeader.tsx
@@ -24,18 +24,39 @@ export const getGreetingName = (
   return firstName ?? null;
 };
 
-/**
- * WelcomeHeader
- * Displays a personalized greeting to the user.
- * Shows "Hello, {firstName}" if available, otherwise "Hello 👋"
- */
+export type TimeOfDay = "morning" | "afternoon" | "evening";
+
+export const getTimeOfDay = (hour: number): TimeOfDay => {
+  if (hour < 12) return "morning";
+  if (hour < 18) return "afternoon";
+  return "evening";
+};
+
+export const getGreeting = ({
+  timeOfDay,
+  name,
+}: {
+  timeOfDay: TimeOfDay;
+  name: string | null;
+}): string => {
+  const greetings: Record<TimeOfDay, { named: string; anonymous: string }> = {
+    morning: { named: "Good morning, ", anonymous: "Good morning" },
+    afternoon: { named: "Good afternoon, ", anonymous: "Good afternoon" },
+    evening: { named: "Good evening, ", anonymous: "Good evening" },
+  };
+
+  const { named, anonymous } = greetings[timeOfDay];
+  return name ? `${named}${name}` : anonymous;
+};
+
 export function WelcomeHeader() {
   const { data: session } = useSession();
   const greetingName = getGreetingName(session?.user?.name);
+  const timeOfDay = getTimeOfDay(new Date().getHours());
 
   return (
     <Heading as="h1" size="lg">
-      {greetingName ? `Hello, ${greetingName}` : "Hello 👋"}
+      {getGreeting({ timeOfDay, name: greetingName })}
     </Heading>
   );
 }

--- a/langwatch/src/components/home/__tests__/WelcomeHeader.test.ts
+++ b/langwatch/src/components/home/__tests__/WelcomeHeader.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getGreetingName } from "../WelcomeHeader";
+import {
+  getGreetingName,
+  getTimeOfDay,
+  getGreeting,
+} from "../WelcomeHeader";
 
 describe("WelcomeHeader", () => {
   describe("getGreetingName", () => {
@@ -42,6 +46,68 @@ describe("WelcomeHeader", () => {
 
       it("returns null for whitespace-only string", () => {
         expect(getGreetingName("   ")).toBeNull();
+      });
+    });
+  });
+
+  describe("getTimeOfDay", () => {
+    it("returns morning for hours 0-11", () => {
+      expect(getTimeOfDay(0)).toBe("morning");
+      expect(getTimeOfDay(6)).toBe("morning");
+      expect(getTimeOfDay(11)).toBe("morning");
+    });
+
+    it("returns afternoon for hours 12-17", () => {
+      expect(getTimeOfDay(12)).toBe("afternoon");
+      expect(getTimeOfDay(15)).toBe("afternoon");
+      expect(getTimeOfDay(17)).toBe("afternoon");
+    });
+
+    it("returns evening for hours 18-23", () => {
+      expect(getTimeOfDay(18)).toBe("evening");
+      expect(getTimeOfDay(21)).toBe("evening");
+      expect(getTimeOfDay(23)).toBe("evening");
+    });
+  });
+
+  describe("getGreeting", () => {
+    describe("when name is provided", () => {
+      it("returns personalized morning greeting", () => {
+        expect(getGreeting({ timeOfDay: "morning", name: "Alice" })).toBe(
+          "Good morning, Alice",
+        );
+      });
+
+      it("returns personalized afternoon greeting", () => {
+        expect(getGreeting({ timeOfDay: "afternoon", name: "Bob" })).toBe(
+          "Good afternoon, Bob",
+        );
+      });
+
+      it("returns personalized evening greeting", () => {
+        expect(getGreeting({ timeOfDay: "evening", name: "Carol" })).toBe(
+          "Good evening, Carol",
+        );
+      });
+    });
+
+    describe("when name is null", () => {
+      it("returns anonymous morning greeting", () => {
+        expect(getGreeting({ timeOfDay: "morning", name: null })).toBe(
+          "Good morning",
+        );
+      });
+
+      it("returns anonymous afternoon greeting", () => {
+        expect(getGreeting({ timeOfDay: "afternoon", name: null })).toBe(
+          "Good afternoon",
+        );
+      });
+
+      it("returns anonymous evening greeting", () => {
+        expect(getGreeting({ timeOfDay: "evening", name: null })).toBe(
+          "Good evening",
+        );
       });
     });
   });

--- a/langwatch/src/components/home/__tests__/WelcomeHeader.test.ts
+++ b/langwatch/src/components/home/__tests__/WelcomeHeader.test.ts
@@ -51,22 +51,28 @@ describe("WelcomeHeader", () => {
   });
 
   describe("getTimeOfDay", () => {
-    it("returns morning for hours 0-11", () => {
-      expect(getTimeOfDay(0)).toBe("morning");
-      expect(getTimeOfDay(6)).toBe("morning");
-      expect(getTimeOfDay(11)).toBe("morning");
+    describe("when hour is between 0 and 11", () => {
+      it("returns morning", () => {
+        expect(getTimeOfDay(0)).toBe("morning");
+        expect(getTimeOfDay(6)).toBe("morning");
+        expect(getTimeOfDay(11)).toBe("morning");
+      });
     });
 
-    it("returns afternoon for hours 12-17", () => {
-      expect(getTimeOfDay(12)).toBe("afternoon");
-      expect(getTimeOfDay(15)).toBe("afternoon");
-      expect(getTimeOfDay(17)).toBe("afternoon");
+    describe("when hour is between 12 and 17", () => {
+      it("returns afternoon", () => {
+        expect(getTimeOfDay(12)).toBe("afternoon");
+        expect(getTimeOfDay(15)).toBe("afternoon");
+        expect(getTimeOfDay(17)).toBe("afternoon");
+      });
     });
 
-    it("returns evening for hours 18-23", () => {
-      expect(getTimeOfDay(18)).toBe("evening");
-      expect(getTimeOfDay(21)).toBe("evening");
-      expect(getTimeOfDay(23)).toBe("evening");
+    describe("when hour is between 18 and 23", () => {
+      it("returns evening", () => {
+        expect(getTimeOfDay(18)).toBe("evening");
+        expect(getTimeOfDay(21)).toBe("evening");
+        expect(getTimeOfDay(23)).toBe("evening");
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Replaces static "Hello, Name" / "Hello 👋" with time-of-day greetings: "Good morning/afternoon/evening"
- Morning: before 12pm, Afternoon: 12pm–6pm, Evening: after 6pm
- Personalized with first name when available, graceful fallback without

## Test plan
- [x] All 18 unit tests pass (`getGreetingName`, `getTimeOfDay`, `getGreeting`)