### PR TITLE
feat(dev): per-worktree Redis DB isolation via REDIS_DB_INDEX

### DIFF
--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -72,7 +72,7 @@ TIKTOKENS_PATH=langwatch/tiktoken
 
 # LangWatch is a composition of multiple services and databases, be sure to have all of them pointing to the right addresses
 # Postgres for primary data storage
-DATABASE_URL="postgresql://postgres@localhost:5432/langwatch_db?schema=langwatch_db"
+DATABASE_URL="postgresql://postgres@localhost:5432/langwatch_db?schema=langwatch_db&connection_limit=5"
 
 # ElasticSearch-compatible endpoint for observability, storing traces, spans, events, evaluation results, doing search, filtering and analytics
 ELASTICSEARCH_NODE_URL="quickwit://localhost:7280/api/v1/_elastic"

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -7,6 +7,25 @@ set -eo pipefail
 # conflict 30s later after Vite/tsx finish booting.
 "$(dirname "$0")/check-ports.sh"
 
+# Dev-only: auto-derive REDIS_DB_INDEX from the PORT slot so each worktree
+# lands on its own Redis DB. PORT=5560 → 0, 5570 → 1, 5580 → 2, …, 5710 → 15.
+# Keeps BullMQ queues, GroupQueue streams, and the fold cache isolated across
+# concurrent `pnpm dev` instances. Explicit REDIS_DB_INDEX wins.
+# Skipped in production (cluster Redis only supports DB 0 anyway).
+if [[ "$NODE_ENV" = "development" ]]; then
+  if [ -z "$REDIS_DB_INDEX" ]; then
+    _PORT_FOR_DB="${PORT:-5560}"
+    REDIS_DB_INDEX=$(( (_PORT_FOR_DB - 5560) / 10 ))
+    if [ "$REDIS_DB_INDEX" -lt 0 ] || [ "$REDIS_DB_INDEX" -gt 15 ]; then
+      REDIS_DB_INDEX=0
+    fi
+    export REDIS_DB_INDEX
+    echo "  ✓ redis db=${REDIS_DB_INDEX} (auto-derived from PORT=${_PORT_FOR_DB})"
+  else
+    echo "  ✓ redis db=${REDIS_DB_INDEX} (explicit)"
+  fi
+fi
+
 RUNTIME_ENV="DEBUG=langwatch:* DEBUG_HIDE_DATE=true DEBUG_COLORS=true"
 if [ -z "$NODE_ENV" ]; then
   RUNTIME_ENV="$RUNTIME_ENV NODE_ENV=production"

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -51,6 +51,10 @@ export function createEnvConfig() {
       ELASTICSEARCH_CONFIGURED: z.boolean().optional(),
       REDIS_URL: z.string().optional(),
       REDIS_CLUSTER_ENDPOINTS: z.string().optional(),
+      REDIS_DB_INDEX: z
+        .string()
+        .regex(/^(?:[0-9]|1[0-5])$/, "REDIS_DB_INDEX must be 0-15")
+        .optional(),
       GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
       AZURE_OPENAI_ENDPOINT: z.string().optional(),
       AZURE_OPENAI_KEY: z.string().optional(),
@@ -160,6 +164,7 @@ export function createEnvConfig() {
       ELASTICSEARCH_CONFIGURED: !!(process.env.ELASTICSEARCH_NODE_URL),
       REDIS_URL: process.env.REDIS_URL,
       REDIS_CLUSTER_ENDPOINTS: process.env.REDIS_CLUSTER_ENDPOINTS,
+      REDIS_DB_INDEX: process.env.REDIS_DB_INDEX,
       GOOGLE_APPLICATION_CREDENTIALS: process.env.GOOGLE_APPLICATION_CREDENTIALS,
       AZURE_OPENAI_ENDPOINT: process.env.AZURE_OPENAI_ENDPOINT,
       AZURE_OPENAI_KEY: process.env.AZURE_OPENAI_KEY,

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -51,10 +51,13 @@ export function createEnvConfig() {
       ELASTICSEARCH_CONFIGURED: z.boolean().optional(),
       REDIS_URL: z.string().optional(),
       REDIS_CLUSTER_ENDPOINTS: z.string().optional(),
-      REDIS_DB_INDEX: z
-        .string()
-        .regex(/^(?:[0-9]|1[0-5])$/, "REDIS_DB_INDEX must be 0-15")
-        .optional(),
+      REDIS_DB_INDEX: z.preprocess(
+        (value) => (value === "" ? undefined : value),
+        z
+          .string()
+          .regex(/^(?:[0-9]|1[0-5])$/, "REDIS_DB_INDEX must be 0-15")
+          .optional(),
+      ),
       GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
       AZURE_OPENAI_ENDPOINT: z.string().optional(),
       AZURE_OPENAI_KEY: z.string().optional(),

--- a/langwatch/src/server/app-layer/clients/redis.factory.ts
+++ b/langwatch/src/server/app-layer/clients/redis.factory.ts
@@ -3,6 +3,11 @@ import IORedis, { Cluster } from "ioredis";
 export interface RedisFactoryOptions {
   url?: string;
   clusterEndpoints?: string;
+  // Redis DB index (0–15). Only applied in standalone mode; cluster ignores it.
+  // Must match the main `connection` in server/redis.ts to keep BroadcastService
+  // and SpanDedupService on the same DB as the rest of the app, or the
+  // REDIS_DB_INDEX dev isolation becomes a split brain.
+  db?: number;
 }
 
 function parseClusterEndpoints(endpointsStr: string) {
@@ -32,6 +37,7 @@ export function createRedisConnectionFromConfig(
   return new IORedis(opts.url!, {
     maxRetriesPerRequest: null,
     offlineQueue: false,
+    db: opts.db ?? 0,
     tls: opts.url?.includes("tls.rejectUnauthorized=false")
       ? { rejectUnauthorized: false }
       : opts.url?.includes("rediss://")

--- a/langwatch/src/server/app-layer/config.ts
+++ b/langwatch/src/server/app-layer/config.ts
@@ -1,4 +1,5 @@
 import { createEnvConfig } from "../../env-create.mjs";
+import { parseRedisDbIndex } from "../redis-db-index";
 
 export type ProcessRole = "web" | "worker" | "migration";
 
@@ -10,6 +11,7 @@ export interface AppConfig {
   clickhouseUrl?: string;
   redisUrl?: string;
   redisClusterEndpoints?: string;
+  redisDbIndex?: number;
 
   // Services
   langevalsEndpoint?: string;
@@ -54,6 +56,7 @@ export function createAppConfigFromEnv(overrides?: {
     clickhouseUrl: env.CLICKHOUSE_URL,
     redisUrl: env.REDIS_URL,
     redisClusterEndpoints: env.REDIS_CLUSTER_ENDPOINTS,
+    redisDbIndex: parseRedisDbIndex(env.REDIS_DB_INDEX),
     langevalsEndpoint: env.LANGEVALS_ENDPOINT,
     baseHost: env.BASE_HOST,
     slackPlanLimitChannel: env.SLACK_PLAN_LIMIT_CHANNEL,

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -135,6 +135,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
   const redis = config.skipRedis ? null : createRedisConnectionFromConfig({
     url: config.redisUrl,
     clusterEndpoints: config.redisClusterEndpoints,
+    db: config.redisDbIndex,
   });
 
   const broadcast = new BroadcastService(redis);

--- a/langwatch/src/server/redis-db-index.ts
+++ b/langwatch/src/server/redis-db-index.ts
@@ -1,0 +1,10 @@
+// Parses the REDIS_DB_INDEX env var into a validated 0..15 integer.
+// Returns 0 for anything unset, malformed, or out of range — this is a dev
+// affordance, not a hard config, so we never throw here.
+const VALID = /^(?:[0-9]|1[0-5])$/;
+
+export const parseRedisDbIndex = (raw: string | undefined): number => {
+  if (!raw) return 0;
+  if (!VALID.test(raw)) return 0;
+  return Number(raw);
+};

--- a/langwatch/src/server/redis.test.ts
+++ b/langwatch/src/server/redis.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseRedisDbIndex } from "./redis";
+import { parseRedisDbIndex } from "./redis-db-index";
 
 describe("parseRedisDbIndex", () => {
   describe("when unset", () => {
@@ -23,6 +23,15 @@ describe("parseRedisDbIndex", () => {
       expect(parseRedisDbIndex("-1")).toBe(0);
       expect(parseRedisDbIndex("16")).toBe(0);
       expect(parseRedisDbIndex("9999")).toBe(0);
+    });
+
+    it("rejects partial numeric matches that parseInt would otherwise accept", () => {
+      // `parseInt("1abc", 10) === 1`; the full-string regex prevents that silent
+      // acceptance even if callers skip the Zod layer.
+      expect(parseRedisDbIndex("1abc")).toBe(0);
+      expect(parseRedisDbIndex("15x")).toBe(0);
+      expect(parseRedisDbIndex(" 2")).toBe(0);
+      expect(parseRedisDbIndex("0x10")).toBe(0);
     });
   });
 });

--- a/langwatch/src/server/redis.test.ts
+++ b/langwatch/src/server/redis.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseRedisDbIndex } from "./redis";
+
+describe("parseRedisDbIndex", () => {
+  describe("when unset", () => {
+    it("returns 0", () => {
+      expect(parseRedisDbIndex(undefined)).toBe(0);
+      expect(parseRedisDbIndex("")).toBe(0);
+    });
+  });
+
+  describe("when set to a valid index", () => {
+    it("returns the parsed number", () => {
+      expect(parseRedisDbIndex("0")).toBe(0);
+      expect(parseRedisDbIndex("1")).toBe(1);
+      expect(parseRedisDbIndex("15")).toBe(15);
+    });
+  });
+
+  describe("when set to something invalid", () => {
+    it("falls back to 0 rather than throwing — redis.ts must never block startup over this dev affordance", () => {
+      expect(parseRedisDbIndex("banana")).toBe(0);
+      expect(parseRedisDbIndex("-1")).toBe(0);
+      expect(parseRedisDbIndex("16")).toBe(0);
+      expect(parseRedisDbIndex("9999")).toBe(0);
+    });
+  });
+});

--- a/langwatch/src/server/redis.ts
+++ b/langwatch/src/server/redis.ts
@@ -44,10 +44,29 @@ function parseClusterEndpoints(endpointsStr: string) {
 
 export let connection: IORedis | Cluster | undefined;
 
+// Dev-only isolation: `pnpm dev` at PORT=5570 lands on DB 1, PORT=5580 on DB 2,
+// etc. Prevents multiple worktrees from contending on the same BullMQ queues
+// and GroupQueue streams. Cluster mode ignores this (cluster supports only
+// DB 0) — we warn below if it's set in that combination.
+export const parseRedisDbIndex = (raw: string | undefined): number => {
+  if (!raw) return 0;
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n) || n < 0 || n > 15) return 0;
+  return n;
+};
+
+const redisDbIndex = parseRedisDbIndex(env.REDIS_DB_INDEX);
+
 if (!isBuildOrNoRedis) {
   // Use validated env inside this block since Redis is definitely needed
   const useCluster = !!env.REDIS_CLUSTER_ENDPOINTS;
   if (useCluster) {
+    if (redisDbIndex !== 0) {
+      logger.warn(
+        { redisDbIndex },
+        "REDIS_DB_INDEX is set but REDIS_CLUSTER_ENDPOINTS is active — cluster mode only supports DB 0, ignoring",
+      );
+    }
     const clusterEndpoints = parseClusterEndpoints(
       env.REDIS_CLUSTER_ENDPOINTS ?? "",
     );
@@ -71,16 +90,17 @@ if (!isBuildOrNoRedis) {
     connection = new IORedis(env.REDIS_URL ?? "", {
       maxRetriesPerRequest: null,
       offlineQueue: false,
+      db: redisDbIndex,
       tls: env.REDIS_URL?.includes("tls.rejectUnauthorized=false")
         ? { rejectUnauthorized: false }
         : (env.REDIS_URL?.includes("rediss://") as any),
     });
 
     connection.on("connect", () => {
-      logger.info("connected");
+      logger.info({ db: redisDbIndex }, "connected");
     });
     connection.on("ready", () => {
-      logger.info("ready to accept commands");
+      logger.info({ db: redisDbIndex }, "ready to accept commands");
     });
   }
 

--- a/langwatch/src/server/redis.ts
+++ b/langwatch/src/server/redis.ts
@@ -3,6 +3,9 @@ import IORedis, { Cluster } from "ioredis";
 const PHASE_PRODUCTION_BUILD = "phase-production-build";
 import { env } from "../env.mjs";
 import { createLogger } from "../utils/logger/server";
+import { parseRedisDbIndex } from "./redis-db-index";
+
+export { parseRedisDbIndex } from "./redis-db-index";
 
 const logger = createLogger("langwatch:redis");
 
@@ -48,17 +51,10 @@ export let connection: IORedis | Cluster | undefined;
 // etc. Prevents multiple worktrees from contending on the same BullMQ queues
 // and GroupQueue streams. Cluster mode ignores this (cluster supports only
 // DB 0) — we warn below if it's set in that combination.
-export const parseRedisDbIndex = (raw: string | undefined): number => {
-  if (!raw) return 0;
-  const n = parseInt(raw, 10);
-  if (Number.isNaN(n) || n < 0 || n > 15) return 0;
-  return n;
-};
-
-const redisDbIndex = parseRedisDbIndex(env.REDIS_DB_INDEX);
 
 if (!isBuildOrNoRedis) {
   // Use validated env inside this block since Redis is definitely needed
+  const redisDbIndex = parseRedisDbIndex(env.REDIS_DB_INDEX);
   const useCluster = !!env.REDIS_CLUSTER_ENDPOINTS;
   if (useCluster) {
     if (redisDbIndex !== 0) {


### PR DESCRIPTION
## Summary

Running `pnpm dev` in multiple worktrees (each with `START_WORKERS=true`) has them all racing to process the **same** BullMQ queues, GroupQueue streams, fold cache, and replay markers — so a trace enqueued by worktree A can get processed by worktree B. Catastrophic when the thing you're changing *is* the event-sourcing pipeline.

This PR adds a single env var, `REDIS_DB_INDEX` (0–15), applied as IORedis's `db` option on the standalone Redis connection. Because every BullMQ queue + the custom GroupQueue + the fold cache + replay markers all share that one global connection, the isolation propagates automatically with zero changes at any queue-construction site.

**`pnpm dev` auto-derives the index from the PORT slot** so you don't have to think about it:

| PORT | REDIS_DB_INDEX |
|---|---|
| 5560 | 0 |
| 5570 | 1 |
| 5580 | 2 |
| … | … |
| 5710 | 15 |

Explicit `REDIS_DB_INDEX` wins. Skipped in production: cluster mode (`REDIS_CLUSTER_ENDPOINTS`) only supports DB 0, so we ignore the var there and log a one-time warning if it's non-zero to catch prod mis-configs.

## Changes

- `langwatch/src/env-create.mjs` — declare `REDIS_DB_INDEX` with a `0–15` zod regex
- `langwatch/src/server/redis.ts` — apply `db` on standalone IORedis; warn on cluster mode + non-zero; log active DB on `connected` / `ready`; export pure `parseRedisDbIndex()` for tests
- `langwatch/scripts/start.sh` — when `NODE_ENV=development`, auto-derive `REDIS_DB_INDEX` from `PORT` if not set, clamp to 0–15, export, print banner
- `langwatch/src/server/redis.test.ts` — new, covers undefined/empty/valid/out-of-range/non-numeric

## Out of scope

- Scenarios workers use an in-memory pool + child processes; no Redis, no change needed.
- ES / OpenSearch / ClickHouse / Postgres isolation across worktrees is separate.

## Test plan

- [x] Unit: `pnpm test:unit src/server/redis.test.ts` → 3 passing.
- [x] Existing `config.test.ts` still green (13 tests across both files).
- [x] `pnpm typecheck` clean.
- [x] Shell matrix for the auto-derivation block in `start.sh` verified across dev+PORT={5560,5570,5580,5710,5800}, dev+explicit override, and production.
- [ ] Manual e2e: two worktrees (`PORT=5560` and `PORT=5570`) both running `pnpm dev`; trace sent to A never shows up in B's worker log; `redis-cli SELECT 0 ; KEYS "*"` and `SELECT 1 ; KEYS "*"` show each worktree's keys in its own DB.