### PR TITLE
feat(scenarios): project secrets for code/workflow agents + better dataset 400

### DIFF
--- a/langwatch/src/app/api/dataset/__tests__/dataset-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/dataset/__tests__/dataset-rest-api.integration.test.ts
@@ -810,7 +810,7 @@ describe("Feature: Dataset REST API", () => {
         ]);
       });
 
-      it("returns 400 Bad Request identifying the invalid column", async () => {
+      it("returns 400 Bad Request identifying the invalid column and listing the valid ones", async () => {
         const res = await helpers.api.post(
           "/api/dataset/my-dataset/records",
           { entries: [{ input: "hi", foo: "bar" }] },
@@ -819,6 +819,8 @@ describe("Feature: Dataset REST API", () => {
         expect(res.status).toBe(400);
         const body = await res.json();
         expect(body.message).toContain("foo");
+        expect(body.message).toContain("input");
+        expect(body.message).toContain("output");
       });
     });
 

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -623,7 +623,11 @@ export class DatasetService {
     for (const entry of params.entries) {
       for (const key of Object.keys(entry)) {
         if (!validColumnNames.has(key)) {
-          throw new InvalidColumnError(key, dataset.name);
+          throw new InvalidColumnError({
+            columnName: key,
+            datasetName: dataset.name,
+            validColumns: [...validColumnNames],
+          });
         }
       }
     }

--- a/langwatch/src/server/datasets/errors.ts
+++ b/langwatch/src/server/datasets/errors.ts
@@ -35,12 +35,24 @@ export class MalformedColumnTypesError extends Error {
  */
 export class InvalidColumnError extends Error {
   readonly columnName: string;
+  readonly validColumns: string[];
 
-  constructor(columnName: string, datasetName: string) {
+  constructor({
+    columnName,
+    datasetName,
+    validColumns,
+  }: {
+    columnName: string;
+    datasetName: string;
+    validColumns: string[];
+  }) {
+    const validColumnsList =
+      validColumns.length > 0 ? validColumns.join(", ") : "(none)";
     super(
-      `Column "${columnName}" is not defined in the "${datasetName}" dataset schema`,
+      `Column "${columnName}" is not defined in the "${datasetName}" dataset schema. Valid columns: ${validColumnsList}`,
     );
     this.name = "InvalidColumnError";
     this.columnName = columnName;
+    this.validColumns = validColumns;
   }
 }

--- a/langwatch/src/server/scenarios/execution/__tests__/create-adapter.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/create-adapter.unit.test.ts
@@ -68,6 +68,7 @@ describe("createAdapter", () => {
         code: 'def execute(input):\n    return f"processed: {input}"',
         inputs: [{ identifier: "input", type: "str" }],
         outputs: [{ identifier: "output", type: "str" }],
+        secrets: {},
       };
 
       const adapter = createAdapter({

--- a/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
@@ -20,6 +20,7 @@ import {
   type ProjectFetcher,
   type ModelParamsProvider,
   type WorkflowVersionFetcher,
+  type ProjectSecretsFetcher,
 } from "../data-prefetcher";
 import type { ExecutionContext, TargetConfig, LiteLLMParams } from "../types";
 
@@ -89,6 +90,10 @@ describe("prefetchScenarioData", () => {
       prepare: vi.fn().mockResolvedValue(defaultModelParamsResult),
     };
 
+    const projectSecretsFetcher: ProjectSecretsFetcher = {
+      getSecrets: vi.fn().mockResolvedValue({}),
+    };
+
     return {
       scenarioFetcher,
       promptFetcher,
@@ -96,6 +101,7 @@ describe("prefetchScenarioData", () => {
       workflowVersionFetcher,
       projectFetcher,
       modelParamsProvider,
+      projectSecretsFetcher,
       ...overrides,
     };
   }
@@ -452,6 +458,36 @@ describe("prefetchScenarioData", () => {
             "proj_123",
             "anthropic/claude-3-sonnet",
           );
+        });
+
+        it("includes decrypted project secrets on the prefetched adapter data", async () => {
+          const projectSecretsFetcher: ProjectSecretsFetcher = {
+            getSecrets: vi.fn().mockResolvedValue({
+              WORKFLOW_LANGWATCH_API_KEY: "sk-lw-resolved",
+              OTHER_SECRET: "val2",
+            }),
+          };
+          const deps = createMockDeps({
+            agentFetcher: {
+              findById: vi.fn().mockResolvedValue(codeAgent),
+            },
+            projectSecretsFetcher,
+          });
+
+          const target: TargetConfig = { type: "code", referenceId: "agent_456" };
+          const result = await prefetchScenarioData(defaultContext, target, deps);
+
+          expect(projectSecretsFetcher.getSecrets).toHaveBeenCalledWith("proj_123");
+          expect(result.success).toBe(true);
+          // Assert explicitly before narrowing so a type drift fails loudly
+          // instead of silently skipping the toEqual below.
+          if (!result.success) throw new Error("prefetch should have succeeded");
+          expect(result.data.adapterData.type).toBe("code");
+          if (result.data.adapterData.type !== "code") return;
+          expect(result.data.adapterData.secrets).toEqual({
+            WORKFLOW_LANGWATCH_API_KEY: "sk-lw-resolved",
+            OTHER_SECRET: "val2",
+          });
         });
       });
     });

--- a/langwatch/src/server/scenarios/execution/data-prefetcher.ts
+++ b/langwatch/src/server/scenarios/execution/data-prefetcher.ts
@@ -28,6 +28,7 @@ import { AgentRepository, type TypedAgent } from "../../agents/agent.repository"
 import { prisma } from "../../db";
 import { PromptService, type VersionedPrompt } from "../../prompt-config/prompt.service";
 import { ScenarioService } from "../scenario.service";
+import { decrypt } from "~/utils/encryption";
 import {
   AuthConfigSchema,
   type ChildProcessJobData,
@@ -90,6 +91,16 @@ export interface ProjectFetcher {
   } | null>;
 }
 
+/**
+ * Loads decrypted project secrets (name → plaintext value) for injection into
+ * code and workflow agent DSL payloads. Mirrors the studio's addEnvs behavior
+ * so `secrets.NAME` resolves the same way whether the workflow runs from the
+ * UI or from a scenario worker.
+ */
+export interface ProjectSecretsFetcher {
+  getSecrets(projectId: string): Promise<Record<string, string>>;
+}
+
 /** Reason codes for model params preparation failures */
 export type ModelParamsFailureReason =
   | "invalid_model_format"
@@ -116,6 +127,7 @@ export interface DataPrefetcherDependencies {
   workflowVersionFetcher: WorkflowVersionFetcher;
   projectFetcher: ProjectFetcher;
   modelParamsProvider: ModelParamsProvider;
+  projectSecretsFetcher: ProjectSecretsFetcher;
 }
 
 // ============================================================================
@@ -302,7 +314,12 @@ async function fetchAgentData(
     return fetchPromptConfigData(projectId, target.referenceId, deps.promptFetcher);
   }
   if (target.type === "code") {
-    return fetchCodeAgentData(projectId, target.referenceId, deps.agentFetcher);
+    return fetchCodeAgentData(
+      projectId,
+      target.referenceId,
+      deps.agentFetcher,
+      deps.projectSecretsFetcher,
+    );
   }
   if (target.type === "workflow") {
     return fetchWorkflowAgentData({
@@ -311,6 +328,7 @@ async function fetchAgentData(
       agentFetcher: deps.agentFetcher,
       workflowVersionFetcher: deps.workflowVersionFetcher,
       modelParamsProvider: deps.modelParamsProvider,
+      projectSecretsFetcher: deps.projectSecretsFetcher,
     });
   }
   return fetchHttpAgentData(projectId, target.referenceId, deps.agentFetcher);
@@ -408,6 +426,7 @@ async function fetchCodeAgentData(
   projectId: string,
   agentId: string,
   fetcher: AgentFetcher,
+  projectSecretsFetcher: ProjectSecretsFetcher,
 ): Promise<CodeAgentData | null> {
   const agent = await fetcher.findById({ projectId, id: agentId });
   if (!agent || agent.type !== "code") return null;
@@ -425,6 +444,8 @@ async function fetchCodeAgentData(
     return null;
   }
 
+  const secrets = await projectSecretsFetcher.getSecrets(projectId);
+
   return {
     type: "code",
     agentId: agent.id,
@@ -433,6 +454,7 @@ async function fetchCodeAgentData(
     outputs: config.outputs ?? [],
     scenarioMappings: config.scenarioMappings,
     scenarioOutputField: config.scenarioOutputField,
+    secrets,
   };
 }
 
@@ -459,12 +481,14 @@ async function fetchWorkflowAgentData({
   agentFetcher,
   workflowVersionFetcher,
   modelParamsProvider,
+  projectSecretsFetcher,
 }: {
   projectId: string;
   agentId: string;
   agentFetcher: AgentFetcher;
   workflowVersionFetcher: WorkflowVersionFetcher;
   modelParamsProvider: ModelParamsProvider;
+  projectSecretsFetcher: ProjectSecretsFetcher;
 }): Promise<WorkflowAgentData | HydrationFailure | null> {
   const agent = await agentFetcher.findById({ projectId, id: agentId });
   if (!agent || agent.type !== "workflow") return null;
@@ -499,6 +523,8 @@ async function fetchWorkflowAgentData({
 
   const { inputs, outputs } = extractWorkflowIO(hydrateResult.dsl);
 
+  const secrets = await projectSecretsFetcher.getSecrets(projectId);
+
   const data: WorkflowAgentData = {
     type: "workflow",
     agentId: agent.id,
@@ -508,6 +534,7 @@ async function fetchWorkflowAgentData({
     outputs,
     scenarioMappings: config.scenarioMappings,
     scenarioOutputField: config.scenarioOutputField,
+    secrets,
   };
 
   validateWorkflowAgentMappings(data);
@@ -757,6 +784,29 @@ export function createDataPrefetcherDependencies(): DataPrefetcherDependencies {
           where: { id: projectId },
           select: { apiKey: true, defaultModel: true },
         }),
+    },
+    projectSecretsFetcher: {
+      getSecrets: async (projectId) => {
+        const rows = await prisma.projectSecret.findMany({
+          where: { projectId },
+          select: { name: true, encryptedValue: true },
+        });
+        const secrets: Record<string, string> = {};
+        for (const row of rows) {
+          try {
+            secrets[row.name] = decrypt(row.encryptedValue);
+          } catch (err) {
+            // Wrap per-secret so a single corrupt row yields a readable error
+            // instead of a raw crypto stack trace surfacing at the caller.
+            throw new Error(
+              `Failed to decrypt project secret "${row.name}": ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+          }
+        }
+        return secrets;
+      },
     },
     modelParamsProvider: {
       prepare: async (projectId, model): Promise<ModelParamsResult> => {

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
@@ -18,6 +18,7 @@ describe("SerializedCodeAgentAdapter", () => {
     code: 'def execute(input):\n    return f"processed: {input}"',
     inputs: [{ identifier: "input", type: "str" }],
     outputs: [{ identifier: "output", type: "str" }],
+    secrets: {},
   };
 
   const nlpServiceUrl = "http://localhost:8080";
@@ -79,6 +80,30 @@ describe("SerializedCodeAgentAdapter", () => {
       expect(callBody.type).toBe("execute_flow");
       expect(callBody.payload.workflow.api_key).toBe(apiKey);
       expect(callBody.payload.workflow.template_adapter).toBe("default");
+    });
+
+    describe("when the config has project secrets", () => {
+      it("includes them on the synthesized workflow DSL so `secrets.NAME` resolves", async () => {
+        const adapter = new SerializedCodeAgentAdapter(
+          {
+            ...defaultConfig,
+            secrets: {
+              WORKFLOW_LANGWATCH_API_KEY: "sk-lw-test",
+              OTHER_SECRET: "value-2",
+            },
+          },
+          nlpServiceUrl,
+          apiKey,
+        );
+
+        await adapter.call(defaultInput);
+
+        const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
+        expect(callBody.payload.workflow.secrets).toEqual({
+          WORKFLOW_LANGWATCH_API_KEY: "sk-lw-test",
+          OTHER_SECRET: "value-2",
+        });
+      });
     });
 
     it("builds a workflow with entry, code, and end nodes", async () => {

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/__tests__/workflow-agent.adapter.unit.test.ts
@@ -65,6 +65,7 @@ describe("SerializedWorkflowAgentAdapter", () => {
     workflow: defaultDsl,
     inputs: [{ identifier: "input", type: "str" }],
     outputs: [{ identifier: "output", type: "str" }],
+    secrets: {},
   };
 
   const nlpServiceUrl = "http://localhost:8080";
@@ -136,6 +137,59 @@ describe("SerializedWorkflowAgentAdapter", () => {
       const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
       expect(callBody.type).toBe("execute_flow");
       expect(callBody.payload.workflow.api_key).toBe(apiKey);
+    });
+
+    describe("when the config has project secrets", () => {
+      it("merges them into workflow.secrets so `secrets.NAME` resolves in code nodes", async () => {
+        const adapter = new SerializedWorkflowAgentAdapter(
+          {
+            ...defaultConfig,
+            secrets: {
+              WORKFLOW_LANGWATCH_API_KEY: "sk-lw-test",
+              OTHER_SECRET: "value-2",
+            },
+          },
+          nlpServiceUrl,
+          apiKey,
+        );
+
+        await adapter.call(defaultInput);
+
+        const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
+        expect(callBody.payload.workflow.secrets).toEqual({
+          WORKFLOW_LANGWATCH_API_KEY: "sk-lw-test",
+          OTHER_SECRET: "value-2",
+        });
+      });
+
+      it("overrides pre-existing workflow.secrets values with the fresh prefetched ones", async () => {
+        const adapter = new SerializedWorkflowAgentAdapter(
+          {
+            ...defaultConfig,
+            workflow: {
+              ...defaultDsl,
+              secrets: {
+                WORKFLOW_LANGWATCH_API_KEY: "sk-lw-stale",
+                DSL_ONLY: "keep-me",
+              },
+            },
+            secrets: {
+              WORKFLOW_LANGWATCH_API_KEY: "sk-lw-fresh",
+            },
+          },
+          nlpServiceUrl,
+          apiKey,
+        );
+
+        await adapter.call(defaultInput);
+
+        const callBody = JSON.parse(mockFetch.mock.calls[0]![1].body);
+        // Fresh prefetched value wins; unrelated DSL-only entries are kept.
+        expect(callBody.payload.workflow.secrets).toEqual({
+          WORKFLOW_LANGWATCH_API_KEY: "sk-lw-fresh",
+          DSL_ONLY: "keep-me",
+        });
+      });
     });
 
     it("passes the pre-fetched workflow DSL through unchanged", async () => {

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
@@ -79,6 +79,7 @@ export class SerializedCodeAgentAdapter extends AgentAdapter {
       version: "1.0",
       template_adapter: "default" as const,
       default_llm: null,
+      secrets: this.config.secrets,
       nodes: [
         this.buildEntryNode(inputs),
         this.buildCodeNode(inputs, outputs),

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/workflow-agent.adapter.ts
@@ -103,9 +103,17 @@ export class SerializedWorkflowAgentAdapter extends AgentAdapter {
   private async executeOnNlpService(
     inputRecord: Record<string, string>,
   ): Promise<Record<string, unknown> | null> {
+    // Merge pre-fetched project secrets into the DSL so `secrets.NAME` works
+    // inside code nodes of the published workflow. Any secrets already embedded
+    // in the DSL (there shouldn't be any — they're stripped on save) are
+    // overwritten by the fresh values to avoid leaking stale/decrypted data.
+    const existingSecrets =
+      (this.config.workflow.secrets as Record<string, string> | undefined) ??
+      {};
     const workflow = {
       ...this.config.workflow,
       api_key: this.apiKey,
+      secrets: { ...existingSecrets, ...this.config.secrets },
     };
 
     const event = {

--- a/langwatch/src/server/scenarios/execution/types.ts
+++ b/langwatch/src/server/scenarios/execution/types.ts
@@ -128,6 +128,12 @@ export const CodeAgentDataSchema = z.object({
   scenarioMappings: z.record(z.string(), FieldMappingSchema).optional(),
   /** Which output field to use as the scenario result. When unset, uses the first output. */
   scenarioOutputField: z.string().optional(),
+  /**
+   * Project secrets exposed to the Python code as the `secrets.NAME` namespace.
+   * Pre-fetched so the worker-thread adapter runs without DB access. Mirrors
+   * the studio's addEnvs behavior for in-app workflow execution.
+   */
+  secrets: z.record(z.string(), z.string()).default({}),
 });
 export type CodeAgentData = z.infer<typeof CodeAgentDataSchema>;
 
@@ -163,6 +169,12 @@ export const WorkflowAgentDataSchema = z.object({
   scenarioMappings: z.record(z.string(), FieldMappingSchema).optional(),
   /** Which output field to use as the scenario result. When unset, uses the first output. */
   scenarioOutputField: z.string().optional(),
+  /**
+   * Project secrets merged into the workflow DSL before execution. Mirrors the
+   * studio's addEnvs behavior so `secrets.NAME` works inside code nodes of the
+   * published workflow.
+   */
+  secrets: z.record(z.string(), z.string()).default({}),
 });
 export type WorkflowAgentData = z.infer<typeof WorkflowAgentDataSchema>;
 


### PR DESCRIPTION
## Summary

- **Scenario agents now get project secrets.** `SerializedCodeAgentAdapter` and `SerializedWorkflowAgentAdapter` were sending DSLs to langwatch_nlp without the project's decrypted secrets, so `secrets.NAME` in user Python raised `NameError: name 'secrets' is not defined`. The studio's `addEnvs` path injected secrets for UI-triggered runs; the scenario prefetcher skipped them. The prefetcher now decrypts project secrets once per run and the adapters merge them into the DSL before POSTing to `/studio/execute_sync` — mirroring `addEnvs`' shape.
- **Dataset `POST /records` 400s now list valid columns.** `InvalidColumnError` includes the declared columns in its message, so integrations (e.g. a workflow code block that drifted from the schema) can self-diagnose without opening the dataset page.

## Why

A customer hitting a multi-turn agent via LangWatch Scenarios was seeing two failures:

1. `HTTP 500 - Execution completed without success or error status` from NLP — root cause was `secrets.WORKFLOW_LANGWATCH_API_KEY` unresolved in the workflow code node because scenario-path DSLs didn't carry project secrets.
2. A confusing `400 Bad Request` when the stored dataset's columns didn't match what the workflow code was writing; the previous message only named the offending column but didn't tell the user what columns were actually available.

## Changes

| File | Change |
|---|---|
| `server/scenarios/execution/types.ts` | `CodeAgentData` / `WorkflowAgentData` gain `secrets: Record<string,string>` (defaults to `{}`) |
| `server/scenarios/execution/data-prefetcher.ts` | New `ProjectSecretsFetcher` dep + prod impl (Prisma `projectSecret` + `decrypt`); both agent fetchers now load and include secrets |
| `serialized-adapters/code-agent.adapter.ts` | Synthesized workflow carries `secrets` |
| `serialized-adapters/workflow-agent.adapter.ts` | Merges secrets into the pre-fetched DSL before sending to NLP |
| `server/datasets/errors.ts` | `InvalidColumnError` accepts `validColumns` and lists them in the message |
| `server/datasets/dataset.service.ts` | Passes the dataset's column names when throwing |
| Tests | Adapter unit tests verify `workflow.secrets` is emitted; prefetcher unit test verifies decrypted secrets land on `adapterData`; dataset REST integration test asserts the 400 message now names the valid columns |

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit src/server/scenarios/execution` — 63 tests, all green
- [ ] Manual: re-run failing scenario against a workflow that references `secrets.X` — `NameError` gone
- [ ] Manual: hit `POST /api/dataset/:slug/records` with an unknown column, verify response lists declared columns