### PR TITLE
fix: eliminate gray flash, session storm, and path accumulation

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -22,7 +22,7 @@
     "format": "pnpm exec biome format src/ --write",
     "postinstall": "make -C .. setup-hooks 2>/dev/null || true",
     "dev": "pnpm run start:prepare:files && NODE_ENV=development START_WORKERS=true FORCE_COLOR=1 pnpm start 2>&1 | tee server.log",
-    "dev:vite": "vite --port 5560",
+    "dev:vite": "vite",
     "start": "./scripts/start.sh",
     "start:app": "tsx src/server.mts",
     "start:quickwit": "cd quickwit && ./quickwit run",

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -14,8 +14,8 @@ if [[ "$START_WORKERS" = "true" || "$START_WORKERS" = "1" ]]; then
   START_WORKERS_COMMAND="pnpm run start:workers && exit 1"
 fi
 
-# In development, Vite runs on 5560 (user-facing) and proxies /api/* to the API server.
-# In production, only the API server runs on 5560.
+# In development, Vite runs on PORT (default 5560) and proxies /api/* to PORT+1000.
+# In production, only the API server runs on PORT (default 5560).
 START_VITE_COMMAND=""
 if [[ "$NODE_ENV" = "development" ]]; then
   START_VITE_COMMAND="pnpm run dev:vite"

--- a/langwatch/src/routes.tsx
+++ b/langwatch/src/routes.tsx
@@ -1,8 +1,8 @@
-import { lazy, Suspense, useEffect, useRef } from "react";
+import { Suspense, useEffect } from "react";
 import {
   createBrowserRouter,
   Outlet,
-  useLocation,
+  useNavigation,
   type RouteObject,
 } from "react-router";
 import NProgress from "nprogress";
@@ -11,28 +11,22 @@ import { InnerProviders } from "./AppProviders";
 /**
  * Root layout — wraps all routes.
  * - InnerProviders: CommandBar, Analytics, PostHog (need Router context)
- * - NProgress: loading bar on navigation
+ * - NProgress: loading bar on navigation (starts when lazy route begins loading)
  */
 function RootLayout() {
-  const location = useLocation();
-  const isFirstRender = useRef(true);
+  const navigation = useNavigation();
 
   useEffect(() => {
     NProgress.configure({ showSpinner: false });
   }, []);
 
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-    NProgress.start();
-    const timeout = setTimeout(() => NProgress.done(), 100);
-    return () => {
-      clearTimeout(timeout);
+    if (navigation.state === "loading") {
+      NProgress.start();
+    } else {
       NProgress.done();
-    };
-  }, [location.pathname]);
+    }
+  }, [navigation.state]);
 
   return (
     <InnerProviders>
@@ -43,382 +37,307 @@ function RootLayout() {
   );
 }
 
