### PR TITLE
fix: align TS SDK setRAGContexts with backend canonical attribute key

### DIFF
--- a/docs/integration/typescript/tutorials/semantic-conventions.mdx
+++ b/docs/integration/typescript/tutorials/semantic-conventions.mdx
@@ -147,7 +147,7 @@ LangWatch provides a comprehensive set of custom attributes for LLM-specific obs
 | `langwatch.gen_ai.streaming` | boolean | Whether the operation involves streaming | `true`, `false` |
 | `langwatch.input` | string/object | Input data for the span | `"Hello, how are you?"` |
 | `langwatch.output` | string/object | Output data from the span | `"I'm doing well, thank you!"` |
-| `langwatch.contexts` | array | RAG contexts for retrieval-augmented generation | Array of document contexts |
+| `langwatch.rag.contexts` | array | RAG contexts for retrieval-augmented generation | Array of document contexts |
 | `langwatch.labels` | array | Labels for categorizing spans | `["chat", "greeting"]` |
 | `langwatch.params` | object | Parameter data for operations | `{ temperature: 0.7 }` |
 | `langwatch.metrics` | object | Custom metrics data | `{ response_time: 1250 }` |
@@ -224,7 +224,7 @@ span.set_attribute(AttributeKey.LangWatchPromptHandle, "customer-support-greetin
 | `ATTR_LANGWATCH_INPUT` | `langwatch.input` |
 | `ATTR_LANGWATCH_OUTPUT` | `langwatch.output` |
 | `ATTR_LANGWATCH_SPAN_TYPE` | `langwatch.span.type` |
-| `ATTR_LANGWATCH_RAG_CONTEXTS` | `langwatch.contexts` |
+| `ATTR_LANGWATCH_RAG_CONTEXTS` | `langwatch.rag.contexts` |
 | `ATTR_LANGWATCH_METRICS` | `langwatch.metrics` |
 | `ATTR_LANGWATCH_SDK_VERSION` | `langwatch.sdk.version` |
 | `ATTR_LANGWATCH_SDK_NAME` | `langwatch.sdk.name` |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8568,7 +8568,7 @@ LangWatch provides a comprehensive set of custom attributes for LLM-specific obs
 | `langwatch.gen_ai.streaming` | boolean | Whether the operation involves streaming | `true`, `false` |
 | `langwatch.input` | string/object | Input data for the span | `"Hello, how are you?"` |
 | `langwatch.output` | string/object | Output data from the span | `"I'm doing well, thank you!"` |
-| `langwatch.contexts` | array | RAG contexts for retrieval-augmented generation | Array of document contexts |
+| `langwatch.rag.contexts` | array | RAG contexts for retrieval-augmented generation | Array of document contexts |
 | `langwatch.labels` | array | Labels for categorizing spans | `["chat", "greeting"]` |
 | `langwatch.params` | object | Parameter data for operations | `{ temperature: 0.7 }` |
 | `langwatch.metrics` | object | Custom metrics data | `{ response_time: 1250 }` |
@@ -8645,7 +8645,7 @@ span.set_attribute(AttributeKey.LangWatchPromptHandle, "customer-support-greetin
 | `ATTR_LANGWATCH_INPUT` | `langwatch.input` |
 | `ATTR_LANGWATCH_OUTPUT` | `langwatch.output` |
 | `ATTR_LANGWATCH_SPAN_TYPE` | `langwatch.span.type` |
-| `ATTR_LANGWATCH_RAG_CONTEXTS` | `langwatch.contexts` |
+| `ATTR_LANGWATCH_RAG_CONTEXTS` | `langwatch.rag.contexts` |
 | `ATTR_LANGWATCH_METRICS` | `langwatch.metrics` |
 | `ATTR_LANGWATCH_SDK_VERSION` | `langwatch.sdk.version` |
 | `ATTR_LANGWATCH_SDK_NAME` | `langwatch.sdk.name` |

--- a/langwatch/packages/stressed-n-blessed/src/generators.ts
+++ b/langwatch/packages/stressed-n-blessed/src/generators.ts
@@ -208,7 +208,7 @@ export function applyRAGAttributes(span: Span, spanName: string): SpanGeneratorR
     'langwatch.span.type': 'rag',
     'langwatch.input': JSON.stringify(input),
     'langwatch.output': JSON.stringify(output),
-    'langwatch.contexts': JSON.stringify(contexts),
+    'langwatch.rag.contexts': JSON.stringify(contexts),
     'rag.retriever': 'vector_store',
     'rag.top_k': contexts.length,
   });

