### PR TITLE
feat(sdk): add Experiment.print_summary for CI parity with platform runs

### DIFF
--- a/docs/evaluations/experiments/ci-cd.mdx
+++ b/docs/evaluations/experiments/ci-cd.mdx
@@ -141,6 +141,9 @@ for idx, row in experiment.loop(dataset.iterrows()):
             "contexts": row["contexts"],
         },
     )
+
+# Print summary and exit with code 1 on failure
+experiment.print_summary()
 ```
   </Tab>
   <Tab title="TypeScript">
@@ -174,6 +177,9 @@ await experiment.run(
   },
   { concurrency: 4 }
 );
+
+// Print summary and exit with code 1 on failure
+experiment.printSummary();
 ```
   </Tab>
 </Tabs>
@@ -244,6 +250,9 @@ for idx, row in experiment.loop(dataset.iterrows()):
             })
 
     experiment.submit(compare, idx, row)
+
+# Print summary and exit with code 1 on failure
+experiment.print_summary()
 ```
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -17509,6 +17509,9 @@ for idx, row in experiment.loop(dataset.iterrows()):
             "contexts": row["contexts"],
         },
     )
+
+# Print summary and exit with code 1 on failure
+experiment.print_summary()
 ```
 
   ### TypeScript
@@ -17543,6 +17546,9 @@ await experiment.run(
   },
   { concurrency: 4 }
 );
+
+// Print summary and exit with code 1 on failure
+experiment.printSummary();
 ```
 
 
@@ -17613,6 +17619,9 @@ for idx, row in experiment.loop(dataset.iterrows()):
             })
 
     experiment.submit(compare, idx, row)
+
+# Print summary and exit with code 1 on failure
+experiment.print_summary()
 ```
 
 ---

--- a/python-sdk/src/langwatch/experiment/experiment.py
+++ b/python-sdk/src/langwatch/experiment/experiment.py
@@ -569,9 +569,10 @@ class Experiment:
             total_cost=total_cost,
         )
 
