### PR TITLE
fix(analytics): rescue 4 broken dashboard widgets in arrayJoin groupBy path

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -208,37 +208,106 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("1__evaluations_evaluation_pass_rate__avg");
     });
 
-    // @regression: `performance.tokens_per_second` with an arrayJoin groupBy
-    // (e.g. metadata.model) previously emitted `avg(ts.TokensPerSecond)` in the
-    // outer SELECT, but `ts` is only in scope inside the CTE and `TokensPerSecond`
-    // was never projected. ClickHouse rejected the query with:
-    //   "Unknown expression or function identifier `ts.TokensPerSecond` in scope"
-    // Fix adds `TokensPerSecond` to the CTE projection as `trace_tokens_per_second`
-    // and wires it into DEDUP_FIELD_MAPPINGS so transformMetricForDedup rewrites
-    // the outer reference to the CTE alias.
-    it("routes performance.tokens_per_second through the CTE alias in arrayJoin groupBy path", () => {
-      const input = {
-        ...baseInput,
-        groupBy: "metadata.model" as const,
-        series: [
-          {
-            metric: "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
-            aggregation: "avg" as const,
-          },
-        ],
+    // @regression: Trace-level metrics emitted `avg(ts.<Column>)` in the outer
+    // SELECT when routed through the arrayJoin groupBy path, but `ts` is only
+    // in scope inside the `deduped_traces` CTE. Columns not registered in
+    // `DEDUP_FIELD_MAPPINGS` and not projected into the CTE caused ClickHouse
+    // to reject the query with:
+    //   "Unknown expression or function identifier `ts.<Column>` in scope"
+    //
+    // Audit of `metric-translator.ts` revealed two trace-level columns with
+    // this bug: `TokensPerSecond` and `TimeToFirstTokenMs`. Both have been
+    // projected into the CTE and wired into DEDUP_FIELD_MAPPINGS so
+    // `transformMetricForDedup` rewrites the outer reference to the CTE alias.
+    it.each([
+      {
+        metric: "performance.tokens_per_second",
+        aggregation: "avg",
+        alias: "trace_tokens_per_second",
+        rawColumn: "TokensPerSecond",
+        outerAggregation: /\bavg\s*\(\s*trace_tokens_per_second\s*\)/,
+      },
+      {
+        metric: "performance.first_token",
+        aggregation: "p90",
+        alias: "trace_time_to_first_token_ms",
+        rawColumn: "TimeToFirstTokenMs",
+        outerAggregation: /\bquantileExact\(0\.9\)\s*\(\s*trace_time_to_first_token_ms\s*\)/,
+      },
+    ])(
+      "routes $metric through the CTE alias in arrayJoin groupBy path",
+      ({ metric, aggregation, alias, rawColumn, outerAggregation }) => {
+        const input = {
+          ...baseInput,
+          groupBy: "metadata.model" as const,
+          series: [
+            {
+              metric: metric as FlattenAnalyticsMetricsEnum,
+              aggregation: aggregation as "avg" | "p90",
+            },
+          ],
+        };
+        const result = buildTimeseriesQuery(input);
+
+        // Must route through the arrayJoin CTE path (Models array)
+        expect(result.sql).toContain("arrayJoin");
+        expect(result.sql).toContain("deduped_traces");
+
+        // The CTE must project the column under the expected alias. A single
+        // `ts.<Column> AS <alias>` reference inside the CTE is expected and
+        // correct — the bug was only that the outer SELECT also used
+        // `ts.<Column>`, where `ts` is out of scope.
+        expect(result.sql).toContain(`ts.${rawColumn} AS ${alias}`);
+
+        // The outer SELECT must reference the CTE alias, not the raw column.
+        const outerPortion = result.sql.slice(
+          result.sql.indexOf("FROM (") + "FROM (".length,
+        ).split("FROM deduped_traces")[1] ?? "";
+        expect(result.sql).toMatch(outerAggregation);
+        expect(outerPortion).not.toContain(`ts.${rawColumn}`);
+      },
+    );
+
+    // @guard: prevent this class of bug from recurring silently. Any
+    // trace-level column referenced via `${ts}.<Column>` in metric-translator
+    // MUST be registered in DEDUP_FIELD_MAPPINGS (which is consumed by
+    // transformMetricForDedup to rewrite outer references to the CTE alias)
+    // AND projected in the CTE (see aggregation-builder.ts:~1168). Columns
+    // not in this list are handled specially (see allowlist below). If a new
+    // trace-level metric is added and this test fails, either add the column
+    // to DEDUP_FIELD_MAPPINGS + CTE, or extend the allowlist with a reason.
+    it("every ${ts}.<Column> reference in metric-translator is handled", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const source = await fs.readFile(
+        path.resolve(__dirname, "../metric-translator.ts"),
+        "utf8",
+      );
+      const referenced = new Set(
+        Array.from(source.matchAll(/\$\{ts\}\.([A-Z][a-zA-Z]+)/g)).map(
+          (m) => m[1]!,
+        ),
+      );
+      // Columns handled by special cases in transformMetricForDedup, not by
+      // DEDUP_FIELD_MAPPINGS lookup. Keep this list minimal and documented.
+      const SPECIAL_CASE_ALLOWLIST = new Set([
+        "TraceId", // -> uniqExact(trace_id)
+        "Attributes", // routed through extractReferencedEvaluationColumns / metadata path
+        "OccurredAt", // used only in period/date boundaries, not in outer aggregations
+      ]);
+      const {
+        __testOnly_DEDUP_FIELD_MAPPINGS,
+      } = __testOnly__ as unknown as {
+        __testOnly_DEDUP_FIELD_MAPPINGS?: Record<string, string>;
       };
-      const result = buildTimeseriesQuery(input);
+      const registered = new Set(
+        Object.keys(__testOnly_DEDUP_FIELD_MAPPINGS ?? {}),
+      );
 
-      // Must route through the arrayJoin CTE path (Models array)
-      expect(result.sql).toContain("arrayJoin");
-      expect(result.sql).toContain("deduped_traces");
-
-      // The CTE must project the column under the expected alias
-      expect(result.sql).toContain("AS trace_tokens_per_second");
-
-      // The outer SELECT must reference the CTE alias, not the raw column
-      expect(result.sql).toContain("avg(trace_tokens_per_second)");
-      expect(result.sql).not.toMatch(/\bavg\s*\(\s*ts\.TokensPerSecond\s*\)/);
+      const unhandled = [...referenced].filter(
+        (col) => !registered.has(col) && !SPECIAL_CASE_ALLOWLIST.has(col),
+      );
+      expect(unhandled).toEqual([]);
     });
 
     // @regression: Pie charts with arrayJoin groupBy (e.g. metadata.labels) add a

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -208,6 +208,39 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("1__evaluations_evaluation_pass_rate__avg");
     });
 
