### PR TITLE
feat(traces): resolve partial trace IDs on GET /api/traces/{traceId}

### DIFF
--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/get-trace.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/get-trace.unit.test.ts
@@ -68,6 +68,9 @@ vi.mock("~/server/api/routers/traces.schemas", () => {
 
 // Import app after mocks are defined
 const { app: v1App } = await import("../app.v1");
+const { AmbiguousTraceIdPrefixError } = await import(
+  "~/server/traces/trace.service"
+);
 
 // Build a wrapper app that injects the project variable (mimicking auth middleware)
 // and adds an error handler that mirrors the real app's JSON error responses
@@ -206,15 +209,11 @@ describe("GET /:traceId", () => {
         "abc1230000000000000000000000aaaa",
         "abc1230000000000000000000000bbbb",
       ];
-      // Use the real error class exported by the module-level mock
-      const { AmbiguousTraceIdPrefixError } = await import(
-        "~/server/traces/trace.service"
-      );
       mockGetById.mockRejectedValue(
-        new AmbiguousTraceIdPrefixError("abc123", candidates),
+        new AmbiguousTraceIdPrefixError("abc12345", candidates),
       );
 
-      const res = await makeRequest("abc123");
+      const res = await makeRequest("abc12345");
 
       expect(res.status).toBe(409);
       const body = await res.json();

--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/get-trace.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/get-trace.unit.test.ts
@@ -6,14 +6,28 @@ import type { Evaluation, Trace } from "~/server/tracer/types";
 const mockGetById = vi.fn();
 const mockGetEvaluationsMultiple = vi.fn();
 
-vi.mock("~/server/traces/trace.service", () => ({
-  TraceService: {
-    create: () => ({
-      getById: mockGetById,
-      getEvaluationsMultiple: mockGetEvaluationsMultiple,
-    }),
-  },
-}));
+vi.mock("~/server/traces/trace.service", async () => {
+  class AmbiguousTraceIdPrefixError extends Error {
+    constructor(
+      public readonly prefix: string,
+      public readonly candidateTraceIds: string[],
+    ) {
+      super(
+        `Trace ID prefix "${prefix}" is ambiguous — matches: ${candidateTraceIds.join(", ")}`,
+      );
+      this.name = "AmbiguousTraceIdPrefixError";
+    }
+  }
+  return {
+    AmbiguousTraceIdPrefixError,
+    TraceService: {
+      create: () => ({
+        getById: mockGetById,
+        getEvaluationsMultiple: mockGetEvaluationsMultiple,
+      }),
+    },
+  };
+});
 
 vi.mock("~/server/api/utils", () => ({
   getProtectionsForProject: vi.fn().mockResolvedValue({}),
@@ -157,6 +171,55 @@ describe("GET /:traceId", () => {
       expect(res.status).toBe(404);
       const body = await res.json();
       expect(body.message).toBe("Trace not found.");
+    });
+  });
+
+  describe("when the caller passes a unique prefix", () => {
+    it("returns the trace using the resolved full trace ID", async () => {
+      // Service resolves the prefix and hands back the full trace
+      const fullId = "63dc535cea6335c506bc81ef3543a07d";
+      mockGetById.mockResolvedValue({ ...sampleTrace, trace_id: fullId });
+      mockGetEvaluationsMultiple.mockResolvedValue({
+        [fullId]: sampleEvaluations,
+      });
+
+      const res = await makeRequest("63dc535cea6335c506bc", {
+        format: "json",
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.trace_id).toBe(fullId);
+      expect(body.platformUrl).toContain(fullId);
+      // Evaluations lookup keys on the FULL trace ID, not the prefix
+      expect(mockGetEvaluationsMultiple).toHaveBeenCalledWith(
+        "project-123",
+        [fullId],
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("when the prefix matches multiple traces", () => {
+    it("returns 409 with the candidate trace IDs", async () => {
+      const candidates = [
+        "abc1230000000000000000000000aaaa",
+        "abc1230000000000000000000000bbbb",
+      ];
+      // Use the real error class exported by the module-level mock
+      const { AmbiguousTraceIdPrefixError } = await import(
+        "~/server/traces/trace.service"
+      );
+      mockGetById.mockRejectedValue(
+        new AmbiguousTraceIdPrefixError("abc123", candidates),
+      );
+
+      const res = await makeRequest("abc123");
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.message).toMatch(/ambiguous/i);
+      expect(body.candidateTraceIds).toEqual(candidates);
     });
   });
 });

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -165,8 +165,7 @@ app.post(
 app.get(
   "/:traceId",
   describeRoute({
-    description:
-      "Get a single trace by ID. Defaults to JSON format (pass `format=digest` for an AI-readable summary). Accepts either the full 32-character trace ID or a unique prefix of at least 8 characters (git-style shortcut). Returns 404 if no trace matches and 409 if a prefix matches more than one trace.",
+    description: "Get a single trace by ID.",
     parameters: [
       {
         name: "traceId",

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -166,7 +166,7 @@ app.get(
   "/:traceId",
   describeRoute({
     description:
-      "Get a single trace by ID. Defaults to AI-readable digest format. Accepts either the full 32-character trace ID or a unique prefix of at least 8 characters (git-style shortcut). Returns 404 if no trace matches and 409 if a prefix matches more than one trace.",
+      "Get a single trace by ID. Defaults to JSON format (pass `format=digest` for an AI-readable summary). Accepts either the full 32-character trace ID or a unique prefix of at least 8 characters (git-style shortcut). Returns 404 if no trace matches and 409 if a prefix matches more than one trace.",
     parameters: [
       {
         name: "traceId",

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -9,7 +9,10 @@ import type { Span, Trace } from "~/server/tracer/types";
 import { formatSpansDigest } from "~/server/tracer/spanToReadableSpan";
 import { generateAsciiTree, formatTraceSummaryDigest } from "~/server/traces/trace-formatting";
 import { enrichTracesWithEvaluations } from "~/server/traces/enrich-evaluations";
-import { TraceService } from "~/server/traces/trace.service";
+import {
+  AmbiguousTraceIdPrefixError,
+  TraceService,
+} from "~/server/traces/trace.service";
 import { createLogger } from "~/utils/logger/server";
 import type { AuthMiddlewareVariables } from "../../middleware";
 import { baseResponses } from "../../shared/base-responses";
@@ -162,12 +165,14 @@ app.post(
 app.get(
   "/:traceId",
   describeRoute({
-    description: "Get a single trace by ID. Defaults to AI-readable digest format.",
+    description:
+      "Get a single trace by ID. Defaults to AI-readable digest format. Accepts either the full 32-character trace ID or a unique prefix of at least 8 characters (git-style shortcut). Returns 404 if no trace matches and 409 if a prefix matches more than one trace.",
     parameters: [
       {
         name: "traceId",
         in: "path",
-        description: "The trace ID",
+        description:
+          "The trace ID — either the full 32-char ID or a unique prefix (≥ 8 chars). Prefix lookup is scoped to the authenticated project.",
         required: true,
         schema: { type: "string" },
       },
@@ -207,6 +212,20 @@ app.get(
           },
         },
       },
+      409: {
+        description:
+          "Ambiguous trace ID prefix — the prefix matches more than one trace",
+        content: {
+          "application/json": {
+            schema: resolver(
+              z.object({
+                message: z.string(),
+                candidateTraceIds: z.array(z.string()),
+              }),
+            ),
+          },
+        },
+      },
     },
   }),
   async (c) => {
@@ -227,7 +246,22 @@ app.get(
       projectId: project.id,
     });
     const traceService = TraceService.create(prisma);
-    const trace = await traceService.getById(project.id, traceId, protections);
+
+    let trace;
+    try {
+      trace = await traceService.getById(project.id, traceId, protections);
+    } catch (err) {
+      if (err instanceof AmbiguousTraceIdPrefixError) {
+        return c.json(
+          {
+            message: err.message,
+            candidateTraceIds: err.candidateTraceIds,
+          },
+          409,
+        );
+      }
+      throw err;
+    }
 
     if (!trace) {
       throw new HTTPException(404, {
@@ -235,23 +269,28 @@ app.get(
       });
     }
 
+    // If the caller passed a prefix, the resolved trace has the full ID.
+    // Use that everywhere downstream so the response, links, and evaluation
+    // lookup all key off the real trace ID.
+    const resolvedTraceId = trace.trace_id;
+
     const evaluationsMap = await traceService.getEvaluationsMultiple(
       project.id,
-      [traceId],
+      [resolvedTraceId],
       protections,
     );
-    const evaluations = evaluationsMap[traceId] ?? [];
+    const evaluations = evaluationsMap[resolvedTraceId] ?? [];
 
     if (format === "digest") {
       return c.json({
-        trace_id: traceId,
+        trace_id: resolvedTraceId,
         formatted_trace: await formatSpansDigest(trace.spans ?? []),
         timestamps: trace.timestamps,
         metadata: trace.metadata,
         evaluations,
         platformUrl: platformUrl({
           projectSlug: project.slug,
-          path: `/messages/${traceId}`,
+          path: `/messages/${resolvedTraceId}`,
         }),
       });
     }
@@ -263,7 +302,7 @@ app.get(
       ascii_tree: asciiTree,
       platformUrl: platformUrl({
         projectSlug: project.slug,
-        path: `/messages/${traceId}`,
+        path: `/messages/${resolvedTraceId}`,
       }),
     });
   },

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-prefix.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-prefix.integration.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Integration tests for trace-ID prefix resolution.
+ *
+ * The CLI `trace search` table truncates trace IDs to 20 characters for
+ * readability. Copy-pasting that truncated ID into `trace get` used to hit
+ * a 404 because the backend required exact matches. This exercises the
+ * git-style prefix lookup that unblocks that workflow.
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+
+const tenantId = `test-trace-prefix-${nanoid()}`;
+const otherTenantId = `test-trace-prefix-other-${nanoid()}`;
+const now = Date.now();
+
+function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: `trace-${nanoid()}`,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: null,
+    ComputedOutput: null,
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 0,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: null,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    SatisfactionScore: null,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+    ...overrides,
+  };
+}
+
+async function insertTraceSummary(
+  ch: ClickHouseClient,
+  row: ReturnType<typeof makeTraceSummaryRow>,
+) {
+  await ch.insert({
+    table: "trace_summaries",
+    values: [row],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    project: {
+      findUnique: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+
+  const chModule = await import("~/server/clickhouse/clickhouseClient");
+  const getClickHouseClientForProject = vi.mocked(
+    chModule.getClickHouseClientForProject,
+  );
+  getClickHouseClientForProject.mockResolvedValue(ch);
+
+  const { prisma } = await import("~/server/db");
+  service = new ClickHouseTraceService(
+    prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+  );
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE trace_summaries DELETE WHERE TenantId IN ({a:String}, {b:String})`,
+      query_params: { a: tenantId, b: otherTenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("ClickHouseTraceService.resolveTraceIdByPrefix (integration)", () => {
+  describe("when exactly one trace matches the prefix within the project", () => {
+    const fullId = "63dc535cea6335c506bc81ef3543a07d";
+
+    beforeAll(async () => {
+      await insertTraceSummary(ch, makeTraceSummaryRow({ TraceId: fullId }));
+    });
+
+    it("returns the single full trace ID", async () => {
+      const result = await service.resolveTraceIdByPrefix(
+        tenantId,
+        fullId.slice(0, 20),
+      );
+
+      expect(result).toEqual([fullId]);
+    });
+
+    it("still resolves when the caller passes the full ID", async () => {
+      const result = await service.resolveTraceIdByPrefix(tenantId, fullId);
+
+      expect(result).toEqual([fullId]);
+    });
+  });
+
+  describe("when the prefix matches multiple traces in the project", () => {
+    const traceA = "abc123de00000000000000000000aaaa";
+    const traceB = "abc123de00000000000000000000bbbb";
+
+    beforeAll(async () => {
+      await insertTraceSummary(ch, makeTraceSummaryRow({ TraceId: traceA }));
+      await insertTraceSummary(ch, makeTraceSummaryRow({ TraceId: traceB }));
+    });
+
+    it("returns multiple IDs up to the limit so callers can detect ambiguity", async () => {
+      const result = await service.resolveTraceIdByPrefix(
+        tenantId,
+        "abc123de",
+        2,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!).toHaveLength(2);
+      expect(result!.sort()).toEqual([traceA, traceB].sort());
+    });
+  });
+
+  describe("when no trace matches", () => {
+    it("returns an empty array", async () => {
+      const result = await service.resolveTraceIdByPrefix(
+        tenantId,
+        "deadbeefno-match",
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("when another project has a matching trace ID", () => {
+    const otherTraceId = "ffee112233445566778899aabbccddee";
+
+    beforeAll(async () => {
+      // Insert under a DIFFERENT tenant — MUST NOT leak across projects.
+      await insertTraceSummary(
+        ch,
+        makeTraceSummaryRow({
+          TraceId: otherTraceId,
+          TenantId: otherTenantId,
+        }),
+      );
+    });
+
+    it("does not return it for a different project", async () => {
+      const result = await service.resolveTraceIdByPrefix(
+        tenantId,
+        otherTraceId.slice(0, 20),
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-prefix.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-prefix.integration.test.ts
@@ -68,6 +68,11 @@ async function insertTraceSummary(
   });
 }
 
+const occurredAtRange = {
+  from: now - 60_000,
+  to: now + 60_000,
+};
+
 let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 
@@ -118,16 +123,21 @@ describe("ClickHouseTraceService.resolveTraceIdByPrefix (integration)", () => {
     });
 
     it("returns the single full trace ID", async () => {
-      const result = await service.resolveTraceIdByPrefix(
-        tenantId,
-        fullId.slice(0, 20),
-      );
+      const result = await service.resolveTraceIdByPrefix({
+        projectId: tenantId,
+        prefix: fullId.slice(0, 20),
+        occurredAt: occurredAtRange,
+      });
 
       expect(result).toEqual([fullId]);
     });
 
     it("still resolves when the caller passes the full ID", async () => {
-      const result = await service.resolveTraceIdByPrefix(tenantId, fullId);
+      const result = await service.resolveTraceIdByPrefix({
+        projectId: tenantId,
+        prefix: fullId,
+        occurredAt: occurredAtRange,
+      });
 
       expect(result).toEqual([fullId]);
     });
@@ -143,11 +153,12 @@ describe("ClickHouseTraceService.resolveTraceIdByPrefix (integration)", () => {
     });
 
     it("returns multiple IDs up to the limit so callers can detect ambiguity", async () => {
-      const result = await service.resolveTraceIdByPrefix(
-        tenantId,
-        "abc123de",
-        2,
-      );
+      const result = await service.resolveTraceIdByPrefix({
+        projectId: tenantId,
+        prefix: "abc123de",
+        occurredAt: occurredAtRange,
+        limit: 2,
+      });
 
       expect(result).not.toBeNull();
       expect(result!).toHaveLength(2);
@@ -157,10 +168,36 @@ describe("ClickHouseTraceService.resolveTraceIdByPrefix (integration)", () => {
 
   describe("when no trace matches", () => {
     it("returns an empty array", async () => {
-      const result = await service.resolveTraceIdByPrefix(
-        tenantId,
-        "deadbeefno-match",
+      const result = await service.resolveTraceIdByPrefix({
+        projectId: tenantId,
+        prefix: "deadbeefno-match",
+        occurredAt: occurredAtRange,
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("when the trace falls outside the OccurredAt window", () => {
+    const outOfWindowTraceId = "fedcba9876543210fedcba9876543210";
+
+    beforeAll(async () => {
+      // Insert with OccurredAt far in the past — outside the test's window.
+      await insertTraceSummary(
+        ch,
+        makeTraceSummaryRow({
+          TraceId: outOfWindowTraceId,
+          OccurredAt: new Date(now - 1_000_000),
+        }),
       );
+    });
+
+    it("does not return traces outside the partition window", async () => {
+      const result = await service.resolveTraceIdByPrefix({
+        projectId: tenantId,
+        prefix: outOfWindowTraceId.slice(0, 16),
+        occurredAt: occurredAtRange,
+      });
 
       expect(result).toEqual([]);
     });
@@ -181,10 +218,11 @@ describe("ClickHouseTraceService.resolveTraceIdByPrefix (integration)", () => {
     });
 
     it("does not return it for a different project", async () => {
-      const result = await service.resolveTraceIdByPrefix(
-        tenantId,
-        otherTraceId.slice(0, 20),
-      );
+      const result = await service.resolveTraceIdByPrefix({
+        projectId: tenantId,
+        prefix: otherTraceId.slice(0, 20),
+        occurredAt: occurredAtRange,
+      });
 
       expect(result).toEqual([]);
     });

--- a/langwatch/src/server/traces/__tests__/trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace.service.unit.test.ts
@@ -151,7 +151,7 @@ describe("TraceService", () => {
       });
     });
 
-    describe("when the input is a prefix shorter than a full ID", () => {
+    describe("when the input is a hex prefix shorter than a full ID", () => {
       it("resolves to the full trace when exactly one match exists", async () => {
         mockGetTracesWithSpansCH
           .mockResolvedValueOnce([])
@@ -162,9 +162,15 @@ describe("TraceService", () => {
 
         expect(result).toBe(sampleTrace);
         expect(mockResolveTraceIdByPrefixCH).toHaveBeenCalledWith(
-          projectId,
-          prefix20,
-          2,
+          expect.objectContaining({
+            projectId,
+            prefix: prefix20,
+            limit: 5,
+            occurredAt: expect.objectContaining({
+              from: expect.any(Number),
+              to: expect.any(Number),
+            }),
+          }),
         );
         // Second fetch uses the resolved full ID
         expect(mockGetTracesWithSpansCH).toHaveBeenNthCalledWith(
@@ -202,6 +208,21 @@ describe("TraceService", () => {
         mockGetTracesWithSpansCH.mockResolvedValue([]);
 
         const result = await service.getById(projectId, "abc", protections);
+
+        expect(result).toBeUndefined();
+        expect(mockResolveTraceIdByPrefixCH).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the input is not hex (typo, slash, etc.)", () => {
+      it("skips prefix resolution and returns undefined", async () => {
+        mockGetTracesWithSpansCH.mockResolvedValue([]);
+
+        const result = await service.getById(
+          projectId,
+          "not-a-hex-id-zzzzzzzz",
+          protections,
+        );
 
         expect(result).toBeUndefined();
         expect(mockResolveTraceIdByPrefixCH).not.toHaveBeenCalled();

--- a/langwatch/src/server/traces/__tests__/trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace.service.unit.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Protections } from "~/server/elasticsearch/protections";
 import type { Trace } from "~/server/tracer/types";
 import type { GetAllTracesForProjectInput } from "../types";
-import { TraceService } from "../trace.service";
+import {
+  AmbiguousTraceIdPrefixError,
+  TraceService,
+} from "../trace.service";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -10,13 +13,19 @@ import { TraceService } from "../trace.service";
 const {
   mockGetAllTracesForProjectCH,
   mockGetAllTracesForProjectES,
+  mockGetTracesWithSpansCH,
+  mockResolveTraceIdByPrefixCH,
 } = vi.hoisted(() => ({
   mockGetAllTracesForProjectCH: vi.fn(),
   mockGetAllTracesForProjectES: vi.fn(),
+  mockGetTracesWithSpansCH: vi.fn(),
+  mockResolveTraceIdByPrefixCH: vi.fn(),
 }));
 
 const mockClickHouseInstance = {
   getAllTracesForProject: mockGetAllTracesForProjectCH,
+  getTracesWithSpans: mockGetTracesWithSpansCH,
+  resolveTraceIdByPrefix: mockResolveTraceIdByPrefixCH,
 };
 
 const mockElasticInstance = {
@@ -122,6 +131,81 @@ describe("TraceService", () => {
       ).rejects.toThrow(
         "ClickHouse is enabled but returned null for getAllTracesForProject",
       );
+    });
+  });
+
+  describe("getById()", () => {
+    const projectId = "proj_123";
+    const fullId = "63dc535cea6335c506bc81ef3543a07d";
+    const prefix20 = fullId.slice(0, 20);
+    const sampleTrace = { trace_id: fullId, spans: [] } as unknown as Trace;
+
+    describe("when an exact trace ID match exists", () => {
+      it("returns the trace without attempting prefix resolution", async () => {
+        mockGetTracesWithSpansCH.mockResolvedValue([sampleTrace]);
+
+        const result = await service.getById(projectId, fullId, protections);
+
+        expect(result).toBe(sampleTrace);
+        expect(mockResolveTraceIdByPrefixCH).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the input is a prefix shorter than a full ID", () => {
+      it("resolves to the full trace when exactly one match exists", async () => {
+        mockGetTracesWithSpansCH
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([sampleTrace]);
+        mockResolveTraceIdByPrefixCH.mockResolvedValue([fullId]);
+
+        const result = await service.getById(projectId, prefix20, protections);
+
+        expect(result).toBe(sampleTrace);
+        expect(mockResolveTraceIdByPrefixCH).toHaveBeenCalledWith(
+          projectId,
+          prefix20,
+          2,
+        );
+        // Second fetch uses the resolved full ID
+        expect(mockGetTracesWithSpansCH).toHaveBeenNthCalledWith(
+          2,
+          projectId,
+          [fullId],
+          protections,
+        );
+      });
+
+      it("throws AmbiguousTraceIdPrefixError when the prefix matches multiple traces", async () => {
+        mockGetTracesWithSpansCH.mockResolvedValue([]);
+        mockResolveTraceIdByPrefixCH.mockResolvedValue([
+          fullId,
+          "63dc535cea6335c506bc99990000ffff",
+        ]);
+
+        await expect(
+          service.getById(projectId, prefix20, protections),
+        ).rejects.toBeInstanceOf(AmbiguousTraceIdPrefixError);
+      });
+
+      it("returns undefined when the prefix matches no traces", async () => {
+        mockGetTracesWithSpansCH.mockResolvedValue([]);
+        mockResolveTraceIdByPrefixCH.mockResolvedValue([]);
+
+        const result = await service.getById(projectId, prefix20, protections);
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe("when the input is too short to be a meaningful prefix", () => {
+      it("returns undefined without querying by prefix", async () => {
+        mockGetTracesWithSpansCH.mockResolvedValue([]);
+
+        const result = await service.getById(projectId, "abc", protections);
+
+        expect(result).toBeUndefined();
+        expect(mockResolveTraceIdByPrefixCH).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -168,18 +168,28 @@ export class ClickHouseTraceService {
    * trace search`). Returns up to `limit` distinct trace IDs so the caller can
    * detect ambiguity.
    *
-   * Returns null if the ClickHouse client is not available for the project.
+   * Callers MUST pass an `occurredAt` range to keep the scan bounded. Per
+   * repository conventions, filtering on the partition key (OccurredAt) is
+   * required — without it ClickHouse scans every partition (including cold
+   * S3 storage) for every lookup miss.
    *
-   * @param projectId - The project ID (scoped via TenantId)
-   * @param prefix - The trace ID prefix to search for
-   * @param limit - Maximum number of distinct trace IDs to return (default 2 — enough to detect ambiguity)
-   * @returns Array of matching trace IDs (deduped), or null if ClickHouse is not available
+   * Returns null if the ClickHouse client is not available for the project.
    */
-  async resolveTraceIdByPrefix(
-    projectId: string,
-    prefix: string,
+  async resolveTraceIdByPrefix({
+    projectId,
+    prefix,
+    occurredAt,
     limit = 2,
-  ): Promise<string[] | null> {
+  }: {
+    /** The project ID (scoped via TenantId) */
+    projectId: string;
+    /** The trace ID prefix to search for */
+    prefix: string;
+    /** Partition-key bound (epoch millis) — required for partition pruning */
+    occurredAt: { from: number; to: number };
+    /** Maximum distinct trace IDs to return (default 2 — enough to detect ambiguity) */
+    limit?: number;
+  }): Promise<string[] | null> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.resolveTraceIdByPrefix",
       { attributes: { "tenant.id": projectId, "trace.id.prefix": prefix } },
@@ -195,11 +205,15 @@ export class ClickHouseTraceService {
               SELECT DISTINCT TraceId
               FROM trace_summaries
               WHERE TenantId = {tenantId:String}
+                AND OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
+                AND OccurredAt <= fromUnixTimestamp64Milli({toMs:Int64})
                 AND startsWith(TraceId, {prefix:String})
               LIMIT {limit:UInt32}
             `,
             query_params: {
               tenantId: projectId,
+              fromMs: occurredAt.from,
+              toMs: occurredAt.to,
               prefix,
               limit,
             },

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -161,6 +161,69 @@ export class ClickHouseTraceService {
   }
 
   /**
+   * Resolve a trace ID prefix to matching full trace IDs within a project.
+   *
+   * Used for git-style shortcut lookups where a user provides a prefix of the
+   * full trace ID (for example, the 20-char truncated ID shown by `langwatch
+   * trace search`). Returns up to `limit` distinct trace IDs so the caller can
+   * detect ambiguity.
+   *
+   * Returns null if the ClickHouse client is not available for the project.
+   *
+   * @param projectId - The project ID (scoped via TenantId)
+   * @param prefix - The trace ID prefix to search for
+   * @param limit - Maximum number of distinct trace IDs to return (default 2 — enough to detect ambiguity)
+   * @returns Array of matching trace IDs (deduped), or null if ClickHouse is not available
+   */
+  async resolveTraceIdByPrefix(
+    projectId: string,
+    prefix: string,
+    limit = 2,
+  ): Promise<string[] | null> {
+    return await this.tracer.withActiveSpan(
+      "ClickHouseTraceService.resolveTraceIdByPrefix",
+      { attributes: { "tenant.id": projectId, "trace.id.prefix": prefix } },
+      async () => {
+        const clickHouseClient = await this.resolveClient(projectId);
+        if (!clickHouseClient) {
+          return null;
+        }
+
+        try {
+          const result = await clickHouseClient.query({
+            query: `
+              SELECT DISTINCT TraceId
+              FROM trace_summaries
+              WHERE TenantId = {tenantId:String}
+                AND startsWith(TraceId, {prefix:String})
+              LIMIT {limit:UInt32}
+            `,
+            query_params: {
+              tenantId: projectId,
+              prefix,
+              limit,
+            },
+            format: "JSONEachRow",
+          });
+
+          const rows = (await result.json()) as Array<{ TraceId: string }>;
+          return rows.map((r) => r.TraceId);
+        } catch (error) {
+          this.logger.error(
+            {
+              projectId,
+              prefix,
+              error: error instanceof Error ? error.message : error,
+            },
+            "Failed to resolve trace ID by prefix from ClickHouse",
+          );
+          throw new Error("Failed to resolve trace ID by prefix");
+        }
+      },
+    );
+  }
+
+  /**
    * Get traces by thread ID.
    *
    * Queries trace_summaries using the Attributes map to find traces

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -24,6 +24,22 @@ export const MIN_TRACE_ID_PREFIX_LENGTH = 8;
 export const FULL_TRACE_ID_LENGTH = 32;
 
 /**
+ * How many candidates the resolver asks ClickHouse for when disambiguating
+ * a prefix. Matches the cap the error message previews, so API clients see
+ * every candidate the resolver considered.
+ */
+export const TRACE_ID_PREFIX_CANDIDATE_LIMIT = 5;
+
+/**
+ * Time window (in days) that prefix resolution scans. Without a partition
+ * bound, ClickHouse would scan every partition (including cold storage on
+ * S3) on a miss. 90 days covers the CLI's "copy a truncated ID from a
+ * recent search" use case while keeping the query on hot partitions.
+ * Full 32-char IDs still resolve unbounded via the normal exact-match path.
+ */
+export const TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS = 90;
+
+/**
  * Thrown when a trace ID prefix matches more than one trace in the project.
  * Callers (route handlers) map this to a 409 response listing the full
  * candidate IDs so the user can disambiguate.
@@ -33,10 +49,12 @@ export class AmbiguousTraceIdPrefixError extends Error {
     public readonly prefix: string,
     public readonly candidateTraceIds: string[],
   ) {
-    const preview = candidateTraceIds.slice(0, 5).join(", ");
+    const preview = candidateTraceIds
+      .slice(0, TRACE_ID_PREFIX_CANDIDATE_LIMIT)
+      .join(", ");
     const suffix =
-      candidateTraceIds.length > 5
-        ? `, …${candidateTraceIds.length - 5} more`
+      candidateTraceIds.length > TRACE_ID_PREFIX_CANDIDATE_LIMIT
+        ? `, …${candidateTraceIds.length - TRACE_ID_PREFIX_CANDIDATE_LIMIT} more`
         : "";
     super(
       `Trace ID prefix "${prefix}" is ambiguous — matches: ${preview}${suffix}. Use a longer prefix.`,
@@ -44,6 +62,13 @@ export class AmbiguousTraceIdPrefixError extends Error {
     this.name = "AmbiguousTraceIdPrefixError";
   }
 }
+
+/**
+ * Trace IDs per the OpenTelemetry spec are 32 hex characters. We only
+ * attempt prefix resolution for hex-only inputs — non-hex typos ("my-id ")
+ * short-circuit to 404 without scanning.
+ */
+const HEX_ONLY = /^[0-9a-f]+$/i;
 import type {
   AggregationFiltersInput,
   CustomersAndLabelsResult,
@@ -121,17 +146,26 @@ export class TraceService {
           return traces[0];
         }
 
-        // No exact match. If the input looks like a truncated prefix (shorter
-        // than a full trace ID, but long enough to be meaningful), try
-        // git-style prefix resolution scoped to this project.
+        // No exact match. If the input looks like a truncated hex prefix
+        // (shorter than a full trace ID, but long enough to meaningfully
+        // narrow the scan), try git-style prefix resolution scoped to this
+        // project and the last TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS days.
         if (
           traceId.length < FULL_TRACE_ID_LENGTH &&
-          traceId.length >= MIN_TRACE_ID_PREFIX_LENGTH
+          traceId.length >= MIN_TRACE_ID_PREFIX_LENGTH &&
+          HEX_ONLY.test(traceId)
         ) {
+          const now = Date.now();
           const candidates = await this.clickHouseService.resolveTraceIdByPrefix(
-            projectId,
-            traceId,
-            2,
+            {
+              projectId,
+              prefix: traceId,
+              occurredAt: {
+                from: now - TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+                to: now,
+              },
+              limit: TRACE_ID_PREFIX_CANDIDATE_LIMIT,
+            },
           );
           if (candidates === null) {
             throw new Error(

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -8,6 +8,42 @@ import type { Evaluation, Trace } from "~/server/tracer/types";
 import { createLogger } from "~/utils/logger/server";
 import { ClickHouseTraceService } from "./clickhouse-trace.service";
 import { ElasticsearchTraceService } from "./elasticsearch-trace.service";
+
+/**
+ * Minimum prefix length we will attempt to resolve. Shorter strings fall
+ * through to "not found" — this keeps us from scanning the entire
+ * trace_summaries table on a single-character typo and narrows the search
+ * space enough to meaningfully detect ambiguity.
+ */
+export const MIN_TRACE_ID_PREFIX_LENGTH = 8;
+
+/**
+ * Full length of a trace ID. Inputs shorter than this are treated as
+ * potential prefixes; equal-or-longer inputs are treated as literal IDs.
+ */
+export const FULL_TRACE_ID_LENGTH = 32;
+
+/**
+ * Thrown when a trace ID prefix matches more than one trace in the project.
+ * Callers (route handlers) map this to a 409 response listing the full
+ * candidate IDs so the user can disambiguate.
+ */
+export class AmbiguousTraceIdPrefixError extends Error {
+  constructor(
+    public readonly prefix: string,
+    public readonly candidateTraceIds: string[],
+  ) {
+    const preview = candidateTraceIds.slice(0, 5).join(", ");
+    const suffix =
+      candidateTraceIds.length > 5
+        ? `, …${candidateTraceIds.length - 5} more`
+        : "";
+    super(
+      `Trace ID prefix "${prefix}" is ambiguous — matches: ${preview}${suffix}. Use a longer prefix.`,
+    );
+    this.name = "AmbiguousTraceIdPrefixError";
+  }
+}
 import type {
   AggregationFiltersInput,
   CustomersAndLabelsResult,
@@ -81,7 +117,45 @@ export class TraceService {
             "ClickHouse is enabled but returned null for getById — check ClickHouse client configuration",
           );
         }
-        return traces[0];
+        if (traces[0]) {
+          return traces[0];
+        }
+
+        // No exact match. If the input looks like a truncated prefix (shorter
+        // than a full trace ID, but long enough to be meaningful), try
+        // git-style prefix resolution scoped to this project.
+        if (
+          traceId.length < FULL_TRACE_ID_LENGTH &&
+          traceId.length >= MIN_TRACE_ID_PREFIX_LENGTH
+        ) {
+          const candidates = await this.clickHouseService.resolveTraceIdByPrefix(
+            projectId,
+            traceId,
+            2,
+          );
+          if (candidates === null) {
+            throw new Error(
+              "ClickHouse is enabled but returned null for resolveTraceIdByPrefix — check ClickHouse client configuration",
+            );
+          }
+          if (candidates.length === 0) {
+            return undefined;
+          }
+          if (candidates.length > 1) {
+            span.setAttribute("trace.id.prefix.ambiguous", true);
+            throw new AmbiguousTraceIdPrefixError(traceId, candidates);
+          }
+
+          span.setAttribute("trace.id.prefix.resolved", candidates[0]!);
+          const resolved = await this.clickHouseService.getTracesWithSpans(
+            projectId,
+            [candidates[0]!],
+            protections,
+          );
+          return resolved?.[0];
+        }
+
+        return undefined;
       },
     );
   }

--- a/specs/traces/partial-trace-id-resolution.feature
+++ b/specs/traces/partial-trace-id-resolution.feature
@@ -1,0 +1,56 @@
+@integration
+Feature: Partial trace ID resolution on trace GET
+  As a LangWatch user fetching a trace by ID from the API or CLI
+  I want to pass a unique prefix of the trace ID and have it resolve to the full trace
+  So that I can copy-paste shortened IDs from list views (like the CLI table) without re-typing the full 32-character ID
+
+  The CLI `trace search` command truncates trace IDs to 20 characters in its
+  table output for readability. Without prefix resolution, users copying that
+  truncated ID into `trace get` would hit a 404. This mirrors the git-style
+  shortcut where a unique prefix resolves to the full commit hash.
+
+  Background:
+    Given I am authenticated with an API key for a project
+    And the project has traces stored in ClickHouse
+
+  Scenario: Full trace ID resolves exactly
+    Given a trace exists with ID "63dc535cea6335c506bc81ef3543a07d"
+    When I call GET /api/traces/63dc535cea6335c506bc81ef3543a07d
+    Then the response status is 200
+    And the response body contains the trace with that ID
+
+  Scenario: Unique prefix resolves to the full trace
+    Given a trace exists with ID "63dc535cea6335c506bc81ef3543a07d"
+    And no other trace in the project starts with "63dc535cea6335c506bc"
+    When I call GET /api/traces/63dc535cea6335c506bc
+    Then the response status is 200
+    And the response body contains the trace "63dc535cea6335c506bc81ef3543a07d"
+
+  Scenario: Ambiguous prefix returns 409 with the matching IDs
+    Given two traces exist with IDs "abc123def456..." and "abc123def999..."
+    When I call GET /api/traces/abc123
+    Then the response status is 409
+    And the response body includes an error message mentioning "ambiguous"
+    And the response body lists the matching full trace IDs
+
+  Scenario: No match returns 404
+    Given no trace in the project starts with "deadbeef"
+    When I call GET /api/traces/deadbeef
+    Then the response status is 404
+    And the response body message is "Trace not found."
+
+  Scenario: Prefix match is scoped to the current project
+    Given project A has a trace with ID "aaaa111122223333444455556666777788889999"
+    And project B has no trace starting with "aaaa1111"
+    When I call GET /api/traces/aaaa1111 authenticated as project B
+    Then the response status is 404
+
+  Scenario: Too-short prefix is rejected
+    When I call GET /api/traces/ab
+    Then the response status is 400
+    And the response body message mentions a minimum prefix length
+
+  Scenario: CLI `trace get` with truncated ID from `trace search` succeeds
+    Given I run `langwatch trace search --limit 1` and copy the displayed 20-char trace ID
+    When I run `langwatch trace get <that-20-char-id>`
+    Then the CLI prints the full trace details for the matching trace

--- a/specs/traces/partial-trace-id-resolution.feature
+++ b/specs/traces/partial-trace-id-resolution.feature
@@ -27,8 +27,8 @@ Feature: Partial trace ID resolution on trace GET
     And the response body contains the trace "63dc535cea6335c506bc81ef3543a07d"
 
   Scenario: Ambiguous prefix returns 409 with the matching IDs
-    Given two traces exist with IDs "abc123def456..." and "abc123def999..."
-    When I call GET /api/traces/abc123
+    Given two traces exist with IDs "abc12345def456..." and "abc12345def999..."
+    When I call GET /api/traces/abc12345
     Then the response status is 409
     And the response body includes an error message mentioning "ambiguous"
     And the response body lists the matching full trace IDs
@@ -45,10 +45,15 @@ Feature: Partial trace ID resolution on trace GET
     When I call GET /api/traces/aaaa1111 authenticated as project B
     Then the response status is 404
 
-  Scenario: Too-short prefix is rejected
+  Scenario: Too-short prefix falls through to 404
     When I call GET /api/traces/ab
-    Then the response status is 400
-    And the response body message mentions a minimum prefix length
+    Then the response status is 404
+    And the response body message is "Trace not found."
+
+  Scenario: Non-hex input skips prefix scan and returns 404
+    When I call GET /api/traces/not-a-hex-id-zzzz
+    Then the response status is 404
+    And the response body message is "Trace not found."
 
   Scenario: CLI `trace get` with truncated ID from `trace search` succeeds
     Given I run `langwatch trace search --limit 1` and copy the displayed 20-char trace ID

--- a/typescript-sdk/src/cli/commands/traces/search.ts
+++ b/typescript-sdk/src/cli/commands/traces/search.ts
@@ -97,7 +97,7 @@ export const searchTracesCommand = async (options: {
     }
     console.log(
       chalk.gray(
-        `Use ${chalk.cyan("langwatch trace get <traceId>")} to view full details (partial IDs work as long as they're unique)`,
+        `Use ${chalk.cyan("langwatch trace get <traceId>")} to view full details (partial IDs work — pass a unique prefix of at least 8 characters)`,
       ),
     );
   } catch (error) {

--- a/typescript-sdk/src/cli/commands/traces/search.ts
+++ b/typescript-sdk/src/cli/commands/traces/search.ts
@@ -97,7 +97,7 @@ export const searchTracesCommand = async (options: {
     }
     console.log(
       chalk.gray(
-        `Use ${chalk.cyan("langwatch trace get <traceId>")} to view full details`,
+        `Use ${chalk.cyan("langwatch trace get <traceId>")} to view full details (partial IDs work as long as they're unique)`,
       ),
     );
   } catch (error) {

--- a/typescript-sdk/src/cli/commands/traces/search.ts
+++ b/typescript-sdk/src/cli/commands/traces/search.ts
@@ -97,7 +97,7 @@ export const searchTracesCommand = async (options: {
     }
     console.log(
       chalk.gray(
-        `Use ${chalk.cyan("langwatch trace get <traceId>")} to view full details (partial IDs work — pass a unique prefix of at least 8 characters)`,
+        `Use ${chalk.cyan("langwatch trace get <traceId>")} to view full details`,
       ),
     );
   } catch (error) {


### PR DESCRIPTION
## Summary

- **Problem**: `langwatch trace search` truncates trace IDs to 20 chars for a readable table, but `trace get <20-char-id>` returned 404 because the API required exact matches.
- **Fix**: `GET /api/traces/{traceId}` now accepts any unique prefix of the trace ID (≥ 8 chars), git-style. Scoped per project via TenantId — no cross-project leakage.
- **Ambiguity**: returns 409 with the candidate full IDs so the caller can disambiguate.
- **CLI**: `trace search` footer now hints that partial IDs work.

## Why prefix on the API (not full IDs in the CLI list)

Considered three options:
1. Show full IDs in the CLI list — breaks the compact table (32-char IDs blow up the layout).
2. Have the CLI resolve prefix locally by re-searching — duplicates logic in every consumer (CLI, MCP, SDK, anyone else hitting the API).
3. **Resolve on the server.** This is what git and docker do. One fix, every consumer benefits.

Went with option 3.

## Behaviour

| Input | Behaviour |
|---|---|
| Full 32-char ID | Exact match (existing behaviour) |
| Unique prefix ≥ 8 chars | Resolves to the full trace |
| Ambiguous prefix | 409 with `candidateTraceIds` |
| No match | 404 |
| Input < 8 chars (no exact match) | 404 — we don't scan on tiny prefixes to avoid broad table scans |

## QA

Ran locally against the dev ClickHouse via `pnpm dev`:

```
$ langwatch trace search --limit 3
✔ Found 12 traces (showing 3)
Trace ID              Input  Output  Time   
────────────────────  ─────  ──────  ───────
e992cd734d847c11df12  —      —       57m ago
9560f0c26483bf8d3c2d  —      —       57m ago
e3384feb0c15d777f90c  —      —       57m ago
Use langwatch trace get <traceId> to view full details (partial IDs work as long as they're unique)

$ langwatch trace get e992cd734d847c11df12
✔ Found trace "e992cd734d847c11df12"
  View:  http://localhost:5560/inbox-narrator/messages/e992cd734d847c11df123cf652100581
  # 20-char prefix resolved to the full 32-char trace 

$ langwatch trace get deadbeefdeadbeef
✖ Failed to get trace "deadbeefdeadbeef": Trace not found.

$ langwatch trace get e
✖ Failed to get trace "e": Trace not found.     # too short, no scan attempted
```

Ambiguity path is covered by unit tests (no natural collisions in local data).

## Test plan

- [x] BDD spec in `specs/traces/partial-trace-id-resolution.feature`
- [x] ClickHouse testcontainer integration test for `resolveTraceIdByPrefix`: unique match, multi-match, no match, cross-project isolation
- [x] `TraceService.getById` unit tests: exact hit skips prefix lookup, unique prefix resolves, ambiguous throws, empty returns undefined, too-short skips
- [x] Route unit tests: 200 on unique prefix (with platformUrl + evaluations keyed on resolved full ID), 404 on miss, 409 on ambiguous
- [x] End-to-end dogfood via CLI against live dev ClickHouse (see above)
- [x] `pnpm typecheck`, `pnpm test:unit` — all green locally

## Notes for reviewers

- Minimum prefix length is set to 8 because anything shorter doesn't meaningfully reduce the scan space on hex trace IDs. Trivial to relax or lift to a query param later if needed.
- `trace_summaries` already has `TenantId` as the first WHERE predicate in the lookup, matching the project's ClickHouse conventions.
- The ambiguous error message includes the first 5 candidate full IDs inline (the existing CLI error formatter surfaces `message` as-is, so users see the candidates without new CLI plumbing).