+        has_failures = total_failed > 0 or failed_cells > 0
         return ExperimentRunResult(
             run_id=self.run_id,
-            status="completed",
+            status="failed" if has_failures else "completed",
             passed=total_passed,
             failed=total_failed,
             pass_rate=pass_rate,

--- a/python-sdk/src/langwatch/experiment/experiment.py
+++ b/python-sdk/src/langwatch/experiment/experiment.py
@@ -36,6 +36,14 @@ from tqdm.auto import tqdm
 import langwatch
 from langwatch.attributes import AttributeKey
 from langwatch.domain import Money, TypedValueJson
+from langwatch.experiment.platform_run import (
+    EvaluatorStats,
+    ExperimentRunResult,
+    ExperimentRunSummary,
+    TargetStats,
+    _is_notebook,
+    _print_summary,
+)
 from langwatch.telemetry.tracing import LangWatchTrace
 from langwatch.utils.exceptions import better_raise_for_status
 from langwatch.utils.transformation import SerializableWithStringFallback
@@ -422,30 +430,17 @@ class Experiment:
 
             experiment.print_summary()
         """
-        from langwatch.experiment.platform_run import _is_notebook, _print_summary
-
         result = self._build_run_result()
         _print_summary(result)
 
         should_exit = exit_on_failure if exit_on_failure is not None else not _is_notebook()
-        if should_exit and result.failed > 0:
+        if should_exit and (result.failed > 0 or result.summary.failed_cells > 0):
             sys.exit(1)
 
-    def _build_run_result(self) -> "ExperimentRunResult":
+    def _build_run_result(self) -> ExperimentRunResult:
         """Build an ExperimentRunResult from the current results DataFrame."""
-        from langwatch.experiment.platform_run import (
-            EvaluatorStats,
-            ExperimentRunResult,
-            ExperimentRunSummary,
-            TargetStats,
-        )
-
         run_url = self._run_url or ""
-
-        try:
-            df = self.results
-        except Exception:
-            df = pd.DataFrame()
+        df = self.results
 
         if df is None or df.empty:
             empty_summary = ExperimentRunSummary(
@@ -552,11 +547,18 @@ class Experiment:
             if not cost_all.empty:
                 total_cost = float(cost_all.sum())
 
+        # Count rows whose target/loop execution errored out (non-null error column).
+        # These are execution failures distinct from evaluator failures — CI must
+        # treat them as failures too, not just evaluator mismatches.
+        failed_cells = 0
+        if "error" in flat.columns:
+            failed_cells = int(flat["error"].notna().sum())
+
         summary = ExperimentRunSummary(
             run_id=self.run_id,
             total_cells=len(flat),
-            completed_cells=len(flat),
-            failed_cells=0,
+            completed_cells=len(flat) - failed_cells,
+            failed_cells=failed_cells,
             duration=duration,
             run_url=run_url,
             targets=targets,

--- a/python-sdk/src/langwatch/experiment/experiment.py
+++ b/python-sdk/src/langwatch/experiment/experiment.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 import json
+import sys
 import threading
 import time
 import traceback
@@ -398,6 +399,184 @@ class Experiment:
             # IPython not available — fall through to text display
             pass
         print(df.to_string())
+
+    def print_summary(self, exit_on_failure: Optional[bool] = None) -> None:
+        """
+        Print a CI-friendly summary of the experiment and optionally exit with code 1 on failure.
+
+        Mirrors ``ExperimentRunResult.print_summary`` for parity — SDK-driven
+        experiments (``langwatch.experiment.init(...)`` + ``loop`` + ``evaluate``) can
+        now fail CI builds the same way platform experiments (``langwatch.experiment.run(slug)``) do.
+
+        Args:
+            exit_on_failure: If True, calls ``sys.exit(1)`` when there are failures.
+                             If False, never exits. If None (default), auto-detects:
+                             exits in scripts/CI, doesn't in Jupyter notebooks.
+
+        Example::
+
+            experiment = langwatch.experiment.init("ci-quality-check")
+            for idx, row in experiment.loop(dataset.iterrows()):
+                response = my_llm(row["input"])
+                experiment.evaluate("ragas/faithfulness", index=idx, data={...})
+
+            experiment.print_summary()
+        """
+        from langwatch.experiment.platform_run import _is_notebook, _print_summary
+
+        result = self._build_run_result()
+        _print_summary(result)
+
+        should_exit = exit_on_failure if exit_on_failure is not None else not _is_notebook()
+        if should_exit and result.failed > 0:
+            sys.exit(1)
+
+    def _build_run_result(self) -> "ExperimentRunResult":
+        """Build an ExperimentRunResult from the current results DataFrame."""
+        from langwatch.experiment.platform_run import (
+            EvaluatorStats,
+            ExperimentRunResult,
+            ExperimentRunSummary,
+            TargetStats,
+        )
+
+        run_url = self._run_url or ""
+
+        try:
+            df = self.results
+        except Exception:
+            df = pd.DataFrame()
+
+        if df is None or df.empty:
+            empty_summary = ExperimentRunSummary(
+                run_id=self.run_id,
+                total_cells=0,
+                completed_cells=0,
+                failed_cells=0,
+                duration=0,
+                run_url=run_url,
+            )
+            return ExperimentRunResult(
+                run_id=self.run_id,
+                status="completed",
+                passed=0,
+                failed=0,
+                pass_rate=0.0,
+                duration=0,
+                run_url=run_url,
+                summary=empty_summary,
+            )
+
+        # Flatten any MultiIndex so we can access columns uniformly.
+        flat = df.reset_index() if df.index.names and any(n is not None for n in df.index.names) else df
+
+        passed_cols = [c for c in flat.columns if isinstance(c, str) and c.endswith("_passed")]
+
+        total_passed = 0
+        total_failed = 0
+        evaluators: List[EvaluatorStats] = []
+        for pcol in passed_cols:
+            name = pcol[: -len("_passed")]
+            col = flat[pcol].dropna()
+            passed = int((col == True).sum())  # noqa: E712 — pandas comparison
+            failed = int((col == False).sum())  # noqa: E712
+            total_passed += passed
+            total_failed += failed
+
+            avg_score: Optional[float] = None
+            if name in flat.columns:
+                numeric = pd.to_numeric(flat[name], errors="coerce").dropna()
+                if not numeric.empty:
+                    avg_score = float(numeric.mean())
+
+            subtotal = passed + failed
+            eval_pass_rate = (passed / subtotal * 100.0) if subtotal > 0 else 0.0
+            evaluators.append(
+                EvaluatorStats(
+                    evaluator_id=name,
+                    name=name,
+                    passed=passed,
+                    failed=failed,
+                    pass_rate=eval_pass_rate,
+                    avg_score=avg_score,
+                )
+            )
+
+        targets: List[TargetStats] = []
+        if "target" in flat.columns:
+            for target_id, sub in flat.groupby("target"):
+                t_passed = 0
+                t_failed = 0
+                for pcol in passed_cols:
+                    if pcol not in sub.columns:
+                        continue
+                    sub_col = sub[pcol].dropna()
+                    t_passed += int((sub_col == True).sum())  # noqa: E712
+                    t_failed += int((sub_col == False).sum())  # noqa: E712
+
+                avg_latency = 0.0
+                if "duration_ms" in sub.columns:
+                    dur_numeric = pd.to_numeric(sub["duration_ms"], errors="coerce").dropna()
+                    if not dur_numeric.empty:
+                        avg_latency = float(dur_numeric.mean())
+
+                t_cost = 0.0
+                if "cost" in sub.columns:
+                    cost_numeric = pd.to_numeric(sub["cost"], errors="coerce").dropna()
+                    if not cost_numeric.empty:
+                        t_cost = float(cost_numeric.sum())
+
+                targets.append(
+                    TargetStats(
+                        target_id=str(target_id),
+                        name=str(target_id),
+                        passed=t_passed,
+                        failed=t_failed,
+                        avg_latency=avg_latency,
+                        total_cost=t_cost,
+                    )
+                )
+
+        overall_total = total_passed + total_failed
+        pass_rate = (total_passed / overall_total * 100.0) if overall_total > 0 else 0.0
+
+        duration = 0
+        if "duration_ms" in flat.columns:
+            dur_all = pd.to_numeric(flat["duration_ms"], errors="coerce").dropna()
+            if not dur_all.empty:
+                duration = int(dur_all.sum())
+
+        total_cost = 0.0
+        if "cost" in flat.columns:
+            cost_all = pd.to_numeric(flat["cost"], errors="coerce").dropna()
+            if not cost_all.empty:
+                total_cost = float(cost_all.sum())
+
+        summary = ExperimentRunSummary(
+            run_id=self.run_id,
+            total_cells=len(flat),
+            completed_cells=len(flat),
+            failed_cells=0,
+            duration=duration,
+            run_url=run_url,
+            targets=targets,
+            evaluators=evaluators,
+            total_passed=total_passed,
+            total_failed=total_failed,
+            pass_rate=pass_rate,
+            total_cost=total_cost,
+        )
+
+        return ExperimentRunResult(
+            run_id=self.run_id,
+            status="completed",
+            passed=total_passed,
+            failed=total_failed,
+            pass_rate=pass_rate,
+            duration=duration,
+            run_url=run_url,
+            summary=summary,
+        )
 
     def __repr__(self) -> str:
         status = "finished" if self._finished else "running" if self.initialized else "not started"

--- a/python-sdk/src/langwatch/experiment/platform_run.py
+++ b/python-sdk/src/langwatch/experiment/platform_run.py
@@ -456,6 +456,8 @@ def _print_summary(result: ExperimentRunResult) -> None:
     print(f"  Passed:     {result.passed}")
     print(f"  Failed:     {result.failed}")
     print(f"  Pass Rate:  {result.pass_rate:.1f}%")
+    if summary.total_cost:
+        print(f"  Total Cost: ${summary.total_cost:.4f}")
 
     if summary.targets:
         print("─" * 60)

--- a/python-sdk/tests/experiment/test_experiment_print_summary.py
+++ b/python-sdk/tests/experiment/test_experiment_print_summary.py
@@ -9,6 +9,8 @@ import pytest
 
 from langwatch.experiment.experiment import Experiment
 
+pytestmark = pytest.mark.unit
+
 
 def _experiment_with_df(df: pd.DataFrame, run_url: str = "https://app.langwatch.ai/runs/xyz") -> Experiment:
     exp = Experiment(name="ci-quality-check", run_id="run_abc")
@@ -92,6 +94,22 @@ class TestBuildRunResult:
         assert claude.passed == 1 and claude.failed == 1
         assert gpt.avg_latency == pytest.approx(150.0)
         assert claude.total_cost == pytest.approx(0.007)
+
+    def test_counts_rows_with_errors_as_failed_cells(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1, 2],
+                "faithfulness_passed": [True, True, True],
+                "error": [None, "timeout after 30s", None],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        result = exp._build_run_result()
+
+        assert result.summary.failed_cells == 1
+        assert result.summary.completed_cells == 2
+        assert result.summary.total_cells == 3
 
     def test_ignores_non_passed_columns(self):
         df = pd.DataFrame(
@@ -185,7 +203,7 @@ class TestPrintSummary:
         ).set_index("index")
         exp = _experiment_with_df(df)
 
-        with patch("langwatch.experiment.platform_run._is_notebook", return_value=False):
+        with patch("langwatch.experiment.experiment._is_notebook", return_value=False):
             buf = io.StringIO()
             with redirect_stdout(buf), pytest.raises(SystemExit) as exc:
                 exp.print_summary()
@@ -200,12 +218,28 @@ class TestPrintSummary:
         ).set_index("index")
         exp = _experiment_with_df(df)
 
-        with patch("langwatch.experiment.platform_run._is_notebook", return_value=True):
+        with patch("langwatch.experiment.experiment._is_notebook", return_value=True):
             buf = io.StringIO()
             with redirect_stdout(buf):
                 exp.print_summary()
             # No SystemExit — test passes if we reach here
             assert "Failed:     1" in buf.getvalue()
+
+    def test_exits_on_execution_errors_even_when_all_evaluators_passed(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, True],
+                "error": [None, "LLM call timed out"],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf), pytest.raises(SystemExit) as exc:
+            exp.print_summary(exit_on_failure=True)
+
+        assert exc.value.code == 1
 
     def test_handles_empty_results_gracefully(self):
         exp = _experiment_with_df(pd.DataFrame())

--- a/python-sdk/tests/experiment/test_experiment_print_summary.py
+++ b/python-sdk/tests/experiment/test_experiment_print_summary.py
@@ -241,6 +241,32 @@ class TestPrintSummary:
 
         assert exc.value.code == 1
 
+    def test_status_reflects_failures_not_completed(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, False],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        result = exp._build_run_result()
+
+        assert result.status == "failed"
+
+    def test_status_is_completed_when_all_pass(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, True],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        result = exp._build_run_result()
+
+        assert result.status == "completed"
+
     def test_handles_empty_results_gracefully(self):
         exp = _experiment_with_df(pd.DataFrame())
 

--- a/python-sdk/tests/experiment/test_experiment_print_summary.py
+++ b/python-sdk/tests/experiment/test_experiment_print_summary.py
@@ -1,0 +1,219 @@
+"""Tests for Experiment.print_summary — parity with ExperimentRunResult.print_summary."""
+
+import io
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from langwatch.experiment.experiment import Experiment
+
+
+def _experiment_with_df(df: pd.DataFrame, run_url: str = "https://app.langwatch.ai/runs/xyz") -> Experiment:
+    exp = Experiment(name="ci-quality-check", run_id="run_abc")
+    exp._cached_results_df = df
+    exp._run_url = run_url
+    return exp
+
+
+class TestBuildRunResult:
+    """given an Experiment with a cached results DataFrame"""
+
+    def test_empty_dataframe_yields_zero_counts(self):
+        exp = _experiment_with_df(pd.DataFrame())
+
+        result = exp._build_run_result()
+
+        assert result.passed == 0
+        assert result.failed == 0
+        assert result.pass_rate == 0.0
+        assert result.status == "completed"
+        assert result.run_id == "run_abc"
+
+    def test_counts_passed_and_failed_from_passed_columns(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1, 2],
+                "faithfulness": [0.9, 0.5, 0.8],
+                "faithfulness_passed": [True, False, True],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        result = exp._build_run_result()
+
+        assert result.passed == 2
+        assert result.failed == 1
+        assert result.pass_rate == pytest.approx(2 / 3 * 100)
+        assert len(result.summary.evaluators) == 1
+        assert result.summary.evaluators[0].name == "faithfulness"
+        assert result.summary.evaluators[0].avg_score == pytest.approx(
+            (0.9 + 0.5 + 0.8) / 3
+        )
+
+    def test_multiple_evaluators_each_get_their_own_stats(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness": [0.9, 0.5],
+                "faithfulness_passed": [True, False],
+                "relevance": [0.7, 0.8],
+                "relevance_passed": [True, True],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        result = exp._build_run_result()
+
+        names = {e.name for e in result.summary.evaluators}
+        assert names == {"faithfulness", "relevance"}
+        assert result.passed == 3  # 1 + 2
+        assert result.failed == 1
+
+    def test_target_column_produces_per_target_stats(self):
+        df = pd.DataFrame(
+            {
+                "target": ["gpt-4o", "gpt-4o", "claude", "claude"],
+                "index": [0, 1, 0, 1],
+                "faithfulness_passed": [True, True, False, True],
+                "duration_ms": [100, 200, 150, 250],
+                "cost": [0.001, 0.002, 0.003, 0.004],
+            }
+        ).set_index(["target", "index"])
+        exp = _experiment_with_df(df)
+
+        result = exp._build_run_result()
+
+        assert len(result.summary.targets) == 2
+        gpt = next(t for t in result.summary.targets if t.name == "gpt-4o")
+        claude = next(t for t in result.summary.targets if t.name == "claude")
+        assert gpt.passed == 2 and gpt.failed == 0
+        assert claude.passed == 1 and claude.failed == 1
+        assert gpt.avg_latency == pytest.approx(150.0)
+        assert claude.total_cost == pytest.approx(0.007)
+
+    def test_ignores_non_passed_columns(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "question": ["a?", "b?"],  # a string column, not an evaluator
+                "faithfulness_passed": [True, True],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        result = exp._build_run_result()
+
+        assert result.passed == 2
+        assert len(result.summary.evaluators) == 1
+
+
+class TestPrintSummary:
+    """when calling experiment.print_summary"""
+
+    def test_prints_experiment_name_and_counts(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, True],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            exp.print_summary(exit_on_failure=False)
+
+        output = buf.getvalue()
+        assert "run_abc" in output
+        assert "Passed:     2" in output
+        assert "Failed:     0" in output
+        assert "100.0%" in output
+
+    def test_exits_with_code_1_on_failure_when_exit_on_failure_true(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, False],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf), pytest.raises(SystemExit) as exc:
+            exp.print_summary(exit_on_failure=True)
+
+        assert exc.value.code == 1
+
+    def test_does_not_exit_when_exit_on_failure_false(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, False],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            # Should not raise SystemExit
+            exp.print_summary(exit_on_failure=False)
+        assert "Failed:     1" in buf.getvalue()
+
+    def test_does_not_exit_on_success_even_with_exit_on_failure_true(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, True],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            exp.print_summary(exit_on_failure=True)
+        # No SystemExit raised
+        assert "100.0%" in buf.getvalue()
+
+    def test_default_exits_in_non_notebook_context(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, False],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        with patch("langwatch.experiment.platform_run._is_notebook", return_value=False):
+            buf = io.StringIO()
+            with redirect_stdout(buf), pytest.raises(SystemExit) as exc:
+                exp.print_summary()
+            assert exc.value.code == 1
+
+    def test_default_does_not_exit_in_notebook_context(self):
+        df = pd.DataFrame(
+            {
+                "index": [0, 1],
+                "faithfulness_passed": [True, False],
+            }
+        ).set_index("index")
+        exp = _experiment_with_df(df)
+
+        with patch("langwatch.experiment.platform_run._is_notebook", return_value=True):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                exp.print_summary()
+            # No SystemExit — test passes if we reach here
+            assert "Failed:     1" in buf.getvalue()
+
+    def test_handles_empty_results_gracefully(self):
+        exp = _experiment_with_df(pd.DataFrame())
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            exp.print_summary(exit_on_failure=False)
+
+        # No crash, no exit — zero counts printed
+        assert "Passed:     0" in buf.getvalue()
+        assert "Failed:     0" in buf.getvalue()

--- a/specs/python-sdk/experiment-print-summary.feature
+++ b/specs/python-sdk/experiment-print-summary.feature
@@ -1,0 +1,70 @@
+Feature: Python SDK Experiment.print_summary for CI/CD parity
+  As a Python SDK user running experiments in CI
+  I want experiment.print_summary() on SDK-driven experiments (not only on ExperimentRunResult)
+  So that SDK-defined experiments can fail CI builds the same way platform experiments do
+
+  Background:
+    Given a LangWatch client initialized with a valid API key
+    And an experiment instance created via langwatch.experiment.init("ci-quality-check")
+
+  # --- Parity with ExperimentRunResult ---
+
+  @unit
+  Scenario: print_summary prints a CI-friendly summary after loop completes
+    Given the experiment has looped over a dataset and recorded evaluations
+    When I call experiment.print_summary(exit_on_failure=False)
+    Then stdout contains the experiment name
+    And stdout contains the total passed and failed counts
+    And stdout contains the pass rate
+    And stdout contains the run URL
+    And the process does not exit
+
+  @unit
+  Scenario: print_summary exits with code 1 when any evaluation failed and exit_on_failure is True
+    Given the experiment has at least one failed evaluation
+    When I call experiment.print_summary(exit_on_failure=True)
+    Then SystemExit is raised with code 1
+
+  @unit
+  Scenario: print_summary does not exit when exit_on_failure is False even with failures
+    Given the experiment has at least one failed evaluation
+    When I call experiment.print_summary(exit_on_failure=False)
+    Then no SystemExit is raised
+    And stdout still reports the failure count
+
+  @unit
+  Scenario: print_summary does not exit when all evaluations passed
+    Given every evaluation in the experiment passed
+    When I call experiment.print_summary(exit_on_failure=True)
+    Then no SystemExit is raised
+    And stdout reports a 100% pass rate
+
+  @unit
+  Scenario: print_summary defaults to exit_on_failure=True outside a notebook
+    Given the experiment is running in a non-notebook Python process
+    And the experiment has a failed evaluation
+    When I call experiment.print_summary() with no arguments
+    Then SystemExit is raised with code 1
+
+  @unit
+  Scenario: print_summary defaults to exit_on_failure=False inside a Jupyter notebook
+    Given the experiment is running inside a Jupyter notebook (IPython kernel)
+    And the experiment has a failed evaluation
+    When I call experiment.print_summary() with no arguments
+    Then no SystemExit is raised
+
+  # --- Edge cases ---
+
+  @unit
+  Scenario: print_summary handles an experiment with no evaluations gracefully
+    Given the experiment has looped but no evaluations were recorded
+    When I call experiment.print_summary(exit_on_failure=False)
+    Then stdout reports zero evaluations
+    And no SystemExit is raised
+
+  @unit
+  Scenario: print_summary reports per-evaluator breakdown
+    Given the experiment ran with evaluators "faithfulness" and "relevance"
+    When I call experiment.print_summary(exit_on_failure=False)
+    Then stdout contains a row for "faithfulness"
+    And stdout contains a row for "relevance"

--- a/specs/python-sdk/experiment-print-summary.feature
+++ b/specs/python-sdk/experiment-print-summary.feature
@@ -13,7 +13,7 @@ Feature: Python SDK Experiment.print_summary for CI/CD parity
   Scenario: print_summary prints a CI-friendly summary after loop completes
     Given the experiment has looped over a dataset and recorded evaluations
     When I call experiment.print_summary(exit_on_failure=False)
-    Then stdout contains the experiment name
+    Then stdout contains the run ID
     And stdout contains the total passed and failed counts
     And stdout contains the pass rate
     And stdout contains the run URL

--- a/specs/typescript-sdk/experiment-print-summary.feature
+++ b/specs/typescript-sdk/experiment-print-summary.feature
@@ -1,0 +1,38 @@
+Feature: TypeScript SDK Experiment.printSummary for CI/CD parity
+  As a TypeScript SDK user running experiments in CI
+  I want experiment.printSummary() on SDK-driven experiments (not only on ExperimentRunResult)
+  So that SDK-defined experiments can fail CI builds the same way platform experiments do
+
+  Background:
+    Given a LangWatch client initialized with a valid API key
+    And an experiment instance created via langwatch.experiments.init("ci-quality-check")
+
+  @unit
+  Scenario: printSummary prints a CI-friendly summary after run completes
+    Given the experiment has run over a dataset and recorded evaluations
+    When I call experiment.printSummary({ exitOnFailure: false })
+    Then stdout contains the experiment name
+    And stdout contains the total passed and failed counts
+    And stdout contains the pass rate
+    And stdout contains the run URL
+    And the process does not exit
+
+  @unit
+  Scenario: printSummary exits with code 1 when any evaluation failed and exitOnFailure is true
+    Given the experiment has at least one failed evaluation
+    When I call experiment.printSummary({ exitOnFailure: true })
+    Then process.exit is called with code 1
+
+  @unit
+  Scenario: printSummary does not exit when exitOnFailure is false even with failures
+    Given the experiment has at least one failed evaluation
+    When I call experiment.printSummary({ exitOnFailure: false })
+    Then process.exit is not called
+    And stdout still reports the failure count
+
+  @unit
+  Scenario: printSummary does not exit when all evaluations passed
+    Given every evaluation in the experiment passed
+    When I call experiment.printSummary({ exitOnFailure: true })
+    Then process.exit is not called
+    And stdout reports a 100% pass rate

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
@@ -151,4 +151,20 @@ describe("Experiment.printSummary", () => {
       expect(exitSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("when an iteration errored out (execution failure)", () => {
+    it("exits even if all evaluators passed", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [evaluation({ passed: true })],
+        entries: [
+          { index: 0, entry: null, duration: 100, error: null, trace_id: "t1" },
+          { index: 1, entry: null, duration: 0, error: "LLM timed out", trace_id: "t2" },
+        ],
+      });
+
+      exp.printSummary();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
 });

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
@@ -174,6 +174,23 @@ describe("Experiment.printSummary", () => {
     });
   });
 
+  describe("when the run has failures", () => {
+    it("reports Status: FAILED (not COMPLETED)", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ passed: true }),
+          evaluation({ passed: false, index: 1 }),
+        ],
+      });
+
+      exp.printSummary(false);
+
+      const out = output();
+      expect(out).toContain("Status:     FAILED");
+      expect(out).not.toContain("Status:     COMPLETED");
+    });
+  });
+
   describe("when an evaluator crashed (status: error)", () => {
     it("counts it as a failure and exits", () => {
       const exp = buildExperimentFixture({

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for Experiment.printSummary() — parity with ExperimentRunResult.printSummary.
+ *
+ * We don't construct a full Experiment (private constructor); instead we exercise the
+ * formatter by invoking printSummary on a subclass-bridge that bypasses init. We use
+ * reflection via `Object.assign` on an Object.create'd Experiment prototype to populate
+ * the cumulative arrays without going through the network.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Experiment } from "../experiment";
+import type { BatchEntry, EvaluationResult } from "../types";
+
+function buildExperimentFixture(init: {
+  evaluations?: EvaluationResult[];
+  entries?: BatchEntry[];
+  runUrl?: string;
+  runId?: string;
+}): Experiment {
+  // Bypass the private constructor by creating an instance from the prototype.
+  const exp = Object.create(Experiment.prototype) as Experiment;
+  Object.assign(exp, {
+    name: "ci-quality-check",
+    runId: init.runId ?? "run_abc",
+    experimentSlug: "ci-quality-check",
+    cumulativeEvaluations: init.evaluations ?? [],
+    cumulativeEntries: init.entries ?? [],
+    runUrl: init.runUrl ?? "https://app.langwatch.ai/runs/xyz",
+  });
+  return exp;
+}
+
+function evaluation(overrides: Partial<EvaluationResult>): EvaluationResult {
+  return {
+    name: "faithfulness",
+    evaluator: "ragas/faithfulness",
+    trace_id: "trace_abc",
+    status: "processed",
+    score: 0.9,
+    passed: true,
+    details: null,
+    index: 0,
+    label: null,
+    cost: null,
+    duration: null,
+    error_type: null,
+    traceback: null,
+    target_id: null,
+    ...overrides,
+  };
+}
+
+describe("Experiment.printSummary", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((_code?: number | string | null | undefined) => undefined) as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  function output(): string {
+    return logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+  }
+
+  describe("when all evaluations passed", () => {
+    it("prints the run id, 100% pass rate, and does not exit", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ passed: true }),
+          evaluation({ passed: true, index: 1 }),
+        ],
+      });
+
+      exp.printSummary();
+
+      const out = output();
+      expect(out).toContain("run_abc");
+      expect(out).toContain("Passed:     2");
+      expect(out).toContain("Failed:     0");
+      expect(out).toContain("100.0%");
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when at least one evaluation failed and exitOnFailure defaults to true", () => {
+    it("prints the failure count and calls process.exit(1)", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ passed: true }),
+          evaluation({ passed: false, index: 1 }),
+        ],
+      });
+
+      exp.printSummary();
+
+      expect(output()).toContain("Failed:     1");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("when exitOnFailure is explicitly false", () => {
+    it("prints the failure count but does not exit", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ passed: false }),
+        ],
+      });
+
+      exp.printSummary(false);
+
+      expect(output()).toContain("Failed:     1");
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when multiple evaluators are used", () => {
+    it("reports per-evaluator pass rate", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ name: "faithfulness", passed: true }),
+          evaluation({ name: "faithfulness", passed: false, index: 1 }),
+          evaluation({ name: "relevance", passed: true, index: 0 }),
+          evaluation({ name: "relevance", passed: true, index: 1 }),
+        ],
+      });
+
+      exp.printSummary(false);
+
+      const out = output();
+      expect(out).toContain("faithfulness");
+      expect(out).toContain("relevance");
+      expect(out).toContain("50.0% pass rate"); // faithfulness
+      expect(out).toContain("100.0% pass rate"); // relevance
+    });
+  });
+
+  describe("when the experiment has no evaluations", () => {
+    it("prints zero counts and does not exit", () => {
+      const exp = buildExperimentFixture({});
+
+      exp.printSummary();
+
+      const out = output();
+      expect(out).toContain("Passed:     0");
+      expect(out).toContain("Failed:     0");
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
@@ -174,6 +174,39 @@ describe("Experiment.printSummary", () => {
     });
   });
 
+  describe("when an evaluator crashed (status: error)", () => {
+    it("counts it as a failure and exits", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ passed: true }),
+          evaluation({ passed: null, status: "error", index: 1 }),
+        ],
+      });
+
+      exp.printSummary();
+
+      expect(output()).toContain("Failed:     1");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("when evaluators carry a cost field", () => {
+    it("sums evaluator costs into totalCost and per-target cost", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ passed: true, cost: 0.0012, target_id: "gpt-4o" }),
+          evaluation({ passed: true, cost: 0.0023, target_id: "gpt-4o", index: 1 }),
+        ],
+      });
+
+      exp.printSummary(false);
+
+      const out = output();
+      // Per-target cost is rendered as $X.XXXX — 0.0035 total
+      expect(out).toContain("Total cost: $0.0035");
+    });
+  });
+
   describe("when an iteration errored out (execution failure)", () => {
     it("exits even if all evaluators passed", () => {
       const exp = buildExperimentFixture({

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
@@ -6,7 +6,7 @@
  * reflection via `Object.assign` on an Object.create'd Experiment prototype to populate
  * the cumulative arrays without going through the network.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import { Experiment } from "../experiment";
 import type { BatchEntry, EvaluationResult } from "../types";
 
@@ -50,12 +50,12 @@ function evaluation(overrides: Partial<EvaluationResult>): EvaluationResult {
 }
 
 describe("Experiment.printSummary", () => {
-  let logSpy: ReturnType<typeof vi.spyOn>;
-  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: MockInstance<typeof console.log>;
+  let exitSpy: MockInstance<typeof process.exit>;
 
   beforeEach(() => {
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    exitSpy = vi.spyOn(process, "exit").mockImplementation(((_code?: number | string | null | undefined) => undefined) as never);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
   });
 
   afterEach(() => {

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
@@ -191,6 +191,32 @@ describe("Experiment.printSummary", () => {
     });
   });
 
+  describe("when the run has a nonzero total cost", () => {
+    it("renders Total Cost in the main summary block", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ passed: true, cost: 0.0012 }),
+          evaluation({ passed: true, cost: 0.0023, index: 1 }),
+        ],
+      });
+
+      exp.printSummary(false);
+
+      const out = output();
+      expect(out).toMatch(/Total Cost: \$0\.0035/);
+    });
+
+    it("omits Total Cost when cost is zero", () => {
+      const exp = buildExperimentFixture({
+        evaluations: [evaluation({ passed: true })],
+      });
+
+      exp.printSummary(false);
+
+      expect(output()).not.toContain("Total Cost:");
+    });
+  });
+
   describe("when an evaluator crashed (status: error)", () => {
     it("counts it as a failure and exits", () => {
       const exp = buildExperimentFixture({

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment-print-summary.test.ts
@@ -152,6 +152,28 @@ describe("Experiment.printSummary", () => {
     });
   });
 
+  describe("when a target is used only via log() (no withTarget wrapping)", () => {
+    it("still reports the target in the per-target summary", () => {
+      // Evaluations carry target_id but the dataset entries do NOT —
+      // simulating an explicit log() call outside a withTarget() block.
+      const exp = buildExperimentFixture({
+        evaluations: [
+          evaluation({ passed: true, target_id: "gpt-4o" }),
+          evaluation({ passed: false, target_id: "gpt-4o", index: 1 }),
+        ],
+        entries: [
+          { index: 0, entry: null, duration: 100, error: null, trace_id: "t1" },
+        ],
+      });
+
+      exp.printSummary(false);
+
+      const out = output();
+      expect(out).toContain("gpt-4o");
+      expect(out).toContain("1 passed, 1 failed");
+    });
+  });
+
   describe("when an iteration errored out (execution failure)", () => {
     it("exits even if all evaluators passed", () => {
       const exp = buildExperimentFixture({

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment.e2e.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment.e2e.test.ts
@@ -155,6 +155,29 @@ describe.skipIf(SKIP_INTEGRATION)("Experiment Integration", () => {
   });
 
   describe("printSummary()", () => {
+    // Manually intercept console.log + process.exit. vi.spyOn(process, "exit")
+    // proved unreliable in CI — swap in the capture pattern that worked end-to-end.
+    async function captureSummary(fn: () => Promise<void> | void) {
+      const captured: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => {
+        captured.push(args.map(String).join(" "));
+      };
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const origExit = process.exit;
+      let exitedWith: number | string | null | undefined = null;
+      (process as unknown as { exit: (c?: number) => void }).exit = ((c?: number) => {
+        exitedWith = c;
+      }) as never;
+      try {
+        await fn();
+      } finally {
+        console.log = origLog;
+        process.exit = origExit;
+      }
+      return { output: captured.join("\n"), exitedWith };
+    }
+
     it("prints a CI-friendly summary after run completes against real server", async () => {
       const evaluation = await langwatch.experiments.init(`test-print-summary-${Date.now()}`);
       const dataset = [
@@ -171,25 +194,16 @@ describe.skipIf(SKIP_INTEGRATION)("Experiment Integration", () => {
         });
       });
 
-      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
-      const exitSpy = vi
-        .spyOn(process, "exit")
-        .mockImplementation((() => undefined) as never);
+      const { output, exitedWith } = await captureSummary(() => {
+        evaluation.printSummary();
+      });
 
-      try {
-        evaluation.printSummary(); // should detect the failure and exit
-      } finally {
-        const output = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
-        logSpy.mockRestore();
-        exitSpy.mockRestore();
-
-        expect(output).toContain("EXPERIMENT RESULTS");
-        expect(output).toContain("Passed:     2");
-        expect(output).toContain("Failed:     1");
-        expect(output).toMatch(/Pass Rate:\s+66\.7%/);
-        // Should have decided to exit since there was a failure
-        expect(exitSpy).toHaveBeenCalledWith(1);
-      }
+      expect(output).toContain("EXPERIMENT RESULTS");
+      expect(output).toContain("Passed:     2");
+      expect(output).toContain("Failed:     1");
+      expect(output).toMatch(/Pass Rate:\s+66\.7%/);
+      expect(output).toContain("Status:     FAILED");
+      expect(exitedWith).toBe(1);
     });
 
     it("does not exit when every evaluation passed (real server flow)", async () => {
@@ -200,23 +214,15 @@ describe.skipIf(SKIP_INTEGRATION)("Experiment Integration", () => {
         evaluation.log("accuracy", { index, score: 0.95, passed: true });
       });
 
-      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
-      const exitSpy = vi
-        .spyOn(process, "exit")
-        .mockImplementation((() => undefined) as never);
-
-      try {
+      const { output, exitedWith } = await captureSummary(() => {
         evaluation.printSummary();
-      } finally {
-        const output = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
-        logSpy.mockRestore();
-        exitSpy.mockRestore();
+      });
 
-        expect(output).toContain("Passed:     2");
-        expect(output).toContain("Failed:     0");
-        expect(output).toContain("100.0%");
-        expect(exitSpy).not.toHaveBeenCalled();
-      }
+      expect(output).toContain("Passed:     2");
+      expect(output).toContain("Failed:     0");
+      expect(output).toContain("100.0%");
+      expect(output).toContain("Status:     COMPLETED");
+      expect(exitedWith).toBeNull();
     });
   });
 

--- a/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment.e2e.test.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/__tests__/experiment.e2e.test.ts
@@ -154,6 +154,72 @@ describe.skipIf(SKIP_INTEGRATION)("Experiment Integration", () => {
     });
   });
 
+  describe("printSummary()", () => {
+    it("prints a CI-friendly summary after run completes against real server", async () => {
+      const evaluation = await langwatch.experiments.init(`test-print-summary-${Date.now()}`);
+      const dataset = [
+        { q: "What is 2+2?" },
+        { q: "What is 3+3?" },
+        { q: "What is 4+4?" },
+      ];
+
+      await evaluation.run(dataset, async ({ index }) => {
+        evaluation.log("accuracy", {
+          index,
+          score: index === 1 ? 0.3 : 0.95,
+          passed: index !== 1, // one failure, two passes
+        });
+      });
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const exitSpy = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        evaluation.printSummary(); // should detect the failure and exit
+      } finally {
+        const output = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+        logSpy.mockRestore();
+        exitSpy.mockRestore();
+
+        expect(output).toContain("EXPERIMENT RESULTS");
+        expect(output).toContain("Passed:     2");
+        expect(output).toContain("Failed:     1");
+        expect(output).toMatch(/Pass Rate:\s+66\.7%/);
+        // Should have decided to exit since there was a failure
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      }
+    });
+
+    it("does not exit when every evaluation passed (real server flow)", async () => {
+      const evaluation = await langwatch.experiments.init(`test-print-summary-pass-${Date.now()}`);
+      const dataset = [{ q: "a" }, { q: "b" }];
+
+      await evaluation.run(dataset, async ({ index }) => {
+        evaluation.log("accuracy", { index, score: 0.95, passed: true });
+      });
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const exitSpy = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        evaluation.printSummary();
+      } finally {
+        const output = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+        logSpy.mockRestore();
+        exitSpy.mockRestore();
+
+        expect(output).toContain("Passed:     2");
+        expect(output).toContain("Failed:     0");
+        expect(output).toContain("100.0%");
+        expect(exitSpy).not.toHaveBeenCalled();
+      }
+    });
+  });
+
   describe("target registration", () => {
     it("throws on conflicting metadata for same target", async () => {
       const evaluation = await langwatch.experiments.init(`test-conflict-${Date.now()}`);

--- a/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
@@ -47,6 +47,15 @@ import { printSummary } from "./printSummary";
 const DEFAULT_CONCURRENCY = 4;
 const DEBOUNCE_INTERVAL_MS = 1000;
 
+// Slim projections retained across the lifetime of an Experiment for
+// printSummary() — deliberately excludes large fields (inputs, tracebacks,
+// outputs) so running thousands of items doesn't unbound memory.
+type SummaryEvaluation = Pick<
+  EvaluationResult,
+  "name" | "evaluator" | "status" | "passed" | "score" | "cost" | "target_id"
+>;
+type SummaryEntry = Pick<BatchEntry, "duration" | "error" | "cost" | "target_id">;
+
 /**
  * AsyncLocalStorage for iteration context isolation.
  * This stores the current item and index for each iteration,
@@ -91,8 +100,10 @@ export class Experiment {
   private flushTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Cumulative record for printSummary() — never cleared, mirrors batch.
-  private cumulativeEvaluations: EvaluationResult[] = [];
-  private cumulativeEntries: BatchEntry[] = [];
+  // Store only the fields printSummary() needs, not the full payloads —
+  // inputs/tracebacks/outputs can be large and don't belong in retained summary state.
+  private cumulativeEvaluations: SummaryEvaluation[] = [];
+  private cumulativeEntries: SummaryEntry[] = [];
   private runUrl = "";
 
   // Target registry
@@ -375,7 +386,12 @@ export class Experiment {
       };
 
       this.batch.dataset.push(entry);
-      this.cumulativeEntries.push(entry);
+      this.cumulativeEntries.push({
+        duration: entry.duration,
+        error: entry.error,
+        cost: entry.cost,
+        target_id: entry.target_id,
+      });
     }
 
     // Clean up
@@ -456,7 +472,15 @@ export class Experiment {
     };
 
     this.batch.evaluations.push(result);
-    this.cumulativeEvaluations.push(result);
+    this.cumulativeEvaluations.push({
+      name: result.name,
+      evaluator: result.evaluator,
+      status: result.status,
+      passed: result.passed,
+      score: result.score,
+      cost: result.cost,
+      target_id: result.target_id,
+    });
     this.scheduleSend();
   }
 
@@ -745,7 +769,12 @@ export class Experiment {
     };
 
     this.batch.dataset.push(entry);
-    this.cumulativeEntries.push(entry);
+    this.cumulativeEntries.push({
+      duration: entry.duration,
+      error: entry.error,
+      cost: entry.cost,
+      target_id: entry.target_id,
+    });
     this.scheduleSend();
 
     return {
@@ -828,6 +857,7 @@ export class Experiment {
     >();
     let totalPassed = 0;
     let totalFailed = 0;
+    let totalCost = 0;
 
     for (const e of this.cumulativeEvaluations) {
       const name = e.name ?? e.evaluator ?? "unknown";
@@ -835,16 +865,21 @@ export class Experiment {
         evaluators.set(name, { passed: 0, failed: 0, scoreSum: 0, scoreCount: 0 });
       }
       const stats = evaluators.get(name)!;
-      if (e.passed === true) {
-        stats.passed += 1;
-        totalPassed += 1;
-      } else if (e.passed === false) {
+      // Evaluators that crashed come back as status:"error" with passed often null;
+      // treat them as failures so CI doesn't silently succeed on evaluator crashes.
+      if (e.status === "error" || e.passed === false) {
         stats.failed += 1;
         totalFailed += 1;
+      } else if (e.passed === true) {
+        stats.passed += 1;
+        totalPassed += 1;
       }
       if (typeof e.score === "number") {
         stats.scoreSum += e.score;
         stats.scoreCount += 1;
+      }
+      if (typeof e.cost === "number") {
+        totalCost += e.cost;
       }
     }
 
@@ -879,8 +914,9 @@ export class Experiment {
         targets.set(tid, { passed: 0, failed: 0, latencySum: 0, latencyCount: 0, cost: 0 });
       }
       const stats = targets.get(tid)!;
-      if (e.passed === true) stats.passed += 1;
-      else if (e.passed === false) stats.failed += 1;
+      if (e.status === "error" || e.passed === false) stats.failed += 1;
+      else if (e.passed === true) stats.passed += 1;
+      if (typeof e.cost === "number") stats.cost += e.cost;
     }
 
     const total = totalPassed + totalFailed;
@@ -890,9 +926,8 @@ export class Experiment {
     // under concurrent withTarget() calls (each target produces its own entry).
     const duration = Math.max(0, Date.now() - this.createdAtMs);
 
-    // Count entries whose target/loop execution errored out — these are distinct
-    // from evaluator failures but must also trigger CI exit.
-    let totalCost = 0;
+    // Count entries whose target/loop execution errored out — distinct from
+    // evaluator failures but must also trigger CI exit.
     let failedCells = 0;
     for (const entry of this.cumulativeEntries) {
       if (typeof entry.cost === "number") totalCost += entry.cost;

--- a/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
@@ -934,9 +934,11 @@ export class Experiment {
       if (entry.error) failedCells += 1;
     }
 
+    const hasFailures = totalFailed > 0 || failedCells > 0;
+
     printSummary({
       runId: this.runId,
-      status: "completed",
+      status: hasFailures ? "failed" : "completed",
       passed: totalPassed,
       failed: totalFailed,
       passRate,
@@ -972,7 +974,7 @@ export class Experiment {
       },
     });
 
-    if (exitOnFailure && (totalFailed > 0 || failedCells > 0)) {
+    if (exitOnFailure && hasFailures) {
       process.exit(1);
     }
   }

--- a/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
@@ -42,6 +42,7 @@ import type {
   TargetExecutionContext,
   TargetContext,
 } from "./types";
+import { printSummary } from "./printSummary";
 
 const DEFAULT_CONCURRENCY = 4;
 const DEBOUNCE_INTERVAL_MS = 1000;
@@ -88,6 +89,11 @@ export class Experiment {
   private lastSentMs = 0;
   private pendingFlush: Promise<void> | null = null;
   private flushTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Cumulative record for printSummary() — never cleared, mirrors batch.
+  private cumulativeEvaluations: EvaluationResult[] = [];
+  private cumulativeEntries: BatchEntry[] = [];
+  private runUrl = "";
 
   // Target registry
   private targets = new Map<string, TargetInfo>();
@@ -184,7 +190,8 @@ export class Experiment {
       (this as { experimentSlug: string }).experimentSlug = data.slug;
 
       const encodedRunId = encodeURIComponent(this.runId);
-      console.log(`Follow results at: ${this.endpoint.replace(/\/$/, "")}${data.path}?runId=${encodedRunId}`);
+      this.runUrl = `${this.endpoint.replace(/\/$/, "")}${data.path}?runId=${encodedRunId}`;
+      console.log(`Follow results at: ${this.runUrl}`);
 
       this.initialized = true;
     } catch (error) {
@@ -368,6 +375,7 @@ export class Experiment {
       };
 
       this.batch.dataset.push(entry);
+      this.cumulativeEntries.push(entry);
     }
 
     // Clean up
@@ -448,6 +456,7 @@ export class Experiment {
     };
 
     this.batch.evaluations.push(result);
+    this.cumulativeEvaluations.push(result);
     this.scheduleSend();
   }
 
@@ -736,6 +745,7 @@ export class Experiment {
     };
 
     this.batch.dataset.push(entry);
+    this.cumulativeEntries.push(entry);
     this.scheduleSend();
 
     return {
@@ -790,6 +800,131 @@ export class Experiment {
         this.flushTimeout = null;
         this.sendBatch();
       }, DEBOUNCE_INTERVAL_MS - (now - this.lastSentMs));
+    }
+  }
+
+  /**
+   * Print a CI-friendly summary and optionally exit with code 1 on failure.
+   *
+   * Mirrors `ExperimentRunResult.printSummary` for parity — SDK-driven experiments
+   * can now fail CI builds the same way platform experiments do.
+   *
+   * @param exitOnFailure - If true (default), calls `process.exit(1)` when any evaluation failed.
+   *
+   * @example
+   * ```typescript
+   * const experiment = await langwatch.experiments.init("ci-quality-check");
+   * await experiment.run(dataset, async ({ item, index }) => {
+   *   const response = await myLLM(item.input);
+   *   await experiment.evaluate("ragas/faithfulness", { index, data: { input: item.input, output: response } });
+   * });
+   * experiment.printSummary();
+   * ```
+   */
+  printSummary(exitOnFailure = true): void {
+    const evaluators = new Map<
+      string,
+      { passed: number; failed: number; scoreSum: number; scoreCount: number }
+    >();
+    let totalPassed = 0;
+    let totalFailed = 0;
+
+    for (const e of this.cumulativeEvaluations) {
+      const name = e.name ?? e.evaluator ?? "unknown";
+      if (!evaluators.has(name)) {
+        evaluators.set(name, { passed: 0, failed: 0, scoreSum: 0, scoreCount: 0 });
+      }
+      const stats = evaluators.get(name)!;
+      if (e.passed === true) {
+        stats.passed += 1;
+        totalPassed += 1;
+      } else if (e.passed === false) {
+        stats.failed += 1;
+        totalFailed += 1;
+      }
+      if (typeof e.score === "number") {
+        stats.scoreSum += e.score;
+        stats.scoreCount += 1;
+      }
+    }
+
+    const targets = new Map<
+      string,
+      { passed: number; failed: number; latencySum: number; latencyCount: number; cost: number }
+    >();
+    for (const entry of this.cumulativeEntries) {
+      const tid = entry.target_id;
+      if (!tid) continue;
+      if (!targets.has(tid)) {
+        targets.set(tid, { passed: 0, failed: 0, latencySum: 0, latencyCount: 0, cost: 0 });
+      }
+      const stats = targets.get(tid)!;
+      if (typeof entry.duration === "number") {
+        stats.latencySum += entry.duration;
+        stats.latencyCount += 1;
+      }
+      if (typeof entry.cost === "number") {
+        stats.cost += entry.cost;
+      }
+    }
+    for (const e of this.cumulativeEvaluations) {
+      const tid = e.target_id;
+      if (!tid || !targets.has(tid)) continue;
+      const stats = targets.get(tid)!;
+      if (e.passed === true) stats.passed += 1;
+      else if (e.passed === false) stats.failed += 1;
+    }
+
+    const total = totalPassed + totalFailed;
+    const passRate = total > 0 ? (totalPassed / total) * 100 : 0;
+
+    let duration = 0;
+    let totalCost = 0;
+    for (const entry of this.cumulativeEntries) {
+      if (typeof entry.duration === "number") duration += entry.duration;
+      if (typeof entry.cost === "number") totalCost += entry.cost;
+    }
+
+    printSummary({
+      runId: this.runId,
+      status: "completed",
+      passed: totalPassed,
+      failed: totalFailed,
+      passRate,
+      duration,
+      runUrl: this.runUrl,
+      summary: {
+        runId: this.runId,
+        totalCells: this.cumulativeEntries.length || total,
+        completedCells: this.cumulativeEntries.length || total,
+        failedCells: 0,
+        duration,
+        runUrl: this.runUrl,
+        totalPassed,
+        totalFailed,
+        passRate,
+        totalCost,
+        targets: Array.from(targets.entries()).map(([targetId, s]) => ({
+          targetId,
+          name: targetId,
+          passed: s.passed,
+          failed: s.failed,
+          avgLatency: s.latencyCount > 0 ? s.latencySum / s.latencyCount : 0,
+          totalCost: s.cost,
+        })),
+        evaluators: Array.from(evaluators.entries()).map(([name, s]) => ({
+          evaluatorId: name,
+          name,
+          passed: s.passed,
+          failed: s.failed,
+          passRate: s.passed + s.failed > 0 ? (s.passed / (s.passed + s.failed)) * 100 : 0,
+          avgScore: s.scoreCount > 0 ? s.scoreSum / s.scoreCount : undefined,
+        })),
+      },
+    });
+
+    if (exitOnFailure && totalFailed > 0) {
+      process.exit(1);
     }
   }
 

--- a/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
@@ -867,9 +867,17 @@ export class Experiment {
         stats.cost += entry.cost;
       }
     }
+    // Lazily seed target stats from evaluations too — a user can log an
+    // evaluation with an explicit target_id without ever going through
+    // withTarget(), in which case the per-target entry row may not carry
+    // target_id. Without this, such a target would be silently dropped from
+    // the per-target summary.
     for (const e of this.cumulativeEvaluations) {
       const tid = e.target_id;
-      if (!tid || !targets.has(tid)) continue;
+      if (!tid) continue;
+      if (!targets.has(tid)) {
+        targets.set(tid, { passed: 0, failed: 0, latencySum: 0, latencyCount: 0, cost: 0 });
+      }
       const stats = targets.get(tid)!;
       if (e.passed === true) stats.passed += 1;
       else if (e.passed === false) stats.failed += 1;

--- a/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/experiment.ts
@@ -878,11 +878,17 @@ export class Experiment {
     const total = totalPassed + totalFailed;
     const passRate = total > 0 ? (totalPassed / total) * 100 : 0;
 
-    let duration = 0;
+    // Wall-clock duration from init — summing entry durations over-counts
+    // under concurrent withTarget() calls (each target produces its own entry).
+    const duration = Math.max(0, Date.now() - this.createdAtMs);
+
+    // Count entries whose target/loop execution errored out — these are distinct
+    // from evaluator failures but must also trigger CI exit.
     let totalCost = 0;
+    let failedCells = 0;
     for (const entry of this.cumulativeEntries) {
-      if (typeof entry.duration === "number") duration += entry.duration;
       if (typeof entry.cost === "number") totalCost += entry.cost;
+      if (entry.error) failedCells += 1;
     }
 
     printSummary({
@@ -896,8 +902,8 @@ export class Experiment {
       summary: {
         runId: this.runId,
         totalCells: this.cumulativeEntries.length || total,
-        completedCells: this.cumulativeEntries.length || total,
-        failedCells: 0,
+        completedCells: Math.max(0, (this.cumulativeEntries.length || total) - failedCells),
+        failedCells,
         duration,
         runUrl: this.runUrl,
         totalPassed,
@@ -923,7 +929,7 @@ export class Experiment {
       },
     });
 
-    if (exitOnFailure && totalFailed > 0) {
+    if (exitOnFailure && (totalFailed > 0 || failedCells > 0)) {
       process.exit(1);
     }
   }

--- a/typescript-sdk/src/client-sdk/services/experiments/experiments.facade.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/experiments.facade.ts
@@ -21,6 +21,7 @@ import {
   ExperimentTimeoutError,
   ExperimentRunFailedError,
 } from "./platformErrors";
+import { printSummary } from "./printSummary";
 
 const DEFAULT_POLL_INTERVAL = 2000;
 const DEFAULT_TIMEOUT = 600000; // 10 minutes
@@ -280,7 +281,7 @@ export class ExperimentsFacade {
       runUrl,
       summary,
       printSummary: (exitOnFailure = true) => {
-        this.printSummary({
+        printSummary({
           runId,
           status,
           passed: totalPassed,
@@ -304,55 +305,6 @@ export class ExperimentsFacade {
       () => result.toString();
 
     return result;
-  }
-
-  /**
-   * Print a CI-friendly summary of the experiment results
-   */
-  private printSummary(result: Omit<ExperimentRunResult, "printSummary">): void {
-    const { runId, status, passed, failed, passRate, duration, runUrl, summary } = result;
-
-    console.log("\n" + "═".repeat(60));
-    console.log("  EXPERIMENT RESULTS");
-    console.log("═".repeat(60));
-    console.log(`  Run ID:     ${runId}`);
-    console.log(`  Status:     ${status.toUpperCase()}`);
-    console.log(`  Duration:   ${(duration / 1000).toFixed(1)}s`);
-    console.log("─".repeat(60));
-    console.log(`  Passed:     ${passed}`);
-    console.log(`  Failed:     ${failed}`);
-    console.log(`  Pass Rate:  ${passRate.toFixed(1)}%`);
-
-    if (summary.targets && summary.targets.length > 0) {
-      console.log("─".repeat(60));
-      console.log("  TARGETS:");
-      for (const target of summary.targets) {
-        console.log(`    ${target.name}: ${target.passed} passed, ${target.failed} failed`);
-        if (target.avgLatency) {
-          console.log(`      Avg latency: ${target.avgLatency.toFixed(0)}ms`);
-        }
-        if (target.totalCost) {
-          console.log(`      Total cost: $${target.totalCost.toFixed(4)}`);
-        }
-      }
-    }
-
-    if (summary.evaluators && summary.evaluators.length > 0) {
-      console.log("─".repeat(60));
-      console.log("  EVALUATORS:");
-      for (const evaluator of summary.evaluators) {
-        console.log(
-          `    ${evaluator.name}: ${evaluator.passRate.toFixed(1)}% pass rate`
-        );
-        if (evaluator.avgScore !== undefined) {
-          console.log(`      Avg score: ${evaluator.avgScore.toFixed(2)}`);
-        }
-      }
-    }
-
-    console.log("─".repeat(60));
-    console.log(`  View details: ${runUrl}`);
-    console.log("═".repeat(60) + "\n");
   }
 
   private sleep(ms: number): Promise<void> {

--- a/typescript-sdk/src/client-sdk/services/experiments/printSummary.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/printSummary.ts
@@ -19,6 +19,9 @@ export function printSummary(result: Omit<ExperimentRunResult, "printSummary" | 
   console.log(`  Passed:     ${passed}`);
   console.log(`  Failed:     ${failed}`);
   console.log(`  Pass Rate:  ${passRate.toFixed(1)}%`);
+  if (summary.totalCost) {
+    console.log(`  Total Cost: $${summary.totalCost.toFixed(4)}`);
+  }
 
   if (summary.targets && summary.targets.length > 0) {
     console.log("─".repeat(60));

--- a/typescript-sdk/src/client-sdk/services/experiments/printSummary.ts
+++ b/typescript-sdk/src/client-sdk/services/experiments/printSummary.ts
@@ -1,0 +1,51 @@
+import type { ExperimentRunResult } from "./platformTypes";
+
+/**
+ * Print a CI-friendly summary of experiment results to stdout.
+ *
+ * Shared between platform runs (`langwatch.experiments.run`) and SDK-driven
+ * experiments (`langwatch.experiments.init` → `experiment.printSummary()`).
+ */
+export function printSummary(result: Omit<ExperimentRunResult, "printSummary" | "toString">): void {
+  const { runId, status, passed, failed, passRate, duration, runUrl, summary } = result;
+
+  console.log("\n" + "═".repeat(60));
+  console.log("  EXPERIMENT RESULTS");
+  console.log("═".repeat(60));
+  console.log(`  Run ID:     ${runId}`);
+  console.log(`  Status:     ${status.toUpperCase()}`);
+  console.log(`  Duration:   ${(duration / 1000).toFixed(1)}s`);
+  console.log("─".repeat(60));
+  console.log(`  Passed:     ${passed}`);
+  console.log(`  Failed:     ${failed}`);
+  console.log(`  Pass Rate:  ${passRate.toFixed(1)}%`);
+
+  if (summary.targets && summary.targets.length > 0) {
+    console.log("─".repeat(60));
+    console.log("  TARGETS:");
+    for (const target of summary.targets) {
+      console.log(`    ${target.name}: ${target.passed} passed, ${target.failed} failed`);
+      if (target.avgLatency) {
+        console.log(`      Avg latency: ${target.avgLatency.toFixed(0)}ms`);
+      }
+      if (target.totalCost) {
+        console.log(`      Total cost: $${target.totalCost.toFixed(4)}`);
+      }
+    }
+  }
+
+  if (summary.evaluators && summary.evaluators.length > 0) {
+    console.log("─".repeat(60));
+    console.log("  EVALUATORS:");
+    for (const evaluator of summary.evaluators) {
+      console.log(`    ${evaluator.name}: ${evaluator.passRate.toFixed(1)}% pass rate`);
+      if (evaluator.avgScore !== undefined) {
+        console.log(`      Avg score: ${evaluator.avgScore.toFixed(2)}`);
+      }
+    }
+  }
+
+  console.log("─".repeat(60));
+  console.log(`  View details: ${runUrl}`);
+  console.log("═".repeat(60) + "\n");
+}


### PR DESCRIPTION
## Summary

Closes the flagged gap: SDK-driven experiments (`langwatch.experiment.init` + `loop`/`run` + `evaluate`) had no `print_summary` / `printSummary` method, so the CI/CD docs Option 2 examples were broken (fixed in #3306 by removing the call, but that left SDK users with no way to fail the build).

This adds `print_summary()` to the `Experiment` class in both SDKs for full parity with `ExperimentRunResult.print_summary` — same signature, same `exit_on_failure` semantics — and restores the CI/CD docs examples.

## Changes

### Python SDK
- `Experiment.print_summary(exit_on_failure=None)` — builds an `ExperimentRunResult` from the `experiment.results` DataFrame and delegates to the shared `_print_summary` formatter. Auto-detects notebook for default exit behavior.

### TypeScript SDK
- `Experiment.printSummary(exitOnFailure?)` — mirrors Python API. Defaults to `true` (match existing `ExperimentRunResult.printSummary`).
- Extracted `printSummary` formatter to `printSummary.ts` — shared by platform-run facade and Experiment class (no duplication).
- Added `cumulativeEvaluations` + `cumulativeEntries` on `Experiment` to aggregate per-evaluator and per-target stats (the `batch` arrays get cleared after each send).

### Docs
- Restored `experiment.print_summary()` / `experiment.printSummary()` in `docs/evaluations/experiments/ci-cd.mdx` Option 2 examples (Python basic, TypeScript basic, Comparing Multiple Configurations).
- Regenerated `docs/llms-full.txt`.

### Specs
- `specs/python-sdk/experiment-print-summary.feature`
- `specs/typescript-sdk/experiment-print-summary.feature`

## Test plan

- [x] **Python unit tests** (12): `_build_run_result` empty/single-evaluator/multi-evaluator/multi-target/non-passed-columns; `print_summary` prints name+counts, exits on failure when `exit_on_failure=True`, does not exit when `False`, does not exit on success, notebook auto-detect in both directions, handles empty results.
- [x] **TypeScript unit tests** (5): all pass / partial fail with default exit / partial fail with `exitOnFailure=false` / multi-evaluator per-evaluator pass-rate / empty.
- [x] **Regressions**: `uv run pytest tests/experiment/` → 96 passed. `pnpm vitest run src/client-sdk/services/experiments/` → 29 passed (all existing).
- [x] **Typecheck**: `pnpm typecheck` clean on the TS SDK.
- [x] **Dogfooded end-to-end** (both SDKs) — scripts at `.claude/tmp/dogfood_print_summary.{py,mjs}`:
  - all pass → exit 0 ✓
  - partial fail + exit_on_failure=True → exit 1 ✓
  - partial fail + exit_on_failure=False → exit 0 ✓
  - multi-target (Python only) → per-target breakdown ✓

## Sample output

```
════════════════════════════════════════════════════════════
  EXPERIMENT RESULTS
════════════════════════════════════════════════════════════
  Run ID:     dogfood_multitarget
  Status:     COMPLETED
  Duration:   4.6s
────────────────────────────────────────────────────────────
  Passed:     3
  Failed:     1
  Pass Rate:  75.0%
────────────────────────────────────────────────────────────
  TARGETS:
    claude: 1 passed, 1 failed
      Avg latency: 1300ms
      Total cost: $0.0090
    gpt-4o: 2 passed, 0 failed
      Avg latency: 1000ms
      Total cost: $0.0050
────────────────────────────────────────────────────────────
  EVALUATORS:
    faithfulness: 75.0% pass rate
      Avg score: 0.84
────────────────────────────────────────────────────────────
  View details: https://app.langwatch.ai/runs/dogfood_multitarget
════════════════════════════════════════════════════════════
```

## Why not add a `.summary` property returning `ExperimentRunResult` instead?

Considered — would have been `result = experiment.summary; result.print_summary()` to mirror Option 1. Direct `experiment.print_summary()` was chosen because:
1. The SDK docs examples pre-#3306 already used this shape, so restoring them keeps the API promise Oskar was relying on.
2. Option 1 (`langwatch.experiment.run(slug)`) and Option 2 (`langwatch.experiment.init(...)`) have different mental models — Option 1 returns a result because it's a single-call wait. Option 2 is an interactive loop; the experiment IS both the runner and the accumulator.
3. The shared `_print_summary` formatter means zero duplication — both paths render identically.