### PR TITLE
fix: use latestVersionId for scenario workflow resolution

### DIFF
--- a/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
@@ -77,7 +77,7 @@ describe("prefetchScenarioData", () => {
     };
 
     const workflowVersionFetcher: WorkflowVersionFetcher = {
-      getPublishedDsl: vi.fn().mockResolvedValue(null),
+      getLatestDsl: vi.fn().mockResolvedValue(null),
     };
 
     const projectFetcher: ProjectFetcher = {
@@ -574,14 +574,14 @@ describe("prefetchScenarioData", () => {
       referenceId: "agent_wf",
     };
 
-    describe("when the agent and published workflow exist", () => {
+    describe("when the agent and workflow have a latest version", () => {
       it("returns WorkflowAgentData with inputs, outputs, mappings and workflow DSL", async () => {
         const deps = createMockDeps({
           agentFetcher: {
             findById: vi.fn().mockResolvedValue(workflowAgent),
           },
           workflowVersionFetcher: {
-            getPublishedDsl: vi.fn().mockResolvedValue({
+            getLatestDsl: vi.fn().mockResolvedValue({
               workflowId: "wf_1",
               dsl: publishedDsl,
             }),
@@ -621,14 +621,14 @@ describe("prefetchScenarioData", () => {
       });
     });
 
-    describe("when the workflow has no published version", () => {
+    describe("when the workflow has no saved version", () => {
       it("returns a friendly 'Workflow agent not found' error", async () => {
         const deps = createMockDeps({
           agentFetcher: {
             findById: vi.fn().mockResolvedValue(workflowAgent),
           },
           workflowVersionFetcher: {
-            getPublishedDsl: vi.fn().mockResolvedValue(null),
+            getLatestDsl: vi.fn().mockResolvedValue(null),
           },
         });
 
@@ -647,7 +647,7 @@ describe("prefetchScenarioData", () => {
 
     describe("when the agent has no workflowId", () => {
       it("returns 'Workflow agent not found' without touching the version fetcher", async () => {
-        const getPublishedDsl = vi.fn();
+        const getLatestDsl = vi.fn();
         const deps = createMockDeps({
           agentFetcher: {
             findById: vi.fn().mockResolvedValue({
@@ -657,7 +657,7 @@ describe("prefetchScenarioData", () => {
             }),
           },
           workflowVersionFetcher: {
-            getPublishedDsl,
+            getLatestDsl,
           },
         });
 
@@ -671,7 +671,34 @@ describe("prefetchScenarioData", () => {
         if (!result.success) {
           expect(result.error).toBe("Workflow agent agent_wf not found");
         }
-        expect(getPublishedDsl).not.toHaveBeenCalled();
+        expect(getLatestDsl).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the workflow has a latest version but was never published", () => {
+      it("resolves DSL from the latest version", async () => {
+        const deps = createMockDeps({
+          agentFetcher: {
+            findById: vi.fn().mockResolvedValue(workflowAgent),
+          },
+          workflowVersionFetcher: {
+            getLatestDsl: vi.fn().mockResolvedValue({
+              workflowId: "wf_1",
+              dsl: publishedDsl,
+            }),
+          },
+        });
+
+        const result = await prefetchScenarioData(
+          defaultContext,
+          workflowTarget,
+          deps,
+        );
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.adapterData.type).toBe("workflow");
+        }
       });
     });
   });

--- a/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
@@ -535,7 +535,7 @@ describe("prefetchScenarioData", () => {
       },
     };
 
-    const publishedDsl = {
+    const workflowDsl = {
       workflow_id: "wf_1",
       nodes: [
         {
@@ -583,7 +583,7 @@ describe("prefetchScenarioData", () => {
           workflowVersionFetcher: {
             getLatestDsl: vi.fn().mockResolvedValue({
               workflowId: "wf_1",
-              dsl: publishedDsl,
+              dsl: workflowDsl,
             }),
           },
         });
@@ -615,7 +615,7 @@ describe("prefetchScenarioData", () => {
               },
             });
             expect(result.data.adapterData.scenarioOutputField).toBe("answer");
-            expect(result.data.adapterData.workflow).toEqual(publishedDsl);
+            expect(result.data.adapterData.workflow).toEqual(workflowDsl);
           }
         }
       });
@@ -675,31 +675,5 @@ describe("prefetchScenarioData", () => {
       });
     });
 
-    describe("when the workflow has a latest version but was never published", () => {
-      it("resolves DSL from the latest version", async () => {
-        const deps = createMockDeps({
-          agentFetcher: {
-            findById: vi.fn().mockResolvedValue(workflowAgent),
-          },
-          workflowVersionFetcher: {
-            getLatestDsl: vi.fn().mockResolvedValue({
-              workflowId: "wf_1",
-              dsl: publishedDsl,
-            }),
-          },
-        });
-
-        const result = await prefetchScenarioData(
-          defaultContext,
-          workflowTarget,
-          deps,
-        );
-
-        expect(result.success).toBe(true);
-        if (result.success) {
-          expect(result.data.adapterData.type).toBe("workflow");
-        }
-      });
-    });
-  });
+});
 });

--- a/langwatch/src/server/scenarios/execution/data-prefetcher.ts
+++ b/langwatch/src/server/scenarios/execution/data-prefetcher.ts
@@ -453,19 +453,19 @@ async function fetchWorkflowAgentData(
     null;
   if (!workflowId) return null;
 
-  const published = await workflowVersionFetcher.getLatestDsl({
+  const latest = await workflowVersionFetcher.getLatestDsl({
     projectId,
     workflowId,
   });
-  if (!published) return null;
+  if (!latest) return null;
 
-  const { inputs, outputs } = extractWorkflowIO(published.dsl);
+  const { inputs, outputs } = extractWorkflowIO(latest.dsl);
 
   return {
     type: "workflow",
     agentId: agent.id,
-    workflowId: published.workflowId,
-    workflow: published.dsl,
+    workflowId: latest.workflowId,
+    workflow: latest.dsl,
     inputs,
     outputs,
     scenarioMappings: config.scenarioMappings,

--- a/langwatch/src/server/scenarios/execution/data-prefetcher.ts
+++ b/langwatch/src/server/scenarios/execution/data-prefetcher.ts
@@ -68,11 +68,11 @@ export interface AgentFetcher {
 }
 
 /**
- * Minimal interface for workflow version lookup - loads the published DSL
+ * Minimal interface for workflow version lookup - loads the latest DSL
  * for a workflow so the worker-thread adapter can execute it without DB access.
  */
 export interface WorkflowVersionFetcher {
-  getPublishedDsl(params: {
+  getLatestDsl(params: {
     projectId: string;
     workflowId: string;
   }): Promise<{ workflowId: string; dsl: Record<string, unknown> } | null>;
@@ -453,7 +453,7 @@ async function fetchWorkflowAgentData(
     null;
   if (!workflowId) return null;
 
-  const published = await workflowVersionFetcher.getPublishedDsl({
+  const published = await workflowVersionFetcher.getLatestDsl({
     projectId,
     workflowId,
   });
@@ -561,14 +561,14 @@ export function createDataPrefetcherDependencies(): DataPrefetcherDependencies {
       findById: (params) => agentRepository.findById(params),
     },
     workflowVersionFetcher: {
-      getPublishedDsl: async ({ projectId, workflowId }) => {
+      getLatestDsl: async ({ projectId, workflowId }) => {
         const workflow = await prisma.workflow.findFirst({
           where: { id: workflowId, projectId, archivedAt: null },
-          select: { id: true, publishedId: true },
+          select: { id: true, latestVersionId: true },
         });
-        if (!workflow?.publishedId) return null;
+        if (!workflow?.latestVersionId) return null;
         const version = await prisma.workflowVersion.findFirst({
-          where: { id: workflow.publishedId, projectId },
+          where: { id: workflow.latestVersionId, projectId },
           select: { dsl: true },
         });
         if (!version) return null;


### PR DESCRIPTION
## Summary

- Scenario runs against unpublished workflow agents failed with "Workflow agent not found" because the data prefetcher required `publishedId`
- Switched `workflowVersionFetcher.getPublishedDsl` → `getLatestDsl` to resolve from `latestVersionId` instead
- Unpublished workflows now work in scenario runs without forcing a publish first

Closes #3152

## Verification Report

| # | Criterion | Evidence | Status |
|---|-----------|----------|--------|
| 1 | Scenario run against unpublished workflow agent succeeds E2E | Requires manual verification against running instance | UNVERIFIED |
| 2 | Data-prefetcher resolves DSL from `latestVersionId` rather than `publishedId` | `data-prefetcher.ts:567,569,571` use `latestVersionId`; zero grep hits for `publishedId` | PASS |
| 3 | Integration test: create workflow agent → save (no publish) → run scenario | No DB-backed integration test pattern exists in this area; unit tests cover logic via DI | UNVERIFIED |
| 4 | No regression for published workflow agents | 15/15 unit tests pass including full happy path with DSL, inputs, outputs, mappings | PASS |

## Test plan

- [x] All existing unit tests pass (15 pass, 1 pre-existing skip)
- [x] No remaining references to `getPublishedDsl` or `publishedId` in data-prefetcher
- [ ] Manual: create workflow agent → save without publishing → run scenario → succeeds
- [ ] Manual: published workflow agent → run scenario → still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>