### PR TITLE
chore(security): add dependency age gates

### DIFF
--- a/agentic-e2e-tests/.npmrc
+++ b/agentic-e2e-tests/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080

--- a/bullboard/.npmrc
+++ b/bullboard/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080

--- a/dev/docs/best_practices/README.md
+++ b/dev/docs/best_practices/README.md
@@ -6,6 +6,7 @@ Project coding conventions. See also `../TESTING_PHILOSOPHY.md`.
 
 - **repository-service.md** - Repository + Service layer pattern
 - **logging-and-tracing.md** - Logging infrastructure and context propagation
+- **dependency-age-gates.md** - Dependency release-age gates and emergency security exceptions
 - **typescript.md** - TypeScript patterns
 - **react.md** - React/Next.js patterns
 - **git.md** - Git workflow

--- a/dev/docs/best_practices/dependency-age-gates.md
+++ b/dev/docs/best_practices/dependency-age-gates.md
@@ -59,10 +59,12 @@ pnpm install --lockfile-only --frozen-lockfile --ignore-scripts
 ### uv
 
 For uv projects, use `exclude-newer-package` in the relevant `pyproject.toml`.
-Set the package to `false` to exempt it from the global 7-day cutoff:
+Package-specific exceptions require uv 0.9.25 or newer. Set the package to
+`false` to exempt it from the global 7-day cutoff:
 
 ```toml
 [tool.uv]
+required-version = ">=0.9.25"
 exclude-newer = "7 days"
 exclude-newer-package = { litellm = false }
 ```
@@ -72,6 +74,7 @@ point in time, use an RFC 3339 timestamp instead:
 
 ```toml
 [tool.uv]
+required-version = ">=0.9.25"
 exclude-newer = "7 days"
 exclude-newer-package = { litellm = "2026-04-27T12:00:00Z" }
 ```

--- a/dev/docs/best_practices/dependency-age-gates.md
+++ b/dev/docs/best_practices/dependency-age-gates.md
@@ -1,0 +1,91 @@
+# Dependency Age Gates
+
+LangWatch delays newly published dependency releases during normal resolution:
+
+- pnpm: `minimumReleaseAge: 10080` waits 7 days before selecting npm packages.
+- uv: `exclude-newer = "7 days"` waits 7 days before selecting PyPI distributions.
+
+These settings apply to direct and transitive dependencies. They protect local
+developer machines as well as automation, so do not disable them globally during
+routine updates.
+
+## Emergency Security Updates
+
+If a 0-day or actively exploited vulnerability requires a patched package before
+the 7-day window has elapsed, add a package-specific exception. Keep the
+exception scoped to the affected package, update the lockfile, and remove the
+exception after the patched release is older than 7 days.
+
+Do not set the global delay to `0`, comment out the global setting, or run broad
+updates while the exception is active.
+
+### pnpm
+
+For pnpm workspaces, add `minimumReleaseAgeExclude` beside
+`minimumReleaseAge` in the relevant `pnpm-workspace.yaml`:
+
+```yaml
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - litellm
+  - '@scope/package'
+```
+
+For standalone pnpm roots that use `.npmrc`, add the package-specific exclude
+there:
+
+```ini
+minimum-release-age=10080
+minimum-release-age-exclude[]=litellm
+minimum-release-age-exclude[]=@scope/package
+```
+
+pnpm also supports version-scoped exceptions when the fix should be pinned to a
+specific release:
+
+```yaml
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - litellm@1.2.3
+```
+
+Then update only the affected package in the lock root that owns the dependency:
+
+```bash
+pnpm update litellm --latest
+pnpm install --lockfile-only --frozen-lockfile --ignore-scripts
+```
+
+### uv
+
+For uv projects, use `exclude-newer-package` in the relevant `pyproject.toml`.
+Set the package to `false` to exempt it from the global 7-day cutoff:
+
+```toml
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { litellm = false }
+```
+
+If the exception should allow only distributions uploaded before a specific
+point in time, use an RFC 3339 timestamp instead:
+
+```toml
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { litellm = "2026-04-27T12:00:00Z" }
+```
+
+Then update only the affected package in the lock root that owns the dependency:
+
+```bash
+uv lock --upgrade-package litellm
+uv lock --check
+```
+
+## Review Checklist
+
+- The exception names only the vulnerable package family that needs the fix.
+- The PR explains why the exception is needed and links the advisory.
+- Lockfile changes are limited to the affected dependency graph.
+- A follow-up issue or PR removes the exception after the 7-day window passes.

