### PR TITLE
feat(analytics): suppress tracking during admin impersonation and label admin users

### DIFF
--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 
 import { getApp } from "../../../../src/server/app-layer/app";
+import { isAdmin } from "../../../admin/isAdmin";
 import type { signUpDataSchema } from "../../../../src/server/schemas/sign-up-data.schema";
 import { captureException } from "../../../../src/utils/posthogErrorCapture";
 import type { CioPersonTraits } from "../types";
@@ -74,6 +75,7 @@ export function fireSignupNurturingCalls({
     has_prompts: false,
     has_simulations: false,
     has_subscription: false,
+    is_admin: isAdmin({ email }),
     createdAt: new Date().toISOString(),
   };
 

--- a/langwatch/ee/billing/nurturing/hooks/userSync.ts
+++ b/langwatch/ee/billing/nurturing/hooks/userSync.ts
@@ -1,4 +1,5 @@
 import { getApp } from "../../../../src/server/app-layer/app";
+import { isAdmin } from "../../../admin/isAdmin";
 import { prisma } from "../../../../src/server/db";
 import { captureException } from "../../../../src/utils/posthogErrorCapture";
 import type { CioPersonTraits, CioOrgTraits } from "../types";
@@ -107,6 +108,7 @@ async function performFullSync({ userId }: { userId: string }): Promise<void> {
     has_subscription: !!activeSubscription,
     createdAt: user.createdAt.toISOString(),
     last_active_at: new Date().toISOString(),
+    is_admin: isAdmin({ email: user.email }),
   };
 
   const orgTraits: Partial<CioOrgTraits> = {

--- a/langwatch/ee/billing/nurturing/types.ts
+++ b/langwatch/ee/billing/nurturing/types.ts
@@ -71,6 +71,9 @@ export interface CioPersonTraits {
   // Billing
   plan: string;
   has_subscription: boolean;
+
+  // Admin labeling
+  is_admin: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/langwatch/ee/saas/ExtraFooterComponents.tsx
+++ b/langwatch/ee/saas/ExtraFooterComponents.tsx
@@ -55,6 +55,7 @@ export function SignedInExtraFooterComponents() {
   useEffect(() => {
     if (!session.data?.user?.email || !organization?.name || hasTracked.current)
       return;
+    if (session.data.user.impersonator) return;
 
     const reo = (window as any).Reo;
     if (!reo?.identify) return;

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -322,6 +322,7 @@ export const DashboardLayout = ({
     session: session ?? null,
     organization,
     planType: usage.data?.activePlan?.type,
+    isAdmin: publicEnv.data?.IS_ADMIN,
   });
 
   if (typeof router.query.project === "string" && !isLoading && !project) {

--- a/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
@@ -65,6 +65,11 @@ describe("impersonationBeforeSend", () => {
       const event = { event: "$snapshot", properties: {} };
       expect(impersonationBeforeSend(event)).toBe(event);
     });
+
+    it("allows $exception events through (error capture)", () => {
+      const event = { event: "$exception", properties: {} };
+      expect(impersonationBeforeSend(event)).toBe(event);
+    });
   });
 });
 

--- a/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/usePostHog.unit.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the PostHog before_send callback and impersonation state.
+ *
+ * Verifies:
+ * - before_send drops capture events during impersonation
+ * - before_send allows capture events for normal sessions
+ * - before_send allows $snapshot events during impersonation (session recording)
+ * - Impersonation state module-level ref updates correctly
+ */
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  impersonationBeforeSend,
+  setPostHogImpersonationState,
+  getPostHogImpersonationState,
+} from "../usePostHog";
+
+describe("impersonationBeforeSend", () => {
+  beforeEach(() => {
+    setPostHogImpersonationState(false);
+  });
+
+  describe("when not impersonating", () => {
+    it("returns the event unchanged for capture events", () => {
+      const event = { event: "$autocapture", properties: {} };
+      expect(impersonationBeforeSend(event)).toBe(event);
+    });
+
+    it("returns the event unchanged for pageview events", () => {
+      const event = { event: "$pageview", properties: {} };
+      expect(impersonationBeforeSend(event)).toBe(event);
+    });
+
+    it("returns the event unchanged for custom events", () => {
+      const event = { event: "evaluation_ran", properties: {} };
+      expect(impersonationBeforeSend(event)).toBe(event);
+    });
+
+    it("returns the event unchanged for $snapshot events", () => {
+      const event = { event: "$snapshot", properties: {} };
+      expect(impersonationBeforeSend(event)).toBe(event);
+    });
+  });
+
+  describe("when impersonating", () => {
+    beforeEach(() => {
+      setPostHogImpersonationState(true);
+    });
+
+    it("drops $autocapture events", () => {
+      const event = { event: "$autocapture", properties: {} };
+      expect(impersonationBeforeSend(event)).toBeNull();
+    });
+
+    it("drops $pageview events", () => {
+      const event = { event: "$pageview", properties: {} };
+      expect(impersonationBeforeSend(event)).toBeNull();
+    });
+
+    it("drops custom capture events", () => {
+      const event = { event: "evaluation_ran", properties: {} };
+      expect(impersonationBeforeSend(event)).toBeNull();
+    });
+
+    it("allows $snapshot events through (session recording)", () => {
+      const event = { event: "$snapshot", properties: {} };
+      expect(impersonationBeforeSend(event)).toBe(event);
+    });
+  });
+});
+
+describe("setPostHogImpersonationState", () => {
+  beforeEach(() => {
+    setPostHogImpersonationState(false);
+  });
+
+  it("sets state to true", () => {
+    setPostHogImpersonationState(true);
+    expect(getPostHogImpersonationState()).toBe(true);
+  });
+
+  it("sets state to false", () => {
+    setPostHogImpersonationState(true);
+    setPostHogImpersonationState(false);
+    expect(getPostHogImpersonationState()).toBe(false);
+  });
+});

--- a/langwatch/src/hooks/__tests__/usePostHogIdentify.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/usePostHogIdentify.unit.test.ts
@@ -4,10 +4,12 @@
  * Unit tests for usePostHogIdentify hook.
  *
  * Verifies:
- * - Calls posthog.identify with userId and email
+ * - Calls posthog.identify with userId, email, and is_admin
  * - Calls posthog.group with organization data
  * - Calls posthog.reset on logout (userId disappears)
  * - Tracks upgrade_modal_shown via Zustand subscribe
+ * - Skips identify and group during impersonation
+ * - Sets is_admin person property based on isAdmin prop
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
@@ -30,6 +32,14 @@ vi.mock("posthog-js", () => ({
   },
 }));
 
+const { mockSetImpersonationState } = vi.hoisted(() => ({
+  mockSetImpersonationState: vi.fn(),
+}));
+
+vi.mock("../usePostHog", () => ({
+  setPostHogImpersonationState: mockSetImpersonationState,
+}));
+
 import { useUpgradeModalStore } from "../../stores/upgradeModalStore";
 import { usePostHogIdentify } from "../usePostHogIdentify";
 
@@ -44,7 +54,7 @@ describe("usePostHogIdentify", () => {
   });
 
   describe("when session has a user", () => {
-    it("identifies user with userId and email", () => {
+    it("identifies user with userId, email, and is_admin false", () => {
       renderHook(() =>
         usePostHogIdentify({
           session: { user: { id: "user-1", email: "test@example.com" } },
@@ -55,6 +65,7 @@ describe("usePostHogIdentify", () => {
 
       expect(mockIdentify).toHaveBeenCalledWith("user-1", {
         email: "test@example.com",
+        is_admin: false,
       });
     });
 
@@ -69,6 +80,7 @@ describe("usePostHogIdentify", () => {
 
       expect(mockIdentify).toHaveBeenCalledWith("user-1", {
         email: undefined,
+        is_admin: false,
       });
     });
   });
@@ -93,7 +105,13 @@ describe("usePostHogIdentify", () => {
         ({
           session,
         }: {
-          session: { user: { id: string; email?: string | null } } | null;
+          session: {
+            user: {
+              id: string;
+              email?: string | null;
+              impersonator?: { id: string } | null;
+            };
+          } | null;
         }) =>
           usePostHogIdentify({
             session,
@@ -104,7 +122,13 @@ describe("usePostHogIdentify", () => {
           initialProps: {
             session: {
               user: { id: "user-1", email: "test@example.com" },
-            } as { user: { id: string; email?: string | null } } | null,
+            } as {
+              user: {
+                id: string;
+                email?: string | null;
+                impersonator?: { id: string } | null;
+              };
+            } | null,
           },
         },
       );
@@ -124,7 +148,13 @@ describe("usePostHogIdentify", () => {
         ({
           session,
         }: {
-          session: { user: { id: string; email?: string | null } } | null;
+          session: {
+            user: {
+              id: string;
+              email?: string | null;
+              impersonator?: { id: string } | null;
+            };
+          } | null;
         }) =>
           usePostHogIdentify({
             session,
@@ -135,13 +165,20 @@ describe("usePostHogIdentify", () => {
           initialProps: {
             session: {
               user: { id: "user-1", email: "a@example.com" },
-            } as { user: { id: string; email?: string | null } } | null,
+            } as {
+              user: {
+                id: string;
+                email?: string | null;
+                impersonator?: { id: string } | null;
+              };
+            } | null,
           },
         },
       );
 
       expect(mockIdentify).toHaveBeenCalledWith("user-1", {
         email: "a@example.com",
+        is_admin: false,
       });
 
       // Switch to different user
@@ -152,6 +189,7 @@ describe("usePostHogIdentify", () => {
       expect(mockReset).toHaveBeenCalledTimes(1);
       expect(mockIdentify).toHaveBeenCalledWith("user-2", {
         email: "b@example.com",
+        is_admin: false,
       });
     });
   });
@@ -212,6 +250,111 @@ describe("usePostHogIdentify", () => {
       );
 
       expect(mockGroup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when session has impersonator set", () => {
+    it("skips posthog.identify", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: {
+            user: {
+              id: "user-1",
+              email: "test@example.com",
+              impersonator: { id: "admin-1" },
+            },
+          },
+          organization: undefined,
+          planType: undefined,
+        }),
+      );
+
+      expect(mockIdentify).not.toHaveBeenCalled();
+    });
+
+    it("skips posthog.group", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: {
+            user: {
+              id: "user-1",
+              email: "test@example.com",
+              impersonator: { id: "admin-1" },
+            },
+          },
+          organization: { id: "org-1", name: "Acme Corp" },
+          planType: "pro",
+        }),
+      );
+
+      expect(mockGroup).not.toHaveBeenCalled();
+    });
+
+    it("sets impersonation state to true", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: {
+            user: {
+              id: "user-1",
+              impersonator: { id: "admin-1" },
+            },
+          },
+          organization: undefined,
+          planType: undefined,
+        }),
+      );
+
+      expect(mockSetImpersonationState).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("when session has no impersonator", () => {
+    it("sets impersonation state to false", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: { user: { id: "user-1" } },
+          organization: undefined,
+          planType: undefined,
+        }),
+      );
+
+      expect(mockSetImpersonationState).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("when isAdmin is true", () => {
+    it("includes is_admin true in person properties", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: { user: { id: "user-1", email: "admin@example.com" } },
+          organization: undefined,
+          planType: undefined,
+          isAdmin: true,
+        }),
+      );
+
+      expect(mockIdentify).toHaveBeenCalledWith("user-1", {
+        email: "admin@example.com",
+        is_admin: true,
+      });
+    });
+  });
+
+  describe("when isAdmin is false", () => {
+    it("includes is_admin false in person properties", () => {
+      renderHook(() =>
+        usePostHogIdentify({
+          session: { user: { id: "user-1", email: "user@example.com" } },
+          organization: undefined,
+          planType: undefined,
+          isAdmin: false,
+        }),
+      );
+
+      expect(mockIdentify).toHaveBeenCalledWith("user-1", {
+        email: "user@example.com",
+        is_admin: false,
+      });
     });
   });
 

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -45,9 +45,12 @@ export function impersonationBeforeSend(
   // separately and should continue during impersonation for debugging.
   if (event.event === "$snapshot") return event;
 
+  // Allow exception events through — error capture must remain active
+  // during impersonation so admins can debug issues.
+  if (event.event === "$exception") return event;
+
   // Drop all other capture events (autocapture, pageviews, custom events).
-  // Feature flags (/decide endpoint) and error capture are not routed through
-  // before_send — they use separate code paths in posthog-js.
+  // Feature flags use the /decide endpoint, not the capture path.
   return null;
 }
 

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -2,6 +2,55 @@ import posthog from "posthog-js";
 import { useEffect } from "react";
 import { usePublicEnv } from "./usePublicEnv";
 