--- a/langwatch/src/components/ops/foundry/traceExecutor.ts
+++ b/langwatch/src/components/ops/foundry/traceExecutor.ts
@@ -126,7 +126,7 @@ function buildSpan(
   }
 
   if (config.rag?.contexts.length) {
-    span.setAttribute("langwatch.contexts", JSON.stringify(config.rag.contexts));
+    span.setAttribute("langwatch.rag.contexts", JSON.stringify(config.rag.contexts));
   }
 
   if (config.prompt) {

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/langwatch.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/langwatch.unit.test.ts
@@ -231,12 +231,12 @@ describe("LangWatchExtractor", () => {
       });
     });
 
-    describe("when span has langwatch.contexts (current TS SDK key)", () => {
-      it("does NOT promote — key is unrecognized by backend", () => {
+    describe("when span has langwatch.contexts (old TS SDK key, pre-fix)", () => {
+      it("does NOT promote — legacy/unrecognized key, SDK now emits langwatch.rag.contexts", () => {
         const contexts = [
           { document_id: "doc-3", chunk_id: "chunk-3", content: "ts sdk data" },
         ];
-        // This simulates what the current TS SDK sends: "langwatch.contexts"
+        // Old TS SDK (<=0.26.0) sent "langwatch.contexts" which is not recognized
         const ctx = createExtractorContext({
           "langwatch.contexts": JSON.stringify({
             type: "json",
@@ -246,7 +246,7 @@ describe("LangWatchExtractor", () => {
 
         extractor.apply(ctx);
 
-        // The bug: this key is NOT recognized, so contexts don't get promoted
+        // Intentionally not promoted — SDK now emits the canonical key
         expect(ctx.out[ATTR_KEYS.LANGWATCH_RAG_CONTEXTS]).toBeUndefined();
       });
     });

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/langwatch.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/langwatch.unit.test.ts
@@ -191,4 +191,64 @@ describe("LangWatchExtractor", () => {
       });
     });
   });
+
+  describe("RAG contexts promotion", () => {
+    describe("when span has langwatch.rag.contexts (canonical key)", () => {
+      it("promotes to canonical output", () => {
+        const contexts = [
+          { document_id: "doc-1", chunk_id: "chunk-1", content: "hello world" },
+        ];
+        const ctx = createExtractorContext({
+          [ATTR_KEYS.LANGWATCH_RAG_CONTEXTS]: contexts,
+        });
+
+        extractor.apply(ctx);
+
+        expect(ctx.setAttr).toHaveBeenCalledWith(
+          ATTR_KEYS.LANGWATCH_RAG_CONTEXTS,
+          contexts,
+        );
+        expect(ctx.out[ATTR_KEYS.LANGWATCH_RAG_CONTEXTS]).toEqual(contexts);
+      });
+    });
+
+    describe("when span has langwatch.rag_contexts (legacy key)", () => {
+      it("promotes to canonical output", () => {
+        const contexts = [
+          { document_id: "doc-2", chunk_id: "chunk-2", content: "legacy data" },
+        ];
+        const ctx = createExtractorContext({
+          [ATTR_KEYS.LANGWATCH_RAG_CONTEXTS_LEGACY]: contexts,
+        });
+
+        extractor.apply(ctx);
+
+        expect(ctx.setAttr).toHaveBeenCalledWith(
+          ATTR_KEYS.LANGWATCH_RAG_CONTEXTS,
+          contexts,
+        );
+        expect(ctx.out[ATTR_KEYS.LANGWATCH_RAG_CONTEXTS]).toEqual(contexts);
+      });
+    });
+
+    describe("when span has langwatch.contexts (current TS SDK key)", () => {
+      it("does NOT promote — key is unrecognized by backend", () => {
+        const contexts = [
+          { document_id: "doc-3", chunk_id: "chunk-3", content: "ts sdk data" },
+        ];
+        // This simulates what the current TS SDK sends: "langwatch.contexts"
+        const ctx = createExtractorContext({
+          "langwatch.contexts": JSON.stringify({
+            type: "json",
+            value: contexts,
+          }),
+        });
+
+        extractor.apply(ctx);
+
+        // The bug: this key is NOT recognized, so contexts don't get promoted
+        expect(ctx.out[ATTR_KEYS.LANGWATCH_RAG_CONTEXTS]).toBeUndefined();
+      });
+    });
+  });
 });

--- a/typescript-sdk/src/observability-sdk/semconv/attributes.ts
+++ b/typescript-sdk/src/observability-sdk/semconv/attributes.ts
@@ -28,7 +28,7 @@ export const ATTR_LANGWATCH_SPAN_TYPE = "langwatch.span.type";
  * LangWatch RAG contexts attribute key
  * Used to store retrieval-augmented generation contexts
  */
-export const ATTR_LANGWATCH_RAG_CONTEXTS = "langwatch.contexts";
+export const ATTR_LANGWATCH_RAG_CONTEXTS = "langwatch.rag.contexts";
 
 /**
  * LangWatch metrics attribute key

--- a/typescript-sdk/src/observability-sdk/span/__tests__/integration/span.integration.test.ts
+++ b/typescript-sdk/src/observability-sdk/span/__tests__/integration/span.integration.test.ts
@@ -334,14 +334,13 @@ describe("Span Integration Tests", () => {
       expect(inputData.value.nested.key).toBe("value");
       expect(inputData.value.nullValue).toBe(null);
 
-      // Verify RAG contexts format
+      // Verify RAG contexts format (plain array, no wrapper)
       const ragData = JSON.parse(
         span.attributes[semconv.ATTR_LANGWATCH_RAG_CONTEXTS] as string,
       );
-      expect(ragData.type).toBe("json");
-      expect(ragData.value).toHaveLength(2);
-      expect(ragData.value[0].document_id).toBe("doc-1");
-      expect(ragData.value[1].document_id).toBe("doc-2");
+      expect(ragData).toHaveLength(2);
+      expect(ragData[0].document_id).toBe("doc-1");
+      expect(ragData[1].document_id).toBe("doc-2");
 
       // Verify metrics format
       const metricsData = JSON.parse(
@@ -419,26 +418,24 @@ describe("Span Integration Tests", () => {
         throw new Error("Expected both RAG context spans to be exported");
       }
 
-      // Verify single RAG context
+      // Verify single RAG context (plain array, no wrapper)
       const singleRagData = JSON.parse(
         singleSpan.attributes[semconv.ATTR_LANGWATCH_RAG_CONTEXTS] as string,
       );
-      expect(singleRagData.type).toBe("json");
-      expect(singleRagData.value).toHaveLength(1);
-      expect(singleRagData.value[0].document_id).toBe("doc-789");
-      expect(singleRagData.value[0].chunk_id).toBe("chunk-012");
-      expect(singleRagData.value[0].content).toContain("🔍");
-      expect(singleRagData.value[0].metadata.score).toBe(0.95);
+      expect(singleRagData).toHaveLength(1);
+      expect(singleRagData[0].document_id).toBe("doc-789");
+      expect(singleRagData[0].chunk_id).toBe("chunk-012");
+      expect(singleRagData[0].content).toContain("🔍");
+      expect(singleRagData[0].metadata.score).toBe(0.95);
 
-      // Verify multiple RAG contexts
+      // Verify multiple RAG contexts (plain array, no wrapper)
       const multipleRagData = JSON.parse(
         multipleSpan.attributes[semconv.ATTR_LANGWATCH_RAG_CONTEXTS] as string,
       );
-      expect(multipleRagData.type).toBe("json");
-      expect(multipleRagData.value).toHaveLength(3);
-      expect(multipleRagData.value[0].document_id).toBe("doc-001");
-      expect(multipleRagData.value[1].document_id).toBe("doc-002");
-      expect(multipleRagData.value[2].document_id).toBe("doc-003");
+      expect(multipleRagData).toHaveLength(3);
+      expect(multipleRagData[0].document_id).toBe("doc-001");
+      expect(multipleRagData[1].document_id).toBe("doc-002");
+      expect(multipleRagData[2].document_id).toBe("doc-003");
     });
 
     it("should handle metrics data with various number types", async () => {

--- a/typescript-sdk/src/observability-sdk/span/__tests__/span.unit.test.ts
+++ b/typescript-sdk/src/observability-sdk/span/__tests__/span.unit.test.ts
@@ -191,10 +191,7 @@ describe("span.ts", () => {
       expect(result).toBe(langwatchSpan);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         intSemconv.ATTR_LANGWATCH_RAG_CONTEXTS,
-        JSON.stringify({
-          type: "json",
-          value: [ragContext],
-        })
+        JSON.stringify([ragContext])
       );
     });
 
@@ -206,10 +203,7 @@ describe("span.ts", () => {
       expect(result).toBe(langwatchSpan);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(
         intSemconv.ATTR_LANGWATCH_RAG_CONTEXTS,
-        JSON.stringify({
-          type: "json",
-          value: ragContexts,
-        })
+        JSON.stringify(ragContexts)
       );
     });
   });

--- a/typescript-sdk/src/observability-sdk/span/__tests__/span.unit.test.ts
+++ b/typescript-sdk/src/observability-sdk/span/__tests__/span.unit.test.ts
@@ -183,6 +183,12 @@ describe("span.ts", () => {
   });
 
   describe("RAG context methods", () => {
+    it("uses the canonical RAG contexts attribute key", () => {
+      expect(intSemconv.ATTR_LANGWATCH_RAG_CONTEXTS).toBe(
+        "langwatch.rag.contexts"
+      );
+    });
+
     it("should set single RAG context", () => {
       const { mockSpan, langwatchSpan } = testScenarios.createSpanTest();
       const ragContext = testData.ragContext();

--- a/typescript-sdk/src/observability-sdk/span/implementation.ts
+++ b/typescript-sdk/src/observability-sdk/span/implementation.ts
@@ -99,10 +99,7 @@ class LangWatchSpanInternal implements LangWatchSpan {
   setRAGContexts(ragContexts: LangWatchSpanRAGContext[]): this {
     return this.setAttribute(
       intSemconv.ATTR_LANGWATCH_RAG_CONTEXTS,
-      JSON.stringify({
-        type: "json",
-        value: ragContexts,
-      })
+      JSON.stringify(ragContexts)
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #3391

The TS SDK `setRAGContexts()` was sending RAG contexts under `langwatch.contexts` with a `{type:"json",value:[...]}` wrapper, but the backend canonicalization pipeline only recognizes `langwatch.rag.contexts` (canonical) or `langwatch.rag_contexts` (legacy) and expects a plain JSON array. This caused contexts to be silently dropped, leaving `span.contexts[]` empty and preventing Ragas evaluators from running on TS-produced traces.

### Root cause

| Problem | TS SDK (before) | Backend expects |
|---------|----------------|-----------------|
| Attribute key | `langwatch.contexts` | `langwatch.rag.contexts` or `langwatch.rag_contexts` |
| Serialization | `{"type":"json","value":[...]}` | Plain `[{document_id, chunk_id, content}]` |

### Changes

| File | Change |
|------|--------|
| `typescript-sdk/.../semconv/attributes.ts` | `"langwatch.contexts"` → `"langwatch.rag.contexts"` |
| `typescript-sdk/.../span/implementation.ts` | Remove `{type,value}` wrapper from `setRAGContexts()` |
| `typescript-sdk/.../span/__tests__/span.unit.test.ts` | Updated assertions to match new format |
| `langwatch/.../extractors/__tests__/langwatch.unit.test.ts` | Added regression tests for RAG context canonicalization |
| `langwatch/.../foundry/traceExecutor.ts` | Same key fix (sweep) |
| `packages/stressed-n-blessed/.../generators.ts` | Same key fix (sweep) |
| `docs/.../semantic-conventions.mdx` | Updated docs to reference correct key |

### Follow-up

- #3395 — Same bug in Go SDK (`sdk-go/attributes.go`)

## Test plan

- [x] Backend canonicalization tests: canonical key promoted, legacy key promoted, old TS SDK key correctly not recognized (14/14 pass)
- [x] TS SDK span unit tests: new key and plain array format (40/40 pass)
- [x] TS SDK typecheck passes
- [x] No remaining `"langwatch.contexts"` in production code (only in regression test)
- [x] Swept foundry traceExecutor and test generators for same bug
- [x] Docs updated to reference canonical key