### PR TITLE
feat: error boundaries and custom 404 page

### DIFF
--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -765,7 +765,7 @@ export const DashboardLayout = ({
             <CurrentDrawer />
 
             {userIsPartOfTeam ? (
-              <ErrorBoundary FallbackComponent={PageErrorFallback}>
+              <ErrorBoundary FallbackComponent={PageErrorFallback} resetKeys={[router.pathname]}>
                 {showSavedViews ? (
                   <SavedViewsProvider>
                     {children}

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -14,7 +14,9 @@ import {
 import { OrganizationUserRole } from "@prisma/client";
 import type { Organization, Project, Team } from "@prisma/client";
 import { Activity, ChevronDown, ChevronRight, Info, KeyRound, Plus } from "lucide-react";
-import ErrorPage from "~/utils/compat/next-error";
+import { ErrorBoundary } from "react-error-boundary";
+import { PageErrorFallback } from "./ui/PageErrorFallback";
+import { NotFoundScene } from "~/components/NotFoundScene";
 import Head from "~/utils/compat/next-head";
 import { useRouter } from "~/utils/compat/next-router";
 import { signOut } from "~/utils/auth-client";
@@ -326,7 +328,7 @@ export const DashboardLayout = ({
   });
 
   if (typeof router.query.project === "string" && !isLoading && !project) {
-    return <ErrorPage statusCode={404} />;
+    return <NotFoundScene />;
   }
 
   const isOpsRoute = router.pathname.startsWith("/ops");
@@ -763,16 +765,18 @@ export const DashboardLayout = ({
             <CurrentDrawer />
 
             {userIsPartOfTeam ? (
-              showSavedViews ? (
-                <SavedViewsProvider>
-                  {children}
-                  {/* Spacer to prevent fixed bottom bar from covering content */}
-                  <Box height="64px" flexShrink={0} />
-                  <SavedViewsBar />
-                </SavedViewsProvider>
-              ) : (
-                children
-              )
+              <ErrorBoundary FallbackComponent={PageErrorFallback}>
+                {showSavedViews ? (
+                  <SavedViewsProvider>
+                    {children}
+                    {/* Spacer to prevent fixed bottom bar from covering content */}
+                    <Box height="64px" flexShrink={0} />
+                    <SavedViewsBar />
+                  </SavedViewsProvider>
+                ) : (
+                  children
+                )}
+              </ErrorBoundary>
             ) : (
               <Alert.Root
                 status="warning"

--- a/langwatch/src/components/NotFoundScene.tsx
+++ b/langwatch/src/components/NotFoundScene.tsx
@@ -205,8 +205,8 @@ export function NotFoundScene() {
       smoothMouse.current.x += (mouse.current.x - smoothMouse.current.x) * 0.06;
       smoothMouse.current.y += (mouse.current.y - smoothMouse.current.y) * 0.06;
 
-      const textDx = smoothMouse.current.x * 10;
-      const textDy = smoothMouse.current.y * 5;
+      const textDx = smoothMouse.current.x * 3;
+      const textDy = smoothMouse.current.y * 1.5;
       if (redTextRef.current) {
         redTextRef.current.style.transform = `translate(${-2 - textDx}px, ${-1 - textDy}px)`;
       }

--- a/langwatch/src/components/NotFoundScene.tsx
+++ b/langwatch/src/components/NotFoundScene.tsx
@@ -1,0 +1,438 @@
+import {
+  Box,
+  Button,
+  Center,
+  HStack,
+  Input,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { ArrowLeft, Home, Settings } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useColorModeValue } from "~/components/ui/color-mode";
+import { SimpleSlider } from "~/components/ui/slider";
+import { useRouter } from "~/utils/compat/next-router";
+import {
+  createNotFoundRenderer,
+  defaultGridParams,
+  MAX_CANVAS_DPR,
+  type CanvasColors,
+  type GridParams,
+} from "./notFoundCanvasRenderer";
+
+function ParamSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <HStack gap={2} width="100%">
+      <Text textStyle="xs" color="fg.muted" width="80px" flexShrink={0}>
+        {label}
+      </Text>
+      <SimpleSlider
+        size="sm"
+        width="120px"
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={(e: { value: number[] }) =>
+          onChange(e.value[0] ?? value)
+        }
+      />
+      <Input
+        size="xs"
+        width="60px"
+        type="number"
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value) || 0)}
+      />
+    </HStack>
+  );
+}
+
+export function NotFoundScene() {
+  const router = useRouter();
+  const isDevMode = process.env.NODE_ENV === "development";
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const redTextRef = useRef<HTMLDivElement>(null);
+  const blueTextRef = useRef<HTMLDivElement>(null);
+  const raf = useRef(0);
+  const mouse = useRef({ x: 0, y: 0 });
+  const smoothMouse = useRef({ x: 0, y: 0 });
+  const rendererRef = useRef(createNotFoundRenderer());
+
+  const [showControls, setShowControls] = useState(false);
+  const [params, setParams] = useState<GridParams>(defaultGridParams);
+  const paramsRef = useRef(params);
+  paramsRef.current = params;
+
+  const updateParam = <K extends keyof GridParams>(
+    key: K,
+    value: GridParams[K],
+  ) => {
+    setParams((p) => ({ ...p, [key]: value }));
+  };
+
+  const gridBaseColor: [number, number, number] = useColorModeValue(
+    [40, 90, 190],
+    [80, 160, 255],
+  );
+  const particleBaseColor: [number, number, number] = useColorModeValue(
+    [60, 110, 180],
+    [140, 180, 255],
+  );
+  const aberrationRed: [number, number, number] = useColorModeValue(
+    [180, 60, 80],
+    [255, 50, 100],
+  );
+  const aberrationBlue: [number, number, number] = useColorModeValue(
+    [60, 90, 190],
+    [50, 120, 255],
+  );
+  const alphaScale = useColorModeValue(1, 1);
+  const textRedColor = useColorModeValue("red.600/70", "red.400/60");
+  const textBlueColor = useColorModeValue("blue.600/70", "blue.400/60");
+  const textBaseOpacity = useColorModeValue(0.14, 0.08);
+
+  const onMove = useCallback((e: MouseEvent) => {
+    const el = containerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    mouse.current.x = (e.clientX - r.left) / r.width - 0.5;
+    mouse.current.y = (e.clientY - r.top) / r.height - 0.5;
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    container.addEventListener("mousemove", onMove);
+
+    const colors: CanvasColors = {
+      gridBaseColor,
+      particleBaseColor,
+      aberrationRed,
+      aberrationBlue,
+      alphaScale,
+    };
+
+    const render = rendererRef.current;
+
+    const loop = (timestamp: number) => {
+      const rect = container.getBoundingClientRect();
+      const dpr = Math.min(window.devicePixelRatio || 1, MAX_CANVAS_DPR);
+      const w = rect.width;
+      const h = rect.height;
+
+      if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
+        canvas.width = w * dpr;
+        canvas.height = h * dpr;
+        canvas.style.width = `${w}px`;
+        canvas.style.height = `${h}px`;
+      }
+
+      smoothMouse.current.x += (mouse.current.x - smoothMouse.current.x) * 0.06;
+      smoothMouse.current.y += (mouse.current.y - smoothMouse.current.y) * 0.06;
+
+      const textDx = smoothMouse.current.x * 10;
+      const textDy = smoothMouse.current.y * 5;
+      if (redTextRef.current) {
+        redTextRef.current.style.transform = `translate(${-2 - textDx}px, ${-1 - textDy}px)`;
+      }
+      if (blueTextRef.current) {
+        blueTextRef.current.style.transform = `translate(${2 + textDx}px, ${1 + textDy}px)`;
+      }
+
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      render({
+        ctx,
+        width: w,
+        height: h,
+        timestamp,
+        params: paramsRef.current,
+        colors,
+        smoothMouse: smoothMouse.current,
+      });
+
+      raf.current = requestAnimationFrame(loop);
+    };
+
+    raf.current = requestAnimationFrame(loop);
+
+    return () => {
+      cancelAnimationFrame(raf.current);
+      container.removeEventListener("mousemove", onMove);
+    };
+  }, [onMove, gridBaseColor, particleBaseColor, aberrationRed, aberrationBlue, alphaScale]);
+
+  return (
+    <Center
+      ref={containerRef}
+      width="100%"
+      height="100%"
+      minHeight="400px"
+      overflow="hidden"
+      position="relative"
+      css={{
+        "@keyframes glitch-1": {
+          "0%, 100%": { clipPath: "inset(0 0 96% 0)" },
+          "20%": { clipPath: "inset(20% 0 60% 0)" },
+          "40%": { clipPath: "inset(60% 0 10% 0)" },
+          "60%": { clipPath: "inset(40% 0 30% 0)" },
+          "80%": { clipPath: "inset(80% 0 5% 0)" },
+        },
+        "@keyframes glitch-2": {
+          "0%, 100%": { clipPath: "inset(95% 0 0 0)" },
+          "25%": { clipPath: "inset(10% 0 70% 0)" },
+          "50%": { clipPath: "inset(50% 0 20% 0)" },
+          "75%": { clipPath: "inset(30% 0 50% 0)" },
+        },
+        "@keyframes drift": {
+          "0%, 100%": { transform: "translateY(0px)" },
+          "50%": { transform: "translateY(-6px)" },
+        },
+        "@keyframes text-glitch": {
+          "0%, 92%, 100%": { transform: "none", opacity: 1 },
+          "93%": { transform: "translateX(-2px) skewX(-1deg)", opacity: 0.8 },
+          "94%": { transform: "translateX(3px) skewX(1deg)", opacity: 0.9 },
+          "95%": { transform: "translateX(-1px)", opacity: 0.7 },
+          "96%": { transform: "none", opacity: 1 },
+        },
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{
+          position: "absolute",
+          inset: 0,
+          pointerEvents: "none",
+        }}
+      />
+
+      {isDevMode && (
+        <Box
+          position="absolute"
+          top={2}
+          right={2}
+          zIndex={10}
+          background="bg.panel"
+          borderRadius="md"
+          padding={showControls ? 3 : 1}
+          boxShadow="lg"
+          maxHeight="90vh"
+          overflowY="auto"
+        >
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={() => setShowControls(!showControls)}
+            marginBottom={showControls ? 2 : 0}
+          >
+            <Settings size={14} />
+            {showControls ? "Hide" : ""}
+          </Button>
+
+          {showControls && (
+            <VStack gap={2} align="stretch">
+              <ParamSlider
+                label="Rotation"
+                value={params.rotation}
+                min={0}
+                max={360}
+                step={1}
+                onChange={(v) => updateParam("rotation", v)}
+              />
+              <ParamSlider
+                label="Z Offset"
+                value={params.zOffset}
+                min={100}
+                max={15000}
+                step={100}
+                onChange={(v) => updateParam("zOffset", v)}
+              />
+              <ParamSlider
+                label="FOV Scale"
+                value={params.fovScale}
+                min={0.1}
+                max={3}
+                step={0.01}
+                onChange={(v) => updateParam("fovScale", v)}
+              />
+              <ParamSlider
+                label="Camera Y"
+                value={params.cameraY}
+                min={0}
+                max={5000}
+                step={10}
+                onChange={(v) => updateParam("cameraY", v)}
+              />
+              <ParamSlider
+                label="Pitch"
+                value={params.pitch}
+                min={-90}
+                max={90}
+                step={1}
+                onChange={(v) => updateParam("pitch", v)}
+              />
+              <ParamSlider
+                label="Aberration"
+                value={params.aberration}
+                min={0}
+                max={30}
+                step={0.5}
+                onChange={(v) => updateParam("aberration", v)}
+              />
+              <ParamSlider
+                label="Grid Size"
+                value={params.gridExtent}
+                min={500}
+                max={10000}
+                step={100}
+                onChange={(v) => updateParam("gridExtent", v)}
+              />
+              <ParamSlider
+                label="Grid Step"
+                value={params.gridStep}
+                min={20}
+                max={500}
+                step={10}
+                onChange={(v) => updateParam("gridStep", v)}
+              />
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={() => setParams(defaultGridParams)}
+              >
+                Reset
+              </Button>
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={() => {
+                  console.log("Grid params:", params);
+                  navigator.clipboard.writeText(
+                    JSON.stringify(params, null, 2),
+                  );
+                }}
+              >
+                Copy Params
+              </Button>
+            </VStack>
+          )}
+        </Box>
+      )}
+
+      <VStack gap={6} zIndex={1}>
+        <Box
+          position="relative"
+          userSelect="none"
+          css={{
+            textShadow:
+              "0 0 60px rgba(100, 160, 255, 0.12), 0 4px 20px rgba(0, 0, 0, 0.25)",
+          }}
+        >
+          <Text
+            fontWeight={800}
+            fontSize="clamp(7rem, 18vw, 12rem)"
+            lineHeight={1}
+            letterSpacing="-0.04em"
+            color="fg.default"
+            opacity={textBaseOpacity}
+          >
+            404
+          </Text>
+
+          <Text
+            ref={redTextRef}
+            aria-hidden
+            position="absolute"
+            inset={0}
+            fontWeight={800}
+            fontSize="clamp(7rem, 18vw, 12rem)"
+            lineHeight={1}
+            letterSpacing="-0.04em"
+            color={textRedColor}
+            animation="glitch-1 3s steps(1) infinite"
+            willChange="transform"
+            style={{ transform: "translate(-2px, -1px)" }}
+          >
+            404
+          </Text>
+          <Text
+            ref={blueTextRef}
+            aria-hidden
+            position="absolute"
+            inset={0}
+            fontWeight={800}
+            fontSize="clamp(7rem, 18vw, 12rem)"
+            lineHeight={1}
+            letterSpacing="-0.04em"
+            color={textBlueColor}
+            animation="glitch-2 2.5s steps(1) infinite"
+            willChange="transform"
+            style={{ transform: "translate(2px, 1px)" }}
+          >
+            404
+          </Text>
+        </Box>
+
+        <VStack
+          gap={2}
+          animation="drift 4s ease-in-out infinite, text-glitch 6s steps(1) infinite"
+        >
+          <Text
+            textStyle="lg"
+            color="fg"
+            fontWeight={400}
+            textAlign="center"
+            css={{ textShadow: "0 1px 12px var(--chakra-colors-bg)" }}
+          >
+            You've wandered out of the simulation
+          </Text>
+          <Text
+            textStyle="sm"
+            color="fg.muted"
+            textAlign="center"
+            css={{ textShadow: "0 1px 12px var(--chakra-colors-bg)" }}
+          >
+            This page doesn't exist or has been moved.
+          </Text>
+        </VStack>
+
+        <HStack gap={3} marginTop={2}>
+          <Button size="sm" variant="solid" onClick={() => router.back()}>
+            <ArrowLeft size={14} />
+            Go back
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            color="fg.muted"
+            onClick={() => void router.push("/")}
+          >
+            <Home size={14} />
+            Home
+          </Button>
+        </HStack>
+      </VStack>
+    </Center>
+  );
+}

--- a/langwatch/src/components/NotFoundScene.tsx
+++ b/langwatch/src/components/NotFoundScene.tsx
@@ -116,8 +116,8 @@ export function NotFoundScene() {
     const el = containerRef.current;
     if (!el) return;
     const r = el.getBoundingClientRect();
-    mouse.current.x = (e.clientX - r.left) / r.width - 0.5;
-    mouse.current.y = (e.clientY - r.top) / r.height - 0.5;
+    mouse.current.x = Math.max(-0.5, Math.min(0.5, (e.clientX - r.left) / r.width - 0.5));
+    mouse.current.y = Math.max(-0.5, Math.min(0.5, (e.clientY - r.top) / r.height - 0.5));
   }, []);
 
   useEffect(() => {

--- a/langwatch/src/components/NotFoundScene.tsx
+++ b/langwatch/src/components/NotFoundScene.tsx
@@ -8,8 +8,8 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { ArrowLeft, Home, Settings } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useColorModeValue } from "~/components/ui/color-mode";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useColorMode, useColorModeValue } from "~/components/ui/color-mode";
 import { SimpleSlider } from "~/components/ui/slider";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { useRouter } from "~/utils/compat/next-router";
@@ -65,6 +65,7 @@ function ParamSlider({
 
 export function NotFoundScene() {
   const router = useRouter();
+  const { colorMode } = useColorMode();
   const isDevMode = process.env.NODE_ENV === "development";
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -91,23 +92,25 @@ export function NotFoundScene() {
     setParams((p) => ({ ...p, [key]: value }));
   };
 
-  const gridBaseColor: [number, number, number] = useColorModeValue(
-    [40, 90, 190],
-    [80, 160, 255],
+  const colors = useMemo<CanvasColors>(
+    () =>
+      colorMode === "dark"
+        ? {
+            gridBaseColor: [80, 160, 255],
+            particleBaseColor: [140, 180, 255],
+            aberrationRed: [255, 50, 100],
+            aberrationBlue: [50, 120, 255],
+            alphaScale: 1,
+          }
+        : {
+            gridBaseColor: [40, 90, 190],
+            particleBaseColor: [60, 110, 180],
+            aberrationRed: [180, 60, 80],
+            aberrationBlue: [60, 90, 190],
+            alphaScale: 1,
+          },
+    [colorMode],
   );
-  const particleBaseColor: [number, number, number] = useColorModeValue(
-    [60, 110, 180],
-    [140, 180, 255],
-  );
-  const aberrationRed: [number, number, number] = useColorModeValue(
-    [180, 60, 80],
-    [255, 50, 100],
-  );
-  const aberrationBlue: [number, number, number] = useColorModeValue(
-    [60, 90, 190],
-    [50, 120, 255],
-  );
-  const alphaScale = useColorModeValue(1, 1);
   const textRedColor = useColorModeValue("red.600/70", "red.400/60");
   const textBlueColor = useColorModeValue("blue.600/70", "blue.400/60");
   const textBaseOpacity = useColorModeValue(0.14, 0.08);
@@ -129,14 +132,6 @@ export function NotFoundScene() {
     if (!ctx) return;
 
     container.addEventListener("mousemove", onMove);
-
-    const colors: CanvasColors = {
-      gridBaseColor,
-      particleBaseColor,
-      aberrationRed,
-      aberrationBlue,
-      alphaScale,
-    };
 
     const render = rendererRef.current;
 
@@ -241,7 +236,7 @@ export function NotFoundScene() {
       document.removeEventListener("visibilitychange", onVisibilityChange);
       observer.disconnect();
     };
-  }, [onMove, gridBaseColor, particleBaseColor, aberrationRed, aberrationBlue, alphaScale, prefersReducedMotion]);
+  }, [onMove, colors, prefersReducedMotion]);
 
   return (
     <Center
@@ -388,9 +383,11 @@ export function NotFoundScene() {
                 variant="outline"
                 onClick={() => {
                   console.log("Grid params:", params);
-                  navigator.clipboard.writeText(
-                    JSON.stringify(params, null, 2),
-                  );
+                  void navigator.clipboard
+                    .writeText(JSON.stringify(params, null, 2))
+                    .catch((error: unknown) => {
+                      console.warn("Copy failed:", error);
+                    });
                 }}
               >
                 Copy Params

--- a/langwatch/src/components/NotFoundScene.tsx
+++ b/langwatch/src/components/NotFoundScene.tsx
@@ -11,6 +11,7 @@ import { ArrowLeft, Home, Settings } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useColorModeValue } from "~/components/ui/color-mode";
 import { SimpleSlider } from "~/components/ui/slider";
+import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { useRouter } from "~/utils/compat/next-router";
 import {
   createNotFoundRenderer,
@@ -79,6 +80,10 @@ export function NotFoundScene() {
   const paramsRef = useRef(params);
   paramsRef.current = params;
 
+  const prefersReducedMotion = useReducedMotion();
+  const isVisible = useRef(true);
+  const isTabActive = useRef(true);
+
   const updateParam = <K extends keyof GridParams>(
     key: K,
     value: GridParams[K],
@@ -135,7 +140,7 @@ export function NotFoundScene() {
 
     const render = rendererRef.current;
 
-    const loop = (timestamp: number) => {
+    const sizeCanvas = () => {
       const rect = container.getBoundingClientRect();
       const dpr = Math.min(window.devicePixelRatio || 1, MAX_CANVAS_DPR);
       const w = rect.width;
@@ -147,6 +152,55 @@ export function NotFoundScene() {
         canvas.style.width = `${w}px`;
         canvas.style.height = `${h}px`;
       }
+
+      return { w, h, dpr };
+    };
+
+    // Reduced motion: render a single static frame, no animation loop
+    if (prefersReducedMotion) {
+      const { w, h, dpr } = sizeCanvas();
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      render({
+        ctx,
+        width: w,
+        height: h,
+        timestamp: 0,
+        params: paramsRef.current,
+        colors,
+        smoothMouse: { x: 0, y: 0 },
+      });
+      return () => {
+        container.removeEventListener("mousemove", onMove);
+      };
+    }
+
+    // Pause when tab is hidden
+    const onVisibilityChange = () => {
+      isTabActive.current = !document.hidden;
+      if (!document.hidden && raf.current === 0) {
+        raf.current = requestAnimationFrame(loop);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    // Pause when scrolled out of view
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        isVisible.current = entry?.isIntersecting ?? true;
+        if (entry?.isIntersecting && raf.current === 0) {
+          raf.current = requestAnimationFrame(loop);
+        }
+      },
+      { threshold: 0 },
+    );
+    observer.observe(container);
+
+    const loop = (timestamp: number) => {
+      raf.current = 0;
+
+      if (!isVisible.current || !isTabActive.current) return;
+
+      const { w, h, dpr } = sizeCanvas();
 
       smoothMouse.current.x += (mouse.current.x - smoothMouse.current.x) * 0.06;
       smoothMouse.current.y += (mouse.current.y - smoothMouse.current.y) * 0.06;
@@ -179,9 +233,12 @@ export function NotFoundScene() {
 
     return () => {
       cancelAnimationFrame(raf.current);
+      raf.current = 0;
       container.removeEventListener("mousemove", onMove);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      observer.disconnect();
     };
-  }, [onMove, gridBaseColor, particleBaseColor, aberrationRed, aberrationBlue, alphaScale]);
+  }, [onMove, gridBaseColor, particleBaseColor, aberrationRed, aberrationBlue, alphaScale, prefersReducedMotion]);
 
   return (
     <Center
@@ -370,7 +427,7 @@ export function NotFoundScene() {
             lineHeight={1}
             letterSpacing="-0.04em"
             color={textRedColor}
-            animation="glitch-1 3s steps(1) infinite"
+            animation={prefersReducedMotion ? "none" : "glitch-1 3s steps(1) infinite"}
             willChange="transform"
             style={{ transform: "translate(-2px, -1px)" }}
           >
@@ -386,7 +443,7 @@ export function NotFoundScene() {
             lineHeight={1}
             letterSpacing="-0.04em"
             color={textBlueColor}
-            animation="glitch-2 2.5s steps(1) infinite"
+            animation={prefersReducedMotion ? "none" : "glitch-2 2.5s steps(1) infinite"}
             willChange="transform"
             style={{ transform: "translate(2px, 1px)" }}
           >
@@ -396,7 +453,7 @@ export function NotFoundScene() {
 
         <VStack
           gap={2}
-          animation="drift 4s ease-in-out infinite, text-glitch 6s steps(1) infinite"
+          animation={prefersReducedMotion ? "none" : "drift 4s ease-in-out infinite, text-glitch 6s steps(1) infinite"}
         >
           <Text
             textStyle="lg"

--- a/langwatch/src/components/NotFoundScene.tsx
+++ b/langwatch/src/components/NotFoundScene.tsx
@@ -146,9 +146,12 @@ export function NotFoundScene() {
       const w = rect.width;
       const h = rect.height;
 
-      if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
-        canvas.width = w * dpr;
-        canvas.height = h * dpr;
+      const pixelWidth = Math.round(w * dpr);
+      const pixelHeight = Math.round(h * dpr);
+
+      if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+        canvas.width = pixelWidth;
+        canvas.height = pixelHeight;
         canvas.style.width = `${w}px`;
         canvas.style.height = `${h}px`;
       }

--- a/langwatch/src/components/notFoundCanvasRenderer.ts
+++ b/langwatch/src/components/notFoundCanvasRenderer.ts
@@ -148,10 +148,7 @@ export function createNotFoundRenderer() {
       return [projectPoint(x1, y1, z1), projectPoint(x2, y2, z2)];
     };
 
-    const abStr =
-      p.aberration +
-      Math.abs(smoothMouse.x) * p.aberration * 2 +
-      Math.abs(smoothMouse.y) * p.aberration * 1.5;
+    const abStr = p.aberration;
 
     const getDepthFade = (y1: number, y2: number) => {
       const avgY = (y1 + y2) * 0.5;
@@ -369,10 +366,13 @@ export function createNotFoundRenderer() {
     for (const line of lineSegments) {
       const shimmer = Math.sin(time * 1.3 + line.id * 0.08) * 0.5 + 0.5;
       const ab = abStr * line.aberrationDepth * (0.7 + shimmer * 0.3);
-      const mouseChromaX = smoothMouse.x * (2 + line.depthFade * 7);
-      const mouseChromaY = smoothMouse.y * (1 + line.depthFade * 4);
-      const splitX = ab + mouseChromaX;
-      const splitY = ab * 0.5 + mouseChromaY;
+      // Mouse steers the split direction; idle drift keeps it alive at center
+      const driftX = Math.sin(time * 0.4) * 0.15;
+      const driftY = Math.cos(time * 0.3) * 0.1;
+      const dirX = smoothMouse.x * 2 + driftX;
+      const dirY = smoothMouse.y * 1.5 + driftY;
+      const splitX = ab * dirX;
+      const splitY = ab * dirY;
       const nearGlow = Math.max(0, line.nearBoost - 1);
       ctx.lineWidth = 1.05 + Math.min(0.55, nearGlow * 0.12);
 

--- a/langwatch/src/components/notFoundCanvasRenderer.ts
+++ b/langwatch/src/components/notFoundCanvasRenderer.ts
@@ -1,0 +1,419 @@
+interface GridParams {
+  rotation: number;
+  zOffset: number;
+  fovScale: number;
+  cameraY: number;
+  aberration: number;
+  gridExtent: number;
+  gridStep: number;
+  pitch: number;
+}
+
+interface GridLineSegment {
+  aberrationDepth: number;
+  depthFade: number;
+  id: number;
+  nearBoost: number;
+  startAlpha: number;
+  endAlpha: number;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  alpha: number;
+}
+
+interface BackgroundCache {
+  canvas: HTMLCanvasElement;
+  height: number;
+  key: string;
+  width: number;
+}
+
+export interface CanvasColors {
+  gridBaseColor: [number, number, number];
+  particleBaseColor: [number, number, number];
+  aberrationRed: [number, number, number];
+  aberrationBlue: [number, number, number];
+  alphaScale: number;
+}
+
+export type { GridParams };
+
+export const MAX_CANVAS_DPR = 1.5;
+
+export const defaultGridParams: GridParams = {
+  rotation: 45,
+  zOffset: 8700,
+  fovScale: 1.135,
+  cameraY: 820,
+  aberration: 5.5,
+  gridExtent: 7200,
+  gridStep: 80,
+  pitch: -4,
+};
+
+export function createNotFoundRenderer() {
+  let bgCache: BackgroundCache | null = null;
+
+  return function render({
+    ctx,
+    width: w,
+    height: h,
+    timestamp,
+    params: p,
+    colors,
+    smoothMouse,
+  }: {
+    ctx: CanvasRenderingContext2D;
+    width: number;
+    height: number;
+    timestamp: number;
+    params: GridParams;
+    colors: CanvasColors;
+    smoothMouse: { x: number; y: number };
+  }) {
+    const { gridBaseColor, particleBaseColor, aberrationRed, aberrationBlue, alphaScale } = colors;
+    const [particleR, particleG, particleB] = particleBaseColor;
+
+    ctx.clearRect(0, 0, w, h);
+
+    const time = timestamp * 0.001;
+    const cx = w / 2;
+    const cy = h / 2;
+
+    const rot = (p.rotation * Math.PI) / 180;
+    const cosR = Math.cos(rot);
+    const sinR = Math.sin(rot);
+
+    const pitchRad = (p.pitch * Math.PI) / 180;
+    const cosP = Math.cos(pitchRad);
+    const sinP = Math.sin(pitchRad);
+
+    const minZ = 100;
+    const focalLength = h * p.fovScale;
+    const horizonY = Math.max(0, -Math.tan(pitchRad) * focalLength);
+
+    const wobbleX = Math.sin(time * 0.13) * 120 + Math.cos(time * 0.07) * 60;
+    const wobbleZ = Math.cos(time * 0.11) * 80 + Math.sin(time * 0.09) * 40;
+
+    const toCamera = (gx: number, gz: number): [number, number, number] => {
+      const wx = gx - wobbleX;
+      const wz = gz - wobbleZ;
+
+      const x = wx * cosR - wz * sinR;
+      let z = wx * sinR + wz * cosR;
+
+      const y = -z * sinP + p.cameraY;
+      z = z * cosP;
+      z += p.zOffset;
+
+      return [x, y, z];
+    };
+
+    const projectPoint = (
+      x: number,
+      y: number,
+      z: number,
+    ): [number, number, number] => {
+      const scale = focalLength / z;
+      const sx = cx + x * scale;
+      const sy = y * scale;
+      return [sx, sy, scale];
+    };
+
+    const projectLine = (
+      gx1: number,
+      gz1: number,
+      gx2: number,
+      gz2: number,
+    ): [[number, number, number], [number, number, number]] | null => {
+      let [x1, y1, z1] = toCamera(gx1, gz1);
+      let [x2, y2, z2] = toCamera(gx2, gz2);
+
+      if (z1 < minZ && z2 < minZ) return null;
+
+      if (z1 < minZ) {
+        const t = (minZ - z1) / (z2 - z1);
+        x1 = x1 + t * (x2 - x1);
+        y1 = y1 + t * (y2 - y1);
+        z1 = minZ;
+      } else if (z2 < minZ) {
+        const t = (minZ - z2) / (z1 - z2);
+        x2 = x2 + t * (x1 - x2);
+        y2 = y2 + t * (y1 - y2);
+        z2 = minZ;
+      }
+
+      return [projectPoint(x1, y1, z1), projectPoint(x2, y2, z2)];
+    };
+
+    const abStr =
+      p.aberration +
+      Math.abs(smoothMouse.x) * p.aberration * 2 +
+      Math.abs(smoothMouse.y) * p.aberration * 1.5;
+
+    const getDepthFade = (y1: number, y2: number) => {
+      const avgY = (y1 + y2) * 0.5;
+      const depthProgress = Math.max(
+        0,
+        Math.min(1, (avgY - horizonY) / Math.max(1, h - horizonY)),
+      );
+      return Math.pow(depthProgress, 1.8);
+    };
+
+    const getAtmosphereFade = (y: number) => {
+      const depthProgress = Math.max(
+        0,
+        Math.min(1, (y - horizonY) / Math.max(1, h - horizonY)),
+      );
+      const fadeStart = 0.18;
+      const delayedDepth = Math.max(
+        0,
+        (depthProgress - fadeStart) / (1 - fadeStart),
+      );
+      return Math.pow(delayedDepth, 2.2);
+    };
+
+    const getNearBoost = (y1: number, y2: number) => {
+      const nearestDepth = Math.max(
+        0,
+        Math.min(
+          1,
+          (Math.max(y1, y2) - horizonY) / Math.max(1, h - horizonY),
+        ),
+      );
+      return 1.25 + Math.pow(nearestDepth, 1.02) * 4.1;
+    };
+
+    // Background cache — only rebuilt when viewport/colors/params change
+    const bgKey = [
+      w, h,
+      ...gridBaseColor, ...particleBaseColor, ...aberrationRed, ...aberrationBlue,
+      alphaScale, p.fovScale, p.pitch,
+    ].join("|");
+
+    if (bgCache?.key !== bgKey) {
+      const backgroundCanvas = document.createElement("canvas");
+      backgroundCanvas.width = w;
+      backgroundCanvas.height = h;
+      const backgroundCtx = backgroundCanvas.getContext("2d");
+
+      if (!backgroundCtx) return;
+
+      const skyGradient = backgroundCtx.createLinearGradient(0, 0, 0, h);
+      skyGradient.addColorStop(
+        0,
+        `rgba(${particleR}, ${particleG}, ${particleB}, 0.08)`,
+      );
+      skyGradient.addColorStop(0.4, "rgba(8, 14, 24, 0.02)");
+      skyGradient.addColorStop(
+        1,
+        `rgba(${particleR}, ${particleG}, ${particleB}, 0.05)`,
+      );
+      backgroundCtx.fillStyle = skyGradient;
+      backgroundCtx.fillRect(0, 0, w, h);
+
+      const horizonGlow = backgroundCtx.createRadialGradient(
+        cx,
+        horizonY,
+        0,
+        cx,
+        horizonY,
+        Math.max(w, h) * 0.7,
+      );
+      horizonGlow.addColorStop(
+        0,
+        `rgba(${particleR}, ${particleG}, ${particleB}, ${0.18 * alphaScale})`,
+      );
+      horizonGlow.addColorStop(
+        0.35,
+        `rgba(${particleR}, ${particleG}, ${particleB}, ${0.09 * alphaScale})`,
+      );
+      horizonGlow.addColorStop(1, "rgba(0, 0, 0, 0)");
+      backgroundCtx.fillStyle = horizonGlow;
+      backgroundCtx.fillRect(0, 0, w, h);
+
+      const floorGlow = backgroundCtx.createLinearGradient(0, horizonY, 0, h);
+      floorGlow.addColorStop(0, "rgba(0, 0, 0, 0)");
+      floorGlow.addColorStop(
+        0.18,
+        `rgba(${particleR}, ${particleG}, ${particleB}, ${0.05 * alphaScale})`,
+      );
+      floorGlow.addColorStop(
+        1,
+        `rgba(${particleR}, ${particleG}, ${particleB}, ${0.12 * alphaScale})`,
+      );
+      backgroundCtx.fillStyle = floorGlow;
+      backgroundCtx.fillRect(0, horizonY, w, h - horizonY);
+
+      const starFieldHeight = Math.max(h * 0.08, horizonY - h * 0.02);
+      const starCount = Math.max(18, Math.floor(w / 42));
+      for (let i = 0; i < starCount; i++) {
+        const seed = i * 12.9898;
+        const px = ((Math.sin(seed) + 1) / 2) * w;
+        const py = ((Math.cos(seed * 1.7) + 1) / 2) * starFieldHeight;
+        const radius = 0.6 + ((Math.sin(seed * 3.1) + 1) / 2) * 1.5;
+        const twinkle = 0.22 + ((Math.sin(seed * 2.4) + 1) / 2) * 0.3;
+
+        backgroundCtx.beginPath();
+        backgroundCtx.fillStyle = `rgba(${particleR}, ${particleG}, ${particleB}, ${twinkle})`;
+        backgroundCtx.arc(px, py, radius, 0, Math.PI * 2);
+        backgroundCtx.fill();
+      }
+
+      const horizonLineGlow = backgroundCtx.createLinearGradient(0, horizonY - 4, 0, horizonY + 6);
+      horizonLineGlow.addColorStop(0, "rgba(0, 0, 0, 0)");
+      horizonLineGlow.addColorStop(0.5, `rgba(${particleR}, ${particleG}, ${particleB}, ${0.06 * alphaScale})`);
+      horizonLineGlow.addColorStop(1, "rgba(0, 0, 0, 0)");
+      backgroundCtx.fillStyle = horizonLineGlow;
+      backgroundCtx.fillRect(0, horizonY - 4, w, 10);
+
+      const vignette = backgroundCtx.createRadialGradient(
+        cx,
+        cy,
+        Math.min(w, h) * 0.1,
+        cx,
+        cy,
+        Math.max(w, h) * 0.75,
+      );
+      vignette.addColorStop(0, "rgba(0, 0, 0, 0)");
+      vignette.addColorStop(1, "rgba(0, 0, 0, 0.22)");
+      backgroundCtx.fillStyle = vignette;
+      backgroundCtx.fillRect(0, 0, w, h);
+
+      bgCache = {
+        canvas: backgroundCanvas,
+        height: h,
+        key: bgKey,
+        width: w,
+      };
+    }
+
+    if (!bgCache) return;
+    ctx.drawImage(bgCache.canvas, 0, 0, bgCache.width, bgCache.height);
+
+    // Line segments — recomputed each frame for camera wobble
+    const lineSegments: GridLineSegment[] = [];
+
+    const pushLine = (
+      id: number,
+      x1: number,
+      y1: number,
+      x2: number,
+      y2: number,
+      alpha: number,
+    ) => {
+      const depthFade = getDepthFade(y1, y2);
+      const nearBoost = getNearBoost(y1, y2);
+      const startAlpha = Math.min(
+        1,
+        alpha * getAtmosphereFade(y1) * nearBoost,
+      );
+      const endAlpha = Math.min(
+        1,
+        alpha * getAtmosphereFade(y2) * nearBoost,
+      );
+      const lineAlpha = Math.max(startAlpha, endAlpha) * depthFade;
+
+      if (lineAlpha < 0.02) return;
+
+      lineSegments.push({
+        aberrationDepth: 0.12 + depthFade * 0.88,
+        depthFade,
+        endAlpha,
+        id,
+        nearBoost,
+        startAlpha,
+        x1,
+        y1,
+        x2,
+        y2,
+        alpha: Math.max(startAlpha, endAlpha),
+      });
+    };
+
+    const gridExtent = p.gridExtent;
+    const step = p.gridStep;
+
+    const edgeFade = (dist: number) => {
+      if (dist < 0.6) return 1;
+      const t = (dist - 0.6) / 0.4;
+      return (1 - t) * (1 - t);
+    };
+
+    for (let gz = -gridExtent; gz <= gridExtent; gz += step) {
+      const result = projectLine(-gridExtent, gz, gridExtent, gz);
+      if (result) {
+        const [[sx1, sy1], [sx2, sy2]] = result;
+        const dist = Math.abs(gz) / gridExtent;
+        const alpha = 0.65 * edgeFade(dist) * alphaScale;
+        pushLine(gz, sx1, sy1, sx2, sy2, alpha);
+      }
+    }
+
+    for (let gx = -gridExtent; gx <= gridExtent; gx += step) {
+      const result = projectLine(gx, -gridExtent, gx, gridExtent);
+      if (result) {
+        const [[sx1, sy1], [sx2, sy2]] = result;
+        const dist = Math.abs(gx) / gridExtent;
+        const alpha = 0.65 * edgeFade(dist) * alphaScale;
+        pushLine(gx + 10000, sx1, sy1, sx2, sy2, alpha);
+      }
+    }
+
+    const [abRedR, abRedG, abRedB] = aberrationRed;
+    const [abBlueR, abBlueG, abBlueB] = aberrationBlue;
+    const [r, g, b] = gridBaseColor;
+
+    for (const line of lineSegments) {
+      const shimmer = Math.sin(time * 1.3 + line.id * 0.08) * 0.5 + 0.5;
+      const ab = abStr * line.aberrationDepth * (0.7 + shimmer * 0.3);
+      const mouseChromaX = smoothMouse.x * (2 + line.depthFade * 7);
+      const mouseChromaY = smoothMouse.y * (1 + line.depthFade * 4);
+      const splitX = ab + mouseChromaX;
+      const splitY = ab * 0.5 + mouseChromaY;
+      const nearGlow = Math.max(0, line.nearBoost - 1);
+      ctx.lineWidth = 1.05 + Math.min(0.55, nearGlow * 0.12);
+
+      const redGradient = ctx.createLinearGradient(
+        line.x1 - splitX, line.y1 - splitY,
+        line.x2 - splitX, line.y2 - splitY,
+      );
+      redGradient.addColorStop(0, `rgba(${abRedR}, ${abRedG}, ${abRedB}, ${line.startAlpha * 0.42})`);
+      redGradient.addColorStop(1, `rgba(${abRedR}, ${abRedG}, ${abRedB}, ${line.endAlpha * 0.42})`);
+
+      ctx.strokeStyle = redGradient;
+      ctx.beginPath();
+      ctx.moveTo(line.x1 - splitX, line.y1 - splitY);
+      ctx.lineTo(line.x2 - splitX, line.y2 - splitY);
+      ctx.stroke();
+
+      const blueGradient = ctx.createLinearGradient(
+        line.x1 + splitX, line.y1 + splitY,
+        line.x2 + splitX, line.y2 + splitY,
+      );
+      blueGradient.addColorStop(0, `rgba(${abBlueR}, ${abBlueG}, ${abBlueB}, ${line.startAlpha * 0.42})`);
+      blueGradient.addColorStop(1, `rgba(${abBlueR}, ${abBlueG}, ${abBlueB}, ${line.endAlpha * 0.42})`);
+
+      ctx.strokeStyle = blueGradient;
+      ctx.beginPath();
+      ctx.moveTo(line.x1 + splitX, line.y1 + splitY);
+      ctx.lineTo(line.x2 + splitX, line.y2 + splitY);
+      ctx.stroke();
+
+      const mainGradient = ctx.createLinearGradient(line.x1, line.y1, line.x2, line.y2);
+      mainGradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, ${line.startAlpha})`);
+      mainGradient.addColorStop(1, `rgba(${r}, ${g}, ${b}, ${line.endAlpha})`);
+
+      ctx.strokeStyle = mainGradient;
+      ctx.shadowColor = `rgba(${r}, ${g}, ${b}, ${0.22 + line.depthFade * 0.32 + nearGlow * 0.24})`;
+      ctx.shadowBlur = 3 + line.depthFade * 6 + nearGlow * 7;
+      ctx.beginPath();
+      ctx.moveTo(line.x1, line.y1);
+      ctx.lineTo(line.x2, line.y2);
+      ctx.stroke();
+      ctx.shadowBlur = 0;
+    }
+  };
+}

--- a/langwatch/src/components/notFoundCanvasRenderer.ts
+++ b/langwatch/src/components/notFoundCanvasRenderer.ts
@@ -330,8 +330,14 @@ export function createNotFoundRenderer() {
       });
     };
 
-    const gridExtent = p.gridExtent;
-    const step = p.gridStep;
+    const gridExtent =
+      Number.isFinite(p.gridExtent) && p.gridExtent > 0
+        ? p.gridExtent
+        : defaultGridParams.gridExtent;
+    const step =
+      Number.isFinite(p.gridStep) && p.gridStep > 0
+        ? p.gridStep
+        : defaultGridParams.gridStep;
 
     const edgeFade = (dist: number) => {
       if (dist < 0.6) return 1;

--- a/langwatch/src/components/ops/shared/OpsPageShell.tsx
+++ b/langwatch/src/components/ops/shared/OpsPageShell.tsx
@@ -1,131 +1,8 @@
-import { useEffect, useState } from "react";
-import {
-  Box,
-  Button,
-  Center,
-  Code,
-  Heading,
-  HStack,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { useEffect } from "react";
 import { useRouter } from "~/utils/compat/next-router";
 import { ErrorBoundary } from "react-error-boundary";
-import { AlertTriangle, Copy, Check, RotateCcw, Home } from "lucide-react";
 import { useOpsPermission } from "~/hooks/useOpsPermission";
-
-function OpsErrorFallback({
-  error,
-  resetErrorBoundary,
-}: {
-  error: unknown;
-  resetErrorBoundary: (...args: unknown[]) => void;
-}) {
-  const router = useRouter();
-  const [copied, setCopied] = useState(false);
-  const message =
-    error instanceof Error ? error.message : String(error);
-  const stack =
-    error instanceof Error ? error.stack : undefined;
-
-  return (
-    <Center minHeight="60vh" padding={8}>
-      <VStack gap={6} maxWidth="560px" width="full">
-        <VStack gap={3}>
-          <Box
-            padding={3}
-            borderRadius="full"
-            bg="red.500/10"
-          >
-            <AlertTriangle size={28} color="var(--chakra-colors-red-400)" />
-          </Box>
-          <Heading size="md" color="fg.default">
-            Something went wrong
-          </Heading>
-          <Text
-            textStyle="sm"
-            color="fg.muted"
-            textAlign="center"
-            maxWidth="400px"
-          >
-            An error occurred in the ops UI. The rest of the platform is
-            unaffected.
-          </Text>
-        </VStack>
-
-        <Box
-          width="full"
-          borderRadius="lg"
-          border="1px solid"
-          borderColor="border"
-          overflow="hidden"
-        >
-          <HStack
-            paddingX={4}
-            paddingY={2.5}
-            bg="bg.subtle"
-            borderBottom="1px solid"
-            borderColor="border"
-            justify="space-between"
-          >
-            <Text textStyle="xs" fontWeight="medium" color="fg.muted">
-              Error details
-            </Text>
-            <Button
-              size="2xs"
-              variant="ghost"
-              color="fg.muted"
-              onClick={() => {
-                const text = stack ?? message;
-                void navigator.clipboard.writeText(text);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 2000);
-              }}
-            >
-              {copied ? <Check size={12} /> : <Copy size={12} />}
-              {copied ? "Copied" : "Copy"}
-            </Button>
-          </HStack>
-          <Code
-            display="block"
-            paddingX={4}
-            paddingY={3}
-            maxHeight="180px"
-            overflow="auto"
-            textStyle="xs"
-            whiteSpace="pre-wrap"
-            wordBreak="break-word"
-            bg="bg.panel"
-            color="red.400"
-            borderRadius={0}
-          >
-            {message}
-          </Code>
-        </Box>
-
-        <HStack gap={3}>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={resetErrorBoundary}
-          >
-            <RotateCcw size={14} />
-            Try again
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            color="fg.muted"
-            onClick={() => void router.push("/ops")}
-          >
-            <Home size={14} />
-            Back to Ops
-          </Button>
-        </HStack>
-      </VStack>
-    </Center>
-  );
-}
+import { PageErrorFallback } from "~/components/ui/PageErrorFallback";
 
 export function OpsPageShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -140,7 +17,7 @@ export function OpsPageShell({ children }: { children: React.ReactNode }) {
   if (isLoading || !hasAccess) return null;
 
   return (
-    <ErrorBoundary FallbackComponent={OpsErrorFallback}>
+    <ErrorBoundary FallbackComponent={PageErrorFallback}>
       {children}
     </ErrorBoundary>
   );

--- a/langwatch/src/components/ops/shared/OpsPageShell.tsx
+++ b/langwatch/src/components/ops/shared/OpsPageShell.tsx
@@ -17,7 +17,7 @@ export function OpsPageShell({ children }: { children: React.ReactNode }) {
   if (isLoading || !hasAccess) return null;
 
   return (
-    <ErrorBoundary FallbackComponent={PageErrorFallback}>
+    <ErrorBoundary FallbackComponent={PageErrorFallback} resetKeys={[router.pathname]}>
       {children}
     </ErrorBoundary>
   );

--- a/langwatch/src/components/ui/PageErrorFallback.tsx
+++ b/langwatch/src/components/ui/PageErrorFallback.tsx
@@ -24,6 +24,8 @@ export function PageErrorFallback({
   const [copied, setCopied] = useState(false);
   const message = error instanceof Error ? error.message : String(error);
   const stack = error instanceof Error ? error.stack : undefined;
+  const isDev = process.env.NODE_ENV === "development";
+
   useEffect(() => {
     captureException(error, {
       tags: { source: "error-boundary" },
@@ -52,58 +54,64 @@ export function PageErrorFallback({
           </Text>
         </VStack>
 
-        <Box
-          width="full"
-          borderRadius="lg"
-          border="1px solid"
-          borderColor="border"
-          overflow="hidden"
-        >
-          <HStack
-            paddingX={4}
-            paddingY={2.5}
-            bg="bg.subtle"
-            borderBottom="1px solid"
+        {isDev ? (
+          <Box
+            width="full"
+            borderRadius="lg"
+            border="1px solid"
             borderColor="border"
-            justify="space-between"
+            overflow="hidden"
           >
-            <Text textStyle="xs" fontWeight="medium" color="fg.muted">
-              Error details
-            </Text>
-            <Button
-              size="2xs"
-              variant="ghost"
-              color="fg.muted"
-              onClick={async () => {
-                try {
-                  await navigator.clipboard.writeText(stack ?? message);
-                  setCopied(true);
-                  setTimeout(() => setCopied(false), 2000);
-                } catch {
-                  // Clipboard API unavailable or denied
-                }
-              }}
+            <HStack
+              paddingX={4}
+              paddingY={2.5}
+              bg="bg.subtle"
+              borderBottom="1px solid"
+              borderColor="border"
+              justify="space-between"
             >
-              {copied ? <Check size={12} /> : <Copy size={12} />}
-              {copied ? "Copied" : "Copy"}
-            </Button>
-          </HStack>
-          <Code
-            display="block"
-            paddingX={4}
-            paddingY={3}
-            maxHeight="180px"
-            overflow="auto"
-            textStyle="xs"
-            whiteSpace="pre-wrap"
-            wordBreak="break-word"
-            bg="bg.panel"
-            color="red.400"
-            borderRadius={0}
-          >
-            {stack ?? message}
-          </Code>
-        </Box>
+              <Text textStyle="xs" fontWeight="medium" color="fg.muted">
+                Error details
+              </Text>
+              <Button
+                size="2xs"
+                variant="ghost"
+                color="fg.muted"
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(stack ?? message);
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                  } catch {
+                    // Clipboard API unavailable or denied
+                  }
+                }}
+              >
+                {copied ? <Check size={12} /> : <Copy size={12} />}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </HStack>
+            <Code
+              display="block"
+              paddingX={4}
+              paddingY={3}
+              maxHeight="180px"
+              overflow="auto"
+              textStyle="xs"
+              whiteSpace="pre-wrap"
+              wordBreak="break-word"
+              bg="bg.panel"
+              color="red.400"
+              borderRadius={0}
+            >
+              {stack ?? message}
+            </Code>
+          </Box>
+        ) : (
+          <Text textStyle="sm" color="fg.muted" textAlign="center">
+            Error reference has been logged automatically.
+          </Text>
+        )}
 
         <HStack gap={3}>
           <Button size="sm" variant="outline" onClick={resetErrorBoundary}>

--- a/langwatch/src/components/ui/PageErrorFallback.tsx
+++ b/langwatch/src/components/ui/PageErrorFallback.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   Button,
@@ -11,6 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { AlertTriangle, Copy, Check, RotateCcw, Home } from "lucide-react";
 import { useRouter } from "~/utils/compat/next-router";
+import { captureException } from "~/utils/posthogErrorCapture";
 
 export function PageErrorFallback({
   error,
@@ -23,6 +24,12 @@ export function PageErrorFallback({
   const [copied, setCopied] = useState(false);
   const message = error instanceof Error ? error.message : String(error);
   const stack = error instanceof Error ? error.stack : undefined;
+  useEffect(() => {
+    captureException(error, {
+      tags: { source: "error-boundary" },
+      extra: { pathname: window.location.pathname },
+    });
+  }, [error]);
 
   return (
     <Center minHeight="60vh" padding={8}>
@@ -67,11 +74,14 @@ export function PageErrorFallback({
               size="2xs"
               variant="ghost"
               color="fg.muted"
-              onClick={() => {
-                const text = stack ?? message;
-                void navigator.clipboard.writeText(text);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 2000);
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(stack ?? message);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 2000);
+                } catch {
+                  // Clipboard API unavailable or denied
+                }
               }}
             >
               {copied ? <Check size={12} /> : <Copy size={12} />}

--- a/langwatch/src/components/ui/PageErrorFallback.tsx
+++ b/langwatch/src/components/ui/PageErrorFallback.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Center,
+  Code,
+  Heading,
+  HStack,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { AlertTriangle, Copy, Check, RotateCcw, Home } from "lucide-react";
+import { useRouter } from "~/utils/compat/next-router";
+
+export function PageErrorFallback({
+  error,
+  resetErrorBoundary,
+}: {
+  error: unknown;
+  resetErrorBoundary: (...args: unknown[]) => void;
+}) {
+  const router = useRouter();
+  const [copied, setCopied] = useState(false);
+  const message = error instanceof Error ? error.message : String(error);
+  const stack = error instanceof Error ? error.stack : undefined;
+
+  return (
+    <Center minHeight="60vh" padding={8}>
+      <VStack gap={6} maxWidth="560px" width="full">
+        <VStack gap={3}>
+          <Box padding={3} borderRadius="full" bg="red.500/10">
+            <AlertTriangle size={28} color="var(--chakra-colors-red-400)" />
+          </Box>
+          <Heading size="md" color="fg.default">
+            Something went wrong
+          </Heading>
+          <Text
+            textStyle="sm"
+            color="fg.muted"
+            textAlign="center"
+            maxWidth="400px"
+          >
+            Sorry about that — our team has been notified and is looking into
+            it. You can try again, or head back to the home page.
+          </Text>
+        </VStack>
+
+        <Box
+          width="full"
+          borderRadius="lg"
+          border="1px solid"
+          borderColor="border"
+          overflow="hidden"
+        >
+          <HStack
+            paddingX={4}
+            paddingY={2.5}
+            bg="bg.subtle"
+            borderBottom="1px solid"
+            borderColor="border"
+            justify="space-between"
+          >
+            <Text textStyle="xs" fontWeight="medium" color="fg.muted">
+              Error details
+            </Text>
+            <Button
+              size="2xs"
+              variant="ghost"
+              color="fg.muted"
+              onClick={() => {
+                const text = stack ?? message;
+                void navigator.clipboard.writeText(text);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+              }}
+            >
+              {copied ? <Check size={12} /> : <Copy size={12} />}
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          </HStack>
+          <Code
+            display="block"
+            paddingX={4}
+            paddingY={3}
+            maxHeight="180px"
+            overflow="auto"
+            textStyle="xs"
+            whiteSpace="pre-wrap"
+            wordBreak="break-word"
+            bg="bg.panel"
+            color="red.400"
+            borderRadius={0}
+          >
+            {stack ?? message}
+          </Code>
+        </Box>
+
+        <HStack gap={3}>
+          <Button size="sm" variant="outline" onClick={resetErrorBoundary}>
+            <RotateCcw size={14} />
+            Try again
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            color="fg.muted"
+            onClick={() => void router.push("/")}
+          >
+            <Home size={14} />
+            Home
+          </Button>
+        </HStack>
+      </VStack>
+    </Center>
+  );
+}

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -259,13 +259,12 @@ export const useOrganizationTeamProject = (
       finalProject.slug !== router.query.project
     ) {
       // Preserve the sub-path so /bad-slug/messages → /good-slug/messages
-      const [pathPart, queryPart] = router.asPath.split("?");
+      const url = new URL(router.asPath, window.location.origin);
       const oldPrefix = `/${router.query.project as string}`;
-      const subPath = pathPart?.startsWith(oldPrefix)
-        ? pathPart.slice(oldPrefix.length)
+      const subPath = url.pathname.startsWith(oldPrefix)
+        ? url.pathname.slice(oldPrefix.length)
         : "";
-      const search = queryPart ? `?${queryPart}` : "";
-      void router.push(`/${finalProject.slug}${subPath}${search}`);
+      void router.push(`/${finalProject.slug}${subPath}${url.search}`);
     }
   }, [
     isDemo,

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -258,11 +258,14 @@ export const useOrganizationTeamProject = (
       typeof router.query.project == "string" &&
       finalProject.slug !== router.query.project
     ) {
-      const returnTo = router.query.return_to;
-      const returnToParam = returnTo
-        ? `?return_to=${encodeURIComponent(returnTo as string)}`
+      // Preserve the sub-path so /bad-slug/messages → /good-slug/messages
+      const [pathPart, queryPart] = router.asPath.split("?");
+      const oldPrefix = `/${router.query.project as string}`;
+      const subPath = pathPart?.startsWith(oldPrefix)
+        ? pathPart.slice(oldPrefix.length)
         : "";
-      void router.push(`/${finalProject.slug}${returnToParam}`);
+      const search = queryPart ? `?${queryPart}` : "";
+      void router.push(`/${finalProject.slug}${subPath}${search}`);
     }
   }, [
     isDemo,

--- a/langwatch/src/hooks/useReducedMotion.ts
+++ b/langwatch/src/hooks/useReducedMotion.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from "react";
+
+const query =
+  typeof window !== "undefined"
+    ? window.matchMedia("(prefers-reduced-motion: reduce)")
+    : null;
+
+function subscribe(callback: () => void) {
+  query?.addEventListener("change", callback);
+  return () => query?.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+  return query?.matches ?? false;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+export function useReducedMotion() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/langwatch/src/hooks/useReducedMotion.ts
+++ b/langwatch/src/hooks/useReducedMotion.ts
@@ -1,23 +1,26 @@
 import { useSyncExternalStore } from "react";
 
-const query =
-  typeof window !== "undefined"
-    ? window.matchMedia("(prefers-reduced-motion: reduce)")
-    : null;
+const MEDIA_QUERY = "(prefers-reduced-motion: reduce)";
+
+function getQuery(): MediaQueryList | null {
+	if (typeof window === "undefined") return null;
+
+	if (typeof window.matchMedia !== "function") return null;
+
+	return window.matchMedia(MEDIA_QUERY);
+}
 
 function subscribe(callback: () => void) {
-  query?.addEventListener("change", callback);
-  return () => query?.removeEventListener("change", callback);
+	const query = getQuery();
+	query?.addEventListener("change", callback);
+	return () => query?.removeEventListener("change", callback);
 }
-
 function getSnapshot() {
-  return query?.matches ?? false;
+	return getQuery()?.matches ?? false;
 }
-
 function getServerSnapshot() {
-  return false;
+	return false;
 }
-
 export function useReducedMotion() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+	return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/langwatch/src/pages/[project]/not-found.tsx
+++ b/langwatch/src/pages/[project]/not-found.tsx
@@ -1,0 +1,10 @@
+import { DashboardLayout } from "~/components/DashboardLayout";
+import { NotFoundScene } from "~/components/NotFoundScene";
+
+export default function ProjectNotFound() {
+  return (
+    <DashboardLayout>
+      <NotFoundScene />
+    </DashboardLayout>
+  );
+}

--- a/langwatch/src/pages/dev/error-test.tsx
+++ b/langwatch/src/pages/dev/error-test.tsx
@@ -1,0 +1,284 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Heading,
+  SimpleGrid,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import {
+  Bomb,
+  FileQuestion,
+  AlertTriangle,
+  PanelRight,
+  Square,
+  Skull,
+} from "lucide-react";
+import { ErrorBoundary } from "react-error-boundary";
+import { Link } from "~/components/ui/link";
+import { Dialog } from "~/components/ui/dialog";
+import { Drawer } from "~/components/ui/drawer";
+import { DashboardLayout } from "~/components/DashboardLayout";
+import { PageErrorFallback } from "~/components/ui/PageErrorFallback";
+
+function ThrowOnRender(): never {
+  throw new Error("Test error: component crashed during render");
+}
+
+function CrashableContent({ label }: { label: string }) {
+  const [shouldCrash, setShouldCrash] = useState(false);
+
+  if (shouldCrash) {
+    return <ThrowOnRender />;
+  }
+
+  return (
+    <VStack gap={3} padding={4}>
+      <Text textStyle="sm">This is the {label} content.</Text>
+      <Button
+        size="sm"
+        colorPalette="red"
+        onClick={() => setShouldCrash(true)}
+      >
+        <Bomb size={14} />
+        Crash it
+      </Button>
+    </VStack>
+  );
+}
+
+function InnerContent({
+  onCrashOuter,
+}: {
+  onCrashOuter: () => void;
+}) {
+  const [shouldCrash, setShouldCrash] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  if (shouldCrash) {
+    return <ThrowOnRender />;
+  }
+
+  return (
+    <>
+      <Box flex={1} padding={8} overflowY="auto">
+        <VStack gap={6} maxWidth="900px" marginX="auto">
+          <VStack gap={2}>
+            <Heading size="lg" color="fg.default">
+              Error Boundary Test
+            </Heading>
+            <Text textStyle="sm" color="fg.muted" textAlign="center">
+              Dev-only page for testing error boundaries and the 404 page.
+            </Text>
+          </VStack>
+
+          <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={4} width="full">
+            {/* Inner crash — stays in shell */}
+            <Box
+              padding={4}
+              borderRadius="lg"
+              border="1px solid"
+              borderColor="border"
+            >
+              <VStack gap={3}>
+                <AlertTriangle
+                  size={20}
+                  color="var(--chakra-colors-red-400)"
+                />
+                <Text textStyle="sm" fontWeight="medium">
+                  Crash page content (inner)
+                </Text>
+                <Text textStyle="xs" color="fg.muted" textAlign="center">
+                  Caught by DashboardLayout's ErrorBoundary — sidebar and header
+                  stay visible.
+                </Text>
+                <Button
+                  size="sm"
+                  colorPalette="red"
+                  onClick={() => setShouldCrash(true)}
+                >
+                  <Bomb size={14} />
+                  Crash inner
+                </Button>
+              </VStack>
+            </Box>
+
+            {/* Outer crash — full-screen fallback */}
+            <Box
+              padding={4}
+              borderRadius="lg"
+              border="1px solid"
+              borderColor="border"
+            >
+              <VStack gap={3}>
+                <Skull
+                  size={20}
+                  color="var(--chakra-colors-red-600)"
+                />
+                <Text textStyle="sm" fontWeight="medium">
+                  Crash entire page (outer)
+                </Text>
+                <Text textStyle="xs" color="fg.muted" textAlign="center">
+                  Crashes outside DashboardLayout — caught by RootLayout's
+                  ErrorBoundary. Full-screen error fallback, no shell.
+                </Text>
+                <Button
+                  size="sm"
+                  colorPalette="red"
+                  variant="solid"
+                  onClick={onCrashOuter}
+                >
+                  <Skull size={14} />
+                  Crash outer
+                </Button>
+              </VStack>
+            </Box>
+
+            {/* Dialog crash */}
+            <Box
+              padding={4}
+              borderRadius="lg"
+              border="1px solid"
+              borderColor="border"
+            >
+              <VStack gap={3}>
+                <Square
+                  size={20}
+                  color="var(--chakra-colors-orange-400)"
+                />
+                <Text textStyle="sm" fontWeight="medium">
+                  Crash inside a Dialog
+                </Text>
+                <Text textStyle="xs" color="fg.muted" textAlign="center">
+                  Opens a dialog, then crashes its content.
+                </Text>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setDialogOpen(true)}
+                >
+                  <Square size={14} />
+                  Open dialog
+                </Button>
+              </VStack>
+            </Box>
+
+            {/* Drawer crash */}
+            <Box
+              padding={4}
+              borderRadius="lg"
+              border="1px solid"
+              borderColor="border"
+            >
+              <VStack gap={3}>
+                <PanelRight
+                  size={20}
+                  color="var(--chakra-colors-blue-400)"
+                />
+                <Text textStyle="sm" fontWeight="medium">
+                  Crash inside a Drawer
+                </Text>
+                <Text textStyle="xs" color="fg.muted" textAlign="center">
+                  Opens a drawer, then crashes its content.
+                </Text>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setDrawerOpen(true)}
+                >
+                  <PanelRight size={14} />
+                  Open drawer
+                </Button>
+              </VStack>
+            </Box>
+
+            {/* 404 link */}
+            <Box
+              padding={4}
+              borderRadius="lg"
+              border="1px solid"
+              borderColor="border"
+            >
+              <VStack gap={3}>
+                <FileQuestion
+                  size={20}
+                  color="var(--chakra-colors-orange-400)"
+                />
+                <Text textStyle="sm" fontWeight="medium">
+                  Test 404 Page
+                </Text>
+                <Text textStyle="xs" color="fg.muted" textAlign="center">
+                  Navigate to a URL that doesn't match any route.
+                </Text>
+                <Button size="sm" variant="outline" asChild>
+                  <Link href="/no-such-project-slug">
+                    <FileQuestion size={14} />
+                    Go to 404
+                  </Link>
+                </Button>
+              </VStack>
+            </Box>
+          </SimpleGrid>
+        </VStack>
+      </Box>
+
+      {/* Dialog with crashable content */}
+      <Dialog.Root
+        open={dialogOpen}
+        onOpenChange={({ open }) => setDialogOpen(open)}
+      >
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Test Dialog</Dialog.Title>
+            <Dialog.CloseTrigger />
+          </Dialog.Header>
+          <Dialog.Body>
+            <ErrorBoundary FallbackComponent={PageErrorFallback}>
+              <CrashableContent label="dialog" />
+            </ErrorBoundary>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      {/* Drawer with crashable content */}
+      <Drawer.Root
+        open={drawerOpen}
+        onOpenChange={({ open }) => setDrawerOpen(open)}
+      >
+        <Drawer.Content>
+          <Drawer.Header>
+            <Drawer.Title>Test Drawer</Drawer.Title>
+            <Drawer.CloseTrigger />
+          </Drawer.Header>
+          <Drawer.Body>
+            <ErrorBoundary FallbackComponent={PageErrorFallback}>
+              <CrashableContent label="drawer" />
+            </ErrorBoundary>
+          </Drawer.Body>
+        </Drawer.Content>
+      </Drawer.Root>
+    </>
+  );
+}
+
+function ErrorTestPage() {
+  const [shouldCrashOuter, setShouldCrashOuter] = useState(false);
+
+  if (process.env.NODE_ENV !== "development") {
+    return null;
+  }
+
+  if (shouldCrashOuter) {
+    return <ThrowOnRender />;
+  }
+
+  return (
+    <DashboardLayout>
+      <InnerContent onCrashOuter={() => setShouldCrashOuter(true)} />
+    </DashboardLayout>
+  );
+}
+
+export default ErrorTestPage;

--- a/langwatch/src/pages/not-found.tsx
+++ b/langwatch/src/pages/not-found.tsx
@@ -1,0 +1,12 @@
+import { DashboardLayout } from "~/components/DashboardLayout";
+import { NotFoundScene } from "~/components/NotFoundScene";
+
+export function NotFoundPage() {
+  return (
+    <DashboardLayout>
+      <NotFoundScene />
+    </DashboardLayout>
+  );
+}
+
+export default NotFoundPage;

--- a/langwatch/src/routes.tsx
+++ b/langwatch/src/routes.tsx
@@ -2,11 +2,15 @@ import { Suspense, useEffect } from "react";
 import {
   createBrowserRouter,
   Outlet,
+  useLocation,
   useNavigation,
   type RouteObject,
 } from "react-router";
+import { ErrorBoundary } from "react-error-boundary";
 import NProgress from "nprogress";
 import { InnerProviders } from "./AppProviders";
+import { PageErrorFallback } from "./components/ui/PageErrorFallback";
+import { NotFoundPage } from "./pages/not-found";
 
 /**
  * Root layout — wraps all routes.
@@ -15,6 +19,7 @@ import { InnerProviders } from "./AppProviders";
  */
 function RootLayout() {
   const navigation = useNavigation();
+  const location = useLocation();
 
   useEffect(() => {
     NProgress.configure({ showSpinner: false });
@@ -30,9 +35,14 @@ function RootLayout() {
 
   return (
     <InnerProviders>
-      <Suspense>
-        <Outlet />
-      </Suspense>
+      <ErrorBoundary
+        FallbackComponent={PageErrorFallback}
+        resetKeys={[location.pathname]}
+      >
+        <Suspense>
+          <Outlet />
+        </Suspense>
+      </ErrorBoundary>
     </InnerProviders>
   );
 }
@@ -399,6 +409,27 @@ const routes: RouteObject[] = [
     path: "/@project/*",
     ...page(() => import("./pages/@project/[...path]/index")),
   },
+
+  // Dev-only error test page
+  ...(process.env.NODE_ENV === "development"
+    ? [
+        {
+          path: "/dev/error-test",
+          ...page(() => import("./pages/dev/error-test")),
+        },
+      ]
+    : []),
+
+  // Unknown sub-path under a project — renders inside DashboardLayout so the
+  // project redirect logic in useOrganizationTeamProject kicks in, then shows
+  // 404 inside the shell if the project is valid but the path isn't.
+  {
+    path: "/:project/*",
+    ...page(() => import("./pages/[project]/not-found")),
+  },
+
+  // 404 catch-all — must be last
+  { path: "*", Component: NotFoundPage },
 ];
 
 export const router = createBrowserRouter([

--- a/langwatch/src/routes.tsx
+++ b/langwatch/src/routes.tsx
@@ -428,7 +428,6 @@ const routes: RouteObject[] = [
   { path: "/settings/*", Component: NotFoundPage },
   { path: "/share/*", Component: NotFoundPage },
   { path: "/ops/*", Component: NotFoundPage },
-  { path: "/admin/*", Component: NotFoundPage },
   { path: "/dev/*", Component: NotFoundPage },
 
   // Unknown sub-path under a project — renders inside DashboardLayout so the

--- a/langwatch/src/routes.tsx
+++ b/langwatch/src/routes.tsx
@@ -420,6 +420,17 @@ const routes: RouteObject[] = [
       ]
     : []),
 
+  // Reserved top-level namespaces — prevent falling into the project catch-all
+  { path: "/auth/*", Component: NotFoundPage },
+  { path: "/invite/*", Component: NotFoundPage },
+  { path: "/mcp/*", Component: NotFoundPage },
+  { path: "/onboarding/*", Component: NotFoundPage },
+  { path: "/settings/*", Component: NotFoundPage },
+  { path: "/share/*", Component: NotFoundPage },
+  { path: "/ops/*", Component: NotFoundPage },
+  { path: "/admin/*", Component: NotFoundPage },
+  { path: "/dev/*", Component: NotFoundPage },
+
   // Unknown sub-path under a project — renders inside DashboardLayout so the
   // project redirect logic in useOrganizationTeamProject kicks in, then shows
   // 404 inside the shell if the project is valid but the path isn't.

--- a/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
@@ -1,0 +1,175 @@
+import {
+  ProjectSensitiveDataVisibilityLevel,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUserProtectionsForProject } from "../utils";
+
+vi.mock("../rbac", () => ({
+  hasProjectPermission: vi.fn(() => Promise.resolve(true)),
+  isDemoProject: vi.fn(() => false),
+}));
+
+const mockPrisma = {
+  project: {
+    findUniqueOrThrow: vi.fn(),
+  },
+  roleBinding: {
+    findMany: vi.fn(),
+  },
+} as any;
+
+const mockSession = {
+  user: { id: "user-rolebinding-only" },
+} as any;
+
+describe("getUserProtectionsForProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when user has RoleBinding but no TeamUser row", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: TeamUserRole.MEMBER },
+      ]);
+    });
+
+    it("grants visibility for VISIBLE_TO_ALL", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(true);
+      expect(result.canSeeCapturedOutput).toBe(true);
+    });
+
+    it("queries roleBinding table with team scope", async () => {
+      await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(mockPrisma.roleBinding.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: "user-rolebinding-only",
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: "team-1",
+        },
+        select: { role: true },
+      });
+    });
+  });
+
+  describe("when user has ADMIN RoleBinding", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: TeamUserRole.ADMIN },
+      ]);
+    });
+
+    it("grants visibility for VISIBLE_TO_ADMIN", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(true);
+      expect(result.canSeeCapturedOutput).toBe(true);
+    });
+  });
+
+  describe("when user has MEMBER RoleBinding and visibility is VISIBLE_TO_ADMIN", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: TeamUserRole.MEMBER },
+      ]);
+    });
+
+    it("denies visibility for non-admin member", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+
+  describe("when user has no RoleBinding", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([]);
+    });
+
+    it("denies visibility even for VISIBLE_TO_ALL", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+
+  describe("when visibility is REDACTED_TO_ALL", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: TeamUserRole.ADMIN },
+      ]);
+    });
+
+    it("denies visibility even for admin", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -37,6 +37,7 @@ import {
   skipPermissionCheckProjectCreation,
 } from "../rbac";
 import { revokeAllTraceShares } from "./share";
+import { getUserProtectionsForProject } from "../utils";
 
 export const projectRouter = createTRPCRouter({
   publicGetById: publicProcedure
@@ -548,66 +549,18 @@ export const projectRouter = createTRPCRouter({
       }),
     )
     .use(checkProjectPermission("project:view"))
-    .query(
-      async ({
-        input,
-        ctx,
-      }: {
-        input: { projectId: string };
-        ctx: { session: Session; prisma: PrismaClient };
-      }) => {
-        const { projectId } = input;
-        const prisma = ctx.prisma;
+    .query(async ({ input, ctx }) => {
+      const protections = await getUserProtectionsForProject(ctx, {
+        projectId: input.projectId,
+      });
 
-        const project = await prisma.project.findUnique({
-          where: { id: projectId },
-          select: {
-            capturedInputVisibility: true,
-            capturedOutputVisibility: true,
-          },
-        });
-        if (!project) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Project not found",
-          });
-        }
-
-        const teamsWithAccess = await prisma.teamUser.findMany({
-          where: {
-            userId: ctx.session.user.id,
-            team: {
-              projects: {
-                some: {
-                  id: projectId,
-                },
-              },
-            },
-          },
-          select: {
-            role: true,
-          },
-        });
-
-        const isUserPrivileged = teamsWithAccess.some(
-          (teamUser: { role: TeamUserRole }) =>
-            teamUser.role === TeamUserRole.ADMIN,
-        );
-
-        return {
-          isRedacted: {
-            input: !canAccessSensitiveData(
-              project.capturedInputVisibility,
-              isUserPrivileged,
-            ),
-            output: !canAccessSensitiveData(
-              project.capturedOutputVisibility,
-              isUserPrivileged,
-            ),
-          },
-        };
-      },
-    ),
+      return {
+        isRedacted: {
+          input: !protections.canSeeCapturedInput,
+          output: !protections.canSeeCapturedOutput,
+        },
+      };
+    }),
   archiveById: protectedProcedure
     .input(z.object({ projectId: z.string(), projectToArchiveId: z.string() }))
     .use(checkProjectPermission("project:delete"))
@@ -691,19 +644,4 @@ async function checkCapturedDataVisibilityPermission({
   return next();
 }
 
-const canAccessSensitiveData = (
-  visibility: ProjectSensitiveDataVisibilityLevel,
-  userIsPrivileged: boolean,
-): boolean => {
-  switch (visibility) {
-    case ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL:
-      return false;
-    case ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL:
-      return true;
-    case ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN:
-      return userIsPrivileged;
-    default:
-      console.error("Unexpected visibility level:", visibility);
-      return false; // Default to not showing
-  }
-};
+

--- a/langwatch/src/server/api/utils.ts
+++ b/langwatch/src/server/api/utils.ts
@@ -1,6 +1,7 @@
 import {
   type PrismaClient,
   ProjectSensitiveDataVisibilityLevel,
+  RoleBindingScopeType,
   TeamUserRole,
 } from "@prisma/client";
 import type { Session } from "~/server/auth";
@@ -90,6 +91,7 @@ export async function getUserProtectionsForProject(
   const project = await ctx.prisma.project.findUniqueOrThrow({
     where: { id: projectId, archivedAt: null },
     select: {
+      teamId: true,
       capturedInputVisibility: true,
       capturedOutputVisibility: true,
     },
@@ -113,40 +115,35 @@ export async function getUserProtectionsForProject(
     };
   }
 
-  // For signed in users, check their team permissions
-  const teamsWithAccess = await ctx.prisma.teamUser.findMany({
+  // For signed in users, check their team permissions via RoleBinding
+  const bindings = await ctx.prisma.roleBinding.findMany({
     where: {
       userId: ctx.session.user.id,
-      team: {
-        projects: {
-          some: {
-            id: projectId,
-          },
-        },
-      },
+      scopeType: RoleBindingScopeType.TEAM,
+      scopeId: project.teamId,
     },
     select: {
       role: true,
     },
   });
 
-  const isAdminInAnyTeam = teamsWithAccess.some(
-    (team) => team.role === TeamUserRole.ADMIN,
+  const isAdminForTeam = bindings.some(
+    (binding) => binding.role === TeamUserRole.ADMIN,
   );
-  const isMemberInAnyTeam = teamsWithAccess.length > 0;
+  const isMemberOfTeam = bindings.length > 0;
 
   const obtainVisibilityLevel = (
     visibility: ProjectSensitiveDataVisibilityLevel,
   ): boolean => {
     switch (true) {
-      case !isMemberInAnyTeam:
+      case !isMemberOfTeam:
         return false;
       case visibility === ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL:
         return false;
       case visibility === ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL:
         return true;
       case visibility === ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN:
-        return isAdminInAnyTeam;
+        return isAdminForTeam;
       default:
         console.error("Unexpected state for visibility:", visibility);
         return false;

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -159,6 +159,26 @@ vi.mock("~/utils/compat/next-dynamic", () => ({
   },
 }));
 
+// Polyfill window.matchMedia for Vitest/JSDOM (not implemented by default).
+// Prevents "TypeError: window.matchMedia is not a function" when components
+// or hooks call matchMedia at module or render time.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string): MediaQueryList =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  });
+}
+
 // Mock ResizeObserver for tests using floating-ui/popper (Chakra menus, tooltips, etc.)
 globalThis.ResizeObserver = class ResizeObserver {
   // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op for test mock


### PR DESCRIPTION
## Summary
- Add a shared `PageErrorFallback` component and wrap page content in `ErrorBoundary` at the root router, `DashboardLayout`, and `OpsPageShell` levels so runtime crashes show a recoverable error UI instead of a white screen
- Add a custom 404 page with an animated perspective-grid canvas scene (chromatic aberration, mouse parallax, glitch effects) that works in both light and dark mode
- Add catch-all routes so unknown paths render 404 inside the correct layout shell; fix project slug redirects to preserve sub-paths (e.g. `/bad-slug/messages` → `/good-slug/messages`)
- Optimize animation: pause rAF when tab is hidden or canvas is off-screen, respect `prefers-reduced-motion` (single static frame, no CSS animations)
- Add dev-only `/dev/error-test` page for verifying error boundary behavior

## Test plan
- [ ] Navigate to a non-existent path (e.g. `/xyz`) — should show the 404 page with animation
- [ ] Navigate to `/valid-project/nonexistent` — should show 404 inside the dashboard shell
- [ ] Navigate to `/bad-slug/messages` — should redirect to `/correct-slug/messages`
- [ ] Switch tabs and return — animation should pause/resume
- [ ] Enable "Reduce motion" in OS accessibility settings — animation should be a static frame, no glitch/drift CSS
- [ ] Visit `/dev/error-test` in development — trigger an error and verify the error boundary catches it