### PR TITLE
refactor(evaluations-v3): unify parallel RowData type (#3460 item 5)

### DIFF
--- a/langwatch/src/evaluations-v3/components/DatasetSection/TableCell.tsx
+++ b/langwatch/src/evaluations-v3/components/DatasetSection/TableCell.tsx
@@ -2,6 +2,7 @@ import { Skeleton, VStack } from "@chakra-ui/react";
 import { type Cell, flexRender } from "@tanstack/react-table";
 import type { DatasetColumnType } from "~/server/datasets/types";
 import { useEvaluationsV3Store } from "../../hooks/useEvaluationsV3Store";
+import type { TableRowData } from "../../types";
 import { EditableCell } from "./EditableCell";
 
 // ============================================================================
@@ -16,17 +17,8 @@ type ColumnMeta = {
   dataType?: DatasetColumnType; // The actual data type (string, json, list, etc.)
 };
 
-type RowData = {
-  rowIndex: number;
-  dataset: Record<string, string>;
-  targets: Record<
-    string,
-    { output: unknown; evaluators: Record<string, unknown> }
-  >;
-};
-
 type TableCellProps = {
-  cell: Cell<RowData, unknown>;
+  cell: Cell<TableRowData, unknown>;
   rowIndex: number;
   activeDatasetId: string;
   isLoading?: boolean;

--- a/langwatch/src/evaluations-v3/types.ts
+++ b/langwatch/src/evaluations-v3/types.ts
@@ -587,9 +587,14 @@ export type TableRowData = {
    * True when the dataset row contains no user-entered values. The table
    * always renders a trailing empty row for Excel-style "click to add,"
    * but that phantom row must not show target outputs or evaluator chips.
-   * The cell renderer uses a truthy check, so `undefined` == not empty.
+   *
+   * Required (non-optional) — every TableRowData built by the rowData
+   * builder in EvaluationsV3Table.tsx sets this. Was briefly optional during
+   * the #3441 sweep because DatasetSection/TableCell.tsx carried a parallel
+   * RowData shape without the field; that parallel shape has been unified
+   * with this type (#3460 item 5), so the optional can go.
    */
-  isEmpty?: boolean;
+  isEmpty: boolean;
   targets: Record<
     string,
     {


### PR DESCRIPTION
> **Stacks on #3457 — will be ready to merge after #3457 lands.** This PR's base is the `issue3441/mini-epic-fix-broken-mappings-across` branch, not `main`. Once #3457 merges, GitHub will auto-rebase this onto `main`.

## Summary

Follow-up #5 from `/review` on PR #3457. `DatasetSection/TableCell.tsx` carried a local `RowData` type that paralleled `TableRowData` in `types.ts` but lacked the `isEmpty` field. PR #3457 had to mark `TableRowData.isEmpty` optional to keep the two types structurally assignable across `Cell<TableRowData>` ↔ `Cell<RowData>` boundaries in `VirtualizedTableBody.tsx`.

This PR removes the parallel type and tightens the contract.

## Changes

- `langwatch/src/evaluations-v3/components/DatasetSection/TableCell.tsx`: drop the local `RowData` type; `import type { TableRowData } from "../../types"` and use it in `TableCellProps`.
- `langwatch/src/evaluations-v3/types.ts`: drop the `?` on `isEmpty`. Every rowData builder already sets it explicitly via `isEmpty: rowIsEmpty`, so this is the truthful shape.

Net: 2 files, +9 / -12.

## Test plan

- [x] `pnpm typecheck` — clean. `Cell<TableRowData>` ↔ `Cell<TableRowData>` is now identity, not subtyping.
- [x] `pnpm test:unit src/evaluations-v3/` — **833 passed, 8 skipped, 0 failed** (identical to #3457 baseline)

## Acceptance criteria (from #3460 item 5)

- [x] Parallel `RowData` type in `DatasetSection/TableCell.tsx` removed.
- [x] `TableRowData.isEmpty` is required (no `?`).
- [x] No behavior change.

Refs #3460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related Issue

- Resolve #3460