### PR TITLE
feat(scenarios): promote provider setup links to prominent buttons (#2920)

### DIFF
--- a/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
+++ b/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
@@ -234,6 +234,7 @@ export function ScenarioAIGeneration({ form }: ScenarioAIGenerationProps) {
 
               <Button colorPalette="blue" asChild size="sm">
                 <a
+                  data-testid="scenario-ai-configure-model-provider-button"
                   href="/settings/model-providers"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -424,6 +425,7 @@ function DefaultModelErrorBanner({ children }: { children: React.ReactNode }) {
       </HStack>
       <Button colorPalette="blue" asChild size="sm">
         <a
+          data-testid="scenario-ai-configure-default-model-button"
           href="/settings/model-providers"
           target="_blank"
           rel="noopener noreferrer"

--- a/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
+++ b/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
@@ -409,7 +409,7 @@ export function ScenarioAIGeneration({ form }: ScenarioAIGenerationProps) {
 
 function DefaultModelErrorBanner({ children }: { children: React.ReactNode }) {
   return (
-    <HStack
+    <VStack
       gap={2}
       padding={2}
       bg="orange.50"
@@ -418,8 +418,19 @@ function DefaultModelErrorBanner({ children }: { children: React.ReactNode }) {
       color="orange.700"
       align="flex-start"
     >
-      <Icon as={AlertTriangle} boxSize={3} flexShrink={0} mt="1px" />
-      <Text>{children}</Text>
-    </HStack>
+      <HStack gap={2} align="flex-start">
+        <Icon as={AlertTriangle} boxSize={3} flexShrink={0} mt="1px" />
+        <Text>{children}</Text>
+      </HStack>
+      <Button colorPalette="blue" asChild size="sm">
+        <a
+          href="/settings/model-providers"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Configure default model
+        </a>
+      </Button>
+    </VStack>
   );
 }

--- a/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
+++ b/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
@@ -231,6 +231,16 @@ export function ScenarioAIGeneration({ form }: ScenarioAIGenerationProps) {
                   Configure model provider
                 </Link>
               </Text>
+
+              <Button colorPalette="blue" asChild size="sm">
+                <a
+                  href="/settings/model-providers"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Configure model provider
+                </a>
+              </Button>
             </VStack>
           </Card.Body>
         </Card.Root>

--- a/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx
@@ -150,6 +150,28 @@ describe("when no model providers are configured", () => {
 
     expect(screen.getByText("Model Provider Required")).toBeInTheDocument();
   });
+
+  it("renders a Configure model provider button linking to /settings/model-providers in a new tab", () => {
+    render(<ScenarioAIGeneration form={null} />, { wrapper: Wrapper });
+
+    // The Card contains both an inline link and a primary button (asChild <a>).
+    // Both have the same name; assert at least one link with the correct attributes exists.
+    const links = screen.getAllByRole("link", { name: "Configure model provider" });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    const primaryLink = links[links.length - 1]!; // button is rendered after the inline link
+    expect(primaryLink).toHaveAttribute("href", "/settings/model-providers");
+    expect(primaryLink).toHaveAttribute("target", "_blank");
+    expect(primaryLink).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(primaryLink).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+  });
+
+  it("keeps the inline explanatory text alongside the button", () => {
+    render(<ScenarioAIGeneration form={null} />, { wrapper: Wrapper });
+
+    expect(
+      screen.getByText(/Scenarios require a model provider to run/i),
+    ).toBeInTheDocument();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx
@@ -157,6 +157,7 @@ describe("when no model providers are configured", () => {
     const primaryLink = screen.getByTestId(
       "scenario-ai-configure-model-provider-button",
     );
+    expect(primaryLink).toHaveAccessibleName("Configure model provider");
     expect(primaryLink).toHaveAttribute("href", "/settings/model-providers");
     expect(primaryLink).toHaveAttribute("target", "_blank");
     expect(primaryLink).toHaveAttribute("rel", expect.stringContaining("noopener"));
@@ -246,6 +247,7 @@ describe("given azure is the only enabled provider and project.defaultModel is n
       const link = screen.getByTestId(
         "scenario-ai-configure-default-model-button",
       );
+      expect(link).toHaveAccessibleName("Configure default model");
       expect(link).toHaveAttribute("href", "/settings/model-providers");
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
@@ -292,6 +294,7 @@ describe("given azure is the only enabled provider and project.defaultModel is o
       const link = screen.getByTestId(
         "scenario-ai-configure-default-model-button",
       );
+      expect(link).toHaveAccessibleName("Configure default model");
       expect(link).toHaveAttribute("href", "/settings/model-providers");
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));

--- a/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx
@@ -237,7 +237,19 @@ describe("given azure is the only enabled provider and project.defaultModel is n
 
       fireEvent.click(screen.getByRole("button", { name: /generate with ai/i }));
 
-      expect(screen.getByText(/default model/i)).toBeInTheDocument();
+      expect(screen.getByText(/no default model set/i)).toBeInTheDocument();
+    });
+
+    it("renders a Configure default model button linking to /settings/model-providers in a new tab", () => {
+      render(<ScenarioAIGeneration form={null} />, { wrapper: Wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /generate with ai/i }));
+
+      const link = screen.getByRole("link", { name: /configure default model/i });
+      expect(link).toHaveAttribute("href", "/settings/model-providers");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
     });
   });
 });
@@ -270,6 +282,18 @@ describe("given azure is the only enabled provider and project.defaultModel is o
       fireEvent.click(screen.getByRole("button", { name: /generate with ai/i }));
 
       expect(screen.getByText(/provider.*disabled|disabled.*provider/i)).toBeInTheDocument();
+    });
+
+    it("renders a Configure default model button linking to /settings/model-providers in a new tab", () => {
+      render(<ScenarioAIGeneration form={null} />, { wrapper: Wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /generate with ai/i }));
+
+      const link = screen.getByRole("link", { name: /configure default model/i });
+      expect(link).toHaveAttribute("href", "/settings/model-providers");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
     });
   });
 });

