### PR TITLE
test(scenarios): regression test for AI SDK provider version alignment

### DIFF
--- a/langwatch/src/server/scenarios/execution/__tests__/ai-sdk-provider-alignment.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/ai-sdk-provider-alignment.unit.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for langwatch/langwatch#3413.
+ *
+ * Why: when `@ai-sdk/provider` resolves to more than one major version in
+ * `node_modules`, `ai` v6 silently falls back to V2 compatibility mode for
+ * models constructed through `@ai-sdk/openai-compatible`. That path powers
+ * scenario runs (`model.factory.ts`, `prompt-config.adapter.ts`,
+ * `scenario-child-process.ts`), and the compat-mode warning was accompanied
+ * by HTTP 500s from the code-agent surface.
+ *
+ * The only observable, deterministic invariant from pure code inspection is
+ * the lockfile: exactly one `@ai-sdk/provider@x.y.z` entry, with major 3.
+ * Everything else (the runtime warning, the HTTP 500) depends on network and
+ * scenario harness state — not suitable for a unit test.
+ */
+
+const LOCKFILE_PATH = join(__dirname, "../../../../..", "pnpm-lock.yaml");
+const PROVIDER_VERSION_RE = /^\s{2}'?@ai-sdk\/provider@(\d+\.\d+\.\d+)'?:/gm;
+
+function uniqueProviderVersions(lockfile: string): string[] {
+  const versions = new Set<string>();
+  for (const match of lockfile.matchAll(PROVIDER_VERSION_RE)) {
+    versions.add(match[1]!);
+  }
+  return [...versions].sort();
+}
+
+describe("@ai-sdk/provider version alignment (regression for #3413)", () => {
+  const lockfile = readFileSync(LOCKFILE_PATH, "utf8");
+  const versions = uniqueProviderVersions(lockfile);
+
+  it("resolves to exactly one @ai-sdk/provider version", () => {
+    expect(
+      versions,
+      `Expected a single @ai-sdk/provider version in pnpm-lock.yaml. ` +
+        `Found: ${versions.join(", ")}. ` +
+        `Multiple majors force 'ai' v6 into V2 compatibility mode — see #3413.`,
+    ).toHaveLength(1);
+  });
+
+  it("pins @ai-sdk/provider to major 3.x", () => {
+    expect(versions).toHaveLength(1);
+    const major = Number(versions[0]!.split(".")[0]);
+    expect(
+      major,
+      `@ai-sdk/provider must be major 3.x (the V3 LanguageModel spec ` +
+        `expected by 'ai' v6). Found: ${versions[0]}.`,
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## Why

Follow-up regression guard for #3413. The fix (bumping `@ai-sdk/openai`, `@ai-sdk/openai-compatible`, and the other `@ai-sdk/*` providers so the lockfile resolves a single `@ai-sdk/provider` major) ships in the parent PR for that issue. This PR adds the test that would have caught it.

The original failure mode was invisible at compile time: two `@ai-sdk/provider` majors (v2 from `@ai-sdk/openai` v2 / `@ai-sdk/openai-compatible` v1, v3 from `ai` v6 / `@langwatch/scenario`) silently coexisted in `node_modules`. `ai` v6 fell back to V2 compatibility mode for models built via `createOpenAICompatible()`, emitting a warning and degrading features — surfacing as HTTP 500s from the code-agent scenario path.

Not `Closes`/`Fixes` — the parent bump PR closes #3413. This one just adds the guard.

## What changed

One new unit test at `langwatch/src/server/scenarios/execution/__tests__/ai-sdk-provider-alignment.unit.test.ts` that reads `langwatch/pnpm-lock.yaml` with `node:fs`, counts unique `@ai-sdk/provider@x.y.z` entries, and asserts:

1. Exactly one version resolves.
2. That version is on major `3.x` (the V3 `LanguageModel` spec expected by `ai` v6).

Both assertions carry rich failure messages pointing back at #3413.

## How it works

The test is deliberately static — it reads the lockfile directly rather than shelling out to `pnpm list` or constructing a model at runtime. Rationale:

- **No subprocess, no PATH dependency.** Works in any CI image that can run vitest.
- **No network / no harness state.** The runtime warning path (`specificationVersion ... compatibility mode`) depends on model providers, API keys, and generation calls — all the things that make integration tests flaky. The lockfile is the deterministic, compile-time invariant that the bug mapped onto.
- **Fast.** ~5ms for the assertion; no install-time cost beyond what tests already require.

Placed under `scenarios/execution/__tests__` because the scenarios execution surface (`model.factory.ts`, `prompt-config.adapter.ts`, `scenario-child-process.ts`) is what the version skew broke. The test is adjacent to the owners.

## Test plan

Ran the test against both states manually before opening the PR (both on `@types/node@18.19.130`, `vitest@4.1.4`, pnpm lockfile v9):

**Pre-bump** (branched off `origin/main` — both `@ai-sdk/provider@2.0.1` and `@ai-sdk/provider@3.0.8` resolved in the lockfile). Test must fail — this IS the regression signal:

```
 RUN  v4.1.4

 ❯ src/server/scenarios/execution/__tests__/ai-sdk-provider-alignment.unit.test.ts (2 tests | 2 failed) 8ms
     × resolves to exactly one @ai-sdk/provider version 6ms
     × pins @ai-sdk/provider to major 3.x 1ms

 FAIL  src/server/scenarios/execution/__tests__/ai-sdk-provider-alignment.unit.test.ts > @ai-sdk/provider version alignment (regression for #3413) > resolves to exactly one @ai-sdk/provider version
AssertionError: Expected a single @ai-sdk/provider version in pnpm-lock.yaml. Found: 2.0.1, 3.0.8. Multiple majors force 'ai' v6 into V2 compatibility mode — see #3413.: expected [ '2.0.1', '3.0.8' ] to have a length of 1 but got 2

 FAIL  src/server/scenarios/execution/__tests__/ai-sdk-provider-alignment.unit.test.ts > @ai-sdk/provider version alignment (regression for #3413) > pins @ai-sdk/provider to major 3.x
AssertionError: expected [ '2.0.1', '3.0.8' ] to have a length of 1 but got 2

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

**Post-bump** (after applying the parent PR's `package.json` + `pnpm-lock.yaml` — only `@ai-sdk/provider@3.0.8` resolves). Test must pass:

```
 RUN  v4.1.4

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  2.93s
```

## Anything surprising?

- **CI on this branch is expected to FAIL until the parent bump PR for #3413 merges into `main`.** That is the intended behaviour — this branch is off pre-bump `main`, so its lockfile still has both `@ai-sdk/provider@2.0.1` and `@ai-sdk/provider@3.0.8`, and the test correctly catches that. Green CI here only becomes meaningful after the parent PR lands and this branch is rebased. **Merge order: parent bump PR first, then rebase + merge this.**
- The test reads the lockfile via a regex on the canonical pnpm v9 layout (`  '@ai-sdk/provider@x.y.z':`). If lockfile format changes in a major pnpm version, the regex needs updating — failure mode is loud (zero versions found → `toHaveLength(1)` fails with `Found: `).
- Only guards `@ai-sdk/provider`. If a future transitive dep introduces another AI SDK internal version skew (e.g. `@ai-sdk/utils`), we'd want a similar guard — not added speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3413