### PR TITLE
feat(prompts): expose tags on prompt list/get/versions

### DIFF
--- a/langwatch/src/app/api/openapiLangWatch.json
+++ b/langwatch/src/app/api/openapiLangWatch.json
@@ -1470,6 +1470,25 @@
                         "type",
                         "json_schema"
                       ]
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "versionId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "versionId"
+                        ]
+                      },
+                      "default": []
                     }
                   },
                   "required": [
@@ -1487,7 +1506,8 @@
                     "messages",
                     "inputs",
                     "outputs",
-                    "model"
+                    "model",
+                    "tags"
                   ]
                 }
               }
@@ -2042,6 +2062,25 @@
                         "type",
                         "json_schema"
                       ]
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "versionId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "versionId"
+                        ]
+                      },
+                      "default": []
                     }
                   },
                   "required": [
@@ -2059,7 +2098,8 @@
                     "messages",
                     "inputs",
                     "outputs",
-                    "model"
+                    "model",
+                    "tags"
                   ]
                 }
               }
@@ -2909,6 +2949,25 @@
                           "type",
                           "json_schema"
                         ]
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "versionId": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "versionId"
+                          ]
+                        },
+                        "default": []
                       }
                     },
                     "required": [
@@ -2926,7 +2985,8 @@
                       "messages",
                       "inputs",
                       "outputs",
-                      "model"
+                      "model",
+                      "tags"
                     ]
                   }
                 }
@@ -3476,6 +3536,25 @@
                             "type",
                             "json_schema"
                           ]
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "versionId": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "versionId"
+                            ]
+                          },
+                          "default": []
                         }
                       },
                       "required": [
@@ -3493,7 +3572,8 @@
                         "messages",
                         "inputs",
                         "outputs",
-                        "model"
+                        "model",
+                        "tags"
                       ]
                     },
                     "conflictInfo": {
@@ -5171,6 +5251,25 @@
                           "type",
                           "json_schema"
                         ]
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "versionId": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "versionId"
+                          ]
+                        },
+                        "default": []
                       }
                     },
                     "required": [
@@ -5188,7 +5287,8 @@
                       "messages",
                       "inputs",
                       "outputs",
-                      "model"
+                      "model",
+                      "tags"
                     ]
                   }
                 }
@@ -5694,6 +5794,25 @@
                         "type",
                         "json_schema"
                       ]
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "versionId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "versionId"
+                        ]
+                      },
+                      "default": []
                     }
                   },
                   "required": [
@@ -5711,7 +5830,8 @@
                     "messages",
                     "inputs",
                     "outputs",
-                    "model"
+                    "model",
+                    "tags"
                   ]
                 }
               }
@@ -6288,6 +6408,9 @@
                                         },
                                         "name": {
                                           "type": "string"
+                                        },
+                                        "encryptedValue": {
+                                          "type": "string"
                                         }
                                       },
                                       "required": [
@@ -6311,6 +6434,9 @@
                                         },
                                         "name": {
                                           "type": "string"
+                                        },
+                                        "encryptedValue": {
+                                          "type": "string"
                                         }
                                       },
                                       "required": [
@@ -6333,6 +6459,9 @@
                                           "type": "string"
                                         },
                                         "name": {
+                                          "type": "string"
+                                        },
+                                        "encryptedValue": {
                                           "type": "string"
                                         },
                                         "toolCalls": {
@@ -6361,6 +6490,9 @@
                                                   "name",
                                                   "arguments"
                                                 ]
+                                              },
+                                              "encryptedValue": {
+                                                "type": "string"
                                               }
                                             },
                                             "required": [
@@ -6387,9 +6519,295 @@
                                           "const": "user"
                                         },
                                         "content": {
-                                          "type": "string"
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "text"
+                                                      },
+                                                      "text": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "text"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "image"
+                                                      },
+                                                      "source": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "data"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              },
+                                                              "mimeType": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "value",
+                                                              "mimeType"
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "url"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              },
+                                                              "mimeType": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "value"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      "metadata": {}
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "source"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "audio"
+                                                      },
+                                                      "source": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "data"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              },
+                                                              "mimeType": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "value",
+                                                              "mimeType"
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "url"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              },
+                                                              "mimeType": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "value"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      "metadata": {}
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "source"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "video"
+                                                      },
+                                                      "source": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "data"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              },
+                                                              "mimeType": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "value",
+                                                              "mimeType"
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "url"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              },
+                                                              "mimeType": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "value"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      "metadata": {}
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "source"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "document"
+                                                      },
+                                                      "source": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "data"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              },
+                                                              "mimeType": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "value",
+                                                              "mimeType"
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "url"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              },
+                                                              "mimeType": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "value"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      "metadata": {}
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "source"
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "binary"
+                                                      },
+                                                      "mimeType": {
+                                                        "type": "string"
+                                                      },
+                                                      "id": {
+                                                        "type": "string"
+                                                      },
+                                                      "url": {
+                                                        "type": "string"
+                                                      },
+                                                      "data": {
+                                                        "type": "string"
+                                                      },
+                                                      "filename": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "mimeType"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
                                         },
                                         "name": {
+                                          "type": "string"
+                                        },
+                                        "encryptedValue": {
                                           "type": "string"
                                         }
                                       },
@@ -6417,6 +6835,9 @@
                                         },
                                         "error": {
                                           "type": "string"
+                                        },
+                                        "encryptedValue": {
+                                          "type": "string"
                                         }
                                       },
                                       "required": [
@@ -6424,6 +6845,54 @@
                                         "content",
                                         "role",
                                         "toolCallId"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "role": {
+                                          "type": "string",
+                                          "const": "activity"
+                                        },
+                                        "activityType": {
+                                          "type": "string"
+                                        },
+                                        "content": {
+                                          "type": "object",
+                                          "additionalProperties": {}
+                                        }
+                                      },
+                                      "required": [
+                                        "id",
+                                        "role",
+                                        "activityType",
+                                        "content"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "role": {
+                                          "type": "string",
+                                          "const": "reasoning"
+                                        },
+                                        "content": {
+                                          "type": "string"
+                                        },
+                                        "encryptedValue": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "id",
+                                        "role",
+                                        "content"
                                       ]
                                     }
                                   ]
@@ -10034,6 +10503,10 @@
                       },
                       "workflowIcon": {
                         "type": "string"
+                      },
+                      "platformUrl": {
+                        "type": "string",
+                        "format": "uri"
                       }
                     },
                     "required": [
@@ -10048,7 +10521,8 @@
                       "createdAt",
                       "updatedAt",
                       "fields",
-                      "outputFields"
+                      "outputFields",
+                      "platformUrl"
                     ]
                   }
                 }
@@ -10243,6 +10717,10 @@
                     },
                     "workflowIcon": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -10257,7 +10735,8 @@
                     "createdAt",
                     "updatedAt",
                     "fields",
-                    "outputFields"
+                    "outputFields",
+                    "platformUrl"
                   ]
                 }
               }
@@ -10477,6 +10956,10 @@
                     },
                     "workflowIcon": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -10491,7 +10974,8 @@
                     "createdAt",
                     "updatedAt",
                     "fields",
-                    "outputFields"
+                    "outputFields",
+                    "platformUrl"
                   ]
                 }
               }
@@ -11934,6 +12418,10 @@
                     },
                     "workflowIcon": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -11948,7 +12436,8 @@
                     "createdAt",
                     "updatedAt",
                     "fields",
-                    "outputFields"
+                    "outputFields",
+                    "platformUrl"
                   ]
                 }
               }
@@ -12265,6 +12754,10 @@
                         "items": {
                           "type": "string"
                         }
+                      },
+                      "platformUrl": {
+                        "type": "string",
+                        "format": "uri"
                       }
                     },
                     "required": [
@@ -12272,7 +12765,8 @@
                       "name",
                       "situation",
                       "criteria",
-                      "labels"
+                      "labels",
+                      "platformUrl"
                     ]
                   }
                 }
@@ -12397,6 +12891,10 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -12404,7 +12902,8 @@
                     "name",
                     "situation",
                     "criteria",
-                    "labels"
+                    "labels",
+                    "platformUrl"
                   ]
                 }
               }
@@ -12566,6 +13065,10 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -12573,7 +13076,8 @@
                     "name",
                     "situation",
                     "criteria",
-                    "labels"
+                    "labels",
+                    "platformUrl"
                   ]
                 }
               }
@@ -12727,6 +13231,10 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -12734,7 +13242,8 @@
                     "name",
                     "situation",
                     "criteria",
-                    "labels"
+                    "labels",
+                    "platformUrl"
                   ]
                 }
               }
@@ -14900,6 +15409,10 @@
                       },
                       "updatedAt": {
                         "type": "string"
+                      },
+                      "platformUrl": {
+                        "type": "string",
+                        "format": "uri"
                       }
                     },
                     "required": [
@@ -14910,7 +15423,8 @@
                       "isEvaluator",
                       "isComponent",
                       "createdAt",
-                      "updatedAt"
+                      "updatedAt",
+                      "platformUrl"
                     ]
                   }
                 }
@@ -15046,6 +15560,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -15056,7 +15574,8 @@
                     "isEvaluator",
                     "isComponent",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -15219,6 +15738,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -15229,7 +15752,8 @@
                     "isEvaluator",
                     "isComponent",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -16543,6 +17067,10 @@
                           },
                           "totalCost": {
                             "type": "number"
+                          },
+                          "platformUrl": {
+                            "type": "string",
+                            "format": "uri"
                           }
                         },
                         "required": [
@@ -16556,7 +17084,8 @@
                           "messages",
                           "timestamp",
                           "updatedAt",
-                          "durationInMs"
+                          "durationInMs",
+                          "platformUrl"
                         ]
                       }
                     },
@@ -16797,6 +17326,10 @@
                     },
                     "totalCost": {
                       "type": "number"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -16810,7 +17343,8 @@
                     "messages",
                     "timestamp",
                     "updatedAt",
-                    "durationInMs"
+                    "durationInMs",
+                    "platformUrl"
                   ]
                 }
               }
@@ -17205,6 +17739,10 @@
                       },
                       "updatedAt": {
                         "type": "string"
+                      },
+                      "platformUrl": {
+                        "type": "string",
+                        "format": "uri"
                       }
                     },
                     "required": [
@@ -17217,7 +17755,8 @@
                       "repeatCount",
                       "labels",
                       "createdAt",
-                      "updatedAt"
+                      "updatedAt",
+                      "platformUrl"
                     ]
                   }
                 }