--- a/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx
@@ -154,11 +154,9 @@ describe("when no model providers are configured", () => {
   it("renders a Configure model provider button linking to /settings/model-providers in a new tab", () => {
     render(<ScenarioAIGeneration form={null} />, { wrapper: Wrapper });
 
-    // The Card contains both an inline link and a primary button (asChild <a>).
-    // Both have the same name; assert at least one link with the correct attributes exists.
-    const links = screen.getAllByRole("link", { name: "Configure model provider" });
-    expect(links.length).toBeGreaterThanOrEqual(1);
-    const primaryLink = links[links.length - 1]!; // button is rendered after the inline link
+    const primaryLink = screen.getByTestId(
+      "scenario-ai-configure-model-provider-button",
+    );
     expect(primaryLink).toHaveAttribute("href", "/settings/model-providers");
     expect(primaryLink).toHaveAttribute("target", "_blank");
     expect(primaryLink).toHaveAttribute("rel", expect.stringContaining("noopener"));
@@ -245,7 +243,9 @@ describe("given azure is the only enabled provider and project.defaultModel is n
 
       fireEvent.click(screen.getByRole("button", { name: /generate with ai/i }));
 
-      const link = screen.getByRole("link", { name: /configure default model/i });
+      const link = screen.getByTestId(
+        "scenario-ai-configure-default-model-button",
+      );
       expect(link).toHaveAttribute("href", "/settings/model-providers");
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
@@ -289,7 +289,9 @@ describe("given azure is the only enabled provider and project.defaultModel is o
 
       fireEvent.click(screen.getByRole("button", { name: /generate with ai/i }));
 
-      const link = screen.getByRole("link", { name: /configure default model/i });
+      const link = screen.getByTestId(
+        "scenario-ai-configure-default-model-button",
+      );
       expect(link).toHaveAttribute("href", "/settings/model-providers");
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));

--- a/langwatch/src/components/shared/AICreateModal.tsx
+++ b/langwatch/src/components/shared/AICreateModal.tsx
@@ -373,6 +373,7 @@ function NoModelProvidersFooter() {
     <HStack gap={2} justify="flex-end">
       <Button colorPalette="blue" asChild>
         <a
+          data-testid="ai-create-modal-configure-model-provider-button"
           href="/settings/model-providers"
           target="_blank"
           rel="noopener noreferrer"

--- a/langwatch/src/components/shared/AICreateModal.tsx
+++ b/langwatch/src/components/shared/AICreateModal.tsx
@@ -369,5 +369,17 @@ function NoModelProvidersWarning() {
 }
 
 function NoModelProvidersFooter() {
-  return null;
+  return (
+    <HStack gap={2} justify="flex-end">
+      <Button colorPalette="blue" asChild>
+        <a
+          href="/settings/model-providers"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Configure model provider
+        </a>
+      </Button>
+    </HStack>
+  );
 }

--- a/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
+++ b/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
@@ -720,9 +720,64 @@ describe("<AICreateModal/>", () => {
       );
 
       const dialog = getDialogContent();
-      const link = within(dialog).getByRole("link", { name: /model provider/i });
-      expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute("href", "/settings/model-providers");
+      // Two links match /model provider/i: the inline body link and the footer button.
+      // Assert the inline body link (first in DOM order) still points to the settings page.
+      const links = within(dialog).getAllByRole("link", { name: /model provider/i });
+      expect(links[0]).toBeInTheDocument();
+      expect(links[0]).toHaveAttribute("href", "/settings/model-providers");
+    });
+
+    describe("footer Configure model provider button", () => {
+      function getFooterConfigureButton(dialog: HTMLElement) {
+        // Both the inline body link and the footer button have accessible name
+        // "Configure model provider". The footer button is last in DOM order.
+        const links = within(dialog).getAllByRole("link", {
+          name: /configure model provider/i,
+        });
+        return links[links.length - 1]!;
+      }
+
+      it("shows primary Configure model provider button in footer", () => {
+        render(
+          <AICreateModal
+            open={true}
+            onClose={vi.fn()}
+            title="Create new scenario"
+            exampleTemplates={defaultExampleTemplates}
+            onGenerate={vi.fn()}
+            onSkip={vi.fn()}
+            hasModelProviders={false}
+          />,
+          { wrapper: Wrapper }
+        );
+
+        const dialog = getDialogContent();
+        const button = getFooterConfigureButton(dialog);
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute("href", "/settings/model-providers");
+        expect(button).toHaveAttribute("target", "_blank");
+      });
+
+      it("footer button uses rel noopener noreferrer", () => {
+        render(
+          <AICreateModal
+            open={true}
+            onClose={vi.fn()}
+            title="Create new scenario"
+            exampleTemplates={defaultExampleTemplates}
+            onGenerate={vi.fn()}
+            onSkip={vi.fn()}
+            hasModelProviders={false}
+          />,
+          { wrapper: Wrapper }
+        );
+
+        const dialog = getDialogContent();
+        const button = getFooterConfigureButton(dialog);
+        const rel = button.getAttribute("rel") ?? "";
+        expect(rel).toContain("noopener");
+        expect(rel).toContain("noreferrer");
+      });
     });
 
   });
@@ -804,6 +859,26 @@ describe("<AICreateModal/>", () => {
       expect(within(dialog).getByText("Customer Support")).toBeInTheDocument();
       expect(within(dialog).getByText("RAG Q&A")).toBeInTheDocument();
       expect(within(dialog).getByText("Tool-calling Agent")).toBeInTheDocument();
+    });
+
+    it("does not show Configure model provider button in footer", () => {
+      render(
+        <AICreateModal
+          open={true}
+          onClose={vi.fn()}
+          title="Create new scenario"
+          exampleTemplates={defaultExampleTemplates}
+          onGenerate={vi.fn()}
+          onSkip={vi.fn()}
+          hasModelProviders={true}
+        />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(
+        within(dialog).queryByRole("link", { name: /configure model provider/i })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
+++ b/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
@@ -720,11 +720,16 @@ describe("<AICreateModal/>", () => {
       );
 
       const dialog = getDialogContent();
-      // Two links match /model provider/i: the inline body link and the footer button.
-      // Assert the inline body link (first in DOM order) still points to the settings page.
+      // Filter out the footer CTA by its test id so we assert the inline body
+      // link regardless of DOM order.
       const links = within(dialog).getAllByRole("link", { name: /model provider/i });
-      expect(links[0]).toBeInTheDocument();
-      expect(links[0]).toHaveAttribute("href", "/settings/model-providers");
+      const inlineLinks = links.filter(
+        (link) =>
+          link.getAttribute("data-testid") !==
+          "ai-create-modal-configure-model-provider-button",
+      );
+      expect(inlineLinks).toHaveLength(1);
+      expect(inlineLinks[0]).toHaveAttribute("href", "/settings/model-providers");
     });
 
     describe("footer Configure model provider button", () => {
@@ -751,6 +756,7 @@ describe("<AICreateModal/>", () => {
         const dialog = getDialogContent();
         const button = getFooterConfigureButton(dialog);
         expect(button).toBeInTheDocument();
+        expect(button).toHaveAccessibleName("Configure model provider");
         expect(button).toHaveAttribute("href", "/settings/model-providers");
         expect(button).toHaveAttribute("target", "_blank");
       });

--- a/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
+++ b/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
@@ -729,12 +729,9 @@ describe("<AICreateModal/>", () => {
 
     describe("footer Configure model provider button", () => {
       function getFooterConfigureButton(dialog: HTMLElement) {
-        // Both the inline body link and the footer button have accessible name
-        // "Configure model provider". The footer button is last in DOM order.
-        const links = within(dialog).getAllByRole("link", {
-          name: /configure model provider/i,
-        });
-        return links[links.length - 1]!;
+        return within(dialog).getByTestId(
+          "ai-create-modal-configure-model-provider-button",
+        );
       }
 
       it("shows primary Configure model provider button in footer", () => {
@@ -877,7 +874,9 @@ describe("<AICreateModal/>", () => {
 
       const dialog = getDialogContent();
       expect(
-        within(dialog).queryByRole("link", { name: /configure model provider/i })
+        within(dialog).queryByTestId(
+          "ai-create-modal-configure-model-provider-button",
+        )
       ).not.toBeInTheDocument();
     });
   });

--- a/langwatch/src/hooks/__tests__/useRunScenario.test.tsx
+++ b/langwatch/src/hooks/__tests__/useRunScenario.test.tsx
@@ -113,6 +113,37 @@ describe("useRunScenario()", () => {
       });
     });
 
+    it("exposes the settings link via the toaster action slot", async () => {
+      const { result } = renderHook(() =>
+        useRunScenario({
+          projectId: "project-123",
+          projectSlug: "my-project",
+        })
+      );
+
+      await result.current.runScenario({
+        scenarioId: "scenario-123",
+        target: { type: "prompt", id: "prompt-123" },
+      });
+
+      await waitFor(() => {
+        expect(mockToasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "No model provider configured",
+            action: expect.objectContaining({
+              label: "Configure model providers",
+            }),
+          })
+        );
+      });
+
+      // The toast must NOT pass JSX/anchor as its description
+      const toastCall = mockToasterCreate.mock.calls[0]![0] as {
+        description?: unknown;
+      };
+      expect(typeof toastCall.description).toBe("string");
+    });
+
     it("does not call run mutation", async () => {
       const { result } = renderHook(() =>
         useRunScenario({

--- a/langwatch/src/hooks/__tests__/useRunScenario.test.tsx
+++ b/langwatch/src/hooks/__tests__/useRunScenario.test.tsx
@@ -114,6 +114,10 @@ describe("useRunScenario()", () => {
     });
 
     it("exposes the settings link via the toaster action slot", async () => {
+      const openSpy = vi
+        .spyOn(window, "open")
+        .mockImplementation(() => null);
+
       const { result } = renderHook(() =>
         useRunScenario({
           projectId: "project-123",
@@ -137,11 +141,22 @@ describe("useRunScenario()", () => {
         );
       });
 
-      // The toast must NOT pass JSX/anchor as its description
       const toastCall = mockToasterCreate.mock.calls[0]![0] as {
         description?: unknown;
+        action?: { onClick: () => void };
       };
+      // Description must be a plain string, not JSX/anchor.
       expect(typeof toastCall.description).toBe("string");
+
+      // Invoking the action opens the provider settings in a new tab.
+      toastCall.action?.onClick();
+      expect(openSpy).toHaveBeenCalledWith(
+        "/settings/model-providers",
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      openSpy.mockRestore();
     });
 
     it("does not call run mutation", async () => {

--- a/langwatch/src/hooks/useRunScenario.tsx
+++ b/langwatch/src/hooks/useRunScenario.tsx
@@ -1,4 +1,3 @@
-import { Text, VStack } from "@chakra-ui/react";
 import { useCallback, useState } from "react";
 import type { TargetValue } from "../components/scenarios/TargetSelector";
 import { toaster } from "../components/ui/toaster";
@@ -52,32 +51,18 @@ export function useRunScenario({
       if (!hasEnabledProviders) {
         toaster.create({
           title: "No model provider configured",
-          description: (
-            <VStack align="start" gap={1}>
-              <Text>
-                A model provider must be configured to run scenarios.
-              </Text>
-              <a
-                href="/settings/model-providers"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  display: "inline-block",
-                  padding: "4px 8px",
-                  marginTop: "4px",
-                  fontSize: "12px",
-                  backgroundColor: "white",
-                  color: "#c53030",
-                  borderRadius: "4px",
-                  textDecoration: "none",
-                }}
-              >
-                Configure model providers
-              </a>
-            </VStack>
-          ),
+          description: "A model provider must be configured to run scenarios.",
           type: "error",
           meta: { closable: true },
+          action: {
+            label: "Configure model providers",
+            onClick: () =>
+              window.open(
+                "/settings/model-providers",
+                "_blank",
+                "noopener,noreferrer"
+              ),
+          },
         });
         return;
       }

--- a/specs/scenarios/provider-setup-link-from-warnings.feature
+++ b/specs/scenarios/provider-setup-link-from-warnings.feature
@@ -1,0 +1,161 @@
+Feature: Provider setup links from "provider not set up" warnings in Scenario surfaces
+  As a LangWatch user who has not configured a model provider
+  I want a prominent action button that takes me to the model provider settings page
+  So that I can configure a provider without losing my in-progress scenario form or run context
+
+  Background:
+    Given I am logged into project "my-project"
+
+  # ============================================================================
+  # Surface 1: AICreateModal footer (primary action)
+  # ============================================================================
+
+  @integration
+  Scenario: AICreateModal footer shows primary Configure model provider button when no providers are enabled
+    Given I have no enabled model providers
+    When I open the Scenario Create modal
+    Then the modal footer shows a primary button with accessible name "Configure model provider"
+    And the button links to "/settings/model-providers"
+    And the button opens the link in a new tab
+
+  @integration
+  Scenario: AICreateModal footer button preserves noopener noreferrer on the new-tab link
+    Given I have no enabled model providers
+    When I open the Scenario Create modal
+    Then the footer "Configure model provider" button uses rel "noopener noreferrer"
+
+  @integration
+  Scenario: AICreateModal footer renders no primary action when providers are configured
+    Given I have at least one enabled model provider
+    When I open the Scenario Create modal
+    Then the modal footer does not show a "Configure model provider" button
+
+  # ============================================================================
+  # Surface 2: Sidebar "AI Generation" panel — no-providers card
+  # ============================================================================
+
+  @integration
+  Scenario: Scenario editor sidebar shows Configure model provider button when no providers are enabled
+    Given I am on the scenario editor
+    And I have no enabled model providers
+    Then the sidebar "Model Provider Required" card shows a primary button with accessible name "Configure model provider"
+    And the button links to "/settings/model-providers"
+    And the button opens the link in a new tab
+
+  @integration
+  Scenario: Sidebar "Model Provider Required" card keeps its inline explanatory text alongside the button
+    Given I am on the scenario editor
+    And I have no enabled model providers
+    Then the sidebar card still explains that a model provider must be configured
+    And the primary "Configure model provider" button is visible in or replacing the inline link
+
+  # ============================================================================
+  # Surface 3: Sidebar default-model banners (no-default / stale-default)
+  # ============================================================================
+
+  @integration
+  Scenario: Sidebar no-default banner shows Configure default model button
+    Given I am on the scenario editor
+    And I have at least one enabled model provider
+    And no default model is selected for the project
+    Then the sidebar banner shows a primary button with accessible name "Configure default model"
+    And the button links to "/settings/model-providers"
+    And the button opens the link in a new tab
+
+  @integration
+  Scenario: Sidebar stale-default banner shows Configure default model button
+    Given I am on the scenario editor
+    And the project's default model points to a provider that is no longer enabled
+    Then the sidebar stale-default banner shows a primary button with accessible name "Configure default model"
+    And the button links to "/settings/model-providers"
+    And the button opens the link in a new tab
+
+  # ============================================================================
+  # Surface 4: useRunScenario toast — uses toaster action slot
+  # ============================================================================
+
+  @integration
+  Scenario: Run-scenario toast exposes the settings link via the toaster action slot
+    Given I am on the scenario editor
+    And I have no enabled model providers
+    When I trigger a scenario run
+    Then a "No model provider configured" toast is shown
+    And the toast uses the toaster's action slot (not an inline anchor) for the settings link
+    And the toast action has an accessible name equivalent to "Configure model provider"
+    And activating the action navigates to "/settings/model-providers"
+    And the action opens the link in a new tab
+
+  @integration
+  Scenario: Run-scenario toast action pattern matches the existing "View failed run" action idiom
+    Given the useRunScenario hook already renders a "View failed run" action on run failure
+    When the "No model provider configured" toast is rendered
+    Then both toasts use the same toaster action slot idiom
+    And neither renders an inline anchor as the primary affordance
+
+  # ============================================================================
+  # Cross-cutting: link target and new-tab behavior preserved across all surfaces
+  # ============================================================================
+
+  @unit
+  Scenario Outline: All four surfaces point at /settings/model-providers and open in a new tab
+    Given the <surface> renders its "provider not set up" warning
+    Then its primary action links to "/settings/model-providers"
+    And the primary action opens in a new tab with rel "noopener noreferrer"
+
+    Examples:
+      | surface                                    |
+      | AICreateModal footer                       |
+      | Scenario editor sidebar no-providers card  |
+      | Scenario editor sidebar no-default banner  |
+      | Scenario editor sidebar stale-default banner |
+      | useRunScenario toast                       |
+
+  @unit
+  Scenario: Existing href assertions for inline links continue to pass
+    Given tests that assert `href="/settings/model-providers"` on the AICreateModal inline link
+    And tests that assert the same href on the sidebar inline link
+    When the surfaces are re-rendered after the primary button is added
+    Then the existing inline-link href assertions still pass
+    And new tests additionally assert the primary button's accessible name and href
+
+  # ============================================================================
+  # Explicit out-of-scope guard
+  # ============================================================================
+
+  @unit
+  Scenario: Orchestrator runtime failure strings are not modified
+    Given the runtime orchestrator error messages "provider_not_found", "provider_not_enabled", and "missing_params"
+    When this feature is implemented
+    Then the strings in orchestrator.ts lines 21-32 are unchanged
+    And no structured-error or UI-link plumbing is added for those runtime failures
+
+  # ============================================================================
+  # AC Coverage Map
+  # ============================================================================
+  # AC 1 (AICreateModal footer primary button to /settings/model-providers, target=_blank)
+  #   -> "AICreateModal footer shows primary Configure model provider button when no providers are enabled"
+  #   -> "AICreateModal footer button preserves noopener noreferrer on the new-tab link"
+  #   -> "AICreateModal footer renders no primary action when providers are configured"
+  #
+  # AC 2 (Sidebar !hasEnabledProviders card includes primary Configure button)
+  #   -> "Scenario editor sidebar shows Configure model provider button when no providers are enabled"
+  #   -> "Sidebar \"Model Provider Required\" card keeps its inline explanatory text alongside the button"
+  #
+  # AC 3 (Sidebar no-default / stale-default banner includes primary Configure default model button)
+  #   -> "Sidebar no-default banner shows Configure default model button"
+  #   -> "Sidebar stale-default banner shows Configure default model button"
+  #
+  # AC 4 (useRunScenario toast uses toaster action slot, like the "View failed run" pattern)
+  #   -> "Run-scenario toast exposes the settings link via the toaster action slot"
+  #   -> "Run-scenario toast action pattern matches the existing \"View failed run\" action idiom"
+  #
+  # AC 5 (Link target /settings/model-providers in all four surfaces; target=_blank rel=noopener noreferrer preserved)
+  #   -> "All four surfaces point at /settings/model-providers and open in a new tab" (Scenario Outline covers all four)
+  #   -> Each surface's scenario above also asserts "/settings/model-providers" and new-tab behavior
+  #
+  # AC 6 (Existing href tests still pass; new tests assert button accessible name + href in each surface)
+  #   -> "Existing href assertions for inline links continue to pass"
+  #   -> Each surface scenario above asserts the new button's accessible name ("Configure model provider" / "Configure default model") and href
+  #
+  # AC 7 (No changes to orchestrator runtime failure strings; that coverage gap is out of scope)
+  #   -> "Orchestrator runtime failure strings are not modified"

--- a/specs/scenarios/provider-setup-link-from-warnings.feature
+++ b/specs/scenarios/provider-setup-link-from-warnings.feature
@@ -47,7 +47,8 @@ Feature: Provider setup links from "provider not set up" warnings in Scenario su
     Given I am on the scenario editor
     And I have no enabled model providers
     Then the sidebar card still explains that a model provider must be configured
-    And the primary "Configure model provider" button is visible in or replacing the inline link
+    And the inline "Configure model provider" link remains available in the explanatory text
+    And the primary "Configure model provider" button is visible alongside it
 
   # ============================================================================
   # Surface 3: Sidebar default-model banners (no-default / stale-default)


### PR DESCRIPTION
## Summary

Closes #2920. UX polish across four scenario-related surfaces: promote the existing inline `/settings/model-providers` text links to prominent action buttons. Fixes the "no way to navigate to provider setup" reported in the issue by making the primary affordance live where users scan for it (footer buttons, banner CTAs, toast action slot).

### Changes

- **Surface 1 — `AICreateModal` footer:** new primary "Configure model provider" button replacing the previously empty `NoModelProvidersFooter`.
- **Surface 2 — Scenario editor sidebar "Model Provider Required" card:** primary "Configure model provider" button added alongside the existing explanatory text/link.
- **Surface 3 — Sidebar `no-default` / `stale-default` banners:** primary "Configure default model" button added to the shared `DefaultModelErrorBanner`.
- **Surface 4 — `useRunScenario` toast:** switched from an inline styled anchor in the description to the toaster's `action` slot (`label` + `onClick` opening `/settings/model-providers` in a new tab), matching the existing "View failed run" idiom in the same file.
- **Test hardening:** stable `data-testid` on each new button; `toHaveAccessibleName` assertions to lock the CTA labels; `useRunScenario` test spies on `window.open` to verify the action actually navigates.
- **Spec:** new feature file `specs/scenarios/provider-setup-link-from-warnings.feature` with coverage mapping for all 7 ACs.

### Out of scope

- Orchestrator runtime failure strings (`provider_not_found` / `provider_not_enabled` / `missing_params`) — separate coverage gap, filed as follow-up.
- Azure-specific Scenario AI generator bug referenced in the issue (tracked separately).
- Consolidating the shared `<ConfigureModelProviderButton>` / `<OpenSettingsLink>` abstraction — follow-up once the Sweep tracking issue lands.

## Test plan
- [x] `pnpm test:unit src/components/shared/__tests__/AICreateModal.test.tsx src/components/scenarios/__tests__/ScenarioAIGeneration.test.tsx src/hooks/__tests__/useRunScenario.test.tsx` — 59/59 passing
- [x] All 7 ACs verified via `/prove-it` (see PR comments)
- [x] Sweep pass: 3 follow-up candidates flagged (ErrorMessage.tsx, TraceDetails.tsx, AddDatasetRecordDrawer.tsx); no must-fix
- [ ] Visual sanity: `make dev` with no providers configured → Scenario Create modal footer shows the new button, sidebar card shows it, default-model banners show it, toast exposes the action — deferred to reviewer since `make dev` requires Docker locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
