### PR TITLE
fix(auth): diagnostic logs on auth-fail + restore X-Auth-Token fallback regression

### DIFF
--- a/langwatch/src/server/pat/__tests__/auth-middleware.unit.test.ts
+++ b/langwatch/src/server/pat/__tests__/auth-middleware.unit.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { extractCredentials } from "../auth-middleware";
+import { extractCredentials, collectAuthDiagnostics } from "../auth-middleware";
 
 function mockGetHeader(headers: Record<string, string>) {
   return (name: string) => headers[name.toLowerCase()] ?? headers[name];
+}
+
+function mockHonoCtx(opts: {
+  path?: string;
+  method?: string;
+  headers?: Record<string, string>;
+}) {
+  return {
+    req: {
+      path: opts.path ?? "/api/scenario-events",
+      method: opts.method ?? "POST",
+      header: mockGetHeader(opts.headers ?? {}),
+    },
+  };
 }
 
 describe("extractCredentials", () => {
@@ -31,13 +45,13 @@ describe("extractCredentials", () => {
       });
     });
 
-    it("returns null for missing colon in decoded value", () => {
+    it("returns null for missing colon in decoded value (no fallback)", () => {
       const encoded = Buffer.from("no-colon-here").toString("base64");
       const c = mockGetHeader({ authorization: `Basic ${encoded}` });
       expect(extractCredentials(c)).toBeNull();
     });
 
-    it("returns null for empty projectId or token", () => {
+    it("returns null for empty projectId or token (no fallback)", () => {
       const encoded1 = Buffer.from(":token").toString("base64");
       const c1 = mockGetHeader({ authorization: `Basic ${encoded1}` });
       expect(extractCredentials(c1)).toBeNull();
@@ -45,6 +59,44 @@ describe("extractCredentials", () => {
       const encoded2 = Buffer.from("proj:").toString("base64");
       const c2 = mockGetHeader({ authorization: `Basic ${encoded2}` });
       expect(extractCredentials(c2)).toBeNull();
+    });
+
+    it("falls back to X-Auth-Token when Basic auth is malformed (no colon)", () => {
+      // A corporate proxy may add Authorization: Basic <some-base64> for its
+      // own upstream auth. That MUST NOT poison the customer's legitimate
+      // X-Auth-Token credential — fall through, not return null.
+      const badBasic = Buffer.from("internal-proxy-token").toString("base64");
+      const c = mockGetHeader({
+        authorization: `Basic ${badBasic}`,
+        "x-auth-token": "sk-lw-customer-key",
+      });
+      expect(extractCredentials(c)).toEqual({
+        token: "sk-lw-customer-key",
+        projectId: null,
+      });
+    });
+
+    it("falls back to X-Auth-Token when Basic auth has empty token", () => {
+      const emptyToken = Buffer.from("projectId:").toString("base64");
+      const c = mockGetHeader({
+        authorization: `Basic ${emptyToken}`,
+        "x-auth-token": "sk-lw-customer-key",
+      });
+      expect(extractCredentials(c)).toEqual({
+        token: "sk-lw-customer-key",
+        projectId: null,
+      });
+    });
+
+    it("falls back to X-Auth-Token when Basic auth is undecodable base64", () => {
+      const c = mockGetHeader({
+        authorization: "Basic !@#$%^",
+        "x-auth-token": "sk-lw-customer-key",
+      });
+      expect(extractCredentials(c)).toEqual({
+        token: "sk-lw-customer-key",
+        projectId: null,
+      });
     });
   });
 
@@ -78,6 +130,28 @@ describe("extractCredentials", () => {
 
       expect(result).toEqual({
         token: "sk-lw-abc123",
+        projectId: null,
+      });
+    });
+
+    it("falls back to X-Auth-Token when Bearer is empty", () => {
+      const c = mockGetHeader({
+        authorization: "Bearer ",
+        "x-auth-token": "sk-lw-customer-key",
+      });
+      expect(extractCredentials(c)).toEqual({
+        token: "sk-lw-customer-key",
+        projectId: null,
+      });
+    });
+
+    it("falls back to X-Auth-Token when Bearer is whitespace-only", () => {
+      const c = mockGetHeader({
+        authorization: "Bearer    ",
+        "x-auth-token": "sk-lw-customer-key",
+      });
+      expect(extractCredentials(c)).toEqual({
+        token: "sk-lw-customer-key",
         projectId: null,
       });
     });
@@ -127,5 +201,66 @@ describe("extractCredentials", () => {
       expect(result?.token).toBe("basic-token");
       expect(result?.projectId).toBe("proj");
     });
+  });
+});
+
+describe("collectAuthDiagnostics", () => {
+  it("captures the userAgent, traceparent, X-Forwarded-For and request path", () => {
+    const c = mockHonoCtx({
+      path: "/api/scenario-events",
+      method: "POST",
+      headers: {
+        "user-agent": "python-httpx/0.28.1",
+        traceparent: "00-1234abcd-5678efgh-01",
+        "x-forwarded-for": "203.0.113.42, 10.0.0.1",
+        "x-auth-token": "sk-lw-abc",
+      },
+    });
+    expect(collectAuthDiagnostics(c)).toEqual({
+      path: "/api/scenario-events",
+      method: "POST",
+      userAgent: "python-httpx/0.28.1",
+      traceparent: "00-1234abcd-5678efgh-01",
+      forwardedFor: "203.0.113.42, 10.0.0.1",
+      hasEmptyAuthToken: false,
+    });
+  });
+
+  it("falls back to X-Real-IP when X-Forwarded-For is absent", () => {
+    const c = mockHonoCtx({ headers: { "x-real-ip": "192.0.2.5" } });
+    expect(collectAuthDiagnostics(c).forwardedFor).toBe("192.0.2.5");
+  });
+
+  it("flags hasEmptyAuthToken when the header was sent but empty", () => {
+    const c = mockHonoCtx({ headers: { "x-auth-token": "" } });
+    const diag = collectAuthDiagnostics(c);
+    expect(diag.hasEmptyAuthToken).toBe(true);
+  });
+
+  it("does NOT flag hasEmptyAuthToken when the header is absent entirely", () => {
+    const c = mockHonoCtx({ headers: {} });
+    const diag = collectAuthDiagnostics(c);
+    expect(diag.hasEmptyAuthToken).toBe(false);
+  });
+
+  it("returns null for missing optional headers (no exceptions)", () => {
+    const c = mockHonoCtx({ headers: {} });
+    const diag = collectAuthDiagnostics(c);
+    expect(diag.userAgent).toBeNull();
+    expect(diag.traceparent).toBeNull();
+    expect(diag.forwardedFor).toBeNull();
+  });
+
+  it("never includes a raw token value", () => {
+    const c = mockHonoCtx({
+      headers: {
+        "x-auth-token": "sk-lw-SUPER-SECRET-VALUE",
+        authorization: "Bearer pat-lw-ANOTHER-SECRET",
+      },
+    });
+    const diag = collectAuthDiagnostics(c);
+    const serialized = JSON.stringify(diag);
+    expect(serialized).not.toContain("SUPER-SECRET-VALUE");
+    expect(serialized).not.toContain("ANOTHER-SECRET");
   });
 });

