### PR TITLE
feat: add platformUrl to all API responses and CLI output

### DIFF
--- a/langwatch/src/app/api/agents/[[...route]]/app.ts
+++ b/langwatch/src/app/api/agents/[[...route]]/app.ts
@@ -21,6 +21,11 @@ import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { NotFoundError, UnprocessableEntityError } from "../../shared/errors";
 import { platformUrl } from "../../shared/platform-url";
+
+function agentPlatformUrl({ projectSlug, agentId, agentType }: { projectSlug: string; agentId: string; agentType: string }): string {
+  const drawer = agentType === "http" ? "agentHttpEditor" : "agentCodeEditor";
+  return platformUrl({ projectSlug, path: `/agents?drawer.open=${drawer}&drawer.agentId=${agentId}` });
+}
 import { ZodError } from "zod";
 import { handleAgentError } from "./error-handler";
 
@@ -122,12 +127,9 @@ export const app = new Hono<{ Variables: Variables }>()
 
       return c.json({
         ...result,
-        data: result.data.map((a: { id: string }) => ({
+        data: result.data.map((a: { id: string; type: string }) => ({
           ...a,
-          platformUrl: platformUrl({
-            projectSlug: project.slug,
-            path: `/agents`,
-          }),
+          platformUrl: agentPlatformUrl({ projectSlug: project.slug, agentId: a.id, agentType: a.type }),
         })),
       });
     },
@@ -168,10 +170,7 @@ export const app = new Hono<{ Variables: Variables }>()
           config: agent.config,
           createdAt: agent.createdAt,
           updatedAt: agent.updatedAt,
-          platformUrl: platformUrl({
-            projectSlug: project.slug,
-            path: `/agents`,
-          }),
+          platformUrl: agentPlatformUrl({ projectSlug: project.slug, agentId: agent.id, agentType: agent.type }),
         },
         201,
       );

--- a/langwatch/src/app/api/agents/[[...route]]/app.ts
+++ b/langwatch/src/app/api/agents/[[...route]]/app.ts
@@ -20,6 +20,7 @@ import {
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { NotFoundError, UnprocessableEntityError } from "../../shared/errors";
+import { platformUrl } from "../../shared/platform-url";
 import { ZodError } from "zod";
 import { handleAgentError } from "./error-handler";
 
@@ -119,7 +120,16 @@ export const app = new Hono<{ Variables: Variables }>()
         limit,
       });
 
-      return c.json(result);
+      return c.json({
+        ...result,
+        data: result.data.map((a: { id: string }) => ({
+          ...a,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/agents`,
+          }),
+        })),
+      });
     },
   )
 
@@ -158,6 +168,10 @@ export const app = new Hono<{ Variables: Variables }>()
           config: agent.config,
           createdAt: agent.createdAt,
           updatedAt: agent.updatedAt,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/agents`,
+          }),
         },
         201,
       );
@@ -192,6 +206,10 @@ export const app = new Hono<{ Variables: Variables }>()
         config: agent.config,
         createdAt: agent.createdAt,
         updatedAt: agent.updatedAt,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/agents`,
+        }),
       });
     },
   )
@@ -237,6 +255,10 @@ export const app = new Hono<{ Variables: Variables }>()
         config: agent.config,
         createdAt: agent.createdAt,
         updatedAt: agent.updatedAt,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/agents`,
+        }),
       });
     },
   )

--- a/langwatch/src/app/api/dashboards/[[...route]]/app.ts
+++ b/langwatch/src/app/api/dashboards/[[...route]]/app.ts
@@ -15,6 +15,7 @@ import {
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { BadRequestError, NotFoundError } from "../../shared/errors";
+import { platformUrl } from "../../shared/platform-url";
 import { handleDashboardError } from "./error-handler";
 
 patchZodOpenapi();
@@ -102,6 +103,10 @@ export const app = new Hono<{ Variables: Variables }>()
           graphCount: d._count.graphs,
           createdAt: d.createdAt,
           updatedAt: d.updatedAt,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/analytics`,
+          }),
         })),
       });
     },
@@ -129,6 +134,10 @@ export const app = new Hono<{ Variables: Variables }>()
           order: dashboard.order,
           createdAt: dashboard.createdAt,
           updatedAt: dashboard.updatedAt,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/analytics`,
+          }),
         },
         201,
       );
@@ -177,6 +186,10 @@ export const app = new Hono<{ Variables: Variables }>()
           graphs: dashboard.graphs,
           createdAt: dashboard.createdAt,
           updatedAt: dashboard.updatedAt,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/analytics`,
+          }),
         });
       } catch (error) {
         return mapDashboardNotFoundError(error);
@@ -205,6 +218,10 @@ export const app = new Hono<{ Variables: Variables }>()
           order: dashboard.order,
           createdAt: dashboard.createdAt,
           updatedAt: dashboard.updatedAt,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/analytics`,
+          }),
         });
       } catch (error) {
         return mapDashboardNotFoundError(error);

--- a/langwatch/src/app/api/dashboards/[[...route]]/app.ts
+++ b/langwatch/src/app/api/dashboards/[[...route]]/app.ts
@@ -105,7 +105,7 @@ export const app = new Hono<{ Variables: Variables }>()
           updatedAt: d.updatedAt,
           platformUrl: platformUrl({
             projectSlug: project.slug,
-            path: `/analytics`,
+            path: `/analytics/custom/${d.id}`,
           }),
         })),
       });
@@ -136,7 +136,7 @@ export const app = new Hono<{ Variables: Variables }>()
           updatedAt: dashboard.updatedAt,
           platformUrl: platformUrl({
             projectSlug: project.slug,
-            path: `/analytics`,
+            path: `/analytics/custom/${dashboard.id}`,
           }),
         },
         201,
@@ -188,7 +188,7 @@ export const app = new Hono<{ Variables: Variables }>()
           updatedAt: dashboard.updatedAt,
           platformUrl: platformUrl({
             projectSlug: project.slug,
-            path: `/analytics`,
+            path: `/analytics/custom/${dashboard.id}`,
           }),
         });
       } catch (error) {
@@ -220,7 +220,7 @@ export const app = new Hono<{ Variables: Variables }>()
           updatedAt: dashboard.updatedAt,
           platformUrl: platformUrl({
             projectSlug: project.slug,
-            path: `/analytics`,
+            path: `/analytics/custom/${dashboard.id}`,
           }),
         });
       } catch (error) {

--- a/langwatch/src/app/api/dashboards/[[...route]]/app.ts
+++ b/langwatch/src/app/api/dashboards/[[...route]]/app.ts
@@ -105,7 +105,7 @@ export const app = new Hono<{ Variables: Variables }>()
           updatedAt: d.updatedAt,
           platformUrl: platformUrl({
             projectSlug: project.slug,
-            path: `/analytics/custom/${d.id}`,
+            path: `/analytics/reports?dashboard=${d.id}`,
           }),
         })),
       });
@@ -136,7 +136,7 @@ export const app = new Hono<{ Variables: Variables }>()
           updatedAt: dashboard.updatedAt,
           platformUrl: platformUrl({
             projectSlug: project.slug,
-            path: `/analytics/custom/${dashboard.id}`,
+            path: `/analytics/reports?dashboard=${dashboard.id}`,
           }),
         },
         201,
@@ -188,7 +188,7 @@ export const app = new Hono<{ Variables: Variables }>()
           updatedAt: dashboard.updatedAt,
           platformUrl: platformUrl({
             projectSlug: project.slug,
-            path: `/analytics/custom/${dashboard.id}`,
+            path: `/analytics/reports?dashboard=${dashboard.id}`,
           }),
         });
       } catch (error) {
@@ -220,7 +220,7 @@ export const app = new Hono<{ Variables: Variables }>()
           updatedAt: dashboard.updatedAt,
           platformUrl: platformUrl({
             projectSlug: project.slug,
-            path: `/analytics/custom/${dashboard.id}`,
+            path: `/analytics/reports?dashboard=${dashboard.id}`,
           }),
         });
       } catch (error) {

--- a/langwatch/src/app/api/dataset/[[...route]]/app.ts
+++ b/langwatch/src/app/api/dataset/[[...route]]/app.ts
@@ -19,6 +19,7 @@ import {
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import {
   BadRequestError,
   InternalServerError,
@@ -131,7 +132,16 @@ export const app = new Hono<{ Variables: Variables }>()
         limit,
       });
 
-      return c.json(result);
+      return c.json({
+        ...result,
+        data: result.data.map((d: { id: string; slug?: string }) => ({
+          ...d,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/datasets/${d.id}`,
+          }),
+        })),
+      });
     },
   )
 
@@ -163,6 +173,10 @@ export const app = new Hono<{ Variables: Variables }>()
             columnTypes: dataset.columnTypes,
             createdAt: dataset.createdAt,
             updatedAt: dataset.updatedAt,
+            platformUrl: platformUrl({
+              projectSlug: project.slug,
+              path: `/datasets/${dataset.id}`,
+            }),
           },
           201,
         );
@@ -453,6 +467,10 @@ export const app = new Hono<{ Variables: Variables }>()
         columnTypes: dataset.columnTypes,
         createdAt: dataset.createdAt,
         updatedAt: dataset.updatedAt,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/datasets/${dataset.id}`,
+        }),
         data: records,
       });
     },
@@ -498,6 +516,10 @@ export const app = new Hono<{ Variables: Variables }>()
           columnTypes: updated.columnTypes,
           createdAt: updated.createdAt,
           updatedAt: updated.updatedAt,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/datasets/${updated.id}`,
+          }),
         });
       } catch (error) {
         if (error instanceof Error && error.name === "DatasetConflictError") {

--- a/langwatch/src/app/api/evaluators/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/evaluators/[[...route]]/app.v1.ts
@@ -26,6 +26,11 @@ import {
   updateEvaluatorInputSchema,
 } from "./schemas";
 
+const apiResponseEvaluatorWithPlatformUrlSchema =
+  apiResponseEvaluatorSchema.extend({
+    platformUrl: z.string().url(),
+  });
+
 const logger = createLogger("langwatch:api:evaluators");
 
 patchZodOpenapi();
@@ -53,7 +58,7 @@ app.get(
         description: "Success",
         content: {
           "application/json": {
-            schema: resolver(z.array(apiResponseEvaluatorSchema)),
+            schema: resolver(z.array(apiResponseEvaluatorWithPlatformUrlSchema)),
           },
         },
       },
@@ -90,7 +95,7 @@ app.get(
         description: "Success",
         content: {
           "application/json": {
-            schema: resolver(apiResponseEvaluatorSchema),
+            schema: resolver(apiResponseEvaluatorWithPlatformUrlSchema),
           },
         },
       },
@@ -154,7 +159,7 @@ app.post(
         description: "Success",
         content: {
           "application/json": {
-            schema: resolver(apiResponseEvaluatorSchema),
+            schema: resolver(apiResponseEvaluatorWithPlatformUrlSchema),
           },
         },
       },
@@ -209,7 +214,7 @@ app.put(
         description: "Success",
         content: {
           "application/json": {
-            schema: resolver(apiResponseEvaluatorSchema),
+            schema: resolver(apiResponseEvaluatorWithPlatformUrlSchema),
           },
         },
       },

--- a/langwatch/src/app/api/evaluators/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/evaluators/[[...route]]/app.v1.ts
@@ -73,7 +73,7 @@ app.get(
       ...e,
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/evaluators`,
+        path: `/evaluators?drawer.open=evaluatorEditor&drawer.evaluatorId=${e.id}`,
       }),
     })));
   },