-// Lazy-load all page components
-const Index = lazy(() => import("./pages/index"));
-const Authorize = lazy(() => import("./pages/authorize"));
-const Onboarding = lazy(() => import("./pages/onboarding"));
-const OnboardingTeamProject = lazy(
-  () => import("./pages/onboarding/[team]/project")
-);
-const OnboardingProduct = lazy(
-  () => import("./pages/onboarding/product/index")
-);
-const OnboardingWelcome = lazy(
-  () => import("./pages/onboarding/welcome")
-);
-const Settings = lazy(() => import("./pages/settings"));
-
-// Auth
-const SignIn = lazy(() => import("./pages/auth/signin"));
-const SignUp = lazy(() => import("./pages/auth/signup"));
-const AuthError = lazy(() => import("./pages/auth/error"));
-
-// Admin
-const Admin = lazy(() => import("./pages/admin/index"));
-
-// Invite
-const InviteAccept = lazy(() => import("./pages/invite/accept"));
-
-// MCP
-const McpAuthorize = lazy(() => import("./pages/mcp/authorize"));
-
-// Share
-const SharePage = lazy(() => import("./pages/share/[id]"));
-
-// Settings sub-pages
-const SettingsAccessAudit = lazy(
-  () => import("./pages/settings/access-audit")
-);
-const SettingsAnnotationScores = lazy(
-  () => import("./pages/settings/annotation-scores")
-);
-const SettingsAuditLog = lazy(
-  () => import("./pages/settings/audit-log")
-);
-const SettingsAuthentication = lazy(
-  () => import("./pages/settings/authentication")
-);
-const SettingsGroups = lazy(() => import("./pages/settings/groups"));
-const SettingsLicense = lazy(() => import("./pages/settings/license"));
-const SettingsMembers = lazy(() => import("./pages/settings/members"));
-const SettingsMemberDetail = lazy(
-  () => import("./pages/settings/members/[userId]")
-);
-const SettingsModelCosts = lazy(
-  () => import("./pages/settings/model-costs")
-);
-const SettingsModelProviders = lazy(
-  () => import("./pages/settings/model-providers")
-);
-const SettingsPlans = lazy(() => import("./pages/settings/plans"));
-const SettingsRoles = lazy(() => import("./pages/settings/roles"));
-const SettingsScim = lazy(() => import("./pages/settings/scim"));
-const SettingsSecrets = lazy(() => import("./pages/settings/secrets"));
-const SettingsSubscription = lazy(
-  () => import("./pages/settings/subscription")
-);
-const SettingsTeams = lazy(() => import("./pages/settings/teams"));
-const SettingsTeamDetail = lazy(
-  () => import("./pages/settings/teams/[team]")
-);
-const SettingsTopicClustering = lazy(
-  () => import("./pages/settings/topic-clustering")
-);
-const SettingsUsage = lazy(() => import("./pages/settings/usage"));
-
-// Project pages
-const ProjectIndex = lazy(() => import("./pages/[project]/index"));
-const ProjectAgents = lazy(() => import("./pages/[project]/agents"));
-const ProjectAutomations = lazy(
-  () => import("./pages/[project]/automations")
-);
-const ProjectDatasets = lazy(
-  () => import("./pages/[project]/datasets")
-);
-const ProjectDatasetDetail = lazy(
-  () => import("./pages/[project]/datasets/[id]")
-);
-const ProjectEvaluators = lazy(
-  () => import("./pages/[project]/evaluators")
-);
-const ProjectEvaluations = lazy(
-  () => import("./pages/[project]/evaluations")
-);
-const ProjectEvaluationsNew = lazy(
-  () => import("./pages/[project]/evaluations/new")
-);
-const ProjectEvaluationsNewChoose = lazy(
-  () => import("./pages/[project]/evaluations/new/choose")
-);
-const ProjectEvaluationsWizard = lazy(
-  () => import("./pages/[project]/evaluations/wizard")
-);
-const ProjectEvaluationsWizardSlug = lazy(
-  () => import("./pages/[project]/evaluations/wizard/[slug]")
-);
-const ProjectEvaluationsEditId = lazy(
-  () => import("./pages/[project]/evaluations/[id]/edit")
-);
-const ProjectEvaluationsEditIdChoose = lazy(
-  () => import("./pages/[project]/evaluations/[id]/edit/choose")
-);
-const ProjectMessages = lazy(
-  () => import("./pages/[project]/messages")
-);
-const ProjectMessageTrace = lazy(
-  () => import("./pages/[project]/messages/[trace]/index")
-);
-const ProjectMessageTraceTab = lazy(
-  () => import("./pages/[project]/messages/[trace]/[openTab]/index")
-);
-const ProjectMessageTraceTabSpan = lazy(
-  () => import("./pages/[project]/messages/[trace]/[openTab]/[span]")
-);
-const ProjectPrompts = lazy(
-  () => import("./pages/[project]/prompts")
-);
-const ProjectSetup = lazy(() => import("./pages/[project]/setup"));
-const ProjectWorkflows = lazy(
-  () => import("./pages/[project]/workflows")
-);
-const ProjectChat = lazy(
-  () => import("./pages/[project]/chat/[workflow]")
-);
-const ProjectStudio = lazy(
-  () => import("./pages/[project]/studio/[workflow]")
-);
-
-// Annotations
-const ProjectAnnotations = lazy(
-  () => import("./pages/[project]/annotations")
-);
-const ProjectAnnotationsSlug = lazy(
-  () => import("./pages/[project]/annotations/[slug]")
-);
-const ProjectAnnotationsAll = lazy(
-  () => import("./pages/[project]/annotations/all")
-);
-const ProjectAnnotationsMe = lazy(
-  () => import("./pages/[project]/annotations/me")
-);
-const ProjectAnnotationsMyQueue = lazy(
-  () => import("./pages/[project]/annotations/my-queue")
-);
-
-// Analytics
-const ProjectAnalytics = lazy(
-  () => import("./pages/[project]/analytics/index")
-);
-const ProjectAnalyticsEvaluations = lazy(
-  () => import("./pages/[project]/analytics/evaluations")
-);
-const ProjectAnalyticsMetrics = lazy(
-  () => import("./pages/[project]/analytics/metrics")
-);
-const ProjectAnalyticsReports = lazy(
-  () => import("./pages/[project]/analytics/reports")
-);
-const ProjectAnalyticsTopics = lazy(
-  () => import("./pages/[project]/analytics/topics")
-);
-const ProjectAnalyticsUsers = lazy(
-  () => import("./pages/[project]/analytics/users")
-);
-const ProjectAnalyticsCustom = lazy(
-  () => import("./pages/[project]/analytics/custom/index")
-);
-const ProjectAnalyticsCustomId = lazy(
-  () => import("./pages/[project]/analytics/custom/[id]")
-);
-
-// Experiments
-const ProjectExperiments = lazy(
-  () => import("./pages/[project]/experiments/index")
-);
-const ProjectExperimentsDetail = lazy(
-  () => import("./pages/[project]/experiments/[experiment]")
-);
-const ProjectExperimentsWorkbench = lazy(
-  () => import("./pages/[project]/experiments/workbench/index")
-);
-const ProjectExperimentsWorkbenchSlug = lazy(
-  () => import("./pages/[project]/experiments/workbench/[slug]")
-);
-
-// @project redirect (Next.js parallel route — redirects to /:project/...)
-const AtProjectRedirect = lazy(
-  () => import("./pages/@project/[...path]/index")
-);
-
-// Simulations (catch-all)
-const ProjectSimulations = lazy(
-  () => import("./pages/[project]/simulations/[[...path]]")
-);
-const ProjectSimulationsScenarios = lazy(
-  () => import("./pages/[project]/simulations/scenarios/index")
-);
+/**
+ * Helper: wraps a dynamic import() into the shape React Router's `lazy` expects.
+ * React Router's lazy keeps the OLD route visible while the new module loads,
+ * eliminating the gray flash that React.lazy + Suspense causes.
+ */
+const page = (importFn: () => Promise<{ default: React.ComponentType }>) => ({
+  lazy: () => importFn().then((m) => ({ Component: m.default })),
+});
 
 const routes: RouteObject[] = [
   // Auth (public)
-  { path: "/auth/signin", Component: SignIn },
-  { path: "/auth/signup", Component: SignUp },
-  { path: "/auth/error", Component: AuthError },
+  { path: "/auth/signin", ...page(() => import("./pages/auth/signin")) },
+  { path: "/auth/signup", ...page(() => import("./pages/auth/signup")) },
+  { path: "/auth/error", ...page(() => import("./pages/auth/error")) },
 
   // Top-level pages
-  { path: "/", Component: Index },
-  { path: "/authorize", Component: Authorize },
-  { path: "/admin", Component: Admin },
-  { path: "/invite/accept", Component: InviteAccept },
-  { path: "/mcp/authorize", Component: McpAuthorize },
-  { path: "/share/:id", Component: SharePage },
+  { path: "/", ...page(() => import("./pages/index")) },
+  { path: "/authorize", ...page(() => import("./pages/authorize")) },
+  { path: "/admin", ...page(() => import("./pages/admin/index")) },
+  { path: "/invite/accept", ...page(() => import("./pages/invite/accept")) },
+  { path: "/mcp/authorize", ...page(() => import("./pages/mcp/authorize")) },
+  { path: "/share/:id", ...page(() => import("./pages/share/[id]")) },
 
   // Onboarding
-  { path: "/onboarding", Component: Onboarding },
-  { path: "/onboarding/:team/project", Component: OnboardingTeamProject },
-  { path: "/onboarding/product", Component: OnboardingProduct },
-  { path: "/onboarding/welcome", Component: OnboardingWelcome },
+  { path: "/onboarding", ...page(() => import("./pages/onboarding")) },
+  {
+    path: "/onboarding/:team/project",
+    ...page(() => import("./pages/onboarding/[team]/project")),
+  },
+  {
+    path: "/onboarding/product",
+    ...page(() => import("./pages/onboarding/product/index")),
+  },
+  {
+    path: "/onboarding/welcome",
+    ...page(() => import("./pages/onboarding/welcome")),
+  },
 
   // Settings
-  { path: "/settings", Component: Settings },
-  { path: "/settings/access-audit", Component: SettingsAccessAudit },
+  { path: "/settings", ...page(() => import("./pages/settings")) },
+  {
+    path: "/settings/access-audit",
+    ...page(() => import("./pages/settings/access-audit")),
+  },
   {
     path: "/settings/annotation-scores",
-    Component: SettingsAnnotationScores,
+    ...page(() => import("./pages/settings/annotation-scores")),
   },
-  { path: "/settings/audit-log", Component: SettingsAuditLog },
-  { path: "/settings/authentication", Component: SettingsAuthentication },
-  { path: "/settings/groups", Component: SettingsGroups },
-  { path: "/settings/license", Component: SettingsLicense },
-  { path: "/settings/members", Component: SettingsMembers },
-  { path: "/settings/members/:userId", Component: SettingsMemberDetail },
-  { path: "/settings/model-costs", Component: SettingsModelCosts },
-  { path: "/settings/model-providers", Component: SettingsModelProviders },
-  { path: "/settings/plans", Component: SettingsPlans },
-  { path: "/settings/roles", Component: SettingsRoles },
-  { path: "/settings/scim", Component: SettingsScim },
-  { path: "/settings/secrets", Component: SettingsSecrets },
-  { path: "/settings/subscription", Component: SettingsSubscription },
-  { path: "/settings/teams", Component: SettingsTeams },
-  { path: "/settings/teams/:team", Component: SettingsTeamDetail },
+  {
+    path: "/settings/audit-log",
+    ...page(() => import("./pages/settings/audit-log")),
+  },
+  {
+    path: "/settings/authentication",
+    ...page(() => import("./pages/settings/authentication")),
+  },
+  {
+    path: "/settings/groups",
+    ...page(() => import("./pages/settings/groups")),
+  },
+  {
+    path: "/settings/license",
+    ...page(() => import("./pages/settings/license")),
+  },
+  {
+    path: "/settings/members",
+    ...page(() => import("./pages/settings/members")),
+  },
+  {
+    path: "/settings/members/:userId",
+    ...page(() => import("./pages/settings/members/[userId]")),
+  },
+  {
+    path: "/settings/model-costs",
+    ...page(() => import("./pages/settings/model-costs")),
+  },
+  {
+    path: "/settings/model-providers",
+    ...page(() => import("./pages/settings/model-providers")),
+  },
+  {
+    path: "/settings/plans",
+    ...page(() => import("./pages/settings/plans")),
+  },
+  {
+    path: "/settings/roles",
+    ...page(() => import("./pages/settings/roles")),
+  },
+  { path: "/settings/scim", ...page(() => import("./pages/settings/scim")) },
+  {
+    path: "/settings/secrets",
+    ...page(() => import("./pages/settings/secrets")),
+  },
+  {
+    path: "/settings/subscription",
+    ...page(() => import("./pages/settings/subscription")),
+  },
+  {
+    path: "/settings/teams",
+    ...page(() => import("./pages/settings/teams")),
+  },
+  {
+    path: "/settings/teams/:team",
+    ...page(() => import("./pages/settings/teams/[team]")),
+  },
   {
     path: "/settings/topic-clustering",
-    Component: SettingsTopicClustering,
+    ...page(() => import("./pages/settings/topic-clustering")),
   },
-  { path: "/settings/usage", Component: SettingsUsage },
+  {
+    path: "/settings/usage",
+    ...page(() => import("./pages/settings/usage")),
+  },
 
   // Project routes
-  { path: "/:project", Component: ProjectIndex },
-  { path: "/:project/agents", Component: ProjectAgents },
-  { path: "/:project/automations", Component: ProjectAutomations },
-  { path: "/:project/datasets", Component: ProjectDatasets },
-  { path: "/:project/datasets/:id", Component: ProjectDatasetDetail },
-  { path: "/:project/evaluators", Component: ProjectEvaluators },
-  { path: "/:project/evaluations", Component: ProjectEvaluations },
-  { path: "/:project/evaluations/new", Component: ProjectEvaluationsNew },
+  {
+    path: "/:project",
+    ...page(() => import("./pages/[project]/index")),
+  },
+  {
+    path: "/:project/agents",
+    ...page(() => import("./pages/[project]/agents")),
+  },
+  {
+    path: "/:project/automations",
+    ...page(() => import("./pages/[project]/automations")),
+  },
+  {
+    path: "/:project/datasets",
+    ...page(() => import("./pages/[project]/datasets")),
+  },
+  {
+    path: "/:project/datasets/:id",
+    ...page(() => import("./pages/[project]/datasets/[id]")),
+  },
+  {
+    path: "/:project/evaluators",
+    ...page(() => import("./pages/[project]/evaluators")),
+  },
+  {
+    path: "/:project/evaluations",
+    ...page(() => import("./pages/[project]/evaluations")),
+  },
+  {
+    path: "/:project/evaluations/new",
+    ...page(() => import("./pages/[project]/evaluations/new")),
+  },
   {
     path: "/:project/evaluations/new/choose",
-    Component: ProjectEvaluationsNewChoose,
+    ...page(() => import("./pages/[project]/evaluations/new/choose")),
   },
   {
     path: "/:project/evaluations/wizard",
-    Component: ProjectEvaluationsWizard,
+    ...page(() => import("./pages/[project]/evaluations/wizard")),
   },
   {
     path: "/:project/evaluations/wizard/:slug",
-    Component: ProjectEvaluationsWizardSlug,
+    ...page(() => import("./pages/[project]/evaluations/wizard/[slug]")),
   },
   {
     path: "/:project/evaluations/:id/edit",
-    Component: ProjectEvaluationsEditId,
+    ...page(() => import("./pages/[project]/evaluations/[id]/edit")),
   },
   {
     path: "/:project/evaluations/:id/edit/choose",
-    Component: ProjectEvaluationsEditIdChoose,
+    ...page(() => import("./pages/[project]/evaluations/[id]/edit/choose")),
   },
-  { path: "/:project/messages", Component: ProjectMessages },
+  {
+    path: "/:project/messages",
+    ...page(() => import("./pages/[project]/messages")),
+  },
   {
     path: "/:project/messages/:trace",
-    Component: ProjectMessageTrace,
+    ...page(() => import("./pages/[project]/messages/[trace]/index")),
   },
   {
     path: "/:project/messages/:trace/:openTab",
-    Component: ProjectMessageTraceTab,
+    ...page(
+      () => import("./pages/[project]/messages/[trace]/[openTab]/index")
+    ),
   },
   {
     path: "/:project/messages/:trace/:openTab/:span",
-    Component: ProjectMessageTraceTabSpan,
+    ...page(
+      () => import("./pages/[project]/messages/[trace]/[openTab]/[span]")
+    ),
   },
-  { path: "/:project/prompts", Component: ProjectPrompts },
-  { path: "/:project/setup", Component: ProjectSetup },
-  { path: "/:project/workflows", Component: ProjectWorkflows },
-  { path: "/:project/chat/:workflow", Component: ProjectChat },
-  { path: "/:project/studio/:workflow", Component: ProjectStudio },
+  {
+    path: "/:project/prompts",
+    ...page(() => import("./pages/[project]/prompts")),
+  },
+  {
+    path: "/:project/setup",
+    ...page(() => import("./pages/[project]/setup")),
+  },
+  {
+    path: "/:project/workflows",
+    ...page(() => import("./pages/[project]/workflows")),
+  },
+  {
+    path: "/:project/chat/:workflow",
+    ...page(() => import("./pages/[project]/chat/[workflow]")),
+  },
+  {
+    path: "/:project/studio/:workflow",
+    ...page(() => import("./pages/[project]/studio/[workflow]")),
+  },
 
   // Annotations
-  { path: "/:project/annotations", Component: ProjectAnnotations },
-  { path: "/:project/annotations/all", Component: ProjectAnnotationsAll },
-  { path: "/:project/annotations/me", Component: ProjectAnnotationsMe },
+  {
+    path: "/:project/annotations",
+    ...page(() => import("./pages/[project]/annotations")),
+  },
+  {
+    path: "/:project/annotations/all",
+    ...page(() => import("./pages/[project]/annotations/all")),
+  },
+  {
+    path: "/:project/annotations/me",
+    ...page(() => import("./pages/[project]/annotations/me")),
+  },
   {
     path: "/:project/annotations/my-queue",
-    Component: ProjectAnnotationsMyQueue,
+    ...page(() => import("./pages/[project]/annotations/my-queue")),
   },
   {
     path: "/:project/annotations/:slug",
-    Component: ProjectAnnotationsSlug,
+    ...page(() => import("./pages/[project]/annotations/[slug]")),
   },
 
   // Analytics
-  { path: "/:project/analytics", Component: ProjectAnalytics },
+  {
+    path: "/:project/analytics",
+    ...page(() => import("./pages/[project]/analytics/index")),
+  },
   {
     path: "/:project/analytics/evaluations",
-    Component: ProjectAnalyticsEvaluations,
+    ...page(() => import("./pages/[project]/analytics/evaluations")),
   },
   {
     path: "/:project/analytics/metrics",
-    Component: ProjectAnalyticsMetrics,
+    ...page(() => import("./pages/[project]/analytics/metrics")),
   },
   {
     path: "/:project/analytics/reports",
-    Component: ProjectAnalyticsReports,
+    ...page(() => import("./pages/[project]/analytics/reports")),
   },
   {
     path: "/:project/analytics/topics",
-    Component: ProjectAnalyticsTopics,
+    ...page(() => import("./pages/[project]/analytics/topics")),
   },
   {
     path: "/:project/analytics/users",
-    Component: ProjectAnalyticsUsers,
+    ...page(() => import("./pages/[project]/analytics/users")),
   },
   {
     path: "/:project/analytics/custom",
-    Component: ProjectAnalyticsCustom,
+    ...page(() => import("./pages/[project]/analytics/custom/index")),
   },
   {
     path: "/:project/analytics/custom/:id",
-    Component: ProjectAnalyticsCustomId,
+    ...page(() => import("./pages/[project]/analytics/custom/[id]")),
   },
 
   // Experiments
-  { path: "/:project/experiments", Component: ProjectExperiments },
+  {
+    path: "/:project/experiments",
+    ...page(() => import("./pages/[project]/experiments/index")),
+  },
   {
     path: "/:project/experiments/workbench",
-    Component: ProjectExperimentsWorkbench,
+    ...page(() => import("./pages/[project]/experiments/workbench/index")),
   },
   {
     path: "/:project/experiments/workbench/:slug",
-    Component: ProjectExperimentsWorkbenchSlug,
+    ...page(() => import("./pages/[project]/experiments/workbench/[slug]")),
   },
   {
     path: "/:project/experiments/:experiment",
-    Component: ProjectExperimentsDetail,
+    ...page(() => import("./pages/[project]/experiments/[experiment]")),
   },
 
   // Simulations (catch-all)
   {
     path: "/:project/simulations/scenarios",
-    Component: ProjectSimulationsScenarios,
+    ...page(() => import("./pages/[project]/simulations/scenarios/index")),
   },
   {
     path: "/:project/simulations/*",
-    Component: ProjectSimulations,
+    ...page(() => import("./pages/[project]/simulations/[[...path]]")),
   },
   {
     path: "/:project/simulations",
-    Component: ProjectSimulations,
+    ...page(() => import("./pages/[project]/simulations/[[...path]]")),
   },
 
   // @project redirect — Next.js parallel route that redirects /@project/path to /:project/path
-  { path: "/@project/*", Component: AtProjectRedirect },
+  {
+    path: "/@project/*",
+    ...page(() => import("./pages/@project/[...path]/index")),
+  },
 ];
 
 export const router = createBrowserRouter([

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -57,12 +57,11 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
   // This was previously done by Next.js instrumentation hook.
   initializeWebApp();
 
-  // Dev: API server on internal port (API_PORT, default 5565).
-  //      Vite dev server runs separately on 5560 and proxies /api/* here.
-  // Prod: Single server on 5560 serves API routes + static files.
-  const port = parseInt(
-    process.env.PORT ?? (dev ? process.env.API_PORT ?? "5565" : "5560")
-  );
+  // Dev: API server on PORT+1000 (default 6560).
+  //      Vite dev server runs separately on PORT (default 5560) and proxies /api/* here.
+  // Prod: Single server on PORT (default 5560) serves API routes + static files.
+  const basePort = parseInt(process.env.PORT ?? "5560");
+  const port = dev ? basePort + 1000 : basePort;
 
   const mcpHandler = createMcpHandler();
   const honoApp = createApiRouter();
@@ -199,7 +198,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
         hostname,
         port,
         fullUrl: `http://${hostname === "0.0.0.0" ? "localhost" : hostname}:${port}`,
-        mode: dev ? "development (API only — Vite on :5560)" : "production",
+        mode: dev ? `development (API only — Vite on :${basePort})` : "production",
       },
       asciiArt
     );

