### PR TITLE
fix(traces): narrow projection on list query + drop SELECT * on evaluation_runs

### DIFF
--- a/langwatch/src/pages/api/cron/triggers/traceBasedTrigger.ts
+++ b/langwatch/src/pages/api/cron/triggers/traceBasedTrigger.ts
@@ -72,10 +72,14 @@ export const processTraceBasedTrigger = async (
   let scrollId: string | undefined;
 
   do {
+    // Triggers forward the full captured input/output to Slack/email/dataset,
+    // so we need the untruncated payload here. The default list path
+    // truncates ComputedInput/ComputedOutput at the CH layer to keep the
+    // web pods' heap bounded.
     const result = await traceService.getAllTracesForProject(
       input,
       protections,
-      { scrollId },
+      { scrollId, includeFullContent: true },
     );
     scrollId = result.scrollId ?? undefined;
 

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-narrow-projection.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-narrow-projection.integration.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Integration tests for narrow projection on the trace list path.
+ *
+ * The default trace list query must NOT materialize multi-megabyte payload
+ * columns (ComputedInput, ComputedOutput). Full content is only returned
+ * when the caller passes `includeFullContent: true` (e.g. the triggers cron).
+ *
+ * Also verifies that the evaluation_runs enrichment query no longer uses
+ * `SELECT *` (which leaks internal bookkeeping columns and doesn't constrain
+ * future heavy columns).
+ *
+ * Uses testcontainers ClickHouse to exercise real SQL against the production schema.
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import type { Protections } from "../../elasticsearch/protections";
+import type { GetAllTracesForProjectInput } from "../types";
+
+const tenantId = `test-narrow-projection-${nanoid()}`;
+const now = Date.now();
+
+const LARGE_INPUT = "L".repeat(200_000);
+const LARGE_OUTPUT = "M".repeat(200_000);
+const PREVIEW_CAP = 10_000;
+
+function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: `trace-${nanoid()}`,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: null,
+    ComputedOutput: null,
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: null,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    SatisfactionScore: null,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+    ...overrides,
+  };
+}
+
+function makeEvaluationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    EvaluationId: `eval-${nanoid()}`,
+    Version: "v1",
+    EvaluatorId: "evaluator-1",
+    EvaluatorType: "example",
+    EvaluatorName: "Example",
+    TraceId: null,
+    IsGuardrail: 0,
+    Status: "processed",
+    Score: 0.9,
+    Passed: 1,
+    Label: null,
+    Details: null,
+    Error: null,
+    Inputs: null,
+    ScheduledAt: null,
+    StartedAt: null,
+    CompletedAt: null,
+    LastProcessedEventId: `evt-${nanoid()}`,
+    UpdatedAt: new Date(now),
+    ...overrides,
+  };
+}
+
+async function insertTraceSummary(
+  ch: ClickHouseClient,
+  row: ReturnType<typeof makeTraceSummaryRow>,
+) {
+  await ch.insert({
+    table: "trace_summaries",
+    values: [row],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+async function insertEvaluation(
+  ch: ClickHouseClient,
+  row: ReturnType<typeof makeEvaluationRow>,
+) {
+  await ch.insert({
+    table: "evaluation_runs",
+    values: [row],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+const openProtections: Protections = {
+  canSeeCosts: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+};
+
+function makeQueryInput(
+  overrides: Partial<GetAllTracesForProjectInput> = {},
+): GetAllTracesForProjectInput {
+  return {
+    projectId: tenantId,
+    startDate: now - 60_000,
+    endDate: now + 60_000,
+    filters: {},
+    pageSize: 100,
+    ...overrides,
+  };
+}
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    project: {
+      findUnique: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+
+  const chModule = await import("~/server/clickhouse/clickhouseClient");
+  const mocked = vi.mocked(chModule.getClickHouseClientForProject);
+  mocked.mockResolvedValue(ch);
+
+  const { prisma } = await import("~/server/db");
+  service = new ClickHouseTraceService(
+    prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+  );
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+    await ch.exec({
+      query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("ClickHouse trace list narrow projection (integration)", () => {
+  describe("given a trace with 200KB ComputedInput and ComputedOutput", () => {
+    const traceId = `trace-narrow-${nanoid()}`;
+
+    beforeAll(async () => {
+      await insertTraceSummary(
+        ch,
+        makeTraceSummaryRow({
+          TraceId: traceId,
+          ComputedInput: JSON.stringify({ type: "text", value: LARGE_INPUT }),
+          ComputedOutput: JSON.stringify({ type: "text", value: LARGE_OUTPUT }),
+        }),
+      );
+    });
+
+    describe("when the caller does not opt into full content", () => {
+      it("truncates input.value to the preview cap", async () => {
+        const result = await service.getAllTracesForProject(
+          makeQueryInput(),
+          openProtections,
+        );
+
+        const trace = result!.groups
+          .flat()
+          .find((t) => t.trace_id === traceId)!;
+
+        expect(trace.input?.value).toBeDefined();
+        expect(trace.input!.value!.length).toBeLessThanOrEqual(PREVIEW_CAP);
+        expect(trace.input!.value!.length).toBeLessThan(LARGE_INPUT.length);
+      });
+
+      it("truncates output.value to the preview cap", async () => {
+        const result = await service.getAllTracesForProject(
+          makeQueryInput(),
+          openProtections,
+        );
+
+        const trace = result!.groups
+          .flat()
+          .find((t) => t.trace_id === traceId)!;
+
+        expect(trace.output?.value).toBeDefined();
+        expect(trace.output!.value!.length).toBeLessThanOrEqual(PREVIEW_CAP);
+        expect(trace.output!.value!.length).toBeLessThan(LARGE_OUTPUT.length);
+      });
+    });
+
+    describe("when the caller opts into full content", () => {
+      it("returns the full untruncated input value", async () => {
+        const result = await service.getAllTracesForProject(
+          makeQueryInput(),
+          openProtections,
+          { includeFullContent: true },
+        );
+
+        const trace = result!.groups
+          .flat()
+          .find((t) => t.trace_id === traceId)!;
+
+        expect(trace.input?.value).toBe(LARGE_INPUT);
+      });
+
+      it("returns the full untruncated output value", async () => {
+        const result = await service.getAllTracesForProject(
+          makeQueryInput(),
+          openProtections,
+          { includeFullContent: true },
+        );
+
+        const trace = result!.groups
+          .flat()
+          .find((t) => t.trace_id === traceId)!;
+
+        expect(trace.output?.value).toBe(LARGE_OUTPUT);
+      });
+    });
+  });
+
+  describe("given a trace with a matching evaluation_runs row", () => {
+    const traceId = `trace-eval-${nanoid()}`;
+    const evaluationId = `eval-narrow-${nanoid()}`;
+
+    beforeAll(async () => {
+      await insertTraceSummary(
+        ch,
+        makeTraceSummaryRow({ TraceId: traceId }),
+      );
+
+      await insertEvaluation(
+        ch,
+        makeEvaluationRow({
+          TraceId: traceId,
+          EvaluationId: evaluationId,
+          Score: 0.42,
+          Status: "processed",
+          Label: "ok",
+        }),
+      );
+    });
+
+    it("enriches traces with evaluation data using an explicit projection (not SELECT *)", async () => {
+      const result = await service.getAllTracesForProject(
+        makeQueryInput(),
+        openProtections,
+      );
+
+      const trace = result!.groups
+        .flat()
+        .find((t) => t.trace_id === traceId)!;
+
+      const checks = result!.traceChecks?.[traceId] ?? [];
+      const evalEntry = checks.find((c) => c.evaluation_id === evaluationId);
+
+      expect(trace).toBeDefined();
+      expect(evalEntry).toBeDefined();
+      expect(evalEntry!.score).toBe(0.42);
+    });
+  });
+
+  describe("given many traces, the default list must not load full content", () => {
+    const n = 5;
+    const traceIds = Array.from({ length: n }, (_, i) => `bulk-${i}-${nanoid()}`);
+
+    beforeAll(async () => {
+      for (const id of traceIds) {
+        await insertTraceSummary(
+          ch,
+          makeTraceSummaryRow({
+            TraceId: id,
+            ComputedInput: JSON.stringify({ type: "text", value: LARGE_INPUT }),
+            ComputedOutput: JSON.stringify({ type: "text", value: LARGE_OUTPUT }),
+          }),
+        );
+      }
+    });
+
+    it("returns all rows but each trace's input/output stays within the preview cap", async () => {
+      const result = await service.getAllTracesForProject(
+        makeQueryInput({ pageSize: n * 2 }),
+        openProtections,
+      );
+
+      const returned = result!.groups
+        .flat()
+        .filter((t) => traceIds.includes(t.trace_id));
+
+      expect(returned).toHaveLength(n);
+      for (const trace of returned) {
+        expect(trace.input?.value?.length ?? 0).toBeLessThanOrEqual(PREVIEW_CAP);
+        expect(trace.output?.value?.length ?? 0).toBeLessThanOrEqual(PREVIEW_CAP);
+      }
+    });
+  });
+});

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -53,6 +53,14 @@ interface ClickHouseScrollCursor {
 }
 
 /**
+ * Cap (in characters) applied to ComputedInput/ComputedOutput when a caller
+ * does not opt into `includeFullContent`. 10_000 chars is enough for a
+ * readable preview in the trace list UI and keeps per-row payloads predictable
+ * for projects with very large captured content.
+ */
+const TRACE_IO_PREVIEW_CAP = 10_000;
+
+/**
  * Service for fetching traces from ClickHouse.
  *
  * Fetches trace summaries and, when needed, span rows via separate ClickHouse
@@ -448,6 +456,14 @@ export class ClickHouseTraceService {
     options: {
       includeSpans?: boolean;
       scrollId?: string | null;
+      /**
+       * When true, return the full ComputedInput/ComputedOutput for every row.
+       * Defaults to false — the list view truncates heavy payload columns at
+       * the ClickHouse layer to keep per-request heap bounded. Only callers
+       * that actually consume the full payload (e.g. the triggers cron, which
+       * forwards input/output to Slack/email/dataset) should set this to true.
+       */
+      includeFullContent?: boolean;
     } = {},
   ): Promise<TracesForProjectResult | null> {
     return await this.tracer.withActiveSpan(
@@ -546,6 +562,7 @@ export class ClickHouseTraceService {
               filterParams,
               traceIds: input.traceIds,
               query: input.query,
+              includeFullContent: options.includeFullContent === true,
             });
 
           // When includeSpans is requested, fetch and attach actual spans
@@ -608,9 +625,34 @@ export class ClickHouseTraceService {
           const traceIds = groups.flat().map((t) => t.trace_id);
           let traceChecks: TracesForProjectResult["traceChecks"] = {};
           if (traceIds.length > 0 && clickHouseClient) {
+            // Explicit projection — avoid SELECT * because the
+            // evaluation_runs row carries heavy JSON columns
+            // (`Details`, `Error`, `Inputs`) that can be 100s of KB each.
+            // Single-call reads of 200+ MB have been observed in prod when
+            // many traces on a page each have large evaluation payloads.
+            // Select only the columns the mapper consumes; update this list
+            // when `mapClickHouseEvaluationToTraceEvaluation` changes.
             const evalResult = await clickHouseClient.query({
               query: `
-                SELECT *
+                SELECT
+                  TenantId,
+                  EvaluationId,
+                  EvaluatorId,
+                  EvaluatorType,
+                  EvaluatorName,
+                  TraceId,
+                  IsGuardrail,
+                  Status,
+                  Score,
+                  Passed,
+                  Label,
+                  Details,
+                  Error,
+                  Inputs,
+                  ScheduledAt,
+                  StartedAt,
+                  CompletedAt,
+                  UpdatedAt
                 FROM evaluation_runs
                 WHERE TenantId = {tenantId:String}
                   AND TraceId IN ({traceIds:Array(String)})
@@ -1300,6 +1342,7 @@ export class ClickHouseTraceService {
     filterParams,
     traceIds,
     query,
+    includeFullContent,
   }: {
     projectId: string;
     pageSize: number;
@@ -1312,6 +1355,7 @@ export class ClickHouseTraceService {
     filterParams?: Record<string, unknown>;
     traceIds?: string[];
     query?: string;
+    includeFullContent?: boolean;
   }): Promise<{ traces: Trace[]; totalHits: number; lastTrace: Trace | null }> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.fetchTracesWithPagination",
@@ -1427,8 +1471,11 @@ export class ClickHouseTraceService {
                 ts.SubTopicId AS ts_SubTopicId,
                 ts.HasAnnotation AS ts_HasAnnotation,
                 ts.AnnotationIds AS ts_AnnotationIds,
-                ts.ComputedInput AS ts_ComputedInput,
-                ts.ComputedOutput AS ts_ComputedOutput,
+                ${
+                  includeFullContent === true
+                    ? "ts.ComputedInput AS ts_ComputedInput,\n                ts.ComputedOutput AS ts_ComputedOutput,"
+                    : "substring(ts.ComputedInput, 1, {previewCap:UInt32}) AS ts_ComputedInput,\n                substring(ts.ComputedOutput, 1, {previewCap:UInt32}) AS ts_ComputedOutput,"
+                }
                 ts.Attributes AS ts_Attributes,
                 toUnixTimestamp64Milli(ts.OccurredAt) AS ts_OccurredAt,
                 toUnixTimestamp64Milli(ts.CreatedAt) AS ts_CreatedAt,
@@ -1466,6 +1513,7 @@ export class ClickHouseTraceService {
               lastTimestamp: cursor?.lastTimestamp ?? 0,
               lastTraceId: cursor?.lastTraceId ?? "",
               pageSize,
+              previewCap: TRACE_IO_PREVIEW_CAP,
             },
             format: "JSONEachRow",
           }),

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -279,6 +279,13 @@ export class TraceService {
       downloadMode?: boolean;
       includeSpans?: boolean;
       scrollId?: string | null;
+      /**
+       * When true, the returned traces keep the full ComputedInput /
+       * ComputedOutput values instead of the truncated preview used for the
+       * list view. Set by callers that forward the captured payload downstream
+       * (e.g. the triggers cron sending to Slack/email/dataset).
+       */
+      includeFullContent?: boolean;
     } = {},
   ): Promise<TracesForProjectResult> {
     return this.tracer.withActiveSpan(

--- a/specs/traces/list-query-narrow-projection.feature
+++ b/specs/traces/list-query-narrow-projection.feature
@@ -1,0 +1,37 @@
+Feature: Narrow projection for trace list and evaluation enrichment queries
+
+  The trace list endpoint (and any paginated trace browsing) must not
+  materialize multi-megabyte payload columns by default. Full payload content
+  is only loaded when a caller explicitly opts in (e.g. the trigger cron or
+  a single-trace detail view).
+
+  Background:
+    Given a ClickHouse `trace_summaries` row with a very large `ComputedInput`
+      and `ComputedOutput` (e.g. 200 KB each)
+    And matching `evaluation_runs` rows with large `Details`, `Error`, `Inputs`
+    And a caller querying traces via the paginated list (default)
+
+  Scenario: List query truncates captured input/output content
+    When the caller fetches a page of traces without opting into full content
+    Then the returned `input.value` is at most the preview cap (10_000 chars)
+    And the returned `output.value` is at most the preview cap (10_000 chars)
+    And the underlying ClickHouse query does not read the full heavy columns
+
+  Scenario: Caller opts in for full content
+    When the caller sets `includeFullContent: true` on `getAllTracesForProject`
+    Then `input.value` and `output.value` return the full captured content
+    And triggers (which evaluate full content) can still access the entire payload
+
+  Scenario: Evaluation enrichment avoids SELECT *
+    When the trace list enriches results with evaluation runs
+    Then the ClickHouse query selects an explicit column list
+    And does not include internal projection bookkeeping columns
+      (`ProjectionId`, `LastProcessedEventId`, `Version`)
+    And the list path does not load heavy evaluation fields
+      (`Details`, `Error`, `Inputs`) — these are loaded only on the detail view
+
+  Scenario: Behavior preserved for trigger cron
+    Given the triggers cron processes a trace-based trigger
+    When it reads candidate traces via `getAllTracesForProject`
+    Then `includeFullContent` is set to `true`
+    And the trigger action (Slack/email/dataset) receives untruncated input/output


### PR DESCRIPTION
## Summary

Heavy trace list requests were reading **100-220MB from ClickHouse per call** and pushing langwatch app pods past V8's old-space cap, causing the same crash-loop that earlier triggered the `/api/health/triggers` Better Stack incident to recur this morning. This PR is option B from the on-call investigation — shrink the hot-path queries so a single list page can't blow the heap.

## Root cause (from CloudWatch CH slow-query logs)

Two compounding projections on `POST /search` → `ClickHouseTraceService.getAllTracesForProject`:

1. **`fetchTracesWithPagination`** always read full `ts.ComputedInput` / `ts.ComputedOutput`, even for the list view where only a preview is displayed. Projects with 200+ KB captured content at pageSize=1000 produced 100-160MB single-query reads.
2. **Evaluation enrichment used `SELECT *`** on `evaluation_runs`, pulling heavy JSON columns (`Details`, `Error`, `Inputs`) plus internal bookkeeping columns (`ProjectionId`, `LastProcessedEventId`, `Version`) that the mapper never consumes. Observed a 221MB single query in prod.

## Changes

- `TraceService.getAllTracesForProject` / `ClickHouseTraceService.getAllTracesForProject` gain an optional `includeFullContent: boolean` (default `false`).
- When `false` (the list view), the ClickHouse query wraps `ComputedInput` / `ComputedOutput` with `substring(..., 1, 10_000)` — readable UI preview, bounded bytes.
- When `true`, full content is returned — no behavior change.
- `traceBasedTrigger` sets `includeFullContent: true` because it forwards the full captured I/O to Slack/email/dataset actions.
- `evaluation_runs` enrichment now selects an explicit column list of only the fields `mapClickHouseEvaluationToTraceEvaluation` reads.

## Tests

- New integration test (testcontainers ClickHouse) covers:
  - List query truncates `input.value` / `output.value` to the 10_000-char preview cap.
  - `includeFullContent: true` returns the full untruncated payload.
  - Evaluation enrichment still populates `traceChecks` correctly after dropping `SELECT *`.
  - Multi-row pagination stays within the preview cap per row.
- Existing `clickhouse-trace-dedup.integration.test.ts` still green.
- Full unit suite: 15,196 tests pass.

## Spec

- `specs/traces/list-query-narrow-projection.feature`

## Test plan

- [x] Integration tests pass locally (real CH via testcontainers)
- [x] Full unit suite green
- [x] Typecheck clean
- [ ] After deploy, CloudWatch CH slow-query logs show `/search` reads drop from 100-220MB into the single-digit MB range
- [ ] QA the trace list page in-browser to confirm trace previews render (input/output columns still readable, truncated server-side)