### PR TITLE
fix(web): return 404 for missing /assets/* to prevent CDN cache poisoning

### DIFF
--- a/langwatch/src/routes.tsx
+++ b/langwatch/src/routes.tsx
@@ -42,21 +42,27 @@ function RootLayout() {
  * React Router's lazy keeps the OLD route visible while the new module loads,
  * eliminating the gray flash that React.lazy + Suspense causes.
  */
+// Minimum gap between self-triggered reloads. Short enough that a second
+// deploy mid-session still reloads; long enough to avoid a loop if the server
+// is genuinely returning broken chunks.
+const CHUNK_RELOAD_COOLDOWN_MS = 10_000;
+
 const page = (importFn: () => Promise<{ default: React.ComponentType }>) => ({
   lazy: () =>
     importFn().then((m) => ({ Component: m.default })).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message.toLowerCase() : "";
       const isChunkError =
         msg.includes("loading chunk") ||
-        msg.includes("failed to fetch dynamically imported module");
+        msg.includes("dynamically imported module") ||
+        msg.includes("importing a module script failed");
 
       if (!isChunkError) throw err;
 
-      // Chunk failed to load — likely a stale build after deployment.
-      // Reload once so the browser fetches the new index.html with current chunk URLs.
-      const alreadyReloaded = sessionStorage.getItem("chunk-reload");
-      if (!alreadyReloaded) {
-        sessionStorage.setItem("chunk-reload", "1");
+      const lastReloadAt = Number(
+        sessionStorage.getItem("chunk-reload-at") ?? "0"
+      );
+      if (Date.now() - lastReloadAt > CHUNK_RELOAD_COOLDOWN_MS) {
+        sessionStorage.setItem("chunk-reload-at", String(Date.now()));
         window.location.reload();
       }
       throw err;

--- a/langwatch/src/server/__tests__/static-handler.unit.test.ts
+++ b/langwatch/src/server/__tests__/static-handler.unit.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, request as httpRequest, type Server } from "http";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { AddressInfo } from "net";
+
+import { serveStaticOrFallback } from "../static-handler";
+
+function rawRequest(
+  port: number,
+  rawPath: string
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: "127.0.0.1", port, method: "GET", path: rawPath },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+          })
+        );
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("serveStaticOrFallback", () => {
+  let clientDistDir: string;
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    clientDistDir = mkdtempSync(join(tmpdir(), "static-handler-test-"));
+    mkdirSync(join(clientDistDir, "assets"), { recursive: true });
+    writeFileSync(
+      join(clientDistDir, "assets", "index-abc123.js"),
+      "console.log('hello from index-abc123');\n"
+    );
+    writeFileSync(
+      join(clientDistDir, "assets", "main-deadbeef.css"),
+      "body { color: red; }\n"
+    );
+    writeFileSync(
+      join(clientDistDir, "index.html"),
+      "<!doctype html><html><body><div id=root></div></body></html>"
+    );
+
+    server = createServer((req, res) => {
+      const pathname = (req.url ?? "/").split("?")[0] ?? "/";
+      const handled = serveStaticOrFallback({ res, pathname, clientDistDir });
+      if (!handled) {
+        res.statusCode = 404;
+        res.end("Not Found");
+      }
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(clientDistDir, { recursive: true, force: true });
+  });
+
+  describe("when an existing /assets/ file is requested", () => {
+    it("returns 200 with correct MIME and immutable cache header", async () => {
+      const res = await fetch(`${baseUrl}/assets/index-abc123.js`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/javascript");
+      expect(res.headers.get("cache-control")).toBe(
+        "public, max-age=31536000, immutable"
+      );
+      expect(await res.text()).toContain("hello from index-abc123");
+    });
+
+    it("serves CSS with correct MIME", async () => {
+      const res = await fetch(`${baseUrl}/assets/main-deadbeef.css`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/css");
+      expect(res.headers.get("cache-control")).toBe(
+        "public, max-age=31536000, immutable"
+      );
+    });
+  });
+
+  describe("when a missing /assets/ file is requested", () => {
+    it("returns 404, not the SPA index.html", async () => {
+      const res = await fetch(`${baseUrl}/assets/does-not-exist-xyz.js`);
+      expect(res.status).toBe(404);
+      const body = await res.text();
+      expect(body).not.toContain("<!doctype html>");
+      expect(body).not.toContain("<div id=root>");
+    });
+
+    it("sets a no-store Cache-Control so CDNs do not poison the URL", async () => {
+      const res = await fetch(`${baseUrl}/assets/missing-chunk.js`);
+      expect(res.status).toBe(404);
+      const cacheControl = res.headers.get("cache-control") ?? "";
+      expect(cacheControl).toMatch(/no-store/);
+      expect(cacheControl).not.toMatch(/immutable/);
+    });
+
+    it("returns 404 even when Accept includes text/html", async () => {
+      const res = await fetch(`${baseUrl}/assets/foo-stale.js`, {
+        headers: { Accept: "text/html,application/xhtml+xml,*/*" },
+      });
+      expect(res.status).toBe(404);
+      expect(await res.text()).not.toContain("<!doctype html>");
+    });
+  });
+
+  describe("when a non-asset route is requested", () => {
+    it("returns the SPA index.html as text/html", async () => {
+      const res = await fetch(`${baseUrl}/projects/foo/traces`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html");
+      expect(await res.text()).toContain("<div id=root>");
+    });
+
+    it("returns 200 + index.html for the root path", async () => {
+      const res = await fetch(`${baseUrl}/`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html");
+    });
+  });
+
+  describe("when an asset path attempts traversal", () => {
+    it("returns 400 before touching the filesystem", async () => {
+      const port = (server.address() as AddressInfo).port;
+      const res = await rawRequest(port, "/assets/../../etc/passwd");
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/langwatch/src/server/static-handler.ts
+++ b/langwatch/src/server/static-handler.ts
@@ -1,0 +1,95 @@
+import fs from "fs";
+import path from "path";
+import type { ServerResponse } from "http";
+
+const MIME_TYPES: Record<string, string> = {
+  ".js": "application/javascript",
+  ".mjs": "application/javascript",
+  ".css": "text/css",
+  ".html": "text/html",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".wasm": "application/wasm",
+};
+
+const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
+const NO_STORE_CACHE = "no-store, max-age=0";
+
+/**
+ * Production static file + SPA fallback handler.
+ *
+ * Returns true when the response was written (caller should not write further).
+ * Returns false only when there is no index.html to fall back to (caller decides
+ * how to 404).
+ *
+ * Why missing /assets/* returns 404 instead of falling through to index.html:
+ * Vite hashes asset filenames per build, so chunk URLs from a previous deploy
+ * point to files that no longer exist. If we returned the SPA shell with a 200
+ * status, a CDN with a "cache everything under /assets/* immutably" rule would
+ * cache the HTML response under the JS URL — every subsequent visitor then hits
+ * a strict-MIME violation in the browser, even after a roll-forward, until the
+ * cache is manually purged.
+ */
+export function serveStaticOrFallback({
+  res,
+  pathname,
+  clientDistDir,
+}: {
+  res: ServerResponse;
+  pathname: string;
+  clientDistDir: string;
+}): boolean {
+  const normalizedRelative = path.normalize(pathname.slice(1));
+  if (
+    normalizedRelative.startsWith("..") ||
+    path.isAbsolute(normalizedRelative)
+  ) {
+    res.statusCode = 400;
+    res.end("Bad Request");
+    return true;
+  }
+
+  const staticPath = path.join(clientDistDir, normalizedRelative);
+  if (fs.existsSync(staticPath) && fs.statSync(staticPath).isFile()) {
+    serveStaticFile(res, staticPath, pathname);
+    return true;
+  }
+
+  if (pathname.startsWith("/assets/")) {
+    res.statusCode = 404;
+    res.setHeader("Content-Type", "text/plain");
+    res.setHeader("Cache-Control", NO_STORE_CACHE);
+    res.end("Not Found");
+    return true;
+  }
+
+  const indexHtml = path.join(clientDistDir, "index.html");
+  if (fs.existsSync(indexHtml)) {
+    res.setHeader("Content-Type", "text/html");
+    fs.createReadStream(indexHtml).pipe(res);
+    return true;
+  }
+
+  return false;
+}
+
+function serveStaticFile(
+  res: ServerResponse,
+  filePath: string,
+  pathname: string
+) {
+  const ext = path.extname(filePath);
+  res.setHeader(
+    "Content-Type",
+    MIME_TYPES[ext] ?? "application/octet-stream"
+  );
+  if (pathname.startsWith("/assets/")) {
+    res.setHeader("Cache-Control", IMMUTABLE_CACHE);
+  }
+  fs.createReadStream(filePath).pipe(res);
+}

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -1,6 +1,5 @@
 import promBundle from "express-prom-bundle";
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
-import fs from "fs";
 import path from "path";
 import { register } from "prom-client";
 import { getApp } from "./server/app-layer/app";
@@ -13,6 +12,7 @@ import { createLogger } from "./utils/logger/server";
 // Hono — unified API router
 import type { Hono } from "hono";
 import { createApiRouter } from "./server/api-router";
+import { serveStaticOrFallback } from "./server/static-handler";
 
 const logger = createLogger("langwatch:start");
 
@@ -148,25 +148,8 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
 
       // ---- Production: serve static assets + SPA fallback ----
       if (clientDistDir) {
-        // Sanitize: reject any pathname containing traversal sequences before touching the filesystem
-        const normalizedRelative = path.normalize(pathname.slice(1));
-        if (normalizedRelative.startsWith("..") || path.isAbsolute(normalizedRelative)) {
-          res.statusCode = 400;
-          res.end("Bad Request");
-          return;
-        }
-        const staticPath = path.join(clientDistDir, normalizedRelative);
-        if (fs.existsSync(staticPath) && fs.statSync(staticPath).isFile()) {
-          serveStaticFile(res, staticPath, pathname);
-          return;
-        }
-        // SPA fallback — serve index.html for all non-API routes
-        const indexHtml = path.join(clientDistDir, "index.html");
-        if (fs.existsSync(indexHtml)) {
-          res.setHeader("Content-Type", "text/html");
-          fs.createReadStream(indexHtml).pipe(res);
-          return;
-        }
+        const handled = serveStaticOrFallback({ res, pathname, clientDistDir });
+        if (handled) return;
       }
 
       res.statusCode = 404;
@@ -295,29 +278,6 @@ async function routeThroughHono(
     res.end(await honoRes.text());
   }
   return true;
-}
-
-function serveStaticFile(res: ServerResponse, filePath: string, pathname: string) {
-  const ext = path.extname(filePath);
-  const mimeTypes: Record<string, string> = {
-    ".js": "application/javascript",
-    ".mjs": "application/javascript",
-    ".css": "text/css",
-    ".html": "text/html",
-    ".json": "application/json",
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".svg": "image/svg+xml",
-    ".ico": "image/x-icon",
-    ".woff": "font/woff",
-    ".woff2": "font/woff2",
-    ".wasm": "application/wasm",
-  };
-  res.setHeader("Content-Type", mimeTypes[ext] ?? "application/octet-stream");
-  if (pathname.startsWith("/assets/")) {
-    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
-  }
-  fs.createReadStream(filePath).pipe(res);
 }
 
 function readBody(req: IncomingMessage): Promise<Uint8Array> {

--- a/specs/server/spa-fallback.feature
+++ b/specs/server/spa-fallback.feature
@@ -1,0 +1,47 @@
+Feature: Production HTTP server — static asset and SPA fallback behavior
+  As an operator running the production Hono server behind a CDN
+  I want missing /assets/* paths to return real 404s
+  So that stale chunk URLs from previous deploys do not poison the CDN
+  with HTML responses served under JavaScript MIME types
+
+  # Background: Vite hashes asset filenames per build. After a deploy, browsers
+  # holding the previous index.html may request chunk URLs whose files no longer
+  # exist on the new image. If the server falls back to index.html (HTML 200) for
+  # those paths, a CDN with a "cache everything under /assets/* with immutable
+  # TTL" rule will cache the HTML response under the JS URL. Subsequent loads then
+  # see strict-MIME violations even after a roll-forward, until the cache is
+  # manually purged. The fix: return a real 404 for missing /assets/* so the CDN
+  # caches a 404 (or nothing), never an HTML 200.
+
+  Background:
+    Given the production server is running with a built client at dist/client
+    And dist/client/index.html exists
+    And dist/client/assets/index-abc123.js exists with JavaScript content
+
+  Scenario: Existing asset is served with the correct MIME type and immutable cache
+    When a client requests /assets/index-abc123.js
+    Then the response status is 200
+    And the Content-Type header is application/javascript
+    And the Cache-Control header is "public, max-age=31536000, immutable"
+    And the response body is the on-disk JavaScript content
+
+  Scenario: Missing asset returns a real 404 with no-cache headers
+    When a client requests /assets/does-not-exist-xyz.js
+    Then the response status is 404
+    And the response is not the index.html document
+    And the Cache-Control header instructs caches not to store the response
+
+  Scenario: Missing asset returns 404 even though Accept includes text/html
+    When a client requests /assets/foo-stale.js with Accept "text/html,*/*"
+    Then the response status is 404
+    And the response is not the index.html document
+
+  Scenario: Unknown non-asset route falls back to index.html for SPA routing
+    When a client requests /projects/foo/traces
+    Then the response status is 200
+    And the Content-Type header is text/html
+    And the response body equals the contents of index.html
+
+  Scenario: Asset path traversal is rejected before touching the filesystem
+    When a client requests /assets/../../etc/passwd
+    Then the response status is 400


### PR DESCRIPTION
## Context — today's incident

We rolled back the frontend from `a203532` → `eafab04`. Users' browsers (running old code from `a203532`) kept requesting hashed chunks like `/assets/prompts-D_lOilKC.js` that only existed in `a203532`. The Hono SPA fallback returned `index.html` as a **200** for those paths. Our Cloudflare "Cache Everything under `/assets/*` with immutable TTL" page rule then cached the HTML body under the JS URL.

Every subsequent visitor — even after we rolled forward again — hit this in the browser console:

> Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html". Strict MIME type checking is enforced for module scripts per HTML spec.

…until we manually purged the Cloudflare cache. That's CDN poisoning, and the origin bug that enabled it is what this PR fixes.

Baseline curl against current prod showing the broken behavior (non-existent asset returning a 200 HTML shell):

```
$ curl -sI "https://app.langwatch.ai/assets/definitely-fake-xyz-not-a-real-hash.js" | grep -iE 'HTTP|content-type|cache-control|cf-cache'
HTTP/2 200
content-type: text/html
cache-control: max-age=14400
cf-cache-status: MISS
```

## Summary

1. **Missing `/assets/*` returns a real 404 with `Cache-Control: no-store`.** Extracted the static-or-fallback logic into `server/static-handler.ts` so it's unit-testable with real HTTP + real fs. The SPA `index.html` fallback now only applies to **non-asset** paths (where navigation is expected to succeed).
2. **Hardened the client-side chunk-reload guard.** Replaced the sticky `sessionStorage` sentinel (which only ever fires once per tab — so a second deploy mid-session would leave the user stuck) with a 10-second cooldown. Also broadened error-message matching to cover Firefox and Safari phrasings, not just Chrome's.
3. **Spec + integration test.** `specs/server/spa-fallback.feature` documents the behavior; `static-handler.unit.test.ts` spins up a real `http.Server` against a tmpdir fixture and asserts status / MIME / cache-control for all five scenarios.

## Why Next.js didn't have this problem

Three reasons, for context — Next solves all three, Vite + Hono leaves them to us:

- **Build ID in the asset path.** Next serves from `/_next/static/<buildId>/...`. URLs from an old build don't exist on the new server and were never cached before, so the CDN returns a clean 404. Vite hashes only the filename, so builds share the `/assets/` prefix and can collide / get poisoned.
- **Strict 404s for missing assets.** Next's static handler doesn't fall through to a page renderer. Ours did.
- **Self-healing on chunk-load errors.** Next auto-reloads; Vite needs you to wire it up yourself (this was already in `routes.tsx`, just hardened here).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit src/server/__tests__/static-handler.unit.test.ts` — 8/8 pass

Test scenarios covered (real http + real fs, no mocks):
```
✓ existing /assets/ file → 200 + correct MIME + immutable cache
✓ CSS asset → 200 + text/css + immutable cache
✓ missing /assets/ file → 404, NOT index.html
✓ missing /assets/ file → Cache-Control: no-store
✓ missing /assets/ file with Accept: text/html → still 404
✓ unknown non-asset route → 200 + text/html (SPA fallback preserved)
✓ root path → 200 + text/html
✓ /assets/../../etc/passwd → 400 (path traversal protection preserved)
```

## Deploy / post-merge checklist

After this ships:
- [ ] Verify a fake asset returns 404: `curl -I https://app.langwatch.ai/assets/fake-hash-XYZ.js` → `HTTP/2 404`
- [ ] Verify a real asset still returns 200 with immutable cache
- [ ] Review Cloudflare Page Rule for `/assets/*` — origin now sets correct `Cache-Control`, so the rule can be relaxed to respect origin headers (or kept as belt-and-braces)