### PR TITLE
test(python-sdk): cleanup prompt leaks in e2e tests (#3164)

### DIFF
--- a/python-sdk/tests/e2e/conftest.py
+++ b/python-sdk/tests/e2e/conftest.py
@@ -4,8 +4,8 @@ pytest configuration and fixtures for e2e tests.
 Provides:
 - prompt_factory: function-scoped fixture that creates prompts and guarantees
   cleanup in teardown, even when the test body raises (issue #3164).
-- _prompt_leak_sweeper: session-scoped autouse fixture that deletes any
-  leftover e2e-prefixed prompts at the end of the test session.
+- _session_prompt_registry: session-scoped safety-net that deletes any prompts
+  created by this session that were not cleaned up by their per-test teardown.
 """
 
 import logging
@@ -14,12 +14,83 @@ from typing import Any, Callable, List
 import pytest
 
 import langwatch
+from langwatch.generated.langwatch_rest_api_client.errors import UnexpectedStatus
 
 logger = logging.getLogger(__name__)
 
 
+def _delete_prompt_with_narrow_handling(prompt_id: str, context: str) -> None:
+    """
+    Delete a single prompt, distinguishing 404 (already gone) from real errors.
+
+    - ``UnexpectedStatus`` with status_code 404 → debug log, continue
+    - ``UnexpectedStatus`` with any other status_code → warning log, continue
+    - Any other exception (network, etc.) → warning log, continue
+
+    Never raises — callers iterate lists and must clean up all remaining ids.
+    """
+    try:
+        langwatch.prompts.delete(prompt_id)
+        logger.info(
+            "%s: deleted prompt on teardown",
+            context,
+            extra={"prompt_id": prompt_id},
+        )
+    except UnexpectedStatus as exc:
+        if exc.status_code == 404:
+            logger.debug(
+                "%s: prompt already gone (404), skipping",
+                context,
+                extra={"prompt_id": prompt_id},
+            )
+        else:
+            logger.warning(
+                "%s: failed to delete prompt (HTTP %s), continuing cleanup",
+                context,
+                exc.status_code,
+                extra={"prompt_id": prompt_id, "status_code": exc.status_code},
+            )
+    except Exception as exc:
+        logger.warning(
+            "%s: failed to delete prompt (%s: %s), continuing cleanup",
+            context,
+            type(exc).__name__,
+            exc,
+            extra={"prompt_id": prompt_id},
+        )
+
+
+@pytest.fixture(scope="session")
+def _session_prompt_registry() -> List[str]:
+    """
+    Session-scoped safety-net registry of all prompt ids created this session.
+
+    The function-scoped ``prompt_factory`` appends to this list in addition to
+    its own per-test list.  At session end, any ids still in the registry are
+    deleted.  This catches prompts whose per-test teardown was skipped (e.g.
+    SIGKILL, process kill).
+
+    Unlike the old prefix-scan sweeper, this registry is collision-free — it
+    only touches ids created by *this* session, not prompts from other
+    concurrent CI runs on the same tenant.
+    """
+    registry: List[str] = []
+    yield registry
+
+    if not registry:
+        logger.debug("_session_prompt_registry: no prompts to sweep, skipping")
+        return
+
+    logger.info(
+        "_session_prompt_registry: sweeping %d prompt(s) left in session registry",
+        len(registry),
+    )
+    for prompt_id in registry:
+        _delete_prompt_with_narrow_handling(prompt_id, "_session_prompt_registry")
+
+
 @pytest.fixture
-def prompt_factory() -> Callable[..., Any]:
+def prompt_factory(_session_prompt_registry: List[str]) -> Callable[..., Any]:
     """
     Function-scoped factory fixture for creating prompts with guaranteed cleanup.
 
@@ -30,9 +101,11 @@ def prompt_factory() -> Callable[..., Any]:
 
     Usage::
 
+        from uuid import uuid4
+
         def test_something(prompt_factory):
             prompt = prompt_factory(
-                handle="e2e-my-prompt",
+                handle=f"e2e-my-prompt-{uuid4().hex[:8]}",
                 prompt="Hello world",
             )
             assert prompt.id
@@ -43,6 +116,7 @@ def prompt_factory() -> Callable[..., Any]:
         """Create a prompt and register it for teardown cleanup."""
         prompt = langwatch.prompts.create(**kwargs)
         created_ids.append(prompt.id)
+        _session_prompt_registry.append(prompt.id)
         logger.info(
             "prompt_factory: created prompt",
             extra={"prompt_id": prompt.id, "handle": kwargs.get("handle")},
@@ -53,80 +127,9 @@ def prompt_factory() -> Callable[..., Any]:
 
     # Teardown — runs even when the test body raised.
     for prompt_id in created_ids:
+        _delete_prompt_with_narrow_handling(prompt_id, "prompt_factory")
+        # Remove from session registry so session-end sweep doesn't double-delete.
         try:
-            langwatch.prompts.delete(prompt_id)
-            logger.info(
-                "prompt_factory: deleted prompt on teardown",
-                extra={"prompt_id": prompt_id},
-            )
-        except Exception as exc:
-            # A 404 means the test already deleted the prompt itself — that is
-            # fine.  Any other error is logged as a warning so it doesn't mask
-            # the original test failure.
-            logger.warning(
-                "prompt_factory: failed to delete prompt on teardown (already deleted or error)",
-                extra={"prompt_id": prompt_id, "error": str(exc)},
-            )
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _prompt_leak_sweeper() -> None:
-    """
-    Session-scoped safety-net that deletes leftover e2e-prefixed prompts.
-
-    Runs after all tests complete.  Matches prompts whose handle starts with
-    ``e2e-`` to avoid touching unrelated data.  Errors are swallowed so a
-    sweep failure never breaks the session teardown.
-    """
-    yield  # let all tests run first
-
-    try:
-        from langwatch.generated.langwatch_rest_api_client.api.default import (
-            get_api_prompts,
-        )
-        from langwatch.state import get_instance
-
-        instance = get_instance()
-        if instance is None:
-            logger.debug("_prompt_leak_sweeper: LangWatch not set up, skipping sweep")
-            return
-
-        resp = get_api_prompts.sync_detailed(client=instance.rest_api_client)
-        if int(resp.status_code) != 200 or not isinstance(resp.parsed, list):
-            logger.warning(
-                "_prompt_leak_sweeper: could not list prompts (status %s), skipping sweep",
-                resp.status_code,
-            )
-            return
-
-        e2e_prompts = [
-            item
-            for item in resp.parsed
-            if isinstance(item.handle, str) and item.handle.startswith("e2e-")
-        ]
-
-        if not e2e_prompts:
-            logger.debug("_prompt_leak_sweeper: no e2e-prefixed prompts found, nothing to sweep")
-            return
-
-        logger.info(
-            "_prompt_leak_sweeper: sweeping %d e2e-prefixed prompt(s)",
-            len(e2e_prompts),
-        )
-
-        for item in e2e_prompts:
-            try:
-                langwatch.prompts.delete(item.id)
-                logger.info(
-                    "_prompt_leak_sweeper: deleted leaked prompt",
-                    extra={"prompt_id": item.id, "handle": item.handle},
-                )
-            except Exception as exc:
-                logger.warning(
-                    "_prompt_leak_sweeper: failed to delete prompt %s (%s): %s",
-                    item.id,
-                    item.handle,
-                    exc,
-                )
-    except Exception as exc:
-        logger.warning("_prompt_leak_sweeper: sweep failed unexpectedly: %s", exc)
+            _session_prompt_registry.remove(prompt_id)
+        except ValueError:
+            pass  # already removed or never added (shouldn't happen)

--- a/python-sdk/tests/e2e/conftest.py
+++ b/python-sdk/tests/e2e/conftest.py
@@ -14,7 +14,6 @@ from typing import Any, Callable, List
 import pytest
 
 import langwatch
-from langwatch.generated.langwatch_rest_api_client.errors import UnexpectedStatus
 
 logger = logging.getLogger(__name__)
 
@@ -23,9 +22,14 @@ def _delete_prompt_with_narrow_handling(prompt_id: str, context: str) -> None:
     """
     Delete a single prompt, distinguishing 404 (already gone) from real errors.
 
-    - ``UnexpectedStatus`` with status_code 404 → debug log, continue
-    - ``UnexpectedStatus`` with any other status_code → warning log, continue
-    - Any other exception (network, etc.) → warning log, continue
+    ``langwatch.prompts.delete`` routes 404 responses through
+    ``unwrap_response``, which raises ``ValueError("Prompt not found: ...")``
+    (see ``langwatch.prompts.errors``).  We key off that message to treat
+    already-gone prompts as a debug-level no-op.
+
+    - ``ValueError`` whose message starts with "Prompt not found" → debug log
+    - Any other ``ValueError`` (e.g. 400) → warning log, continue
+    - Any other exception (network, 5xx, etc.) → warning log, continue
 
     Never raises — callers iterate lists and must clean up all remaining ids.
     """
@@ -36,8 +40,8 @@ def _delete_prompt_with_narrow_handling(prompt_id: str, context: str) -> None:
             context,
             extra={"prompt_id": prompt_id},
         )
-    except UnexpectedStatus as exc:
-        if exc.status_code == 404:
+    except ValueError as exc:
+        if str(exc).startswith("Prompt not found"):
             logger.debug(
                 "%s: prompt already gone (404), skipping",
                 context,
@@ -45,10 +49,10 @@ def _delete_prompt_with_narrow_handling(prompt_id: str, context: str) -> None:
             )
         else:
             logger.warning(
-                "%s: failed to delete prompt (HTTP %s), continuing cleanup",
+                "%s: failed to delete prompt (ValueError: %s), continuing cleanup",
                 context,
-                exc.status_code,
-                extra={"prompt_id": prompt_id, "status_code": exc.status_code},
+                exc,
+                extra={"prompt_id": prompt_id},
             )
     except Exception as exc:
         logger.warning(

--- a/python-sdk/tests/e2e/conftest.py
+++ b/python-sdk/tests/e2e/conftest.py
@@ -1,0 +1,132 @@
+"""
+pytest configuration and fixtures for e2e tests.
+
+Provides:
+- prompt_factory: function-scoped fixture that creates prompts and guarantees
+  cleanup in teardown, even when the test body raises (issue #3164).
+- _prompt_leak_sweeper: session-scoped autouse fixture that deletes any
+  leftover e2e-prefixed prompts at the end of the test session.
+"""
+
+import logging
+from typing import Any, Callable, List
+
+import pytest
+
+import langwatch
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def prompt_factory() -> Callable[..., Any]:
+    """
+    Function-scoped factory fixture for creating prompts with guaranteed cleanup.
+
+    Returns a callable that accepts the same keyword arguments as
+    ``langwatch.prompts.create(**kwargs)``.  Every prompt created through the
+    factory is tracked and deleted during fixture teardown — including when the
+    test body raises an exception (construction-enforced cleanup, issue #3164).
+
+    Usage::
+
+        def test_something(prompt_factory):
+            prompt = prompt_factory(
+                handle="e2e-my-prompt",
+                prompt="Hello world",
+            )
+            assert prompt.id
+    """
+    created_ids: List[str] = []
+
+    def create(**kwargs: Any) -> Any:
+        """Create a prompt and register it for teardown cleanup."""
+        prompt = langwatch.prompts.create(**kwargs)
+        created_ids.append(prompt.id)
+        logger.info(
+            "prompt_factory: created prompt",
+            extra={"prompt_id": prompt.id, "handle": kwargs.get("handle")},
+        )
+        return prompt
+
+    yield create
+
+    # Teardown — runs even when the test body raised.
+    for prompt_id in created_ids:
+        try:
+            langwatch.prompts.delete(prompt_id)
+            logger.info(
+                "prompt_factory: deleted prompt on teardown",
+                extra={"prompt_id": prompt_id},
+            )
+        except Exception as exc:
+            # A 404 means the test already deleted the prompt itself — that is
+            # fine.  Any other error is logged as a warning so it doesn't mask
+            # the original test failure.
+            logger.warning(
+                "prompt_factory: failed to delete prompt on teardown (already deleted or error)",
+                extra={"prompt_id": prompt_id, "error": str(exc)},
+            )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prompt_leak_sweeper() -> None:
+    """
+    Session-scoped safety-net that deletes leftover e2e-prefixed prompts.
+
+    Runs after all tests complete.  Matches prompts whose handle starts with
+    ``e2e-`` to avoid touching unrelated data.  Errors are swallowed so a
+    sweep failure never breaks the session teardown.
+    """
+    yield  # let all tests run first
+
+    try:
+        from langwatch.generated.langwatch_rest_api_client.api.default import (
+            get_api_prompts,
+        )
+        from langwatch.state import get_instance
+
+        instance = get_instance()
+        if instance is None:
+            logger.debug("_prompt_leak_sweeper: LangWatch not set up, skipping sweep")
+            return
+
+        resp = get_api_prompts.sync_detailed(client=instance.rest_api_client)
+        if int(resp.status_code) != 200 or not isinstance(resp.parsed, list):
+            logger.warning(
+                "_prompt_leak_sweeper: could not list prompts (status %s), skipping sweep",
+                resp.status_code,
+            )
+            return
+
+        e2e_prompts = [
+            item
+            for item in resp.parsed
+            if isinstance(item.handle, str) and item.handle.startswith("e2e-")
+        ]
+
+        if not e2e_prompts:
+            logger.debug("_prompt_leak_sweeper: no e2e-prefixed prompts found, nothing to sweep")
+            return
+
+        logger.info(
+            "_prompt_leak_sweeper: sweeping %d e2e-prefixed prompt(s)",
+            len(e2e_prompts),
+        )
+
+        for item in e2e_prompts:
+            try:
+                langwatch.prompts.delete(item.id)
+                logger.info(
+                    "_prompt_leak_sweeper: deleted leaked prompt",
+                    extra={"prompt_id": item.id, "handle": item.handle},
+                )
+            except Exception as exc:
+                logger.warning(
+                    "_prompt_leak_sweeper: failed to delete prompt %s (%s): %s",
+                    item.id,
+                    item.handle,
+                    exc,
+                )
+    except Exception as exc:
+        logger.warning("_prompt_leak_sweeper: sweep failed unexpectedly: %s", exc)

--- a/python-sdk/tests/e2e/test_fetch_policies_e2e.py
+++ b/python-sdk/tests/e2e/test_fetch_policies_e2e.py
@@ -175,7 +175,7 @@ class TestFetchPoliciesE2E:
             langwatch.setup(debug=True)
 
             # Create prompt on server
-            created_prompt = prompt_factory(
+            prompt_factory(
                 handle=handle,
                 prompt=prompt_content,
             )
@@ -212,7 +212,7 @@ class TestFetchPoliciesE2E:
             langwatch.setup(debug=True)
 
             # Create prompt on server
-            created_prompt = prompt_factory(
+            prompt_factory(
                 handle=handle,
                 prompt=prompt_content,
             )
@@ -298,7 +298,7 @@ class TestFetchPoliciesE2E:
             langwatch.setup(debug=True)
 
             # Create prompt on server
-            created_prompt = prompt_factory(
+            prompt_factory(
                 handle=handle,
                 prompt=prompt_content,
             )

--- a/python-sdk/tests/e2e/test_fetch_policies_e2e.py
+++ b/python-sdk/tests/e2e/test_fetch_policies_e2e.py
@@ -15,7 +15,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 import contextlib
-import logging
 import subprocess
 import tempfile
 import time
@@ -29,8 +28,6 @@ import pytest
 import langwatch
 from langwatch.prompts.local_loader import LocalPromptLoader
 from langwatch.prompts.types import FetchPolicy
-
-logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
@@ -161,7 +158,7 @@ class TestFetchPoliciesE2E:
             assert calls["count"] == 0
 
     def test_materialized_first_falls_back_to_api_when_local_missing(
-        self, temp_workspace
+        self, prompt_factory, temp_workspace
     ):
         """
         Test MATERIALIZED_FIRST policy falls back to API when local missing.
@@ -178,36 +175,28 @@ class TestFetchPoliciesE2E:
             langwatch.setup(debug=True)
 
             # Create prompt on server
-            created_prompt = langwatch.prompts.create(
+            created_prompt = prompt_factory(
                 handle=handle,
                 prompt=prompt_content,
             )
 
-            try:
-                # Run the example with HTTP request counting
-                with http_request_counter() as calls:
-                    prompt = langwatch.prompts.get(
-                        handle
-                    )  # Uses default MATERIALIZED_FIRST
+            # Run the example with HTTP request counting
+            with http_request_counter() as calls:
+                prompt = langwatch.prompts.get(
+                    handle
+                )  # Uses default MATERIALIZED_FIRST
 
-                # Verify the prompt was returned correctly
-                assert prompt is not None
-                assert prompt.handle == handle
-                assert prompt_content in (prompt.prompt or "")
+            # Verify the prompt was returned correctly
+            assert prompt is not None
+            assert prompt.handle == handle
+            assert prompt_content in (prompt.prompt or "")
 
-                # Should have made at least one API call (since no local file exists)
-                assert calls["count"] > 0
+            # Should have made at least one API call (since no local file exists)
+            assert calls["count"] > 0
 
-            finally:
-                # Clean up
-                try:
-                    langwatch.prompts.delete(created_prompt.id)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to delete prompt %s: %s", created_prompt.id, e
-                    )
-
-    def test_always_fetch_returns_server_prompt_and_hits_api(self, temp_workspace):
+    def test_always_fetch_returns_server_prompt_and_hits_api(
+        self, prompt_factory, temp_workspace
+    ):
         """
         Test ALWAYS_FETCH policy returns server prompt and calls API.
 
@@ -223,37 +212,27 @@ class TestFetchPoliciesE2E:
             langwatch.setup(debug=True)
 
             # Create prompt on server
-            created_prompt = langwatch.prompts.create(
+            created_prompt = prompt_factory(
                 handle=handle,
                 prompt=prompt_content,
             )
 
-            try:
-                # Run the example with HTTP request counting
-                with http_request_counter() as calls:
-                    prompt = langwatch.prompts.get(
-                        handle, fetch_policy=FetchPolicy.ALWAYS_FETCH
-                    )
+            # Run the example with HTTP request counting
+            with http_request_counter() as calls:
+                prompt = langwatch.prompts.get(
+                    handle, fetch_policy=FetchPolicy.ALWAYS_FETCH
+                )
 
-                # Verify the prompt was returned correctly
-                assert prompt is not None
-                assert prompt.handle == handle
-                assert prompt_content in (prompt.prompt or "")
+            # Verify the prompt was returned correctly
+            assert prompt is not None
+            assert prompt.handle == handle
+            assert prompt_content in (prompt.prompt or "")
 
-                # Should have made at least one API call
-                assert calls["count"] > 0
-
-            finally:
-                # Clean up
-                try:
-                    langwatch.prompts.delete(created_prompt.id)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to delete prompt %s: %s", created_prompt.id, e
-                    )
+            # Should have made at least one API call
+            assert calls["count"] > 0
 
     def test_materialized_only_returns_local_prompt_without_api_call(
-        self, temp_workspace
+        self, prompt_factory, temp_workspace
     ):
         """
         Test MATERIALIZED_ONLY policy uses local files without API calls.
@@ -272,7 +251,7 @@ class TestFetchPoliciesE2E:
             langwatch.setup(debug=True)
 
             # Create prompt on server
-            server_prompt = langwatch.prompts.create(
+            server_prompt = prompt_factory(
                 handle=handle, prompt="Hello from MATERIALIZED_ONLY policy test"
             )
 
@@ -301,7 +280,9 @@ class TestFetchPoliciesE2E:
             # Should NOT have made any API calls
             assert calls["count"] == 0
 
-    def test_cache_ttl_caches_then_refreshes_after_expiry(self, temp_workspace):
+    def test_cache_ttl_caches_then_refreshes_after_expiry(
+        self, prompt_factory, temp_workspace
+    ):
         """
         Test CACHE_TTL policy caches responses and refreshes after TTL expiry.
 
@@ -317,46 +298,36 @@ class TestFetchPoliciesE2E:
             langwatch.setup(debug=True)
 
             # Create prompt on server
-            created_prompt = langwatch.prompts.create(
+            created_prompt = prompt_factory(
                 handle=handle,
                 prompt=prompt_content,
             )
 
-            try:
-                # First call - should hit API and cache
-                with http_request_counter() as calls_first:
-                    prompt1 = langwatch.prompts.get(
-                        handle,
-                        fetch_policy=FetchPolicy.CACHE_TTL,
-                        cache_ttl_minutes=0.0005,
-                    )  # Very short TTL
+            # First call - should hit API and cache
+            with http_request_counter() as calls_first:
+                prompt1 = langwatch.prompts.get(
+                    handle,
+                    fetch_policy=FetchPolicy.CACHE_TTL,
+                    cache_ttl_minutes=0.0005,
+                )  # Very short TTL
 
-                assert prompt1 is not None
-                assert calls_first["count"] > 0
+            assert prompt1 is not None
+            assert calls_first["count"] > 0
 
-                # Wait for cache to expire
-                time.sleep(0.1)  # 0.1 seconds > 0.03 seconds TTL
+            # Wait for cache to expire
+            time.sleep(0.1)  # 0.1 seconds > 0.03 seconds TTL
 
-                # Second call - cache expired, should hit API again
-                with http_request_counter() as calls_second:
-                    prompt2 = langwatch.prompts.get(
-                        handle,
-                        fetch_policy=FetchPolicy.CACHE_TTL,
-                        cache_ttl_minutes=0.0005,
-                    )
+            # Second call - cache expired, should hit API again
+            with http_request_counter() as calls_second:
+                prompt2 = langwatch.prompts.get(
+                    handle,
+                    fetch_policy=FetchPolicy.CACHE_TTL,
+                    cache_ttl_minutes=0.0005,
+                )
 
-                assert prompt2 is not None
-                assert calls_second["count"] > 0
+            assert prompt2 is not None
+            assert calls_second["count"] > 0
 
-                # Both prompts should be the same
-                assert prompt1.handle == prompt2.handle
-                assert prompt1.id == prompt2.id
-
-            finally:
-                # Clean up
-                try:
-                    langwatch.prompts.delete(created_prompt.id)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to delete prompt %s: %s", created_prompt.id, e
-                    )
+            # Both prompts should be the same
+            assert prompt1.handle == prompt2.handle
+            assert prompt1.id == prompt2.id

--- a/python-sdk/tests/e2e/test_prompt_cleanup_fixture_e2e.py
+++ b/python-sdk/tests/e2e/test_prompt_cleanup_fixture_e2e.py
@@ -1,0 +1,143 @@
+"""
+Regression tests for issue #3164 — prompt_factory fixture cleanup.
+
+These tests prove that the `prompt_factory` fixture deletes prompts during
+teardown even when the test body raises an exception, i.e. cleanup is
+construction-enforced rather than depending on the test's own try/finally.
+
+Prerequisites:
+- LANGWATCH_API_KEY environment variable must be set
+- The LangWatch server must be reachable
+"""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import logging
+from uuid import uuid4
+
+import pytest
+
+import langwatch
+from langwatch.prompts.local_loader import LocalPromptLoader
+from langwatch.prompts.types import FetchPolicy
+
+logger = logging.getLogger(__name__)
+
+# Module-level slot used to pass data from the xfail test to the proof test.
+# Tests run sequentially within a class, so alphabetical ordering guarantees
+# test_factory_creates_prompt_and_raises runs before
+# test_previous_raising_test_still_cleaned_up_its_prompt.
+_leaked_prompt_id: str | None = None
+
+
+@pytest.fixture
+def api_key():
+    """Ensure API key is available for e2e tests."""
+    key = os.getenv("LANGWATCH_API_KEY")
+    if not key:
+        pytest.skip("LANGWATCH_API_KEY environment variable not set")
+    return key
+
+
+@pytest.mark.e2e
+class TestPromptFactoryCleanup:
+    """
+    Regression tests for issue #3164.
+
+    Verify that the `prompt_factory` fixture deletes every prompt it created
+    during teardown — even when the test body raises before returning.
+
+    To run:
+        export LANGWATCH_API_KEY="your-api-key"
+        pytest tests/e2e/test_prompt_cleanup_fixture_e2e.py -v
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_langwatch(self, api_key):
+        """Set up LangWatch for each test."""
+        LocalPromptLoader._cached_project_root = None
+        LocalPromptLoader._warned_no_prompts_path = False
+        langwatch.setup(api_key=api_key)
+        yield
+        LocalPromptLoader._cached_project_root = None
+        LocalPromptLoader._warned_no_prompts_path = False
+
+    # ------------------------------------------------------------------
+    # Sanity check — prompt_factory returns a prompt with an id
+    # ------------------------------------------------------------------
+
+    def test_prompt_factory_yields_created_prompt_with_id(self, prompt_factory):
+        """
+        GIVEN a test requests the prompt_factory fixture
+        WHEN the factory is called to create a prompt
+        THEN the returned object has a non-empty id attribute
+        """
+        prompt = prompt_factory(
+            handle=f"e2e-factory-sanity-{uuid4().hex[:8]}",
+            prompt="Sanity check prompt from prompt_factory fixture",
+        )
+
+        assert prompt is not None
+        assert hasattr(prompt, "id")
+        assert prompt.id  # non-empty / truthy
+
+    # ------------------------------------------------------------------
+    # Cleanup-on-raise proof — two-test sequence
+    #
+    # Test A (xfail strict): creates a prompt and raises.
+    #   The fixture teardown must still delete the prompt.
+    #
+    # Test B: reads the prompt id recorded by test A and asserts it is gone.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.xfail(
+        reason="intentional raise to prove prompt_factory cleans up on exception",
+        strict=True,
+    )
+    def test_factory_creates_prompt_and_raises(self, prompt_factory):
+        """
+        GIVEN a test creates a prompt via prompt_factory
+        WHEN the test body raises after creation
+        THEN prompt_factory teardown still deletes the prompt
+        (this test is marked xfail strict — it is expected to raise)
+        """
+        global _leaked_prompt_id
+
+        prompt = prompt_factory(
+            handle=f"e2e-cleanup-raise-{uuid4().hex[:8]}",
+            prompt="This prompt must be deleted by the fixture even though we raise",
+        )
+
+        # Record the id so the sibling proof test can verify deletion.
+        _leaked_prompt_id = prompt.id
+
+        # Intentionally raise to simulate a test crash (CI kill, assertion, etc.)
+        raise RuntimeError(
+            "Intentional raise to verify construction-enforced cleanup (issue #3164)"
+        )
+
+    def test_previous_raising_test_still_cleaned_up_its_prompt(self):
+        """
+        GIVEN test_factory_creates_prompt_and_raises ran before this test
+        AND it raised an exception after creating a prompt
+        WHEN we look up the prompt id it recorded
+        THEN the prompt no longer exists on the server (fixture cleaned it up)
+
+        The SDK raises ValueError("... not found ...") on 404 for a deleted
+        prompt (see PromptsFacade.get). A successful cleanup therefore surfaces
+        as that ValueError; any other outcome (the call succeeding, or a
+        different exception) means the fixture failed to clean up.
+        """
+        if _leaked_prompt_id is None:
+            pytest.fail(
+                "test_factory_creates_prompt_and_raises did not record a prompt id — "
+                "check that it ran before this test"
+            )
+
+        with pytest.raises(ValueError, match="not found"):
+            langwatch.prompts.get(
+                _leaked_prompt_id, fetch_policy=FetchPolicy.ALWAYS_FETCH
+            )

--- a/python-sdk/tests/e2e/test_prompt_cleanup_fixture_e2e.py
+++ b/python-sdk/tests/e2e/test_prompt_cleanup_fixture_e2e.py
@@ -26,12 +26,6 @@ from langwatch.prompts.types import FetchPolicy
 
 logger = logging.getLogger(__name__)
 
-# Module-level slot used to pass data from the xfail test to the proof test.
-# Tests run sequentially within a class, so alphabetical ordering guarantees
-# test_factory_creates_prompt_and_raises runs before
-# test_previous_raising_test_still_cleaned_up_its_prompt.
-_leaked_prompt_id: str | None = None
-
 
 @pytest.fixture
 def api_key():
@@ -40,6 +34,25 @@ def api_key():
     if not key:
         pytest.skip("LANGWATCH_API_KEY environment variable not set")
     return key
+
+
+@pytest.fixture(scope="class")
+def _shared_state():
+    """
+    Class-scoped container for sharing state between ordered tests.
+
+    Used to pass the prompt id recorded by the xfail raise-test to the proof
+    test that asserts the id is gone.  A dict is preferred over a module global
+    because:
+    - The state is explicit and pytest-managed (cleaned up between class runs).
+    - It avoids mutation of module-level globals, which can bleed across test
+      collection if tests are re-run without a fresh process.
+
+    Test ordering within the class is guaranteed by CPython's method-definition
+    order, which pytest preserves.  The xfail test is defined first, so it runs
+    first and populates "prompt_id" before the proof test reads it.
+    """
+    return {}
 
 
 @pytest.mark.e2e
@@ -91,53 +104,55 @@ class TestPromptFactoryCleanup:
     #   The fixture teardown must still delete the prompt.
     #
     # Test B: reads the prompt id recorded by test A and asserts it is gone.
+    #
+    # Ordering: CPython preserves method-definition order; pytest collects in
+    # that order.  Test A is defined first, so it always runs before test B.
     # ------------------------------------------------------------------
 
     @pytest.mark.xfail(
         reason="intentional raise to prove prompt_factory cleans up on exception",
         strict=True,
     )
-    def test_factory_creates_prompt_and_raises(self, prompt_factory):
+    def test_factory_creates_prompt_and_raises(self, prompt_factory, _shared_state):
         """
         GIVEN a test creates a prompt via prompt_factory
         WHEN the test body raises after creation
         THEN prompt_factory teardown still deletes the prompt
         (this test is marked xfail strict — it is expected to raise)
         """
-        global _leaked_prompt_id
-
         prompt = prompt_factory(
             handle=f"e2e-cleanup-raise-{uuid4().hex[:8]}",
             prompt="This prompt must be deleted by the fixture even though we raise",
         )
 
         # Record the id so the sibling proof test can verify deletion.
-        _leaked_prompt_id = prompt.id
+        _shared_state["prompt_id"] = prompt.id
 
         # Intentionally raise to simulate a test crash (CI kill, assertion, etc.)
         raise RuntimeError(
             "Intentional raise to verify construction-enforced cleanup (issue #3164)"
         )
 
-    def test_previous_raising_test_still_cleaned_up_its_prompt(self):
+    def test_previous_raising_test_still_cleaned_up_its_prompt(self, _shared_state):
         """
         GIVEN test_factory_creates_prompt_and_raises ran before this test
         AND it raised an exception after creating a prompt
         WHEN we look up the prompt id it recorded
         THEN the prompt no longer exists on the server (fixture cleaned it up)
 
-        The SDK raises ValueError("... not found ...") on 404 for a deleted
+        The SDK raises ValueError("... found ...") on 404 for a deleted
         prompt (see PromptsFacade.get). A successful cleanup therefore surfaces
         as that ValueError; any other outcome (the call succeeding, or a
         different exception) means the fixture failed to clean up.
         """
-        if _leaked_prompt_id is None:
+        prompt_id = _shared_state.get("prompt_id")
+        if prompt_id is None:
             pytest.fail(
                 "test_factory_creates_prompt_and_raises did not record a prompt id — "
                 "check that it ran before this test"
             )
 
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(ValueError, match="found"):
             langwatch.prompts.get(
-                _leaked_prompt_id, fetch_policy=FetchPolicy.ALWAYS_FETCH
+                prompt_id, fetch_policy=FetchPolicy.ALWAYS_FETCH
             )

--- a/python-sdk/tests/e2e/test_prompt_tags_e2e.py
+++ b/python-sdk/tests/e2e/test_prompt_tags_e2e.py
@@ -147,7 +147,7 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-update-tags-{uuid4().hex[:8]}"
 
-        created = prompt_factory(
+        prompt_factory(
             handle=handle,
             prompt="Original content",
         )

--- a/python-sdk/tests/e2e/test_prompt_tags_e2e.py
+++ b/python-sdk/tests/e2e/test_prompt_tags_e2e.py
@@ -54,7 +54,7 @@ class TestPromptTagsE2E:
         LocalPromptLoader._cached_project_root = None
         LocalPromptLoader._warned_no_prompts_path = False
 
-    def test_assign_tag_then_fetch_by_tag(self):
+    def test_assign_tag_then_fetch_by_tag(self, prompt_factory):
         """
         GIVEN a prompt with a version on the server
         WHEN I assign the "production" tag to that version
@@ -63,32 +63,26 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-tag-assign-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Hello from tag assignment e2e test",
         )
 
-        try:
-            # Assign "production" tag to the created version
-            langwatch.prompts.tags.assign(
-                handle,
-                tag="production",
-                version_id=created.version_id,
-            )
+        # Assign "production" tag to the created version
+        langwatch.prompts.tags.assign(
+            handle,
+            tag="production",
+            version_id=created.version_id,
+        )
 
-            # Fetch by tag
-            fetched = langwatch.prompts.get(handle, tag="production")
+        # Fetch by tag
+        fetched = langwatch.prompts.get(handle, tag="production")
 
-            assert fetched is not None
-            assert fetched.handle == handle
-            assert fetched.version_id == created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.handle == handle
+        assert fetched.version_id == created.version_id
 
-    def test_fetch_without_tag_returns_latest(self):
+    def test_fetch_without_tag_returns_latest(self, prompt_factory):
         """
         GIVEN a prompt with two versions, where "production" is assigned to v1
         WHEN I fetch without a tag
@@ -96,40 +90,34 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-tag-latest-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Version 1 content",
         )
 
-        try:
-            # Assign production to v1
-            langwatch.prompts.tags.assign(
-                handle,
-                tag="production",
-                version_id=created.version_id,
-            )
+        # Assign production to v1
+        langwatch.prompts.tags.assign(
+            handle,
+            tag="production",
+            version_id=created.version_id,
+        )
 
-            # Update to create v2
-            updated = langwatch.prompts.update(
-                handle,
-                scope="PROJECT",
-                commit_message="Create v2 for tag test",
-                prompt="Version 2 content",
-            )
+        # Update to create v2
+        updated = langwatch.prompts.update(
+            handle,
+            scope="PROJECT",
+            commit_message="Create v2 for tag test",
+            prompt="Version 2 content",
+        )
 
-            # Fetch without tag -- expect latest (v2)
-            fetched = langwatch.prompts.get(handle)
+        # Fetch without tag -- expect latest (v2)
+        fetched = langwatch.prompts.get(handle)
 
-            assert fetched is not None
-            assert fetched.version_id == updated.version_id
-            assert fetched.version_id != created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.version_id == updated.version_id
+        assert fetched.version_id != created.version_id
 
-    def test_create_prompt_with_tags(self):
+    def test_create_prompt_with_tags(self, prompt_factory):
         """
         GIVEN a new prompt
         WHEN I create it with tags=["production"]
@@ -138,26 +126,20 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-create-tags-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Created with production tag",
             tags=["production"],
         )
 
-        try:
-            # Fetch by tag to verify assignment
-            fetched = langwatch.prompts.get(handle, tag="production")
+        # Fetch by tag to verify assignment
+        fetched = langwatch.prompts.get(handle, tag="production")
 
-            assert fetched is not None
-            assert fetched.handle == handle
-            assert fetched.version_id == created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.handle == handle
+        assert fetched.version_id == created.version_id
 
-    def test_update_prompt_with_tags(self):
+    def test_update_prompt_with_tags(self, prompt_factory):
         """
         GIVEN an existing prompt
         WHEN I update it with tags=["staging"]
@@ -165,33 +147,27 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-update-tags-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Original content",
         )
 
-        try:
-            updated = langwatch.prompts.update(
-                handle,
-                scope="PROJECT",
-                commit_message="Update with staging tag",
-                prompt="Updated with staging tag",
-                tags=["staging"],
-            )
+        updated = langwatch.prompts.update(
+            handle,
+            scope="PROJECT",
+            commit_message="Update with staging tag",
+            prompt="Updated with staging tag",
+            tags=["staging"],
+        )
 
-            # Fetch by staging tag
-            fetched = langwatch.prompts.get(handle, tag="staging")
+        # Fetch by staging tag
+        fetched = langwatch.prompts.get(handle, tag="staging")
 
-            assert fetched is not None
-            assert fetched.handle == handle
-            assert fetched.version_id == updated.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.handle == handle
+        assert fetched.version_id == updated.version_id
 
-    def test_fetch_by_explicit_version_number(self):
+    def test_fetch_by_explicit_version_number(self, prompt_factory):
         """
         GIVEN a prompt with two versions
         WHEN I fetch with version_number=1
@@ -199,32 +175,26 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-version-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Version 1",
         )
 
-        try:
-            langwatch.prompts.update(
-                handle,
-                scope="PROJECT",
-                commit_message="Create v2",
-                prompt="Version 2",
-            )
+        langwatch.prompts.update(
+            handle,
+            scope="PROJECT",
+            commit_message="Create v2",
+            prompt="Version 2",
+        )
 
-            # Fetch v1 explicitly
-            fetched = langwatch.prompts.get(handle, version_number=1)
+        # Fetch v1 explicitly
+        fetched = langwatch.prompts.get(handle, version_number=1)
 
-            assert fetched is not None
-            assert fetched.version == 1
-            assert fetched.version_id == created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.version == 1
+        assert fetched.version_id == created.version_id
 
-    def test_shorthand_version_passes_through_as_id(self):
+    def test_shorthand_version_passes_through_as_id(self, prompt_factory):
         """
         GIVEN a prompt with two versions
         WHEN SDK calls get("handle:1")
@@ -232,32 +202,26 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-shorthand-ver-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Version 1",
         )
 
-        try:
-            langwatch.prompts.update(
-                handle,
-                scope="PROJECT",
-                commit_message="Create v2",
-                prompt="Version 2",
-            )
+        langwatch.prompts.update(
+            handle,
+            scope="PROJECT",
+            commit_message="Create v2",
+            prompt="Version 2",
+        )
 
-            # Use version shorthand - SDK passes "handle:1" to the API
-            fetched = langwatch.prompts.get(f"{handle}:1")
+        # Use version shorthand - SDK passes "handle:1" to the API
+        fetched = langwatch.prompts.get(f"{handle}:1")
 
-            assert fetched is not None
-            assert fetched.version == 1
-            assert fetched.version_id == created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.version == 1
+        assert fetched.version_id == created.version_id
 
-    def test_create_prompt_with_multiple_tags(self):
+    def test_create_prompt_with_multiple_tags(self, prompt_factory):
         """
         GIVEN a new prompt
         WHEN I create it with tags=["production", "staging"]
@@ -265,30 +229,24 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-multi-tags-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Created with multiple tags",
             tags=["production", "staging"],
         )
 
-        try:
-            fetched_prod = langwatch.prompts.get(handle, tag="production")
-            fetched_staging = langwatch.prompts.get(handle, tag="staging")
+        fetched_prod = langwatch.prompts.get(handle, tag="production")
+        fetched_staging = langwatch.prompts.get(handle, tag="staging")
 
-            assert fetched_prod is not None
-            assert fetched_prod.handle == handle
-            assert fetched_prod.version_id == created.version_id
+        assert fetched_prod is not None
+        assert fetched_prod.handle == handle
+        assert fetched_prod.version_id == created.version_id
 
-            assert fetched_staging is not None
-            assert fetched_staging.handle == handle
-            assert fetched_staging.version_id == created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched_staging is not None
+        assert fetched_staging.handle == handle
+        assert fetched_staging.version_id == created.version_id
 
-    def test_assign_custom_tag_then_fetch_by_tag(self):
+    def test_assign_custom_tag_then_fetch_by_tag(self, prompt_factory):
         """
         GIVEN a prompt with a version on the server
         WHEN I assign tag="canary" to that version
@@ -297,30 +255,24 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-custom-tag-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Hello from custom tag e2e test",
         )
 
-        try:
-            langwatch.prompts.tags.assign(
-                handle,
-                tag="canary",
-                version_id=created.version_id,
-            )
+        langwatch.prompts.tags.assign(
+            handle,
+            tag="canary",
+            version_id=created.version_id,
+        )
 
-            fetched = langwatch.prompts.get(handle, tag="canary")
+        fetched = langwatch.prompts.get(handle, tag="canary")
 
-            assert fetched is not None
-            assert fetched.handle == handle
-            assert fetched.version_id == created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.handle == handle
+        assert fetched.version_id == created.version_id
 
-    def test_shorthand_syntax_with_custom_tag(self):
+    def test_shorthand_syntax_with_custom_tag(self, prompt_factory):
         """
         GIVEN a prompt with tag="canary" assigned
         WHEN SDK calls get("handle:canary")
@@ -328,28 +280,22 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-shorthand-canary-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Shorthand custom tag test",
         )
 
-        try:
-            langwatch.prompts.tags.assign(
-                handle,
-                tag="canary",
-                version_id=created.version_id,
-            )
+        langwatch.prompts.tags.assign(
+            handle,
+            tag="canary",
+            version_id=created.version_id,
+        )
 
-            fetched = langwatch.prompts.get(f"{handle}:canary")
+        fetched = langwatch.prompts.get(f"{handle}:canary")
 
-            assert fetched is not None
-            assert fetched.handle == handle
-            assert fetched.version_id == created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.handle == handle
+        assert fetched.version_id == created.version_id
 
     def test_create_list_delete_tag_round_trip(self):
         """
@@ -401,7 +347,7 @@ class TestPromptTagsE2E:
             except Exception as e:
                 logger.warning("Failed to delete tag %s: %s", tag_b, e)
 
-    def test_delete_tag_cascades_to_assignments(self):
+    def test_delete_tag_cascades_to_assignments(self, prompt_factory):
         """
         GIVEN a prompt with a custom tag assigned
         WHEN I delete the tag
@@ -412,7 +358,7 @@ class TestPromptTagsE2E:
         handle = f"e2e-cascade-prompt-{uuid4().hex[:8]}"
 
         langwatch.prompts.tags.create(tag_name)
-        created = langwatch.prompts.create(handle=handle, prompt="Cascade test")
+        created = prompt_factory(handle=handle, prompt="Cascade test")
 
         try:
             langwatch.prompts.tags.assign(
@@ -432,15 +378,11 @@ class TestPromptTagsE2E:
             assert fetched.handle == handle
         finally:
             try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
-            try:
                 langwatch.prompts.tags.delete(tag_name)
             except Exception:
                 pass
 
-    def test_shorthand_syntax_passes_through_as_id(self):
+    def test_shorthand_syntax_passes_through_as_id(self, prompt_factory):
         """
         GIVEN a prompt with a tag assigned via explicit assign
         WHEN SDK calls get("handle:production")
@@ -449,27 +391,21 @@ class TestPromptTagsE2E:
         """
         handle = f"e2e-shorthand-{uuid4().hex[:8]}"
 
-        created = langwatch.prompts.create(
+        created = prompt_factory(
             handle=handle,
             prompt="Shorthand test",
         )
 
-        try:
-            # Assign tag explicitly first (create-with-tags may have timing issues)
-            langwatch.prompts.tags.assign(
-                handle,
-                tag="production",
-                version_id=created.version_id,
-            )
+        # Assign tag explicitly first (create-with-tags may have timing issues)
+        langwatch.prompts.tags.assign(
+            handle,
+            tag="production",
+            version_id=created.version_id,
+        )
 
-            # Use the shorthand syntax - the SDK passes it through to the API
-            fetched = langwatch.prompts.get(f"{handle}:production")
+        # Use the shorthand syntax - the SDK passes it through to the API
+        fetched = langwatch.prompts.get(f"{handle}:production")
 
-            assert fetched is not None
-            assert fetched.handle == handle
-            assert fetched.version_id == created.version_id
-        finally:
-            try:
-                langwatch.prompts.delete(created.id)
-            except Exception as e:
-                logger.warning("Failed to delete prompt %s: %s", created.id, e)
+        assert fetched is not None
+        assert fetched.handle == handle
+        assert fetched.version_id == created.version_id


### PR DESCRIPTION
## Why

Closes #3164

`sdk-python-ci` is failing on `main` because the CI tenant hit its 10000-prompt license cap. Every e2e run creates prompts and cleans them up via an ad-hoc `try/finally + prompts.delete(...)` block repeated in every test. That pattern leaks on crashes, CI timeouts, and SIGKILL — and forgetting the block in a new test is silent. Over time the tenant filled up and every PR that runs `sdk-python-ci` now 403s with `resource_limit_exceeded`.

## What changed

Three commits on this branch:

1. **Fixture**: Introduces a `prompt_factory` pytest fixture in `python-sdk/tests/e2e/conftest.py` so prompt cleanup is construction-enforced rather than test-author-enforced. Tests request the factory, call it to create prompts, and the fixture's yield-based teardown deletes every prompt it created — even when the test body raises. Also adds a regression test proving cleanup-on-raise.

2. **Migration**: Migrates the existing 15 `try/finally` tests to use the `prompt_factory` fixture, removing all ad-hoc cleanup blocks.

3. **Review fixes**: Narrows exception handling in teardown (distinguishes 404 from real errors), replaces the prefix-scan sweeper with a session-scoped id registry (collision-free in parallel CI runs), replaces the module-global two-test dance with a class-scoped fixture container, and other review feedback.

## How it works

- `prompt_factory` (function-scoped) — yields a callable `create(**kwargs)` that calls `langwatch.prompts.create(**kwargs)` and appends the resulting prompt id to a teardown list. After `yield`, the fixture iterates the list and calls `langwatch.prompts.delete(id)`. It distinguishes 404 (already gone — debug log) from other HTTP errors and network errors (warning log), and never raises so cleanup continues for all tracked ids.
- `_session_prompt_registry` (session-scoped) — a list of every prompt id created by the factory this session. At session end, any ids not yet cleaned up by per-test teardown are deleted. Unlike the old prefix-scan sweeper, this only touches ids from *this* session — safe against concurrent CI runs on the same tenant.

## Test plan

Regression test at `python-sdk/tests/e2e/test_prompt_cleanup_fixture_e2e.py`:

1. `test_prompt_factory_yields_created_prompt_with_id` — sanity check: the factory returns a prompt object with an `id`.
2. `test_factory_creates_prompt_and_raises` (`xfail(strict=True)`) — creates a prompt via the factory, records its id in a class-scoped state fixture, then raises `RuntimeError`. The test is expected to fail (that's the point), but teardown must still delete the prompt.
3. `test_previous_raising_test_still_cleaned_up_its_prompt` — reads the recorded id and asserts that `langwatch.prompts.get(id, ALWAYS_FETCH)` raises `ValueError` matching "found", proving the fixture teardown ran despite the prior test raising.

## Anything surprising?

- **CI tenant purge is out of scope** — the 10000 accumulated prompts still need a one-time manual delete before `main` will go green. This PR stops new leaks; it doesn't unblock CI by itself.
- The session-scoped registry replaces the old `_prompt_leak_sweeper` which scanned by handle prefix — the registry is faster and won't collide with other CI runs sharing the same tenant.

# Related Issue

- Resolve #3164