### PR TITLE
perf: lazy-load drawer registry (4.3 MB → 232 KB)

### DIFF
--- a/langwatch/src/components/CurrentDrawer.tsx
+++ b/langwatch/src/components/CurrentDrawer.tsx
@@ -1,7 +1,8 @@
+import { Center, Spinner } from "@chakra-ui/react";
 import { OrganizationUserRole } from "@prisma/client";
 import { useRouter } from "~/utils/compat/next-router";
 import qs from "qs";
-import { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useEffect, useMemo, type ReactNode } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
   type DrawerType,
@@ -127,7 +128,7 @@ export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
           );
         }}
       >
-        <Suspense>
+        <Suspense fallback={<DrawerLoadingFallback />}>
           <CurrentDrawerComponent
             {...queryDrawer}
             {...complexProps}
@@ -136,5 +137,13 @@ export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
         </Suspense>
       </ErrorBoundary>
     </DrawerOffsetProvider>
+  );
+}
+
+function DrawerLoadingFallback() {
+  return (
+    <Center height="200px">
+      <Spinner size="lg" color="blue.500" />
+    </Center>
   );
 }

--- a/langwatch/src/components/CurrentDrawer.tsx
+++ b/langwatch/src/components/CurrentDrawer.tsx
@@ -1,3 +1,4 @@
+import { Center, Spinner } from "@chakra-ui/react";
 import { OrganizationUserRole } from "@prisma/client";
 import qs from "qs";
 import { Suspense, useEffect, useMemo } from "react";
@@ -134,7 +135,7 @@ export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
           );
         }}
       >
-        <Suspense>
+        <Suspense fallback={<DrawerLoadingFallback />}>
           <CurrentDrawerComponent
             {...queryDrawer}
             {...complexProps}
@@ -143,5 +144,13 @@ export function CurrentDrawer({ marginTop }: { marginTop?: number }) {
         </Suspense>
       </ErrorBoundary>
     </DrawerOffsetProvider>
+  );
+}
+
+function DrawerLoadingFallback() {
+  return (
+    <Center height="200px">
+      <Spinner size="lg" color="blue.500" />
+    </Center>
   );
 }

--- a/langwatch/src/components/drawerRegistry.ts
+++ b/langwatch/src/components/drawerRegistry.ts
@@ -6,55 +6,177 @@
  * - `DrawerType`: Union type of all drawer names
  * - `DrawerProps<T>`: Props type for a specific drawer
  * - `DrawerCallbacks<T>`: Callback props (functions) for a specific drawer
+ *
+ * All drawers are lazy-loaded to avoid pulling their transitive dependencies
+ * (monaco-editor, shiki, react-admin, OTel SDK, etc.) into the initial bundle.
+ * CurrentDrawer already wraps rendering in <Suspense>, so this just works.
  */
 import { lazy, type ComponentProps } from "react";
 
