### PR TITLE
fix(invites): require PENDING status before accepting invites

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for acceptInvite status guard.
+ *
+ * Regression tests for #450: acceptInvite must require status === "PENDING"
+ * before applying the invite. Non-PENDING statuses (PAYMENT_PENDING,
+ * WAITING_APPROVAL) must be rejected with BAD_REQUEST.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { organizationRouter } from "../organization";
+import { createInnerTRPCContext } from "../../trpc";
+import {
+  INVITE_ALREADY_ACCEPTED_MESSAGE,
+  INVITE_NOT_READY_MESSAGE,
+} from "../../../invites/errors";
+
+vi.mock("../../../../env.mjs", () => ({
+  env: {
+    SENDGRID_API_KEY: "test-key",
+    BASE_HOST: "http://localhost:3000",
+  },
+}));
+
+vi.mock("../../../auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    skipPermissionCheck: ({ ctx, next }: any) => {
+      ctx.permissionChecked = true;
+      return next();
+    },
+    checkOrganizationPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+    checkTeamPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+function makeInvite(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "inv-1",
+    email: "user@example.com",
+    inviteCode: "test-code",
+    status: "PENDING",
+    expiration: new Date(Date.now() + 86400000),
+    organizationId: "org-1",
+    teamIds: "team-1",
+    teamAssignments: null,
+    role: "MEMBER",
+    requestedBy: null,
+    subscriptionId: null,
+    organization: { id: "org-1", name: "Test Org" },
+    ...overrides,
+  };
+}
+
+describe("organization.acceptInvite", () => {
+  let findUniqueMock: ReturnType<typeof vi.fn>;
+  let transactionMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findUniqueMock = vi.fn();
+    transactionMock = vi.fn();
+  });
+
+  function createCaller(email = "user@example.com") {
+    const ctx = createInnerTRPCContext({
+      session: {
+        user: { id: "user-1", name: "Test User", email },
+        expires: "2099-01-01",
+      },
+    });
+    (ctx as any).prisma = {
+      organizationInvite: { findUnique: findUniqueMock },
+      project: { findFirst: vi.fn().mockResolvedValue(null) },
+      $transaction: transactionMock,
+    };
+    return organizationRouter.createCaller(ctx);
+  }
+
+  describe("when invite status is PENDING", () => {
+    it("proceeds to apply the invite", async () => {
+      findUniqueMock.mockResolvedValue(makeInvite({ status: "PENDING" }));
+      transactionMock.mockImplementation(async (fn: any) => {
+        // Simulate successful transaction — the actual applyInvite
+        // internals are not under test here
+        await fn({
+          organizationUser: { createMany: vi.fn() },
+          roleBinding: { deleteMany: vi.fn(), create: vi.fn() },
+          organizationInvite: {
+            update: vi.fn().mockResolvedValue(makeInvite({ status: "ACCEPTED" })),
+            findFirst: vi.fn().mockResolvedValue(null),
+          },
+          project: { findFirst: vi.fn().mockResolvedValue(null) },
+        });
+      });
+
+      const caller = createCaller();
+      const result = await caller.acceptInvite({ inviteCode: "test-code" });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("when invite status is PAYMENT_PENDING", () => {
+    it("rejects with BAD_REQUEST", async () => {
+      findUniqueMock.mockResolvedValue(
+        makeInvite({ status: "PAYMENT_PENDING", expiration: null })
+      );
+
+      const caller = createCaller();
+
+      await expect(
+        caller.acceptInvite({ inviteCode: "test-code" })
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message: INVITE_NOT_READY_MESSAGE,
+      });
+    });
+
+    it("does not call the transaction", async () => {
+      findUniqueMock.mockResolvedValue(
+        makeInvite({ status: "PAYMENT_PENDING", expiration: null })
+      );
+
+      const caller = createCaller();
+
+      await caller
+        .acceptInvite({ inviteCode: "test-code" })
+        .catch(() => {});
+
+      expect(transactionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when invite status is WAITING_APPROVAL", () => {
+    it("rejects with BAD_REQUEST", async () => {
+      findUniqueMock.mockResolvedValue(
+        makeInvite({ status: "WAITING_APPROVAL", expiration: null })
+      );
+
+      const caller = createCaller();
+
+      await expect(
+        caller.acceptInvite({ inviteCode: "test-code" })
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message: INVITE_NOT_READY_MESSAGE,
+      });
+    });
+
+    it("does not call the transaction", async () => {
+      findUniqueMock.mockResolvedValue(
+        makeInvite({ status: "WAITING_APPROVAL", expiration: null })
+      );
+
+      const caller = createCaller();
+
+      await caller
+        .acceptInvite({ inviteCode: "test-code" })
+        .catch(() => {});
+
+      expect(transactionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when invite status is ACCEPTED", () => {
+    it("rejects with the already-accepted message", async () => {
+      findUniqueMock.mockResolvedValue(makeInvite({ status: "ACCEPTED" }));
+
+      const caller = createCaller();
+
+      await expect(
+        caller.acceptInvite({ inviteCode: "test-code" })
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message: INVITE_ALREADY_ACCEPTED_MESSAGE,
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts
@@ -111,6 +111,7 @@ describe("organization.acceptInvite", () => {
       const result = await caller.acceptInvite({ inviteCode: "test-code" });
 
       expect(result.success).toBe(true);
+      expect(transactionMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -28,6 +28,7 @@ import {
 import {
   DuplicateInviteError,
   INVITE_ALREADY_ACCEPTED_MESSAGE,
+  INVITE_NOT_READY_MESSAGE,
   InviteNotFoundError,
   OrganizationNotFoundError,
 } from "../../invites/errors";
@@ -1000,6 +1001,13 @@ export const organizationRouter = createTRPCRouter({
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: INVITE_ALREADY_ACCEPTED_MESSAGE,
+        });
+      }
+
+      if (invite.status !== "PENDING") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: INVITE_NOT_READY_MESSAGE,
         });
       }
 

--- a/langwatch/src/server/invites/__tests__/invite.service.unit.test.ts
+++ b/langwatch/src/server/invites/__tests__/invite.service.unit.test.ts
@@ -579,4 +579,118 @@ describe("InviteService", () => {
       });
     });
   });
+
+  describe("subscription invite flow: create → approve → apply", () => {
+    describe("when a PAYMENT_PENDING invite is approved and then applied", () => {
+      const mockOrganization = { id: "org-1", name: "Test Org" };
+      let roleBindingsCreated: Array<Record<string, unknown>>;
+
+      beforeEach(() => {
+        roleBindingsCreated = [];
+
+        // Step 1: createPaymentPendingInvite creates a PAYMENT_PENDING record
+        mockPrisma.organizationInvite.create.mockResolvedValue({
+          id: "inv-flow-1",
+          email: "sub-user@example.com",
+          inviteCode: "flow-code-1",
+          status: "PAYMENT_PENDING",
+          subscriptionId: "sub-flow-1",
+          organizationId: "org-1",
+          teamIds: "team-1",
+          teamAssignments: null,
+          role: "MEMBER",
+          expiration: null,
+        });
+
+        // Step 2: approvePaymentPendingInvites finds the invite and transitions it
+        mockPrisma.organizationInvite.findMany.mockResolvedValue([
+          {
+            id: "inv-flow-1",
+            email: "sub-user@example.com",
+            inviteCode: "flow-code-1",
+            status: "PAYMENT_PENDING",
+            subscriptionId: "sub-flow-1",
+            organizationId: "org-1",
+            organization: mockOrganization,
+          },
+        ]);
+        mockPrisma.organizationInvite.update.mockResolvedValue({
+          id: "inv-flow-1",
+          email: "sub-user@example.com",
+          inviteCode: "flow-code-1",
+          status: "PENDING",
+          subscriptionId: "sub-flow-1",
+          organizationId: "org-1",
+          teamIds: "team-1",
+          teamAssignments: null,
+          role: "MEMBER",
+          expiration: new Date(Date.now() + 48 * 60 * 60 * 1000),
+        });
+        mockSendInviteEmail.mockResolvedValue(undefined);
+
+        // Step 3: applyInvite — track RoleBinding creation
+        (mockPrisma as any).organizationUser = {
+          createMany: vi.fn(),
+        };
+        (mockPrisma as any).roleBinding = {
+          deleteMany: vi.fn(),
+          create: vi.fn().mockImplementation(({ data }) => {
+            roleBindingsCreated.push(data);
+            return Promise.resolve(data);
+          }),
+        };
+      });
+
+      it("transitions through PAYMENT_PENDING → PENDING → ACCEPTED and creates RoleBindings", async () => {
+        // Step 1: Create PAYMENT_PENDING invite
+        const invite = await service.createPaymentPendingInvite({
+          email: "sub-user@example.com",
+          role: "MEMBER" as any,
+          organizationId: "org-1",
+          teamIds: "team-1",
+          subscriptionId: "sub-flow-1",
+        });
+
+        expect(invite.status).toBe("PAYMENT_PENDING");
+
+        // Step 2: Simulate webhook approval
+        const approved = await service.approvePaymentPendingInvites({
+          subscriptionId: "sub-flow-1",
+          organizationId: "org-1",
+        });
+
+        expect(approved).toHaveLength(1);
+        expect(approved[0]!.status).toBe("PENDING");
+
+        // Step 3: Apply the now-PENDING invite (simulating acceptInvite)
+        await service.applyInvite({
+          userId: "user-flow-1",
+          invite: approved[0]! as any,
+        });
+
+        // Verify: org-scoped RoleBinding was created (MEMBER gets org binding)
+        const orgBinding = roleBindingsCreated.find(
+          (rb) => rb.scopeType === "ORGANIZATION"
+        );
+        expect(orgBinding).toBeDefined();
+        expect(orgBinding!.userId).toBe("user-flow-1");
+        expect(orgBinding!.organizationId).toBe("org-1");
+
+        // Verify: team-scoped RoleBinding was created
+        const teamBinding = roleBindingsCreated.find(
+          (rb) => rb.scopeType === "TEAM"
+        );
+        expect(teamBinding).toBeDefined();
+        expect(teamBinding!.userId).toBe("user-flow-1");
+        expect(teamBinding!.scopeId).toBe("team-1");
+
+        // Verify: invite was marked ACCEPTED
+        expect(mockPrisma.organizationInvite.update).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            data: { status: "ACCEPTED" },
+          })
+        );
+      });
+    });
+  });
 });

--- a/langwatch/src/server/invites/__tests__/invite.service.unit.test.ts
+++ b/langwatch/src/server/invites/__tests__/invite.service.unit.test.ts
@@ -685,7 +685,7 @@ describe("InviteService", () => {
         expect(teamBinding!.scopeId).toBe("team-1");
 
         // Verify: invite was marked ACCEPTED
-        expect(mockPrisma.organizationInvite.update).toHaveBeenLastCalledWith(
+        expect(mockPrisma.organizationInvite.update).toHaveBeenCalledWith(
           expect.objectContaining({
             data: { status: "ACCEPTED" },
           })

--- a/langwatch/src/server/invites/__tests__/invite.service.unit.test.ts
+++ b/langwatch/src/server/invites/__tests__/invite.service.unit.test.ts
@@ -693,4 +693,44 @@ describe("InviteService", () => {
       });
     });
   });
+
+  describe("applyInvite", () => {
+    describe("when invite status is not PENDING", () => {
+      it("throws for PAYMENT_PENDING invites", async () => {
+        await expect(
+          service.applyInvite({
+            userId: "user-1",
+            invite: {
+              id: "inv-guard-1",
+              status: "PAYMENT_PENDING",
+              organizationId: "org-1",
+              teamIds: "team-1",
+              teamAssignments: null,
+              role: "MEMBER",
+            } as any,
+          })
+        ).rejects.toThrow(
+          "Cannot apply invite inv-guard-1: status is PAYMENT_PENDING, expected PENDING"
+        );
+      });
+
+      it("throws for ACCEPTED invites", async () => {
+        await expect(
+          service.applyInvite({
+            userId: "user-1",
+            invite: {
+              id: "inv-guard-2",
+              status: "ACCEPTED",
+              organizationId: "org-1",
+              teamIds: "team-1",
+              teamAssignments: null,
+              role: "MEMBER",
+            } as any,
+          })
+        ).rejects.toThrow(
+          "Cannot apply invite inv-guard-2: status is ACCEPTED, expected PENDING"
+        );
+      });
+    });
+  });
 });

--- a/langwatch/src/server/invites/errors.ts
+++ b/langwatch/src/server/invites/errors.ts
@@ -11,6 +11,9 @@
 export const INVITE_ALREADY_ACCEPTED_MESSAGE =
   "Invite was already accepted" as const;
 
+export const INVITE_NOT_READY_MESSAGE =
+  "Invite is not ready to be accepted" as const;
+
 export class DuplicateInviteError extends Error {
   constructor(email: string) {
     super(`An active invitation for ${email} already exists`);

--- a/langwatch/src/server/invites/errors.ts
+++ b/langwatch/src/server/invites/errors.ts
@@ -30,6 +30,15 @@ export class InviteNotFoundError extends Error {
   }
 }
 
+export class InviteNotReadyError extends Error {
+  constructor(inviteId: string, status: string) {
+    super(
+      `Cannot apply invite ${inviteId}: status is ${status}, expected PENDING`
+    );
+    this.name = "InviteNotReadyError";
+  }
+}
+
 export class OrganizationNotFoundError extends Error {
   constructor() {
     super("Organization not found");

--- a/langwatch/src/server/invites/invite.service.ts
+++ b/langwatch/src/server/invites/invite.service.ts
@@ -533,6 +533,12 @@ export class InviteService {
     userId: string;
     invite: OrganizationInvite;
   }): Promise<void> {
+    if (invite.status !== "PENDING") {
+      throw new Error(
+        `Cannot apply invite ${invite.id}: status is ${invite.status}, expected PENDING`
+      );
+    }
+
     await this.prisma.organizationUser.createMany({
       data: [
         {

--- a/langwatch/src/server/invites/invite.service.ts
+++ b/langwatch/src/server/invites/invite.service.ts
@@ -11,6 +11,7 @@ import { KSUID_RESOURCES } from "~/utils/constants";
 import {
   DuplicateInviteError,
   InviteNotFoundError,
+  InviteNotReadyError,
   OrganizationNotFoundError,
 } from "./errors";
 import { LimitExceededError } from "../license-enforcement/errors";
@@ -534,9 +535,7 @@ export class InviteService {
     invite: OrganizationInvite;
   }): Promise<void> {
     if (invite.status !== "PENDING") {
-      throw new Error(
-        `Cannot apply invite ${invite.id}: status is ${invite.status}, expected PENDING`
-      );
+      throw new InviteNotReadyError(invite.id, invite.status);
     }
 
     await this.prisma.organizationUser.createMany({


### PR DESCRIPTION
## Summary

- Adds explicit `status === "PENDING"` guard in `acceptInvite` (tRPC router) before calling `applyInvite`, rejecting non-PENDING invites with `BAD_REQUEST`
- Adds defense-in-depth guard inside `InviteService.applyInvite` itself, protecting all callers (including the SSO auto-join path in `better-auth/hooks.ts`)
- Adds regression tests proving `PAYMENT_PENDING`, `WAITING_APPROVAL`, and `ACCEPTED` invites are rejected
- Adds subscription invite flow test (PAYMENT_PENDING → PENDING → ACCEPTED with RoleBinding creation)

Closes langwatch/langwatch-saas#450

## Test plan

- [x] `pnpm test:unit src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts` — 6/6 pass
- [x] `pnpm test:unit src/server/invites/__tests__/invite.service.unit.test.ts` — 29/29 pass

# Related Issue

- Resolve #450