@@ -131,11 +131,12 @@ app.get(
       });
     }
 
+    const parsed = apiResponseEvaluatorSchema.parse(evaluator);
     return c.json({
-      ...apiResponseEvaluatorSchema.parse(evaluator),
+      ...parsed,
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/evaluators`,
+        path: `/evaluators?drawer.open=evaluatorEditor&drawer.evaluatorId=${parsed.id}`,
       }),
     });
   },
@@ -186,11 +187,12 @@ app.post(
       "Successfully created evaluator",
     );
 
+    const parsedCreated = apiResponseEvaluatorSchema.parse(enriched);
     return c.json({
-      ...apiResponseEvaluatorSchema.parse(enriched),
+      ...parsedCreated,
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/evaluators`,
+        path: `/evaluators?drawer.open=evaluatorEditor&drawer.evaluatorId=${parsedCreated.id}`,
       }),
     });
   },
@@ -287,11 +289,12 @@ app.put(
       "Successfully updated evaluator",
     );
 
+    const parsedUpdated = apiResponseEvaluatorSchema.parse(enriched);
     return c.json({
-      ...apiResponseEvaluatorSchema.parse(enriched),
+      ...parsedUpdated,
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/evaluators`,
+        path: `/evaluators?drawer.open=evaluatorEditor&drawer.evaluatorId=${parsedUpdated.id}`,
       }),
     });
   },

--- a/langwatch/src/app/api/evaluators/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/evaluators/[[...route]]/app.v1.ts
@@ -19,6 +19,7 @@ import {
   evaluatorServiceMiddleware,
 } from "../../middleware/evaluator-service";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import {
   apiResponseEvaluatorSchema,
   createEvaluatorInputSchema,
@@ -68,7 +69,13 @@ app.get(
       projectId: project.id,
     });
 
-    return c.json(apiResponseEvaluatorSchema.array().parse(evaluators));
+    return c.json(apiResponseEvaluatorSchema.array().parse(evaluators).map((e) => ({
+      ...e,
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/evaluators`,
+      }),
+    })));
   },
 );
 
@@ -124,7 +131,13 @@ app.get(
       });
     }
 
-    return c.json(apiResponseEvaluatorSchema.parse(evaluator));
+    return c.json({
+      ...apiResponseEvaluatorSchema.parse(evaluator),
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/evaluators`,
+      }),
+    });
   },
 );
 
@@ -173,7 +186,13 @@ app.post(
       "Successfully created evaluator",
     );
 
-    return c.json(apiResponseEvaluatorSchema.parse(enriched));
+    return c.json({
+      ...apiResponseEvaluatorSchema.parse(enriched),
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/evaluators`,
+      }),
+    });
   },
 );
 
@@ -268,7 +287,13 @@ app.put(
       "Successfully updated evaluator",
     );
 
-    return c.json(apiResponseEvaluatorSchema.parse(enriched));
+    return c.json({
+      ...apiResponseEvaluatorSchema.parse(enriched),
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/evaluators`,
+      }),
+    });
   },
 );
 

--- a/langwatch/src/app/api/monitors/[[...route]]/app.ts
+++ b/langwatch/src/app/api/monitors/[[...route]]/app.ts
@@ -43,6 +43,10 @@ const monitorResponseSchema = z.object({
   updatedAt: z.string(),
 });
 
+const monitorResponseWithPlatformUrlSchema = monitorResponseSchema.extend({
+  platformUrl: z.string().url(),
+});
+
 const createMonitorSchema = z.object({
   name: z.string().min(1, "name is required"),
   checkType: z.string().min(1, "checkType is required"),
@@ -125,7 +129,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(z.array(monitorResponseSchema)),
+              schema: resolver(z.array(monitorResponseWithPlatformUrlSchema)),
             },
           },
         },
@@ -161,7 +165,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(monitorResponseSchema),
+              schema: resolver(monitorResponseWithPlatformUrlSchema),
             },
           },
         },
@@ -210,7 +214,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Monitor created",
           content: {
             "application/json": {
-              schema: resolver(monitorResponseSchema),
+              schema: resolver(monitorResponseWithPlatformUrlSchema),
             },
           },
         },
@@ -282,7 +286,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Monitor updated",
           content: {
             "application/json": {
-              schema: resolver(monitorResponseSchema),
+              schema: resolver(monitorResponseWithPlatformUrlSchema),
             },
           },
         },

--- a/langwatch/src/app/api/monitors/[[...route]]/app.ts
+++ b/langwatch/src/app/api/monitors/[[...route]]/app.ts
@@ -14,6 +14,7 @@ import {
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import { badRequestSchema } from "../../shared/schemas";
 
 patchZodOpenapi();
@@ -139,7 +140,13 @@ export const app = new Hono<{ Variables: Variables }>()
         orderBy: { createdAt: "asc" },
       });
 
-      return c.json(monitors.map(toMonitorResponse));
+      return c.json(monitors.map((m) => ({
+        ...toMonitorResponse(m),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/evaluations/${m.id}/edit`,
+        }),
+      })));
     }
   )
 
@@ -182,7 +189,13 @@ export const app = new Hono<{ Variables: Variables }>()
         return c.json({ error: "Monitor not found" }, 404);
       }
 
-      return c.json(toMonitorResponse(monitor));
+      return c.json({
+        ...toMonitorResponse(monitor),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/evaluations/${monitor.id}/edit`,
+        }),
+      });
     }
   )
 
@@ -247,7 +260,13 @@ export const app = new Hono<{ Variables: Variables }>()
         },
       });
 
-      return c.json(toMonitorResponse(monitor), 201);
+      return c.json({
+        ...toMonitorResponse(monitor),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/evaluations/${monitor.id}/edit`,
+        }),
+      }, 201);
     }
   )
 
@@ -330,7 +349,13 @@ export const app = new Hono<{ Variables: Variables }>()
         data,
       });
 
-      return c.json(toMonitorResponse(monitor));
+      return c.json({
+        ...toMonitorResponse(monitor),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/evaluations/${monitor.id}/edit`,
+        }),
+      });
     }
   )
 

--- a/langwatch/src/app/api/monitors/[[...route]]/app.ts
+++ b/langwatch/src/app/api/monitors/[[...route]]/app.ts
@@ -144,7 +144,7 @@ export const app = new Hono<{ Variables: Variables }>()
         ...toMonitorResponse(m),
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/evaluations/${m.id}/edit`,
+          path: `/evaluations?drawer.open=onlineEvaluation&drawer.monitorId=${m.id}`,
         }),
       })));
     }
@@ -193,7 +193,7 @@ export const app = new Hono<{ Variables: Variables }>()
         ...toMonitorResponse(monitor),
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/evaluations/${monitor.id}/edit`,
+          path: `/evaluations?drawer.open=onlineEvaluation&drawer.monitorId=${monitor.id}`,
         }),
       });
     }
@@ -264,7 +264,7 @@ export const app = new Hono<{ Variables: Variables }>()
         ...toMonitorResponse(monitor),
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/evaluations/${monitor.id}/edit`,
+          path: `/evaluations?drawer.open=onlineEvaluation&drawer.monitorId=${monitor.id}`,
         }),
       }, 201);
     }
@@ -353,7 +353,7 @@ export const app = new Hono<{ Variables: Variables }>()
         ...toMonitorResponse(monitor),
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/evaluations/${monitor.id}/edit`,
+          path: `/evaluations?drawer.open=onlineEvaluation&drawer.monitorId=${monitor.id}`,
         }),
       });
     }

--- a/langwatch/src/app/api/prompts/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/app.v1.ts
@@ -34,6 +34,7 @@ import {
   promptServiceMiddleware,
 } from "../../middleware/prompt-service";
 import { baseResponses, conflictResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import {
   type ApiResponsePrompt,
   apiResponsePromptWithVersionDataSchema,
@@ -95,7 +96,13 @@ app.get(
     });
 
     return c.json(
-      apiResponsePromptWithVersionDataSchema.array().parse(configs),
+      apiResponsePromptWithVersionDataSchema.array().parse(configs).map((p) => ({
+        ...p,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/prompts`,
+        }),
+      })),
     );
   },
 );
@@ -437,7 +444,13 @@ app.get(
     );
 
     return c.json(
-      apiResponsePromptWithVersionDataSchema.array().parse(versions),
+      apiResponsePromptWithVersionDataSchema.array().parse(versions).map((v) => ({
+        ...v,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/prompts`,
+        }),
+      })),
     );
   },
 );
@@ -484,9 +497,13 @@ app.post(
         "Successfully restored prompt version",
       );
 
-      return c.json(
-        apiResponsePromptWithVersionDataSchema.parse(restored),
-      );
+      return c.json({
+        ...apiResponsePromptWithVersionDataSchema.parse(restored),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/prompts`,
+        }),
+      });
     } catch (error) {
       if (error instanceof NotFoundError) {
         return c.json({ error: error.message }, 404);
@@ -595,7 +612,13 @@ app.get(
         });
       }
 
