### PR TITLE
feat(onboarding): instrument product flow with viewed/exited/selected events

### DIFF
--- a/langwatch/src/features/onboarding/components/ScreenLifecycle.tsx
+++ b/langwatch/src/features/onboarding/components/ScreenLifecycle.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from "react";
+import { useAnalytics } from "react-contextual-analytics";
+
+export const ScreenLifecycle: React.FC = () => {
+  const { emit } = useAnalytics();
+  const emitRef = useRef(emit);
+  emitRef.current = emit;
+
+  useEffect(() => {
+    const start = Date.now();
+    return () => {
+      emitRef.current("exited", void 0, {
+        timeOnScreenMs: Date.now() - start,
+      });
+    };
+  }, []);
+
+  return null;
+};

--- a/langwatch/src/features/onboarding/screens/ProductScreen.tsx
+++ b/langwatch/src/features/onboarding/screens/ProductScreen.tsx
@@ -7,6 +7,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useProjectBySlugOrLatest } from "~/hooks/useProjectBySlugOrLatest";
 import { OnboardingContainer } from "../components/containers/OnboardingContainer";
 
+import { ScreenLifecycle } from "../components/ScreenLifecycle";
 import { ActiveProjectProvider } from "../contexts/ActiveProjectContext";
 import { useProductFlow } from "../hooks/use-product-flow";
 import { useCreateProductScreens } from "./create-product-screens";
