### PR TITLE
fix: wire new Hono API routes and remove dead Next.js wrappers

### DIFF
--- a/langwatch/src/app/api/graphs/[[...route]]/route.ts
+++ b/langwatch/src/app/api/graphs/[[...route]]/route.ts
@@ -1,7 +1,0 @@
-import { handle } from "hono/vercel";
-import { app } from "./app";
-
-export const GET = handle(app);
-export const POST = handle(app);
-export const PATCH = handle(app);
-export const DELETE = handle(app);

--- a/langwatch/src/app/api/monitors/[[...route]]/route.ts
+++ b/langwatch/src/app/api/monitors/[[...route]]/route.ts
@@ -1,7 +1,0 @@
-import { handle } from "hono/vercel";
-import { app } from "./app";
-
-export const GET = handle(app);
-export const POST = handle(app);
-export const PATCH = handle(app);
-export const DELETE = handle(app);

--- a/langwatch/src/app/api/secrets/[[...route]]/route.ts
+++ b/langwatch/src/app/api/secrets/[[...route]]/route.ts
@@ -1,7 +1,0 @@
-import { handle } from "hono/vercel";
-import { app } from "./app";
-
-export const GET = handle(app);
-export const POST = handle(app);
-export const PUT = handle(app);
-export const DELETE = handle(app);

--- a/langwatch/src/app/api/simulation-runs/[[...route]]/route.ts
+++ b/langwatch/src/app/api/simulation-runs/[[...route]]/route.ts
@@ -1,4 +1,0 @@
-import { handle } from "hono/vercel";
-import { app } from "./app";
-
-export const GET = handle(app);

--- a/langwatch/src/app/api/suites/[[...route]]/route.ts
+++ b/langwatch/src/app/api/suites/[[...route]]/route.ts
@@ -1,7 +1,0 @@
-import { handle } from "hono/vercel";
-import { app } from "./app";
-
-export const GET = handle(app);
-export const POST = handle(app);
-export const PATCH = handle(app);
-export const DELETE = handle(app);

--- a/langwatch/src/app/api/triggers/[[...route]]/route.ts
+++ b/langwatch/src/app/api/triggers/[[...route]]/route.ts
@@ -1,7 +1,0 @@
-import { handle } from "hono/vercel";
-import { app } from "./app";
-
-export const GET = handle(app);
-export const POST = handle(app);
-export const PATCH = handle(app);
-export const DELETE = handle(app);

--- a/langwatch/src/app/api/workflows/[[...route]]/route.ts
+++ b/langwatch/src/app/api/workflows/[[...route]]/route.ts
@@ -1,6 +1,0 @@
-import { handle } from "hono/vercel";
-import { app } from "./app";
-
-export const GET = handle(app);
-export const PATCH = handle(app);
-export const DELETE = handle(app);

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -1,15 +1,9 @@
 /**
- * Unified Hono API router that consolidates all API routes.
- *
- * This replaces:
- * - Next.js App Router API routes (src/app/api/.../route.ts with hono/vercel adapter)
- * - Next.js Pages Router API routes (src/pages/api/...ts)
- *
- * All routes are mounted under their original /api/* paths.
+ * Unified Hono API router — all /api/* routes mounted here.
+ * Each sub-app sets its own basePath (e.g. "/api/traces").
  */
 import { Hono } from "hono";
 
-// --- App Router Hono apps (already pure Hono) ---
 import { app as agentsApp } from "../app/api/agents/[[...route]]/app";
 import { app as analyticsApp } from "../app/api/analytics/[...route]/app";
 import { app as copilotKitApp } from "../app/api/copilotkit/[[...route]]/app";
@@ -17,13 +11,19 @@ import { app as dashboardsApp } from "../app/api/dashboards/[[...route]]/app";
 import { app as datasetApp } from "../app/api/dataset/[[...route]]/app";
 import { app as evaluatorsApp } from "../app/api/evaluators/[[...route]]/app";
 import { app as exportTracesApp } from "../app/api/export/traces/[[...route]]/app";
+import { app as graphsApp } from "../app/api/graphs/[[...route]]/app";
 import { app as modelProvidersApp } from "../app/api/model-providers/[[...route]]/app";
+import { app as monitorsApp } from "../app/api/monitors/[[...route]]/app";
 import { app as promptsApp } from "../app/api/prompts/[[...route]]/app";
 import { app as scenarioEventsApp } from "../app/api/scenario-events/[[...route]]/app";
 import { app as scenariosApp } from "../app/api/scenarios/[[...route]]/app";
+import { app as secretsApp } from "../app/api/secrets/[[...route]]/app";
+import { app as simulationRunsApp } from "../app/api/simulation-runs/[[...route]]/app";
+import { app as suitesApp } from "../app/api/suites/[[...route]]/app";
 import { app as tracesApp } from "../app/api/traces/[[...route]]/app";