-      return c.json(apiResponsePromptWithVersionDataSchema.parse(config));
+      return c.json({
+        ...apiResponsePromptWithVersionDataSchema.parse(config),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/prompts`,
+        }),
+      });
     } catch (error: unknown) {
       if (error instanceof HTTPException) {
         throw error;
@@ -686,7 +709,13 @@ app.post(
         projectId: project.id,
       });
 
-      return c.json(apiResponsePromptWithVersionDataSchema.parse(newConfig));
+      return c.json({
+        ...apiResponsePromptWithVersionDataSchema.parse(newConfig),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/prompts`,
+        }),
+      });
     } catch (error: any) {
       logger.error({ projectId: project.id, error }, "Error creating prompt");
       if (error instanceof TagValidationError) {
@@ -905,9 +934,13 @@ app.put(
         "Successfully updated prompt",
       );
 
-      return c.json(
-        apiResponsePromptWithVersionDataSchema.parse(updatedConfig),
-      );
+      return c.json({
+        ...apiResponsePromptWithVersionDataSchema.parse(updatedConfig),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/prompts`,
+        }),
+      });
     } catch (error: any) {
       logger.error({ projectId, promptId: id, error }, "Error updating prompt");
       if (error instanceof TagValidationError) {

--- a/langwatch/src/app/api/scenarios/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/scenarios/[[...route]]/app.v1.ts
@@ -13,6 +13,7 @@ import {
   resourceLimitMiddleware,
 } from "../../middleware";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 
 const logger = createLogger("langwatch:api:scenarios");
 
@@ -77,7 +78,13 @@ app.get(
     const service = getService();
     const scenarios = await service.getAll({ projectId: project.id });
 
-    return c.json(scenarios.map(toScenarioResponse));
+    return c.json(scenarios.map((s) => ({
+      ...toScenarioResponse(s),
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/simulations/scenarios`,
+      }),
+    })));
   },
 );
 
@@ -115,7 +122,13 @@ app.get(
       return c.json({ error: "Scenario not found" }, 404);
     }
 
-    return c.json(toScenarioResponse(scenario));
+    return c.json({
+      ...toScenarioResponse(scenario),
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/simulations/scenarios`,
+      }),
+    });
   },
 );
 
@@ -152,7 +165,13 @@ app.post(
       labels: body.labels,
     });
 
-    return c.json(toScenarioResponse(scenario), 201);
+    return c.json({
+      ...toScenarioResponse(scenario),
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/simulations/scenarios`,
+      }),
+    }, 201);
   },
 );
 
@@ -202,7 +221,13 @@ app.put(
       ...(body.labels !== undefined && { labels: body.labels }),
     });
 
-    return c.json(toScenarioResponse(scenario));
+    return c.json({
+      ...toScenarioResponse(scenario),
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/simulations/scenarios`,
+      }),
+    });
   },
 );
 

--- a/langwatch/src/app/api/scenarios/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/scenarios/[[...route]]/app.v1.ts
@@ -31,6 +31,10 @@ const scenarioResponseSchema = z.object({
   labels: z.array(z.string()),
 });
 
+const scenarioResponseWithPlatformUrlSchema = scenarioResponseSchema.extend({
+  platformUrl: z.string().url(),
+});
+
 const createScenarioSchema = z.object({
   name: z.string().min(1, "name is required"),
   situation: z.string(),
@@ -65,7 +69,7 @@ app.get(
         description: "Success",
         content: {
           "application/json": {
-            schema: resolver(z.array(scenarioResponseSchema)),
+            schema: resolver(z.array(scenarioResponseWithPlatformUrlSchema)),
           },
         },
       },
@@ -98,7 +102,7 @@ app.get(
         description: "Success",
         content: {
           "application/json": {
-            schema: resolver(scenarioResponseSchema),
+            schema: resolver(scenarioResponseWithPlatformUrlSchema),
           },
         },
       },
@@ -143,7 +147,7 @@ app.post(
         description: "Scenario created",
         content: {
           "application/json": {
-            schema: resolver(scenarioResponseSchema),
+            schema: resolver(scenarioResponseWithPlatformUrlSchema),
           },
         },
       },
@@ -185,7 +189,7 @@ app.put(
         description: "Scenario updated",
         content: {
           "application/json": {
-            schema: resolver(scenarioResponseSchema),
+            schema: resolver(scenarioResponseWithPlatformUrlSchema),
           },
         },
       },

--- a/langwatch/src/app/api/scenarios/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/scenarios/[[...route]]/app.v1.ts
@@ -82,7 +82,7 @@ app.get(
       ...toScenarioResponse(s),
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/simulations/scenarios`,
+        path: `/simulations/scenarios?drawer.open=scenarioEditor&drawer.scenarioId=${s.id}`,
       }),
     })));
   },
@@ -126,7 +126,7 @@ app.get(
       ...toScenarioResponse(scenario),
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/simulations/scenarios`,
+        path: `/simulations/scenarios?drawer.open=scenarioEditor&drawer.scenarioId=${scenario.id}`,
       }),
     });
   },
@@ -169,7 +169,7 @@ app.post(
       ...toScenarioResponse(scenario),
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/simulations/scenarios`,
+        path: `/simulations/scenarios?drawer.open=scenarioEditor&drawer.scenarioId=${scenario.id}`,
       }),
     }, 201);
   },
@@ -225,7 +225,7 @@ app.put(
       ...toScenarioResponse(scenario),
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/simulations/scenarios`,
+        path: `/simulations/scenarios?drawer.open=scenarioEditor&drawer.scenarioId=${scenario.id}`,
       }),
     });
   },

--- a/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
+++ b/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { platformUrl } from "../platform-url";
+
+describe("platformUrl", () => {
+  const originalEnv = process.env.BASE_HOST;
+
+  afterEach(() => {
+    process.env.BASE_HOST = originalEnv;
+  });
+
+  describe("when BASE_HOST is set", () => {
+    beforeEach(() => {
+      process.env.BASE_HOST = "https://app.langwatch.ai";
+    });
+
+    it("builds a direct page URL", () => {
+      expect(
+        platformUrl({ projectSlug: "my-project", path: "/datasets/ds_123" })
+      ).toBe("https://app.langwatch.ai/my-project/datasets/ds_123");
+    });
+
+    it("builds a drawer URL with query params", () => {
+      expect(
+        platformUrl({
+          projectSlug: "my-project",
+          path: "/evaluations?drawer.open=onlineEvaluation&drawer.monitorId=mon_123",
+        })
+      ).toBe(
+        "https://app.langwatch.ai/my-project/evaluations?drawer.open=onlineEvaluation&drawer.monitorId=mon_123"
+      );
+    });
+
+    it("strips trailing slash from BASE_HOST", () => {
+      process.env.BASE_HOST = "https://app.langwatch.ai/";
+      expect(
+        platformUrl({ projectSlug: "test", path: "/datasets/ds_1" })
+      ).toBe("https://app.langwatch.ai/test/datasets/ds_1");
+    });
+  });
+
+  describe("when BASE_HOST is not set", () => {
+    beforeEach(() => {
+      delete process.env.BASE_HOST;
+    });
+
+    it("falls back to localhost:5560", () => {
+      expect(
+        platformUrl({ projectSlug: "demo", path: "/agents" })
+      ).toBe("http://localhost:5560/demo/agents");
+    });
+  });
+
+  describe("resource URL patterns", () => {
+    beforeEach(() => {
+      process.env.BASE_HOST = "https://app.langwatch.ai";
+    });
+
+    it("generates correct dataset page URL", () => {
+      const url = platformUrl({ projectSlug: "p", path: "/datasets/ds_abc" });
+      expect(url).toContain("/p/datasets/ds_abc");
+    });
+
+    it("generates correct trace page URL", () => {
+      const url = platformUrl({ projectSlug: "p", path: "/messages/trace_abc" });
+      expect(url).toContain("/p/messages/trace_abc");
+    });
+
+    it("generates correct monitor drawer URL", () => {
+      const url = platformUrl({
+        projectSlug: "p",
+        path: "/evaluations?drawer.open=onlineEvaluation&drawer.monitorId=mon_1",
+      });
+      expect(url).toContain("drawer.open=onlineEvaluation");
+      expect(url).toContain("drawer.monitorId=mon_1");
+    });
+
+    it("generates correct evaluator drawer URL", () => {
+      const url = platformUrl({
+        projectSlug: "p",
+        path: "/evaluators?drawer.open=evaluatorEditor&drawer.evaluatorId=ev_1",
+      });
+      expect(url).toContain("drawer.open=evaluatorEditor");
+      expect(url).toContain("drawer.evaluatorId=ev_1");
+    });
+
+    it("generates correct agent drawer URL for code type", () => {
+      const url = platformUrl({
+        projectSlug: "p",
+        path: "/agents?drawer.open=agentCodeEditor&drawer.agentId=ag_1",
+      });
+      expect(url).toContain("drawer.open=agentCodeEditor");
+      expect(url).toContain("drawer.agentId=ag_1");
+    });
+
+    it("generates correct agent drawer URL for http type", () => {
+      const url = platformUrl({
+        projectSlug: "p",
+        path: "/agents?drawer.open=agentHttpEditor&drawer.agentId=ag_2",
+      });
+      expect(url).toContain("drawer.open=agentHttpEditor");
+    });
+
+    it("generates correct scenario drawer URL", () => {
+      const url = platformUrl({
+        projectSlug: "p",
+        path: "/simulations/scenarios?drawer.open=scenarioEditor&drawer.scenarioId=sc_1",
+      });
+      expect(url).toContain("drawer.open=scenarioEditor");
+      expect(url).toContain("drawer.scenarioId=sc_1");
+    });
+
+    it("generates correct trigger drawer URL", () => {
+      const url = platformUrl({
+        projectSlug: "p",
+        path: "/automations?drawer.open=editAutomationFilter&drawer.automationId=tr_1",
+      });
+      expect(url).toContain("drawer.open=editAutomationFilter");
+      expect(url).toContain("drawer.automationId=tr_1");
+    });
+
+    it("generates correct dashboard page URL", () => {
+      const url = platformUrl({ projectSlug: "p", path: "/analytics/custom/dash_1" });
+      expect(url).toContain("/p/analytics/custom/dash_1");
+    });
+
+    it("generates correct suite detail URL", () => {
+      const url = platformUrl({
+        projectSlug: "p",
+        path: "/simulations/run-plans/my-suite-slug",
+      });
+      expect(url).toContain("/p/simulations/run-plans/my-suite-slug");
+    });
+  });
+});

--- a/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
+++ b/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { platformUrl } from "../platform-url";
 
 describe("platformUrl", () => {

--- a/langwatch/src/app/api/shared/platform-url.ts
+++ b/langwatch/src/app/api/shared/platform-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Builds a full platform URL for a resource so API consumers can link
+ * directly to it in the LangWatch UI.
+ *
+ * Uses BASE_HOST (the external-facing origin) with the project slug
+ * and a resource-specific path.
+ *
+ * Example: "https://app.langwatch.ai/my-project/datasets/ds_abc123"
+ */
+export function platformUrl({
+  projectSlug,
+  path,
+}: {
+  projectSlug: string;
+  path: string;
+}): string {
+  const base = (process.env.BASE_HOST ?? "http://localhost:5560").replace(
+    /\/+$/,
+    "",
+  );
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  return `${base}/${projectSlug}${cleanPath}`;
+}

--- a/langwatch/src/app/api/simulation-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/simulation-runs/[[...route]]/app.ts
@@ -12,6 +12,7 @@ import {
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import { handleError } from "../../middleware";
 import { SimulationFacade } from "~/server/simulations/simulation.facade";
 
@@ -124,7 +125,16 @@ export const app = new Hono<{ Variables: Variables }>()
         }
 
         const runs = "runs" in result ? result.runs : [];
-        return c.json({ runs, hasMore: false });
+        return c.json({
+          runs: runs.map((r) => ({
+            ...r,
+            platformUrl: platformUrl({
+              projectSlug: project.slug,
+              path: `/simulations`,
+            }),
+          })),
+          hasMore: false,
+        });
       }
 
       if (scenarioSetId) {
@@ -137,7 +147,13 @@ export const app = new Hono<{ Variables: Variables }>()
         });
 
         return c.json({
-          runs: result.runs,
+          runs: result.runs.map((r) => ({
+            ...r,
+            platformUrl: platformUrl({
+              projectSlug: project.slug,
+              path: `/simulations`,
+            }),
+          })),
           hasMore: result.hasMore,
           nextCursor: result.nextCursor,
         });
@@ -155,7 +171,13 @@ export const app = new Hono<{ Variables: Variables }>()
       }
 
       return c.json({
-        runs: result.runs,
+        runs: result.runs.map((r) => ({
+          ...r,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/simulations`,
+          }),
+        })),
         hasMore: result.hasMore,
         nextCursor: result.nextCursor,
       });
