### PR TITLE
wip: bundle of stress-test findings for #3526 (umbrella PR)

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -41,6 +41,7 @@ x-common-env: &common-env
   CLICKHOUSE_URL: http://default:langwatch@clickhouse:8123/langwatch
   LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
   LANGEVALS_ENDPOINT: http://langevals:5562
+  LANGWATCH_ENDPOINT: http://app:5560
 
 services:
   # =============================================================================
@@ -224,9 +225,6 @@ services:
     command: sh -c "export PATH=/opt/goose-bin:$$PATH && corepack enable && while true; do pnpm -w exec tsx --tsconfig tsconfig.workers.json src/workers.ts; sleep 1; done"
     environment:
       <<: *common-env
-      # Override BASE_HOST for Docker networking - scenario child processes post events here
-      BASE_HOST: http://app:5560
-      LANGWATCH_ENDPOINT: http://app:5560
       PINO_LOG_LEVEL: ${PINO_LOG_LEVEL:-info}
       # To enable verbose scenario SDK logging, add: SCENARIO_VERBOSE: "true"
     env_file:
@@ -250,8 +248,6 @@ services:
     env_file:
       - langwatch_nlp/.env
     # No host port - accessed via docker network as "langwatch_nlp:5561"
-    environment:
-      LANGWATCH_ENDPOINT: http://app:5560
     deploy:
       resources:
         limits:
@@ -316,7 +312,6 @@ services:
       - "${AI_SERVER_PORT:-3456}:3456"
     environment:
       <<: *common-env
-      LANGWATCH_ENDPOINT: "http://app:5560/"
       # LANGWATCH_API_KEY comes from langwatch/.env via env_file below
       PINO_CONSOLE_LEVEL: "debug"
       LOG_LEVEL: "debug"

--- a/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
+++ b/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
@@ -1,18 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { platformUrl } from "../platform-url";
 
