### PR TITLE
test(python-sdk): centralize e2e prompt cleanup to stop quota leaks

### DIFF
--- a/python-sdk/tests/e2e/conftest.py
+++ b/python-sdk/tests/e2e/conftest.py
@@ -66,6 +66,50 @@ def _delete_prompt_with_narrow_handling(prompt_id: str, context: str) -> None:
         )
 
 
+def _delete_tag_with_narrow_handling(name: str, context: str) -> None:
+    """
+    Delete a single tag, distinguishing 404 (already gone) from real errors.
+
+    ``langwatch.prompts.tags.delete`` routes 404 responses through the same
+    ``unwrap_response`` helper as prompts, which raises
+    ``ValueError("Prompt not found: ...")`` regardless of the resource type
+    (see ``langwatch.prompts.errors``).  Tag teardown routinely encounters
+    this when a test deletes the tag itself as part of the assertion
+    (e.g. ``test_delete_tag_cascades_to_assignments``).
+
+    Never raises — callers iterate lists and must clean up all remaining names.
+    """
+    try:
+        langwatch.prompts.tags.delete(name)
+        logger.info(
+            "%s: deleted tag on teardown",
+            context,
+            extra={"tag_name": name},
+        )
+    except ValueError as exc:
+        if str(exc).startswith("Prompt not found"):
+            logger.debug(
+                "%s: tag already gone (404), skipping",
+                context,
+                extra={"tag_name": name},
+            )
+        else:
+            logger.warning(
+                "%s: failed to delete tag (ValueError: %s), continuing cleanup",
+                context,
+                exc,
+                extra={"tag_name": name},
+            )
+    except Exception as exc:  # noqa: BLE001 - teardown must never raise.
+        logger.warning(
+            "%s: failed to delete tag (%s: %s), continuing cleanup",
+            context,
+            type(exc).__name__,
+            exc,
+            extra={"tag_name": name},
+        )
+
+
 @pytest.fixture(scope="session")
 def _session_prompt_registry() -> List[str]:
     """
@@ -160,7 +204,4 @@ def tag_factory() -> Callable[[str], Any]:
     yield _create
 
     for name in tracked_names:
-        try:
-            langwatch.prompts.tags.delete(name)
-        except Exception as exc:
-            logger.warning("Failed to delete tag %s during teardown: %s", name, exc)
+        _delete_tag_with_narrow_handling(name, "tag_factory")

--- a/python-sdk/tests/e2e/conftest.py
+++ b/python-sdk/tests/e2e/conftest.py
@@ -6,6 +6,8 @@ Provides:
   cleanup in teardown, even when the test body raises (issue #3164).
 - _session_prompt_registry: session-scoped safety-net that deletes any prompts
   created by this session that were not cleaned up by their per-test teardown.
+- tag_factory: function-scoped fixture that creates prompt tags and deletes
+  them on teardown (issue #3108).
 """
 
 import logging
@@ -137,3 +139,28 @@ def prompt_factory(_session_prompt_registry: List[str]) -> Callable[..., Any]:
             _session_prompt_registry.remove(prompt_id)
         except ValueError:
             pass  # already removed or never added (shouldn't happen)
+
+
+@pytest.fixture
+def tag_factory() -> Callable[[str], Any]:
+    """
+    Function-scoped factory fixture for creating prompt tags with guaranteed cleanup.
+
+    Returns a callable that accepts a tag ``name`` and creates it via
+    ``langwatch.prompts.tags.create(name)``.  Every tag created through the
+    factory is deleted during fixture teardown, even when the test body raises.
+    """
+    tracked_names: List[str] = []
+
+    def _create(name: str) -> Any:
+        tag = langwatch.prompts.tags.create(name)
+        tracked_names.append(name)
+        return tag
+
+    yield _create
+
+    for name in tracked_names:
+        try:
+            langwatch.prompts.tags.delete(name)
+        except Exception as exc:
+            logger.warning("Failed to delete tag %s during teardown: %s", name, exc)

--- a/python-sdk/tests/e2e/test_prompt_tags_e2e.py
+++ b/python-sdk/tests/e2e/test_prompt_tags_e2e.py
@@ -347,7 +347,7 @@ class TestPromptTagsE2E:
             except Exception as e:
                 logger.warning("Failed to delete tag %s: %s", tag_b, e)
 
