### PR TITLE
perf(analytics): cut PostHog bill — dedup pageviews + backend local eval

### DIFF
--- a/dev/docs/adr/005-feature-flags.md
+++ b/dev/docs/adr/005-feature-flags.md
@@ -92,9 +92,18 @@ Cache key format: `{flagKey}:{distinctId}:{projectId}:{organizationId}`
 
 ### Local evaluation (PostHog)
 
-When `POSTHOG_FEATURE_FLAGS_KEY` (Feature Flags Secure key, `phs_*`) is set, `posthog-node` is initialised with `personalApiKey` + `featureFlagsPollingInterval` (default 5 min). The SDK polls flag definitions in the background and resolves `isFeatureEnabled` in-process — no `/flags` request per call.
+When `POSTHOG_FEATURE_FLAGS_KEY` is set, `posthog-node` is initialised with `personalApiKey` + `featureFlagsPollingInterval` (default 5 min). The SDK polls flag definitions in the background and resolves `isFeatureEnabled` in-process — no `/flags` request per call.
 
-This collapses the cost of per-span killswitch checks: without local evaluation each cache miss is one billable PostHog request; with it, the only billable traffic is the polling itself (10 evaluations × 1 poll per 5 min × 1 server ≈ ~86 k/month/server).
+The env var accepts either:
+- a Feature Flags Secure key (`phs_*`) — the current PostHog recommendation, scoped to flag evaluation only, **or**
+- a legacy Personal API key (`phx_*`) — supported for backward compatibility.
+
+This collapses the cost of per-span killswitch checks. Without local evaluation, each cache miss is one billable PostHog request; with it, the only billable traffic is the polling itself, **independent of evaluation volume**.
+
+PostHog bills each local-evaluation poll as 10 feature-flag requests (a single poll fetches all flag definitions in one HTTP request, but the billing multiplier is 10×). At the default 5 min interval:
+
+- 12 polls/hour × 24 × 30 ≈ **8.6 k poll requests / server / month** (HTTP)
+- × 10 billing multiplier ≈ **86 k billable units / server / month**
 
 Set `POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS` to lower the poll interval if you need flag changes to propagate faster than 5 min.
 

