### PR TITLE
ci(e2e): run e2e against production server path

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -36,7 +36,12 @@ jobs:
       API_TOKEN_JWT_SECRET: "test-jwt-secret-for-e2e"
       SKIP_ENV_VALIDATION: "true"
       DISABLE_PII_REDACTION: "true"
-      NODE_ENV: "development"
+      # Run e2e against the production server path so static SPA files are
+      # served by the Node API process. Post-Vite migration, NODE_ENV=development
+      # puts the server in "API only — Vite on :5560" mode which returns 404 for
+      # `/`, and the e2e global-setup's waitForApp ping fails. The Build step
+      # still overrides with NODE_ENV=test, so only the runtime is affected.
+      NODE_ENV: "production"
       # Test runner configuration
       BASE_URL: "http://localhost:5570"
       CI: "true"


### PR DESCRIPTION
## Problem

The e2e CI job has been failing since the Vite migration (PR #3170) landed. `waitForApp` (`agentic-e2e-tests/tests/global-setup.ts`) pings `GET http://localhost:5570/` and expects 2xx or 302. It's been getting **404 × 30** for every run.

## Root cause

PR #3170 split the Node server:

- **Development** (`NODE_ENV=development` → `dev=true` in `src/start.ts`): server is API-only on `:5570`, Vite serves SPA on `:5560`. `GET /` on the API port is a 404 by design.
- **Production** (`NODE_ENV=production`): single process serves both API *and* the built SPA via `clientDistDir` + SPA fallback.

The e2e workflow sets `NODE_ENV: "development"` at the job level (`.github/workflows/e2e-ci.yml:39`), so `pnpm start` boots the server in API-only mode and `GET /` returns 404 — exactly what `waitForApp` has been observing.

## Fix

Set `NODE_ENV: "production"` at the job level. The **Build** step already overrides to `NODE_ENV=test` (`run: NODE_ENV=test pnpm build`), so the build phase is unchanged. Only the runtime server starts in production mode, which was the implicit assumption pre-migration.

## Test plan

- [ ] CI e2e turns green on this branch
- [ ] Verify `waitForApp` succeeds (check job log for `✅ App is ready`)

Surfaced while reviewing CI on unrelated PR #3188 — e2e was red there too, but with identical 404 retry pattern, confirming it's a universal issue not caused by that PR's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)