### PR TITLE
fix: vite migration follow-up fixes

### DIFF
--- a/langwatch/src/components/AddAnnotationQueueDrawer.tsx
+++ b/langwatch/src/components/AddAnnotationQueueDrawer.tsx
@@ -12,7 +12,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { Check, ChevronDown, Plus } from "react-feather";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -125,6 +125,24 @@ export const AddAnnotationQueueDrawer = ({
       name: score.annotationScore.name,
     })) ?? [],
   );
+
+  // Sync local state when queue data loads (edit mode hydration)
+  useEffect(() => {
+    if (!queue.data) return;
+    setParticipants(
+      queue.data.members.map((m) => ({ id: m.user.id, name: m.user.name })),
+    );
+    setScoreTypes(
+      queue.data.AnnotationQueueScores.map((s) => ({
+        id: s.annotationScore.id,
+        name: s.annotationScore.name,
+      })),
+    );
+    reset({
+      name: queue.data.name,
+      description: queue.data.description ?? "",
+    });
+  }, [queue.data, reset]);
 
   const onSubmit = (data: FormData) => {
     if (participants.length === 0 || scoreTypes.length === 0) {
@@ -273,13 +291,15 @@ export const AddAnnotationQueueDrawer = ({
                               (p) => p.id === member.user.id,
                             );
                             return (
-                              <HStack
+                              <Button
                                 key={member.user.id}
-                                cursor="pointer"
+                                variant="ghost"
                                 width="full"
+                                justifyContent="flex-start"
                                 padding={1}
-                                borderRadius="md"
-                                _hover={{ bg: "bg.muted" }}
+                                height="auto"
+                                fontWeight="normal"
+                                aria-pressed={isSelected}
                                 onClick={() =>
                                   toggleParticipant(
                                     member.user.id,
@@ -296,7 +316,7 @@ export const AddAnnotationQueueDrawer = ({
                                   name={member.user.name ?? ""}
                                 />
                                 <Text fontSize="sm">{member.user.name}</Text>
-                              </HStack>
+                              </Button>
                             );
                           })}
                         </VStack>
@@ -367,13 +387,15 @@ export const AddAnnotationQueueDrawer = ({
                                 (s) => s.id === score.id,
                               );
                               return (
-                                <HStack
+                                <Button
                                   key={score.id}
-                                  cursor="pointer"
+                                  variant="ghost"
                                   width="full"
+                                  justifyContent="flex-start"
                                   padding={1}
-                                  borderRadius="md"
-                                  _hover={{ bg: "bg.muted" }}
+                                  height="auto"
+                                  fontWeight="normal"
+                                  aria-pressed={isSelected}
                                   onClick={() =>
                                     toggleScoreType(score.id, score.name)
                                   }
@@ -385,7 +407,7 @@ export const AddAnnotationQueueDrawer = ({
                                     }
                                   />
                                   <Text fontSize="sm">{score.name}</Text>
-                                </HStack>
+                                </Button>
                               );
                             })}
                           </VStack>

--- a/langwatch/src/components/AddAnnotationQueueDrawer.tsx
+++ b/langwatch/src/components/AddAnnotationQueueDrawer.tsx
@@ -5,14 +5,14 @@ import {
   HStack,
   Input,
   Spacer,
+  Tag,
   Text,
   Textarea,
   useDisclosure,
   VStack,
 } from "@chakra-ui/react";
-import { chakraComponents, Select as MultiSelect } from "chakra-react-select";
+import { Check, ChevronDown, Plus } from "react-feather";
 import { useState } from "react";
-import { Plus } from "react-feather";
 import { useForm } from "react-hook-form";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -20,6 +20,7 @@ import { api } from "~/utils/api";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
 import { slugify } from "~/utils/slugify";
 import { Drawer } from "../components/ui/drawer";
+import { Popover } from "../components/ui/popover";
 import { toaster } from "../components/ui/toaster";
 import { AddOrEditAnnotationScore } from "./annotations/AddOrEditAnnotationScore";
 import { FullWidthFormControl } from "./FullWidthFormControl";
@@ -45,7 +46,7 @@ export const AddAnnotationQueueDrawer = ({
       projectId: project?.id ?? "",
     },
     {
-      enabled: !!project && !!queueId && open,
+      enabled: !!project && !!queueId && !!open,
     },
   );
 
@@ -65,7 +66,7 @@ export const AddAnnotationQueueDrawer = ({
       projectId: project?.id ?? "",
     },
     {
-      enabled: !!project && open,
+      enabled: !!project && !!open,
     },
   );
 
@@ -82,9 +83,10 @@ export const AddAnnotationQueueDrawer = ({
         organizationId: organization?.id ?? "",
       },
       {
-        enabled: !!organization && open,
+        enabled: !!organization && !!open,
       },
     );
+
   const {
     register,
     handleSubmit,
@@ -175,6 +177,8 @@ export const AddAnnotationQueueDrawer = ({
   };
 
   const scoreTypeDrawerOpen = useDisclosure();
+  const participantsPopoverOpen = useDisclosure();
+  const scoreTypesPopoverOpen = useDisclosure();
 
   const name = watch("name");
   const slug = slugify((name || "").replace("_", "-"), {
@@ -182,10 +186,26 @@ export const AddAnnotationQueueDrawer = ({
     strict: true,
   });
 
+  const toggleParticipant = (id: string, memberName: string | null) => {
+    setParticipants((prev) =>
+      prev.some((p) => p.id === id)
+        ? prev.filter((p) => p.id !== id)
+        : [...prev, { id, name: memberName }],
+    );
+  };
+
+  const toggleScoreType = (id: string, scoreName: string) => {
+    setScoreTypes((prev) =>
+      prev.some((s) => s.id === id)
+        ? prev.filter((s) => s.id !== id)
+        : [...prev, { id, name: scoreName }],
+    );
+  };
+
   return (
     <>
       <Drawer.Root
-        open={open}
+        open={!!open}
         placement="end"
         size="lg"
         onOpenChange={({ open }) => {
@@ -209,68 +229,81 @@ export const AddAnnotationQueueDrawer = ({
             {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
             <form onSubmit={handleSubmit(onSubmit)}>
               <VStack align="start">
-                <MultiSelect
-                  options={users.data?.members.map((member) => ({
-                    label: member.user.name ?? "",
-                    value: member.user.id,
-                  }))}
-                  onChange={(newValue) => {
-                    setParticipants(
-                      newValue.map((v) => ({
-                        id: v.value,
-                        name: v.label,
-                      })),
-                    );
-                  }}
-                  value={participants.map((p) => ({
-                    value: p.id,
-                    label: p.name ?? "",
-                  }))}
-                  isMulti
-                  closeMenuOnSelect={false}
-                  selectedOptionStyle="check"
-                  hideSelectedOptions={true}
-                  placeholder="Add Participants"
-                  components={{
-                    Menu: ({ children, ...props }) => (
-                      <chakraComponents.Menu
-                        {...props}
-                        innerProps={{
-                          ...props.innerProps,
-                          style: { width: "300px" },
-                        }}
+                <FullWidthFormControl
+                  label="Participants"
+                  helper="Select the participants for this annotation queue"
+                >
+                  <Popover.Root
+                    open={participantsPopoverOpen.open}
+                    onOpenChange={({ open }) =>
+                      participantsPopoverOpen.setOpen(open)
+                    }
+                    positioning={{ placement: "bottom-start" }}
+                  >
+                    <Popover.Trigger asChild>
+                      <Button
+                        variant="outline"
+                        width="full"
+                        justifyContent="space-between"
+                        fontWeight="normal"
+                        color={
+                          participants.length === 0 ? "fg.subtle" : "fg"
+                        }
+                        paddingX={3}
                       >
-                        {children}
-                      </chakraComponents.Menu>
-                    ),
-                    Option: ({ children, ...props }) => (
-                      <chakraComponents.Option {...props}>
-                        <VStack align="start">
-                          <HStack>
-                            <RandomColorAvatar
-                              size="2xs"
-                              name={props.data.label}
-                            />
-                            <Text>{children}</Text>
+                        {participants.length === 0 ? (
+                          "Add Participants"
+                        ) : (
+                          <HStack gap={1} flexWrap="wrap" flex={1}>
+                            {participants.map((p) => (
+                              <Tag.Root key={p.id} size="sm">
+                                <Tag.Label>{p.name}</Tag.Label>
+                              </Tag.Root>
+                            ))}
                           </HStack>
+                        )}
+                        <ChevronDown size={16} />
+                      </Button>
+                    </Popover.Trigger>
+                    <Popover.Content width="300px">
+                      <Popover.Body>
+                        <VStack align="start" gap={1}>
+                          {users.data?.members.map((member) => {
+                            const isSelected = participants.some(
+                              (p) => p.id === member.user.id,
+                            );
+                            return (
+                              <HStack
+                                key={member.user.id}
+                                cursor="pointer"
+                                width="full"
+                                padding={1}
+                                borderRadius="md"
+                                _hover={{ bg: "bg.muted" }}
+                                onClick={() =>
+                                  toggleParticipant(
+                                    member.user.id,
+                                    member.user.name,
+                                  )
+                                }
+                              >
+                                <Check
+                                  size={16}
+                                  color={isSelected ? "green" : "transparent"}
+                                />
+                                <RandomColorAvatar
+                                  size="2xs"
+                                  name={member.user.name ?? ""}
+                                />
+                                <Text fontSize="sm">{member.user.name}</Text>
+                              </HStack>
+                            );
+                          })}
                         </VStack>
-                      </chakraComponents.Option>
-                    ),
-                    MultiValueLabel: ({ children, ...props }) => (
-                      <chakraComponents.MultiValueLabel {...props}>
-                        <VStack align="start" padding={1} paddingX={0}>
-                          <HStack>
-                            <RandomColorAvatar
-                              size="2xs"
-                              name={props.data.label}
-                            />
-                            <Text>{children}</Text>
-                          </HStack>
-                        </VStack>
-                      </chakraComponents.MultiValueLabel>
-                    ),
-                  }}
-                />
+                      </Popover.Body>
+                    </Popover.Content>
+                  </Popover.Root>
+                </FullWidthFormControl>
 
                 <FullWidthFormControl
                   label="Name Annotation Queue"
@@ -289,95 +322,97 @@ export const AddAnnotationQueueDrawer = ({
                   <Textarea {...register("description")} required />
                 </FullWidthFormControl>
 
-                <Field.Root>
-                  <VStack align="start" gap={1}>
-                    <Field.Label margin={0}>Score Type</Field.Label>
-                    <Field.HelperText margin={0}>
-                      Select the score type for this annotation queue
-                    </Field.HelperText>
-
-                    <MultiSelect
-                      options={annotationScores.data?.map((score) => ({
-                        label: score.name,
-                        value: score.id,
-                      }))}
-                      onChange={(newValue) => {
-                        setScoreTypes(
-                          newValue.map((v) => ({
-                            id: v.value,
-                            name: v.label,
-                          })),
-                        );
-                      }}
-                      value={scoreTypes.map((v) => ({
-                        value: v.id,
-                        label: v.name ?? "",
-                      }))}
-                      isMulti
-                      closeMenuOnSelect={false}
-                      selectedOptionStyle="check"
-                      hideSelectedOptions={true}
-                      placeholder="Add Score Type"
-                      components={{
-                        Menu: ({ children, ...props }) => (
-                          <chakraComponents.Menu
-                            {...props}
-                            innerProps={{
-                              ...props.innerProps,
-                              style: { width: "300px" },
+                <FullWidthFormControl
+                  label="Score Type"
+                  helper="Select the score type for this annotation queue"
+                >
+                  <Popover.Root
+                    open={scoreTypesPopoverOpen.open}
+                    onOpenChange={({ open }) =>
+                      scoreTypesPopoverOpen.setOpen(open)
+                    }
+                    positioning={{ placement: "bottom-start" }}
+                  >
+                    <Popover.Trigger asChild>
+                      <Button
+                        variant="outline"
+                        width="full"
+                        justifyContent="space-between"
+                        fontWeight="normal"
+                        color={
+                          scoreTypes.length === 0 ? "fg.subtle" : "fg"
+                        }
+                        paddingX={3}
+                      >
+                        {scoreTypes.length === 0 ? (
+                          "Add Score Type"
+                        ) : (
+                          <HStack gap={1} flexWrap="wrap" flex={1}>
+                            {scoreTypes.map((s) => (
+                              <Tag.Root key={s.id} size="sm">
+                                <Tag.Label>{s.name}</Tag.Label>
+                              </Tag.Root>
+                            ))}
+                          </HStack>
+                        )}
+                        <ChevronDown size={16} />
+                      </Button>
+                    </Popover.Trigger>
+                    <Popover.Content width="300px">
+                      <Popover.Body padding={0}>
+                        <Box maxH="250px" overflowY="auto" padding={2}>
+                          <VStack align="start" gap={1}>
+                            {annotationScores.data?.map((score) => {
+                              const isSelected = scoreTypes.some(
+                                (s) => s.id === score.id,
+                              );
+                              return (
+                                <HStack
+                                  key={score.id}
+                                  cursor="pointer"
+                                  width="full"
+                                  padding={1}
+                                  borderRadius="md"
+                                  _hover={{ bg: "bg.muted" }}
+                                  onClick={() =>
+                                    toggleScoreType(score.id, score.name)
+                                  }
+                                >
+                                  <Check
+                                    size={16}
+                                    color={
+                                      isSelected ? "green" : "transparent"
+                                    }
+                                  />
+                                  <Text fontSize="sm">{score.name}</Text>
+                                </HStack>
+                              );
+                            })}
+                          </VStack>
+                        </Box>
+                        <Box
+                          padding={2}
+                          borderTop="1px solid"
+                          borderColor="border.muted"
+                        >
+                          <Button
+                            width="100%"
+                            colorPalette="blue"
+                            onClick={() => {
+                              scoreTypesPopoverOpen.onClose();
+                              scoreTypeDrawerOpen.onOpen();
                             }}
+                            variant="outline"
+                            size="sm"
                           >
-                            {children}
-                          </chakraComponents.Menu>
-                        ),
-                        MultiValueLabel: ({ ...props }) => (
-                          <chakraComponents.MultiValueLabel {...props}>
-                            <VStack align="start" padding={1} paddingX={0}>
-                              <HStack>
-                                <Text>{props.data.label}</Text>
-                              </HStack>
-                            </VStack>
-                          </chakraComponents.MultiValueLabel>
-                        ),
-                        MenuList: (props) => (
-                          <chakraComponents.MenuList {...props} maxHeight={300}>
-                            <Box
-                              maxH="250px"
-                              overflowY="auto"
-                              css={{
-                                "&::-webkit-scrollbar": {
-                                  display: "none",
-                                },
-                                msOverflowStyle: "none", // IE and Edge
-                                scrollbarWidth: "none", // Firefox
-                              }}
-                            >
-                              {props.children}
-                            </Box>
-                            <Box
-                              p={2}
-                              position="sticky"
-                              bottom={0}
-                              bg="bg.panel"
-                              borderTop="1px solid"
-                              borderColor="border.muted"
-                            >
-                              <Button
-                                width="100%"
-                                colorPalette="blue"
-                                onClick={scoreTypeDrawerOpen.onOpen}
-                                variant="outline"
-                                size="sm"
-                              >
-                                <Plus /> Add New
-                              </Button>
-                            </Box>
-                          </chakraComponents.MenuList>
-                        ),
-                      }}
-                    />
-                  </VStack>
-                </Field.Root>
+                            <Plus /> Add New
+                          </Button>
+                        </Box>
+                      </Popover.Body>
+                    </Popover.Content>
+                  </Popover.Root>
+                </FullWidthFormControl>
+
                 <HStack width="full">
                   <Spacer />
                   <Button

--- a/langwatch/src/components/datasets/DatasetSelector.tsx
+++ b/langwatch/src/components/datasets/DatasetSelector.tsx
@@ -62,7 +62,7 @@ export function DatasetSelector<T extends { datasetId: string }>({
         </Select.Trigger>
         <Select.Content portalled={false}>
           {datasetCollection.items.map((dataset) => (
-            <Select.Item key={dataset.value} item={dataset} marginY={3}>
+            <Select.Item key={dataset.value} item={dataset}>
               {dataset.label}
             </Select.Item>
           ))}

--- a/langwatch/src/main.tsx
+++ b/langwatch/src/main.tsx
@@ -14,7 +14,7 @@ if (!container) throw new Error("Root element not found");
 
 createRoot(container).render(
   <OuterProviders>
-    <Suspense>
+    <Suspense fallback={null}>
       <RouterProvider router={router} />
     </Suspense>
   </OuterProviders>

--- a/langwatch/src/utils/compat/__tests__/next-dynamic.unit.test.ts
+++ b/langwatch/src/utils/compat/__tests__/next-dynamic.unit.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.unmock("~/utils/compat/next-dynamic");
+import { resolveModule } from "../next-dynamic";
+
+describe("resolveModule()", () => {
+  describe("when module has ES default export (function)", () => {
+    it("returns the function as default", () => {
+      const MyComponent = () => null;
+      const result = resolveModule({ default: MyComponent });
+      expect(result.default).toBe(MyComponent);
+    });
+  });
+
+  describe("when module is a CJS module wrapped by Vite", () => {
+    it("unwraps { default: componentFn } to find the function", () => {
+      const MyComponent = () => null;
+      const result = resolveModule({ default: MyComponent });
+      expect(result.default).toBe(MyComponent);
+    });
+  });
+
+  describe("when module is double-wrapped CJS", () => {
+    it("resolves through { default: { default: componentFn } }", () => {
+      const MyComponent = () => null;
+      const result = resolveModule({ default: { default: MyComponent } });
+      expect(result.default).toBe(MyComponent);
+    });
+  });
+
+  describe("when module default is a non-function object (UMD)", () => {
+    it("returns the object as fallback", () => {
+      const moduleObj = { reactJsonView: () => null, someOther: "thing" };
+      const result = resolveModule({ default: moduleObj });
+      // moduleObj is not a function, and moduleObj.default is undefined,
+      // so it falls through to the fallback
+      expect(result.default).toBe(moduleObj);
+    });
+  });
+
+  describe("when module itself is the component (no wrapping)", () => {
+    it("returns the function as default", () => {
+      const MyComponent = () => null;
+      const result = resolveModule(MyComponent);
+      expect(result.default).toBe(MyComponent);
+    });
+  });
+
+  describe("when module is null/undefined", () => {
+    it("handles null gracefully", () => {
+      const result = resolveModule(null);
+      expect(result.default).toBeNull();
+    });
+
+    it("handles undefined gracefully", () => {
+      const result = resolveModule(undefined);
+      expect(result.default).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/utils/compat/__tests__/next-router.unit.test.ts
+++ b/langwatch/src/utils/compat/__tests__/next-router.unit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+
+// The global test-setup mocks ~/utils/compat/next-router. We need the real module.
+vi.unmock("~/utils/compat/next-router");
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const { resolvePathname, buildUrl } = await vi.importActual<
+  typeof import("../next-router")
+>("~/utils/compat/next-router");
+
+describe("resolvePathname()", () => {
+  describe("when path matches a project route", () => {
+    it("converts /my-project/messages to /[project]/messages", () => {
+      expect(resolvePathname("/my-project/messages")).toBe("/[project]/messages");
+    });
+
+    it("converts /my-project/analytics to /[project]/analytics", () => {
+      expect(resolvePathname("/my-project/analytics")).toBe(
+        "/[project]/analytics"
+      );
+    });
+
+    it("converts /my-project/evaluations to /[project]/evaluations", () => {
+      expect(resolvePathname("/my-project/evaluations")).toBe(
+        "/[project]/evaluations"
+      );
+    });
+  });
+
+  describe("when path matches a nested project route", () => {
+    it("converts /my-project/analytics/custom/123 to /[project]/analytics/custom/[id]", () => {
+      expect(resolvePathname("/my-project/analytics/custom/123")).toBe(
+        "/[project]/analytics/custom/[id]"
+      );
+    });
+
+    it("converts /my-project/messages/trace-abc/traceDetails to /[project]/messages/[trace]/[openTab]", () => {
+      expect(
+        resolvePathname("/my-project/messages/trace-abc/traceDetails")
+      ).toBe("/[project]/messages/[trace]/[openTab]");
+    });
+  });
+
+  describe("when path matches a static route", () => {
+    it("returns /auth/signin as-is", () => {
+      expect(resolvePathname("/auth/signin")).toBe("/auth/signin");
+    });
+
+    it("returns /settings as-is", () => {
+      expect(resolvePathname("/settings")).toBe("/settings");
+    });
+  });
+
+  describe("when path matches a catch-all route", () => {
+    it("converts /settings/models/foo to /settings/[[...path]]", () => {
+      expect(resolvePathname("/settings/models/foo")).toBe(
+        "/settings/[[...path]]"
+      );
+    });
+  });
+
+  describe("when path has no match", () => {
+    it("returns the path unchanged", () => {
+      expect(resolvePathname("/unknown/deeply/nested")).toBe(
+        "/unknown/deeply/nested"
+      );
+    });
+  });
+});
+
+describe("buildUrl()", () => {
+  describe("when url is a string", () => {
+    it("returns it as-is", () => {
+      expect(buildUrl("/foo/bar?x=1")).toBe("/foo/bar?x=1");
+    });
+  });
+
+  describe("when url is an object with pathname and query", () => {
+    it("builds URL from pathname and query params", () => {
+      const result = buildUrl({
+        pathname: "/my-project/messages",
+        query: { view: "table" },
+      });
+      expect(result).toBe("/my-project/messages?view=table");
+    });
+  });
+
+  describe("when query contains route params", () => {
+    it("strips route params from query string", () => {
+      const result = buildUrl(
+        {
+          pathname: "/my-project/messages",
+          query: { project: "my-project", view: "table" },
+        },
+        new Set(["project"])
+      );
+      expect(result).toBe("/my-project/messages?view=table");
+    });
+  });
+
+  describe("when pathname contains [param] patterns", () => {
+    it("resolves [project] from query values", () => {
+      const result = buildUrl({
+        pathname: "/[project]/messages",
+        query: { project: "inbox-narrator", view: "table" },
+      });
+      expect(result).toBe("/inbox-narrator/messages?view=table");
+    });
+
+    it("resolves multiple [param] patterns", () => {
+      const result = buildUrl({
+        pathname: "/[project]/messages/[trace]/[openTab]",
+        query: {
+          project: "inbox-narrator",
+          trace: "abc-123",
+          openTab: "traceDetails",
+        },
+      });
+      expect(result).toBe(
+        "/inbox-narrator/messages/abc-123/traceDetails"
+      );
+    });
+
+    it("resolves [[...path]] catch-all from array query value", () => {
+      const result = buildUrl({
+        pathname: "/settings/[[...path]]",
+        query: { path: ["models", "openai"] },
+      });
+      expect(result).toBe("/settings/models/openai");
+    });
+  });
+
+  describe("when query has undefined/null values", () => {
+    it("omits undefined values from query string", () => {
+      const result = buildUrl({
+        pathname: "/foo",
+        query: { a: "1", b: undefined, c: null, d: "2" },
+      });
+      expect(result).toBe("/foo?a=1&d=2");
+    });
+  });
+
+  describe("when query has array values", () => {
+    it("appends multiple values for the same key", () => {
+      const result = buildUrl({
+        pathname: "/foo",
+        query: { tags: ["a", "b", "c"] },
+      });
+      expect(result).toBe("/foo?tags=a&tags=b&tags=c");
+    });
+  });
+
+  describe("when no query is provided", () => {
+    it("returns just the pathname", () => {
+      const result = buildUrl({ pathname: "/foo" });
+      expect(result).toBe("/foo");
+    });
+  });
+});

--- a/langwatch/src/utils/compat/__tests__/next-router.unit.test.ts
+++ b/langwatch/src/utils/compat/__tests__/next-router.unit.test.ts
@@ -152,6 +152,24 @@ describe("buildUrl()", () => {
     });
   });
 
+  describe("when url is a query-only string with route params", () => {
+    it("strips route param keys from query string", () => {
+      const result = buildUrl(
+        "?project=inbox-narrator&view=table&drawer.open=traceDetails",
+        new Set(["project"])
+      );
+      expect(result).toBe("?view=table&drawer.open=traceDetails");
+    });
+
+    it("strips multiple route param keys", () => {
+      const result = buildUrl(
+        "?project=inbox-narrator&trace=abc&view=table",
+        new Set(["project", "trace"])
+      );
+      expect(result).toBe("?view=table");
+    });
+  });
+
   describe("when no query is provided", () => {
     it("returns just the pathname", () => {
       const result = buildUrl({ pathname: "/foo" });

--- a/langwatch/src/utils/compat/next-dynamic.ts
+++ b/langwatch/src/utils/compat/next-dynamic.ts
@@ -4,7 +4,7 @@
  * Next.js `dynamic()` is essentially React.lazy() with optional SSR control
  * and a loading component. Since we no longer have SSR, this is a thin wrapper.
  */
-import { lazy, type ComponentType, type ReactNode } from "react";
+import { lazy, Suspense, createElement, forwardRef, type ComponentType, type ReactNode } from "react";
 
 interface DynamicOptions {
   loading?: () => ReactNode;
@@ -36,7 +36,20 @@ export function resolveModule(mod: any): { default: ComponentType<any> } {
 
 export default function dynamic<P extends Record<string, any>>(
   importFn: () => Promise<any>,
-  _options?: DynamicOptions
+  options?: DynamicOptions
 ): ComponentType<P> {
-  return lazy(async () => resolveModule(await importFn())) as ComponentType<P>;
+  const LazyComponent = lazy(async () => resolveModule(await importFn()));
+  const fallback = options?.loading ? createElement(options.loading) : null;
+
+  // Wrap in Suspense so the lazy component doesn't bubble up to the root
+  // Suspense boundary and flash the entire page gray while loading.
+  const DynamicWrapper = forwardRef<any, P>(function DynamicWrapper(props, ref) {
+    return createElement(
+      Suspense,
+      { fallback },
+      createElement(LazyComponent as any, { ...props, ref })
+    );
+  });
+  DynamicWrapper.displayName = `Dynamic(${(LazyComponent as any).displayName || "Component"})`;
+  return DynamicWrapper as unknown as ComponentType<P>;
 }

--- a/langwatch/src/utils/compat/next-dynamic.ts
+++ b/langwatch/src/utils/compat/next-dynamic.ts
@@ -17,11 +17,21 @@ export default function dynamic<P extends Record<string, any>>(
 ): ComponentType<P> {
   return lazy(async () => {
     const mod = await importFn();
-    // Support both { default: Component } and direct function exports
-    if (mod && typeof mod === "object" && "default" in mod) {
-      return mod;
+    // Vite wraps CJS modules as { default: moduleExports }.
+    // The actual component could be:
+    //   1. mod.default (ES module default export — already a function/class)
+    //   2. mod.default.default (CJS module.exports wrapped by Vite, then re-wrapped)
+    //   3. mod itself (direct function export)
+    const resolved = mod?.default ?? mod;
+    // If resolved is a function/class, it's the component
+    if (typeof resolved === "function") {
+      return { default: resolved };
     }
-    // If the module itself is the component
-    return { default: mod };
+    // If resolved is an object with a default that's a function (double-wrapped CJS)
+    if (resolved && typeof resolved === "object" && typeof resolved.default === "function") {
+      return { default: resolved.default };
+    }
+    // Fallback: return as-is and let React error if it's wrong
+    return { default: resolved };
   }) as ComponentType<P>;
 }

--- a/langwatch/src/utils/compat/next-dynamic.ts
+++ b/langwatch/src/utils/compat/next-dynamic.ts
@@ -11,27 +11,32 @@ interface DynamicOptions {
   ssr?: boolean;
 }
 
+/**
+ * Resolve a dynamically imported module to a { default: Component } shape
+ * that React.lazy expects. Handles ESM, CJS, and double-wrapped modules.
+ * @internal Exported for testing only
+ */
+export function resolveModule(mod: any): { default: ComponentType<any> } {
+  const resolved = mod?.default ?? mod;
+  // If resolved is a function/class, it's the component
+  if (typeof resolved === "function") {
+    return { default: resolved };
+  }
+  // If resolved is an object with a default that's a function (double-wrapped CJS)
+  if (
+    resolved &&
+    typeof resolved === "object" &&
+    typeof resolved.default === "function"
+  ) {
+    return { default: resolved.default };
+  }
+  // Fallback: return as-is and let React error if it's wrong
+  return { default: resolved };
+}
+
 export default function dynamic<P extends Record<string, any>>(
   importFn: () => Promise<any>,
   _options?: DynamicOptions
 ): ComponentType<P> {
-  return lazy(async () => {
-    const mod = await importFn();
-    // Vite wraps CJS modules as { default: moduleExports }.
-    // The actual component could be:
-    //   1. mod.default (ES module default export — already a function/class)
-    //   2. mod.default.default (CJS module.exports wrapped by Vite, then re-wrapped)
-    //   3. mod itself (direct function export)
-    const resolved = mod?.default ?? mod;
-    // If resolved is a function/class, it's the component
-    if (typeof resolved === "function") {
-      return { default: resolved };
-    }
-    // If resolved is an object with a default that's a function (double-wrapped CJS)
-    if (resolved && typeof resolved === "object" && typeof resolved.default === "function") {
-      return { default: resolved.default };
-    }
-    // Fallback: return as-is and let React error if it's wrong
-    return { default: resolved };
-  }) as ComponentType<P>;
+  return lazy(async () => resolveModule(await importFn())) as ComponentType<P>;
 }

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -160,7 +160,21 @@ export function buildUrl(
   url: string | { pathname?: string; query?: Record<string, any> },
   routeParamKeys?: Set<string>
 ): string {
-  if (typeof url === "string") return url;
+  if (typeof url === "string") {
+    // For query-only strings ("?foo=bar"), strip route param keys that
+    // leaked in from router.query spreads. Components do:
+    //   router.replace("?" + qs.stringify({ ...router.query, newKey: "val" }))
+    // which includes route params like `project` in the query string.
+    if (url.startsWith("?") && routeParamKeys?.size) {
+      const searchParams = new URLSearchParams(url.slice(1));
+      for (const key of routeParamKeys) {
+        searchParams.delete(key);
+      }
+      const cleaned = searchParams.toString();
+      return cleaned ? `?${cleaned}` : window.location.pathname;
+    }
+    return url;
+  }
   // If pathname is omitted, use the current URL path (Next.js behavior)
   let pathname = url.pathname ?? window.location.pathname;
   const { query } = url;

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -85,7 +85,8 @@ const ROUTE_PATTERNS = [
   "/",
 ];
 
-function resolvePathname(path: string): string {
+/** @internal Exported for testing only */
+export function resolvePathname(path: string): string {
   for (const pattern of ROUTE_PATTERNS) {
     if (matchPath(pattern, path)) {
       // Convert React Router params (:param) back to Next.js style ([param])
@@ -154,20 +155,42 @@ export interface CompatRouter {
   isFallback: boolean;
 }
 
-function buildUrl(
+/** @internal Exported for testing only */
+export function buildUrl(
   url: string | { pathname?: string; query?: Record<string, any> },
   routeParamKeys?: Set<string>
 ): string {
   if (typeof url === "string") return url;
   // If pathname is omitted, use the current URL path (Next.js behavior)
-  const pathname = url.pathname ?? window.location.pathname;
+  let pathname = url.pathname ?? window.location.pathname;
   const { query } = url;
+
+  // Resolve Next.js-style [param] and [[...param]] in pathname using query values.
+  // Components do router.push({ pathname: router.pathname, query: {...} }) where
+  // router.pathname is "/[project]/messages". We need to replace [project] with
+  // the actual value from query before navigating.
+  const resolvedKeys = new Set<string>();
+  if (query && pathname.includes("[")) {
+    pathname = pathname
+      .replace(/\[\[\.\.\.(\w+)\]\]/g, (_match, key) => {
+        resolvedKeys.add(key);
+        const val = query[key];
+        if (Array.isArray(val)) return val.join("/");
+        return val != null ? String(val) : "";
+      })
+      .replace(/\[(\w+)\]/g, (_match, key) => {
+        resolvedKeys.add(key);
+        const val = query[key];
+        return val != null ? String(Array.isArray(val) ? val[0] : val) : "";
+      });
+  }
+
   if (!query || Object.keys(query).length === 0) return pathname;
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(query)) {
     if (value === undefined || value === null) continue;
-    // Skip route params — they're part of the URL path, not the query string
-    if (routeParamKeys?.has(key)) continue;
+    // Skip route params and resolved [param] keys — they're in the URL path
+    if (routeParamKeys?.has(key) || resolvedKeys.has(key)) continue;
     if (Array.isArray(value)) {
       for (const v of value) params.append(key, String(v));
     } else {

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -302,7 +302,14 @@ export function useRouter(): CompatRouter {
       query.path = catchAll ? catchAll.split("/") : [];
       delete query["*"];
     }
+    // Track which keys come from route params so we don't double-merge them
+    const routeParamKeySet = new Set(Object.keys(params));
     searchParams.forEach((value, key) => {
+      // Skip search params that shadow route params — the route param
+      // already has the canonical value. Without this guard, `project`
+      // (a route param) leaks into the query string and accumulates
+      // on every navigation (`project=x&project[0]=x&project[1]=x`).
+      if (routeParamKeySet.has(key)) return;
       const existing = query[key];
       if (existing !== undefined) {
         if (Array.isArray(existing)) {


### PR DESCRIPTION
## Summary

Follow-up fixes for the Vite migration (#3170).

## Fixes
1. **dynamic() CJS/UMD module handling** — Vite wraps CJS modules as `{ default: moduleObject }` where `moduleObject` isn't a component. The `dynamic()` compat now resolves through multiple levels of wrapping to find the actual component function. Fixes `@microlink/react-json-view` and `@monaco-editor/react`.

## Known Issues (investigating)
- `project` route param leaking into query string (`project=inbox-narrator&project%5B0%5D=...`)
- Gray flash when opening trace details drawer (Suspense boundary)
- `/inbox-narrator/messages` redirecting to `[project]/messages` then wrong project