+import { app as triggersApp } from "../app/api/triggers/[[...route]]/app";
+import { app as workflowsCrudApp } from "../app/api/workflows/[[...route]]/app";
 
-// --- Newly migrated App Router routes (were handle(app) or raw NextRequest) ---
 import { app as datasetGenerateApp } from "./routes/dataset-generate";
 import { app as evaluationsV3App } from "./routes/evaluations-v3";
 import { app as healthChecksApp } from "./routes/health-checks";
@@ -34,7 +34,6 @@ import { app as scimApp } from "./routes/scim";
 import { app as webhooksApp } from "./routes/webhooks";
 import { app as workflowsApp } from "./routes/workflows";
 
-// --- Pages Router migrations (now pure Hono) ---
 import { app as adminApp } from "./routes/admin";
 import { app as annotationsApp } from "./routes/annotations";
 import { app as authApp } from "./routes/auth";
@@ -47,17 +46,10 @@ import { app as sseApp } from "./routes/sse";
 import { app as tracesLegacyApp } from "./routes/traces-legacy";
 import { app as trpcApp } from "./routes/trpc";
 
-/**
- * Creates the unified API Hono app.
- * Each sub-app already has its basePath set (e.g., "/api/traces"),
- * so we mount them all on the root.
- */
 export function createApiRouter() {
   const api = new Hono();
 
-  // ---- URL Rewrites (migrated from next.config.mjs) ----
-  // Legacy OAuth callback paths → BetterAuth paths.
-  // Customer IdPs are registered with the old URLs.
+  // Legacy OAuth callback rewrites — customer IdPs registered with old URLs
   api.all("/api/auth/callback/auth0", (c) => {
     const url = new URL(c.req.url);
     url.pathname = "/api/auth/oauth2/callback/auth0";
@@ -69,19 +61,11 @@ export function createApiRouter() {
     return api.fetch(new Request(url.toString(), c.req.raw));
   });
 
-  // Mount all Hono sub-apps. Each already has basePath like "/api/traces"
-  // so we mount at "/" and they handle their own path matching.
-  //
-  // ORDERING MATTERS: More specific routes must come before catch-all routes
-  // that share the same basePath. For example, /api/dataset/generate must be
-  // mounted before /api/dataset/:slugOrId to avoid "generate" matching as a slug.
+  // ORDERING: specific paths before catch-all siblings with same basePath
+  api.route("/", datasetGenerateApp);    // /api/dataset/generate (before datasetApp's /:slugOrId)
+  api.route("/", workflowsApp);          // /api/workflows/code-completion, /post_event
+  api.route("/", healthChecksApp);       // /api/health/collector, /evaluations, etc.
 
-  // Routes with specific paths that must come before catch-all siblings
-  api.route("/", datasetGenerateApp);    // POST /api/dataset/generate (before datasetApp's /:slugOrId)
-  api.route("/", workflowsApp);          // POST /api/workflows/code-completion, /post_event
-  api.route("/", healthChecksApp);       // GET  /api/health/collector, /evaluations, etc.
-
-  // App Router Hono apps (pre-existing)
   api.route("/", agentsApp);
   api.route("/", analyticsApp);
   api.route("/", copilotKitApp);
@@ -89,13 +73,19 @@ export function createApiRouter() {
   api.route("/", datasetApp);
   api.route("/", evaluatorsApp);
   api.route("/", exportTracesApp);
+  api.route("/", graphsApp);
   api.route("/", modelProvidersApp);
+  api.route("/", monitorsApp);
   api.route("/", promptsApp);
   api.route("/", scenarioEventsApp);
   api.route("/", scenariosApp);
+  api.route("/", secretsApp);
+  api.route("/", simulationRunsApp);
+  api.route("/", suitesApp);
   api.route("/", tracesApp);
+  api.route("/", triggersApp);
+  api.route("/", workflowsCrudApp);      // CRUD — complements workflowsApp (code-completion, post_event)
 
-  // Newly migrated App Router routes
   api.route("/", evaluationsV3App);
   api.route("/", otelApp);
   api.route("/", playgroundApp);
@@ -103,7 +93,6 @@ export function createApiRouter() {
   api.route("/", scimApp);
   api.route("/", webhooksApp);
 
-  // Pages Router migrations
   api.route("/", adminApp);
   api.route("/", annotationsApp);
   api.route("/", authApp);


### PR DESCRIPTION
## Summary

- Registers 7 new Hono apps from PR #3168 (six-pillar coverage) in `api-router.ts`: graphs, monitors, secrets, simulation-runs, suites, triggers, workflows CRUD
- Without this, those endpoints silently 404 in production (they were only wired via Next.js `route.ts` wrappers which no longer run)
- Removes the 7 dead Next.js `route.ts` wrappers
- Cleans up section comments in api-router.ts — imports sorted alphabetically, no temporary migration markers

## Test plan

- [x] `pnpm typecheck` passes
- [ ] CI green
- [ ] Verify new endpoints respond (e.g. `GET /api/graphs`, `GET /api/monitors`)