### PR TITLE
fix: clamp negative durations to 0 before ClickHouse insert

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.mapProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.mapProjection.ts
@@ -83,7 +83,7 @@ export class ExperimentRunResultStorageMapProjection
       DatasetEntry: JSON.stringify(event.data.entry),
       Predicted: event.data.predicted ? JSON.stringify(event.data.predicted) : null,
       TargetCost: event.data.cost ?? null,
-      TargetDurationMs: event.data.duration ?? null,
+      TargetDurationMs: event.data.duration != null ? Math.max(0, event.data.duration) : null,
       TargetError: event.data.error ?? null,
       TraceId: event.data.traceId ?? null,
       EvaluatorId: null,
@@ -138,7 +138,7 @@ export class ExperimentRunResultStorageMapProjection
       EvaluationDetails: event.data.details ?? null,
       EvaluationCost: event.data.cost ?? null,
       EvaluationInputs: event.data.inputs ? JSON.stringify(event.data.inputs) : null,
-      EvaluationDurationMs: event.data.duration ?? null,
+      EvaluationDurationMs: event.data.duration != null ? Math.max(0, event.data.duration) : null,
       OccurredAt: new Date(event.occurredAt),
     };
   }

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.mapProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.mapProjection.ts
@@ -6,6 +6,7 @@ import {
   type TargetResultEvent,
   type EvaluatorResultEvent,
 } from "../schemas/events";
+import { normalizeDurationMs } from "../utils/duration.utils";
 import { IdUtils } from "../utils/id.utils";
 
 /**
@@ -83,7 +84,7 @@ export class ExperimentRunResultStorageMapProjection
       DatasetEntry: JSON.stringify(event.data.entry),
       Predicted: event.data.predicted ? JSON.stringify(event.data.predicted) : null,
       TargetCost: event.data.cost ?? null,
-      TargetDurationMs: event.data.duration != null ? Math.max(0, event.data.duration) : null,
+      TargetDurationMs: normalizeDurationMs(event.data.duration),
       TargetError: event.data.error ?? null,
       TraceId: event.data.traceId ?? null,
       EvaluatorId: null,
@@ -138,7 +139,7 @@ export class ExperimentRunResultStorageMapProjection
       EvaluationDetails: event.data.details ?? null,
       EvaluationCost: event.data.cost ?? null,
       EvaluationInputs: event.data.inputs ? JSON.stringify(event.data.inputs) : null,
-      EvaluationDurationMs: event.data.duration != null ? Math.max(0, event.data.duration) : null,
+      EvaluationDurationMs: normalizeDurationMs(event.data.duration),
       OccurredAt: new Date(event.occurredAt),
     };
   }

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunState.foldProjection.ts
@@ -4,6 +4,7 @@ import {
   type FoldEventHandlers,
 } from "../../../projections/abstractFoldProjection";
 import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
+import { normalizeDurationMs } from "../utils/duration.utils";
 import { EXPERIMENT_RUN_PROJECTION_VERSIONS } from "../schemas/constants";
 import type {
   ExperimentRunStartedEvent,
@@ -173,8 +174,9 @@ export class ExperimentRunStateFoldProjection
     }
 
     let totalDurationMs = state.TotalDurationMs;
-    if (event.data.duration != null) {
-      totalDurationMs = (totalDurationMs ?? 0) + event.data.duration;
+    const clampedDuration = normalizeDurationMs(event.data.duration);
+    if (clampedDuration != null) {
+      totalDurationMs = (totalDurationMs ?? 0) + clampedDuration;
     }
 
     const progress = completedCount + failedCount;

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/utils/duration.utils.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/utils/duration.utils.ts
@@ -1,6 +1,6 @@
 /**
  * Clamps a nullable duration to a non-negative value.
- * Clock skew can produce negative durations that overflow ClickHouse UInt64 columns.
+ * Clock skew can produce negative durations which unsigned duration columns reject.
  */
 export function normalizeDurationMs(duration: number | null | undefined): number | null {
   return duration != null ? Math.max(0, duration) : null;

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/utils/duration.utils.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/utils/duration.utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Clamps a nullable duration to a non-negative value.
+ * Clock skew can produce negative durations that overflow ClickHouse UInt64 columns.
+ */
+export function normalizeDurationMs(duration: number | null | undefined): number | null {
+  return duration != null ? Math.max(0, duration) : null;
+}


### PR DESCRIPTION
## Summary
- `TargetDurationMs` and `EvaluationDurationMs` columns in ClickHouse are `Nullable(UInt32)` (unsigned), but `finished_at - started_at` can produce negative values due to clock skew
- This causes inserts to fail with: *"Unsigned type must not contain '-' symbol"*
- Clamps both duration fields to `Math.max(0, duration)` in the map projection before insertion

## Test plan
- [ ] Verify experiment runs with normal durations still insert correctly
- [ ] Verify experiment runs where clock skew produces negative duration no longer fail