### PR TITLE
feat(dev): pre-flight port check for pnpm dev

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -27,7 +27,7 @@
     "start:app": "tsx src/server.mts",
     "start:quickwit": "cd quickwit && ./quickwit run",
     "start:prepare:files": "pnpm run generate:sdk-versions && pnpm run copy:langevals-types && pnpm run types:zod:generate && pnpm run prisma:generate:typescript && pnpm run build:mcp-server",
-    "build:mcp-server": "pnpm --filter @langwatch/mcp-server run build",
+    "build:mcp-server": "./scripts/build-mcp-server.sh",
     "generate:sdk-versions": "bash scripts/generate-sdk-versions.sh",
     "start:prepare:db": "pnpm run prisma:migrate && pnpm run clickhouse:migrate",
     "start:workers": "tsx --tsconfig tsconfig.workers.json src/workers.ts",

--- a/langwatch/scripts/build-mcp-server.sh
+++ b/langwatch/scripts/build-mcp-server.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Silent wrapper around `pnpm --filter @langwatch/mcp-server run build`.
+# Called from `pnpm run start:prepare:files` — the full tsup + esbuild
+# output is noise in that context. Prints one line with the elapsed time,
+# or the full captured output on failure.
+
+set -eo pipefail
+
+printf 'building mcp server... '
+start=$(node -e 'console.log(Date.now())')
+
+if ! output=$(pnpm --silent --filter @langwatch/mcp-server run build 2>&1); then
+  printf 'FAILED\n'
+  printf '%s\n' "$output"
+  exit 1
+fi
+
+elapsed=$(node -e "console.log(((Date.now() - $start) / 1000).toFixed(1))")
+printf 'built in %ss\n' "$elapsed"

