### PR TITLE
fix(llm-config-popover): always render Max Tokens slider for chat models

### DIFF
--- a/langwatch/src/components/llmPromptConfigs/__tests__/LLMConfigPopover.test.tsx
+++ b/langwatch/src/components/llmPromptConfigs/__tests__/LLMConfigPopover.test.tsx
@@ -140,6 +140,9 @@ vi.mock("../../ModelSelector", () => ({
       <option value="openai/gpt-4.1">GPT-4.1</option>
       <option value="openai/gpt-5">GPT-5</option>
       <option value="anthropic/claude-3.5-sonnet">Claude 3.5 Sonnet</option>
+      <option value="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0">
+        Claude Haiku 4.5 (Bedrock)
+      </option>
     </select>
   ),
 }));

--- a/langwatch/src/components/llmPromptConfigs/__tests__/LLMConfigPopover.test.tsx
+++ b/langwatch/src/components/llmPromptConfigs/__tests__/LLMConfigPopover.test.tsx
@@ -89,6 +89,19 @@ const mockModelMetadata = {
     pricing: { inputCostPerToken: 0.000003, outputCostPerToken: 0.000015 },
     reasoningConfig: undefined,
   },
+  "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    id: "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    name: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    provider: "bedrock",
+    supportedParameters: ["temperature"],
+    contextLength: 0,
+    maxCompletionTokens: 8192,
+    defaultParameters: null,
+    supportsImageInput: false,
+    supportsAudioInput: false,
+    pricing: { inputCostPerToken: 0, outputCostPerToken: 0 },
+    reasoningConfig: undefined,
+  },
 };
 
 vi.mock("~/hooks/useModelProvidersSettings", () => ({
@@ -110,6 +123,7 @@ vi.mock("../../ModelSelector", () => ({
     "openai/gpt-4.1",
     "openai/gpt-5",
     "anthropic/claude-3.5-sonnet",
+    "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
   ],
   ModelSelector: ({
     model,
@@ -299,6 +313,34 @@ describe("LLMConfigPopover", () => {
           values: { model: "openai/gpt-5", reasoning: "medium" },
         });
         expect(screen.queryByText("Top P")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when the model entry omits max_tokens from supportedParameters", () => {
+    describe("for a managed-Bedrock chat custom model registered with only temperature", () => {
+      it("renders the Max Tokens slider so the user can configure per-invocation output limits", () => {
+        renderComponent({
+          values: {
+            model: "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            temperature: 1,
+          },
+        });
+        expect(
+          screen.getByTestId("parameter-row-max_tokens"),
+        ).toBeInTheDocument();
+      });
+
+      it("still renders the Temperature slider that the entry does declare", () => {
+        renderComponent({
+          values: {
+            model: "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            temperature: 1,
+          },
+        });
+        expect(
+          screen.getByTestId("parameter-row-temperature"),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/llmPromptConfigs/parameterRegistry.ts
+++ b/langwatch/src/components/llmPromptConfigs/parameterRegistry.ts
@@ -188,23 +188,32 @@ export class ParameterRegistry {
 
   /**
    * Filter and sort parameters for display.
+   *
+   * `max_tokens` is always included regardless of whether the model entry
+   * declares it: every chat model accepts a per-invocation token ceiling,
+   * and the popover is chat-only. Treating it as opt-in caused the slider
+   * to flicker-then-disappear for legacy custom models (notably managed
+   * Bedrock entries registered with `["temperature"]` only).
    */
   getDisplayParameters(supportedParameters: string[]): string[] {
-    if (!supportedParameters || supportedParameters.length === 0) {
-      return ["temperature", "max_tokens"]; // Default
-    }
-
     const displayOrder = this.getDisplayOrder();
 
-    return supportedParameters
-      .filter((param) => this.parameters.has(param))
-      .sort((a, b) => {
-        const aIndex = displayOrder.indexOf(a);
-        const bIndex = displayOrder.indexOf(b);
-        const aOrder = aIndex === -1 ? 999 : aIndex;
-        const bOrder = bIndex === -1 ? 999 : bIndex;
-        return aOrder - bOrder;
-      });
+    const base =
+      !supportedParameters || supportedParameters.length === 0
+        ? ["temperature"]
+        : supportedParameters.filter((param) => this.parameters.has(param));
+
+    const withMaxTokens = base.includes("max_tokens")
+      ? base
+      : [...base, "max_tokens"];
+
+    return withMaxTokens.sort((a, b) => {
+      const aIndex = displayOrder.indexOf(a);
+      const bIndex = displayOrder.indexOf(b);
+      const aOrder = aIndex === -1 ? 999 : aIndex;
+      const bOrder = bIndex === -1 ? 999 : bIndex;
+      return aOrder - bOrder;
+    });
   }
 
   /**

--- a/langwatch/src/components/settings/AddCustomModelDialog.tsx
+++ b/langwatch/src/components/settings/AddCustomModelDialog.tsx
@@ -24,20 +24,21 @@ import { Checkbox } from "../ui/checkbox";
 import { HorizontalFormControl } from "../HorizontalFormControl";
 
 /**
- * Parameters shown in the dialog — only the ones we actually
- * render in LLMConfigPopover. The "Max Tokens" field above captures
- * the model's ceiling; this checkbox controls whether users can
- * configure max_tokens per-invocation in the LLM config popover.
+ * Optional sampling parameters the popover renders for this model.
+ *
+ * `max_tokens` is intentionally absent: every chat model accepts a
+ * per-invocation token ceiling, so the popover always renders that slider
+ * regardless of what's stored here. The numeric "Max Tokens" field elsewhere
+ * in this dialog captures the model's hard ceiling.
  */
 const DIALOG_PARAMETERS: { value: SupportedParameter; label: string }[] = [
   { value: "temperature", label: "Temperature" },
-  { value: "max_tokens", label: "Max Tokens" },
   { value: "top_p", label: "Top P" },
   { value: "top_k", label: "Top K" },
   { value: "reasoning", label: "Reasoning" },
 ];
 
-const DEFAULT_PARAMETERS: SupportedParameter[] = ["temperature", "max_tokens"];
+const DEFAULT_PARAMETERS: SupportedParameter[] = ["temperature"];
 const DEFAULT_MAX_TOKENS = 8192;
 
 const MULTIMODAL_LABELS: Record<MultimodalInput, string> = {

--- a/langwatch/src/tasks/__tests__/migrateCustomModels.unit.test.ts
+++ b/langwatch/src/tasks/__tests__/migrateCustomModels.unit.test.ts
@@ -87,7 +87,6 @@ describe("migrateCustomModelsRow()", () => {
           maxTokens: 8192,
           supportedParameters: [
             "temperature",
-            "max_tokens",
           ],
         },
       ]);
@@ -175,7 +174,6 @@ describe("migrateCustomModelsRow()", () => {
           maxTokens: 8192,
           supportedParameters: [
             "temperature",
-            "max_tokens",
           ],
         },
       ]);

--- a/langwatch/src/tasks/migrateCustomModels.ts
+++ b/langwatch/src/tasks/migrateCustomModels.ts
@@ -47,7 +47,7 @@ type MigrationResult = {
 // ============================================================================
 
 const CHAT_DEFAULTS = {
-  supportedParameters: ["temperature", "max_tokens"],
+  supportedParameters: ["temperature"],
   maxTokens: 8192,
 } as const;
 

--- a/specs/model-providers/custom-model-max-tokens.feature
+++ b/specs/model-providers/custom-model-max-tokens.feature
@@ -1,45 +1,47 @@
-Feature: Custom Model Max Tokens Parameter
-  As an admin registering a custom chat model (e.g. a Bedrock model routed through a managed provider)
-  I want to declare that the model supports the max_tokens sampling parameter
-  So that users in my organization can configure the output limit per workflow node and per LLM-as-judge evaluator
+Feature: Max Tokens is universal for chat models
+  Every chat model is token-based and accepts a max_tokens limit at invocation time.
+  The Max Tokens slider must always render in the LLM config popover for chat
+  models, regardless of what supportedParameters the model entry declares. There
+  is no opt-out at the model-registration level.
 
-  Background:
+  This contract was tightened after a managed-Bedrock customer registered a
+  custom chat model whose supportedParameters list did not include max_tokens
+  (the previous default). The popover then hid the slider after the model
+  metadata loaded — a flicker, then nothing — leaving the user unable to set
+  per-invocation output limits.
+
+  @integration
+  Scenario: Max Tokens slider always renders for a chat model with a token ceiling
+    Given a chat model whose stored supportedParameters does NOT include "max_tokens"
+    And the model has a configured maxTokens ceiling
+    When a user opens the LLM Config popover for that model
+    Then the Max Tokens slider is visible
+    And the slider's maximum equals the model's configured maxTokens ceiling
+
+  @integration
+  Scenario: Max Tokens slider renders without a flicker for managed-Bedrock custom models
+    Given a managed Bedrock provider configured for the organization
+    And the admin has registered a Bedrock chat model with supportedParameters ["temperature"]
+    When a user opens an LLM-as-judge evaluator drawer for that model
+    Then the Max Tokens slider is visible from first paint
+    And it does not disappear after model metadata finishes loading
+
+  @integration
+  Scenario: Add Custom Model dialog does not expose Max Tokens as a supported-parameter checkbox
     Given I am an org admin on the model provider settings page
-    And I have opened the Add Custom Model dialog for a chat model
+    When I open the Add Custom Model dialog for a chat model
+    Then the Supported Parameters checkbox list does NOT include "Max Tokens"
+    And the numeric "Max Tokens" field above (the model's ceiling) is still required
 
   @integration
-  Scenario: max_tokens appears as a supported parameter option
-    When I view the Supported Parameters checkbox list
-    Then I should see a "Max Tokens" checkbox alongside Temperature, Top P, Top K, and Reasoning
+  Scenario: Max Tokens slider renders for a reasoning chat model
+    Given a chat model that supports the unified reasoning parameter
+    And the model entry's supportedParameters list omits "max_tokens"
+    When a user opens the LLM Config popover for that model
+    Then the Max Tokens slider is visible alongside the Reasoning selector
 
   @integration
-  Scenario: max_tokens is enabled by default for new custom models
-    When I open the dialog to add a new model
-    Then the "Max Tokens" checkbox should be checked
-    And the "Temperature" checkbox should be checked
-
-  @integration
-  Scenario: Admin can opt out of max_tokens for reasoning-only models
-    Given I am registering a reasoning-only custom model
-    When I uncheck the "Max Tokens" checkbox
-    And I save the custom model
-    Then the saved custom model should not include "max_tokens" in its supportedParameters
-
-  @integration
-  Scenario: Custom model with max_tokens enabled shows the slider in the LLM config popover
-    Given I have saved a custom chat model with supportedParameters including "max_tokens"
-    When a user opens the LLM Config popover for that model on a workflow LLM node
-    Then they should see the Max Tokens slider
-    And the slider's maximum should respect the custom model's declared maxTokens ceiling
-
-  @integration
-  Scenario: Custom model with max_tokens enabled exposes the slider in LLM-as-judge evaluators
-    Given I have saved a custom chat model with supportedParameters including "max_tokens"
-    When a user opens the LLM config popover on a custom LLM evaluator (boolean, score, or category)
-    Then they should see the Max Tokens slider
-
-  @integration
-  Scenario: Editing an existing custom model preserves the max_tokens setting
-    Given I have previously saved a custom model with "max_tokens" in its supportedParameters
-    When I open the dialog to edit that model
-    Then the "Max Tokens" checkbox should be checked
+  Scenario: Embedding popovers are unaffected
+    Given an embedding model
+    When a user opens the embedding configuration UI
+    Then no Max Tokens slider is rendered


### PR DESCRIPTION
## Summary

Every chat model accepts a per-invocation token ceiling. The Max Tokens slider in the LLM Config popover must therefore always render — it is not opt-in. Treating it as opt-in produced a flicker-then-disappear regression for legacy custom models, most visibly hit by a managed-Bedrock customer following up on #3344.

## Repro

1. Configure Bedrock provider for an org/project (managed AWS keys or own keys).
2. Register a Bedrock chat model — e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0` — with `supportedParameters: ["temperature"]`. (Pre-#3344 dialog default; existing tenants still hold this shape.)
3. Open an LLM-as-judge evaluator drawer for that model.

**Before this PR** — the customer's screenshot. Note the popover only shows Temperature; Max Tokens row is missing. The customer also reported "it flashes briefly for the max tokens" — first paint hits the `DEFAULT_SUPPORTED_PARAMETERS` fallback, then `["temperature"]` lands and removes the slider:

![customer-bug](https://i.img402.dev/k0fjrn4twb.png)

**After this PR** — Max Tokens (8192) renders from first paint and stays:

![after-fix-popover](https://i.img402.dev/ph7o3jw6fs.png)

Reopening the popover — no flicker, slider stays:

![after-fix-reopen](https://i.img402.dev/shtxg5ia37.png)

## What changed

| File | Change |
|---|---|
| `langwatch/src/components/llmPromptConfigs/parameterRegistry.ts` | `getDisplayParameters` always includes `"max_tokens"`, sorted into the right display-order slot |
| `langwatch/src/components/settings/AddCustomModelDialog.tsx` | Removed `"Max Tokens"` from `DIALOG_PARAMETERS` and `DEFAULT_PARAMETERS` — the numeric ceiling field remains |
| `langwatch/src/tasks/migrateCustomModels.ts` | `CHAT_DEFAULTS.supportedParameters` no longer writes `"max_tokens"` (display logic is the single source of truth) |
| `langwatch/src/components/llmPromptConfigs/__tests__/LLMConfigPopover.test.tsx` | New scenario reproducing the customer entry: `bedrock/us.anthropic.claude-haiku-…` with `supportedParameters: ["temperature"]` — asserts the slider is rendered |
| `langwatch/src/tasks/__tests__/migrateCustomModels.unit.test.ts` | Updated existing assertions to drop `"max_tokens"` from migrated output |
| `specs/model-providers/custom-model-max-tokens.feature` | Rewritten: scenarios cover universal max_tokens for chat, no-flicker on managed-Bedrock customs, dialog no longer exposes the checkbox, embedding popovers unaffected |

The Add Model dialog after the change — note the absence of a "Max Tokens" checkbox in Supported Parameters:

![add-model-dialog](https://i.img402.dev/qupffev8n6.png)

## Why not just backfill stored data?

PR #3344 added a migration default of `["temperature", "max_tokens"]` for *new* legacy-shape conversions, but `migrateCustomModelsRow` returns `null` for already-object entries (`isLegacyCustomModels` check) — so existing tenants who registered customs pre-#3344 still hold `["temperature"]` only. A backfill task would clear that for them, but it would also override any future *intentional* opt-out post-fix.

The display-time fix is robust regardless of stored shape: storage is no longer the gate. Existing data stays valid (the enum still accepts `"max_tokens"`), and admins who edit a legacy model just no longer see the (now-meaningless) checkbox.

## Sweep

Searched for other consumers gating on `supportedParameters.includes("max_tokens")` — none. Backend dispatch (`evaluation-execution.factories.ts`, `evaluationsWorker.ts`) iterates a hardcoded `generationParams` list that always includes `max_tokens`, so per-invocation values flow through whenever set.

## Tradeoff

If an admin used the post-#3344 dialog to *explicitly* uncheck Max Tokens for a chat model, the popover will now show the slider anyway. Niche scenario, and per the conversation that triggered this PR: **all current chat models are token-based** and need the slider. If we ever need a true opt-out, the right path is a dedicated `excludesMaxTokens: true` field, not the absence-as-opt-out we had.

## Test plan

- [x] `pnpm test:unit src/components` (199 files, 2430 passed)
- [x] `pnpm typecheck`
- [x] Live browser QA: registered `us.anthropic.claude-haiku-4-5-20251001-v1:0` as a Bedrock custom model with stored `supportedParameters: ["temperature"]`. Opened LLM-as-Judge Boolean Evaluator → Max Tokens (8192) renders. Closed and reopened popover → slider persists. Screenshots above.
- [ ] CI green
- [ ] CodeRabbit pass