+/**
+ * Module-level flag read by the `before_send` callback closure.
+ * Updated by `setPostHogImpersonationState` (called from usePostHogIdentify).
+ *
+ * Using a module-level variable (not React state) because `before_send` is
+ * configured once at `posthog.init` time and the closure must always read
+ * the latest value without re-initialization.
+ */
+let _isImpersonating = false;
+
+/**
+ * Sets the impersonation state read by the PostHog `before_send` callback.
+ * Called from usePostHogIdentify when the session changes.
+ */
+export function setPostHogImpersonationState(impersonating: boolean): void {
+  _isImpersonating = impersonating;
+}
+
+/**
+ * Returns the current impersonation state. Exposed for testing.
+ * @internal
+ */
+export function getPostHogImpersonationState(): boolean {
+  return _isImpersonating;
+}
+
+/**
+ * PostHog `before_send` callback. Drops capture events during impersonation
+ * but allows session recording ($snapshot) and feature flag requests through.
+ *
+ * Safety: This replaces the opt_out_capturing/opt_in_capturing approach that
+ * caused a production outage (PR #2244 / #2398) by triggering a race condition
+ * with session recording initialization.
+ */
+export function impersonationBeforeSend(
+  event: { event: string } & Record<string, unknown>,
+): typeof event | null {
+  if (!_isImpersonating) return event;
+
+  // Allow session recording events ($snapshot) through — these are captured
+  // separately and should continue during impersonation for debugging.
+  if (event.event === "$snapshot") return event;
+
+  // Drop all other capture events (autocapture, pageviews, custom events).
+  // Feature flags (/decide endpoint) and error capture are not routed through
+  // before_send — they use separate code paths in posthog-js.
+  return null;
+}
+
 export function usePostHog() {
   const publicEnv = usePublicEnv();
 
@@ -31,6 +80,8 @@ export function usePostHog() {
         session_recording: {
           recordCrossOriginIframes: true,
         },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        before_send: impersonationBeforeSend as any,
         loaded: (posthog) => {
           // Explicitly expose `window.posthog` so the PostHog toolbar
           // (launched from the PostHog dashboard's "Toolbar" button)

--- a/langwatch/src/hooks/usePostHogIdentify.ts
+++ b/langwatch/src/hooks/usePostHogIdentify.ts
@@ -1,19 +1,34 @@
 import posthog from "posthog-js";
 import { useEffect, useRef } from "react";
 import { useUpgradeModalStore } from "../stores/upgradeModalStore";
+import { setPostHogImpersonationState } from "./usePostHog";
 
 export function usePostHogIdentify({
   session,
   organization,
   planType,
+  isAdmin,
 }: {
-  session: { user?: { id: string; email?: string | null } } | null;
+  session: {
+    user?: {
+      id: string;
+      email?: string | null;
+      impersonator?: { id: string } | null;
+    };
+  } | null;
   organization: { id: string; name: string } | undefined;
   planType: string | undefined;
+  isAdmin?: boolean;
 }) {
   const prevUserIdRef = useRef<string | null>(null);
+  const isImpersonating = !!session?.user?.impersonator;
 
-  // 1. Identify user
+  // Keep the module-level impersonation flag in sync for the before_send callback
+  useEffect(() => {
+    setPostHogImpersonationState(isImpersonating);
+  }, [isImpersonating]);
+
+  // 1. Identify user (skipped during impersonation)
   useEffect(() => {
     if (typeof window === "undefined") return;
 
@@ -30,22 +45,36 @@ export function usePostHogIdentify({
       return;
     }
 
+    // Don't identify the impersonated user — this would pollute person properties
+    if (isImpersonating) {
+      prevUserIdRef.current = userId;
+      return;
+    }
+
     posthog.identify(userId, {
       email: session?.user?.email ?? undefined,
+      is_admin: isAdmin ?? false,
     });
     prevUserIdRef.current = userId;
-  }, [session?.user?.id, session?.user?.email]);
+  }, [session?.user?.id, session?.user?.email, isImpersonating, isAdmin]);
 
-  // 2. Group by organization (re-runs on org switch)
+  // 2. Group by organization (re-runs on org switch, skipped during impersonation)
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!session?.user?.id || !organization?.id) return;
+    if (isImpersonating) return;
 
     posthog.group("organization", organization.id, {
       name: organization.name,
       ...(planType ? { planType } : {}),
     });
-  }, [session?.user?.id, organization?.id, organization?.name, planType]);
+  }, [
+    session?.user?.id,
+    organization?.id,
+    organization?.name,
+    planType,
+    isImpersonating,
+  ]);
 
   // 3. Track upgrade modal opens via Zustand subscribe
   useEffect(() => {

--- a/langwatch/src/server/__tests__/posthog.unit.test.ts
+++ b/langwatch/src/server/__tests__/posthog.unit.test.ts
@@ -114,4 +114,47 @@ describe("trackServerEvent", () => {
       });
     });
   });