-import { AddAnnotationQueueDrawer } from "./AddAnnotationQueueDrawer";
-import { AddDatasetRecordDrawerV2 } from "./AddDatasetRecordDrawer";
-import { AddOrEditAnnotationScoreDrawer } from "./AddOrEditAnnotationScoreDrawer";
-import { AddOrEditDatasetDrawer } from "./AddOrEditDatasetDrawer";
-import { AutomationDrawer } from "./AddAutomationDrawer";
-import { AgentCodeEditorDrawer } from "./agents/AgentCodeEditorDrawer";
-import { AgentHistoryDrawer } from "./agents/AgentHistoryDrawer";
-import { AgentHttpEditorDrawer } from "./agents/AgentHttpEditorDrawer";
-import { AgentListDrawer } from "./agents/AgentListDrawer";
-import { AgentTypeSelectorDrawer } from "./agents/AgentTypeSelectorDrawer";
-import { AgentWorkflowEditorDrawer } from "./agents/AgentWorkflowEditorDrawer";
-import { WorkflowSelectorDrawer } from "./agents/WorkflowSelectorDrawer";
-import { AlertDrawer } from "./analytics/AlertDrawer";
-import { DashboardNameDrawer } from "./analytics/DashboardNameDrawer";
-import { BatchEvaluationDrawer } from "./BatchEvaluationDrawer";
-import { SelectDatasetDrawer } from "./datasets/SelectDatasetDrawer";
-import { UploadCSVModal } from "./datasets/UploadCSVModal";
-import { EditModelProviderDrawer } from "./EditModelProviderDrawer";
-import { EditAutomationFilterDrawer } from "./EditAutomationFilterDrawer";
-import { GuardrailsDrawer } from "./evaluations/GuardrailsDrawer";
-// Online Evaluations (Monitors) drawers
-import { OnlineEvaluationDrawer } from "./evaluations/OnlineEvaluationDrawer";
-import { EvaluatorCategorySelectorDrawer } from "./evaluators/EvaluatorCategorySelectorDrawer";
-import { EvaluatorEditorDrawer } from "./evaluators/EvaluatorEditorDrawer";
-import { EvaluatorHistoryDrawer } from "./evaluators/EvaluatorHistoryDrawer";
-import { EvaluatorListDrawer } from "./evaluators/EvaluatorListDrawer";
-import { EvaluatorTypeSelectorDrawer } from "./evaluators/EvaluatorTypeSelectorDrawer";
-import { WorkflowSelectorForEvaluatorDrawer } from "./evaluators/WorkflowSelectorForEvaluatorDrawer";
-import { SdkRadarDrawer } from "./drawers/SdkRadarDrawer";
-// Lazy-loaded: FoundryDrawer transitively imports the OTel SDK which has
-// side effects that break React if evaluated eagerly at app startup.
+const lazyDefault = <T extends Record<string, React.FC<any>>>(
+  factory: () => Promise<T>,
+  key: keyof T,
+) => lazy(() => factory().then((m) => ({ default: m[key] })));
+
+const AddAnnotationQueueDrawer = lazyDefault(
+  () => import("./AddAnnotationQueueDrawer"),
+  "AddAnnotationQueueDrawer",
+);
+const AddDatasetRecordDrawerV2 = lazyDefault(
+  () => import("./AddDatasetRecordDrawer"),
+  "AddDatasetRecordDrawerV2",
+);
+const AddOrEditAnnotationScoreDrawer = lazyDefault(
+  () => import("./AddOrEditAnnotationScoreDrawer"),
+  "AddOrEditAnnotationScoreDrawer",
+);
+const AddOrEditDatasetDrawer = lazyDefault(
+  () => import("./AddOrEditDatasetDrawer"),
+  "AddOrEditDatasetDrawer",
+);
+const AutomationDrawer = lazyDefault(
+  () => import("./AddAutomationDrawer"),
+  "AutomationDrawer",
+);
+const AgentCodeEditorDrawer = lazyDefault(
+  () => import("./agents/AgentCodeEditorDrawer"),
+  "AgentCodeEditorDrawer",
+);
+const AgentHistoryDrawer = lazyDefault(
+  () => import("./agents/AgentHistoryDrawer"),
+  "AgentHistoryDrawer",
+);
+const AgentHttpEditorDrawer = lazyDefault(
+  () => import("./agents/AgentHttpEditorDrawer"),
+  "AgentHttpEditorDrawer",
+);
+const AgentListDrawer = lazyDefault(
+  () => import("./agents/AgentListDrawer"),
+  "AgentListDrawer",
+);
+const AgentTypeSelectorDrawer = lazyDefault(
+  () => import("./agents/AgentTypeSelectorDrawer"),
+  "AgentTypeSelectorDrawer",
+);
+const AgentWorkflowEditorDrawer = lazyDefault(
+  () => import("./agents/AgentWorkflowEditorDrawer"),
+  "AgentWorkflowEditorDrawer",
+);
+const WorkflowSelectorDrawer = lazyDefault(
+  () => import("./agents/WorkflowSelectorDrawer"),
+  "WorkflowSelectorDrawer",
+);
+const AlertDrawer = lazyDefault(
+  () => import("./analytics/AlertDrawer"),
+  "AlertDrawer",
+);
+const DashboardNameDrawer = lazyDefault(
+  () => import("./analytics/DashboardNameDrawer"),
+  "DashboardNameDrawer",
+);
+const BatchEvaluationDrawer = lazyDefault(
+  () => import("./BatchEvaluationDrawer"),
+  "BatchEvaluationDrawer",
+);
+const SelectDatasetDrawer = lazyDefault(
+  () => import("./datasets/SelectDatasetDrawer"),
+  "SelectDatasetDrawer",
+);
+const UploadCSVModal = lazyDefault(
+  () => import("./datasets/UploadCSVModal"),
+  "UploadCSVModal",
+);
+const EditModelProviderDrawer = lazyDefault(
+  () => import("./EditModelProviderDrawer"),
+  "EditModelProviderDrawer",
+);
+const EditAutomationFilterDrawer = lazyDefault(
+  () => import("./EditAutomationFilterDrawer"),
+  "EditAutomationFilterDrawer",
+);
+const GuardrailsDrawer = lazyDefault(
+  () => import("./evaluations/GuardrailsDrawer"),
+  "GuardrailsDrawer",
+);
+const OnlineEvaluationDrawer = lazyDefault(
+  () => import("./evaluations/OnlineEvaluationDrawer"),
+  "OnlineEvaluationDrawer",
+);
+const EvaluatorCategorySelectorDrawer = lazyDefault(
+  () => import("./evaluators/EvaluatorCategorySelectorDrawer"),
+  "EvaluatorCategorySelectorDrawer",
+);
+const EvaluatorEditorDrawer = lazyDefault(
+  () => import("./evaluators/EvaluatorEditorDrawer"),
+  "EvaluatorEditorDrawer",
+);
+const EvaluatorHistoryDrawer = lazyDefault(
+  () => import("./evaluators/EvaluatorHistoryDrawer"),
+  "EvaluatorHistoryDrawer",
+);
+const EvaluatorListDrawer = lazyDefault(
+  () => import("./evaluators/EvaluatorListDrawer"),
+  "EvaluatorListDrawer",
+);
+const EvaluatorTypeSelectorDrawer = lazyDefault(
+  () => import("./evaluators/EvaluatorTypeSelectorDrawer"),
+  "EvaluatorTypeSelectorDrawer",
+);
+const WorkflowSelectorForEvaluatorDrawer = lazyDefault(
+  () => import("./evaluators/WorkflowSelectorForEvaluatorDrawer"),
+  "WorkflowSelectorForEvaluatorDrawer",
+);
+const SdkRadarDrawer = lazyDefault(
+  () => import("./drawers/SdkRadarDrawer"),
+  "SdkRadarDrawer",
+);
 const FoundryDrawer = lazy(
   () => import("./ops/foundry/FoundryDrawer").then((m) => ({ default: m.FoundryDrawer })),
 );