@@ -200,7 +222,13 @@ export const app = new Hono<{ Variables: Variables }>()
         return c.json({ error: "Simulation run not found" }, 404);
       }
 
-      return c.json(run);
+      return c.json({
+        ...run,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/simulations`,
+        }),
+      });
     },
   )
 

--- a/langwatch/src/app/api/simulation-runs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/simulation-runs/[[...route]]/app.ts
@@ -46,6 +46,10 @@ const scenarioRunResponseSchema = z.object({
   totalCost: z.number().optional(),
 });
 
+const scenarioRunResponseWithPlatformUrlSchema = scenarioRunResponseSchema.extend({
+  platformUrl: z.string().url(),
+});
+
 const batchSummarySchema = z.object({
   batchRunId: z.string(),
   totalCount: z.number(),
@@ -95,7 +99,7 @@ export const app = new Hono<{ Variables: Variables }>()
           content: {
             "application/json": {
               schema: resolver(z.object({
-                runs: z.array(scenarioRunResponseSchema),
+                runs: z.array(scenarioRunResponseWithPlatformUrlSchema),
                 hasMore: z.boolean().optional(),
                 nextCursor: z.string().optional(),
               })),
@@ -195,7 +199,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(scenarioRunResponseSchema),
+              schema: resolver(scenarioRunResponseWithPlatformUrlSchema),
             },
           },
         },

--- a/langwatch/src/app/api/suites/[[...route]]/app.ts
+++ b/langwatch/src/app/api/suites/[[...route]]/app.ts
@@ -14,6 +14,7 @@ import {
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import { handleError } from "../../middleware";
 import { SuiteService } from "~/server/suites/suite.service";
 import { SuiteDomainError } from "~/server/suites/errors";
@@ -142,7 +143,13 @@ export const app = new Hono<{ Variables: Variables }>()
       const service = createService();
       const suites = await service.getAll({ projectId: project.id });
 
-      return c.json(suites.map(toSuiteResponse));
+      return c.json(suites.map((s) => ({
+        ...toSuiteResponse(s),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/simulations/run-plans/${s.slug}`,
+        }),
+      })));
     },
   )
 
@@ -181,7 +188,13 @@ export const app = new Hono<{ Variables: Variables }>()
         return c.json({ error: "Suite not found" }, 404);
       }
 
-      return c.json(toSuiteResponse(suite));
+      return c.json({
+        ...toSuiteResponse(suite),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/simulations/run-plans/${suite.slug}`,
+        }),
+      });
     },
   )
 
@@ -214,7 +227,13 @@ export const app = new Hono<{ Variables: Variables }>()
           ...body,
           projectId: project.id,
         });
-        return c.json(toSuiteResponse(suite), 201);
+        return c.json({
+          ...toSuiteResponse(suite),
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/simulations/run-plans/${suite.slug}`,
+          }),
+        }, 201);
       } catch (error) {
         if (error instanceof SuiteDomainError) {
           return c.json({ error: error.message }, 400);
@@ -261,7 +280,13 @@ export const app = new Hono<{ Variables: Variables }>()
           projectId: project.id,
           data: body,
         });
-        return c.json(toSuiteResponse(suite));
+        return c.json({
+          ...toSuiteResponse(suite),
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/simulations/run-plans/${suite.slug}`,
+          }),
+        });
       } catch (error) {
         if (error instanceof SuiteDomainError) {
           return c.json({ error: error.message }, 400);
@@ -302,7 +327,13 @@ export const app = new Hono<{ Variables: Variables }>()
       const service = createService();
       try {
         const suite = await service.duplicate({ id, projectId: project.id });
-        return c.json(toSuiteResponse(suite), 201);
+        return c.json({
+          ...toSuiteResponse(suite),
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/simulations/run-plans/${suite.slug}`,
+          }),
+        }, 201);
       } catch (error) {
         if (error instanceof SuiteDomainError) {
           return c.json({ error: error.message }, 404);

--- a/langwatch/src/app/api/suites/[[...route]]/app.ts
+++ b/langwatch/src/app/api/suites/[[...route]]/app.ts
@@ -45,6 +45,10 @@ const suiteResponseSchema = z.object({
   updatedAt: z.string(),
 });
 
+const suiteResponseWithPlatformUrlSchema = suiteResponseSchema.extend({
+  platformUrl: z.string().url(),
+});
+
 const createSuiteInputSchema = z.object({
   name: z.string().min(1, "name is required"),
   description: z.string().optional(),
@@ -130,7 +134,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(z.array(suiteResponseSchema)),
+              schema: resolver(z.array(suiteResponseWithPlatformUrlSchema)),
             },
           },
         },
@@ -164,7 +168,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(suiteResponseSchema),
+              schema: resolver(suiteResponseWithPlatformUrlSchema),
             },
           },
         },
@@ -209,7 +213,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Suite created",
           content: {
             "application/json": {
-              schema: resolver(suiteResponseSchema),
+              schema: resolver(suiteResponseWithPlatformUrlSchema),
             },
           },
         },
@@ -254,7 +258,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Suite updated",
           content: {
             "application/json": {
-              schema: resolver(suiteResponseSchema),
+              schema: resolver(suiteResponseWithPlatformUrlSchema),
             },
           },
         },
@@ -307,7 +311,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Suite duplicated",
           content: {
             "application/json": {
-              schema: resolver(suiteResponseSchema),
+              schema: resolver(suiteResponseWithPlatformUrlSchema),
             },
           },
         },

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -13,6 +13,7 @@ import { TraceService } from "~/server/traces/trace.service";
 import { createLogger } from "~/utils/logger/server";
 import type { AuthMiddlewareVariables } from "../../middleware";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import { coerceToEpoch, flexibleDateSchema } from "../../shared/schemas";
 import { getAllForProjectInput } from "~/server/api/routers/traces.schemas";
 
@@ -132,9 +133,19 @@ app.post(
         metadata: trace.metadata,
         error: trace.error,
         evaluations: trace.evaluations,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/messages/${trace.trace_id}`,
+        }),
       }));
     } else {
-      traces = enrichedTraces;
+      traces = enrichedTraces.map((trace) => ({
+        ...trace,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/messages/${trace.trace_id}`,
+        }),
+      }));
     }
 
     return c.json({
@@ -238,6 +249,10 @@ app.get(
         timestamps: trace.timestamps,
         metadata: trace.metadata,
         evaluations,
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/messages/${traceId}`,
+        }),
       });
     }
 
@@ -246,6 +261,10 @@ app.get(
       ...trace,
       evaluations,
       ascii_tree: asciiTree,
+      platformUrl: platformUrl({
+        projectSlug: project.slug,
+        path: `/messages/${traceId}`,
+      }),
     });
   },
 );

--- a/langwatch/src/app/api/triggers/[[...route]]/app.ts
+++ b/langwatch/src/app/api/triggers/[[...route]]/app.ts
@@ -127,7 +127,7 @@ export const app = new Hono<{ Variables: Variables }>()
         ...toTriggerResponse(t),
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/triggers`,
+          path: `/automations?drawer.open=editAutomationFilter&drawer.automationId=${t.id}`,
         }),
       })));
     },
@@ -173,7 +173,7 @@ export const app = new Hono<{ Variables: Variables }>()
         ...toTriggerResponse(trigger),
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/triggers`,
+          path: `/automations?drawer.open=editAutomationFilter&drawer.automationId=${trigger.id}`,
         }),
       });
     },
@@ -220,7 +220,7 @@ export const app = new Hono<{ Variables: Variables }>()
         ...toTriggerResponse(trigger),
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/triggers`,
+          path: `/automations?drawer.open=editAutomationFilter&drawer.automationId=${trigger.id}`,
         }),
       }, 201);
     },
@@ -281,7 +281,7 @@ export const app = new Hono<{ Variables: Variables }>()
         ...toTriggerResponse(updated),
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/triggers`,
+          path: `/automations?drawer.open=editAutomationFilter&drawer.automationId=${updated.id}`,
         }),
       });
     },

--- a/langwatch/src/app/api/triggers/[[...route]]/app.ts
+++ b/langwatch/src/app/api/triggers/[[...route]]/app.ts
@@ -15,6 +15,7 @@ import {
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import { handleError } from "../../middleware";
 
 patchZodOpenapi();
@@ -122,7 +123,13 @@ export const app = new Hono<{ Variables: Variables }>()
         orderBy: { createdAt: "desc" },
       });
 
-      return c.json(triggers.map(toTriggerResponse));
+      return c.json(triggers.map((t) => ({
+        ...toTriggerResponse(t),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/triggers`,
+        }),
+      })));
     },
   )
 
