### PR TITLE
fix(dev): make compose.dev.yml + vite work behind a reverse proxy

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -109,6 +109,8 @@ services:
       - ./langwatch:/app
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
+      - ./typescript-sdk:/typescript-sdk:ro
+      - ./python-sdk:/python-sdk:ro
       - app_modules:/app/node_modules
       - pnpm_store:/root/.local/share/pnpm/store
       - goose_bin:/opt/goose-bin
@@ -148,6 +150,8 @@ services:
       - ./langwatch:/app
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
+      - ./typescript-sdk:/typescript-sdk:ro
+      - ./python-sdk:/python-sdk:ro
       - app_modules:/app/node_modules
       - goose_bin:/opt/goose-bin:ro
     command: >
@@ -208,6 +212,8 @@ services:
       - ./langwatch:/app
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
+      - ./typescript-sdk:/typescript-sdk:ro
+      - ./python-sdk:/python-sdk:ro
       - app_modules:/app/node_modules
       - goose_bin:/opt/goose-bin:ro
     command: sh -c "export PATH=/opt/goose-bin:$$PATH && corepack enable && while true; do pnpm -w exec tsx --tsconfig tsconfig.workers.json src/workers.ts; sleep 1; done"
@@ -297,6 +303,8 @@ services:
       - ./langwatch:/app
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
+      - ./typescript-sdk:/typescript-sdk:ro
+      - ./python-sdk:/python-sdk:ro
       - app_modules:/app/node_modules
     command: sh -c "corepack enable && pnpm -w exec tsx scripts/ai-server.ts"
     ports:

--- a/langwatch/vite.config.ts
+++ b/langwatch/vite.config.ts
@@ -34,7 +34,20 @@ export default defineConfig({
     sourcemap: true,
   },
   server: {
+    watch: {
+      ignored: [
+        "**/.git/**",
+        "**/node_modules/.pnpm/**",
+        "**/.pnpm-store/**",
+        "**/dist/**",
+        "**/.next/**",
+        "**/coverage/**",
+        "**/server.log",
+      ],
+    },
     // Frontend always on 5560 — same port as with Next.js
+    host: true,
+    allowedHosts: true,
     port: 5560,
     strictPort: true,
     // Proxy API requests to the Hono backend (internal port)


### PR DESCRIPTION
## Summary

Fixes 4 boot blockers that prevent #3170's `compose.dev.yml` path from working behind a reverse proxy (Boxd forks, preview deploys, LAN reviewers, tunneling services).

Before these fixes a fresh dev boot dies with a restart loop on `Cannot find module '//typescript-sdk/package.json'`, then an `ENOSPC` hang on Vite, then a 502 (Vite bound to localhost only), then a 403 (host not in `allowedHosts`). After: `HTTP 200` on the fork URL.

## Fixes

1. **`compose.dev.yml`** — add `./typescript-sdk` + `./python-sdk` read-only bind mounts to `init` / `app` / `workers` / `ai-server`. The prod Dockerfile COPYs these in at build time; dev mode needs the sibling dirs at the same repo-root path so `generate-sdk-versions.sh` can find them.
2. **`vite.config.ts`** — add `server.watch.ignored` excluding `.pnpm-store`, `node_modules/.pnpm`, `dist`, `.git`, `coverage`, `server.log`. Stops Vite from exhausting `fs.inotify.max_user_watches` on pnpms content-addressable cache.
3. **`vite.config.ts`** — set `server.host: true` so Vite binds `0.0.0.0` instead of container-local loopback. Without this, Docker port forwarding reaches a dead socket.
4. **`vite.config.ts`** — set `server.allowedHosts: true` for dev. Vite 8 returns 403 for any Host header not in the allow-list.

## Test plan

- [x] Boots cleanly on a Boxd fork behind HTTPS reverse proxy: https://vite-fixes--drew.boxd.sh → `HTTP 200`
- [ ] Local `make dev` still works (no regression expected — additions only)
- [ ] Production Docker build unaffected (no Dockerfile changes)

## Base

Targets #3170. Once that merges, this can merge directly to `main`; until then, consider landing this on top of `worktree-vite` to unblock other reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
