### PR TITLE
fix(scenarios): runs filters navigate to correct URL (#3191)

### DIFF
--- a/langwatch/src/components/suites/__tests__/RunsFilterUrlSync.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunsFilterUrlSync.integration.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression test for bug #3191 — applying a filter on the Runs page must not
+ * flip the page into the "external set" view with the querystring rendered as
+ * the set identifier.
+ *
+ * Exercises the real compat layer (~/utils/compat/next-router) inside a real
+ * react-router MemoryRouter, so the buildUrl/routeParamKeys logic introduced
+ * in #3205 is actually under test. No useRouter mocks.
+ *
+ * @see https://github.com/langwatch/langwatch/issues/3191
+ * @see https://github.com/langwatch/langwatch/pull/3205
+ */
+import React, { useEffect, useRef } from "react";
+import { render, screen, act, cleanup, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router";
+
+// The global test-setup.ts stubs ~/utils/compat/next-router with an empty
+// router. For these tests we need the real compat layer because the bug
+// under test lives in its buildUrl / routeParamKeys logic.
+vi.unmock("~/utils/compat/next-router");
+vi.mock("~/utils/compat/next-router", async () =>
+  await vi.importActual<object>("~/utils/compat/next-router"),
+);
+
+import {
+  ALL_RUNS_ID,
+  EXTERNAL_SET_PREFIX,
+  useSuiteRouting,
+} from "../useSuiteRouting";
+import { createRunHistoryStore } from "../useRunHistoryStore";
+import { useRouter } from "~/utils/compat/next-router";
+
+type Store = ReturnType<typeof createRunHistoryStore>;
+
+/**
+ * Mirrors RunHistoryPanel's syncToUrl-on-filter-change pattern without
+ * pulling in its heavy dependencies (tRPC hooks, Chakra, etc).
+ */
+function Harness({ store }: { store: Store }) {
+  const { selectedSuiteSlug } = useSuiteRouting();
+  const router = useRouter();
+  const location = useLocation();
+
+  const syncToUrl = store((s) => s.syncToUrl);
+  const filters = store((s) => s.filters);
+  const groupBy = store((s) => s.groupBy);
+
+  const prevFilters = useRef(filters);
+  const prevGroupBy = useRef(groupBy);
+
+  useEffect(() => {
+    if (
+      prevFilters.current !== filters ||
+      prevGroupBy.current !== groupBy
+    ) {
+      prevFilters.current = filters;
+      prevGroupBy.current = groupBy;
+      syncToUrl(router);
+    }
+  }, [filters, groupBy, syncToUrl, router]);
+
+  return (
+    <div>
+      <span data-testid="selection">{selectedSuiteSlug ?? "loading"}</span>
+      <span data-testid="pathname">{location.pathname}</span>
+      <span data-testid="search">{location.search}</span>
+    </div>
+  );
+}
+
+function renderHarness(initialUrl: string) {
+  const store = createRunHistoryStore();
+  render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <Routes>
+        <Route
+          path="/:project/simulations/*"
+          element={<Harness store={store} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+  return store;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("given the Runs page at /my-project/simulations (All Runs)", () => {
+  describe("when a passFailStatus filter is applied", () => {
+    it("keeps selection as all-runs and puts filter in the querystring", async () => {
+      const store = renderHarness("/my-project/simulations");
+
+      expect(screen.getByTestId("selection").textContent).toBe(ALL_RUNS_ID);
+      expect(screen.getByTestId("pathname").textContent).toBe(
+        "/my-project/simulations",
+      );
+
+      await act(async () => {
+        store.getState().setFilter("passFailStatus", "fail");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("search").textContent).toContain(
+          "passFailStatus=fail",
+        );
+      });
+
+      expect(screen.getByTestId("selection").textContent).toBe(ALL_RUNS_ID);
+      expect(screen.getByTestId("pathname").textContent).toBe(
+        "/my-project/simulations",
+      );
+      expect(screen.getByTestId("selection").textContent).not.toContain(
+        EXTERNAL_SET_PREFIX,
+      );
+    });
+  });
+
+  describe("when a scenarioId filter is applied", () => {
+    it("keeps selection as all-runs and puts filter in the querystring", async () => {
+      const store = renderHarness("/my-project/simulations");
+
+      expect(screen.getByTestId("selection").textContent).toBe(ALL_RUNS_ID);
+
+      await act(async () => {
+        store.getState().setFilter("scenarioId", "scen_1");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("search").textContent).toContain(
+          "scenarioId=scen_1",
+        );
+      });
+
+      expect(screen.getByTestId("selection").textContent).toBe(ALL_RUNS_ID);
+      expect(screen.getByTestId("pathname").textContent).toBe(
+        "/my-project/simulations",
+      );
+    });
+  });
+
+  describe("when a groupBy is applied", () => {
+    it("keeps selection as all-runs and puts groupBy in the querystring", async () => {
+      const store = renderHarness("/my-project/simulations");
+
+      expect(screen.getByTestId("selection").textContent).toBe(ALL_RUNS_ID);
+
+      await act(async () => {
+        store.getState().setGroupBy("scenario");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("search").textContent).toContain(
+          "groupBy=scenario",
+        );
+      });
+
+      expect(screen.getByTestId("selection").textContent).toBe(ALL_RUNS_ID);
+      expect(screen.getByTestId("pathname").textContent).toBe(
+        "/my-project/simulations",
+      );
+    });
+  });
+});
+
+describe("given the Runs page at /my-project/simulations/run-plans/critical-path (suite detail)", () => {
+  describe("when a filter is applied", () => {
+    it("keeps selection as critical-path and preserves the suite path", async () => {
+      const store = renderHarness(
+        "/my-project/simulations/run-plans/critical-path",
+      );
+
+      expect(screen.getByTestId("selection").textContent).toBe("critical-path");
+
+      await act(async () => {
+        store.getState().setFilter("passFailStatus", "pass");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("search").textContent).toContain(
+          "passFailStatus=pass",
+        );
+      });
+
+      expect(screen.getByTestId("selection").textContent).toBe("critical-path");
+      expect(screen.getByTestId("pathname").textContent).toBe(
+        "/my-project/simulations/run-plans/critical-path",
+      );
+    });
+  });
+});
+
+describe("given the Runs page at /my-project/simulations/python-examples (external set)", () => {
+  describe("when a filter is applied", () => {
+    it("keeps selection as external:python-examples and preserves the set path", async () => {
+      const store = renderHarness(
+        "/my-project/simulations/python-examples",
+      );
+
+      expect(screen.getByTestId("selection").textContent).toBe(
+        `${EXTERNAL_SET_PREFIX}python-examples`,
+      );
+
+      await act(async () => {
+        store.getState().setFilter("scenarioId", "scen_1");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("search").textContent).toContain(
+          "scenarioId=scen_1",
+        );
+      });
+
+      expect(screen.getByTestId("selection").textContent).toBe(
+        `${EXTERNAL_SET_PREFIX}python-examples`,
+      );
+      expect(screen.getByTestId("pathname").textContent).toBe(
+        "/my-project/simulations/python-examples",
+      );
+      // Bug symptom: selection would become "external:?scenarioId=scen_1" or
+      // similar if the compat layer leaks the querystring into path segments.
+      expect(screen.getByTestId("selection").textContent).not.toContain("?");
+      expect(screen.getByTestId("selection").textContent).not.toContain(
+        "scen_1",
+      );
+    });
+  });
+});