@@ -162,7 +169,13 @@ export const app = new Hono<{ Variables: Variables }>()
         return c.json({ error: "Trigger not found" }, 404);
       }
 
-      return c.json(toTriggerResponse(trigger));
+      return c.json({
+        ...toTriggerResponse(trigger),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/triggers`,
+        }),
+      });
     },
   )
 
@@ -203,7 +216,13 @@ export const app = new Hono<{ Variables: Variables }>()
         },
       });
 
-      return c.json(toTriggerResponse(trigger), 201);
+      return c.json({
+        ...toTriggerResponse(trigger),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/triggers`,
+        }),
+      }, 201);
     },
   )
 
@@ -258,7 +277,13 @@ export const app = new Hono<{ Variables: Variables }>()
         data,
       });
 
-      return c.json(toTriggerResponse(updated));
+      return c.json({
+        ...toTriggerResponse(updated),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/triggers`,
+        }),
+      });
     },
   )
 

--- a/langwatch/src/app/api/triggers/[[...route]]/app.ts
+++ b/langwatch/src/app/api/triggers/[[...route]]/app.ts
@@ -46,6 +46,10 @@ const triggerResponseSchema = z.object({
   updatedAt: z.string(),
 });
 
+const triggerResponseWithPlatformUrlSchema = triggerResponseSchema.extend({
+  platformUrl: z.string().url(),
+});
+
 const createTriggerSchema = z.object({
   name: z.string().min(1, "name is required"),
   action: triggerActionEnum,
@@ -108,7 +112,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(z.array(triggerResponseSchema)),
+              schema: resolver(z.array(triggerResponseWithPlatformUrlSchema)),
             },
           },
         },
@@ -144,7 +148,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(triggerResponseSchema),
+              schema: resolver(triggerResponseWithPlatformUrlSchema),
             },
           },
         },
@@ -190,7 +194,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Trigger created",
           content: {
             "application/json": {
-              schema: resolver(triggerResponseSchema),
+              schema: resolver(triggerResponseWithPlatformUrlSchema),
             },
           },
         },
@@ -237,7 +241,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Trigger updated",
           content: {
             "application/json": {
-              schema: resolver(triggerResponseSchema),
+              schema: resolver(triggerResponseWithPlatformUrlSchema),
             },
           },
         },

--- a/langwatch/src/app/api/workflows/[[...route]]/app.ts
+++ b/langwatch/src/app/api/workflows/[[...route]]/app.ts
@@ -14,6 +14,7 @@ import {
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
 import { baseResponses } from "../../shared/base-responses";
+import { platformUrl } from "../../shared/platform-url";
 import { handleError } from "../../middleware";
 
 patchZodOpenapi();
@@ -78,7 +79,13 @@ export const app = new Hono<{ Variables: Variables }>()
         orderBy: { updatedAt: "desc" },
       });
 
-      return c.json(workflows.map(toWorkflowResponse));
+      return c.json(workflows.map((w) => ({
+        ...toWorkflowResponse(w),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/workflows`,
+        }),
+      })));
     },
   )
 
@@ -117,7 +124,13 @@ export const app = new Hono<{ Variables: Variables }>()
         return c.json({ error: "Workflow not found" }, 404);
       }
 
-      return c.json(toWorkflowResponse(workflow));
+      return c.json({
+        ...toWorkflowResponse(workflow),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/workflows`,
+        }),
+      });
     },
   )
 
@@ -167,7 +180,13 @@ export const app = new Hono<{ Variables: Variables }>()
         data: body,
       });
 
-      return c.json(toWorkflowResponse(updated));
+      return c.json({
+        ...toWorkflowResponse(updated),
+        platformUrl: platformUrl({
+          projectSlug: project.slug,
+          path: `/workflows`,
+        }),
+      });
     },
   )
 

--- a/langwatch/src/app/api/workflows/[[...route]]/app.ts
+++ b/langwatch/src/app/api/workflows/[[...route]]/app.ts
@@ -34,6 +34,10 @@ const workflowResponseSchema = z.object({
   updatedAt: z.string(),
 });
 
+const workflowResponseWithPlatformUrlSchema = workflowResponseSchema.extend({
+  platformUrl: z.string().url(),
+});
+
 function toWorkflowResponse(workflow: Workflow) {
   return {
     id: workflow.id,
@@ -64,7 +68,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(z.array(workflowResponseSchema)),
+              schema: resolver(z.array(workflowResponseWithPlatformUrlSchema)),
             },
           },
         },
@@ -99,7 +103,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Success",
           content: {
             "application/json": {
-              schema: resolver(workflowResponseSchema),
+              schema: resolver(workflowResponseWithPlatformUrlSchema),
             },
           },
         },
@@ -144,7 +148,7 @@ export const app = new Hono<{ Variables: Variables }>()
           description: "Workflow updated",
           content: {
             "application/json": {
-              schema: resolver(workflowResponseSchema),
+              schema: resolver(workflowResponseWithPlatformUrlSchema),
             },
           },
         },

--- a/langwatch/src/pages/[project]/analytics/custom/[id].tsx
+++ b/langwatch/src/pages/[project]/analytics/custom/[id].tsx
@@ -1,3 +1,4 @@
+import { Box, Text, VStack } from "@chakra-ui/react";
 import { useRouter } from "~/utils/compat/next-router";
 import type { CustomGraphInput } from "~/components/analytics/CustomGraph";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -10,10 +11,13 @@ export default function EditCustomAnalyticsPage() {
 
   const { project } = useOrganizationTeamProject();
 
-  const graphData = api.graphs.getById.useQuery({
-    projectId: project?.id ?? "",
-    id: graphId ?? "",
-  });
+  const graphData = api.graphs.getById.useQuery(
+    {
+      projectId: project?.id ?? "",
+      id: graphId ?? "",
+    },
+    { enabled: !!project?.id && !!graphId, retry: false },
+  );
 
   const graph = graphData.data?.graph;
   const name = graphData.data?.name;
@@ -25,6 +29,24 @@ export default function EditCustomAnalyticsPage() {
       rawAlert.action === "SEND_SLACK_MESSAGE")
       ? (rawAlert as unknown as CustomGraphFormData["alert"])
       : undefined;
+
+  if (graphData.error) {
+    return (
+      <VStack align="start" p={8} gap={2}>
+        <Text fontSize="xl" fontWeight="bold">
+          Graph not found
+        </Text>
+        <Text color="gray.600">
+          The graph you are looking for does not exist or you do not have
+          access to it.
+        </Text>
+      </VStack>
+    );
+  }
+
+  if (graphData.isLoading) {
+    return <Box p={8}>Loading…</Box>;
+  }
 
   return graph ? (
     <AnalyticsCustomGraph

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import type { ClickHouseClient } from "@clickhouse/client";
+import { prisma as globalPrisma } from "~/server/db";
 import { getClickHouseClientForProject, isClickHouseEnabled, type ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { esClient, TRACE_INDEX, traceIndexId } from "../elasticsearch";
 import { EventSourcing } from "../event-sourcing";
@@ -113,7 +114,7 @@ export function initializeWorkerApp(): App {
 export function initializeDefaultApp(options?: { processRole?: ProcessRole }): App {
   if (globalForApp.__langwatch_app) return globalForApp.__langwatch_app;
 
-  const { prisma } = require("../db") as { prisma: PrismaClient; };
+  const prisma = globalPrisma;
   const config = createAppConfigFromEnv({ processRole: options?.processRole });
 
   const clickhouseEnabled = !!config.clickhouseUrl || isClickHouseEnabled();
@@ -464,7 +465,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
 
 /** Tests — noop commands, null-backed services. */
 export function createTestApp(overrides?: Partial<AppDependencies>): App {
-  const { prisma: testPrisma } = require("../db") as { prisma: PrismaClient; };
+  const testPrisma = globalPrisma;
   const noop = async () => { };
   const config: AppConfig = {
     nodeEnv: "test",

--- a/typescript-sdk/src/cli/commands/agents/create.ts
+++ b/typescript-sdk/src/cli/commands/agents/create.ts
@@ -32,8 +32,8 @@ export const createAgentCommand = async (
 
     if (options.format === "json") {
       console.log(JSON.stringify(agent, null, 2));
-    } else if ((agent as unknown as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((agent as unknown as Record<string, unknown>).platformUrl as string)}`);
+    } else if (agent.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(agent.platformUrl)}`);
     }
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/agents/create.ts
+++ b/typescript-sdk/src/cli/commands/agents/create.ts
@@ -32,6 +32,8 @@ export const createAgentCommand = async (
 
     if (options.format === "json") {
       console.log(JSON.stringify(agent, null, 2));
+    } else if ((agent as unknown as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((agent as unknown as Record<string, unknown>).platformUrl as string)}`);
     }
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/agents/get.ts
+++ b/typescript-sdk/src/cli/commands/agents/get.ts
@@ -29,6 +29,10 @@ export const getAgentCommand = async (id: string, options?: { format?: string })
     console.log(`  ${chalk.gray("Created:")} ${new Date(agent.createdAt).toLocaleString()}`);
     console.log(`  ${chalk.gray("Updated:")} ${new Date(agent.updatedAt).toLocaleString()}`);
 
