### PR TITLE
test(event-sourcing): unskip 4 stale it.skip in replayEventLoader

### DIFF
--- a/langwatch/src/server/event-sourcing/replay/__tests__/replayEventLoader.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/replay/__tests__/replayEventLoader.integration.test.ts
@@ -137,8 +137,7 @@ describe("replayEventLoader", () => {
   });
 
   describe("countEventsForAggregates", () => {
-    // Skipped: requires live ClickHouse. Run with testcontainers or make dev-full to enable.
-    it.skip("counts all events for discovered aggregates", async () => {
+    it("counts all events for discovered aggregates", async () => {
       const client = getTestClickHouseClient()!;
       const count = await countEventsForAggregates({
         client,
@@ -204,8 +203,7 @@ describe("replayEventLoader", () => {
   });
 
   describe("batchLoadAggregateEvents", () => {
-    // Skipped: requires live ClickHouse. Run with testcontainers or make dev-full to enable.
-    it.skip("loads events up to cutoff", async () => {
+    it("loads events up to cutoff", async () => {
       const client = getTestClickHouseClient()!;
       const events = await batchLoadAggregateEvents({
         client,
@@ -261,8 +259,7 @@ describe("replayEventLoader", () => {
     });
 
     describe("when batchSize limits results", () => {
-      // Skipped: requires live ClickHouse. Run with testcontainers or make dev-full to enable.
-      it.skip("returns at most batchSize events", async () => {
+      it("returns at most batchSize events", async () => {
         const client = getTestClickHouseClient()!;
         const events = await batchLoadAggregateEvents({
           client,
@@ -280,8 +277,7 @@ describe("replayEventLoader", () => {
     });
 
     describe("when another tenant has the same aggregateId", () => {
-      // Skipped: requires live ClickHouse. Run with testcontainers or make dev-full to enable.
-      it.skip("returns only the requested tenant's events", async () => {
+      it("returns only the requested tenant's events", async () => {
         const client = getTestClickHouseClient()!;
         const events = await batchLoadAggregateEvents({
           client,

--- a/langwatch/src/server/event-sourcing/replay/__tests__/replayEventLoader.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/replay/__tests__/replayEventLoader.integration.test.ts
@@ -23,12 +23,16 @@ describe("replayEventLoader", () => {
 
     const client = getTestClickHouseClient()!;
 
-    // Insert test events into event_log
+    // Insert test events into event_log.
+    // IdempotencyKey must be unique per event — event_log is a ReplacingMergeTree
+    // keyed by (TenantId, AggregateType, AggregateId, IdempotencyKey), so events
+    // sharing that tuple get collapsed to a single row on merge.
     const events = [
       {
         TenantId: tenantId,
         AggregateType: "test",
         AggregateId: "agg-1",
+        IdempotencyKey: "evt-001",
         EventId: "evt-001",
         EventType: "test.event",
         EventTimestamp: 1700000000000,
@@ -40,6 +44,7 @@ describe("replayEventLoader", () => {
         TenantId: tenantId,
         AggregateType: "test",
         AggregateId: "agg-1",
+        IdempotencyKey: "evt-002",
         EventId: "evt-002",
         EventType: "test.event",
         EventTimestamp: 1700000001000,
@@ -51,6 +56,7 @@ describe("replayEventLoader", () => {
         TenantId: tenantId,
         AggregateType: "test",
         AggregateId: "agg-2",
+        IdempotencyKey: "evt-003",
         EventId: "evt-003",
         EventType: "test.event",
         EventTimestamp: 1700000002000,
@@ -63,6 +69,7 @@ describe("replayEventLoader", () => {
         TenantId: otherTenantId,
         AggregateType: "test",
         AggregateId: "agg-1",
+        IdempotencyKey: "evt-other-001",
         EventId: "evt-other-001",
         EventType: "test.event",
         EventTimestamp: 1700000000500,


### PR DESCRIPTION
## Summary
- Unskip 4 stale \`it.skip\` tests in \`replayEventLoader.integration.test.ts\` — the \`it.skip\` comments said "requires live ClickHouse", but the rest of the file's tests use the same ClickHouse client successfully, so the skips were dead weight.
- These are pure ClickHouse read-path tests with no async-worker dependency.
- Scope: only \`replayEventLoader\`. The 5 other files in issue #3299 (\`eventSourcing\`, \`traceProcessing\`, \`suiteRunProcessing\`, \`evaluationProcessing\`, \`experimentRunProcessing\`) hit the genuine async-event-handler race tracked in #3240 and are **not** touched here.
- Additional file \`customEvaluationSync.reactor.integration.test.ts\` was skipped in the same commit (a4283c5f0) with identical root cause — not in the original #3299 list, tracked separately.

## Why draft
Pushed before local verification (Docker booting). CI is the verifier — will promote to ready-for-review once all checks pass.

## Test plan
- [ ] CI runs integration test job: \`replayEventLoader\` → all tests execute (no skips)
- [ ] 4 newly-active tests pass:
  - \`countEventsForAggregates > counts all events for discovered aggregates\`
  - \`batchLoadAggregateEvents > loads events up to cutoff\`
  - \`batchLoadAggregateEvents > when batchSize limits results > returns at most batchSize events\`
  - \`batchLoadAggregateEvents > when another tenant has the same aggregateId > returns only the requested tenant's events\`

## Closes / Refs
Part of #3299 (scope narrowed). Async-worker flakes for the other 5 files remain blocked by #3240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3299