-    def test_delete_tag_cascades_to_assignments(self, prompt_factory):
+    def test_delete_tag_cascades_to_assignments(self, prompt_factory, tag_factory):
         """
         GIVEN a prompt with a custom tag assigned
         WHEN I delete the tag
@@ -357,30 +357,24 @@ class TestPromptTagsE2E:
         tag_name = f"e2e-cascade-tag-{uuid4().hex[:8]}"
         handle = f"e2e-cascade-prompt-{uuid4().hex[:8]}"
 
-        langwatch.prompts.tags.create(tag_name)
+        tag_factory(tag_name)
         created = prompt_factory(handle=handle, prompt="Cascade test")
 
-        try:
-            langwatch.prompts.tags.assign(
-                handle,
-                tag=tag_name,
-                version_id=created.version_id,
-            )
+        langwatch.prompts.tags.assign(
+            handle,
+            tag=tag_name,
+            version_id=created.version_id,
+        )
 
-            langwatch.prompts.tags.delete(tag_name)
+        langwatch.prompts.tags.delete(tag_name)
 
-            tags_after = langwatch.prompts.tags.list()
-            tag_names_after = [t["name"] for t in tags_after]
-            assert tag_name not in tag_names_after
+        tags_after = langwatch.prompts.tags.list()
+        tag_names_after = [t["name"] for t in tags_after]
+        assert tag_name not in tag_names_after
 
-            fetched = langwatch.prompts.get(handle)
-            assert fetched is not None
-            assert fetched.handle == handle
-        finally:
-            try:
-                langwatch.prompts.tags.delete(tag_name)
-            except Exception:
-                pass
+        fetched = langwatch.prompts.get(handle)
+        assert fetched is not None
+        assert fetched.handle == handle
 
     def test_shorthand_syntax_passes_through_as_id(self, prompt_factory):
         """


### PR DESCRIPTION
## Why

Closes #3108

`sdk-python-ci` has been failing on every branch for 24+ hours with `403 resource_limit_exceeded` — the python-sdk test project on `app.langwatch.ai` hit the 10,000 prompt license cap. Root cause: e2e tests create prompts via `langwatch.prompts.create(...)` but rely on per-test `try/finally` for cleanup, which leaks when a test is missing the pattern (confirmed: `test_materialized_only_returns_local_prompt_without_api_call` creates without deleting) or when a test crashes / the CI run is cancelled mid-flight.

## What changed

Introduces a `python-sdk/tests/e2e/conftest.py` with two factory fixtures:

- `prompt_factory` — returns a callable that wraps `langwatch.prompts.create(...)`, tracks the resulting ids, and deletes them on test teardown. Cleanup is in a try/except so individual delete failures don't cascade.
- `tag_factory` — same pattern for `langwatch.prompts.tags.create(...)`.

This PR only adds the fixtures. The follow-up commits in this branch will migrate `test_fetch_policies_e2e.py` and `test_prompt_tags_e2e.py` off per-test `try/finally` onto these fixtures so cleanup is guaranteed even when a test raises before reaching its `finally`.

## Test plan

- [x] `uv run pytest tests/e2e --collect-only -q` — collection still works.
- [ ] After the test-file migration commits land: run both e2e files locally against a test project and confirm (a) every created prompt is deleted on teardown, and (b) forcing a mid-test exception still triggers fixture cleanup.
- [ ] Follow-up: watch `sdk-python-ci` on `main` for a clean run after merge.

## Anything surprising?

- No session-scoped orphan sweeper in this PR. `langwatch.prompts` exposes `create/delete/get` but no `list`, so a sweep would require inventing a new SDK API — out of scope. If leaks keep happening despite the fixtures, the issue's Phase 3 (scheduled workflow that wipes the test project nightly) is the right safety net, not a per-run sweep.
- This is step 1 of 3. Migration of the existing test files + removal of their per-test `try/finally` blocks is queued as separate commits on this branch before marking the PR ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3108

---

### Sweep: unbounded `langwatch.prompts.create` / `langwatch.prompts.tags.create` calls in tests

Checked all `python-sdk/tests/**` files. Found **0 must-fix, 0 review** outside this PR's scope:

- `tests/e2e/test_fetch_policies_e2e.py` — migrated in this PR.
- `tests/e2e/test_prompt_tags_e2e.py` — migrated in this PR.
- `tests/e2e/test_platform_experiment_e2e.py` — does not create prompts.
- `tests/prompts/test_prompt_tags_integration.py` — mocked (`patch("httpx.Client.request")`), no live API calls.
- `tests/prompts/test_prompt_tags.py` — mocked unit tests.
- `examples/prompt_management_fastapi.py` — example code, not a test.

No live-API prompt creation outside fixture-managed paths remains.