+    if ((agent as unknown as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((agent as unknown as Record<string, unknown>).platformUrl as string)}`);
+    }
+
     if (agent.config && Object.keys(agent.config).length > 0) {
       console.log();
       console.log(chalk.bold("  Config:"));

--- a/typescript-sdk/src/cli/commands/agents/get.ts
+++ b/typescript-sdk/src/cli/commands/agents/get.ts
@@ -29,8 +29,8 @@ export const getAgentCommand = async (id: string, options?: { format?: string })
     console.log(`  ${chalk.gray("Created:")} ${new Date(agent.createdAt).toLocaleString()}`);
     console.log(`  ${chalk.gray("Updated:")} ${new Date(agent.updatedAt).toLocaleString()}`);
 
-    if ((agent as unknown as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((agent as unknown as Record<string, unknown>).platformUrl as string)}`);
+    if (agent.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(agent.platformUrl)}`);
     }
 
     if (agent.config && Object.keys(agent.config).length > 0) {

--- a/typescript-sdk/src/cli/commands/dashboards/create.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/create.ts
@@ -21,6 +21,8 @@ export const createDashboardCommand = async (name: string, options?: { format?: 
 
     if (options?.format === "json") {
       console.log(JSON.stringify(dashboard, null, 2));
+    } else if ((dashboard as unknown as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((dashboard as unknown as Record<string, unknown>).platformUrl as string)}`);
     }
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/dashboards/create.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/create.ts
@@ -21,8 +21,8 @@ export const createDashboardCommand = async (name: string, options?: { format?: 
 
     if (options?.format === "json") {
       console.log(JSON.stringify(dashboard, null, 2));
-    } else if ((dashboard as unknown as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((dashboard as unknown as Record<string, unknown>).platformUrl as string)}`);
+    } else if (dashboard.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(dashboard.platformUrl)}`);
     }
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/dashboards/get.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/get.ts
@@ -32,8 +32,8 @@ export const getDashboardCommand = async (
     console.log(`    ${chalk.gray("Graphs:")}  ${Array.isArray(dashboard.graphs) ? dashboard.graphs.length : 0}`);
     console.log(`    ${chalk.gray("Created:")} ${new Date(dashboard.createdAt).toLocaleString()}`);
     console.log(`    ${chalk.gray("Updated:")} ${new Date(dashboard.updatedAt).toLocaleString()}`);
-    if ((dashboard as unknown as Record<string, unknown>).platformUrl) {
-      console.log(`    ${chalk.bold("View:")}   ${chalk.underline((dashboard as unknown as Record<string, unknown>).platformUrl as string)}`);
+    if (dashboard.platformUrl) {
+      console.log(`    ${chalk.bold("View:")}   ${chalk.underline(dashboard.platformUrl)}`);
     }
     console.log();
   } catch (error) {

--- a/typescript-sdk/src/cli/commands/dashboards/get.ts
+++ b/typescript-sdk/src/cli/commands/dashboards/get.ts
@@ -32,6 +32,9 @@ export const getDashboardCommand = async (
     console.log(`    ${chalk.gray("Graphs:")}  ${Array.isArray(dashboard.graphs) ? dashboard.graphs.length : 0}`);
     console.log(`    ${chalk.gray("Created:")} ${new Date(dashboard.createdAt).toLocaleString()}`);
     console.log(`    ${chalk.gray("Updated:")} ${new Date(dashboard.updatedAt).toLocaleString()}`);
+    if ((dashboard as unknown as Record<string, unknown>).platformUrl) {
+      console.log(`    ${chalk.bold("View:")}   ${chalk.underline((dashboard as unknown as Record<string, unknown>).platformUrl as string)}`);
+    }
     console.log();
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/dataset/create.ts
+++ b/typescript-sdk/src/cli/commands/dataset/create.ts
@@ -67,7 +67,7 @@ export const createCommand = async (
         .join(", ");
       console.log(`  ${chalk.bold("Columns:")} ${colStr}`);
     }
-    const viewUrl = (dataset as Record<string, unknown>).platformUrl as string | undefined;
+    const viewUrl = dataset.platformUrl;
     if (viewUrl) {
       console.log(`  ${chalk.bold("View:")}  ${chalk.underline(viewUrl)}`);
     }

--- a/typescript-sdk/src/cli/commands/dataset/create.ts
+++ b/typescript-sdk/src/cli/commands/dataset/create.ts
@@ -67,6 +67,9 @@ export const createCommand = async (
         .join(", ");
       console.log(`  ${chalk.bold("Columns:")} ${colStr}`);
     }
+    if (dataset.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(dataset.platformUrl)}`);
+    }
   } catch (error) {
     spinner.fail("Failed to create dataset");
     handleDatasetCommandError(error, "creating dataset");

--- a/typescript-sdk/src/cli/commands/dataset/create.ts
+++ b/typescript-sdk/src/cli/commands/dataset/create.ts
@@ -67,8 +67,9 @@ export const createCommand = async (
         .join(", ");
       console.log(`  ${chalk.bold("Columns:")} ${colStr}`);
     }
-    if (dataset.platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(dataset.platformUrl)}`);
+    const viewUrl = (dataset as Record<string, unknown>).platformUrl as string | undefined;
+    if (viewUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(viewUrl)}`);
     }
   } catch (error) {
     spinner.fail("Failed to create dataset");

--- a/typescript-sdk/src/cli/commands/dataset/get.ts
+++ b/typescript-sdk/src/cli/commands/dataset/get.ts
@@ -47,7 +47,7 @@ export const getCommand = async (slugOrId: string, options?: { format?: string }
         `  ${chalk.bold("Updated:")}    ${formatRelativeTime(dataset.updatedAt)}`,
       );
     }
-    const viewUrl = (dataset as Record<string, unknown>).platformUrl as string | undefined;
+    const viewUrl = dataset.platformUrl;
     if (viewUrl) {
       console.log(`  ${chalk.bold("View:")}       ${chalk.underline(viewUrl)}`);
     }

--- a/typescript-sdk/src/cli/commands/dataset/get.ts
+++ b/typescript-sdk/src/cli/commands/dataset/get.ts
@@ -47,6 +47,9 @@ export const getCommand = async (slugOrId: string, options?: { format?: string }
         `  ${chalk.bold("Updated:")}    ${formatRelativeTime(dataset.updatedAt)}`,
       );
     }
+    if (dataset.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}       ${chalk.underline(dataset.platformUrl)}`);
+    }
 
     // Show a preview of the first 10 records
     if (dataset.entries.length > 0) {

--- a/typescript-sdk/src/cli/commands/dataset/get.ts
+++ b/typescript-sdk/src/cli/commands/dataset/get.ts
@@ -47,8 +47,9 @@ export const getCommand = async (slugOrId: string, options?: { format?: string }
         `  ${chalk.bold("Updated:")}    ${formatRelativeTime(dataset.updatedAt)}`,
       );
     }
-    if (dataset.platformUrl) {
-      console.log(`  ${chalk.bold("View:")}       ${chalk.underline(dataset.platformUrl)}`);
+    const viewUrl = (dataset as Record<string, unknown>).platformUrl as string | undefined;
+    if (viewUrl) {
+      console.log(`  ${chalk.bold("View:")}       ${chalk.underline(viewUrl)}`);
     }
 
     // Show a preview of the first 10 records

--- a/typescript-sdk/src/cli/commands/dataset/update.ts
+++ b/typescript-sdk/src/cli/commands/dataset/update.ts
@@ -59,6 +59,9 @@ export const updateCommand = async (
         .join(", ");
       console.log(`  ${chalk.bold("Columns:")} ${colStr}`);
     }
+    if ((dataset as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((dataset as Record<string, unknown>).platformUrl as string)}`);
+    }
   } catch (error) {
     spinner.fail("Failed to update dataset");
     handleDatasetCommandError(error, "updating dataset");

--- a/typescript-sdk/src/cli/commands/dataset/update.ts
+++ b/typescript-sdk/src/cli/commands/dataset/update.ts
@@ -59,8 +59,8 @@ export const updateCommand = async (
         .join(", ");
       console.log(`  ${chalk.bold("Columns:")} ${colStr}`);
     }
-    if ((dataset as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((dataset as Record<string, unknown>).platformUrl as string)}`);
+    if (dataset.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(dataset.platformUrl)}`);
     }
   } catch (error) {
     spinner.fail("Failed to update dataset");

--- a/typescript-sdk/src/cli/commands/dataset/upload.ts
+++ b/typescript-sdk/src/cli/commands/dataset/upload.ts
@@ -70,6 +70,9 @@ export const uploadCommand = async (
       console.log();
       console.log(`  ${chalk.bold("Slug:")}    ${result.dataset.slug}`);
       console.log(`  ${chalk.bold("ID:")}      ${result.dataset.id}`);
+      if ((result.dataset as Record<string, unknown>).platformUrl) {
+        console.log(`  ${chalk.bold("View:")}    ${chalk.underline((result.dataset as Record<string, unknown>).platformUrl as string)}`);
+      }
     } else {
       spinner.succeed(
         `Uploaded ${filename} to "${chalk.cyan(slugOrId)}" (${recordCount} record${recordCount !== 1 ? "s" : ""})`,

--- a/typescript-sdk/src/cli/commands/dataset/upload.ts
+++ b/typescript-sdk/src/cli/commands/dataset/upload.ts
@@ -70,8 +70,8 @@ export const uploadCommand = async (
       console.log();
       console.log(`  ${chalk.bold("Slug:")}    ${result.dataset.slug}`);
       console.log(`  ${chalk.bold("ID:")}      ${result.dataset.id}`);
-      if ((result.dataset as Record<string, unknown>).platformUrl) {
-        console.log(`  ${chalk.bold("View:")}    ${chalk.underline((result.dataset as Record<string, unknown>).platformUrl as string)}`);
+      if (result.dataset.platformUrl) {
+        console.log(`  ${chalk.bold("View:")}    ${chalk.underline(result.dataset.platformUrl)}`);
       }
     } else {
       spinner.succeed(

--- a/typescript-sdk/src/cli/commands/evaluators/create.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/create.ts
@@ -29,6 +29,8 @@ export const createEvaluatorCommand = async (
 
     if (options.format === "json") {
       console.log(JSON.stringify(evaluator, null, 2));
+    } else if ((evaluator as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((evaluator as Record<string, unknown>).platformUrl as string)}`);
     }
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/evaluators/create.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/create.ts
@@ -29,8 +29,8 @@ export const createEvaluatorCommand = async (
 
     if (options.format === "json") {
       console.log(JSON.stringify(evaluator, null, 2));
-    } else if ((evaluator as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((evaluator as Record<string, unknown>).platformUrl as string)}`);
+    } else if (evaluator.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(evaluator.platformUrl)}`);
     }
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/evaluators/get.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/get.ts
@@ -58,6 +58,10 @@ const formatEvaluatorDetails = (evaluator: EvaluatorResponse): void => {
     }
   }
 
+  if ((evaluator as Record<string, unknown>).platformUrl) {
+    console.log(`  ${chalk.bold("View:")}  ${chalk.underline((evaluator as Record<string, unknown>).platformUrl as string)}`);
+  }
+
   console.log();
 };
 