--- a/langwatch/src/utils/__tests__/auth-client-session-cache.unit.test.ts
+++ b/langwatch/src/utils/__tests__/auth-client-session-cache.unit.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+// We need to test the real module, not the test-setup mock
+vi.unmock("~/utils/auth-client");
+
+// Mock better-auth/react before importing auth-client
+vi.mock("better-auth/react", () => ({
+  createAuthClient: () => ({
+    useSession: () => ({ data: null, isPending: true }),
+    signIn: { email: vi.fn(), social: vi.fn() },
+    signOut: vi.fn(),
+  }),
+}));
+
+// Mock fetch for session requests
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Fresh import for each describe block — module-level cache persists across tests
+// so we use dynamic import + resetModules
+describe("useSession session caching", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockSessionResponse = {
+    session: { id: "sess-1", userId: "user-1", token: "tok" },
+    user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  };
+
+  it("fetches session only once across multiple hook instances", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSessionResponse,
+    });
+
+    const { useSession } = await import("../auth-client");
+
+    const { result: result1 } = renderHook(() => useSession());
+    const { result: result2 } = renderHook(() => useSession());
+
+    await waitFor(() => {
+      expect(result1.current.status).toBe("authenticated");
+    });
+
+    await waitFor(() => {
+      expect(result2.current.status).toBe("authenticated");
+    });
+
+    // Only ONE fetch call despite two hooks mounting
+    const sessionCalls = mockFetch.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/auth/session")
+    );
+    expect(sessionCalls).toHaveLength(1);
+  });
+
+  it("returns cached session immediately on subsequent mounts (no flash)", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSessionResponse,
+    });
+
+    const { useSession } = await import("../auth-client");
+
+    // First mount — fetches
+    const { result: first, unmount } = renderHook(() => useSession());
+    await waitFor(() => {
+      expect(first.current.status).toBe("authenticated");
+    });
+
+    // Unmount first hook (simulates page navigation)
+    unmount();
+
+    // Reset fetch to track new calls
+    mockFetch.mockClear();
+
+    // Second mount — should have cached data immediately
+    const { result: second } = renderHook(() => useSession());
+
+    // IMMEDIATELY has data (no "loading" state)
+    expect(second.current.data).not.toBeNull();
+    expect(second.current.data?.user.email).toBe("test@example.com");
+    expect(second.current.status).toBe("authenticated");
+
+    // No new fetch calls — served from cache
+    const sessionCalls = mockFetch.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("/api/auth/session")
+    );
+    expect(sessionCalls).toHaveLength(0);
+  });
+
+  it("clears cache on signOut", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSessionResponse,
+    });
+
+    const mod = await import("../auth-client");
+
+    // First mount — fetches and caches
+    const { result, unmount } = renderHook(() => mod.useSession());
+    await waitFor(() => {
+      expect(result.current.status).toBe("authenticated");
+    });
+    unmount();
+
+    // Sign out — clears cache
+    // signOut navigates to /api/auth/logout, so we just test the cache clear
+    // by calling signOut with redirect: false
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    await act(async () => {
+      await mod.signOut({ redirect: false });
+    });
+
+    // Next mount should start with null (cache cleared)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSessionResponse,
+    });
+    const { result: afterLogout } = renderHook(() => mod.useSession());
+
+    // Initially pending since cache was cleared
+    expect(afterLogout.current.status).toBe("loading");
+  });
+});

