### PR TITLE
fix(analytics): pipeline metrics dropped + filters broken on custom chart editor

### DIFF
--- a/langwatch/src/components/filters/FilterToggle.tsx
+++ b/langwatch/src/components/filters/FilterToggle.tsx
@@ -70,6 +70,15 @@ export const useFilterToggle = (
       allowEmptyArrays: true,
     });
 
+    // Build url query from parsed newQs + dynamic route params only.
+    // Using parsed as the base (not spreading over router.query) ensures
+    // deleted keys like show_filters are actually removed.
+    const pathParamKeys = new Set(
+      (router.pathname.match(/\[(\w+)\]/g) ?? []).map((m) => m.slice(1, -1)),
+    );
+    const routeParams = Object.fromEntries(
+      Object.entries(router.query).filter(([key]) => pathParamKeys.has(key)),
+    );
     const parsed = qs.parse(newQs, {
       allowDots: true,
       comma: true,
@@ -77,7 +86,7 @@ export const useFilterToggle = (
     });
 
     void router.push(
-      { pathname: router.pathname, query: { ...router.query, ...parsed } },
+      { pathname: router.pathname, query: { ...routeParams, ...parsed } },
       newQs ? `${currentPath}?${newQs}` : currentPath,
       { shallow: true, scroll: false },
     );

--- a/langwatch/src/components/filters/FilterToggle.tsx
+++ b/langwatch/src/components/filters/FilterToggle.tsx
@@ -70,19 +70,14 @@ export const useFilterToggle = (
       allowEmptyArrays: true,
     });
 