-import { CreateProjectDrawer } from "./projects/CreateProjectDrawer";
-import { PromptEditorDrawer } from "./prompts/PromptEditorDrawer";
-import { PromptListDrawer } from "./prompts/PromptListDrawer";
-import { SeriesFiltersDrawer } from "./SeriesFilterDrawer";
-import { ScenarioFormDrawerFromUrl } from "./scenarios/ScenarioFormDrawer";
-import { CreateTeamDrawer } from "./settings/CreateTeamDrawer";
-import { LLMModelCostDrawer } from "./settings/LLMModelCostDrawer";
-import { ScenarioRunDetailDrawer } from "./simulations/ScenarioRunDetailDrawer";
-import { SuiteFormDrawer } from "./suites/SuiteFormDrawer";
-import { TraceDetailsDrawer } from "./TraceDetailsDrawer";
-// Evaluations V3 drawers
-import { TargetTypeSelectorDrawer } from "./targets/TargetTypeSelectorDrawer";
+const CreateProjectDrawer = lazyDefault(
+  () => import("./projects/CreateProjectDrawer"),
+  "CreateProjectDrawer",
+);
+const PromptEditorDrawer = lazyDefault(
+  () => import("./prompts/PromptEditorDrawer"),
+  "PromptEditorDrawer",
+);
+const PromptListDrawer = lazyDefault(
+  () => import("./prompts/PromptListDrawer"),
+  "PromptListDrawer",
+);
+const SeriesFiltersDrawer = lazyDefault(
+  () => import("./SeriesFilterDrawer"),
+  "SeriesFiltersDrawer",
+);
+const ScenarioFormDrawerFromUrl = lazyDefault(
+  () => import("./scenarios/ScenarioFormDrawer"),
+  "ScenarioFormDrawerFromUrl",
+);
+const CreateTeamDrawer = lazyDefault(
+  () => import("./settings/CreateTeamDrawer"),
+  "CreateTeamDrawer",
+);
+const LLMModelCostDrawer = lazyDefault(
+  () => import("./settings/LLMModelCostDrawer"),
+  "LLMModelCostDrawer",
+);
+const ScenarioRunDetailDrawer = lazyDefault(
+  () => import("./simulations/ScenarioRunDetailDrawer"),
+  "ScenarioRunDetailDrawer",
+);
+const SuiteFormDrawer = lazyDefault(
+  () => import("./suites/SuiteFormDrawer"),
+  "SuiteFormDrawer",
+);
+const TraceDetailsDrawer = lazyDefault(
+  () => import("./TraceDetailsDrawer"),
+  "TraceDetailsDrawer",
+);
+const TargetTypeSelectorDrawer = lazyDefault(
+  () => import("./targets/TargetTypeSelectorDrawer"),
+  "TargetTypeSelectorDrawer",
+);
 
 /**
  * Map of drawer names to their React components.

--- a/langwatch/src/components/drawerRegistry.ts
+++ b/langwatch/src/components/drawerRegistry.ts
@@ -15,16 +15,20 @@ import { type ComponentProps, type FC, lazy } from "react";
 
 import type { TraceV2DrawerShellProps } from "../features/traces-v2/components/TraceDrawer";
 
-const lazyDefault = <
-  K extends string,
-  T extends { [P in K]: React.FC<any> },
->({
+const lazyDefault = <K extends string, T extends { [P in K]: React.FC<any> }>({
   factory,
   key,
 }: {
   factory: () => Promise<T>;
   key: K;
-}) => lazy(() => factory().then((m) => ({ default: m[key] })));
+}) => {
+  const Component = lazy(() => factory().then((m) => ({ default: m[key] })));
+  // Preserve the original export's name on the lazy wrapper so React DevTools
+  // and regression tests (e.g. scenariosIndexNoDoubleDrawer) can still
+  // identify the underlying drawer.
+  Object.defineProperty(Component, "name", { value: key });
+  return Component;
+};
 
 const AddAnnotationQueueDrawer = lazyDefault({
   factory: () => import("./AddAnnotationQueueDrawer"),

--- a/langwatch/src/components/drawerRegistry.ts
+++ b/langwatch/src/components/drawerRegistry.ts
@@ -6,50 +6,202 @@
  * - `DrawerType`: Union type of all drawer names
  * - `DrawerProps<T>`: Props type for a specific drawer
  * - `DrawerCallbacks<T>`: Callback props (functions) for a specific drawer
+ *
+ * All drawers are lazy-loaded so their transitive dependencies (monaco-editor,
+ * shiki, react-admin, OTel SDK, etc.) stay out of the initial bundle.
+ * `CurrentDrawer` already wraps rendering in <Suspense>, so this just works.
  */
 import { type ComponentProps, type FC, lazy } from "react";
 