+    // @regression: `performance.tokens_per_second` with an arrayJoin groupBy
+    // (e.g. metadata.model) previously emitted `avg(ts.TokensPerSecond)` in the
+    // outer SELECT, but `ts` is only in scope inside the CTE and `TokensPerSecond`
+    // was never projected. ClickHouse rejected the query with:
+    //   "Unknown expression or function identifier `ts.TokensPerSecond` in scope"
+    // Fix adds `TokensPerSecond` to the CTE projection as `trace_tokens_per_second`
+    // and wires it into DEDUP_FIELD_MAPPINGS so transformMetricForDedup rewrites
+    // the outer reference to the CTE alias.
+    it("routes performance.tokens_per_second through the CTE alias in arrayJoin groupBy path", () => {
+      const input = {
+        ...baseInput,
+        groupBy: "metadata.model" as const,
+        series: [
+          {
+            metric: "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
+            aggregation: "avg" as const,
+          },
+        ],
+      };
+      const result = buildTimeseriesQuery(input);
+
+      // Must route through the arrayJoin CTE path (Models array)
+      expect(result.sql).toContain("arrayJoin");
+      expect(result.sql).toContain("deduped_traces");
+
+      // The CTE must project the column under the expected alias
+      expect(result.sql).toContain("AS trace_tokens_per_second");
+
+      // The outer SELECT must reference the CTE alias, not the raw column
+      expect(result.sql).toContain("avg(trace_tokens_per_second)");
+      expect(result.sql).not.toMatch(/\bavg\s*\(\s*ts\.TokensPerSecond\s*\)/);
+    });
+
     // @regression: Pie charts with arrayJoin groupBy (e.g. metadata.labels) add a
     // pipeline { field: "trace_id", aggregation: "sum" } which sets requiresSubquery.
     // buildArrayJoinTimeseriesQuery previously dropped all subquery metrics, returning

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -268,6 +268,54 @@ describe("aggregation-builder", () => {
       },
     );
 
