### PR TITLE
fix: remove commas from page titles

### DIFF
--- a/langwatch/src/utils/compat/next-head.tsx
+++ b/langwatch/src/utils/compat/next-head.tsx
@@ -25,7 +25,8 @@ export default function Head({ children }: HeadProps) {
           child.type === "title" &&
           child.props?.children
         ) {
-          document.title = String(child.props.children);
+          const c = child.props.children;
+          document.title = Array.isArray(c) ? c.join("") : String(c);
         }
       }
     }


### PR DESCRIPTION
## Summary

- Page titles showed commas: "LangWatch, - Skills," instead of "LangWatch - Skills"
- Root cause: the `Head` compat layer used `String(children)` to set `document.title`, but when `<title>` has multiple JSX expression children, `children` is an array — and `String([...])` joins with commas
- Fix: use `.join("")` instead of `String()` for array children

One-line fix in `src/utils/compat/next-head.tsx`.

## Test plan

- [x] `pnpm typecheck` passes
- [ ] Manual: verify page titles show correctly without commas