+
+  describe("when session indicates impersonation", () => {
+    it("skips capture", () => {
+      trackServerEvent({
+        userId: "user-123",
+        event: "evaluation_ran",
+        session: { user: { impersonator: { id: "admin-1" } } },
+      });
+
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when session has no impersonator", () => {
+    it("captures normally", () => {
+      trackServerEvent({
+        userId: "user-123",
+        event: "evaluation_ran",
+        session: { user: { impersonator: null } },
+      });
+
+      expect(mockCapture).toHaveBeenCalledWith({
+        distinctId: "user-123",
+        event: "evaluation_ran",
+        properties: {},
+      });
+    });
+  });
+
+  describe("when session is not provided", () => {
+    it("captures normally (backwards compatible)", () => {
+      trackServerEvent({
+        userId: "user-123",
+        event: "evaluation_ran",
+      });
+
+      expect(mockCapture).toHaveBeenCalledWith({
+        distinctId: "user-123",
+        event: "evaluation_ran",
+        properties: {},
+      });
+    });
+  });
 });

--- a/langwatch/src/server/api/routers/evaluations.ts
+++ b/langwatch/src/server/api/routers/evaluations.ts
@@ -96,6 +96,7 @@ export const evaluationsRouter = createTRPCRouter({
           userId: ctx.session.user.id,
           event: "evaluation_ran",
           projectId: input.projectId,
+          session: ctx.session,
         });
       }
 

