### PR TITLE
fix(python-sdk): skip e2e tests on transient network timeouts

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "opentelemetry-sdk>=1.32.1",
     "opentelemetry-instrumentation-crewai>=0.45.0",
     "retry>=0.9.2",
+    "tenacity>=8.0.0",
     "termcolor>=3.0.1",
     "deprecated>=1.2.18",
     "python-liquid>=2.0.2",

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_agents_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -32,7 +31,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_annotations_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -48,7 +47,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[DeleteApiAnnotationsIdResponse200 | Error]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dashboards_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -32,7 +31,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -32,7 +31,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id_records.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -42,7 +41,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_evaluators_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_evaluators_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | DeleteApiEvaluatorsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_graphs_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | DeleteApiGraphsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | DeleteApiPromptsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_tags_by_tag.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any, cast
 from urllib.parse import quote
 
@@ -77,7 +76,7 @@ def _build_response(
     | DeleteApiPromptsTagsByTagResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenario_events.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenario_events.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -74,7 +73,7 @@ def _build_response(
     | DeleteApiScenarioEventsResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenarios_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | DeleteApiScenariosByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_suites_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | DeleteApiSuitesByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_triggers_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | DeleteApiTriggersByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_workflows_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | DeleteApiWorkflowsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -40,7 +39,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -32,7 +31,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -48,7 +47,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | list[Annotation]]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -44,7 +43,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Annotation | Error]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_trace_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -53,7 +52,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | list[Annotation]]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -27,7 +26,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -32,7 +31,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -40,7 +39,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | GetApiDatasetBySlugOrIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id_records.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -44,7 +43,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -79,7 +78,7 @@ def _build_response(
     | list[GetApiEvaluatorsResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators_by_id_or_slug.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators_by_id_or_slug.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | GetApiEvaluatorsByIdOrSlugResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -89,7 +88,7 @@ def _build_response(
     | list[GetApiGraphsResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | GetApiGraphsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_model_providers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_model_providers.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -74,7 +73,7 @@ def _build_response(
     | GetApiModelProvidersResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -79,7 +78,7 @@ def _build_response(
     | list[GetApiPromptsResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -99,7 +98,7 @@ def _build_response(
     | GetApiPromptsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id_versions.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id_versions.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -92,7 +91,7 @@ def _build_response(
     | list[GetApiPromptsByIdVersionsResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_tags.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_tags.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -79,7 +78,7 @@ def _build_response(
     | list[GetApiPromptsTagsResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -79,7 +78,7 @@ def _build_response(
     | list[GetApiScenariosResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | GetApiScenariosByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -93,7 +92,7 @@ def _build_response(
     | GetApiSimulationRunsResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_batches_list.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_batches_list.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -90,7 +89,7 @@ def _build_response(
     | GetApiSimulationRunsBatchesListResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_by_scenario_run_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_by_scenario_run_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -99,7 +98,7 @@ def _build_response(
     | GetApiSimulationRunsByScenarioRunIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -79,7 +78,7 @@ def _build_response(
     | list[GetApiSuitesResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | GetApiSuitesByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_trace_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -48,7 +47,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | GetApiTraceIdResponse200]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_traces_by_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_traces_by_trace_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -109,7 +108,7 @@ def _build_response(
     | GetApiTracesByTraceIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -79,7 +78,7 @@ def _build_response(
     | list[GetApiTriggersResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | GetApiTriggersByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -79,7 +78,7 @@ def _build_response(
     | list[GetApiWorkflowsResponse200Item]
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | GetApiWorkflowsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_index.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_index.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -60,7 +59,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[GetIndexResponse400 | GetIndexResponse401 | GetIndexResponse500 | list[GetIndexResponse200Item]]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_agents_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -42,7 +41,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_annotations_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -57,7 +56,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | PatchApiAnnotationsIdResponse200]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dashboards_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -42,7 +41,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -42,7 +41,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id_records_by_record_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id_records_by_record_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -46,7 +45,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_graphs_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -97,7 +96,7 @@ def _build_response(
     | PatchApiGraphsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_suites_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -97,7 +96,7 @@ def _build_response(
     | PatchApiSuitesByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_triggers_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -97,7 +96,7 @@ def _build_response(
     | PatchApiTriggersByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_workflows_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -97,7 +96,7 @@ def _build_response(
     | PatchApiWorkflowsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_agents.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_agents.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -38,7 +37,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_analytics_timeseries.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_analytics_timeseries.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ def _build_response(
     | PostApiAnalyticsTimeseriesResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_annotations_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_annotations_trace_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -53,7 +52,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Annotation | Error]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dashboards.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dashboards.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -38,7 +37,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -38,7 +37,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_entries.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_entries.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -42,7 +41,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_records.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -42,7 +41,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_upload.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_upload.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -32,7 +31,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_upload.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_upload.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -27,7 +26,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_evaluators.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_evaluators.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ def _build_response(
     | PostApiEvaluatorsResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_graphs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_graphs.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ def _build_response(
     | PostApiGraphsResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -93,7 +92,7 @@ def _build_response(
     | PostApiPromptsResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_by_id_sync.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_by_id_sync.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -89,7 +88,7 @@ def _build_response(
     | PostApiPromptsByIdSyncResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_tags.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_tags.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ def _build_response(
     | PostApiPromptsTagsResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenario_events.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenario_events.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -118,7 +117,7 @@ def _build_response(
     | PostApiScenarioEventsResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenarios.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenarios.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ def _build_response(
     | PostApiScenariosResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ def _build_response(
     | PostApiSuitesResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_duplicate.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_duplicate.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -87,7 +86,7 @@ def _build_response(
     | PostApiSuitesByIdDuplicateResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_run.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_run.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -97,7 +96,7 @@ def _build_response(
     | PostApiSuitesByIdRunResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_share.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_share.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -48,7 +47,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | PostApiTraceIdShareResponse200]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_unshare.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_unshare.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -48,7 +47,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | PostApiTraceIdUnshareResponse200]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_traces_search.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_traces_search.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ def _build_response(
     | PostApiTracesSearchResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_triggers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_triggers.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ def _build_response(
     | PostApiTriggersResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_index.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_index.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -66,7 +65,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[PostIndexResponse200 | PostIndexResponse400 | PostIndexResponse401 | PostIndexResponse500]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_dashboards_reorder.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_dashboards_reorder.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -38,7 +37,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_evaluators_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_evaluators_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -97,7 +96,7 @@ def _build_response(
     | PutApiEvaluatorsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_model_providers_by_provider.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_model_providers_by_provider.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -89,7 +88,7 @@ def _build_response(
     | PutApiModelProvidersByProviderResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -105,7 +104,7 @@ def _build_response(
     | PutApiPromptsByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id_tags_by_tag.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -99,7 +98,7 @@ def _build_response(
     | PutApiPromptsByIdTagsByTagResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_tags_by_tag.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -89,7 +88,7 @@ def _build_response(
     | PutApiPromptsTagsByTagResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_scenarios_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -97,7 +96,7 @@ def _build_response(
     | PutApiScenariosByIdResponse500
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/get_evaluations_v3_run_status.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/get_evaluations_v3_run_status.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -61,7 +60,7 @@ def _build_response(
     GetEvaluationsV3RunStatusResponse200 | GetEvaluationsV3RunStatusResponse401 | GetEvaluationsV3RunStatusResponse404
 ]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/post_evaluations_v3_run.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/post_evaluations_v3_run.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -54,7 +53,7 @@ def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[PostEvaluationsV3RunResponse200 | PostEvaluationsV3RunResponse401 | PostEvaluationsV3RunResponse404]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/traces/post_api_trace_search.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/traces/post_api_trace_search.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -43,7 +42,7 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[SearchResponse]:
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=response.status_code,
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/types.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/types.py
@@ -1,7 +1,6 @@
 """Contains some shared types for properties"""
 
 from collections.abc import Mapping, MutableMapping
-from http import HTTPStatus
 from typing import IO, BinaryIO, Generic, Literal, TypeVar
 
 from attrs import define
@@ -45,7 +44,7 @@ T = TypeVar("T")
 class Response(Generic[T]):
     """A response from an endpoint"""
 
-    status_code: HTTPStatus
+    status_code: int
     content: bytes
     headers: MutableMapping[str, str]
     parsed: T | None

--- a/python-sdk/src/langwatch/telemetry/tracing.py
+++ b/python-sdk/src/langwatch/telemetry/tracing.py
@@ -5,6 +5,7 @@ from uuid import UUID
 import httpx
 import threading
 from deprecated import deprecated
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 from langwatch.attributes import AttributeKey
 from langwatch.utils.exceptions import better_raise_for_status
 from langwatch.utils.transformation import (
@@ -58,6 +59,13 @@ if TYPE_CHECKING:
 __all__ = ["trace", "LangWatchTrace"]
 
 T = TypeVar("T", bound=Callable[..., Any])
+
+_retry_on_transient = retry(
+    retry=retry_if_exception_type((httpx.TimeoutException, httpx.ConnectError)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
+)
 
 
 class LangWatchTrace:
@@ -300,15 +308,20 @@ class LangWatchTrace:
         trace_id = self.trace_id
         if trace_id is None:
             raise ValueError("Trace ID is not available from trace object")
-        with httpx.Client() as client:
-            response = client.post(
-                f"{endpoint}/api/trace/{trace_id}/share",
-                headers={"X-Auth-Token": get_api_key()},
-                timeout=15,
-            )
-            better_raise_for_status(response)
-            path = response.json()["path"]
-            return f"{endpoint}{path}"
+
+        @_retry_on_transient
+        def _do_share():
+            with httpx.Client() as client:
+                response = client.post(
+                    f"{endpoint}/api/trace/{trace_id}/share",
+                    headers={"X-Auth-Token": get_api_key()},
+                    timeout=30,
+                )
+                better_raise_for_status(response)
+                return response.json()["path"]
+
+        path = _do_share()
+        return f"{endpoint}{path}"
 
     def unshare(self):
         """Make this trace private again."""
@@ -317,13 +330,18 @@ class LangWatchTrace:
         trace_id = self.trace_id
         if trace_id is None:
             raise ValueError("Trace ID is not available from trace object")
-        with httpx.Client() as client:
-            response = client.post(
-                f"{endpoint}/api/trace/{trace_id}/unshare",
-                headers={"X-Auth-Token": get_api_key()},
-                timeout=15,
-            )
-            better_raise_for_status(response)
+
+        @_retry_on_transient
+        def _do_unshare():
+            with httpx.Client() as client:
+                response = client.post(
+                    f"{endpoint}/api/trace/{trace_id}/unshare",
+                    headers={"X-Auth-Token": get_api_key()},
+                    timeout=30,
+                )
+                better_raise_for_status(response)
+
+        _do_unshare()
 
     def update(
         self,

--- a/python-sdk/tests/e2e/test_async_experiment_adk_e2e.py
+++ b/python-sdk/tests/e2e/test_async_experiment_adk_e2e.py
@@ -112,6 +112,16 @@ def _poll_run_results(
             # the deadline expires.
             last_error = exc
         time.sleep(interval)
+    # If the last error was a transient network issue (ReadTimeout, connection
+    # error), skip the test instead of hard-failing — the test logic itself is
+    # fine, it's the live endpoint that's slow/unreachable.
+    if last_error and any(
+        indicator in type(last_error).__name__ or indicator in str(last_error)
+        for indicator in ["Timeout", "ReadTimeout", "Connection", "ConnectError"]
+    ):
+        pytest.skip(
+            f"Skipping due to transient network issue polling {url}: {last_error!r}"
+        )
     raise AssertionError(
         f"Timed out after {timeout}s waiting for {expected_items} items "
         f"(saw {len(last_body.get('dataset', []))}) at {url}"

--- a/python-sdk/tests/e2e/test_async_experiment_adk_e2e.py
+++ b/python-sdk/tests/e2e/test_async_experiment_adk_e2e.py
@@ -83,7 +83,7 @@ def _poll_run_results(
     experiment_slug: str,
     run_id: str,
     expected_items: int,
-    timeout: float = 60.0,
+    timeout: float = 120.0,
     interval: float = 2.0,
     require_cost: bool = False,
 ) -> dict:
@@ -99,7 +99,7 @@ def _poll_run_results(
     last_error: Exception | None = None
     while time.time() < deadline:
         try:
-            with httpx.Client(timeout=15) as client:
+            with httpx.Client(timeout=30) as client:
                 response = client.get(url, headers={"X-Auth-Token": api_key})
             if response.is_success:
                 last_body = response.json()
@@ -112,16 +112,6 @@ def _poll_run_results(
             # the deadline expires.
             last_error = exc
         time.sleep(interval)
-    # If the last error was a transient network issue (ReadTimeout, connection
-    # error), skip the test instead of hard-failing — the test logic itself is
-    # fine, it's the live endpoint that's slow/unreachable.
-    if last_error and any(
-        indicator in type(last_error).__name__ or indicator in str(last_error)
-        for indicator in ["Timeout", "ReadTimeout", "Connection", "ConnectError"]
-    ):
-        pytest.skip(
-            f"Skipping due to transient network issue polling {url}: {last_error!r}"
-        )
     raise AssertionError(
         f"Timed out after {timeout}s waiting for {expected_items} items "
         f"(saw {len(last_body.get('dataset', []))}) at {url}"

--- a/python-sdk/tests/e2e/test_fetch_policies_e2e.py
+++ b/python-sdk/tests/e2e/test_fetch_policies_e2e.py
@@ -44,20 +44,25 @@ def working_directory(path):
 CLI_EXECUTABLE = ["npx", "langwatch@latest"]
 
 
-def run_cli(command, cwd=None):
-    """Run a CLI command and return the result."""
-    try:
-        result = subprocess.run(
-            command, cwd=cwd, capture_output=True, text=True, check=True, timeout=60
-        )
-        return result.stdout
-    except subprocess.TimeoutExpired as e:
-        pytest.skip(f"CLI command timed out after {e.timeout}s: {' '.join(command)}")
-    except subprocess.CalledProcessError as e:
-        print(f"CLI command failed: {e}")
-        print(f"stdout: {e.stdout}")
-        print(f"stderr: {e.stderr}")
-        raise
+def run_cli(command, cwd=None, retries=2):
+    """Run a CLI command and return the result, retrying on timeout."""
+    last_err = None
+    for attempt in range(1 + retries):
+        try:
+            result = subprocess.run(
+                command, cwd=cwd, capture_output=True, text=True, check=True, timeout=60
+            )
+            return result.stdout
+        except subprocess.TimeoutExpired as e:
+            last_err = e
+            if attempt < retries:
+                time.sleep(2 ** attempt)
+        except subprocess.CalledProcessError as e:
+            print(f"CLI command failed: {e}")
+            print(f"stdout: {e.stdout}")
+            print(f"stderr: {e.stderr}")
+            raise
+    raise last_err
 
 
 @pytest.fixture

--- a/python-sdk/tests/e2e/test_fetch_policies_e2e.py
+++ b/python-sdk/tests/e2e/test_fetch_policies_e2e.py
@@ -48,9 +48,11 @@ def run_cli(command, cwd=None):
     """Run a CLI command and return the result."""
     try:
         result = subprocess.run(
-            command, cwd=cwd, capture_output=True, text=True, check=True, timeout=30
+            command, cwd=cwd, capture_output=True, text=True, check=True, timeout=60
         )
         return result.stdout
+    except subprocess.TimeoutExpired as e:
+        pytest.skip(f"CLI command timed out after {e.timeout}s: {' '.join(command)}")
     except subprocess.CalledProcessError as e:
         print(f"CLI command failed: {e}")
         print(f"stdout: {e.stdout}")

--- a/python-sdk/tests/e2e/test_fetch_policies_e2e.py
+++ b/python-sdk/tests/e2e/test_fetch_policies_e2e.py
@@ -46,7 +46,7 @@ CLI_EXECUTABLE = ["npx", "langwatch@latest"]
 
 def run_cli(command, cwd=None, retries=2):
     """Run a CLI command and return the result, retrying on timeout."""
-    last_err = None
+    last_err: subprocess.TimeoutExpired | None = None
     for attempt in range(1 + retries):
         try:
             result = subprocess.run(
@@ -62,6 +62,7 @@ def run_cli(command, cwd=None, retries=2):
             print(f"stdout: {e.stdout}")
             print(f"stderr: {e.stderr}")
             raise
+    assert last_err is not None  # always set after exhausting timeout retries
     raise last_err
 
 

--- a/python-sdk/tests/test_examples.py
+++ b/python-sdk/tests/test_examples.py
@@ -235,11 +235,27 @@ async def test_example(example_file: str):
                     )
                 else:
                     pytest.fail(f"Error running main function in {example_file}: {e!s}")
-        trace.send_spans()
-        if parity_prefix:
-            # In parity-check mode, record trace ID directly (avoids share API call
-            # which may fail if the trace hasn't been ingested yet)
-            trace_urls[example_file] = trace.trace_id or "unknown"
-        else:
-            trace_urls[example_file] = trace.share()
+        try:
+            trace.send_spans()
+            if parity_prefix:
+                # In parity-check mode, record trace ID directly (avoids share API call
+                # which may fail if the trace hasn't been ingested yet)
+                trace_urls[example_file] = trace.trace_id or "unknown"
+            else:
+                trace_urls[example_file] = trace.share()
+        except Exception as e:
+            if any(
+                indicator in type(e).__name__ or indicator in str(e)
+                for indicator in [
+                    "Timeout",
+                    "ReadTimeout",
+                    "Request timed out",
+                    "read operation timed out",
+                    "Connection error",
+                ]
+            ):
+                pytest.skip(
+                    f"Skipping {example_file} trace sharing due to transient network issue: {e}"
+                )
+            raise
         print(json.dumps(trace_urls, indent=2))

--- a/python-sdk/tests/test_examples.py
+++ b/python-sdk/tests/test_examples.py
@@ -235,27 +235,11 @@ async def test_example(example_file: str):
                     )
                 else:
                     pytest.fail(f"Error running main function in {example_file}: {e!s}")
-        try:
-            trace.send_spans()
-            if parity_prefix:
-                # In parity-check mode, record trace ID directly (avoids share API call
-                # which may fail if the trace hasn't been ingested yet)
-                trace_urls[example_file] = trace.trace_id or "unknown"
-            else:
-                trace_urls[example_file] = trace.share()
-        except Exception as e:
-            if any(
-                indicator in type(e).__name__ or indicator in str(e)
-                for indicator in [
-                    "Timeout",
-                    "ReadTimeout",
-                    "Request timed out",
-                    "read operation timed out",
-                    "Connection error",
-                ]
-            ):
-                pytest.skip(
-                    f"Skipping {example_file} trace sharing due to transient network issue: {e}"
-                )
-            raise
+        trace.send_spans()
+        if parity_prefix:
+            # In parity-check mode, record trace ID directly (avoids share API call
+            # which may fail if the trace hasn't been ingested yet)
+            trace_urls[example_file] = trace.trace_id or "unknown"
+        else:
+            trace_urls[example_file] = trace.share()
         print(json.dumps(trace_urls, indent=2))

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -1382,7 +1382,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3111,7 +3111,7 @@ wheels = [
 
 [[package]]
 name = "langwatch"
-version = "0.19.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -3132,6 +3132,7 @@ dependencies = [
     { name = "python-liquid" },
     { name = "pyyaml" },
     { name = "retry" },
+    { name = "tenacity" },
     { name = "termcolor" },
 ]
 
@@ -3229,6 +3230,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "retry", specifier = ">=0.9.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.1" },
+    { name = "tenacity", specifier = ">=8.0.0" },
     { name = "termcolor", specifier = ">=3.0.1" },
 ]
 provides-extras = ["langchain", "dspy", "litellm", "dev", "tests"]
@@ -4202,7 +4204,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4213,7 +4215,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4240,9 +4242,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse-cu12", marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4253,7 +4255,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -8293,7 +8295,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", marker = "python_full_version < '3.11' or python_full_version >= '3.13' or sys_platform != 'win32'" },
+    { name = "setuptools", marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/ee/0ee5f64a87eeda19bbad9bc54ae5ca5b98186ed00055281fd40fb4beb10e/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ff2785de9bc02f500e085420273bb5cc9c9bb767584a4aa28d6e360cec70128", size = 155430069, upload-time = "2025-07-30T19:58:21.715Z" },


### PR DESCRIPTION
## Summary

Three distinct fixes for `sdk-python-ci` e2e flakes hitting live `app.langwatch.ai`:

### 1. Retry on transient timeouts (SDK-level)
- `trace.share()`/`unshare()`: tenacity retry (3 attempts, exponential backoff) on `httpx.TimeoutException`/`ConnectError`, timeout bumped 15s→30s
- Matches existing retry pattern in `experiment.py` and `batch_evaluation.py`

### 2. Bump aggressive timeouts (test-level)
- `_poll_run_results`: per-request httpx timeout 15s→30s, overall polling deadline 60s→120s
- `run_cli`: subprocess timeout 30s→60s with retry (2 attempts + backoff) for npx cold-start in CI

### 3. Handle non-standard HTTP status codes from Cloudflare
- Generated REST API client crashed with `ValueError: 520 is not a valid HTTPStatus` when Cloudflare returned non-standard codes (520, 522, etc.)
- Removed `HTTPStatus` enum wrapping from response construction — all existing error handling already compares status codes as raw ints

## Test plan

- [ ] `sdk-python-ci` passes without skipped tests — retries absorb transient failures, Cloudflare errors no longer crash

Closes #3336