### PR TITLE
chore(skills-publish): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/skills-publish.yml
+++ b/.github/workflows/skills-publish.yml
@@ -7,6 +7,7 @@ on:
       - 'skills/*/SKILL.md'
       - 'skills/recipes/*/SKILL.md'
       - 'skills/version.txt'
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to `.github/workflows/skills-publish.yml` so the skills-publish workflow can be triggered manually from the Actions UI or `gh workflow run skills-publish.yml`, without needing to bump `skills/version.txt` or touch a `SKILL.md` just to re-run it.

## Test plan

- [ ] After merge, run `gh workflow run skills-publish.yml --repo langwatch/langwatch --ref main` and confirm the run starts and pushes to `langwatch/skills`