### PR TITLE
fix: prevent custom evaluator input field race condition

### DIFF
--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -295,10 +295,10 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
     return undefined;
   }, [promptQuery.data]);
 
-  // Seed configValues from initialLocalConfig (if any) so the form watch
-  // subscription's first synchronous fire carries the caller's edits, not
-  // defaults. The init useEffect below later resets with merged server data.
-  // See localConfigToFormValues for the #3155 rationale.
+  // Seed configValues from initialLocalConfig so the form watch subscription's
+  // first synchronous fire carries the caller's edits, not defaults. Without
+  // this seed, the subscription fires on defaults before the init useEffect
+  // runs and clobbers the caller's local edits (#3155).
   const [configValues, setConfigValues] = useState<PromptConfigFormValues>(
     () => localConfigToFormValues(props.initialLocalConfig),
   );

--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -306,7 +306,22 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
   //   drawer session. Prevents re-initialization when deps change.
   //
   const [configValues, setConfigValues] = useState<PromptConfigFormValues>(
-    buildDefaultFormValues,
+    () =>
+      props.initialLocalConfig
+        ? buildDefaultFormValues({
+            version: {
+              configData: {
+                llm: props.initialLocalConfig.llm,
+                messages:
+                  props.initialLocalConfig.messages as PromptConfigFormValues["version"]["configData"]["messages"],
+                inputs:
+                  props.initialLocalConfig.inputs as PromptConfigFormValues["version"]["configData"]["inputs"],
+                outputs:
+                  props.initialLocalConfig.outputs as PromptConfigFormValues["version"]["configData"]["outputs"],
+              },
+            },
+          })
+        : buildDefaultFormValues(),
   );
   const [isFormInitialized, setIsFormInitialized] = useState(false);
   // Ref set directly in init/reset effects so the watch subscription

--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -46,6 +46,7 @@ import { usePromptConfigForm } from "~/prompts/hooks/usePromptConfigForm";
 import type { PromptConfigFormValues } from "~/prompts/types";
 import { areFormValuesEqual } from "~/prompts/utils/areFormValuesEqual";
 import { buildDefaultFormValues } from "~/prompts/utils/buildDefaultFormValues";
+import { localConfigToFormValues } from "./utils/localConfigToFormValues";
 import {
   formValuesToTriggerSaveVersionParams,
   versionedPromptToPromptConfigFormValuesWithSystemMessage,
@@ -294,34 +295,12 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
     return undefined;
   }, [promptQuery.data]);
 