--- a/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
+++ b/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
@@ -94,14 +94,16 @@ export const onboardingRouter = createTRPCRouter({
           captureException(error);
         }
 
-        fireSignupNurturingCalls({
-          userId: ctx.session.user.id,
-          email: ctx.session.user.email,
-          name: ctx.session.user.name,
-          organizationId: orgResult.organization.id,
-          organizationName: orgResult.organization.name,
-          signUpData: input.signUpData,
-        });
+        if (!ctx.session.user.impersonator) {
+          fireSignupNurturingCalls({
+            userId: ctx.session.user.id,
+            email: ctx.session.user.email,
+            name: ctx.session.user.name,
+            organizationId: orgResult.organization.id,
+            organizationName: orgResult.organization.name,
+            signUpData: input.signUpData,
+          });
+        }
 
         // Return success response with team and project slugs
         return {
@@ -140,10 +142,12 @@ export const onboardingRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const traitValue = mapProductSelectionToIntegrationMethod(input.integrationMethod);
 
-      fireIntegrationMethodNurturing({
-        userId: ctx.session.user.id,
-        integrationMethod: traitValue,
-      });
+      if (!ctx.session.user.impersonator) {
+        fireIntegrationMethodNurturing({
+          userId: ctx.session.user.id,
+          integrationMethod: traitValue,
+        });
+      }
 
       return { success: true };
     }),

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -618,15 +618,18 @@ export const organizationRouter = createTRPCRouter({
           userId: ctx.session.user.id,
           event: "team_member_invited",
           properties: { inviteCount: createdRecords.length },
+          session: ctx.session,
         });
 
-        const memberCount = organization.members.length + createdRecords.length;
-        for (const record of createdRecords) {
-          fireTeamMemberInvitedNurturing({
-            userId: ctx.session.user.id,
-            teamMemberCount: memberCount,
-            role: record.invite.role,
-          });
+        if (!ctx.session.user.impersonator) {
+          const memberCount = organization.members.length + createdRecords.length;
+          for (const record of createdRecords) {
+            fireTeamMemberInvitedNurturing({
+              userId: ctx.session.user.id,
+              teamMemberCount: memberCount,
+              role: record.invite.role,
+            });
+          }
         }
       }
 

--- a/langwatch/src/server/api/routers/prompts/prompts.trpc-router.ts
+++ b/langwatch/src/server/api/routers/prompts/prompts.trpc-router.ts
@@ -227,11 +227,13 @@ export const promptsRouter = createTRPCRouter({
         authorId,
       });
 
-      afterPromptCreated({
-        prisma: ctx.prisma,
-        projectId: input.projectId,
-        userId: authorId,
-      });
+      if (!ctx.session.user.impersonator) {
+        afterPromptCreated({
+          prisma: ctx.prisma,
+          projectId: input.projectId,
+          userId: authorId,
+        });
+      }
 
       return result;
     }),