-describe("platformUrl", () => {
-  const originalEnv = process.env.BASE_HOST;
+// Mutable env object so individual tests can override BASE_HOST
+const mockEnv = { BASE_HOST: "https://app.langwatch.ai" as string | undefined };
 
-  afterEach(() => {
-    process.env.BASE_HOST = originalEnv;
+vi.mock("~/env.mjs", () => ({ env: mockEnv }));
+
+describe("platformUrl", () => {
+  beforeEach(() => {
+    mockEnv.BASE_HOST = "https://app.langwatch.ai";
   });
 
   describe("when BASE_HOST is set", () => {
-    beforeEach(() => {
-      process.env.BASE_HOST = "https://app.langwatch.ai";
-    });
-
     it("builds a direct page URL", () => {
       expect(
         platformUrl({ projectSlug: "my-project", path: "/datasets/ds_123" })
@@ -31,7 +30,7 @@ describe("platformUrl", () => {
     });
 
     it("strips trailing slash from BASE_HOST", () => {
-      process.env.BASE_HOST = "https://app.langwatch.ai/";
+      mockEnv.BASE_HOST = "https://app.langwatch.ai/";
       expect(
         platformUrl({ projectSlug: "test", path: "/datasets/ds_1" })
       ).toBe("https://app.langwatch.ai/test/datasets/ds_1");
@@ -40,21 +39,17 @@ describe("platformUrl", () => {
 
   describe("when BASE_HOST is not set", () => {
     beforeEach(() => {
-      delete process.env.BASE_HOST;
+      mockEnv.BASE_HOST = undefined;
     });
 
-    it("falls back to localhost:5560", () => {
+    it("returns a URL with empty base", () => {
       expect(
         platformUrl({ projectSlug: "demo", path: "/agents" })
-      ).toBe("http://localhost:5560/demo/agents");
+      ).toBe("/demo/agents");
     });
   });
 
   describe("resource URL patterns", () => {
-    beforeEach(() => {
-      process.env.BASE_HOST = "https://app.langwatch.ai";
-    });
-
     it("generates correct dataset page URL", () => {
       const url = platformUrl({ projectSlug: "p", path: "/datasets/ds_abc" });
       expect(url).toContain("/p/datasets/ds_abc");

--- a/langwatch/src/app/api/shared/platform-url.ts
+++ b/langwatch/src/app/api/shared/platform-url.ts
@@ -1,3 +1,5 @@
+import { env } from "~/env.mjs";
+
 /**
  * Builds a full platform URL for a resource so API consumers can link
  * directly to it in the LangWatch UI.
@@ -14,7 +16,7 @@ export function platformUrl({
   projectSlug: string;
   path: string;
 }): string {
-  const base = (process.env.BASE_HOST ?? "http://localhost:5560").replace(
+  const base = (env.BASE_HOST ?? "").replace(
     /\/+$/,
     "",
   );

--- a/langwatch/src/components/IntegrationChecks.tsx
+++ b/langwatch/src/components/IntegrationChecks.tsx
@@ -13,6 +13,9 @@ export const useIntegrationChecks = () => {
     { projectId: project?.id ?? "" },
     {
       enabled: !!project,
+      // Onboarding checklist: staleTime: Infinity is fine here because
+      // refetchOnWindowFocus picks up out-of-band changes (first message
+      // synced, first workflow created, etc.) when the user returns to the tab.
       refetchOnWindowFocus: true,
       refetchOnMount: false,
       staleTime: Infinity,

--- a/langwatch/src/components/copilot-kit/TraceMessage.tsx
+++ b/langwatch/src/components/copilot-kit/TraceMessage.tsx
@@ -17,8 +17,9 @@ const TRACE_QUERY_CONFIG = {
   retry: 10,
   retryDelay: (attemptIndex: number) =>
     Math.min(2000 * 2 ** attemptIndex, 60000),
-  staleTime: Infinity, // Never consider successful data stale
-  cacheTime: Infinity, // Cache successful results indefinitely
+  // Traces are immutable once written, so caching forever is correct.
+  staleTime: Infinity,
+  cacheTime: Infinity,
 } as const;
 
 interface TraceMessageProps extends StackProps {

--- a/langwatch/src/components/evaluations/wizard/hooks/useInitialLoadExperiment.ts
+++ b/langwatch/src/components/evaluations/wizard/hooks/useInitialLoadExperiment.ts
@@ -54,6 +54,9 @@ export const useInitialLoadExperiment = () => {
       },
       {
         enabled: !!project && !!initialLoadExperimentSlug,
+        // One-shot bootstrap: result is hydrated into the Zustand wizard store
+        // (setDSL/setExperimentId/setExperimentSlug below) and the user edits
+        // from there. A background refetch would clobber unsaved edits.
         refetchOnMount: false,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,

--- a/langwatch/src/components/scenarios/ModelProviderRequiredModal.tsx
+++ b/langwatch/src/components/scenarios/ModelProviderRequiredModal.tsx
@@ -1,0 +1,61 @@
+import {
+  Box,
+  Button,
+  HStack,
+  Icon,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { AlertTriangle } from "lucide-react";
+import { Dialog } from "../ui/dialog";
+
+export interface ModelProviderRequiredModalProps {
+  open: boolean;
+  onClose: () => void;
+  onProceedAnyway: () => void;
+}
+
+export function ModelProviderRequiredModal({
+  open,
+  onClose,
+  onProceedAnyway,
+}: ModelProviderRequiredModalProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(d) => !d.open && onClose()}>
+      <Dialog.Content>
+        <Dialog.CloseTrigger />
+        <Dialog.Header>
+          <Dialog.Title>Model provider not ready</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
+          <VStack gap={4} py={4} align="center" justify="center">
+            <Box p={3} borderRadius="full" bg="orange.100" color="orange.600">
+              <Icon as={AlertTriangle} boxSize={6} />
+            </Box>
+            <Text color="fg.muted" fontSize="sm" textAlign="center">
+              Scenarios need an enabled provider with a default model to run. Configure default model provider to get started, or proceed to create a new scenario anyway.
+            </Text>
+          </VStack>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <HStack gap={2} justify="flex-end">
+            <Button variant="ghost" onClick={onProceedAnyway}>
+              Proceed anyway
+            </Button>
+            <Button colorPalette="blue" asChild>
+              <a
+                data-testid="model-provider-required-modal-configure-button"
+                href="/settings/model-providers"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: "white" }}
+              >
+                Configure model provider
+              </a>
+            </Button>
+          </HStack>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/langwatch/src/components/scenarios/ScenarioCreateModal.tsx
+++ b/langwatch/src/components/scenarios/ScenarioCreateModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { AICreateModal, type ExampleTemplate } from "../shared/AICreateModal";
+import { ModelProviderRequiredModal } from "./ModelProviderRequiredModal";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useModelProvidersSettings } from "~/hooks/useModelProvidersSettings";
@@ -8,6 +9,7 @@ import { isHandledByGlobalHandler } from "~/utils/trpcError";
 import { generateScenarioWithAI } from "./services/scenarioGeneration";
 import type { ScenarioFormData, ScenarioInitialData } from "./ScenarioForm";
 import { getDefaultModelState } from "./utils/defaultModelState";
+import { api } from "~/utils/api";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -64,10 +66,18 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
     projectId: project?.id,
   });
 
+  // Use server-resolved default model so env-fallback providers are considered
+  // (new self-host / dev projects where project.defaultModel may be null).
+  const { data: resolvedModelData } = api.project.getResolvedDefaultModel.useQuery(
+    { projectId: project?.id ?? "" },
+    { enabled: !!project?.id },
+  );
+  const resolvedDefaultModel = resolvedModelData?.resolvedDefaultModel;
+
   const defaultModelState = getDefaultModelState({
     hasEnabledProviders,
     providers,
-    defaultModel: project?.defaultModel,
+    defaultModel: resolvedDefaultModel ?? project?.defaultModel,
   });
 
   const openEditorWithData = useCallback(
@@ -91,23 +101,6 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
         throw new Error("No project selected");
       }
 
-      if (!defaultModelState.ok) {
-        if (defaultModelState.reason === "no-default") {
-          throw new Error(
-            "No default model set. Configure one in Settings → Model Providers."
-          );
-        }
-        if (defaultModelState.reason === "stale-default") {
-          throw new Error(
-            "Your default model's provider is disabled. Configure a new default in Settings → Model Providers."
-          );
-        }
-        // no-providers: AICreateModal hides the Generate button, so this is unreachable in practice
-        const _exhaustiveCheck: "no-providers" = defaultModelState.reason;
-        void _exhaustiveCheck;
-        return;
-      }
-
       try {
         const generatedData = await generateScenarioWithAI(description, project.id);
         openEditorWithData(generatedData);
@@ -116,7 +109,7 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
         throw error;
       }
     },
-    [project?.id, defaultModelState, openEditorWithData]
+    [project?.id, openEditorWithData]
   );
 
   const handleSkip = useCallback(() => {
@@ -127,7 +120,15 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
     });
   }, [openEditorWithData]);
 
-  const hasModelProviders = defaultModelState.ok || defaultModelState.reason !== "no-providers";
+  if (!defaultModelState.ok) {
+    return (
+      <ModelProviderRequiredModal
+        open={open}
+        onClose={onClose}
+        onProceedAnyway={() => checkAndProceed(handleSkip)}
+      />
+    );
+  }
 
   return (
     <AICreateModal
@@ -139,7 +140,6 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
       onGenerate={(desc) => checkAndProceed(() => handleGenerate(desc))}
       onSkip={() => checkAndProceed(handleSkip)}
       generatingText={GENERATING_TEXT}
-      hasModelProviders={hasModelProviders}
     />
   );
 }

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -184,13 +184,19 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
     async (data: ScenarioFormData, { skipTransition = false } = {}): Promise<Scenario | null> => {
       if (!project?.id) return null;
 
-      // Edit mode: scenarioId is in URL and scenario data is loaded
+      // Edit mode: scenarioId is in URL and scenario data is loaded.
+      // Catch mutation errors here so save failures never surface as "Failed to run scenario"
+      // in the save-and-run path — the mutation's own onError toast handles user feedback.
       if (scenario) {
-        return updateMutation.mutateAsync({
-          projectId: project.id,
-          id: scenario.id,
-          ...data,
-        });
+        try {
+          return await updateMutation.mutateAsync({
+            projectId: project.id,
+            id: scenario.id,
+            ...data,
+          });
+        } catch {
+          return null;
+        }
       }
 
       // Create mode: no scenarioId in URL yet

--- a/langwatch/src/components/scenarios/__tests__/ScenarioCreateModal.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioCreateModal.test.tsx
@@ -362,14 +362,17 @@ describe("<ScenarioCreateModal/>", () => {
       mockProviders = {};
     });
 
-    it("shows warning message instead of form", () => {
+    it("shows the model-provider-required modal instead of the AI form", () => {
       render(
         <ScenarioCreateModal open={true} onClose={vi.fn()} />,
         { wrapper: Wrapper }
       );
 
       const dialog = getDialogContent();
-      expect(within(dialog).getByText("No model provider configured")).toBeInTheDocument();
+      expect(within(dialog).getByText("Model provider not ready")).toBeInTheDocument();
+      expect(
+        within(dialog).getByTestId("model-provider-required-modal-configure-button")
+      ).toHaveAccessibleName("Configure model provider");
     });
 
     it("hides textarea", () => {
@@ -541,9 +544,11 @@ describe("given azure is the only enabled provider and project.defaultModel is a
 });
 
 describe("given azure is the only enabled provider and project.defaultModel is null", () => {
-  describe("when user clicks Generate with AI", () => {
+  // null defaultModel → getDefaultModelState returns { ok: false, reason: "no-default" }
+  // The modal must show the same "Configure model provider" UI it shows for no-providers,
+  // so the user can self-recover instead of hitting a dead-end error.
+  describe("when the modal opens", () => {
     beforeEach(() => {
-      // null defaultModel → getDefaultModelState returns { ok: false, reason: "no-default" }
       mockProject = { id: "p1", slug: "proj", defaultModel: undefined };
       mockHasEnabledProviders = true;
       mockProviders = { azure: { enabled: true }, openai: { enabled: false } };
@@ -554,65 +559,48 @@ describe("given azure is the only enabled provider and project.defaultModel is n
       });
     });
 
+    it("shows the Configure model provider footer button", () => {
+      render(
+        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(
+        within(dialog).getByTestId("model-provider-required-modal-configure-button")
+      ).toHaveAccessibleName("Configure model provider");
+    });
+
+    it("does not render the description textarea or Generate button", () => {
+      render(
+        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(within(dialog).queryByRole("textbox")).not.toBeInTheDocument();
+      expect(within(dialog).queryByRole("button", { name: /generate with ai/i })).not.toBeInTheDocument();
+    });
+
     it("does not call generateScenarioWithAI", async () => {
       render(
         <ScenarioCreateModal open={true} onClose={vi.fn()} />,
         { wrapper: Wrapper }
       );
 
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test missing default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      // Wait briefly to allow any async state to settle
+      // Nothing the user can do in the modal triggers a generation.
       await waitFor(() => {
-        // fetch must NOT have been called — no valid default model
         expect(global.fetch).not.toHaveBeenCalled();
-      });
-    });
-
-    it("renders an error state with a message not containing API keys not configured", async () => {
-      render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test missing default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      // Wait for the error state to appear (any error), then assert on the message
-      await waitFor(() => {
-        expect(within(dialog).getByText(/something went wrong/i)).toBeInTheDocument();
-      });
-      // The error message must NOT be the misleading "API keys not configured" text
-      expect(within(dialog).queryByText(/api keys not configured/i)).not.toBeInTheDocument();
-    });
-
-    it("renders an error mentioning default model", async () => {
-      render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test missing default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      await waitFor(() => {
-        expect(within(dialog).getByText(/default model/i)).toBeInTheDocument();
       });
     });
   });
 });
 
 describe("given azure is the only enabled provider and project.defaultModel is openai/gpt-5.2 (stale)", () => {
-  describe("when user clicks Generate with AI", () => {
+  // Stale default → getDefaultModelState returns { ok: false, reason: "stale-default" }
+  // Same contract as no-default: surface the recovery affordance, suppress generation.
+  describe("when the modal opens", () => {
     beforeEach(() => {
-      // Stale default: openai provider is disabled → getDefaultModelState returns { ok: false, reason: "stale-default" }
       mockProject = { id: "p1", slug: "proj", defaultModel: "openai/gpt-5.2" };
       mockHasEnabledProviders = true;
       mockProviders = { azure: { enabled: true }, openai: { enabled: false } };
@@ -623,54 +611,37 @@ describe("given azure is the only enabled provider and project.defaultModel is o
       });
     });
 
+    it("shows the Configure model provider footer button", () => {
+      render(
+        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(
+        within(dialog).getByTestId("model-provider-required-modal-configure-button")
+      ).toHaveAccessibleName("Configure model provider");
+    });
+
+    it("does not render the description textarea or Generate button", () => {
+      render(
+        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(within(dialog).queryByRole("textbox")).not.toBeInTheDocument();
+      expect(within(dialog).queryByRole("button", { name: /generate with ai/i })).not.toBeInTheDocument();
+    });
+
     it("does not call generateScenarioWithAI", async () => {
       render(
         <ScenarioCreateModal open={true} onClose={vi.fn()} />,
         { wrapper: Wrapper }
       );
 
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test stale default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
       await waitFor(() => {
         expect(global.fetch).not.toHaveBeenCalled();
-      });
-    });
-
-    it("renders an error state with a message not containing API keys not configured", async () => {
-      render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test stale default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      // Wait for the error state to appear (any error), then assert on the message
-      await waitFor(() => {
-        expect(within(dialog).getByText(/something went wrong/i)).toBeInTheDocument();
-      });
-      // The error message must NOT be the misleading "API keys not configured" text
-      expect(within(dialog).queryByText(/api keys not configured/i)).not.toBeInTheDocument();
-    });
-
-    it("renders an error mentioning the provider is disabled", async () => {
-      render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test stale default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      await waitFor(() => {
-        expect(within(dialog).getByText(/provider.*disabled|disabled.*provider/i)).toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.save-and-run.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.save-and-run.integration.test.tsx
@@ -1,0 +1,370 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for Save & Run data-loss regression (Bug #8).
+ *
+ * Verifies that:
+ * - When the save mutation succeeds and run fails, the save is NOT rolled back.
+ * - A save failure in Save & Run is not misreported as "Failed to run scenario".
+ * - The drawer stays open when the save mutation fails during Save & Run.
+ *
+ * Root cause: handleSave for edit mode propagated updateMutation.mutateAsync
+ * rejections through handleSubmit's callback to the outer try/catch in
+ * handleSaveAndRun, which reported every save error as "Failed to run scenario".
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../prompts/PromptEditorDrawer", () => ({
+  PromptEditorDrawer: () => null,
+}));
+vi.mock("../../agents/AgentTypeSelectorDrawer", () => ({
+  AgentTypeSelectorDrawer: () => null,
+}));
+vi.mock("../ScenarioEditorSidebar", () => ({
+  ScenarioEditorSidebar: () => null,
+}));
+
+vi.mock("../SaveAndRunMenu", () => ({
+  SaveAndRunMenu: ({
+    onSaveAndRun,
+    onSaveWithoutRunning,
+    selectedTarget,
+  }: {
+    onSaveAndRun?: (target: { type: string; id: string }) => void;
+    onSaveWithoutRunning?: () => void;
+    selectedTarget?: { type: string; id: string } | null;
+    onCreateAgent?: () => void;
+    isLoading?: boolean;
+    onTargetChange?: (target: unknown) => void;
+    onCreatePrompt?: () => void;
+  }) => (
+    <div data-testid="save-and-run-menu">
+      <button
+        data-testid="save-and-run-button"
+        onClick={() =>
+          onSaveAndRun?.(selectedTarget ?? { type: "http", id: "agent-1" })
+        }
+      >
+        Save and Run
+      </button>
+      <button data-testid="save-button" onClick={onSaveWithoutRunning}>
+        Save
+      </button>
+    </div>
+  ),
+}));
+
+import { ScenarioFormDrawer } from "../ScenarioFormDrawer";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  mockUpdateMutateAsync: vi.fn(),
+  mockRunScenario: vi.fn(),
+  mockOpenDrawer: vi.fn(),
+  mockCloseDrawer: vi.fn(),
+  mockRouterPush: vi.fn(),
+  mockGetByIdData: null as Record<string, unknown> | null,
+  persistedTarget: null as { type: string; id: string } | null,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    scenarios: {
+      create: {
+        useMutation: ({
+          onSuccess,
+        }: {
+          onSuccess?: (data: unknown) => void;
+          onError?: (error: Error) => void;
+        }) => ({
+          mutateAsync: vi.fn(async (input: unknown) => {
+            const result = {
+              id: "new-id",
+              ...((input as Record<string, unknown>) ?? {}),
+            };
+            onSuccess?.(result);
+            return result;
+          }),
+          isPending: false,
+        }),
+      },
+      update: {
+        useMutation: ({
+          onSuccess,
+          onError,
+        }: {
+          onSuccess?: (data: unknown) => void;
+          onError?: (error: Error) => void;
+        }) => ({
+          mutateAsync: vi.fn(async (input: unknown) => {
+            try {
+              const result = await mocks.mockUpdateMutateAsync(input);
+              onSuccess?.(result);
+              return result;
+            } catch (error) {
+              onError?.(error as Error);
+              throw error;
+            }
+          }),
+          isPending: false,
+        }),
+      },
+      getById: {
+        useQuery: () => ({
+          data: mocks.mockGetByIdData,
+          isLoading: false,
+        }),
+      },
+    },
+    agents: {
+      getAll: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+    prompts: {
+      getAllPromptsForProject: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+    licenseEnforcement: {
+      checkLimit: {
+        useQuery: () => ({
+          data: { allowed: true, current: 0, max: 100 },
+          isLoading: false,
+        }),
+      },
+      reportLimitBlocked: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+    useContext: () => ({
+      scenarios: {
+        getAll: { invalidate: vi.fn() },
+        getById: { invalidate: vi.fn() },
+      },
+      agents: {
+        getById: { fetch: vi.fn() },
+      },
+    }),
+  },
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: mocks.mockOpenDrawer,
+    closeDrawer: mocks.mockCloseDrawer,
+    drawerOpen: vi.fn(() => true),
+    goBack: vi.fn(),
+    canGoBack: false,
+  }),
+  useDrawerParams: () => ({}),
+  getComplexProps: () => ({}),
+  setFlowCallbacks: vi.fn(),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project-123", slug: "my-project" },
+    organization: { id: "org-123" },
+  }),
+}));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    query: { project: "my-project" },
+    pathname: "/[project]/simulations/scenarios",
+    asPath: "/my-project/simulations/scenarios",
+    push: mocks.mockRouterPush,
+    replace: vi.fn(),
+    isReady: true,
+  }),
+}));
+
+vi.mock("~/hooks/useRunScenario", () => ({
+  useRunScenario: () => ({
+    runScenario: mocks.mockRunScenario,
+    isRunning: false,
+  }),
+}));
+
+vi.mock("~/hooks/useScenarioTarget", () => ({
+  useScenarioTarget: () => ({
+    target: mocks.persistedTarget,
+    setTarget: vi.fn(),
+    clearTarget: vi.fn(),
+    hasPersistedTarget: false,
+  }),
+}));
+
+vi.mock("~/stores/upgradeModalStore", () => ({
+  useUpgradeModalStore: (selector: unknown) => {
+    if (typeof selector === "function") {
+      return (selector as (state: { open: () => void }) => unknown)({
+        open: vi.fn(),
+      });
+    }
+    return { open: vi.fn() };
+  },
+}));
+
+const mockToasterCreate = vi.fn();
+vi.mock("../../ui/toaster", () => ({
+  toaster: {
+    create: (args: unknown) => mockToasterCreate(args),
+  },
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderEditModeDrawer() {
+  mocks.mockGetByIdData = {
+    id: "scenario-1",
+    name: "Refund Flow",
+    situation: "User requests a refund",
+    criteria: ["Agent must acknowledge the issue"],
+    labels: [],
+  };
+  return render(
+    <ScenarioFormDrawer open={true} scenarioId="scenario-1" />,
+    { wrapper: Wrapper },
+  );
+}
+
+describe("<ScenarioFormDrawer /> save-and-run data-loss regression", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockGetByIdData = null;
+    mocks.persistedTarget = null;
+    mocks.mockRunScenario.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given the drawer is in edit mode with an existing scenario", () => {
+    describe("when save succeeds and run is dispatched (fire-and-forget)", () => {
+      beforeEach(() => {
+        mocks.mockUpdateMutateAsync.mockResolvedValue({
+          id: "scenario-1",
+          name: "Refund Flow",
+          situation: "User requests a refund",
+          criteria: ["Agent must acknowledge the issue"],
+          labels: [],
+        });
+        // Simulate run being dispatched asynchronously (void-ed)
+        mocks.mockRunScenario.mockResolvedValue(undefined);
+      });
+
+      it("calls update mutation and navigates to simulations page", async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        renderEditModeDrawer();
+
+        await user.click(screen.getByTestId("save-and-run-button"));
+
+        await waitFor(() => {
+          expect(mocks.mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+        });
+
+        expect(onClose).not.toHaveBeenCalled(); // drawer uses closeDrawer internally
+        await waitFor(() => {
+          expect(mocks.mockRouterPush).toHaveBeenCalledWith(
+            expect.stringMatching(/^\/my-project\/simulations\?pendingBatch=/),
+          );
+        });
+      });
+
+      it("does not show 'Failed to run scenario' when only run fails asynchronously", async () => {
+        // Run fails asynchronously after the save completes — handled inside useRunScenario
+        mocks.mockRunScenario.mockRejectedValue(new Error("Provider error"));
+        const user = userEvent.setup();
+        renderEditModeDrawer();
+
+        await user.click(screen.getByTestId("save-and-run-button"));
+
+        await waitFor(() => {
+          expect(mocks.mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+        });
+
+        // The outer catch in handleSaveAndRun must NOT fire for async run failures
+        // because runScenario is void-ed (fire-and-forget)
+        expect(mockToasterCreate).not.toHaveBeenCalledWith(
+          expect.objectContaining({ title: "Failed to run scenario" }),
+        );
+      });
+    });
+
+    describe("when save fails (update mutation rejects)", () => {
+      beforeEach(() => {
+        mocks.mockUpdateMutateAsync.mockRejectedValue(
+          new Error("Network error"),
+        );
+      });
+
+      it("does NOT show 'Failed to run scenario' — save error must not be misreported as run failure", async () => {
+        const user = userEvent.setup();
+        renderEditModeDrawer();
+
+        await user.click(screen.getByTestId("save-and-run-button"));
+
+        await waitFor(() => {
+          expect(mocks.mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+        });
+
+        // Must NOT misreport the save failure as a run failure
+        expect(mockToasterCreate).not.toHaveBeenCalledWith(
+          expect.objectContaining({ title: "Failed to run scenario" }),
+        );
+      });
+
+      it("shows the save-specific error from the mutation onError callback", async () => {
+        const user = userEvent.setup();
+        renderEditModeDrawer();
+
+        await user.click(screen.getByTestId("save-and-run-button"));
+
+        await waitFor(() => {
+          expect(mockToasterCreate).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title: "Failed to update scenario",
+              type: "error",
+            }),
+          );
+        });
+      });
+
+      it("does not navigate to simulations — save must not be treated as successful", async () => {
+        const user = userEvent.setup();
+        renderEditModeDrawer();
+
+        await user.click(screen.getByTestId("save-and-run-button"));
+
+        await waitFor(() => {
+          expect(mocks.mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+        });
+
+        expect(mocks.mockRouterPush).not.toHaveBeenCalled();
+      });
+
+      it("does not dispatch run when save failed", async () => {
+        const user = userEvent.setup();
+        renderEditModeDrawer();
+
+        await user.click(screen.getByTestId("save-and-run-button"));
+
+        await waitFor(() => {
+          expect(mocks.mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+        });
+
+        expect(mocks.mockRunScenario).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/scenarios/ui/CriteriaInput.tsx
+++ b/langwatch/src/components/scenarios/ui/CriteriaInput.tsx
@@ -99,6 +99,7 @@ export function CriteriaInput({
                 value={editingValue}
                 onChange={(e) => setEditingValue(e.target.value)}
                 onKeyDown={handleEditKeyDown}
+                onBlur={handleSaveEdit}
                 size="sm"
                 autoresize
                 rows={2}
@@ -120,6 +121,7 @@ export function CriteriaInput({
                   type="button"
                   size="xs"
                   variant="outline"
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => setEditingIndex(null)}
                 >
                   Cancel
@@ -178,6 +180,7 @@ export function CriteriaInput({
               placeholder={placeholder}
               flex={1}
               onKeyDown={handleAddKeyDown}
+              onBlur={handleSaveNew}
               _placeholder={{ color: "gray.400", fontStyle: "italic" }}
               autoresize
               rows={2}
@@ -188,6 +191,7 @@ export function CriteriaInput({
               type="button"
               size="xs"
               variant="outline"
+              onMouseDown={(e) => e.preventDefault()}
               onClick={() => {
                 setInputValue("");
                 setIsAddingNew(false);

--- a/langwatch/src/components/scenarios/ui/__tests__/CriteriaInput.test.tsx
+++ b/langwatch/src/components/scenarios/ui/__tests__/CriteriaInput.test.tsx
@@ -59,6 +59,33 @@ describe("CriteriaInput", () => {
         expect(onChange).toHaveBeenCalledWith(["New criterion"]);
       });
     });
+
+    it("saves criterion on blur (regression: typing and tabbing away must persist)", async () => {
+      const onChange = vi.fn();
+      renderWithChakra(
+        <CriteriaInput value={[]} onChange={onChange} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Add the first criteria")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("Add the first criteria"));
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("Add a criterion...")).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText("Add a criterion...");
+      fireEvent.change(input, { target: { value: "Criterion typed then blurred" } });
+
+      // Blur without clicking Save — simulates the user tabbing/clicking away
+      fireEvent.blur(input);
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(["Criterion typed then blurred"]);
+      });
+    });
   });
 
   describe("when criteria exist", () => {
@@ -143,6 +170,37 @@ describe("CriteriaInput", () => {
 
       await waitFor(() => {
         expect(onChange).toHaveBeenCalledWith(["first", "third"]);
+      });
+    });
+
+    it("saves edited criterion on blur (regression: editing and clicking away must persist)", async () => {
+      const onChange = vi.fn();
+      renderWithChakra(
+        <CriteriaInput
+          value={["first", "second", "third"]}
+          onChange={onChange}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("second")).toBeInTheDocument();
+      });
+
+      // Click to enter edit mode
+      fireEvent.click(screen.getByText("second"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("second")).toBeInTheDocument();
+      });
+
+      const textarea = screen.getByDisplayValue("second");
+      fireEvent.change(textarea, { target: { value: "second edited" } });
+
+      // Blur without clicking Save — simulates the user tabbing/clicking away
+      fireEvent.blur(textarea);
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(["first", "second edited", "third"]);
       });
     });
   });

--- a/langwatch/src/components/scenarios/utils/__tests__/classifyGenerationError.test.ts
+++ b/langwatch/src/components/scenarios/utils/__tests__/classifyGenerationError.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { classifyGenerationError } from "../classifyGenerationError";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Minimal TRPCClientError-shaped object (without importing the real class). */
+function makeTrpcError(message: string, dataMessage?: string): Error & { data?: { message?: string } } {
+  const err = new Error(message) as Error & { data?: { message?: string } };
+  if (dataMessage !== undefined) {
+    err.data = { message: dataMessage };
+  }
+  return err;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("classifyGenerationError", () => {
+  // ── config tier ────────────────────────────────────────────────────────────
+
+  describe("given an error matching /no default model/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("No default model set for this project"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+      expect(result.copy).toContain("no default model");
+    });
+  });
+
+  describe("given an error matching /no.*provider/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("No provider found for this project"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  describe("given an error matching /provider.*not.*configured/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("Provider is not configured"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  describe("given an error matching /stale/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("Stale provider reference detected"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+      expect(result.copy).toContain("provider is disabled");
+    });
+  });
+
+  describe("given an error matching /provider.*disabled/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("The provider has been disabled"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  // ── auth tier ──────────────────────────────────────────────────────────────
+
+  describe("given an Error with message matching /invalid api key/", () => {
+    it("returns auth tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("Invalid API key provided"));
+
+      expect(result.tier).toBe("auth");
+      expect(result.cta).toBe("configure");
+      expect(result.copy).toContain("API key");
+    });
+  });
+
+  describe("given an error matching /authentication/", () => {
+    it("returns auth tier", () => {
+      const result = classifyGenerationError(new Error("Authentication failed"));
+
+      expect(result.tier).toBe("auth");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  describe("given an error matching /unauthorized/", () => {
+    it("returns auth tier", () => {
+      const result = classifyGenerationError(new Error("401 Unauthorized"));
+
+      expect(result.tier).toBe("auth");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  // ── rate-limit tier ────────────────────────────────────────────────────────
+
+  describe("given an error matching /rate limit/", () => {
+    it("returns rate-limit tier with configure-and-retry CTA", () => {
+      const result = classifyGenerationError(new Error("You have exceeded the rate limit"));
+
+      expect(result.tier).toBe("rate-limit");
+      expect(result.cta).toBe("configure-and-retry");
+    });
+  });
+
+  describe("given an error matching /quota/", () => {
+    it("returns rate-limit tier", () => {
+      const result = classifyGenerationError(new Error("Quota exceeded for this period"));
+
+      expect(result.tier).toBe("rate-limit");
+      expect(result.cta).toBe("configure-and-retry");
+    });
+  });
+
+  // ── timeout tier ───────────────────────────────────────────────────────────
+
+  describe("given an error matching /timeout/", () => {
+    it("returns timeout tier with retry CTA", () => {
+      const result = classifyGenerationError(new Error("The request timed out"));
+
+      expect(result.tier).toBe("timeout");
+      expect(result.cta).toBe("retry");
+    });
+  });
+
+  // ── unknown tier ───────────────────────────────────────────────────────────
+
+  describe("given an Error with an unrecognised message", () => {
+    it("returns unknown tier with retry-or-skip CTA and preserves raw message", () => {
+      const result = classifyGenerationError(new Error("Unexpected internal server error"));
+
+      expect(result.tier).toBe("unknown");
+      expect(result.cta).toBe("retry-or-skip");
+      if (result.tier === "unknown") {
+        expect(result.rawMessage).toBe("Unexpected internal server error");
+      }
+    });
+  });
+
+  // ── input shape variants ───────────────────────────────────────────────────
+
+  describe("given a TRPCClientError shape with data.message", () => {
+    it("extracts message from data.message", () => {
+      const err = makeTrpcError("Outer wrapper message", "Invalid API key from provider");
+      const result = classifyGenerationError(err);
+
+      // data.message takes priority — matches auth tier
+      expect(result.tier).toBe("auth");
+    });
+  });
+
+  describe("given a TRPCClientError shape without data.message", () => {
+    it("falls back to error.message", () => {
+      const err = makeTrpcError("Invalid API key from error.message");
+      const result = classifyGenerationError(err);
+
+      expect(result.tier).toBe("auth");
+    });
+  });
+
+  describe("given a plain string error", () => {
+    it("treats the string as the message", () => {
+      const result = classifyGenerationError("rate limit exceeded");
+
+      expect(result.tier).toBe("rate-limit");
+    });
+  });
+
+  describe("given an unknown non-Error value", () => {
+    it("returns unknown tier with string-coerced raw message", () => {
+      const result = classifyGenerationError({ code: 500 });
+
+      expect(result.tier).toBe("unknown");
+      if (result.tier === "unknown") {
+        expect(result.rawMessage).toBe("[object Object]");
+      }
+    });
+  });
+
+  describe("given case-insensitive matching", () => {
+    it("matches INVALID API KEY in upper case", () => {
+      const result = classifyGenerationError(new Error("INVALID API KEY"));
+
+      expect(result.tier).toBe("auth");
+    });
+  });
+});

--- a/langwatch/src/components/scenarios/utils/classifyGenerationError.ts
+++ b/langwatch/src/components/scenarios/utils/classifyGenerationError.ts
@@ -1,0 +1,115 @@
+/**
+ * Classifies a generation error into a tier with tailored copy and a recovery CTA.
+ *
+ * Tier-1: known error shapes → specific, actionable copy.
+ * Tier-2 (unknown): generic copy + raw backend message verbatim.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type GenerationErrorClass =
+  | { tier: "config"; cta: "configure"; copy: string }
+  | { tier: "auth"; cta: "configure"; copy: string }
+  | { tier: "rate-limit"; cta: "configure-and-retry"; copy: string }
+  | { tier: "timeout"; cta: "retry"; copy: string }
+  | { tier: "unknown"; cta: "retry-or-skip"; copy: string; rawMessage: string };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Message extraction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extracts a plain string message from an arbitrary unknown error value.
+ *
+ * Handles:
+ * - Error instances (including TRPCClientError, which extends Error)
+ * - Plain strings
+ * - Everything else via String()
+ */
+function extractMessage(error: unknown): string {
+  if (typeof error === "string") return error;
+
+  if (error instanceof Error) {
+    // TRPCClientError stores the server message in error.message already,
+    // but also exposes data.message on some shapes. Prefer data.message when present.
+    const trpcLike = error as Error & {
+      data?: { message?: string };
+    };
+    if (trpcLike.data?.message) {
+      return trpcLike.data.message;
+    }
+    return error.message;
+  }
+
+  return String(error);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maps a generation error to a classified tier with tailored copy and a recovery CTA.
+ *
+ * Regex matching is performed case-insensitively against the extracted message string.
+ */
+export function classifyGenerationError(error: unknown): GenerationErrorClass {
+  const message = extractMessage(error);
+
+  if (/no default model/i.test(message)) {
+    return {
+      tier: "config",
+      cta: "configure",
+      copy: "Your project has no default model configured. Set one to continue.",
+    };
+  }
+
+  if (/no.*provider|provider.*not.*configured/i.test(message)) {
+    return {
+      tier: "config",
+      cta: "configure",
+      copy: "No model provider is configured. Add one to continue.",
+    };
+  }
+
+  if (/stale|provider.*disabled/i.test(message)) {
+    return {
+      tier: "config",
+      cta: "configure",
+      copy: "The configured default model's provider is disabled. Reconfigure to continue.",
+    };
+  }
+
+  if (/invalid api key|authentication|unauthorized/i.test(message)) {
+    return {
+      tier: "auth",
+      cta: "configure",
+      copy: "There was a problem reaching your model provider. Check your provider configuration and that your API key is correct.",
+    };
+  }
+
+  if (/rate limit|quota/i.test(message)) {
+    return {
+      tier: "rate-limit",
+      cta: "configure-and-retry",
+      copy: "Rate limit reached on your provider. Wait a moment or check your provider's usage settings.",
+    };
+  }
+
+  if (/timeout/i.test(message)) {
+    return {
+      tier: "timeout",
+      cta: "retry",
+      copy: "The generation request timed out. Try again — the backend may be slow.",
+    };
+  }
+
+  return {
+    tier: "unknown",
+    cta: "retry-or-skip",
+    copy: "Something went wrong while generating your scenario.",
+    rawMessage: message,
+  };
+}

--- a/langwatch/src/components/shared/AICreateModal.tsx
+++ b/langwatch/src/components/shared/AICreateModal.tsx
@@ -1,16 +1,17 @@
 import {
   Box,
   Button,
+  Code,
   HStack,
   Icon,
-  Link,
   Spinner,
   Text,
   Textarea,
   VStack,
 } from "@chakra-ui/react";
-import { AlertCircle, AlertTriangle, Sparkles } from "lucide-react";
+import { AlertCircle, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { classifyGenerationError } from "../scenarios/utils/classifyGenerationError";
 import { Dialog } from "../ui/dialog";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -39,8 +40,6 @@ export interface AICreateModalProps {
   onSkip: () => void;
   /** Text shown during generation (default: "Generating...") */
   generatingText?: string;
-  /** Whether model providers are configured (default: true) */
-  hasModelProviders?: boolean;
 }
 
 type ModalState = "idle" | "generating" | "error";
@@ -67,11 +66,10 @@ export function AICreateModal({
   onGenerate,
   onSkip,
   generatingText = DEFAULT_GENERATING_TEXT,
-  hasModelProviders = true,
 }: AICreateModalProps) {
   const [description, setDescription] = useState("");
   const [modalState, setModalState] = useState<ModalState>("idle");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [capturedError, setCapturedError] = useState<unknown>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Clear timeout on unmount or when state changes
@@ -88,7 +86,7 @@ export function AICreateModal({
     if (open) {
       setDescription("");
       setModalState("idle");
-      setErrorMessage("");
+      setCapturedError(null);
     }
   }, [open]);
 
@@ -112,7 +110,7 @@ export function AICreateModal({
 
     // Action is proceeding - show generating state
     setModalState("generating");
-    setErrorMessage("");
+    setCapturedError(null);
 
     // Set up timeout
     const timeoutPromise = new Promise<never>((_, reject) => {
@@ -124,10 +122,9 @@ export function AICreateModal({
     try {
       await Promise.race([generationPromise, timeoutPromise]);
     } catch (error) {
+      console.error("[AICreateModal] generation error:", error);
       setModalState("error");
-      setErrorMessage(
-        error instanceof Error ? error.message : "An unexpected error occurred"
-      );
+      setCapturedError(error);
     } finally {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -164,11 +161,7 @@ export function AICreateModal({
           <Dialog.Title>{title}</Dialog.Title>
         </Dialog.Header>
         <Dialog.Body>
-          {!hasModelProviders && (
-            <NoModelProvidersWarning />
-          )}
-
-          {hasModelProviders && modalState === "idle" && (
+          {modalState === "idle" && (
             <IdleState
               description={description}
               placeholder={placeholder}
@@ -178,18 +171,12 @@ export function AICreateModal({
             />
           )}
 
-          {hasModelProviders && modalState === "generating" && <GeneratingState text={generatingText} />}
+          {modalState === "generating" && <GeneratingState text={generatingText} />}
 
-          {hasModelProviders && modalState === "error" && (
-            <ErrorState errorMessage={errorMessage} />
-          )}
+          {modalState === "error" && <ErrorState error={capturedError} />}
         </Dialog.Body>
         <Dialog.Footer>
-          {!hasModelProviders && (
-            <NoModelProvidersFooter />
-          )}
-
-          {hasModelProviders && modalState === "idle" && (
+          {modalState === "idle" && (
             <IdleFooter
               onSkip={handleSkip}
               onGenerate={handleGenerate}
@@ -197,8 +184,12 @@ export function AICreateModal({
             />
           )}
 
-{hasModelProviders && modalState === "error" && (
-            <ErrorFooter onSkip={handleSkip} onTryAgain={handleTryAgain} />
+          {modalState === "error" && (
+            <ErrorFooter
+              error={capturedError}
+              onSkip={handleSkip}
+              onTryAgain={handleTryAgain}
+            />
           )}
         </Dialog.Footer>
       </Dialog.Content>
@@ -272,25 +263,36 @@ function GeneratingState({ text }: GeneratingStateProps) {
 }
 
 interface ErrorStateProps {
-  errorMessage: string;
+  error: unknown;
 }
 
-function ErrorState({ errorMessage }: ErrorStateProps) {
+function ErrorState({ error }: ErrorStateProps) {
+  const classified = classifyGenerationError(error);
+
   return (
     <VStack gap={4} py={4}>
-      <Box
-        p={3}
-        borderRadius="full"
-        bg="red.100"
-        color="red.600"
-      >
+      <Box p={3} borderRadius="full" bg="red.100" color="red.600">
         <Icon as={AlertCircle} boxSize={6} />
       </Box>
       <VStack gap={1}>
         <Text fontWeight="semibold">Something went wrong</Text>
         <Text color="fg.muted" fontSize="sm" textAlign="center">
-          {errorMessage}
+          {classified.copy}
         </Text>
+        {classified.tier === "unknown" && classified.rawMessage && (
+          <Code
+            fontSize="xs"
+            mt={2}
+            px={2}
+            py={1}
+            borderRadius="md"
+            whiteSpace="pre-wrap"
+            wordBreak="break-word"
+            maxW="100%"
+          >
+            {classified.rawMessage}
+          </Code>
+        )}
       </VStack>
     </VStack>
   );
@@ -321,66 +323,45 @@ function IdleFooter({ onSkip, onGenerate, isGenerateDisabled }: IdleFooterProps)
 }
 
 interface ErrorFooterProps {
+  error: unknown;
   onSkip: () => void;
   onTryAgain: () => void;
 }
 
-function ErrorFooter({ onSkip, onTryAgain }: ErrorFooterProps) {
+function ErrorFooter({ error, onSkip, onTryAgain }: ErrorFooterProps) {
+  const classified = classifyGenerationError(error);
+
+  const showConfigure =
+    classified.cta === "configure" || classified.cta === "configure-and-retry";
+  const showRetry =
+    classified.cta === "retry" ||
+    classified.cta === "configure-and-retry" ||
+    classified.cta === "retry-or-skip";
+
   return (
     <HStack gap={2} justify="flex-end">
       <Button variant="ghost" onClick={onSkip}>
         I'll write it myself
       </Button>
-      <Button colorPalette="blue" onClick={onTryAgain}>
-        Try again
-      </Button>
-    </HStack>
-  );
-}
-
-function NoModelProvidersWarning() {
-  return (
-    <VStack gap={4} py={8} align="center" justify="center">
-      <Box
-        p={3}
-        borderRadius="full"
-        bg="orange.100"
-        color="orange.600"
-      >
-        <Icon as={AlertTriangle} boxSize={6} />
-      </Box>
-      <VStack gap={1}>
-        <Text fontWeight="semibold">No model provider configured</Text>
-        <Text color="fg.muted" fontSize="sm" textAlign="center">
-          Scenarios require a model provider to run. Please configure one to get started.{" "}
-          <Link
+      {showConfigure && (
+        <Button colorPalette="blue" asChild>
+          <a
+            data-testid="error-configure-model-provider-button"
             href="/settings/model-providers"
             target="_blank"
             rel="noopener noreferrer"
-            color="blue.500"
-            fontWeight="medium"
+            style={{ color: "white" }}
           >
             Configure model provider
-          </Link>
-        </Text>
-      </VStack>
-    </VStack>
-  );
-}
-
-function NoModelProvidersFooter() {
-  return (
-    <HStack gap={2} justify="flex-end">
-      <Button colorPalette="blue" asChild>
-        <a
-          data-testid="ai-create-modal-configure-model-provider-button"
-          href="/settings/model-providers"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Configure model provider
-        </a>
-      </Button>
+          </a>
+        </Button>
+      )}
+      {showRetry && (
+        <Button colorPalette="blue" onClick={onTryAgain}>
+          Try again
+        </Button>
+      )}
     </HStack>
   );
 }
+

--- a/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
+++ b/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
@@ -606,206 +606,178 @@ describe("<AICreateModal/>", () => {
     });
   });
 
-  describe("when hasModelProviders is false", () => {
-    it("displays warning message", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
+  // ─────────────────────────────────────────────────────────────────────────
+  // Error classifier integration
+  // ─────────────────────────────────────────────────────────────────────────
 
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).getByText("No model provider configured")
-      ).toBeInTheDocument();
-    });
+  describe("given an auth-shape error", () => {
+    describe("when ErrorState renders", () => {
+      it("shows the Configure model provider button", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("Invalid API key provided by the provider"));
 
-    it("does not render textarea", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(within(dialog).queryByRole("textbox")).not.toBeInTheDocument();
-    });
-
-    it("does not render Generate with AI button", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).queryByRole("button", { name: /generate with ai/i })
-      ).not.toBeInTheDocument();
-    });
-
-    it("does not render example template pills", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(within(dialog).queryByText("Customer Support")).not.toBeInTheDocument();
-      expect(within(dialog).queryByText("RAG Q&A")).not.toBeInTheDocument();
-      expect(within(dialog).queryByText("Tool-calling Agent")).not.toBeInTheDocument();
-    });
-
-    it("does not render I'll write it myself button", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).queryByRole("button", { name: /i'll write it myself/i })
-      ).not.toBeInTheDocument();
-    });
-
-    it("renders link to model provider settings", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      // Filter out the footer CTA by its test id so we assert the inline body
-      // link regardless of DOM order.
-      const links = within(dialog).getAllByRole("link", { name: /model provider/i });
-      const inlineLinks = links.filter(
-        (link) =>
-          link.getAttribute("data-testid") !==
-          "ai-create-modal-configure-model-provider-button",
-      );
-      expect(inlineLinks).toHaveLength(1);
-      expect(inlineLinks[0]).toHaveAttribute("href", "/settings/model-providers");
-    });
-
-    describe("footer Configure model provider button", () => {
-      function getFooterConfigureButton(dialog: HTMLElement) {
-        return within(dialog).getByTestId(
-          "ai-create-modal-configure-model-provider-button",
-        );
-      }
-
-      it("shows primary Configure model provider button in footer", () => {
         render(
           <AICreateModal
             open={true}
             onClose={vi.fn()}
             title="Create new scenario"
             exampleTemplates={defaultExampleTemplates}
-            onGenerate={vi.fn()}
+            onGenerate={onGenerate}
             onSkip={vi.fn()}
-            hasModelProviders={false}
           />,
           { wrapper: Wrapper }
         );
 
         const dialog = getDialogContent();
-        const button = getFooterConfigureButton(dialog);
-        expect(button).toBeInTheDocument();
-        expect(button).toHaveAccessibleName("Configure model provider");
-        expect(button).toHaveAttribute("href", "/settings/model-providers");
-        expect(button).toHaveAttribute("target", "_blank");
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          expect(
+            within(dialog).getByTestId("error-configure-model-provider-button")
+          ).toBeInTheDocument();
+        });
       });
 
-      it("footer button uses rel noopener noreferrer", () => {
+      it("shows tailored copy about API key", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("Invalid API key provided"));
+
         render(
           <AICreateModal
             open={true}
             onClose={vi.fn()}
             title="Create new scenario"
             exampleTemplates={defaultExampleTemplates}
-            onGenerate={vi.fn()}
+            onGenerate={onGenerate}
             onSkip={vi.fn()}
-            hasModelProviders={false}
           />,
           { wrapper: Wrapper }
         );
 
         const dialog = getDialogContent();
-        const button = getFooterConfigureButton(dialog);
-        const rel = button.getAttribute("rel") ?? "";
-        expect(rel).toContain("noopener");
-        expect(rel).toContain("noreferrer");
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          expect(within(dialog).getByText(/api key/i)).toBeInTheDocument();
+        });
       });
     });
-
   });
 
-  describe("when hasModelProviders is true", () => {
-    it("does not display warning message", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={true}
-        />,
-        { wrapper: Wrapper }
-      );
+  describe("given an unknown error", () => {
+    describe("when ErrorState renders", () => {
+      it("shows the raw error message verbatim", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("Completely unexpected server meltdown 42"));
 
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).queryByText(/no model provider/i)
-      ).not.toBeInTheDocument();
+        render(
+          <AICreateModal
+            open={true}
+            onClose={vi.fn()}
+            title="Create new scenario"
+            exampleTemplates={defaultExampleTemplates}
+            onGenerate={onGenerate}
+            onSkip={vi.fn()}
+          />,
+          { wrapper: Wrapper }
+        );
+
+        const dialog = getDialogContent();
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          expect(
+            within(dialog).getByText("Completely unexpected server meltdown 42")
+          ).toBeInTheDocument();
+        });
+      });
+
+      it("does not show Configure model provider button", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("Completely unexpected server meltdown 42"));
+
+        render(
+          <AICreateModal
+            open={true}
+            onClose={vi.fn()}
+            title="Create new scenario"
+            exampleTemplates={defaultExampleTemplates}
+            onGenerate={onGenerate}
+            onSkip={vi.fn()}
+          />,
+          { wrapper: Wrapper }
+        );
+
+        const dialog = getDialogContent();
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          expect(
+            within(dialog).queryByTestId("error-configure-model-provider-button")
+          ).not.toBeInTheDocument();
+        });
+      });
     });
+  });
 
+  describe("given a config-shape error", () => {
+    describe("when Configure is clicked", () => {
+      it("links to settings/model-providers in a new tab", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("No default model configured for this project"));
+
+        render(
+          <AICreateModal
+            open={true}
+            onClose={vi.fn()}
+            title="Create new scenario"
+            exampleTemplates={defaultExampleTemplates}
+            onGenerate={onGenerate}
+            onSkip={vi.fn()}
+          />,
+          { wrapper: Wrapper }
+        );
+
+        const dialog = getDialogContent();
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          const configureBtn = within(dialog).getByTestId(
+            "error-configure-model-provider-button"
+          );
+          expect(configureBtn).toHaveAttribute("href", "/settings/model-providers");
+          expect(configureBtn).toHaveAttribute("target", "_blank");
+        });
+      });
+    });
+  });
+
+  describe("when rendered with default props", () => {
     it("renders textarea", () => {
       render(
         <AICreateModal
@@ -815,7 +787,6 @@ describe("<AICreateModal/>", () => {
           exampleTemplates={defaultExampleTemplates}
           onGenerate={vi.fn()}
           onSkip={vi.fn()}
-          hasModelProviders={true}
         />,
         { wrapper: Wrapper }
       );
@@ -833,7 +804,6 @@ describe("<AICreateModal/>", () => {
           exampleTemplates={defaultExampleTemplates}
           onGenerate={vi.fn()}
           onSkip={vi.fn()}
-          hasModelProviders={true}
         />,
         { wrapper: Wrapper }
       );
@@ -853,7 +823,6 @@ describe("<AICreateModal/>", () => {
           exampleTemplates={defaultExampleTemplates}
           onGenerate={vi.fn()}
           onSkip={vi.fn()}
-          hasModelProviders={true}
         />,
         { wrapper: Wrapper }
       );
@@ -862,28 +831,6 @@ describe("<AICreateModal/>", () => {
       expect(within(dialog).getByText("Customer Support")).toBeInTheDocument();
       expect(within(dialog).getByText("RAG Q&A")).toBeInTheDocument();
       expect(within(dialog).getByText("Tool-calling Agent")).toBeInTheDocument();
-    });
-
-    it("does not show Configure model provider button in footer", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={true}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).queryByTestId(
-          "ai-create-modal-configure-model-provider-button",
-        )
-      ).not.toBeInTheDocument();
     });
   });
 });

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -72,7 +72,8 @@ export function createEnvConfig() {
       AZURE_OPENAI_KEY: z.string().optional(),
       OPENAI_API_KEY: z.string().optional(),
       SENDGRID_API_KEY: z.string().optional(),
-      LANGWATCH_NLP_SERVICE: z.string().optional(),
+      LANGWATCH_NLP_SERVICE: optionalIfBuildTime(z.string().url()),
+      LANGWATCH_ENDPOINT: optionalIfBuildTime(z.string().url()),
       TOPIC_CLUSTERING_SERVICE: z.string().optional(),
       LANGEVALS_ENDPOINT: z.string().optional(),
       DEMO_PROJECT_ID: z.string().optional(),
@@ -169,6 +170,7 @@ export function createEnvConfig() {
 
       // SCIM
       AUTH0_SCIM_WEBHOOK_SECRET: z.string().optional(),
+
     },
 
     // No client-side env vars — use `publicEnv.ts` instead.
@@ -201,6 +203,7 @@ export function createEnvConfig() {
       OPENAI_API_KEY: process.env.OPENAI_API_KEY,
       SENDGRID_API_KEY: process.env.SENDGRID_API_KEY,
       LANGWATCH_NLP_SERVICE: process.env.LANGWATCH_NLP_SERVICE,
+      LANGWATCH_ENDPOINT: process.env.LANGWATCH_ENDPOINT,
       // Temporary, ideally we want to move this to lambda too
       TOPIC_CLUSTERING_SERVICE: process.env.TOPIC_CLUSTERING_SERVICE
         ? process.env.TOPIC_CLUSTERING_SERVICE

--- a/langwatch/src/hooks/__tests__/useProviderFormSubmit.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useProviderFormSubmit.unit.test.ts
@@ -1,0 +1,195 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
+
+// Must be declared before vi.mock() calls (hoisted)
+const mockMutateAsync = vi.fn().mockResolvedValue({});
+
+vi.mock("../../utils/api", () => ({
+  api: {
+    useContext: () => ({
+      organization: { getAll: { invalidate: vi.fn() } },
+    }),
+    modelProvider: {
+      update: {
+        useMutation: () => ({ mutateAsync: mockMutateAsync }),
+      },
+    },
+    project: {
+      updateProjectDefaultModels: {
+        useMutation: () => ({ mutateAsync: vi.fn().mockResolvedValue({}) }),
+      },
+    },
+  },
+}));
+
+vi.mock("../../components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+import {
+  useProviderFormSubmit,
+  type FormSnapshot,
+} from "../useProviderFormSubmit";
+
+const baseProvider = {
+  id: "provider-1",
+  provider: "openai" as const,
+  enabled: true,
+  customKeys: null,
+  models: null,
+  embeddingsModels: null,
+  disabledByDefault: false,
+  deploymentMapping: null,
+  extraHeaders: [],
+};
+
+function makeSnapshot(
+  overrides: Partial<FormSnapshot> = {},
+): FormSnapshot {
+  return {
+    provider: baseProvider,
+    name: "OpenAI",
+    projectId: "project-1",
+    isUsingEnvVars: false,
+    customKeys: {},
+    initialKeys: {},
+    providerKeysSchema: null,
+    extraHeaders: [],
+    customModels: [],
+    customEmbeddingsModels: [],
+    useAsDefaultProvider: false,
+    projectDefaultModel: null,
+    projectTopicClusteringModel: null,
+    projectEmbeddingsModel: null,
+    ...overrides,
+  };
+}
+
+describe("useProviderFormSubmit()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given all API keys are still masked (unchanged placeholder)", () => {
+    describe("when submitting", () => {
+      it("omits all masked keys from the payload", async () => {
+        const snapshot = makeSnapshot({
+          customKeys: {
+            OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+          },
+        });
+
+        const { result } = renderHook(() =>
+          useProviderFormSubmit({ getFormSnapshot: () => snapshot }),
+        );
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledOnce();
+        const firstCall = mockMutateAsync.mock.calls[0];
+        if (!firstCall) throw new Error("mockMutateAsync was not called");
+        const calledWith = firstCall[0] as Record<string, unknown>;
+        const customKeys = calledWith.customKeys as Record<string, string> | undefined;
+        expect(customKeys).not.toHaveProperty("OPENAI_API_KEY");
+      });
+    });
+  });
+
+  describe("given user edited one key but left another masked", () => {
+    describe("when submitting", () => {
+      it("includes edited key and omits masked key", async () => {
+        const snapshot = makeSnapshot({
+          customKeys: {
+            OPENAI_API_KEY: "sk-real-user-key",
+            OPENAI_BASE_URL: MASKED_KEY_PLACEHOLDER,
+          },
+        });
+
+        const { result } = renderHook(() =>
+          useProviderFormSubmit({ getFormSnapshot: () => snapshot }),
+        );
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledOnce();
+        const firstCall = mockMutateAsync.mock.calls[0];
+        if (!firstCall) throw new Error("mockMutateAsync was not called");
+        const calledWith = firstCall[0] as Record<string, unknown>;
+        const customKeys = calledWith.customKeys as Record<string, string>;
+        expect(customKeys).toHaveProperty("OPENAI_API_KEY", "sk-real-user-key");
+        expect(customKeys).not.toHaveProperty("OPENAI_BASE_URL");
+      });
+    });
+  });
+
+  describe("given user cleared a key (empty string)", () => {
+    describe("when submitting", () => {
+      it("preserves the empty string clear in the payload", async () => {
+        const snapshot = makeSnapshot({
+          customKeys: {
+            OPENAI_API_KEY: "",
+          },
+        });
+
+        const { result } = renderHook(() =>
+          useProviderFormSubmit({ getFormSnapshot: () => snapshot }),
+        );
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledOnce();
+        const firstCall = mockMutateAsync.mock.calls[0];
+        if (!firstCall) throw new Error("mockMutateAsync was not called");
+        const calledWith = firstCall[0] as Record<string, unknown>;
+        const customKeys = calledWith.customKeys as Record<string, string>;
+        expect(customKeys).toHaveProperty("OPENAI_API_KEY", "");
+      });
+    });
+  });
+
+  describe("given keys are freshly typed (no masked placeholder)", () => {
+    describe("when submitting", () => {
+      it("submits all keys as typed", async () => {
+        const snapshot = makeSnapshot({
+          customKeys: {
+            OPENAI_API_KEY: "sk-fresh-key-abc123",
+            OPENAI_BASE_URL: "https://api.openai.com/v1",
+          },
+        });
+
+        const { result } = renderHook(() =>
+          useProviderFormSubmit({ getFormSnapshot: () => snapshot }),
+        );
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledOnce();
+        const firstCall = mockMutateAsync.mock.calls[0];
+        if (!firstCall) throw new Error("mockMutateAsync was not called");
+        const calledWith = firstCall[0] as Record<string, unknown>;
+        const customKeys = calledWith.customKeys as Record<string, string>;
+        expect(customKeys).toHaveProperty("OPENAI_API_KEY", "sk-fresh-key-abc123");
+        expect(customKeys).toHaveProperty(
+          "OPENAI_BASE_URL",
+          "https://api.openai.com/v1",
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -56,7 +56,12 @@ export const useOrganizationTeamProject = (
     { isDemo: isDemo },
     {
       enabled: !!session.data || !isPublicRoute,
-      staleTime: keepFetching ? undefined : Infinity,
+      // Small reference query that drives load-bearing client state (current
+      // project incl. defaultModel). Cheap to refetch — prefer freshness over
+      // a "cache forever" default. Background refetch on focus picks up edits
+      // made via SDK, API, or another tab.
+      staleTime: keepFetching ? 0 : 30_000,
+      refetchOnWindowFocus: true,
       refetchInterval: keepFetching ? 5_000 : undefined,
     },
   );

--- a/langwatch/src/hooks/useProviderFormSubmit.ts
+++ b/langwatch/src/hooks/useProviderFormSubmit.ts
@@ -163,7 +163,11 @@ export function useProviderFormSubmit({
       let customKeysToSend: Record<string, unknown> | undefined;
       const userEnteredNewKey = hasUserEnteredNewApiKey(customKeys);
       if (!isUsingEnvVars) {
-        customKeysToSend = { ...customKeys };
+        // Strip any masked placeholder values — they appear when the provider
+        // was configured via env vars in a prior session and the user opened
+        // the drawer without editing. Submitting the placeholder string would
+        // fail backend validation; omitting it preserves the existing key.
+        customKeysToSend = filterMaskedApiKeys(customKeys);
       } else if (userEnteredNewKey || hasNonApiKeyChanges) {
         customKeysToSend = userEnteredNewKey
           ? { ...customKeys }

--- a/langwatch/src/hooks/usePublicEnv.ts
+++ b/langwatch/src/hooks/usePublicEnv.ts
@@ -4,6 +4,8 @@ export const usePublicEnv = () => {
   return api.publicEnv.useQuery(
     {},
     {
+      // Server env vars don't change while the app is open — caching forever
+      // is correct. Server restart gives the user a new bundle anyway.
       staleTime: Infinity,
       refetchOnMount: false,
       refetchOnWindowFocus: false,

--- a/langwatch/src/optimization_studio/hooks/useLoadWorkflow.ts
+++ b/langwatch/src/optimization_studio/hooks/useLoadWorkflow.ts
@@ -11,7 +11,13 @@ export const useLoadWorkflow = () => {
   const { project } = useOrganizationTeamProject();
   const workflow = api.workflow.getById.useQuery(
     { workflowId: workflowId ?? "", projectId: project?.id ?? "" },
-    { enabled: !!project && !!workflowId, staleTime: Infinity },
+    {
+      enabled: !!project && !!workflowId,
+      // One-shot bootstrap for the studio editor. The result feeds the
+      // Zustand workflow store and AutoSave writes back from there — a
+      // background refetch would clobber unsaved edits.
+      staleTime: Infinity,
+    },
   );
 
   return { workflow };

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -254,6 +254,15 @@ export const projectRouter = createTRPCRouter({
 
       return { firstMessage: project?.firstMessage ?? false };
     }),
+  getResolvedDefaultModel: protectedProcedure
+    .input(z.object({ projectId: z.string() }))
+    .use(checkProjectPermission("project:view"))
+    .query(async ({ input }) => {
+      const resolvedModel = await getApp().projects.resolveDefaultModel(
+        input.projectId,
+      );
+      return { resolvedDefaultModel: resolvedModel };
+    }),
   regenerateApiKey: protectedProcedure
     .input(z.object({ projectId: z.string() }))
     .use(checkProjectPermission("project:manage"))

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -32,6 +32,7 @@ import { NullOrganizationRepository } from "./organizations/repositories/organiz
 import { PromptTagRepository } from "~/server/prompt-config/repositories/prompt-tag.repository";
 import { ProjectService } from "./projects/project.service";
 import { PrismaProjectRepository } from "./projects/repositories/project.prisma.repository";
+import { ModelProviderService } from "../modelProviders/modelProvider.service";
 import { NullProjectRepository } from "./projects/repositories/project.repository";
 import { DspyStepService } from "./dspy-steps/dspy-step.service";
 import { DspyStepClickHouseRepository } from "./dspy-steps/repositories/dspy-step.clickhouse.repository";
@@ -187,7 +188,10 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     "OrganizationService",
   );
   const projects = traced(
-    new ProjectService(new PrismaProjectRepository(prisma)),
+    new ProjectService(
+      new PrismaProjectRepository(prisma),
+      ModelProviderService.create(prisma),
+    ),
     "ProjectService",
   );
 

--- a/langwatch/src/server/app-layer/projects/__tests__/project.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/projects/__tests__/project.service.unit.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project } from "@prisma/client";
+import type { ModelProviderService } from "~/server/modelProviders/modelProvider.service";
+import type { MaybeStoredModelProvider } from "~/server/modelProviders/registry";
+import { ProjectService } from "../project.service";
+import type { ProjectRepository } from "../repositories/project.repository";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "proj_test",
+    name: "Test Project",
+    slug: "test-project",
+    apiKey: "test-api-key",
+    defaultModel: null,
+    embeddingsModel: null,
+    language: "en",
+    framework: null,
+    firstMessage: false,
+    integrated: false,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    teamId: "team_1",
+    topicClusteringModel: null,
+    s3Bucket: null,
+    archivedAt: null,
+    ...overrides,
+  } as unknown as Project;
+}
+
+function makeProvider(
+  provider: string,
+  enabled: boolean,
+): MaybeStoredModelProvider {
+  return {
+    provider,
+    enabled,
+    customKeys: null,
+    deploymentMapping: null,
+    extraHeaders: [],
+  } as MaybeStoredModelProvider;
+}
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+function makeRepo(project: Project | null): ProjectRepository {
+  return {
+    getById: vi.fn().mockResolvedValue(project),
+    getWithTeam: vi.fn(),
+    updateMetadata: vi.fn(),
+    getWithOrgAdmin: vi.fn(),
+    searchByQuery: vi.fn(),
+  };
+}
+
+function makeModelProviderService(
+  providers: Record<string, MaybeStoredModelProvider>,
+): Pick<ModelProviderService, "getProjectModelProviders"> {
+  return {
+    getProjectModelProviders: vi.fn().mockResolvedValue(providers),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ProjectService", () => {
+  describe("resolveDefaultModel", () => {
+    describe("given project.defaultModel is set AND its provider is enabled", () => {
+      it("returns project.defaultModel (user override wins)", async () => {
+        const project = makeProject({ defaultModel: "openai/gpt-4-turbo" });
+        const repo = makeRepo(project);
+        const mpService = makeModelProviderService({
+          openai: makeProvider("openai", true),
+        });
+
+        const service = new ProjectService(
+          repo,
+          mpService as unknown as ModelProviderService,
+        );
+
+        const result = await service.resolveDefaultModel("proj_test");
+
+        expect(result).toBe("openai/gpt-4-turbo");
+      });
+    });
+
+    describe("given project.defaultModel is set BUT its provider is disabled", () => {
+      it("falls through to the first enabled provider's canonical default", async () => {
+        const project = makeProject({
+          defaultModel: "anthropic/claude-3-opus",
+        });
+        const repo = makeRepo(project);
+        // anthropic is disabled; openai is enabled
+        const mpService = makeModelProviderService({
+          anthropic: makeProvider("anthropic", false),
+          openai: makeProvider("openai", true),
+        });
+
+        const service = new ProjectService(
+          repo,
+          mpService as unknown as ModelProviderService,
+        );
+
+        const result = await service.resolveDefaultModel("proj_test");
+
+        // Falls through to openai's canonical default
+        expect(result).toBe("openai/gpt-5.2");
+      });
+    });
+
+    describe("given project.defaultModel is null", () => {
+      it("returns first usable provider's canonical default when enabled", async () => {
+        const project = makeProject({ defaultModel: null });
+        const repo = makeRepo(project);
+        const mpService = makeModelProviderService({
+          openai: makeProvider("openai", true),
+        });
+
+        const service = new ProjectService(
+          repo,
+          mpService as unknown as ModelProviderService,
+        );
+
+        const result = await service.resolveDefaultModel("proj_test");
+
+        expect(result).toBe("openai/gpt-5.2");
+      });
+
+      it("skips providers with no entry in PROVIDER_DEFAULT_MODELS (e.g. bedrock) and returns next match", async () => {
+        const project = makeProject({ defaultModel: null });
+        const repo = makeRepo(project);
+        // Only bedrock is enabled — has no canonical default
+        const mpService = makeModelProviderService({
+          bedrock: makeProvider("bedrock", true),
+        });
+
+        const service = new ProjectService(
+          repo,
+          mpService as unknown as ModelProviderService,
+        );
+
+        const result = await service.resolveDefaultModel("proj_test");
+
+        // bedrock has no entry in PROVIDER_DEFAULT_MODELS → falls through to null
+        expect(result).toBeNull();
+      });
+
+      it("skips bedrock and returns anthropic when both are enabled", async () => {
+        const project = makeProject({ defaultModel: null });
+        const repo = makeRepo(project);
+        const mpService = makeModelProviderService({
+          bedrock: makeProvider("bedrock", true),
+          anthropic: makeProvider("anthropic", true),
+        });
+
+        const service = new ProjectService(
+          repo,
+          mpService as unknown as ModelProviderService,
+        );
+
+        const result = await service.resolveDefaultModel("proj_test");
+
+        // anthropic appears before bedrock in PROVIDER_RESOLUTION_ORDER
+        expect(result).toBe("anthropic/claude-sonnet-4-5");
+      });
+    });
+
+    describe("given no usable providers are available", () => {
+      it("returns null", async () => {
+        const project = makeProject({ defaultModel: null });
+        const repo = makeRepo(project);
+        const mpService = makeModelProviderService({
+          openai: makeProvider("openai", false),
+          anthropic: makeProvider("anthropic", false),
+        });
+
+        const service = new ProjectService(
+          repo,
+          mpService as unknown as ModelProviderService,
+        );
+
+        const result = await service.resolveDefaultModel("proj_test");
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("given project does not exist", () => {
+      it("returns null", async () => {
+        const repo = makeRepo(null);
+        const mpService = makeModelProviderService({});
+
+        const service = new ProjectService(
+          repo,
+          mpService as unknown as ModelProviderService,
+        );
+
+        const result = await service.resolveDefaultModel("proj_missing");
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("given no modelProviderService is injected (null preset)", () => {
+      it("returns null without throwing", async () => {
+        const repo = makeRepo(makeProject());
+
+        const service = new ProjectService(repo);
+
+        const result = await service.resolveDefaultModel("proj_test");
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/projects/project.service.ts
+++ b/langwatch/src/server/app-layer/projects/project.service.ts
@@ -1,6 +1,11 @@
 import type { Project } from "@prisma/client";
 import { createLogger } from "~/utils/logger/server";
 import { captureException } from "~/utils/posthogErrorCapture";
+import type { ModelProviderService } from "../../modelProviders/modelProvider.service";
+import {
+  PROVIDER_DEFAULT_MODELS,
+  PROVIDER_RESOLUTION_ORDER,
+} from "../../modelProviders/providerDefaultModels";
 import type {
   ProjectRepository,
   ProjectWithTeam,
@@ -26,7 +31,10 @@ const NULL_RESOLUTION: OrgAdminResolution = {
 };
 
 export class ProjectService {
-  constructor(readonly repo: ProjectRepository) {}
+  constructor(
+    readonly repo: ProjectRepository,
+    private readonly modelProviderService?: ModelProviderService,
+  ) {}
 
   async getById(id: string): Promise<Project | null> {
     return this.repo.getById(id);
@@ -54,6 +62,59 @@ export class ProjectService {
   ): Promise<boolean> {
     const project = await this.repo.getById(projectId);
     return project ? Boolean(project[flag]) : false;
+  }
+
+  /**
+   * Single source of truth for the project's default model.
+   *
+   * Use this — not `project.defaultModel` directly — when you need to know
+   * what model to use. The `project.defaultModel` column is the user-set
+   * override; this method applies the full resolution chain:
+   *
+   *   1. If project.defaultModel is set AND its provider is enabled → return it.
+   *   2. Else walk enabled providers in preferred order; return the first one
+   *      that has a usable key (custom key OR env fallback) and a known
+   *      canonical default model in PROVIDER_DEFAULT_MODELS.
+   *   3. Else → return null.
+   *
+   * Returns null when no providers are usable (new self-host install with no
+   * env vars set, or all providers disabled). Callers should treat null as
+   * "not configured yet" and surface an appropriate message.
+   */
+  async resolveDefaultModel(projectId: string): Promise<string | null> {
+    if (!this.modelProviderService) {
+      // Null preset — no DB access available; fall through to null.
+      return null;
+    }
+
+    const [project, modelProviders] = await Promise.all([
+      this.repo.getById(projectId),
+      this.modelProviderService.getProjectModelProviders(projectId, true),
+    ]);
+
+    if (!project) return null;
+
+    // 1. User override wins when its provider is still enabled.
+    if (project.defaultModel) {
+      const providerKey = project.defaultModel.split("/")[0] ?? "";
+      if (modelProviders[providerKey]?.enabled) {
+        return project.defaultModel;
+      }
+    }
+
+    // 2. Walk providers in preferred order, return first usable canonical default.
+    for (const providerId of PROVIDER_RESOLUTION_ORDER) {
+      const provider = modelProviders[providerId];
+      if (!provider?.enabled) continue;
+
+      const canonicalModel = PROVIDER_DEFAULT_MODELS[providerId];
+      if (!canonicalModel) continue;
+
+      return canonicalModel;
+    }
+
+    // 3. Nothing usable.
+    return null;
   }
 
   /**

--- a/langwatch/src/server/evaluations/getEvaluator.ts
+++ b/langwatch/src/server/evaluations/getEvaluator.ts
@@ -16,12 +16,19 @@ export const getEvaluatorDefinitions = (evaluator: string) => {
 export const getEvaluatorDefaultSettings = <T extends EvaluatorTypes>(
   evaluator: EvaluatorDefinition<T> | undefined,
   project?: { defaultModel?: string | null; embeddingsModel?: string | null },
+  /**
+   * Pre-resolved default model from ProjectService.resolveDefaultModel().
+   * When provided, takes precedence over project.defaultModel so that
+   * env-fallback providers are correctly used for new projects.
+   * When omitted, falls back to project.defaultModel ?? DEFAULT_MODEL.
+   */
+  resolvedDefaultModel?: string | null,
 ) => {
   if (!evaluator) return {};
   return Object.fromEntries(
     Object.entries(evaluator.settings).map(([key, setting]) => {
       if (key === "model" && evaluator.name.includes("LLM-as-a-Judge")) {
-        return [key, project?.defaultModel ?? DEFAULT_MODEL];
+        return [key, resolvedDefaultModel ?? project?.defaultModel ?? DEFAULT_MODEL];
       }
       if (key === "embeddings_model") {
         return [key, project?.embeddingsModel ?? DEFAULT_EMBEDDINGS_MODEL];

--- a/langwatch/src/server/modelProviders/providerDefaultModels.ts
+++ b/langwatch/src/server/modelProviders/providerDefaultModels.ts
@@ -1,0 +1,43 @@
+/**
+ * Canonical default model for each LLM provider.
+ *
+ * This is the single source of truth for per-provider defaults. Providers that
+ * have no meaningful default (Bedrock, Groq, Vertex AI, Cerebras) are omitted
+ * intentionally — resolveDefaultModel skips them and moves to the next enabled
+ * provider rather than returning a null model.
+ *
+ * The keys match the server-side registry keys in `src/server/modelProviders/registry.ts`.
+ * The values are fully-qualified model IDs in the "provider/model" wire format.
+ *
+ * Update this map whenever a provider's recommended default model changes;
+ * the onboarding registry.tsx imports from here to stay in sync.
+ */
+export const PROVIDER_DEFAULT_MODELS: Partial<Record<string, string>> = {
+  openai: "openai/gpt-5.2",
+  anthropic: "anthropic/claude-sonnet-4-5",
+  gemini: "gemini/gemini-2.5-flash",
+  azure: "azure/gpt-5",
+  deepseek: "deepseek/deepseek-r1",
+  xai: "xai/grok-4",
+  // bedrock: omitted — no single canonical default model
+  // groq: omitted — no single canonical default model
+  // vertex_ai: omitted — no single canonical default model
+  // cerebras: omitted — no single canonical default model
+  // custom: omitted — user-defined endpoint, default is unknowable
+};
+
+/**
+ * Provider keys in preferred iteration order for default-model resolution.
+ *
+ * When no project.defaultModel is set, resolveDefaultModel walks this list
+ * and returns the first enabled provider's canonical model. The order
+ * matches the onboarding registry.tsx display order so the UX is consistent.
+ */
+export const PROVIDER_RESOLUTION_ORDER: string[] = [
+  "openai",
+  "anthropic",
+  "gemini",
+  "azure",
+  "deepseek",
+  "xai",
+];

--- a/langwatch/src/server/modelProviders/utils.ts
+++ b/langwatch/src/server/modelProviders/utils.ts
@@ -19,6 +19,11 @@ export const getVercelAIModel = async (projectId: string, model?: string) => {
 
   const modelProviders = await getProjectModelProviders(projectId);
 
+  // Callers that need env-fallback default-model resolution should call
+  // ProjectService.resolveDefaultModel(projectId) and pass the result as
+  // `model` rather than relying on project.defaultModel directly. This keeps
+  // resolveModel() pure (no DB round-trip) and lets callers skip the hit when
+  // they already have an explicit model.
   const model_ = resolveModel({
     explicit: model,
     projectDefault: project.defaultModel,

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -6,6 +6,9 @@ import type {
 } from "@prisma/client";
 import type { z } from "zod";
 import { createLogger } from "~/utils/logger";
+import { ModelProviderService } from "../modelProviders/modelProvider.service";
+import { ProjectService } from "../app-layer/projects/project.service";
+import { PrismaProjectRepository } from "../app-layer/projects/repositories/project.prisma.repository";
 import {
   deriveResponseFormatFromOutputs,
   type inputsSchema,
@@ -439,6 +442,16 @@ export class PromptService {
       );
     }
 
+    // Resolve the effective default model before entering the transaction so
+    // env-fallback providers are considered (new self-host / dev projects).
+    const projectService = new ProjectService(
+      new PrismaProjectRepository(this.prisma),
+      ModelProviderService.create(this.prisma),
+    );
+    const resolvedDefaultModel = await projectService.resolveDefaultModel(
+      params.projectId,
+    );
+
     const config = await this.repository.createConfigWithInitialVersion({
       configData: {
         name: params.handle,
@@ -449,6 +462,7 @@ export class PromptService {
         authorId: params.authorId,
         copiedFromPromptId: null,
       },
+      resolvedDefaultModel,
       versionData: shouldCreateVersion
         ? {
             configData: this.transformToDbFormat({

--- a/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
@@ -457,8 +457,15 @@ export class LlmConfigRepository {
     > & {
       prompt?: string;
     };
+    /**
+     * Pre-resolved default model from ProjectService.resolveDefaultModel().
+     * When provided, this takes precedence over project.defaultModel so that
+     * env-fallback providers are correctly reflected in newly-created configs.
+     * When omitted, falls back to project.defaultModel ?? DEFAULT_MODEL.
+     */
+    resolvedDefaultModel?: string | null;
   }): Promise<LlmConfigWithLatestVersion> {
-    const { configData, versionData } = params;
+    const { configData, versionData, resolvedDefaultModel } = params;
 
     // Sanity check on the authorId
     if (
@@ -493,7 +500,9 @@ export class LlmConfigRepository {
         },
       });
       const { project } = newConfig;
-      const defaultModel = project.defaultModel ?? DEFAULT_MODEL;
+      // Use pre-resolved model when provided (prefers env-fallback providers);
+      // fall back to project.defaultModel ?? DEFAULT_MODEL for backwards compat.
+      const defaultModel = resolvedDefaultModel ?? project.defaultModel ?? DEFAULT_MODEL;
 
       // Set the version data to the provided version data, or undefined if no version data is provided.
       let newVersionData: Partial<CreateLlmConfigVersionParams> | undefined =

--- a/langwatch/src/server/scenarios/__tests__/orchestrator.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/orchestrator.unit.test.ts
@@ -49,6 +49,7 @@ function createTestDeps(overrides?: Partial<OrchestratorDependencies>): Orchestr
     projectRepository: {
       getProject: async () => defaultProject,
     },
+    defaultModelResolver: async () => defaultProject.defaultModel,
     modelParamsProvider: {
       prepare: async () => ({ success: true as const, params: defaultParams }),
     },
@@ -144,6 +145,7 @@ describe("ScenarioExecutionOrchestrator", () => {
             projectRepository: {
               getProject: async () => ({ apiKey: "test-api-key", defaultModel: null }),
             },
+            defaultModelResolver: async () => null,
           });
           const orchestrator = new ScenarioExecutionOrchestrator(deps);
 

--- a/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
@@ -27,8 +27,9 @@ import type { ExecutionContext, TargetConfig, LiteLLMParams } from "../types";
 // Mock only env.mjs since it's a module-level import
 vi.mock("~/env.mjs", () => ({
   env: {
-    LANGWATCH_NLP_SERVICE: "http://localhost:8080",
-    BASE_HOST: "http://localhost:3000",
+    LANGWATCH_NLP_SERVICE: "http://langwatch_nlp:5561",
+    LANGWATCH_ENDPOINT: "http://app:5560",
+    // BASE_HOST no longer needed — telemetry endpoint comes from LANGWATCH_ENDPOINT
   },
 }));
 
@@ -509,42 +510,30 @@ describe("prefetchScenarioData", () => {
 
       describe("when prefetching scenario data", () => {
         it("returns success with complete data", async () => {
-          // The source reads process.env.LANGWATCH_ENDPOINT directly (not via env.mjs)
-          const previousLangwatchEndpoint = process.env.LANGWATCH_ENDPOINT;
-          process.env.LANGWATCH_ENDPOINT = "http://localhost:3000";
+          const deps = createMockDeps({
+            promptFetcher: {
+              getPromptByIdOrHandle: vi.fn().mockResolvedValue(promptWithModel),
+            },
+          });
 
-          try {
-            const deps = createMockDeps({
-              promptFetcher: {
-                getPromptByIdOrHandle: vi.fn().mockResolvedValue(promptWithModel),
-              },
+          const target: TargetConfig = { type: "prompt", referenceId: "prompt_123" };
+          const result = await prefetchScenarioData(defaultContext, target, deps);
+
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(result.data.context).toEqual(defaultContext);
+            expect(result.data.scenario).toEqual(defaultScenario);
+            expect(result.data.adapterData).toMatchObject({
+              type: "prompt",
+              promptId: "prompt_123",
+              systemPrompt: "You are helpful",
             });
-
-            const target: TargetConfig = { type: "prompt", referenceId: "prompt_123" };
-            const result = await prefetchScenarioData(defaultContext, target, deps);
-
-            expect(result.success).toBe(true);
-            if (result.success) {
-              expect(result.data.context).toEqual(defaultContext);
-              expect(result.data.scenario).toEqual(defaultScenario);
-              expect(result.data.adapterData).toMatchObject({
-                type: "prompt",
-                promptId: "prompt_123",
-                systemPrompt: "You are helpful",
-              });
-              expect(result.data.modelParams).toEqual(defaultModelParams);
-              expect(result.data.target).toEqual({ type: "prompt", referenceId: "prompt_123" });
-              expect(result.telemetry).toEqual({
-                endpoint: "http://localhost:3000",
-                apiKey: "test-api-key",
-              });
-            }
-          } finally {
-            if (previousLangwatchEndpoint === undefined) {
-              delete process.env.LANGWATCH_ENDPOINT;
-            } else {
-              process.env.LANGWATCH_ENDPOINT = previousLangwatchEndpoint;
-            }
+            expect(result.data.modelParams).toEqual(defaultModelParams);
+            expect(result.data.target).toEqual({ type: "prompt", referenceId: "prompt_123" });
+            expect(result.telemetry).toEqual({
+              endpoint: "http://app:5560",
+              apiKey: "test-api-key",
+            });
           }
         });
       });

--- a/langwatch/src/server/scenarios/execution/data-prefetcher.ts
+++ b/langwatch/src/server/scenarios/execution/data-prefetcher.ts
@@ -126,6 +126,12 @@ export interface DataPrefetcherDependencies {
   agentFetcher: AgentFetcher;
   workflowVersionFetcher: WorkflowVersionFetcher;
   projectFetcher: ProjectFetcher;
+  /**
+   * Resolves the effective default model for a project, including env-fallback
+   * providers. Injected so callers can wire in ProjectService.resolveDefaultModel.
+   * When provided, overrides the project.defaultModel ?? DEFAULT_MODEL fallback.
+   */
+  defaultModelResolver?: (projectId: string) => Promise<string | null>;
   modelParamsProvider: ModelParamsProvider;
   projectSecretsFetcher: ProjectSecretsFetcher;
 }
@@ -177,7 +183,11 @@ export async function prefetchScenarioData(
     return { success: false, error: `Scenario ${context.scenarioId} not found` };
   }
 
-  const projectResult = await fetchProject(context.projectId, deps.projectFetcher);
+  const projectResult = await fetchProject(
+    context.projectId,
+    deps.projectFetcher,
+    deps.defaultModelResolver,
+  );
   if (!projectResult.success) {
     logger.warn({ projectId: context.projectId, error: projectResult.error }, "Project fetch failed");
     return { success: false, error: projectResult.error };
@@ -247,11 +257,11 @@ export async function prefetchScenarioData(
       scenario,
       adapterData,
       modelParams,
-      nlpServiceUrl: env.LANGWATCH_NLP_SERVICE ?? "http://localhost:8080",
+      nlpServiceUrl: env.LANGWATCH_NLP_SERVICE ?? "",
       target,
     },
     telemetry: {
-      endpoint: process.env.LANGWATCH_ENDPOINT!,
+      endpoint: env.LANGWATCH_ENDPOINT ?? "",
       apiKey: project.apiKey,
     },
   };
@@ -284,6 +294,7 @@ type FetchProjectResult =
 async function fetchProject(
   projectId: string,
   fetcher: ProjectFetcher,
+  defaultModelResolver?: (projectId: string) => Promise<string | null>,
 ): Promise<FetchProjectResult> {
   const project = await fetcher.findUnique(projectId);
   if (!project) {
@@ -292,12 +303,16 @@ async function fetchProject(
   if (!project.apiKey) {
     return { success: false, error: `Project ${projectId} missing API key` };
   }
-  // Fall back to DEFAULT_MODEL like the rest of the app does
+  // Prefer the resolver (considers env-fallback providers for new projects);
+  // fall back to project.defaultModel ?? DEFAULT_MODEL for backwards compat.
+  const resolvedModel = defaultModelResolver
+    ? await defaultModelResolver(projectId)
+    : null;
   return {
     success: true,
     data: {
       apiKey: project.apiKey,
-      defaultModel: project.defaultModel ?? DEFAULT_MODEL,
+      defaultModel: resolvedModel ?? project.defaultModel ?? DEFAULT_MODEL,
     },
   };
 }

--- a/langwatch/src/server/scenarios/execution/orchestrator.ts
+++ b/langwatch/src/server/scenarios/execution/orchestrator.ts
@@ -54,13 +54,14 @@ export class ScenarioExecutionOrchestrator {
         return this.notFound("Project", context.projectId);
       }
 
-      if (!project.defaultModel) {
+      const resolvedModel = await this.deps.defaultModelResolver(context.projectId);
+      if (!resolvedModel) {
         return this.failure("Project default model is not configured");
       }
 
       const modelParamsResult = await this.prepareModelParams(
         context.projectId,
-        project.defaultModel,
+        resolvedModel,
       );
       if (!modelParamsResult.success) {
         logger.warn(

--- a/langwatch/src/server/scenarios/execution/orchestrator.types.ts
+++ b/langwatch/src/server/scenarios/execution/orchestrator.types.ts
@@ -72,6 +72,11 @@ export interface ScenarioExecutor {
 export interface OrchestratorDependencies {
   scenarioRepository: ScenarioRepository;
   projectRepository: ProjectRepository;
+  /**
+   * Resolves the effective default model for a project, including env-fallback
+   * providers. Injected so callers can wire in ProjectService.resolveDefaultModel.
+   */
+  defaultModelResolver: (projectId: string) => Promise<string | null>;
   modelParamsProvider: ModelParamsProvider;
   adapterFactory: AdapterFactory;
   tracerFactory: TracerFactory;

--- a/langwatch/src/server/scenarios/execution/scenario-child-process.ts
+++ b/langwatch/src/server/scenarios/execution/scenario-child-process.ts
@@ -12,7 +12,8 @@
  * a non-zero exit code.
  *
  * OTEL isolation is achieved by:
- * 1. Parent sets LANGWATCH_API_KEY and LANGWATCH_ENDPOINT env vars
+ * 1. Parent injects LANGWATCH_API_KEY (project.apiKey) and LANGWATCH_ENDPOINT
+ *    (BASE_HOST) as env vars via buildChildProcessEnv in scenario.processor.ts
  * 2. This process imports @langwatch/scenario which calls setupObservability()
  *    at module load time, reading from those env vars
  * 3. Each child process gets its own OTEL TracerProvider
@@ -86,14 +87,11 @@ async function readJobDataFromStdin(): Promise<ChildProcessJobData> {
 async function executeScenario(jobData: ChildProcessJobData): Promise<void> {
   const { context, scenario, adapterData, modelParams, nlpServiceUrl, target } = jobData;
 
-  const langwatchEndpoint = process.env.LANGWATCH_ENDPOINT;
-  const langwatchApiKey = process.env.LANGWATCH_API_KEY;
-  if (!langwatchEndpoint) {
-    throw new Error("LANGWATCH_ENDPOINT env var is required but not set");
-  }
-  if (!langwatchApiKey) {
-    throw new Error("LANGWATCH_API_KEY env var is required but not set");
-  }
+  // These are injected as env vars by the parent process (scenario.processor.ts
+  // buildChildProcessEnv). They originate from prefetchScenarioData telemetry:
+  // endpoint = BASE_HOST, apiKey = project.apiKey.
+  const langwatchEndpoint = process.env.LANGWATCH_ENDPOINT ?? "";
+  const langwatchApiKey = process.env.LANGWATCH_API_KEY ?? "";
 
   const adapter = createAdapter({
     adapterData,

--- a/langwatch/src/server/scenarios/simulation-runner.service.ts
+++ b/langwatch/src/server/scenarios/simulation-runner.service.ts
@@ -1,11 +1,13 @@
 import ScenarioRunner, { type AgentAdapter } from "@langwatch/scenario";
 import type { PrismaClient } from "@prisma/client";
 import { env } from "~/env.mjs";
-import { DEFAULT_MODEL } from "~/utils/constants";
 import { createLogger } from "~/utils/logger/server";
 import type { SimulationTarget } from "../api/routers/scenarios";
 import { getVercelAIModel } from "../modelProviders/utils";
+import { ModelProviderService } from "../modelProviders/modelProvider.service";
 import { PromptService } from "../prompt-config/prompt.service";
+import { PrismaProjectRepository } from "../app-layer/projects/repositories/project.prisma.repository";
+import { ProjectService } from "../app-layer/projects/project.service";
 import { HttpAgentAdapter } from "./adapters/http-agent.adapter";
 import { PromptConfigAdapter } from "./adapters/prompt-config.adapter";
 import { bridgeTraceIdFromAdapterToJudge } from "./execution/bridge-trace-id";
@@ -55,20 +57,26 @@ export class SimulationRunnerService {
       }
 
       // 2. Fetch project config
-      // TODO: We should use the project service or repository instead of prisma directly
+      const projectService = new ProjectService(
+        new PrismaProjectRepository(this.prisma),
+        ModelProviderService.create(this.prisma),
+      );
       const project = await this.prisma.project.findUnique({
         where: { id: projectId },
-        select: { apiKey: true, defaultModel: true },
+        select: { apiKey: true },
       });
 
       if (!project?.apiKey) {
         throw new Error(`Project ${projectId} not found or has no API key`);
       }
 
-      // 3. Get project's default model for simulator and judge agents
-      const defaultModel = project.defaultModel ?? DEFAULT_MODEL;
-      const simulatorModel = await getVercelAIModel(projectId, defaultModel);
-      const judgeModel = await getVercelAIModel(projectId, defaultModel);
+      // 3. Get project's default model for simulator and judge agents using
+      //    the resolver so env-fallback providers are considered.
+      const defaultModel = await projectService.resolveDefaultModel(projectId);
+      // null means no usable provider — getVercelAIModel will throw with a
+      // clear error message if it can't find a provider for the resolved model.
+      const simulatorModel = await getVercelAIModel(projectId, defaultModel ?? undefined);
+      const judgeModel = await getVercelAIModel(projectId, defaultModel ?? undefined);
 
       // 4. Resolve target to adapter
       logger.debug(
@@ -108,7 +116,7 @@ export class SimulationRunnerService {
 
       // For HTTP targets, use remote span judge to collect spans from the
       // user's agent. For other targets, use standard in-process judge.
-      const langwatchEndpoint = this.getLangWatchEndpoint();
+      const langwatchEndpoint = env.LANGWATCH_ENDPOINT ?? "";
       let remoteSpanJudge: RemoteSpanJudgeAgent | undefined;
       const judgeAgentInstance =
         target.type === "http"
@@ -172,14 +180,6 @@ export class SimulationRunnerService {
         "Scenario execution failed",
       );
     }
-  }
-
-  private getLangWatchEndpoint(): string {
-    const endpoint = process.env.LANGWATCH_ENDPOINT;
-    if (!endpoint) {
-      throw new Error("LANGWATCH_ENDPOINT env var is required but not set");
-    }
-    return endpoint;
   }
 
   private resolveAdapter(


### PR DESCRIPTION
## Summary

**Umbrella WIP PR for #3526** — bundled validation testbed for 9 findings surfaced during the stress-test walk-through of all 3 agent pathways (code / http / workflow).

This PR will **not** be merged. It exists so Drew can validate the entire bundle works end-to-end before each finding splits off into its own focused PR for review.

## Strategy

| Phase | Status |
|-------|--------|
| 1. Bundle all findings into this WIP umbrella branch | ✅ done |
| 2. Drew validates bundle works end-to-end | 🟡 in progress |
| 3. Split into 5 themed PRs against main, each with its own issue + plan + ACs | pending |
| 4. Each split goes through normal review → Slack dev channel | pending |
| 5. Umbrella branch rebased on top as splits merge (or closed once all splits merge) | pending |

See #3526 for the full split plan + per-finding ACs.

## Findings included (9 total, fix-in-this-PR scope from #3526)

- **F1** — Scenario create modal dead-end on `no-default` / `stale-default` states
- **F2** — Server-side `resolveDefaultModel` service (single source of truth)
- **F3** — Provider drawer masked-key no-op (don't re-submit placeholder)
- **F4** — `useOrganizationTeamProject` cache: drop `staleTime: Infinity`
- **F5** — `AICreateModal` `ErrorState` real-error + classifier
- **F6** — Scenario editor criteria-on-blur (silent data loss)
- **F8** — Save-and-run: failed run must not roll back save
- **F10** — Telemetry routing + env-contract sweep (drop localhost fallbacks)

Filed elsewhere: F7 (#3411), F9 (#3412) — both under mini-epic #3441.

## Test plan

- [ ] Manual: stress-test matrix per #3526 (code / http / workflow × OpenAI / Gemini)
- [ ] Manual: each finding's reproducer no longer reproduces
- [ ] Per-split PRs validate their own slice independently (with their own tests + reviewers)

## Reviewer guidance

**Don't review this PR.** It's a validation bundle. Review the split PRs (linked from #3526) once they're cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3526