### PR TITLE
fix(dev/check-ports): skip pre-flight in prod and inside Docker

### DIFF
--- a/langwatch/scripts/check-ports.sh
+++ b/langwatch/scripts/check-ports.sh
@@ -13,6 +13,18 @@
 # the port is free, which is the *good* path for us — it should not abort
 # the whole script.
 
+# This pre-flight check is a dev-host-only quality-of-life affordance: it
+# catches the common case where two `pnpm dev` invocations on the same laptop
+# fight for the same ports. In any other context it's pointless noise:
+#   - Production: if the port is taken the node server will fail to bind and
+#     surface its own clean error — we must not fail-fast the container start.
+#   - Docker: each container has its own network namespace, so collisions are
+#     impossible by definition, and `lsof` inside a distroless-ish image can
+#     misreport PID 1 (the node entrypoint itself) as holding the port.
+if [ "${NODE_ENV:-production}" != "development" ] || [ -f /.dockerenv ]; then
+  exit 0
+fi
+
 PORT="${PORT:-5560}"
 API_PORT=$((PORT + 1000))
 WORKER_METRICS_PORT="${WORKER_METRICS_PORT:-$((PORT - 2561))}"


### PR DESCRIPTION
## Summary

Prod pods are crashlooping on startup because `check-ports.sh` false-positives inside the container — `lsof` reports PID 1 (our own node entrypoint) as holding 5560, the script exits 1, and the pod dies:

```
✗ port conflict — refusing to start
  ✗ port 5560 (api server) held by pid 1    /usr/local/bin/node    0    /dev/null:
 ELIFECYCLE  Command failed with exit code 1.
```

Two separate problems:
1. **We must never fail-fast container start** over this. The node server already surfaces a clean bind error if anything actually collides — there's no value in pre-empting it.
2. The pre-flight was only ever designed for the dev-host case where two `pnpm dev` invocations on the same laptop contend for ports. Containers have their own network namespace, so collisions are impossible there by construction.

## Fix

Exit 0 immediately when:
- `NODE_ENV != development` (covers prod deploys), or
- `/.dockerenv` exists (the marker every Docker container has — covers dev-in-Docker too).

Dev-on-host behavior is unchanged: it still detects conflicts and fails fast with the nice banner.

## Test plan

- [x] Prod mode + port 5560 taken → exits 0 silently.
- [x] Unset NODE_ENV (defaults to prod) + port taken → exits 0 silently.
- [x] Dev mode on host + port taken → still fails fast with the conflict banner (exit 1).
- [x] Dev mode + simulated `/.dockerenv` marker → exits 0 silently.
- [ ] Prod pod startup unblocked.