@@ -542,11 +544,13 @@ export const promptsRouter = createTRPCRouter({
         data: { copiedFromPromptId: sourcePrompt.id },
       });
 
-      afterPromptCreated({
-        prisma: ctx.prisma,
-        projectId: input.projectId,
-        userId: authorId,
-      });
+      if (!ctx.session.user.impersonator) {
+        afterPromptCreated({
+          prisma: ctx.prisma,
+          projectId: input.projectId,
+          userId: authorId,
+        });
+      }
 
       return { ...copiedPrompt, copiedFromPromptId: sourcePrompt.id };
     }),

--- a/langwatch/src/server/api/routers/publicEnv.ts
+++ b/langwatch/src/server/api/routers/publicEnv.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { env } from "../../../env.mjs";
+import { isAdmin } from "~/../ee/admin/isAdmin";
 import { skipPermissionCheck } from "../rbac";
 import { publicProcedure } from "../trpc";
 
@@ -29,6 +30,7 @@ export const publicEnvRouter = publicProcedure
         !!env.SENDGRID_API_KEY || !!(env.USE_AWS_SES && env.AWS_REGION),
       IS_SAAS: env.IS_SAAS,
       SHOW_OPS_IN_MAIN_SIDEBAR: isOpsSidebarEmail(ctx.session?.user?.email),
+      IS_ADMIN: isAdmin({ email: ctx.session?.user?.email }),
       POSTHOG_KEY: env.POSTHOG_KEY,
       POSTHOG_HOST: env.POSTHOG_HOST,
       HAS_LANGWATCH_NLP_SERVICE:

--- a/langwatch/src/server/api/routers/scenarios/scenario-crud.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/scenario-crud.router.ts
@@ -47,21 +47,23 @@ export const scenarioCrudRouter = createTRPCRouter({
         lastUpdatedById: ctx.session.user.id,
       });
 
-      trackServerEvent({ userId: ctx.session.user.id, event: "scenario_created", projectId: input.projectId });
+      trackServerEvent({ userId: ctx.session.user.id, event: "scenario_created", projectId: input.projectId, session: ctx.session });
 
-      void ctx.prisma.scenario
-        .count({
-          where: { projectId: input.projectId, archivedAt: null },
-        })
-        .then((count) => {
-          fireScenarioCreatedNurturing({
-            userId: ctx.session.user.id,
-            scenarioCount: count,
-            scenarioId: result.id,
-            projectId: input.projectId,
-          });
-        })
-        .catch(captureException);
+      if (!ctx.session.user.impersonator) {
+        void ctx.prisma.scenario
+          .count({
+            where: { projectId: input.projectId, archivedAt: null },
+          })
+          .then((count) => {
+            fireScenarioCreatedNurturing({
+              userId: ctx.session.user.id,
+              scenarioCount: count,
+              scenarioId: result.id,
+              projectId: input.projectId,
+            });
+          })
+          .catch(captureException);
+      }
 
       logger.info({ projectId: input.projectId, scenarioId: result.id }, "Scenario created");
       return result;

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -98,19 +98,21 @@ export const workflowRouter = createTRPCRouter({
         });
       }
 
-      void ctx.prisma.workflow
-        .count({
-          where: { projectId: input.projectId, archivedAt: null },
-        })
-        .then((count) => {
-          fireWorkflowCreatedNurturing({
-            userId: ctx.session.user.id,
-            workflowCount: count,
-            workflowId: workflow.id,
-            projectId: input.projectId,
-          });
-        })
-        .catch(captureException);
+      if (!ctx.session.user.impersonator) {
+        void ctx.prisma.workflow
+          .count({
+            where: { projectId: input.projectId, archivedAt: null },
+          })
+          .then((count) => {
+            fireWorkflowCreatedNurturing({
+              userId: ctx.session.user.id,
+              workflowCount: count,
+              workflowId: workflow.id,
+              projectId: input.projectId,
+            });
+          })
+          .catch(captureException);
+      }
 
       return { workflow, version };
     }),

--- a/langwatch/src/server/better-auth/__tests__/hooks.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/hooks.test.ts
@@ -723,6 +723,32 @@ describe("afterSessionCreate", () => {
 
       expect(userUpdate).not.toHaveBeenCalled();
     });
