### PR TITLE
fix(tests): align test expectations with current implementation

### DIFF
--- a/langwatch/src/app/api/suites/__tests__/suites-api.integration.test.ts
+++ b/langwatch/src/app/api/suites/__tests__/suites-api.integration.test.ts
@@ -245,7 +245,12 @@ describe("Feature: Suites REST API", () => {
 
     it("rejects duplicate names", async () => {
       const scenario = await createScenario("Dupe Scenario");
-      await createSuite({ name: "Duplicate Name", scenarioIds: [scenario.id] });
+      // Create first suite via the API so the service assigns the canonical slug
+      await helpers.api.post("/api/suites", {
+        name: "Duplicate Name",
+        scenarioIds: [scenario.id],
+        targets: [{ type: "http", referenceId: "agent_abc" }],
+      });
 
       const res = await helpers.api.post("/api/suites", {
         name: "Duplicate Name",

--- a/langwatch/src/components/suites/__tests__/run-history-transforms.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/run-history-transforms.unit.test.ts
@@ -86,21 +86,25 @@ describe("groupRunsByBatchId() with scenarioSetIds", () => {
 
   describe("when given runs with scenario set IDs", () => {
     it("groups runs and includes scenarioSetId for each batch", () => {
+      const now = Date.now();
       const runs = [
         makeScenarioRunData({
           batchRunId: "batch_1",
           scenarioRunId: "run_1",
           scenarioId: "scen_1",
+          timestamp: now,
         }),
         makeScenarioRunData({
           batchRunId: "batch_1",
           scenarioRunId: "run_2",
           scenarioId: "scen_2",
+          timestamp: now,
         }),
         makeScenarioRunData({
           batchRunId: "batch_2",
           scenarioRunId: "run_3",
           scenarioId: "scen_3",
+          timestamp: now - 1000,
         }),
       ];
 

--- a/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
@@ -107,13 +107,13 @@ describe("LicenseEnforcementRepository", () => {
   });
 
   describe("getPromptCount", () => {
-    it("queries prompts with organization filter (no archive filter)", async () => {
+    it("queries prompts with organization filter and deletedAt null", async () => {
       mockPrisma.llmPromptConfig.count.mockResolvedValue(10);
 
       const result = await repository.getPromptCount(organizationId);
 
       expect(mockPrisma.llmPromptConfig.count).toHaveBeenCalledWith({
-        where: { project: { team: { organizationId } } },
+        where: { project: { team: { organizationId } }, deletedAt: null },
       });
       expect(result).toBe(10);
     });

--- a/langwatch/src/server/suites/__tests__/suite.repository.unit.test.ts
+++ b/langwatch/src/server/suites/__tests__/suite.repository.unit.test.ts
@@ -213,7 +213,7 @@ describe("SuiteRepository", () => {
           where: { id: "suite_abc123", projectId: "proj_1" },
           data: {
             archivedAt: expect.any(Date),
-            slug: "critical-path--archived",
+            slug: "critical-path--archived-abc123",
           },
         });
       });


### PR DESCRIPTION
## Summary

- **suite.repository**: Update archived slug expectation from `critical-path--archived` to `critical-path--archived-abc123` — the implementation appends `-${suite.id.slice(-6)}` to prevent collisions when re-archiving
- **license-enforcement.repository**: Add missing `deletedAt: null` to `getPromptCount` expected query — implementation filters soft-deleted prompts but test wasn't updated
- **suites-api integration**: Fix "rejects duplicate names" test by creating the first suite through the API instead of directly via Prisma. The `createSuite()` helper generated a random slug, so `ensureSlugAvailable` never found a conflict
- **run-history-transforms**: Fix non-deterministic sort in "groups runs and includes scenarioSetId for each batch" — two batches shared the same `Date.now()` timestamp causing random ordering in CI. Added explicit `timestamp: now - 1000` to batch_2 runs

## Test plan

- [ ] `pnpm test:unit` passes locally for all four affected files
- [ ] CI unit and integration test jobs pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)