### PR TITLE
feat(api): enforce plan limits on REST resource creation endpoints

### DIFF
--- a/langwatch/src/app/api/graphs/[[...route]]/app.ts
+++ b/langwatch/src/app/api/graphs/[[...route]]/app.ts
@@ -11,6 +11,7 @@ import { createLogger } from "~/utils/logger/server";
 import {
   type AuthMiddlewareVariables,
   authMiddleware,
+  resourceLimitMiddleware,
 } from "../../middleware";
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
@@ -158,6 +159,7 @@ export const app = new Hono<{ Variables: Variables }>()
   // ── Create Graph ───────────────────────────────────────────
   .post(
     "/",
+    resourceLimitMiddleware("customGraphs"),
     describeRoute({
       description: "Create a custom graph on a dashboard",
       responses: {

--- a/langwatch/src/app/api/middleware/__tests__/resource-limit-enforcement.integration.test.ts
+++ b/langwatch/src/app/api/middleware/__tests__/resource-limit-enforcement.integration.test.ts
@@ -1,0 +1,278 @@
+import type { Organization, Project, Team } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { projectFactory } from "~/factories/project.factory";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import { createTestApp } from "~/server/app-layer/presets";
+import {
+  PlanProviderService,
+  type PlanProvider,
+} from "~/server/app-layer/subscription/plan-provider";
+import { prisma } from "~/server/db";
+import { FREE_PLAN } from "../../../../../ee/licensing/constants";
+
+import { app as triggersApp } from "../../triggers/[[...route]]/app";
+import { app as monitorsApp } from "../../monitors/[[...route]]/app";
+import { app as graphsApp } from "../../graphs/[[...route]]/app";
+import { app as suitesApp } from "../../suites/[[...route]]/app";
+
+/**
+ * Integration tests verifying that resourceLimitMiddleware is correctly wired
+ * into each REST route that creates resources. Each test creates enough resources
+ * to hit the free plan limit, then verifies the next creation returns 403.
+ *
+ * See: https://github.com/langwatch/langwatch/issues/3352
+ */
+describe("Feature: REST API resource limit enforcement parity", () => {
+  let testApiKey: string;
+  let testProjectId: string;
+  let testOrganization: Organization;
+  let testTeam: Team;
+  let testProject: Project;
+
+  const authHeaders = (apiKey: string) => ({
+    "X-Auth-Token": apiKey,
+    "Content-Type": "application/json",
+  });
+
+  beforeEach(async () => {
+    resetApp();
+    const mockGetActivePlan = vi.fn().mockResolvedValue(FREE_PLAN);
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: mockGetActivePlan as PlanProvider["getActivePlan"],
+      }),
+      usageLimits: {
+        notifyPlanLimitReached: vi.fn().mockResolvedValue(undefined),
+        checkAndSendWarning: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    });
+
+    testOrganization = await prisma.organization.create({
+      data: {
+        name: "Test Organization",
+        slug: `test-org-${nanoid()}`,
+      },
+    });
+
+    testTeam = await prisma.team.create({
+      data: {
+        name: "Test Team",
+        slug: `test-team-${nanoid()}`,
+        organizationId: testOrganization.id,
+      },
+    });
+
+    testProject = projectFactory.build({ slug: nanoid() });
+    testProject = await prisma.project.create({
+      data: {
+        ...testProject,
+        teamId: testTeam.id,
+      },
+    });
+
+    testApiKey = testProject.apiKey;
+    testProjectId = testProject.id;
+  });
+
+  afterEach(async () => {
+    if (!testProjectId) return;
+
+    await prisma.trigger.deleteMany({ where: { projectId: testProjectId } });
+    await prisma.monitor.deleteMany({ where: { projectId: testProjectId } });
+    await prisma.customGraph.deleteMany({ where: { projectId: testProjectId } });
+    await prisma.simulationSuite.deleteMany({ where: { projectId: testProjectId } });
+    await prisma.experiment.deleteMany({ where: { projectId: testProjectId } });
+    await prisma.scenario.deleteMany({ where: { projectId: testProjectId } });
+    await prisma.project.delete({ where: { id: testProjectId } });
+    await prisma.team.delete({ where: { id: testTeam.id } });
+    await prisma.organization.delete({ where: { id: testOrganization.id } });
+    resetApp();
+  });
+
+  describe("POST /api/triggers (automations limit)", () => {
+    const limit = FREE_PLAN.maxAutomations;
+
+    describe("when below the limit", () => {
+      it("allows creation and returns 201", async () => {
+        const res = await triggersApp.request("/api/triggers", {
+          method: "POST",
+          headers: authHeaders(testApiKey),
+          body: JSON.stringify({
+            name: "First Trigger",
+            action: "SEND_EMAIL",
+          }),
+        });
+
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.name).toBe("First Trigger");
+      });
+    });
+
+    describe("when the automations limit is reached", () => {
+      beforeEach(async () => {
+        for (let i = 0; i < limit; i++) {
+          await prisma.trigger.create({
+            data: {
+              id: nanoid(),
+              projectId: testProjectId,
+              name: `Trigger ${i}`,
+              action: "SEND_EMAIL",
+              actionParams: {},
+              filters: "{}",
+              lastRunAt: Date.now(),
+            },
+          });
+        }
+      });
+
+      it("returns 403 with resource_limit_exceeded", async () => {
+        const res = await triggersApp.request("/api/triggers", {
+          method: "POST",
+          headers: authHeaders(testApiKey),
+          body: JSON.stringify({
+            name: "Excess Trigger",
+            action: "SEND_EMAIL",
+          }),
+        });
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe("resource_limit_exceeded");
+        expect(body.limitType).toBe("automations");
+        expect(body.current).toBe(limit);
+        expect(body.max).toBe(limit);
+      });
+    });
+  });
+
+  describe("POST /api/monitors (onlineEvaluations limit)", () => {
+    const limit = FREE_PLAN.maxOnlineEvaluations;
+
+    describe("when the onlineEvaluations limit is reached", () => {
+      beforeEach(async () => {
+        for (let i = 0; i < limit; i++) {
+          await prisma.monitor.create({
+            data: {
+              projectId: testProjectId,
+              name: `Monitor ${i}`,
+              slug: `monitor-${i}-${nanoid(5)}`,
+              checkType: "custom",
+              executionMode: "ON_MESSAGE",
+              preconditions: [],
+              parameters: {},
+              sample: 1.0,
+              enabled: true,
+              level: "trace",
+            },
+          });
+        }
+      });
+
+      it("returns 403 with resource_limit_exceeded", async () => {
+        const res = await monitorsApp.request("/api/monitors", {
+          method: "POST",
+          headers: authHeaders(testApiKey),
+          body: JSON.stringify({
+            name: "Excess Monitor",
+            checkType: "custom",
+          }),
+        });
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe("resource_limit_exceeded");
+        expect(body.limitType).toBe("onlineEvaluations");
+        expect(body.current).toBe(limit);
+        expect(body.max).toBe(limit);
+      });
+    });
+  });
+
+  describe("POST /api/graphs (customGraphs limit)", () => {
+    const limit = FREE_PLAN.maxCustomGraphs;
+
+    describe("when the customGraphs limit is reached", () => {
+      beforeEach(async () => {
+        for (let i = 0; i < limit; i++) {
+          await prisma.customGraph.create({
+            data: {
+              id: nanoid(),
+              projectId: testProjectId,
+              name: `Graph ${i}`,
+              graph: {},
+            },
+          });
+        }
+      });
+
+      it("returns 403 with resource_limit_exceeded", async () => {
+        const res = await graphsApp.request("/api/graphs", {
+          method: "POST",
+          headers: authHeaders(testApiKey),
+          body: JSON.stringify({
+            name: "Excess Graph",
+            graph: { type: "bar" },
+          }),
+        });
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe("resource_limit_exceeded");
+        expect(body.limitType).toBe("customGraphs");
+        expect(body.current).toBe(limit);
+        expect(body.max).toBe(limit);
+      });
+    });
+  });
+
+  describe("POST /api/suites (experiments limit)", () => {
+    const limit = FREE_PLAN.maxExperiments;
+
+    describe("when the experiments limit is reached", () => {
+      beforeEach(async () => {
+        for (let i = 0; i < limit; i++) {
+          await prisma.experiment.create({
+            data: {
+              projectId: testProjectId,
+              name: `Experiment ${i}`,
+              slug: `experiment-${i}-${nanoid(5)}`,
+              type: "BATCH_EVALUATION",
+              workbenchState: { task: "batch" },
+            },
+          });
+        }
+      });
+
+      it("returns 403 with resource_limit_exceeded", async () => {
+        const scenario = await prisma.scenario.create({
+          data: {
+            projectId: testProjectId,
+            name: "Test Scenario",
+            situation: "Test situation",
+            criteria: ["criterion"],
+            labels: [],
+          },
+        });
+
+        const res = await suitesApp.request("/api/suites", {
+          method: "POST",
+          headers: authHeaders(testApiKey),
+          body: JSON.stringify({
+            name: "Excess Suite",
+            scenarioIds: [scenario.id],
+            targets: [{ type: "http", referenceId: "agent_test" }],
+          }),
+        });
+
+        const body = await res.json();
+        expect(res.status).toBe(403);
+        expect(body.error).toBe("resource_limit_exceeded");
+        expect(body.limitType).toBe("experiments");
+        expect(body.current).toBe(limit);
+        expect(body.max).toBe(limit);
+      });
+    });
+  });
+});

