### PR TITLE
fix(triggers): dedup before fetch and cap examined groups at 1k

### DIFF
--- a/langwatch/src/pages/api/cron/triggers/__tests__/traceBasedTrigger.test.ts
+++ b/langwatch/src/pages/api/cron/triggers/__tests__/traceBasedTrigger.test.ts
@@ -42,7 +42,6 @@ vi.mock("../actions/addToDataset", () => ({
 
 vi.mock("../utils", () => ({
   addTriggersSent: vi.fn(),
-  getLatestUpdatedAt: vi.fn(() => 1234567890),
   triggerSentForMany: vi.fn(() => []),
   updateAlert: vi.fn(),
 }));
@@ -51,12 +50,7 @@ import { handleAddToAnnotationQueue } from "../actions/addToAnnotationQueue";
 import { handleAddToDataset } from "../actions/addToDataset";
 import { handleSendEmail } from "../actions/sendEmail";
 import { handleSendSlackMessage } from "../actions/sendSlackMessage";
-import {
-  addTriggersSent,
-  getLatestUpdatedAt,
-  triggerSentForMany,
-  updateAlert,
-} from "../utils";
+import { addTriggersSent, triggerSentForMany, updateAlert } from "../utils";
 
 describe("processTraceBasedTrigger", () => {
   const mockProjects: Project[] = [
@@ -108,7 +102,7 @@ describe("processTraceBasedTrigger", () => {
 
       expect(result).toEqual({
         triggerId: "trigger-1",
-        updatedAt: 1234567890,
+        updatedAt: 2000,
         status: "triggered",
         totalFound: 2,
       });
@@ -181,11 +175,7 @@ describe("processTraceBasedTrigger", () => {
 
       await processTraceBasedTrigger(trigger, mockProjects);
 
-      expect(updateAlert).toHaveBeenCalledWith(
-        "trigger-1",
-        1234567890,
-        "project-1",
-      );
+      expect(updateAlert).toHaveBeenCalledWith("trigger-1", 1000, "project-1");
     });
   });
 

--- a/langwatch/src/pages/api/cron/triggers/traceBasedTrigger.ts
+++ b/langwatch/src/pages/api/cron/triggers/traceBasedTrigger.ts
@@ -8,13 +8,9 @@ import { handleAddToAnnotationQueue } from "./actions/addToAnnotationQueue";
 import { handleAddToDataset } from "./actions/addToDataset";
 import { handleSendEmail } from "./actions/sendEmail";
 import { handleSendSlackMessage } from "./actions/sendSlackMessage";
+import type { Trace } from "~/server/tracer/types";
 import type { TraceGroups, TriggerData, TriggerResult } from "./types";
-import {
-  addTriggersSent,
-  getLatestUpdatedAt,
-  triggerSentForMany,
-  updateAlert,
-} from "./utils";
+import { addTriggersSent, triggerSentForMany, updateAlert } from "./utils";
 
 const logger = createLogger("langwatch:cron:triggers:trace-based");
 
@@ -65,7 +61,14 @@ export const processTraceBasedTrigger = async (
   const traceService = TraceService.create(prisma);
   const protections = await getProtectionsForProject(prisma, { projectId });
 
-  const allGroups: TraceGroups["groups"] = [];
+  // Dedup against already-sent traces page-by-page so we never hold the full
+  // result set in memory. Cap examined groups at 1_000 (was 10_000) — alerts
+  // don't need more examples than that and the heavy `Trace` payload pushes
+  // Node past V8's old-space limit for projects with many active triggers.
+  const MAX_EXAMINED_GROUPS = 1_000;
+  const tracesToSend: TraceGroups["groups"] = [];
+  let latestUpdatedAt: number | undefined;
+  let examinedGroups = 0;
   let scrollId: string | undefined;
 
   do {
@@ -74,17 +77,35 @@ export const processTraceBasedTrigger = async (
       protections,
       { scrollId },
     );
-    allGroups.push(...result.groups);
     scrollId = result.scrollId ?? undefined;
-  } while (scrollId && allGroups.length < 10_000);
 
-  const traces: TraceGroups = { groups: allGroups };
+    if (result.groups.length > 0) {
+      const pageTraceIds = result.groups.flatMap((group) =>
+        group.map((trace) => trace.trace_id),
+      );
+      const sent = await triggerSentForMany(
+        triggerId,
+        pageTraceIds,
+        input.projectId,
+      );
+      const sentIds = new Set(sent.map((s) => s.traceId));
 
-  const tracesToSend = await getTracesToSend(
-    traces,
-    triggerId,
-    input.projectId,
-  );
+      for (const group of result.groups) {
+        examinedGroups += 1;
+        const updatedAt = getLatestUpdatedAtForGroup(group);
+        if (
+          updatedAt !== undefined &&
+          (latestUpdatedAt === undefined || updatedAt > latestUpdatedAt)
+        ) {
+          latestUpdatedAt = updatedAt;
+        }
+        if (group.every((trace) => !sentIds.has(trace.trace_id))) {
+          tracesToSend.push(group);
+        }
+        if (examinedGroups >= MAX_EXAMINED_GROUPS) break;
+      }
+    }
+  } while (scrollId && examinedGroups < MAX_EXAMINED_GROUPS);
 
   if (tracesToSend.length > 0) {
     const triggerData: TriggerData[] = tracesToSend.flatMap((group) =>
@@ -131,7 +152,7 @@ export const processTraceBasedTrigger = async (
     }
 
     await addTriggersSent(triggerId, triggerData);
-    const updatedAt = getLatestUpdatedAt(traces) ?? Date.now();
+    const updatedAt = latestUpdatedAt ?? Date.now();
 
     try {
       await updateAlert(triggerId, updatedAt, project.id);
@@ -157,22 +178,13 @@ export const processTraceBasedTrigger = async (
   };
 };
 
-const getTracesToSend = async (
-  traces: TraceGroups,
-  triggerId: string,
-  projectId: string,
-) => {
-  const traceIds = traces.groups.flatMap((group) =>
-    group.map((trace) => trace.trace_id),
-  );
-
-  const triggersSent = await triggerSentForMany(triggerId, traceIds, projectId);
-
-  const tracesToSend = traces.groups.filter((group) => {
-    return group.every((trace) => {
-      return !triggersSent.some((sent) => sent.traceId === trace.trace_id);
-    });
-  });
-
-  return tracesToSend;
+const getLatestUpdatedAtForGroup = (group: Trace[]): number | undefined => {
+  let latest: number | undefined;
+  for (const trace of group) {
+    const ts = trace.timestamps?.updated_at;
+    if (ts !== undefined && (latest === undefined || ts > latest)) {
+      latest = ts;
+    }
+  }
+  return latest;
 };


### PR DESCRIPTION
## Summary

Investigation of an `/api/health/triggers` Better Stack incident traced back to langwatch app pods crash-looping (35-46 restarts per pod over 5h) with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`. A single `/api/cron/triggers` curl call from inside the cluster reproduced the OOM, spiking two pods by ~1.5GB each.

The crash-loop killed the `alert-triggers` k8s CronJob (`curl: (52) Empty reply from server`), which in turn fired the `/api/health/triggers` Better Stack alert when no trigger ran for >1h.

**Root cause:** `processTraceBasedTrigger` was loading up to **10,000 full traces** into memory per active trigger (with `Messages`, `input.value`, `output.value`, full `Trace` payloads) **before** running the dedup check against already-sent traces. With **145 active triggers** in prod (34 in a single project), the scroll loop happily piled gigabytes onto the V8 heap inside a single shared HTTP request — and most of those traces had already been sent.

## Changes

1. **Move the `triggerSentForMany` dedup INTO the scroll loop.** Each page (500 traces) is filtered against the sent set before the next page is fetched, so the working set stays bounded by page size instead of the full result.
2. **Lower the examined-groups cap from 10_000 to 1_000.** Alerts don't need more examples than that to fire, and even 1k full traces is plenty for any real action (Slack/email/dataset/annotation queue).
3. Track `latestUpdatedAt` incrementally during the scroll instead of recomputing it from the full `TraceGroups` at the end — so we no longer need to keep the full set in memory just to find the max timestamp.

## Companion PR (infra)

A sibling PR in `langwatch-saas` raises the V8 old-space cap and pod memory limits as a safety net so a single bad trigger can't take down the cluster again: https://github.com/langwatch/langwatch-saas/pull/456

## Test plan

- [x] All 11 `traceBasedTrigger.test.ts` cases pass
- [x] Full triggers test directory: 69/69 pass
- [x] Typecheck clean
- [ ] After deploy, `/api/cron/triggers` should complete without OOM, pod restart count should plateau, and `/api/health/triggers` returns 200 again