### PR TITLE
fix(traces): parse JSON-string langwatch.input when extracting primary I/O

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/trace-io-extraction.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-io-extraction.service.unit.test.ts
@@ -192,5 +192,65 @@ describe("TraceIOExtractionService", () => {
         expect(result!.text).toBe("Tell me about AI");
       });
     });
+
+    describe("when langwatch.input is a JSON-encoded string with 'message' and 'history'", () => {
+      it("parses the JSON and extracts the message field", () => {
+        const payload = {
+          message:
+            "I think you should have some options for me to easily select, like 1, 2, 3",
+          history: [
+            { role: "user", content: "decide my dinner tonight" },
+            { role: "assistant", content: "some long suggestion" },
+          ],
+          thread_id: "c9d826f2-d1d1-4807-a3f8-77a016883b14",
+        };
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": JSON.stringify(payload),
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe(
+          "I think you should have some options for me to easily select, like 1, 2, 3",
+        );
+        expect(result!.source).toBe("langwatch");
+      });
+    });
+
+    describe("when langwatch.input is a non-JSON string that contains braces", () => {
+      it("returns the raw string without erroring", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.input": "{not really json",
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "input");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("{not really json");
+      });
+    });
+
+    describe("when langwatch.output is a JSON-encoded string with 'output' key", () => {
+      it("parses the JSON and extracts the output field", () => {
+        const span = createTestSpan({
+          spanAttributes: {
+            "langwatch.output": JSON.stringify({
+              output: "The answer is 42",
+              trace_id: "abc",
+            }),
+          },
+        });
+
+        const result = service.extractRichIOFromSpan(span, "output");
+
+        expect(result).not.toBeNull();
+        expect(result!.text).toBe("The answer is 42");
+      });
+    });
   });
 });