--- a/langwatch/src/app/api/monitors/[[...route]]/app.ts
+++ b/langwatch/src/app/api/monitors/[[...route]]/app.ts
@@ -10,6 +10,7 @@ import {
   type AuthMiddlewareVariables,
   authMiddleware,
   handleError,
+  resourceLimitMiddleware,
 } from "../../middleware";
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
@@ -206,6 +207,7 @@ export const app = new Hono<{ Variables: Variables }>()
   // ── Create Monitor ──────────────────────────────────────────
   .post(
     "/",
+    resourceLimitMiddleware("onlineEvaluations"),
     describeRoute({
       description: "Create a new online evaluation monitor",
       responses: {

--- a/langwatch/src/app/api/suites/[[...route]]/app.ts
+++ b/langwatch/src/app/api/suites/[[...route]]/app.ts
@@ -10,6 +10,7 @@ import { createLogger } from "~/utils/logger/server";
 import {
   type AuthMiddlewareVariables,
   authMiddleware,
+  resourceLimitMiddleware,
 } from "../../middleware";
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
@@ -205,6 +206,7 @@ export const app = new Hono<{ Variables: Variables }>()
   // ── Create Suite ───────────────────────────────────────────
   .post(
     "/",
+    resourceLimitMiddleware("experiments"),
     describeRoute({
       description: "Create a new suite (run plan)",
       responses: {

--- a/langwatch/src/app/api/triggers/[[...route]]/app.ts
+++ b/langwatch/src/app/api/triggers/[[...route]]/app.ts
@@ -11,6 +11,7 @@ import { createLogger } from "~/utils/logger/server";
 import {
   type AuthMiddlewareVariables,
   authMiddleware,
+  resourceLimitMiddleware,
 } from "../../middleware";
 import { loggerMiddleware } from "../../middleware/logger";
 import { tracerMiddleware } from "../../middleware/tracer";
@@ -186,6 +187,7 @@ export const app = new Hono<{ Variables: Variables }>()
   // ── Create Trigger ─────────────────────────────────────────
   .post(
     "/",
+    resourceLimitMiddleware("automations"),
     describeRoute({
       description: "Create a new trigger (automation)",
       responses: {

--- a/langwatch/src/components/suites/SuiteFormDrawer.tsx
+++ b/langwatch/src/components/suites/SuiteFormDrawer.tsx
@@ -32,8 +32,10 @@ import {
   useDrawerParams,
   getFlowCallbacks,
 } from "~/hooks/useDrawer";
+import { useLicenseEnforcement } from "~/hooks/useLicenseEnforcement";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
+import { isHandledByGlobalHandler } from "~/utils/trpcError";
 import { AgentHttpEditorDrawer } from "../agents/AgentHttpEditorDrawer";
 import { ScenarioFormDrawer } from "../scenarios/ScenarioFormDrawer";
 import { Drawer } from "../ui/drawer";
@@ -109,6 +111,9 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
   const isEditMode = !!suiteId;
   const title = isEditMode ? "Edit Run Plan" : "New Run Plan";
 
+  // License enforcement for suite creation
+  const { checkAndProceed } = useLicenseEnforcement("experiments");
+
   const suiteForm = useSuiteForm({
     suite: suite ?? null,
     isOpen,
@@ -149,6 +154,8 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
     },
     onError: (err) => {
       saveAndRunRef.current = false;
+      // Skip toast if already handled by global license handler (shows modal instead)
+      if (isHandledByGlobalHandler(err)) return;
       toaster.create({
         title: "Failed to create run plan",
         description: err.message,
@@ -204,10 +211,12 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
       if (isEditMode && suite) {
         updateMutation.mutate({ ...payload, id: suite.id });
       } else {
-        createMutation.mutate(payload);
+        checkAndProceed(() => {
+          createMutation.mutate(payload);
+        });
       }
     },
-    [project, isEditMode, suite, createMutation, updateMutation],
+    [project, isEditMode, suite, createMutation, updateMutation, checkAndProceed],
   );
 
   const submitAndRun = useCallback(
@@ -215,7 +224,6 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
       if (!project) return;
       const payload = buildMutationPayload(data, project.id);
 
-      saveAndRunRef.current = true;
       const onSuccess = (saved: SimulationSuite) => {
         saveAndRunRef.current = false;
         closeDrawer();
@@ -227,9 +235,13 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
       };
 
       if (isEditMode && suite) {
+        saveAndRunRef.current = true;
         updateMutation.mutate({ ...payload, id: suite.id }, { onSuccess });
       } else {
-        createMutation.mutate(payload, { onSuccess });
+        checkAndProceed(() => {
+          saveAndRunRef.current = true;
+          createMutation.mutate(payload, { onSuccess });
+        });
       }
     },
     [
@@ -242,6 +254,7 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
       onRunRequested,
       runMutation,
       idempotencyKey,
+      checkAndProceed,
     ],
   );
 

--- a/langwatch/src/components/suites/__tests__/SuiteFormDrawer.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteFormDrawer.integration.test.tsx
@@ -107,6 +107,14 @@ vi.mock("~/utils/api", () => ({
         useQuery: vi.fn(() => ({ data: undefined })),
       },
     },
+    licenseEnforcement: {
+      checkLimit: {
+        useQuery: vi.fn(() => ({ data: { allowed: true, current: 0, max: 3, limitType: "experiments" } })),
+      },
+      reportLimitBlocked: {
+        useMutation: vi.fn(() => ({ mutate: vi.fn() })),
+      },
+    },
     useContext: vi.fn(() => ({
       suites: {
         getAll: { invalidate: vi.fn() },

--- a/langwatch/src/server/api/routers/suites/suite.router.ts
+++ b/langwatch/src/server/api/routers/suites/suite.router.ts
@@ -64,8 +64,13 @@ export const suiteRouter = createTRPCRouter({
     .input(projectSchema.extend({ id: z.string() }))
     .use(checkProjectPermission("scenarios:manage"))
     .mutation(async ({ ctx, input }) => {
-      await enforceLicenseLimit(ctx, input.projectId, "experiments");
       const service = SuiteService.create({ prisma: ctx.prisma, suiteRunService: getApp().suiteRuns.runs });
+      // Validate source suite exists before checking limits — avoids masking NOT_FOUND with a limit error
+      const source = await service.getById(input);
+      if (!source) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Suite not found" });
+      }
+      await enforceLicenseLimit(ctx, input.projectId, "experiments");
       try {
         return await service.duplicate(input);
       } catch (error) {

--- a/langwatch/src/server/api/routers/suites/suite.router.ts
+++ b/langwatch/src/server/api/routers/suites/suite.router.ts
@@ -14,6 +14,7 @@ import { ProjectRepository } from "~/server/projects/project.repository";
 import { SimulationFacade } from "~/server/simulations/simulation.facade";
 import { extractSuiteId } from "~/server/suites/suite-set-id";
 import type { SuiteRunSummary } from "~/server/scenarios/scenario-event.types";
+import { enforceLicenseLimit } from "~/server/license-enforcement";
 import { checkProjectPermission } from "../../rbac";
 import { createSuiteSchema, projectSchema, suiteTargetSchema, updateSuiteSchema } from "./schemas";
 
@@ -22,6 +23,7 @@ export const suiteRouter = createTRPCRouter({
     .input(createSuiteSchema)
     .use(checkProjectPermission("scenarios:manage"))
     .mutation(async ({ ctx, input }) => {
+      await enforceLicenseLimit(ctx, input.projectId, "experiments");
       const service = SuiteService.create({ prisma: ctx.prisma, suiteRunService: getApp().suiteRuns.runs });
       return service.create(input);
     }),
@@ -62,6 +64,7 @@ export const suiteRouter = createTRPCRouter({
     .input(projectSchema.extend({ id: z.string() }))
     .use(checkProjectPermission("scenarios:manage"))
     .mutation(async ({ ctx, input }) => {
+      await enforceLicenseLimit(ctx, input.projectId, "experiments");
       const service = SuiteService.create({ prisma: ctx.prisma, suiteRunService: getApp().suiteRuns.runs });
       try {
         return await service.duplicate(input);


### PR DESCRIPTION
## Summary

Closes #3352

- Add `resourceLimitMiddleware` to 4 REST POST routes that were missing plan limit enforcement, closing the parity gap with their tRPC equivalents
- Add `enforceLicenseLimit` to tRPC `suites.create` and `suites.duplicate` mutations
- Add `useLicenseEnforcement("experiments")` + `checkAndProceed` to `SuiteFormDrawer` (Create Run Plan UI) — lets users fill the form, then shows upgrade modal on submit if at limit
- Add `isHandledByGlobalHandler` guard to avoid duplicate error toasts when global handler shows the modal
- Add integration tests verifying each REST enforcement point returns 403 at the free plan limit

| REST Endpoint | Limit Type | tRPC Equivalent |
|---|---|---|
| `POST /api/triggers/` | `automations` | `automations.create` |
| `POST /api/monitors/` | `onlineEvaluations` | `monitors.create` |
| `POST /api/graphs/` | `customGraphs` | `graphs.create` |
| `POST /api/suites/` | `experiments` | `suites.create`, `suites.duplicate` |

**Not gated (by design):**
- `POST /api/suites/:id/run` — the `scenarios` limit counts scenario definitions, not runs
- `POST /api/workflows/` — intentionally excluded

## Test plan

- [x] `pnpm typecheck` passes
- [x] 5 integration tests pass (`resource-limit-enforcement.integration.test.ts`):
  - Triggers POST returns 403 at automations limit
  - Monitors POST returns 403 at onlineEvaluations limit
  - Graphs POST returns 403 at customGraphs limit
  - Suites POST returns 403 at experiments limit
  - Triggers POST allows creation below limit (happy path)
- [x] Existing tRPC enforcement unchanged (verified via grep)
- [ ] Manual: Create Run Plan shows upgrade modal when experiments limit reached