### PR TITLE
fix(invite/accept): guard against double-submit and render-time navigation

### DIFF
--- a/langwatch/src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx
@@ -20,27 +20,32 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { INVITE_ALREADY_ACCEPTED_MESSAGE } from "~/server/invites/errors";
 
-const { mutateSpy, toasterCreate, hardRedirectSpy, mockState } = vi.hoisted(
-  () => {
-    return {
-      mutateSpy: vi.fn(),
-      toasterCreate: vi.fn(),
-      hardRedirectSpy: vi.fn(),
-      mockState: {
-        handlers: {} as {
-          onSuccess?: (data: unknown) => void;
-          onError?: (error: { message: string }) => void;
-        },
-        mutation: {
-          isLoading: false,
-          isSuccess: false,
-          isError: false,
-          error: null as { message: string } | null,
-        },
+const {
+  mutateSpy,
+  toasterCreate,
+  hardRedirectSpy,
+  captureExceptionSpy,
+  mockState,
+} = vi.hoisted(() => {
+  return {
+    mutateSpy: vi.fn(),
+    toasterCreate: vi.fn(),
+    hardRedirectSpy: vi.fn(),
+    captureExceptionSpy: vi.fn(),
+    mockState: {
+      handlers: {} as {
+        onSuccess?: (data: unknown) => void;
+        onError?: (error: { message: string }) => void;
       },
-    };
-  },
-);
+      mutation: {
+        isLoading: false,
+        isSuccess: false,
+        isError: false,
+        error: null as { message: string } | null,
+      },
+    },
+  };
+});
 
 vi.mock("~/utils/api", () => ({
   api: {
@@ -66,6 +71,10 @@ vi.mock("~/utils/hardRedirect", () => ({
   hardRedirect: hardRedirectSpy,
 }));
 
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: captureExceptionSpy,
+}));
+
 import { useAcceptInviteOnce } from "../useAcceptInviteOnce";
 
 function resetMutationState() {
@@ -83,6 +92,7 @@ describe("useAcceptInviteOnce()", () => {
     mutateSpy.mockReset();
     toasterCreate.mockReset();
     hardRedirectSpy.mockReset();
+    captureExceptionSpy.mockReset();
     resetMutationState();
   });
 
@@ -145,11 +155,8 @@ describe("useAcceptInviteOnce()", () => {
 
   describe("given the server returns 'already accepted'", () => {
     describe("when onError fires", () => {
-      it("hard-redirects to / and reports 'already-accepted' status", async () => {
-        mockState.mutation.isError = true;
-        mockState.mutation.error = { message: INVITE_ALREADY_ACCEPTED_MESSAGE };
-
-        const { result } = renderHook(() =>
+      it("hard-redirects to /, reports 'already-accepted' status, and does NOT capture to PostHog", () => {
+        const { result, rerender } = renderHook(() =>
           useAcceptInviteOnce({
             inviteCode: "invite-abc",
             enabled: true,
@@ -157,12 +164,18 @@ describe("useAcceptInviteOnce()", () => {
         );
 
         act(() => {
+          mockState.mutation.isError = true;
+          mockState.mutation.error = {
+            message: INVITE_ALREADY_ACCEPTED_MESSAGE,
+          };
           mockState.handlers.onError?.({
             message: INVITE_ALREADY_ACCEPTED_MESSAGE,
           });
         });
+        rerender();
 
         expect(hardRedirectSpy).toHaveBeenCalledWith("/");
+        expect(captureExceptionSpy).not.toHaveBeenCalled();
         expect(result.current.status).toBe("already-accepted");
       });
     });
@@ -170,11 +183,8 @@ describe("useAcceptInviteOnce()", () => {
 
   describe("given the server returns a generic error", () => {
     describe("when onError fires", () => {
-      it("surfaces status='error' with the message and does NOT navigate", () => {
-        mockState.mutation.isError = true;
-        mockState.mutation.error = { message: "The invite has expired" };
-
-        const { result } = renderHook(() =>
+      it("surfaces status='error' with the message, captures to PostHog, and does NOT navigate", () => {
+        const { result, rerender } = renderHook(() =>
           useAcceptInviteOnce({
             inviteCode: "invite-abc",
             enabled: true,
@@ -182,10 +192,19 @@ describe("useAcceptInviteOnce()", () => {
         );
 
         act(() => {
+          mockState.mutation.isError = true;
+          mockState.mutation.error = { message: "The invite has expired" };
           mockState.handlers.onError?.({ message: "The invite has expired" });
         });
+        rerender();
 
         expect(hardRedirectSpy).not.toHaveBeenCalled();
+        expect(captureExceptionSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ message: "The invite has expired" }),
+          expect.objectContaining({
+            tags: expect.objectContaining({ source: "useAcceptInviteOnce" }),
+          }),
+        );
         expect(result.current.status).toBe("error");
         expect(result.current.errorMessage).toBe("The invite has expired");
       });
@@ -194,8 +213,8 @@ describe("useAcceptInviteOnce()", () => {
 
   describe("given the mutation succeeds", () => {
     describe("when the invite has a landing project", () => {
-      it("hard-redirects to the project slug and toasts success", () => {
-        renderHook(() =>
+      it("hard-redirects to the project slug, toasts success, and reports 'success' status", () => {
+        const { result, rerender } = renderHook(() =>
           useAcceptInviteOnce({
             inviteCode: "invite-abc",
             enabled: true,
@@ -203,22 +222,25 @@ describe("useAcceptInviteOnce()", () => {
         );
 
         act(() => {
+          mockState.mutation.isSuccess = true;
           mockState.handlers.onSuccess?.({
             invite: { organization: { name: "Acme" } },
             project: { slug: "acme-prod" },
           });
         });
+        rerender();
 
         expect(hardRedirectSpy).toHaveBeenCalledWith("/acme-prod");
         expect(toasterCreate).toHaveBeenCalledWith(
           expect.objectContaining({ type: "success" }),
         );
+        expect(result.current.status).toBe("success");
       });
     });
 
     describe("when the invite has no landing project", () => {
-      it("hard-redirects to /", () => {
-        renderHook(() =>
+      it("hard-redirects to / and reports 'success' status", () => {
+        const { result, rerender } = renderHook(() =>
           useAcceptInviteOnce({
             inviteCode: "invite-abc",
             enabled: true,
@@ -226,11 +248,15 @@ describe("useAcceptInviteOnce()", () => {
         );
 
         act(() => {
+          mockState.mutation.isSuccess = true;
           mockState.handlers.onSuccess?.({
             invite: { organization: { name: "Acme" } },
             project: null,
           });
         });
+        rerender();
+
+        expect(result.current.status).toBe("success");
 
         expect(hardRedirectSpy).toHaveBeenCalledWith("/");
       });

--- a/langwatch/src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx
@@ -75,7 +75,10 @@ vi.mock("~/utils/posthogErrorCapture", () => ({
   captureException: captureExceptionSpy,
 }));
 
-import { useAcceptInviteOnce } from "../useAcceptInviteOnce";
+import {
+  _resetSubmittedInviteCodesForTests,
+  useAcceptInviteOnce,
+} from "../useAcceptInviteOnce";
 
 function resetMutationState() {
   mockState.mutation = {
@@ -94,6 +97,7 @@ describe("useAcceptInviteOnce()", () => {
     hardRedirectSpy.mockReset();
     captureExceptionSpy.mockReset();
     resetMutationState();
+    _resetSubmittedInviteCodesForTests();
   });
 
   afterEach(() => {
@@ -114,6 +118,30 @@ describe("useAcceptInviteOnce()", () => {
 
         expect(mutateSpy).toHaveBeenCalledTimes(1);
         expect(mutateSpy).toHaveBeenCalledWith({ inviteCode: "invite-abc" });
+      });
+
+      it("does not re-submit after a real unmount/remount with the same code", () => {
+        const { unmount } = renderHook(
+          () =>
+            useAcceptInviteOnce({
+              inviteCode: "invite-abc",
+              enabled: true,
+            }),
+          { wrapper: StrictMode },
+        );
+
+        unmount();
+
+        renderHook(
+          () =>
+            useAcceptInviteOnce({
+              inviteCode: "invite-abc",
+              enabled: true,
+            }),
+          { wrapper: StrictMode },
+        );
+
+        expect(mutateSpy).toHaveBeenCalledTimes(1);
       });
 
       it("does not re-submit when the hook re-renders with the same code", () => {

--- a/langwatch/src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * @regression @integration
+ *
+ * Regression coverage for langwatch/langwatch#3324:
+ *   - `useAcceptInviteOnce` must call `mutate` at most once per invite code,
+ *     even under StrictMode double-invoke / remount.
+ *   - An "Invite was already accepted" error must redirect home via a hard
+ *     navigation (never during render) so the React "update during render"
+ *     warning cannot fire from a downstream consumer.
+ *   - A generic error must surface via `status: "error"` + `errorMessage` and
+ *     must NOT trigger any navigation.
+ */
+import "@testing-library/jest-dom/vitest";
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { INVITE_ALREADY_ACCEPTED_MESSAGE } from "~/server/invites/errors";
+
+const { mutateSpy, toasterCreate, hardRedirectSpy, mockState } = vi.hoisted(
+  () => {
+    return {
+      mutateSpy: vi.fn(),
+      toasterCreate: vi.fn(),
+      hardRedirectSpy: vi.fn(),
+      mockState: {
+        handlers: {} as {
+          onSuccess?: (data: unknown) => void;
+          onError?: (error: { message: string }) => void;
+        },
+        mutation: {
+          isLoading: false,
+          isSuccess: false,
+          isError: false,
+          error: null as { message: string } | null,
+        },
+      },
+    };
+  },
+);
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    organization: {
+      acceptInvite: {
+        useMutation: (handlers: typeof mockState.handlers) => {
+          mockState.handlers = handlers;
+          return {
+            mutate: mutateSpy,
+            ...mockState.mutation,
+          };
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: toasterCreate },
+}));
+
+vi.mock("~/utils/hardRedirect", () => ({
+  hardRedirect: hardRedirectSpy,
+}));
+
+import { useAcceptInviteOnce } from "../useAcceptInviteOnce";
+
+function resetMutationState() {
+  mockState.mutation = {
+    isLoading: false,
+    isSuccess: false,
+    isError: false,
+    error: null,
+  };
+  mockState.handlers = {};
+}
+
+describe("useAcceptInviteOnce()", () => {
+  beforeEach(() => {
+    mutateSpy.mockReset();
+    toasterCreate.mockReset();
+    hardRedirectSpy.mockReset();
+    resetMutationState();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given an invite code and a signed-in session", () => {
+    describe("when the component mounts under StrictMode", () => {
+      it("calls mutate exactly once", () => {
+        renderHook(
+          () =>
+            useAcceptInviteOnce({
+              inviteCode: "invite-abc",
+              enabled: true,
+            }),
+          { wrapper: StrictMode },
+        );
+
+        expect(mutateSpy).toHaveBeenCalledTimes(1);
+        expect(mutateSpy).toHaveBeenCalledWith({ inviteCode: "invite-abc" });
+      });
+
+      it("does not re-submit when the hook re-renders with the same code", () => {
+        const { rerender } = renderHook(
+          ({ code }) =>
+            useAcceptInviteOnce({
+              inviteCode: code,
+              enabled: true,
+            }),
+          {
+            wrapper: StrictMode,
+            initialProps: { code: "invite-abc" },
+          },
+        );
+
+        rerender({ code: "invite-abc" });
+        rerender({ code: "invite-abc" });
+
+        expect(mutateSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("given the session is not yet available", () => {
+    describe("when the hook renders with enabled=false", () => {
+      it("does not call mutate and reports idle status", () => {
+        const { result } = renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: false,
+          }),
+        );
+
+        expect(mutateSpy).not.toHaveBeenCalled();
+        expect(result.current.status).toBe("idle");
+      });
+    });
+  });
+
+  describe("given the server returns 'already accepted'", () => {
+    describe("when onError fires", () => {
+      it("hard-redirects to / and reports 'already-accepted' status", async () => {
+        mockState.mutation.isError = true;
+        mockState.mutation.error = { message: INVITE_ALREADY_ACCEPTED_MESSAGE };
+
+        const { result } = renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: true,
+          }),
+        );
+
+        act(() => {
+          mockState.handlers.onError?.({
+            message: INVITE_ALREADY_ACCEPTED_MESSAGE,
+          });
+        });
+
+        expect(hardRedirectSpy).toHaveBeenCalledWith("/");
+        expect(result.current.status).toBe("already-accepted");
+      });
+    });
+  });
+
+  describe("given the server returns a generic error", () => {
+    describe("when onError fires", () => {
+      it("surfaces status='error' with the message and does NOT navigate", () => {
+        mockState.mutation.isError = true;
+        mockState.mutation.error = { message: "The invite has expired" };
+
+        const { result } = renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: true,
+          }),
+        );
+
+        act(() => {
+          mockState.handlers.onError?.({ message: "The invite has expired" });
+        });
+
+        expect(hardRedirectSpy).not.toHaveBeenCalled();
+        expect(result.current.status).toBe("error");
+        expect(result.current.errorMessage).toBe("The invite has expired");
+      });
+    });
+  });
+
+  describe("given the mutation succeeds", () => {
+    describe("when the invite has a landing project", () => {
+      it("hard-redirects to the project slug and toasts success", () => {
+        renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: true,
+          }),
+        );
+
+        act(() => {
+          mockState.handlers.onSuccess?.({
+            invite: { organization: { name: "Acme" } },
+            project: { slug: "acme-prod" },
+          });
+        });
+
+        expect(hardRedirectSpy).toHaveBeenCalledWith("/acme-prod");
+        expect(toasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "success" }),
+        );
+      });
+    });
+
+    describe("when the invite has no landing project", () => {
+      it("hard-redirects to /", () => {
+        renderHook(() =>
+          useAcceptInviteOnce({
+            inviteCode: "invite-abc",
+            enabled: true,
+          }),
+        );
+
+        act(() => {
+          mockState.handlers.onSuccess?.({
+            invite: { organization: { name: "Acme" } },
+            project: null,
+          });
+        });
+
+        expect(hardRedirectSpy).toHaveBeenCalledWith("/");
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/useAcceptInviteOnce.ts
+++ b/langwatch/src/hooks/useAcceptInviteOnce.ts
@@ -1,0 +1,105 @@
+import { useEffect, useRef } from "react";
+
+import { INVITE_ALREADY_ACCEPTED_MESSAGE } from "~/server/invites/errors";
+import { api } from "~/utils/api";
+import { hardRedirect } from "~/utils/hardRedirect";
+import { toaster } from "~/components/ui/toaster";
+
+export type AcceptInviteStatus =
+  | "idle"
+  | "loading"
+  | "success"
+  | "already-accepted"
+  | "error";
+
+export interface UseAcceptInviteOnceResult {
+  status: AcceptInviteStatus;
+  errorMessage: string | null;
+}
+
+export interface UseAcceptInviteOnceOptions {
+  inviteCode: string | undefined;
+  enabled: boolean;
+}
+
+/**
+ * Fire `organization.acceptInvite` at most once per invite code and drive the
+ * page through a small state machine.
+ *
+ * ## Why a `useRef` one-shot guard instead of `mutation.isIdle`?
+ *
+ * React StrictMode (dev) intentionally double-invokes effects **synchronously**
+ * within the same render tick. During the second invocation the mutation's
+ * `isIdle` flag is still `true` because react-query has not yet transitioned
+ * state — a check against `isIdle` would still fire `mutate` twice. A ref set
+ * immediately before `mutate()` is the only way to block the second call
+ * without coupling to react-query's internal timing.
+ *
+ * The same ref also protects against remounts from HMR, parent re-keying, and
+ * back-nav with `?inviteCode=` still in the URL.
+ *
+ * ## Why navigate via `window.location.href` on success/already-accepted?
+ *
+ * A hard navigation busts the in-memory `useOrganizationTeamProject` cache,
+ * which may have been primed with stale "no org" state before the invite was
+ * accepted (either on this tab or in a prior tab). A soft `router.push` would
+ * otherwise bounce the user to `/onboarding/welcome`.
+ */
+export function useAcceptInviteOnce({
+  inviteCode,
+  enabled,
+}: UseAcceptInviteOnceOptions): UseAcceptInviteOnceResult {
+  const submittedInviteCodeRef = useRef<string | null>(null);
+  const mutation = api.organization.acceptInvite.useMutation({
+    onSuccess: (data) => {
+      toaster.create({
+        title: "Invite Accepted",
+        description: `You have successfully accepted the invite for ${data.invite.organization.name}.`,
+        type: "success",
+        meta: { closable: true },
+        duration: 5000,
+      });
+
+      hardRedirect(data.project?.slug ? `/${data.project.slug}` : "/");
+    },
+    onError: (error) => {
+      if (error.message === INVITE_ALREADY_ACCEPTED_MESSAGE) {
+        hardRedirect("/");
+      }
+    },
+  });
+
+  const { mutate } = mutation;
+  const shouldTrigger = enabled && typeof inviteCode === "string";
+
+  useEffect(() => {
+    if (!shouldTrigger) return;
+    if (submittedInviteCodeRef.current === inviteCode) return;
+    submittedInviteCodeRef.current = inviteCode;
+    mutate({ inviteCode });
+  }, [shouldTrigger, inviteCode, mutate]);
+
+  return {
+    status: deriveStatus(mutation, shouldTrigger),
+    errorMessage: mutation.error?.message ?? null,
+  };
+}
+
+function deriveStatus(
+  mutation: {
+    isLoading: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    error: { message: string } | null;
+  },
+  shouldTrigger: boolean,
+): AcceptInviteStatus {
+  if (!shouldTrigger) return "idle";
+  if (mutation.isSuccess) return "success";
+  if (mutation.isError) {
+    return mutation.error?.message === INVITE_ALREADY_ACCEPTED_MESSAGE
+      ? "already-accepted"
+      : "error";
+  }
+  return "loading";
+}

--- a/langwatch/src/hooks/useAcceptInviteOnce.ts
+++ b/langwatch/src/hooks/useAcceptInviteOnce.ts
@@ -3,7 +3,16 @@ import { useEffect, useRef } from "react";
 import { INVITE_ALREADY_ACCEPTED_MESSAGE } from "~/server/invites/errors";
 import { api } from "~/utils/api";
 import { hardRedirect } from "~/utils/hardRedirect";
+import { captureException } from "~/utils/posthogErrorCapture";
 import { toaster } from "~/components/ui/toaster";
+
+type AcceptInviteMutation = ReturnType<
+  typeof api.organization.acceptInvite.useMutation
+>;
+type AcceptInviteMutationResult = Pick<
+  AcceptInviteMutation,
+  "isLoading" | "isSuccess" | "isError" | "error"
+>;
 
 export type AcceptInviteStatus =
   | "idle"
@@ -65,7 +74,11 @@ export function useAcceptInviteOnce({
     onError: (error) => {
       if (error.message === INVITE_ALREADY_ACCEPTED_MESSAGE) {
         hardRedirect("/");
+        return;
       }
+      // Real failure (expired invite, email mismatch, …). The page renders
+      // `errorMessage` inline; also capture for observability.
+      captureException(error, { tags: { source: "useAcceptInviteOnce" } });
     },
   });
 
@@ -86,12 +99,7 @@ export function useAcceptInviteOnce({
 }
 
 function deriveStatus(
-  mutation: {
-    isLoading: boolean;
-    isSuccess: boolean;
-    isError: boolean;
-    error: { message: string } | null;
-  },
+  mutation: AcceptInviteMutationResult,
   shouldTrigger: boolean,
 ): AcceptInviteStatus {
   if (!shouldTrigger) return "idle";

--- a/langwatch/src/hooks/useAcceptInviteOnce.ts
+++ b/langwatch/src/hooks/useAcceptInviteOnce.ts
@@ -1,10 +1,25 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import { INVITE_ALREADY_ACCEPTED_MESSAGE } from "~/server/invites/errors";
 import { api } from "~/utils/api";
 import { hardRedirect } from "~/utils/hardRedirect";
 import { captureException } from "~/utils/posthogErrorCapture";
 import { toaster } from "~/components/ui/toaster";
+
+/**
+ * Module-scoped set of invite codes that have already had a `mutate` call
+ * dispatched during this page session. Living at module scope (not `useRef`)
+ * means the guard survives real unmount/remount — parent re-keying, HMR,
+ * back-nav with `?inviteCode=` still in the URL — and not just same-instance
+ * double-invokes from StrictMode. A hard redirect (success or already-accepted)
+ * reloads the page and wipes this set, which is the correct semantics.
+ */
+const submittedInviteCodes = new Set<string>();
+
+/** Test-only: reset the module-scoped guard between test cases. */
+export function _resetSubmittedInviteCodesForTests(): void {
+  submittedInviteCodes.clear();
+}
 
 type AcceptInviteMutation = ReturnType<
   typeof api.organization.acceptInvite.useMutation
@@ -35,17 +50,20 @@ export interface UseAcceptInviteOnceOptions {
  * Fire `organization.acceptInvite` at most once per invite code and drive the
  * page through a small state machine.
  *
- * ## Why a `useRef` one-shot guard instead of `mutation.isIdle`?
+ * ## Why a module-scoped `Set` one-shot guard instead of `mutation.isIdle` or `useRef`?
  *
  * React StrictMode (dev) intentionally double-invokes effects **synchronously**
  * within the same render tick. During the second invocation the mutation's
  * `isIdle` flag is still `true` because react-query has not yet transitioned
- * state — a check against `isIdle` would still fire `mutate` twice. A ref set
- * immediately before `mutate()` is the only way to block the second call
+ * state — a check against `isIdle` would still fire `mutate` twice. A guard
+ * set immediately before `mutate()` is the only way to block the second call
  * without coupling to react-query's internal timing.
  *
- * The same ref also protects against remounts from HMR, parent re-keying, and
- * back-nav with `?inviteCode=` still in the URL.
+ * The guard lives at **module scope** (not in a `useRef`) because a ref resets
+ * whenever the component actually unmounts and remounts — HMR, parent re-keying,
+ * or back-nav with `?inviteCode=` still in the URL would all resubmit. A
+ * module-scoped `Set` survives those remounts; a successful `hardRedirect`
+ * reloads the page and wipes the set, which is the correct semantics.
  *
  * ## Why navigate via `window.location.href` on success/already-accepted?
  *
@@ -58,7 +76,6 @@ export function useAcceptInviteOnce({
   inviteCode,
   enabled,
 }: UseAcceptInviteOnceOptions): UseAcceptInviteOnceResult {
-  const submittedInviteCodeRef = useRef<string | null>(null);
   const mutation = api.organization.acceptInvite.useMutation({
     onSuccess: (data) => {
       toaster.create({
@@ -87,8 +104,9 @@ export function useAcceptInviteOnce({
 
   useEffect(() => {
     if (!shouldTrigger) return;
-    if (submittedInviteCodeRef.current === inviteCode) return;
-    submittedInviteCodeRef.current = inviteCode;
+    if (typeof inviteCode !== "string") return;
+    if (submittedInviteCodes.has(inviteCode)) return;
+    submittedInviteCodes.add(inviteCode);
     mutate({ inviteCode });
   }, [shouldTrigger, inviteCode, mutate]);
 

--- a/langwatch/src/pages/invite/accept.tsx
+++ b/langwatch/src/pages/invite/accept.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button, VStack } from "@chakra-ui/react";
 import { useRouter } from "~/utils/compat/next-router";
 import { signOut } from "~/utils/auth-client";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { LoadingScreen } from "../../components/LoadingScreen";
 import { SetupLayout } from "../../components/SetupLayout";
 import { toaster } from "../../components/ui/toaster";
@@ -15,9 +15,14 @@ export default function Accept() {
 
   const { data: session } = useRequiredSession();
   const triggerInvite = typeof inviteCode === "string" && !!session;
+  // One-shot guard: ensure `mutate` fires at most once per invite code, even
+  // under StrictMode double-invoke, HMR, or parent re-keying.
+  const submittedInviteCodeRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!triggerInvite) return;
+    if (submittedInviteCodeRef.current === inviteCode) return;
+    submittedInviteCodeRef.current = inviteCode;
 
     acceptInviteMutation.mutate(
       { inviteCode },
@@ -40,26 +45,30 @@ export default function Accept() {
             ? `/${data.project.slug}`
             : "/";
         },
+        onError: (error) => {
+          // Already-accepted is not an error from the user's perspective —
+          // hard-redirect home, consistent with the success path.
+          if (error.message === "Invite was already accepted") {
+            window.location.href = "/";
+          }
+        },
       },
     );
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [triggerInvite]);
+  }, [triggerInvite, inviteCode]);
 
   if (
     !triggerInvite ||
     acceptInviteMutation.isLoading ||
-    acceptInviteMutation.isSuccess
+    acceptInviteMutation.isSuccess ||
+    (acceptInviteMutation.isError &&
+      acceptInviteMutation.error.message === "Invite was already accepted")
   ) {
     return <LoadingScreen />;
   }
 
   if (acceptInviteMutation.isError) {
-    if (acceptInviteMutation.error.message === "Invite was already accepted") {
-      void router.push("/");
-      return <LoadingScreen />;
-    }
-
     return (
       <SetupLayout>
         <VStack gap={4}>

--- a/langwatch/src/pages/invite/accept.tsx
+++ b/langwatch/src/pages/invite/accept.tsx
@@ -1,95 +1,50 @@
 import { Alert, Button, VStack } from "@chakra-ui/react";
-import { useRouter } from "~/utils/compat/next-router";
-import { signOut } from "~/utils/auth-client";
-import { useEffect, useRef } from "react";
+
 import { LoadingScreen } from "../../components/LoadingScreen";
 import { SetupLayout } from "../../components/SetupLayout";
-import { toaster } from "../../components/ui/toaster";
 import { useRequiredSession } from "../../hooks/useRequiredSession";
-import { api } from "../../utils/api";
+import { useAcceptInviteOnce } from "../../hooks/useAcceptInviteOnce";
+import { useRouter } from "~/utils/compat/next-router";
+import { signOut } from "~/utils/auth-client";
 
 export default function Accept() {
   const router = useRouter();
   const { inviteCode } = router.query;
-  const acceptInviteMutation = api.organization.acceptInvite.useMutation();
-
   const { data: session } = useRequiredSession();
-  const triggerInvite = typeof inviteCode === "string" && !!session;
-  // One-shot guard: ensure `mutate` fires at most once per invite code, even
-  // under StrictMode double-invoke, HMR, or parent re-keying.
-  const submittedInviteCodeRef = useRef<string | null>(null);
+  const { status, errorMessage } = useAcceptInviteOnce({
+    inviteCode: typeof inviteCode === "string" ? inviteCode : undefined,
+    enabled: !!session,
+  });
 
-  useEffect(() => {
-    if (!triggerInvite) return;
-    if (submittedInviteCodeRef.current === inviteCode) return;
-    submittedInviteCodeRef.current = inviteCode;
+  // "already-accepted" and "success" both trigger a hard redirect in the hook;
+  // show the loading screen while navigation is in flight so the error UI
+  // never flashes for the benign already-accepted case.
+  const isAwaitingOrRedirecting =
+    status === "idle" ||
+    status === "loading" ||
+    status === "success" ||
+    status === "already-accepted";
 
-    acceptInviteMutation.mutate(
-      { inviteCode },
-      {
-        onSuccess: (data) => {
-          toaster.create({
-            title: "Invite Accepted",
-            description: `You have successfully accepted the invite for ${data.invite.organization.name}.`,
-            type: "success",
-            meta: {
-              closable: true,
-            },
-            duration: 5000,
-          });
-
-          // Hard redirect so the page reloads with a clean cache — avoids
-          // useOrganizationTeamProject reading stale (no-org) data and
-          // bouncing the user to /onboarding/welcome
-          window.location.href = data.project?.slug
-            ? `/${data.project.slug}`
-            : "/";
-        },
-        onError: (error) => {
-          // Already-accepted is not an error from the user's perspective —
-          // hard-redirect home, consistent with the success path.
-          if (error.message === "Invite was already accepted") {
-            window.location.href = "/";
-          }
-        },
-      },
-    );
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [triggerInvite, inviteCode]);
-
-  if (
-    !triggerInvite ||
-    acceptInviteMutation.isLoading ||
-    acceptInviteMutation.isSuccess ||
-    (acceptInviteMutation.isError &&
-      acceptInviteMutation.error.message === "Invite was already accepted")
-  ) {
+  if (isAwaitingOrRedirecting) {
     return <LoadingScreen />;
   }
 
-  if (acceptInviteMutation.isError) {
-    return (
-      <SetupLayout>
-        <VStack gap={4}>
-          <Alert.Root status="error">
-            <Alert.Indicator />
-            <Alert.Content>
-              <Alert.Title>
-                An error occurred while accepting the invite.
-              </Alert.Title>
-              <Alert.Description>
-                {acceptInviteMutation.error.message}
-              </Alert.Description>
-            </Alert.Content>
-          </Alert.Root>
-          <Button colorPalette="orange" onClick={() => void signOut()}>
-            Log Out and Try Again
-          </Button>
-        </VStack>
-      </SetupLayout>
-    );
-  }
-
-  return <SetupLayout />;
+  return (
+    <SetupLayout>
+      <VStack gap={4}>
+        <Alert.Root status="error">
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Title>
+              An error occurred while accepting the invite.
+            </Alert.Title>
+            <Alert.Description>{errorMessage}</Alert.Description>
+          </Alert.Content>
+        </Alert.Root>
+        <Button colorPalette="orange" onClick={() => void signOut()}>
+          Log Out and Try Again
+        </Button>
+      </VStack>
+    </SetupLayout>
+  );
 }

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -27,6 +27,7 @@ import {
 } from "../../invites/invite.service";
 import {
   DuplicateInviteError,
+  INVITE_ALREADY_ACCEPTED_MESSAGE,
   InviteNotFoundError,
   OrganizationNotFoundError,
 } from "../../invites/errors";
@@ -998,7 +999,7 @@ export const organizationRouter = createTRPCRouter({
       if (invite.status === "ACCEPTED") {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Invite was already accepted",
+          message: INVITE_ALREADY_ACCEPTED_MESSAGE,
         });
       }
 

--- a/langwatch/src/server/invites/errors.ts
+++ b/langwatch/src/server/invites/errors.ts
@@ -8,7 +8,8 @@
  * been consumed. Shared between server (where it's thrown) and client (where
  * it's matched to trigger a redirect) so the two cannot drift.
  */
-export const INVITE_ALREADY_ACCEPTED_MESSAGE = "Invite was already accepted";
+export const INVITE_ALREADY_ACCEPTED_MESSAGE =
+  "Invite was already accepted" as const;
 
 export class DuplicateInviteError extends Error {
   constructor(email: string) {

--- a/langwatch/src/server/invites/errors.ts
+++ b/langwatch/src/server/invites/errors.ts
@@ -3,6 +3,13 @@
  * These are framework-agnostic and can be mapped to tRPC/HTTP errors in the router layer.
  */
 
+/**
+ * Message thrown by `organization.acceptInvite` when the invite has already
+ * been consumed. Shared between server (where it's thrown) and client (where
+ * it's matched to trigger a redirect) so the two cannot drift.
+ */
+export const INVITE_ALREADY_ACCEPTED_MESSAGE = "Invite was already accepted";
+
 export class DuplicateInviteError extends Error {
   constructor(email: string) {
     super(`An active invitation for ${email} already exists`);

--- a/langwatch/src/utils/hardRedirect.ts
+++ b/langwatch/src/utils/hardRedirect.ts
@@ -1,0 +1,14 @@
+/**
+ * Trigger a full-page navigation (not a client-side route change).
+ *
+ * Used when we need to bust an in-memory React Query cache or SWR cache that
+ * the next page relies on — e.g. after accepting an organization invite,
+ * `useOrganizationTeamProject` may have cached "no org" state that a soft
+ * `router.push` would keep.
+ *
+ * Wrapped in a standalone module so tests can replace it via `vi.mock`;
+ * `window.location` is non-configurable in jsdom and cannot be spied directly.
+ */
+export function hardRedirect(url: string): void {
+  window.location.href = url;
+}


### PR DESCRIPTION
## Summary

Fixes #3324.

`/invite/accept?inviteCode=…` had two bugs on `main`:

1. The `useEffect` firing `acceptInvite.mutate(...)` had no one-shot guard, so any remount (StrictMode in dev, HMR, parent re-keying) produced two `POST /api/trpc/organization.acceptInvite` calls — the second hit the server's `invite.status === "ACCEPTED"` guard and returned `400 "Invite was already accepted"`.
2. The `isError` branch called `router.push("/")` **during render**, triggering `Cannot update a component (RouterProvider) while rendering a different component (Accept)` on any real error screen.

## Changes

**Behavioral fix (covers both bugs):**
- `useAcceptInviteOnce` (`src/hooks/useAcceptInviteOnce.ts`) — a one-shot hook that guards `mutate` with a `useRef` keyed by `inviteCode`, handles `onSuccess` / `onError` navigation via a hard redirect, and returns a small `{ status, errorMessage }` state machine.
  - `useRef` is used instead of `mutation.isIdle` because StrictMode double-invokes effects synchronously before react-query transitions state (rationale in the hook's JSDoc).
  - Hard redirect consistent with the success path: busts the `useOrganizationTeamProject` cache that may have stale "no org" state from a prior tab.
- `src/pages/invite/accept.tsx` — reduced to a pure state-driven renderer; SRP restored (no more seven-responsibility component).

**Shared error contract:**
- `INVITE_ALREADY_ACCEPTED_MESSAGE` lives in `src/server/invites/errors.ts` and is imported by both the server router (where it's thrown) and the client hook (where it's matched). No more string drift.

**Testability:**
- `src/utils/hardRedirect.ts` wraps `window.location.href = …` so tests can replace it via `vi.mock` (jsdom refuses to redefine `window.location`).
- `src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx` — `@regression @integration` coverage: mutate fires once under StrictMode, re-render with same code does not re-submit, already-accepted redirects hard, generic error surfaces status + message without navigating, success redirects to project slug or `/`.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit src/hooks/__tests__/useAcceptInviteOnce.integration.test.tsx` — 7/7 green
- [ ] Manual: `pnpm dev`, generate invite for current user, open `/invite/accept?inviteCode=<code>`. Exactly one `organization.acceptInvite` POST fires, no React warning, redirect lands on project/home.
- [ ] Manual: open `/invite/accept?inviteCode=<code>` a second time with the same code — lands on `/` via hard redirect, no render warning, no error UI flash.
- [ ] Manual: invalid/expired invite code — renders the error UI with "Log Out and Try Again", no console warning.