### PR TITLE
fix(pr-auto-approve): treat LOW_RISK_PULL_REQUESTS.md as restricted path

### DIFF
--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -227,7 +227,9 @@ jobs:
         id: path-check
         if: steps.pr-data.outputs.oversized == 'false'
         run: |
-          RESTRICTED_PATTERN='^(\.github/workflows/|(auth|security|migrations|prisma)/|.*/(auth|security|migrations|prisma)/)'
+          # dev/docs/LOW_RISK_PULL_REQUESTS.md is the policy doc the LLM
+          # evaluator reads — changes to it are never themselves low-risk.
+          RESTRICTED_PATTERN='^(\.github/workflows/|dev/docs/LOW_RISK_PULL_REQUESTS\.md$|(auth|security|migrations|prisma)/|.*/(auth|security|migrations|prisma)/)'
           if grep -qE "$RESTRICTED_PATTERN" /tmp/pr_files.txt; then
             echo "Restricted paths detected:"
             grep -E "$RESTRICTED_PATTERN" /tmp/pr_files.txt


### PR DESCRIPTION
## Why

Follow-up to #3219 and #3222. Noticed during an audit: the LLM low-risk evaluator reads its policy from `dev/docs/LOW_RISK_PULL_REQUESTS.md`. A PR that *edits* that policy doc would be evaluated against the pre-edit policy (we deliberately read from `base.sha`), but once merged the new — potentially weaker — policy governs every future PR. Changes to the policy itself should never be auto-approved.

## What changed

Add `dev/docs/LOW_RISK_PULL_REQUESTS.md` to `RESTRICTED_PATTERN` in the evaluator's path check. Any PR touching it falls through to the "restricted paths" branch, posts the standard explanation comment, and requires a human review.

## Test plan

- A PR touching only `dev/docs/LOW_RISK_PULL_REQUESTS.md` should hit the restricted-path branch, not the LLM evaluator, and not get an auto-approval.
- YAML still parses (`python3 -c 'import yaml; yaml.safe_load(...)'`).
