### PR TITLE
fix(tests): unskip REST API feature integration tests (agents, dataset, suites, dashboards)

### DIFF
--- a/langwatch/src/app/api/agents/__tests__/agents-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/agents/__tests__/agents-rest-api.integration.test.ts
@@ -20,9 +20,7 @@ const VALID_SIGNATURE_CONFIG = {
   prompt: "You are a helpful assistant",
 };
 
-// Skipped: app-layer init regression on main after es-migration refactor
-// — see langwatch/langwatch#3240.
-describe.skip("Feature: Agent REST API", () => {
+describe("Feature: Agent REST API", () => {
   let testApiKey: string;
   let testProjectId: string;
   let testOrganization: Organization;

--- a/langwatch/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/dashboards/__tests__/dashboard-rest-api.integration.test.ts
@@ -12,9 +12,7 @@ import { prisma } from "~/server/db";
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import { app } from "../[[...route]]/app";
 
-// Skipped: app-layer init regression on main after es-migration refactor
-// — see langwatch/langwatch#3240.
-describe.skip("Feature: Dashboard REST API", () => {
+describe("Feature: Dashboard REST API", () => {
   let testApiKey: string;
   let testProjectId: string;
   let testOrganization: Organization;

--- a/langwatch/src/app/api/dataset/__tests__/dataset-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/dataset/__tests__/dataset-rest-api.integration.test.ts
@@ -12,8 +12,7 @@ import { prisma } from "~/server/db";
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import { app } from "../[[...route]]/app";
 
-// Skipped: app-layer init regression on main (#2508) — see langwatch/langwatch#3240.
-describe.skip("Feature: Dataset REST API", () => {
+describe("Feature: Dataset REST API", () => {
   let testApiKey: string;
   let testProjectId: string;
   let testOrganization: Organization;

--- a/langwatch/src/app/api/dataset/__tests__/dataset-upload-api.integration.test.ts
+++ b/langwatch/src/app/api/dataset/__tests__/dataset-upload-api.integration.test.ts
@@ -13,8 +13,7 @@ import type { DatasetColumns } from "~/server/datasets/types";
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import { app } from "../[[...route]]/app";
 
-// Skipped: app-layer init regression on main (#2508) — see langwatch/langwatch#3240.
-describe.skip("Feature: Dataset File Upload REST API", () => {
+describe("Feature: Dataset File Upload REST API", () => {
   let testApiKey: string;
   let testProjectId: string;
   let testOrganization: Organization;

--- a/langwatch/src/app/api/suites/__tests__/suites-api.integration.test.ts
+++ b/langwatch/src/app/api/suites/__tests__/suites-api.integration.test.ts
@@ -12,8 +12,7 @@ import { prisma } from "~/server/db";
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import { app } from "../[[...route]]/app";
 
-// Skipped: app-layer init regression on main (#2508) — see langwatch/langwatch#3240.
-describe.skip("Feature: Suites REST API", () => {
+describe("Feature: Suites REST API", () => {
   let testApiKey: string;
   let testProjectId: string;
   let testOrganization: Organization;


### PR DESCRIPTION
## Summary

Unskip 5 REST API feature integration test suites that were marked `describe.skip()`:

- `agents-rest-api.integration.test.ts`
- `dashboard-rest-api.integration.test.ts`
- `dataset-rest-api.integration.test.ts`
- `dataset-upload-api.integration.test.ts`
- `suites-api.integration.test.ts`

Closes #3293

## Context

The skip comments referenced an "app-layer init regression on main after es-migration refactor" (#2508). That ES migration PR has since merged (2026-04-15), so the underlying regression should be resolved.

This PR removes the skips and lets CI verify. If tests still fail, the next iteration will diagnose the root cause and patch.

## Test plan

- [ ] CI runs the 5 integration test suites
- [ ] All assertions pass, or remaining failures are diagnosed and fixed in follow-up commits


# Related Issue

- Resolve #3293