-  // ============================================================================
-  // CONFIG VALUES STATE - Single Source of Truth for Form Initialization
-  // ============================================================================
-  //
-  // configValues: The baseline config that the form uses. Updated on:
-  //   1. Initialization (when drawer opens)
-  //   2. After save (with fresh server data)
-  //
-  // isFormInitialized: Tracks whether we've done the initial setup for this
-  //   drawer session. Prevents re-initialization when deps change.
-  //
+  // Seed configValues from initialLocalConfig (if any) so the form watch
+  // subscription's first synchronous fire carries the caller's edits, not
+  // defaults. The init useEffect below later resets with merged server data.
+  // See localConfigToFormValues for the #3155 rationale.
   const [configValues, setConfigValues] = useState<PromptConfigFormValues>(
-    () =>
-      props.initialLocalConfig
-        ? buildDefaultFormValues({
-            version: {
-              configData: {
-                llm: props.initialLocalConfig.llm,
-                messages:
-                  props.initialLocalConfig.messages as PromptConfigFormValues["version"]["configData"]["messages"],
-                inputs:
-                  props.initialLocalConfig.inputs as PromptConfigFormValues["version"]["configData"]["inputs"],
-                outputs:
-                  props.initialLocalConfig.outputs as PromptConfigFormValues["version"]["configData"]["outputs"],
-              },
-            },
-          })
-        : buildDefaultFormValues(),
+    () => localConfigToFormValues(props.initialLocalConfig),
   );
   const [isFormInitialized, setIsFormInitialized] = useState(false);
   // Ref set directly in init/reset effects so the watch subscription

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -938,7 +938,7 @@ describe("PromptEditorDrawer", () => {
   describe("when initialLocalConfig has custom inputs (#3155 regression)", () => {
     it("initializes form with custom inputs instead of default 'input' field", () => {
       const initialLocalConfig = {
-        llm: { model: "openai/gpt-4o" },
+        llm: { model: "openai/gpt-5-mini" },
         messages: [
           {
             role: "user" as const,

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -91,6 +91,9 @@ vi.mock("~/optimization_studio/components/nodes/Nodes", () => ({
   TypeLabel: ({ type }: { type: string }) => <span>{type}</span>,
 }));
 
+// Track initialConfigValues passed to usePromptConfigForm
+const capturedInitialConfigValues: unknown[] = [];
+
 // Mock usePromptConfigForm to return a real form
 const mockDefaultFormValues = {
   isNew: true,
@@ -112,6 +115,7 @@ vi.mock("~/prompts/hooks/usePromptConfigForm", () => ({
   }: {
     initialConfigValues?: unknown;
   }) => {
+    capturedInitialConfigValues.push(initialConfigValues);
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const methods = useForm({
       defaultValues: initialConfigValues ?? mockDefaultFormValues,
@@ -269,9 +273,20 @@ vi.mock("~/components/outputs", () => ({
   FormOutputsSection: () => <div data-testid="outputs-field">Outputs</div>,
 }));
 
-// Mock buildDefaultFormValues
+// Mock buildDefaultFormValues — supports overrides to test initialLocalConfig seeding
 vi.mock("~/prompts/utils/buildDefaultFormValues", () => ({
-  buildDefaultFormValues: () => mockDefaultFormValues,
+  buildDefaultFormValues: (
+    overrides?: Record<string, unknown>,
+  ) => {
+    if (!overrides) return mockDefaultFormValues;
+    // Deep merge overrides into defaults (simplified for test)
+    const merged = JSON.parse(JSON.stringify(mockDefaultFormValues));
+    const ov = overrides as any;
+    if (ov?.version?.configData) {
+      Object.assign(merged.version.configData, ov.version.configData);
+    }
+    return merged;
+  },
 }));
 
 // Mock the conversion utils
@@ -320,6 +335,7 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe("PromptEditorDrawer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    capturedInitialConfigValues.length = 0;
     mockGetByIdOrHandle.mockReturnValue({ data: undefined, isLoading: false });
     // Default: form values equal saved values (no changes)
     mockAreFormValuesEqual.mockReturnValue(true);
@@ -916,6 +932,71 @@ describe("PromptEditorDrawer", () => {
 
       // Should have called closeDrawer
       expect(mockCloseDrawer).toHaveBeenCalled();
+    });
+  });
+
+  describe("when initialLocalConfig has custom inputs (#3155 regression)", () => {
+    it("initializes form with custom inputs instead of default 'input' field", () => {
+      const initialLocalConfig = {
+        llm: { model: "openai/gpt-4o" },
+        messages: [
+          {
+            role: "user" as const,
+            content: "Check this for bias: {{llm_output}}",
+          },
+        ],
+        inputs: [{ identifier: "llm_output", type: "str" as const }],
+        outputs: [{ identifier: "output", type: "str" as const }],
+      };
+
+      renderWithProviders(
+        <PromptEditorDrawer
+          open={true}
+          initialLocalConfig={initialLocalConfig}
+          onLocalConfigChange={vi.fn()}
+        />,
+      );
+
+      // The very first configValues passed to usePromptConfigForm must
+      // contain the custom "llm_output" input, NOT the default "input".
+      // Before the fix, configValues was always buildDefaultFormValues()
+      // which has inputs: [{identifier: "input"}], causing a race where
+      // the form watch fires with "input" before the init effect runs.
+      const firstCall = capturedInitialConfigValues[0] as Record<
+        string,
+        unknown
+      >;
+      const inputs = (
+        firstCall as {
+          version: {
+            configData: { inputs: Array<{ identifier: string }> };
+          };
+        }
+      ).version.configData.inputs;
+      expect(inputs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ identifier: "llm_output" }),
+        ]),
+      );
+      expect(inputs).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ identifier: "input" }),
+        ]),
+      );
+    });
+
+    it("keeps default 'input' field when no initialLocalConfig is provided", () => {
+      renderWithProviders(<PromptEditorDrawer open={true} />);
+
+      const firstCall = capturedInitialConfigValues[0] as {
+        version: { configData: { inputs: Array<{ identifier: string }> } };
+      };
+      const inputs = firstCall.version.configData.inputs;
+      expect(inputs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ identifier: "input" }),
+        ]),
+      );
     });
   });
 