@@ -62,6 +63,7 @@ export const ProductScreen: React.FC = () => {
 
   return (
     <AnalyticsBoundary name="onboarding_product" sendViewedEvent>
+      <ScreenLifecycle />
       <OnboardingContainer
         title={currentScreen.heading}
         subTitle={currentScreen.subHeading}
@@ -77,7 +79,14 @@ export const ProductScreen: React.FC = () => {
             value={{ project: activeProject, organization }}
           >
             {!isLoading && currentScreen.component ? (
-              <currentScreen.component />
+              <AnalyticsBoundary
+                key={currentScreen.id}
+                name={currentScreen.id}
+                sendViewedEvent
+              >
+                <ScreenLifecycle />
+                <currentScreen.component />
+              </AnalyticsBoundary>
             ) : null}
           </ActiveProjectProvider>
         </Box>

--- a/langwatch/src/features/onboarding/screens/create-product-screens.tsx
+++ b/langwatch/src/features/onboarding/screens/create-product-screens.tsx
@@ -12,6 +12,24 @@ import {
   type ProductSelection,
 } from "../types/types";
 
+interface ProductSelectionScreenWithAnalyticsProps {
+  onSelectProduct: (product: ProductSelection) => void;
+}
+
+const ProductSelectionScreenWithAnalytics: React.FC<
+  ProductSelectionScreenWithAnalyticsProps
+> = ({ onSelectProduct }) => {
+  const { emit } = useAnalytics();
+  return (
+    <ProductSelectionScreen
+      onSelectProduct={(product) => {
+        emit("selected", "product", { product });
+        onSelectProduct(product);
+      }}
+    />
+  );
+};
+
 interface UseProductScreensProps {
   flow: ProductFlowConfig;
   onSelectProduct: (product: ProductSelection) => void;
@@ -21,17 +39,17 @@ export const useCreateProductScreens = ({
   flow,
   onSelectProduct,
 }: UseProductScreensProps): OnboardingScreen[] => {
-  const ProductSelectionScreenWrapped: React.FC = () => {
-    const { emit } = useAnalytics();
-    return (
-      <ProductSelectionScreen
-        onSelectProduct={(product) => {
-          emit("selected", "product", { product });
-          onSelectProduct(product);
-        }}
-      />
-    );
-  };
+  const BoundProductSelectionScreen = useMemo<React.FC>(
+    () =>
+      function BoundProductSelectionScreen() {
+        return (
+          <ProductSelectionScreenWithAnalytics
+            onSelectProduct={onSelectProduct}
+          />
+        );
+      },
+    [onSelectProduct],
+  );
 
   const screensBase: Record<ProductScreenIndex, OnboardingScreen> = useMemo(
     () => ({
@@ -41,7 +59,7 @@ export const useCreateProductScreens = ({
         heading: "Pick your flavour",
         subHeading:
           "Choose a starting point. You can explore the rest anytime.",
-        component: ProductSelectionScreenWrapped,
+        component: BoundProductSelectionScreen,
       },
       [ProductScreenIndex.VIA_CLAUDE_CODE]: {
         id: "via-claude-code",
@@ -78,8 +96,7 @@ export const useCreateProductScreens = ({
         component: ObservabilityScreen,
       },
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [onSelectProduct],
+    [BoundProductSelectionScreen],
   );
 
   return flow.visibleScreens.map((idx) => screensBase[idx]);

--- a/langwatch/src/features/onboarding/screens/create-product-screens.tsx
+++ b/langwatch/src/features/onboarding/screens/create-product-screens.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useAnalytics } from "react-contextual-analytics";
 import { ObservabilityScreen } from "../components/sections/ObservabilityScreen";
 import { ProductSelectionScreen } from "../components/sections/ProductSelectionScreen";
 import { ViaClaudeCodeScreen } from "../components/sections/ViaClaudeCodeScreen";
@@ -20,9 +21,17 @@ export const useCreateProductScreens = ({
   flow,
   onSelectProduct,
 }: UseProductScreensProps): OnboardingScreen[] => {
-  const ProductSelectionScreenWrapped: React.FC = () => (
-    <ProductSelectionScreen onSelectProduct={onSelectProduct} />
-  );
+  const ProductSelectionScreenWrapped: React.FC = () => {
+    const { emit } = useAnalytics();
+    return (
+      <ProductSelectionScreen
+        onSelectProduct={(product) => {
+          emit("selected", "product", { product });
+          onSelectProduct(product);
+        }}
+      />
+    );
+  };
 
   const screensBase: Record<ProductScreenIndex, OnboardingScreen> = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

Adds the missing PostHog instrumentation for the "Pick your flavour" step of onboarding. Before this change, the entire product flow emitted a single semantic event (`onboarding_product.viewed`) — no selection signal, no per-flavour views, no exit events, so funnel analysis past the welcome step was impossible.

New PostHog events emitted from `/onboarding/product`:

| Event | When |
| --- | --- |
| `onboarding_product.product-selection.viewed` | user lands on the flavour-picker |
| `onboarding_product.product-selection.selected.product` | user clicks a flavour card (attr: `product` — one of `via-claude-code`, `via-platform`, `via-claude-desktop`, `manually`) |
| `onboarding_product.product-selection.exited` | user leaves the flavour-picker (attr: `timeOnScreenMs`) |
| `onboarding_product.<flavour>.viewed` | user opens a flavour-specific screen |
| `onboarding_product.<flavour>.exited` | user leaves a flavour-specific screen (attr: `timeOnScreenMs`) |
| `onboarding_product.exited` | user leaves the product step entirely (attr: `timeOnScreenMs`) |

## Implementation

- New helper `src/features/onboarding/components/ScreenLifecycle.tsx` — a side-effect-only component that emits `exited` on unmount with `timeOnScreenMs`, reading its emit function from the nearest `AnalyticsBoundary` via `useAnalytics`. Uses a ref so the cleanup effect can stay on empty deps (emit identity churns each render, but we only want one exit event).
- `ProductScreen.tsx` — places a `<ScreenLifecycle />` inside the outer `onboarding_product` boundary, and wraps the active screen component in a new inner `<AnalyticsBoundary key={currentScreen.id} name={currentScreen.id} sendViewedEvent>` with its own `<ScreenLifecycle />`. The `key` forces unmount/remount on screen change so the cleanup fires with the correct boundary bound.
- `create-product-screens.tsx` — wraps `ProductSelectionScreen`'s `onSelectProduct` callback with `emit("selected", "product", { product })` via `useAnalytics`. The hook sees the inner `onboarding_product.product-selection` boundary because the wrapper renders inside it.

No behavioural changes outside analytics. `$pageview` and PostHog autocapture remain as-is.

## Test plan

- [ ] Run `pnpm dev`, open devtools, walk through onboarding, confirm the new event names print via the console analytics provider on every screen transition.
- [ ] Verify `timeOnScreenMs` values look sensible (growing monotonically with dwell).
- [ ] In PostHog (staging), filter Live Events by your `distinct_id` and verify the events arrive in the expected order: `onboarding_product.viewed` → `onboarding_product.product-selection.viewed` → `selected.product` → `product-selection.exited` → `<flavour>.viewed` → `<flavour>.exited` → `onboarding_product.exited` on nav to dashboard.
- [ ] Build a funnel in PostHog from `onboarding_welcome.clicked.finish` through to `onboarding_product.<flavour>.exited` and confirm the new steps are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)