### PR TITLE
feat(simulations): run again navigates to runs list, not nested drawer

### DIFF
--- a/langwatch/src/hooks/__tests__/useDrawerRunCallbacks.test.tsx
+++ b/langwatch/src/hooks/__tests__/useDrawerRunCallbacks.test.tsx
@@ -5,37 +5,41 @@ import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useDrawerRunCallbacks } from "../useDrawerRunCallbacks";
 
-const mockOpenDrawer = vi.hoisted(() => vi.fn());
+const mockPush = vi.hoisted(() => vi.fn());
 
-vi.mock("~/hooks/useDrawer", () => ({
-  useDrawer: () => ({
-    openDrawer: mockOpenDrawer,
-    closeDrawer: vi.fn(),
-  }),
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("../useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { slug: "proj-slug" } }),
 }));
 
 describe("useDrawerRunCallbacks()", () => {
-  describe("when onRunComplete is called", () => {
-    it("opens the scenarioRunDetail drawer with the run id", () => {
+  describe("when onRunComplete is called with a batchRunId", () => {
+    it("navigates to the simulations page with the batch highlighted", () => {
+      mockPush.mockClear();
       const { result } = renderHook(() => useDrawerRunCallbacks());
 
-      result.current.onRunComplete({ scenarioRunId: "run-abc" });
-
-      expect(mockOpenDrawer).toHaveBeenCalledWith("scenarioRunDetail", {
-        urlParams: { scenarioRunId: "run-abc" },
+      result.current.onRunComplete({
+        scenarioRunId: "run-abc",
+        batchRunId: "batch-123",
       });
+
+      expect(mockPush).toHaveBeenCalledWith(
+        "/proj-slug/simulations?pendingBatch=batch-123",
+      );
     });
   });
 
-  describe("when onRunFailed is called", () => {
-    it("opens the scenarioRunDetail drawer with the run id", () => {
+  describe("when onRunFailed is called without a batchRunId", () => {
+    it("navigates to the simulations page without query params", () => {
+      mockPush.mockClear();
       const { result } = renderHook(() => useDrawerRunCallbacks());
 
       result.current.onRunFailed({ scenarioRunId: "run-xyz" });
 
-      expect(mockOpenDrawer).toHaveBeenCalledWith("scenarioRunDetail", {
-        urlParams: { scenarioRunId: "run-xyz" },
-      });
+      expect(mockPush).toHaveBeenCalledWith("/proj-slug/simulations");
     });
   });
 });

--- a/langwatch/src/hooks/useDrawerRunCallbacks.ts
+++ b/langwatch/src/hooks/useDrawerRunCallbacks.ts
@@ -1,22 +1,29 @@
 import { useCallback } from "react";
-import { useDrawer } from "./useDrawer";
+import { useRouter } from "~/utils/compat/next-router";
+import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
 
 /**
- * Returns callbacks that navigate to the scenario run detail drawer.
+ * Returns callbacks that navigate to the simulations page (runs list)
+ * when a scenario run completes or fails.
  *
- * Shared between ScenarioRunDetailDrawer and ScenarioFormDrawer to avoid
- * duplicating the `openDrawer("scenarioRunDetail", ...)` pattern.
+ * Mirrors the navigation behavior already used by ScenarioFormDrawer on
+ * its initial Save-and-Run, so "Run Again" from a run-detail drawer
+ * lands the user on the runs list with the new batch highlighted
+ * instead of stacking another drawer on the same page.
  */
 export function useDrawerRunCallbacks() {
-  const { openDrawer } = useDrawer();
+  const router = useRouter();
+  const { project } = useOrganizationTeamProject();
 
   const onRunComplete = useCallback(
-    (result: { scenarioRunId: string }) => {
-      openDrawer("scenarioRunDetail", {
-        urlParams: { scenarioRunId: result.scenarioRunId },
-      });
+    (result: { scenarioRunId: string; batchRunId?: string }) => {
+      if (!project?.slug) return;
+      const query = result.batchRunId
+        ? `?pendingBatch=${result.batchRunId}`
+        : "";
+      void router.push(`/${project.slug}/simulations${query}`);
     },
-    [openDrawer],
+    [router, project?.slug],
   );
 
   return { onRunComplete, onRunFailed: onRunComplete };

--- a/langwatch/src/hooks/useDrawerRunCallbacks.ts
+++ b/langwatch/src/hooks/useDrawerRunCallbacks.ts
@@ -17,6 +17,8 @@ export function useDrawerRunCallbacks() {
 
   const onRunComplete = useCallback(
     (result: { scenarioRunId: string; batchRunId?: string }) => {
+      // Transient null during initial auth/project resolve. By the time a
+      // user can click Run Again from a drawer, project.slug is present.
       if (!project?.slug) return;
       const query = result.batchRunId
         ? `?pendingBatch=${result.batchRunId}`


### PR DESCRIPTION
## Summary

When the user clicks **Run Again** from inside the scenario run detail drawer, the new run currently opens *another* drawer stacked on the same page — instead of taking the user to the runs view where they can actually watch it through.

## Change

`useDrawerRunCallbacks` now does `router.push('/<slug>/simulations?pendingBatch=<batchRunId>')` instead of `openDrawer('scenarioRunDetail', ...)`.

This mirrors the navigation pattern already used by `ScenarioFormDrawer.tsx:287` on its Save-and-Run flow, so the two entry points behave consistently. The `pendingBatch` query param is what the simulations page uses to highlight a freshly-fired batch.

## Test plan

- [x] Updated unit test for `useDrawerRunCallbacks` (mocks router + project — asserts `push` called with the right URL with and without `batchRunId`)
- [x] Manually click Run Again on a scenario run detail drawer → lands on `/<project>/simulations?pendingBatch=...` with the new run visible
- [x] Existing ScenarioFormDrawer Save-and-Run flow still navigates the same way (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)