--- a/langwatch/src/components/suites/__tests__/RunsFilterUrlSync.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/RunsFilterUrlSync.integration.test.tsx
@@ -36,8 +36,11 @@ import { useRouter } from "~/utils/compat/next-router";
 type Store = ReturnType<typeof createRunHistoryStore>;
 
 /**
- * Mirrors RunHistoryPanel's syncToUrl-on-filter-change pattern without
- * pulling in its heavy dependencies (tRPC hooks, Chakra, etc).
+ * Mirrors the syncToUrl-on-filter-change effect in RunHistoryPanel
+ * (src/components/suites/RunHistoryPanel.tsx, look for the prevFilters/
+ * prevGroupBy useRef + useEffect). Must be kept in sync with that component.
+ * Extracting into a shared hook would be cleaner, but the effect is small
+ * enough that duplication is cheaper than the indirection for now.
  */
 function Harness({ store }: { store: Store }) {
   const { selectedSuiteSlug } = useSuiteRouting();

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -164,8 +164,14 @@ export interface CompatRouter {
 /** @internal Exported for testing only */
 export function buildUrl(
   url: string | { pathname?: string; query?: Record<string, any> },
-  routeParamKeys?: Set<string>
+  routeParamKeys?: Set<string>,
+  currentPathname?: string
 ): string {
+  // React Router's location is the source of truth in an SPA. Callers inside
+  // the useRouter() hook pass it explicitly; other callers fall back to
+  // window.location.pathname, which matches in BrowserRouter but is stale or
+  // wrong under MemoryRouter / race conditions.
+  const effectivePathname = currentPathname ?? window.location.pathname;
   if (typeof url === "string") {
     // For query-only strings ("?foo=bar"), strip route param keys that
     // leaked in from router.query spreads. Components do:
@@ -177,12 +183,12 @@ export function buildUrl(
         searchParams.delete(key);
       }
       const cleaned = searchParams.toString();
-      return cleaned ? `?${cleaned}` : window.location.pathname;
+      return cleaned ? `?${cleaned}` : effectivePathname;
     }
     return url;
   }
   // If pathname is omitted, use the current URL path (Next.js behavior)
-  let pathname = url.pathname ?? window.location.pathname;
+  let pathname = url.pathname ?? effectivePathname;
   const { query } = url;
 
   // Resolve Next.js-style [param] and [[...param]] in pathname using query values.
@@ -410,7 +416,7 @@ export function useRouter(): CompatRouter {
         // When `as` is provided (Next.js (url, as) overload), use it directly.
         // The `as` string is the actual browser URL; `url` is the internal route
         // descriptor which may contain [param] placeholders.
-        const target = _as ?? buildUrl(url, routeParamKeys);
+        const target = _as ?? buildUrl(url, routeParamKeys, location.pathname);
         navigate(target, { replace: false });
         if (options?.scroll !== false) {
           window.scrollTo(0, 0);
@@ -418,7 +424,7 @@ export function useRouter(): CompatRouter {
         return Promise.resolve(true);
       },
       replace: (url, _as?, options?) => {
-        const target = _as ?? buildUrl(url, routeParamKeys);
+        const target = _as ?? buildUrl(url, routeParamKeys, location.pathname);
         navigate(target, { replace: true });
         if (options?.scroll !== false) {
           window.scrollTo(0, 0);

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -84,6 +84,9 @@ const mockRouter = {
   beforePopState: vi.fn(),
 };
 
+// To opt out of this global mock (e.g. when testing the compat layer itself
+// against a real react-router MemoryRouter), see the vi.unmock pattern in
+// src/components/suites/__tests__/RunsFilterUrlSync.integration.test.tsx.
 vi.mock("~/utils/compat/next-router", () => ({
   useRouter: () => mockRouter,
   default: mockRouter,


### PR DESCRIPTION
## Why

Closes #3191.

On `/<project>/simulations/` (the Runs page), every filter — pass/fail status, scenario name, groupBy — navigated the user to `/?passFailStatus=fail` instead of `/<project>/simulations?passFailStatus=fail`. The Simulations route unmounted and, when the page re-rendered, the dangling querystring was interpreted as an external-set identifier, producing the broken UI:

```
EXTERNAL SET
?passFailStatus=fail
No run data found for this set.
```

Discovered during manual QA of Scenarios after the Vite migration (#3170). Affected every filter because they share the same URL-sync code path.

## What changed

`buildUrl` in the next-router compat layer fell back to `window.location.pathname` when a caller pushed a query-only URL (no explicit pathname). In a real SPA, React Router's `location` is the source of truth — `window.location` can be `/` (jsdom under test), stale after a programmatic navigate, or otherwise out of sync.

The fix threads the React Router `location.pathname` through as an explicit `currentPathname` parameter from inside the `useRouter()` hook. Callers without a React context (the `RouterSingleton` default export) keep the `window.location` fallback unchanged.

## Test plan

- New integration test `RunsFilterUrlSync.integration.test.tsx` exercises the **real** compat layer inside a `MemoryRouter` (no `useRouter` mocks). Covers:
  - `/simulations` + passFailStatus filter
  - `/simulations` + scenarioId filter
  - `/simulations` + groupBy
  - `/simulations/run-plans/critical-path` + filter
  - `/simulations/python-examples` + filter

  All five fail on the commit before the fix (`No routes matched location "/?…"`). All pass after.
- `pnpm test:unit src/utils/compat src/components/suites` → 521 passing, 0 regressions.
- `pnpm test:unit src/utils/compat/__tests__/next-router.unit.test.ts` → 24 passing (existing `buildUrl` unit tests still green — the new parameter is optional and defaults to prior behaviour).

## Anything surprising?

- This test file is the first under `src/components/suites/` to opt *out* of the global `~/utils/compat/next-router` mock from `test-setup.ts` via `vi.unmock` + `vi.importActual`. That global mock would otherwise hide any bug in the compat layer itself.
- PR #3205 previously fixed a related symptom (route params leaking into querystrings) by threading `routeParamKeys` into `buildUrl`. This PR is complementary — same function, different parameter that was still stale.


# Related Issue

- Resolve #3191