### PR TITLE
fix: use RoleBinding for team memberships in updateMemberRole

### DIFF
--- a/langwatch/src/components/settings/MemberDetailDialog.tsx
+++ b/langwatch/src/components/settings/MemberDetailDialog.tsx
@@ -125,6 +125,7 @@ export function MemberDetailDialog({
 
       await Promise.all([
         queryClient.roleBinding.listForUser.invalidate(),
+        queryClient.roleBinding.listForOrg.invalidate(),
         queryClient.organization.getOrganizationWithMembersAndTheirTeams.invalidate(),
         queryClient.organization.getAll.invalidate(),
       ]);

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -1229,29 +1229,34 @@ export const organizationRouter = createTRPCRouter({
       });
       const organizationTeamIds = organizationTeams.map((team) => team.id);
 
-      const currentMemberships = await prisma.teamUser.findMany({
+      const currentTeamBindings = await prisma.roleBinding.findMany({
         where: {
+          organizationId: input.organizationId,
           userId: input.userId,
-          teamId: { in: organizationTeamIds },
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: { in: organizationTeamIds },
         },
-        select: { teamId: true, role: true, assignedRoleId: true },
+        select: { scopeId: true, role: true, customRoleId: true },
       });
 
+      const currentMemberships = currentTeamBindings.map((b) => ({
+        teamId: b.scopeId,
+        role: b.role,
+      }));
+
       const userPermissions = await (async () => {
-        const teamIds = organizationTeamIds;
-        if (teamIds.length === 0) return undefined;
-        const teamUsers = await prisma.teamUser.findMany({
-          where: {
-            userId: input.userId,
-            teamId: { in: teamIds },
-            assignedRoleId: { not: null },
-          },
-          include: { assignedRole: true },
+        const customRoleIds = currentTeamBindings
+          .map((b) => b.customRoleId)
+          .filter((id): id is string => !!id);
+        if (customRoleIds.length === 0) return undefined;
+        const customRoles = await prisma.customRole.findMany({
+          where: { id: { in: customRoleIds } },
+          select: { permissions: true },
         });
         const allPermissions: string[] = [];
-        for (const tu of teamUsers) {
-          if (tu.assignedRole?.permissions) {
-            allPermissions.push(...(tu.assignedRole.permissions as string[]));
+        for (const cr of customRoles) {
+          if (cr.permissions) {
+            allPermissions.push(...(cr.permissions as string[]));
           }
         }
         return allPermissions.length > 0 ? allPermissions : undefined;


### PR DESCRIPTION
## Summary
- `organization.updateMemberRole` router read `currentMemberships` from the legacy `TeamUser` table, but the repo validates team role updates against `RoleBinding` (TEAM-scoped)
- Toggling a member's org role ADMIN → EXTERNAL → ADMIN would generate team updates from stale `TeamUser` rows that had no matching `RoleBinding`, throwing `team_membership_not_found`
- Switched the router to read `currentMemberships` from `RoleBinding` (TEAM-scoped) — same source the repo validates against
- Also derive `userPermissions` (for license change detection) from `RoleBinding.customRoleId` instead of `TeamUser.assignedRoleId`
- Added `queryClient.roleBinding.listForOrg.invalidate()` in `MemberDetailDialog.handleSave` so the members table Access column refreshes after a role/binding change

## Test plan
- [ ] Toggle a member's org role between ADMIN and EXTERNAL multiple times on `/settings/members` — no "team not found" errors
- [ ] After saving a role change, the Access column on the members table reflects the new bindings without a manual refresh
- [ ] Lite Member (EXTERNAL) team-role fallback to VIEWER still works
- [ ] License/plan checks (lite seat counts) still fire correctly when promoting/demoting

🤖 Generated with [Claude Code](https://claude.com/claude-code)