### PR TITLE
refactor(attribution): address module review feedback from PR #3316

### DIFF
--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
@@ -1,7 +1,7 @@
 import type { z } from "zod";
 
 import { getApp } from "../../../../src/server/app-layer/app";
-import type { signUpDataSchema } from "../../../../src/server/api/routers/onboarding/schemas/sign-up-data.schema";
+import type { signUpDataSchema } from "../../../../src/server/schemas/sign-up-data.schema";
 import { captureException } from "../../../../src/utils/posthogErrorCapture";
 import type { CioPersonTraits } from "../types";
 

--- a/langwatch/ee/billing/types.ts
+++ b/langwatch/ee/billing/types.ts
@@ -2,7 +2,7 @@ import type { z } from "zod";
 import type { PlanInfo } from "../licensing/planInfo";
 import type { LimitType } from "../../src/server/license-enforcement/types";
 import type { PlanTypes } from "./planTypes";
-import type { signUpDataSchema } from "../../src/server/api/routers/onboarding/schemas/sign-up-data.schema";
+import type { signUpDataSchema } from "../../src/server/schemas/sign-up-data.schema";
 
 export type BillingPlanProvider = {
   getActivePlan(

--- a/langwatch/src/features/onboarding/hooks/use-onboarding-flow.ts
+++ b/langwatch/src/features/onboarding/hooks/use-onboarding-flow.ts
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { usePublicEnv } from "~/hooks/usePublicEnv";
-import { readAttribution } from "~/hooks/attribution";
+import { readAttribution } from "~/utils/attribution";
 import { getOnboardingFlowConfig } from "../constants/onboarding-flow";
 import {
   type CompanySize,
@@ -82,7 +82,7 @@ export const useOnboardingFlow = () => {
     solutionType,
     selectedDesires,
     role,
-    ...attribution,
+    attribution,
   });
 
   const getFlowState = (): OnboardingFlowState => ({
@@ -100,7 +100,7 @@ export const useOnboardingFlow = () => {
       solutionType,
       selectedDesires,
       role,
-      ...attribution,
+      attribution,
       setOrganizationName,
       setAgreement,
       setUsageStyle,

--- a/langwatch/src/features/onboarding/screens/WelcomeScreen.tsx
+++ b/langwatch/src/features/onboarding/screens/WelcomeScreen.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState } from "react";
 import { AnalyticsBoundary } from "react-contextual-analytics";
 import { LoadingScreen } from "~/components/LoadingScreen";
 import { toaster } from "~/components/ui/toaster";
-import { pickAttribution } from "~/hooks/attribution";
 import { useRequiredSession } from "~/hooks/useRequiredSession";
 import { api } from "~/utils/api";
 import { trackEventOnce } from "~/utils/tracking";
@@ -85,7 +84,7 @@ export const WelcomeScreen: React.FC = () => {
           companySize: form.companySize,
           yourRole: form.role,
           featureUsage: form.selectedDesires.join("\n"),
-          ...pickAttribution(form),
+          ...form.attribution,
         },
       },
       {

--- a/langwatch/src/features/onboarding/types/types.ts
+++ b/langwatch/src/features/onboarding/types/types.ts
@@ -1,4 +1,4 @@
-import type { Attribution } from "~/hooks/attribution";
+import type { Attribution } from "~/utils/attribution";
 
 export enum OnboardingScreenIndex {
   ORGANIZATION = 0,
@@ -62,10 +62,7 @@ export type SolutionType = (typeof SOLUTION_TYPES)[number];
 export type DesireType = (typeof DESIRE_TYPES)[number];
 export type RoleType = (typeof ROLE_TYPES)[number];
 
-// First-touch attribution fields (leadSource, utm*, referrer) are sourced
-// from `readAttribution()` and carried on the form via `Partial<Attribution>`
-// so the shape stays single-sourced in `~/hooks/attribution`.
-export interface OnboardingFormData extends Partial<Attribution> {
+export interface OnboardingFormData {
   organizationName?: string;
   agreement?: boolean;
   usageStyle?: UsageStyle;
@@ -74,6 +71,7 @@ export interface OnboardingFormData extends Partial<Attribution> {
   solutionType?: SolutionType;
   selectedDesires: DesireType[];
   role?: RoleType;
+  attribution?: Attribution;
 }
 
 export interface OnboardingScreen {

--- a/langwatch/src/hooks/__tests__/useAttributionCapture.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useAttributionCapture.unit.test.ts
@@ -3,7 +3,7 @@
  */
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { readAttribution } from "../attribution";
+import { readAttribution } from "~/utils/attribution";
 import { useAttributionCapture } from "../useAttributionCapture";
 
 function setUrl(search: string) {

--- a/langwatch/src/hooks/useAttributionCapture.ts
+++ b/langwatch/src/hooks/useAttributionCapture.ts
@@ -3,7 +3,7 @@ import {
   URL_PARAM_TO_FIELD,
   setAttributionIfAbsent,
   type AttributionField,
-} from "./attribution";
+} from "~/utils/attribution";
 
 /**
  * Strips query and fragment from a referrer URL so we never forward
@@ -30,7 +30,7 @@ function sanitizeReferrer(referrer: string): string | null {
  * unauthenticated public pages — before any navigation can drop the query
  * string.
  *
- * All storage access + schema lives in `./attribution`; this hook is the
+ * All storage access + schema lives in `~/utils/attribution`; this hook is the
  * React-side write trigger only.
  */
 export function useAttributionCapture(): void {

--- a/langwatch/src/server/api/routers/onboarding/index.ts
+++ b/langwatch/src/server/api/routers/onboarding/index.ts
@@ -1,2 +1,2 @@
 export * from "./onboarding.router";
-export * from "./schemas/sign-up-data.schema";
+export * from "~/server/schemas/sign-up-data.schema";

--- a/langwatch/src/server/api/routers/onboarding/index.ts
+++ b/langwatch/src/server/api/routers/onboarding/index.ts
@@ -1,2 +1,1 @@
 export * from "./onboarding.router";
-export * from "~/server/schemas/sign-up-data.schema";

--- a/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
+++ b/langwatch/src/server/api/routers/onboarding/onboarding.router.ts
@@ -12,7 +12,7 @@ import { skipPermissionCheck } from "../../rbac";
 import { organizationRouter } from "../organization";
 import { projectRouter } from "../project";
 
-import { signUpDataSchema } from "./schemas/sign-up-data.schema";
+import { signUpDataSchema } from "~/server/schemas/sign-up-data.schema";
 
 /**
  * Router for handling onboarding-related operations.

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -41,7 +41,7 @@ import { LimitExceededError } from "../../license-enforcement/errors";
 import { captureException } from "~/utils/posthogErrorCapture";
 import { skipPermissionCheck } from "../rbac";
 import { checkOrganizationPermission, checkTeamPermission } from "../rbac";
-import { signUpDataSchema } from "./onboarding";
+import { signUpDataSchema } from "~/server/schemas/sign-up-data.schema";
 import { LITE_MEMBER_VIEWER_ONLY_ERROR } from "~/server/app-layer/organizations/compute-effective-team-role-updates";
 import type { FullyLoadedOrganization } from "~/server/app-layer/organizations/repositories/organization.repository";
 import { PrismaRoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.prisma.repository";

--- a/langwatch/src/server/schemas/sign-up-data.schema.ts
+++ b/langwatch/src/server/schemas/sign-up-data.schema.ts
@@ -1,4 +1,19 @@
 import { z } from "zod";
+import {
+  ATTRIBUTION_FIELDS,
+  type AttributionField,
+} from "~/utils/attribution";
+
+const attributionShape = ATTRIBUTION_FIELDS.reduce(
+  (acc, field) => {
+    acc[field] = z.string().optional().nullable();
+    return acc;
+  },
+  {} as Record<
+    AttributionField,
+    z.ZodNullable<z.ZodOptional<z.ZodString>>
+  >,
+);
 
 /**
  * Input schema for organization signup data
@@ -14,14 +29,7 @@ export const signUpDataSchema = z.object({
   otherCompanyType: z.string().optional().nullable(),
   otherProjectType: z.string().optional().nullable(),
   otherHowDidYouHearAboutUs: z.string().optional().nullable(),
-  utmCampaign: z.string().optional().nullable(),
   yourRole: z.string().optional().nullable(),
   featureUsage: z.string().optional().nullable(),
-  // First-touch attribution (from landing URL / document.referrer)
-  leadSource: z.string().optional().nullable(),
-  utmSource: z.string().optional().nullable(),
-  utmMedium: z.string().optional().nullable(),
-  utmTerm: z.string().optional().nullable(),
-  utmContent: z.string().optional().nullable(),
-  referrer: z.string().optional().nullable(),
+  ...attributionShape,
 });

--- a/langwatch/src/utils/attribution.ts
+++ b/langwatch/src/utils/attribution.ts
@@ -7,15 +7,19 @@
  * mutation, Customer.io identify/track).
  *
  * Pure module — no React. The mount-time write effect lives in
- * `useAttributionCapture.ts`, which imports from here.
+ * `~/hooks/useAttributionCapture.ts`, which imports from here.
  */
+
+import { captureException } from "~/utils/posthogErrorCapture";
+
+let storageErrorReported = false;
 
 /**
  * Canonical list of attribution fields. Single source of truth — add a
  * field here plus one line in `URL_PARAM_TO_FIELD` below if it's
  * URL-sourced, and everything downstream (types, readers, pickers) follows.
  */
-const ATTRIBUTION_FIELDS = [
+export const ATTRIBUTION_FIELDS = [
   "leadSource",
   "utmSource",
   "utmMedium",
@@ -48,11 +52,21 @@ function storageKey(field: AttributionField): string {
   return STORAGE_PREFIX + field;
 }
 
+function reportStorageError(error: unknown): void {
+  if (storageErrorReported) return;
+  storageErrorReported = true;
+  captureException(error, {
+    tags: { module: "attribution" },
+    level: "warning",
+  });
+}
+
 function safeGet(field: AttributionField): string | null {
   if (typeof window === "undefined") return null;
   try {
     return window.sessionStorage.getItem(storageKey(field));
-  } catch {
+  } catch (error) {
+    reportStorageError(error);
     return null;
   }
 }
@@ -72,8 +86,8 @@ export function setAttributionIfAbsent(
     const key = storageKey(field);
     if (window.sessionStorage.getItem(key) !== null) return;
     window.sessionStorage.setItem(key, value);
-  } catch {
-    // sessionStorage may be unavailable (private browsing, disabled) — ignore.
+  } catch (error) {
+    reportStorageError(error);
   }
 }
 
@@ -82,20 +96,6 @@ export function readAttribution(): Attribution {
   const result = {} as Attribution;
   for (const field of ATTRIBUTION_FIELDS) {
     result[field] = safeGet(field);
-  }
-  return result;
-}
-
-/**
- * Projects any object containing attribution fields onto the `Attribution`
- * shape. Missing fields become null. Useful for extracting the attribution
- * subset from a larger form object without repeating the field list at
- * every call site.
- */
-export function pickAttribution(source: Partial<Attribution>): Attribution {
-  const result = {} as Attribution;
-  for (const field of ATTRIBUTION_FIELDS) {
-    result[field] = source[field] ?? null;
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Addresses review feedback from #3316 (first-touch attribution capture) tracked in langwatch/langwatch-saas#454.

- **Move `attribution.ts`** from `src/hooks/` to `src/utils/` — pure module with no React, shouldn't live alongside hooks
- **Fix layering violation** — moved `signUpDataSchema` from `src/server/api/routers/onboarding/schemas/` to `src/server/schemas/` so EE billing code no longer imports from a tRPC router
- **Observable storage errors** — added `captureException` with module-level dedup flag to `setAttributionIfAbsent` and `safeGet`, so private-browsing breakage is reported once per session instead of silently swallowed
- **Nest attribution in form data** — changed `OnboardingFormData extends Partial<Attribution>` to `attribution?: Attribution` nested field, keeping the shape grouped and eliminating `pickAttribution()`
- **Eliminate schema drift** — zod attribution fields in `signUpDataSchema` are now derived from the canonical `ATTRIBUTION_FIELDS` array, so adding a field in one place automatically includes it in both

## Test plan

- [x] `pnpm typecheck` passes
- [x] 15/15 `useAttributionCapture.unit.test.ts` tests pass
- [x] 16/16 `signupIdentification.unit.test.ts` tests pass
- [ ] CI passes

# Related Issue

- Resolve #454