### PR TITLE
fix(skills-publish): stop sync.sh nuking target repo's .git

### DIFF
--- a/.github/workflows/skills-publish.yml
+++ b/.github/workflows/skills-publish.yml
@@ -31,6 +31,10 @@ jobs:
 
       - name: Commit and push
         run: |
+          if [ ! -d _skills-publish/.git ]; then
+            echo "::error::_skills-publish/.git missing — sync likely wiped the checkout. Refusing to commit into the wrong repo."
+            exit 1
+          fi
           cd _skills-publish
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/skills/_publish/sync.sh
+++ b/skills/_publish/sync.sh
@@ -6,7 +6,7 @@ TARGET_DIR="${1:?Usage: sync.sh <path-to-skills-repo>}"
 echo "Syncing skills to $TARGET_DIR..."
 
 # Clean target (except .git and README)
-find "$TARGET_DIR" -maxdepth 1 -type d ! -name '.git' ! -name '.' | while read dir; do
+find "$TARGET_DIR" -mindepth 1 -maxdepth 1 -type d ! -name '.git' | while read dir; do
   rm -rf "$dir"
 done
 


### PR DESCRIPTION
## Summary

- `skills/_publish/sync.sh`'s cleanup `find` had no `-mindepth 1`, so it listed the target dir itself and `rm -rf`'d the `langwatch/skills` checkout including its `.git`. Subsequent `cd _skills-publish && git add -A` walked up to the parent `langwatch/langwatch` repo and tried to push there, producing the `403` regardless of `SKILLS_PUBLISH_TOKEN`.
- Add `-mindepth 1` so the target dir is excluded from cleanup.
- Add a guard in `.github/workflows/skills-publish.yml` that fails the step with a clear error if `_skills-publish/.git` is missing, so a future broken sync can never silently commit into the wrong repo.

Root cause trace: the failing run's commit listing showed paths like `_skills-publish/analytics/SKILL.md` — a commit made inside `_skills-publish/` as its own repo would have shown `analytics/SKILL.md`, confirming the sync had destroyed the nested `.git`.

## Test plan

- [ ] After merge, confirm the next push to `main` that changes `skills/**/SKILL.md` or `skills/version.txt` triggers the workflow
- [ ] Confirm the run pushes to `langwatch/skills` (not `langwatch/langwatch`) and the commit/tag appear on the skills repo
- [ ] If the sync script ever regresses, confirm the new guard surfaces a `::error::` annotation instead of a cryptic 403