### PR TITLE
feat(analytics): expose span-type filter in dashboard filter sidebar

### DIFF
--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -94,6 +94,7 @@ export function FieldsFilters({
 	const filterKeys: FilterField[] = [
 		"traces.origin",
 		"metadata.prompt_ids",
+		"spans.type",
 		"spans.model",
 		"metadata.labels",
 		"evaluations.passed",


### PR DESCRIPTION
## Summary

- Add `"spans.type"` to the `filterKeys` array in `FieldsFilters.tsx` so "Span Type" appears in the analytics filter sidebar and per-series filter drawer.

The entire backend infrastructure was already in place (field mapping, filter translator, filter options query, group-by support) — it was just never surfaced in the UI list.

## Context

Flagged by Rogerio during the April 9 Backspace sync. Users building dashboards that isolate behavior of specific span types (LLM, tool, retrieval, etc.) couldn't filter by span type in analytics despite it being available in the dataset builder.

## What this enables

- Filter dashboard graphs by span type (llm, tool, chain, agent, retrieval, rag, etc.)
- Compose span-type filter with all other existing filters (model, labels, metadata, evaluations)
- Group-by "Span Type" already worked — now filtering matches

Closes #3339

## Test plan

- [ ] Open analytics dashboard, verify "Span Type" appears in filter sidebar
- [ ] Select a span type (e.g. "llm"), confirm graph data updates to only show matching spans
- [ ] Open custom graph editor → series filter drawer, verify "Span Type" is available there too
- [ ] Combine with another filter (e.g. model), confirm composition works

# Related Issue

- Resolve #3339