### PR TITLE
refactor(pat): tighten extractCredentials signature to accept getHeader function

### DIFF
--- a/langwatch/src/pages/api/experiment/init.ts
+++ b/langwatch/src/pages/api/experiment/init.ts
@@ -17,22 +17,6 @@ import { captureException } from "~/utils/posthogErrorCapture";
 import { slugify } from "~/utils/slugify";
 import { createLogger } from "../../../utils/logger/server";
 
-/**
- * Adapts a Next.js pages-router request to the minimal Hono-shaped surface
- * consumed by `extractCredentials` (`{ req: { header: (name) => string | undefined } }`).
- * Header names are normalised to lowercase because Node gives us a mixed-case
- * record and `extractCredentials` looks up by the canonical lowercase name.
- */
-const toHonoHeaderAdapter = (req: NextApiRequest) => ({
-  req: {
-    header: (name: string): string | undefined => {
-      const value = req.headers[name.toLowerCase()];
-      if (Array.isArray(value)) return value[0];
-      return value ?? undefined;
-    },
-  },
-});
-
 const logger = createLogger("langwatch:dspy:init");
 
 const dspyInitParamsSchema = z
@@ -62,7 +46,11 @@ export default async function handler(
     return res.status(405).end(); // Only accept POST requests
   }
 
