### PR TITLE
fix(evaluators): persist name updates for all evaluator types

### DIFF
--- a/langwatch/src/components/evaluators/EvaluatorEditorDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorEditorDrawer.tsx
@@ -451,7 +451,7 @@ export function EvaluatorEditorDrawer(props: EvaluatorEditorDrawerProps) {
     if (evaluatorId && isWorkflowEvaluator) {
       const formValues = form.getValues();
       const newName = formValues.name.trim();
-      const nameChanged = newName !== (evaluatorQuery.data?.name ?? "");
+      const nameChanged = newName !== (evaluatorQuery.data?.name?.trim() ?? "");
 
       if (nameChanged) {
         updateMutation.mutate({

--- a/langwatch/src/components/evaluators/EvaluatorEditorDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorEditorDrawer.tsx
@@ -280,6 +280,7 @@ export function EvaluatorEditorDrawer(props: EvaluatorEditorDrawerProps) {
   } | null>(null);
   const onLocalConfigChangeRef = useRef(onLocalConfigChange);
   onLocalConfigChangeRef.current = onLocalConfigChange;
+  const initializedForEvaluatorRef = useRef<string | null>(null);
 
   // Initialize form with evaluator data (merging local config if present)
   useEffect(() => {
@@ -293,16 +294,19 @@ export function EvaluatorEditorDrawer(props: EvaluatorEditorDrawerProps) {
       };
       savedFormValuesRef.current = savedValues;
 
-      // Merge local config over DB data if present
-      const formValues = initialLocalConfig
-        ? {
-            name: initialLocalConfig.name,
-            settings: initialLocalConfig.settings ?? savedValues.settings,
-          }
-        : savedValues;
+      // Only reset form on first data load for this evaluator, not on refetches
+      if (initializedForEvaluatorRef.current !== evaluatorQuery.data.id) {
+        initializedForEvaluatorRef.current = evaluatorQuery.data.id;
+        const formValues = initialLocalConfig
+          ? {
+              name: initialLocalConfig.name,
+              settings: initialLocalConfig.settings ?? savedValues.settings,
+            }
+          : savedValues;
 
-      form.reset(formValues);
-      setHasUnsavedChanges(!!initialLocalConfig);
+        form.reset(formValues);
+        setHasUnsavedChanges(!!initialLocalConfig);
+      }
     }
   }, [evaluatorQuery.data, form, initialLocalConfig]);
 
@@ -443,20 +447,31 @@ export function EvaluatorEditorDrawer(props: EvaluatorEditorDrawerProps) {
   const handleSave = useCallback(() => {
     if (!project?.id || !isValid) return;
 
-    // For existing workflow evaluators, we're just "selecting" them, not saving
-    // Call onSave directly without requiring evaluatorType
+    // For existing workflow evaluators, persist name changes via mutation
     if (evaluatorId && isWorkflowEvaluator) {
-      const freshOnSave = getFlowCallbacks("evaluatorEditor")?.onSave ?? onSave;
-      const handledNavigation = freshOnSave?.({
-        id: evaluatorId,
-        name: evaluatorQuery.data?.name ?? "",
-      });
-      if (handledNavigation) return;
-      // Default: go back if there's a stack, otherwise close
-      if (getDrawerStack().length > 1) {
-        goBack();
+      const formValues = form.getValues();
+      const newName = formValues.name.trim();
+      const nameChanged = newName !== (evaluatorQuery.data?.name ?? "");
+
+      if (nameChanged) {
+        updateMutation.mutate({
+          id: evaluatorId,
+          projectId: project.id,
+          name: newName,
+        });
       } else {
-        onClose();
+        const freshOnSave =
+          getFlowCallbacks("evaluatorEditor")?.onSave ?? onSave;
+        const handledNavigation = freshOnSave?.({
+          id: evaluatorId,
+          name: evaluatorQuery.data?.name ?? "",
+        });
+        if (handledNavigation) return;
+        if (getDrawerStack().length > 1) {
+          goBack();
+        } else {
+          onClose();
+        }
       }
       return;
     }

--- a/langwatch/src/components/evaluators/__tests__/EvaluatorEditorDrawer.test.tsx
+++ b/langwatch/src/components/evaluators/__tests__/EvaluatorEditorDrawer.test.tsx
@@ -363,6 +363,44 @@ describe("EvaluatorEditorDrawer — name update regression (#3442)", () => {
         }),
       );
     });
+
+    it("does not call updateMutation when name is unchanged", async () => {
+      const user = userEvent.setup();
+
+      mockGetByIdData.current = {
+        id: "eval-wf-2",
+        projectId: "test-project-id",
+        name: "Unchanged Name",
+        type: "workflow",
+        workflowId: "workflow-2",
+        config: {},
+        fields: [],
+        outputFields: [],
+        slug: "unchanged-name",
+        archivedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        copiedFromEvaluatorId: null,
+      };
+
+      render(
+        <EvaluatorEditorDrawer
+          open={true}
+          evaluatorId="eval-wf-2"
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("evaluator-name-input")).toBeInTheDocument();
+      });
+
+      // Click save without changing the name
+      const saveButton = screen.getByTestId("save-evaluator-button");
+      await user.click(saveButton);
+
+      expect(mockUpdateMutate).not.toHaveBeenCalled();
+    });
   });
 
   describe("when query refetches while user is editing", () => {

--- a/langwatch/src/components/evaluators/__tests__/EvaluatorEditorDrawer.test.tsx
+++ b/langwatch/src/components/evaluators/__tests__/EvaluatorEditorDrawer.test.tsx
@@ -65,12 +65,23 @@ vi.mock("~/hooks/useDrawer", () => ({
     closeDrawer: mockCloseDrawer,
     openDrawer: mockOpenDrawer,
     drawerOpen: vi.fn(() => false),
+    canGoBack: false,
+    goBack: vi.fn(),
   }),
   getComplexProps: () => ({
     evaluatorType: "langevals/exact_match",
     category: "expected_answer",
   }),
   useDrawerParams: () => ({ category: "expected_answer" }),
+  getDrawerStack: () => [],
+  getFlowCallbacks: () => null,
+  setFlowCallbacks: vi.fn(),
+}));
+
+vi.mock("~/hooks/useLicenseEnforcement", () => ({
+  useLicenseEnforcement: () => ({
+    checkAndProceed: (fn: () => void) => fn(),
+  }),
 }));
 
 vi.mock("~/hooks/useOrganizationTeamProject", () => ({
@@ -84,6 +95,8 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 
 // Mock the tRPC API
 const mockCreateMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockGetByIdData = { current: null as Record<string, unknown> | null };
 
 vi.mock("~/utils/api", () => ({
   api: {
@@ -96,13 +109,13 @@ vi.mock("~/utils/api", () => ({
       },
       getById: {
         useQuery: vi.fn(() => ({
-          data: null,
+          data: mockGetByIdData.current,
           isLoading: false,
         })),
       },
       update: {
         useMutation: vi.fn(() => ({
-          mutate: vi.fn(),
+          mutate: mockUpdateMutate,
           isPending: false,
         })),
       },
@@ -283,6 +296,131 @@ describe.skip("EvaluatorEditorDrawer", () => {
         // Check for SVG - LuArrowLeft renders as SVG
         const svg = backButton.querySelector("svg");
         expect(svg).toBeInTheDocument();
+      });
+    });
+  });
+});
+
+/**
+ * Regression tests for bug #3442: Evaluator name update does not persist.
+ * These use the module-level mocks but override getById data per test.
+ */
+describe("EvaluatorEditorDrawer — name update regression (#3442)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetByIdData.current = null;
+  });
+
+  afterEach(() => {
+    mockGetByIdData.current = null;
+    cleanup();
+  });
+
+  describe("when editing a workflow evaluator name", () => {
+    it("calls updateMutation with the new name", async () => {
+      const user = userEvent.setup();
+
+      mockGetByIdData.current = {
+        id: "eval-wf-1",
+        projectId: "test-project-id",
+        name: "Original Workflow Name",
+        type: "workflow",
+        workflowId: "workflow-1",
+        config: {},
+        fields: [],
+        outputFields: [],
+        slug: "original-workflow-name",
+        archivedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        copiedFromEvaluatorId: null,
+      };
+
+      render(
+        <EvaluatorEditorDrawer
+          open={true}
+          evaluatorId="eval-wf-1"
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("evaluator-name-input")).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByTestId("evaluator-name-input");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Updated Workflow Name");
+
+      const saveButton = screen.getByTestId("save-evaluator-button");
+      await user.click(saveButton);
+
+      expect(mockUpdateMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "eval-wf-1",
+          projectId: "test-project-id",
+          name: "Updated Workflow Name",
+        }),
+      );
+    });
+  });
+
+  describe("when query refetches while user is editing", () => {
+    it("preserves user edits and does not reset the form", async () => {
+      const user = userEvent.setup();
+
+      mockGetByIdData.current = {
+        id: "eval-bi-1",
+        projectId: "test-project-id",
+        name: "DB Name",
+        type: "evaluator",
+        config: { evaluatorType: "langevals/exact_match", settings: {} },
+        fields: [],
+        outputFields: [],
+        slug: "db-name",
+        archivedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        copiedFromEvaluatorId: null,
+        workflowId: null,
+      };
+
+      const { rerender } = render(
+        <EvaluatorEditorDrawer
+          open={true}
+          evaluatorId="eval-bi-1"
+          evaluatorType="langevals/exact_match"
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("evaluator-name-input")).toBeInTheDocument();
+      });
+
+      // User types a new name
+      const nameInput = screen.getByTestId("evaluator-name-input");
+      await user.clear(nameInput);
+      await user.type(nameInput, "My New Name");
+
+      expect(nameInput).toHaveValue("My New Name");
+
+      // Simulate query refetch (new object reference, same data)
+      mockGetByIdData.current = { ...mockGetByIdData.current };
+
+      rerender(
+        <EvaluatorEditorDrawer
+          open={true}
+          evaluatorId="eval-bi-1"
+          evaluatorType="langevals/exact_match"
+        />,
+      );
+
+      // Name should still be the user's edit, not reset to DB value
+      await waitFor(() => {
+        expect(screen.getByTestId("evaluator-name-input")).toHaveValue(
+          "My New Name",
+        );
       });
     });
   });