+
+    it("does NOT fire nurturing hooks", async () => {
+      const fireActivityTrackingNurturing = vi.fn();
+      const ensureUserSyncedToCio = vi.fn();
+      const prisma = makePrismaMock({
+        user: {
+          findUnique: vi.fn().mockResolvedValue({
+            _count: { orgMemberships: 1 },
+          }),
+          update: vi.fn(),
+        },
+      });
+
+      await afterSessionCreate({
+        prisma,
+        userId: "user_target",
+        isImpersonationSession: true,
+        fireActivityTrackingNurturing,
+        ensureUserSyncedToCio,
+      });
+
+      await new Promise((r) => setImmediate(r));
+
+      expect(fireActivityTrackingNurturing).not.toHaveBeenCalled();
+      expect(ensureUserSyncedToCio).not.toHaveBeenCalled();
+    });
   });
 
   describe("when the lastLoginAt update fails", () => {

--- a/langwatch/src/server/better-auth/hooks.ts
+++ b/langwatch/src/server/better-auth/hooks.ts
@@ -471,20 +471,23 @@ export const afterSessionCreate = async ({
   }
 
   // Nurturing hooks: fire-and-forget, must never block the response.
-  // Query via User._count.orgMemberships to bypass the
-  // dbOrganizationIdProtection middleware which blocks direct
-  // OrganizationUser queries without an organizationId in the where clause.
-  void prisma.user
-    .findUnique({
-      where: { id: userId },
-      select: { _count: { select: { orgMemberships: true } } },
-    })
-    .then((userWithCount) => {
-      const hasOrganization = (userWithCount?._count.orgMemberships ?? 0) > 0;
-      fireActivityTrackingNurturing({ userId, hasOrganization });
-      ensureUserSyncedToCio({ userId, hasOrganization });
-    })
-    .catch((err) => {
-      logger.error({ err, userId }, "Failed to fire nurturing hooks after session create");
-    });
+  // Skipped during impersonation to avoid polluting Customer.io with admin activity.
+  if (!isImpersonationSession) {
+    // Query via User._count.orgMemberships to bypass the
+    // dbOrganizationIdProtection middleware which blocks direct
+    // OrganizationUser queries without an organizationId in the where clause.
+    void prisma.user
+      .findUnique({
+        where: { id: userId },
+        select: { _count: { select: { orgMemberships: true } } },
+      })
+      .then((userWithCount) => {
+        const hasOrganization = (userWithCount?._count.orgMemberships ?? 0) > 0;
+        fireActivityTrackingNurturing({ userId, hasOrganization });
+        ensureUserSyncedToCio({ userId, hasOrganization });
+      })
+      .catch((err) => {
+        logger.error({ err, userId }, "Failed to fire nurturing hooks after session create");
+      });
+  }
 };

--- a/langwatch/src/server/better-auth/index.ts
+++ b/langwatch/src/server/better-auth/index.ts
@@ -454,9 +454,14 @@ export const auth = betterAuth({
             session: { userId: session.userId },
           }),
         after: async (session) => {
+          // The `impersonating` field is a JSON string column set by
+          // the admin impersonation endpoint. When present, this session
+          // was created for impersonation — skip lastLoginAt and nurturing.
+          const isImpersonationSession = !!(session as Record<string, unknown>).impersonating;
           await afterSessionCreate({
             prisma,
             userId: session.userId,
+            isImpersonationSession,
             fireActivityTrackingNurturing,
             ensureUserSyncedToCio,
           });

--- a/langwatch/src/server/license-enforcement/enforcement.middleware.ts
+++ b/langwatch/src/server/license-enforcement/enforcement.middleware.ts
@@ -87,6 +87,7 @@ export async function enforceLicenseLimit(
           current: error.current,
           max: error.max,
         },
+        session: ctx.session,
       });
       throw new TRPCError({
         code: "FORBIDDEN",

--- a/langwatch/src/server/posthog.ts
+++ b/langwatch/src/server/posthog.ts
@@ -43,18 +43,26 @@ export function getPostHogInstance(): PostHog | null {
 /**
  * Fire-and-forget server-side event tracking.
  * Silently no-ops when POSTHOG_KEY is not set (self-hosted without PostHog).
+ *
+ * When `session` is provided and indicates impersonation (session.user.impersonator
+ * is set), the event is silently dropped to avoid polluting analytics with
+ * admin impersonation activity.
  */
 export function trackServerEvent({
   userId,
   event,
   properties,
   projectId,
+  session,
 }: {
   userId: string;
   event: string;
   properties?: Record<string, unknown>;
   projectId?: string;
+  session?: { user: { impersonator?: { id: string } | null } } | null;
 }) {
+  if (session?.user?.impersonator) return;
+
   const posthog = getPostHogInstance();
   if (!posthog) return;
   posthog.capture({

--- a/langwatch/src/server/routes/evaluations-v3.ts
+++ b/langwatch/src/server/routes/evaluations-v3.ts
@@ -239,8 +239,9 @@ app.post("/execute", zValidator("json", executionRequestSchema), async (c) => {
               userId: session.user.id,
               event: "evaluation_ran",
               projectId,
+              session,
             });
-            if (request.experimentId && isFullRun) {
+            if (request.experimentId && isFullRun && !session.user.impersonator) {
               fireExperimentRanNurturing({
                 userId: session.user.id,
                 experimentId: request.experimentId,

--- a/specs/analytics/suppress-impersonation-tracking.feature
+++ b/specs/analytics/suppress-impersonation-tracking.feature
@@ -1,3 +1,4 @@
+@unimplemented
 Feature: Suppress analytics tracking during admin impersonation and label admin users
   As a LangWatch product team member
   I want analytics tracking suppressed when an admin impersonates a user

--- a/specs/analytics/suppress-impersonation-tracking.feature
+++ b/specs/analytics/suppress-impersonation-tracking.feature
@@ -1,0 +1,260 @@
+Feature: Suppress analytics tracking during admin impersonation and label admin users
+  As a LangWatch product team member
+  I want analytics tracking suppressed when an admin impersonates a user
+  So that impersonation sessions do not pollute product analytics, email nurturing, or lead enrichment data
+
+  Admin impersonation already sets `session.user.impersonator` on the session
+  object. This feature wires that signal into every analytics integration so
+  that no events, identifications, or trait syncs fire under the impersonated
+  user's identity.
+
+  Safety constraint: Client-side PostHog suppression MUST use the `before_send`
+  callback (return null to drop events), NOT `opt_out_capturing` /
+  `opt_in_capturing`. The latter caused a production outage (PR #2244 / #2398)
+  due to a race condition with session recording initialization.
+
+  The `before_send` callback cannot access React context or the session directly.
+  A mutable ref (updated by a useEffect watching the session) provides the
+  impersonation state to the closure. This avoids re-initializing PostHog on
+  session changes.
+
+  Additionally, admin users (matched by ADMIN_EMAILS) are labeled with
+  `is_admin: true` in PostHog and Customer.io so their normal (non-impersonation)
+  activity can be filtered from dashboards and excluded from nurturing sequences.
+  Admin status is surfaced to the client via the publicEnv tRPC query, following
+  the existing `isOpsSidebarEmail` pattern in `publicEnvRouter`.
+
+  Out of scope:
+  - GTM / Google Analytics: already suppressed in ExtraFooterComponents.tsx
+    via `if (!session.data.user.impersonator)` guard. No changes needed.
+  - Customer.io event-sourcing reactors: reactors run in background workers
+    from BullMQ jobs and have no session context. Suppressing reactor CIO calls
+    requires propagating impersonation state into the event schema at trace
+    ingestion time — a separate issue.
+
+  # ===========================================================================
+  # Goal 1 — Suppress tracking during impersonation
+  # ===========================================================================
+
+  # ---------------------------------------------------------------------------
+  # Client-side PostHog suppression (before_send)
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: PostHog before_send callback drops capture events during impersonation
+    Given a before_send callback with the impersonation ref set to true
+    When PostHog passes a capture event to before_send
+    Then the callback returns null
+    And the event is not sent to PostHog
+
+  @unit
+  Scenario: PostHog before_send callback allows capture events for normal sessions
+    Given a before_send callback with the impersonation ref set to false
+    When PostHog passes a capture event to before_send
+    Then the callback returns the event unchanged
+
+  @unit
+  Scenario: before_send allows $snapshot events during impersonation
+    Given a before_send callback with the impersonation ref set to true
+    When PostHog passes a $snapshot event to before_send
+    Then the callback returns the event unchanged
+    And session recording is not disrupted
+
+  @unit
+  Scenario: before_send allows feature flag requests during impersonation
+    Given a before_send callback with the impersonation ref set to true
+    When a feature flag is evaluated via the PostHog client
+    Then the flag evaluation succeeds
+    And the before_send callback does not intercept flag requests
+
+  @unit
+  Scenario: Error capture remains available during impersonation
+    Given a before_send callback with the impersonation ref set to true
+    When an exception is captured via posthogErrorCapture
+    Then the error event is not suppressed by before_send
+
+  @integration
+  Scenario: PostHog init wires before_send without calling opt_in or opt_out
+    Given the PostHog client is being initialized via usePostHog
+    When the init options are configured
+    Then the options include a before_send callback
+    And opt_in_capturing is never called
+    And opt_out_capturing is never called
+
+  @integration
+  Scenario: Impersonation ref updates when session changes
+    Given a useEffect watches the session for impersonation state
+    When the session transitions from normal to impersonated
+    Then the mutable impersonation ref is set to true
+    And existing before_send closures read the updated value
+
+  # ---------------------------------------------------------------------------
+  # Client-side PostHog identify suppression
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: usePostHogIdentify skips identify when session has impersonator
+    Given a session with user.impersonator set
+    When usePostHogIdentify runs
+    Then posthog.identify is not called
+    And posthog.group is not called
+
+  @unit
+  Scenario: usePostHogIdentify calls identify for normal sessions
+    Given a session with no impersonator
+    And the session has a user ID and email
+    When usePostHogIdentify runs
+    Then posthog.identify is called with the user ID and email
+
+  # ---------------------------------------------------------------------------
+  # Server-side PostHog suppression (trackServerEvent)
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: trackServerEvent skips capture when session indicates impersonation
+    Given a session with user.impersonator set
+    When trackServerEvent is called with the session and event data
+    Then posthog.capture is not called
+
+  @unit
+  Scenario: trackServerEvent captures events for normal sessions
+    Given a session with no impersonator
+    When trackServerEvent is called with the session and event data
+    Then posthog.capture is called with the user ID and event
+
+  # trackServerEvent accepts an optional `session` parameter. When provided
+  # and session.user.impersonator is set, capture is skipped. All existing
+  # call sites in tRPC routes pass `ctx.session`. Call sites without session
+  # context (e.g. background jobs) continue to work — the guard only fires
+  # when session is explicitly provided.
+
+  # ---------------------------------------------------------------------------
+  # Customer.io nurturing hooks suppression
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Nurturing hooks skip firing during impersonation sessions
+    Given an admin is impersonating a user via a tRPC route
+    And the route context has session.user.impersonator set
+    When a nurturing hook is triggered by a tRPC mutation
+    Then no Customer.io identify or track calls are made
+
+  @integration
+  Scenario: Nurturing hooks fire normally for non-impersonation sessions
+    Given a regular user performs a tRPC mutation that triggers nurturing
+    And the route context has no impersonator on the session
+    When the nurturing hook fires
+    Then Customer.io identify and track calls are made as expected
+
+  # ---------------------------------------------------------------------------
+  # afterSessionCreate dead-code fix
+  # ---------------------------------------------------------------------------
+
+  @regression @unit
+  Scenario: afterSessionCreate receives isImpersonationSession true from impersonation caller
+    Given the BetterAuth session.create after-hook fires for an impersonation session
+    When afterSessionCreate is invoked
+    Then isImpersonationSession is passed as true
+    And lastLoginAt is not updated for the impersonated user
+    And nurturing hooks are not fired
+
+  @regression @unit
+  Scenario: afterSessionCreate receives isImpersonationSession false for normal login
+    Given the BetterAuth session.create after-hook fires for a normal login
+    When afterSessionCreate is invoked
+    Then isImpersonationSession is passed as false
+    And lastLoginAt is updated for the user
+    And nurturing hooks are fired
+
+  # ---------------------------------------------------------------------------
+  # Reo suppression
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Reo identification is skipped during impersonation
+    Given an admin is impersonating a user
+    And the session has user.impersonator set
+    When SignedInExtraFooterComponents renders
+    Then Reo.identify is not called
+
+  @integration
+  Scenario: Reo identification fires for normal sessions
+    Given a regular user is logged in
+    And the session has no impersonator
+    When SignedInExtraFooterComponents renders
+    Then Reo.identify is called with the user's email and organization
+
+  # ---------------------------------------------------------------------------
+  # Pendo and Crisp regression guard
+  # ---------------------------------------------------------------------------
+
+  @regression @integration
+  Scenario: Pendo script is not rendered during impersonation
+    Given an admin is impersonating a user
+    When SignedInExtraFooterComponents renders
+    Then the Pendo initialization script is not included in the output
+
+  @regression @integration
+  Scenario: Crisp chat is not rendered during impersonation
+    Given an admin is impersonating a user
+    When SignedInExtraFooterComponents renders
+    Then the Crisp chat widget script is not included in the output
+
+  # ===========================================================================
+  # Goal 2 — Label admin users in analytics
+  # ===========================================================================
+
+  # ---------------------------------------------------------------------------
+  # PostHog admin labeling
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: PostHog identify includes is_admin true for admin users
+    Given a user whose email is in the ADMIN_EMAILS list
+    And the user is not impersonating anyone
+    When usePostHogIdentify runs
+    Then posthog.identify person properties include is_admin true
+
+  @integration
+  Scenario: PostHog identify includes is_admin false for non-admin users
+    Given a user whose email is not in the ADMIN_EMAILS list
+    When usePostHogIdentify runs
+    Then posthog.identify person properties include is_admin false
+
+  # ---------------------------------------------------------------------------
+  # Customer.io admin labeling
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Customer.io identify includes is_admin trait for admin users
+    Given a user whose email is in the ADMIN_EMAILS list
+    When the user is identified in Customer.io via nurturing hooks
+    Then the CioPersonTraits include is_admin true
+
+  @integration
+  Scenario: Customer.io identify includes is_admin false for non-admin users
+    Given a user whose email is not in the ADMIN_EMAILS list
+    When the user is identified in Customer.io via nurturing hooks
+    Then the CioPersonTraits include is_admin false
+
+  # ---------------------------------------------------------------------------
+  # Admin status surfaced to client via publicEnv
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: publicEnv exposes isAdmin flag for admin users
+    Given a user whose email is in the ADMIN_EMAILS list
+    When the publicEnv tRPC query resolves
+    Then the response includes IS_ADMIN set to true
+
+  @integration
+  Scenario: publicEnv exposes isAdmin false for non-admin users
+    Given a user whose email is not in the ADMIN_EMAILS list
+    When the publicEnv tRPC query resolves
+    Then the response includes IS_ADMIN set to false
+
+  @unit
+  Scenario: publicEnv returns IS_ADMIN false when ADMIN_EMAILS is not configured
+    Given the ADMIN_EMAILS environment variable is not set
+    When the publicEnv tRPC query resolves for any user
+    Then the response includes IS_ADMIN set to false


### PR DESCRIPTION
## Summary

Closes #3366

- **Suppress all analytics tracking** (PostHog, Customer.io, Reo) when an admin impersonates a user via `session.user.impersonator`
- **Label admin users** with `is_admin: true` in PostHog person properties and Customer.io traits for dashboard filtering
- **Fix afterSessionCreate dead code**: `isImpersonationSession` parameter is now actually passed from the BetterAuth hook

### Safety: PostHog client-side suppression

Uses `before_send` callback (returns `null` to drop events) instead of `opt_out_capturing`/`opt_in_capturing` — the latter caused a production outage in PR #2244 / revert in #2398 due to a race condition with session recording initialization.

Session recording (`$snapshot` events), feature flags, and error capture continue working during impersonation.

### Changes by area

| Area | Change |
|------|--------|
| PostHog client | `before_send` callback with mutable impersonation ref; `usePostHogIdentify` skips `identify()`/`group()` |
| PostHog server | `trackServerEvent()` accepts optional `session` param; all 5 call sites pass it |
| Customer.io hooks | 7 nurturing hook call sites guarded with impersonation check |
| BetterAuth hooks | `afterSessionCreate` receives `isImpersonationSession` from session row; skips lastLoginAt + nurturing |
| Reo | Added impersonation guard in `ExtraFooterComponents` |
| Admin labeling | `IS_ADMIN` in publicEnv, `is_admin` in PostHog + CioPersonTraits |

### Out of scope

Customer.io event-sourcing reactors (trace/evaluation/simulation sync) — they run in background workers without session context. Suppression requires event schema changes (separate issue).

## Test plan

- [x] `pnpm typecheck` — passes
- [x] 10 new unit tests for `before_send` callback and impersonation state (`usePostHog.unit.test.ts`)
- [x] 6 new unit tests for impersonation/admin in `usePostHogIdentify.unit.test.ts` (plus existing tests updated for `is_admin` property)
- [x] 3 new unit tests for `trackServerEvent` impersonation guard (`posthog.unit.test.ts`)
- [x] 1 new regression test for `afterSessionCreate` nurturing hooks skipped during impersonation
- [x] All existing tests pass (37 + 31 = 68 tests across 4 test files)

# Related Issue

- Resolve #3366