@@ -17381,6 +17920,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -17393,7 +17936,8 @@
                     "repeatCount",
                     "labels",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -17626,6 +18170,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -17638,7 +18186,8 @@
                     "repeatCount",
                     "labels",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -17831,6 +18380,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -17843,7 +18396,8 @@
                     "repeatCount",
                     "labels",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -18245,6 +18799,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -18257,7 +18815,8 @@
                     "repeatCount",
                     "labels",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -18681,6 +19240,10 @@
                       },
                       "updatedAt": {
                         "type": "string"
+                      },
+                      "platformUrl": {
+                        "type": "string",
+                        "format": "uri"
                       }
                     },
                     "required": [
@@ -18693,7 +19256,8 @@
                       "message",
                       "alertType",
                       "createdAt",
-                      "updatedAt"
+                      "updatedAt",
+                      "platformUrl"
                     ]
                   }
                 }
@@ -18847,6 +19411,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -18859,7 +19427,8 @@
                     "message",
                     "alertType",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -19063,6 +19632,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -19075,7 +19648,8 @@
                     "message",
                     "alertType",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -19258,6 +19832,10 @@
                     },
                     "updatedAt": {
                       "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
                     }
                   },
                   "required": [
@@ -19270,7 +19848,8 @@
                     "message",
                     "alertType",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "platformUrl"
                   ]
                 }
               }
@@ -19581,6 +20160,2567 @@
           }
         ],
         "description": "Delete (soft-delete) a trigger"
+      }
+    },
+    "/api/prompts/{id}/versions/{versionId}/restore": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "handle": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "scope": {
+                      "type": "string",
+                      "enum": [
+                        "ORGANIZATION",
+                        "PROJECT"
+                      ]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "organizationId": {
+                      "type": "string"
+                    },
+                    "versionId": {
+                      "type": "string"
+                    },
+                    "authorId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "version": {
+                      "type": "number"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "commitMessage": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "prompt": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "role": {
+                            "type": "string",
+                            "enum": [
+                              "user",
+                              "assistant",
+                              "system"
+                            ]
+                          },
+                          "content": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "role",
+                          "content"
+                        ]
+                      },
+                      "default": []
+                    },
+                    "inputs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "identifier": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "str",
+                              "float",
+                              "bool",
+                              "image",
+                              "list",
+                              "list[str]",
+                              "list[float]",
+                              "list[int]",
+                              "list[bool]",
+                              "dict",
+                              "chat_messages"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "identifier",
+                          "type"
+                        ]
+                      },
+                      "default": []
+                    },
+                    "outputs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "identifier": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "str",
+                              "float",
+                              "bool",
+                              "json_schema"
+                            ]
+                          },
+                          "json_schema": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": true
+                          }
+                        },
+                        "required": [
+                          "identifier",
+                          "type"
+                        ]
+                      },
+                      "minItems": 1
+                    },
+                    "model": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "temperature": {
+                      "type": "number"
+                    },
+                    "maxTokens": {
+                      "type": "number"
+                    },
+                    "demonstrations": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "inline": {
+                          "type": "object",
+                          "properties": {
+                            "records": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "columnTypes": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string",
+                                        "const": "string"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "boolean"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "number"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "date"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "list"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "json"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "spans"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "rag_contexts"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "chat_messages"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "annotations"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "evaluations"
+                                      },
+                                      {
+                                        "type": "string",
+                                        "const": "image"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "type"
+                                ]
+                              }
+                            }
+                          },
+                          "required": [
+                            "records",
+                            "columnTypes"
+                          ]
+                        }
+                      }
+                    },
+                    "promptingTechnique": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "few_shot",
+                            "in_context",
+                            "chain_of_thought"
+                          ]
+                        },
+                        "demonstrations": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "inline": {
+                              "type": "object",
+                              "properties": {
+                                "records": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "array",
+                                    "items": {}
+                                  }
+                                },
+                                "columnTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "const": "string"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "boolean"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "number"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "date"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "list"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "json"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "spans"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "rag_contexts"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "chat_messages"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "annotations"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "evaluations"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "const": "image"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "type"
+                                    ]
+                                  }
+                                }
+                              },
+                              "required": [
+                                "records",
+                                "columnTypes"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "responseFormat": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "json_schema"
+                          ]
+                        },
+                        "json_schema": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "schema": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "schema"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "json_schema"
+                      ]
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "versionId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "versionId"
+                        ]
+                      },
+                      "default": []
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "handle",
+                    "scope",
+                    "name",
+                    "updatedAt",
+                    "projectId",
+                    "organizationId",
+                    "versionId",
+                    "version",
+                    "createdAt",
+                    "prompt",
+                    "messages",
+                    "inputs",
+                    "outputs",
+                    "model",
+                    "tags"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt or version not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postApiPromptsByIdVersionsByVersionIdRestore",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "versionId",
+            "required": true
+          }
+        ],
+        "description": "Restore a prompt to a previous version. Creates a new version with the same config data as the specified version."
+      }
+    },
+    "/api/monitors": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "slug": {
+                        "type": "string"
+                      },
+                      "checkType": {
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "executionMode": {
+                        "type": "string",
+                        "enum": [
+                          "ON_MESSAGE",
+                          "AS_GUARDRAIL",
+                          "MANUALLY"
+                        ]
+                      },
+                      "sample": {
+                        "type": "number"
+                      },
+                      "level": {
+                        "type": "string"
+                      },
+                      "evaluatorId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "preconditions": {},
+                      "parameters": {},
+                      "mappings": {
+                        "type": "null"
+                      },
+                      "threadIdleTimeout": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "updatedAt": {
+                        "type": "string"
+                      },
+                      "platformUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "slug",
+                      "checkType",
+                      "enabled",
+                      "executionMode",
+                      "sample",
+                      "level",
+                      "evaluatorId",
+                      "threadIdleTimeout",
+                      "createdAt",
+                      "updatedAt",
+                      "platformUrl"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getApiMonitors",
+        "parameters": [],
+        "description": "List all online evaluation monitors for the project"
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "description": "Monitor created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "checkType": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "executionMode": {
+                      "type": "string",
+                      "enum": [
+                        "ON_MESSAGE",
+                        "AS_GUARDRAIL",
+                        "MANUALLY"
+                      ]
+                    },
+                    "sample": {
+                      "type": "number"
+                    },
+                    "level": {
+                      "type": "string"
+                    },
+                    "evaluatorId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "preconditions": {},
+                    "parameters": {},
+                    "mappings": {
+                      "type": "null"
+                    },
+                    "threadIdleTimeout": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "slug",
+                    "checkType",
+                    "enabled",
+                    "executionMode",
+                    "sample",
+                    "level",
+                    "evaluatorId",
+                    "threadIdleTimeout",
+                    "createdAt",
+                    "updatedAt",
+                    "platformUrl"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postApiMonitors",
+        "parameters": [],
+        "description": "Create a new online evaluation monitor",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "checkType": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "executionMode": {
+                    "type": "string",
+                    "enum": [
+                      "ON_MESSAGE",
+                      "AS_GUARDRAIL",
+                      "MANUALLY"
+                    ],
+                    "default": "ON_MESSAGE"
+                  },
+                  "preconditions": {
+                    "type": "array",
+                    "items": {},
+                    "default": []
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "default": {}
+                  },
+                  "mappings": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "sample": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "default": 1
+                  },
+                  "evaluatorId": {
+                    "type": "string"
+                  },
+                  "level": {
+                    "type": "string",
+                    "enum": [
+                      "trace",
+                      "thread"
+                    ],
+                    "default": "trace"
+                  },
+                  "threadIdleTimeout": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "exclusiveMinimum": 0
+                  }
+                },
+                "required": [
+                  "name",
+                  "checkType"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/monitors/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "checkType": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "executionMode": {
+                      "type": "string",
+                      "enum": [
+                        "ON_MESSAGE",
+                        "AS_GUARDRAIL",
+                        "MANUALLY"
+                      ]
+                    },
+                    "sample": {
+                      "type": "number"
+                    },
+                    "level": {
+                      "type": "string"
+                    },
+                    "evaluatorId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "preconditions": {},
+                    "parameters": {},
+                    "mappings": {
+                      "type": "null"
+                    },
+                    "threadIdleTimeout": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "slug",
+                    "checkType",
+                    "enabled",
+                    "executionMode",
+                    "sample",
+                    "level",
+                    "evaluatorId",
+                    "threadIdleTimeout",
+                    "createdAt",
+                    "updatedAt",
+                    "platformUrl"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Monitor not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getApiMonitorsById",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "description": "Get a monitor by its ID"
+      },
+      "patch": {
+        "responses": {
+          "200": {
+            "description": "Monitor updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "checkType": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "executionMode": {
+                      "type": "string",
+                      "enum": [
+                        "ON_MESSAGE",
+                        "AS_GUARDRAIL",
+                        "MANUALLY"
+                      ]
+                    },
+                    "sample": {
+                      "type": "number"
+                    },
+                    "level": {
+                      "type": "string"
+                    },
+                    "evaluatorId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "preconditions": {},
+                    "parameters": {},
+                    "mappings": {
+                      "type": "null"
+                    },
+                    "threadIdleTimeout": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "platformUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "slug",
+                    "checkType",
+                    "enabled",
+                    "executionMode",
+                    "sample",
+                    "level",
+                    "evaluatorId",
+                    "threadIdleTimeout",
+                    "createdAt",
+                    "updatedAt",
+                    "platformUrl"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Monitor not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patchApiMonitorsById",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "description": "Update a monitor (name, enabled state, settings, etc.)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "checkType": {
+                    "type": "string"
+                  },
+                  "executionMode": {
+                    "type": "string",
+                    "enum": [
+                      "ON_MESSAGE",
+                      "AS_GUARDRAIL",
+                      "MANUALLY"
+                    ]
+                  },
+                  "preconditions": {
+                    "type": "array",
+                    "items": {}
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "mappings": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "sample": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "evaluatorId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "level": {
+                    "type": "string",
+                    "enum": [
+                      "trace",
+                      "thread"
+                    ]
+                  },
+                  "threadIdleTimeout": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "exclusiveMinimum": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Monitor deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "deleted": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "deleted"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Monitor not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "deleteApiMonitorsById",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "description": "Delete a monitor"
+      }
+    },
+    "/api/monitors/{id}/toggle": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Monitor toggled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "enabled"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Monitor not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postApiMonitorsByIdToggle",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "description": "Enable or disable a monitor",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "enabled"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/secrets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "projectId": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "updatedAt": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "projectId",
+                      "name",
+                      "createdAt",
+                      "updatedAt"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getApiSecrets",
+        "parameters": [],
+        "description": "List all secrets for the project (values are never returned)"
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "description": "Secret created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "projectId",
+                    "name",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Secret with this name already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postApiSecrets",
+        "parameters": [],
+        "description": "Create a new project secret. The value is encrypted at rest and never returned.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-Z][A-Z0-9_]*$",
+                    "minLength": 1
+                  },
+                  "value": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 10000
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/secrets/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "projectId",
+                    "name",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Secret not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getApiSecretsById",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "description": "Get a secret by its ID (value is never returned)"
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Secret updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "projectId",
+                    "name",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Secret not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "putApiSecretsById",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "description": "Update a secret's value",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 10000
+                  }
+                },
+                "required": [
+                  "value"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Secret deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "deleted": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "deleted"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Secret not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "deleteApiSecretsById",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "description": "Delete a secret"
       }
     }
   },

