### PR TITLE
fix(prompts): deploy dialog button styling and popover dismiss behavior

### DIFF
--- a/langwatch/src/components/llmPromptConfigs/ParameterRow.tsx
+++ b/langwatch/src/components/llmPromptConfigs/ParameterRow.tsx
@@ -90,7 +90,6 @@ export function ParameterRow({
       open={isOpen}
       onOpenChange={({ open }) => onOpenChange(open)}
       positioning={{ placement: "bottom-end", offset: { mainAxis: 4, crossAxis: 130 } }}
-      closeOnInteractOutside={false}
     >
       <Popover.Trigger asChild disabled={disabled}>
         <HStack

--- a/langwatch/src/prompts/components/DeployPromptDialog.tsx
+++ b/langwatch/src/prompts/components/DeployPromptDialog.tsx
@@ -484,12 +484,12 @@ export function DeployPromptDialog({
               Cancel
             </Button>
             <Button
-              colorPalette="orange"
+              colorPalette="blue"
               size="sm"
               onClick={() => void handleSave()}
               loading={isSaving}
             >
-              Save changes
+              Save
             </Button>
           </HStack>
         </DialogFooter>

--- a/langwatch/src/prompts/components/__tests__/DeployPromptDialog.integration.test.tsx
+++ b/langwatch/src/prompts/components/__tests__/DeployPromptDialog.integration.test.tsx
@@ -334,12 +334,12 @@ describe.skip("Feature: Deploy Prompt Dialog", () => {
     });
 
     describe("when showing dialog controls", () => {
-      it("displays the Save changes button", () => {
+      it("displays the Save button", () => {
         setupQueries();
         renderDialog();
 
         expect(
-          screen.getByRole("button", { name: /save changes/i }),
+          screen.getByRole("button", { name: /^save$/i }),
         ).toBeInTheDocument();
       });
     });
@@ -361,7 +361,7 @@ describe.skip("Feature: Deploy Prompt Dialog", () => {
         const prodSelect = screen.getByLabelText("Production version");
         fireEvent.change(prodSelect, { target: { value: "v3-id" } });
 
-        const saveButton = screen.getByRole("button", { name: /save changes/i });
+        const saveButton = screen.getByRole("button", { name: /^save$/i });
         fireEvent.click(saveButton);
 
         await waitFor(() => {
@@ -392,7 +392,7 @@ describe.skip("Feature: Deploy Prompt Dialog", () => {
         const stagSelect = screen.getByLabelText("Staging version");
         fireEvent.change(stagSelect, { target: { value: "v2-id" } });
 
-        const saveButton = screen.getByRole("button", { name: /save changes/i });
+        const saveButton = screen.getByRole("button", { name: /^save$/i });
         fireEvent.click(saveButton);
 
         await waitFor(() => {
@@ -427,7 +427,7 @@ describe.skip("Feature: Deploy Prompt Dialog", () => {
           target: { value: "v1-id" },
         });
 
-        fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+        fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
 
         await waitFor(() => {
           expect(mockMutateAsync).toHaveBeenCalledTimes(2);
@@ -450,7 +450,7 @@ describe.skip("Feature: Deploy Prompt Dialog", () => {
         });
         renderDialog({ onClose });
 
-        fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+        fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
 
         await waitFor(() => {
           expect(onClose).toHaveBeenCalled();

--- a/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
+++ b/langwatch/src/prompts/forms/fields/ModelSelectFieldMini.tsx
@@ -79,7 +79,6 @@ export const ModelSelectFieldMini = React.memo(function ModelSelectFieldMini({
         return (
           <Popover.Root
             positioning={{ placement: "bottom-start" }}
-            closeOnInteractOutside={false}
             open={popoverOpen}
             onOpenChange={({ open }) => setPopoverOpen(open)}
           >


### PR DESCRIPTION
## Summary

Three small prompt-UI fixes bundled together:

1. **Deploy prompt dialog — "Save" button** now uses the platform's blue `colorPalette` and a shorter label. Previously stood out as the only `colorPalette="orange"` save button with the wordy "Save changes" label.
2. **Model selector popover (`ModelSelectFieldMini`) closes on outside click.** Previously had `closeOnInteractOutside={false}`, so clicking anywhere outside the popover did nothing — it could only be dismissed by clicking the anchor again or pressing Escape.
3. **Parameter popover (`ParameterRow`) closes on outside click.** Same `closeOnInteractOutside={false}` override, same user-visible behavior.

## The "both modals open" side-effect

Fix 2 also resolves a secondary bug: when the model popover was open and the user clicked "Save version", the save-version dialog opened on top while the model popover stayed visible — two overlapping UIs at once. Root cause was the same `closeOnInteractOutside={false}` override; clicking "Save version" is an outside interaction that should have dismissed the popover first.

## What stayed intact

The controlled `open` / `onOpenChange` pattern is unchanged. Removing `closeOnInteractOutside={false}` just lets Zag/Chakra call `onOpenChange({ open: false })` on outside interaction, which feeds back into the existing state — so the manual toggle via the anchor click still works.

The `Popover.Anchor` workaround in `ModelSelectFieldMini` (for [#2390](https://github.com/langwatch/langwatch/issues/2390) — Zag's internal onClick handler conflicting with Drawer's dismissable layer) is preserved; only the `closeOnInteractOutside` override was removed.

## Test plan

- [x] `DeployPromptDialog` unit tests updated (button accessible name now `/^save$/i` instead of `/save changes/i`)
- [ ] Manual: open the deploy prompt dialog, confirm the primary button is blue and labelled "Save"
- [ ] Manual: open the model popover in a prompt config form, click outside → popover closes
- [ ] Manual: open the model popover, click "Save version" → popover closes, only the save-version dialog is visible
- [ ] Manual: open the parameters popover, click outside → popover closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)