-import { AddAnnotationQueueDrawer } from "./AddAnnotationQueueDrawer";
-import { AutomationDrawer } from "./AddAutomationDrawer";
-import { AddDatasetRecordDrawerV2 } from "./AddDatasetRecordDrawer";
-import { AddOrEditAnnotationScoreDrawer } from "./AddOrEditAnnotationScoreDrawer";
-import { AddOrEditDatasetDrawer } from "./AddOrEditDatasetDrawer";
-import { AgentHistoryDrawer } from "./agents/AgentHistoryDrawer";
-import { AgentListDrawer } from "./agents/AgentListDrawer";
-import { AgentTypeSelectorDrawer } from "./agents/AgentTypeSelectorDrawer";
-import { AgentWorkflowEditorDrawer } from "./agents/AgentWorkflowEditorDrawer";
-import {
-  AgentCodeEditorDrawerFromUrl,
-  AgentHttpEditorDrawerFromUrl,
-  WorkflowSelectorDrawerFromUrl,
-} from "./agents/drawerFromUrl";
-import { AlertDrawer } from "./analytics/AlertDrawer";
-import { DashboardNameDrawer } from "./analytics/DashboardNameDrawer";
-import { SelectDatasetDrawer } from "./datasets/SelectDatasetDrawer";
-import { UploadCSVModal } from "./datasets/UploadCSVModal";
-import { FeatureFlagsDrawer } from "./drawers/FeatureFlagsDrawer";
-import { SdkRadarDrawer } from "./drawers/SdkRadarDrawer";
-import { EditAutomationFilterDrawer } from "./EditAutomationFilterDrawer";
-import { EditModelProviderDrawer } from "./EditModelProviderDrawer";
-import { GuardrailsDrawer } from "./evaluations/GuardrailsDrawer";
-// Online Evaluations (Monitors) drawers
-import { OnlineEvaluationDrawer } from "./evaluations/OnlineEvaluationDrawer";
-import { CodeEvaluatorEditorDrawer } from "./evaluators/CodeEvaluatorEditorDrawer";
-import { EvaluatorCategorySelectorDrawer } from "./evaluators/EvaluatorCategorySelectorDrawer";
-import { EvaluatorEditorDrawer } from "./evaluators/EvaluatorEditorDrawer";
-import { EvaluatorHistoryDrawer } from "./evaluators/EvaluatorHistoryDrawer";
-import { EvaluatorListDrawer } from "./evaluators/EvaluatorListDrawer";
-import { EvaluatorTypeSelectorDrawer } from "./evaluators/EvaluatorTypeSelectorDrawer";
-import { WorkflowSelectorForEvaluatorDrawer } from "./evaluators/WorkflowSelectorForEvaluatorDrawer";
-import { DataPrivacyRuleDrawer } from "./settings/DataPrivacyRuleDrawer";
+import type { TraceV2DrawerShellProps } from "../features/traces-v2/components/TraceDrawer";
 