--- a/langwatch/src/server/pat/auth-middleware.ts
+++ b/langwatch/src/server/pat/auth-middleware.ts
@@ -47,23 +47,29 @@ function extractCredentials(
     try {
       const decoded = Buffer.from(encoded, "base64").toString("utf-8");
       const colonIndex = decoded.indexOf(":");
-      if (colonIndex === -1) return null;
-
-      const projectId = decoded.slice(0, colonIndex);
-      const token = decoded.slice(colonIndex + 1);
-      if (!projectId || !token) return null;
-
-      return { token, projectId };
+      if (colonIndex !== -1) {
+        const projectId = decoded.slice(0, colonIndex);
+        const token = decoded.slice(colonIndex + 1);
+        if (projectId && token) {
+          return { token, projectId };
+        }
+      }
+      // Fall through to X-Auth-Token below: a malformed Basic header (e.g.
+      // injected by a corporate proxy for upstream auth) must not poison
+      // the customer's legitimate X-Auth-Token credential.
     } catch {
-      return null;
+      // Same fallthrough on undecodable base64.
     }
   }
 
   // Priority 2: Bearer token
   if (authHeader?.toLowerCase().startsWith("bearer ")) {
-    const token = authHeader.slice(7);
-    if (!token) return null;
-    return { token, projectId: xProjectId ?? null };
+    const token = authHeader.slice(7).trim();
+    if (token) {
+      return { token, projectId: xProjectId ?? null };
+    }
+    // Empty Bearer also falls through to X-Auth-Token — same proxy-injection
+    // hardening as Basic above.
   }
 
   // Priority 3: X-Auth-Token header (legacy)
