### PR TITLE
fix(strands): preserve conversation message order in span processing

### DIFF
--- a/langwatch/src/server/app-layer/traces/canonicalisation/eventBag.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/eventBag.ts
@@ -38,6 +38,20 @@ export class EventBag {
     return out;
   }
 
+  /** Take all events matching any of the given names, preserving original order */
+  takeAllByNames(names: readonly string[]): NormalizedEvent[] {
+    const nameSet = new Set(names);
+    const out: NormalizedEvent[] = [];
+    for (let i = 0; i < this.events.length; i++) {
+      if (this.consumed.has(i)) continue;
+      if (nameSet.has(this.events[i]?.name ?? "")) {
+        this.consumed.add(i);
+        out.push(this.events[i]!);
+      }
+    }
+    return out;
+  }
+
   /** Events that remain after consumption */
   remaining(): NormalizedEvent[] {
     const out: NormalizedEvent[] = [];

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/strands.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/strands.unit.test.ts
@@ -156,6 +156,44 @@ describe("StrandsExtractor", () => {
       expect(ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES]).toBeUndefined();
     });
 
+    it("preserves conversation order across interleaved roles", () => {
+      const ctx = createStrandsContext({}, [
+        {
+          name: "gen_ai.user.message",
+          attributes: { content: "First question" },
+        },
+        {
+          name: "gen_ai.assistant.message",
+          attributes: { content: "First answer" },
+        },
+        {
+          name: "gen_ai.user.message",
+          attributes: { content: "Follow-up question" },
+        },
+        {
+          name: "gen_ai.assistant.message",
+          attributes: { content: "Follow-up answer" },
+        },
+        {
+          name: "gen_ai.user.message",
+          attributes: { content: "Current turn" },
+        },
+      ]);
+
+      extractor.apply(ctx);
+
+      const messages = JSON.parse(
+        ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES] as string,
+      ) as Array<{ role: string; content: string }>;
+      expect(messages).toEqual([
+        { role: "user", content: "First question" },
+        { role: "assistant", content: "First answer" },
+        { role: "user", content: "Follow-up question" },
+        { role: "assistant", content: "Follow-up answer" },
+        { role: "user", content: "Current turn" },
+      ]);
+    });
+
     it("strips system messages from input and promotes to system_instruction", () => {
       const ctx = createStrandsContext({}, [
         {

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/strands.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/strands.unit.test.ts
@@ -194,6 +194,35 @@ describe("StrandsExtractor", () => {
       ]);
     });
 
+    it("promotes system message to system_instruction even when not first event", () => {
+      const ctx = createStrandsContext({}, [
+        {
+          name: "gen_ai.user.message",
+          attributes: { content: "Hi" },
+        },
+        {
+          name: "gen_ai.system.message",
+          attributes: { content: "Be helpful" },
+        },
+        {
+          name: "gen_ai.assistant.message",
+          attributes: { content: "Hello!" },
+        },
+      ]);
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.GEN_AI_SYSTEM_INSTRUCTIONS]).toBe("Be helpful");
+
+      const messages = JSON.parse(
+        ctx.out[ATTR_KEYS.GEN_AI_INPUT_MESSAGES] as string,
+      ) as Array<{ role: string }>;
+      expect(messages).toEqual([
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Hello!" },
+      ]);
+    });
+
     it("strips system messages from input and promotes to system_instruction", () => {
       const ctx = createStrandsContext({}, [
         {

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/strands.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/strands.ts
@@ -166,19 +166,26 @@ export class StrandsExtractor implements CanonicalAttributesExtractor {
       }
 
       if (inputMessages.length > 0) {
-        // Extract system instruction from assembled messages
-        const sysInstruction = extractSystemInstructionFromMessages(inputMessages);
-        if (sysInstruction !== null) {
-          ctx.setAttrIfAbsent(
-            ATTR_KEYS.GEN_AI_SYSTEM_INSTRUCTIONS,
-            sysInstruction,
-          );
+        // Always strip system messages — they are promoted to gen_ai.system_instructions.
+        // Filter to system-only first so extractSystemInstructionFromMessages sees
+        // the system message at position 0 regardless of where it appeared chronologically.
+        const chatMessages = stripSystemMessages(inputMessages);
+        const systemOnly = inputMessages.filter(
+          (m) =>
+            typeof m === "object" &&
+            m !== null &&
+            (m as Record<string, unknown>).role === "system",
+        );
+        if (systemOnly.length > 0) {
+          const sysInstruction =
+            extractSystemInstructionFromMessages(systemOnly);
+          if (sysInstruction !== null) {
+            ctx.setAttrIfAbsent(
+              ATTR_KEYS.GEN_AI_SYSTEM_INSTRUCTIONS,
+              sysInstruction,
+            );
+          }
         }
-
-        // Strip system messages — they are promoted to gen_ai.system_instructions
-        const chatMessages = sysInstruction !== null
-          ? stripSystemMessages(inputMessages)
-          : inputMessages;
 
         if (chatMessages.length > 0) {
           ctx.setAttr(ATTR_KEYS.GEN_AI_INPUT_MESSAGES, chatMessages);

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/strands.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/strands.ts
@@ -145,21 +145,23 @@ export class StrandsExtractor implements CanonicalAttributesExtractor {
     if (!ctx.bag.attrs.has(ATTR_KEYS.GEN_AI_INPUT_MESSAGES)) {
       const inputMessages: unknown[] = [];
 
-      for (const eventName of ROLE_EVENT_NAMES) {
-        const events = ctx.bag.events.takeAll(eventName);
-        for (const event of events) {
-          // Infer role from event name (e.g., "gen_ai.user.message" → "user")
-          const role = eventName.split(".")[1];
-          const eventAttrs = (event.attributes ?? {}) as Record<
-            string,
-            unknown
-          >;
+      // Take all role-based events in their original array order to preserve
+      // conversation interleaving (user, assistant, user, assistant, ...).
+      // Previously iterating by role name grouped all messages of the same
+      // role together, destroying chronological order.
+      const roleEvents = ctx.bag.events.takeAllByNames(ROLE_EVENT_NAMES);
+      for (const event of roleEvents) {
+        // Infer role from event name (e.g., "gen_ai.user.message" → "user")
+        const role = event.name.split(".")[1];
+        const eventAttrs = (event.attributes ?? {}) as Record<
+          string,
+          unknown
+        >;
 
-          const content = extractStrandsContent(eventAttrs);
+        const content = extractStrandsContent(eventAttrs);
 
-          if (content !== void 0) {
-            inputMessages.push({ role, content });
-          }
+        if (content !== void 0) {
+          inputMessages.push({ role, content });
         }
       }
 


### PR DESCRIPTION
## Summary
- The Strands extractor iterated through `ROLE_EVENT_NAMES` sequentially (system → user → assistant → tool), grouping all messages of each role together and destroying chronological conversation order
- Added `EventBag.takeAllByNames()` to consume events matching multiple names while preserving original array order
- Updated the extractor to use this method, so multi-turn conversations retain their natural user/assistant interleaving

## Test plan
- [x] New unit test verifies interleaved conversation order is preserved (user, assistant, user, assistant, user)
- [x] All 11 existing Strands extractor tests pass
- [ ] Verify on the reported trace (project `celeste-prod-FzsKx-`, span `5772aacbdc7089f5`) that re-ingested data shows correct message ordering