--- a/langwatch/src/utils/auth-client.tsx
+++ b/langwatch/src/utils/auth-client.tsx
@@ -78,6 +78,38 @@ interface UseSessionOptions {
  * to the impersonated identity. This mirrors how NextAuth's `useSession`
  * worked — both server and client saw the same impersonation-aware session.
  */
+// Module-level session cache — survives component unmount/remount so
+// navigating between pages doesn't flash <LoadingScreen /> while the
+// session is re-fetched. The first successful fetch populates this;
+// subsequent mounts of useSession() start with the cached value.
+let _cachedSession: CompatSession | null = null;
+// Dedup in-flight fetches: multiple useSession() hooks mounting at the
+// same time share a single /api/auth/session request instead of each
+// firing their own.
+let _inflight: Promise<CompatSession | null> | null = null;
+// Subscribers: all mounted useSession() hooks that need to be notified
+// when the shared fetch resolves.
+const _subscribers = new Set<(session: CompatSession | null) => void>();
+
+async function _fetchSessionShared(): Promise<CompatSession | null> {
+  if (_inflight) return _inflight;
+  _inflight = (async () => {
+    try {
+      const res = await fetch("/api/auth/session", { credentials: "include" });
+      if (!res.ok) return _cachedSession;
+      const json = await res.json();
+      const session = adaptSession(json);
+      _cachedSession = session;
+      return session;
+    } catch {
+      return _cachedSession;
+    } finally {
+      _inflight = null;
+    }
+  })();
+  return _inflight;
+}
+
 export const useSession = (
   options?: UseSessionOptions,
 ): {
@@ -85,32 +117,30 @@ export const useSession = (
   status: SessionStatus;
   update: () => Promise<void>;
 } => {
-  const [data, setData] = useState<CompatSession | null>(null);
-  const [isPending, setIsPending] = useState(true);
-
-  const fetchSession = useCallback(async () => {
-    try {
-      const res = await fetch("/api/auth/session", { credentials: "include" });
-      if (!res.ok) {
-        // Network succeeded but server returned an error (5xx, etc.).
-        // Don't treat this as "unauthenticated" — keep the previous state
-        // so transient server errors don't flash the user as logged out.
-        setIsPending(false);
-        return;
-      }
-      const json = await res.json();
-      setData(adaptSession(json));
-    } catch {
-      // Network error — keep previous state, don't flash as logged out.
-      setIsPending(false);
-      return;
-    }
-    setIsPending(false);
-  }, []);
+  const [data, setData] = useState<CompatSession | null>(_cachedSession);
+  const [isPending, setIsPending] = useState(_cachedSession === null);
 
   useEffect(() => {
-    void fetchSession();
-  }, [fetchSession]);
+    // Subscribe to shared fetch results so all hooks update together
+    const handler = (session: CompatSession | null) => {
+      setData(session);
+      setIsPending(false);
+    };
+    _subscribers.add(handler);
+
+    // If we already have cached data, skip fetching
+    if (_cachedSession) {
+      setData(_cachedSession);
+      setIsPending(false);
+    } else {
+      void _fetchSessionShared().then((session) => {
+        // Notify all subscribers (including this one)
+        for (const sub of _subscribers) sub(session);
+      });
+    }
+
+    return () => { _subscribers.delete(handler); };
+  }, []);
 
   const status: SessionStatus = isPending
     ? "loading"
@@ -128,10 +158,17 @@ export const useSession = (
     }
   }, [options?.required, options?.onUnauthenticated, status]);
 