@@ -100,8 +106,19 @@ export function createUnifiedAuthMiddleware({
 
   return async (c, next) => {
     const credentials = extractCredentials((name) => c.req.header(name));
+    // Diagnostic context for auth failures — lets on-call attribute a 401 to
+    // a specific customer/SDK without needing the customer to reproduce with
+    // debug logs. Read once and reuse across both failure paths so values
+    // are consistent. No raw token / body content is included.
+    const diag = collectAuthDiagnostics(c);
 
     if (!credentials) {
+      logger.warn(
+        diag,
+        diag.hasEmptyAuthToken
+          ? "Authentication failed: X-Auth-Token sent but empty"
+          : "Authentication failed: no auth header present",
+      );
       return c.json(
         {
           error: "Unauthorized",
@@ -121,9 +138,8 @@ export function createUnifiedAuthMiddleware({
     } catch (error) {
       logger.error(
         {
+          ...diag,
           error,
-          path: c.req.path,
-          method: c.req.method,
         },
         "Database error during authentication",
       );
@@ -140,6 +156,7 @@ export function createUnifiedAuthMiddleware({
     if (!resolved) {
       logger.warn(
         {
+          ...diag,
           hasToken: true,
           tokenType: credentials.token.startsWith("pat-lw-")
             ? "pat"
@@ -180,6 +197,44 @@ export function createUnifiedAuthMiddleware({
 }
 
 export { extractCredentials };
+
+/**
+ * Diagnostic fields safe to emit on auth failure. Captures enough request
+ * fingerprint to attribute 401s to a specific customer/SDK in CloudWatch
+ * without leaking credentials or request bodies. `traceparent` lets us join
+ * the failed POST to the customer's downstream OTel trace, which usually
+ * carries identifying metadata even when the auth header path doesn't.
+ *
+ * `hasEmptyAuthToken` distinguishes "X-Auth-Token sent as an empty string"
+ * (typically a customer-side env-var misconfig) from "no auth header at all"
+ * (typically a misconfigured SDK or unauthenticated probe). Both produce the
+ * same 401 today — the log line tells them apart.
+ */
+export type AuthDiagnostics = {
+  path: string;
+  method: string;
+  userAgent: string | null;
+  traceparent: string | null;
+  forwardedFor: string | null;
+  hasEmptyAuthToken: boolean;
+};
+
+export function collectAuthDiagnostics(c: {
+  req: { path: string; method: string; header: (name: string) => string | undefined };
+}): AuthDiagnostics {
+  const get = (name: string) => c.req.header(name) ?? null;
+  const xAuthToken = c.req.header("x-auth-token");
+  return {
+    path: c.req.path,
+    method: c.req.method,
+    userAgent: get("user-agent"),
+    traceparent: get("traceparent"),
+    forwardedFor: get("x-forwarded-for") ?? get("x-real-ip"),
+    // Sent-but-empty is distinct from absent (SDK with a misconfigured
+    // empty api_key still serializes the header).
+    hasEmptyAuthToken: xAuthToken !== undefined && xAuthToken === "",
+  };
+}
 
 /**
  * Enforces the PAT permission ceiling for an already-resolved token.

--- a/specs/auth/diagnostic-logging-on-auth-failure.feature
+++ b/specs/auth/diagnostic-logging-on-auth-failure.feature
@@ -1,0 +1,59 @@
+Feature: Diagnostic logging on auth failure
+  As an on-call engineer triaging customer reports of "events aren't arriving"
+  I want auth-failure logs to carry enough request fingerprint detail
+  So that I can identify which customer is sending bad credentials within minutes
+  Without having to ask the customer to enable debug mode and reproduce
+
+  Background:
+    Given the unified auth middleware is mounted on a Hono route
+    And a request reaches the middleware
+
+  @unit
+  Scenario: extractCredentials returns null because no auth header was sent
+    When the request has no Authorization, X-Auth-Token, or X-Project-Id headers
+    Then the middleware emits a single WARN-level log line at "langwatch:api:unified-auth"
+    And the log line contains userAgent, traceparent, x-forwarded-for, path, method
+    And the log line records hasEmptyAuthToken=false (no header at all)
+
+  @unit
+  Scenario: extractCredentials returns null because X-Auth-Token was sent empty
+    When the request has X-Auth-Token: "" (empty string)
+    Then the middleware emits a single WARN-level log line at "langwatch:api:unified-auth"
+    And the log line records hasEmptyAuthToken=true
+    And the message specifically calls out an empty-token submission so the
+      caller knows their api_key resolved to an empty string
+
+  @unit
+  Scenario: Resolver returns null because credentials don't match any project
+    Given the request carries a valid-looking but unknown api key
+    When the resolver fails to resolve the token to a project
+    Then the existing "Authentication failed: invalid credentials" log fires
+    And userAgent, traceparent, and x-forwarded-for are also present in that log
+
+  @unit
+  Scenario: Successful auth does not emit the diagnostic log
+    Given the request carries valid credentials
+    When the middleware passes auth
+    Then no diagnostic auth-failure log is emitted
+
+  @unit
+  Scenario: Diagnostic fields are safe to log
+    Then the log NEVER includes the raw token value
+    And the log NEVER includes the request body
+    And only the prefix of the token (first 8 chars) is included when the resolver path is taken
+
+  @unit
+  Scenario: Authorization header from a proxy does not poison X-Auth-Token fallback
+    Given a corporate proxy injects "Authorization: Basic <its-own-base64>" into the request
+    And the customer's request also carries "X-Auth-Token: <valid-key>"
+    When the middleware runs extractCredentials
+    Then the credential extraction must fall back to X-Auth-Token
+    And the customer's legitimate token is used for project resolution
+    And the request is not 401'd by the proxy header
+
+  @unit
+  Scenario: Empty or whitespace-only Bearer token does not poison X-Auth-Token fallback
+    Given a request carries "Authorization: Bearer " (empty or whitespace-only)
+    And the same request carries "X-Auth-Token: <valid-key>"
+    When the middleware runs extractCredentials
+    Then it falls through and returns the X-Auth-Token credential


### PR DESCRIPTION
## Summary

Two fixes in the unified auth middleware, motivated by a customer auth incident where we couldn't attribute 401s and found a real fallback regression while looking.

### 1. Diagnostic logging on every auth failure
Every 401 from `createUnifiedAuthMiddleware` now emits a single WARN line at `langwatch:api:unified-auth` with: `userAgent`, `traceparent`, `x-forwarded-for` / `x-real-ip`, request path/method, and `hasEmptyAuthToken` (true iff `X-Auth-Token` was sent as an empty string vs absent entirely). Lets on-call attribute a failed POST to a specific customer/SDK from CloudWatch in seconds rather than asking the customer to enable debug logs and reproduce. `traceparent` in particular lets us join the failed POST to the customer's downstream OTel trace, which carries identifying metadata even when the auth path doesn't. Raw token values and request bodies are never logged.

### 2. Don't let a malformed `Authorization` header poison the `X-Auth-Token` fallback
The OLD pre-PAT auth middleware preferred `X-Auth-Token` unconditionally:

\`\`\`ts
const apiKey = c.req.header(\"X-Auth-Token\") ?? c.req.header(\"Authorization\")?.split(\" \")[1];
\`\`\`

The unified middleware introduced with PAT (#3212 / #3213, in prod since 2026-04-26 06:32 UTC) reordered priority and returned \`null\` immediately if \`Authorization\` matched \`Basic\` or \`Bearer\` but was malformed — even when a perfectly valid \`X-Auth-Token\` was also present.

This breaks anyone behind a corporate proxy that injects its own \`Authorization\` for upstream auth (a Basic header with no colon when decoded is the canonical failure case; \`Authorization: Bearer \` empty has the same problem). Found while reproducing the customer's symptom; \`NTLM\`/\`Negotiate\` were fine because the prefix doesn't match the \`Basic\`/\`Bearer\` checks.

Fix: on malformed/empty \`Basic\` or \`Bearer\`, fall through to the \`X-Auth-Token\` path instead of short-circuiting to null. Well-formed \`Basic\`/\`Bearer\` unchanged.

Spec: \`specs/auth/diagnostic-logging-on-auth-failure.feature\`

## Test plan
- [x] \`pnpm test:unit src/server/pat/__tests__/auth-middleware.unit.test.ts\` — 22 passing including 5 new tests for the fallback-poisoning hardening + 6 for \`collectAuthDiagnostics\` (incl. one that asserts no raw token value leaks into the log struct).
- [ ] Watch CloudWatch for \`langwatch:api:unified-auth\` warns after deploy — confirm \`userAgent\`, \`traceparent\`, \`forwardedFor\`, \`hasEmptyAuthToken\` all appear; will be the diagnostic for the open Skai investigation.

## Volume note
Adds ~one extra WARN log per 401, no user-agent gating. Currently ~50-200k 401s/day so log volume is meaningful but not 10x. Easy to revert or add filtering later if needed; the value of attribution outweighs the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)