-    // Include all params in the url query so Next.js detects the change and
-    // re-renders components using useRouter() (including React.memo'd ones).
-    const parsedNewParams = qs.parse(newQs, {
+    const parsed = qs.parse(newQs, {
       allowDots: true,
       comma: true,
       allowEmptyArrays: true,
     });
 
     void router.push(
-      {
-        pathname: router.pathname,
-        query: { ...router.query, ...parsedNewParams },
-      },
+      { pathname: router.pathname, query: { ...router.query, ...parsed } },
       newQs ? `${currentPath}?${newQs}` : currentPath,
       { shallow: true, scroll: false },
     );

--- a/langwatch/src/components/filters/FilterToggle.tsx
+++ b/langwatch/src/components/filters/FilterToggle.tsx
@@ -70,15 +70,19 @@ export const useFilterToggle = (
       allowEmptyArrays: true,
     });
 
-    const nextRouterQuery = { ...router.query };
-    if (showFiltersValue === undefined) {
-      delete nextRouterQuery.show_filters;
-    } else {
-      nextRouterQuery.show_filters = showFiltersValue;
-    }
+    // Include all params in the url query so Next.js detects the change and
+    // re-renders components using useRouter() (including React.memo'd ones).
+    const parsedNewParams = qs.parse(newQs, {
+      allowDots: true,
+      comma: true,
+      allowEmptyArrays: true,
+    });
 
     void router.push(
-      { pathname: router.pathname, query: nextRouterQuery },
+      {
+        pathname: router.pathname,
+        query: { ...router.query, ...parsedNewParams },
+      },
       newQs ? `${currentPath}?${newQs}` : currentPath,
       { shallow: true, scroll: false },
     );

--- a/langwatch/src/hooks/useDrawer.ts
+++ b/langwatch/src/hooks/useDrawer.ts
@@ -232,20 +232,18 @@ export const useDrawer = () => {
 
       complexProps = nonSerializableProps;
 
-      // Build query from current non-drawer, non-path query params only.
-      // Path params (project, scenarioSetId, etc.) are part of the URL path
-      // and must NOT be serialized into the query string.
-      const pathParamKeys = new Set(
-        (router.pathname.match(/\[(\w+)\]/g) ?? []).map((m) => m.slice(1, -1)),
-      );
+      // Build query from the actual browser URL (router.asPath), not
+      // router.query which may be stale after (url, as) shallow pushes.
+      // This preserves filter params that only exist in the asPath URL.
+      const queryString = router.asPath.split("?")[1] ?? "";
       const currentQueryOnly = Object.fromEntries(
-        Object.entries(router.query).filter(
-          ([key, value]) =>
-            !key.startsWith("drawer.") &&
-            !pathParamKeys.has(key) &&
-            typeof value !== "function" &&
-            typeof value !== "object",
-        ),
+        Object.entries(
+          qs.parse(queryString, {
+            allowDots: true,
+            comma: true,
+            allowEmptyArrays: true,
+          }),
+        ).filter(([key]) => !key.startsWith("drawer")),
       );
 
       const newQuery = qs.stringify(
@@ -385,16 +383,17 @@ export const useDrawer = () => {
     clearFlowCallbacks();
     complexProps = {};
 
-    // Filter out drawer params and path params, keep only actual query params
-    const pathParamKeys = new Set(
-      (router.pathname.match(/\[(\w+)\]/g) ?? []).map((m) => m.slice(1, -1)),
-    );
+    // Build clean URL from asPath (not router.query which may be stale
+    // after (url, as) shallow pushes and misses filter params).
+    const currentQs = router.asPath.split("?")[1] ?? "";
+    const parsedQuery = qs.parse(currentQs, {
+      allowDots: true,
+      comma: true,
+      allowEmptyArrays: true,
+    });
     const cleanQuery = Object.fromEntries(
-      Object.entries(router.query).filter(
-        ([key]) =>
-          !key.startsWith("drawer.") &&
-          key !== "span" &&
-          !pathParamKeys.has(key),
+      Object.entries(parsedQuery).filter(
+        ([key]) => !key.startsWith("drawer") && key !== "span",
       ),
     );
     const queryString = qs.stringify(cleanQuery, {

--- a/langwatch/src/hooks/useFilterParams.ts
+++ b/langwatch/src/hooks/useFilterParams.ts
@@ -125,13 +125,12 @@ export const useFilterParams = () => {
   // for shallow navigation, so the push silently does nothing.
   //
   // The (url, as) overload avoids this:
-  //   url  = { pathname, query: { ...router.query, ...parsed } }  →  tells Next.js "same page" with updated params
-  //   as   = currentPath + "?" + newQs                            →  what the browser shows
+  //   url  = { pathname, query: { ...router.query, ...parsed } }
+  //   as   = currentPath + "?" + newQs
   //
-  // IMPORTANT: the url's query MUST include the new params so Next.js detects
-  // a change and re-renders components that use useRouter(). If only the `as`
-  // URL changes, React.memo'd components (like CustomGraph_) won't re-render
-  // because the router context stays the same.
+  // The url's query MUST include the new params so Next.js detects a route
+  // change and updates the router context. Without this, React.memo'd
+  // components using useRouter() won't re-render when filters change.
   const shallowPush = (newQs: string) => {
     const currentPath = router.asPath.split("?")[0] ?? router.asPath;
     const parsed = qs.parse(newQs, {

--- a/langwatch/src/hooks/useFilterParams.ts
+++ b/langwatch/src/hooks/useFilterParams.ts
@@ -125,21 +125,28 @@ export const useFilterParams = () => {
   // for shallow navigation, so the push silently does nothing.
   //
   // The (url, as) overload avoids this:
-  //   url  = { pathname, query: { ...router.query, ...parsed } }
+  //   url  = { pathname, query: { ...routeParams, ...parsed } }
   //   as   = currentPath + "?" + newQs
   //
-  // The url's query MUST include the new params so Next.js detects a route
-  // change and updates the router context. Without this, React.memo'd
-  // components using useRouter() won't re-render when filters change.
+  // The url's query is built from parsed newQs + dynamic route params only
+  // (not router.query which may carry stale keys). This ensures:
+  //   - Next.js detects a route change → re-renders components using useRouter()
+  //   - Deleted keys (e.g. cleared filters) are actually removed
   const shallowPush = (newQs: string) => {
     const currentPath = router.asPath.split("?")[0] ?? router.asPath;
+    const pathParamKeys = new Set(
+      (router.pathname.match(/\[(\w+)\]/g) ?? []).map((m) => m.slice(1, -1)),
+    );
+    const routeParams = Object.fromEntries(
+      Object.entries(router.query).filter(([key]) => pathParamKeys.has(key)),
+    );
     const parsed = qs.parse(newQs, {
       allowDots: true,
       comma: true,
       allowEmptyArrays: true,
     });
     void router.push(
-      { pathname: router.pathname, query: { ...router.query, ...parsed } },
+      { pathname: router.pathname, query: { ...routeParams, ...parsed } },
       currentPath + "?" + newQs,
       { shallow: true, scroll: false },
     );

--- a/langwatch/src/hooks/useFilterParams.ts
+++ b/langwatch/src/hooks/useFilterParams.ts
@@ -125,12 +125,22 @@ export const useFilterParams = () => {
   // for shallow navigation, so the push silently does nothing.
   //
   // The (url, as) overload avoids this:
-  //   url  = { pathname, query: router.query }  →  tells Next.js "same page"
-  //   as   = currentPath + "?" + newQs           →  what the browser shows
+  //   url  = { pathname, query: { ...router.query, ...parsed } }  →  tells Next.js "same page" with updated params
+  //   as   = currentPath + "?" + newQs                            →  what the browser shows
+  //
+  // IMPORTANT: the url's query MUST include the new params so Next.js detects
+  // a change and re-renders components that use useRouter(). If only the `as`
+  // URL changes, React.memo'd components (like CustomGraph_) won't re-render
+  // because the router context stays the same.
   const shallowPush = (newQs: string) => {
     const currentPath = router.asPath.split("?")[0] ?? router.asPath;
+    const parsed = qs.parse(newQs, {
+      allowDots: true,
+      comma: true,
+      allowEmptyArrays: true,
+    });
     void router.push(
-      { pathname: router.pathname, query: router.query },
+      { pathname: router.pathname, query: { ...router.query, ...parsed } },
       currentPath + "?" + newQs,
       { shallow: true, scroll: false },
     );

--- a/langwatch/src/pages/[project]/analytics/custom/index.tsx
+++ b/langwatch/src/pages/[project]/analytics/custom/index.tsx
@@ -431,7 +431,10 @@ function AnalyticsCustomGraphContent({
               </Card.Header>
               <Card.Body>
                 {debouncedCustomGraphInput && (
-                  <CustomGraph input={debouncedCustomGraphInput} />
+                  <CustomGraph
+                    input={debouncedCustomGraphInput}
+                    filters={filterParams.filters}
+                  />
                 )}
               </Card.Body>
             </Card.Root>

--- a/langwatch/src/pages/[project]/analytics/custom/index.tsx
+++ b/langwatch/src/pages/[project]/analytics/custom/index.tsx
@@ -433,7 +433,14 @@ function AnalyticsCustomGraphContent({
                 {debouncedCustomGraphInput && (
                   <CustomGraph
                     input={debouncedCustomGraphInput}
-                    filters={filterParams.filters}
+                    filters={
+                      filterParams.filters as
+                        | Record<
+                            FilterField,
+                            string[] | Record<string, string[]>
+                          >
+                        | undefined
+                    }
                   />
                 )}
               </Card.Body>

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -268,6 +268,12 @@ describe("aggregation-builder", () => {
       const labelsParam = paramKeys.find((k) => k.startsWith("labels"));
       expect(labelsParam).toBeDefined();
       expect(result.params[labelsParam!]).toEqual(["populator", "conversation"]);
+
+      // Outer query must restrict group_key to only the filtered labels
+      // (arrayJoin expands ALL labels from matching traces — without this,
+      // unfiltered labels leak into pie/bar chart results)
+      expect(result.sql).toContain("group_key IN");
+      expect(result.params.groupByFilterValues).toEqual(["populator", "conversation"]);
     });
 
     it("does not JOIN stored_spans when metadata.span_type uses cardinality alongside trace-level metrics", () => {

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -207,6 +207,36 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("1__evaluations_evaluation_pass_rate__avg");
     });
 
+    // @regression: Pie charts with arrayJoin groupBy (e.g. metadata.labels) add a
+    // pipeline { field: "trace_id", aggregation: "sum" } which sets requiresSubquery.
+    // buildArrayJoinTimeseriesQuery previously dropped all subquery metrics, returning
+    // empty data. The fix re-translates trace_id pipeline metrics as simple metrics
+    // since the CTE already deduplicates by (trace_id, group_key).
+    it("includes pipeline metrics with trace_id field in arrayJoin groupBy path", () => {
+      const input = {
+        ...baseInput,
+        groupBy: "metadata.labels" as const,
+        series: [
+          {
+            metric: "metadata.trace_count" as FlattenAnalyticsMetricsEnum,
+            aggregation: "count" as const,
+            pipeline: { field: "trace_id" as const, aggregation: "sum" as const },
+          },
+        ],
+      };
+      const result = buildTimeseriesQuery(input);
+
+      // Must route through the arrayJoin CTE path
+      expect(result.sql).toContain("arrayJoin");
+      expect(result.sql).toContain("deduped_traces");
+
+      // The metric alias must be present in the outer SELECT (not silently dropped)
+      expect(result.sql).toContain("0__metadata_trace_count__count");
+
+      // The metric should be converted to uniqExact(trace_id) via transformMetricForDedup
+      expect(result.sql).toContain("uniqExact(trace_id)");
+    });
+
     it("does not JOIN stored_spans when metadata.span_type uses cardinality alongside trace-level metrics", () => {
       const input = {
         ...baseInput,
@@ -748,6 +778,32 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("0__performance_total_cost__sum");
       expect(result.sql).toContain("1__evaluations_evaluation_pass_rate__avg");
       expect(result.sql).toContain("2__metadata_thread_id__cardinality");
+    });
+
+    // @regression: buildDateBucketedPipelineQuery previously only received pipeline
+    // metrics, silently dropping simple metrics when mixed with pipeline metrics
+    // on numeric timeScale.
+    it("preserves simple metrics alongside pipeline metrics with numeric timeScale", () => {
+      const input = {
+        ...baseInput,
+        timeScale: 60,
+        series: [
+          { metric: "performance.total_cost" as FlattenAnalyticsMetricsEnum, aggregation: "sum" as const },
+          {
+            metric: "metadata.thread_id" as FlattenAnalyticsMetricsEnum,
+            aggregation: "cardinality" as const,
+            pipeline: { field: "user_id" as const, aggregation: "avg" as const },
+          },
+        ],
+      };
+      const result = buildTimeseriesQuery(input);
+
+      // Both metric aliases must be present
+      expect(result.sql).toContain("0__performance_total_cost__sum");
+      expect(result.sql).toContain("1__metadata_thread_id__cardinality");
+
+      // Simple metrics should be in a simple_metrics CTE
+      expect(result.sql).toContain("simple_metrics");
     });
 
     // @regression: count-like trace metrics (count(), uniq(TraceId)) mixed with eval

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -237,6 +237,39 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("uniqExact(trace_id)");
     });
 
+    // Verify that page-level filters are applied inside the arrayJoin CTE
+    // when combined with pipeline metrics and groupBy labels.
+    it("applies label filters in arrayJoin groupBy path with pipeline metrics", () => {
+      const input = {
+        ...baseInput,
+        groupBy: "metadata.labels" as const,
+        filters: {
+          "metadata.labels": ["populator", "conversation"],
+        },
+        series: [
+          {
+            metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+            aggregation: "cardinality" as const,
+            pipeline: { field: "trace_id" as const, aggregation: "sum" as const },
+          },
+        ],
+      };
+      const result = buildTimeseriesQuery(input);
+
+      // Must route through arrayJoin CTE path
+      expect(result.sql).toContain("deduped_traces");
+
+      // Filter must be in the CTE WHERE clause
+      expect(result.sql).toContain("hasAny");
+      expect(result.sql).toContain("langwatch.labels");
+
+      // Filter params must be present
+      const paramKeys = Object.keys(result.params);
+      const labelsParam = paramKeys.find((k) => k.startsWith("labels"));
+      expect(labelsParam).toBeDefined();
+      expect(result.params[labelsParam!]).toEqual(["populator", "conversation"]);
+    });
+
     it("does not JOIN stored_spans when metadata.span_type uses cardinality alongside trace-level metrics", () => {
       const input = {
         ...baseInput,

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -218,8 +218,8 @@ describe("aggregation-builder", () => {
         groupBy: "metadata.labels" as const,
         series: [
           {
-            metric: "metadata.trace_count" as FlattenAnalyticsMetricsEnum,
-            aggregation: "count" as const,
+            metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+            aggregation: "cardinality" as const,
             pipeline: { field: "trace_id" as const, aggregation: "sum" as const },
           },
         ],
@@ -231,7 +231,7 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("deduped_traces");
 
       // The metric alias must be present in the outer SELECT (not silently dropped)
-      expect(result.sql).toContain("0__metadata_trace_count__count");
+      expect(result.sql).toContain("0__metadata_trace_id__cardinality");
 
       // The metric should be converted to uniqExact(trace_id) via transformMetricForDedup
       expect(result.sql).toContain("uniqExact(trace_id)");

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -595,6 +595,7 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
   if (subqueryMetrics.length > 0 && typeof input.timeScale === "number") {
     return buildDateBucketedPipelineQuery({
       input,
+      simpleMetrics,
       pipelineMetrics: subqueryMetrics,
       groupByColumn,
       groupByHandlesUnknown,
@@ -1065,6 +1066,36 @@ function buildArrayJoinTimeseriesQuery(
   //
   // @regression issue #3088
   const simpleMetrics = metricTranslations.filter((m) => !m.requiresSubquery);
+
+  // Pipeline metrics that group by trace_id are redundant in the arrayJoin path
+  // because the CTE already deduplicates by (trace_id, group_key). Re-translate
+  // them as simple metrics so they participate in the outer SELECT instead of
+  // being silently dropped.
+  for (let i = 0; i < input.series.length; i++) {
+    const series = input.series[i]!;
+    const translation = metricTranslations[i]!;
+    if (!translation.requiresSubquery || !series.pipeline) continue;
+
+    if (series.pipeline.field === "trace_id") {
+      const innerTranslation = translateMetric(
+        series.metric,
+        series.aggregation,
+        i,
+        series.key,
+        series.subkey,
+      );
+      simpleMetrics.push({
+        ...innerTranslation,
+        alias: translation.alias,
+        selectExpression: innerTranslation.selectExpression.replace(
+          new RegExp(
+            ` AS ${innerTranslation.alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
+          ),
+          ` AS ${translation.alias}`,
+        ),
+      });
+    }
+  }
   const hasEvalMixWithTrace = hasEvalMixedWithTraceMetrics(simpleMetrics);
 
   // When eval metrics are mixed with trace metrics, switch from SELECT DISTINCT
@@ -1616,6 +1647,7 @@ function buildSubqueryTimeseriesQuery(
  */
 function buildDateBucketedPipelineQuery({
   input,
+  simpleMetrics = [],
   pipelineMetrics,
   groupByColumn,
   groupByHandlesUnknown,
@@ -1626,6 +1658,7 @@ function buildDateBucketedPipelineQuery({
   timeZone,
 }: {
   input: TimeseriesQueryInput;
+  simpleMetrics?: MetricTranslation[];
   pipelineMetrics: MetricTranslation[];
   groupByColumn: string | null;
   groupByHandlesUnknown: boolean;
@@ -1662,7 +1695,7 @@ function buildDateBucketedPipelineQuery({
     groupByKey: input.groupByKey,
   });
 
-  const ctes = pipelineMetrics.map((metric) =>
+  const ctes: string[] = pipelineMetrics.map((metric) =>
     buildPipelineMetricCTE(metric, {
       ts,
       periodCase,
@@ -1676,34 +1709,79 @@ function buildDateBucketedPipelineQuery({
     }),
   );
 
-  // Build final SELECT
-  let finalSelect: string;
-  if (pipelineMetrics.length === 1) {
-    const cteName = `cte_${pipelineMetrics[0]!.alias}`;
-    finalSelect = `SELECT * FROM ${cteName} WHERE period IS NOT NULL ORDER BY period, date`;
-  } else {
-    // Multiple pipeline metrics: FULL OUTER JOIN on (period, date[, group_key])
-    const firstCteName = `cte_${pipelineMetrics[0]!.alias}`;
-    const joinKeys = groupByColumn
-      ? ["period", "date", "group_key"]
-      : ["period", "date"];
-
-    let joinSql = firstCteName;
-    const selectCols = [
-      ...joinKeys.map((k) => `${firstCteName}.${k}`),
-      `${firstCteName}.${quoteIdentifier(pipelineMetrics[0]!.alias)}`,
+  // Build a CTE for simple (non-pipeline) metrics so they are not dropped
+  // when mixed with pipeline metrics on numeric timeScale.
+  const hasSimple = simpleMetrics.length > 0;
+  if (hasSimple) {
+    const simpleSelectExprs = [
+      `${periodCase} AS period`,
+      `${dateTrunc} AS date`,
+      ...(groupKeyExpr ? [groupKeyExpr] : []),
+      ...simpleMetrics.map((m) => m.selectExpression),
     ];
+    const simpleGroupByCols = ["period", "date"];
+    if (groupByColumn) simpleGroupByCols.push("group_key");
 
-    for (let i = 1; i < pipelineMetrics.length; i++) {
-      const cteName = `cte_${pipelineMetrics[i]!.alias}`;
-      const onClause = joinKeys
-        .map((k) => `${firstCteName}.${k} = ${cteName}.${k}`)
-        .join(" AND ");
-      joinSql += `\n    FULL OUTER JOIN ${cteName} ON ${onClause}`;
-      selectCols.push(`${cteName}.${quoteIdentifier(pipelineMetrics[i]!.alias)}`);
+    ctes.push(`
+      simple_metrics AS (
+        SELECT
+          ${simpleSelectExprs.join(",\n          ")}
+        FROM ${dedupedTraceSummaries(ts)}
+        ${joinClauses}
+        WHERE ${baseWhere}
+          ${fullFilterWhere}
+        GROUP BY ${simpleGroupByCols.join(", ")}
+        ${groupKeyHaving}
+      )`);
+  }
+
+  // Build final SELECT — join all CTEs on (period, date[, group_key])
+  const joinKeys = groupByColumn
+    ? ["period", "date", "group_key"]
+    : ["period", "date"];
+
+  // Determine the anchor CTE (first source in the FROM/JOIN chain)
+  const firstPipelineCteName = `cte_${pipelineMetrics[0]!.alias}`;
+  const anchorCte = hasSimple ? "simple_metrics" : firstPipelineCteName;
+
+  let finalSelect: string;
+  if (!hasSimple && pipelineMetrics.length === 1) {
+    // Single pipeline metric, no simple metrics — simple path
+    finalSelect = `SELECT * FROM ${firstPipelineCteName} WHERE period IS NOT NULL ORDER BY period, date`;
+  } else {
+    // Multiple sources: FULL OUTER JOIN on (period, date[, group_key])
+    let joinSql = anchorCte;
+    const selectCols = [...joinKeys.map((k) => `${anchorCte}.${k}`)];
+
+    // Add simple metric columns from anchor
+    if (hasSimple) {
+      for (const m of simpleMetrics) {
+        selectCols.push(`${anchorCte}.${quoteIdentifier(m.alias)}`);
+      }
     }
 
-    finalSelect = `SELECT ${selectCols.join(", ")} FROM ${joinSql} WHERE ${firstCteName}.period IS NOT NULL ORDER BY ${firstCteName}.period, ${firstCteName}.date`;
+    // Determine which pipeline CTEs need joining (skip anchor if it's the first pipeline CTE)
+    const pipelineCTEsToJoin = hasSimple
+      ? pipelineMetrics
+      : pipelineMetrics.slice(1);
+
+    // If anchor is the first pipeline CTE, add its column
+    if (!hasSimple) {
+      selectCols.push(
+        `${firstPipelineCteName}.${quoteIdentifier(pipelineMetrics[0]!.alias)}`,
+      );
+    }
+
+    for (const metric of pipelineCTEsToJoin) {
+      const cteName = `cte_${metric.alias}`;
+      const onClause = joinKeys
+        .map((k) => `${anchorCte}.${k} = ${cteName}.${k}`)
+        .join(" AND ");
+      joinSql += `\n    FULL OUTER JOIN ${cteName} ON ${onClause}`;
+      selectCols.push(`${cteName}.${quoteIdentifier(metric.alias)}`);
+    }
+
+    finalSelect = `SELECT ${selectCols.join(", ")} FROM ${joinSql} WHERE ${anchorCte}.period IS NOT NULL ORDER BY ${anchorCte}.period, ${anchorCte}.date`;
   }
 
   const sql = `

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -1260,12 +1260,29 @@ function buildArrayJoinTimeseriesQuery(
     `;
   }
 
+  // When the groupBy field uses arrayJoin (e.g. metadata.labels) and a filter
+  // exists for the same field, the trace-level filter (hasAny) only selects
+  // traces that have at least one matching value. But arrayJoin then expands
+  // ALL values from those traces, so unfiltered values leak into the results.
+  // Add a group_key restriction in the outer query to show only the filtered values.
+  let groupKeyFilter = "";
+  const groupKeyFilterParams: Record<string, unknown> = {};
+  if (input.groupBy && input.filters && groupByColumn.includes("arrayJoin")) {
+    const filterValues = input.filters[input.groupBy as keyof typeof input.filters];
+    if (Array.isArray(filterValues) && filterValues.length > 0) {
+      const paramName = "groupByFilterValues";
+      groupKeyFilter = `AND group_key IN ({${paramName}:Array(String)})`;
+      groupKeyFilterParams[paramName] = filterValues;
+    }
+  }
+
   const sql = `
     WITH deduped_traces AS (${cteBody})
     SELECT
       ${outerSelectExprs.join(",\n      ")}
     FROM deduped_traces
     WHERE period IS NOT NULL
+      ${groupKeyFilter}
     GROUP BY ${outerGroupBy.join(", ")}
     ${havingClause}
     ORDER BY period${dateTrunc ? ", date" : ""}
@@ -1280,6 +1297,7 @@ function buildArrayJoinTimeseriesQuery(
       previousStart: input.previousPeriodStartDate,
       previousEnd: input.startDate,
       ...filterParams,
+      ...groupKeyFilterParams,
       ...(input.groupByKey ? { groupByKey: input.groupByKey } : {}),
     },
   };

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -1067,16 +1067,23 @@ function buildArrayJoinTimeseriesQuery(
   // @regression issue #3088
   const simpleMetrics = metricTranslations.filter((m) => !m.requiresSubquery);
 
-  // Pipeline metrics that group by trace_id are redundant in the arrayJoin path
-  // because the CTE already deduplicates by (trace_id, group_key). Re-translate
-  // them as simple metrics so they participate in the outer SELECT instead of
-  // being silently dropped.
+  // Pipeline metrics that group by trace_id with "sum" aggregation are redundant
+  // in the arrayJoin path because the CTE already deduplicates by (trace_id,
+  // group_key). Re-translate them as simple metrics so they participate in the
+  // outer SELECT instead of being silently dropped.
+  //
+  // Only safe for "sum" aggregation: sum(value_per_trace) is equivalent to the
+  // standard aggregation over deduped traces. Other pipeline aggregations
+  // (avg/min/max) have different semantics and cannot be rewritten this way.
   for (let i = 0; i < input.series.length; i++) {
     const series = input.series[i]!;
     const translation = metricTranslations[i]!;
     if (!translation.requiresSubquery || !series.pipeline) continue;
 
-    if (series.pipeline.field === "trace_id") {
+    if (
+      series.pipeline.field === "trace_id" &&
+      series.pipeline.aggregation === "sum"
+    ) {
       const innerTranslation = translateMetric(
         series.metric,
         series.aggregation,
@@ -1084,13 +1091,17 @@ function buildArrayJoinTimeseriesQuery(
         series.key,
         series.subkey,
       );
+      // Swap alias to match the pipeline translation's alias (they're identical
+      // for trace_id pipelines, but be explicit for clarity)
+      const escapedAlias = innerTranslation.alias.replace(
+        /[.*+?^${}()|[\]\\]/g,
+        "\\$&",
+      );
       simpleMetrics.push({
         ...innerTranslation,
         alias: translation.alias,
         selectExpression: innerTranslation.selectExpression.replace(
-          new RegExp(
-            ` AS ${innerTranslation.alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
-          ),
+          new RegExp(` AS ${escapedAlias}$`),
           ` AS ${translation.alias}`,
         ),
       });
@@ -1711,23 +1722,61 @@ function buildDateBucketedPipelineQuery({
 
   // Build a CTE for simple (non-pipeline) metrics so they are not dropped
   // when mixed with pipeline metrics on numeric timeScale.
+  // Quote aliases that start with digits for ClickHouse compatibility.
+  // Use only the joins required by simple metrics (+ groupBy + filters) to
+  // avoid fan-out inflation from evaluation_runs or stored_spans joins that
+  // are only needed by pipeline metrics.
   const hasSimple = simpleMetrics.length > 0;
   if (hasSimple) {
     const simpleSelectExprs = [
       `${periodCase} AS period`,
       `${dateTrunc} AS date`,
       ...(groupKeyExpr ? [groupKeyExpr] : []),
-      ...simpleMetrics.map((m) => m.selectExpression),
+      ...simpleMetrics.map((m) => {
+        const quotedAlias = quoteIdentifier(m.alias);
+        return m.selectExpression.replace(
+          ` AS ${m.alias}`,
+          ` AS ${quotedAlias}`,
+        );
+      }),
     ];
     const simpleGroupByCols = ["period", "date"];
     if (groupByColumn) simpleGroupByCols.push("group_key");
+
+    // Build minimal join clauses: only joins needed by simple metrics, the
+    // groupBy column, and filters — not pipeline metrics.
+    const simpleJoins = new Set<CHTable>();
+    for (const m of simpleMetrics) {
+      for (const j of m.requiredJoins) simpleJoins.add(j);
+    }
+    if (input.groupBy) {
+      const gExpr = getGroupByExpression(input.groupBy, input.groupByKey);
+      for (const j of gExpr.requiredJoins) simpleJoins.add(j);
+    }
+    // Include filter joins by re-translating (idempotent, no side effects
+    // that affect query correctness — param names are already in filterParams)
+    if (input.filters) {
+      const filterJoins = translateAllFilters(input.filters).requiredJoins;
+      for (const j of filterJoins) simpleJoins.add(j);
+    }
+    const allSimpleExprs = [
+      ...simpleMetrics.map((m) => m.selectExpression),
+      fullFilterWhere,
+      groupByColumn ?? "",
+    ];
+    const simpleJoinClauses = Array.from(simpleJoins)
+      .map((table) => {
+        const requiredColumns = resolveRequiredColumns(table, allSimpleExprs);
+        return buildJoinClause(table, requiredColumns);
+      })
+      .join("\n");
 
     ctes.push(`
       simple_metrics AS (
         SELECT
           ${simpleSelectExprs.join(",\n          ")}
         FROM ${dedupedTraceSummaries(ts)}
-        ${joinClauses}
+        ${simpleJoinClauses}
         WHERE ${baseWhere}
           ${fullFilterWhere}
         GROUP BY ${simpleGroupByCols.join(", ")}

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -160,9 +160,22 @@ function buildUrl(
 ): string {
   if (typeof url === "string") return url;
   // If pathname is omitted, use the current URL path (Next.js behavior)
-  const pathname = url.pathname ?? window.location.pathname;
+  let pathname = url.pathname ?? window.location.pathname;
   const { query } = url;
   if (!query || Object.keys(query).length === 0) return pathname;
+
+  // Replace [param] placeholders in pathname with values from query.
+  // resolvePathname returns Next.js-style patterns like /[project]/analytics/custom/[id],
+  // but React Router needs the actual path segments.
+  if (routeParamKeys) {
+    for (const key of routeParamKeys) {
+      const value = query[key];
+      if (value !== undefined && value !== null) {
+        pathname = pathname.replace(`[${key}]`, String(value));
+      }
+    }
+  }
+
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(query)) {
     if (value === undefined || value === null) continue;
@@ -228,7 +241,7 @@ class RouterSingleton {
     _as?: string,
     options?: NextRouterOptions
   ): Promise<boolean> {
-    const target = buildUrl(url);
+    const target = _as ?? buildUrl(url);
     if (_routerInstance) {
       _routerInstance.navigate(target);
     } else {
@@ -246,7 +259,7 @@ class RouterSingleton {
     _as?: string,
     options?: NextRouterOptions
   ): Promise<boolean> {
-    const target = buildUrl(url);
+    const target = _as ?? buildUrl(url);
     if (_routerInstance) {
       _routerInstance.navigate(target);
     } else {
@@ -334,7 +347,10 @@ export function useRouter(): CompatRouter {
       events: routerEvents,
       isFallback: false,
       push: (url, _as?, options?) => {
-        const target = buildUrl(url, routeParamKeys);
+        // When `as` is provided (Next.js (url, as) overload), use it directly.
+        // The `as` string is the actual browser URL; `url` is the internal route
+        // descriptor which may contain [param] placeholders.
+        const target = _as ?? buildUrl(url, routeParamKeys);
         navigate(target, { replace: false });
         if (options?.scroll !== false) {
           window.scrollTo(0, 0);
@@ -342,7 +358,7 @@ export function useRouter(): CompatRouter {
         return Promise.resolve(true);
       },
       replace: (url, _as?, options?) => {
-        const target = buildUrl(url, routeParamKeys);
+        const target = _as ?? buildUrl(url, routeParamKeys);
         navigate(target, { replace: true });
         if (options?.scroll !== false) {
           window.scrollTo(0, 0);


### PR DESCRIPTION
## Summary

Fixes three categories of bugs on the custom analytics chart editor page:

### 1. Backend: Pipeline metrics dropped in arrayJoin groupBy
- Pie/donut charts with groupBy label add a `pipeline: { field: "trace_id", aggregation: "sum" }` which sets `requiresSubquery`. `buildArrayJoinTimeseriesQuery` filtered out all subquery metrics, returning empty data.
- **Fix:** Re-translate trace_id/sum pipeline metrics as simple metrics since the CTE already deduplicates by (trace_id, group_key).
- Also fixed `buildDateBucketedPipelineQuery` which only received pipeline metrics, silently dropping simple metrics when mixed with pipeline metrics on numeric timeScale.

### 2. Backend: arrayJoin groupBy shows unfiltered labels
- When filtering by label (e.g. populator, smalltalk) and grouping by label, the trace-level `hasAny` filter selects traces with at least one matching label, but `arrayJoin` then expands ALL labels from those traces — so unrelated labels leak into pie/bar charts.
- **Fix:** Added `group_key IN (...)` clause to the outer query so only filtered labels appear.

### 3. Frontend: Filters crash and don't apply on custom chart editor
- **Compat router crash:** `buildUrl` in the Next.js→React Router compat layer didn't replace `[param]` placeholders with query values, and `push`/`replace` ignored the `as` parameter. Filter buttons navigated to literal `/[project]/analytics/custom/[id]` URLs, crashing the page.
- **Filters not triggering re-renders:** `shallowPush` in `useFilterParams` used stale `router.query` (only has route params) instead of building from parsed `newQs` + route params. Same issue in `FilterToggle.setShowFilters`.
- **Drawer strips filters:** `useDrawer.updateDrawerUrl` and `closeDrawer` rebuilt URLs from stale `router.query`, losing all filter params when drawers open/close.
- **CustomGraph not re-rendering:** `React.memo` on `CustomGraph_` prevented re-renders when only the URL changed. Added explicit `filters` prop from parent.

### Files changed
- `aggregation-builder.ts` — arrayJoin pipeline metric fix + group_key filter
- `aggregation-builder.test.ts` — 3 regression tests
- `useFilterParams.ts` — shallowPush builds url query from parsed newQs + route params
- `FilterToggle.tsx` — same fix for setShowFilters
- `useDrawer.ts` — parse from router.asPath instead of stale router.query
- `custom/index.tsx` — pass filters prop to CustomGraph
- `next-router.ts` — buildUrl replaces [param] placeholders; push/replace honor `as` param

## Test plan
- [x] 78 aggregation builder tests pass (including 3 new regression tests)
- [x] Typecheck clean
- [x] Manual: pie chart with groupBy label + label filter shows only filtered labels
- [x] Manual: filter buttons don't crash on edit page (/[project]/analytics/custom/[id])
- [x] Manual: series filter drawer persists selections on re-edit
- [x] Manual: opening/closing drawers preserves filter params

Closes #3173
Refs #3150, #3176