### PR TITLE
test(billing): verify plan limit parity between SaaS and self-hosted

### DIFF
--- a/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
@@ -16,7 +16,6 @@ const NUMERIC_LIMIT_FIELDS = [
   "maxTeams",
   "maxProjects",
   "maxMessagesPerMonth",
-  "evaluationsCredit",
   "maxWorkflows",
   "maxPrompts",
   "maxEvaluators",
@@ -49,8 +48,9 @@ describe("PLAN_LIMITS", () => {
     const planEntries = Object.entries(PLAN_LIMITS) as [string, PlanInfo][];
 
     describe("when checking SaaS plans for numeric limit completeness", () => {
+      /** @scenario SaaS-sourced plan populates all limit fields */
       it.each(planEntries)(
-        "populates all 17 numeric limit fields for %s",
+        "populates all 16 numeric limit fields for %s",
         (_planType, plan) => {
           for (const field of NUMERIC_LIMIT_FIELDS) {
             const value = plan[field];
@@ -79,14 +79,13 @@ describe("PLAN_LIMITS", () => {
           maxMembers: 10,
           maxProjects: 99,
           maxMessagesPerMonth: 100_000,
-          evaluationsCredit: 100,
           maxWorkflows: 50,
           canPublish: true,
-          // All optional fields omitted — tests default fill
         },
       };
 
-      it("populates all 17 numeric limit fields via defaults", () => {
+      /** @scenario License-sourced plan populates all limit fields */
+      it("populates all 16 numeric limit fields via defaults", () => {
         const plan = mapToPlanInfo(minimalLicense);
 
         for (const field of NUMERIC_LIMIT_FIELDS) {

--- a/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
@@ -10,7 +10,7 @@ import type { LicenseData } from "../../licensing/types";
  * All required numeric limit fields on PlanInfo.
  * Used to verify both SaaS and license plans populate every field.
  */
-const NUMERIC_LIMIT_FIELDS: (keyof PlanInfo)[] = [
+const NUMERIC_LIMIT_FIELDS = [
   "maxMembers",
   "maxMembersLite",
   "maxTeams",
@@ -28,7 +28,7 @@ const NUMERIC_LIMIT_FIELDS: (keyof PlanInfo)[] = [
   "maxDashboards",
   "maxCustomGraphs",
   "maxAutomations",
-];
+] as const satisfies readonly (keyof PlanInfo)[];
 
 describe("PLAN_LIMITS", () => {
   describe("when checking critical plan-specific fields", () => {

--- a/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from "vitest";
 import { PLAN_LIMITS } from "../planLimits";
 import { PlanTypes } from "../planTypes";
+import type { PlanInfo } from "../../licensing/planInfo";
+import { mapToPlanInfo } from "../../licensing/planMapping";
+import { DEFAULT_LIMIT } from "../../licensing/constants";
+import type { LicenseData } from "../../licensing/types";
+
+/**
+ * All required numeric limit fields on PlanInfo.
+ * Used to verify both SaaS and license plans populate every field.
+ */
+const NUMERIC_LIMIT_FIELDS: (keyof PlanInfo)[] = [
+  "maxMembers",
+  "maxMembersLite",
+  "maxTeams",
+  "maxProjects",
+  "maxMessagesPerMonth",
+  "evaluationsCredit",
+  "maxWorkflows",
+  "maxPrompts",
+  "maxEvaluators",
+  "maxScenarios",
+  "maxAgents",
+  "maxExperiments",
+  "maxOnlineEvaluations",
+  "maxDatasets",
+  "maxDashboards",
+  "maxCustomGraphs",
+  "maxAutomations",
+];
 
 describe("PLAN_LIMITS", () => {
   describe("when checking critical plan-specific fields", () => {
@@ -14,6 +42,81 @@ describe("PLAN_LIMITS", () => {
 
     it("sets FREE maxProjects to 2", () => {
       expect(PLAN_LIMITS[PlanTypes.FREE].maxProjects).toBe(2);
+    });
+  });
+
+  describe("field completeness parity", () => {
+    const planEntries = Object.entries(PLAN_LIMITS) as [string, PlanInfo][];
+
+    describe("when checking SaaS plans for numeric limit completeness", () => {
+      it.each(planEntries)(
+        "populates all 17 numeric limit fields for %s",
+        (_planType, plan) => {
+          for (const field of NUMERIC_LIMIT_FIELDS) {
+            const value = plan[field];
+            expect(value, `${_planType}.${field} is undefined`).toBeDefined();
+            expect(typeof value, `${_planType}.${field} is not a number`).toBe(
+              "number",
+            );
+          }
+        },
+      );
+    });
+
+    describe("when checking license-sourced plan field completeness", () => {
+      const minimalLicense: LicenseData = {
+        licenseId: "lic-test",
+        version: 1,
+        organizationName: "Test Org",
+        email: "test@example.com",
+        issuedAt: new Date().toISOString(),
+        expiresAt: new Date(
+          Date.now() + 365 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+        plan: {
+          type: "PRO",
+          name: "Pro",
+          maxMembers: 10,
+          maxProjects: 99,
+          maxMessagesPerMonth: 100_000,
+          evaluationsCredit: 100,
+          maxWorkflows: 50,
+          canPublish: true,
+          // All optional fields omitted — tests default fill
+        },
+      };
+
+      it("populates all 17 numeric limit fields via defaults", () => {
+        const plan = mapToPlanInfo(minimalLicense);
+
+        for (const field of NUMERIC_LIMIT_FIELDS) {
+          const value = plan[field];
+          expect(value, `license.${field} is undefined`).toBeDefined();
+          expect(typeof value, `license.${field} is not a number`).toBe(
+            "number",
+          );
+        }
+      });
+
+      it("defaults usageUnit to traces for legacy licenses", () => {
+        const plan = mapToPlanInfo(minimalLicense);
+        expect(plan.usageUnit).toBe("traces");
+      });
+
+      it("defaults missing optional fields to DEFAULT_LIMIT", () => {
+        const plan = mapToPlanInfo(minimalLicense);
+
+        expect(plan.maxPrompts).toBe(DEFAULT_LIMIT);
+        expect(plan.maxEvaluators).toBe(DEFAULT_LIMIT);
+        expect(plan.maxScenarios).toBe(DEFAULT_LIMIT);
+        expect(plan.maxAgents).toBe(DEFAULT_LIMIT);
+        expect(plan.maxExperiments).toBe(DEFAULT_LIMIT);
+        expect(plan.maxOnlineEvaluations).toBe(DEFAULT_LIMIT);
+        expect(plan.maxDatasets).toBe(DEFAULT_LIMIT);
+        expect(plan.maxDashboards).toBe(DEFAULT_LIMIT);
+        expect(plan.maxCustomGraphs).toBe(DEFAULT_LIMIT);
+        expect(plan.maxAutomations).toBe(DEFAULT_LIMIT);
+      });
     });
   });
 });

--- a/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
@@ -54,10 +54,10 @@ describe("PLAN_LIMITS", () => {
         (_planType, plan) => {
           for (const field of NUMERIC_LIMIT_FIELDS) {
             const value = plan[field];
-            expect(value, `${_planType}.${field} is undefined`).toBeDefined();
-            expect(typeof value, `${_planType}.${field} is not a number`).toBe(
-              "number",
-            );
+            expect(
+              Number.isFinite(value),
+              `${_planType}.${field} is not a finite number`,
+            ).toBe(true);
           }
         },
       );
@@ -90,10 +90,10 @@ describe("PLAN_LIMITS", () => {
 
         for (const field of NUMERIC_LIMIT_FIELDS) {
           const value = plan[field];
-          expect(value, `license.${field} is undefined`).toBeDefined();
-          expect(typeof value, `license.${field} is not a number`).toBe(
-            "number",
-          );
+          expect(
+            Number.isFinite(value),
+            `license.${field} is not a finite number`,
+          ).toBe(true);
         }
       });
 

--- a/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
@@ -76,6 +76,8 @@ describe("createCompositePlanProvider", () => {
   });
 
   describe("when no valid license exists", () => {
+    /** @scenario Subscription-only organization uses SaaS limits */
+    /** @scenario Expired license falls through to SaaS subscription */
     it("selects SaaS plan", async () => {
       const provider = createCompositePlanProvider({
         licensePlanProvider: mockLicense,
@@ -113,6 +115,8 @@ describe("createCompositePlanProvider", () => {
       );
     });
 
+    /** @scenario License-only organization uses license limits */
+    /** @scenario Organization with both license and subscription uses license */
     it("selects license plan over SaaS plan", async () => {
       const provider = createCompositePlanProvider({
         licensePlanProvider: mockLicense,
@@ -153,6 +157,7 @@ describe("createCompositePlanProvider", () => {
       expect(plan.overrideAddingLimitations).toBe(false);
     });
 
+    /** @scenario Override is false for non-impersonated user on SaaS plan */
     it("is false for regular user without impersonator on SaaS plan", async () => {
       const provider = createCompositePlanProvider({
         licensePlanProvider: mockLicense,
@@ -168,6 +173,7 @@ describe("createCompositePlanProvider", () => {
       expect(plan.overrideAddingLimitations).toBe(false);
     });
 
+    /** @scenario Override is true for admin-impersonated user on SaaS plan */
     it("is true when impersonated by admin on SaaS plan", async () => {
       const provider = createCompositePlanProvider({
         licensePlanProvider: mockLicense,
@@ -205,6 +211,7 @@ describe("createCompositePlanProvider", () => {
       expect(plan.overrideAddingLimitations).toBe(false);
     });
 
+    /** @scenario Override is true for admin-impersonated user on license plan */
     it("recomputes override even when license plan is selected", async () => {
       vi.mocked(mockLicense.getActivePlan).mockResolvedValue(
         ENTERPRISE_LICENSE_PLAN,
@@ -229,6 +236,7 @@ describe("createCompositePlanProvider", () => {
       expect(plan.overrideAddingLimitations).toBe(true);
     });
 
+    /** @scenario Override is false for non-impersonated user on license plan */
     it("does not leak SaaS override value into license plan", async () => {
       // SaaS provider returns plan with override=true
       vi.mocked(mockSaas.getActivePlan).mockResolvedValue({
@@ -261,6 +269,8 @@ describe("createCompositePlanProvider", () => {
   // verify that the composite provider correctly falls through when the
   // license provider returns FREE_PLAN (the result of expiry or absence).
   describe("when license provider returns FREE (expired or absent)", () => {
+    /** @scenario Expired license without subscription falls to FREE */
+    /** @scenario No license and no subscription falls to FREE */
     it("falls to FREE when SaaS also returns FREE", async () => {
       vi.mocked(mockSaas.getActivePlan).mockResolvedValue({
         ...FREE_PLAN,
@@ -284,6 +294,7 @@ describe("createCompositePlanProvider", () => {
   });
 
   describe("when license is less generous than subscription", () => {
+    /** @scenario License wins even when subscription has more generous limits */
     it("still selects license (license-first precedence)", async () => {
       const modestLicensePlan: PlanInfo = {
         ...ENTERPRISE_LICENSE_PLAN,

--- a/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
@@ -153,7 +153,7 @@ describe("createCompositePlanProvider", () => {
       expect(plan.overrideAddingLimitations).toBe(false);
     });
 
-    it("is false for regular user without impersonator", async () => {
+    it("is false for regular user without impersonator on SaaS plan", async () => {
       const provider = createCompositePlanProvider({
         licensePlanProvider: mockLicense,
         saasPlanProvider: mockSaas,
@@ -164,10 +164,11 @@ describe("createCompositePlanProvider", () => {
         user: { id: "u1", email: "user@example.com" },
       });
 
+      expect(plan.planSource).toBe("subscription");
       expect(plan.overrideAddingLimitations).toBe(false);
     });
 
-    it("is true when impersonated by admin", async () => {
+    it("is true when impersonated by admin on SaaS plan", async () => {
       const provider = createCompositePlanProvider({
         licensePlanProvider: mockLicense,
         saasPlanProvider: mockSaas,
@@ -182,6 +183,7 @@ describe("createCompositePlanProvider", () => {
         },
       });
 
+      expect(plan.planSource).toBe("subscription");
       expect(plan.overrideAddingLimitations).toBe(true);
     });
 
@@ -222,6 +224,7 @@ describe("createCompositePlanProvider", () => {
       });
 
       // License plan selected (ENTERPRISE), but override recomputed from context
+      expect(plan.planSource).toBe("license");
       expect(plan.type).toBe("ENTERPRISE");
       expect(plan.overrideAddingLimitations).toBe(true);
     });
@@ -254,54 +257,11 @@ describe("createCompositePlanProvider", () => {
     });
   });
 
-  describe("when license expires", () => {
-    it("falls through to SaaS subscription", async () => {
-      // License expired → returns FREE_PLAN (free=true)
-      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(FREE_PLAN);
-      // SaaS has active subscription
-      vi.mocked(mockSaas.getActivePlan).mockResolvedValue(SAAS_PRO_PLAN);
-
-      const provider = createCompositePlanProvider({
-        licensePlanProvider: mockLicense,
-        saasPlanProvider: mockSaas,
-      });
-
-      const plan = await provider.getActivePlan({
-        organizationId: "org-1",
-      });
-
-      expect(plan.planSource).toBe("subscription");
-      expect(plan.type).toBe("PRO");
-      expect(plan.maxMessagesPerMonth).toBe(50_000);
-    });
-
-    it("falls to FREE when no subscription exists either", async () => {
-      // License expired → FREE_PLAN
-      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(FREE_PLAN);
-      // No SaaS subscription → also FREE
-      vi.mocked(mockSaas.getActivePlan).mockResolvedValue({
-        ...FREE_PLAN,
-        planSource: "free",
-      });
-
-      const provider = createCompositePlanProvider({
-        licensePlanProvider: mockLicense,
-        saasPlanProvider: mockSaas,
-      });
-
-      const plan = await provider.getActivePlan({
-        organizationId: "org-1",
-      });
-
-      expect(plan.planSource).toBe("free");
-      expect(plan.type).toBe("FREE");
-      expect(plan.free).toBe(true);
-    });
-  });
-
-  describe("when neither license nor subscription exists", () => {
-    it("returns FREE plan", async () => {
-      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(FREE_PLAN);
+  // License expiry is handled inside LicensePlanProvider — these scenarios
+  // verify that the composite provider correctly falls through when the
+  // license provider returns FREE_PLAN (the result of expiry or absence).
+  describe("when license provider returns FREE (expired or absent)", () => {
+    it("falls to FREE when SaaS also returns FREE", async () => {
       vi.mocked(mockSaas.getActivePlan).mockResolvedValue({
         ...FREE_PLAN,
         planSource: "free",
@@ -352,84 +312,6 @@ describe("createCompositePlanProvider", () => {
       expect(plan.maxMembers).toBe(10);
       expect(plan.maxMessagesPerMonth).toBe(10_000);
       expect(mockSaas.getActivePlan).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("overrideAddingLimitations across plan sources", () => {
-    it("is false for non-impersonated user on license plan", async () => {
-      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(
-        ENTERPRISE_LICENSE_PLAN,
-      );
-
-      const provider = createCompositePlanProvider({
-        licensePlanProvider: mockLicense,
-        saasPlanProvider: mockSaas,
-      });
-
-      const plan = await provider.getActivePlan({
-        organizationId: "org-1",
-        user: { id: "u1", email: "user@example.com" },
-      });
-
-      expect(plan.planSource).toBe("license");
-      expect(plan.overrideAddingLimitations).toBe(false);
-    });
-
-    it("is true for admin-impersonated user on license plan", async () => {
-      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(
-        ENTERPRISE_LICENSE_PLAN,
-      );
-
-      const provider = createCompositePlanProvider({
-        licensePlanProvider: mockLicense,
-        saasPlanProvider: mockSaas,
-      });
-
-      const plan = await provider.getActivePlan({
-        organizationId: "org-1",
-        user: {
-          id: "u1",
-          email: "user@example.com",
-          impersonator: { email: "admin@langwatch.ai" },
-        },
-      });
-
-      expect(plan.planSource).toBe("license");
-      expect(plan.overrideAddingLimitations).toBe(true);
-    });
-
-    it("is false for non-impersonated user on SaaS plan", async () => {
-      const provider = createCompositePlanProvider({
-        licensePlanProvider: mockLicense,
-        saasPlanProvider: mockSaas,
-      });
-
-      const plan = await provider.getActivePlan({
-        organizationId: "org-1",
-        user: { id: "u1", email: "user@example.com" },
-      });
-
-      expect(plan.planSource).toBe("subscription");
-      expect(plan.overrideAddingLimitations).toBe(false);
-    });
-
-    it("is true for admin-impersonated user on SaaS plan", async () => {
-      const provider = createCompositePlanProvider({
-        licensePlanProvider: mockLicense,
-        saasPlanProvider: mockSaas,
-      });
-
-      const plan = await provider.getActivePlan({
-        organizationId: "org-1",
-        user: {
-          id: "u1",
-          email: "user@example.com",
-          impersonator: { email: "admin@langwatch.ai" },
-        },
-      });
-
-      expect(plan.planSource).toBe("subscription");
-      expect(plan.overrideAddingLimitations).toBe(true);
     });
   });
 

--- a/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
+++ b/langwatch/src/server/app-layer/subscription/__tests__/composite-plan-provider.unit.test.ts
@@ -254,6 +254,185 @@ describe("createCompositePlanProvider", () => {
     });
   });
 
+  describe("when license expires", () => {
+    it("falls through to SaaS subscription", async () => {
+      // License expired → returns FREE_PLAN (free=true)
+      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(FREE_PLAN);
+      // SaaS has active subscription
+      vi.mocked(mockSaas.getActivePlan).mockResolvedValue(SAAS_PRO_PLAN);
+
+      const provider = createCompositePlanProvider({
+        licensePlanProvider: mockLicense,
+        saasPlanProvider: mockSaas,
+      });
+
+      const plan = await provider.getActivePlan({
+        organizationId: "org-1",
+      });
+
+      expect(plan.planSource).toBe("subscription");
+      expect(plan.type).toBe("PRO");
+      expect(plan.maxMessagesPerMonth).toBe(50_000);
+    });
+
+    it("falls to FREE when no subscription exists either", async () => {
+      // License expired → FREE_PLAN
+      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(FREE_PLAN);
+      // No SaaS subscription → also FREE
+      vi.mocked(mockSaas.getActivePlan).mockResolvedValue({
+        ...FREE_PLAN,
+        planSource: "free",
+      });
+
+      const provider = createCompositePlanProvider({
+        licensePlanProvider: mockLicense,
+        saasPlanProvider: mockSaas,
+      });
+
+      const plan = await provider.getActivePlan({
+        organizationId: "org-1",
+      });
+
+      expect(plan.planSource).toBe("free");
+      expect(plan.type).toBe("FREE");
+      expect(plan.free).toBe(true);
+    });
+  });
+
+  describe("when neither license nor subscription exists", () => {
+    it("returns FREE plan", async () => {
+      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(FREE_PLAN);
+      vi.mocked(mockSaas.getActivePlan).mockResolvedValue({
+        ...FREE_PLAN,
+        planSource: "free",
+      });
+
+      const provider = createCompositePlanProvider({
+        licensePlanProvider: mockLicense,
+        saasPlanProvider: mockSaas,
+      });
+
+      const plan = await provider.getActivePlan({
+        organizationId: "org-1",
+      });
+
+      expect(plan.planSource).toBe("free");
+      expect(plan.type).toBe("FREE");
+      expect(plan.free).toBe(true);
+      expect(plan.maxMembers).toBe(FREE_PLAN.maxMembers);
+    });
+  });
+
+  describe("when license is less generous than subscription", () => {
+    it("still selects license (license-first precedence)", async () => {
+      const modestLicensePlan: PlanInfo = {
+        ...ENTERPRISE_LICENSE_PLAN,
+        maxMembers: 10,
+        maxMessagesPerMonth: 10_000,
+      };
+      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(modestLicensePlan);
+
+      const generousSubscription: PlanInfo = {
+        ...SAAS_PRO_PLAN,
+        maxMembers: 50,
+        maxMessagesPerMonth: 500_000,
+      };
+      vi.mocked(mockSaas.getActivePlan).mockResolvedValue(generousSubscription);
+
+      const provider = createCompositePlanProvider({
+        licensePlanProvider: mockLicense,
+        saasPlanProvider: mockSaas,
+      });
+
+      const plan = await provider.getActivePlan({
+        organizationId: "org-1",
+      });
+
+      expect(plan.planSource).toBe("license");
+      expect(plan.maxMembers).toBe(10);
+      expect(plan.maxMessagesPerMonth).toBe(10_000);
+      expect(mockSaas.getActivePlan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("overrideAddingLimitations across plan sources", () => {
+    it("is false for non-impersonated user on license plan", async () => {
+      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(
+        ENTERPRISE_LICENSE_PLAN,
+      );
+
+      const provider = createCompositePlanProvider({
+        licensePlanProvider: mockLicense,
+        saasPlanProvider: mockSaas,
+      });
+
+      const plan = await provider.getActivePlan({
+        organizationId: "org-1",
+        user: { id: "u1", email: "user@example.com" },
+      });
+
+      expect(plan.planSource).toBe("license");
+      expect(plan.overrideAddingLimitations).toBe(false);
+    });
+
+    it("is true for admin-impersonated user on license plan", async () => {
+      vi.mocked(mockLicense.getActivePlan).mockResolvedValue(
+        ENTERPRISE_LICENSE_PLAN,
+      );
+
+      const provider = createCompositePlanProvider({
+        licensePlanProvider: mockLicense,
+        saasPlanProvider: mockSaas,
+      });
+
+      const plan = await provider.getActivePlan({
+        organizationId: "org-1",
+        user: {
+          id: "u1",
+          email: "user@example.com",
+          impersonator: { email: "admin@langwatch.ai" },
+        },
+      });
+
+      expect(plan.planSource).toBe("license");
+      expect(plan.overrideAddingLimitations).toBe(true);
+    });
+
+    it("is false for non-impersonated user on SaaS plan", async () => {
+      const provider = createCompositePlanProvider({
+        licensePlanProvider: mockLicense,
+        saasPlanProvider: mockSaas,
+      });
+
+      const plan = await provider.getActivePlan({
+        organizationId: "org-1",
+        user: { id: "u1", email: "user@example.com" },
+      });
+
+      expect(plan.planSource).toBe("subscription");
+      expect(plan.overrideAddingLimitations).toBe(false);
+    });
+
+    it("is true for admin-impersonated user on SaaS plan", async () => {
+      const provider = createCompositePlanProvider({
+        licensePlanProvider: mockLicense,
+        saasPlanProvider: mockSaas,
+      });
+
+      const plan = await provider.getActivePlan({
+        organizationId: "org-1",
+        user: {
+          id: "u1",
+          email: "user@example.com",
+          impersonator: { email: "admin@langwatch.ai" },
+        },
+      });
+
+      expect(plan.planSource).toBe("subscription");
+      expect(plan.overrideAddingLimitations).toBe(true);
+    });
+  });
+
   describe("select-one completeness", () => {
     it("returns all fields from the selected license plan", async () => {
       vi.mocked(mockLicense.getActivePlan).mockResolvedValue(

--- a/specs/licensing/plan-limit-parity.feature
+++ b/specs/licensing/plan-limit-parity.feature
@@ -1,0 +1,112 @@
+Feature: Plan limit parity between SaaS subscription and self-hosted license
+  As a platform operator
+  I want the same enforcement logic to apply regardless of plan source
+  So that self-hosted license users get identical limit enforcement as SaaS subscribers
+
+  Background:
+    Given the composite plan provider resolves plans with license-first precedence
+
+  # --- Composite provider selection scenarios ---
+
+  @unit
+  Scenario: License-only organization uses license limits
+    Given the organization has a valid Enterprise license
+    And the organization has no SaaS subscription
+    When the composite provider resolves the active plan
+    Then the plan source is "license"
+    And the SaaS provider is not called
+
+  @unit
+  Scenario: Subscription-only organization uses SaaS limits
+    Given the organization has no license
+    And the organization has an active Pro subscription
+    When the composite provider resolves the active plan
+    Then the plan source is "subscription"
+    And the plan type is "PRO"
+
+  @unit
+  Scenario: Organization with both license and subscription uses license
+    Given the organization has a valid Enterprise license
+    And the organization has an active Pro subscription
+    When the composite provider resolves the active plan
+    Then the plan source is "license"
+    And the SaaS provider is not called
+
+  @unit
+  Scenario: Expired license falls through to SaaS subscription
+    Given the organization has an expired license
+    And the organization has an active Pro subscription
+    When the composite provider resolves the active plan
+    Then the plan source is "subscription"
+    And the plan type is "PRO"
+
+  @unit
+  Scenario: Expired license without subscription falls to FREE
+    Given the organization has an expired license
+    And the organization has no SaaS subscription
+    When the composite provider resolves the active plan
+    Then the plan source is "free"
+    And the plan type is "FREE"
+
+  @unit
+  Scenario: No license and no subscription falls to FREE
+    Given the organization has no license
+    And the organization has no SaaS subscription
+    When the composite provider resolves the active plan
+    Then the plan source is "free"
+    And the plan type is "FREE"
+
+  @unit
+  Scenario: License wins even when subscription has more generous limits
+    Given the organization has a valid license with maxMembers 10
+    And the organization has an active subscription with maxMembers 50
+    When the composite provider resolves the active plan
+    Then the plan source is "license"
+    And maxMembers is 10
+
+  # --- Field completeness scenarios ---
+
+  @unit
+  Scenario: License-sourced plan populates all limit fields
+    Given a license with all optional fields omitted
+    When the license is mapped to PlanInfo
+    Then all 17 numeric limit fields have defined values
+    And usageUnit defaults to "traces"
+
+  @unit
+  Scenario: SaaS-sourced plan populates all limit fields
+    Given an active subscription on any paid plan
+    When the SaaS provider resolves the plan
+    Then all 17 numeric limit fields have defined values
+
+  # --- overrideAddingLimitations consistency ---
+
+  @unit
+  Scenario: Override is false for non-impersonated user on license plan
+    Given the organization has a valid license
+    And the user is not impersonated
+    When the composite provider resolves the active plan
+    Then overrideAddingLimitations is false
+
+  @unit
+  Scenario: Override is true for admin-impersonated user on license plan
+    Given the organization has a valid license
+    And the user is impersonated by an admin
+    When the composite provider resolves the active plan
+    Then overrideAddingLimitations is true
+
+  @unit
+  Scenario: Override is false for non-impersonated user on SaaS plan
+    Given the organization has no license
+    And the organization has an active subscription
+    And the user is not impersonated
+    When the composite provider resolves the active plan
+    Then overrideAddingLimitations is false
+
+  @unit
+  Scenario: Override is true for admin-impersonated user on SaaS plan
+    Given the organization has no license
+    And the organization has an active subscription
+    And the user is impersonated by an admin
+    When the composite provider resolves the active plan
+    Then overrideAddingLimitations is true

--- a/specs/licensing/plan-limit-parity.feature
+++ b/specs/licensing/plan-limit-parity.feature
@@ -70,14 +70,14 @@ Feature: Plan limit parity between SaaS subscription and self-hosted license
   Scenario: License-sourced plan populates all limit fields
     Given a license with all optional fields omitted
     When the license is mapped to PlanInfo
-    Then all 17 numeric limit fields have defined values
+    Then all 16 numeric limit fields have defined values
     And usageUnit defaults to "traces"
 
   @unit
   Scenario: SaaS-sourced plan populates all limit fields
     Given an active subscription on any paid plan
     When the SaaS provider resolves the plan
-    Then all 17 numeric limit fields have defined values
+    Then all 16 numeric limit fields have defined values
 
   # --- overrideAddingLimitations consistency ---
 


### PR DESCRIPTION
## Summary
- Add BDD feature spec (`specs/licensing/plan-limit-parity.feature`) documenting 13 scenarios for composite plan provider behavior
- Add unit tests verifying all 16 numeric limit fields are populated for both SaaS (PLAN_LIMITS) and license-sourced plans (mapToPlanInfo + resolvePlanDefaults)
- Add unit tests for composite provider edge cases: license-first precedence when subscription is more generous, both-free fallback, field completeness
- Add `@scenario` annotations binding all 13 feature scenarios to their test implementations
- Verify `overrideAddingLimitations` is consistently recomputed from user context regardless of plan source

## Test plan
- [x] `planLimits.unit.test.ts` — 16 numeric field completeness for every SaaS plan type + license defaults
- [x] `composite-plan-provider.unit.test.ts` — selection logic, override consistency, edge cases
- [x] Feature-parity check: 13/13 scenarios bound
- [x] All unit and integration tests pass in CI
- [x] Typecheck passes (no errors in changed files)

Closes #3353