### PR TITLE
fix(pat): bugbash UI polish — token hints, styles, copy, masking, permission picker

### DIFF
--- a/langwatch/src/pages/settings/api-keys/CodeBlock.tsx
+++ b/langwatch/src/pages/settings/api-keys/CodeBlock.tsx
@@ -18,6 +18,7 @@ export function CodeBlock({
   revealedDisplay,
   copyToastTitle,
   ariaLabel,
+  defaultRevealed = false,
 }: {
   label?: string;
   display: string;
@@ -25,15 +26,16 @@ export function CodeBlock({
   revealedDisplay?: string;
   copyToastTitle?: string;
   ariaLabel?: string;
+  defaultRevealed?: boolean;
 }) {
-  const [revealed, setRevealed] = useState(false);
+  const [revealed, setRevealed] = useState(defaultRevealed);
   const canReveal = Boolean(revealedDisplay);
   const shown = revealed && revealedDisplay ? revealedDisplay : display;
 
   const handleCopy = () => {
     if (!navigator.clipboard) {
       toaster.create({
-        title: "Clipboard not available — copy manually",
+        title: "Clipboard not available. Copy manually.",
         type: "error",
         duration: 3000,
         meta: { closable: true },

--- a/langwatch/src/pages/settings/api-keys/CreatePatDrawer.tsx
+++ b/langwatch/src/pages/settings/api-keys/CreatePatDrawer.tsx
@@ -2,6 +2,7 @@ import {
   Badge,
   Box,
   Button,
+  createListCollection,
   Heading,
   HStack,
   Input,
@@ -11,8 +12,9 @@ import {
 } from "@chakra-ui/react";
 import { useMemo, useState } from "react";
 import { Drawer } from "../../../components/ui/drawer";
+import { Radio, RadioGroup } from "../../../components/ui/radio";
 import { Select } from "../../../components/ui/select";
-import type { RouterOutputs } from "../../../utils/api";
+import type { RouterInputs, RouterOutputs } from "../../../utils/api";
 import { EXPIRATION_OPTIONS, expirationCollection } from "./utils";
 
 type MyBindingsData = RouterOutputs["personalAccessToken"]["myBindings"];
@@ -21,17 +23,35 @@ type MyBindings = {
   isLoading: boolean;
 };
 
+type RoleBindingInput =
+  RouterInputs["personalAccessToken"]["create"]["bindings"][number];
+
+type PermissionMode = "all" | "readonly" | "restricted";
+
+const STANDARD_ROLES = ["ADMIN", "MEMBER", "VIEWER"] as const;
+
+function rolesAtOrBelow(
+  role: string,
+): Array<{ label: string; value: string }> {
+  const idx = STANDARD_ROLES.indexOf(
+    role as (typeof STANDARD_ROLES)[number],
+  );
+  if (idx === -1) return [];
+  return STANDARD_ROLES.slice(idx).map((r) => ({ label: r, value: r }));
+}
+
 export type CreatePatInput = {
   name: string;
   description: string;
   expiresAt: Date | undefined;
+  bindings: RoleBindingInput[];
 };
 
 /**
  * Drawer form for creating a new PAT. Owns the transient form state
- * (name / description / expiration) and clears it every time it closes so
- * re-opening starts from a blank slate. The parent owns the network call
- * and token-display lifecycle.
+ * (name / description / expiration / permission mode) and clears it every
+ * time it closes so re-opening starts from a blank slate. The parent owns
+ * the network call and token-display lifecycle.
  */
 export function CreatePatDrawer({
   isOpen,
@@ -50,6 +70,12 @@ export function CreatePatDrawer({
   const [description, setDescription] = useState("");
   const [expirationPreset, setExpirationPreset] = useState("");
   const [customDate, setCustomDate] = useState("");
+  const [permissionMode, setPermissionMode] =
+    useState<PermissionMode>("all");
+  const [roleOverrides, setRoleOverrides] = useState<
+    Record<string, string>
+  >({});
+
   const minCustomDate = useMemo(() => {
     const d = new Date();
     d.setDate(d.getDate() + 1);
@@ -64,6 +90,49 @@ export function CreatePatDrawer({
     setDescription("");
     setExpirationPreset("");
     setCustomDate("");
+    setPermissionMode("all");
+    setRoleOverrides({});
+  };
+
+  const computeBindings = (): CreatePatInput["bindings"] => {
+    const data = myBindings.data;
+    if (!data) return [];
+    switch (permissionMode) {
+      case "all":
+        return data.map((b) => ({
+          role: b.role,
+          customRoleId: b.customRoleId,
+          scopeType: b.scopeType,
+          scopeId: b.scopeId,
+        }));
+      case "readonly":
+        return data.map((b) => ({
+          role: "VIEWER" as const,
+          customRoleId: null,
+          scopeType: b.scopeType,
+          scopeId: b.scopeId,
+        }));
+      case "restricted":
+        return data.map((b) => {
+          const overriddenRole = roleOverrides[b.id] as
+            | RoleBindingInput["role"]
+            | undefined;
+          if (overriddenRole && overriddenRole !== b.role) {
+            return {
+              role: overriddenRole,
+              customRoleId: null,
+              scopeType: b.scopeType,
+              scopeId: b.scopeId,
+            };
+          }
+          return {
+            role: b.role,
+            customRoleId: b.customRoleId,
+            scopeType: b.scopeType,
+            scopeId: b.scopeId,
+          };
+        });
+    }
   };
 
   const handleCreate = () => {
@@ -74,7 +143,12 @@ export function CreatePatDrawer({
       const days = parseInt(expirationPreset, 10);
       expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
     }
-    onCreate({ name, description, expiresAt });
+    onCreate({
+      name,
+      description,
+      expiresAt,
+      bindings: computeBindings(),
+    });
   };
 
   return (
@@ -126,21 +200,50 @@ export function CreatePatDrawer({
               <Text fontWeight="600" fontSize="sm">
                 Access
               </Text>
+              <RadioGroup
+                value={permissionMode}
+                onChange={(e) =>
+                  setPermissionMode(e.target.value as PermissionMode)
+                }
+              >
+                <HStack gap={4}>
+                  <Radio value="all">All permissions</Radio>
+                  <Radio value="readonly">Read only</Radio>
+                  <Radio value="restricted">Restricted</Radio>
+                </HStack>
+              </RadioGroup>
               <Box
                 width="full"
                 padding={3}
                 borderWidth="1px"
                 borderColor="border"
                 borderRadius="md"
-                background="bg.muted"
+                background="bg.subtle"
               >
-                <Text fontSize="sm">
-                  This token will inherit{" "}
-                  <Text as="span" fontWeight="600">
-                    your current permissions
-                  </Text>{" "}
-                  in this organization:
-                </Text>
+                {permissionMode === "all" && (
+                  <Text fontSize="sm">
+                    This token will inherit{" "}
+                    <Text as="span" fontWeight="600">
+                      your current permissions
+                    </Text>{" "}
+                    in this organization:
+                  </Text>
+                )}
+                {permissionMode === "readonly" && (
+                  <Text fontSize="sm">
+                    This token will have{" "}
+                    <Text as="span" fontWeight="600">
+                      read-only access
+                    </Text>{" "}
+                    (Viewer role) at every scope:
+                  </Text>
+                )}
+                {permissionMode === "restricted" && (
+                  <Text fontSize="sm">
+                    Choose a role for each scope, capped by your current
+                    permissions:
+                  </Text>
+                )}
                 {myBindings.isLoading ? (
                   <Text fontSize="xs" color="fg.muted" marginTop={2}>
                     Loading your role bindings…
@@ -158,15 +261,62 @@ export function CreatePatDrawer({
                           : b.scopeType === "TEAM"
                             ? `Team: ${b.scopeName ?? b.scopeId}`
                             : `Project: ${b.scopeName ?? b.scopeId}`;
+
+                      const isCustom = b.role === "CUSTOM";
+                      const availableRoles = rolesAtOrBelow(b.role);
+                      const effectiveRole =
+                        permissionMode === "readonly"
+                          ? "VIEWER"
+                          : permissionMode === "restricted"
+                            ? (roleOverrides[b.id] ?? b.role)
+                            : b.role;
                       const roleLabel =
-                        b.role === "CUSTOM"
-                          ? b.customRoleName ?? "Custom"
-                          : b.role;
+                        isCustom && permissionMode !== "readonly"
+                          ? (b.customRoleName ?? "Custom")
+                          : effectiveRole;
+
+                      const showSelector =
+                        permissionMode === "restricted" &&
+                        !isCustom &&
+                        availableRoles.length > 1;
+
                       return (
                         <HStack key={b.id} gap={2} fontSize="xs">
-                          <Badge size="sm" variant="subtle">
-                            {roleLabel}
-                          </Badge>
+                          {showSelector ? (
+                            <Select.Root
+                              collection={createListCollection({
+                                items: availableRoles,
+                              })}
+                              size="xs"
+                              value={[effectiveRole]}
+                              onValueChange={(details) => {
+                                const val = details.value[0];
+                                if (val)
+                                  setRoleOverrides((prev) => ({
+                                    ...prev,
+                                    [b.id]: val,
+                                  }));
+                              }}
+                            >
+                              <Select.Trigger minWidth="100px">
+                                <Select.ValueText />
+                              </Select.Trigger>
+                              <Select.Content>
+                                {availableRoles.map((opt) => (
+                                  <Select.Item
+                                    key={opt.value}
+                                    item={opt}
+                                  >
+                                    {opt.label}
+                                  </Select.Item>
+                                ))}
+                              </Select.Content>
+                            </Select.Root>
+                          ) : (
+                            <Badge size="sm" variant="subtle">
+                              {roleLabel}
+                            </Badge>
+                          )}
                           <Text color="fg.muted">{scopeLabel}</Text>
                         </HStack>
                       );
@@ -174,7 +324,7 @@ export function CreatePatDrawer({
                   </VStack>
                 )}
                 <Text fontSize="xs" color="fg.muted" marginTop={3}>
-                  Your access acts as a ceiling — if your role is later
+                  Your access acts as a ceiling. If your role is later
                   reduced, the token loses those permissions automatically.
                 </Text>
               </Box>
@@ -220,6 +370,7 @@ export function CreatePatDrawer({
               Cancel
             </Button>
             <Button
+              colorPalette="blue"
               onClick={handleCreate}
               disabled={
                 isCreating ||

--- a/langwatch/src/pages/settings/api-keys/CreatePatDrawer.tsx
+++ b/langwatch/src/pages/settings/api-keys/CreatePatDrawer.tsx
@@ -15,7 +15,13 @@ import { Drawer } from "../../../components/ui/drawer";
 import { Radio, RadioGroup } from "../../../components/ui/radio";
 import { Select } from "../../../components/ui/select";
 import type { RouterInputs, RouterOutputs } from "../../../utils/api";
-import { EXPIRATION_OPTIONS, expirationCollection } from "./utils";
+import {
+  computeBindings,
+  EXPIRATION_OPTIONS,
+  expirationCollection,
+  rolesAtOrBelow,
+  type PermissionMode,
+} from "./utils";
 
 type MyBindingsData = RouterOutputs["personalAccessToken"]["myBindings"];
 type MyBindings = {
@@ -25,20 +31,6 @@ type MyBindings = {
 
 type RoleBindingInput =
   RouterInputs["personalAccessToken"]["create"]["bindings"][number];
-
-type PermissionMode = "all" | "readonly" | "restricted";
-
-const STANDARD_ROLES = ["ADMIN", "MEMBER", "VIEWER"] as const;
-
-function rolesAtOrBelow(
-  role: string,
-): Array<{ label: string; value: string }> {
-  const idx = STANDARD_ROLES.indexOf(
-    role as (typeof STANDARD_ROLES)[number],
-  );
-  if (idx === -1) return [];
-  return STANDARD_ROLES.slice(idx).map((r) => ({ label: r, value: r }));
-}
 
 export type CreatePatInput = {
   name: string;
@@ -85,6 +77,23 @@ export function CreatePatDrawer({
     return `${yyyy}-${mm}-${dd}`;
   }, []);
 
+  const roleCollections = useMemo(() => {
+    const map = new Map<
+      string,
+      ReturnType<typeof createListCollection<{ label: string; value: string }>>
+    >();
+    if (!myBindings.data) return map;
+    for (const b of myBindings.data) {
+      if (!map.has(b.role)) {
+        map.set(
+          b.role,
+          createListCollection({ items: rolesAtOrBelow(b.role) }),
+        );
+      }
+    }
+    return map;
+  }, [myBindings.data]);
+
   const resetForm = () => {
     setName("");
     setDescription("");
@@ -92,47 +101,6 @@ export function CreatePatDrawer({
     setCustomDate("");
     setPermissionMode("all");
     setRoleOverrides({});
-  };
-
-  const computeBindings = (): CreatePatInput["bindings"] => {
-    const data = myBindings.data;
-    if (!data) return [];
-    switch (permissionMode) {
-      case "all":
-        return data.map((b) => ({
-          role: b.role,
-          customRoleId: b.customRoleId,
-          scopeType: b.scopeType,
-          scopeId: b.scopeId,
-        }));
-      case "readonly":
-        return data.map((b) => ({
-          role: "VIEWER" as const,
-          customRoleId: null,
-          scopeType: b.scopeType,
-          scopeId: b.scopeId,
-        }));
-      case "restricted":
-        return data.map((b) => {
-          const overriddenRole = roleOverrides[b.id] as
-            | RoleBindingInput["role"]
-            | undefined;
-          if (overriddenRole && overriddenRole !== b.role) {
-            return {
-              role: overriddenRole,
-              customRoleId: null,
-              scopeType: b.scopeType,
-              scopeId: b.scopeId,
-            };
-          }
-          return {
-            role: b.role,
-            customRoleId: b.customRoleId,
-            scopeType: b.scopeType,
-            scopeId: b.scopeId,
-          };
-        });
-    }
   };
 
   const handleCreate = () => {
@@ -143,12 +111,12 @@ export function CreatePatDrawer({
       const days = parseInt(expirationPreset, 10);
       expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
     }
-    onCreate({
-      name,
-      description,
-      expiresAt,
-      bindings: computeBindings(),
-    });
+    const bindings = computeBindings({
+      data: myBindings.data,
+      permissionMode,
+      roleOverrides,
+    }) as RoleBindingInput[];
+    onCreate({ name, description, expiresAt, bindings });
   };
 
   return (
@@ -263,7 +231,8 @@ export function CreatePatDrawer({
                             : `Project: ${b.scopeName ?? b.scopeId}`;
 
                       const isCustom = b.role === "CUSTOM";
-                      const availableRoles = rolesAtOrBelow(b.role);
+                      const collection = roleCollections.get(b.role);
+                      const availableRoles = collection?.items ?? [];
                       const effectiveRole =
                         permissionMode === "readonly"
                           ? "VIEWER"
@@ -282,11 +251,9 @@ export function CreatePatDrawer({
 
                       return (
                         <HStack key={b.id} gap={2} fontSize="xs">
-                          {showSelector ? (
+                          {showSelector && collection ? (
                             <Select.Root
-                              collection={createListCollection({
-                                items: availableRoles,
-                              })}
+                              collection={collection}
                               size="xs"
                               value={[effectiveRole]}
                               onValueChange={(details) => {
@@ -302,7 +269,7 @@ export function CreatePatDrawer({
                                 <Select.ValueText />
                               </Select.Trigger>
                               <Select.Content>
-                                {availableRoles.map((opt) => (
+                                {rolesAtOrBelow(b.role).map((opt) => (
                                   <Select.Item
                                     key={opt.value}
                                     item={opt}

--- a/langwatch/src/pages/settings/api-keys/CreatePatDrawer.tsx
+++ b/langwatch/src/pages/settings/api-keys/CreatePatDrawer.tsx
@@ -170,9 +170,10 @@ export function CreatePatDrawer({
               </Text>
               <RadioGroup
                 value={permissionMode}
-                onChange={(e) =>
-                  setPermissionMode(e.target.value as PermissionMode)
-                }
+                onValueChange={(e) => {
+                  const value = e.value as PermissionMode;
+                  setPermissionMode(value);
+                }}
               >
                 <HStack gap={4}>
                   <Radio value="all">All permissions</Radio>

--- a/langwatch/src/pages/settings/api-keys/PersonalAccessTokensSection.tsx
+++ b/langwatch/src/pages/settings/api-keys/PersonalAccessTokensSection.tsx
@@ -190,7 +190,7 @@ export function PersonalAccessTokensSection({
                         fontFamily="monospace"
                         color="fg.muted"
                       >
-                        pat-lw-...{pat.lookupId.slice(-4)}
+                        pat-lw-...{pat.lookupIdSuffix}
                       </Text>
                     </Table.Cell>
                     <Table.Cell>

--- a/langwatch/src/pages/settings/api-keys/PersonalAccessTokensSection.tsx
+++ b/langwatch/src/pages/settings/api-keys/PersonalAccessTokensSection.tsx
@@ -11,6 +11,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { Key, Plus, Trash2 } from "lucide-react";
+import { PageLayout } from "../../../components/ui/layouts/PageLayout";
 import { useMemo, useState } from "react";
 import { toaster } from "../../../components/ui/toaster";
 import { usePublicEnv } from "../../../hooks/usePublicEnv";
@@ -55,16 +56,7 @@ export function PersonalAccessTokensSection({
   const [patToRevoke, setPatToRevoke] = useState<string | null>(null);
 
   const handleCreate = (input: CreatePatInput) => {
-    // Mirror the caller's own RoleBindings onto the PAT. A future
-    // "Advanced" UI will let users narrow this down per-scope/role.
-    const bindings = (myBindings.data ?? []).map((b) => ({
-      role: b.role,
-      customRoleId: b.customRoleId,
-      scopeType: b.scopeType,
-      scopeId: b.scopeId,
-    }));
-
-    if (bindings.length === 0) {
+    if (input.bindings.length === 0) {
       toaster.create({
         title: "No permissions to grant",
         description:
@@ -84,7 +76,7 @@ export function PersonalAccessTokensSection({
           ? input.description.trim()
           : undefined,
         expiresAt: input.expiresAt,
-        bindings,
+        bindings: input.bindings,
       },
       {
         onSuccess: (result) => {
@@ -142,13 +134,13 @@ export function PersonalAccessTokensSection({
         <HStack width="full">
           <Text fontSize="sm" color="fg.muted">
             User-scoped tokens that authenticate API requests on your behalf.
-            Shown once at creation — copy it immediately.
+            Shown once at creation. Copy it immediately.
           </Text>
           <Spacer />
-          <Button size="sm" onClick={onCreateOpen}>
+          <PageLayout.HeaderButton onClick={onCreateOpen}>
             <Plus size={16} />
             Create Token
-          </Button>
+          </PageLayout.HeaderButton>
         </HStack>
 
         <Card.Root width="full" overflow="hidden">
@@ -157,6 +149,7 @@ export function PersonalAccessTokensSection({
               <Table.Header>
                 <Table.Row>
                   <Table.ColumnHeader>Name</Table.ColumnHeader>
+                  <Table.ColumnHeader>Secret Key</Table.ColumnHeader>
                   <Table.ColumnHeader>Permissions</Table.ColumnHeader>
                   <Table.ColumnHeader>Expires</Table.ColumnHeader>
                   <Table.ColumnHeader>Created</Table.ColumnHeader>
@@ -167,7 +160,7 @@ export function PersonalAccessTokensSection({
               <Table.Body>
                 {activePats.length === 0 && (
                   <Table.Row>
-                    <Table.Cell colSpan={6}>
+                    <Table.Cell colSpan={7}>
                       <Text color="fg.muted" textAlign="center" paddingY={4}>
                         No active tokens. Create one to get started.
                       </Text>
@@ -190,6 +183,15 @@ export function PersonalAccessTokensSection({
                           )}
                         </VStack>
                       </HStack>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Text
+                        fontSize="xs"
+                        fontFamily="monospace"
+                        color="fg.muted"
+                      >
+                        pat-lw-...{pat.lookupId.slice(-4)}
+                      </Text>
                     </Table.Cell>
                     <Table.Cell>
                       <Text fontSize="sm" color="fg.muted">

--- a/langwatch/src/pages/settings/api-keys/TokenCreatedDialog.tsx
+++ b/langwatch/src/pages/settings/api-keys/TokenCreatedDialog.tsx
@@ -34,12 +34,13 @@ export function TokenCreatedDialog({
         <Dialog.CloseTrigger />
         <Dialog.Body paddingBottom={6}>
           <VStack gap={5} align="stretch">
-            <Text color="orange.500" fontWeight="600">
+            <Text color="red.500" fontWeight="600">
               Copy this token now. You won&apos;t be able to see it again.
             </Text>
             {newToken && (
               <CodeBlock
                 label=".env"
+                defaultRevealed
                 display={formatEnvLines([
                   { key: "LANGWATCH_API_KEY", value: newToken, mask: true },
                   {
@@ -82,7 +83,7 @@ export function TokenCreatedDialog({
 
             <VStack gap={2} align="stretch" width="full">
               <Text fontWeight="600" fontSize="sm">
-                Option 1 — Bearer token
+                Option 1: Bearer token
               </Text>
               <Text fontSize="sm" color="fg.muted">
                 Use the <code>Authorization</code> header plus{" "}
@@ -106,7 +107,7 @@ export function TokenCreatedDialog({
 
             <VStack gap={2} align="stretch" width="full">
               <Text fontWeight="600" fontSize="sm">
-                Option 2 — Basic Auth (SDK clients)
+                Option 2: Basic Auth (SDK clients)
               </Text>
               <Text fontSize="sm" color="fg.muted">
                 Encode the project ID and token as{" "}

--- a/langwatch/src/pages/settings/api-keys/utils.ts
+++ b/langwatch/src/pages/settings/api-keys/utils.ts
@@ -30,6 +30,81 @@ export function formatEnvLines(
     .join("\n");
 }
 
+export const STANDARD_ROLES = ["ADMIN", "MEMBER", "VIEWER"] as const;
+
+/** Returns the list of standard roles at or below the given role in the hierarchy. */
+export function rolesAtOrBelow(
+  role: string,
+): Array<{ label: string; value: string }> {
+  const idx = STANDARD_ROLES.indexOf(
+    role as (typeof STANDARD_ROLES)[number],
+  );
+  if (idx === -1) return [];
+  return STANDARD_ROLES.slice(idx).map((r) => ({ label: r, value: r }));
+}
+
+export type PermissionMode = "all" | "readonly" | "restricted";
+
+/** Computes the effective bindings array based on the selected permission mode. */
+export function computeBindings({
+  data,
+  permissionMode,
+  roleOverrides,
+}: {
+  data:
+    | Array<{
+        id: string;
+        role: string;
+        customRoleId: string | null;
+        scopeType: string;
+        scopeId: string;
+      }>
+    | undefined;
+  permissionMode: PermissionMode;
+  roleOverrides: Record<string, string>;
+}): Array<{
+  role: string;
+  customRoleId: string | null | undefined;
+  scopeType: string;
+  scopeId: string;
+}> {
+  if (!data) return [];
+  switch (permissionMode) {
+    case "all":
+      return data.map((b) => ({
+        role: b.role,
+        customRoleId: b.customRoleId,
+        scopeType: b.scopeType,
+        scopeId: b.scopeId,
+      }));
+    case "readonly":
+      return data.map((b) => ({
+        role: "VIEWER" as const,
+        customRoleId: null,
+        scopeType: b.scopeType,
+        scopeId: b.scopeId,
+      }));
+    case "restricted":
+      return data.map((b) => {
+        const overriddenRole = roleOverrides[b.id];
+        if (overriddenRole && overriddenRole !== b.role) {
+          return {
+            role: overriddenRole,
+            customRoleId: null,
+            scopeType: b.scopeType,
+            scopeId: b.scopeId,
+          };
+        }
+        return {
+          role: b.role,
+          customRoleId: b.customRoleId,
+          scopeType: b.scopeType,
+          scopeId: b.scopeId,
+        };
+      });
+  }
+}
+
 /** One-line summary of a role-binding set for table display. */
 export function roleSummary(
   bindings: Array<{

--- a/langwatch/src/pages/settings/api-keys/utils.ts
+++ b/langwatch/src/pages/settings/api-keys/utils.ts
@@ -102,6 +102,10 @@ export function computeBindings({
           scopeId: b.scopeId,
         };
       });
+    default: {
+      const _exhaustive: never = permissionMode;
+      return _exhaustive;
+    }
   }
 }
 

--- a/langwatch/src/pages/settings/api-keys/utils.unit.test.ts
+++ b/langwatch/src/pages/settings/api-keys/utils.unit.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeBindings,
+  rolesAtOrBelow,
+  type PermissionMode,
+} from "./utils";
+
+describe("rolesAtOrBelow", () => {
+  describe("when given ADMIN", () => {
+    it("returns ADMIN, MEMBER, VIEWER", () => {
+      expect(rolesAtOrBelow("ADMIN")).toEqual([
+        { label: "ADMIN", value: "ADMIN" },
+        { label: "MEMBER", value: "MEMBER" },
+        { label: "VIEWER", value: "VIEWER" },
+      ]);
+    });
+  });
+
+  describe("when given MEMBER", () => {
+    it("returns MEMBER, VIEWER", () => {
+      expect(rolesAtOrBelow("MEMBER")).toEqual([
+        { label: "MEMBER", value: "MEMBER" },
+        { label: "VIEWER", value: "VIEWER" },
+      ]);
+    });
+  });
+
+  describe("when given VIEWER", () => {
+    it("returns only VIEWER", () => {
+      expect(rolesAtOrBelow("VIEWER")).toEqual([
+        { label: "VIEWER", value: "VIEWER" },
+      ]);
+    });
+  });
+
+  describe("when given CUSTOM", () => {
+    it("returns empty array", () => {
+      expect(rolesAtOrBelow("CUSTOM")).toEqual([]);
+    });
+  });
+
+  describe("when given unknown role", () => {
+    it("returns empty array", () => {
+      expect(rolesAtOrBelow("UNKNOWN")).toEqual([]);
+    });
+  });
+});
+
+describe("computeBindings", () => {
+  const bindings = [
+    {
+      id: "b1",
+      role: "ADMIN",
+      customRoleId: null,
+      scopeType: "ORGANIZATION",
+      scopeId: "org-1",
+    },
+    {
+      id: "b2",
+      role: "MEMBER",
+      customRoleId: null,
+      scopeType: "PROJECT",
+      scopeId: "proj-1",
+    },
+  ];
+
+  const customBinding = [
+    {
+      id: "b3",
+      role: "CUSTOM",
+      customRoleId: "cr-1",
+      scopeType: "TEAM",
+      scopeId: "team-1",
+    },
+  ];
+
+  describe("when data is undefined", () => {
+    it("returns empty array", () => {
+      const result = computeBindings({
+        data: undefined,
+        permissionMode: "all",
+        roleOverrides: {},
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("when permissionMode is all", () => {
+    it("passes through roles unchanged", () => {
+      const result = computeBindings({
+        data: bindings,
+        permissionMode: "all",
+        roleOverrides: {},
+      });
+      expect(result).toEqual([
+        {
+          role: "ADMIN",
+          customRoleId: null,
+          scopeType: "ORGANIZATION",
+          scopeId: "org-1",
+        },
+        {
+          role: "MEMBER",
+          customRoleId: null,
+          scopeType: "PROJECT",
+          scopeId: "proj-1",
+        },
+      ]);
+    });
+
+    it("preserves customRoleId for CUSTOM roles", () => {
+      const result = computeBindings({
+        data: customBinding,
+        permissionMode: "all",
+        roleOverrides: {},
+      });
+      expect(result[0]!.customRoleId).toBe("cr-1");
+    });
+  });
+
+  describe("when permissionMode is readonly", () => {
+    it("sets all roles to VIEWER", () => {
+      const result = computeBindings({
+        data: bindings,
+        permissionMode: "readonly",
+        roleOverrides: {},
+      });
+      expect(result.every((b) => b.role === "VIEWER")).toBe(true);
+    });
+
+    it("clears customRoleId", () => {
+      const result = computeBindings({
+        data: customBinding,
+        permissionMode: "readonly",
+        roleOverrides: {},
+      });
+      expect(result[0]!.customRoleId).toBeNull();
+    });
+
+    it("preserves scope information", () => {
+      const result = computeBindings({
+        data: bindings,
+        permissionMode: "readonly",
+        roleOverrides: {},
+      });
+      expect(result[0]).toMatchObject({
+        scopeType: "ORGANIZATION",
+        scopeId: "org-1",
+      });
+    });
+  });
+
+  describe("when permissionMode is restricted", () => {
+    describe("when no overrides are set", () => {
+      it("keeps original roles", () => {
+        const result = computeBindings({
+          data: bindings,
+          permissionMode: "restricted",
+          roleOverrides: {},
+        });
+        expect(result[0]!.role).toBe("ADMIN");
+        expect(result[1]!.role).toBe("MEMBER");
+      });
+    });
+
+    describe("when an override changes the role", () => {
+      it("applies the overridden role", () => {
+        const result = computeBindings({
+          data: bindings,
+          permissionMode: "restricted",
+          roleOverrides: { b1: "VIEWER" },
+        });
+        expect(result[0]!.role).toBe("VIEWER");
+      });
+
+      it("clears customRoleId for overridden bindings", () => {
+        const result = computeBindings({
+          data: customBinding,
+          permissionMode: "restricted",
+          roleOverrides: { b3: "VIEWER" },
+        });
+        expect(result[0]!.role).toBe("VIEWER");
+        expect(result[0]!.customRoleId).toBeNull();
+      });
+    });
+
+    describe("when override matches the original role", () => {
+      it("keeps the original binding unchanged", () => {
+        const result = computeBindings({
+          data: bindings,
+          permissionMode: "restricted",
+          roleOverrides: { b1: "ADMIN" },
+        });
+        expect(result[0]!.role).toBe("ADMIN");
+        expect(result[0]!.customRoleId).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/personalAccessToken.ts
+++ b/langwatch/src/server/api/routers/personalAccessToken.ts
@@ -141,6 +141,7 @@ export const personalAccessTokenRouter = createTRPCRouter({
 
       return pats.map((pat) => ({
         id: pat.id,
+        lookupId: pat.lookupId,
         name: pat.name,
         description: pat.description,
         createdAt: pat.createdAt,

--- a/langwatch/src/server/api/routers/personalAccessToken.ts
+++ b/langwatch/src/server/api/routers/personalAccessToken.ts
@@ -141,7 +141,7 @@ export const personalAccessTokenRouter = createTRPCRouter({
 
       return pats.map((pat) => ({
         id: pat.id,
-        lookupId: pat.lookupId,
+        lookupIdSuffix: pat.lookupId.slice(-4),
         name: pat.name,
         description: pat.description,
         createdAt: pat.createdAt,


### PR DESCRIPTION
## Why

Closes #3367

The PAT (Personal Access Tokens) feature shipped recently and a bugbash surfaced 7 UI polish items: tokens are indistinguishable after creation, button styles don't match app conventions, warning colors feel off-brand, em dashes clutter the copy, the token masking UX contradicts the "copy now" message, and there's no way to scope token permissions below full access.

## What changed

**7 items addressed across 6 files:**

1. **Token hint column** — the tRPC `list` procedure now returns a `lookupIdSuffix` (last 4 chars of the public `lookupId`), and the table shows a "Secret Key" column with `pat-lw-...XXXX` hints so users can tell tokens apart.

2. **Warning color** — replaced `orange.500` with `red.500` in the Token Created dialog to match the app's semantic color palette (red = urgent/destructive).

3. **Button styles** — added `colorPalette="blue"` to the drawer's Create Token button (matching `secrets.tsx`, `CreateGroupDialog`), and switched the table header button to `PageLayout.HeaderButton` (matching `members.tsx`).

4. **Access section background** — changed from `bg.muted` to `bg.subtle` so ADMIN badges don't blend into the background.

5. **Em dash removal** — replaced all 5 user-facing em dashes with periods or colons across 4 files.

6. **Token masking UX** — added a `defaultRevealed` prop to `CodeBlock` and set it in the Token Created dialog so the .env block starts revealed (consistent with "copy this token now").

7. **Permission level picker** — added a RadioGroup with All / Read only / Restricted modes to `CreatePatDrawer`. "All" mirrors current behavior, "Read only" sends VIEWER bindings at every scope, "Restricted" shows per-scope role selectors capped by the user's ceiling. Pure frontend change — the backend already validates ceiling enforcement.

## How it works

The permission picker introduces `computeBindings()` (extracted to `utils.ts` for testability) which maps the selected mode + any role overrides into the binding array sent to the `create` mutation. Role collections for the per-scope Select dropdowns are memoized via `useMemo` to avoid recreating them on every render.

The server returns only `lookupIdSuffix` (last 4 chars) rather than the full `lookupId` as a defense-in-depth measure — the client only needs the suffix for display.

## Test plan

- [x] `pnpm typecheck` passes clean
- [ ] Create a PAT with "All permissions" → token table shows `pat-lw-...XXXX` hint
- [ ] Create a PAT with "Read only" → bindings sent as VIEWER at every scope
- [ ] Create a PAT with "Restricted" → per-scope role selector appears, roles capped by user ceiling
- [ ] Token Created dialog shows red warning text, token is revealed by default
- [ ] Header "Create Token" button renders as outline/sm, drawer submit button is blue
- [ ] No em dashes in user-facing copy
- [ ] Access section background doesn't swallow badge contrast

# Related Issue

- Resolve #3367

## Test evidence

Browser QA performed against `http://localhost:5562` with all 7 items verified end-to-end.
See [comment with screenshots](https://github.com/langwatch/langwatch/pull/3371#issuecomment-4291885744).

- [x] Token table shows "Secret Key" column with `pat-lw-...XXXX` hints
- [x] Token Created dialog uses red warning color (not orange)
- [x] Blue CTA button on drawer submit, outline header button
- [x] Permission picker (All / Read only / Restricted) works with per-scope selectors
- [x] Em dashes removed from all user-facing copy
- [x] Access section background uses bg.subtle (badges visible)
- [x] Token defaults to revealed in creation dialog
- [x] `pnpm typecheck` passes clean
- [x] 15 unit tests pass for `computeBindings` and `rolesAtOrBelow`