### PR TITLE
fix(studio): merge localPromptConfig into parameters on workflow save

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
@@ -60,10 +60,16 @@ describe("saveOrCommitWorkflowVersion", () => {
   });
 
   afterAll(async () => {
-    // Unset FK references before deleting to avoid circular dependency
+    // Unset all FK references before deleting to avoid circular dependencies
+    // (Workflow → WorkflowVersion via latestVersionId/currentVersionId,
+    //  WorkflowVersion → WorkflowVersion via parentId)
     await prisma.workflow.updateMany({
       where: { projectId },
       data: { latestVersionId: null, currentVersionId: null },
+    });
+    await prisma.workflowVersion.updateMany({
+      where: { projectId },
+      data: { parentId: null },
     });
     await prisma.workflowVersion.deleteMany({ where: { projectId } });
     await prisma.workflow.deleteMany({ where: { projectId } });

--- a/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
@@ -32,6 +32,7 @@ describe("saveOrCommitWorkflowVersion", () => {
         id: teamId,
         slug: `test-team-${nanoid(6)}`,
         name: "Test Team",
+        // organizationId has no FK constraint (Prisma relationMode = "prisma")
         organizationId: `test_org_${nanoid(8)}`,
         members: { create: { userId, role: "ADMIN" } },
       },
@@ -116,7 +117,8 @@ describe("saveOrCommitWorkflowVersion", () => {
       expect(instructions?.value).toContain("strict boolean evaluator");
       expect(instructions?.value).not.toContain("helpful assistant");
 
-      // Messages must reference the evaluation inputs
+      // mergeLocalConfigsIntoDsl splits the system message into instructions
+      // and keeps only non-system messages in the messages parameter
       expect(messages?.value).toEqual([
         { role: "user", content: "{{input}}" },
       ]);

--- a/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
@@ -60,9 +60,8 @@ describe("saveOrCommitWorkflowVersion", () => {
   });
 
   afterAll(async () => {
-    // Unset all FK references before deleting to avoid circular dependencies
-    // (Workflow → WorkflowVersion via latestVersionId/currentVersionId,
-    //  WorkflowVersion → WorkflowVersion via parentId)
+    // Delete in reverse dependency order, nulling circular FKs first.
+    // CI enforces real FK constraints unlike local (relationMode = "prisma").
     await prisma.workflow.updateMany({
       where: { projectId },
       data: { latestVersionId: null, currentVersionId: null },
@@ -74,6 +73,9 @@ describe("saveOrCommitWorkflowVersion", () => {
     await prisma.workflowVersion.deleteMany({ where: { projectId } });
     await prisma.workflow.deleteMany({ where: { projectId } });
     await prisma.project.deleteMany({ where: { id: projectId } });
+    await prisma.$executeRawUnsafe(
+      `DELETE FROM "TeamUser" WHERE "teamId" = '${teamId}'`,
+    );
     await prisma.team.deleteMany({ where: { id: teamId } });
     await prisma.user.deleteMany({ where: { id: userId } });
   });

--- a/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { nanoid } from "nanoid";
+import type { Session } from "~/server/auth";
+import { prisma } from "~/server/db";
+import { saveOrCommitWorkflowVersion } from "../workflows";
+
+/**
+ * Integration test for saveOrCommitWorkflowVersion.
+ *
+ * Verifies that localPromptConfig is merged into parameters before
+ * persisting — the root cause of #3437 where workflow evaluators
+ * used a stale prompt when triggered from trace monitors.
+ */
+describe("saveOrCommitWorkflowVersion", () => {
+  const projectId = `test_project_${nanoid(8)}`;
+  const userId = `test_user_${nanoid(8)}`;
+  const teamId = `test_team_${nanoid(8)}`;
+  const workflowId = `test_workflow_${nanoid(8)}`;
+
+  const ctx = {
+    prisma: prisma as PrismaClient,
+    session: { user: { id: userId } } as Session,
+  };
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: userId, email: `${userId}@test.com`, name: "Test User" },
+    });
+    const team = await prisma.team.create({
+      data: {
+        id: teamId,
+        slug: `test-team-${nanoid(6)}`,
+        name: "Test Team",
+        organizationId: `test_org_${nanoid(8)}`,
+        members: { create: { userId, role: "ADMIN" } },
+      },
+    });
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        name: "Test Project",
+        slug: `test-${nanoid(6)}`,
+        teamId: team.id,
+        language: "en",
+        framework: "custom",
+        apiKey: `sk-test-${nanoid(12)}`,
+      },
+    });
+    await prisma.workflow.create({
+      data: {
+        id: workflowId,
+        projectId,
+        name: "Test Workflow",
+        icon: "🧪",
+        description: "test",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.workflowVersion.deleteMany({ where: { projectId } });
+    await prisma.workflow.deleteMany({ where: { projectId } });
+    await prisma.project.deleteMany({ where: { id: projectId } });
+    await prisma.team.deleteMany({ where: { id: teamId } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+  });
+
+  describe("when a signature node has localPromptConfig", () => {
+    it("merges localPromptConfig into parameters in the persisted DSL", async () => {
+      const dsl = buildDslWithLocalPromptConfig({
+        oldInstructions: "You are a helpful assistant.",
+        oldMessages: [{ role: "user", content: "{{input}}" }],
+        localPromptConfig: {
+          llm: { model: "openai/gpt-5-mini", temperature: 0.5 },
+          messages: [
+            {
+              role: "system",
+              content:
+                "You are a strict boolean evaluator.\n\nCheck if classifier_output matches fetch_report_code_input.\n\n- fetch_report_code_input: {{fetch_report_code_input}}\n- classifier_output: {{classifier_output}}",
+            },
+            { role: "user", content: "{{input}}" },
+          ],
+          inputs: [
+            { identifier: "input", type: "str" },
+            { identifier: "classifier_output", type: "str" },
+            { identifier: "fetch_report_code_input", type: "str" },
+          ],
+          outputs: [
+            { identifier: "passed", type: "bool" },
+            { identifier: "reason", type: "str" },
+          ],
+        },
+      });
+
+      const version = await saveOrCommitWorkflowVersion({
+        ctx,
+        input: { projectId, workflowId, dsl },
+        autoSaved: false,
+        commitMessage: "test localPromptConfig merge",
+      });
+
+      const savedDsl = version.dsl as any;
+      const signatureNode = savedDsl.nodes.find(
+        (n: any) => n.type === "signature",
+      );
+      expect(signatureNode).toBeDefined();
+
+      const params = signatureNode.data.parameters;
+      const instructions = params.find(
+        (p: any) => p.identifier === "instructions",
+      );
+      const messages = params.find((p: any) => p.identifier === "messages");
+
+      // The NEW prompt must be in parameters, not the old one
+      expect(instructions?.value).toContain("strict boolean evaluator");
+      expect(instructions?.value).not.toContain("helpful assistant");
+
+      // Messages must reference the evaluation inputs
+      expect(messages?.value).toEqual([
+        { role: "user", content: "{{input}}" },
+      ]);
+
+      // localPromptConfig must be stripped
+      expect(signatureNode.data.localPromptConfig).toBeUndefined();
+
+      // Inputs/outputs must reflect the local config
+      expect(signatureNode.data.inputs).toEqual([
+        { identifier: "input", type: "str" },
+        { identifier: "classifier_output", type: "str" },
+        { identifier: "fetch_report_code_input", type: "str" },
+      ]);
+    });
+  });
+
+  describe("when a signature node has NO localPromptConfig", () => {
+    it("preserves parameters as-is", async () => {
+      const dsl = buildDslWithoutLocalPromptConfig({
+        instructions: "You are a bias evaluator.",
+        messages: [{ role: "user", content: "Evaluate: {{output}}" }],
+      });
+
+      const version = await saveOrCommitWorkflowVersion({
+        ctx,
+        input: { projectId, workflowId, dsl },
+        autoSaved: false,
+        commitMessage: "test no localPromptConfig",
+      });
+
+      const savedDsl = version.dsl as any;
+      const signatureNode = savedDsl.nodes.find(
+        (n: any) => n.type === "signature",
+      );
+      const instructions = signatureNode.data.parameters.find(
+        (p: any) => p.identifier === "instructions",
+      );
+
+      expect(instructions?.value).toBe("You are a bias evaluator.");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildDslWithLocalPromptConfig({
+  oldInstructions,
+  oldMessages,
+  localPromptConfig,
+}: {
+  oldInstructions: string;
+  oldMessages: Array<{ role: string; content: string }>;
+  localPromptConfig: any;
+}) {
+  return {
+    workflow_id: "test",
+    spec_version: "1.3",
+    name: "Test Workflow",
+    icon: "🧪",
+    description: "test",
+    version: "1",
+    nodes: [
+      {
+        id: "entry",
+        type: "entry",
+        position: { x: 0, y: 0 },
+        data: {
+          name: "Entry",
+          outputs: [{ identifier: "input", type: "str" }],
+        },
+      },
+      {
+        id: "llm_call",
+        type: "signature",
+        position: { x: 200, y: 0 },
+        data: {
+          name: "Prompt",
+          inputs: [{ identifier: "input", type: "str" }],
+          outputs: [{ identifier: "output", type: "str" }],
+          parameters: [
+            {
+              identifier: "llm",
+              type: "llm",
+              value: { model: "openai/gpt-5-mini" },
+            },
+            {
+              identifier: "instructions",
+              type: "str",
+              value: oldInstructions,
+            },
+            {
+              identifier: "messages",
+              type: "chat_messages",
+              value: oldMessages,
+            },
+          ],
+          localPromptConfig,
+        },
+      },
+    ],
+    edges: [],
+    state: {},
+  } as any;
+}
+
+function buildDslWithoutLocalPromptConfig({
+  instructions,
+  messages,
+}: {
+  instructions: string;
+  messages: Array<{ role: string; content: string }>;
+}) {
+  return buildDslWithLocalPromptConfig({
+    oldInstructions: instructions,
+    oldMessages: messages,
+    localPromptConfig: undefined,
+  });
+}

--- a/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
@@ -166,6 +166,8 @@ describe("saveOrCommitWorkflowVersion", () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
+let versionCounter = 0;
+
 function buildDslWithLocalPromptConfig({
   oldInstructions,
   oldMessages,
@@ -175,13 +177,14 @@ function buildDslWithLocalPromptConfig({
   oldMessages: Array<{ role: string; content: string }>;
   localPromptConfig: any;
 }) {
+  versionCounter++;
   return {
     workflow_id: "test",
     spec_version: "1.3",
     name: "Test Workflow",
     icon: "🧪",
     description: "test",
-    version: "1",
+    version: `${versionCounter}`,
     nodes: [
       {
         id: "entry",

--- a/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
@@ -60,6 +60,11 @@ describe("saveOrCommitWorkflowVersion", () => {
   });
 
   afterAll(async () => {
+    // Unset FK references before deleting to avoid circular dependency
+    await prisma.workflow.updateMany({
+      where: { projectId },
+      data: { latestVersionId: null, currentVersionId: null },
+    });
     await prisma.workflowVersion.deleteMany({ where: { projectId } });
     await prisma.workflow.deleteMany({ where: { projectId } });
     await prisma.project.deleteMany({ where: { id: projectId } });

--- a/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
-import type { PrismaClient } from "@prisma/client";
 import { nanoid } from "nanoid";
-import type { Session } from "~/server/auth";
+import { getTestUser } from "~/utils/testUtils";
 import { prisma } from "~/server/db";
 import { saveOrCommitWorkflowVersion } from "../workflows";
+import type { Session } from "~/server/auth";
 
 /**
  * Integration test for saveOrCommitWorkflowVersion.
@@ -13,41 +13,15 @@ import { saveOrCommitWorkflowVersion } from "../workflows";
  * used a stale prompt when triggered from trace monitors.
  */
 describe("saveOrCommitWorkflowVersion", () => {
-  const projectId = `test_project_${nanoid(8)}`;
-  const userId = `test_user_${nanoid(8)}`;
-  const teamId = `test_team_${nanoid(8)}`;
   const workflowId = `test_workflow_${nanoid(8)}`;
-
-  const ctx = {
-    prisma: prisma as PrismaClient,
-    session: { user: { id: userId } } as Session,
-  };
+  let projectId: string;
+  let userId: string;
 
   beforeAll(async () => {
-    await prisma.user.create({
-      data: { id: userId, email: `${userId}@test.com`, name: "Test User" },
-    });
-    const team = await prisma.team.create({
-      data: {
-        id: teamId,
-        slug: `test-team-${nanoid(6)}`,
-        name: "Test Team",
-        // organizationId has no FK constraint (Prisma relationMode = "prisma")
-        organizationId: `test_org_${nanoid(8)}`,
-        members: { create: { userId, role: "ADMIN" } },
-      },
-    });
-    await prisma.project.create({
-      data: {
-        id: projectId,
-        name: "Test Project",
-        slug: `test-${nanoid(6)}`,
-        teamId: team.id,
-        language: "en",
-        framework: "custom",
-        apiKey: `sk-test-${nanoid(12)}`,
-      },
-    });
+    const user = await getTestUser();
+    projectId = "test-project-id";
+    userId = user.id;
+
     await prisma.workflow.create({
       data: {
         id: workflowId,
@@ -60,31 +34,30 @@ describe("saveOrCommitWorkflowVersion", () => {
   });
 
   afterAll(async () => {
-    // Delete in reverse dependency order, nulling circular FKs first.
-    // CI enforces real FK constraints unlike local (relationMode = "prisma").
-    await prisma.workflow.updateMany({
-      where: { projectId },
-      data: { latestVersionId: null, currentVersionId: null },
-    });
-    await prisma.workflowVersion.updateMany({
-      where: { projectId },
-      data: { parentId: null },
-    });
-    await prisma.workflowVersion.deleteMany({ where: { projectId } });
-    await prisma.workflow.deleteMany({ where: { projectId } });
-    await prisma.project.deleteMany({ where: { id: projectId } });
-    await prisma.$executeRawUnsafe(
-      `DELETE FROM "TeamUser" WHERE "teamId" = '${teamId}'`,
-    );
-    await prisma.team.deleteMany({ where: { id: teamId } });
-    await prisma.user.deleteMany({ where: { id: userId } });
+    await prisma.workflow
+      .update({
+        where: { id: workflowId, projectId },
+        data: { latestVersionId: null, currentVersionId: null },
+      })
+      .catch(() => {});
+    await prisma.workflowVersion
+      .deleteMany({ where: { workflowId, projectId } })
+      .catch(() => {});
+    await prisma.workflow
+      .delete({ where: { id: workflowId, projectId } })
+      .catch(() => {});
+  });
+
+  const getCtx = () => ({
+    prisma,
+    session: { user: { id: userId } } as Session,
   });
 
   describe("when a signature node has localPromptConfig", () => {
     it("merges localPromptConfig into parameters in the persisted DSL", async () => {
-      const dsl = buildDslWithLocalPromptConfig({
-        oldInstructions: "You are a helpful assistant.",
-        oldMessages: [{ role: "user", content: "{{input}}" }],
+      const dsl = buildDsl({
+        instructions: "You are a helpful assistant.",
+        messages: [{ role: "user", content: "{{input}}" }],
         localPromptConfig: {
           llm: { model: "openai/gpt-5-mini", temperature: 0.5 },
           messages: [
@@ -108,7 +81,7 @@ describe("saveOrCommitWorkflowVersion", () => {
       });
 
       const version = await saveOrCommitWorkflowVersion({
-        ctx,
+        ctx: getCtx(),
         input: { projectId, workflowId, dsl },
         autoSaved: false,
         commitMessage: "test localPromptConfig merge",
@@ -150,13 +123,13 @@ describe("saveOrCommitWorkflowVersion", () => {
 
   describe("when a signature node has NO localPromptConfig", () => {
     it("preserves parameters as-is", async () => {
-      const dsl = buildDslWithoutLocalPromptConfig({
+      const dsl = buildDsl({
         instructions: "You are a bias evaluator.",
         messages: [{ role: "user", content: "Evaluate: {{output}}" }],
       });
 
       const version = await saveOrCommitWorkflowVersion({
-        ctx,
+        ctx: getCtx(),
         input: { projectId, workflowId, dsl },
         autoSaved: false,
         commitMessage: "test no localPromptConfig",
@@ -181,14 +154,14 @@ describe("saveOrCommitWorkflowVersion", () => {
 
 let versionCounter = 0;
 
-function buildDslWithLocalPromptConfig({
-  oldInstructions,
-  oldMessages,
+function buildDsl({
+  instructions,
+  messages,
   localPromptConfig,
 }: {
-  oldInstructions: string;
-  oldMessages: Array<{ role: string; content: string }>;
-  localPromptConfig: any;
+  instructions: string;
+  messages: Array<{ role: string; content: string }>;
+  localPromptConfig?: any;
 }) {
   versionCounter++;
   return {
@@ -222,15 +195,11 @@ function buildDslWithLocalPromptConfig({
               type: "llm",
               value: { model: "openai/gpt-5-mini" },
             },
-            {
-              identifier: "instructions",
-              type: "str",
-              value: oldInstructions,
-            },
+            { identifier: "instructions", type: "str", value: instructions },
             {
               identifier: "messages",
               type: "chat_messages",
-              value: oldMessages,
+              value: messages,
             },
           ],
           localPromptConfig,
@@ -240,18 +209,4 @@ function buildDslWithLocalPromptConfig({
     edges: [],
     state: {},
   } as any;
-}
-
-function buildDslWithoutLocalPromptConfig({
-  instructions,
-  messages,
-}: {
-  instructions: string;
-  messages: Array<{ role: string; content: string }>;
-}) {
-  return buildDslWithLocalPromptConfig({
-    oldInstructions: instructions,
-    oldMessages: messages,
-    localPromptConfig: undefined,
-  });
 }

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -11,6 +11,7 @@ import {
   type Workflow,
   workflowJsonSchema,
 } from "../../../optimization_studio/types/dsl";
+import { mergeLocalConfigsIntoDsl } from "../../../optimization_studio/utils/mergeLocalConfigs";
 import { migrateDSLVersion } from "../../../optimization_studio/types/migrate";
 import {
   clearDsl,
@@ -1287,12 +1288,12 @@ export const saveOrCommitWorkflowVersion = async ({
   const [versionMajor] = (latestVersion?.version ?? "0.0").split(".");
   const nextVersion = `${parseInt(versionMajor ?? "0") + 1}`;
 
-  const dslWithoutStates = JSON.parse(
-    JSON.stringify({
-      ...input.dsl,
-      state: {},
-    }),
-  );
+  const dslWithMergedConfigs = {
+    ...input.dsl,
+    nodes: mergeLocalConfigsIntoDsl(input.dsl.nodes as any) as any,
+    state: {},
+  };
+  const dslWithoutStates = JSON.parse(JSON.stringify(dslWithMergedConfigs));
   const data = {
     commitMessage,
     authorId: ctx.session.user.id,

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -1288,6 +1288,10 @@ export const saveOrCommitWorkflowVersion = async ({
   const [versionMajor] = (latestVersion?.version ?? "0.0").split(".");
   const nextVersion = `${parseInt(versionMajor ?? "0") + 1}`;
 
+  // Cast required: input.dsl.nodes is z.array(z.any()) from the Zod schema,
+  // while mergeLocalConfigsIntoDsl expects Node<Component>[]. The Zod schema
+  // uses z.any() for nodes because the DSL node types are too polymorphic
+  // for a single Zod discriminated union.
   const dslWithMergedConfigs = {
     ...input.dsl,
     nodes: mergeLocalConfigsIntoDsl(input.dsl.nodes as any) as any,


### PR DESCRIPTION
## Why

Closes #3437

Workflow evaluators using Prompt (signature) nodes always failed when triggered from trace monitors, even though they worked correctly in the workflow editor. A customer reported that their "classifier relevance" evaluator consistently failed on traces with generic LLM responses ("I don't have access to the data...") while passing when run from the editor.

## What changed

Call `mergeLocalConfigsIntoDsl()` in `saveOrCommitWorkflowVersion()` before persisting the DSL. This function already existed and was called by all 5 editor execution hooks, but was never called on save — so `parameters` (read by the backend) stayed stale while `localPromptConfig` (used by the editor) had the correct prompt.

The fix is a single call site in `saveOrCommitWorkflowVersion`, which is the chokepoint for all 10 workflow save paths (workflows, experiments, evaluators, agents).

## How it works

The workflow editor stores prompt edits in `localPromptConfig` on the node data. The backend (`llm.py.jinja`) reads `parameters.instructions` and `parameters.messages` to build the LLM prompt. These two were never synced on save:

- **Before**: `localPromptConfig` saved as-is, `parameters` retained creation-time values → backend used stale prompt
- **After**: `mergeLocalConfigsIntoDsl()` runs on save → extracts system message into `parameters.instructions`, non-system messages into `parameters.messages`, strips `localPromptConfig` → backend gets the correct prompt

## Test plan

- **Integration test**: `workflows.saveOrCommit.integration.test.ts` — verifies `localPromptConfig` is merged into `parameters` in the persisted DSL, and that nodes without `localPromptConfig` pass through unchanged
- **Manual E2E reproduction**: Created a workflow evaluator with a Code → Prompt pipeline, set up a monitor with span-level trace mappings, sent multi-span traces via populator. Before fix: evaluator always failed with stale prompt. After fix: evaluator passes with correct entity matching
- **Existing unit tests**: All 16 `mergeLocalConfigs.unit.test.ts` tests pass (the merge logic itself is unchanged)

## Anything surprising?

- Existing broken workflows require one re-save + re-publish cycle. The correct prompt is already in `localPromptConfig` in the current version — the fix syncs it to `parameters` on the next save. No data migration needed.
- The `as any` casts on the merge call are forced by `z.array(z.any())` in the workflow Zod schema. Tracked as a follow-up to tighten the schema boundary.