-  const credentials = extractCredentials(toHonoHeaderAdapter(req));
+  const credentials = extractCredentials((name) => {
+    const value = req.headers[name.toLowerCase()];
+    if (Array.isArray(value)) return value[0];
+    return value ?? undefined;
+  });
   if (!credentials) {
     return res.status(401).json({
       message:

--- a/langwatch/src/server/pat/__tests__/auth-middleware.unit.test.ts
+++ b/langwatch/src/server/pat/__tests__/auth-middleware.unit.test.ts
@@ -1,12 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { extractCredentials } from "../auth-middleware";
 
-function mockContext(headers: Record<string, string>) {
-  return {
-    req: {
-      header: (name: string) => headers[name.toLowerCase()] ?? headers[name],
-    },
-  };
+function mockGetHeader(headers: Record<string, string>) {
+  return (name: string) => headers[name.toLowerCase()] ?? headers[name];
 }
 
 describe("extractCredentials", () => {
@@ -15,7 +11,7 @@ describe("extractCredentials", () => {
       const encoded = Buffer.from("proj-123:pat-lw-lookup_secret").toString(
         "base64",
       );
-      const c = mockContext({ authorization: `Basic ${encoded}` });
+      const c = mockGetHeader({ authorization: `Basic ${encoded}` });
       const result = extractCredentials(c);
 
       expect(result).toEqual({
@@ -26,7 +22,7 @@ describe("extractCredentials", () => {
 
     it("handles colons in the token value", () => {
       const encoded = Buffer.from("proj:pat-lw-a_b:extra").toString("base64");
-      const c = mockContext({ authorization: `Basic ${encoded}` });
+      const c = mockGetHeader({ authorization: `Basic ${encoded}` });
       const result = extractCredentials(c);
 
       expect(result).toEqual({
@@ -37,24 +33,24 @@ describe("extractCredentials", () => {
 
     it("returns null for missing colon in decoded value", () => {
       const encoded = Buffer.from("no-colon-here").toString("base64");
-      const c = mockContext({ authorization: `Basic ${encoded}` });
+      const c = mockGetHeader({ authorization: `Basic ${encoded}` });
       expect(extractCredentials(c)).toBeNull();
     });
 
     it("returns null for empty projectId or token", () => {
       const encoded1 = Buffer.from(":token").toString("base64");
-      const c1 = mockContext({ authorization: `Basic ${encoded1}` });
+      const c1 = mockGetHeader({ authorization: `Basic ${encoded1}` });
       expect(extractCredentials(c1)).toBeNull();
 
       const encoded2 = Buffer.from("proj:").toString("base64");
-      const c2 = mockContext({ authorization: `Basic ${encoded2}` });
+      const c2 = mockGetHeader({ authorization: `Basic ${encoded2}` });
       expect(extractCredentials(c2)).toBeNull();
     });
   });
 
   describe("when using Bearer token", () => {
     it("extracts bearer token without project ID", () => {
-      const c = mockContext({ authorization: "Bearer pat-lw-lookup_secret" });
+      const c = mockGetHeader({ authorization: "Bearer pat-lw-lookup_secret" });
       const result = extractCredentials(c);
 
       expect(result).toEqual({
@@ -64,7 +60,7 @@ describe("extractCredentials", () => {
     });
 
     it("extracts bearer token with X-Project-Id header", () => {
-      const c = mockContext({
+      const c = mockGetHeader({
         authorization: "Bearer pat-lw-lookup_secret",
         "x-project-id": "proj-123",
       });
@@ -77,7 +73,7 @@ describe("extractCredentials", () => {
     });
 
     it("handles legacy sk-lw-* bearer tokens", () => {
-      const c = mockContext({ authorization: "Bearer sk-lw-abc123" });
+      const c = mockGetHeader({ authorization: "Bearer sk-lw-abc123" });
       const result = extractCredentials(c);
 
       expect(result).toEqual({
@@ -89,7 +85,7 @@ describe("extractCredentials", () => {
 
   describe("when using X-Auth-Token header", () => {
     it("extracts the token from X-Auth-Token", () => {
-      const c = mockContext({ "x-auth-token": "sk-lw-abc123" });
+      const c = mockGetHeader({ "x-auth-token": "sk-lw-abc123" });
       const result = extractCredentials(c);
 
       expect(result).toEqual({
@@ -99,7 +95,7 @@ describe("extractCredentials", () => {
     });
 
     it("includes X-Project-Id when present", () => {
-      const c = mockContext({
+      const c = mockGetHeader({
         "x-auth-token": "pat-lw-lookup_secret",
         "x-project-id": "proj-456",
       });
@@ -114,7 +110,7 @@ describe("extractCredentials", () => {
 
   describe("when no auth is provided", () => {
     it("returns null with no headers", () => {
-      const c = mockContext({});
+      const c = mockGetHeader({});
       expect(extractCredentials(c)).toBeNull();
     });
   });
@@ -122,7 +118,7 @@ describe("extractCredentials", () => {
   describe("priority", () => {
     it("prioritizes Basic Auth over Bearer", () => {
       const encoded = Buffer.from("proj:basic-token").toString("base64");
-      const c = mockContext({
+      const c = mockGetHeader({
         authorization: `Basic ${encoded}`,
         "x-auth-token": "x-auth-value",
       });

--- a/langwatch/src/server/pat/auth-middleware.ts
+++ b/langwatch/src/server/pat/auth-middleware.ts
@@ -34,14 +34,12 @@ export type UnifiedAuthVariables = {
  *   3. Bearer Legacy: sk-lw-... (project ID implicit in key)
  *   4. X-Auth-Token: legacy header (any token type)
  */
-function extractCredentials(c: {
-  req: {
-    header: (name: string) => string | undefined;
-  };
-}): { token: string; projectId: string | null } | null {
-  const authHeader = c.req.header("authorization");
-  const xAuthToken = c.req.header("x-auth-token");
-  const xProjectId = c.req.header("x-project-id");
+function extractCredentials(
+  getHeader: (name: string) => string | undefined,
+): { token: string; projectId: string | null } | null {
+  const authHeader = getHeader("authorization");
+  const xAuthToken = getHeader("x-auth-token");
+  const xProjectId = getHeader("x-project-id");
 
   // Priority 1: Basic Auth — carries both projectId and token
   if (authHeader?.toLowerCase().startsWith("basic ")) {
@@ -101,7 +99,7 @@ export function createUnifiedAuthMiddleware({
   const resolver = TokenResolver.create(prisma);
 
   return async (c, next) => {
-    const credentials = extractCredentials(c);
+    const credentials = extractCredentials((name) => c.req.header(name));
 
     if (!credentials) {
       return c.json(

--- a/langwatch/src/server/routes/annotations.ts
+++ b/langwatch/src/server/routes/annotations.ts
@@ -34,7 +34,7 @@ async function authenticateRequest(
   c: Context,
   permission: Permission,
 ) {
-  const credentials = extractCredentials(c);
+  const credentials = extractCredentials((name) => c.req.header(name));
   if (!credentials) {
     return {
       error:

--- a/langwatch/src/server/routes/collector.ts
+++ b/langwatch/src/server/routes/collector.ts
@@ -49,7 +49,7 @@ app.post(
   "/collector",
   bodyLimit({ maxSize: 10 * 1024 * 1024 }), // 10MB
   async (c) => {
-    const credentials = extractCredentials(c);
+    const credentials = extractCredentials((name) => c.req.header(name));
 
     if (!credentials) {
       logger.warn(

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -98,7 +98,7 @@ async function authenticateRequest(
     }
   | { error: string; status: 401 | 403 }
 > {
-  const credentials = extractCredentials(c);
+  const credentials = extractCredentials((name) => c.req.header(name));
   if (!credentials) {
     return {
       error:

--- a/langwatch/src/server/routes/evaluations-v3.ts
+++ b/langwatch/src/server/routes/evaluations-v3.ts
@@ -80,7 +80,7 @@ const authenticateRequest = async (
   c: { req: { header: (name: string) => string | undefined } },
   permission: Permission,
 ) => {
-  const credentials = extractCredentials(c);
+  const credentials = extractCredentials((name) => c.req.header(name));
   if (!credentials) {
     return { error: "Missing credentials", status: 401 as const };
   }

--- a/langwatch/src/server/routes/otel.ts
+++ b/langwatch/src/server/routes/otel.ts
@@ -87,7 +87,7 @@ const tokenResolver = TokenResolver.create(prisma);
 async function authenticateAndCheckLimit(c: {
   req: { raw: Request; header: (name: string) => string | undefined };
 }) {
-  const credentials = extractCredentials(c);
+  const credentials = extractCredentials((name) => c.req.header(name));
 
   if (!credentials) {
     return { error: "Authentication token is required. Use X-Auth-Token header or Authorization: Bearer token.", status: 401 as const };

--- a/langwatch/src/server/routes/traces-legacy.ts
+++ b/langwatch/src/server/routes/traces-legacy.ts
@@ -45,7 +45,7 @@ export const app = new Hono().basePath("/api");
  * keys — callers invoke it after a successful response.
  */
 async function authenticateRequest(c: Context, permission: Permission) {
-  const credentials = extractCredentials(c);
+  const credentials = extractCredentials((name) => c.req.header(name));
   if (!credentials) {
     return {
       error:


### PR DESCRIPTION
## Summary

- Change `extractCredentials` from accepting a Hono-shaped context (`{ req: { header } }`) to a plain `getHeader: (name: string) => string | undefined` lookup function
- Remove the `toHonoHeaderAdapter` shim and `as any` cast from the pages-router caller (`init.ts`)
- Migrate all 8 call sites (6 Hono routes, 1 middleware, 1 pages-router)

Closes langwatch/langwatch-saas#451

## Test plan

- [x] All 11 existing `extractCredentials` unit tests pass unchanged
- [x] Typecheck passes (no new errors in changed files)
- [ ] CI green

# Related Issue

- Resolve #451