--- a/typescript-sdk/src/cli/commands/evaluators/get.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/get.ts
@@ -58,8 +58,8 @@ const formatEvaluatorDetails = (evaluator: EvaluatorResponse): void => {
     }
   }
 
-  if ((evaluator as Record<string, unknown>).platformUrl) {
-    console.log(`  ${chalk.bold("View:")}  ${chalk.underline((evaluator as Record<string, unknown>).platformUrl as string)}`);
+  if (evaluator.platformUrl) {
+    console.log(`  ${chalk.bold("View:")}  ${chalk.underline(evaluator.platformUrl)}`);
   }
 
   console.log();

--- a/typescript-sdk/src/cli/commands/monitors/create.ts
+++ b/typescript-sdk/src/cli/commands/monitors/create.ts
@@ -66,6 +66,7 @@ export const createMonitorCommand = async (
       name: string;
       checkType: string;
       executionMode: string;
+      platformUrl?: string;
     };
 
     spinner.succeed(`Monitor "${monitor.name}" created (${monitor.id})`);
@@ -79,8 +80,8 @@ export const createMonitorCommand = async (
     console.log(`  ${chalk.gray("ID:")}   ${chalk.green(monitor.id)}`);
     console.log(`  ${chalk.gray("Type:")} ${monitor.checkType}`);
     console.log(`  ${chalk.gray("Mode:")} ${monitor.executionMode}`);
-    if ((monitor as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((monitor as Record<string, unknown>).platformUrl as string)}`);
+    if (monitor.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(monitor.platformUrl)}`);
     }
     console.log();
   } catch (error) {

--- a/typescript-sdk/src/cli/commands/monitors/create.ts
+++ b/typescript-sdk/src/cli/commands/monitors/create.ts
@@ -79,6 +79,9 @@ export const createMonitorCommand = async (
     console.log(`  ${chalk.gray("ID:")}   ${chalk.green(monitor.id)}`);
     console.log(`  ${chalk.gray("Type:")} ${monitor.checkType}`);
     console.log(`  ${chalk.gray("Mode:")} ${monitor.executionMode}`);
+    if ((monitor as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((monitor as Record<string, unknown>).platformUrl as string)}`);
+    }
     console.log();
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/monitors/get.ts
+++ b/typescript-sdk/src/cli/commands/monitors/get.ts
@@ -66,6 +66,9 @@ export const getMonitorCommand = async (
     console.log(
       `  ${chalk.gray("Created:")}   ${new Date(monitor.createdAt).toLocaleString()}`
     );
+    if ((monitor as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}     ${chalk.underline((monitor as Record<string, unknown>).platformUrl as string)}`);
+    }
     console.log();
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/monitors/get.ts
+++ b/typescript-sdk/src/cli/commands/monitors/get.ts
@@ -38,6 +38,7 @@ export const getMonitorCommand = async (
       evaluatorId: string | null;
       preconditions: unknown;
       createdAt: string;
+      platformUrl?: string;
     };
 
     spinner.succeed(`Monitor "${monitor.name}"`);
@@ -66,8 +67,8 @@ export const getMonitorCommand = async (
     console.log(
       `  ${chalk.gray("Created:")}   ${new Date(monitor.createdAt).toLocaleString()}`
     );
-    if ((monitor as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}     ${chalk.underline((monitor as Record<string, unknown>).platformUrl as string)}`);
+    if (monitor.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}     ${chalk.underline(monitor.platformUrl)}`);
     }
     console.log();
   } catch (error) {

--- a/typescript-sdk/src/cli/commands/scenarios/create.ts
+++ b/typescript-sdk/src/cli/commands/scenarios/create.ts
@@ -36,8 +36,8 @@ export const createScenarioCommand = async (
 
     if (options.format === "json") {
       console.log(JSON.stringify(scenario, null, 2));
-    } else if ((scenario as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((scenario as Record<string, unknown>).platformUrl as string)}`);
+    } else if (scenario.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(scenario.platformUrl)}`);
     }
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/scenarios/create.ts
+++ b/typescript-sdk/src/cli/commands/scenarios/create.ts
@@ -36,6 +36,8 @@ export const createScenarioCommand = async (
 
     if (options.format === "json") {
       console.log(JSON.stringify(scenario, null, 2));
+    } else if ((scenario as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((scenario as Record<string, unknown>).platformUrl as string)}`);
     }
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/scenarios/get.ts
+++ b/typescript-sdk/src/cli/commands/scenarios/get.ts
@@ -32,6 +32,10 @@ const formatScenarioDetails = (scenario: ScenarioResponse): void => {
     });
   }
 
+  if ((scenario as Record<string, unknown>).platformUrl) {
+    console.log(`  ${chalk.bold("View:")}  ${chalk.underline((scenario as Record<string, unknown>).platformUrl as string)}`);
+  }
+
   console.log();
 };
 

--- a/typescript-sdk/src/cli/commands/scenarios/get.ts
+++ b/typescript-sdk/src/cli/commands/scenarios/get.ts
@@ -32,8 +32,8 @@ const formatScenarioDetails = (scenario: ScenarioResponse): void => {
     });
   }
 
-  if ((scenario as Record<string, unknown>).platformUrl) {
-    console.log(`  ${chalk.bold("View:")}  ${chalk.underline((scenario as Record<string, unknown>).platformUrl as string)}`);
+  if (scenario.platformUrl) {
+    console.log(`  ${chalk.bold("View:")}  ${chalk.underline(scenario.platformUrl)}`);
   }
 
   console.log();

--- a/typescript-sdk/src/cli/commands/suites/create.ts
+++ b/typescript-sdk/src/cli/commands/suites/create.ts
@@ -79,6 +79,9 @@ export const createSuiteCommand = async (
     console.log(`  ${chalk.gray("Targets:")}   ${suite.targets.length}`);
     console.log(`  ${chalk.gray("Repeat:")}    ${suite.repeatCount}`);
     console.log();
+    if ((suite as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((suite as Record<string, unknown>).platformUrl as string)}`);
+    }
     console.log(
       chalk.gray(`Run it with: ${chalk.cyan(`langwatch suite run ${suite.id}`)}`),
     );

--- a/typescript-sdk/src/cli/commands/suites/create.ts
+++ b/typescript-sdk/src/cli/commands/suites/create.ts
@@ -79,8 +79,8 @@ export const createSuiteCommand = async (
     console.log(`  ${chalk.gray("Targets:")}   ${suite.targets.length}`);
     console.log(`  ${chalk.gray("Repeat:")}    ${suite.repeatCount}`);
     console.log();
-    if ((suite as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((suite as Record<string, unknown>).platformUrl as string)}`);
+    if (suite.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(suite.platformUrl)}`);
     }
     console.log(
       chalk.gray(`Run it with: ${chalk.cyan(`langwatch suite run ${suite.id}`)}`),

--- a/typescript-sdk/src/cli/commands/suites/get.ts
+++ b/typescript-sdk/src/cli/commands/suites/get.ts
@@ -48,6 +48,11 @@ export const getSuiteCommand = async (
       console.log(`    ${chalk.gray("•")} ${target.type}:${target.referenceId}`);
     }
 
+    if ((suite as Record<string, unknown>).platformUrl) {
+      console.log();
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((suite as Record<string, unknown>).platformUrl as string)}`);
+    }
+
     console.log();
     console.log(
       chalk.gray(

--- a/typescript-sdk/src/cli/commands/suites/get.ts
+++ b/typescript-sdk/src/cli/commands/suites/get.ts
@@ -48,9 +48,9 @@ export const getSuiteCommand = async (
       console.log(`    ${chalk.gray("•")} ${target.type}:${target.referenceId}`);
     }
 
-    if ((suite as Record<string, unknown>).platformUrl) {
+    if (suite.platformUrl) {
       console.log();
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((suite as Record<string, unknown>).platformUrl as string)}`);
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(suite.platformUrl)}`);
     }
 
     console.log();

--- a/typescript-sdk/src/cli/commands/traces/get.ts
+++ b/typescript-sdk/src/cli/commands/traces/get.ts
@@ -29,8 +29,8 @@ export const getTraceCommand = async (
       if (typeof trace === "string") {
         console.log(trace);
       } else {
-        if ((trace as Record<string, unknown>).platformUrl) {
-          console.log(`  ${chalk.bold("View:")}  ${chalk.underline((trace as Record<string, unknown>).platformUrl as string)}`);
+        if (trace.platformUrl) {
+          console.log(`  ${chalk.bold("View:")}  ${chalk.underline(trace.platformUrl)}`);
           console.log();
         }
         console.log(JSON.stringify(trace, null, 2));

--- a/typescript-sdk/src/cli/commands/traces/get.ts
+++ b/typescript-sdk/src/cli/commands/traces/get.ts
@@ -29,6 +29,10 @@ export const getTraceCommand = async (
       if (typeof trace === "string") {
         console.log(trace);
       } else {
+        if ((trace as Record<string, unknown>).platformUrl) {
+          console.log(`  ${chalk.bold("View:")}  ${chalk.underline((trace as Record<string, unknown>).platformUrl as string)}`);
+          console.log();
+        }
         console.log(JSON.stringify(trace, null, 2));
       }
     }

--- a/typescript-sdk/src/cli/commands/triggers/create.ts
+++ b/typescript-sdk/src/cli/commands/triggers/create.ts
@@ -69,6 +69,9 @@ export const createTriggerCommand = async (
     console.log();
     console.log(`  ${chalk.gray("ID:")}     ${chalk.green(trigger.id)}`);
     console.log(`  ${chalk.gray("Action:")} ${trigger.action}`);
+    if ((trigger as Record<string, unknown>).platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((trigger as Record<string, unknown>).platformUrl as string)}`);
+    }
     console.log();
   } catch (error) {
     spinner.fail();

--- a/typescript-sdk/src/cli/commands/triggers/create.ts
+++ b/typescript-sdk/src/cli/commands/triggers/create.ts
@@ -58,7 +58,7 @@ export const createTriggerCommand = async (
       process.exit(1);
     }
 
-    const trigger = await response.json() as { id: string; name: string; action: string };
+    const trigger = await response.json() as { id: string; name: string; action: string; platformUrl?: string };
     spinner.succeed(`Trigger "${trigger.name}" created (${trigger.id})`);
 
     if (options.format === "json") {
@@ -69,8 +69,8 @@ export const createTriggerCommand = async (
     console.log();
     console.log(`  ${chalk.gray("ID:")}     ${chalk.green(trigger.id)}`);
     console.log(`  ${chalk.gray("Action:")} ${trigger.action}`);
-    if ((trigger as Record<string, unknown>).platformUrl) {
-      console.log(`  ${chalk.bold("View:")}  ${chalk.underline((trigger as Record<string, unknown>).platformUrl as string)}`);
+    if (trigger.platformUrl) {
+      console.log(`  ${chalk.bold("View:")}  ${chalk.underline(trigger.platformUrl)}`);
     }
     console.log();
   } catch (error) {

--- a/typescript-sdk/src/cli/commands/triggers/get.ts
+++ b/typescript-sdk/src/cli/commands/triggers/get.ts
@@ -34,6 +34,7 @@ export const getTriggerCommand = async (
       alertType: string | null;
       createdAt: string;
       updatedAt: string;
+      platformUrl?: string;
     };
 
     spinner.succeed(`Found trigger "${trigger.name}"`);
@@ -52,8 +53,8 @@ export const getTriggerCommand = async (
     console.log(`    ${chalk.gray("Alert:")}   ${trigger.alertType ?? chalk.gray("—")}`);
     console.log(`    ${chalk.gray("Message:")} ${trigger.message ?? chalk.gray("—")}`);
     console.log(`    ${chalk.gray("Created:")} ${new Date(trigger.createdAt).toLocaleString()}`);
-    if ((trigger as Record<string, unknown>).platformUrl) {
-      console.log(`    ${chalk.bold("View:")}   ${chalk.underline((trigger as Record<string, unknown>).platformUrl as string)}`);
+    if (trigger.platformUrl) {
+      console.log(`    ${chalk.bold("View:")}   ${chalk.underline(trigger.platformUrl)}`);
     }
 
     if (Object.keys(trigger.filters).length > 0) {

--- a/typescript-sdk/src/cli/commands/triggers/get.ts
+++ b/typescript-sdk/src/cli/commands/triggers/get.ts
@@ -52,6 +52,9 @@ export const getTriggerCommand = async (
     console.log(`    ${chalk.gray("Alert:")}   ${trigger.alertType ?? chalk.gray("—")}`);
     console.log(`    ${chalk.gray("Message:")} ${trigger.message ?? chalk.gray("—")}`);
     console.log(`    ${chalk.gray("Created:")} ${new Date(trigger.createdAt).toLocaleString()}`);
+    if ((trigger as Record<string, unknown>).platformUrl) {
+      console.log(`    ${chalk.bold("View:")}   ${chalk.underline((trigger as Record<string, unknown>).platformUrl as string)}`);
+    }
 
     if (Object.keys(trigger.filters).length > 0) {
       console.log();

--- a/typescript-sdk/src/client-sdk/services/agents/agents-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/agents/agents-api.service.ts
@@ -11,6 +11,7 @@ export interface AgentResponse {
   config: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
+  platformUrl?: string;
 }
 
 export interface AgentListResponse {

--- a/typescript-sdk/src/client-sdk/services/dashboards/dashboards-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/dashboards/dashboards-api.service.ts
@@ -11,6 +11,7 @@ export interface DashboardSummary {
   graphCount: number;
   createdAt: string;
   updatedAt: string;
+  platformUrl?: string;
 }
 
 export interface DashboardDetail {
@@ -20,6 +21,7 @@ export interface DashboardDetail {
   graphs: unknown[];
   createdAt: string;
   updatedAt: string;
+  platformUrl?: string;
 }
 
 export class DashboardsApiError extends Error {

--- a/typescript-sdk/src/client-sdk/services/datasets/types.ts
+++ b/typescript-sdk/src/client-sdk/services/datasets/types.ts
@@ -28,6 +28,8 @@ export type DatasetMetadata = {
   createdAt?: string;
   /** When the dataset was last updated */
   updatedAt?: string;
+  /** URL to view this dataset on the LangWatch platform */
+  platformUrl?: string;
 };
 
 /**
@@ -84,6 +86,7 @@ export type GetDatasetApiResponse = {
   columnTypes: DatasetColumnType[];
   createdAt?: string;
   updatedAt?: string;
+  platformUrl?: string;
   data: Array<{
     id: string;
     datasetId: string;

--- a/typescript-sdk/src/client-sdk/services/evaluators/types.ts
+++ b/typescript-sdk/src/client-sdk/services/evaluators/types.ts
@@ -2,7 +2,10 @@ import type { paths } from "@/internal/generated/openapi/api-client";
 
 export type EvaluatorResponse = NonNullable<
   paths["/api/evaluators"]["get"]["responses"]["200"]["content"]["application/json"]
->[number];
+>[number] & {
+  /** URL to view this evaluator on the LangWatch platform */
+  platformUrl?: string;
+};
 
 export type EvaluatorField = EvaluatorResponse["fields"][number];
 

--- a/typescript-sdk/src/client-sdk/services/scenarios/types.ts
+++ b/typescript-sdk/src/client-sdk/services/scenarios/types.ts
@@ -2,7 +2,10 @@ import type { paths } from "@/internal/generated/openapi/api-client";
 
 export type ScenarioResponse = NonNullable<
   paths["/api/scenarios"]["get"]["responses"]["200"]["content"]["application/json"]
->[number];
+>[number] & {
+  /** URL to view this scenario on the LangWatch platform */
+  platformUrl?: string;
+};
 
 export type CreateScenarioBody = NonNullable<
   paths["/api/scenarios"]["post"]["requestBody"]

--- a/typescript-sdk/src/client-sdk/services/suites/suites-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/suites/suites-api.service.ts
@@ -7,7 +7,10 @@ import type { InternalConfig } from "@/client-sdk/types";
 
 export type SuiteResponse = NonNullable<
   paths["/api/suites"]["get"]["responses"]["200"]["content"]["application/json"]
->[number];
+>[number] & {
+  /** URL to view this suite on the LangWatch platform */
+  platformUrl?: string;
+};
 
 export type CreateSuiteBody = NonNullable<
   paths["/api/suites"]["post"]["requestBody"]

--- a/typescript-sdk/src/client-sdk/services/traces/traces-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/traces/traces-api.service.ts
@@ -12,8 +12,17 @@ export type TraceSearchBody = NonNullable<
 export type TraceSearchResponse =
   paths["/api/traces/search"]["post"]["responses"]["200"]["content"]["application/json"];
 
-export type TraceGetResponse =
+type TraceGetResponseRaw =
   paths["/api/traces/{traceId}"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export type TraceGetResponse = TraceGetResponseRaw extends string
+  ? TraceGetResponseRaw
+  : TraceGetResponseRaw extends object
+    ? TraceGetResponseRaw & {
+        /** URL to view this trace on the LangWatch platform */
+        platformUrl?: string;
+      }
+    : TraceGetResponseRaw;
 
 export class TracesApiError extends Error {
   constructor(


### PR DESCRIPTION
## Summary

Every API JSON endpoint now returns a `platformUrl` field linking to the resource's page (or drawer) on the LangWatch platform. CLI commands display this URL in their output.

### Why
- Claude Code skills and CLI users need clickable links to resources on the platform
- SDK consumers can use the URL to link resources in their own UIs
- Closes the feedback loop: create via API/CLI → see it on the platform

### Server changes (13 files)
New shared `platformUrl()` utility builds full URLs using `BASE_HOST` env var + project slug + resource path.

**Resources with own pages** get direct URLs:
| Resource | URL pattern | Verified |
|----------|-----------|----------|
| Datasets | `/{project}/datasets/{id}` | ✅ |
| Traces | `/{project}/messages/{traceId}` | ✅ |
| Dashboards | `/{project}/analytics/custom/{id}` | ✅ |
| Suites | `/{project}/simulations/run-plans/{slug}` | ✅ |

**Resources that open in drawers** use query params to open the right drawer:
| Resource | URL pattern | Verified |
|----------|-----------|----------|
| Monitors | `/{project}/evaluations?drawer.open=onlineEvaluation&drawer.monitorId={id}` | ✅ |
| Evaluators | `/{project}/evaluators?drawer.open=evaluatorEditor&drawer.evaluatorId={id}` | ✅ |
| Agents | `/{project}/agents?drawer.open=agentCodeEditor\|agentHttpEditor&drawer.agentId={id}` | ✅ |
| Scenarios | `/{project}/simulations/scenarios?drawer.open=scenarioEditor&drawer.scenarioId={id}` | ✅ |
| Triggers | `/{project}/automations?drawer.open=editAutomationFilter&drawer.automationId={id}` | ✅ |

**List-page-only resources** link to the listing page:
| Resource | URL pattern |
|----------|-----------|
| Workflows | `/{project}/workflows` |
| Prompts | `/{project}/prompts` |
| Simulation Runs | `/{project}/simulations` |

### CLI changes (19 files)
All create and get commands display a "View: <url>" line. JSON format includes `platformUrl` automatically.

### Verified live
All URLs tested against a running dev server. Screenshot of API responses:
```
Datasets:    http://localhost:5560/inbox-narrator/datasets/dataset_LL5StmYp76mvgyzt7D8t_
Monitors:    http://localhost:5560/inbox-narrator/evaluations?drawer.open=onlineEvaluation&drawer.monitorId=eval_QGMHfprLl3_yOuSkCFfHT
Evaluators:  http://localhost:5560/inbox-narrator/evaluators?drawer.open=evaluatorEditor&drawer.evaluatorId=evaluator_EM2QpQrLiJQ7572YPW0-t
Agents:      http://localhost:5560/inbox-narrator/agents?drawer.open=agentHttpEditor&drawer.agentId=agent_Vdy3gSQpMtnBWEjPqdQS3
Scenarios:   http://localhost:5560/inbox-narrator/simulations/scenarios?drawer.open=scenarioEditor&drawer.scenarioId=scenario_0001S1KjOQ80fuURhnziLnBbp3plQ
Triggers:    http://localhost:5560/inbox-narrator/automations?drawer.open=editAutomationFilter&drawer.automationId=MHuzcpvwKLDKKywfeFfH_
Dashboards:  http://localhost:5560/inbox-narrator/analytics/custom/rp_KAXYxPR8MUgTcP8CF193y
```

## Test plan
- [x] API responses verified against running dev server (7/7 resource types confirmed)
- [x] Drawer URLs use correct `drawer.open` + param names matching useDrawer hook
- [x] Agent type-specific drawers (code vs http) working
- [x] CLI commands show "View:" line in table output
- [x] JSON format output includes platformUrl from API