--- a/langwatch/src/components/prompts/utils/localConfigToFormValues.ts
+++ b/langwatch/src/components/prompts/utils/localConfigToFormValues.ts
@@ -1,0 +1,36 @@
+import type { LocalPromptConfig } from "~/evaluations-v3/types";
+import type { PromptConfigFormValues } from "~/prompts/types";
+import { buildDefaultFormValues } from "~/prompts/utils/buildDefaultFormValues";
+import type { DeepPartial } from "~/utils/types";
+
+type ConfigData = PromptConfigFormValues["version"]["configData"];
+
+/**
+ * Builds form values seeded with a caller-supplied local prompt config, padded
+ * with form-level defaults for fields not present on `LocalPromptConfig`
+ * (handle, scope, commit metadata, etc.).
+ *
+ * Why: `usePromptConfigForm`'s watch subscription fires synchronously on
+ * first render with whatever `configValues` is at mount. If we initialize
+ * with bare defaults, the first fire carries the default `input`/`output`
+ * fields and clobbers the caller's local edits before the init effect
+ * below can reset them — this is the #3155 race condition.
+ */
+export const localConfigToFormValues = (
+  local: LocalPromptConfig | undefined,
+): PromptConfigFormValues => {
+  if (!local) return buildDefaultFormValues();
+
+  const overrides = {
+    version: {
+      configData: {
+        llm: local.llm,
+        messages: local.messages as ConfigData["messages"],
+        inputs: local.inputs as ConfigData["inputs"],
+        outputs: local.outputs as ConfigData["outputs"],
+      },
+    },
+  } satisfies DeepPartial<PromptConfigFormValues>;
+
+  return buildDefaultFormValues(overrides);
+};

--- a/langwatch/src/components/prompts/utils/localConfigToFormValues.ts
+++ b/langwatch/src/components/prompts/utils/localConfigToFormValues.ts
@@ -1,9 +1,32 @@
 import type { LocalPromptConfig } from "~/evaluations-v3/types";
 import type { PromptConfigFormValues } from "~/prompts/types";
 import { buildDefaultFormValues } from "~/prompts/utils/buildDefaultFormValues";
-import type { DeepPartial } from "~/utils/types";
 
 type ConfigData = PromptConfigFormValues["version"]["configData"];