--- a/langwatch/src/server/app-layer/traces/trace-io-extraction.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-io-extraction.service.ts
@@ -193,10 +193,7 @@ export class TraceIOExtractionService {
     // Priority 2: LangWatch attribute
     const langwatchValue = attrs[keys.langwatch];
     if (langwatchValue !== undefined && langwatchValue !== null) {
-      const text =
-        typeof langwatchValue === "string"
-          ? langwatchValue
-          : messagesToText(langwatchValue, type);
+      const text = messagesToText(langwatchValue, type);
       if (text) {
         return { raw: langwatchValue, text, source: "langwatch" };
       }

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "opentelemetry-sdk>=1.32.1",
     "opentelemetry-instrumentation-crewai>=0.45.0",
     "retry>=0.9.2",
+    "tenacity>=8.0.0",
     "termcolor>=3.0.1",
     "deprecated>=1.2.18",
     "python-liquid>=2.0.2",

--- a/python-sdk/src/langwatch/telemetry/tracing.py
+++ b/python-sdk/src/langwatch/telemetry/tracing.py
@@ -5,6 +5,7 @@ from uuid import UUID
 import httpx
 import threading
 from deprecated import deprecated
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 from langwatch.attributes import AttributeKey
 from langwatch.utils.auth import build_auth_headers
 from langwatch.utils.exceptions import better_raise_for_status
@@ -59,6 +60,13 @@ if TYPE_CHECKING:
 __all__ = ["trace", "LangWatchTrace"]
 
 T = TypeVar("T", bound=Callable[..., Any])
+
+_retry_on_transient = retry(
+    retry=retry_if_exception_type((httpx.TimeoutException, httpx.ConnectError)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
+)
 
 
 class LangWatchTrace:
@@ -301,15 +309,20 @@ class LangWatchTrace:
         trace_id = self.trace_id
         if trace_id is None:
             raise ValueError("Trace ID is not available from trace object")
-        with httpx.Client() as client:
-            response = client.post(
-                f"{endpoint}/api/trace/{trace_id}/share",
-                headers=build_auth_headers(get_api_key()),
-                timeout=15,
-            )
-            better_raise_for_status(response)
-            path = response.json()["path"]
-            return f"{endpoint}{path}"
+
+        @_retry_on_transient
+        def _do_share() -> str:
+            with httpx.Client() as client:
+                response = client.post(
+                    f"{endpoint}/api/trace/{trace_id}/share",
+                    headers=build_auth_headers(get_api_key()),
+                    timeout=30,
+                )
+                better_raise_for_status(response)
+                return response.json()["path"]
+
+        path = _do_share()
+        return f"{endpoint}{path}"
 
     def unshare(self):
         """Make this trace private again."""
@@ -318,13 +331,18 @@ class LangWatchTrace:
         trace_id = self.trace_id
         if trace_id is None:
             raise ValueError("Trace ID is not available from trace object")
-        with httpx.Client() as client:
-            response = client.post(
-                f"{endpoint}/api/trace/{trace_id}/unshare",
-                headers=build_auth_headers(get_api_key()),
-                timeout=15,
-            )
-            better_raise_for_status(response)
+
+        @_retry_on_transient
+        def _do_unshare() -> None:
+            with httpx.Client() as client:
+                response = client.post(
+                    f"{endpoint}/api/trace/{trace_id}/unshare",
+                    headers=build_auth_headers(get_api_key()),
+                    timeout=30,
+                )
+                better_raise_for_status(response)
+
+        _do_unshare()
 
     def update(
         self,

--- a/python-sdk/tests/telemetry/test_tracing.py
+++ b/python-sdk/tests/telemetry/test_tracing.py
@@ -3,7 +3,9 @@
 
 import json
 import os
+from uuid import uuid4
 
+import httpx
 import pytest
 
 import langwatch
@@ -69,6 +71,71 @@ def test_metadata_on_root_span():
         root_metadata = trace.root_span._span.attributes.get("metadata")
 
         assert json.loads(root_metadata) == {"a": 1, "b": 3, "c": 4}
+
+
+def test_share_retries_on_transient_timeout(monkeypatch):
+    """share() must retry on httpx.TimeoutException — fixes sdk-python-ci flake."""
+    trace = LangWatchTrace()
+    trace._trace_id = int(uuid4().hex, 16)
+
+    call_count = {"n": 0}
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def post(self, url, headers=None, timeout=None):
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                raise httpx.ReadTimeout("read operation timed out")
+            return httpx.Response(
+                200,
+                json={"path": f"/share/fake-{call_count['n']}"},
+                request=httpx.Request("POST", url),
+            )
+
+    monkeypatch.setattr(httpx, "Client", lambda: _FakeClient())
+    # Collapse tenacity's exponential backoff so the test is fast.
+    import time as time_module
+
+    monkeypatch.setattr(time_module, "sleep", lambda *a, **kw: None)
+
+    url = trace.share()
+
+    assert call_count["n"] == 3, "expected 2 retries before success"
+    assert url.endswith("/share/fake-3")
+
+
+def test_share_gives_up_after_max_attempts(monkeypatch):
+    """share() must raise once retries are exhausted — avoids silent hangs."""
+    trace = LangWatchTrace()
+    trace._trace_id = int(uuid4().hex, 16)
+
+    call_count = {"n": 0}
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def post(self, url, headers=None, timeout=None):
+            call_count["n"] += 1
+            raise httpx.ReadTimeout("read operation timed out")
+
+    monkeypatch.setattr(httpx, "Client", lambda: _FakeClient())
+    import time as time_module
+
+    monkeypatch.setattr(time_module, "sleep", lambda *a, **kw: None)
+
+    with pytest.raises(httpx.ReadTimeout):
+        trace.share()
+
+    assert call_count["n"] == 3, "expected exactly 3 attempts (stop_after_attempt=3)"
 
 
 def test_metadata_not_lost_on_multiple_updates():

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -3113,6 +3113,7 @@ dependencies = [
     { name = "python-liquid" },
     { name = "pyyaml" },
     { name = "retry" },
+    { name = "tenacity" },
     { name = "termcolor" },
 ]
 
@@ -3210,6 +3211,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "retry", specifier = ">=0.9.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.1" },
+    { name = "tenacity", specifier = ">=8.0.0" },
     { name = "termcolor", specifier = ">=3.0.1" },
 ]
 provides-extras = ["langchain", "dspy", "litellm", "dev", "tests"]

--- a/specs/traces/trace-io-extraction.feature
+++ b/specs/traces/trace-io-extraction.feature
@@ -1,0 +1,85 @@
+Feature: Trace primary input/output extraction
+  As a LangWatch user
+  I want each trace to display a concise primary input and output
+  So that I can scan a trace list and understand what happened without opening individual spans
+
+  # =========================================================================
+  # What this covers
+  # =========================================================================
+  #
+  # When the ingestion pipeline processes spans, it derives a single primary
+  # "input" and "output" to show at the trace level (list view + trace drawer
+  # header). The logic lives in TraceIOExtractionService.
+  #
+  # Priority order for a given span, highest first:
+  #   1. gen_ai.input.messages / gen_ai.output.messages (OTel GenAI semconv)
+  #   2. langwatch.input / langwatch.output (LangWatch canonical attribute)
+  #
+  # For langwatch.input/output, the value may be:
+  #   - a plain string  → used directly
+  #   - a JSON object   → searched for a recognized "text" key
+  #   - a JSON-encoded string (stringified object) → parsed, then searched
+  #
+  # The last case is common in practice: OTel serializes complex attribute
+  # values to strings on the wire, so `langwatch.input` frequently arrives as
+  # a JSON string even when the SDK set it as a dict/object.
+  #
+  # =========================================================================
+  # Recognized "text" keys (COMMON_TEXT_KEYS)
+  # =========================================================================
+  #
+  # When the value (or its parsed form) is an object and not message-shaped,
+  # the first key found from this ordered list wins:
+  #
+  #   text, input, question, user_query, query, message, input_value,
+  #   output, answer, content, prompt
+  #
+  # Nested wrappers are also supported:
+  #   - { inputs: { input: "..." } }   (LangChain)
+  #   - { outputs: { output: "..." } } (LangChain)
+  #
+  # Message-shaped objects (with role + content/parts/text/value) take
+  # precedence over plain-JSON key lookup.
+
+  Background:
+    Given a trace with a single root span
+
+  Scenario: langwatch.input is a plain string
+    Given the span has langwatch.input = "hello world"
+    When the service extracts the primary input
+    Then the primary input text is "hello world"
+
+  Scenario: langwatch.input is a JSON object with the "message" key
+    Given the span has langwatch.input = { "message": "what's for dinner?", "thread_id": "abc" }
+    When the service extracts the primary input
+    Then the primary input text is "what's for dinner?"
+
+  Scenario: langwatch.input is a JSON-encoded string with "message" + "history"
+    # Regression: OTel frequently delivers complex values as stringified JSON.
+    # The heuristic must parse the string before searching for text keys,
+    # otherwise the entire JSON blob is shown verbatim on the trace list.
+    Given the span has langwatch.input set to the JSON-string '{"message":"I think you should have some options","history":[{"role":"user","content":"decide my dinner tonight"}],"thread_id":"c9d826f2"}'
+    When the service extracts the primary input
+    Then the primary input text is "I think you should have some options"
+
+  Scenario: langwatch.input is a JSON object with a LangChain-style inputs wrapper
+    Given the span has langwatch.input = { "inputs": { "input": "nested hello" } }
+    When the service extracts the primary input
+    Then the primary input text is "nested hello"
+
+  Scenario: langwatch.input is a plain non-JSON string that happens to contain braces
+    # The JSON.parse attempt must fail gracefully and return the string as-is.
+    Given the span has langwatch.input = "{not really json"
+    When the service extracts the primary input
+    Then the primary input text is "{not really json"
+
+  Scenario: langwatch.input is an object with no recognized text key
+    Given the span has langwatch.input = { "foo": "bar", "baz": 123 }
+    When the service extracts the primary input
+    Then no primary input is extracted
+
+  Scenario: gen_ai.input.messages takes priority over langwatch.input
+    Given the span has gen_ai.input.messages = [{ "role": "user", "content": "from gen_ai" }]
+    And the span has langwatch.input = "from langwatch"
+    When the service extracts the primary input
+    Then the primary input text is "from gen_ai"


### PR DESCRIPTION
## Summary

Two related fixes to this file-change set:

### 1. `langwatch/` — parse JSON-string `langwatch.input` when extracting primary I/O

Primary-input heuristic was short-circuiting on any string, so a span with a JSON-stringified `langwatch.input` (the common case when traveling over OTel — see `collectorSpan.utils.ts:48` which literally `JSON.stringify`s the incoming input) displayed the raw JSON blob on the trace list instead of the extracted `message`/`input`/... text. Route strings through `messagesToText`, which already attempts `JSON.parse` and recurses into `COMMON_TEXT_KEYS` — falling through to the raw string when parse fails, so plain strings like `"hello world"` are unchanged.

Adds BDD spec (`specs/traces/trace-io-extraction.feature`) + regression tests.

**Real-world payload that triggered this:**
```json
{
  "message": "I think you should have some options for me to easily select, like 1, 2, 3",
  "history": [ { "role": "user", "content": "..." }, ... ],
  "thread_id": "c9d826f2-..."
}
```
Before: the whole JSON blob was shown in the trace-list input column.
After: `"I think you should have some options for me to easily select, like 1, 2, 3"`.

### 2. `python-sdk/` — retry `share()`/`unshare()` on transient timeouts

`sdk-python-ci` was failing on this very PR with `httpx.ReadTimeout` at `trace.share()` — the same flake tracked in #3336 and fixed in the abandoned PR #3341 (closed by author without merging).

Ports just the SDK portion: `trace.share()`/`unshare()` get a tenacity retry (3 attempts, 2-10s exponential backoff) on `httpx.TimeoutException`/`ConnectError`, per-attempt timeout bumped 15s→30s. Matches the retry pattern already used by `experiment.py` and `batch_evaluation.py`. `tenacity` is declared as an explicit dep rather than relying on transitive inclusion. Unit tests cover both success-after-retry and exhausted-retries paths.

## Out of scope (noted, not touched)

- `model-cost-matching.ts:70-71` reads `langwatch.output` and only handles the object shape when looking up guardrail cost. Same string-JSON blind spot, different concern (cost, not display). Leaving for a follow-up.

## Test plan

- [x] `pnpm test:unit src/server/app-layer/traces/` — 434 pass
- [x] `pnpm typecheck` — clean
- [x] `uv run pytest tests/telemetry/` — 66 pass (including the 2 new retry tests)
- [ ] CI green on `sdk-python-ci` (the motivation for the 2nd commit)
- [ ] QA: trace-list input column shows the extracted text on a real trace (screenshots to follow)