### PR TITLE
fix(traces): query RoleBinding instead of TeamUser for trace redaction

### DIFF
--- a/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
@@ -1,0 +1,186 @@
+import {
+  ProjectSensitiveDataVisibilityLevel,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUserProtectionsForProject } from "../utils";
+
+vi.mock("../rbac", () => ({
+  hasProjectPermission: vi.fn(() => Promise.resolve(true)),
+  isDemoProject: vi.fn(() => false),
+}));
+
+const mockPrisma = {
+  project: {
+    findUniqueOrThrow: vi.fn(),
+  },
+  roleBinding: {
+    findMany: vi.fn(),
+  },
+  teamUser: {
+    findMany: vi.fn(),
+  },
+} as any;
+
+const mockSession = {
+  user: { id: "user-rolebinding-only" },
+} as any;
+
+describe("getUserProtectionsForProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when user has RoleBinding but no TeamUser row", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+      });
+
+      // User has a RoleBinding for the team
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: TeamUserRole.MEMBER },
+      ]);
+
+      // No TeamUser row exists (post-BetterAuth user)
+      mockPrisma.teamUser.findMany.mockResolvedValue([]);
+    });
+
+    it("grants visibility for VISIBLE_TO_ALL", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(true);
+      expect(result.canSeeCapturedOutput).toBe(true);
+    });
+
+    it("queries roleBinding table, not teamUser", async () => {
+      await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(mockPrisma.roleBinding.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: "user-rolebinding-only",
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: "team-1",
+        },
+        select: { role: true },
+      });
+    });
+  });
+
+  describe("when user has ADMIN RoleBinding", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: TeamUserRole.ADMIN },
+      ]);
+      mockPrisma.teamUser.findMany.mockResolvedValue([]);
+    });
+
+    it("grants visibility for VISIBLE_TO_ADMIN", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(true);
+      expect(result.canSeeCapturedOutput).toBe(true);
+    });
+  });
+
+  describe("when user has MEMBER RoleBinding and visibility is VISIBLE_TO_ADMIN", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: TeamUserRole.MEMBER },
+      ]);
+      mockPrisma.teamUser.findMany.mockResolvedValue([]);
+    });
+
+    it("denies visibility for non-admin member", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+
+  describe("when user has no RoleBinding and no TeamUser", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([]);
+      mockPrisma.teamUser.findMany.mockResolvedValue([]);
+    });
+
+    it("denies visibility even for VISIBLE_TO_ALL", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+
+  describe("when visibility is REDACTED_TO_ALL", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: TeamUserRole.ADMIN },
+      ]);
+      mockPrisma.teamUser.findMany.mockResolvedValue([]);
+    });
+
+    it("denies visibility even for admin", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
@@ -18,9 +18,6 @@ const mockPrisma = {
   roleBinding: {
     findMany: vi.fn(),
   },
-  teamUser: {
-    findMany: vi.fn(),
-  },
 } as any;
 
 const mockSession = {
@@ -42,13 +39,9 @@ describe("getUserProtectionsForProject", () => {
           ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
       });
 
-      // User has a RoleBinding for the team
       mockPrisma.roleBinding.findMany.mockResolvedValue([
         { role: TeamUserRole.MEMBER },
       ]);
-
-      // No TeamUser row exists (post-BetterAuth user)
-      mockPrisma.teamUser.findMany.mockResolvedValue([]);
     });
 
     it("grants visibility for VISIBLE_TO_ALL", async () => {
@@ -61,7 +54,7 @@ describe("getUserProtectionsForProject", () => {
       expect(result.canSeeCapturedOutput).toBe(true);
     });
 
-    it("queries roleBinding table, not teamUser", async () => {
+    it("queries roleBinding table with team scope", async () => {
       await getUserProtectionsForProject(
         { prisma: mockPrisma, session: mockSession },
         { projectId: "project-1" },
@@ -91,7 +84,6 @@ describe("getUserProtectionsForProject", () => {
       mockPrisma.roleBinding.findMany.mockResolvedValue([
         { role: TeamUserRole.ADMIN },
       ]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([]);
     });
 
     it("grants visibility for VISIBLE_TO_ADMIN", async () => {
@@ -118,7 +110,6 @@ describe("getUserProtectionsForProject", () => {
       mockPrisma.roleBinding.findMany.mockResolvedValue([
         { role: TeamUserRole.MEMBER },
       ]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([]);
     });
 
     it("denies visibility for non-admin member", async () => {
@@ -132,7 +123,7 @@ describe("getUserProtectionsForProject", () => {
     });
   });
 
-  describe("when user has no RoleBinding and no TeamUser", () => {
+  describe("when user has no RoleBinding", () => {
     beforeEach(() => {
       mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
         teamId: "team-1",
@@ -143,7 +134,6 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([]);
     });
 
     it("denies visibility even for VISIBLE_TO_ALL", async () => {
@@ -170,7 +160,6 @@ describe("getUserProtectionsForProject", () => {
       mockPrisma.roleBinding.findMany.mockResolvedValue([
         { role: TeamUserRole.ADMIN },
       ]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([]);
     });
 
     it("denies visibility even for admin", async () => {

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -562,6 +562,7 @@ export const projectRouter = createTRPCRouter({
         const project = await prisma.project.findUnique({
           where: { id: projectId },
           select: {
+            teamId: true,
             capturedInputVisibility: true,
             capturedOutputVisibility: true,
           },
@@ -573,25 +574,20 @@ export const projectRouter = createTRPCRouter({
           });
         }
 
-        const teamsWithAccess = await prisma.teamUser.findMany({
+        const bindings = await prisma.roleBinding.findMany({
           where: {
             userId: ctx.session.user.id,
-            team: {
-              projects: {
-                some: {
-                  id: projectId,
-                },
-              },
-            },
+            scopeType: RoleBindingScopeType.TEAM,
+            scopeId: project.teamId,
           },
           select: {
             role: true,
           },
         });
 
-        const isUserPrivileged = teamsWithAccess.some(
-          (teamUser: { role: TeamUserRole }) =>
-            teamUser.role === TeamUserRole.ADMIN,
+        const isUserPrivileged = bindings.some(
+          (binding: { role: TeamUserRole }) =>
+            binding.role === TeamUserRole.ADMIN,
         );
 
         return {

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -37,6 +37,7 @@ import {
   skipPermissionCheckProjectCreation,
 } from "../rbac";
 import { revokeAllTraceShares } from "./share";
+import { getUserProtectionsForProject } from "../utils";
 
 export const projectRouter = createTRPCRouter({
   publicGetById: publicProcedure
@@ -548,62 +549,18 @@ export const projectRouter = createTRPCRouter({
       }),
     )
     .use(checkProjectPermission("project:view"))
-    .query(
-      async ({
-        input,
-        ctx,
-      }: {
-        input: { projectId: string };
-        ctx: { session: Session; prisma: PrismaClient };
-      }) => {
-        const { projectId } = input;
-        const prisma = ctx.prisma;
+    .query(async ({ input, ctx }) => {
+      const protections = await getUserProtectionsForProject(ctx, {
+        projectId: input.projectId,
+      });
 
-        const project = await prisma.project.findUnique({
-          where: { id: projectId },
-          select: {
-            teamId: true,
-            capturedInputVisibility: true,
-            capturedOutputVisibility: true,
-          },
-        });
-        if (!project) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Project not found",
-          });
-        }
-
-        const bindings = await prisma.roleBinding.findMany({
-          where: {
-            userId: ctx.session.user.id,
-            scopeType: RoleBindingScopeType.TEAM,
-            scopeId: project.teamId,
-          },
-          select: {
-            role: true,
-          },
-        });
-
-        const isUserPrivileged = bindings.some(
-          (binding: { role: TeamUserRole }) =>
-            binding.role === TeamUserRole.ADMIN,
-        );
-
-        return {
-          isRedacted: {
-            input: !canAccessSensitiveData(
-              project.capturedInputVisibility,
-              isUserPrivileged,
-            ),
-            output: !canAccessSensitiveData(
-              project.capturedOutputVisibility,
-              isUserPrivileged,
-            ),
-          },
-        };
-      },
-    ),
+      return {
+        isRedacted: {
+          input: !protections.canSeeCapturedInput,
+          output: !protections.canSeeCapturedOutput,
+        },
+      };
+    }),
   archiveById: protectedProcedure
     .input(z.object({ projectId: z.string(), projectToArchiveId: z.string() }))
     .use(checkProjectPermission("project:delete"))
@@ -687,19 +644,4 @@ async function checkCapturedDataVisibilityPermission({
   return next();
 }
 
-const canAccessSensitiveData = (
-  visibility: ProjectSensitiveDataVisibilityLevel,
-  userIsPrivileged: boolean,
-): boolean => {
-  switch (visibility) {
-    case ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL:
-      return false;
-    case ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL:
-      return true;
-    case ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN:
-      return userIsPrivileged;
-    default:
-      console.error("Unexpected visibility level:", visibility);
-      return false; // Default to not showing
-  }
-};
+

--- a/langwatch/src/server/api/utils.ts
+++ b/langwatch/src/server/api/utils.ts
@@ -1,6 +1,7 @@
 import {
   type PrismaClient,
   ProjectSensitiveDataVisibilityLevel,
+  RoleBindingScopeType,
   TeamUserRole,
 } from "@prisma/client";
 import type { Session } from "~/server/auth";
@@ -90,6 +91,7 @@ export async function getUserProtectionsForProject(
   const project = await ctx.prisma.project.findUniqueOrThrow({
     where: { id: projectId, archivedAt: null },
     select: {
+      teamId: true,
       capturedInputVisibility: true,
       capturedOutputVisibility: true,
     },
@@ -113,27 +115,22 @@ export async function getUserProtectionsForProject(
     };
   }
 
-  // For signed in users, check their team permissions
-  const teamsWithAccess = await ctx.prisma.teamUser.findMany({
+  // For signed in users, check their team permissions via RoleBinding
+  const bindings = await ctx.prisma.roleBinding.findMany({
     where: {
       userId: ctx.session.user.id,
-      team: {
-        projects: {
-          some: {
-            id: projectId,
-          },
-        },
-      },
+      scopeType: RoleBindingScopeType.TEAM,
+      scopeId: project.teamId,
     },
     select: {
       role: true,
     },
   });
 
-  const isAdminInAnyTeam = teamsWithAccess.some(
-    (team) => team.role === TeamUserRole.ADMIN,
+  const isAdminInAnyTeam = bindings.some(
+    (binding) => binding.role === TeamUserRole.ADMIN,
   );
-  const isMemberInAnyTeam = teamsWithAccess.length > 0;
+  const isMemberInAnyTeam = bindings.length > 0;
 
   const obtainVisibilityLevel = (
     visibility: ProjectSensitiveDataVisibilityLevel,

--- a/langwatch/src/server/api/utils.ts
+++ b/langwatch/src/server/api/utils.ts
@@ -127,23 +127,23 @@ export async function getUserProtectionsForProject(
     },
   });
 
-  const isAdminInAnyTeam = bindings.some(
+  const isAdminForTeam = bindings.some(
     (binding) => binding.role === TeamUserRole.ADMIN,
   );
-  const isMemberInAnyTeam = bindings.length > 0;
+  const isMemberOfTeam = bindings.length > 0;
 
   const obtainVisibilityLevel = (
     visibility: ProjectSensitiveDataVisibilityLevel,
   ): boolean => {
     switch (true) {
-      case !isMemberInAnyTeam:
+      case !isMemberOfTeam:
         return false;
       case visibility === ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL:
         return false;
       case visibility === ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL:
         return true;
       case visibility === ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN:
-        return isAdminInAnyTeam;
+        return isAdminForTeam;
       default:
         console.error("Unexpected state for visibility:", visibility);
         return false;


### PR DESCRIPTION
## Summary

- **Root cause**: `getUserProtectionsForProject()` and `getFieldRedactionStatus` queried only the `TeamUser` table for team membership. Post-BetterAuth migration (#3121), new users only get `RoleBinding` rows — no `TeamUser`. This caused all trace content to show `[REDACTED]` for post-migration users, even when visibility was `VISIBLE_TO_ALL`.
- Replaced `teamUser.findMany` with `roleBinding.findMany` (scoped by `TEAM` + `project.teamId`) in `utils.ts`
- Eliminated duplicated visibility logic in `project.ts` by delegating `getFieldRedactionStatus` to `getUserProtectionsForProject` (also fixes a missing non-member guard)
- Removed dead `canAccessSensitiveData` function

Closes #3422

## Test plan

- [x] Regression tests: 6 unit tests covering RoleBinding-only user visibility for all visibility levels (VISIBLE_TO_ALL, VISIBLE_TO_ADMIN, REDACTED_TO_ALL) and non-member denial
- [x] Tests confirmed to fail before fix, pass after
- [x] Existing test suites pass (154 tests across rbac, traces, demo-public-sharing)
- [x] Typecheck clean

## Sweep

Checked codebase for same anti-pattern (`teamUser` used for membership checks). Found 2 review items:
- `role.service.ts:106` — same anti-pattern for custom role assignment (different domain, tracked for follow-up)
- `secrets/app.ts:222` — uses `teamUser` to find any team member as owner (not a membership check, low risk)

# Related Issue

- Resolve #3422