### PR TITLE
fix(pr-auto-approve): --repo flag and trust external approvals

### DIFF
--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -48,7 +48,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_JSON=$(gh pr view "$PR_NUMBER" --json headRefOid,labels)
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,labels)
           HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
           # Bracket-pad the label CSV so `contains()` matches exact label
           # names (`,foo,`) and never substrings.
@@ -193,10 +193,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr view "$PR_NUMBER" --json title,body --template '{{.title}}' > /tmp/pr_title.txt
-          gh pr view "$PR_NUMBER" --json title,body --template '{{.body}}' > /tmp/pr_body.txt
-          gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > /tmp/pr_files.txt
-          gh pr diff "$PR_NUMBER" > /tmp/pr_diff.txt
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json title,body --template '{{.title}}' > /tmp/pr_title.txt
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json title,body --template '{{.body}}' > /tmp/pr_body.txt
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path' > /tmp/pr_files.txt
+          gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > /tmp/pr_diff.txt
 
           # Fail closed if diff exceeds model window — large PRs could hide risky changes.
           DIFF_LIMIT=100000

--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -76,17 +76,21 @@ jobs:
               r.state === "APPROVED" && r.commit_id === headSha
             );
 
-            const botApproved = approvalsForHead.some(r => r.user?.login === "github-actions[bot]");
-            const humanApproved = approvalsForHead.some(r => r.user?.type === "User");
+            const selfApproved = approvalsForHead.some(r => r.user?.login === "github-actions[bot]");
+            // Any other approval — human or another bot like Renovate/Dependabot —
+            // counts as a trusted approval and short-circuits this workflow. We
+            // only exclude *our own* bot's approval because acting on it would
+            // be a re-approval loop.
+            const otherApproved = approvalsForHead.some(r => r.user?.login !== "github-actions[bot]");
 
-            if (botApproved) {
+            if (selfApproved) {
               core.setOutput("short_circuit", "true");
-              core.setOutput("reason", "bot-already-approved");
+              core.setOutput("reason", "self-already-approved");
               core.info(`Bot already approved head_sha ${headSha}; skipping all jobs.`);
-            } else if (humanApproved) {
+            } else if (otherApproved) {
               core.setOutput("short_circuit", "true");
-              core.setOutput("reason", "human-approved");
-              core.info(`Human approval present on head_sha ${headSha}; skipping all jobs.`);
+              core.setOutput("reason", "external-approval");
+              core.info(`External approval present on head_sha ${headSha}; skipping all jobs.`);
             } else {
               core.setOutput("short_circuit", "false");
               core.setOutput("reason", "");


### PR DESCRIPTION
## Why

Two follow-up fixes to #3219 after it shipped:

1. **Preflight was crashing.** The consolidated workflow failed on its first run (PR #3220) at the `Resolve PR context` step with `failed to run git: fatal: not a git repository`. The preflight job doesn't check out the repo (it doesn't need to — it only needs PR metadata), so `gh pr view` had no git context to infer the repo from.
2. **Approval check missed app bots.** The short-circuit was using `r.user?.type === "User"`, which skips approving reviews from app bots (Renovate, Dependabot, etc). Those are trusted external approvals that should short-circuit this workflow too.

## What changed

- Pass `--repo "$GITHUB_REPOSITORY"` to every `gh pr view` and `gh pr diff` call inside the workflow.
- Replace the `type === "User"` filter with a negative check against our own bot's login: any approval whose author isn't `github-actions[bot]` counts as an external approval. Only our own approvals are excluded (acting on them would loop).

## Test plan

- Merge. The next PR that hits `pr-auto-approve` should progress past the preflight step.
- A PR approved by a human *or* by another app bot (Renovate, etc.) should cause the preflight to short-circuit — no redundant bot review.
- `python3 -c 'import yaml; yaml.safe_load(...)'` confirms the file still parses.