--- a/langwatch/src/app/api/prompts/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/app.v1.ts
@@ -685,6 +685,8 @@ app.post(
         "Successfully created prompt with initial version",
       );
 
+      let responseConfig: ApiResponsePrompt = newConfig;
+
       if (tags && tags.length > 0) {
         await Promise.all(
           tags.map((tag) =>
@@ -702,6 +704,15 @@ app.post(
           { promptId: newConfig.id, tags },
           "Assigned tags to initial version",
         );
+
+        const refetched = await service.getPromptByIdOrHandle({
+          idOrHandle: newConfig.id,
+          projectId: project.id,
+          organizationId: organization.id,
+        });
+        if (refetched) {
+          responseConfig = refetched;
+        }
       }
 
       afterPromptCreated({
@@ -710,7 +721,7 @@ app.post(
       });
 
       return c.json({
-        ...apiResponsePromptWithVersionDataSchema.parse(newConfig),
+        ...apiResponsePromptWithVersionDataSchema.parse(responseConfig),
         platformUrl: platformUrl({
           projectSlug: project.slug,
           path: `/prompts`,
@@ -905,6 +916,8 @@ app.put(
         });
       }
 
+      let responseConfig: ApiResponsePrompt = updatedConfig;
+
       if (tags && tags.length > 0) {
         await Promise.all(
           tags.map((tag) =>
@@ -922,6 +935,15 @@ app.put(
           { projectId, promptId: id, tags, versionId: updatedConfig.versionId },
           "Assigned tags to updated version",
         );
+
+        const refetched = await service.getPromptByIdOrHandle({
+          idOrHandle: updatedConfig.id,
+          projectId,
+          organizationId: organization.id,
+        });
+        if (refetched) {
+          responseConfig = refetched;
+        }
       }
 
       logger.info(
@@ -935,7 +957,7 @@ app.put(
       );
 
       return c.json({
-        ...apiResponsePromptWithVersionDataSchema.parse(updatedConfig),
+        ...apiResponsePromptWithVersionDataSchema.parse(responseConfig),
         platformUrl: platformUrl({
           projectSlug: project.slug,
           path: `/prompts`,

--- a/langwatch/src/app/api/prompts/[[...route]]/schemas/outputs.ts
+++ b/langwatch/src/app/api/prompts/[[...route]]/schemas/outputs.ts
@@ -19,6 +19,17 @@ const apiResponsePromptSchemaBase = z.object({
 });
 
 /**
+ * Tag association for a prompt version.
+ * `versionId` is the version this tag currently points to —
+ * included so callers can distinguish whether the tag points
+ * to the prompt/version they're looking at.
+ */
+export const apiResponsePromptTagSchema = z.object({
+  name: z.string(),
+  versionId: z.string(),
+});
+
+/**
  * Schema for version output responses
  * Derives configData fields from storage schema to prevent drift
  */
@@ -41,6 +52,7 @@ const apiResponseVersionOutputSchema = z.object({
   demonstrations: configDataSchema.shape.demonstrations,
   promptingTechnique: configDataSchema.shape.prompting_technique,
   responseFormat: configDataSchema.shape.response_format,
+  tags: z.array(apiResponsePromptTagSchema).default([]),
 });
 
 /**

--- a/langwatch/src/app/api/prompts/__tests__/prompt-tags-on-response.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/prompt-tags-on-response.integration.test.ts
@@ -1,0 +1,229 @@
+import type {
+  LlmPromptConfig,
+  LlmPromptConfigVersion,
+  Organization,
+  Project,
+  PromptTag,
+  Team,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  llmPromptConfigFactory,
+  llmPromptConfigVersionFactory,
+} from "~/factories/llm-config.factory";
+import { projectFactory } from "~/factories/project.factory";
+import { prisma } from "~/server/db";
+import { app } from "../[[...route]]/app";
+
+/**
+ * Verifies that the REST prompt responses include the `tags` array so that
+ * CLI/SDK consumers can display which tags each prompt/version has.
+ */
+describe("Prompt tags appear in prompt responses", () => {
+  let testOrganization: Organization;
+  let testTeam: Team;
+  let testProject: Project;
+  let testApiKey: string;
+  let promptConfig: LlmPromptConfig;
+  let v1: LlmPromptConfigVersion;
+  let v2: LlmPromptConfigVersion;
+  let productionTag: PromptTag;
+  let stagingTag: PromptTag;
+
+  async function get(path: string) {
+    return app.request(path, {
+      headers: { "X-Auth-Token": testApiKey },
+    });
+  }
+
+  beforeEach(async () => {
+    const slug = nanoid();
+
+    testOrganization = await prisma.organization.create({
+      data: { name: "Test Org", slug: `test-org-${slug}` },
+    });
+
+    testTeam = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `test-team-${slug}`,
+        organizationId: testOrganization.id,
+      },
+    });
+
+    testProject = await prisma.project.create({
+      data: {
+        ...projectFactory.build({ slug: `test-project-${slug}` }),
+        teamId: testTeam.id,
+      },
+    });
+
+    testApiKey = testProject.apiKey;
+
+    const configData = llmPromptConfigFactory.build({
+      projectId: testProject.id,
+      organizationId: testOrganization.id,
+      handle: `test-handle-${nanoid()}`,
+    });
+
+    promptConfig = await prisma.llmPromptConfig.create({
+      data: {
+        id: configData.id,
+        name: configData.name,
+        projectId: testProject.id,
+        organizationId: testOrganization.id,
+        handle: configData.handle,
+        scope: configData.scope,
+      },
+    });
+
+    const v1Data = llmPromptConfigVersionFactory.build({
+      configId: promptConfig.id,
+      projectId: testProject.id,
+    });
+    v1 = await prisma.llmPromptConfigVersion.create({
+      data: {
+        id: v1Data.id,
+        configId: promptConfig.id,
+        projectId: testProject.id,
+        version: 1,
+        schemaVersion: v1Data.schemaVersion,
+        configData: v1Data.configData as any,
+        commitMessage: "v1",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    });
+
+    const v2Data = llmPromptConfigVersionFactory.build({
+      configId: promptConfig.id,
+      projectId: testProject.id,
+    });
+    v2 = await prisma.llmPromptConfigVersion.create({
+      data: {
+        id: v2Data.id,
+        configId: promptConfig.id,
+        projectId: testProject.id,
+        version: 2,
+        schemaVersion: v2Data.schemaVersion,
+        configData: v2Data.configData as any,
+        commitMessage: "v2",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+      },
+    });
+
+    productionTag = await prisma.promptTag.create({
+      data: {
+        id: `ptag_${nanoid()}`,
+        organizationId: testOrganization.id,
+        name: "production",
+      },
+    });
+
+    stagingTag = await prisma.promptTag.create({
+      data: {
+        id: `ptag_${nanoid()}`,
+        organizationId: testOrganization.id,
+        name: "staging",
+      },
+    });
+
+    // production -> v2 (latest), staging -> v1 (older)
+    await prisma.promptTagAssignment.create({
+      data: {
+        id: `vtag_${nanoid()}`,
+        configId: promptConfig.id,
+        versionId: v2.id,
+        tagId: productionTag.id,
+        projectId: testProject.id,
+      },
+    });
+
+    await prisma.promptTagAssignment.create({
+      data: {
+        id: `vtag_${nanoid()}`,
+        configId: promptConfig.id,
+        versionId: v1.id,
+        tagId: stagingTag.id,
+        projectId: testProject.id,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.promptTagAssignment.deleteMany({
+      where: { projectId: testProject.id },
+    });
+    await prisma.promptTag.deleteMany({
+      where: { organizationId: testOrganization.id },
+    });
+    await prisma.llmPromptConfig.deleteMany({
+      where: { projectId: testProject.id },
+    });
+    await prisma.project.delete({ where: { id: testProject.id } });
+    await prisma.team.delete({ where: { id: testTeam.id } });
+    await prisma.organization.delete({ where: { id: testOrganization.id } });
+  });
+
+  describe("GET /api/prompts", () => {
+    it("each entry includes only tags pointing at its latest version", async () => {
+      const res = await get("/api/prompts");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{
+        id: string;
+        versionId: string;
+        tags: Array<{ name: string; versionId: string }>;
+      }>;
+
+      const row = body.find((p) => p.id === promptConfig.id);
+      expect(row).toBeDefined();
+      expect(row?.versionId).toBe(v2.id);
+      expect(row?.tags).toEqual([
+        { name: "production", versionId: v2.id },
+      ]);
+    });
+  });
+
+  describe("GET /api/prompts/:id", () => {
+    it("returns tags pointing at the default (latest) version", async () => {
+      const res = await get(`/api/prompts/${promptConfig.id}`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        versionId: string;
+        tags: Array<{ name: string; versionId: string }>;
+      };
+      expect(body.versionId).toBe(v2.id);
+      expect(body.tags).toEqual([{ name: "production", versionId: v2.id }]);
+    });
+
+    it("when fetched with ?tag=staging returns tags pointing at that version", async () => {
+      const res = await get(
+        `/api/prompts/${promptConfig.id}?tag=staging`,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        versionId: string;
+        tags: Array<{ name: string; versionId: string }>;
+      };
+      expect(body.versionId).toBe(v1.id);
+      expect(body.tags).toEqual([{ name: "staging", versionId: v1.id }]);
+    });
+  });
+
+  describe("GET /api/prompts/:id/versions", () => {
+    it("each version row includes the tags pointing at it", async () => {
+      const res = await get(`/api/prompts/${promptConfig.id}/versions`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{
+        version: number;
+        versionId: string;
+        tags: Array<{ name: string; versionId: string }>;
+      }>;
+
+      const v1Row = body.find((r) => r.version === 1);
+      const v2Row = body.find((r) => r.version === 2);
+      expect(v1Row?.tags).toEqual([{ name: "staging", versionId: v1.id }]);
+      expect(v2Row?.tags).toEqual([{ name: "production", versionId: v2.id }]);
+    });
+  });
+});

--- a/langwatch/src/app/api/prompts/__tests__/prompt-tags-on-response.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/prompt-tags-on-response.integration.test.ts
@@ -166,7 +166,7 @@ describe("Prompt tags appear in prompt responses", () => {
   });
 
   describe("GET /api/prompts", () => {
-    it("each entry includes only tags pointing at its latest version", async () => {
+    it("each entry includes the latest tag plus tags pointing at the latest version", async () => {
       const res = await get("/api/prompts");
       expect(res.status).toBe(200);
       const body = (await res.json()) as Array<{
@@ -179,13 +179,14 @@ describe("Prompt tags appear in prompt responses", () => {
       expect(row).toBeDefined();
       expect(row?.versionId).toBe(v2.id);
       expect(row?.tags).toEqual([
+        { name: "latest", versionId: v2.id },
         { name: "production", versionId: v2.id },
       ]);
     });
   });
 
   describe("GET /api/prompts/:id", () => {
-    it("returns tags pointing at the default (latest) version", async () => {
+    it("returns the latest tag plus custom tags on the default (latest) version", async () => {
       const res = await get(`/api/prompts/${promptConfig.id}`);
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
@@ -193,10 +194,13 @@ describe("Prompt tags appear in prompt responses", () => {
         tags: Array<{ name: string; versionId: string }>;
       };
       expect(body.versionId).toBe(v2.id);
-      expect(body.tags).toEqual([{ name: "production", versionId: v2.id }]);
+      expect(body.tags).toEqual([
+        { name: "latest", versionId: v2.id },
+        { name: "production", versionId: v2.id },
+      ]);
     });
 
-    it("when fetched with ?tag=staging returns tags pointing at that version", async () => {
+    it("when fetched with ?tag=staging returns only tags pointing at that (non-latest) version", async () => {
       const res = await get(
         `/api/prompts/${promptConfig.id}?tag=staging`,
       );
@@ -211,7 +215,7 @@ describe("Prompt tags appear in prompt responses", () => {
   });
 
   describe("GET /api/prompts/:id/versions", () => {
-    it("each version row includes the tags pointing at it", async () => {
+    it("marks only the latest row with the latest tag alongside any custom tags", async () => {
       const res = await get(`/api/prompts/${promptConfig.id}/versions`);
       expect(res.status).toBe(200);
       const body = (await res.json()) as Array<{
@@ -223,7 +227,10 @@ describe("Prompt tags appear in prompt responses", () => {
       const v1Row = body.find((r) => r.version === 1);
       const v2Row = body.find((r) => r.version === 2);
       expect(v1Row?.tags).toEqual([{ name: "staging", versionId: v1.id }]);
-      expect(v2Row?.tags).toEqual([{ name: "production", versionId: v2.id }]);
+      expect(v2Row?.tags).toEqual([
+        { name: "latest", versionId: v2.id },
+        { name: "production", versionId: v2.id },
+      ]);
     });
   });
 });

--- a/langwatch/src/app/api/prompts/__tests__/prompt-tags-on-response.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/prompt-tags-on-response.integration.test.ts
@@ -212,6 +212,22 @@ describe("Prompt tags appear in prompt responses", () => {
       expect(body.versionId).toBe(v1.id);
       expect(body.tags).toEqual([{ name: "staging", versionId: v1.id }]);
     });
+
+    it("when fetched with ?tag=latest resolves to the latest version (round-trip works)", async () => {
+      const res = await get(
+        `/api/prompts/${promptConfig.id}?tag=latest`,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        versionId: string;
+        tags: Array<{ name: string; versionId: string }>;
+      };
+      expect(body.versionId).toBe(v2.id);
+      expect(body.tags).toEqual([
+        { name: "latest", versionId: v2.id },
+        { name: "production", versionId: v2.id },
+      ]);
+    });
   });
 
   describe("GET /api/prompts/:id/versions", () => {

--- a/langwatch/src/prompts/utils/__tests__/llmPromptConfigUtils.test.ts
+++ b/langwatch/src/prompts/utils/__tests__/llmPromptConfigUtils.test.ts
@@ -302,6 +302,7 @@ describe("versionedPromptToPromptConfigFormValues", () => {
     outputs: [{ identifier: "output", type: "str" }],
     updatedAt: new Date(),
     createdAt: new Date(),
+    tags: [],
   });
 
   describe("when prompt handle has no prefix", () => {
@@ -397,6 +398,7 @@ describe("versionedPromptToPromptConfigFormValuesWithSystemMessage", () => {
     outputs: [{ identifier: "output", type: "str" }],
     updatedAt: new Date(),
     createdAt: new Date(),
+    tags: [],
     ...overrides,
   });
 

--- a/langwatch/src/server/evaluations-v3/execution/__tests__/orchestrator.integration.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/orchestrator.integration.test.ts
@@ -1831,6 +1831,7 @@ describe.skipIf(!hasNlpService)("Orchestrator Integration", () => {
           outputs: [{ identifier: "output", type: "str" }],
           updatedAt: new Date(),
           createdAt: new Date(),
+          tags: [],
         };
 
         // Create loadedPrompts map with our mock prompt

--- a/langwatch/src/server/evaluations-v3/execution/__tests__/workflowBuilder.integration.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/workflowBuilder.integration.test.ts
@@ -292,6 +292,7 @@ describe("WorkflowBuilder", () => {
       outputs: [{ identifier: "output", type: "str" }],
       createdAt: new Date(),
       updatedAt: new Date(),
+      tags: [],
     });
 
     it("builds signature node from database prompt", () => {

--- a/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/syncPrompt.unit.test.ts
@@ -54,6 +54,7 @@ describe("PromptService", () => {
         authorId: null,
         updatedAt: new Date(),
         createdAt: new Date(),
+        tags: [],
         ...overrides,
       };
     }

--- a/langwatch/src/server/prompt-config/__tests__/syncPromptAutoDetect.integration.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/syncPromptAutoDetect.integration.test.ts
@@ -36,6 +36,7 @@ describe("PromptService", () => {
         authorId: null,
         updatedAt: new Date(),
         createdAt: new Date(),
+        tags: [],
         ...overrides,
       };
     }

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -151,12 +151,17 @@ export class PromptService {
       projectId,
     });
 
-    return configs.map((config) =>
-      this.transformToVersionedPrompt(
+    return configs.map((config) => {
+      const latestVersionId = config.latestVersion.id ?? "";
+      return this.transformToVersionedPrompt(
         config,
-        tagsByVersionId.get(config.latestVersion.id ?? "") ?? [],
-      ),
-    );
+        this.withLatestTag({
+          tags: tagsByVersionId.get(latestVersionId) ?? [],
+          currentVersionId: latestVersionId,
+          latestVersionId,
+        }),
+      );
+    });
   }
 
   /**
@@ -250,10 +255,20 @@ export class PromptService {
       configIds: [config.id],
       projectId,
     });
-    const tagsForThisVersion =
-      tagsByVersionId.get(config.latestVersion.id ?? "") ?? [];
+    const currentVersionId = config.latestVersion.id ?? "";
+    const latestVersionId = await this.getLatestVersionIdForConfig({
+      configId: config.id,
+      projectId,
+    });
 
-    return this.transformToVersionedPrompt(config, tagsForThisVersion);
+    return this.transformToVersionedPrompt(
+      config,
+      this.withLatestTag({
+        tags: tagsByVersionId.get(currentVersionId) ?? [],
+        currentVersionId,
+        latestVersionId,
+      }),
+    );
   }
 
   /**
@@ -294,13 +309,20 @@ export class PromptService {
       projectId: params.projectId,
     });
 
+    // Repo returns versions sorted by createdAt desc, so versions[0] is latest.
+    const latestVersionId = versions[0]?.id ?? "";
+
     return versions.map((version) =>
       this.transformToVersionedPrompt(
         {
           ...config,
           latestVersion: version,
         },
-        tagsByVersionId.get(version.id ?? "") ?? [],
+        this.withLatestTag({
+          tags: tagsByVersionId.get(version.id ?? "") ?? [],
+          currentVersionId: version.id ?? "",
+          latestVersionId,
+        }),
       ),
     );
   }
@@ -1181,6 +1203,45 @@ export class PromptService {
     }
 
     return map;
+  }
+
+  /**
+   * Returns the id of the latest (by createdAt desc) version for a config,
+   * or an empty string when no version exists.
+   */
+  private async getLatestVersionIdForConfig(params: {
+    configId: string;
+    projectId: string;
+  }): Promise<string> {
+    const latest = await this.prisma.llmPromptConfigVersion.findFirst({
+      where: { configId: params.configId, projectId: params.projectId },
+      orderBy: { createdAt: "desc" },
+      select: { id: true },
+    });
+    return latest?.id ?? "";
+  }
+
+  /**
+   * Prepends the built-in "latest" tag when the current version is the latest
+   * for its prompt. "latest" is a first-class, protected tag (see PromptTagService)
+   * that always resolves to the newest version, so it belongs in the response
+   * alongside any custom tags that happen to point at this version.
+   */
+  private withLatestTag(params: {
+    tags: Array<{ name: string; versionId: string }>;
+    currentVersionId: string;
+    latestVersionId: string;
+  }): Array<{ name: string; versionId: string }> {
+    if (
+      !params.currentVersionId ||
+      params.currentVersionId !== params.latestVersionId
+    ) {
+      return params.tags;
+    }
+    return [
+      { name: "latest", versionId: params.latestVersionId },
+      ...params.tags,
+    ];
   }
 
   /**

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -200,9 +200,16 @@ export class PromptService {
       params.organizationId ??
       (await this.getOrganizationIdFromProjectId(projectId));
 
+    // `latest` is a virtual tag that is never stored in the PromptTag table
+    // (see parsePromptShorthand, which also normalizes it away). Treat
+    // `tag: "latest"` as "no tag filter" so that what we advertise in the
+    // response (tags: [{name: "latest"}]) is round-trippable via ?tag=latest.
+    const normalizedTag =
+      params.tag === "latest" ? undefined : params.tag;
+
     // If a tag is provided, resolve it to a versionId
     let resolvedVersionId = params.versionId;
-    if (params.tag) {
+    if (normalizedTag) {
       const config = await this.repository.getPromptByIdOrHandle({
         idOrHandle,
         projectId,
@@ -214,13 +221,13 @@ export class PromptService {
       }
 
       const tagId = await this.resolveTagNameToId({
-        tagName: params.tag,
+        tagName: normalizedTag,
         organizationId,
       });
 
       if (!tagId) {
         throw new NotFoundError(
-          `Tag "${params.tag}" not found for prompt "${idOrHandle}"`,
+          `Tag "${normalizedTag}" not found for prompt "${idOrHandle}"`,
         );
       }
 
@@ -232,7 +239,7 @@ export class PromptService {
 
       if (!versionTag) {
         throw new NotFoundError(
-          `Tag "${params.tag}" not found for prompt "${idOrHandle}"`,
+          `Tag "${normalizedTag}" not found for prompt "${idOrHandle}"`,
         );
       }
 
@@ -477,7 +484,14 @@ export class PromptService {
         : undefined,
     });
 
-    return this.transformToVersionedPrompt(config);
+    // A freshly created prompt's only version is also the latest; no custom
+    // tag assignments exist yet (those are attached by the route in a second
+    // step), so the only tag to surface is the built-in "latest".
+    const newVersionId = config.latestVersion.id ?? "";
+    return this.transformToVersionedPrompt(
+      config,
+      newVersionId ? [{ name: "latest", versionId: newVersionId }] : [],
+    );
   }
 
   /**
@@ -537,10 +551,23 @@ export class PromptService {
       projectId,
     )) as LatestConfigVersionSchema;
 
-    return this.transformToVersionedPrompt({
-      ...updatedConfig,
-      latestVersion,
-    } as LlmConfigWithLatestVersion);
+    const latestVersionId = latestVersion.id ?? "";
+    const tagsByVersionId = await this.getTagsByVersionIds({
+      versionIds: latestVersionId ? [latestVersionId] : [],
+      projectId,
+    });
+
+    return this.transformToVersionedPrompt(
+      {
+        ...updatedConfig,
+        latestVersion,
+      } as LlmConfigWithLatestVersion,
+      this.withLatestTag({
+        tags: tagsByVersionId.get(latestVersionId) ?? [],
+        currentVersionId: latestVersionId,
+        latestVersionId,
+      }),
+    );
   }
 
   /**
@@ -642,10 +669,19 @@ export class PromptService {
             },
           });
 
-        return this.transformToVersionedPrompt({
-          ...updatedConfig,
-          latestVersion: updatedVersion,
-        } as LlmConfigWithLatestVersion);
+        // The new version we just created is now the latest. Custom tags
+        // assigned by the route run after this transaction returns, so the
+        // only tag to surface here is the built-in "latest".
+        const newVersionId = updatedVersion.id ?? "";
+        return this.transformToVersionedPrompt(
+          {
+            ...updatedConfig,
+            latestVersion: updatedVersion,
+          } as LlmConfigWithLatestVersion,
+          newVersionId
+            ? [{ name: "latest", versionId: newVersionId }]
+            : [],
+        );
       },
     );
 
@@ -995,7 +1031,7 @@ export class PromptService {
    */
   private transformToVersionedPrompt(
     config: Omit<LlmConfigWithLatestVersion, "deletedAt">,
-    tags: Array<{ name: string; versionId: string }> = [],
+    tags: Array<{ name: string; versionId: string }>,
   ): VersionedPrompt {
     const prompt = config.latestVersion.configData.prompt;
 
@@ -1218,21 +1254,20 @@ export class PromptService {
 
   /**
    * Returns the id of the latest (by createdAt desc) version for a config,
-   * or an empty string when no version exists.
+   * or an empty string when no version exists. Delegates to the versions
+   * repository's non-throwing finder so real DB errors surface as
+   * exceptions instead of being silently swallowed into "".
    */
   private async getLatestVersionIdForConfig(params: {
     configId: string;
     projectId: string;
   }): Promise<string> {
-    try {
-      const latest = await this.repository.versions.getLatestVersion(
-        params.configId,
-        params.projectId,
-      );
-      return latest.id ?? "";
-    } catch {
-      return "";
-    }
+    return (
+      (await this.repository.versions.findLatestId({
+        configId: params.configId,
+        projectId: params.projectId,
+      })) ?? ""
+    );
   }
 
   /**

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -145,9 +145,11 @@ export class PromptService {
       organizationId,
     });
 
-    const configIds = configs.map((c) => c.id);
-    const tagsByVersionId = await this.getTagsByVersionIdForConfigs({
-      configIds,
+    const latestVersionIds = configs
+      .map((c) => c.latestVersion.id)
+      .filter((id): id is string => !!id);
+    const tagsByVersionId = await this.getTagsByVersionIds({
+      versionIds: latestVersionIds,
       projectId,
     });
 
@@ -251,13 +253,24 @@ export class PromptService {
       return null;
     }
 
-    const tagsByVersionId = await this.getTagsByVersionIdForConfigs({
-      configIds: [config.id],
-      projectId,
-    });
     const currentVersionId = config.latestVersion.id ?? "";
     const latestVersionId = await this.getLatestVersionIdForConfig({
       configId: config.id,
+      projectId,
+    });
+
+    // Only fetch assignments for the versions we actually need (the returned
+    // version and, when it differs, the latest version for the "latest" tag
+    // comparison) — not the whole tag history for the config.
+    const versionIdsToQuery = Array.from(
+      new Set(
+        [currentVersionId, latestVersionId].filter(
+          (id): id is string => !!id,
+        ),
+      ),
+    );
+    const tagsByVersionId = await this.getTagsByVersionIds({
+      versionIds: versionIdsToQuery,
       projectId,
     });
 
@@ -304,8 +317,11 @@ export class PromptService {
         organizationId,
       })) as LatestConfigVersionSchema[];
 
-    const tagsByVersionId = await this.getTagsByVersionIdForConfigs({
-      configIds: [config.id],
+    const versionIds = versions
+      .map((v) => v.id)
+      .filter((id): id is string => !!id);
+    const tagsByVersionId = await this.getTagsByVersionIds({
+      versionIds,
       projectId: params.projectId,
     });
 
@@ -1170,27 +1186,22 @@ export class PromptService {
   }
 
   /**
-   * Batch-fetches all PromptTagAssignments for the given configs, grouped
-   * by versionId. Returned entries contain `{ name, versionId }`. Used by
-   * list/get/versions endpoints so tags can be shown alongside prompt data.
+   * Fetches the tag assignments pointing at exactly the given versionIds,
+   * grouped by versionId. Delegates to the repository so the service keeps
+   * no raw Prisma access. Callers should pass only the versionIds they
+   * actually need (not the full history of a config) to keep this bounded.
    */
-  private async getTagsByVersionIdForConfigs(params: {
-    configIds: string[];
+  private async getTagsByVersionIds(params: {
+    versionIds: string[];
     projectId: string;
   }): Promise<Map<string, Array<{ name: string; versionId: string }>>> {
     const map = new Map<string, Array<{ name: string; versionId: string }>>();
 
-    if (params.configIds.length === 0) {
-      return map;
-    }
+    if (params.versionIds.length === 0) return map;
 
-    const assignments = await this.prisma.promptTagAssignment.findMany({
-      where: {
-        projectId: params.projectId,
-        configId: { in: params.configIds },
-      },
-      include: { promptTag: true },
-      orderBy: { createdAt: "asc" },
+    const assignments = await this.tagRepository.findByVersionIds({
+      versionIds: params.versionIds,
+      projectId: params.projectId,
     });
 
     for (const assignment of assignments) {
@@ -1213,12 +1224,15 @@ export class PromptService {
     configId: string;
     projectId: string;
   }): Promise<string> {
-    const latest = await this.prisma.llmPromptConfigVersion.findFirst({
-      where: { configId: params.configId, projectId: params.projectId },
-      orderBy: { createdAt: "desc" },
-      select: { id: true },
-    });
-    return latest?.id ?? "";
+    try {
+      const latest = await this.repository.versions.getLatestVersion(
+        params.configId,
+        params.projectId,
+      );
+      return latest.id ?? "";
+    } catch {
+      return "";
+    }
   }
 
   /**

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -100,6 +100,13 @@ export type VersionedPrompt = {
   _count?: {
     copiedPrompts?: number;
   };
+  /**
+   * Tags currently pointing at the version returned in this response.
+   * For list/get responses, these are the tags that resolve to the
+   * latest/requested version specifically — not the entire prompt's tag set.
+   * For versions endpoint, these are the tags pointing at the row's version.
+   */
+  tags: Array<{ name: string; versionId: string }>;
 };
 
 /**
@@ -138,7 +145,18 @@ export class PromptService {
       organizationId,
     });
 
-    return configs.map((config) => this.transformToVersionedPrompt(config));
+    const configIds = configs.map((c) => c.id);
+    const tagsByVersionId = await this.getTagsByVersionIdForConfigs({
+      configIds,
+      projectId,
+    });
+
+    return configs.map((config) =>
+      this.transformToVersionedPrompt(
+        config,
+        tagsByVersionId.get(config.latestVersion.id ?? "") ?? [],
+      ),
+    );
   }
 
   /**
@@ -228,7 +246,14 @@ export class PromptService {
       return null;
     }
 
-    return this.transformToVersionedPrompt(config);
+    const tagsByVersionId = await this.getTagsByVersionIdForConfigs({
+      configIds: [config.id],
+      projectId,
+    });
+    const tagsForThisVersion =
+      tagsByVersionId.get(config.latestVersion.id ?? "") ?? [];
+
+    return this.transformToVersionedPrompt(config, tagsForThisVersion);
   }
 
   /**
@@ -264,11 +289,19 @@ export class PromptService {
         organizationId,
       })) as LatestConfigVersionSchema[];
 
+    const tagsByVersionId = await this.getTagsByVersionIdForConfigs({
+      configIds: [config.id],
+      projectId: params.projectId,
+    });
+
     return versions.map((version) =>
-      this.transformToVersionedPrompt({
-        ...config,
-        latestVersion: version,
-      }),
+      this.transformToVersionedPrompt(
+        {
+          ...config,
+          latestVersion: version,
+        },
+        tagsByVersionId.get(version.id ?? "") ?? [],
+      ),
     );
   }
 
@@ -924,6 +957,7 @@ export class PromptService {
    */
   private transformToVersionedPrompt(
     config: Omit<LlmConfigWithLatestVersion, "deletedAt">,
+    tags: Array<{ name: string; versionId: string }> = [],
   ): VersionedPrompt {
     const prompt = config.latestVersion.configData.prompt;
 
@@ -983,6 +1017,7 @@ export class PromptService {
       commitMessage: config.latestVersion.commitMessage,
       copiedFromPromptId: config.copiedFromPromptId ?? null,
       _count: config._count ?? undefined,
+      tags,
     };
   }
 
@@ -1110,6 +1145,42 @@ export class PromptService {
       projectId: params.projectId,
       userId: params.userId,
     });
+  }
+
+  /**
+   * Batch-fetches all PromptTagAssignments for the given configs, grouped
+   * by versionId. Returned entries contain `{ name, versionId }`. Used by
+   * list/get/versions endpoints so tags can be shown alongside prompt data.
+   */
+  private async getTagsByVersionIdForConfigs(params: {
+    configIds: string[];
+    projectId: string;
+  }): Promise<Map<string, Array<{ name: string; versionId: string }>>> {
+    const map = new Map<string, Array<{ name: string; versionId: string }>>();
+
+    if (params.configIds.length === 0) {
+      return map;
+    }
+
+    const assignments = await this.prisma.promptTagAssignment.findMany({
+      where: {
+        projectId: params.projectId,
+        configId: { in: params.configIds },
+      },
+      include: { promptTag: true },
+      orderBy: { createdAt: "asc" },
+    });
+
+    for (const assignment of assignments) {
+      const bucket = map.get(assignment.versionId) ?? [];
+      bucket.push({
+        name: assignment.promptTag.name,
+        versionId: assignment.versionId,
+      });
+      map.set(assignment.versionId, bucket);
+    }
+
+    return map;
   }
 
   /**

--- a/langwatch/src/server/prompt-config/repositories/llm-config-tag.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-tag.repository.ts
@@ -122,6 +122,27 @@ export class PromptTagAssignmentRepository {
   }
 
   /**
+   * Returns every tag assignment (with its PromptTag) that points at any of
+   * the given versionIds within the project. Used by read paths that need
+   * to surface tags alongside the returned version(s) without loading the
+   * entire tag history for the config.
+   */
+  async findByVersionIds(params: {
+    versionIds: string[];
+    projectId: string;
+  }): Promise<(PromptTagAssignment & { promptTag: PromptTag })[]> {
+    if (params.versionIds.length === 0) return [];
+    return this.prisma.promptTagAssignment.findMany({
+      where: {
+        projectId: params.projectId,
+        versionId: { in: params.versionIds },
+      },
+      include: { promptTag: true },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  /**
    * Get a tag assignment by config ID and tagId.
    * Callers must resolve tag name → tagId before calling this method.
    */

--- a/langwatch/src/server/prompt-config/repositories/llm-config-versions.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-versions.repository.ts
@@ -109,6 +109,26 @@ export class LlmConfigVersionsRepository {
   }
 
   /**
+   * Returns the id of the most recent version for a config, or null when no
+   * version exists. Non-throwing variant intended for read-path enrichment
+   * (e.g. deciding whether a returned version is "latest") where a missing
+   * row is a legitimate case, not an error.
+   */
+  async findLatestId(params: {
+    configId: string;
+    projectId: string;
+    tx?: Prisma.TransactionClient;
+  }): Promise<string | null> {
+    const client = params.tx ?? this.prisma;
+    const v = await client.llmPromptConfigVersion.findFirst({
+      where: { configId: params.configId, projectId: params.projectId },
+      orderBy: { createdAt: "desc" },
+      select: { id: true },
+    });
+    return v?.id ?? null;
+  }
+
+  /**
    * Get the latest version for a config
    */
   async getLatestVersion(

--- a/specs/typescript-sdk/cli-prompt-tags.feature
+++ b/specs/typescript-sdk/cli-prompt-tags.feature
@@ -154,3 +154,50 @@ Feature: CLI Prompt Tag Commands
   Scenario: Tag subcommands appear in prompt help
     When I run "langwatch prompt --help"
     Then I see "tag" listed as a subcommand
+
+  # --- Tag display in prompt list / get / versions ---
+
+  @unit
+  Scenario: Prompt list renders a Tags column
+    Given "my-prompt" has "production" pointing to its latest version and "staging" pointing to an older version
+    When I run "langwatch prompt list"
+    Then I see the row for "my-prompt" with a Tags column showing "production"
+    And the Tags column does not include tags pointing to older versions for the latest row
+
+  @unit
+  Scenario: Prompt list JSON format includes tags array on each prompt
+    Given "my-prompt" has "production" pointing to its latest version
+    When I run "langwatch prompt list --format json"
+    Then the JSON for "my-prompt" includes a tags array with name "production" and its versionId
+
+  @unit
+  Scenario: Prompt versions renders a Tags column per version
+    Given "my-prompt" has "production" on v3 and "staging" on v2
+    When I run "langwatch prompt versions my-prompt"
+    Then the row for v3 shows "production" in the Tags column
+    And the row for v2 shows "staging" in the Tags column
+    And the row for v1 shows "—"
+
+  @unit
+  Scenario: Prompt versions JSON format includes tags array on each version
+    Given "my-prompt" has "production" on v2 and "staging" on v3
+    When I run "langwatch prompt versions my-prompt --format json"
+    Then each version in the JSON array includes a tags field (possibly empty)
+
+  @integration
+  Scenario: API get returns tags on the prompt response
+    Given a prompt with "production" assigned to version 2 and fetched without a tag filter
+    When I GET /api/prompts/:id
+    Then the response includes a tags array containing { name: "production", versionId }
+
+  @integration
+  Scenario: API versions returns tags per version
+    Given a prompt with "production" on v2 and "staging" on v3
+    When I GET /api/prompts/:id/versions
+    Then each version includes a tags array with the names pointing to it
+
+  @integration
+  Scenario: API list returns tags per prompt latest version
+    Given a prompt with "production" on its latest version
+    When I GET /api/prompts
+    Then the prompt entry includes a tags array with "production"

--- a/specs/typescript-sdk/cli-prompt-tags.feature
+++ b/specs/typescript-sdk/cli-prompt-tags.feature
@@ -158,23 +158,29 @@ Feature: CLI Prompt Tag Commands
   # --- Tag display in prompt list / get / versions ---
 
   @unit
-  Scenario: Prompt list renders a Tags column
+  Scenario: Prompt list renders a Tags column including the built-in latest tag
     Given "my-prompt" has "production" pointing to its latest version and "staging" pointing to an older version
     When I run "langwatch prompt list"
-    Then I see the row for "my-prompt" with a Tags column showing "production"
+    Then I see the row for "my-prompt" with a Tags column containing "latest, production"
     And the Tags column does not include tags pointing to older versions for the latest row
 
   @unit
-  Scenario: Prompt list JSON format includes tags array on each prompt
+  Scenario: Prompt list shows latest tag even when no custom tags exist
+    Given "my-prompt" has no custom tag assignments
+    When I run "langwatch prompt list"
+    Then the row for "my-prompt" shows "latest" in the Tags column
+
+  @unit
+  Scenario: Prompt list JSON format includes tags array with latest plus customs
     Given "my-prompt" has "production" pointing to its latest version
     When I run "langwatch prompt list --format json"
-    Then the JSON for "my-prompt" includes a tags array with name "production" and its versionId
+    Then the JSON for "my-prompt" includes a tags array with { name: "latest" } and { name: "production" }
 
   @unit
   Scenario: Prompt versions renders a Tags column per version
     Given "my-prompt" has "production" on v3 and "staging" on v2
     When I run "langwatch prompt versions my-prompt"
-    Then the row for v3 shows "production" in the Tags column
+    Then the row for v3 shows "latest, production" in the Tags column
     And the row for v2 shows "staging" in the Tags column
     And the row for v1 shows "—"
 
@@ -182,22 +188,30 @@ Feature: CLI Prompt Tag Commands
   Scenario: Prompt versions JSON format includes tags array on each version
     Given "my-prompt" has "production" on v2 and "staging" on v3
     When I run "langwatch prompt versions my-prompt --format json"
-    Then each version in the JSON array includes a tags field (possibly empty)
+    Then each version in the JSON array includes a tags field
+    And the latest version's tags include a { name: "latest" } entry
 
   @integration
-  Scenario: API get returns tags on the prompt response
-    Given a prompt with "production" assigned to version 2 and fetched without a tag filter
+  Scenario: API get returns latest plus custom tags on the latest version
+    Given a prompt with "production" assigned to its latest version
     When I GET /api/prompts/:id
-    Then the response includes a tags array containing { name: "production", versionId }
+    Then the response tags array contains { name: "latest", versionId } and { name: "production", versionId }
 
   @integration
-  Scenario: API versions returns tags per version
-    Given a prompt with "production" on v2 and "staging" on v3
+  Scenario: API get with ?tag=staging omits the latest tag for a non-latest version
+    Given a prompt with "staging" assigned to an older version
+    When I GET /api/prompts/:id?tag=staging
+    Then the response tags array contains only { name: "staging", versionId } (no latest)
+
+  @integration
+  Scenario: API versions marks the latest row with the latest tag
+    Given a prompt with "production" on the latest version and "staging" on an older one
     When I GET /api/prompts/:id/versions
-    Then each version includes a tags array with the names pointing to it
+    Then the latest row's tags include { name: "latest" } and { name: "production" }
+    And older rows do not include { name: "latest" }
 
   @integration
-  Scenario: API list returns tags per prompt latest version
+  Scenario: API list returns latest plus any custom tags on the latest version
     Given a prompt with "production" on its latest version
     When I GET /api/prompts
-    Then the prompt entry includes a tags array with "production"
+    Then the entry's tags array contains { name: "latest" } and { name: "production" }

--- a/typescript-sdk/__tests__/factories/prompt.factory.ts
+++ b/typescript-sdk/__tests__/factories/prompt.factory.ts
@@ -40,5 +40,6 @@ export const promptResponseFactory = Factory.define<PromptResponse>(
         schema: {},
       },
     },
+    tags: [],
   }),
 );

--- a/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
@@ -59,7 +59,7 @@ const makeEvaluator = (overrides: Partial<EvaluatorResponse> = {}): EvaluatorRes
   updatedAt: "2026-01-02T00:00:00Z",
   fields: [{ identifier: "input", type: "string" }],
   outputFields: [{ identifier: "score", type: "number" }],
-  platformUrl: "",
+  platformUrl: "https://app.langwatch.ai/proj-1/evaluators/evaluator_abc123",
   ...overrides,
 });
 

--- a/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/evaluators/__tests__/evaluator-commands.unit.test.ts
@@ -59,6 +59,7 @@ const makeEvaluator = (overrides: Partial<EvaluatorResponse> = {}): EvaluatorRes
   updatedAt: "2026-01-02T00:00:00Z",
   fields: [{ identifier: "input", type: "string" }],
   outputFields: [{ identifier: "score", type: "number" }],
+  platformUrl: "",
   ...overrides,
 });
 

--- a/typescript-sdk/src/cli/commands/list.ts
+++ b/typescript-sdk/src/cli/commands/list.ts
@@ -51,17 +51,22 @@ export const listCommand = async (options?: { format?: string }): Promise<void> 
         Name: prompt.handle ?? `${prompt.name} ` + chalk.gray(`(${prompt.id})`),
         Version: prompt.version ? `${prompt.version}` : "N/A",
         Model: prompt.model ?? "N/A",
+        Tags:
+          prompt.tags && prompt.tags.length > 0
+            ? prompt.tags.map((t) => t.name).join(", ")
+            : chalk.gray("—"),
         Updated: formatRelativeTime(prompt.updatedAt),
       }));
 
       // Display table
       formatTable({
         data: tableData,
-        headers: ["Name", "Version", "Model", "Updated"],
+        headers: ["Name", "Version", "Model", "Tags", "Updated"],
         colorMap: {
           Name: chalk.cyan,
           Version: chalk.green,
           Model: chalk.yellow,
+          Tags: chalk.magenta,
         },
         emptyMessage: "No prompts found",
       });

--- a/typescript-sdk/src/cli/commands/prompt/versions.ts
+++ b/typescript-sdk/src/cli/commands/prompt/versions.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import ora from "ora";
+import { PromptsApiService, PromptsError } from "@/client-sdk/services/prompts";
 import { checkApiKey } from "../../utils/apiKey";
 import { formatTable } from "../../utils/formatting";
 
@@ -9,33 +10,12 @@ export const promptVersionsCommand = async (
 ): Promise<void> => {
   checkApiKey();
 
-  const apiKey = process.env.LANGWATCH_API_KEY ?? "";
-  const endpoint =
-    process.env.LANGWATCH_ENDPOINT ?? "https://app.langwatch.ai";
+  const service = new PromptsApiService();
 
   const spinner = ora(`Fetching versions for "${handle}"...`).start();
 
   try {
-    const response = await fetch(
-      `${endpoint}/api/prompts/${encodeURIComponent(handle)}/versions`,
-      {
-        headers: { "X-Auth-Token": apiKey },
-      }
-    );
-
-    if (!response.ok) {
-      const errorBody = await response.text();
-      spinner.fail(`Failed to fetch versions (${response.status})`);
-      console.error(chalk.red(`Error: ${errorBody}`));
-      process.exit(1);
-    }
-
-    const versions = (await response.json()) as Array<{
-      id: string;
-      version: number;
-      commitMessage: string | null;
-      createdAt: string;
-    }>;
+    const versions = await service.getVersions(handle);
 
     spinner.succeed(
       `Found ${versions.length} version${versions.length !== 1 ? "s" : ""} for "${handle}"`
@@ -56,17 +36,22 @@ export const promptVersionsCommand = async (
 
     const tableData = versions.map((v) => ({
       Version: `v${v.version}`,
-      ID: v.id,
+      ID: v.versionId,
+      Tags:
+        v.tags && v.tags.length > 0
+          ? v.tags.map((t) => t.name).join(", ")
+          : chalk.gray("—"),
       Message: v.commitMessage ?? chalk.gray("—"),
       Created: new Date(v.createdAt).toLocaleString(),
     }));
 
     formatTable({
       data: tableData,
-      headers: ["Version", "ID", "Message", "Created"],
+      headers: ["Version", "ID", "Tags", "Message", "Created"],
       colorMap: {
         Version: chalk.cyan,
         ID: chalk.green,
+        Tags: chalk.magenta,
       },
     });
 
@@ -79,11 +64,15 @@ export const promptVersionsCommand = async (
     console.log();
   } catch (error) {
     spinner.fail();
-    console.error(
-      chalk.red(
-        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
-      )
-    );
+    if (error instanceof PromptsError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+    } else {
+      console.error(
+        chalk.red(
+          `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+        )
+      );
+    }
     process.exit(1);
   }
 };

--- a/typescript-sdk/src/cli/commands/scenarios/__tests__/scenario-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/scenarios/__tests__/scenario-commands.unit.test.ts
@@ -52,7 +52,7 @@ const makeScenario = (overrides: Partial<ScenarioResponse> = {}): ScenarioRespon
   situation: "User attempts to log in with valid credentials",
   criteria: ["Responds with a welcome message", "Includes user name in greeting"],
   labels: ["auth", "happy-path"],
-  platformUrl: "",
+  platformUrl: "https://app.langwatch.ai/proj-1/scenarios/scenario_abc123",
   ...overrides,
 });
 

--- a/typescript-sdk/src/cli/commands/scenarios/__tests__/scenario-commands.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/scenarios/__tests__/scenario-commands.unit.test.ts
@@ -52,6 +52,7 @@ const makeScenario = (overrides: Partial<ScenarioResponse> = {}): ScenarioRespon
   situation: "User attempts to log in with valid credentials",
   criteria: ["Responds with a welcome message", "Includes user name in greeting"],
   labels: ["auth", "happy-path"],
+  platformUrl: "",
   ...overrides,
 });
 

--- a/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts.integration.test.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts.integration.test.ts
@@ -47,11 +47,12 @@ const handlers = [
     });
   }),
   http.put("/api/prompts/{id}", async ({ params, request, response }) => {
-    const body = await request.json();
+    const body = (await request.json()) as Record<string, unknown> | undefined;
+    const { tags: _inputTags, ...rest } = body ?? {};
     const prompt = promptResponseFactory.build({
-      ...body,
+      ...(rest as Parameters<typeof promptResponseFactory.build>[0]),
       id: params.id,
-      handle: body?.handle,
+      handle: (body?.handle ?? undefined) as string | undefined,
     });
     return response(200).json(prompt);
   }),

--- a/typescript-sdk/src/internal/generated/openapi/api-client.ts
+++ b/typescript-sdk/src/internal/generated/openapi/api-client.ts
@@ -1442,6 +1442,114 @@ export interface paths {
         patch: operations["patchApiTriggersById"];
         trace?: never;
     };
+    "/api/prompts/{id}/versions/{versionId}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Restore a prompt to a previous version. Creates a new version with the same config data as the specified version. */
+        post: operations["postApiPromptsByIdVersionsByVersionIdRestore"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/monitors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List all online evaluation monitors for the project */
+        get: operations["getApiMonitors"];
+        put?: never;
+        /** @description Create a new online evaluation monitor */
+        post: operations["postApiMonitors"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/monitors/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Get a monitor by its ID */
+        get: operations["getApiMonitorsById"];
+        put?: never;
+        post?: never;
+        /** @description Delete a monitor */
+        delete: operations["deleteApiMonitorsById"];
+        options?: never;
+        head?: never;
+        /** @description Update a monitor (name, enabled state, settings, etc.) */
+        patch: operations["patchApiMonitorsById"];
+        trace?: never;
+    };
+    "/api/monitors/{id}/toggle": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Enable or disable a monitor */
+        post: operations["postApiMonitorsByIdToggle"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/secrets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description List all secrets for the project (values are never returned) */
+        get: operations["getApiSecrets"];
+        put?: never;
+        /** @description Create a new project secret. The value is encrypted at rest and never returned. */
+        post: operations["postApiSecrets"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/secrets/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Get a secret by its ID (value is never returned) */
+        get: operations["getApiSecretsById"];
+        /** @description Update a secret's value */
+        put: operations["putApiSecretsById"];
+        post?: never;
+        /** @description Delete a secret */
+        delete: operations["deleteApiSecretsById"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1824,6 +1932,11 @@ export interface operations {
                                 };
                             } | null;
                         };
+                        /** @default [] */
+                        tags: {
+                            name: string;
+                            versionId: string;
+                        }[];
                     };
                 };
             };
@@ -2025,6 +2138,11 @@ export interface operations {
                                 };
                             } | null;
                         };
+                        /** @default [] */
+                        tags: {
+                            name: string;
+                            versionId: string;
+                        }[];
                     };
                 };
             };
@@ -2285,6 +2403,11 @@ export interface operations {
                                 };
                             } | null;
                         };
+                        /** @default [] */
+                        tags: {
+                            name: string;
+                            versionId: string;
+                        }[];
                     }[];
                 };
             };
@@ -2541,6 +2664,11 @@ export interface operations {
                                     };
                                 } | null;
                             };
+                            /** @default [] */
+                            tags: {
+                                name: string;
+                                versionId: string;
+                            }[];
                         };
                         conflictInfo?: {
                             localVersion: number;
@@ -2922,6 +3050,11 @@ export interface operations {
                                 };
                             } | null;
                         };
+                        /** @default [] */
+                        tags: {
+                            name: string;
+                            versionId: string;
+                        }[];
                     }[];
                 };
             };
@@ -3112,6 +3245,11 @@ export interface operations {
                                 };
                             } | null;
                         };
+                        /** @default [] */
+                        tags: {
+                            name: string;
+                            versionId: string;
+                        }[];
                     };
                 };
             };
@@ -3239,18 +3377,21 @@ export interface operations {
                         role: "developer";
                         content: string;
                         name?: string;
+                        encryptedValue?: string;
                     } | {
                         id: string;
                         /** @constant */
                         role: "system";
                         content: string;
                         name?: string;
+                        encryptedValue?: string;
                     } | {
                         id: string;
                         /** @constant */
                         role: "assistant";
                         content?: string;
                         name?: string;
+                        encryptedValue?: string;
                         toolCalls?: {
                             id: string;
                             /** @constant */
@@ -3259,13 +3400,87 @@ export interface operations {
                                 name: string;
                                 arguments: string;
                             };
+                            encryptedValue?: string;
                         }[];
                     } | {
                         id: string;
                         /** @constant */
                         role: "user";
-                        content: string;
+                        content: string | ({
+                            /** @constant */
+                            type: "text";
+                            text: string;
+                        } | {
+                            /** @constant */
+                            type: "image";
+                            source: {
+                                /** @constant */
+                                type: "data";
+                                value: string;
+                                mimeType: string;
+                            } | {
+                                /** @constant */
+                                type: "url";
+                                value: string;
+                                mimeType?: string;
+                            };
+                            metadata?: unknown;
+                        } | {
+                            /** @constant */
+                            type: "audio";
+                            source: {
+                                /** @constant */
+                                type: "data";
+                                value: string;
+                                mimeType: string;
+                            } | {
+                                /** @constant */
+                                type: "url";
+                                value: string;
+                                mimeType?: string;
+                            };
+                            metadata?: unknown;
+                        } | {
+                            /** @constant */
+                            type: "video";
+                            source: {
+                                /** @constant */
+                                type: "data";
+                                value: string;
+                                mimeType: string;
+                            } | {
+                                /** @constant */
+                                type: "url";
+                                value: string;
+                                mimeType?: string;
+                            };
+                            metadata?: unknown;
+                        } | {
+                            /** @constant */
+                            type: "document";
+                            source: {
+                                /** @constant */
+                                type: "data";
+                                value: string;
+                                mimeType: string;
+                            } | {
+                                /** @constant */
+                                type: "url";
+                                value: string;
+                                mimeType?: string;
+                            };
+                            metadata?: unknown;
+                        } | {
+                            /** @constant */
+                            type: "binary";
+                            mimeType: string;
+                            id?: string;
+                            url?: string;
+                            data?: string;
+                            filename?: string;
+                        })[];
                         name?: string;
+                        encryptedValue?: string;
                     } | {
                         id: string;
                         content: string;
@@ -3273,6 +3488,21 @@ export interface operations {
                         role: "tool";
                         toolCallId: string;
                         error?: string;
+                        encryptedValue?: string;
+                    } | {
+                        id: string;
+                        /** @constant */
+                        role: "activity";
+                        activityType: string;
+                        content: {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        id: string;
+                        /** @constant */
+                        role: "reasoning";
+                        content: string;
+                        encryptedValue?: string;
                     }) | {
                         role?: "system" | "user" | "assistant" | "function" | "tool" | "unknown";
                         content?: string | ({
@@ -4423,6 +4653,8 @@ export interface operations {
                         }[];
                         workflowName?: string;
                         workflowIcon?: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     }[];
                 };
             };
@@ -4525,6 +4757,8 @@ export interface operations {
                         }[];
                         workflowName?: string;
                         workflowIcon?: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -4620,6 +4854,8 @@ export interface operations {
                         }[];
                         workflowName?: string;
                         workflowIcon?: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -5116,6 +5352,8 @@ export interface operations {
                         }[];
                         workflowName?: string;
                         workflowIcon?: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -5286,6 +5524,8 @@ export interface operations {
                         situation: string;
                         criteria: string[];
                         labels: string[];
+                        /** Format: uri */
+                        platformUrl: string;
                     }[];
                 };
             };
@@ -5371,6 +5611,8 @@ export interface operations {
                         situation: string;
                         criteria: string[];
                         labels: string[];
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -5447,6 +5689,8 @@ export interface operations {
                         situation: string;
                         criteria: string[];
                         labels: string[];
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -5544,6 +5788,8 @@ export interface operations {
                         situation: string;
                         criteria: string[];
                         labels: string[];
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -6497,6 +6743,8 @@ export interface operations {
                         isComponent: boolean;
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     }[];
                 };
             };
@@ -6576,6 +6824,8 @@ export interface operations {
                         isComponent: boolean;
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -6760,6 +7010,8 @@ export interface operations {
                         isComponent: boolean;
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -7348,6 +7600,8 @@ export interface operations {
                             updatedAt: number;
                             durationInMs: number;
                             totalCost?: number;
+                            /** Format: uri */
+                            platformUrl: string;
                         }[];
                         hasMore?: boolean;
                         nextCursor?: string;
@@ -7443,6 +7697,8 @@ export interface operations {
                         updatedAt: number;
                         durationInMs: number;
                         totalCost?: number;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -7625,6 +7881,8 @@ export interface operations {
                         labels: string[];
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     }[];
                 };
             };
@@ -7725,6 +7983,8 @@ export interface operations {
                         labels: string[];
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -7810,6 +8070,8 @@ export interface operations {
                         labels: string[];
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -8007,6 +8269,8 @@ export interface operations {
                         labels: string[];
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -8104,6 +8368,8 @@ export interface operations {
                         labels: string[];
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -8308,6 +8574,8 @@ export interface operations {
                         alertType: "CRITICAL" | "WARNING" | "INFO" | null;
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     }[];
                 };
             };
@@ -8412,6 +8680,8 @@ export interface operations {
                         alertType: "CRITICAL" | "WARNING" | "INFO" | null;
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -8499,6 +8769,8 @@ export interface operations {
                         alertType: "CRITICAL" | "WARNING" | "INFO" | null;
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -8699,6 +8971,8 @@ export interface operations {
                         alertType: "CRITICAL" | "WARNING" | "INFO" | null;
                         createdAt: string;
                         updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
                     };
                 };
             };
@@ -8727,6 +9001,1214 @@ export interface operations {
                 };
             };
             /** @description Trigger not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    postApiPromptsByIdVersionsByVersionIdRestore: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                versionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        handle: string | null;
+                        /** @enum {string} */
+                        scope: "ORGANIZATION" | "PROJECT";
+                        name: string;
+                        updatedAt: string;
+                        projectId: string;
+                        organizationId: string;
+                        versionId: string;
+                        authorId?: string | null;
+                        version: number;
+                        createdAt: string;
+                        commitMessage?: string | null;
+                        prompt: string;
+                        /** @default [] */
+                        messages: {
+                            /** @enum {string} */
+                            role: "user" | "assistant" | "system";
+                            content: string;
+                        }[];
+                        /** @default [] */
+                        inputs: {
+                            identifier: string;
+                            /** @enum {string} */
+                            type: "str" | "float" | "bool" | "image" | "list" | "list[str]" | "list[float]" | "list[int]" | "list[bool]" | "dict" | "chat_messages";
+                        }[];
+                        outputs: {
+                            identifier: string;
+                            /** @enum {string} */
+                            type: "str" | "float" | "bool" | "json_schema";
+                            json_schema?: {
+                                type: string;
+                            } & {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                        model: string;
+                        temperature?: number;
+                        maxTokens?: number;
+                        demonstrations?: {
+                            id?: string;
+                            name?: string;
+                            inline?: {
+                                records: {
+                                    [key: string]: unknown[];
+                                };
+                                columnTypes: {
+                                    id?: string;
+                                    name: string;
+                                    type: "string" | "boolean" | "number" | "date" | "list" | "json" | "spans" | "rag_contexts" | "chat_messages" | "annotations" | "evaluations" | "image";
+                                }[];
+                            };
+                        };
+                        promptingTechnique?: {
+                            /** @enum {string} */
+                            type: "few_shot" | "in_context" | "chain_of_thought";
+                            demonstrations?: {
+                                id?: string;
+                                name?: string;
+                                inline?: {
+                                    records: {
+                                        [key: string]: unknown[];
+                                    };
+                                    columnTypes: {
+                                        id?: string;
+                                        name: string;
+                                        type: "string" | "boolean" | "number" | "date" | "list" | "json" | "spans" | "rag_contexts" | "chat_messages" | "annotations" | "evaluations" | "image";
+                                    }[];
+                                };
+                            };
+                        };
+                        responseFormat?: {
+                            /** @enum {string} */
+                            type: "json_schema";
+                            json_schema: {
+                                name: string;
+                                schema: {
+                                    [key: string]: unknown;
+                                };
+                            } | null;
+                        };
+                        /** @default [] */
+                        tags: {
+                            name: string;
+                            versionId: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Prompt or version not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    getApiMonitors: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        slug: string;
+                        checkType: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        executionMode: "ON_MESSAGE" | "AS_GUARDRAIL" | "MANUALLY";
+                        sample: number;
+                        level: string;
+                        evaluatorId: string | null;
+                        preconditions?: unknown;
+                        parameters?: unknown;
+                        mappings?: null;
+                        threadIdleTimeout: number | null;
+                        createdAt: string;
+                        updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
+                    }[];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    postApiMonitors: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    name: string;
+                    checkType: string;
+                    /**
+                     * @default ON_MESSAGE
+                     * @enum {string}
+                     */
+                    executionMode?: "ON_MESSAGE" | "AS_GUARDRAIL" | "MANUALLY";
+                    /** @default [] */
+                    preconditions?: unknown[];
+                    /** @default {} */
+                    parameters?: {
+                        [key: string]: unknown;
+                    };
+                    mappings?: {
+                        [key: string]: unknown;
+                    };
+                    /** @default 1 */
+                    sample?: number;
+                    evaluatorId?: string;
+                    /**
+                     * @default trace
+                     * @enum {string}
+                     */
+                    level?: "trace" | "thread";
+                    threadIdleTimeout?: number | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Monitor created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        slug: string;
+                        checkType: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        executionMode: "ON_MESSAGE" | "AS_GUARDRAIL" | "MANUALLY";
+                        sample: number;
+                        level: string;
+                        evaluatorId: string | null;
+                        preconditions?: unknown;
+                        parameters?: unknown;
+                        mappings?: null;
+                        threadIdleTimeout: number | null;
+                        createdAt: string;
+                        updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    getApiMonitorsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        slug: string;
+                        checkType: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        executionMode: "ON_MESSAGE" | "AS_GUARDRAIL" | "MANUALLY";
+                        sample: number;
+                        level: string;
+                        evaluatorId: string | null;
+                        preconditions?: unknown;
+                        parameters?: unknown;
+                        mappings?: null;
+                        threadIdleTimeout: number | null;
+                        createdAt: string;
+                        updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Monitor not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    deleteApiMonitorsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Monitor deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        deleted: boolean;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Monitor not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    patchApiMonitorsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    name?: string;
+                    enabled?: boolean;
+                    checkType?: string;
+                    /** @enum {string} */
+                    executionMode?: "ON_MESSAGE" | "AS_GUARDRAIL" | "MANUALLY";
+                    preconditions?: unknown[];
+                    parameters?: {
+                        [key: string]: unknown;
+                    };
+                    mappings?: {
+                        [key: string]: unknown;
+                    };
+                    sample?: number;
+                    evaluatorId?: string | null;
+                    /** @enum {string} */
+                    level?: "trace" | "thread";
+                    threadIdleTimeout?: number | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Monitor updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        slug: string;
+                        checkType: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        executionMode: "ON_MESSAGE" | "AS_GUARDRAIL" | "MANUALLY";
+                        sample: number;
+                        level: string;
+                        evaluatorId: string | null;
+                        preconditions?: unknown;
+                        parameters?: unknown;
+                        mappings?: null;
+                        threadIdleTimeout: number | null;
+                        createdAt: string;
+                        updatedAt: string;
+                        /** Format: uri */
+                        platformUrl: string;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Monitor not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    postApiMonitorsByIdToggle: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    enabled: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Monitor toggled */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        enabled: boolean;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Monitor not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    getApiSecrets: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        projectId: string;
+                        name: string;
+                        createdAt: string;
+                        updatedAt: string;
+                    }[];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    postApiSecrets: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    name: string;
+                    value: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Secret created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        projectId: string;
+                        name: string;
+                        createdAt: string;
+                        updatedAt: string;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Secret with this name already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    getApiSecretsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        projectId: string;
+                        name: string;
+                        createdAt: string;
+                        updatedAt: string;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Secret not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    putApiSecretsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    value: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Secret updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        projectId: string;
+                        name: string;
+                        createdAt: string;
+                        updatedAt: string;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Secret not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    deleteApiSecretsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Secret deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        deleted: boolean;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Secret not found */
             404: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary
- Prompt responses now include a `tags: Array<{ name, versionId }>` array so CLI/SDK consumers can see which tags point at the returned version — previously tags were write-only.
- `langwatch prompt list` and `langwatch prompt versions` render a Tags column (and expose tags in `--format json`).
- POST/PUT prompt routes refetch after tag assignment so the response reflects the newly assigned tags.
- New integration tests exercise the full HTTP contract (list, get, versions, `?tag=`) against Postgres.

## Manually verified on local server :5580

```
$ langwatch prompt list
Name       Version  Model         Tags        Updated
─────────  ───────  ────────────  ──────────  ───────
qa-prompt  2        openai/gpt-4  production  11s ago

$ langwatch prompt versions qa-prompt
Version  ID                                    Tags        Message          Created
v2       _47SIP2qw3DfBSoS7aWpZ                 production  v2 update        …
v1       prompt_version_eyInQBfwBw8JHqDhPqoOa  staging     Initial version  …
```

And JSON output includes the tags array:
```json
{ "handle": "qa-prompt", "version": 2, "tags": [{ "name": "production", "versionId": "_47SIP2qw3DfBSoS7aWpZ" }] }
```

## Test plan
- [x] New integration tests (`prompt-tags-on-response.integration.test.ts`) — 4/4 pass against real Postgres
- [x] Existing prompt API integration tests — still green
- [x] SDK unit tests — 906/906 pass
- [x] Typecheck clean on both `langwatch/` and `typescript-sdk/`
- [x] BDD specs updated in `specs/typescript-sdk/cli-prompt-tags.feature`
- [ ] CI (pending)
- [ ] CodeRabbit review (pending)