### PR TITLE
feat(onboarding): capture first-touch attribution and forward to Customer.io

### DIFF
--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
@@ -1,6 +1,27 @@
+import type { Attribution } from "../../../../src/hooks/attribution";
 import { getApp } from "../../../../src/server/app-layer/app";
 import { captureException } from "../../../../src/utils/posthogErrorCapture";
 import type { CioPersonTraits } from "../types";
+
+/**
+ * Returns a new object with null, undefined, and empty-string values
+ * removed. Lets call sites list traits as data (`lead_source: foo?.bar`)
+ * instead of boilerplate conditional spreads. The return type narrows
+ * values to `NonNullable<T[K]>` so the result is assignable to trait
+ * containers that don't accept null.
+ */
+function pickDefined<T extends Record<string, unknown>>(
+  obj: T,
+): { [K in keyof T]?: NonNullable<T[K]> } {
+  const result: Record<string, unknown> = {};
+  for (const key in obj) {
+    const value = obj[key];
+    if (value !== undefined && value !== null && value !== "") {
+      result[key] = value;
+    }
+  }
+  return result as { [K in keyof T]?: NonNullable<T[K]> };
+}
 
 /**
  * Identifies a new user in Customer.io during onboarding.
@@ -21,37 +42,38 @@ export function fireSignupNurturingCalls({
   name: string | null | undefined;
   organizationId: string;
   organizationName: string;
-  signUpData?: {
-    yourRole?: string | null;
-    companySize?: string | null;
-    usage?: string | null;
-    solution?: string | null;
-    featureUsage?: string | null;
-    utmCampaign?: string | null;
-    howDidYouHearAboutUs?: string | null;
-  } | null;
+  signUpData?:
+    | (Partial<Attribution> & {
+        yourRole?: string | null;
+        companySize?: string | null;
+        usage?: string | null;
+        solution?: string | null;
+        featureUsage?: string | null;
+        howDidYouHearAboutUs?: string | null;
+      })
+    | null;
 }): void {
   const nurturing = getApp().nurturing;
   if (!nurturing) return;
 
   const traits: Partial<CioPersonTraits> = {
-    ...(email ? { email } : {}),
-    ...(name ? { name } : {}),
-    ...(signUpData?.yourRole ? { role: signUpData.yourRole } : {}),
-    ...(signUpData?.companySize
-      ? { company_size: signUpData.companySize }
-      : {}),
-    ...(signUpData?.usage ? { signup_usage: signUpData.usage } : {}),
-    ...(signUpData?.solution ? { signup_solution: signUpData.solution } : {}),
-    ...(signUpData?.featureUsage
-      ? { signup_feature_usage: signUpData.featureUsage }
-      : {}),
-    ...(signUpData?.utmCampaign
-      ? { utm_campaign: signUpData.utmCampaign }
-      : {}),
-    ...(signUpData?.howDidYouHearAboutUs
-      ? { how_heard: signUpData.howDidYouHearAboutUs }
-      : {}),
+    ...pickDefined({
+      email,
+      name,
+      role: signUpData?.yourRole,
+      company_size: signUpData?.companySize,
+      signup_usage: signUpData?.usage,
+      signup_solution: signUpData?.solution,
+      signup_feature_usage: signUpData?.featureUsage,
+      utm_campaign: signUpData?.utmCampaign,
+      how_heard: signUpData?.howDidYouHearAboutUs,
+      lead_source: signUpData?.leadSource,
+      utm_source: signUpData?.utmSource,
+      utm_medium: signUpData?.utmMedium,
+      utm_term: signUpData?.utmTerm,
+      utm_content: signUpData?.utmContent,
+      referrer: signUpData?.referrer,
+    }),
     has_traces: false,
     has_evaluations: false,
     has_prompts: false,
@@ -60,23 +82,25 @@ export function fireSignupNurturingCalls({
     createdAt: new Date().toISOString(),
   };
 
+  void nurturing.identifyUser({ userId, traits }).catch(captureException);
+
   void nurturing
-    .identifyUser({ userId, traits })
+    .groupUser({
+      userId,
+      groupId: organizationId,
+      traits: {
+        name: organizationName,
+        ...pickDefined({ company_size: signUpData?.companySize }),
+        plan: "free",
+      },
+    })
     .catch(captureException);
 
   void nurturing
-    .groupUser({ userId, groupId: organizationId, traits: {
-      name: organizationName,
-      ...(signUpData?.companySize
-        ? { company_size: signUpData.companySize }
-        : {}),
-      plan: "free",
-    }})
-    .catch(captureException);
-
-  void nurturing
-    .trackEvent({ userId, event: "signed_up", properties: {
-      ...(signUpData ?? {}),
-    }})
+    .trackEvent({
+      userId,
+      event: "signed_up",
+      properties: { ...(signUpData ?? {}) },
+    })
     .catch(captureException);
 }

--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
@@ -95,7 +95,7 @@ export function fireSignupNurturingCalls({
     .trackEvent({
       userId,
       event: "signed_up",
-      properties: pickDefined({ ...(signUpData ?? {}) }),
+      properties: pickDefined(signUpData ?? {}),
     })
     .catch(captureException);
 }

--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
@@ -1,7 +1,11 @@
-import type { Attribution } from "../../../../src/hooks/attribution";
+import type { z } from "zod";
+
 import { getApp } from "../../../../src/server/app-layer/app";
+import type { signUpDataSchema } from "../../../../src/server/api/routers/onboarding/schemas/sign-up-data.schema";
 import { captureException } from "../../../../src/utils/posthogErrorCapture";
 import type { CioPersonTraits } from "../types";
+
+type SignUpData = z.infer<typeof signUpDataSchema>;
 
 /**
  * Returns a new object with null, undefined, and empty-string values
@@ -42,16 +46,7 @@ export function fireSignupNurturingCalls({
   name: string | null | undefined;
   organizationId: string;
   organizationName: string;
-  signUpData?:
-    | (Partial<Attribution> & {
-        yourRole?: string | null;
-        companySize?: string | null;
-        usage?: string | null;
-        solution?: string | null;
-        featureUsage?: string | null;
-        howDidYouHearAboutUs?: string | null;
-      })
-    | null;
+  signUpData?: SignUpData | null;
 }): void {
   const nurturing = getApp().nurturing;
   if (!nurturing) return;
@@ -100,7 +95,7 @@ export function fireSignupNurturingCalls({
     .trackEvent({
       userId,
       event: "signed_up",
-      properties: { ...(signUpData ?? {}) },
+      properties: pickDefined({ ...(signUpData ?? {}) }),
     })
     .catch(captureException);
 }

--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.unit.test.ts
@@ -172,6 +172,103 @@ describe("Signup identification hook", () => {
       expect(args.traits.utm_campaign).toBeUndefined();
       expect(args.traits.how_heard).toBeUndefined();
     });
+
+    it("omits lead_source, utm_source, utm_medium, utm_term, utm_content, and referrer from traits", () => {
+      fireSignupNurturingCalls({
+        userId: "user-123",
+        email: "jane@example.com",
+        name: "Jane Doe",
+        organizationId: "org-456",
+        organizationName: "Acme Corp",
+        signUpData: {
+          yourRole: "engineer",
+          companySize: "11-50",
+        },
+      });
+
+      const args = mockNurturing.identifyUser.mock.calls[0]![0];
+      expect(args.traits.lead_source).toBeUndefined();
+      expect(args.traits.utm_source).toBeUndefined();
+      expect(args.traits.utm_medium).toBeUndefined();
+      expect(args.traits.utm_term).toBeUndefined();
+      expect(args.traits.utm_content).toBeUndefined();
+      expect(args.traits.referrer).toBeUndefined();
+    });
+  });
+
+  describe("when signup data includes first-touch attribution", () => {
+    const attributionArgs = {
+      userId: "user-123",
+      email: "jane@example.com",
+      name: "Jane Doe",
+      organizationId: "org-456",
+      organizationName: "Acme Corp",
+      signUpData: {
+        yourRole: "engineer",
+        leadSource: "website",
+        utmSource: "newsletter",
+        utmMedium: "email",
+        utmCampaign: "apr2026",
+        utmTerm: "agents",
+        utmContent: "cta",
+        referrer: "https://www.langwatch.ai/",
+      },
+    };
+
+    it("maps leadSource to lead_source identify trait", () => {
+      fireSignupNurturingCalls(attributionArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          lead_source: "website",
+        }),
+      });
+    });
+
+    it("maps the utm tuple to snake_case identify traits", () => {
+      fireSignupNurturingCalls(attributionArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          utm_source: "newsletter",
+          utm_medium: "email",
+          utm_campaign: "apr2026",
+          utm_term: "agents",
+          utm_content: "cta",
+        }),
+      });
+    });
+
+    it("includes referrer in identify traits", () => {
+      fireSignupNurturingCalls(attributionArgs);
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        traits: expect.objectContaining({
+          referrer: "https://www.langwatch.ai/",
+        }),
+      });
+    });
+
+    it("forwards attribution fields as signed_up event properties", () => {
+      fireSignupNurturingCalls(attributionArgs);
+
+      expect(mockNurturing.trackEvent).toHaveBeenCalledWith({
+        userId: "user-123",
+        event: "signed_up",
+        properties: expect.objectContaining({
+          leadSource: "website",
+          utmSource: "newsletter",
+          utmMedium: "email",
+          utmCampaign: "apr2026",
+          utmTerm: "agents",
+          utmContent: "cta",
+          referrer: "https://www.langwatch.ai/",
+        }),
+      });
+    });
   });
 
   describe("when Customer.io API is unavailable", () => {

--- a/langwatch/ee/billing/nurturing/types.ts
+++ b/langwatch/ee/billing/nurturing/types.ts
@@ -23,6 +23,17 @@ export interface CioPersonTraits {
   createdAt: string;
   integration_method: string;
 
+  // Attribution (first-touch URL params — captured client-side, forwarded
+  // via signUpData). Optional because callers always use
+  // `Partial<CioPersonTraits>` and set them conditionally; marking them
+  // required would lie about the runtime contract.
+  lead_source?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_term?: string;
+  utm_content?: string;
+  referrer?: string;
+
   // Trace milestones (customerIoTraceSync reactor)
   has_traces: boolean;
   sdk_language: string;

--- a/langwatch/src/AppProviders.tsx
+++ b/langwatch/src/AppProviders.tsx
@@ -7,6 +7,7 @@ import { createAppAnalyticsClient } from "~/utils/analyticsClient";
 import { SessionProvider } from "~/utils/auth-client";
 import { ColorModeProvider } from "./components/ui/color-mode";
 import { Toaster } from "./components/ui/toaster";
+import { useAttributionCapture } from "./hooks/useAttributionCapture";
 import { usePostHog } from "./hooks/usePostHog";
 import { ExtraFooterComponents } from "../ee/saas/ExtraFooterComponents";
 import { CommandBarProvider } from "./features/command-bar";
@@ -18,6 +19,11 @@ import { TRPCProvider } from "./utils/api";
  * These wrap around <RouterProvider>.
  */
 export function OuterProviders({ children }: { children: ReactNode }) {
+  // Capture first-touch attribution at the outermost mount point so it
+  // runs on every landing URL — including unauthenticated/public pages —
+  // before any navigation can drop the query string.
+  useAttributionCapture();
+
   return (
     <SessionProvider refetchInterval={0} refetchOnWindowFocus={false}>
       <TRPCProvider>

--- a/langwatch/src/features/onboarding/hooks/use-onboarding-flow.ts
+++ b/langwatch/src/features/onboarding/hooks/use-onboarding-flow.ts
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { usePublicEnv } from "~/hooks/usePublicEnv";
+import { readAttribution } from "~/hooks/attribution";
 import { getOnboardingFlowConfig } from "../constants/onboarding-flow";
 import {
   type CompanySize,
@@ -67,6 +68,11 @@ export const useOnboardingFlow = () => {
   const { currentScreenIndex, direction, navigation } =
     useGenericOnboardingFlow(flow, canProceed);
 
+  // Snapshot first-touch attribution once per mount. `readAttribution` is a
+  // pure sessionStorage read; memoizing keeps getFormData / formContextValue
+  // consuming the same object and avoids six storage reads per render.
+  const attribution = useMemo(() => readAttribution(), []);
+
   const getFormData = (): OnboardingFormData => ({
     organizationName,
     agreement,
@@ -76,10 +82,7 @@ export const useOnboardingFlow = () => {
     solutionType,
     selectedDesires,
     role,
-    utmCampaign:
-      typeof window !== "undefined"
-        ? window.sessionStorage.getItem("utm_campaign")
-        : null,
+    ...attribution,
   });
 
   const getFlowState = (): OnboardingFlowState => ({
@@ -97,10 +100,7 @@ export const useOnboardingFlow = () => {
       solutionType,
       selectedDesires,
       role,
-      utmCampaign:
-        typeof window !== "undefined"
-          ? window.sessionStorage.getItem("utm_campaign")
-          : null,
+      ...attribution,
       setOrganizationName,
       setAgreement,
       setUsageStyle,
@@ -121,6 +121,7 @@ export const useOnboardingFlow = () => {
       solutionType,
       selectedDesires,
       role,
+      attribution,
     ],
   );
   return {

--- a/langwatch/src/features/onboarding/screens/WelcomeScreen.tsx
+++ b/langwatch/src/features/onboarding/screens/WelcomeScreen.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { AnalyticsBoundary } from "react-contextual-analytics";
 import { LoadingScreen } from "~/components/LoadingScreen";
 import { toaster } from "~/components/ui/toaster";
+import { pickAttribution } from "~/hooks/attribution";
 import { useRequiredSession } from "~/hooks/useRequiredSession";
 import { api } from "~/utils/api";
 import { trackEventOnce } from "~/utils/tracking";
@@ -84,7 +85,7 @@ export const WelcomeScreen: React.FC = () => {
           companySize: form.companySize,
           yourRole: form.role,
           featureUsage: form.selectedDesires.join("\n"),
-          utmCampaign: form.utmCampaign,
+          ...pickAttribution(form),
         },
       },
       {

--- a/langwatch/src/features/onboarding/types/types.ts
+++ b/langwatch/src/features/onboarding/types/types.ts
@@ -1,3 +1,5 @@
+import type { Attribution } from "~/hooks/attribution";
+
 export enum OnboardingScreenIndex {
   ORGANIZATION = 0,
   BASIC_INFO = 1,
@@ -60,7 +62,10 @@ export type SolutionType = (typeof SOLUTION_TYPES)[number];
 export type DesireType = (typeof DESIRE_TYPES)[number];
 export type RoleType = (typeof ROLE_TYPES)[number];
 
-export interface OnboardingFormData {
+// First-touch attribution fields (leadSource, utm*, referrer) are sourced
+// from `readAttribution()` and carried on the form via `Partial<Attribution>`
+// so the shape stays single-sourced in `~/hooks/attribution`.
+export interface OnboardingFormData extends Partial<Attribution> {
   organizationName?: string;
   agreement?: boolean;
   usageStyle?: UsageStyle;
@@ -69,7 +74,6 @@ export interface OnboardingFormData {
   solutionType?: SolutionType;
   selectedDesires: DesireType[];
   role?: RoleType;
-  utmCampaign?: string | null;
 }
 
 export interface OnboardingScreen {

--- a/langwatch/src/hooks/__tests__/useAttributionCapture.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useAttributionCapture.unit.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { readAttribution } from "../attribution";
+import { useAttributionCapture } from "../useAttributionCapture";
+
+function setUrl(search: string) {
+  window.history.replaceState({}, "", `/${search}`);
+}
+
+function setReferrer(value: string) {
+  Object.defineProperty(document, "referrer", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("useAttributionCapture()", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    setUrl("");
+    setReferrer("");
+  });
+
+  describe("given no existing attribution in sessionStorage", () => {
+    describe("when the URL contains ?ref=website", () => {
+      beforeEach(() => {
+        setUrl("?ref=website");
+      });
+
+      it("captures ref into lw_attrib.leadSource", () => {
+        renderHook(() => useAttributionCapture());
+
+        expect(window.sessionStorage.getItem("lw_attrib.leadSource")).toBe(
+          "website",
+        );
+      });
+    });
+
+    describe("when the URL contains the full utm tuple", () => {
+      beforeEach(() => {
+        setUrl(
+          "?utm_source=news&utm_medium=email&utm_campaign=apr&utm_term=agents&utm_content=cta",
+        );
+      });
+
+      it("captures utm_source into lw_attrib.utmSource", () => {
+        renderHook(() => useAttributionCapture());
+        expect(window.sessionStorage.getItem("lw_attrib.utmSource")).toBe(
+          "news",
+        );
+      });
+
+      it("captures utm_medium into lw_attrib.utmMedium", () => {
+        renderHook(() => useAttributionCapture());
+        expect(window.sessionStorage.getItem("lw_attrib.utmMedium")).toBe(
+          "email",
+        );
+      });
+
+      it("captures utm_campaign into lw_attrib.utmCampaign", () => {
+        renderHook(() => useAttributionCapture());
+        expect(window.sessionStorage.getItem("lw_attrib.utmCampaign")).toBe(
+          "apr",
+        );
+      });
+
+      it("captures utm_term into lw_attrib.utmTerm", () => {
+        renderHook(() => useAttributionCapture());
+        expect(window.sessionStorage.getItem("lw_attrib.utmTerm")).toBe(
+          "agents",
+        );
+      });
+
+      it("captures utm_content into lw_attrib.utmContent", () => {
+        renderHook(() => useAttributionCapture());
+        expect(window.sessionStorage.getItem("lw_attrib.utmContent")).toBe(
+          "cta",
+        );
+      });
+    });
+
+    describe("when document.referrer is set", () => {
+      beforeEach(() => {
+        setReferrer("https://www.langwatch.ai/");
+      });
+
+      it("captures referrer into lw_attrib.referrer", () => {
+        renderHook(() => useAttributionCapture());
+
+        expect(window.sessionStorage.getItem("lw_attrib.referrer")).toBe(
+          "https://www.langwatch.ai/",
+        );
+      });
+    });
+
+    describe("when the URL contains an empty ref param", () => {
+      beforeEach(() => {
+        setUrl("?ref=");
+      });
+
+      it("does not set lw_attrib.leadSource", () => {
+        renderHook(() => useAttributionCapture());
+
+        expect(
+          window.sessionStorage.getItem("lw_attrib.leadSource"),
+        ).toBeNull();
+      });
+    });
+
+    describe("when no attribution is present", () => {
+      it("writes nothing to sessionStorage", () => {
+        renderHook(() => useAttributionCapture());
+
+        expect(window.sessionStorage.length).toBe(0);
+      });
+    });
+  });
+
+  describe("given lw_attrib.leadSource is already set to original", () => {
+    beforeEach(() => {
+      window.sessionStorage.setItem("lw_attrib.leadSource", "original");
+      setUrl("?ref=later");
+    });
+
+    it("does not overwrite the first-touch value", () => {
+      renderHook(() => useAttributionCapture());
+
+      expect(window.sessionStorage.getItem("lw_attrib.leadSource")).toBe(
+        "original",
+      );
+    });
+  });
+});
+
+describe("readAttribution()", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  describe("given sessionStorage has ref, utm tuple, and referrer", () => {
+    beforeEach(() => {
+      window.sessionStorage.setItem("lw_attrib.leadSource", "website");
+      window.sessionStorage.setItem("lw_attrib.utmSource", "news");
+      window.sessionStorage.setItem("lw_attrib.utmMedium", "email");
+      window.sessionStorage.setItem("lw_attrib.utmCampaign", "apr");
+      window.sessionStorage.setItem("lw_attrib.utmTerm", "agents");
+      window.sessionStorage.setItem("lw_attrib.utmContent", "cta");
+      window.sessionStorage.setItem(
+        "lw_attrib.referrer",
+        "https://www.langwatch.ai/",
+      );
+    });
+
+    it("exposes leadSource", () => {
+      expect(readAttribution().leadSource).toBe("website");
+    });
+
+    it("exposes the full utm tuple in camelCase", () => {
+      const attr = readAttribution();
+      expect(attr.utmSource).toBe("news");
+      expect(attr.utmMedium).toBe("email");
+      expect(attr.utmCampaign).toBe("apr");
+      expect(attr.utmTerm).toBe("agents");
+      expect(attr.utmContent).toBe("cta");
+    });
+
+    it("exposes referrer", () => {
+      expect(readAttribution().referrer).toBe("https://www.langwatch.ai/");
+    });
+  });
+
+  describe("given sessionStorage is empty", () => {
+    it("returns null for every field", () => {
+      expect(readAttribution()).toEqual({
+        leadSource: null,
+        utmSource: null,
+        utmMedium: null,
+        utmCampaign: null,
+        utmTerm: null,
+        utmContent: null,
+        referrer: null,
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useAttributionCapture.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useAttributionCapture.unit.test.ts
@@ -96,6 +96,20 @@ describe("useAttributionCapture()", () => {
       });
     });
 
+    describe("when document.referrer contains query params and hash", () => {
+      beforeEach(() => {
+        setReferrer("https://example.com/page?token=secret#section");
+      });
+
+      it("strips query and hash before storing", () => {
+        renderHook(() => useAttributionCapture());
+
+        expect(window.sessionStorage.getItem("lw_attrib.referrer")).toBe(
+          "https://example.com/page",
+        );
+      });
+    });
+
     describe("when the URL contains an empty ref param", () => {
       beforeEach(() => {
         setUrl("?ref=");

--- a/langwatch/src/hooks/attribution.ts
+++ b/langwatch/src/hooks/attribution.ts
@@ -1,0 +1,101 @@
+/**
+ * First-touch acquisition attribution.
+ *
+ * Captures `?ref=` + `utm_*` URL params and `document.referrer` into
+ * sessionStorage (first-touch: never overwritten), and reads them back into
+ * a structured `Attribution` object for downstream consumers (signup
+ * mutation, Customer.io identify/track).
+ *
+ * Pure module — no React. The mount-time write effect lives in
+ * `useAttributionCapture.ts`, which imports from here.
+ */
+
+/**
+ * Canonical list of attribution fields. Single source of truth — add a
+ * field here plus one line in `URL_PARAM_TO_FIELD` below if it's
+ * URL-sourced, and everything downstream (types, readers, pickers) follows.
+ */
+const ATTRIBUTION_FIELDS = [
+  "leadSource",
+  "utmSource",
+  "utmMedium",
+  "utmCampaign",
+  "utmTerm",
+  "utmContent",
+  "referrer",
+] as const;
+
+export type AttributionField = (typeof ATTRIBUTION_FIELDS)[number];
+export type Attribution = Record<AttributionField, string | null>;
+
+/**
+ * Maps URL search param → internal Attribution field. `referrer` is
+ * intentionally absent because it comes from `document.referrer`, not the
+ * query string.
+ */
+export const URL_PARAM_TO_FIELD = {
+  ref: "leadSource",
+  utm_source: "utmSource",
+  utm_medium: "utmMedium",
+  utm_campaign: "utmCampaign",
+  utm_term: "utmTerm",
+  utm_content: "utmContent",
+} as const satisfies Record<string, AttributionField>;
+
+const STORAGE_PREFIX = "lw_attrib.";
+
+function storageKey(field: AttributionField): string {
+  return STORAGE_PREFIX + field;
+}
+
+function safeGet(field: AttributionField): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage.getItem(storageKey(field));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Writes the value only if the key is currently unset (first-touch
+ * semantics). Empty strings are ignored. No-op on SSR or when storage is
+ * unavailable (private browsing).
+ */
+export function setAttributionIfAbsent(
+  field: AttributionField,
+  value: string,
+): void {
+  if (typeof window === "undefined") return;
+  if (value.length === 0) return;
+  try {
+    const key = storageKey(field);
+    if (window.sessionStorage.getItem(key) !== null) return;
+    window.sessionStorage.setItem(key, value);
+  } catch {
+    // sessionStorage may be unavailable (private browsing, disabled) — ignore.
+  }
+}
+
+/** Reads every attribution field from sessionStorage. Unset fields → null. */
+export function readAttribution(): Attribution {
+  const result = {} as Attribution;
+  for (const field of ATTRIBUTION_FIELDS) {
+    result[field] = safeGet(field);
+  }
+  return result;
+}
+
+/**
+ * Projects any object containing attribution fields onto the `Attribution`
+ * shape. Missing fields become null. Useful for extracting the attribution
+ * subset from a larger form object without repeating the field list at
+ * every call site.
+ */
+export function pickAttribution(source: Partial<Attribution>): Attribution {
+  const result = {} as Attribution;
+  for (const field of ATTRIBUTION_FIELDS) {
+    result[field] = source[field] ?? null;
+  }
+  return result;
+}

--- a/langwatch/src/hooks/useAttributionCapture.ts
+++ b/langwatch/src/hooks/useAttributionCapture.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import {
+  URL_PARAM_TO_FIELD,
+  setAttributionIfAbsent,
+  type AttributionField,
+} from "./attribution";
+
+/**
+ * Captures first-touch attribution on mount.
+ *
+ * Writes `?ref=` + utm_* URL params and `document.referrer` into
+ * sessionStorage via `setAttributionIfAbsent`. Mount once at the app root
+ * (see `OuterProviders`) so it fires for every landing URL — including
+ * unauthenticated public pages — before any navigation can drop the query
+ * string.
+ *
+ * All storage access + schema lives in `./attribution`; this hook is the
+ * React-side write trigger only.
+ */
+export function useAttributionCapture(): void {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const params = new URLSearchParams(window.location.search);
+    for (const [urlParam, field] of Object.entries(URL_PARAM_TO_FIELD) as [
+      string,
+      AttributionField,
+    ][]) {
+      const value = params.get(urlParam);
+      if (value) setAttributionIfAbsent(field, value);
+    }
+
+    if (document.referrer) {
+      setAttributionIfAbsent("referrer", document.referrer);
+    }
+  }, []);
+}

--- a/langwatch/src/hooks/useAttributionCapture.ts
+++ b/langwatch/src/hooks/useAttributionCapture.ts
@@ -7,8 +7,8 @@ import {
 
 /**
  * Strips query and fragment from a referrer URL so we never forward
- * sensitive path/query/hash data (e.g. tokens in redirect URLs) to
- * Customer.io. Returns null when the referrer isn't a parseable URL.
+ * sensitive query params or hash data to Customer.io.
+ * Returns null when the referrer isn't a parseable URL.
  */
 function sanitizeReferrer(referrer: string): string | null {
   try {

--- a/langwatch/src/hooks/useAttributionCapture.ts
+++ b/langwatch/src/hooks/useAttributionCapture.ts
@@ -6,6 +6,22 @@ import {
 } from "./attribution";
 
 /**
+ * Strips query and fragment from a referrer URL so we never forward
+ * sensitive path/query/hash data (e.g. tokens in redirect URLs) to
+ * Customer.io. Returns null when the referrer isn't a parseable URL.
+ */
+function sanitizeReferrer(referrer: string): string | null {
+  try {
+    const url = new URL(referrer);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Captures first-touch attribution on mount.
  *
  * Writes `?ref=` + utm_* URL params and `document.referrer` into
@@ -30,8 +46,11 @@ export function useAttributionCapture(): void {
       if (value) setAttributionIfAbsent(field, value);
     }
 
-    if (document.referrer) {
-      setAttributionIfAbsent("referrer", document.referrer);
+    const referrer = document.referrer
+      ? sanitizeReferrer(document.referrer)
+      : null;
+    if (referrer) {
+      setAttributionIfAbsent("referrer", referrer);
     }
   }, []);
 }

--- a/langwatch/src/pages/index.tsx
+++ b/langwatch/src/pages/index.tsx
@@ -7,13 +7,6 @@ export default function Index() {
   const { project, team } = useOrganizationTeamProject();
   const router = useRouter();
 
-  if (router.query.utm_campaign && typeof window !== "undefined") {
-    window.sessionStorage.setItem(
-      "utm_campaign",
-      router.query.utm_campaign as string,
-    );
-  }
-
   useEffect(() => {
     if (project) {
       void router.replace(`/${project.slug}`);

--- a/langwatch/src/server/api/routers/onboarding/schemas/sign-up-data.schema.ts
+++ b/langwatch/src/server/api/routers/onboarding/schemas/sign-up-data.schema.ts
@@ -17,4 +17,11 @@ export const signUpDataSchema = z.object({
   utmCampaign: z.string().optional().nullable(),
   yourRole: z.string().optional().nullable(),
   featureUsage: z.string().optional().nullable(),
+  // First-touch attribution (from landing URL / document.referrer)
+  leadSource: z.string().optional().nullable(),
+  utmSource: z.string().optional().nullable(),
+  utmMedium: z.string().optional().nullable(),
+  utmTerm: z.string().optional().nullable(),
+  utmContent: z.string().optional().nullable(),
+  referrer: z.string().optional().nullable(),
 });

--- a/specs/features/customer-io-nurturing-integration.feature
+++ b/specs/features/customer-io-nurturing-integration.feature
@@ -474,3 +474,65 @@ Feature: Customer.io nurturing integration
     And the user traits sent to Customer.io include has_simulations false
     And the user traits sent to Customer.io include has_traces false
     And the user traits sent to Customer.io include has_evaluations false
+
+  # ---------------------------------------------------------------------------
+  # R14: Attribution capture — URL -> Customer.io
+  #
+  # Captures first-touch URL parameters (ref, utm_*) and document.referrer
+  # on the first pageview after hydration, persists them in sessionStorage,
+  # and forwards them through the onboarding signUpData so they land in
+  # Customer.io as identify traits AND signed_up event properties.
+  #
+  # First-touch semantics: once captured, subsequent navigations do not
+  # overwrite the value. This prevents internal link clicks from clobbering
+  # the original acquisition source.
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Attribution hook captures ref param in sessionStorage on first touch
+    Given no existing attribution in sessionStorage
+    And the URL contains "?ref=website"
+    When the attribution capture hook mounts
+    Then sessionStorage key "lw_attrib.ref" equals "website"
+
+  @unit
+  Scenario: Attribution hook does not overwrite existing first-touch values
+    Given sessionStorage "lw_attrib.ref" is already "original"
+    And the URL contains "?ref=later"
+    When the attribution capture hook mounts
+    Then sessionStorage key "lw_attrib.ref" remains "original"
+
+  @unit
+  Scenario: Attribution hook captures full utm tuple when present in URL
+    Given no existing attribution in sessionStorage
+    And the URL contains utm_source, utm_medium, utm_campaign, utm_term, utm_content
+    When the attribution capture hook mounts
+    Then sessionStorage contains all five lw_attrib.utm_* keys with the URL values
+
+  @unit
+  Scenario: Attribution hook captures document.referrer when present
+    Given no existing attribution in sessionStorage
+    And document.referrer is "https://www.langwatch.ai/"
+    When the attribution capture hook mounts
+    Then sessionStorage key "lw_attrib.referrer" equals "https://www.langwatch.ai/"
+
+  @integration
+  Scenario: Signup with ref in URL sends lead_source trait and event property to Customer.io
+    Given a user lands on the app with "?ref=website" in the URL
+    And completes onboarding
+    When the onboarding flow completes
+    Then the user traits sent to Customer.io include lead_source "website"
+    And the "signed_up" event properties include leadSource "website"
+
+  @integration
+  Scenario: Signup forwards utm tuple to Customer.io
+    Given a user lands on the app with utm_source, utm_medium, utm_campaign, utm_term, utm_content in the URL
+    And completes onboarding
+    When the onboarding flow completes
+    Then the user traits sent to Customer.io include utm_source, utm_medium, utm_campaign, utm_term, utm_content
+
+  @integration
+  Scenario: Signup without attribution omits those fields from Customer.io traits
+    Given a user completes onboarding with no attribution data
+    When the onboarding flow completes
+    Then the user traits sent to Customer.io do not include lead_source, utm_source, utm_medium, utm_term, utm_content, or referrer keys

--- a/specs/features/customer-io-nurturing-integration.feature
+++ b/specs/features/customer-io-nurturing-integration.feature
@@ -493,14 +493,14 @@ Feature: Customer.io nurturing integration
     Given no existing attribution in sessionStorage
     And the URL contains "?ref=website"
     When the attribution capture hook mounts
-    Then sessionStorage key "lw_attrib.ref" equals "website"
+    Then sessionStorage key "lw_attrib.leadSource" equals "website"
 
   @unit
   Scenario: Attribution hook does not overwrite existing first-touch values
-    Given sessionStorage "lw_attrib.ref" is already "original"
+    Given sessionStorage "lw_attrib.leadSource" is already "original"
     And the URL contains "?ref=later"
     When the attribution capture hook mounts
-    Then sessionStorage key "lw_attrib.ref" remains "original"
+    Then sessionStorage key "lw_attrib.leadSource" remains "original"
 
   @unit
   Scenario: Attribution hook captures full utm tuple when present in URL

--- a/specs/features/customer-io-nurturing-integration.feature
+++ b/specs/features/customer-io-nurturing-integration.feature
@@ -535,4 +535,4 @@ Feature: Customer.io nurturing integration
   Scenario: Signup without attribution omits those fields from Customer.io traits
     Given a user completes onboarding with no attribution data
     When the onboarding flow completes
-    Then the user traits sent to Customer.io do not include lead_source, utm_source, utm_medium, utm_term, utm_content, or referrer keys
+    Then the user traits sent to Customer.io do not include lead_source, utm_source, utm_medium, utm_campaign, utm_term, utm_content, or referrer keys


### PR DESCRIPTION
## Summary

- Capture first-touch `?ref=` + UTM tuple + `document.referrer` on any landing URL (including deep-linked marketing pages that survive the Auth0 round-trip) and forward to Customer.io as both `identify` traits (`lead_source`, `utm_*`, `referrer`) and `signed_up` event properties.
- New pure `src/hooks/attribution.ts` module owns the `Attribution` type, `URL_PARAM_TO_FIELD` mapping, and storage helpers. A thin `useAttributionCapture` hook mounts in `OuterProviders` so it fires on every tab before navigation drops query params.
- Delete the buggy render-phase `utm_campaign` capture in `pages/index.tsx` (fired only on `/`, wrote during render).
- Extract `pickDefined` helper in `signupIdentification` to collapse the spread-if-truthy boilerplate; mark new `CioPersonTraits` attribution fields optional to match the `Partial<CioPersonTraits>` writer contract.

## Why

Marketing needs to know where signups came from. Today links like `https://www.langwatch.ai` → `https://app.langwatch.ai/…?ref=…` carry the `?ref=` value through Auth0 (NextAuth preserves it via `callbackUrl`), but nothing on the client reads it, so Customer.io never sees a `lead_source`.

Plan: `~/.claude/plans/snuggly-squishing-ullman.md`

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit src/hooks/__tests__/useAttributionCapture.unit.test.ts ee/billing/nurturing/hooks/signupIdentification.unit.test.ts` — 30/30 pass
- [ ] Manual: fresh browser, visit `/any/path?ref=manualqa&utm_source=newsletter&utm_campaign=apr2026` → sign up → confirm Customer.io `identify` + `signed_up` payloads include `lead_source`, `utm_source`, `utm_campaign`
- [ ] CI green