### PR TITLE
fix(simulations): prevent query string from being treated as external set

### DIFF
--- a/langwatch/src/components/suites/__tests__/useSuiteRouting.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/useSuiteRouting.unit.test.ts
@@ -157,7 +157,6 @@ describe("useSuiteRouting()", () => {
       const { result } = renderHook(() => useSuiteRouting());
 
       expect(result.current.selectedSuiteSlug).toBe(ALL_RUNS_ID);
-      mockRouter.asPath = "/my-project/simulations";
     });
   });
 

--- a/langwatch/src/components/suites/__tests__/useSuiteRouting.unit.test.ts
+++ b/langwatch/src/components/suites/__tests__/useSuiteRouting.unit.test.ts
@@ -149,6 +149,18 @@ describe("useSuiteRouting()", () => {
     });
   });
 
+  describe("given /simulations with a query string (no path segments)", () => {
+    it("falls back to all-runs instead of treating the query as an external set", () => {
+      mockRouter.query = { project: "my-project", pendingBatch: "scenariobatch_xxx" };
+      mockRouter.asPath = "/my-project/simulations/?pendingBatch=scenariobatch_xxx";
+
+      const { result } = renderHook(() => useSuiteRouting());
+
+      expect(result.current.selectedSuiteSlug).toBe(ALL_RUNS_ID);
+      mockRouter.asPath = "/my-project/simulations";
+    });
+  });
+
   describe("when router is not ready", () => {
     it("returns null", () => {
       mockRouter.isReady = false;

--- a/langwatch/src/components/suites/useSuiteRouting.ts
+++ b/langwatch/src/components/suites/useSuiteRouting.ts
@@ -109,7 +109,10 @@ export function deriveFromPath({
 }): { selectedSuiteSlug: string | typeof ALL_RUNS_ID | null; highlightBatchId: string | null } {
   if (!isReady) return { selectedSuiteSlug: null, highlightBatchId: null };
 
-  const segments = Array.isArray(path) ? path : path ? [path] : [];
+  const rawSegments = Array.isArray(path) ? path : path ? [path] : [];
+  // Drop segments that are actually query strings leaking in from the URL
+  // (e.g. when a redirect fires before the catch-all has stripped "?foo=bar").
+  const segments = rawSegments.filter((s) => s && !s.startsWith("?") && !s.includes("="));
 
   // [] → All Runs
   if (segments.length === 0) {
@@ -133,7 +136,8 @@ export function deriveFromPath({
 
 /** Extract path segments from asPath (e.g., "/project/simulations/run-plans/slug" → ["run-plans", "slug"]) */
 function extractPathFromAsPath(asPath: string): string[] | undefined {
-  const match = asPath.match(/\/simulations(?:\/(.+?))?(?:\?|$)/);
+  const pathOnly = asPath.split("?")[0]?.split("#")[0] ?? "";
+  const match = pathOnly.match(/\/simulations\/(.+?)\/?$/);
   if (!match?.[1]) return undefined;
-  return match[1].split("/");
+  return match[1].split("/").filter(Boolean);
 }


### PR DESCRIPTION
## Summary
- After "Save and Run" on a scenario, the simulations page briefly rendered an **EXTERNAL SET** view with the query string itself as the set id (`?pendingBatch=scenariobatch_...`). A full page reload cleared it.
- Root cause in `useSuiteRouting.ts`: `extractPathFromAsPath`'s regex `/\/simulations(?:\/(.+?))?(?:\?|$)/` lazily captured the query string as a path segment when the URL carried a trailing slash before `?` (e.g. `/p/simulations/?pendingBatch=…`), so `deriveFromPath` treated `?pendingBatch=…` as an external-set slug.
- Fix:
  - `extractPathFromAsPath` now strips `?` / `#` before matching, and only accepts real path segments.
  - `deriveFromPath` defensively filters segments that look like query strings (contain `?` or `=`) in case a leak still reaches `router.query.path`.
- Regression test added covering the `/simulations/?pendingBatch=…` case.

## Test plan
- [x] `pnpm test:unit src/components/suites/__tests__/useSuiteRouting.unit.test.ts` (15 passed)
- [x] Manual: on the Simulations page, trigger Save & Run; verify the page lands directly on All Runs with the pending-batch placeholder, not the "EXTERNAL SET / ?pendingBatch=..." screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)