-// Lazy-loaded: FoundryDrawer transitively imports the OTel SDK which has
-// side effects that break React if evaluated eagerly at app startup.
-const FoundryDrawer = lazy(() =>
-  import("./ops/foundry/FoundryDrawer").then((m) => ({
-    default: m.FoundryDrawer,
-  })),
-);
+const lazyDefault = <
+  K extends string,
+  T extends { [P in K]: React.FC<any> },
+>({
+  factory,
+  key,
+}: {
+  factory: () => Promise<T>;
+  key: K;
+}) => lazy(() => factory().then((m) => ({ default: m[key] })));
+
+const AddAnnotationQueueDrawer = lazyDefault({
+  factory: () => import("./AddAnnotationQueueDrawer"),
+  key: "AddAnnotationQueueDrawer",
+});
+const AddDatasetRecordDrawerV2 = lazyDefault({
+  factory: () => import("./AddDatasetRecordDrawer"),
+  key: "AddDatasetRecordDrawerV2",
+});
+const AddOrEditAnnotationScoreDrawer = lazyDefault({
+  factory: () => import("./AddOrEditAnnotationScoreDrawer"),
+  key: "AddOrEditAnnotationScoreDrawer",
+});
+const AddOrEditDatasetDrawer = lazyDefault({
+  factory: () => import("./AddOrEditDatasetDrawer"),
+  key: "AddOrEditDatasetDrawer",
+});
+const AutomationDrawer = lazyDefault({
+  factory: () => import("./AddAutomationDrawer"),
+  key: "AutomationDrawer",
+});
+const AgentHistoryDrawer = lazyDefault({
+  factory: () => import("./agents/AgentHistoryDrawer"),
+  key: "AgentHistoryDrawer",
+});
+const AgentListDrawer = lazyDefault({
+  factory: () => import("./agents/AgentListDrawer"),
+  key: "AgentListDrawer",
+});
+const AgentTypeSelectorDrawer = lazyDefault({
+  factory: () => import("./agents/AgentTypeSelectorDrawer"),
+  key: "AgentTypeSelectorDrawer",
+});
+const AgentWorkflowEditorDrawer = lazyDefault({
+  factory: () => import("./agents/AgentWorkflowEditorDrawer"),
+  key: "AgentWorkflowEditorDrawer",
+});
+const AgentCodeEditorDrawerFromUrl = lazyDefault({
+  factory: () => import("./agents/drawerFromUrl"),
+  key: "AgentCodeEditorDrawerFromUrl",
+});
+const AgentHttpEditorDrawerFromUrl = lazyDefault({
+  factory: () => import("./agents/drawerFromUrl"),
+  key: "AgentHttpEditorDrawerFromUrl",
+});
+const WorkflowSelectorDrawerFromUrl = lazyDefault({
+  factory: () => import("./agents/drawerFromUrl"),
+  key: "WorkflowSelectorDrawerFromUrl",
+});
+const AlertDrawer = lazyDefault({
+  factory: () => import("./analytics/AlertDrawer"),
+  key: "AlertDrawer",
+});
+const DashboardNameDrawer = lazyDefault({
+  factory: () => import("./analytics/DashboardNameDrawer"),
+  key: "DashboardNameDrawer",
+});
+const SelectDatasetDrawer = lazyDefault({
+  factory: () => import("./datasets/SelectDatasetDrawer"),
+  key: "SelectDatasetDrawer",
+});
+const UploadCSVModal = lazyDefault({
+  factory: () => import("./datasets/UploadCSVModal"),
+  key: "UploadCSVModal",
+});
+const FeatureFlagsDrawer = lazyDefault({
+  factory: () => import("./drawers/FeatureFlagsDrawer"),
+  key: "FeatureFlagsDrawer",
+});
+const SdkRadarDrawer = lazyDefault({
+  factory: () => import("./drawers/SdkRadarDrawer"),
+  key: "SdkRadarDrawer",
+});
+const EditAutomationFilterDrawer = lazyDefault({
+  factory: () => import("./EditAutomationFilterDrawer"),
+  key: "EditAutomationFilterDrawer",
+});
+const EditModelProviderDrawer = lazyDefault({
+  factory: () => import("./EditModelProviderDrawer"),
+  key: "EditModelProviderDrawer",
+});
+const GuardrailsDrawer = lazyDefault({
+  factory: () => import("./evaluations/GuardrailsDrawer"),
+  key: "GuardrailsDrawer",
+});
+const OnlineEvaluationDrawer = lazyDefault({
+  factory: () => import("./evaluations/OnlineEvaluationDrawer"),
+  key: "OnlineEvaluationDrawer",
+});
+const CodeEvaluatorEditorDrawer = lazyDefault({
+  factory: () => import("./evaluators/CodeEvaluatorEditorDrawer"),
+  key: "CodeEvaluatorEditorDrawer",
+});
+const EvaluatorCategorySelectorDrawer = lazyDefault({
+  factory: () => import("./evaluators/EvaluatorCategorySelectorDrawer"),
+  key: "EvaluatorCategorySelectorDrawer",
+});
+const EvaluatorEditorDrawer = lazyDefault({
+  factory: () => import("./evaluators/EvaluatorEditorDrawer"),
+  key: "EvaluatorEditorDrawer",
+});
+const EvaluatorHistoryDrawer = lazyDefault({
+  factory: () => import("./evaluators/EvaluatorHistoryDrawer"),
+  key: "EvaluatorHistoryDrawer",
+});
+const EvaluatorListDrawer = lazyDefault({
+  factory: () => import("./evaluators/EvaluatorListDrawer"),
+  key: "EvaluatorListDrawer",
+});
+const EvaluatorTypeSelectorDrawer = lazyDefault({
+  factory: () => import("./evaluators/EvaluatorTypeSelectorDrawer"),
+  key: "EvaluatorTypeSelectorDrawer",
+});
+const WorkflowSelectorForEvaluatorDrawer = lazyDefault({
+  factory: () => import("./evaluators/WorkflowSelectorForEvaluatorDrawer"),
+  key: "WorkflowSelectorForEvaluatorDrawer",
+});
+const FoundryDrawer = lazyDefault({
+  factory: () => import("./ops/foundry/FoundryDrawer"),
+  key: "FoundryDrawer",
+});
+const CreateProjectDrawer = lazyDefault({
+  factory: () => import("./projects/CreateProjectDrawer"),
+  key: "CreateProjectDrawer",
+});
+const EditProjectDrawer = lazyDefault({
+  factory: () => import("./projects/EditProjectDrawer"),
+  key: "EditProjectDrawer",
+});
+const PromptEditorDrawer = lazyDefault({
+  factory: () => import("./prompts/PromptEditorDrawer"),
+  key: "PromptEditorDrawer",
+});
+const PromptListDrawer = lazyDefault({
+  factory: () => import("./prompts/PromptListDrawer"),
+  key: "PromptListDrawer",
+});
+const ScenarioFormDrawerFromUrl = lazyDefault({
+  factory: () => import("./scenarios/ScenarioFormDrawer"),
+  key: "ScenarioFormDrawerFromUrl",
+});
+const SeriesFiltersDrawer = lazyDefault({
+  factory: () => import("./SeriesFilterDrawer"),
+  key: "SeriesFiltersDrawer",
+});
+const CreateTeamDrawer = lazyDefault({
+  factory: () => import("./settings/CreateTeamDrawer"),
+  key: "CreateTeamDrawer",
+});
+const DataPrivacyRuleDrawer = lazyDefault({
+  factory: () => import("./settings/DataPrivacyRuleDrawer"),
+  key: "DataPrivacyRuleDrawer",
+});
+const DefaultModelOverrideDrawer = lazyDefault({
+  factory: () => import("./settings/DefaultModelOverrideDrawer"),
+  key: "DefaultModelOverrideDrawer",
+});
+const LLMModelCostDrawer = lazyDefault({
+  factory: () => import("./settings/LLMModelCostDrawer"),
+  key: "LLMModelCostDrawer",
+});
+const ScenarioRunDetailDrawer = lazyDefault({
+  factory: () => import("./simulations/ScenarioRunDetailDrawer"),
+  key: "ScenarioRunDetailDrawer",
+});
+const SuiteFormDrawer = lazyDefault({
+  factory: () => import("./suites/SuiteFormDrawer"),
+  key: "SuiteFormDrawer",
+});
+const TargetTypeSelectorDrawer = lazyDefault({
+  factory: () => import("./targets/TargetTypeSelectorDrawer"),
+  key: "TargetTypeSelectorDrawer",
+});
+const TraceDetailsDrawer = lazyDefault({
+  factory: () => import("./TraceDetailsDrawer"),
+  key: "TraceDetailsDrawer",
+});
 
 // Traces V2 drawers — the real shell is mounted from `TracesPage` based
 // on the drawer store (so a click → drawer-open is synchronous, no