+    // @regression: Dashboard widgets `avgCostPerModel` and `avgTokensPerModel`
+    // emit `pipeline: { field: "trace_id", aggregation: "avg" }` on a
+    // trace-level metric (`performance.total_cost`, `performance.completion_tokens`)
+    // with `groupBy: metadata.model`. The arrayJoin CTE path previously only
+    // rewrote pipelines with `aggregation: "sum"`; `"avg"` (and min/max) fell
+    // through and the metric was silently dropped from the outer SELECT — the
+    // query returned 200 OK with no values, and the UI showed "No data".
+    //
+    // For trace-level columns the CTE already deduplicates by (trace_id,
+    // group_key), so the per-trace inner aggregation is identity — sum/avg/min/max
+    // all collapse to the per-trace scalar, and the outer aggregation equals
+    // the direct aggregation over deduped traces.
+    it.each([
+      {
+        metric: "performance.total_cost",
+        pipelineAgg: "avg",
+        outerAggregation: /\bavg\s*\(\s*trace_total_cost\s*\)/,
+      },
+      {
+        metric: "performance.completion_tokens",
+        pipelineAgg: "avg",
+        outerAggregation: /\bavg\s*\(\s*trace_completion_tokens\s*\)/,
+      },
+    ])(
+      "rewrites trace_id pipeline with $pipelineAgg aggregation on $metric in arrayJoin groupBy",
+      ({ metric, pipelineAgg, outerAggregation }) => {
+        const input = {
+          ...baseInput,
+          groupBy: "metadata.model" as const,
+          series: [
+            {
+              metric: metric as FlattenAnalyticsMetricsEnum,
+              aggregation: "avg" as const,
+              pipeline: {
+                field: "trace_id" as const,
+                aggregation: pipelineAgg as "avg",
+              },
+            },
+          ],
+        };
+        const result = buildTimeseriesQuery(input);
+
+        expect(result.sql).toContain("deduped_traces");
+        // Metric must survive to the outer SELECT (not silently dropped)
+        expect(result.sql).toMatch(outerAggregation);
+      },
+    );
+
     // @guard: prevent this class of bug from recurring silently. Any
     // trace-level column referenced via `${ts}.<Column>` in metric-translator
     // MUST be registered in DEDUP_FIELD_MAPPINGS (which is consumed by

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -1094,14 +1094,26 @@ function buildArrayJoinTimeseriesQuery(
   // @regression issue #3088
   const simpleMetrics = metricTranslations.filter((m) => !m.requiresSubquery);
 
-  // Pipeline metrics that group by trace_id with "sum" aggregation are redundant
-  // in the arrayJoin path because the CTE already deduplicates by (trace_id,
-  // group_key). Re-translate them as simple metrics so they participate in the
-  // outer SELECT instead of being silently dropped.
+  // Pipeline metrics that group by trace_id are redundant in the arrayJoin
+  // path because the CTE already deduplicates by (trace_id, group_key): each
+  // trace contributes at most one row per group, so the inner `<agg> BY
+  // trace_id` step becomes identity for trace-level columns. Re-translate
+  // these as simple metrics so they participate in the outer SELECT instead
+  // of being silently dropped (which is what the `avgCostPerModel` and
+  // `avgTokensPerModel` dashboard widgets were hitting — they emit
+  // `pipeline: {field: trace_id, aggregation: avg}` and got blanked out).
   //
-  // Only safe for "sum" aggregation: sum(value_per_trace) is equivalent to the
-  // standard aggregation over deduped traces. Other pipeline aggregations
-  // (avg/min/max) have different semantics and cannot be rewritten this way.
+  // Safe for sum/avg/min/max: on a per-trace scalar `v`, the inner
+  // aggregation collapses to `v` for all four, so the outer aggregation
+  // equals the standard aggregation over deduped traces. Other inner
+  // aggregations (quantile, uniq, etc.) are intentionally left to fall
+  // through — they'd need separate reasoning.
+  const TRACE_ID_PIPELINE_SAFE_AGGS = new Set<string>([
+    "sum",
+    "avg",
+    "min",
+    "max",
+  ]);
   for (let i = 0; i < input.series.length; i++) {
     const series = input.series[i]!;
     const translation = metricTranslations[i]!;
@@ -1109,7 +1121,7 @@ function buildArrayJoinTimeseriesQuery(
 
     if (
       series.pipeline.field === "trace_id" &&
-      series.pipeline.aggregation === "sum"
+      TRACE_ID_PIPELINE_SAFE_AGGS.has(series.pipeline.aggregation)
     ) {
       const innerTranslation = translateMetric(
         series.metric,

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -1177,6 +1177,9 @@ function buildArrayJoinTimeseriesQuery(
   cteSelectExprs.push(
     `${traceColumnWrapper(`${ts}.TotalCompletionTokenCount`)} AS trace_completion_tokens`,
   );
+  cteSelectExprs.push(
+    `${traceColumnWrapper(`${ts}.TokensPerSecond`)} AS trace_tokens_per_second`,
+  );
 
   // When pre-aggregating eval metrics per-trace, emit each eval metric's full
   // expression (without its alias) as a `<alias>__per_trace` column inside the
@@ -2009,6 +2012,7 @@ const DEDUP_FIELD_MAPPINGS: Record<string, string> = {
   TotalDurationMs: "trace_duration_ms",
   TotalPromptTokenCount: "trace_prompt_tokens",
   TotalCompletionTokenCount: "trace_completion_tokens",
+  TokensPerSecond: "trace_tokens_per_second",
 };
 
 /** Aggregation patterns and their transformation logic */

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -1180,6 +1180,9 @@ function buildArrayJoinTimeseriesQuery(
   cteSelectExprs.push(
     `${traceColumnWrapper(`${ts}.TokensPerSecond`)} AS trace_tokens_per_second`,
   );
+  cteSelectExprs.push(
+    `${traceColumnWrapper(`${ts}.TimeToFirstTokenMs`)} AS trace_time_to_first_token_ms`,
+  );
 
   // When pre-aggregating eval metrics per-trace, emit each eval metric's full
   // expression (without its alias) as a `<alias>__per_trace` column inside the
@@ -2013,6 +2016,7 @@ const DEDUP_FIELD_MAPPINGS: Record<string, string> = {
   TotalPromptTokenCount: "trace_prompt_tokens",
   TotalCompletionTokenCount: "trace_completion_tokens",
   TokensPerSecond: "trace_tokens_per_second",
+  TimeToFirstTokenMs: "trace_time_to_first_token_ms",
 };
 
 /** Aggregation patterns and their transformation logic */
@@ -2555,4 +2559,5 @@ export const __testOnly__ = {
   extractTraceAggregationColumn,
   replaceColumnWithAlias,
   hasEvalMixedWithTraceMetrics,
+  __testOnly_DEDUP_FIELD_MAPPINGS: DEDUP_FIELD_MAPPINGS,
 };


### PR DESCRIPTION
## Summary

Three related analytics bugs, all in the same `arrayJoin` groupBy dedup path in `aggregation-builder.ts`. Each produced empty or 500-ing dashboard widgets. Audit of `metric-translator.ts` + the dedup pipeline rewriting caught all three at once.

## The bugs

### 1. Missing CTE projection + DEDUP mapping → 500s

Two trace-level columns were emitted in the outer SELECT as `ts.<Column>` but never projected into the `deduped_traces` CTE and never registered in `DEDUP_FIELD_MAPPINGS`:

- `TokensPerSecond` → powers **Tokens per second** chart
- `TimeToFirstTokenMs` → powers **90th Percentile time to first token** in the LLM Performance Summary

ClickHouse rejected both queries with:

```
Unknown expression or function identifier `ts.<Column>` in scope
```

The outer SELECT references `ts.<Column>`, but `ts` only exists inside the CTE, and the column isn't projected anyway. Code at `aggregation-builder.ts:1160-1167` explicitly warns about this — guidance was missed twice.

### 2. Silent drop of trace_id pipeline avg/min/max → empty widgets

Two widgets use `pipeline: { field: "trace_id", aggregation: "avg" }` on trace-level metrics with `groupBy: metadata.model`:

- `avgCostPerModel` → **Average Cost Per Message**
- `avgTokensPerModel` → **Average Tokens Per Message**

The pipeline-rewrite step only handled `"sum"`; `"avg"` fell through the loop and the metric was **silently dropped** from the outer SELECT. Query returned `200 OK` with the metric alias missing → UI showed "No data — try adjusting the date range."

The previous comment claimed `avg/min/max` "have different semantics and cannot be rewritten this way." That concern applies to span-level fanout, but the CTE already dedupes by `(trace_id, group_key)` before this code runs — each trace contributes at most one row per group, so inner sum/avg/min/max on a trace-level scalar are all **identity** and collapse cleanly to the direct aggregation.

## What this PR does

### Fix A — project the two missing columns

```diff
  cteSelectExprs.push(
    `${traceColumnWrapper(`${ts}.TotalCompletionTokenCount`)} AS trace_completion_tokens`,
  );
+ cteSelectExprs.push(
+   `${traceColumnWrapper(`${ts}.TokensPerSecond`)} AS trace_tokens_per_second`,
+ );
+ cteSelectExprs.push(
+   `${traceColumnWrapper(`${ts}.TimeToFirstTokenMs`)} AS trace_time_to_first_token_ms`,
+ );
```

```diff
  const DEDUP_FIELD_MAPPINGS: Record<string, string> = {
    TotalCost: "trace_total_cost",
    TotalDurationMs: "trace_duration_ms",
    TotalPromptTokenCount: "trace_prompt_tokens",
    TotalCompletionTokenCount: "trace_completion_tokens",
+   TokensPerSecond: "trace_tokens_per_second",
+   TimeToFirstTokenMs: "trace_time_to_first_token_ms",
  };
```

### Fix B — extend pipeline rewrite allowlist

```diff
+ const TRACE_ID_PIPELINE_SAFE_AGGS = new Set<string>([
+   "sum",
+   "avg",
+   "min",
+   "max",
+ ]);
  for (...) {
    ...
-   if (series.pipeline.field === "trace_id" && series.pipeline.aggregation === "sum") {
+   if (series.pipeline.field === "trace_id" && TRACE_ID_PIPELINE_SAFE_AGGS.has(series.pipeline.aggregation)) {
      // re-translate as simple metric
    }
  }
```

### Fix C — drift guard test

Scans `metric-translator.ts` for every `${ts}.<Column>` reference and asserts each is either in `DEDUP_FIELD_MAPPINGS` or on a small documented allowlist (`TraceId` → `uniqExact(trace_id)`, `Attributes` → metadata, `OccurredAt` → period/date boundaries). Any future trace-level metric added without being wired into the CTE **fails at build time** rather than silently 500ing in production.

## Regression tests

Parameterized cases pinning all four broken widgets:

| Metric | Aggregation | Path | Expected |
|---|---|---|---|
| `performance.tokens_per_second` | `avg` | direct | `avg(trace_tokens_per_second)` in outer |
| `performance.first_token` | `p90` | direct | `quantileExact(0.9)(trace_time_to_first_token_ms)` in outer |
| `performance.total_cost` | `avg` + `pipeline:{trace_id,avg}` | pipeline | `avg(trace_total_cost)` in outer |
| `performance.completion_tokens` | `avg` + `pipeline:{trace_id,avg}` | pipeline | `avg(trace_completion_tokens)` in outer |

Plus the drift guard.

## Verified locally

- `pnpm test:unit aggregation-builder.test.ts` — 83/83 (78 existing + 3 parameterized regression + 1 pipeline regression block + 1 drift guard)
- `pnpm typecheck` — clean in analytics/clickhouse
- Manual end-to-end: sent real Gemini-backed mock traces across three models via the local dev stack. Confirmed in browser:
  - TPS chart renders
  - Time-to-first-token renders
  - Average Cost Per Message renders
  - Average Tokens Per Message renders

## Not in scope

The existing `TODO(#3115)` to port this path to `extractTraceAggregationColumn` remains — that's a larger refactor. This PR keeps the hand-registered pattern and makes it safe via the drift guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