--- a/langwatch/src/server/api/routers/agents.ts
+++ b/langwatch/src/server/api/routers/agents.ts
@@ -154,9 +154,11 @@ export const agentsRouter = createTRPCRouter({
         id: input.id,
         projectId: input.projectId,
         data: {
-          ...(input.name && { name: input.name }),
-          ...(input.type && { type: input.type }),
-          ...(input.config && { config: input.config as AgentComponentConfig }),
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.type !== undefined && { type: input.type }),
+          ...(input.config !== undefined && {
+            config: input.config as AgentComponentConfig,
+          }),
           ...(input.workflowId !== undefined && {
             workflowId: input.workflowId,
           }),

--- a/langwatch/src/server/api/routers/evaluators.ts
+++ b/langwatch/src/server/api/routers/evaluators.ts
@@ -136,9 +136,9 @@ export const evaluatorsRouter = createTRPCRouter({
         id: input.id,
         projectId: input.projectId,
         data: {
-          ...(input.name && { name: input.name }),
-          ...(input.type && { type: input.type }),
-          ...(input.config && {
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.type !== undefined && { type: input.type }),
+          ...(input.config !== undefined && {
             config: input.config as Prisma.InputJsonValue,
           }),
           ...(input.workflowId !== undefined && {


### PR DESCRIPTION
Closes #3442

## Summary

- **Workflow evaluators:** `handleSave` was returning early without calling `updateMutation.mutate()`, so name changes were never persisted. Now checks if name changed and calls the mutation.
- **Form reset guard:** `useEffect` unconditionally reset the form on every `evaluatorQuery.data` change (e.g., window refocus refetch), overwriting user edits. Now uses `initializedForEvaluatorRef` to only reset on first data load per evaluator ID.
- **Router consistency:** Changed `input.name &&` to `input.name !== undefined &&` (and same for `type`, `config`) to match the existing `workflowId` pattern.
- **Sweep:** Applied the same `!== undefined` fix to `agents.ts` router (identical pattern).

## Test plan

- [x] Regression test: workflow evaluator name update calls `updateMutation` with new name
- [x] Regression test: form preserves user edits when query refetches
- [x] Existing integration tests pass (22/22)
- [x] Typecheck passes
- [x] Sweep: zero `input.X &&` patterns remain across all routers