+  const update = useCallback(async () => {
+    // Force a fresh fetch (bypass inflight dedup) and notify all subscribers
+    _inflight = null;
+    const session = await _fetchSessionShared();
+    for (const sub of _subscribers) sub(session);
+  }, []);
+
   return {
     data,
     status,
-    update: fetchSession,
+    update,
   };
 };
 
@@ -248,6 +285,10 @@ export const signOut = async (opts?: {
   callbackUrl?: string;
   redirect?: boolean;
 }): Promise<void> => {
+  // Clear module-level session cache so the next useSession mount
+  // doesn't serve stale data after logout.
+  _cachedSession = null;
+
   if (opts?.redirect === false) {
     // Programmatic logout without redirect. The caller is responsible for
     // updating the UI (e.g., calling session.update() or navigating).

--- a/langwatch/src/utils/compat/__tests__/next-router.unit.test.ts
+++ b/langwatch/src/utils/compat/__tests__/next-router.unit.test.ts
@@ -176,4 +176,76 @@ describe("buildUrl()", () => {
       expect(result).toBe("/foo");
     });
   });
+
+  describe("when query contains catch-all 'path' param (renamed from *)", () => {
+    it("strips path array from query string when path is in routeParamKeys", () => {
+      const result = buildUrl(
+        {
+          pathname: "/my-project/simulations/run-plans/great-run-plan",
+          query: {
+            project: "my-project",
+            path: ["run-plans", "great-run-plan"],
+            scenarioId: "scenario_001",
+          },
+        },
+        new Set(["project", "path"])
+      );
+      expect(result).toBe(
+        "/my-project/simulations/run-plans/great-run-plan?scenarioId=scenario_001"
+      );
+    });
+
+    it("does not accumulate path params across navigations", () => {
+      // Simulates what happens when a component does:
+      //   router.push({ query: { ...router.query, newFilter: "value" } })
+      // where router.query includes path from the catch-all route
+      const result = buildUrl(
+        {
+          pathname: "/my-project/simulations/run-plans/great-run-plan",
+          query: {
+            project: "my-project",
+            path: ["run-plans", "great-run-plan"],
+            startDate: "2026-01-14",
+            newFilter: "value",
+          },
+        },
+        new Set(["project", "path"])
+      );
+      expect(result).toBe(
+        "/my-project/simulations/run-plans/great-run-plan?startDate=2026-01-14&newFilter=value"
+      );
+      // path and project should NOT appear in the query string
+      expect(result).not.toContain("path=");
+      expect(result).not.toContain("project=");
+    });
+  });
+
+  describe("when query-only string contains catch-all path param", () => {
+    it("strips path from query string", () => {
+      const result = buildUrl(
+        "?path=run-plans&path=great-run-plan&scenarioId=scenario_001",
+        new Set(["project", "path"])
+      );
+      expect(result).toBe("?scenarioId=scenario_001");
+    });
+  });
+
+  describe("when routeParamKeys contains resolved [param] keys", () => {
+    it("strips all route params even when pathname has no [param] placeholders", () => {
+      // When pathname is the actual URL (not a pattern), route params
+      // should still be filtered from the query string
+      const result = buildUrl(
+        {
+          pathname: "/inbox-narrator/messages",
+          query: {
+            project: "inbox-narrator",
+            trace: "abc-123",
+            view: "table",
+          },
+        },
+        new Set(["project", "trace"])
+      );
+      expect(result).toBe("/inbox-narrator/messages?view=table");
+    });
+  });
 });

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -352,8 +352,13 @@ export function useRouter(): CompatRouter {
       query.path = catchAll ? catchAll.split("/") : [];
       delete query["*"];
     }
