### PR TITLE
refactor: route every setFlowCallbacks evaluatorEditor through the shared helper (#3460 item 6)

### DIFF
--- a/langwatch/src/evaluations-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/evaluations-v3/components/EvaluationsV3Table.tsx
@@ -50,6 +50,7 @@ import type {
 } from "../types";
 import { convertInlineToRowRecords } from "../utils/datasetConversion";
 import { isRowEmpty } from "../utils/emptyRowDetection";
+import { createEvaluatorEditorCallbacks } from "../utils/evaluatorEditorCallbacks";
 import { isCellInExecution } from "../utils/executionScope";
 import {
   convertFromUIMapping,
@@ -511,21 +512,24 @@ export function EvaluationsV3Table({
     // 1. Fetch the newly created evaluator from DB
     // 2. Add it to the workbench
     // 3. Close the drawer
-    setFlowCallbacks("evaluatorEditor", {
-      onSave: async (savedEvaluator: { id: string; name: string }) => {
-        // Fetch the full evaluator data from DB
-        const evaluator = await trpcUtils.evaluators.getById.fetch({
-          id: savedEvaluator.id,
-          projectId: project?.id ?? "",
-        });
+    setFlowCallbacks(
+      "evaluatorEditor",
+      createEvaluatorEditorCallbacks({
+        onSave: async (savedEvaluator: { id: string; name: string }) => {
+          // Fetch the full evaluator data from DB
+          const evaluator = await trpcUtils.evaluators.getById.fetch({
+            id: savedEvaluator.id,
+            projectId: project?.id ?? "",
+          });
 
-        if (evaluator) {
-          addEvaluatorToWorkbench(evaluator);
-        }
-        closeDrawer(); // Close drawer after adding evaluator to workbench
-        return true; // Indicate navigation was handled to prevent default back behavior
-      },
-    });
+          if (evaluator) {
+            addEvaluatorToWorkbench(evaluator);
+          }
+          closeDrawer(); // Close drawer after adding evaluator to workbench
+          return true; // Indicate navigation was handled to prevent default back behavior
+        },
+      }),
+    );
 
     openDrawer("evaluatorList");
   }, [
@@ -673,24 +677,27 @@ export function EvaluationsV3Table({
     });
     // Set up flow callback for when a NEW evaluator is created during the target flow
     // This handles: add comparison > evaluator > create new > category > fill form > create
-    setFlowCallbacks("evaluatorEditor", {
-      onSave: async (savedEvaluator: { id: string; name: string }) => {
-        // Fetch the full evaluator data from DB to get computed fields
-        const evaluator = await trpcUtils.evaluators.getById.fetch({
-          id: savedEvaluator.id,
-          projectId: project?.id ?? "",
-        });
+    setFlowCallbacks(
+      "evaluatorEditor",
+      createEvaluatorEditorCallbacks({
+        onSave: async (savedEvaluator: { id: string; name: string }) => {
+          // Fetch the full evaluator data from DB to get computed fields
+          const evaluator = await trpcUtils.evaluators.getById.fetch({
+            id: savedEvaluator.id,
+            projectId: project?.id ?? "",
+          });
 
-        if (!evaluator) {
-          closeDrawer();
-          return true;
-        }
+          if (!evaluator) {
+            closeDrawer();
+            return true;
+          }
 
-        // Use handleSelectEvaluatorAsTarget to add the target with proper fields
-        handleSelectEvaluatorAsTarget(evaluator);
-        return true; // Indicate navigation was handled to prevent default back behavior
-      },
-    });
+          // Use handleSelectEvaluatorAsTarget to add the target with proper fields
+          handleSelectEvaluatorAsTarget(evaluator);
+          return true; // Indicate navigation was handled to prevent default back behavior
+        },
+      }),
+    );
     openDrawer("targetTypeSelector");
   }, [
     buildAvailableSources,

--- a/langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts
+++ b/langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import { createEvaluatorEditorCallbacks } from "~/evaluations-v3/utils/evaluatorEditorCallbacks";
 import { setFlowCallbacks, useDrawer } from "~/hooks/useDrawer";
 import type { Component, Field } from "../types/dsl";
 import type { NodeWithOptionalPosition } from "~/types";
@@ -143,7 +144,10 @@ export function useEvaluatorPickerFlow() {
             }
           };
           // Both built-in and workflow evaluator creation paths
-          setFlowCallbacks("evaluatorEditor", { onSave: onEvaluatorSaved });
+          setFlowCallbacks(
+            "evaluatorEditor",
+            createEvaluatorEditorCallbacks({ onSave: onEvaluatorSaved }),
+          );
           setFlowCallbacks("workflowSelectorForEvaluator", { onSave: onEvaluatorSaved });
           openDrawer("evaluatorCategorySelector");
         },

--- a/langwatch/src/pages/[project]/evaluators.tsx
+++ b/langwatch/src/pages/[project]/evaluators.tsx
@@ -16,6 +16,7 @@ import { DashboardLayout } from "~/components/DashboardLayout";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
 import { toaster } from "~/components/ui/toaster";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
+import { createEvaluatorEditorCallbacks } from "~/evaluations-v3/utils/evaluatorEditorCallbacks";
 import { setFlowCallbacks, useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
@@ -141,12 +142,15 @@ function Page() {
   const handleCreateNewEvaluator = () => {
     // Set up callback to close drawer after creating new evaluator
     // (instead of going back through category → type → editor stack)
-    setFlowCallbacks("evaluatorEditor", {
-      onSave: () => {
-        closeDrawer();
-        return true; // Signal that we handled navigation
-      },
-    });
+    setFlowCallbacks(
+      "evaluatorEditor",
+      createEvaluatorEditorCallbacks({
+        onSave: () => {
+          closeDrawer();
+          return true; // Signal that we handled navigation
+        },
+      }),
+    );
     openDrawer("evaluatorCategorySelector");
   };
 


### PR DESCRIPTION
## Summary

Follow-up #6 from PR #3457's `/review`. The `createEvaluatorEditorCallbacks` helper exists specifically *"so we never forget a required callback"* (per its JSDoc). Yet four production sites bypassed it and called `setFlowCallbacks("evaluatorEditor", { onSave: ... })` directly. If a future change adds a new required callback to the helper, those four sites silently miss it — exactly the regression class that hit `TargetCell.tsx`'s chip-edit path on PR #3457 (missing `onMappingChange`, mappings section silently hid).

This PR re-routes every direct `setFlowCallbacks("evaluatorEditor", ...)` call site through the helper. All four touched sites pass only `onSave` today, so the change is a pure passthrough — but the type-level enforcement now stops new callbacks from skipping any site.

## Sites converted

- `langwatch/src/evaluations-v3/components/EvaluationsV3Table.tsx:514` — add evaluator to workbench flow
- `langwatch/src/evaluations-v3/components/EvaluationsV3Table.tsx:676` — add comparison > evaluator > create new flow
- `langwatch/src/optimization_studio/hooks/useEvaluatorPickerFlow.ts:146` — workflow studio evaluator picker
- `langwatch/src/pages/[project]/evaluators.tsx:144` — evaluators management page "create new" path

## NOT converted (intentional)

- **`langwatch/src/evaluations-v3/components/TargetSection/TargetCell.tsx`** — PR #3457 already wires this path through the helper as part of the mappings-section regression fix. Touching it here would conflict, so deferred to merge-after.

## Already correct (no change needed)

- `langwatch/src/evaluations-v3/hooks/useOpenTargetEditor.ts:344` — already uses the helper (PR #3114).
- `langwatch/src/components/evaluations/OnlineEvaluationDrawer.tsx` — all three call sites already use the helper.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit src/evaluations-v3/` — **826 passed, 8 skipped, 0 failed** across 57 files
- [x] `pnpm test:unit src/optimization_studio/hooks/` — **67 passed**, 0 failed
- [x] No tests live in `pages/[project]/` for the touched site; manually verified the call shape is byte-identical to the pre-refactor `{ onSave }` semantics.

## Acceptance criteria (for #3460 item 6)

- [x] Sweep all `setFlowCallbacks("evaluatorEditor", …)` call sites through `createEvaluatorEditorCallbacks` — except `TargetCell.tsx` which is being addressed by PR #3457
- [ ] Optional ESLint rule banning direct `setFlowCallbacks("evaluatorEditor", {...})` outside the helper — **deferred** as an explicit follow-up, file under #3460 item 6 once the rule infrastructure exists in the repo

Refs #3460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related Issue

- Resolve #3460