### PR TITLE
fix(analytics): preserve filters when toggling filter panel and clearing

### DIFF
--- a/langwatch/src/components/filters/FilterToggle.tsx
+++ b/langwatch/src/components/filters/FilterToggle.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, HStack, Text } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import qs from "qs";
 import { X } from "react-feather";
 import { type FilterParam, useFilterParams } from "../../hooks/useFilterParams";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
@@ -39,23 +40,47 @@ export const useFilterToggle = (
       : defaultShowFilters;
 
   const setShowFilters = (show: boolean) => {
+    const currentPath = router.asPath.split("?")[0] ?? router.asPath;
+    const queryString = router.asPath.split("?")[1] ?? "";
+    const queryParams = qs.parse(queryString.replaceAll("%2C", ","), {
+      allowDots: true,
+      comma: true,
+      allowEmptyArrays: true,
+    });
+
+    const showFiltersValue = show
+      ? defaultShowFilters
+        ? undefined
+        : "true"
+      : defaultShowFilters
+        ? "false"
+        : undefined;
+
+    const newParams = { ...queryParams };
+    if (showFiltersValue === undefined) {
+      delete newParams.show_filters;
+    } else {
+      newParams.show_filters = showFiltersValue;
+    }
+
+    const newQs = qs.stringify(newParams, {
+      allowDots: true,
+      arrayFormat: "comma" as const,
+      // @ts-ignore
+      allowEmptyArrays: true,
+    });
+
+    const nextRouterQuery = { ...router.query };
+    if (showFiltersValue === undefined) {
+      delete nextRouterQuery.show_filters;
+    } else {
+      nextRouterQuery.show_filters = showFiltersValue;
+    }
+
     void router.push(
-      {
-        query: Object.fromEntries(
-          Object.entries({
-            ...router.query,
-            show_filters: show
-              ? defaultShowFilters
-                ? undefined
-                : "true"
-              : defaultShowFilters
-                ? "false"
-                : undefined,
-          }).filter(([, value]) => value !== undefined),
-        ),
-      },
-      undefined,
-      { shallow: true },
+      { pathname: router.pathname, query: nextRouterQuery },
+      newQs ? `${currentPath}?${newQs}` : currentPath,
+      { shallow: true, scroll: false },
     );
   };
 

--- a/langwatch/src/hooks/__tests__/useFilterParams-write.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useFilterParams-write.integration.test.ts
@@ -135,16 +135,48 @@ describe("useFilterParams() write operations", () => {
           query: "hello world",
           view: "table",
         };
+        mockRouterAsPath =
+          "/test-project/messages?origin=application&model=gpt-5-mini&query=hello+world&view=table";
 
         const { result } = renderHook(() => useFilterParams());
         result.current.clearFilters();
 
-        const query = lastPushQuery();
-        expect(query).not.toHaveProperty("origin");
-        expect(query).not.toHaveProperty("model");
-        expect(query).not.toHaveProperty("query");
+        const url = lastPushUrl();
+        expect(url).not.toContain("origin=");
+        expect(url).not.toContain("model=");
+        expect(url).not.toContain("query=");
         // Layout params preserved
-        expect(query).toHaveProperty("view", "table");
+        expect(url).toContain("view=table");
+      });
+    });
+
+    describe("when on a dynamic route page with [id] param", () => {
+      beforeEach(() => {
+        mockRouterQuery = {
+          project: "my-project",
+          id: "graph-abc",
+        };
+        mockRouterAsPath =
+          "/my-project/analytics/custom/graph-abc?dashboard=dash-123&show_filters=true&origin=application";
+      });
+
+      it("clears filter params but preserves non-filter params", () => {
+        const { result } = renderHook(() => useFilterParams());
+        result.current.clearFilters();
+
+        const url = lastPushUrl();
+        expect(url).not.toContain("origin=");
+        expect(url).toContain("dashboard=dash-123");
+        expect(url).toContain("show_filters=true");
+      });
+
+      it("does not leak route params into the display URL", () => {
+        const { result } = renderHook(() => useFilterParams());
+        result.current.clearFilters();
+
+        const url = lastPushUrl();
+        expect(url).not.toContain("project=");
+        expect(url).not.toContain("id=");
       });
     });
   });

--- a/langwatch/src/hooks/useFilterParams.ts
+++ b/langwatch/src/hooks/useFilterParams.ts
@@ -188,23 +188,17 @@ export const useFilterParams = () => {
   };
 
   const clearFilters = () => {
-    void router.push(
-      {
-        pathname: router.pathname,
-        query: Object.fromEntries(
-          Object.entries(router.query).filter(
-            ([key]) =>
-              key !== "query" &&
-              !Object.values(availableFilters).some(
-                (filter) =>
-                  key === filter.urlKey || key.startsWith(filter.urlKey + "."),
-              ),
+    const cleared = Object.fromEntries(
+      Object.entries(queryParams).filter(
+        ([key]) =>
+          key !== "query" &&
+          !Object.values(availableFilters).some(
+            (filter) =>
+              key === filter.urlKey || key.startsWith(filter.urlKey + "."),
           ),
-        ),
-      },
-      undefined,
-      { shallow: true, scroll: false },
+      ),
     );
+    shallowPush(qs.stringify(cleared, qsOpts));
   };
 
   const filterParams = {


### PR DESCRIPTION
## Summary

- Fix `setShowFilters` in `FilterToggle.tsx` — toggling the filter panel was clearing all URL filter params
- Fix `clearFilters` in `useFilterParams.ts` — same root cause, used stale `router.query` instead of `router.asPath`
- Both now use the `shallowPush` / `(url, as)` pattern established in #3150
- The "Clear all filters" X button still intentionally clears filters (but now preserves non-filter params like `dashboard`, `show_filters`)

## Root cause

PR #3150 migrated `setFilter`/`setFilters`/`setNegateFilters` to the `(url, as)` overload of `router.push`. This correctly updates the browser URL via the `as` parameter, but `router.query` is NOT updated with the new filter params — it only contains the route segments (e.g. `{ project, id }`).

Two functions were left using `router.query` to rebuild URLs:
1. **`setShowFilters`** — spread `router.query` to preserve params, lost all filters
2. **`clearFilters`** — filtered `router.query` to remove filter keys, but there were none to remove; also lost non-filter params like `dashboard`

## Fix

- `setShowFilters`: parse from `router.asPath` via `qs.parse`, update `show_filters`, push via `(url, as)` overload
- `clearFilters`: filter `queryParams` (already parsed from `router.asPath`) and use `shallowPush`

Closes #3171

## Test plan

- [x] 11 integration tests pass (was 9 — added 2 for `clearFilters` on dynamic route pages)
- [ ] Manual: open custom chart with saved filters → click "Add Graph Filter" → filters preserved
- [ ] Manual: click "Filters" toggle in header → filters preserved
- [ ] Manual: click X "Clear all filters" → filters cleared, `dashboard`/`show_filters` preserved
- [ ] Manual: verify filters on messages page (no regression on non-dynamic routes)

# Related Issue

- Resolve #3171