-    // Track which keys come from route params so we don't double-merge them
+    // Track which keys come from route params so we don't double-merge them.
+    // Include "path" (the renamed catch-all) so it's filtered from query strings.
     const routeParamKeySet = new Set(Object.keys(params));
+    if (routeParamKeySet.has("*")) {
+      routeParamKeySet.delete("*");
+      routeParamKeySet.add("path");
+    }
     searchParams.forEach((value, key) => {
       // Skip search params that shadow route params — the route param
       // already has the canonical value. Without this guard, `project`
@@ -378,8 +383,13 @@ export function useRouter(): CompatRouter {
       (location.search ? location.search : "") +
       (location.hash ? location.hash : "");
 
-    // Track which keys are route params (vs query string params)
+    // Track which keys are route params (vs query string params).
+    // Mirror the * → path rename so buildUrl filters "path" from query strings.
     const routeParamKeys = new Set(Object.keys(params));
+    if (routeParamKeys.has("*")) {
+      routeParamKeys.delete("*");
+      routeParamKeys.add("path");
+    }
 
     return {
       query,

--- a/langwatch/vite.config.ts
+++ b/langwatch/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
+const FRONTEND_PORT = parseInt(process.env.PORT ?? "5560");
+const API_PORT = FRONTEND_PORT + 1000;
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -45,15 +48,15 @@ export default defineConfig({
         "**/server.log",
       ],
     },
-    // Frontend always on 5560 — same port as with Next.js
+    // Frontend port (default 5560, configurable via PORT env var)
     host: true,
     allowedHosts: true,
-    port: 5560,
+    port: FRONTEND_PORT,
     strictPort: true,
-    // Proxy API requests to the Hono backend (internal port)
+    // Proxy API requests to the Hono backend (PORT + 1000)
     proxy: {
       "/api": {
-        target: `http://localhost:${process.env.API_PORT ?? "5565"}`,
+        target: `http://localhost:${API_PORT}`,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

Three navigation issues fixed from the Vite migration:

- **Gray flash between pages**: Replaced `React.lazy()` + `Component` with React Router's `lazy` route property. The old page now stays visible while the new module loads (no Suspense fallback flash). NProgress uses `useNavigation()` to start the loading bar immediately on click instead of after the module loads.

- **Session request storm**: `useSession()` created fresh `useState(null)` on every mount, causing dozens of `GET /api/auth/session` requests and a `<LoadingScreen />` flash on every navigation. Now uses a module-level cache with in-flight request deduplication — one fetch on initial load, zero on subsequent navigations.

- **Path param accumulation on catch-all routes** (e.g. simulations): The `*` → `path` rename in `useRouter` wasn't reflected in `routeParamKeys`, so `buildUrl` didn't filter `path` from query strings. Each filter selection doubled the `path=` params in the URL.

Also: `PORT` env var now derives API port as `PORT+1000` (default `5560`→`6560`), replacing the hardcoded `5565`. Set `PORT=5570` and the API automatically runs on `6570`.

## Test plan

- [x] 24 unit tests for `next-router` compat (including new catch-all path filtering tests)
- [x] 3 unit tests for session cache (dedup, cache hit on re-mount, cache clear on sign-out)
- [x] `pnpm typecheck` passes
- [x] Manual QA: navigate between pages — no gray flash, no LoadingScreen between routes
- [x] Manual QA: check network tab — only 1 session request on load, 0 on navigation
- [x] Manual QA: simulations page — select filters, verify no `path=` accumulation in URL
- [x] CI green