--- a/dev/docs/adr/005-feature-flags.md
+++ b/dev/docs/adr/005-feature-flags.md
@@ -79,12 +79,24 @@ PostHog receives these as `personProperties.project_id` and `personProperties.or
 
 ### Caching Strategy
 
-A 5-second TTL (`FEATURE_FLAG_CACHE_TTL_MS`) is used at two levels:
+Two TTLs cover different access patterns:
 
-1. **Server-side**: `StaleWhileRevalidateCache` with Redis (shared) + memory (per-instance)
-2. **Client-side**: React Query `staleTime`
+| Constant | Default | Used by |
+|----------|---------|---------|
+| `FEATURE_FLAG_CACHE_TTL_MS` | 5 s | Frontend `useFeatureFlag`, server-side default |
+| `KILL_SWITCH_CACHE_TTL_MS` | 60 s | Hot-path backend killswitches (per-span / per-event) |
+
+Both share one Redis-backed `StaleWhileRevalidateCache` instance whose underlying storage TTL equals the larger of the two windows. Per-call callers pass `cacheTtlMs` via `FeatureFlagOptions` to opt into the longer window; everyone else gets the 5 s default.
 
 Cache key format: `{flagKey}:{distinctId}:{projectId}:{organizationId}`
+
+### Local evaluation (PostHog)
+
+When `POSTHOG_FEATURE_FLAGS_KEY` (Feature Flags Secure key, `phs_*`) is set, `posthog-node` is initialised with `personalApiKey` + `featureFlagsPollingInterval` (default 5 min). The SDK polls flag definitions in the background and resolves `isFeatureEnabled` in-process — no `/flags` request per call.
+
+This collapses the cost of per-span killswitch checks: without local evaluation each cache miss is one billable PostHog request; with it, the only billable traffic is the polling itself (10 evaluations × 1 poll per 5 min × 1 server ≈ ~86 k/month/server).
+
+Set `POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS` to lower the poll interval if you need flag changes to propagate faster than 5 min.
 
 ### Flag Naming Convention
 

--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -61,20 +61,6 @@ API_TOKEN_JWT_SECRET="change me to a random string"
 # Usage tracking for product insights, set to true if you would like to disable this.
 # DISABLE_USAGE_STATS=
 
-# PostHog product analytics + feature flags (optional, used for SaaS).
-# POSTHOG_KEY=
-# POSTHOG_HOST=https://eu.i.posthog.com
-# Feature Flags Secure API key (phs_*) enables LOCAL feature flag evaluation
-# in posthog-node. Without it, every server-side feature flag check hits the
-# /flags endpoint (1 billable request per uncached call). With it, flag
-# definitions are polled in the background and evaluated in-process.
-# Legacy Personal API keys (phx_*) also work in this slot.
-# https://posthog.com/docs/feature-flags/local-evaluation
-# POSTHOG_FEATURE_FLAGS_KEY=
-# Polling interval (ms) for local flag definition refresh. Defaults to 5min.
-# Each poll is billed as 10 flag evaluations.
-# POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS=300000
-
 # If you want you can download TikTokens directly from the repository to avoid remote fetching.
 # Example setup:
 # mkdir -p langwatch/tiktoken

--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -61,6 +61,20 @@ API_TOKEN_JWT_SECRET="change me to a random string"
 # Usage tracking for product insights, set to true if you would like to disable this.
 # DISABLE_USAGE_STATS=
 
+# PostHog product analytics + feature flags (optional, used for SaaS).
+# POSTHOG_KEY=
+# POSTHOG_HOST=https://eu.i.posthog.com
+# Feature Flags Secure API key (phs_*) enables LOCAL feature flag evaluation
+# in posthog-node. Without it, every server-side feature flag check hits the
+# /flags endpoint (1 billable request per uncached call). With it, flag
+# definitions are polled in the background and evaluated in-process.
+# Legacy Personal API keys (phx_*) also work in this slot.
+# https://posthog.com/docs/feature-flags/local-evaluation
+# POSTHOG_FEATURE_FLAGS_KEY=
+# Polling interval (ms) for local flag definition refresh. Defaults to 5min.
+# Each poll is billed as 10 flag evaluations.
+# POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS=300000
+
 # If you want you can download TikTokens directly from the repository to avoid remote fetching.
 # Example setup:
 # mkdir -p langwatch/tiktoken

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -121,7 +121,12 @@ export function createEnvConfig() {
       // Polling interval (ms) for local flag definition refresh. PostHog default
       // is 30s; we default to 5min because each poll counts as 10 flag evaluations
       // for billing. Lower this if you need flag changes to propagate faster.
-      POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS: z.coerce.number().int().positive().optional(),
+      // Empty-string values in .env are coerced to undefined so they fall back
+      // to the runtime default instead of failing .positive() with 0.
+      POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS: z.preprocess(
+        (value) => (value === "" ? undefined : value),
+        z.coerce.number().int().positive().optional(),
+      ),
       DISABLE_USAGE_STATS: z.boolean().optional(),
       LANGWATCH_NLP_LAMBDA_CONFIG: z.string().optional(),
 

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -112,6 +112,16 @@ export function createEnvConfig() {
 
       POSTHOG_KEY: z.string().optional(),
       POSTHOG_HOST: z.string().optional(),
+      // Feature Flags Secure API key (phs_*) — or a legacy Personal API key
+      // (phx_*) — enables local feature flag evaluation in posthog-node. When
+      // set, server-side `isFeatureEnabled` does NOT hit /flags per call;
+      // instead the SDK polls flag definitions periodically and evaluates
+      // locally. See https://posthog.com/docs/feature-flags/local-evaluation
+      POSTHOG_FEATURE_FLAGS_KEY: z.string().optional(),
+      // Polling interval (ms) for local flag definition refresh. PostHog default
+      // is 30s; we default to 5min because each poll counts as 10 flag evaluations
+      // for billing. Lower this if you need flag changes to propagate faster.
+      POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS: z.coerce.number().int().positive().optional(),
       DISABLE_USAGE_STATS: z.boolean().optional(),
       LANGWATCH_NLP_LAMBDA_CONFIG: z.string().optional(),
 
@@ -216,6 +226,9 @@ export function createEnvConfig() {
       COGNITO_CLIENT_SECRET: process.env.COGNITO_CLIENT_SECRET,
       POSTHOG_KEY: process.env.POSTHOG_KEY,
       POSTHOG_HOST: process.env.POSTHOG_HOST,
+      POSTHOG_FEATURE_FLAGS_KEY: process.env.POSTHOG_FEATURE_FLAGS_KEY,
+      POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS:
+        process.env.POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS,
       DISABLE_USAGE_STATS:
         process.env.DISABLE_USAGE_STATS === "1" ||
         process.env.DISABLE_USAGE_STATS?.toLowerCase() === "true",

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -1,10 +1,8 @@
-import { useRouter } from "~/utils/compat/next-router";
 import posthog from "posthog-js";
 import { useEffect } from "react";
 import { usePublicEnv } from "./usePublicEnv";
 
 export function usePostHog() {
-  const router = useRouter();
   const publicEnv = usePublicEnv();
 
   useEffect(() => {
@@ -14,6 +12,11 @@ export function usePostHog() {
     const posthogHost = publicEnv.data?.POSTHOG_HOST;
 
     if (posthogKey) {
+      // posthog-js auto-captures $pageview on History API navigation in SPAs
+      // (capture_pageview defaults to "history_change"). We deliberately do not
+      // also call posthog.capture("$pageview") on routeChangeComplete — doing
+      // both used to double-count, and prior to the next-router compat dedup
+      // it multiplied pageviews by every mounted useRouter() consumer.
       posthog.init(posthogKey, {
         api_host: posthogHost ?? "https://eu.i.posthog.com",
         person_profiles: "always",
@@ -26,16 +29,8 @@ export function usePostHog() {
           if (publicEnv.data?.NODE_ENV === "development") posthog.debug();
         },
       });
-
-      const handleRouteChange = () => posthog?.capture("$pageview");
-
-      router.events.on("routeChangeComplete", handleRouteChange);
-
-      return () => {
-        router.events.off("routeChangeComplete", handleRouteChange);
-      };
     }
-  }, [publicEnv.data, router.events]);
+  }, [publicEnv.data]);
 
   return publicEnv.data?.POSTHOG_KEY ? posthog : undefined;
 }

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -12,15 +12,21 @@ export function usePostHog() {
     const posthogHost = publicEnv.data?.POSTHOG_HOST;
 
     if (posthogKey) {
-      // posthog-js auto-captures $pageview on History API navigation in SPAs
-      // (capture_pageview defaults to "history_change"). We deliberately do not
-      // also call posthog.capture("$pageview") on routeChangeComplete — doing
-      // both used to double-count, and prior to the next-router compat dedup
-      // it multiplied pageviews by every mounted useRouter() consumer.
+      // capture_pageview: "history_change" tells posthog-js to capture
+      // $pageview on every History API navigation (pushState / popstate),
+      // not just on initial page load. In posthog-js 1.369 this defaults
+      // to true (initial load only) unless `defaults` is set to >=
+      // '2025-05-24', so we set it explicitly to avoid silently dropping
+      // SPA pageviews after the migration off Next.js.
+      // We deliberately do NOT also call posthog.capture("$pageview") on
+      // routeChangeComplete — letting posthog-js handle it avoids the
+      // multiplier bug from the next-router compat layer (every mounted
+      // useRouter() instance used to fan out one capture per consumer).
       posthog.init(posthogKey, {
         api_host: posthogHost ?? "https://eu.i.posthog.com",
         person_profiles: "always",
         autocapture: true,
+        capture_pageview: "history_change",
         capture_exceptions: true,
         session_recording: {
           recordCrossOriginIframes: true,

--- a/langwatch/src/server/__tests__/posthog-local-evaluation.unit.test.ts
+++ b/langwatch/src/server/__tests__/posthog-local-evaluation.unit.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for posthog-node initialization with local evaluation.
+ *
+ * Local evaluation is enabled when POSTHOG_FEATURE_FLAGS_KEY is set.
+ * It dramatically reduces feature flag costs because the SDK polls flag
+ * definitions in the background and evaluates them in-process instead of
+ * hitting the /flags endpoint per call.
+ *
+ * @see specs/analytics/posthog-cost-control.feature
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { ctorSpy } = vi.hoisted(() => ({
+  ctorSpy: vi.fn(),
+}));
+
+vi.mock("posthog-node", () => ({
+  PostHog: function (apiKey: string, opts: unknown) {
+    ctorSpy(apiKey, opts);
+    return {
+      capture: vi.fn(),
+      isFeatureEnabled: vi.fn(),
+      shutdown: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe("posthog-node initialization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe("when POSTHOG_FEATURE_FLAGS_KEY is set", () => {
+    it("enables local evaluation with the configured personal API key", async () => {
+      vi.doMock("~/env.mjs", () => ({
+        env: {
+          POSTHOG_KEY: "phc_test_key",
+          POSTHOG_HOST: "https://us.i.posthog.com",
+          POSTHOG_FEATURE_FLAGS_KEY: "phx_personal_key",
+        },
+      }));
+
+      await import("../posthog");
+
+      expect(ctorSpy).toHaveBeenCalledWith(
+        "phc_test_key",
+        expect.objectContaining({
+          host: "https://us.i.posthog.com",
+          personalApiKey: "phx_personal_key",
+          featureFlagsPollingInterval: expect.any(Number),
+        }),
+      );
+    });
+
+    it("respects an explicit polling interval override", async () => {
+      vi.doMock("~/env.mjs", () => ({
+        env: {
+          POSTHOG_KEY: "phc_test_key",
+          POSTHOG_HOST: "https://us.i.posthog.com",
+          POSTHOG_FEATURE_FLAGS_KEY: "phx_personal_key",
+          POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS: 60_000,
+        },
+      }));
+
+      await import("../posthog");
+
+      expect(ctorSpy).toHaveBeenCalledWith(
+        "phc_test_key",
+        expect.objectContaining({
+          featureFlagsPollingInterval: 60_000,
+        }),
+      );
+    });
+  });
+
+  describe("when POSTHOG_FEATURE_FLAGS_KEY is not set", () => {
+    it("does not enable local evaluation", async () => {
+      vi.doMock("~/env.mjs", () => ({
+        env: {
+          POSTHOG_KEY: "phc_test_key",
+          POSTHOG_HOST: "https://us.i.posthog.com",
+        },
+      }));
+
+      await import("../posthog");
+
+      expect(ctorSpy).toHaveBeenCalledWith(
+        "phc_test_key",
+        expect.not.objectContaining({
+          personalApiKey: expect.anything(),
+          featureFlagsPollingInterval: expect.anything(),
+        }),
+      );
+    });
+  });
+
+  describe("when POSTHOG_KEY is not set", () => {
+    it("does not construct a PostHog instance", async () => {
+      vi.doMock("~/env.mjs", () => ({
+        env: {},
+      }));
+
+      await import("../posthog");
+
+      expect(ctorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/__tests__/span-token-estimation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/span-token-estimation.service.unit.test.ts
@@ -482,6 +482,7 @@ describe("OtlpSpanTokenEstimationService", () => {
           "token-estimation-killswitch",
           "global",
           false,
+          expect.objectContaining({ cacheTtlMs: expect.any(Number) }),
         );
       });
     });
@@ -527,7 +528,10 @@ describe("OtlpSpanTokenEstimationService", () => {
           "token-estimation-project-killswitch",
           "project-456",
           false,
-          { projectId: "project-456" },
+          expect.objectContaining({
+            projectId: "project-456",
+            cacheTtlMs: expect.any(Number),
+          }),
         );
       });
     });

--- a/langwatch/src/server/app-layer/traces/span-token-estimation.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-token-estimation.service.ts
@@ -1,5 +1,6 @@
 import type { OtlpSpan } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 import type { TokenizerClient } from "../clients/tokenizer/tokenizer.client";
+import { KILL_SWITCH_CACHE_TTL_MS } from "../../featureFlag/constants";
 import type { FeatureFlagServiceInterface } from "../../featureFlag/types";
 
 /**
@@ -149,11 +150,15 @@ export class OtlpSpanTokenEstimationService {
   }): Promise<boolean> {
     if (!this.deps.featureFlagService) return false;
 
-    // Global kill switch — disables for all projects
+    // Global kill switch — disables for all projects.
+    // Both checks pass cacheTtlMs to widen the cache window beyond the
+    // 5s frontend-flag default, since this method runs on the per-span
+    // hot path and a cache miss = one billable PostHog /flags request.
     const globalDisabled = await this.deps.featureFlagService.isEnabled(
       GLOBAL_KILL_SWITCH_KEY,
       "global",
       false,
+      { cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS },
     );
     if (globalDisabled) return true;
 
@@ -163,7 +168,7 @@ export class OtlpSpanTokenEstimationService {
         PROJECT_KILL_SWITCH_KEY,
         tenantId,
         false,
-        { projectId: tenantId },
+        { projectId: tenantId, cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS },
       );
       if (projectDisabled) return true;
     }

--- a/langwatch/src/server/event-sourcing/utils/__tests__/killSwitch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/utils/__tests__/killSwitch.unit.test.ts
@@ -83,6 +83,7 @@ describe("isComponentDisabled", () => {
         "es-trace-command-recordSpan-killswitch",
         "tenant-1",
         false,
+        expect.objectContaining({ cacheTtlMs: expect.any(Number) }),
       );
     });
 
@@ -138,6 +139,7 @@ describe("isComponentDisabled", () => {
         "my-custom-flag",
         "tenant-1",
         false,
+        expect.objectContaining({ cacheTtlMs: expect.any(Number) }),
       );
     });
   });

--- a/langwatch/src/server/event-sourcing/utils/killSwitch.ts
+++ b/langwatch/src/server/event-sourcing/utils/killSwitch.ts
@@ -1,4 +1,5 @@
 import type { createLogger } from "~/utils/logger/server";
+import { KILL_SWITCH_CACHE_TTL_MS } from "../../featureFlag/constants";
 import type { FeatureFlagServiceInterface } from "../../featureFlag/types";
 import type { AggregateType } from "../domain/aggregateType";
 
@@ -47,6 +48,7 @@ export async function isComponentDisabled({
       flagKey,
       tenantId,
       false,
+      { cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS },
     );
     if (isDisabled && logger) {
       logger.debug(

--- a/langwatch/src/server/featureFlag/__tests__/staleWhileRevalidateCache.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/staleWhileRevalidateCache.unit.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the cacheTtlMs override path used by hot-path kill switch
+ * callers. The underlying storage TTL must be wide enough that the override
+ * actually wins, otherwise Redis evicts before the override window expires.
+ *
+ * @see specs/analytics/posthog-cost-control.feature
+ */
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+
+// Force memory-only mode (no Redis) so tests are deterministic.
+vi.mock("../../redis", () => ({
+  isBuildOrNoRedis: true,
+  connection: null,
+}));
+
+import { StaleWhileRevalidateCache } from "../staleWhileRevalidateCache.redis";
+
+describe("StaleWhileRevalidateCache with ttl override", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("when caller passes ttlOverrideMs longer than the default", () => {
+    it("returns cached value past the default staleness window", async () => {
+      const cache = new StaleWhileRevalidateCache(
+        5_000, // default staleness
+        5_000,
+        60_000, // underlying max TTL — must accommodate longest override
+      );
+
+      await cache.set("k", true);
+
+      vi.advanceTimersByTime(10_000); // past the default
+
+      const withDefault = await cache.get("k");
+      expect(withDefault).toBeUndefined();
+
+      // Re-set so we can test the override path on a fresh entry.
+      await cache.set("k", true);
+      vi.advanceTimersByTime(10_000);
+
+      const withOverride = await cache.get("k", 60_000);
+      expect(withOverride?.value).toBe(true);
+    });
+
+    it("evicts past the override window too", async () => {
+      const cache = new StaleWhileRevalidateCache(5_000, 5_000, 60_000);
+      await cache.set("k", true);
+
+      vi.advanceTimersByTime(70_000);
+
+      const result = await cache.get("k", 60_000);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("when no override is passed", () => {
+    it("uses the default staleness threshold", async () => {
+      const cache = new StaleWhileRevalidateCache(5_000, 5_000, 60_000);
+      await cache.set("k", true);
+
+      vi.advanceTimersByTime(2_000);
+      expect((await cache.get("k"))?.value).toBe(true);
+
+      vi.advanceTimersByTime(10_000); // total 12s, past default 5s
+      expect(await cache.get("k")).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/featureFlag/constants.ts
+++ b/langwatch/src/server/featureFlag/constants.ts
@@ -5,13 +5,27 @@
  */
 
 /**
- * Cache TTL for feature flags in milliseconds.
+ * Cache TTL for user-facing feature flags in milliseconds.
  *
  * This value is used for:
- * - Server-side Redis/memory cache (StaleWhileRevalidateCache)
+ * - Server-side Redis/memory cache (StaleWhileRevalidateCache) for frontend flags
  * - Client-side React Query staleTime (useFeatureFlag)
  *
- * A 5-second TTL provides fast kill switch response while minimizing
- * PostHog API calls. Changes to flags propagate within 5 seconds.
+ * A 5-second TTL provides fast feature flag toggling for the UI while keeping
+ * PostHog request volume tied to active user sessions.
  */
 export const FEATURE_FLAG_CACHE_TTL_MS = 5_000;
+
+/**
+ * Cache TTL for backend kill switches in milliseconds.
+ *
+ * Kill switches are checked on hot paths (per span, per event, per command).
+ * They do not need second-level freshness — flipping a kill switch in PostHog
+ * propagating in 60s is fine, and the longer TTL prevents per-tenant cache
+ * fragmentation from stampeding /flags requests under high traffic.
+ *
+ * When local evaluation is enabled (POSTHOG_FEATURE_FLAGS_KEY), this only
+ * affects the in-memory dedup window; flag values are computed in-process
+ * either way.
+ */
+export const KILL_SWITCH_CACHE_TTL_MS = 60_000;

--- a/langwatch/src/server/featureFlag/featureFlagService.posthog.ts
+++ b/langwatch/src/server/featureFlag/featureFlagService.posthog.ts
@@ -1,7 +1,10 @@
 import { getLangWatchTracer } from "langwatch";
 import { createLogger } from "~/utils/logger/server";
 import { getPostHogInstance } from "../posthog";
-import { FEATURE_FLAG_CACHE_TTL_MS } from "./constants";
+import {
+  FEATURE_FLAG_CACHE_TTL_MS,
+  KILL_SWITCH_CACHE_TTL_MS,
+} from "./constants";
 import { StaleWhileRevalidateCache } from "./staleWhileRevalidateCache.redis";
 import type { FeatureFlagOptions, FeatureFlagServiceInterface } from "./types";
 
@@ -39,9 +42,13 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
     "langwatch.posthog-feature-flag-service",
   );
 
+  // Underlying storage TTL is the larger of the two windows so kill-switch
+  // callers passing ttlOverrideMs = KILL_SWITCH_CACHE_TTL_MS don't get
+  // evicted by Redis at the frontend-flag staleness window.
   private readonly cache = new StaleWhileRevalidateCache(
     FEATURE_FLAG_CACHE_TTL_MS,
     FEATURE_FLAG_CACHE_TTL_MS,
+    KILL_SWITCH_CACHE_TTL_MS,
   );
 
   constructor() {
@@ -87,8 +94,9 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
         const orgId = options?.organizationId;
         const cacheKey = `${flagKey}:${distinctId}:${projectId ?? ""}:${orgId ?? ""}`;
 
-        // Check hybrid cache first
-        const cachedResult = await this.cache.get(cacheKey);
+        // Check hybrid cache first. Hot-path callers may pass a longer
+        // cacheTtlMs to extend the staleness window without hitting PostHog.
+        const cachedResult = await this.cache.get(cacheKey, options?.cacheTtlMs);
         if (cachedResult !== undefined) {
           span.setAttribute("feature.flag.source", "posthog-cached");
           span.setAttribute("feature.flag.enabled", cachedResult.value);

--- a/langwatch/src/server/featureFlag/staleWhileRevalidateCache.redis.ts
+++ b/langwatch/src/server/featureFlag/staleWhileRevalidateCache.redis.ts
@@ -51,15 +51,28 @@ export class StaleWhileRevalidateCache {
    * @param ttlOverrideMs optional caller-provided staleness threshold. Used by
    *   hot-path callers (kill switches) to extend the cache window without
    *   changing the global default that user-facing flags rely on.
+   *
+   * Eviction rule: physically delete only when the absolute storage TTL
+   * (maxTtlMs) is exceeded. For shorter per-caller thresholds, return
+   * `undefined` silently — that way a short-window caller hitting a still-
+   * valid entry doesn't evict it from under a long-window caller. This
+   * matters if the same cache key is read from both a 5 s consumer and a
+   * 60 s consumer; without it, the short-window read would defeat the
+   * override the long-window caller asked for.
    */
   async get(
     key: string,
     ttlOverrideMs?: number,
   ): Promise<CacheEntry | undefined> {
     const entry = await this.cache.get(key);
-    const threshold = ttlOverrideMs ?? this.staleThresholdMs;
-    if (entry && Date.now() - entry.timestamp > threshold) {
+    if (!entry) return undefined;
+    const age = Date.now() - entry.timestamp;
+    if (age > this.maxTtlMs) {
       await this.cache.delete(key);
+      return undefined;
+    }
+    const threshold = ttlOverrideMs ?? this.staleThresholdMs;
+    if (age > threshold) {
       return undefined;
     }
     return entry;

--- a/langwatch/src/server/featureFlag/staleWhileRevalidateCache.redis.ts
+++ b/langwatch/src/server/featureFlag/staleWhileRevalidateCache.redis.ts
@@ -24,17 +24,41 @@ interface CacheEntry {
 export class StaleWhileRevalidateCache {
   private readonly staleThresholdMs: number;
   private readonly refreshThresholdMs: number;
+  private readonly maxTtlMs: number;
   private readonly cache: TtlCache<CacheEntry>;
 
-  constructor(staleThresholdMs: number, refreshThresholdMs: number) {
+  /**
+   * @param staleThresholdMs default staleness threshold (returned to callers
+   *   that don't pass an override). Frontend flags use this.
+   * @param refreshThresholdMs background refresh threshold.
+   * @param maxTtlMs underlying storage TTL — must be >= the longest
+   *   per-call ttlOverrideMs any caller might pass, so Redis doesn't evict
+   *   the entry before the override window expires. Defaults to staleThresholdMs.
+   */
+  constructor(
+    staleThresholdMs: number,
+    refreshThresholdMs: number,
+    maxTtlMs: number = staleThresholdMs,
+  ) {
     this.staleThresholdMs = staleThresholdMs;
     this.refreshThresholdMs = refreshThresholdMs;
-    this.cache = new TtlCache<CacheEntry>(staleThresholdMs, "feature_flag:");
+    this.maxTtlMs = Math.max(staleThresholdMs, maxTtlMs);
+    this.cache = new TtlCache<CacheEntry>(this.maxTtlMs, "feature_flag:");
   }
 
-  async get(key: string): Promise<CacheEntry | undefined> {
+  /**
+   * @param key cache key
+   * @param ttlOverrideMs optional caller-provided staleness threshold. Used by
+   *   hot-path callers (kill switches) to extend the cache window without
+   *   changing the global default that user-facing flags rely on.
+   */
+  async get(
+    key: string,
+    ttlOverrideMs?: number,
+  ): Promise<CacheEntry | undefined> {
     const entry = await this.cache.get(key);
-    if (entry && this.isStale(entry)) {
+    const threshold = ttlOverrideMs ?? this.staleThresholdMs;
+    if (entry && Date.now() - entry.timestamp > threshold) {
       await this.cache.delete(key);
       return undefined;
     }

--- a/langwatch/src/server/featureFlag/types.ts
+++ b/langwatch/src/server/featureFlag/types.ts
@@ -4,6 +4,13 @@
 export interface FeatureFlagOptions {
   projectId?: string;
   organizationId?: string;
+  /**
+   * Override the cache TTL (ms) for this evaluation. Used by hot-path
+   * callers (kill switches checked per span/event) to avoid stampeding
+   * PostHog with one /flags request per cache key per 5 seconds when local
+   * evaluation is unavailable. Falls back to the service default when omitted.
+   */
+  cacheTtlMs?: number;
 }
 
 /**

--- a/langwatch/src/server/posthog.ts
+++ b/langwatch/src/server/posthog.ts
@@ -4,10 +4,31 @@ import { env } from "../env.mjs";
 
 const logger = createLogger("langwatch:posthog:client");
 
-// Create a private singleton instance
+// Default poll interval for local flag evaluation. 5min × 10 evals/poll =
+// ~86_400 billed evals per server per month, vs. one billed call per
+// uncached flag check without local evaluation. With dozens of per-span
+// killswitch checks per second, the local-evaluation path is dramatically
+// cheaper. Override via POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS.
+const DEFAULT_FLAGS_POLLING_INTERVAL_MS = 5 * 60 * 1000;
+
+// Create a private singleton instance.
+// When POSTHOG_FEATURE_FLAGS_KEY is set (Feature Flags Secure API key, phs_*,
+// or a legacy Personal API key, phx_*), posthog-node enables local
+// evaluation: flag definitions are polled in the background and
+// `isFeatureEnabled` resolves in-process without a /flags request per call.
+// The SDK option is named `personalApiKey` for historical reasons but accepts
+// both key types.
 const _posthogInstance = env.POSTHOG_KEY
   ? new PostHog(env.POSTHOG_KEY, {
       host: env.POSTHOG_HOST,
+      ...(env.POSTHOG_FEATURE_FLAGS_KEY
+        ? {
+            personalApiKey: env.POSTHOG_FEATURE_FLAGS_KEY,
+            featureFlagsPollingInterval:
+              env.POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS ??
+              DEFAULT_FLAGS_POLLING_INTERVAL_MS,
+          }
+        : {}),
     })
   : null;
 

--- a/langwatch/src/utils/compat/__tests__/next-router-emit-dedup.integration.test.tsx
+++ b/langwatch/src/utils/compat/__tests__/next-router-emit-dedup.integration.test.tsx
@@ -20,7 +20,10 @@ vi.mock("~/utils/compat/next-router", async () =>
   await vi.importActual<object>("~/utils/compat/next-router"),
 );
 
-import Router, { useRouter } from "~/utils/compat/next-router";
+import Router, {
+  __resetRouteEmitDedupForTests,
+  useRouter,
+} from "~/utils/compat/next-router";
 
 function ConsumerA() {
   // Component that just calls useRouter — analogous to the ~120 components
@@ -78,6 +81,10 @@ describe("next-router compat: routeChangeComplete dedup", () => {
   let onRouteChange: ReturnType<typeof vi.fn<(path: string) => void>>;
 
   beforeEach(() => {
+    // Reset the module-scoped _lastEmittedPath so tests can re-use paths
+    // (e.g. "/a", "/b") without an earlier test silently de-duping the
+    // first emit of a later test.
+    __resetRouteEmitDedupForTests();
     onRouteChange = vi.fn<(path: string) => void>();
     Router.events.on("routeChangeComplete", onRouteChange);
   });

--- a/langwatch/src/utils/compat/__tests__/next-router-emit-dedup.integration.test.tsx
+++ b/langwatch/src/utils/compat/__tests__/next-router-emit-dedup.integration.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression test for the PostHog cost spike caused by the Vite migration's
+ * next-router compat layer.
+ *
+ * Before the fix, every mounted useRouter() instance emitted
+ * routeChangeComplete on every navigation. With ~120 useRouter() consumers
+ * in the app, a single navigation produced ~120 $pageview captures.
+ *
+ * @see specs/analytics/posthog-cost-control.feature
+ */
+import React, { useEffect } from "react";
+import { render, act, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router";
+
+vi.unmock("~/utils/compat/next-router");
+vi.mock("~/utils/compat/next-router", async () =>
+  await vi.importActual<object>("~/utils/compat/next-router"),
+);
+
+import Router, { useRouter } from "~/utils/compat/next-router";
+
+function ConsumerA() {
+  // Component that just calls useRouter — analogous to the ~120 components
+  // across the app that read router.query, router.pathname, etc.
+  useRouter();
+  return null;
+}
+
+function ConsumerB() {
+  useRouter();
+  return null;
+}
+
+function ConsumerC() {
+  useRouter();
+  return null;
+}
+
+function Navigator({ to }: { to: string }) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate(to);
+  }, [navigate, to]);
+  return null;
+}
+
+function MultiRouterTree({ navTarget }: { navTarget: string | null }) {
+  // Render multiple useRouter consumers + a navigator. This mirrors the
+  // production tree: dozens of components each subscribe to useRouter,
+  // and a navigation event happens once.
+  return (
+    <Routes>
+      <Route
+        path="*"
+        element={
+          <>
+            <ConsumerA />
+            <ConsumerB />
+            <ConsumerC />
+            <ConsumerA />
+            <ConsumerB />
+            <ConsumerC />
+            <ConsumerA />
+            <ConsumerB />
+            <ConsumerC />
+            {navTarget !== null ? <Navigator to={navTarget} /> : null}
+          </>
+        }
+      />
+    </Routes>
+  );
+}
+
+describe("next-router compat: routeChangeComplete dedup", () => {
+  let onRouteChange: ReturnType<typeof vi.fn<(path: string) => void>>;
+
+  beforeEach(() => {
+    onRouteChange = vi.fn<(path: string) => void>();
+    Router.events.on("routeChangeComplete", onRouteChange);
+  });
+
+  afterEach(() => {
+    Router.events.off("routeChangeComplete", onRouteChange);
+    cleanup();
+  });
+
+  describe("when many components subscribe to useRouter", () => {
+    it("emits routeChangeComplete exactly once per navigation", async () => {
+      const { rerender } = render(
+        <MemoryRouter initialEntries={["/start"]}>
+          <MultiRouterTree navTarget={null} />
+        </MemoryRouter>,
+      );
+
+      onRouteChange.mockClear();
+
+      await act(async () => {
+        rerender(
+          <MemoryRouter initialEntries={["/start"]}>
+            <MultiRouterTree navTarget="/next" />
+          </MemoryRouter>,
+        );
+      });
+
+      // Even with 9 useRouter() consumers mounted, one navigation = one emit.
+      // Pre-fix behavior would have emitted at least 9 times.
+      expect(onRouteChange).toHaveBeenCalledTimes(1);
+      expect(onRouteChange).toHaveBeenCalledWith("/next");
+    });
+
+    it("does not re-emit for the same path on remount", async () => {
+      const { rerender } = render(
+        <MemoryRouter initialEntries={["/same"]}>
+          <MultiRouterTree navTarget={null} />
+        </MemoryRouter>,
+      );
+      onRouteChange.mockClear();
+
+      // Re-render the same MemoryRouter with the same path — no new
+      // navigation, so no emit even though useRouter effects rerun.
+      await act(async () => {
+        rerender(
+          <MemoryRouter initialEntries={["/same"]}>
+            <MultiRouterTree navTarget={null} />
+          </MemoryRouter>,
+        );
+      });
+
+      expect(onRouteChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when listeners on routerEvents are attached", () => {
+    it("invokes each listener exactly once per navigation", async () => {
+      const listenerOne = vi.fn<(path: string) => void>();
+      const listenerTwo = vi.fn<(path: string) => void>();
+      Router.events.on("routeChangeComplete", listenerOne);
+      Router.events.on("routeChangeComplete", listenerTwo);
+
+      try {
+        const { rerender } = render(
+          <MemoryRouter initialEntries={["/a"]}>
+            <MultiRouterTree navTarget={null} />
+          </MemoryRouter>,
+        );
+        listenerOne.mockClear();
+        listenerTwo.mockClear();
+
+        await act(async () => {
+          rerender(
+            <MemoryRouter initialEntries={["/a"]}>
+              <MultiRouterTree navTarget="/b" />
+            </MemoryRouter>,
+          );
+        });
+
+        expect(listenerOne).toHaveBeenCalledTimes(1);
+        expect(listenerTwo).toHaveBeenCalledTimes(1);
+      } finally {
+        Router.events.off("routeChangeComplete", listenerOne);
+        Router.events.off("routeChangeComplete", listenerTwo);
+      }
+    });
+  });
+});

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -14,7 +14,7 @@
  * - router.back()
  * - router.events (fires routeChangeComplete on navigation for PostHog/activity tracking)
  */
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 import {
   useLocation,
   useNavigate,
@@ -129,6 +129,17 @@ const routerEvents = {
     routerEventListeners.get(event)?.forEach((handler) => handler(...args));
   },
 };
+
+// Module-level dedup for routeChangeComplete. Without this, every mounted
+// useRouter() instance (~120+) would emit the event independently, fanning
+// each navigation out to N×listeners — which previously multiplied PostHog
+// $pageview captures by the size of the React tree.
+let _lastEmittedPath: string | null = null;
+function emitRouteChangeOnce(path: string): void {
+  if (_lastEmittedPath === path) return;
+  _lastEmittedPath = path;
+  routerEvents.emit("routeChangeComplete", path);
+}
 
 // Alias for code that imports `NextRouter` type from next/router
 export type NextRouter = CompatRouter;
@@ -343,14 +354,11 @@ export function useRouter(): CompatRouter {
   const params = useParams();
   const [searchParams] = useSearchParams();
 
-  // Fire routeChangeComplete when location changes (for PostHog, activity tracking)
-  const prevPathRef = useRef(location.pathname + location.search);
+  // Fire routeChangeComplete exactly once per location change, not once per
+  // useRouter() instance. The dedup is at module scope (emitRouteChangeOnce)
+  // so the count is independent of how many components subscribe to useRouter.
   useEffect(() => {
-    const currentPath = location.pathname + location.search;
-    if (prevPathRef.current !== currentPath) {
-      prevPathRef.current = currentPath;
-      routerEvents.emit("routeChangeComplete", currentPath);
-    }
+    emitRouteChangeOnce(location.pathname + location.search);
   }, [location.pathname, location.search]);
 
   return useMemo(() => {

--- a/langwatch/src/utils/compat/next-router.ts
+++ b/langwatch/src/utils/compat/next-router.ts
@@ -141,6 +141,16 @@ function emitRouteChangeOnce(path: string): void {
   routerEvents.emit("routeChangeComplete", path);
 }
 
+/**
+ * Reset module-level dedup state. Test-only — production code never calls
+ * this. Lets test files use a clean state without juggling vi.resetModules().
+ *
+ * @internal
+ */
+export function __resetRouteEmitDedupForTests(): void {
+  _lastEmittedPath = null;
+}
+
 // Alias for code that imports `NextRouter` type from next/router
 export type NextRouter = CompatRouter;
 

--- a/specs/analytics/posthog-cost-control.feature
+++ b/specs/analytics/posthog-cost-control.feature
@@ -1,0 +1,83 @@
+Feature: PostHog cost control
+  As a LangWatch operator
+  I want PostHog feature flag and analytics traffic to scale with real user activity, not with the size of the React tree or the volume of spans
+  So that the bill is predictable and proportional to real usage
+
+  Background:
+    Given the langwatch app uses posthog-js for client-side analytics
+    And the langwatch app uses posthog-node for server-side feature flag evaluation
+    And feature flags target users, projects, and organizations via personProperties
+
+  # --- Frontend pageview emission ---
+
+  Scenario: A single client-side navigation produces exactly one pageview event
+    Given the application is rendered with N components that call useRouter()
+    When the user navigates from "/projectA/messages" to "/projectA/analytics"
+    Then exactly one $pageview event is captured by PostHog
+    And the count is independent of N
+
+  Scenario: Mounting additional useRouter() consumers does not multiply pageviews
+    Given the user is on a page with K useRouter() consumers
+    When K more components mount that also call useRouter()
+    And the user navigates to a new route
+    Then exactly one $pageview event is captured by PostHog
+
+  Scenario: useRouter consumers do not need to subscribe to routeChangeComplete to navigate
+    Given the application uses the next-router compat layer
+    When the user navigates between pages
+    Then router.events listeners that components register are notified once per navigation
+    And no listener is invoked more than once for a single navigation
+
+  Scenario: Initial page load is captured exactly once
+    When the user first opens the app
+    Then exactly one $pageview event is captured for the initial URL
+
+  Scenario: Search-only URL changes do not flood PostHog
+    Given the user is on "/projectA/messages"
+    When the user changes a query string parameter via router.replace
+    Then at most one $pageview is captured for the search-only update
+
+  # --- Backend feature flag evaluation ---
+
+  Scenario: Backend feature flag service uses local evaluation when available
+    Given POSTHOG_KEY and POSTHOG_FEATURE_FLAGS_KEY are configured
+    When the backend evaluates any feature flag
+    Then the flag is evaluated locally without calling the PostHog /flags endpoint
+    And no /flags request is made for that evaluation
+
+  Scenario: Backend falls back to remote evaluation when no personal API key is configured
+    Given POSTHOG_KEY is configured but POSTHOG_FEATURE_FLAGS_KEY is not
+    When the backend evaluates a feature flag
+    Then the value is fetched from PostHog /flags
+    And the result is cached per the configured TTL
+
+  Scenario: Hot-path killswitches are cached longer than user-facing flags
+    Given the backend evaluates an event-sourcing killswitch like "es-trace-projection-killswitch"
+    When the same killswitch is checked again within the killswitch TTL window
+    Then the cached value is returned without calling PostHog
+    And the killswitch TTL is at least 60 seconds
+
+  Scenario: Frontend feature flags keep their fast 5-second TTL
+    Given the frontend asks for a flag in FRONTEND_FEATURE_FLAGS
+    When the same flag is requested again within 5 seconds
+    Then the cached value is returned
+    And the cache TTL is 5 seconds (so kill-switch-style changes propagate within 5s)
+
+  Scenario: Token estimation kill switch does not stampede PostHog under high span volume
+    Given 10,000 LLM spans are processed for a single project within one minute
+    When each span checks the global and per-project token-estimation killswitches
+    Then PostHog receives no remote /flags requests when local evaluation is enabled
+    And PostHog receives at most a small bounded number of /flags requests when local evaluation is disabled
+
+  # --- Resilience ---
+
+  Scenario: PostHog outage does not break flag evaluation
+    Given the PostHog service is unreachable
+    When the backend evaluates a feature flag
+    Then the configured default value is returned
+    And the request continues without raising
+
+  Scenario: Local evaluation polling failure does not break flag evaluation
+    Given local evaluation is enabled but the polling request fails
+    When a flag is evaluated
+    Then the last-known value is used if available, otherwise the default value


### PR DESCRIPTION
## Why

Last week's PostHog bill spiked. Two distinct culprits identified after auditing the code paths:

| Driver | Pre-fix behavior | Post-fix |
|---|---|---|
| Frontend `\$pageview` | Each navigation fanned out to ~120× captures (one per mounted `useRouter()` consumer), then doubled by posthog-js's own SPA pageview tracking | Exactly 1 capture per real navigation |
| Backend `/flags` | Every uncached `isFeatureEnabled` call hit PostHog (no local evaluation, 5 s cache fragmented per-tenant under high traffic) | Local evaluation in-process; killswitches cached 60 s |

The pageview spike on the analytics chart aligns precisely with the Vite migration (PR #3170, April 14). The backend `/flags` cost has been there since the kill-switch hot paths landed and just compounds with traffic.

## Changes

**Frontend pageview dedup**
- `src/utils/compat/next-router.ts` — moved `routeChangeComplete` emission out of the per-`useRouter()` effect into a module-scope `emitRouteChangeOnce(path)` helper. Same-path remounts become no-ops; multiple consumers no longer multiply the count.
- `src/hooks/usePostHog.ts` — dropped the manual `posthog.capture("\$pageview")` subscription. `posthog-js` already auto-captures on History API navigation (default `capture_pageview`), so we'd been double-counting on top of the multiplier.

**Backend local feature flag evaluation**
- `src/server/posthog.ts` + `src/env-create.mjs` — accept `POSTHOG_FEATURE_FLAGS_KEY` (Feature Flags Secure key `phs_*`, or legacy Personal API key `phx_*`) and pass to `posthog-node` as `personalApiKey` + `featureFlagsPollingInterval` (default 5 min). With this, `isFeatureEnabled` resolves in-process; no `/flags` request per call.
- The actual `phs_*` key is already in AWS Secrets Manager (`langwatch_secrets`) under `POSTHOG_FEATURE_FLAGS_KEY`, so Terraform spreads it as an env var on next deploy. No infra changes needed in `langwatch-saas/infrastructure`.
- `POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS` is exposed for tuning (default 5 min ≈ ~86 k billed evals / server / month, vs unbounded per-span calls today).

**Backend killswitch cache TTL**
- New `KILL_SWITCH_CACHE_TTL_MS` (60 s) in `featureFlag/constants.ts`.
- `FeatureFlagOptions.cacheTtlMs` lets hot-path callers opt into the longer window. Frontend flags keep their 5 s default for fast UI toggles.
- `StaleWhileRevalidateCache` now takes a `maxTtlMs` so the underlying Redis storage TTL accommodates the longest override (otherwise Redis would evict before the override window expired).
- Wired through `OtlpSpanTokenEstimationService.isDisabledByKillSwitch` (per-span hot path) and `isComponentDisabled` (per-event/per-projection/per-command).

## Test plan

- [x] `pnpm typecheck` clean
- [x] All affected unit + integration tests pass (78 tests, 9 files)
- [x] New integration test `next-router-emit-dedup.integration.test.tsx` renders 9 `useRouter()` consumers and asserts exactly 1 emit per navigation, 0 on remount of same path
- [x] New `posthog-local-evaluation.unit.test.ts` covers all three init modes (with key / without key / no POSTHOG_KEY)
- [x] New `staleWhileRevalidateCache.unit.test.ts` proves the `cacheTtlMs` override extends staleness window without Redis evicting prematurely
- [x] **Real Chromium QA** against the live Vite bundle on `localhost:5570`:

  ![QA proof — routeChangeComplete dedup](https://i.img402.dev/mw6gtcf9qj.png)

  - Raw `routerEvents.emit` × 20 → 20 invocations per listener (emitter intact)
  - 5 `router.push` covering 2 unique paths → 2 invocations per listener (dedup collapses duplicates)

## Spec & ADR
- `specs/analytics/posthog-cost-control.feature` (new)
- `dev/docs/adr/005-feature-flags.md` updated with local-evaluation section + killswitch TTL table

## Rollout notes
- The `POSTHOG_FEATURE_FLAGS_KEY` secret was added to `langwatch_secrets` in `lw-prod / eu-central-1` already (preserved all 57 existing keys, added one). No Terraform change required — the existing `dynamic "env" { for_each = local.secrets_map }` block in `langwatch.tf` will spread it on next deploy.
- Frontend changes deploy with the next app release; pageview spike should subside immediately.
- Backend local evaluation kicks in once the env var lands on a deployed pod.