+
+/**
+ * Narrows `json_schema: unknown` from the local-config shape to the form's
+ * `{ type: string, ...passthrough }` shape. Drops the value if it doesn't
+ * structurally match; the init useEffect later re-merges server data over
+ * the seed, so losing a malformed json_schema on first render is fine.
+ */
+const normalizeOutputs = (
+  outputs: LocalPromptConfig["outputs"],
+): ConfigData["outputs"] =>
+  outputs.map(({ json_schema, ...rest }) => {
+    if (
+      json_schema &&
+      typeof json_schema === "object" &&
+      "type" in json_schema &&
+      typeof (json_schema as { type: unknown }).type === "string"
+    ) {
+      return {
+        ...rest,
+        json_schema: json_schema as ConfigData["outputs"][number]["json_schema"],
+      };
+    }
+    return rest;
+  });
 
 /**
  * Builds form values seeded with a caller-supplied local prompt config, padded
@@ -21,16 +44,14 @@ export const localConfigToFormValues = (
 ): PromptConfigFormValues => {
   if (!local) return buildDefaultFormValues();
 
-  const overrides = {
+  return buildDefaultFormValues({
     version: {
       configData: {
         llm: local.llm,
-        messages: local.messages as ConfigData["messages"],
-        inputs: local.inputs as ConfigData["inputs"],
-        outputs: local.outputs as ConfigData["outputs"],
+        messages: local.messages,
+        inputs: local.inputs,
+        outputs: normalizeOutputs(local.outputs),
       },
     },
-  } satisfies DeepPartial<PromptConfigFormValues>;
-
-  return buildDefaultFormValues(overrides);
+  });
 };

--- a/langwatch/src/optimization_studio/hooks/__tests__/usePostEvent.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/__tests__/usePostEvent.unit.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { WorkflowStore } from "../useWorkflowStore";
+import type { StudioServerEvent } from "../../types/events";
+
+// Mock toaster
+vi.mock("../../../components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+// Mock logger
+vi.mock("../../../utils/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { useHandleServerMessage } from "../usePostEvent";
+
+function createMockStore(
+  overrides: Partial<WorkflowStore> = {},
+): WorkflowStore {
+  return {
+    setSocketStatus: vi.fn(),
+    getWorkflow: vi.fn().mockReturnValue({
+      state: { execution: {} },
+      nodes: [],
+      edges: [],
+    }),
+    setComponentExecutionState: vi.fn(),
+    setWorkflowExecutionState: vi.fn(),
+    setEvaluationState: vi.fn(),
+    setOptimizationState: vi.fn(),
+    checkIfUnreachableErrorMessage: vi.fn(),
+    stopWorkflowIfRunning: vi.fn(),
+    setOpenResultsPanelRequest: vi.fn(),
+    setSelectedNode: vi.fn(),
+    setPropertiesExpanded: vi.fn(),
+    ...overrides,
+  } as unknown as WorkflowStore;
+}
+
+describe("useHandleServerMessage", () => {
+  describe("when component_state_change completes", () => {
+    it("does not auto-select the node (avoids jumping during multi-node workflows)", () => {
+      const store = createMockStore();
+      const alertOnComponent = vi.fn();
+
+      const { result } = renderHook(() =>
+        useHandleServerMessage({
+          workflowStore: store,
+          alertOnComponent,
+        }),
+      );
+
+      const event: StudioServerEvent = {
+        type: "component_state_change",
+        payload: {
+          component_id: "node-1",
+          execution_state: { status: "success" },
+        },
+      };
+
+      result.current(event);
+
+      expect(store.setSelectedNode).not.toHaveBeenCalled();
+      expect(store.setPropertiesExpanded).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when execution_state_change completes with until_node_id", () => {
+    it("auto-selects the target node and expands properties", () => {
+      const store = createMockStore({
+        getWorkflow: vi.fn().mockReturnValue({
+          state: {
+            execution: { until_node_id: "llm-node-1" },
+          },
+          nodes: [],
+          edges: [],
+        }),
+      } as unknown as Partial<WorkflowStore>);
+      const alertOnComponent = vi.fn();
+
+      const { result } = renderHook(() =>
+        useHandleServerMessage({
+          workflowStore: store,
+          alertOnComponent,
+        }),
+      );
+
+      const event: StudioServerEvent = {
+        type: "execution_state_change",
+        payload: {
+          execution_state: { status: "success" },
+        },
+      };
+
+      result.current(event);
+
+      expect(store.setSelectedNode).toHaveBeenCalledWith("llm-node-1");
+      expect(store.setPropertiesExpanded).toHaveBeenCalledWith(true);
+    });
+
+    it("does not auto-select when there is no until_node_id (full workflow run)", () => {
+      const store = createMockStore();
+      const alertOnComponent = vi.fn();
+
+      const { result } = renderHook(() =>
+        useHandleServerMessage({
+          workflowStore: store,
+          alertOnComponent,
+        }),
+      );
+
+      const event: StudioServerEvent = {
+        type: "execution_state_change",
+        payload: {
+          execution_state: { status: "success" },
+        },
+      };
+
+      result.current(event);
+
+      expect(store.setSelectedNode).not.toHaveBeenCalled();
+      expect(store.setPropertiesExpanded).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/optimization_studio/hooks/__tests__/usePostEvent.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/__tests__/usePostEvent.unit.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { renderHook } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { WorkflowStore } from "../useWorkflowStore";
 import type { StudioServerEvent } from "../../types/events";
 

--- a/langwatch/src/optimization_studio/hooks/usePostEvent.tsx
+++ b/langwatch/src/optimization_studio/hooks/usePostEvent.tsx
@@ -248,15 +248,6 @@ export const useHandleServerMessage = ({
             });
           }
 
-          // Auto-select the node and expand properties when execution completes,
-          // so the user can see the results without having to click manually.
-          if (
-            message.payload.execution_state?.status === "success" ||
-            message.payload.execution_state?.status === "error"
-          ) {
-            workflowStore.setSelectedNode(message.payload.component_id);
-            workflowStore.setPropertiesExpanded(true);
-          }
           break;
         case "execution_state_change":
           logger.debug(
@@ -264,6 +255,22 @@ export const useHandleServerMessage = ({
             "execution_state_change received",
           );
           setWorkflowExecutionState(message.payload.execution_state);
+
+          // Auto-select the target node and expand properties when a
+          // "Run workflow until here" execution completes, so the user
+          // can see the results without clicking manually.
+          if (
+            message.payload.execution_state?.status === "success" ||
+            message.payload.execution_state?.status === "error"
+          ) {
+            const untilNodeId =
+              getWorkflow().state.execution?.until_node_id;
+            if (untilNodeId) {
+              workflowStore.setSelectedNode(untilNodeId);
+              workflowStore.setPropertiesExpanded(true);
+            }
+          }
+
           if (message.payload.execution_state?.status === "error") {
             alertOnError(message.payload.execution_state.error);
             stopWorkflowIfRunning(message.payload.execution_state.error);

--- a/langwatch/src/optimization_studio/hooks/usePostEvent.tsx
+++ b/langwatch/src/optimization_studio/hooks/usePostEvent.tsx
@@ -248,8 +248,15 @@ export const useHandleServerMessage = ({
             });
           }
 
-          // Don't auto-open the drawer when execution completes —
-          // let the user open it themselves if they want to inspect results
+          // Auto-select the node and expand properties when execution completes,
+          // so the user can see the results without having to click manually.
+          if (
+            message.payload.execution_state?.status === "success" ||
+            message.payload.execution_state?.status === "error"
+          ) {
+            workflowStore.setSelectedNode(message.payload.component_id);
+            workflowStore.setPropertiesExpanded(true);
+          }
           break;
         case "execution_state_change":
           logger.debug(


### PR DESCRIPTION
## Summary
- **Issue 1+2 fix**: Seed `PromptEditorDrawer`'s `configValues` from `initialLocalConfig` when provided, so the form watch subscription's first synchronous fire carries the caller's edits instead of defaults. This eliminates the race that corrupted LLM node inputs and remapped edges on click. Extracted into `localConfigToFormValues` helper with explicit output-shape normalization (addresses review feedback on cast-hidden schema drift).
- **Issue 3 fix**: Restore auto-select and expand of properties panel when a "Run workflow until here" execution completes (success or error). Scoped to `execution_state_change` with `until_node_id` guard — only fires for targeted workflow runs, not multi-node full workflow executions.

Closes #3155

## Test plan
- [x] Regression test: form initialized with `initialLocalConfig.inputs = [{identifier: "llm_output"}]` receives custom inputs, not default `input`
- [x] Regression test: form without `initialLocalConfig` still receives default `input` field
- [x] Unit test: `component_state_change` does NOT auto-select nodes (prevents jumping during multi-node workflows)
- [x] Unit test: `execution_state_change` with `until_node_id` auto-selects the target node
- [x] Unit test: `execution_state_change` without `until_node_id` (full workflow run) does NOT auto-select
- [x] All 26 `SignaturePromptEditorBridge` integration tests pass
- [x] `pnpm typecheck` clean after helper extraction with strict output-shape normalization
- [ ] Manual: create custom evaluator from template, click LLM node — verify no spurious `input` field appears
- [ ] Manual: "Run workflow until here" — verify results auto-display

## Review follow-ups
- Extracted initialization logic into `src/components/prompts/utils/localConfigToFormValues.ts` so the intent ("seed so first watch-fire carries user edits") is explicit
- Removed type-casting of outputs; replaced with explicit `normalizeOutputs` that narrows `json_schema: unknown` to `{ type: string, ...passthrough }` at compile time
- Fixed a test-fixture model string per project convention (`gpt-5-mini`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)