### PR TITLE
feat(scenarios): workflow agent input/output mapping layer (#3201)

### DIFF
--- a/langwatch/src/components/agents/__tests__/getAgentEditorDrawer.unit.test.ts
+++ b/langwatch/src/components/agents/__tests__/getAgentEditorDrawer.unit.test.ts
@@ -20,4 +20,12 @@ describe("getAgentEditorDrawer", () => {
       expect(getAgentEditorDrawer("workflow")).toBe("agentWorkflowEditor");
     });
   });
+
+  describe("when editing a signature agent", () => {
+    it("throws because signature agents have no editor drawer", () => {
+      expect(() => getAgentEditorDrawer("signature")).toThrow(
+        /signature agents have no editor drawer/,
+      );
+    });
+  });
 });

--- a/langwatch/src/components/agents/__tests__/getAgentEditorDrawer.unit.test.ts
+++ b/langwatch/src/components/agents/__tests__/getAgentEditorDrawer.unit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { getAgentEditorDrawer } from "../getAgentEditorDrawer";
+
+describe("getAgentEditorDrawer", () => {
+  describe("when editing a code agent", () => {
+    it("returns agentCodeEditor", () => {
+      expect(getAgentEditorDrawer("code")).toBe("agentCodeEditor");
+    });
+  });
+
+  describe("when editing an http agent", () => {
+    it("returns agentHttpEditor", () => {
+      expect(getAgentEditorDrawer("http")).toBe("agentHttpEditor");
+    });
+  });
+
+  describe("when editing a workflow agent", () => {
+    it("returns agentWorkflowEditor (not workflowSelector, which is create-only)", () => {
+      expect(getAgentEditorDrawer("workflow")).toBe("agentWorkflowEditor");
+    });
+  });
+});

--- a/langwatch/src/components/agents/getAgentEditorDrawer.ts
+++ b/langwatch/src/components/agents/getAgentEditorDrawer.ts
@@ -1,0 +1,23 @@
+import type { AgentType } from "~/components/agents/AgentTypeSelectorDrawer";
+
+type AgentEditorDrawerName =
+  | "agentCodeEditor"
+  | "agentHttpEditor"
+  | "agentWorkflowEditor";
+
+export function getAgentEditorDrawer(
+  type: AgentType,
+): AgentEditorDrawerName {
+  switch (type) {
+    case "code":
+      return "agentCodeEditor";
+    case "http":
+      return "agentHttpEditor";
+    case "workflow":
+      return "agentWorkflowEditor";
+    default: {
+      const _exhaustive: never = type;
+      throw new Error(`Unhandled agent type: ${_exhaustive as string}`);
+    }
+  }
+}

--- a/langwatch/src/components/agents/getAgentEditorDrawer.ts
+++ b/langwatch/src/components/agents/getAgentEditorDrawer.ts
@@ -1,4 +1,4 @@
-import type { AgentType } from "~/components/agents/AgentTypeSelectorDrawer";
+import type { AgentType } from "~/server/agents/agent.repository";
 
 type AgentEditorDrawerName =
   | "agentCodeEditor"
@@ -15,6 +15,10 @@ export function getAgentEditorDrawer(
       return "agentHttpEditor";
     case "workflow":
       return "agentWorkflowEditor";
+    case "signature":
+      throw new Error(
+        `Unhandled agent type: ${type} — signature agents have no editor drawer`,
+      );
     default: {
       const _exhaustive: never = type;
       throw new Error(`Unhandled agent type: ${_exhaustive as string}`);

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -17,6 +17,7 @@ import { isHandledByGlobalHandler } from "../../utils/trpcError";
 import type { TypedAgent } from "../../server/agents/agent.repository";
 import type { CustomComponentConfig } from "../../optimization_studio/types/dsl";
 import { PromptEditorDrawer } from "../prompts/PromptEditorDrawer";
+import { hasScenarioInputMapping } from "../suites/ScenarioInputMappingSection";
 import { TagList } from "../ui/TagList";
 import { Drawer } from "../ui/drawer";
 import { toaster } from "../ui/toaster";
@@ -245,14 +246,10 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
           if (agent) {
             const config = agent.config as CustomComponentConfig;
             const mappings = config.scenarioMappings ?? {};
-            const hasMappings = Object.keys(mappings).length > 0;
-            // Check that at least one mapping wires to a required scenario field
-            // (input or messages). We don't have workflow outputs here, so we
-            // can't fully validate — the server-side pre-run check covers that.
-            const hasRequiredInput = hasMappings && Object.values(mappings).some(
-              (m) => m.type === "source" && (m.path[0] === "input" || m.path[0] === "messages"),
-            );
-            if (!hasRequiredInput) {
+            // We don't have workflow outputs here — server-side pre-run check
+            // covers output validation. Share the input half of the rule with
+            // the editor drawer via hasScenarioInputMapping.
+            if (!hasScenarioInputMapping(mappings)) {
               toaster.create({
                 title: "Configure scenario mappings",
                 description:

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -15,6 +15,7 @@ import { useScenarioTarget } from "../../hooks/useScenarioTarget";
 import { api } from "../../utils/api";
 import { isHandledByGlobalHandler } from "../../utils/trpcError";
 import type { TypedAgent } from "../../server/agents/agent.repository";
+import type { CustomComponentConfig } from "../../optimization_studio/types/dsl";
 import { PromptEditorDrawer } from "../prompts/PromptEditorDrawer";
 import { TagList } from "../ui/TagList";
 import { Drawer } from "../ui/drawer";
@@ -233,6 +234,41 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
         });
         return;
       }
+
+      // Gate: workflow agents require valid scenario mappings before running.
+      if (target.type === "workflow") {
+        try {
+          const agent = await utils.agents.getById.fetch({
+            id: target.id,
+            projectId: project.id,
+          });
+          if (agent) {
+            const config = agent.config as CustomComponentConfig;
+            const mappings = config.scenarioMappings ?? {};
+            const hasMappings = Object.keys(mappings).length > 0;
+            // Check that at least one mapping wires to a required scenario field
+            // (input or messages). We don't have workflow outputs here, so we
+            // can't fully validate — the server-side pre-run check covers that.
+            const hasRequiredInput = hasMappings && Object.values(mappings).some(
+              (m) => m.type === "source" && (m.path[0] === "input" || m.path[0] === "messages"),
+            );
+            if (!hasRequiredInput) {
+              toaster.create({
+                title: "Configure scenario mappings",
+                description:
+                  "Set up how this workflow agent maps scenario inputs and outputs before running.",
+                type: "warning",
+                meta: { closable: true },
+              });
+              openDrawer("agentWorkflowEditor", { agentId: target.id });
+              return;
+            }
+          }
+        } catch {
+          // If agent fetch fails, allow the run to proceed — server will validate.
+        }
+      }
+
       try {
         await form.handleSubmit(async (data) => {
           const savedScenario = await handleSave(data);
@@ -261,7 +297,7 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
         });
       }
     },
-    [handleSave, project?.id, project?.slug, persistTarget, runScenario, formInstance, onClose, router],
+    [handleSave, project?.id, project?.slug, persistTarget, runScenario, formInstance, onClose, router, utils, openDrawer],
   );
   const handleSaveWithoutRunning = useCallback(async () => {
     const form = formInstance;

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -257,7 +257,9 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
                 type: "warning",
                 meta: { closable: true },
               });
-              openDrawer("agentWorkflowEditor", { agentId: target.id });
+              openDrawer("agentWorkflowEditor", {
+                urlParams: { agentId: target.id },
+              });
               return;
             }
           }

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
@@ -288,7 +288,7 @@ describe("<ScenarioFormDrawer /> mapping gate", () => {
       await waitFor(() => {
         expect(mocks.mockOpenDrawer).toHaveBeenCalledWith(
           "agentWorkflowEditor",
-          { agentId: "workflow-agent-1" },
+          { urlParams: { agentId: "workflow-agent-1" } },
         );
       });
 
@@ -312,18 +312,16 @@ describe("<ScenarioFormDrawer /> mapping gate", () => {
     });
   });
 