--- a/langwatch/scripts/check-ports.sh
+++ b/langwatch/scripts/check-ports.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Pre-flight port check for `pnpm dev` / `pnpm start`.
+#
+# Default port layout (PORT=5560):
+#   - PORT          (5560) Vite dev server (frontend)
+#   - PORT + 1000   (6560) API / Hono backend
+#   - PORT - 2561   (2999) Worker metrics
+#
+# Picking PORT in increments of 10 (5570, 5580, …) keeps room for the
+# adjacent NLP / langevals services that already sit on 5561 / 5562.
+
+# Intentionally NOT using `set -e` / `pipefail`: `lsof -tiTCP:N` exits 1 when
+# the port is free, which is the *good* path for us — it should not abort
+# the whole script.
+
+PORT="${PORT:-5560}"
+API_PORT=$((PORT + 1000))
+WORKER_METRICS_PORT="${WORKER_METRICS_PORT:-$((PORT - 2561))}"
+
+NODE_ENV_VAL="${NODE_ENV:-production}"
+START_WORKERS_VAL="${START_WORKERS:-false}"
+
+PORTS_TO_CHECK=()
+PORT_LABELS=()
+
+if [ "$NODE_ENV_VAL" = "development" ]; then
+  PORTS_TO_CHECK+=("$PORT")          ; PORT_LABELS+=("vite frontend")
+  PORTS_TO_CHECK+=("$API_PORT")      ; PORT_LABELS+=("api backend")
+else
+  PORTS_TO_CHECK+=("$PORT")          ; PORT_LABELS+=("api server")
+fi
+
+if [ "$START_WORKERS_VAL" = "true" ] || [ "$START_WORKERS_VAL" = "1" ]; then
+  PORTS_TO_CHECK+=("$WORKER_METRICS_PORT") ; PORT_LABELS+=("worker metrics")
+fi
+
+# `lsof -tiTCP:N -sTCP:LISTEN` prints PIDs (one per line) holding port N.
+port_holder() {
+  lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null | head -1
+}
+
+port_holder_command() {
+  local pid="$1"
+  ps -o command= -p "$pid" 2>/dev/null | sed 's/  */ /g' | cut -c1-100
+}
+
+conflicts=()
+for i in "${!PORTS_TO_CHECK[@]}"; do
+  port="${PORTS_TO_CHECK[$i]}"
+  label="${PORT_LABELS[$i]}"
+  pid=$(port_holder "$port")
+  if [ -n "$pid" ]; then
+    conflicts+=("$port|$label|$pid")
+  fi
+done
+
+if [ "${#conflicts[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+# Find the next free PORT slot in increments of 10. We need ALL three derived
+# ports (slot, slot+1000, slot-2561) free.
+suggested_port=""
+slot="$PORT"
+for _ in $(seq 1 30); do
+  slot=$((slot + 10))
+  vite_p="$slot"
+  api_p=$((slot + 1000))
+  metrics_p=$((slot - 2561))
+  if [ -z "$(port_holder "$vite_p")" ] && \
+     [ -z "$(port_holder "$api_p")" ] && \
+     [ -z "$(port_holder "$metrics_p")" ]; then
+    suggested_port="$slot"
+    break
+  fi
+done
+
+# ANSI colors (skip if NO_COLOR or non-tty)
+if [ -t 1 ] && [ -z "$NO_COLOR" ]; then
+  RED=$'\033[0;31m'; YEL=$'\033[0;33m'; CYA=$'\033[0;36m'; BLD=$'\033[1m'; RST=$'\033[0m'
+else
+  RED=""; YEL=""; CYA=""; BLD=""; RST=""
+fi
+
+echo ""
+echo "${RED}${BLD}✗ port conflict — refusing to start${RST}"
+echo ""
+for c in "${conflicts[@]}"; do
+  port="${c%%|*}"; rest="${c#*|}"
+  label="${rest%%|*}"; pid="${rest#*|}"
+  cmd="$(port_holder_command "$pid")"
+  echo "  ${RED}✗${RST} port ${BLD}${port}${RST} (${label}) held by pid ${pid}: ${cmd}"
+done
+echo ""
+echo "${YEL}${BLD}options:${RST}"
+echo ""
+if [ -n "$suggested_port" ]; then
+  echo "  ${CYA}1)${RST} use a free port slot (vite=${suggested_port}, api=$((suggested_port + 1000)), metrics=$((suggested_port - 2561))):"
+  echo ""
+  echo "       ${BLD}PORT=${suggested_port} pnpm dev${RST}"
+  echo ""
+fi
+echo "  ${CYA}2)${RST} kill the existing langwatch dev tree (safe — only kills node procs holding our ports, leaves Docker etc alone):"
+echo ""
+echo "       ${BLD}lsof -t -a -iTCP:${PORT},${API_PORT},${WORKER_METRICS_PORT} -sTCP:LISTEN -c node 2>/dev/null \\"
+echo "         | xargs -I{} ps -o pgid= -p {} 2>/dev/null | tr -d ' ' | sort -u \\"
+echo "         | xargs -I{} kill -TERM -{}${RST}"
+echo ""
+
+exit 1

--- a/langwatch/scripts/check-ports.sh
+++ b/langwatch/scripts/check-ports.sh
@@ -100,9 +100,12 @@ if [ -n "$suggested_port" ]; then
   echo "       ${BLD}PORT=${suggested_port} pnpm dev${RST}"
   echo ""
 fi
+# Target exactly the ports we actually check — so if workers aren't enabled,
+# the kill doesn't sweep whatever happens to live on PORT - 2561.
+PORT_LIST_CSV=$(IFS=,; echo "${PORTS_TO_CHECK[*]}")
 echo "  ${CYA}2)${RST} kill the existing langwatch dev tree (safe — only kills node procs holding our ports, leaves Docker etc alone):"
 echo ""
-echo "       ${BLD}lsof -t -a -iTCP:${PORT},${API_PORT},${WORKER_METRICS_PORT} -sTCP:LISTEN -c node 2>/dev/null \\"
+echo "       ${BLD}lsof -t -a -iTCP:${PORT_LIST_CSV} -sTCP:LISTEN -c node 2>/dev/null \\"
 echo "         | xargs -I{} ps -o pgid= -p {} 2>/dev/null | tr -d ' ' | sort -u \\"
 echo "         | xargs -I{} kill -TERM -{}${RST}"
 echo ""

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+# Fail fast if any port we'd bind to is already taken (stale `pnpm dev`,
+# Docker exposing the same port, etc). Without this, we'd only discover the
+# conflict 30s later after Vite/tsx finish booting.
+"$(dirname "$0")/check-ports.sh"
+
 RUNTIME_ENV="DEBUG=langwatch:* DEBUG_HIDE_DATE=true DEBUG_COLORS=true"
 if [ -z "$NODE_ENV" ]; then
   RUNTIME_ENV="$RUNTIME_ENV NODE_ENV=production"

--- a/langwatch/src/server/background/config.test.ts
+++ b/langwatch/src/server/background/config.test.ts
@@ -2,57 +2,84 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_WORKER_METRICS_PORT, getWorkerMetricsPort } from "./config";
 
 describe("getWorkerMetricsPort", () => {
-  const originalEnv = process.env.WORKER_METRICS_PORT;
+  const originalMetricsEnv = process.env.WORKER_METRICS_PORT;
+  const originalPortEnv = process.env.PORT;
 
   beforeEach(() => {
     delete process.env.WORKER_METRICS_PORT;
+    delete process.env.PORT;
   });
 
   afterEach(() => {
-    if (originalEnv === undefined) {
+    if (originalMetricsEnv === undefined) {
       delete process.env.WORKER_METRICS_PORT;
     } else {
-      process.env.WORKER_METRICS_PORT = originalEnv;
+      process.env.WORKER_METRICS_PORT = originalMetricsEnv;
+    }
+    if (originalPortEnv === undefined) {
+      delete process.env.PORT;
+    } else {
+      process.env.PORT = originalPortEnv;
     }
   });
 
-  it("returns default port when environment variable is not set", () => {
-    expect(getWorkerMetricsPort()).toBe(DEFAULT_WORKER_METRICS_PORT);
+  describe("when WORKER_METRICS_PORT is not set", () => {
+    it("returns 2999 when PORT is also unset", () => {
+      expect(getWorkerMetricsPort()).toBe(DEFAULT_WORKER_METRICS_PORT);
+    });
+
+    it("derives default from PORT (PORT - 2561) so non-default slots don't collide", () => {
+      process.env.PORT = "5570";
+      expect(getWorkerMetricsPort()).toBe(3009);
+    });
+
+    it("falls back to 2999 when PORT is non-numeric", () => {
+      process.env.PORT = "banana";
+      expect(getWorkerMetricsPort()).toBe(DEFAULT_WORKER_METRICS_PORT);
+    });
   });
 
-  it("returns configured port from environment variable", () => {
-    process.env.WORKER_METRICS_PORT = "3001";
-    expect(getWorkerMetricsPort()).toBe(3001);
-  });
+  describe("when WORKER_METRICS_PORT is set", () => {
+    it("returns the configured port", () => {
+      process.env.WORKER_METRICS_PORT = "3001";
+      expect(getWorkerMetricsPort()).toBe(3001);
+    });
 
-  it("throws an error for non-numeric port values", () => {
-    process.env.WORKER_METRICS_PORT = "banana";
-    expect(() => getWorkerMetricsPort()).toThrow(
-      'Invalid WORKER_METRICS_PORT: "banana"'
-    );
-  });
+    it("overrides the PORT-derived default", () => {
+      process.env.PORT = "5570";
+      process.env.WORKER_METRICS_PORT = "4242";
+      expect(getWorkerMetricsPort()).toBe(4242);
+    });
 
-  it("throws an error for port below valid range", () => {
-    process.env.WORKER_METRICS_PORT = "0";
-    expect(() => getWorkerMetricsPort()).toThrow(
-      'Invalid WORKER_METRICS_PORT: "0"'
-    );
-  });
+    it("throws an error for non-numeric port values", () => {
+      process.env.WORKER_METRICS_PORT = "banana";
+      expect(() => getWorkerMetricsPort()).toThrow(
+        'Invalid WORKER_METRICS_PORT: "banana"'
+      );
+    });
 
-  it("throws an error for port above valid range", () => {
-    process.env.WORKER_METRICS_PORT = "999999";
-    expect(() => getWorkerMetricsPort()).toThrow(
-      'Invalid WORKER_METRICS_PORT: "999999"'
-    );
-  });
+    it("throws an error for port below valid range", () => {
+      process.env.WORKER_METRICS_PORT = "0";
+      expect(() => getWorkerMetricsPort()).toThrow(
+        'Invalid WORKER_METRICS_PORT: "0"'
+      );
+    });
 
-  it("accepts valid port at lower boundary", () => {
-    process.env.WORKER_METRICS_PORT = "1";
-    expect(getWorkerMetricsPort()).toBe(1);
-  });
+    it("throws an error for port above valid range", () => {
+      process.env.WORKER_METRICS_PORT = "999999";
+      expect(() => getWorkerMetricsPort()).toThrow(
+        'Invalid WORKER_METRICS_PORT: "999999"'
+      );
+    });
 
-  it("accepts valid port at upper boundary", () => {
-    process.env.WORKER_METRICS_PORT = "65535";
-    expect(getWorkerMetricsPort()).toBe(65535);
+    it("accepts valid port at lower boundary", () => {
+      process.env.WORKER_METRICS_PORT = "1";
+      expect(getWorkerMetricsPort()).toBe(1);
+    });
+
+    it("accepts valid port at upper boundary", () => {
+      process.env.WORKER_METRICS_PORT = "65535";
+      expect(getWorkerMetricsPort()).toBe(65535);
+    });
   });
 });

--- a/langwatch/src/server/background/config.ts
+++ b/langwatch/src/server/background/config.ts
@@ -1,8 +1,24 @@
+// Worker metrics port follows PORT so non-default PORT slots (5570, 5580…)
+// don't all collide on 2999. PORT=5560 → 2999 (back-compat).
+const WORKER_METRICS_PORT_OFFSET = 2561;
+
 export const DEFAULT_WORKER_METRICS_PORT = 2999;
+
+const getDefaultWorkerMetricsPort = (): number => {
+  const portString = process.env.PORT;
+  if (portString === undefined || portString === "") {
+    return DEFAULT_WORKER_METRICS_PORT;
+  }
+  const basePort = parseInt(portString, 10);
+  if (Number.isNaN(basePort)) {
+    return DEFAULT_WORKER_METRICS_PORT;
+  }
+  return basePort - WORKER_METRICS_PORT_OFFSET;
+};
 
 export const getWorkerMetricsPort = (): number => {
   const portString =
-    process.env.WORKER_METRICS_PORT ?? String(DEFAULT_WORKER_METRICS_PORT);
+    process.env.WORKER_METRICS_PORT ?? String(getDefaultWorkerMetricsPort());
   const port = parseInt(portString, 10);
 
   if (Number.isNaN(port) || port < 1 || port > 65535) {


### PR DESCRIPTION
## Summary

- **Fail fast on port conflicts.** `pnpm dev` used to boot Vite + tsx for ~30s before discovering that PORT 5560 / 6560 / 2999 was already taken (stale dev tree, Docker, another worktree…). New `langwatch/scripts/check-ports.sh` runs first and aborts sub-second with a clear report of *who* holds each port.
- **Tailored kill command.** Concurrently restarts children, so "kill whatever's on 2999" doesn't work. The suggested command walks `lsof -t -a -iTCP:… -sTCP:LISTEN -c node` → PGID → `kill -TERM -<pgid>`, which drops the whole 15-proc tree (pnpm dev → sh → tee → pnpm start → start.sh → concurrently → workers/vite/api + their tsx children) in one shot. The `-a` flag makes `-c node` AND'd with the TCP filter — without it, Docker/Zed/unrelated PGIDs would get swept up.
- **`WORKER_METRICS_PORT` now follows `PORT`.** Default is `PORT - 2561` (so `PORT=5560 → 2999`, back-compat; `PORT=5570 → 3009`, no collision). Running multiple worktrees on `PORT=5570, 5580, …` no longer fights over 2999. Explicit `WORKER_METRICS_PORT` still wins.
- **Suggested next slot respects +10 increments.** `PORT=5561/5562` are already used by NLP / langevals, so we step in tens. The suggester verifies *all three* derived ports (slot, slot+1000, slot-2561) are free before proposing.

## Test plan

- [x] Unit tests: 10 tests in `config.test.ts` covering the new PORT-derived default + existing validation (all passing).
- [x] Live verification with user's running dev tree: correctly flagged Docker on 5560 + node on 2999, suggested `PORT=5590`, dry-run of kill command targeted exactly PGID 74071 (15 procs) and nothing else.
- [x] Clean path verified: `PORT=5590 NODE_ENV=development START_WORKERS=true` exits 0.
- [ ] CI green.