### PR TITLE
fix(docs): remove invalid experiment.print_summary() from CI/CD examples

### DIFF
--- a/docs/evaluations/experiments/ci-cd.mdx
+++ b/docs/evaluations/experiments/ci-cd.mdx
@@ -141,9 +141,6 @@ for idx, row in experiment.loop(dataset.iterrows()):
             "contexts": row["contexts"],
         },
     )
-
-# Print summary and exit on failure
-experiment.print_summary()
 ```
   </Tab>
   <Tab title="TypeScript">
@@ -177,9 +174,6 @@ await experiment.run(
   },
   { concurrency: 4 }
 );
-
-// Print summary and exit on failure
-experiment.printSummary();
 ```
   </Tab>
 </Tabs>
@@ -250,8 +244,6 @@ for idx, row in experiment.loop(dataset.iterrows()):
             })
 
     experiment.submit(compare, idx, row)
-
-experiment.print_summary()
 ```
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -17509,9 +17509,6 @@ for idx, row in experiment.loop(dataset.iterrows()):
             "contexts": row["contexts"],
         },
     )
-
-# Print summary and exit on failure
-experiment.print_summary()
 ```
 
   ### TypeScript
@@ -17546,9 +17543,6 @@ await experiment.run(
   },
   { concurrency: 4 }
 );
-
-// Print summary and exit on failure
-experiment.printSummary();
 ```
 
 
@@ -17619,8 +17613,6 @@ for idx, row in experiment.loop(dataset.iterrows()):
             })
 
     experiment.submit(compare, idx, row)
-
-experiment.print_summary()
 ```
 
 ---


### PR DESCRIPTION
## Summary

The SDK-driven `Experiment` class (returned by `langwatch.experiment.init()`) has no `print_summary()` / `printSummary()` method — it exists only on `ExperimentRunResult` returned by `langwatch.experiment.run()` (the platform-experiments path). The Option 2 (SDK) examples in `docs/evaluations/experiments/ci-cd.mdx` were calling `experiment.print_summary()` which would fail at runtime.

Reported by Oskar Rubensson (\"heads up, this code snippet is incorrect\").

## Changes

- Remove `experiment.print_summary()` from the Python basic Option 2 example
- Remove `experiment.printSummary()` from the TypeScript basic Option 2 example
- Remove `experiment.print_summary()` from the \"Comparing Multiple Configurations\" Python example
- Regenerate `docs/llms-full.txt` to match

All valid `result.print_summary()` calls (Option 1, platform experiments) are preserved.

## Test plan

- [x] Grep confirms no remaining `experiment.print_summary` / `experiment.printSummary` references in `docs/`
- [x] Verified against SDK source: `python-sdk/src/langwatch/experiment/platform_run.py:130` (method exists on `ExperimentRunResult`) vs `python-sdk/src/langwatch/experiment/experiment.py` (no such method on `Experiment`)
- [x] TS equivalent verified at `typescript-sdk/src/client-sdk/services/experiments/experiments.facade.ts:282` (on result, not on `Experiment` class)