### PR TITLE
fix(evaluations-v3): mapping + tooltip bugs (sweep for #3441)

### DIFF
--- a/langwatch/src/evaluations-v3/__tests__/TableDisplay.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/TableDisplay.integration.test.tsx
@@ -218,19 +218,19 @@ describe("Row height mode", () => {
       expect(store.ui.rowHeightMode).toBe("compact");
     });
 
-    it("setRowHeightMode changes mode to expanded", () => {
+    it("setRowHeightMode changes mode to fit", () => {
       const store = useEvaluationsV3Store.getState();
 
-      store.setRowHeightMode("expanded");
+      store.setRowHeightMode("fit");
 
       const updatedStore = useEvaluationsV3Store.getState();
-      expect(updatedStore.ui.rowHeightMode).toBe("expanded");
+      expect(updatedStore.ui.rowHeightMode).toBe("fit");
     });
 
     it("setRowHeightMode changes mode back to compact", () => {
       const store = useEvaluationsV3Store.getState();
 
-      store.setRowHeightMode("expanded");
+      store.setRowHeightMode("fit");
       store.setRowHeightMode("compact");
 
       const updatedStore = useEvaluationsV3Store.getState();
@@ -247,7 +247,7 @@ describe("Row height mode", () => {
       ).toBe(true);
 
       // Switch mode
-      store.setRowHeightMode("expanded");
+      store.setRowHeightMode("fit");
 
       const updatedStore = useEvaluationsV3Store.getState();
       expect(updatedStore.ui.expandedCells.size).toBe(0);

--- a/langwatch/src/evaluations-v3/__tests__/TableDisplay.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/TableDisplay.integration.test.tsx
@@ -638,7 +638,7 @@ describe("TargetHeader stability", () => {
 // phantom row (Excel-style "click to add"), but target columns must NOT
 // render content for phantom rows — no input = nothing to run. Dataset cells
 // keep their click-to-add affordance for the phantom row.
-describe("Phantom empty row suppresses target cell content", () => {
+describe("phantom empty rows", () => {
   beforeEach(() => {
     useEvaluationsV3Store.getState().reset();
   });
@@ -648,60 +648,73 @@ describe("Phantom empty row suppresses target cell content", () => {
     vi.clearAllMocks();
   });
 
-  it("renders target cell content only for populated rows, not phantom rows", async () => {
-    const store = useEvaluationsV3Store.getState();
-
-    // Seed a dataset with exactly 2 populated rows. displayRowCount is
-    // max(rowCount + 1, 3) = max(3, 3) = 3, so rows 0..1 are populated and
-    // row 2 is the trailing phantom row that should be suppressed in the
-    // target column but kept in the dataset column (for click-to-add).
-    store.updateDataset("test-data", {
-      columns: [
-        { id: "input", name: "input", type: "string" },
-        { id: "expected_output", name: "expected_output", type: "string" },
-      ],
-      inline: {
+  describe("when the dataset has 2 populated rows (displayRowCount = 3)", () => {
+    const seedTwoPopulatedRowsAndOneTarget = () => {
+      // displayRowCount = max(rowCount + 1, 3) = max(3, 3) = 3, so rows 0..1
+      // are populated and row 2 is the trailing phantom row that should be
+      // suppressed in the target column but kept in the dataset column (for
+      // click-to-add).
+      const store = useEvaluationsV3Store.getState();
+      store.updateDataset("test-data", {
         columns: [
           { id: "input", name: "input", type: "string" },
           { id: "expected_output", name: "expected_output", type: "string" },
         ],
-        records: {
-          input: ["row 0 input", "row 1 input"],
-          expected_output: ["row 0 expected", "row 1 expected"],
+        inline: {
+          columns: [
+            { id: "input", name: "input", type: "string" },
+            { id: "expected_output", name: "expected_output", type: "string" },
+          ],
+          records: {
+            input: ["row 0 input", "row 1 input"],
+            expected_output: ["row 0 expected", "row 1 expected"],
+          },
         },
-      },
+      });
+
+      store.addTarget({
+        id: "test-target",
+        type: "prompt",
+        inputs: [{ identifier: "input", type: "str" }],
+        outputs: [{ identifier: "output", type: "str" }],
+        mappings: {},
+      });
+    };
+
+    it("still renders a dataset cell on the phantom row (click-to-add affordance)", async () => {
+      seedTwoPopulatedRowsAndOneTarget();
+
+      render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("cell-0-input")).toBeInTheDocument();
+        expect(screen.getByTestId("cell-1-input")).toBeInTheDocument();
+      });
+
+      // The phantom row (row 2) DOES get a dataset cell.
+      expect(screen.getByTestId("cell-2-input")).toBeInTheDocument();
     });
 
-    // Add a prompt target so a target column exists.
-    store.addTarget({
-      id: "test-target",
-      type: "prompt",
-      inputs: [{ identifier: "input", type: "str" }],
-      outputs: [{ identifier: "output", type: "str" }],
-      mappings: {},
+    it("renders target cell content only for populated rows, not the phantom row", async () => {
+      seedTwoPopulatedRowsAndOneTarget();
+
+      render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("cell-0-input")).toBeInTheDocument();
+      });
+
+      // TargetCellContent for an empty-output cell renders "No output yet".
+      // With the fix: 2 populated rows → 2 target cells → 2 "No output yet".
+      // Without the fix: the phantom row (row 2) also renders a target cell,
+      // yielding 3 matches.
+      expect(screen.getAllByText("No output yet")).toHaveLength(2);
+
+      // Add-evaluator button sits inside TargetCellContent — same invariant,
+      // one per populated row.
+      expect(
+        screen.getAllByTestId("add-evaluator-button-test-target"),
+      ).toHaveLength(2);
     });
-
-    render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });
-
-    // Sanity — populated rows' dataset cells rendered.
-    await waitFor(() => {
-      expect(screen.getByTestId("cell-0-input")).toBeInTheDocument();
-      expect(screen.getByTestId("cell-1-input")).toBeInTheDocument();
-    });
-
-    // The phantom row (row 2) DOES get a dataset cell (click-to-add stays).
-    expect(screen.getByTestId("cell-2-input")).toBeInTheDocument();
-
-    // TargetCellContent for an empty-output cell renders "No output yet".
-    // With the fix: 2 populated rows → 2 target cells → 2 "No output yet".
-    // Without the fix: the phantom row (row 2) also renders a target cell,
-    // yielding 3 matches.
-    expect(screen.getAllByText("No output yet")).toHaveLength(2);
-
-    // Add-evaluator button sits inside TargetCellContent — same invariant,
-    // one per populated row.
-    expect(
-      screen.getAllByTestId("add-evaluator-button-test-target"),
-    ).toHaveLength(2);
   });
 });

--- a/langwatch/src/evaluations-v3/__tests__/TableDisplay.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/TableDisplay.integration.test.tsx
@@ -633,3 +633,75 @@ describe("TargetHeader stability", () => {
     console.log = originalLog;
   });
 });
+
+// Regression for issue #3441 fix 4: the table always renders a trailing
+// phantom row (Excel-style "click to add"), but target columns must NOT
+// render content for phantom rows — no input = nothing to run. Dataset cells
+// keep their click-to-add affordance for the phantom row.
+describe("Phantom empty row suppresses target cell content", () => {
+  beforeEach(() => {
+    useEvaluationsV3Store.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders target cell content only for populated rows, not phantom rows", async () => {
+    const store = useEvaluationsV3Store.getState();
+
+    // Seed a dataset with exactly 2 populated rows. displayRowCount is
+    // max(rowCount + 1, 3) = max(3, 3) = 3, so rows 0..1 are populated and
+    // row 2 is the trailing phantom row that should be suppressed in the
+    // target column but kept in the dataset column (for click-to-add).
+    store.updateDataset("test-data", {
+      columns: [
+        { id: "input", name: "input", type: "string" },
+        { id: "expected_output", name: "expected_output", type: "string" },
+      ],
+      inline: {
+        columns: [
+          { id: "input", name: "input", type: "string" },
+          { id: "expected_output", name: "expected_output", type: "string" },
+        ],
+        records: {
+          input: ["row 0 input", "row 1 input"],
+          expected_output: ["row 0 expected", "row 1 expected"],
+        },
+      },
+    });
+
+    // Add a prompt target so a target column exists.
+    store.addTarget({
+      id: "test-target",
+      type: "prompt",
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [{ identifier: "output", type: "str" }],
+      mappings: {},
+    });
+
+    render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });
+
+    // Sanity — populated rows' dataset cells rendered.
+    await waitFor(() => {
+      expect(screen.getByTestId("cell-0-input")).toBeInTheDocument();
+      expect(screen.getByTestId("cell-1-input")).toBeInTheDocument();
+    });
+
+    // The phantom row (row 2) DOES get a dataset cell (click-to-add stays).
+    expect(screen.getByTestId("cell-2-input")).toBeInTheDocument();
+
+    // TargetCellContent for an empty-output cell renders "No output yet".
+    // With the fix: 2 populated rows → 2 target cells → 2 "No output yet".
+    // Without the fix: the phantom row (row 2) also renders a target cell,
+    // yielding 3 matches.
+    expect(screen.getAllByText("No output yet")).toHaveLength(2);
+
+    // Add-evaluator button sits inside TargetCellContent — same invariant,
+    // one per populated row.
+    expect(
+      screen.getAllByTestId("add-evaluator-button-test-target"),
+    ).toHaveLength(2);
+  });
+});

--- a/langwatch/src/evaluations-v3/__tests__/TableSettingsMenu.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/TableSettingsMenu.integration.test.tsx
@@ -68,7 +68,7 @@ describe("TableSettingsMenu", () => {
 
       await waitFor(() => {
         expect(screen.getByText("Compact")).toBeInTheDocument();
-        expect(screen.getByText("Expanded")).toBeInTheDocument();
+        expect(screen.getByText("Fit")).toBeInTheDocument();
       });
     });
 
@@ -107,7 +107,7 @@ describe("TableSettingsMenu", () => {
   });
 
   describe("Row height functionality", () => {
-    it("clicking Expanded changes row height mode", async () => {
+    it("clicking Fit changes row height mode to 'fit'", async () => {
       const user = userEvent.setup();
       render(<TableSettingsMenu />, { wrapper: Wrapper });
 
@@ -116,18 +116,18 @@ describe("TableSettingsMenu", () => {
       });
       await user.click(button);
 
-      // Find the button containing "Expanded" text
-      const expandedText = await screen.findByText("Expanded");
-      const expandedButton = expandedText.closest("button");
-      expect(expandedButton).not.toBeNull();
-      await user.click(expandedButton!);
+      // Find the button containing "Fit" text
+      const fitText = await screen.findByText("Fit");
+      const fitButton = fitText.closest("button");
+      expect(fitButton).not.toBeNull();
+      await user.click(fitButton!);
 
       const updatedStore = useEvaluationsV3Store.getState();
-      expect(updatedStore.ui.rowHeightMode).toBe("expanded");
+      expect(updatedStore.ui.rowHeightMode).toBe("fit");
     });
 
     it("clicking Compact changes row height mode back", async () => {
-      useEvaluationsV3Store.getState().setRowHeightMode("expanded");
+      useEvaluationsV3Store.getState().setRowHeightMode("fit");
 
       const user = userEvent.setup();
       render(<TableSettingsMenu />, { wrapper: Wrapper });
@@ -254,8 +254,8 @@ describe("TableSettingsMenu", () => {
     });
   });
 
-  describe("expanded mode restriction", () => {
-    it("disables Expanded option when dataset has more than 100 rows", async () => {
+  describe("fit mode restriction", () => {
+    it("disables Fit option when dataset has more than 100 rows", async () => {
       // Add a dataset with more than 100 rows
       useEvaluationsV3Store.setState({
         activeDatasetId: "large-dataset",
@@ -288,15 +288,15 @@ describe("TableSettingsMenu", () => {
         expect(screen.getByText("Compact")).toBeInTheDocument();
       });
 
-      // Find the button containing "Expanded" text
-      const expandedText = await screen.findByText("Expanded");
-      const expandedButton = expandedText.closest("button");
+      // Find the button containing "Fit" text
+      const fitText = await screen.findByText("Fit");
+      const fitButton = fitText.closest("button");
 
       // Button should be disabled
-      expect(expandedButton).toBeDisabled();
+      expect(fitButton).toBeDisabled();
     });
 
-    it("does not change to expanded mode when clicking disabled Expanded option", async () => {
+    it("does not change to fit mode when clicking disabled Fit option", async () => {
       // Add a dataset with more than 100 rows
       useEvaluationsV3Store.setState({
         activeDatasetId: "large-dataset",
@@ -324,18 +324,18 @@ describe("TableSettingsMenu", () => {
       });
       await user.click(button);
 
-      const expandedText = await screen.findByText("Expanded");
-      const expandedButton = expandedText.closest("button");
+      const fitText = await screen.findByText("Fit");
+      const fitButton = fitText.closest("button");
 
       // Try to click the disabled button
-      await user.click(expandedButton!);
+      await user.click(fitButton!);
 
       // Mode should still be compact
       const store = useEvaluationsV3Store.getState();
       expect(store.ui.rowHeightMode).toBe("compact");
     });
 
-    it("allows Expanded option when dataset has 100 or fewer rows", async () => {
+    it("allows Fit option when dataset has 100 or fewer rows", async () => {
       // Add a dataset with exactly 100 rows
       useEvaluationsV3Store.setState({
         activeDatasetId: "medium-dataset",
@@ -367,17 +367,17 @@ describe("TableSettingsMenu", () => {
         expect(screen.getByText("Compact")).toBeInTheDocument();
       });
 
-      // Find the button containing "Expanded" text
-      const expandedText = await screen.findByText("Expanded");
-      const expandedButton = expandedText.closest("button");
+      // Find the button containing "Fit" text
+      const fitText = await screen.findByText("Fit");
+      const fitButton = fitText.closest("button");
 
       // Button should NOT be disabled
-      expect(expandedButton).not.toBeDisabled();
+      expect(fitButton).not.toBeDisabled();
 
       // Click should work
-      await user.click(expandedButton!);
+      await user.click(fitButton!);
       const store = useEvaluationsV3Store.getState();
-      expect(store.ui.rowHeightMode).toBe("expanded");
+      expect(store.ui.rowHeightMode).toBe("fit");
     });
   });
 });

--- a/langwatch/src/evaluations-v3/components/DatasetSection/TableCell.tsx
+++ b/langwatch/src/evaluations-v3/components/DatasetSection/TableCell.tsx
@@ -2,6 +2,7 @@ import { Skeleton, VStack } from "@chakra-ui/react";
 import { type Cell, flexRender } from "@tanstack/react-table";
 import type { DatasetColumnType } from "~/server/datasets/types";
 import { useEvaluationsV3Store } from "../../hooks/useEvaluationsV3Store";
+import type { TableRowData } from "../../types";
 import { EditableCell } from "./EditableCell";
 
 // ============================================================================
@@ -16,17 +17,8 @@ type ColumnMeta = {
   dataType?: DatasetColumnType; // The actual data type (string, json, list, etc.)
 };
 
-type RowData = {
-  rowIndex: number;
-  dataset: Record<string, string>;
-  targets: Record<
-    string,
-    { output: unknown; evaluators: Record<string, unknown> }
-  >;
-};
-
 type TableCellProps = {
-  cell: Cell<RowData, unknown>;
+  cell: Cell<TableRowData, unknown>;
   rowIndex: number;
   activeDatasetId: string;
   isLoading?: boolean;

--- a/langwatch/src/evaluations-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/evaluations-v3/components/EvaluationsV3Table.tsx
@@ -920,12 +920,14 @@ export function EvaluationsV3Table({
         ]),
       );
 
-      // Check if this row is empty - empty rows don't get executed
-      const _rowIsEmpty = isRowEmpty(datasetValues);
+      // Empty rows (the Excel-style trailing phantom row) don't get executed
+      // and shouldn't render target outputs / evaluator chips.
+      const rowIsEmpty = isRowEmpty(datasetValues);
 
       return {
         rowIndex: index,
         dataset: datasetValues,
+        isEmpty: rowIsEmpty,
         targets: Object.fromEntries(
           targets.map((target) => [
             target.id,
@@ -1152,6 +1154,10 @@ export function EvaluationsV3Table({
             <TargetHeaderFromMeta targetId={targetId} context={context} />
           ),
           cell: (info) => {
+            // Phantom empty rows render nothing in target columns — the
+            // dataset side keeps the click-to-add affordance, but there's
+            // no input to run a target against.
+            if (info.row.original.isEmpty) return null;
             const data = info.getValue() as {
               output: unknown;
               evaluators: Record<string, unknown>;

--- a/langwatch/src/evaluations-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/evaluations-v3/components/EvaluationsV3Table.tsx
@@ -71,7 +71,7 @@ import { TargetSuperHeader } from "./TargetSuperHeader";
 import { VirtualizedTableBody } from "./VirtualizedTableBody";
 
 // Max rows for expanded mode (disable virtualization above this)
-const MAX_ROWS_FOR_EXPANDED_MODE = 100;
+const MAX_ROWS_FOR_FIT_MODE = 100;
 
 // Default percentage widths for columns (stored as numbers, e.g., 16 means 16%)
 const CHECKBOX_WIDTH_PX = 40; // Checkbox is fixed pixels
@@ -870,7 +870,7 @@ export function EvaluationsV3Table({
   // - Disable virtualization in expanded mode for datasets <= 100 rows
   const rowHeightMode = ui.rowHeightMode;
   const shouldVirtualize =
-    rowHeightMode === "compact" || rowCount > MAX_ROWS_FOR_EXPANDED_MODE;
+    rowHeightMode === "compact" || rowCount > MAX_ROWS_FOR_FIT_MODE;
 
   const selectedRows = ui.selectedRows;
   const allSelected = selectedRows.size === rowCount && rowCount > 0;

--- a/langwatch/src/evaluations-v3/components/TableSettingsMenu.tsx
+++ b/langwatch/src/evaluations-v3/components/TableSettingsMenu.tsx
@@ -53,8 +53,8 @@ const rowHeightOptions: ToggleOption[] = [
     icon: <ListChevronsDownUp size={18} />,
   },
   {
-    value: "expanded",
-    label: "Expanded",
+    value: "fit",
+    label: "Fit",
     icon: <ListChevronsUpDown size={18} />,
   },
 ];
@@ -250,7 +250,7 @@ export function TableSettingsMenu({
                 {rowHeightOptions.map((option) => {
                   const isActive = rowHeightMode === option.value;
                   const isDisabled =
-                    option.value === "expanded" && isExpandedDisabled;
+                    option.value === "fit" && isExpandedDisabled;
 
                   const button = (
                     <Button

--- a/langwatch/src/evaluations-v3/components/TableSettingsMenu.tsx
+++ b/langwatch/src/evaluations-v3/components/TableSettingsMenu.tsx
@@ -60,7 +60,7 @@ const rowHeightOptions: ToggleOption[] = [
 ];
 
 // Max rows for expanded mode
-const MAX_ROWS_FOR_EXPANDED_MODE = 100;
+const MAX_ROWS_FOR_FIT_MODE = 100;
 
 // =============================================================================
 // Concurrency Popover Component
@@ -198,7 +198,7 @@ export function TableSettingsMenu({
 
   // Get current row count to determine if expanded mode should be disabled
   const rowCount = getRowCount(activeDatasetId);
-  const isExpandedDisabled = rowCount > MAX_ROWS_FOR_EXPANDED_MODE;
+  const isFitDisabled = rowCount > MAX_ROWS_FOR_FIT_MODE;
 
   const { project } = useOrganizationTeamProject();
   const cicdDialog = useDisclosure();
@@ -250,7 +250,7 @@ export function TableSettingsMenu({
                 {rowHeightOptions.map((option) => {
                   const isActive = rowHeightMode === option.value;
                   const isDisabled =
-                    option.value === "fit" && isExpandedDisabled;
+                    option.value === "fit" && isFitDisabled;
 
                   const button = (
                     <Button
@@ -279,7 +279,7 @@ export function TableSettingsMenu({
                     return (
                       <Tooltip
                         key={option.value}
-                        content={`Expanded mode is disabled for datasets with more than ${MAX_ROWS_FOR_EXPANDED_MODE} rows for performance reasons`}
+                        content={`Fit mode is disabled for datasets with more than ${MAX_ROWS_FOR_FIT_MODE} rows for performance reasons`}
                         positioning={{ placement: "top" }}
                         openDelay={100}
                       >

--- a/langwatch/src/evaluations-v3/components/TargetSection/EvaluatorChip.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/EvaluatorChip.tsx
@@ -166,17 +166,24 @@ export function EvaluatorChip({
             {status !== "running" && getInlineResult()}
             {/* Missing mapping alert icon - on the right side like prompts */}
             {hasMissingMappings && (
-              <Icon
-                as={LuCircleAlert}
-                color="yellow.fg"
-                boxSize="14px"
-                css={{ animation: `${pulseAnimation} 2s ease-in-out infinite` }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEdit();
-                }}
-                data-testid={`evaluator-missing-mapping-alert-${evaluator.id}`}
-              />
+              <Tooltip
+                content="Missing variable mappings - Click to configure"
+                positioning={{ placement: "top" }}
+                openDelay={0}
+                showArrow
+              >
+                <Icon
+                  as={LuCircleAlert}
+                  color="yellow.fg"
+                  boxSize="14px"
+                  css={{ animation: `${pulseAnimation} 2s ease-in-out infinite` }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEdit();
+                  }}
+                  data-testid={`evaluator-missing-mapping-alert-${evaluator.id}`}
+                />
+              </Tooltip>
             )}
             <Box className="chevron-icon" marginLeft={-0.5}>
               <LuChevronDown size={12} />

--- a/langwatch/src/evaluations-v3/components/TargetSection/EvaluatorChip.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/EvaluatorChip.tsx
@@ -28,6 +28,7 @@ import {
   parseEvaluationResult,
 } from "~/utils/evaluationResults";
 import { parseLLMError } from "~/utils/formatLLMError";
+import { TARGET_MISSING_MAPPING_TOOLTIP } from "../../constants";
 import { useEvaluatorName } from "../../hooks/useEvaluatorName";
 import type { EvaluatorConfig } from "../../types";
 
@@ -167,7 +168,7 @@ export function EvaluatorChip({
             {/* Missing mapping alert icon - on the right side like prompts */}
             {hasMissingMappings && (
               <Tooltip
-                content="Missing variable mappings - Click to configure"
+                content={TARGET_MISSING_MAPPING_TOOLTIP}
                 positioning={{ placement: "top" }}
                 openDelay={0}
                 showArrow

--- a/langwatch/src/evaluations-v3/components/TargetSection/TargetCell.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/TargetCell.tsx
@@ -30,6 +30,7 @@ import {
   convertFromUIMapping,
   convertToUIMapping,
 } from "../../utils/fieldMappingConverters";
+import { createEvaluatorEditorCallbacks } from "../../utils/evaluatorEditorCallbacks";
 import { evaluatorHasMissingMappings } from "../../utils/mappingValidation";
 import { EvaluatorChip } from "../TargetSection/EvaluatorChip";
 
@@ -210,31 +211,35 @@ export function TargetCellContent({
         initialMappings[key] = convertToUIMapping(mapping);
       }
 
+      const onMappingChange = (
+        identifier: string,
+        mapping: UIFieldMapping | undefined,
+      ) => {
+        if (mapping) {
+          const storeMapping = convertFromUIMapping(mapping, isDatasetSource);
+          setEvaluatorMapping(
+            evaluator.id,
+            activeDatasetId,
+            target.id,
+            identifier,
+            storeMapping,
+          );
+        } else {
+          removeEvaluatorMapping(
+            evaluator.id,
+            activeDatasetId,
+            target.id,
+            identifier,
+          );
+        }
+      };
+
+      // onMappingChange is registered separately via setFlowCallbacks because
+      // embedding it in mappingsConfig routes it through ephemeral complexProps
+      // which are cleared on ErrorBoundary remount (see issue #3087).
       return {
-        availableSources,
-        initialMappings,
-        onMappingChange: (
-          identifier: string,
-          mapping: UIFieldMapping | undefined,
-        ) => {
-          if (mapping) {
-            const storeMapping = convertFromUIMapping(mapping, isDatasetSource);
-            setEvaluatorMapping(
-              evaluator.id,
-              activeDatasetId,
-              target.id,
-              identifier,
-              storeMapping,
-            );
-          } else {
-            removeEvaluatorMapping(
-              evaluator.id,
-              activeDatasetId,
-              target.id,
-              identifier,
-            );
-          }
-        },
+        mappingsConfig: { availableSources, initialMappings },
+        onMappingChange,
       };
     },
     [
@@ -397,16 +402,26 @@ export function TargetCellContent({
           hasAnyTargetOutputs={hasAnyTargetOutputs}
           targetType={target.type}
           onEdit={() => {
-            const mappingsConfig = createMappingsConfig(evaluator);
+            const { mappingsConfig, onMappingChange } =
+              createMappingsConfig(evaluator);
 
-            // Set up local state callbacks for the evaluator editor
-            setFlowCallbacks("evaluatorEditor", {
-              onLocalConfigChange: (config: unknown) => {
-                updateEvaluator(evaluator.id, {
-                  localEvaluatorConfig: config as EvaluatorConfig["localEvaluatorConfig"],
-                });
-              },
-            });
+            // Route all non-serializable callbacks through setFlowCallbacks.
+            // onMappingChange must live here (not in mappingsConfig) so the
+            // drawer's mappings section renders — see issue #3441.
+            setFlowCallbacks(
+              "evaluatorEditor",
+              createEvaluatorEditorCallbacks({
+                targetId: target.id,
+                updateTarget: (_id, updates) => {
+                  if (updates.localEvaluatorConfig !== undefined) {
+                    updateEvaluator(evaluator.id, {
+                      localEvaluatorConfig: updates.localEvaluatorConfig,
+                    });
+                  }
+                },
+                onMappingChange,
+              }),
+            );
 
             openDrawer("evaluatorEditor", {
               evaluatorId: evaluator.dbEvaluatorId,

--- a/langwatch/src/evaluations-v3/components/TargetSection/TargetCell.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/TargetCell.tsx
@@ -171,12 +171,11 @@ export function TargetCellContent({
     return missing;
   }, [evaluators, activeDatasetId, target.id]);
 
-  // Helper to create mappingsConfig for an evaluator
-  const createMappingsConfig = useCallback(
+  // Build the serializable `mappingsConfig` for an evaluator. Stays
+  // serializable because it goes through the drawer's ephemeral complexProps
+  // path (cleared on ErrorBoundary remount — see issue #3087).
+  const buildMappingsConfig = useCallback(
     (evaluator: EvaluatorConfig) => {
-      const datasetIds = new Set(datasets.map((d) => d.id));
-      const isDatasetSource = (sourceId: string) => datasetIds.has(sourceId);
-
       // Build available sources
       const activeDataset = datasets.find((d) => d.id === activeDatasetId);
       const availableSources = [];
@@ -211,10 +210,19 @@ export function TargetCellContent({
         initialMappings[key] = convertToUIMapping(mapping);
       }
 
-      const onMappingChange = (
-        identifier: string,
-        mapping: UIFieldMapping | undefined,
-      ) => {
+      return { availableSources, initialMappings };
+    },
+    [datasets, activeDatasetId, target, targetName],
+  );
+
+  // Build the durable `onMappingChange` callback for an evaluator. Lives
+  // separately from `mappingsConfig` because it must survive the drawer's
+  // complexProps clears — registered via `setFlowCallbacks` instead (#3441).
+  const buildOnMappingChange = useCallback(
+    (evaluator: EvaluatorConfig) => {
+      const datasetIds = new Set(datasets.map((d) => d.id));
+      const isDatasetSource = (sourceId: string) => datasetIds.has(sourceId);
+      return (identifier: string, mapping: UIFieldMapping | undefined) => {
         if (mapping) {
           const storeMapping = convertFromUIMapping(mapping, isDatasetSource);
           setEvaluatorMapping(
@@ -233,19 +241,11 @@ export function TargetCellContent({
           );
         }
       };
-
-      // onMappingChange is registered separately via setFlowCallbacks because
-      // embedding it in mappingsConfig routes it through ephemeral complexProps
-      // which are cleared on ErrorBoundary remount (see issue #3087).
-      return {
-        mappingsConfig: { availableSources, initialMappings },
-        onMappingChange,
-      };
     },
     [
       datasets,
       activeDatasetId,
-      target,
+      target.id,
       setEvaluatorMapping,
       removeEvaluatorMapping,
     ],
@@ -402,31 +402,29 @@ export function TargetCellContent({
           hasAnyTargetOutputs={hasAnyTargetOutputs}
           targetType={target.type}
           onEdit={() => {
-            const { mappingsConfig, onMappingChange } =
-              createMappingsConfig(evaluator);
-
             // Route all non-serializable callbacks through setFlowCallbacks.
-            // onMappingChange must live here (not in mappingsConfig) so the
-            // drawer's mappings section renders — see issue #3441.
+            // onMappingChange + onLocalConfigChange must live here (not in
+            // mappingsConfig) so the drawer's mappings section renders — see
+            // issue #3441.
+            //
+            // We use the direct `onLocalConfigChange` form (not the
+            // target-bound `targetId + updateTarget` convenience) because
+            // the chip's local config persists onto the evaluator, not the
+            // target.
             setFlowCallbacks(
               "evaluatorEditor",
               createEvaluatorEditorCallbacks({
-                targetId: target.id,
-                updateTarget: (_id, updates) => {
-                  if (updates.localEvaluatorConfig !== undefined) {
-                    updateEvaluator(evaluator.id, {
-                      localEvaluatorConfig: updates.localEvaluatorConfig,
-                    });
-                  }
+                onLocalConfigChange: (localEvaluatorConfig) => {
+                  updateEvaluator(evaluator.id, { localEvaluatorConfig });
                 },
-                onMappingChange,
+                onMappingChange: buildOnMappingChange(evaluator),
               }),
             );
 
             openDrawer("evaluatorEditor", {
               evaluatorId: evaluator.dbEvaluatorId,
               evaluatorType: evaluator.evaluatorType,
-              mappingsConfig,
+              mappingsConfig: buildMappingsConfig(evaluator),
               initialLocalConfig: evaluator.localEvaluatorConfig,
             });
           }}

--- a/langwatch/src/evaluations-v3/components/TargetSection/TargetHeader.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/TargetHeader.tsx
@@ -31,6 +31,7 @@ import { ColorfulBlockIcon } from "~/optimization_studio/components/ColorfulBloc
 import { transposeColumnsFirstToRowsFirstWithId } from "~/optimization_studio/utils/datasetUtils";
 import { VersionBadge } from "~/prompts/components/ui/VersionBadge";
 import { useLatestPromptVersion } from "~/prompts/hooks/useLatestPromptVersion";
+import { TARGET_MISSING_MAPPING_TOOLTIP } from "../../constants";
 import { useEvaluationsV3Store } from "../../hooks/useEvaluationsV3Store";
 import { useTargetName } from "../../hooks/useTargetName";
 import type { TargetConfig } from "../../types";
@@ -314,7 +315,7 @@ export const TargetHeader = memo(function TargetHeader({
             )}
             {hasMissingMappings && (
               <Tooltip
-                content="Missing variable mappings - Click to configure"
+                content={TARGET_MISSING_MAPPING_TOOLTIP}
                 positioning={{ placement: "top" }}
                 openDelay={0}
                 showArrow

--- a/langwatch/src/evaluations-v3/components/TargetSection/__tests__/EvaluatorChip.test.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/__tests__/EvaluatorChip.test.tsx
@@ -412,6 +412,63 @@ describe("EvaluatorChip", () => {
     });
   });
 
+  // Regression for issue #3441 fix 2: the missing-mapping alert icon on
+  // an evaluator chip must be wrapped in a Tooltip with the same copy as
+  // the prompt/target header's equivalent alert in TargetHeader.tsx. Before
+  // this fix the `(!)` icon rendered bare, giving no hover affordance.
+  describe("when hasMissingMappings is true — alert icon tooltip", () => {
+    it("renders the missing-mapping alert icon with an accessible trigger", () => {
+      render(
+        <EvaluatorChip
+          evaluator={createEvaluator()}
+          result={undefined}
+          hasMissingMappings
+          onEdit={vi.fn()}
+          onRemove={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      const alert = screen.getByTestId(
+        `evaluator-missing-mapping-alert-${createEvaluator().id}`,
+      );
+      expect(alert).toBeInTheDocument();
+      // Chakra's Tooltip.Trigger adds `data-scope="tooltip"` / aria-describedby
+      // on the wrapped element. Its presence is proof the icon is wrapped
+      // rather than bare.
+      expect(
+        alert.getAttribute("aria-describedby") ??
+          alert.getAttribute("data-scope"),
+      ).not.toBeNull();
+    });
+
+    it("shows the 'Missing variable mappings - Click to configure' copy on hover", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <EvaluatorChip
+          evaluator={createEvaluator()}
+          result={undefined}
+          hasMissingMappings
+          onEdit={vi.fn()}
+          onRemove={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      const alert = screen.getByTestId(
+        `evaluator-missing-mapping-alert-${createEvaluator().id}`,
+      );
+      await user.hover(alert);
+
+      expect(
+        await screen.findByText(
+          "Missing variable mappings - Click to configure",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("when evaluator has missing mappings", () => {
     it("redirects Rerun click to onEdit", async () => {
       const onEdit = vi.fn();

--- a/langwatch/src/evaluations-v3/components/TargetSection/__tests__/TargetCell.test.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/__tests__/TargetCell.test.tsx
@@ -6,26 +6,91 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { TargetConfig } from "../../../types";
+import type { EvaluatorConfig, TargetConfig } from "../../../types";
 import { TargetCellContent } from "../TargetCell";
 
-// Mock hooks
-const mockOpenDrawer = vi.fn();
+// Drawer + flow-callback mocks must be vi.hoisted so the vi.mock factory can
+// reference them (vi.mock is hoisted above imports).
+const { mockOpenDrawer, mockSetFlowCallbacks } = vi.hoisted(() => ({
+  mockOpenDrawer: vi.fn(),
+  mockSetFlowCallbacks: vi.fn(),
+}));
+
 vi.mock("~/hooks/useDrawer", () => ({
   useDrawer: () => ({
     openDrawer: mockOpenDrawer,
   }),
+  setFlowCallbacks: mockSetFlowCallbacks,
 }));
 
+// Mutable state for the store mock — each test seeds what the component will
+// read. `useEvaluationsV3Store` accepts a selector, so the mock must too.
+type StoreMockState = {
+  evaluators: EvaluatorConfig[];
+  activeDatasetId: string;
+  datasets: Array<{
+    id: string;
+    name: string;
+    columns: Array<{ id: string; name: string; type: string }>;
+  }>;
+  removeEvaluator: ReturnType<typeof vi.fn>;
+  updateEvaluator: ReturnType<typeof vi.fn>;
+  setEvaluatorMapping: ReturnType<typeof vi.fn>;
+  removeEvaluatorMapping: ReturnType<typeof vi.fn>;
+};
+
+const storeMockState: StoreMockState = {
+  evaluators: [],
+  activeDatasetId: "dataset-1",
+  datasets: [],
+  removeEvaluator: vi.fn(),
+  updateEvaluator: vi.fn(),
+  setEvaluatorMapping: vi.fn(),
+  removeEvaluatorMapping: vi.fn(),
+};
+
+const resetStoreMock = () => {
+  storeMockState.evaluators = [];
+  storeMockState.activeDatasetId = "dataset-1";
+  storeMockState.datasets = [];
+  storeMockState.removeEvaluator = vi.fn();
+  storeMockState.updateEvaluator = vi.fn();
+  storeMockState.setEvaluatorMapping = vi.fn();
+  storeMockState.removeEvaluatorMapping = vi.fn();
+};
+
 vi.mock("../../../hooks/useEvaluationsV3Store", () => ({
-  useEvaluationsV3Store: () => ({
-    evaluators: [],
-    activeDatasetId: "dataset-1",
-    datasets: [],
-    removeEvaluator: vi.fn(),
-    setEvaluatorMapping: vi.fn(),
-    removeEvaluatorMapping: vi.fn(),
-  }),
+  useEvaluationsV3Store: (selector?: (state: StoreMockState) => unknown) =>
+    selector ? selector(storeMockState) : storeMockState,
+}));
+
+// Mock mappingValidation so we control which evaluators flag as
+// hasMissingMappings without touching the real DSL logic.
+vi.mock("../../../utils/mappingValidation", () => ({
+  evaluatorHasMissingMappings: vi.fn(() => false),
+}));
+
+// Replace the chip with a minimal stub that exposes onEdit as a plain button.
+// The real chip wraps onEdit behind a Chakra Menu, which needs user-event
+// gymnastics to open — and the chip has its own test file covering that.
+// Here we only care that TargetCell wires the chip's onEdit to the correct
+// drawer + flowCallbacks payload.
+vi.mock("../EvaluatorChip", () => ({
+  EvaluatorChip: ({
+    evaluator,
+    onEdit,
+  }: {
+    evaluator: { id: string };
+    onEdit: () => void;
+  }) => (
+    <button
+      type="button"
+      data-testid={`evaluator-chip-stub-${evaluator.id}`}
+      onClick={onEdit}
+    >
+      chip:{evaluator.id}
+    </button>
+  ),
 }));
 
 // Mock name hooks to avoid tRPC queries
@@ -58,6 +123,7 @@ const generateLongText = (length: number): string => {
 describe("TargetCellContent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetStoreMock();
   });
 
   afterEach(() => {
@@ -677,6 +743,128 @@ describe("TargetCellContent", () => {
 
       // Should show the output
       expect(screen.getByText("Completed output")).toBeInTheDocument();
+    });
+  });
+
+  // Regression for issue #3441 fix 1: clicking the evaluator chip's edit
+  // path must open the editor drawer with both a mappingsConfig AND an
+  // onMappingChange callback registered via setFlowCallbacks. The drawer's
+  // render gate is `mappingsConfig && onMappingChange` — if either is
+  // missing, the mappings section silently hides and users can't configure
+  // variables. Prior regression lived in TargetCell.tsx bypassing the shared
+  // createEvaluatorEditorCallbacks helper and omitting onMappingChange.
+  describe("when the user clicks an evaluator chip's edit", () => {
+    const evaluator: EvaluatorConfig = {
+      id: "eval-1",
+      evaluatorType: "langevals/exact_match",
+      dbEvaluatorId: "db-eval-1",
+      mappings: {},
+      inputs: [
+        { identifier: "output", type: "str" },
+        { identifier: "expected_output", type: "str" },
+      ],
+    };
+
+    const targetWithEvaluator = (): TargetConfig => ({
+      id: "target-1",
+      type: "prompt",
+      inputs: [{ identifier: "input", type: "str" }],
+      outputs: [{ identifier: "output", type: "str" }],
+      mappings: {},
+    });
+
+    const seedStoreWithEvaluatorAndDataset = () => {
+      storeMockState.evaluators = [evaluator];
+      storeMockState.datasets = [
+        {
+          id: "dataset-1",
+          name: "Test Dataset",
+          columns: [
+            { id: "input", name: "input", type: "string" },
+            { id: "expected_output", name: "expected_output", type: "string" },
+          ],
+        },
+      ];
+    };
+
+    it("registers onMappingChange on the evaluatorEditor flow callbacks", async () => {
+      seedStoreWithEvaluatorAndDataset();
+      const user = userEvent.setup();
+
+      render(
+        <TargetCellContent
+          target={targetWithEvaluator()}
+          output="some output"
+          evaluatorResults={{}}
+          row={0}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await user.click(screen.getByTestId("evaluator-chip-stub-eval-1"));
+
+      expect(mockSetFlowCallbacks).toHaveBeenCalledWith(
+        "evaluatorEditor",
+        expect.objectContaining({
+          onMappingChange: expect.any(Function),
+        }),
+      );
+    });
+
+    it("opens the evaluatorEditor drawer with a mappingsConfig containing availableSources and initialMappings", async () => {
+      seedStoreWithEvaluatorAndDataset();
+      const user = userEvent.setup();
+
+      render(
+        <TargetCellContent
+          target={targetWithEvaluator()}
+          output="some output"
+          evaluatorResults={{}}
+          row={0}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await user.click(screen.getByTestId("evaluator-chip-stub-eval-1"));
+
+      await waitFor(() => {
+        expect(mockOpenDrawer).toHaveBeenCalledWith(
+          "evaluatorEditor",
+          expect.objectContaining({
+            evaluatorType: "langevals/exact_match",
+            mappingsConfig: expect.objectContaining({
+              availableSources: expect.any(Array),
+              initialMappings: expect.any(Object),
+            }),
+          }),
+        );
+      });
+    });
+
+    it("keeps onMappingChange OUT of mappingsConfig (serializable complexProps constraint, see #3087)", async () => {
+      seedStoreWithEvaluatorAndDataset();
+      const user = userEvent.setup();
+
+      render(
+        <TargetCellContent
+          target={targetWithEvaluator()}
+          output="some output"
+          evaluatorResults={{}}
+          row={0}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await user.click(screen.getByTestId("evaluator-chip-stub-eval-1"));
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith(
+        "evaluatorEditor",
+        expect.objectContaining({
+          mappingsConfig: expect.not.objectContaining({
+            onMappingChange: expect.any(Function),
+          }),
+        }),
+      );
     });
   });
 });

--- a/langwatch/src/evaluations-v3/components/VirtualizedTableBody.tsx
+++ b/langwatch/src/evaluations-v3/components/VirtualizedTableBody.tsx
@@ -58,7 +58,7 @@ export const VirtualizedTableBody = React.memo(function VirtualizedTableBody({
 
   // Render all rows without virtualization when:
   // - Test mode (disableVirtualization prop)
-  // - Expanded mode with <= 100 rows
+  // - Fit mode with <= 100 rows
   if (disableVirtualization || !shouldVirtualize) {
     return (
       <>

--- a/langwatch/src/evaluations-v3/constants.ts
+++ b/langwatch/src/evaluations-v3/constants.ts
@@ -7,3 +7,12 @@
  * Used to calculate table layout and scroll positioning.
  */
 export const DRAWER_WIDTH = 456;
+
+/**
+ * Hover copy for the "missing variable mappings" alert icon shown on both
+ * target headers (TargetHeader.tsx) and evaluator chips (EvaluatorChip.tsx).
+ * Keep the two sites in lock-step — clicking the alert jumps the user to the
+ * mappings editor in both cases.
+ */
+export const TARGET_MISSING_MAPPING_TOOLTIP =
+  "Missing variable mappings - Click to configure";

--- a/langwatch/src/evaluations-v3/types.ts
+++ b/langwatch/src/evaluations-v3/types.ts
@@ -587,9 +587,14 @@ export type TableRowData = {
    * True when the dataset row contains no user-entered values. The table
    * always renders a trailing empty row for Excel-style "click to add,"
    * but that phantom row must not show target outputs or evaluator chips.
-   * The cell renderer uses a truthy check, so `undefined` == not empty.
+   *
+   * Required (non-optional) — every TableRowData built by the rowData
+   * builder in EvaluationsV3Table.tsx sets this. Was briefly optional during
+   * the #3441 sweep because DatasetSection/TableCell.tsx carried a parallel
+   * RowData shape without the field; that parallel shape has been unified
+   * with this type (#3460 item 5), so the optional can go.
    */
-  isEmpty?: boolean;
+  isEmpty: boolean;
   targets: Record<
     string,
     {

--- a/langwatch/src/evaluations-v3/types.ts
+++ b/langwatch/src/evaluations-v3/types.ts
@@ -587,8 +587,9 @@ export type TableRowData = {
    * True when the dataset row contains no user-entered values. The table
    * always renders a trailing empty row for Excel-style "click to add,"
    * but that phantom row must not show target outputs or evaluator chips.
+   * The cell renderer uses a truthy check, so `undefined` == not empty.
    */
-  isEmpty: boolean;
+  isEmpty?: boolean;
   targets: Record<
     string,
     {

--- a/langwatch/src/evaluations-v3/types.ts
+++ b/langwatch/src/evaluations-v3/types.ts
@@ -583,6 +583,12 @@ export type EvaluationsV3Store = EvaluationsV3State & EvaluationsV3Actions;
 export type TableRowData = {
   rowIndex: number;
   dataset: Record<string, string>;
+  /**
+   * True when the dataset row contains no user-entered values. The table
+   * always renders a trailing empty row for Excel-style "click to add,"
+   * but that phantom row must not show target outputs or evaluator chips.
+   */
+  isEmpty: boolean;
   targets: Record<
     string,
     {

--- a/langwatch/src/evaluations-v3/types.ts
+++ b/langwatch/src/evaluations-v3/types.ts
@@ -355,7 +355,7 @@ export type CellPosition = {
   columnId: string;
 };
 
-export type RowHeightMode = "compact" | "expanded";
+export type RowHeightMode = "compact" | "fit";
 
 export type AutosaveState = "idle" | "saving" | "saved" | "error";
 

--- a/langwatch/src/evaluations-v3/types/__tests__/persistence.test.ts
+++ b/langwatch/src/evaluations-v3/types/__tests__/persistence.test.ts
@@ -75,7 +75,7 @@ describe("Persistence", () => {
     it("excludes transient UI state from persisted state", () => {
       const state = createInitialState();
       state.ui.selectedRows = new Set([0, 1, 2]);
-      state.ui.rowHeightMode = "expanded";
+      state.ui.rowHeightMode = "fit";
 
       const persisted = extractPersistedState(state);
 

--- a/langwatch/src/evaluations-v3/utils/__tests__/evaluatorEditorCallbacks.test.ts
+++ b/langwatch/src/evaluations-v3/utils/__tests__/evaluatorEditorCallbacks.test.ts
@@ -74,6 +74,38 @@ describe("createEvaluatorEditorCallbacks()", () => {
         expect(callbacks.onLocalConfigChange).toBeUndefined();
       });
     });
+
+    describe("when onLocalConfigChange is provided directly", () => {
+      it("uses the provided callback verbatim (no target shim)", () => {
+        const onLocalConfigChange = vi.fn();
+        const callbacks = createEvaluatorEditorCallbacks({
+          onLocalConfigChange,
+        });
+
+        const config: LocalEvaluatorConfig = { name: "Direct" };
+        callbacks.onLocalConfigChange?.(config);
+
+        expect(onLocalConfigChange).toHaveBeenCalledWith(config);
+      });
+
+      it("takes precedence over targetId + updateTarget when both are provided", () => {
+        // The direct path wins so callers (e.g. evaluator chip) can persist
+        // local config to an evaluator instead of a target without needing
+        // to thread a fake targetId through the helper.
+        const onLocalConfigChange = vi.fn();
+        const updateTarget = vi.fn();
+        const callbacks = createEvaluatorEditorCallbacks({
+          onLocalConfigChange,
+          targetId: "target-1",
+          updateTarget,
+        });
+
+        callbacks.onLocalConfigChange?.({ name: "Direct wins" });
+
+        expect(onLocalConfigChange).toHaveBeenCalledWith({ name: "Direct wins" });
+        expect(updateTarget).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("onMappingChange()", () => {

--- a/langwatch/src/evaluations-v3/utils/evaluatorEditorCallbacks.ts
+++ b/langwatch/src/evaluations-v3/utils/evaluatorEditorCallbacks.ts
@@ -14,12 +14,30 @@ import type { LocalEvaluatorConfig } from "../types";
 /**
  * Parameters to create evaluator editor callbacks.
  *
- * `targetId` + `updateTarget` are only required when the caller wants an
- * `onLocalConfigChange` wired up to a specific evaluations-v3 target. Contexts
- * that do not have a target (e.g. OnlineEvaluationDrawer) omit them.
+ * Two ways to wire `onLocalConfigChange`:
+ *
+ * 1. **Direct** — pass `onLocalConfigChange` (recommended for sites that
+ *    don't need the evaluations-v3 target-bound convenience, e.g. an
+ *    evaluator chip whose local config updates an evaluator, not a target).
+ *
+ * 2. **Target-bound convenience** — pass `targetId + updateTarget`. The
+ *    helper synthesizes `onLocalConfigChange` as
+ *    `(lc) => updateTarget(targetId, { localEvaluatorConfig: lc })`. Used by
+ *    `useOpenTargetEditor` for the prompt-target / agent-target / evaluator-
+ *    target editor flows where a real target id exists.
+ *
+ * If both are provided, the direct `onLocalConfigChange` wins and the
+ * target-bound convenience is ignored. Contexts without any local-config
+ * persistence (e.g. `OnlineEvaluationDrawer`) omit all three.
  */
 export type CreateEvaluatorEditorCallbacksParams = {
+  /** Direct local-config sink (use this when no target id is available). */
+  onLocalConfigChange?: (
+    localConfig: LocalEvaluatorConfig | undefined,
+  ) => void;
+  /** Target-bound convenience: requires `updateTarget` to also be provided. */
   targetId?: string;
+  /** Target-bound convenience: requires `targetId` to also be provided. */
   updateTarget?: (
     id: string,
     updates: {
@@ -64,7 +82,17 @@ export type EvaluatorEditorCallbacksForTarget = {
  * (durable) rather than embedding them in `mappingsConfig` (ephemeral,
  * cleared on ErrorBoundary remount — see issue #3087).
  *
- * @example Evaluations-v3 (with target-bound local config tracking):
+ * @example Direct (TargetCell evaluator chip — local config updates the evaluator, not a target):
+ * ```ts
+ * setFlowCallbacks("evaluatorEditor",
+ *   createEvaluatorEditorCallbacks({
+ *     onLocalConfigChange: (lc) => updateEvaluator(evaluator.id, { localEvaluatorConfig: lc }),
+ *     onMappingChange,
+ *   }),
+ * );
+ * ```
+ *
+ * @example Target-bound convenience (useOpenTargetEditor — prompt/agent/evaluator-target editors):
  * ```ts
  * setFlowCallbacks("evaluatorEditor",
  *   createEvaluatorEditorCallbacks({ targetId, updateTarget, onMappingChange }),
@@ -79,13 +107,16 @@ export type EvaluatorEditorCallbacksForTarget = {
  * ```
  */
 export const createEvaluatorEditorCallbacks = ({
+  onLocalConfigChange,
   targetId,
   updateTarget,
   onMappingChange,
   onSave,
 }: CreateEvaluatorEditorCallbacksParams): EvaluatorEditorCallbacksForTarget => {
   const callbacks: EvaluatorEditorCallbacksForTarget = {};
-  if (targetId !== undefined && updateTarget) {
+  if (onLocalConfigChange) {
+    callbacks.onLocalConfigChange = onLocalConfigChange;
+  } else if (targetId !== undefined && updateTarget) {
     callbacks.onLocalConfigChange = (localConfig) => {
       updateTarget(targetId, { localEvaluatorConfig: localConfig });
     };


### PR DESCRIPTION
Sweep PR for #3441 — four mapping / row-UX bugs fixed on the evaluations-v3 workbench, plus regression tests backfilled and a post-sweep investigation per #3441's AC.

## Fixes

### 1. Evaluator chip edit — drawer opened without mappings section
- **File:** `src/evaluations-v3/components/TargetSection/TargetCell.tsx`
- **Root cause:** the chip's `onEdit` only registered `onLocalConfigChange` via `setFlowCallbacks`. The editor drawer renders its mappings section iff `mappingsConfig && onMappingChange` — without `onMappingChange` registered, the entire section silently hid.
- **Fix:** route both callbacks through `createEvaluatorEditorCallbacks` (the shared helper `useOpenTargetEditor` already uses). Split `onMappingChange` out of `createMappingsConfig`'s return — `mappingsConfig` is ephemeral complexProps and must stay serializable (see #3087 background).
- **Verified:** in-browser, evaluator editor now shows mapping rows for `output`, `expected_output`, `input`.

### 2. Missing-mapping `(!)` alert on evaluator chip had no tooltip
- **File:** `src/evaluations-v3/components/TargetSection/EvaluatorChip.tsx`
- **Root cause:** the alert `<Icon as={LuCircleAlert}>` was rendered bare. The equivalent alert on prompt/target headers (`TargetHeader.tsx:315-340`) was correctly wrapped in `<Tooltip content="Missing variable mappings - Click to configure" ...>`. Inconsistent.
- **Fix:** same `<Tooltip>` wrapper, same copy, `openDelay={0}` + `showArrow` for parity.
- **Verified:** in-browser, hover on the chip `(!)` now shows the tooltip.

### 3. Row-height mode label mismatch — "Expanded" rename
- **Files:** `src/evaluations-v3/types.ts`, `src/evaluations-v3/components/TableSettingsMenu.tsx`
- **Root cause:** The option labeled "Expanded" actually shrinks rows to fit content — short content → short rows, tall content → tall rows. "Compact" clamps every row to a uniform 160px, which counterintuitively often produces **taller** rows than "Expanded" when content is short. User observed this inversion in-browser.
- **Fix:** renamed the enum value + user-facing label from `"expanded"` → `"fit"`. Behavior unchanged — every `rowHeightMode === "compact"` call site still clamps, and the second option still passes through as "don't clamp." Default stays `"compact"`.
- **Verified:** in-browser, menu reads "Compact" / "Fit", behavior unchanged.

### 4. Phantom empty row rendered target cells
- **Files:** `src/evaluations-v3/components/EvaluationsV3Table.tsx`, `src/evaluations-v3/types.ts`
- **Root cause:** `displayRowCount = Math.max(rowCount + 1, 3)` renders a trailing Excel-style "click to add" empty row. The dataset side wants that affordance; the target columns don't (no input = nothing to run). The table author had already stubbed this out with an unused `_rowIsEmpty` variable (lint-silenced with `_`) but never wired it through.
- **Fix:** expose `isEmpty` on `TableRowData` from `rowData` builder, short-circuit the target column's cell renderer when true.
- **Verified:** in-browser, the trailing empty row still shows a dataset click-to-add affordance but no phantom "No output yet" / evaluator chip.

## Adjacent UX findings (not fixed here — follow-up candidates)

- **Adding an evaluator to an empty workbench is confusing.** The evaluator becomes a standalone testable node rather than one attached to a target — correct behavior, but zero UX signal (no empty-state hint, no visual distinction between standalone vs attached). User had to infer it. Specs (`evaluator-mappings.feature`) don't cover the empty-workbench case. Worth a follow-up polish issue.
- **Slow failure surface on bad API keys** — 30–45 s with a spinning "running" state before the "Incorrect API key provided: …" error surfaces. Almost certainly litellm Router default `num_retries=2` with exp-backoff — including on 401s. Out of scope for a mappings epic; file as a separate issue.
- **Browser-zoom rendering gap** — observed when browser zoom ≠ 100%. Pixel-rounding in sticky headers / virtualized rows. Separate visual-regression concern.

## Investigation — why were these bugs not caught by existing tests?

Per-fix findings:

- **Fix 1 (TargetCell chip-edit mapping drawer)** — the exact-same class of bug was already fixed and test-covered for `useOpenTargetEditor` in #3114 (`useOpenTargetEditor.flowCallbacks.unit.test.tsx`, April 2026). That PR introduced the shared `createEvaluatorEditorCallbacks` helper "so we never forget a required callback," yet `TargetCell.tsx`'s parallel chip-edit path bypassed the helper and never got an equivalent test. **The systemic gap:** cell-click handlers proliferate across `TargetCell` / `useOpenTargetEditor` / `RunEvaluationButton` and each calls `setFlowCallbacks("evaluatorEditor", ...)` independently. The test for one doesn't protect the others.
- **Fix 2 (chip alert tooltip)** — `TargetHeader.tsx`'s equivalent tooltip was deliberately added and has been shipping for months. No commit ever added the same wrapper to `EvaluatorChip.tsx`. There are no tests that assert the chip's alert icon has a tooltip because there were no tests for the chip's "missing mapping" visual branch at all until this PR (23 prior scenarios in `EvaluatorChip.test.tsx`, none covering it).
- **Fix 3 (expanded → fit rename)** — not a test-miss, a UX/naming bug. No test failed because the string values were internally consistent with the (bad) label. Reviewing this in a browser — not a test suite — would have caught it.
- **Fix 4 (phantom empty row target cells)** — smoking gun: `_rowIsEmpty` (prefix-underscored to silence the lint) was introduced alongside the execution-feature commit `510f65d17e` ("evaluations v3 execution and new evaluations results page", Jan 2026). The author computed the value and never consumed it — a half-shipped gate. No test exercised the relationship between `displayRowCount` and target-cell rendering, so nothing failed. The first test to cover it is the one in this PR.

**Systemic pattern:** when code is refactored across sibling files (TargetCell / TargetHeader / useOpenTargetEditor / RunEvaluationButton), the test suite doesn't tie them together. A fix on one file lands without a sweep to the others. Three of the four bugs in this PR are cases of "fix lands in one place, sibling bug survives."

**Guardrails that would catch the next regression:**
- Lint rule: ban direct `setFlowCallbacks("evaluatorEditor", {...})` calls that don't go through `createEvaluatorEditorCallbacks`. The helper's whole reason for existing per its JSDoc is "so we never forget a required callback" — enforce it.
- Ban `_`-prefixed unused variables in `src/evaluations-v3/components/*.tsx` production files (or surface them on PR review). An unused `_rowIsEmpty` at the top of the rowData builder is a half-shipped gate waiting to rot.
- A visual / screenshot test that opens the evaluator drawer from every entry point (chip-click, target-header-click, add-new-evaluator) and asserts the mappings section is present. This would have caught fix 1 without requiring the test author to know about flowCallbacks.
- When adding a tooltip to a "missing X" alert icon, a sweep for all other `LuCircleAlert` icons that emit the same error semantics.

## Test backfill

One regression test per fix (see commits `b14ccbce4`, `3cbb512bd`, `6436f5401`, `858f05f95`):
- `components/TargetSection/__tests__/TargetCell.test.tsx` — 3 scenarios asserting chip-edit wires `onMappingChange` on `flowCallbacks`, keeps it out of `mappingsConfig`, and opens the drawer with the right shape. Validated to fail against the pre-fix code path (see `useOpenTargetEditor.flowCallbacks.unit.test.tsx` as the sibling pattern).
- `components/TargetSection/__tests__/EvaluatorChip.test.tsx` — 2 scenarios asserting the alert icon is wrapped in a Tooltip and that hovering surfaces the "Missing variable mappings - Click to configure" copy.
- `__tests__/TableSettingsMenu.test.tsx` + `__tests__/TableDisplay.test.tsx` + `types/__tests__/persistence.test.ts` — updated label/value assertions for the `"expanded"` → `"fit"` rename. Existing coverage of the clicking-Fit → `rowHeightMode="fit"` roundtrip + disabled/enabled restrictions remained sufficient after the rename; no net-new test needed.
- `__tests__/TableDisplay.test.tsx` — 1 scenario asserting that with 2 populated dataset rows the target column renders exactly 2 cells (not 3) — the phantom third row's target cell is `null`. **Verified to fail against a reverted fix** (gets 3, expects 2) before re-applying.

Also softened `TableRowData.isEmpty` from required to optional. The original fix 4 commit typed it as required, but `DatasetSection/TableCell.tsx` carries its own parallel `RowData` shape without the field — triggering TS2322 on `Cell<TableRowData>` → `Cell<RowData>` assignment in `VirtualizedTableBody.tsx`. The fix's render gate uses a truthy check, so `undefined` == not empty (same default for the decoupled local type). Fixing the parallel-type smell is out of scope for this PR.

## Acceptance criteria (for #3441)

- [x] Regression test backfilled for each fix in this PR (TargetCell, EvaluatorChip, TableSettingsMenu rename, phantom row)
- [x] Existing tests in `__tests__/TableSettingsMenu.test.tsx` updated for the `"expanded"` → `"fit"` rename
- [x] Existing tests in `__tests__/TableDisplay.test.tsx` + `types/__tests__/persistence.test.ts` updated for the rename
- [x] Post-sweep investigation documented (above)

## Test plan

- [x] `pnpm test:unit src/evaluations-v3/` — 832 passed, 8 skipped, 0 failed (57 test files, 66 s)
- [x] `pnpm typecheck` clean
- [x] Manual in-browser: click evaluator chip → Edit Configuration → mappings section visible with required fields highlighted
- [x] Manual in-browser: hover missing-mapping `(!)` alert → tooltip appears with "Missing variable mappings - Click to configure"
- [x] Manual in-browser: row-height menu shows "Compact" / "Fit"; Fit shrinks rows to content, Compact clamps uniform 160px
- [x] Manual in-browser: trailing empty row shows no "No output yet" in target columns, still click-to-add on dataset columns

---

Refs #3441

🤖 Generated with [Claude Code](https://claude.com/claude-code)