--- a/langevals/evaluators/azure/pyproject.toml
+++ b/langevals/evaluators/azure/pyproject.toml
@@ -27,5 +27,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["langevals_azure"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 langevals-core = { workspace = true }

--- a/langevals/evaluators/langevals/pyproject.toml
+++ b/langevals/evaluators/langevals/pyproject.toml
@@ -32,5 +32,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["langevals_langevals"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 langevals-core = { workspace = true }

--- a/langevals/evaluators/legacy/pyproject.toml
+++ b/langevals/evaluators/legacy/pyproject.toml
@@ -34,5 +34,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["langevals_legacy"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 langevals-core = { workspace = true }

--- a/langevals/evaluators/lingua/pyproject.toml
+++ b/langevals/evaluators/lingua/pyproject.toml
@@ -25,5 +25,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["langevals_lingua"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 langevals-core = { workspace = true }

--- a/langevals/evaluators/openai/pyproject.toml
+++ b/langevals/evaluators/openai/pyproject.toml
@@ -26,5 +26,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["langevals_openai"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 langevals-core = { workspace = true }

--- a/langevals/evaluators/presidio/pyproject.toml
+++ b/langevals/evaluators/presidio/pyproject.toml
@@ -29,6 +29,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["langevals_presidio"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 langevals-core = { workspace = true }
 en-core-web-lg = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.7.1/en_core_web_lg-3.7.1-py3-none-any.whl" }

--- a/langevals/evaluators/ragas/pyproject.toml
+++ b/langevals/evaluators/ragas/pyproject.toml
@@ -34,5 +34,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["langevals_ragas"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 langevals-core = { workspace = true }

--- a/langevals/langevals_core/pyproject.toml
+++ b/langevals/langevals_core/pyproject.toml
@@ -32,3 +32,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["langevals_core"]
+
+[tool.uv]
+exclude-newer = "7 days"

--- a/langevals/notebooks/pyproject.toml
+++ b/langevals/notebooks/pyproject.toml
@@ -53,6 +53,7 @@ build-backend = "hatchling.build"
 
 # Mark as non-publishable (equivalent to package-mode = false)
 [tool.uv]
+exclude-newer = "7 days"
 package = false
 
 [tool.uv.sources]

--- a/langevals/pyproject.toml
+++ b/langevals/pyproject.toml
@@ -65,6 +65,13 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["langevals"]
 
+[tool.uv]
+exclude-newer = "7 days"
+override-dependencies = [
+    "langchain>=0.3.30",
+    "langsmith>=0.8.0",
+]
+
 [tool.uv.workspace]
 members = [
     "langevals_core",
@@ -82,12 +89,6 @@ langevals-langevals = { workspace = true }
 langevals-presidio = { workspace = true }
 langevals-legacy = { workspace = true }
 langevals-topic_clustering = { workspace = true }
-
-[tool.uv]
-override-dependencies = [
-    "langchain>=0.3.30",
-    "langsmith>=0.8.0",
-]
 
 # PyTorch CPU index for Linux
 [[tool.uv.index]]

--- a/langevals/uv.lock
+++ b/langevals/uv.lock
@@ -13,6 +13,10 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-04-19T17:07:22.760704Z"
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "langevals",

--- a/langwatch/packages/analytics-parity-check/.npmrc
+++ b/langwatch/packages/analytics-parity-check/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080

--- a/langwatch/pnpm-workspace.yaml
+++ b/langwatch/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
   - "packages/*"
   - "../mcp-server"
 
+minimumReleaseAge: 10080
+
 overrides:
   pino: ^10.3.0
   pino-pretty: ^13.0.0

--- a/langwatch_nlp/pyproject.toml
+++ b/langwatch_nlp/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
 ]
 
 [tool.uv]
+exclude-newer = "7 days"
 package = false
 override-dependencies = ["python-multipart>=0.0.27"]
 

--- a/langwatch_nlp/uv.lock
+++ b/langwatch_nlp/uv.lock
@@ -13,6 +13,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "2026-05-10T06:01:18.960386Z"
+exclude-newer-span = "P7D"
+
 [manifest]
 overrides = [{ name = "python-multipart", specifier = ">=0.0.27" }]
 
@@ -1887,7 +1891,7 @@ examples = [
     { name = "langchain-openai", specifier = ">=0.3.0,<1.0.0" },
     { name = "langchain-text-splitters", specifier = ">=0.3.0,<1.0.0" },
     { name = "langgraph", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langsmith", specifier = ">=0.6.3" },
+    { name = "langsmith", specifier = ">=0.8.0" },
     { name = "litellm", specifier = ">=1.52.1" },
     { name = "nltk", specifier = ">=3.9.4" },
     { name = "openai", specifier = ">=1.68.2,<2.8.0" },
@@ -1900,7 +1904,7 @@ examples = [
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pypdf", specifier = ">=6.8.0" },
     { name = "pytest", specifier = ">=7.4.2,<8.0.0" },
-    { name = "python-dotenv", specifier = "==1.2.1" },
+    { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "strands-agents", extras = ["otel"], specifier = ">=1.14.0,<2.0.0" },
     { name = "streamlit", specifier = ">=1.37.1,<2.0.0" },
     { name = "unstructured", extras = ["pdf"], specifier = ">=0.18.18" },
@@ -1909,7 +1913,7 @@ examples = [
 tests = [
     { name = "factory-boy", specifier = ">=3.3.3" },
     { name = "pytest-asyncio", specifier = ">=0.21.2" },
-    { name = "python-dotenv", specifier = "==1.2.1" },
+    { name = "python-dotenv", specifier = "==1.2.2" },
 ]
 
 [[package]]

--- a/mcp-server/pnpm-workspace.yaml
+++ b/mcp-server/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+minimumReleaseAge: 10080
+
 onlyBuiltDependencies:
   - node-pty

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -13,5 +13,8 @@ dependencies = [
     "tenacity>=9.1.2",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 langwatch = { path = "../python-sdk", editable = true }

--- a/mcp-server/uv.lock
+++ b/mcp-server/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "2026-05-10T06:01:42.280437Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -985,7 +989,7 @@ examples = [
     { name = "langchain-openai", specifier = ">=0.3.0,<1.0.0" },
     { name = "langchain-text-splitters", specifier = ">=0.3.0,<1.0.0" },
     { name = "langgraph", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langsmith", specifier = ">=0.6.3" },
+    { name = "langsmith", specifier = ">=0.8.0" },
     { name = "litellm", specifier = ">=1.52.1" },
     { name = "nltk", specifier = ">=3.9.4" },
     { name = "openai", specifier = ">=1.68.2,<2.8.0" },
@@ -998,7 +1002,7 @@ examples = [
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pypdf", specifier = ">=6.8.0" },
     { name = "pytest", specifier = ">=7.4.2,<8.0.0" },
-    { name = "python-dotenv", specifier = "==1.2.1" },
+    { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "strands-agents", extras = ["otel"], specifier = ">=1.14.0,<2.0.0" },
     { name = "streamlit", specifier = ">=1.37.1,<2.0.0" },
     { name = "unstructured", extras = ["pdf"], specifier = ">=0.18.18" },
@@ -1007,7 +1011,7 @@ examples = [
 tests = [
     { name = "factory-boy", specifier = ">=3.3.3" },
     { name = "pytest-asyncio", specifier = ">=0.21.2" },
-    { name = "python-dotenv", specifier = "==1.2.1" },
+    { name = "python-dotenv", specifier = "==1.2.2" },
 ]
 
 [[package]]

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -115,3 +115,6 @@ tests = [
     "pytest-asyncio>=0.21.2",
     "python-dotenv==1.2.2"
 ]
+
+[tool.uv]
+exclude-newer = "7 days"

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -19,6 +19,10 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 's390x' and sys_platform != 'darwin'",
 ]
 
+[options]
+exclude-newer = "2026-04-19T17:07:22.760709Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "accelerate"
 version = "1.10.0"

--- a/skills/.npmrc
+++ b/skills/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080

--- a/specs/dependencies/supply-chain-age-gates.feature
+++ b/specs/dependencies/supply-chain-age-gates.feature
@@ -1,0 +1,11 @@
+Feature: Supply chain dependency age gates
+
+  Scenario: JavaScript dependency resolution waits before accepting new releases
+    Given a maintainer installs or updates JavaScript dependencies with pnpm
+    When pnpm resolves direct and transitive package versions
+    Then package versions published less than 7 days ago are not selected
+
+  Scenario: Python dependency resolution waits before accepting new releases
+    Given a maintainer locks, syncs, or updates Python dependencies with uv
+    When uv resolves direct and transitive package distributions
+    Then package distributions uploaded less than 7 days ago are not selected

--- a/specs/dependencies/supply-chain-age-gates.feature
+++ b/specs/dependencies/supply-chain-age-gates.feature
@@ -9,3 +9,9 @@ Feature: Supply chain dependency age gates
     Given a maintainer locks, syncs, or updates Python dependencies with uv
     When uv resolves direct and transitive package distributions
     Then package distributions uploaded less than 7 days ago are not selected
+
+  Scenario: Emergency security updates bypass only the affected package
+    Given a 0-day vulnerability requires a newly published patched dependency
+    When a maintainer adds an age-gate exception for the affected package
+    Then unrelated packages still wait for the 7-day age gate
+    And the exception is documented for removal after the patched release ages out

--- a/typescript-sdk/pnpm-workspace.yaml
+++ b/typescript-sdk/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - .
+
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Adds package-manager level age gates so local installs and updates avoid newly published packages by default.

- Configures pnpm lock roots with a 7-day `minimumReleaseAge` (`10080` minutes).
- Configures uv projects with `exclude-newer = "7 days"` and refreshes uv lock metadata.
- Documents the expected behavior in `specs/dependencies/supply-chain-age-gates.feature`.
- Adds `dev/docs/best_practices/dependency-age-gates.md` for emergency 0-day/package-specific exceptions.

## Why

This reduces exposure to fast-moving supply-chain attacks by preventing direct and transitive dependency resolution from selecting package releases published less than 7 days ago. This protects developer machines too, rather than relying on another CI-only guard.

Preventing exposure to issues like this: https://news.ycombinator.com/item?id=47501729

## Emergency Updates

0-day fixes should use package-specific exceptions instead of disabling the global delay:

- pnpm: `minimumReleaseAgeExclude` / `minimum-release-age-exclude[]`
- uv: `exclude-newer-package`

The docs include examples and a review checklist for removing exceptions after the patched release ages out.

## Validation

- `git diff --check`
- Verified all pnpm lock roots read `minimumReleaseAge=10080`.
- `uv lock --check` in `.`, `python-sdk`, `mcp-server`, `langwatch_nlp`, and `langevals`.
- Verified the pnpm `.npmrc` exclude array syntax reads correctly locally.