-  describe("when target is a workflow agent with incomplete mappings", () => {
+  describe("when target is a workflow agent with no input-field mapping", () => {
     beforeEach(() => {
-      // Agent has mappings, but they're incomplete — "input" and "messages" missing
-      // isScenarioMappingValid checks: at least one of input/messages mapped,
-      // and output mapped. Here we have no source mappings at all that cover input/messages.
+      // Agent has scenarioMappings but none wire a source path to the
+      // scenario "input" or "messages" field — fails hasScenarioInputMapping.
       mocks.mockAgentsGetByIdFetch.mockResolvedValue({
         id: "workflow-agent-2",
         type: "workflow",
-        name: "Incomplete Mapping Agent",
+        name: "No Input Mapping Agent",
         config: {
           workflow_id: "wf-456",
-          // mappings exist but don't cover "input" or "messages"
           scenarioMappings: {
             someOtherField: {
               type: "value",
@@ -343,7 +341,7 @@ describe("<ScenarioFormDrawer /> mapping gate", () => {
       await waitFor(() => {
         expect(mocks.mockOpenDrawer).toHaveBeenCalledWith(
           "agentWorkflowEditor",
-          { agentId: "workflow-agent-2" },
+          { urlParams: { agentId: "workflow-agent-2" } },
         );
       });
 

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
@@ -1,0 +1,371 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the mapping gate in ScenarioFormDrawer.
+ *
+ * Verifies that:
+ * - Clicking Save & Run with a workflow agent that has no mappings opens the
+ *   AgentWorkflowEditorDrawer instead of starting the run.
+ * - Clicking Save & Run with a workflow agent that has incomplete (invalid)
+ *   mappings also opens the drawer.
+ * - Clicking Save & Run with a non-workflow agent (code) proceeds normally.
+ *
+ * @see specs/scenarios/workflow-agent-mapping-gate.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock heavy sub-components
+vi.mock("../../prompts/PromptEditorDrawer", () => ({
+  PromptEditorDrawer: () => null,
+}));
+vi.mock("../../agents/AgentTypeSelectorDrawer", () => ({
+  AgentTypeSelectorDrawer: () => null,
+}));
+vi.mock("../ScenarioEditorSidebar", () => ({
+  ScenarioEditorSidebar: () => null,
+}));
+
+// SaveAndRunMenu mock — exposes a button that calls onSaveAndRun with the
+// current selectedTarget (passed in via props).
+vi.mock("../SaveAndRunMenu", () => ({
+  SaveAndRunMenu: ({
+    onSaveAndRun,
+    selectedTarget,
+  }: {
+    onSaveAndRun?: (target: { type: string; id: string }) => void;
+    selectedTarget?: { type: string; id: string } | null;
+    onSaveWithoutRunning?: () => void;
+    onCreateAgent?: () => void;
+    isLoading?: boolean;
+    onTargetChange?: (target: unknown) => void;
+    onCreatePrompt?: () => void;
+  }) => (
+    <div data-testid="save-and-run-menu">
+      <button
+        data-testid="save-and-run-button"
+        onClick={() => {
+          if (selectedTarget) {
+            onSaveAndRun?.(selectedTarget);
+          }
+        }}
+      >
+        Save and Run
+      </button>
+    </div>
+  ),
+}));
+
+import { ScenarioFormDrawer } from "../ScenarioFormDrawer";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  mockUpdateMutateAsync: vi.fn(),
+  mockOpenDrawer: vi.fn(),
+  mockCloseDrawer: vi.fn(),
+  mockRunScenario: vi.fn(),
+  mockRouterPush: vi.fn(),
+  mockGetByIdData: null as Record<string, unknown> | null,
+  mockAgentsGetByIdFetch: vi.fn(),
+  // Persisted target for useScenarioTarget — controls what selectedTarget starts as
+  persistedTarget: null as { type: string; id: string } | null,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    scenarios: {
+      create: {
+        useMutation: ({
+          onSuccess,
+        }: {
+          onSuccess?: (data: unknown) => void;
+          onError?: (error: Error) => void;
+        }) => ({
+          mutateAsync: vi.fn(async (input: unknown) => {
+            const result = { id: "new-id", ...((input as Record<string, unknown>) ?? {}) };
+            onSuccess?.(result);
+            return result;
+          }),
+          isPending: false,
+        }),
+      },
+      update: {
+        useMutation: ({
+          onSuccess,
+          onError,
+        }: {
+          onSuccess?: (data: unknown) => void;
+          onError?: (error: Error) => void;
+        }) => ({
+          mutateAsync: vi.fn(async (input: unknown) => {
+            try {
+              const result = await mocks.mockUpdateMutateAsync(input);
+              onSuccess?.(result);
+              return result;
+            } catch (error) {
+              onError?.(error as Error);
+              throw error;
+            }
+          }),
+          isPending: false,
+        }),
+      },
+      getById: {
+        useQuery: () => ({
+          data: mocks.mockGetByIdData,
+          isLoading: false,
+        }),
+      },
+    },
+    agents: {
+      getAll: {
+        useQuery: () => ({ data: [] }),
+      },
+      getById: {
+        // useQuery not used by ScenarioFormDrawer directly — only via utils.fetch
+      },
+    },
+    prompts: {
+      getAllPromptsForProject: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+    licenseEnforcement: {
+      checkLimit: {
+        useQuery: () => ({
+          data: { allowed: true, current: 0, max: 100 },
+          isLoading: false,
+        }),
+      },
+      reportLimitBlocked: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+    useContext: () => ({
+      scenarios: {
+        getAll: { invalidate: vi.fn() },
+        getById: { invalidate: vi.fn() },
+      },
+      agents: {
+        getById: {
+          fetch: mocks.mockAgentsGetByIdFetch,
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: mocks.mockOpenDrawer,
+    closeDrawer: mocks.mockCloseDrawer,
+    drawerOpen: vi.fn(() => true),
+    goBack: vi.fn(),
+    canGoBack: false,
+  }),
+  useDrawerParams: () => ({}),
+  getComplexProps: () => ({}),
+  setFlowCallbacks: vi.fn(),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project-123", slug: "my-project" },
+    organization: { id: "org-123" },
+  }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    query: { project: "my-project" },
+    pathname: "/[project]/simulations/scenarios",
+    asPath: "/my-project/simulations/scenarios",
+    push: mocks.mockRouterPush,
+    replace: vi.fn(),
+    isReady: true,
+  }),
+}));
+
+vi.mock("~/hooks/useRunScenario", () => ({
+  useRunScenario: () => ({
+    runScenario: mocks.mockRunScenario,
+    isRunning: false,
+  }),
+}));
+
+vi.mock("~/hooks/useScenarioTarget", () => ({
+  useScenarioTarget: () => ({
+    target: mocks.persistedTarget,
+    setTarget: vi.fn(),
+    clearTarget: vi.fn(),
+    hasPersistedTarget: false,
+  }),
+}));
+
+vi.mock("~/stores/upgradeModalStore", () => ({
+  useUpgradeModalStore: (selector: unknown) => {
+    if (typeof selector === "function") {
+      return (selector as (state: { open: () => void }) => unknown)({
+        open: vi.fn(),
+      });
+    }
+    return { open: vi.fn() };
+  },
+}));
+
+const mockToasterCreate = vi.fn();
+vi.mock("../../ui/toaster", () => ({
+  toaster: {
+    create: (args: unknown) => mockToasterCreate(args),
+  },
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+// Helpers
+
+/** Render the drawer pre-loaded with an existing scenario and a persisted target. */
+function renderWithTarget(target: { type: string; id: string }) {
+  mocks.persistedTarget = target;
+  mocks.mockGetByIdData = {
+    id: "scenario-1",
+    name: "Test Scenario",
+    situation: "Test situation",
+    criteria: ["Criterion"],
+    labels: [],
+  };
+  mocks.mockUpdateMutateAsync.mockResolvedValue({
+    id: "scenario-1",
+    name: "Test Scenario",
+    situation: "Test situation",
+    criteria: ["Criterion"],
+    labels: [],
+  });
+
+  return render(
+    <ScenarioFormDrawer open={true} scenarioId="scenario-1" />,
+    { wrapper: Wrapper },
+  );
+}
+
+describe("<ScenarioFormDrawer /> mapping gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.persistedTarget = null;
+    mocks.mockGetByIdData = null;
+    mocks.mockRunScenario.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when target is a workflow agent with no scenario mappings", () => {
+    beforeEach(() => {
+      // Agent fetch returns a workflow agent with empty scenarioMappings
+      mocks.mockAgentsGetByIdFetch.mockResolvedValue({
+        id: "workflow-agent-1",
+        type: "workflow",
+        name: "My Workflow Agent",
+        config: {
+          // no scenarioMappings key
+          workflow_id: "wf-123",
+        },
+      });
+    });
+
+    it("opens the AgentWorkflowEditorDrawer instead of starting the run", async () => {
+      const user = userEvent.setup();
+      renderWithTarget({ type: "workflow", id: "workflow-agent-1" });
+
+      await user.click(screen.getByTestId("save-and-run-button"));
+
+      await waitFor(() => {
+        expect(mocks.mockOpenDrawer).toHaveBeenCalledWith(
+          "agentWorkflowEditor",
+          { agentId: "workflow-agent-1" },
+        );
+      });
+
+      expect(mocks.mockRunScenario).not.toHaveBeenCalled();
+    });
+
+    it("shows a toast explaining that mappings need to be configured", async () => {
+      const user = userEvent.setup();
+      renderWithTarget({ type: "workflow", id: "workflow-agent-1" });
+
+      await user.click(screen.getByTestId("save-and-run-button"));
+
+      await waitFor(() => {
+        expect(mockToasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "Configure scenario mappings",
+            type: "warning",
+          }),
+        );
+      });
+    });
+  });
+
+  describe("when target is a workflow agent with incomplete mappings", () => {
+    beforeEach(() => {
+      // Agent has mappings, but they're incomplete — "input" and "messages" missing
+      // isScenarioMappingValid checks: at least one of input/messages mapped,
+      // and output mapped. Here we have no source mappings at all that cover input/messages.
+      mocks.mockAgentsGetByIdFetch.mockResolvedValue({
+        id: "workflow-agent-2",
+        type: "workflow",
+        name: "Incomplete Mapping Agent",
+        config: {
+          workflow_id: "wf-456",
+          // mappings exist but don't cover "input" or "messages"
+          scenarioMappings: {
+            someOtherField: {
+              type: "value",
+              value: "hardcoded",
+            },
+          },
+        },
+      });
+    });
+
+    it("opens the AgentWorkflowEditorDrawer instead of starting the run", async () => {
+      const user = userEvent.setup();
+      renderWithTarget({ type: "workflow", id: "workflow-agent-2" });
+
+      await user.click(screen.getByTestId("save-and-run-button"));
+
+      await waitFor(() => {
+        expect(mocks.mockOpenDrawer).toHaveBeenCalledWith(
+          "agentWorkflowEditor",
+          { agentId: "workflow-agent-2" },
+        );
+      });
+
+      expect(mocks.mockRunScenario).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when target is a non-workflow agent (code)", () => {
+    it("proceeds with the normal run without opening the mapping drawer", async () => {
+      const user = userEvent.setup();
+      renderWithTarget({ type: "code", id: "code-agent-1" });
+
+      await user.click(screen.getByTestId("save-and-run-button"));
+
+      await waitFor(() => {
+        expect(mocks.mockRunScenario).toHaveBeenCalled();
+      });
+
+      expect(mocks.mockOpenDrawer).not.toHaveBeenCalledWith(
+        "agentWorkflowEditor",
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/langwatch/src/components/suites/ScenarioInputMappingSection.tsx
+++ b/langwatch/src/components/suites/ScenarioInputMappingSection.tsx
@@ -114,6 +114,21 @@ function buildAgentOutputSource(outputs: Variable[]): AvailableSource {
 }
 
 /**
+ * Checks whether at least one source mapping wires to a required scenario
+ * input field (`input` or `messages`). Shared between the full mapping check
+ * and the Save & Run drawer gate — keeps both sides in agreement on what
+ * "mapped enough to run" means for the input half.
+ */
+export function hasScenarioInputMapping(
+  mappings: Record<string, FieldMapping>,
+): boolean {
+  const mappedPaths = Object.values(mappings)
+    .filter((m) => m.type === "source")
+    .map((m) => m.path[0]);
+  return mappedPaths.includes("input") || mappedPaths.includes("messages");
+}
+
+/**
  * Checks whether the scenario mappings are valid.
  * - At least one of input or messages must be mapped.
  * - An output must be selected (not cleared).
@@ -127,16 +142,10 @@ export function isScenarioMappingValid({
   outputs?: Variable[];
   outputField?: string;
 }): boolean {
-  const mappedPaths = Object.values(mappings)
-    .filter((m) => m.type === "source")
-    .map((m) => m.path[0]);
-  const hasRequiredInput =
-    mappedPaths.includes("input") ||
-    mappedPaths.includes("messages");
   const hasOutputs = (outputs ?? []).length > 0;
   // outputField === "" means explicitly cleared; undefined means auto-populate
   const hasOutputMapping = hasOutputs && outputField !== "";
-  return hasRequiredInput && hasOutputMapping;
+  return hasScenarioInputMapping(mappings) && hasOutputMapping;
 }
 
 export function ScenarioInputMappingSection({

--- a/langwatch/src/pages/[project]/agents.tsx
+++ b/langwatch/src/pages/[project]/agents.tsx
@@ -10,6 +10,7 @@ import { Bot, Plus } from "lucide-react";
 import { useRouter } from "~/utils/compat/next-router";
 import { useCallback, useState } from "react";
 import { AgentCard } from "~/components/agents/AgentCard";
+import { getAgentEditorDrawer } from "~/components/agents/getAgentEditorDrawer";
 import { CopyAgentDialog } from "~/components/agents/CopyAgentDialog";
 import { PushToCopiesDialog } from "~/components/agents/PushToCopiesDialog";
 import { CascadeArchiveDialog } from "~/components/CascadeArchiveDialog";
@@ -123,22 +124,9 @@ function Page() {
   });
 
   const handleEditAgent = (agent: TypedAgent) => {
-    // Open the appropriate editor based on agent type
-    switch (agent.type) {
-      case "code":
-        openDrawer("agentCodeEditor", { urlParams: { agentId: agent.id } });
-        break;
-      case "http":
-        openDrawer("agentHttpEditor", { urlParams: { agentId: agent.id } });
-        break;
-      case "workflow":
-        // Workflow agents can't be edited directly, just view
-        openDrawer("workflowSelector", { urlParams: { agentId: agent.id } });
-        break;
-      default: {
-        throw new Error(`Unhandled agent type: ${agent.type}`);
-      }
-    }
+    openDrawer(getAgentEditorDrawer(agent.type), {
+      urlParams: { agentId: agent.id },
+    });
   };
 
   const handleDeleteAgent = (agent: TypedAgent) => {

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -25,6 +25,9 @@ import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { fireWorkflowCreatedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
 import { captureException } from "~/utils/posthogErrorCapture";
 import { autoComputeAgentMappings } from "../../workflows/auto-compute-agent-mappings";
+import { createLogger } from "../../../utils/logger/server";
+
+const autoComputeLogger = createLogger("langwatch:workflows:auto-compute");
 
 export const workflowRouter = createTRPCRouter({
   create: protectedProcedure
@@ -1334,11 +1337,19 @@ export const saveOrCommitWorkflowVersion = async ({
     },
   });
 
-  void autoComputeAgentMappings({
+  // Fire-and-forget: auto-compute handles its own errors internally, but the
+  // outer .catch guards against synchronous throws (e.g. invalid args) that
+  // would otherwise surface as an unhandled promise rejection.
+  autoComputeAgentMappings({
     prisma: ctx.prisma,
     workflowId: input.workflowId,
     projectId: input.projectId,
     dsl: input.dsl,
+  }).catch((err) => {
+    autoComputeLogger.error(
+      { err, workflowId: input.workflowId, projectId: input.projectId },
+      "autoComputeAgentMappings dispatch failed",
+    );
   });
 
   return updatedVersion;

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -24,6 +24,7 @@ import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { fireWorkflowCreatedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
 import { captureException } from "~/utils/posthogErrorCapture";
+import { autoComputeAgentMappings } from "../../workflows/auto-compute-agent-mappings";
 
 export const workflowRouter = createTRPCRouter({
   create: protectedProcedure
@@ -1331,6 +1332,13 @@ export const saveOrCommitWorkflowVersion = async ({
         ? updatedVersion.id
         : latestVersion?.id,
     },
+  });
+
+  void autoComputeAgentMappings({
+    prisma: ctx.prisma,
+    workflowId: input.workflowId,
+    projectId: input.projectId,
+    dsl: input.dsl,
   });
 
   return updatedVersion;

--- a/langwatch/src/server/scenarios/execution/__tests__/validate-workflow-mappings.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/validate-workflow-mappings.unit.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for validateWorkflowAgentMappings.
+ *
+ * Covers the four cases: multi-input without mappings (error), single-input
+ * without mappings (passes), multi-input with mappings (passes), and zero
+ * inputs without mappings (passes).
+ */
+
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+import { validateWorkflowAgentMappings } from "../validate-workflow-mappings";
+
+describe("validateWorkflowAgentMappings", () => {
+  describe("when the workflow has multiple inputs and no mappings are configured", () => {
+    it("throws a BAD_REQUEST TRPCError with an actionable message", () => {
+      expect(() =>
+        validateWorkflowAgentMappings({
+          agentId: "agent-abc",
+          inputs: [
+            { identifier: "query", type: "str" },
+            { identifier: "context", type: "str" },
+          ],
+          scenarioMappings: undefined,
+        })
+      ).toThrow(TRPCError);
+    });
+
+    it("includes the agent id in the error message", () => {
+      expect(() =>
+        validateWorkflowAgentMappings({
+          agentId: "agent-abc",
+          inputs: [
+            { identifier: "query", type: "str" },
+            { identifier: "context", type: "str" },
+          ],
+          scenarioMappings: undefined,
+        })
+      ).toThrow("agent-abc");
+    });
+
+    it("includes the input count in the error message", () => {
+      expect(() =>
+        validateWorkflowAgentMappings({
+          agentId: "agent-abc",
+          inputs: [
+            { identifier: "query", type: "str" },
+            { identifier: "context", type: "str" },
+          ],
+          scenarioMappings: undefined,
+        })
+      ).toThrow("2 inputs");
+    });
+
+    it("directs the user to the agent editor", () => {
+      expect(() =>
+        validateWorkflowAgentMappings({
+          agentId: "agent-abc",
+          inputs: [
+            { identifier: "query", type: "str" },
+            { identifier: "context", type: "str" },
+          ],
+          scenarioMappings: undefined,
+        })
+      ).toThrow("agent editor");
+    });
+
+    it("sets the TRPCError code to BAD_REQUEST", () => {
+      let thrown: unknown;
+      try {
+        validateWorkflowAgentMappings({
+          agentId: "agent-abc",
+          inputs: [
+            { identifier: "query", type: "str" },
+            { identifier: "context", type: "str" },
+          ],
+          scenarioMappings: undefined,
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(TRPCError);
+      expect((thrown as TRPCError).code).toBe("BAD_REQUEST");
+    });
+
+    it("also throws when scenarioMappings is an empty object", () => {
+      expect(() =>
+        validateWorkflowAgentMappings({
+          agentId: "agent-xyz",
+          inputs: [
+            { identifier: "q", type: "str" },
+            { identifier: "ctx", type: "str" },
+          ],
+          scenarioMappings: {},
+        })
+      ).toThrow(TRPCError);
+    });
+  });
+
+  describe("when the workflow has exactly one input and no mappings are configured", () => {
+    it("does not throw (legacy single-input fallback handles it)", () => {
+      expect(() =>
+        validateWorkflowAgentMappings({
+          agentId: "agent-single",
+          inputs: [{ identifier: "input", type: "str" }],
+          scenarioMappings: undefined,
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe("when the workflow has multiple inputs and mappings are configured", () => {
+    it("does not throw", () => {
+      expect(() =>
+        validateWorkflowAgentMappings({
+          agentId: "agent-mapped",
+          inputs: [
+            { identifier: "query", type: "str" },
+            { identifier: "context", type: "str" },
+          ],
+          scenarioMappings: {
+            query: { type: "source", sourceId: "scenario", path: ["input"] },
+            context: { type: "value", value: "static context" },
+          },
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe("when the workflow has zero inputs and no mappings are configured", () => {
+    it("does not throw (edge case — adapter synthesises a default input)", () => {
+      expect(() =>
+        validateWorkflowAgentMappings({
+          agentId: "agent-empty",
+          inputs: [],
+          scenarioMappings: undefined,
+        })
+      ).not.toThrow();
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/execution/data-prefetcher.ts
+++ b/langwatch/src/server/scenarios/execution/data-prefetcher.ts
@@ -10,10 +10,12 @@
  * - Tests can inject mocks without vi.mock
  */
 
+import type { Edge, Node } from "@xyflow/react";
 import { z } from "zod";
 import { env } from "~/env.mjs";
 import { DEFAULT_MODEL } from "~/utils/constants";
 import { createLogger } from "~/utils/logger/server";
+import { getInputsOutputs } from "../../../optimization_studio/utils/nodeUtils";
 import { validateWorkflowAgentMappings } from "./validate-workflow-mappings";
 
 const logger = createLogger("langwatch:scenarios:data-prefetcher");
@@ -481,56 +483,42 @@ async function fetchWorkflowAgentData(
 /**
  * Extract declared entry inputs and end outputs from an opaque workflow DSL.
  *
- * Mirrors `getInputsOutputs` in optimization_studio/utils/nodeUtils but is
- * defensive: the DSL is `Record<string, unknown>` so we narrow each access.
- * Workflows without an entry/end node return empty arrays; the adapter then
- * falls back to synthesizing a single `input`/`output` identifier.
+ * The DSL is stored as `Record<string, unknown>` (JSON column), so we narrow
+ * into the `Edge[]`/`Node[]` shape `getInputsOutputs` expects and then flatten
+ * its loose return value into typed `WorkflowField`s. Workflows without an
+ * entry/end node yield empty arrays; the adapter synthesises a single
+ * `input`/`output` identifier as a fallback.
  */
 function extractWorkflowIO(dsl: Record<string, unknown>): {
   inputs: WorkflowField[];
   outputs: WorkflowField[];
 } {
-  const nodes = Array.isArray(dsl.nodes) ? (dsl.nodes as unknown[]) : [];
-  const edges = Array.isArray(dsl.edges) ? (dsl.edges as unknown[]) : [];
+  const nodes = (Array.isArray(dsl.nodes) ? dsl.nodes : []) as Node[];
+  const edges = (Array.isArray(dsl.edges) ? dsl.edges : []) as Edge[];
 
-  // Inputs: unique outputs of entry-sourced edges, in first-seen order.
-  const seenSourceHandles = new Set<string>();
-  const inputs: WorkflowField[] = [];
-  for (const edge of edges) {
-    if (typeof edge !== "object" || edge === null) continue;
-    const e = edge as { source?: unknown; sourceHandle?: unknown };
-    if (e.source !== "entry") continue;
-    const handle = typeof e.sourceHandle === "string" ? e.sourceHandle : null;
-    if (!handle || seenSourceHandles.has(handle)) continue;
-    seenSourceHandles.add(handle);
-    const identifier = handle.split(".")[1];
-    if (!identifier) continue;
-    inputs.push({ identifier, type: "str" });
-  }
+  const { inputs: rawInputs, outputs: rawOutputs } = getInputsOutputs(
+    edges,
+    nodes,
+  );
 
-  // Outputs: inputs declared on the end node.
-  const endNode = nodes.find((n): n is Record<string, unknown> => {
-    if (typeof n !== "object" || n === null) return false;
-    const node = n as { id?: unknown; type?: unknown };
-    return node.id === "end" || node.type === "end";
-  });
-  const outputs: WorkflowField[] = [];
-  if (endNode) {
-    const data =
-      typeof endNode.data === "object" && endNode.data !== null
-        ? (endNode.data as Record<string, unknown>)
-        : {};
-    const rawInputs = Array.isArray(data.inputs) ? data.inputs : [];
-    for (const item of rawInputs) {
-      if (typeof item !== "object" || item === null) continue;
-      const field = item as { identifier?: unknown; type?: unknown };
-      if (typeof field.identifier !== "string") continue;
-      outputs.push({
-        identifier: field.identifier,
-        type: typeof field.type === "string" ? field.type : "str",
-      });
-    }
-  }
+  const inputs: WorkflowField[] = (rawInputs ?? []).flatMap((i) =>
+    typeof i.identifier === "string"
+      ? [{ identifier: i.identifier, type: "str" }]
+      : [],
+  );
+
+  const outputs: WorkflowField[] = (Array.isArray(rawOutputs) ? rawOutputs : [])
+    .flatMap((o: unknown): WorkflowField[] => {
+      if (typeof o !== "object" || o === null) return [];
+      const field = o as { identifier?: unknown; type?: unknown };
+      if (typeof field.identifier !== "string") return [];
+      return [
+        {
+          identifier: field.identifier,
+          type: typeof field.type === "string" ? field.type : "str",
+        },
+      ];
+    });
 
   return { inputs, outputs };
 }

--- a/langwatch/src/server/scenarios/execution/data-prefetcher.ts
+++ b/langwatch/src/server/scenarios/execution/data-prefetcher.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { env } from "~/env.mjs";
 import { DEFAULT_MODEL } from "~/utils/constants";
 import { createLogger } from "~/utils/logger/server";
+import { validateWorkflowAgentMappings } from "./validate-workflow-mappings";
 
 const logger = createLogger("langwatch:scenarios:data-prefetcher");
 import {
@@ -461,7 +462,7 @@ async function fetchWorkflowAgentData(
 
   const { inputs, outputs } = extractWorkflowIO(latest.dsl);
 
-  return {
+  const data: WorkflowAgentData = {
     type: "workflow",
     agentId: agent.id,
     workflowId: latest.workflowId,
@@ -471,6 +472,10 @@ async function fetchWorkflowAgentData(
     scenarioMappings: config.scenarioMappings,
     scenarioOutputField: config.scenarioOutputField,
   };
+
+  validateWorkflowAgentMappings(data);
+
+  return data;
 }
 
 /**

--- a/langwatch/src/server/scenarios/execution/validate-workflow-mappings.ts
+++ b/langwatch/src/server/scenarios/execution/validate-workflow-mappings.ts
@@ -1,0 +1,44 @@
+/**
+ * Pre-run validation for workflow agent scenario mappings.
+ *
+ * Validates that a workflow agent has the necessary scenario mappings
+ * configured before execution begins. This prevents confusing runtime
+ * failures when a multi-input workflow receives empty strings for all
+ * but its first input.
+ */
+
+import { TRPCError } from "@trpc/server";
+import type { WorkflowAgentData } from "./types";
+
+/**
+ * Validates that a workflow agent's scenario mappings are sufficient to
+ * execute the workflow.
+ *
+ * Throws a structured BAD_REQUEST error when the workflow has more than one
+ * declared input and no scenario mappings are configured. The single-input
+ * case is allowed through because the legacy fallback (first input ← last
+ * user message) handles it correctly.
+ */
+export function validateWorkflowAgentMappings({
+  agentId,
+  inputs,
+  scenarioMappings,
+}: Pick<
+  WorkflowAgentData,
+  "agentId" | "inputs" | "scenarioMappings"
+>): void {
+  const hasMappings =
+    scenarioMappings !== undefined &&
+    Object.keys(scenarioMappings).length > 0;
+
+  if (hasMappings) return;
+
+  if (inputs.length <= 1) return;
+
+  throw new TRPCError({
+    code: "BAD_REQUEST",
+    message:
+      `Workflow agent '${agentId}' has ${inputs.length} inputs but no scenario mappings configured. ` +
+      `Open the agent editor to configure how scenario data maps to the workflow's inputs.`,
+  });
+}

--- a/langwatch/src/server/workflows/__tests__/auto-compute-agent-mappings.unit.test.ts
+++ b/langwatch/src/server/workflows/__tests__/auto-compute-agent-mappings.unit.test.ts
@@ -66,9 +66,10 @@ function buildPrismaMock({
           where,
           data,
         }: {
-          where: { id: string; projectId: string };
+          where: { id: string; projectId?: string };
           data: { config: Record<string, unknown> };
         }) => {
+          expect(where.projectId).toBeDefined();
           updatedConfigs[where.id] = data.config as Record<string, unknown>;
           return { id: where.id, config: data.config };
         },
@@ -286,6 +287,95 @@ describe("autoComputeAgentMappings", () => {
       });
 
       expect(prisma.agent.update).not.toHaveBeenCalled();
+    });
+
+    it("preserves user-set mappings for non-stale keys when another key is stale", async () => {
+      // Workflow now declares "prompt" and "extra" — but the agent's mapping
+      // for "old_query" is stale. Re-computing must preserve the user's
+      // custom mapping for "extra" rather than clobbering it with a best-match
+      // guess.
+      const dsl = buildDSL({ inputs: ["prompt", "extra"], output: "response" });
+      const existingMappings = {
+        old_query: { type: "source", sourceId: "scenario", path: ["input"] },
+        extra: {
+          type: "source",
+          sourceId: "scenario",
+          path: ["custom", "user_picked"],
+        },
+      };
+      const { prisma, updatedConfigs } = buildPrismaMock({
+        agents: [
+          {
+            id: "agent-1",
+            config: {
+              type: "workflow",
+              scenarioMappings: existingMappings,
+            },
+          },
+        ],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.update).toHaveBeenCalled();
+      const config = updatedConfigs["agent-1"];
+      expect(config).toBeDefined();
+      const mappings = config!["scenarioMappings"] as Record<
+        string,
+        { type: string; sourceId: string; path: string[] }
+      >;
+      expect(mappings["old_query"]).toBeUndefined();
+      expect(mappings["prompt"]).toBeDefined();
+      expect(mappings["extra"]).toEqual({
+        type: "source",
+        sourceId: "scenario",
+        path: ["custom", "user_picked"],
+      });
+    });
+  });
+
+  describe("when scenarioOutputField is stale but input mappings are current", () => {
+    it("repairs scenarioOutputField to the new first output", async () => {
+      // Inputs unchanged, but the end output was renamed from "old_out" → "new_out".
+      const dsl = buildDSL({ inputs: ["prompt"], output: "new_out" });
+      const currentMappings = {
+        prompt: { type: "source", sourceId: "scenario", path: ["input"] },
+      };
+      const { prisma, updatedConfigs } = buildPrismaMock({
+        agents: [
+          {
+            id: "agent-1",
+            config: {
+              type: "workflow",
+              scenarioMappings: currentMappings,
+              scenarioOutputField: "old_out",
+            },
+          },
+        ],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.update).toHaveBeenCalled();
+      const config = updatedConfigs["agent-1"];
+      expect(config!["scenarioOutputField"]).toBe("new_out");
+      // Input mappings are preserved verbatim.
+      const mappings = config!["scenarioMappings"] as Record<string, unknown>;
+      expect(mappings["prompt"]).toEqual({
+        type: "source",
+        sourceId: "scenario",
+        path: ["input"],
+      });
     });
   });
 

--- a/langwatch/src/server/workflows/__tests__/auto-compute-agent-mappings.unit.test.ts
+++ b/langwatch/src/server/workflows/__tests__/auto-compute-agent-mappings.unit.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { autoComputeAgentMappings } from "../auto-compute-agent-mappings";
 import type { PrismaClient } from "@prisma/client";
 
@@ -336,6 +336,60 @@ describe("autoComputeAgentMappings", () => {
         sourceId: "scenario",
         path: ["custom", "user_picked"],
       });
+    });
+  });
+
+  describe("when the workflow has no end outputs at all", () => {
+    it("clears a stale scenarioOutputField rather than leaving it pointing to a removed output", async () => {
+      // Build a DSL whose end node has no inputs — i.e. no outputs.
+      const dsl = {
+        nodes: [
+          {
+            id: "end",
+            type: "end",
+            position: { x: 0, y: 0 },
+            data: { name: "End", inputs: [] as Array<unknown> },
+          },
+        ],
+        edges: [
+          {
+            id: "e-entry-0",
+            source: "entry",
+            sourceHandle: "outputs.query",
+            target: "llm_call",
+            targetHandle: "inputs.query",
+            type: "default",
+          },
+        ],
+      };
+      const { prisma, updatedConfigs } = buildPrismaMock({
+        agents: [
+          {
+            id: "agent-1",
+            config: {
+              type: "workflow",
+              scenarioMappings: {
+                query: { type: "source", sourceId: "scenario", path: ["input"] },
+              },
+              scenarioOutputField: "response",
+            },
+          },
+        ],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.update).toHaveBeenCalled();
+      const config = updatedConfigs["agent-1"];
+      expect(config).toBeDefined();
+      // Stale scenarioOutputField must be removed, not left pointing at
+      // a non-existent output field.
+      expect(config!["scenarioOutputField"]).toBeUndefined();
     });
   });
 

--- a/langwatch/src/server/workflows/__tests__/auto-compute-agent-mappings.unit.test.ts
+++ b/langwatch/src/server/workflows/__tests__/auto-compute-agent-mappings.unit.test.ts
@@ -206,6 +206,89 @@ describe("autoComputeAgentMappings", () => {
     });
   });
 
+  describe("when the workflow still has blank-template placeholder fields", () => {
+    it("skips auto-compute and leaves scenarioMappings empty", async () => {
+      // Blank template: entry outputs "question", end inputs "output"
+      const dsl = buildDSL({ inputs: ["question"], output: "output" });
+      const { prisma } = buildPrismaMock({
+        agents: [{ id: "agent-1", config: { type: "workflow" } }],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when existing scenarioMappings reference stale fields", () => {
+    it("re-computes mappings against the current workflow inputs", async () => {
+      // Workflow now has "prompt" — but agent still maps "old_query"
+      const dsl = buildDSL({ inputs: ["prompt"], output: "response" });
+      const staleExistingMappings = {
+        old_query: { type: "source", sourceId: "scenario", path: ["input"] },
+      };
+      const { prisma, updatedConfigs } = buildPrismaMock({
+        agents: [
+          {
+            id: "agent-1",
+            config: {
+              type: "workflow",
+              scenarioMappings: staleExistingMappings,
+            },
+          },
+        ],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.update).toHaveBeenCalled();
+      const config = updatedConfigs["agent-1"];
+      expect(config).toBeDefined();
+      const mappings = config!["scenarioMappings"] as Record<string, unknown>;
+      // Stale key must be gone
+      expect(mappings["old_query"]).toBeUndefined();
+      // New field "prompt" must be present
+      expect(mappings["prompt"]).toBeDefined();
+    });
+
+    it("preserves non-stale mappings (does not re-compute when all keys are current)", async () => {
+      const dsl = buildDSL({ inputs: ["prompt"], output: "response" });
+      const currentMappings = {
+        prompt: { type: "source", sourceId: "scenario", path: ["input"] },
+      };
+      const { prisma } = buildPrismaMock({
+        agents: [
+          {
+            id: "agent-1",
+            config: {
+              type: "workflow",
+              scenarioMappings: currentMappings,
+            },
+          },
+        ],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when no agents are linked to the workflow", () => {
     it("does not attempt any updates", async () => {
       const dsl = buildDSL({ inputs: ["query"], output: "response" });

--- a/langwatch/src/server/workflows/__tests__/auto-compute-agent-mappings.unit.test.ts
+++ b/langwatch/src/server/workflows/__tests__/auto-compute-agent-mappings.unit.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { autoComputeAgentMappings } from "../auto-compute-agent-mappings";
+import type { PrismaClient } from "@prisma/client";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a minimal DSL with the given input identifiers and a single output.
+ *
+ * Each entry edge has sourceHandle "outputs.<identifier>", which is the shape
+ * that getInputsOutputs / getEntryInputs expect.
+ */
+function buildDSL({
+  inputs,
+  output,
+}: {
+  inputs: string[];
+  output: string;
+}) {
+  const edges = inputs.map((identifier, i) => ({
+    id: `e-entry-${i}`,
+    source: "entry",
+    sourceHandle: `outputs.${identifier}`,
+    target: "llm_call",
+    targetHandle: `inputs.${identifier}`,
+    type: "default",
+  }));
+
+  const nodes = [
+    {
+      id: "end",
+      type: "end",
+      position: { x: 0, y: 0 },
+      data: {
+        name: "End",
+        inputs: [{ identifier: output, type: "str" }],
+      },
+    },
+  ];
+
+  return { nodes, edges };
+}
+
+// ---------------------------------------------------------------------------
+// Prisma mock factory
+// ---------------------------------------------------------------------------
+
+function buildPrismaMock({
+  agents,
+}: {
+  agents: Array<{ id: string; config: Record<string, unknown> }>;
+}) {
+  const updatedConfigs: Record<string, Record<string, unknown>> = {};
+
+  const prisma = {
+    agent: {
+      findMany: vi.fn().mockResolvedValue(agents),
+      update: vi.fn().mockImplementation(
+        async ({
+          where,
+          data,
+        }: {
+          where: { id: string; projectId: string };
+          data: { config: Record<string, unknown> };
+        }) => {
+          updatedConfigs[where.id] = data.config as Record<string, unknown>;
+          return { id: where.id, config: data.config };
+        },
+      ),
+    },
+  } as unknown as PrismaClient;
+
+  return { prisma, updatedConfigs };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("autoComputeAgentMappings", () => {
+  describe("when a workflow agent has no scenarioMappings and conventional inputs", () => {
+    it("maps query to scenario input field", async () => {
+      const dsl = buildDSL({ inputs: ["query", "history"], output: "response" });
+      const { prisma, updatedConfigs } = buildPrismaMock({
+        agents: [{ id: "agent-1", config: { type: "workflow" } }],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      const config = updatedConfigs["agent-1"];
+      expect(config).toBeDefined();
+      const mappings = config!["scenarioMappings"] as Record<
+        string,
+        { type: string; sourceId: string; path: string[] }
+      >;
+      expect(mappings["query"]).toEqual({
+        type: "source",
+        sourceId: "scenario",
+        path: ["input"],
+      });
+    });
+
+    it("maps history to scenario messages field", async () => {
+      const dsl = buildDSL({ inputs: ["query", "history"], output: "response" });
+      const { prisma, updatedConfigs } = buildPrismaMock({
+        agents: [{ id: "agent-1", config: { type: "workflow" } }],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      const config = updatedConfigs["agent-1"];
+      expect(config).toBeDefined();
+      const mappings = config!["scenarioMappings"] as Record<
+        string,
+        { type: string; sourceId: string; path: string[] }
+      >;
+      expect(mappings["history"]).toEqual({
+        type: "source",
+        sourceId: "scenario",
+        path: ["messages"],
+      });
+    });
+
+    it("sets scenarioOutputField to the first workflow output", async () => {
+      const dsl = buildDSL({ inputs: ["query", "history"], output: "response" });
+      const { prisma, updatedConfigs } = buildPrismaMock({
+        agents: [{ id: "agent-1", config: { type: "workflow" } }],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      const config = updatedConfigs["agent-1"];
+      expect(config).toBeDefined();
+      expect(config!["scenarioOutputField"]).toBe("response");
+    });
+
+    it("queries agents by workflowId and projectId excluding archived", async () => {
+      const dsl = buildDSL({ inputs: ["query"], output: "response" });
+      const { prisma } = buildPrismaMock({
+        agents: [{ id: "agent-1", config: {} }],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            workflowId: "wf-1",
+            projectId: "proj-1",
+            archivedAt: null,
+          },
+        }),
+      );
+    });
+  });
+
+  describe("when an agent already has scenarioMappings configured", () => {
+    it("skips the agent without overwriting existing mappings", async () => {
+      const dsl = buildDSL({ inputs: ["query"], output: "response" });
+      const existingMappings = {
+        query: { type: "source", sourceId: "scenario", path: ["input"] },
+      };
+      const { prisma } = buildPrismaMock({
+        agents: [
+          {
+            id: "agent-1",
+            config: { type: "workflow", scenarioMappings: existingMappings },
+          },
+        ],
+      });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when no agents are linked to the workflow", () => {
+    it("does not attempt any updates", async () => {
+      const dsl = buildDSL({ inputs: ["query"], output: "response" });
+      const { prisma } = buildPrismaMock({ agents: [] });
+
+      await autoComputeAgentMappings({
+        prisma,
+        workflowId: "wf-1",
+        projectId: "proj-1",
+        dsl,
+      });
+
+      expect(prisma.agent.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when Prisma throws an error", () => {
+    it("does not propagate the error (non-blocking)", async () => {
+      const dsl = buildDSL({ inputs: ["query"], output: "response" });
+      const prisma = {
+        agent: {
+          findMany: vi.fn().mockRejectedValue(new Error("DB connection lost")),
+          update: vi.fn(),
+        },
+      } as unknown as PrismaClient;
+
+      await expect(
+        autoComputeAgentMappings({
+          prisma,
+          workflowId: "wf-1",
+          projectId: "proj-1",
+          dsl,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
+++ b/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
@@ -5,7 +5,7 @@
  * so that the workflow save is never blocked.
  */
 
-import type { PrismaClient } from "@prisma/client";
+import type { PrismaClient, Prisma } from "@prisma/client";
 import type { Edge, Node } from "@xyflow/react";
 import { computeBestMatchMappings } from "../scenarios/execution/resolve-field-mappings";
 import { getInputsOutputs } from "../../optimization_studio/utils/nodeUtils";
@@ -167,7 +167,7 @@ export async function autoComputeAgentMappings({
 
       await prisma.agent.update({
         where: { id: agent.id, projectId },
-        data: { config: updatedConfig },
+        data: { config: updatedConfig as Prisma.InputJsonValue },
       });
     }
   } catch (error) {

--- a/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
+++ b/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
@@ -70,9 +70,9 @@ function isBlankTemplateDSL({
 }): boolean {
   return (
     inputs.length === 1 &&
-    inputs[0]!.identifier === BLANK_TEMPLATE_INPUT &&
+    inputs[0]?.identifier === BLANK_TEMPLATE_INPUT &&
     outputs.length === 1 &&
-    outputs[0]!.identifier === BLANK_TEMPLATE_OUTPUT
+    outputs[0]?.identifier === BLANK_TEMPLATE_OUTPUT
   );
 }
 
@@ -150,9 +150,16 @@ export async function autoComputeAgentMappings({
         ...preservedMappings,
       };
 
+      // "Changed" means the set of keys differs from current, OR the source
+      // of any preserved key changed. Since preservedMappings is a subset of
+      // currentMappings (same entries, just filtered), we only need to detect
+      // key-set differences between nextMappings and currentMappings.
+      const currentKeys = Object.keys(currentMappings);
+      const nextKeys = Object.keys(nextMappings);
       const mappingsChanged =
         hasExistingMappings &&
-        JSON.stringify(nextMappings) !== JSON.stringify(currentMappings);
+        (currentKeys.length !== nextKeys.length ||
+          currentKeys.some((k) => !(k in nextMappings)));
       const needsInitialMappings =
         !hasExistingMappings && Object.keys(nextMappings).length > 0;
 

--- a/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
+++ b/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
@@ -77,21 +77,6 @@ function isBlankTemplateDSL({
 }
 
 /**
- * Returns true when the agent's existing scenarioMappings contain at least one
- * key that no longer exists as a workflow input identifier (stale mapping).
- */
-function hasStaleMappings({
-  existingMappings,
-  inputs,
-}: {
-  existingMappings: Record<string, unknown>;
-  inputs: Array<{ identifier: string }>;
-}): boolean {
-  const inputIdentifiers = new Set(inputs.map((i) => i.identifier));
-  return Object.keys(existingMappings).some((key) => !inputIdentifiers.has(key));
-}
-
-/**
  * Auto-computes and persists scenarioMappings for all workflow-linked agents that
  * have no mappings configured, or whose existing mappings reference stale fields.
  *
@@ -132,6 +117,9 @@ export async function autoComputeAgentMappings({
     const scenarioOutputField =
       outputs[0]?.identifier !== undefined ? outputs[0].identifier : undefined;
 
+    const inputIdentifiers = new Set(inputs.map((i) => i.identifier));
+    const outputIdentifiers = new Set(outputs.map((o) => o.identifier));
+
     for (const agent of agents) {
       const config =
         typeof agent.config === "object" && agent.config !== null
@@ -139,30 +127,59 @@ export async function autoComputeAgentMappings({
           : {};
 
       const existingMappings = config["scenarioMappings"];
-      const hasExistingMappings =
-        existingMappings !== undefined &&
+      const currentMappings =
         existingMappings !== null &&
         typeof existingMappings === "object" &&
-        Object.keys(existingMappings).length > 0;
+        !Array.isArray(existingMappings)
+          ? (existingMappings as Record<string, unknown>)
+          : {};
+      const hasExistingMappings = Object.keys(currentMappings).length > 0;
 
-      if (hasExistingMappings) {
-        // Re-compute only when existing mappings reference fields that no longer exist
-        const stale = hasStaleMappings({
-          existingMappings: existingMappings as Record<string, unknown>,
-          inputs,
-        });
-        if (!stale) continue;
+      // Preserve mappings whose keys are still valid workflow inputs; drop stale ones.
+      const preservedMappings = Object.fromEntries(
+        Object.entries(currentMappings).filter(([key]) =>
+          inputIdentifiers.has(key),
+        ),
+      );
+
+      // Fill in auto-computed best-match defaults only for inputs the user has
+      // not already mapped. This avoids clobbering user-configured mappings
+      // when another input becomes stale.
+      const nextMappings: Record<string, unknown> = {
+        ...mappings,
+        ...preservedMappings,
+      };
+
+      const mappingsChanged =
+        hasExistingMappings &&
+        JSON.stringify(nextMappings) !== JSON.stringify(currentMappings);
+      const needsInitialMappings =
+        !hasExistingMappings && Object.keys(nextMappings).length > 0;
+
+      // Evaluate output-field staleness independently from input mappings.
+      // Only repair when the existing value is a string that points to a field
+      // that no longer exists. Initialize on first auto-compute (no existing
+      // mappings + new output available). Don't clobber an intentionally-unset
+      // field on agents that already have mappings configured.
+      const existingOutputField = config["scenarioOutputField"];
+      const outputFieldIsStale =
+        typeof existingOutputField === "string" &&
+        !outputIdentifiers.has(existingOutputField);
+      const shouldUpdateOutputField =
+        scenarioOutputField !== undefined &&
+        (outputFieldIsStale ||
+          (!hasExistingMappings && existingOutputField === undefined));
+
+      if (!mappingsChanged && !needsInitialMappings && !shouldUpdateOutputField) {
+        continue;
       }
-
-      // Skip if there are no mappings to apply
-      if (Object.keys(mappings).length === 0) continue;
 
       const updatedConfig: Record<string, unknown> = {
         ...config,
-        scenarioMappings: mappings,
-        ...(scenarioOutputField !== undefined
-          ? { scenarioOutputField }
+        ...((mappingsChanged || needsInitialMappings)
+          ? { scenarioMappings: nextMappings }
           : {}),
+        ...(shouldUpdateOutputField ? { scenarioOutputField } : {}),
       };
 
       await prisma.agent.update({

--- a/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
+++ b/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
@@ -176,13 +176,31 @@ export async function autoComputeAgentMappings({
         scenarioOutputField !== undefined &&
         (outputFieldIsStale ||
           (!hasExistingMappings && existingOutputField === undefined));
+      // If the stored output field is stale AND there is no replacement
+      // (workflow has no outputs), strip the stale field so the adapter does
+      // not try to read a non-existent identifier at run time.
+      const shouldRemoveOutputField =
+        outputFieldIsStale && scenarioOutputField === undefined;
 
-      if (!mappingsChanged && !needsInitialMappings && !shouldUpdateOutputField) {
+      if (
+        !mappingsChanged &&
+        !needsInitialMappings &&
+        !shouldUpdateOutputField &&
+        !shouldRemoveOutputField
+      ) {
         continue;
       }
 
+      const baseConfig = shouldRemoveOutputField
+        ? Object.fromEntries(
+            Object.entries(config).filter(
+              ([key]) => key !== "scenarioOutputField",
+            ),
+          )
+        : config;
+
       const updatedConfig: Record<string, unknown> = {
-        ...config,
+        ...baseConfig,
         ...((mappingsChanged || needsInitialMappings)
           ? { scenarioMappings: nextMappings }
           : {}),

--- a/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
+++ b/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
@@ -1,0 +1,127 @@
+/**
+ * Auto-computes scenarioMappings for workflow-linked agents when a workflow version is saved.
+ *
+ * This is a best-effort, non-blocking operation: any failure is caught and logged
+ * so that the workflow save is never blocked.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+import type { Edge, Node } from "@xyflow/react";
+import { computeBestMatchMappings } from "../scenarios/execution/resolve-field-mappings";
+import { getInputsOutputs } from "../../optimization_studio/utils/nodeUtils";
+
+/** Minimal DSL shape needed for I/O extraction — avoids importing the full Workflow type. */
+interface WorkflowDSL {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+/**
+ * Extracts normalized inputs and outputs from a workflow DSL.
+ *
+ * Replicates the client-side extractVariables helper server-side so we do not
+ * depend on browser-only modules.
+ */
+function extractVariablesFromDSL({ dsl }: { dsl: WorkflowDSL }): {
+  inputs: Array<{ identifier: string }>;
+  outputs: Array<{ identifier: string }>;
+} {
+  const { inputs: rawInputs, outputs: rawOutputs } = getInputsOutputs(
+    dsl.edges,
+    dsl.nodes,
+  );
+
+  const inputs = (rawInputs ?? []).flatMap(
+    (i): Array<{ identifier: string }> =>
+      typeof i.identifier === "string" ? [{ identifier: i.identifier }] : [],
+  );
+
+  const outputs = (Array.isArray(rawOutputs) ? rawOutputs : []).flatMap(
+    (o: unknown): Array<{ identifier: string }> => {
+      if (typeof o !== "object" || o === null) return [];
+      const field = o as { identifier?: unknown };
+      return typeof field.identifier === "string"
+        ? [{ identifier: field.identifier }]
+        : [];
+    },
+  );
+
+  return { inputs, outputs };
+}
+
+/**
+ * Auto-computes and persists scenarioMappings for all workflow-linked agents that
+ * have no mappings configured.
+ *
+ * Wrapped in try/catch so that any failure is logged and does not block the
+ * calling workflow save.
+ */
+export async function autoComputeAgentMappings({
+  prisma,
+  workflowId,
+  projectId,
+  dsl,
+}: {
+  prisma: PrismaClient;
+  workflowId: string;
+  projectId: string;
+  dsl: WorkflowDSL;
+}): Promise<void> {
+  try {
+    const agents = await prisma.agent.findMany({
+      where: {
+        workflowId,
+        projectId,
+        archivedAt: null,
+      },
+      select: { id: true, config: true },
+    });
+
+    if (agents.length === 0) return;
+
+    const { inputs, outputs } = extractVariablesFromDSL({ dsl });
+
+    const mappings = computeBestMatchMappings({ inputs });
+    const scenarioOutputField =
+      outputs[0]?.identifier !== undefined ? outputs[0].identifier : undefined;
+
+    for (const agent of agents) {
+      const config =
+        typeof agent.config === "object" && agent.config !== null
+          ? (agent.config as Record<string, unknown>)
+          : {};
+
+      // Only update agents that have no scenarioMappings configured
+      const existingMappings = config["scenarioMappings"];
+      if (
+        existingMappings !== undefined &&
+        existingMappings !== null &&
+        typeof existingMappings === "object" &&
+        Object.keys(existingMappings).length > 0
+      ) {
+        continue;
+      }
+
+      // Skip if there are no mappings to apply
+      if (Object.keys(mappings).length === 0) continue;
+
+      const updatedConfig: Record<string, unknown> = {
+        ...config,
+        scenarioMappings: mappings,
+        ...(scenarioOutputField !== undefined
+          ? { scenarioOutputField }
+          : {}),
+      };
+
+      await prisma.agent.update({
+        where: { id: agent.id, projectId },
+        data: { config: updatedConfig },
+      });
+    }
+  } catch (error) {
+    console.error(
+      "[autoComputeAgentMappings] Failed to auto-compute agent mappings:",
+      error,
+    );
+  }
+}

--- a/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
+++ b/langwatch/src/server/workflows/auto-compute-agent-mappings.ts
@@ -50,8 +50,52 @@ function extractVariablesFromDSL({ dsl }: { dsl: WorkflowDSL }): {
 }
 
 /**
+ * Identifiers used by the blank template's entry output and end input.
+ * When the workflow still has these exact placeholder fields, the user has not
+ * yet designed their workflow, so auto-compute should be skipped.
+ */
+const BLANK_TEMPLATE_INPUT = "question";
+const BLANK_TEMPLATE_OUTPUT = "output";
+
+/**
+ * Returns true when the DSL still matches the blank-template placeholders
+ * exactly — i.e. the user has not customised their workflow yet.
+ */
+function isBlankTemplateDSL({
+  inputs,
+  outputs,
+}: {
+  inputs: Array<{ identifier: string }>;
+  outputs: Array<{ identifier: string }>;
+}): boolean {
+  return (
+    inputs.length === 1 &&
+    inputs[0]!.identifier === BLANK_TEMPLATE_INPUT &&
+    outputs.length === 1 &&
+    outputs[0]!.identifier === BLANK_TEMPLATE_OUTPUT
+  );
+}
+
+/**
+ * Returns true when the agent's existing scenarioMappings contain at least one
+ * key that no longer exists as a workflow input identifier (stale mapping).
+ */
+function hasStaleMappings({
+  existingMappings,
+  inputs,
+}: {
+  existingMappings: Record<string, unknown>;
+  inputs: Array<{ identifier: string }>;
+}): boolean {
+  const inputIdentifiers = new Set(inputs.map((i) => i.identifier));
+  return Object.keys(existingMappings).some((key) => !inputIdentifiers.has(key));
+}
+
+/**
  * Auto-computes and persists scenarioMappings for all workflow-linked agents that
- * have no mappings configured.
+ * have no mappings configured, or whose existing mappings reference stale fields.
+ *
+ * Skips agents whose workflow still matches the blank-template placeholders.
  *
  * Wrapped in try/catch so that any failure is logged and does not block the
  * calling workflow save.
@@ -81,6 +125,9 @@ export async function autoComputeAgentMappings({
 
     const { inputs, outputs } = extractVariablesFromDSL({ dsl });
 
+    // Skip auto-compute for blank-template placeholder workflows
+    if (isBlankTemplateDSL({ inputs, outputs })) return;
+
     const mappings = computeBestMatchMappings({ inputs });
     const scenarioOutputField =
       outputs[0]?.identifier !== undefined ? outputs[0].identifier : undefined;
@@ -91,15 +138,20 @@ export async function autoComputeAgentMappings({
           ? (agent.config as Record<string, unknown>)
           : {};
 
-      // Only update agents that have no scenarioMappings configured
       const existingMappings = config["scenarioMappings"];
-      if (
+      const hasExistingMappings =
         existingMappings !== undefined &&
         existingMappings !== null &&
         typeof existingMappings === "object" &&
-        Object.keys(existingMappings).length > 0
-      ) {
-        continue;
+        Object.keys(existingMappings).length > 0;
+
+      if (hasExistingMappings) {
+        // Re-compute only when existing mappings reference fields that no longer exist
+        const stale = hasStaleMappings({
+          existingMappings: existingMappings as Record<string, unknown>,
+          inputs,
+        });
+        if (!stale) continue;
       }
 
       // Skip if there are no mappings to apply

--- a/specs/features/scenarios/workflow-agent-mapping-layer.feature
+++ b/specs/features/scenarios/workflow-agent-mapping-layer.feature
@@ -58,9 +58,9 @@ Feature: Workflow agent input/output mapping layer
     And the user can configure the mappings before running
 
   @integration
-  Scenario: Opens mapping drawer when workflow agent has incomplete mappings
+  Scenario: Opens mapping drawer when workflow agent has no input-field mapping
     Given a workflow agent selected as the scenario target
-    And the agent has scenarioMappings that do not cover all required fields
+    And the agent has scenarioMappings but none wire a source to scenario "input" or "messages"
     When the user clicks Save & Run
     Then the AgentWorkflowEditorDrawer opens instead of starting the run
 
@@ -140,7 +140,7 @@ Feature: Workflow agent input/output mapping layer
 # AC 1: "Auto-compute mappings on workflow save" → Scenario: Re-computes mappings when existing mappings reference stale fields
 # AC 1: "Auto-compute mappings on workflow save" → Scenario: Auto-compute does not block the workflow save on failure
 # AC 2: "Mapping drawer gate at Save & Run" → Scenario: Opens mapping drawer when running a scenario with an unmapped workflow agent
-# AC 2: "Mapping drawer gate at Save & Run" → Scenario: Opens mapping drawer when workflow agent has incomplete mappings
+# AC 2: "Mapping drawer gate at Save & Run" → Scenario: Opens mapping drawer when workflow agent has no input-field mapping
 # AC 2: "Mapping drawer gate at Save & Run" → Scenario: Scenario runs successfully after user configures mappings via drawer
 # AC 3: "Pre-run validation for multi-input workflows" → Scenario: Returns actionable error for multi-input workflow agent without mappings
 # AC 3: "Pre-run validation for multi-input workflows" → Scenario: Allows single-input workflow agent to run without explicit mappings

--- a/specs/features/scenarios/workflow-agent-mapping-layer.feature
+++ b/specs/features/scenarios/workflow-agent-mapping-layer.feature
@@ -9,7 +9,7 @@ Feature: Workflow agent input/output mapping layer
 
   # --- Layer 1: Auto-compute on workflow save ---
 
-  @integration
+  @unit
   Scenario: Auto-computes mappings when workflow with conventional inputs is saved
     Given a workflow agent linked to the scenario
     And the agent has no scenarioMappings configured

--- a/specs/features/scenarios/workflow-agent-mapping-layer.feature
+++ b/specs/features/scenarios/workflow-agent-mapping-layer.feature
@@ -111,15 +111,40 @@ Feature: Workflow agent input/output mapping layer
     Then the ScenarioInputMappingSection is displayed
     And the user can view and modify the scenarioMappings
 
+  # --- Layer 5: Agents list edit routing ---
+
+  @integration
+  Scenario: Editing a workflow agent from the agents list opens the editor populated with existing data
+    Given an existing workflow agent with a saved workflow and configured scenarioMappings
+    And the user is on the /[project]/agents page
+    When the user clicks edit on the workflow agent card
+    Then AgentWorkflowEditorDrawer opens with the agent id
+    And the drawer is populated with the agent's name, linked workflow, and scenarioMappings
+    And WorkflowSelectorDrawer is not opened
+
+  @unit
+  Scenario Outline: Agents page routes each agent type to its matching editor drawer
+    Given the /[project]/agents page edit handler
+    When the user edits a "<type>" agent
+    Then the drawer name resolved for editing is "<drawer>"
+
+    Examples:
+      | type     | drawer              |
+      | code     | agentCodeEditor     |
+      | http     | agentHttpEditor     |
+      | workflow | agentWorkflowEditor |
+
 # --- AC Coverage Map ---
 # AC 1: "Auto-compute mappings on workflow save" → Scenario: Auto-computes mappings when workflow with conventional inputs is saved
 # AC 1: "Auto-compute mappings on workflow save" → Scenario: Skips auto-compute when workflow still has blank-template placeholder fields
 # AC 1: "Auto-compute mappings on workflow save" → Scenario: Re-computes mappings when existing mappings reference stale fields
 # AC 1: "Auto-compute mappings on workflow save" → Scenario: Auto-compute does not block the workflow save on failure
-# AC 2: "Auto-open mapping drawer on target selection" → Scenario: Opens mapping drawer when running a scenario with an unmapped workflow agent
-# AC 2: "Auto-open mapping drawer on target selection" → Scenario: Opens mapping drawer when workflow agent has incomplete mappings
-# AC 2: "Auto-open mapping drawer on target selection" → Scenario: Scenario runs successfully after user configures mappings via drawer
-# AC 3: "Pre-run validation for incomplete mappings" → Scenario: Returns actionable error for multi-input workflow agent without mappings
-# AC 3: "Pre-run validation for incomplete mappings" → Scenario: Allows single-input workflow agent to run without explicit mappings
+# AC 2: "Mapping drawer gate at Save & Run" → Scenario: Opens mapping drawer when running a scenario with an unmapped workflow agent
+# AC 2: "Mapping drawer gate at Save & Run" → Scenario: Opens mapping drawer when workflow agent has incomplete mappings
+# AC 2: "Mapping drawer gate at Save & Run" → Scenario: Scenario runs successfully after user configures mappings via drawer
+# AC 3: "Pre-run validation for multi-input workflows" → Scenario: Returns actionable error for multi-input workflow agent without mappings
+# AC 3: "Pre-run validation for multi-input workflows" → Scenario: Allows single-input workflow agent to run without explicit mappings
 # AC 4: "No change to the current create flow" → Scenario: Create flow navigates directly to workflow studio without mapping panel
 # AC 5: "Existing edit path unchanged" → Scenario: Edit flow continues to show mapping panel as before
+# AC 6: "Edit from agents list opens the edit drawer, not the create drawer" → Scenario: Editing a workflow agent from the agents list opens the editor populated with existing data
+# AC 6: "Edit from agents list opens the edit drawer, not the create drawer" → Scenario: Agents list routes each agent type to its matching editor drawer

--- a/specs/features/scenarios/workflow-agent-mapping-layer.feature
+++ b/specs/features/scenarios/workflow-agent-mapping-layer.feature
@@ -1,0 +1,125 @@
+Feature: Workflow agent input/output mapping layer
+  As a scenario author
+  I want workflow agents to have their inputs and outputs mapped to the scenario contract
+  So that scenario runs against workflow agents succeed without manual wiring guesswork
+
+  Background:
+    Given a project with a scenario that expects "input" and "messages" fields
+    And the scenario expects "response" as the agent output
+
+  # --- Layer 1: Auto-compute on workflow save ---
+
+  @integration
+  Scenario: Auto-computes mappings when workflow with conventional inputs is saved
+    Given a workflow agent linked to the scenario
+    And the agent has no scenarioMappings configured
+    And the workflow has inputs named "query" and "history"
+    And the workflow has an output named "response"
+    When the workflow version is saved
+    Then the agent's scenarioMappings map "query" to the scenario "input" field
+    And the agent's scenarioMappings map "history" to the scenario "messages" field
+    And the agent's scenarioMappings map the workflow output "response" to the scenario output
+
+  @unit
+  Scenario: Skips auto-compute when workflow still has blank-template placeholder fields
+    Given a workflow agent linked to the scenario
+    And the agent has no scenarioMappings configured
+    And the workflow has the default blank-template inputs "question" and output "output"
+    When the workflow version is saved
+    Then the agent's scenarioMappings remain empty
+
+  @unit
+  Scenario: Re-computes mappings when existing mappings reference stale fields
+    Given a workflow agent linked to the scenario
+    And the agent has scenarioMappings referencing a field "old_query" that no longer exists
+    And the workflow now has an input named "prompt"
+    When the workflow version is saved
+    Then the agent's scenarioMappings are re-computed against the current workflow I/O
+    And the stale "old_query" mapping is replaced
+
+  @unit
+  Scenario: Auto-compute does not block the workflow save on failure
+    Given a workflow agent linked to the scenario
+    And the agent has no scenarioMappings configured
+    And the auto-compute logic encounters an error
+    When the workflow version is saved
+    Then the workflow save succeeds
+    And the error is logged
+    And the agent's scenarioMappings remain empty
+
+  # --- Layer 2: Client-side mapping check at Save & Run ---
+
+  @integration
+  Scenario: Opens mapping drawer when running a scenario with an unmapped workflow agent
+    Given a workflow agent selected as the scenario target
+    And the agent has empty scenarioMappings
+    When the user clicks Save & Run
+    Then the AgentWorkflowEditorDrawer opens instead of starting the run
+    And the user can configure the mappings before running
+
+  @integration
+  Scenario: Opens mapping drawer when workflow agent has incomplete mappings
+    Given a workflow agent selected as the scenario target
+    And the agent has scenarioMappings that do not cover all required fields
+    When the user clicks Save & Run
+    Then the AgentWorkflowEditorDrawer opens instead of starting the run
+
+  @e2e
+  Scenario: Scenario runs successfully after user configures mappings via drawer
+    Given a workflow agent selected as the scenario target
+    And the agent has empty scenarioMappings
+    When the user clicks Save & Run
+    And the mapping drawer opens
+    And the user configures valid mappings and saves
+    And the user clicks Save & Run again
+    Then the scenario run executes successfully
+
+  # --- Layer 3: Pre-run validation ---
+
+  @integration
+  Scenario: Returns actionable error for multi-input workflow agent without mappings
+    Given a workflow agent as the scenario target
+    And the workflow has multiple declared inputs
+    And the agent has no scenarioMappings configured
+    When the scenario run is triggered via any entry point
+    Then the run returns a structured validation error
+    And the error message directs the user to configure mappings
+
+  @unit
+  Scenario: Allows single-input workflow agent to run without explicit mappings
+    Given a workflow agent as the scenario target
+    And the workflow has exactly one declared input
+    And the agent has no scenarioMappings configured
+    When the scenario run is triggered
+    Then the run proceeds using the legacy single-input fallback
+    And no validation error is raised
+
+  # --- Layer 4: Existing flows unchanged ---
+
+  @integration
+  Scenario: Create flow navigates directly to workflow studio without mapping panel
+    Given the user is creating a new workflow agent from the scenario form
+    When the user submits the WorkflowSelectorDrawer
+    Then a blank workflow and linked agent are created
+    And the user is navigated to the workflow studio
+    And no mapping drawer or panel is shown during creation
+
+  @integration
+  Scenario: Edit flow continues to show mapping panel as before
+    Given an existing workflow agent with a saved workflow
+    When the user opens the agent for editing via AgentWorkflowEditorDrawer
+    Then the ScenarioInputMappingSection is displayed
+    And the user can view and modify the scenarioMappings
+
+# --- AC Coverage Map ---
+# AC 1: "Auto-compute mappings on workflow save" → Scenario: Auto-computes mappings when workflow with conventional inputs is saved
+# AC 1: "Auto-compute mappings on workflow save" → Scenario: Skips auto-compute when workflow still has blank-template placeholder fields
+# AC 1: "Auto-compute mappings on workflow save" → Scenario: Re-computes mappings when existing mappings reference stale fields
+# AC 1: "Auto-compute mappings on workflow save" → Scenario: Auto-compute does not block the workflow save on failure
+# AC 2: "Auto-open mapping drawer on target selection" → Scenario: Opens mapping drawer when running a scenario with an unmapped workflow agent
+# AC 2: "Auto-open mapping drawer on target selection" → Scenario: Opens mapping drawer when workflow agent has incomplete mappings
+# AC 2: "Auto-open mapping drawer on target selection" → Scenario: Scenario runs successfully after user configures mappings via drawer
+# AC 3: "Pre-run validation for incomplete mappings" → Scenario: Returns actionable error for multi-input workflow agent without mappings
+# AC 3: "Pre-run validation for incomplete mappings" → Scenario: Allows single-input workflow agent to run without explicit mappings
+# AC 4: "No change to the current create flow" → Scenario: Create flow navigates directly to workflow studio without mapping panel
+# AC 5: "Existing edit path unchanged" → Scenario: Edit flow continues to show mapping panel as before


### PR DESCRIPTION
## Summary

- Auto-compute `scenarioMappings` on workflow save — when a workflow linked to an agent is saved, extract entry/end node I/O and persist best-match mappings to the agent config (non-blocking, fire-and-forget)
- Gate at Save & Run — before running a scenario with a workflow agent that has missing/incomplete mappings, open the existing `AgentWorkflowEditorDrawer` with a warning toast
- Pre-run server validation — multi-input workflow agents without mappings get a `BAD_REQUEST` error instead of a cryptic 500; single-input workflows keep the legacy fallback
- Agents list edit routing — `getAgentEditorDrawer` helper routes each agent type to its matching editor drawer (workflow agents go to `agentWorkflowEditor`, not `workflowSelector` which is create-only)

Closes #3201

## Follow-ups

- Follow-up: #3368 — post-#3201 cleanups (drawer unify + test tightening + DRY + function complexity)
- Related: #3362 — unwired entry fields invisible in mapping UI (surfaced during testing)
- Related: #3365 — scenario runs orphan at QUEUED when worker maxRuntime restart kills child process (infra race surfaced during testing)

## Test plan

- [ ] Unit tests: `auto-compute-agent-mappings.unit.test.ts` (13 tests) — auto-compute, blank-template skip, stale-field re-compute, preserve non-stale on partial staleness, repair stale `scenarioOutputField`, remove stale `scenarioOutputField` when no replacement output exists, non-blocking on failure
- [ ] Unit tests: `validate-workflow-mappings.unit.test.ts` (9 tests) — multi-input validation, single-input passthrough
- [ ] Unit tests: `getAgentEditorDrawer.unit.test.ts` (4 tests) — per-type drawer routing + signature throws
- [ ] Integration tests: `ScenarioFormDrawer.mapping-gate.integration.test.tsx` (4 tests) — drawer opens for unmapped / no-input-field-mapping, passes through for code agents
- [ ] Manual: create workflow agent → design in studio → Save & Run on scenario → mapping drawer appears → configure → runs successfully
- [ ] Manual: verify create flow unchanged (WorkflowSelectorDrawer → studio)
- [ ] Manual: verify edit flow unchanged (AgentWorkflowEditorDrawer)
- [ ] Manual: edit workflow agent from agents list → opens `AgentWorkflowEditorDrawer` populated with existing mappings (not `WorkflowSelectorDrawer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3201
