### PR TITLE
fix(tests): make getTestUser parallel-safe with upserts

### DIFF
--- a/langwatch/src/utils/testUtils.ts
+++ b/langwatch/src/utils/testUtils.ts
@@ -27,7 +27,6 @@ async function ignoreUniqueViolation<T>(promise: Promise<T>): Promise<T | null> 
 }
 
 export async function getTestUser() {
-  // Upsert everything: concurrent test files in the same shard race on findUnique + create.
   const user = await prisma.user.upsert({
     where: { email: "test-user@example.com" },
     update: {},
@@ -71,9 +70,6 @@ export async function getTestUser() {
     },
   });
 
-  // Use create + swallow P2002 for composite-unique memberships: Prisma upsert
-  // isn't atomic, so concurrent callers can still race on userId_teamId /
-  // userId_organizationId. Ignoring only the unique-violation preserves real errors.
   await ignoreUniqueViolation(
     prisma.teamUser.create({
       data: {

--- a/langwatch/src/utils/testUtils.ts
+++ b/langwatch/src/utils/testUtils.ts
@@ -12,24 +12,16 @@ import { prisma } from "../server/db";
 import { ENTERPRISE_LICENSE_KEY } from "../../ee/licensing/__tests__/fixtures/testLicenses";
 
 export async function getTestUser() {
-  // Ensure a user exists
-  let user = await prisma.user.findUnique({
-    where: {
+  // Upsert everything: concurrent test files in the same shard race on findUnique + create.
+  const user = await prisma.user.upsert({
+    where: { email: "test-user@example.com" },
+    update: {},
+    create: {
+      name: "Test User",
       email: "test-user@example.com",
     },
   });
-  if (!user) {
-    user = await prisma.user.create({
-      data: {
-        name: "Test User",
-        email: "test-user@example.com",
-      },
-    });
-  }
 
-  // Ensure an organization exists with an enterprise license.
-  // The license allows integration tests to create many resources without hitting FREE tier limits.
-  // Uses upsert to always ensure the license is set correctly.
   const organization = await prisma.organization.upsert({
     where: { slug: "test-organization" },
     update: { license: ENTERPRISE_LICENSE_KEY },
@@ -40,79 +32,54 @@ export async function getTestUser() {
     },
   });
 
-  // Ensure a team exists
-  let team = await prisma.team.findUnique({
-    where: {
+  const team = await prisma.team.upsert({
+    where: { slug: "test-team", organizationId: organization.id },
+    update: {},
+    create: {
+      name: "Test Team",
       slug: "test-team",
       organizationId: organization.id,
     },
   });
-  if (!team) {
-    team = await prisma.team.create({
-      data: {
-        name: "Test Team",
-        slug: "test-team",
-        organizationId: organization.id,
-      },
-    });
-  }
 
-  // Ensure a project with "test-project-id" exists
-  const projectExists = await prisma.project.findUnique({
-    where: {
+  await prisma.project.upsert({
+    where: { id: "test-project-id" },
+    update: {},
+    create: {
       id: "test-project-id",
+      name: "Test Project",
+      slug: "test-project",
+      apiKey: "test-api-key",
+      teamId: team.id,
+      language: "en",
+      framework: "test-framework",
     },
   });
-  if (!projectExists) {
-    await prisma.project.create({
-      data: {
-        id: "test-project-id",
-        name: "Test Project",
-        slug: "test-project",
-        apiKey: "test-api-key",
-        teamId: team.id,
-        language: "en",
-        framework: "test-framework",
-      },
-    });
-  }
 
-  // Ensure the user is a member of the team
-  const teamUserExists = await prisma.teamUser.findUnique({
-    where: {
-      userId_teamId: {
-        userId: user.id,
-        teamId: team.id,
-      },
+  await prisma.teamUser.upsert({
+    where: { userId_teamId: { userId: user.id, teamId: team.id } },
+    update: {},
+    create: {
+      userId: user.id,
+      teamId: team.id,
+      role: TeamUserRole.MEMBER,
     },
   });
-  if (!teamUserExists) {
-    await prisma.teamUser.create({
-      data: {
-        userId: user.id,
-        teamId: team.id,
-        role: TeamUserRole.MEMBER,
-      },
-    });
-  }
-  // Ensure the user is a member of the organization
-  const orgUserExists = await prisma.organizationUser.findUnique({
+
+  await prisma.organizationUser.upsert({
     where: {
       userId_organizationId: {
         userId: user.id,
         organizationId: organization.id,
       },
     },
+    update: {},
+    create: {
+      userId: user.id,
+      organizationId: organization.id,
+      role: OrganizationUserRole.MEMBER,
+    },
   });
-  if (!orgUserExists) {
-    await prisma.organizationUser.create({
-      data: {
-        userId: user.id,
-        organizationId: organization.id,
-        role: OrganizationUserRole.MEMBER,
-      },
-    });
-  }
 
   return user;
 }

--- a/langwatch/src/utils/testUtils.ts
+++ b/langwatch/src/utils/testUtils.ts
@@ -1,6 +1,7 @@
 import {
   OrganizationUserRole,
   PIIRedactionLevel,
+  Prisma,
   type Project,
   ProjectSensitiveDataVisibilityLevel,
   TeamUserRole,
@@ -10,6 +11,20 @@ import type { NextApiRequest, NextApiResponse } from "~/types/next-stubs";
 import { createMocks, type RequestMethod } from "node-mocks-http";
 import { prisma } from "../server/db";
 import { ENTERPRISE_LICENSE_KEY } from "../../ee/licensing/__tests__/fixtures/testLicenses";
+
+async function ignoreUniqueViolation<T>(promise: Promise<T>): Promise<T | null> {
+  try {
+    return await promise;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
 
 export async function getTestUser() {
   // Upsert everything: concurrent test files in the same shard race on findUnique + create.
@@ -56,30 +71,28 @@ export async function getTestUser() {
     },
   });
 
-  await prisma.teamUser.upsert({
-    where: { userId_teamId: { userId: user.id, teamId: team.id } },
-    update: {},
-    create: {
-      userId: user.id,
-      teamId: team.id,
-      role: TeamUserRole.MEMBER,
-    },
-  });
+  // Use create + swallow P2002 for composite-unique memberships: Prisma upsert
+  // isn't atomic, so concurrent callers can still race on userId_teamId /
+  // userId_organizationId. Ignoring only the unique-violation preserves real errors.
+  await ignoreUniqueViolation(
+    prisma.teamUser.create({
+      data: {
+        userId: user.id,
+        teamId: team.id,
+        role: TeamUserRole.MEMBER,
+      },
+    }),
+  );
 
-  await prisma.organizationUser.upsert({
-    where: {
-      userId_organizationId: {
+  await ignoreUniqueViolation(
+    prisma.organizationUser.create({
+      data: {
         userId: user.id,
         organizationId: organization.id,
+        role: OrganizationUserRole.MEMBER,
       },
-    },
-    update: {},
-    create: {
-      userId: user.id,
-      organizationId: organization.id,
-      role: OrganizationUserRole.MEMBER,
-    },
-  });
+    }),
+  );
 
   return user;
 }


### PR DESCRIPTION
## Summary
- Integration tests on main were flaking with `Unique constraint failed on the fields: (email | slug | ...)` thrown from `beforeAll` in test files that call `getTestUser()` (e.g. `agents.integration.test.ts`, `evaluators.integration.test.ts`).
- Root cause: `getTestUser()` used `findUnique` + conditional `create` for user / team / project / teamUser / organizationUser. Two integration test files in the same shard both miss `findUnique`, then both call `create`, and one loses with P2002.
- Fix: convert each to `upsert`. Behavior is unchanged — existing rows are reused, missing rows are created. Organization still refreshes the enterprise license on update, as before.

## Why this doesn't change test quality
- Same fixtures, same reuse semantics (`update: {}` on found = original no-op branch).
- No new fixtures introduced; all tests continue to share the single `test-user@example.com` / `test-organization` / `test-team` / `test-project-id` setup.
- The only functional change is that the setup is now race-safe.

## Test plan
- [x] `npx vitest run -c vitest.integration.config.ts src/server/api/routers/__tests__/agents.integration.test.ts` — 18/18 pass locally.
- [ ] Full integration shards in CI pass without the flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)