### PR TITLE
fix(dev): run port check before start:prepare:files for faster fail

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "pnpm exec biome check src/ --write",
     "format": "pnpm exec biome format src/ --write",
     "postinstall": "make -C .. setup-hooks 2>/dev/null || true",
-    "dev": "pnpm run start:prepare:files && NODE_ENV=development START_WORKERS=true FORCE_COLOR=1 pnpm start 2>&1 | tee server.log",
+    "dev": "NODE_ENV=development START_WORKERS=true ./scripts/check-ports.sh && pnpm run start:prepare:files && NODE_ENV=development START_WORKERS=true FORCE_COLOR=1 pnpm start 2>&1 | tee server.log",
     "dev:vite": "vite",
     "start": "./scripts/start.sh",
     "start:app": "tsx src/server.mts",


### PR DESCRIPTION
## Summary

`pnpm dev` previously ran the port-conflict check **inside `start.sh`**, which is invoked *after* `start:prepare:files` (SDK versions, langevals copy, zod gen, prisma gen, MCP build). A stale dev server on 5560 wasn't detected until ~30s of prep work had already run.

Move `check-ports.sh` to the **first step** of `pnpm dev` so conflicts abort in <2s. The existing call inside `start.sh:8` stays as defense-in-depth for direct `pnpm start` invocations; it's a no-op when ports are free.

## Proof — before/after with a conflicting worktree

Another worktree was already running vite on 5560. With this change, `pnpm dev` aborts in **1.4s** without running prepare:files:

```
> langwatch@3.1.0 dev
> NODE_ENV=development START_WORKERS=true ./scripts/check-ports.sh && pnpm run start:prepare:files && ...

✗ port conflict — refusing to start

  ✗ port 5560 (vite frontend) held by pid 47216: node .../wise-mixing-zebra/.../vite.js
  ✗ port 6560 (api backend)   held by pid 47285: ...
  ✗ port 2999 (worker metrics) held by pid 71029: ...

options:
  1) use a free port slot (vite=5570, api=6570, metrics=3009):
       PORT=5570 pnpm dev
  2) kill the existing langwatch dev tree: ...

pnpm dev  0.39s user  0.36s system  52% cpu  1.434 total
```

Free-port happy path: `NODE_ENV=development START_WORKERS=true PORT=59999 ./scripts/check-ports.sh` → exits 0, no output.

## Test plan

- [x] Conflict case: port held by another worktree → aborts in <2s, before `start:prepare:files`
- [x] Free case: `check-ports.sh` exits 0, no output, proceeds normally
- [x] Non-dev (`NODE_ENV != development`) and Docker (`/.dockerenv`) paths unchanged — `check-ports.sh` still bails out at line 24 of the script