### PR TITLE
fix(evaluations): skip remaining OnlineEvaluationDrawer tests to unblock CI aggregators

### DIFF
--- a/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawer.test.tsx
+++ b/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawer.test.tsx
@@ -66,7 +66,8 @@ Element.prototype.scrollIntoView = vi.fn();
  * CRITICAL Integration test - Tests the REAL navigation flow where the drawer's
  * open prop actually changes during navigation (as happens in production).
  */
-describe("OnlineEvaluationDrawer + EvaluatorListDrawer Integration", () => {
+// TODO(#3240): re-enable after react-admin 5.13.1 provider wrapper fix
+describe.skip("OnlineEvaluationDrawer + EvaluatorListDrawer Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetState();

--- a/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawerFeatures.test.tsx
+++ b/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawerFeatures.test.tsx
@@ -53,7 +53,8 @@ vi.mock("~/hooks/useLicenseEnforcement", async () =>
 // Mock scrollIntoView which jsdom doesn't support
 Element.prototype.scrollIntoView = vi.fn();
 
-describe("OnlineEvaluationDrawer - Features", () => {
+// TODO(#3240): re-enable after react-admin 5.13.1 provider wrapper fix
+describe.skip("OnlineEvaluationDrawer - Features", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetState();

--- a/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawerIssueFixes.test.tsx
+++ b/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawerIssueFixes.test.tsx
@@ -63,7 +63,8 @@ Element.prototype.scrollIntoView = vi.fn();
  * These tests verify the expected behaviors for the 4 reported issues.
  * They should FAIL initially and pass after fixes are implemented.
  */
-describe("OnlineEvaluationDrawer Issue Fixes", () => {
+// TODO(#3240): re-enable after react-admin 5.13.1 provider wrapper fix
+describe.skip("OnlineEvaluationDrawer Issue Fixes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetState();

--- a/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawerMappings.test.tsx
+++ b/langwatch/src/components/evaluations/__tests__/OnlineEvaluationDrawerMappings.test.tsx
@@ -57,7 +57,8 @@ Element.prototype.scrollIntoView = vi.fn();
  * 4. User clicks on mapping input and sees trace fields
  * 5. User selects a nested field (e.g., metadata.thread_id)
  */
-describe("OnlineEvaluationDrawer + EvaluatorEditorDrawer Mapping Integration", () => {
+// TODO(#3240): re-enable after react-admin 5.13.1 provider wrapper fix
+describe.skip("OnlineEvaluationDrawer + EvaluatorEditorDrawer Mapping Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetState();


### PR DESCRIPTION
## Summary

- Skip the 4 remaining top-level `describe`s in `OnlineEvaluationDrawer*.test.tsx` that were broken by the react-admin pin in #3241
- Combined with existing skips in `EditSave`/`NewIssues`, this re-greens `langwatch-app-complete` on `main`
- Unblocks branch-protection updates for the 12 `-complete` aggregators (follow-up to #3223 / #3230)

**Skip-to-green only.** Tests are not deleted — actual fix tracked in #3240.

Closes #3255

## Files touched

- `OnlineEvaluationDrawer.test.tsx` — top-level describe at line 70
- `OnlineEvaluationDrawerFeatures.test.tsx`
- `OnlineEvaluationDrawerIssueFixes.test.tsx`
- `OnlineEvaluationDrawerMappings.test.tsx`

`OnlineEvaluationDrawerEditSave.test.tsx` and `OnlineEvaluationDrawerNewIssues.test.tsx` were already skipped from a prior change — left untouched per "no other test files touched" AC.

## Test plan

- [x] `pnpm test:unit src/components/evaluations/__tests__/OnlineEvaluationDrawer` → **7 files skipped, 103 tests skipped, 0 failures**
- [ ] `langwatch-app-complete` aggregator goes green on PR CI
- [ ] `langwatch-app-complete` goes green on `main` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related Issue

- Resolve #3255