### PR TITLE
fix(ci): expose feature-parity output from detect-changes action (#3461)

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -2,18 +2,29 @@
 #
 # On `pull_request` / `pull_request_target` we diff the PR against its
 # base using dorny/paths-filter. On every other event (push, schedule,
-# workflow_dispatch, merge_group) we force `relevant=true` so the real
-# jobs always run — required aggregator checks need a concrete result.
+# workflow_dispatch, merge_group) we force every declared filter to
+# `true` so the real jobs always run — required aggregator checks need
+# a concrete result.
 #
 # The caller MUST check out the repo first so this composite action is
 # accessible — dorny/paths-filter then reads the diff against the PR
 # base.
 #
+# IMPORTANT: every filter key the caller wants to consume must be
+# declared as an `outputs.<key>` entry below AND echoed into the force
+# step. dorny/paths-filter sets per-key outputs internally, but a
+# composite action only exposes outputs it explicitly declares — silently
+# missing entries land as empty strings. See #3461 for the regression
+# that added `feature-parity` here after callers had been reading an
+# undeclared output.
+#
 # Usage:
 #   jobs:
 #     changes:
 #       runs-on: ubuntu-latest
-#       outputs: { relevant: ${{ steps.detect.outputs.relevant }} }
+#       outputs:
+#         relevant: ${{ steps.detect.outputs.relevant }}
+#         feature-parity: ${{ steps.detect.outputs.feature-parity }}
 #       steps:
 #         - uses: actions/checkout@...
 #         - uses: ./.github/actions/detect-changes
@@ -22,16 +33,21 @@
 #             filters: |
 #               relevant:
 #                 - 'foo/**'
+#               feature-parity:
+#                 - 'specs/**'
 name: detect-changes
 description: Decide whether a path-filtered workflow should run real work.
 inputs:
   filters:
-    description: YAML filter block for dorny/paths-filter (must define a `relevant` filter).
+    description: YAML filter block for dorny/paths-filter (must define `relevant` + `feature-parity` filters).
     required: true
 outputs:
   relevant:
     description: "'true' if relevant paths changed, or if event is not a PR."
     value: ${{ steps.filter.outputs.relevant || steps.force.outputs.relevant }}
+  feature-parity:
+    description: "'true' if feature-parity-relevant paths changed, or if event is not a PR."
+    value: ${{ steps.filter.outputs.feature-parity || steps.force.outputs.feature-parity }}
 
 runs:
   using: composite
@@ -43,8 +59,10 @@ runs:
       with:
         filters: ${{ inputs.filters }}
 
-    - name: Force relevant on non-PR events
+    - name: Force every filter true on non-PR events
       if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
       id: force
       shell: bash
-      run: echo "relevant=true" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "relevant=true" >> "$GITHUB_OUTPUT"
+        echo "feature-parity=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The composite action `.github/actions/detect-changes/action.yml` declared only `relevant` as an output, but `.github/workflows/langwatch-app-ci.yml` reads `needs.changes.outputs.feature-parity` (added on PR #3298). Composite actions only re-expose outputs they explicitly declare — undeclared outputs land as empty strings — so the parity gating expression `if: outputs.feature-parity == 'true'` was always false and the `feature-parity` CI job has been silently skipped on every PR + main push since #3298 landed.

The script itself (`pnpm check:feature-parity`) is correct; only the CI gate was inert.

## Fix

Three small additions to the composite action:

1. **Declare `feature-parity` as a second composite output**, mirroring how `relevant` is wired (read `steps.filter.outputs.<key>` for PRs, fall through to `steps.force.outputs.<key>` for non-PR events).
2. **Add `feature-parity=true` to the force step** so non-PR events (push, merge_group, etc.) run the parity job unconditionally — same intent as `relevant`.
3. **Update the action docstring** with a warning that every filter key the caller consumes must be declared here too. The silent-empty-string failure mode is exactly the one this regression hit; calling it out inline is the cheapest guardrail.

## Test plan

- [ ] CI on this PR runs the `feature-parity` job (since the workflow file isn't touched here, only the action this PR is *gating itself with*; the consuming workflow comes via #3298 once that lands)
- [ ] On main push after merge, `feature-parity` job appears in run logs (currently it's absent — see issue body for run links)
- [ ] No regression to other path-gated jobs — `relevant` wiring unchanged
- [ ] Future-proofing: if a new filter key is added without the matching `outputs.<key>` declaration, the docstring warning catches it on review

## Acceptance criteria (from #3461)

- [x] `feature-parity` CI job is wired through the composite action (this PR's diff)
- [x] On main push, force step includes `feature-parity=true` (consistent with other always-run jobs)
- [ ] Verifiable: introduce a PR with an intentional unbound `@unit` scenario in a non-`LEGACY_UNBOUND` file; CI fails on the `feature-parity` job — **deferred** until #3298 merges (which adds the consuming `feature-parity` job to `langwatch-app-ci.yml`)
- [x] No regression to other path-gated jobs

## Notes

- This PR is independent of #3298. Either ordering works:
  - If this lands first, #3298 inherits the fix automatically.
  - If #3298 lands first, the parity job is silently skipped until this lands.

Resolves #3461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related Issue

- Resolve #3461