### PR TITLE
fix: image proxy broken after Vite migration

### DIFF
--- a/langwatch/index.html
+++ b/langwatch/index.html
@@ -5,10 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LangWatch</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/nprogress@0.2.0/nprogress.css"
-    />
   </head>
   <body>
     <div id="root"></div>

--- a/langwatch/src/components/ExternalImage.tsx
+++ b/langwatch/src/components/ExternalImage.tsx
@@ -80,7 +80,7 @@ export const getProxiedImageUrl = (url: string): string => {
   if (url.startsWith("data:")) return url;
   if (url.startsWith("/")) return url;
 
-  return `/image-proxy?url=${encodeURIComponent(url)}`;
+  return `/api/image-proxy?url=${encodeURIComponent(url)}`;
 };
 
 export const ExternalImage = ({

--- a/langwatch/src/main.tsx
+++ b/langwatch/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from "react-router";
 import { router } from "./routes";
 import { OuterProviders } from "./AppProviders";
 import { setRouterInstance } from "./utils/compat/next-router";
+import "nprogress/nprogress.css";
 import "./styles/globals.scss";
 
 // Enable imperative navigation from outside React (e.g. navigateToDrawer)


### PR DESCRIPTION
## Summary

Two Vite migration follow-up fixes:

- **Image proxy broken**: `getProxiedImageUrl()` requested `/image-proxy` but after the Vite migration only `/api/*` paths reach Hono. The route lives at `/api/image-proxy` (misc app has `basePath("/api")`). Fixed by updating the URL to `/api/image-proxy`.

- **NProgress CSS blocked by CSP**: The stylesheet was loaded from `unpkg.com` which isn't in the Content Security Policy `style-src` directive, causing it to be blocked in production. Fixed by importing the CSS from the npm package (`nprogress/nprogress.css`) so Vite bundles it.

## Test plan

- [x] `pnpm typecheck` passes
- [ ] Manual: open experiment page with images — images load correctly
- [ ] Manual: verify NProgress loading bar appears and is styled (no CSP errors in console)
- [ ] CI green