### PR TITLE
fix(ci): remove node-pty from onlyBuiltDependencies

### DIFF
--- a/langwatch/pnpm-workspace.yaml
+++ b/langwatch/pnpm-workspace.yaml
@@ -49,7 +49,6 @@ onlyBuiltDependencies:
   - cpu-features
   - esbuild
   - msgpackr-extract
-  - node-pty
   - prisma
   - protobufjs
   - sharp


### PR DESCRIPTION
## Summary

Fixes the saas CI build failure caused by `node-pty` native compilation failing on ARM runners.

`node-pty` is used by the MCP CLI client for terminal features, not by the server. Removing it from `onlyBuiltDependencies` in `pnpm-workspace.yaml` tells pnpm to skip the native build — the package is still installed, just without the native addon.

## Test plan
- [x] `pnpm install` succeeds locally
- [x] `pnpm run build` succeeds locally