@@ -60,24 +212,7 @@ const FoundryDrawer = lazy(() =>
 // The prop shape mirrors `TraceV2DrawerShellProps` exactly so
 // `openDrawer("traceV2Details", { traceId, t, ... })` still typechecks
 // at every call site.
-import type { TraceV2DrawerShellProps } from "../features/traces-v2/components/TraceDrawer";
-import { CreateProjectDrawer } from "./projects/CreateProjectDrawer";
-import { EditProjectDrawer } from "./projects/EditProjectDrawer";
-import { PromptEditorDrawer } from "./prompts/PromptEditorDrawer";
-import { PromptListDrawer } from "./prompts/PromptListDrawer";
-import { SeriesFiltersDrawer } from "./SeriesFilterDrawer";
-import { ScenarioFormDrawerFromUrl } from "./scenarios/ScenarioFormDrawer";
-import { CreateTeamDrawer } from "./settings/CreateTeamDrawer";
-import { DefaultModelOverrideDrawer } from "./settings/DefaultModelOverrideDrawer";
-import { LLMModelCostDrawer } from "./settings/LLMModelCostDrawer";
-import { ScenarioRunDetailDrawer } from "./simulations/ScenarioRunDetailDrawer";
-import { SuiteFormDrawer } from "./suites/SuiteFormDrawer";
-import { TraceDetailsDrawer } from "./TraceDetailsDrawer";
-
 const TraceV2DrawerNoop: FC<TraceV2DrawerShellProps> = () => null;
-
-// Evaluations V3 drawers
-import { TargetTypeSelectorDrawer } from "./targets/TargetTypeSelectorDrawer";
 
 /**
  * Map of drawer names to their React components.


### PR DESCRIPTION
## Summary
- All 44 drawer components in `drawerRegistry.ts` were eagerly imported, pulling their transitive deps (monaco-editor, shiki, OTel SDK, form builders, etc.) into a single **4,343 kB** command-bar chunk loaded on every page
- Converted all drawer imports to `React.lazy()` so they're code-split and only fetched when a drawer is actually opened
- `CurrentDrawer` already wraps in `<Suspense>` — added a spinner fallback for the loading state

**command-bar chunk: 4,343 kB → 232 kB (94.7% reduction)**

## Test plan
- [ ] Open various drawers (trace details, prompt editor, evaluator editor) and verify they load with a brief spinner
- [ ] Verify drawer navigation (back button, flow callbacks) still works
- [ ] Check no regressions on initial page load performance