### PR TITLE
fix(scenarios): simulations page 500 — aggregate alias shadows ScenarioSetId column in WHERE

### DIFF
--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -239,8 +239,7 @@ describe("SimulationClickHouseRepository (integration)", () => {
 
   describe("getRunDataForAllSuites()", () => {
     describe("when internal suite runs have metadata", () => {
-      // Skipped: requires live ClickHouse. Run with testcontainers or make dev-full to enable.
-      it.skip("returns runs through the all-suites query", async () => {
+      it("returns runs through the all-suites query", async () => {
         const scenarioSetId = `__internal__allsuites_${nanoid()}__suite`;
         const batchRunId = `batch-allsuites-${nanoid()}`;
 
@@ -265,8 +264,7 @@ describe("SimulationClickHouseRepository (integration)", () => {
     });
 
     describe("when a batch has empty-string ScenarioSetId (legacy data)", () => {
-      // Skipped: requires live ClickHouse. Run with testcontainers or make dev-full to enable.
-      it.skip("normalizes the empty-string to 'default' in the scenarioSetIds map", async () => {
+      it("normalizes the empty-string to 'default' in the scenarioSetIds map", async () => {
         const batchRunId = `batch-legacy-${nanoid()}`;
 
         await insertRow(ch, makeInsertRow({
@@ -287,8 +285,7 @@ describe("SimulationClickHouseRepository (integration)", () => {
     });
 
     describe("when batches have both empty-string and 'default' ScenarioSetId for different batches", () => {
-      // Skipped: requires live ClickHouse. Run with testcontainers or make dev-full to enable.
-      it.skip("collapses both to 'default' and reports a single distinct set", async () => {
+      it("collapses both to 'default' and reports a single distinct set", async () => {
         const batchEmpty = `batch-empty-${nanoid()}`;
         const batchDefault = `batch-default-${nanoid()}`;
 
@@ -312,6 +309,36 @@ describe("SimulationClickHouseRepository (integration)", () => {
         if (!result.changed) throw new Error("expected changed");
         expect(result.scenarioSetIds[batchEmpty]).toBe("default");
         expect(result.scenarioSetIds[batchDefault]).toBe("default");
+      });
+    });
+
+    // Regression for langwatch/langwatch#3265:
+    // The previous outer SELECT aliased `any(IF(ScenarioSetId = '', 'default', ScenarioSetId))
+    // AS ScenarioSetId`. That alias shadowed the `ScenarioSetId` column referenced inside the
+    // dedup IN-tuple in WHERE, and ClickHouse rejected the query with
+    //   "Aggregate function any(...) AS ScenarioSetId is found in WHERE in query."
+    // This test proves the rewritten query (alias renamed to NormalizedSetId) actually
+    // executes against ClickHouse instead of throwing.
+    describe("when the query runs against real ClickHouse", () => {
+      it("does not throw 'Aggregate function ... found in WHERE' (regression for langwatch/langwatch#3265)", async () => {
+        const batchRunId = `batch-regression-3265-${nanoid()}`;
+
+        await insertRow(ch, makeInsertRow({
+          ScenarioRunId: `run-regression-3265-${nanoid()}`,
+          BatchRunId: batchRunId,
+          ScenarioSetId: "",
+        }));
+
+        // The assertion that matters is that this call resolves without throwing.
+        // Before the fix it threw a TRPCClientError wrapping the ClickHouse error.
+        const result = await repo.getRunDataForAllSuites({
+          projectId: tenantId,
+          limit: 20,
+        });
+
+        expect(result.changed).toBe(true);
+        if (!result.changed) throw new Error("expected changed");
+        expect(result.scenarioSetIds[batchRunId]).toBe("default");
       });
     });
   });

--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -5,6 +5,7 @@ import {
   startTestContainers,
   stopTestContainers,
 } from "../../../event-sourcing/__tests__/integration/testContainers";
+import { createResilientClickHouseClient } from "../../clients/clickhouse";
 import { SimulationClickHouseRepository } from "../repositories/simulation.clickhouse.repository";
 
 const tenantId = `test-sim-repo-${nanoid()}`;
@@ -60,7 +61,11 @@ let repo: SimulationClickHouseRepository;
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
-  repo = new SimulationClickHouseRepository(async () => ch);
+  // Wrap with the resilient client so the `langwatch_*` ClickHouse settings
+  // the repository emits get stripped before they hit ClickHouse (matches the
+  // production factory path — bare clients would be rejected by ClickHouse).
+  const resilient = createResilientClickHouseClient({ client: ch });
+  repo = new SimulationClickHouseRepository(async () => resilient);
 }, 60_000);
 
 afterAll(async () => {

--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.unit.test.ts
@@ -381,12 +381,12 @@ describe("SimulationClickHouseRepository", () => {
             {
               BatchRunId: "batch-1",
               MaxCreatedAt: "3000",
-              ScenarioSetId: "__internal__foo__suite",
+              NormalizedSetId: "__internal__foo__suite",
             },
             {
               BatchRunId: "batch-2",
               MaxCreatedAt: "2000",
-              ScenarioSetId: "__internal__bar__suite",
+              NormalizedSetId: "__internal__bar__suite",
             },
           ],
           [
@@ -445,12 +445,12 @@ describe("SimulationClickHouseRepository", () => {
             {
               BatchRunId: "batch-1",
               MaxCreatedAt: "3000",
-              ScenarioSetId: "__internal__a__suite",
+              NormalizedSetId: "__internal__a__suite",
             },
             {
               BatchRunId: "batch-2",
               MaxCreatedAt: "2000",
-              ScenarioSetId: "__internal__b__suite",
+              NormalizedSetId: "__internal__b__suite",
             },
           ],
           [

--- a/langwatch/src/server/app-layer/simulations/repositories/__tests__/simulation.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/__tests__/simulation.clickhouse.repository.unit.test.ts
@@ -117,7 +117,7 @@ describe("SimulationClickHouseRepository", () => {
                   {
                     BatchRunId: "batch-1",
                     MaxCreatedAt: "1710000000000",
-                    ScenarioSetId: "default",
+                    NormalizedSetId: "default",
                   },
                 ];
               }
@@ -145,6 +145,34 @@ describe("SimulationClickHouseRepository", () => {
         );
         expect(batchQuery?.query).not.toMatch(
           /any\(ScenarioSetId\)\s+AS\s+ScenarioSetId/
+        );
+      });
+    });
+
+    // Regression: ClickHouse rejects queries where a SELECT alias shadows a
+    // column referenced in WHERE — the aggregate any(IF(...)) must NOT be
+    // aliased as ScenarioSetId because the dedup IN-tuple in WHERE references
+    // the underlying ScenarioSetId column.
+    // See: simulation.clickhouse.repository.ts getRunDataForAllSuites()
+    describe("when the outer SELECT aggregates the normalized set id", () => {
+      it("does not alias the aggregate as ScenarioSetId (would shadow the column in WHERE)", async () => {
+        const { client, getCapturedQueries } =
+          makeMockClientWithQueryCapture({
+            rowsForQuery: () => [],
+          });
+        const resolver = vi.fn().mockResolvedValue(client);
+        const repo = new SimulationClickHouseRepository(resolver);
+
+        await repo.getRunDataForAllSuites({ projectId: "project-1" });
+
+        const batchQuery = getCapturedQueries().find((q) =>
+          q.query.includes("GROUP BY BatchRunId")
+        );
+        expect(batchQuery?.query).not.toMatch(
+          /any\(IF\(ScenarioSetId[^)]*\)\)\s+AS\s+ScenarioSetId\b/
+        );
+        expect(batchQuery?.query).toMatch(
+          /any\(IF\(ScenarioSetId[^)]*\)\)\s+AS\s+NormalizedSetId\b/
         );
       });
     });

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -703,15 +703,19 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     
     const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.havingClause].filter(Boolean).join(" AND ")}`;
 
+    // NOTE: The aggregate is aliased as NormalizedSetId (not ScenarioSetId) on
+    // purpose — aliasing as ScenarioSetId would shadow the underlying column
+    // referenced in the dedup IN-tuple below, causing ClickHouse to reject the
+    // query with "Aggregate function ... is found in WHERE in query".
     const batchRows = await this.queryRows<{
       BatchRunId: string;
       MaxCreatedAt: string;
-      ScenarioSetId: string;
+      NormalizedSetId: string;
     }>(
       `SELECT
         BatchRunId,
         toString(toUnixTimestamp64Milli(max(CreatedAt))) AS MaxCreatedAt,
-        any(IF(ScenarioSetId = '', 'default', ScenarioSetId)) AS ScenarioSetId -- Must match DEFAULT_SET_ID from internal-set-id.ts
+        any(IF(ScenarioSetId = '', 'default', ScenarioSetId)) AS NormalizedSetId -- Must match DEFAULT_SET_ID from internal-set-id.ts
        FROM ${TABLE_NAME}
        WHERE TenantId = {tenantId:String}
          ${dateFilter.whereClause}
@@ -743,7 +747,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
 
     const scenarioSetIds: Record<string, string> = {};
     for (const row of pageRows) {
-      scenarioSetIds[row.BatchRunId] = row.ScenarioSetId;
+      scenarioSetIds[row.BatchRunId] = row.NormalizedSetId;
     }
 
     const batchRunIds = pageRows.map((r) => r.BatchRunId);


### PR DESCRIPTION
## Why

Closes #3265

The Simulations page has been returning a 500 on every `scenarios.getSuiteRunData` call since #3163 merged. ClickHouse rejects the query with:

```
Aggregate function any(IF(ScenarioSetId = '', 'default', ScenarioSetId))
AS ScenarioSetId is found in WHERE in query.
```

Users see a perpetually-empty suite run history and the tRPC client hammers the server with retries on every focus event.

## What changed

In `getRunDataForAllSuites()` (`simulation.clickhouse.repository.ts`), renamed the outer SELECT alias from `ScenarioSetId` → `NormalizedSetId`. That's it — one alias, two consumer updates (row type + map build), plus a comment explaining why the alias must not be `ScenarioSetId`.

## How it works

The offending query:

```sql
SELECT
  BatchRunId,
  toString(toUnixTimestamp64Milli(max(CreatedAt))) AS MaxCreatedAt,
  any(IF(ScenarioSetId = '', 'default', ScenarioSetId)) AS ScenarioSetId  -- alias shadows column
FROM simulation_runs
WHERE TenantId = {tenantId:String}
  AND ArchivedAt IS NULL
  AND (TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, UpdatedAt) IN ( ... )
GROUP BY BatchRunId
```

Before #3163 this worked because the `ScenarioSetId` column reference lived in a **nested subquery** (`FROM (SELECT ... LIMIT 1 BY ...)`) and the aggregate alias lived in the outer query — two scopes, no collision. #3163 flattened both into the same scope to use the IN-tuple dedup pattern, and ClickHouse started resolving `ScenarioSetId` in the WHERE-tuple to the **SELECT alias** (the aggregate) instead of the raw column. Aggregates aren't allowed in WHERE → query rejected.

The fix is a rename, not a structural change. Matches the `NormalizedSetId` convention already used in `getSetSummaries`.

## Test plan

- Added a unit regression test in `simulation.clickhouse.repository.unit.test.ts` that asserts the outer SELECT does **not** alias the aggregate as `ScenarioSetId` (to prevent regression). Fails on main, passes here.
- Updated mocked rows in the two existing `getRunDataForAllSuites` unit tests to use `NormalizedSetId` (matching the new SELECT alias), since the repo maps that field into the public `scenarioSetIds` record.
- `pnpm typecheck` — clean.
- `pnpm test:unit` on both affected files — 28/28 passing.

## Anything surprising?

**Detection gap.** All unit tests for this path use a mock ClickHouse client that only inspects the generated SQL string — the query is never executed, so ClickHouse's alias resolution error never fired in CI. The skipped integration tests (`simulation.clickhouse.repository.integration.test.ts:240`) cover this exact path but require a live ClickHouse; worth un-skipping via testcontainers as a follow-up so this class of bug can't slip through again.

Other 8 call sites touched by #3163 were audited and are **not** affected — they either don't alias anything as `ScenarioSetId` in the outer SELECT, or (like `getSetSummaries`) use `NormalizedSetId` already.