### PR TITLE
fix(otel): log projectId + customerTraceIds on every /api/otel/v1 error

### DIFF
--- a/langwatch/src/app/api/middleware/trace-limit.ts
+++ b/langwatch/src/app/api/middleware/trace-limit.ts
@@ -36,6 +36,16 @@ export const blockTraceUsageExceededMiddleware: MiddlewareHandler = async (
       logger.error({ error, projectId: project.id }, "Plan limit notification failed");
     }
 
+    logger.info(
+      {
+        projectId: project.id,
+        currentMonthMessagesCount: result.count,
+        activePlanName: result.planName,
+        maxMessagesPerMonth: result.maxMessagesPerMonth,
+      },
+      "Project has reached plan limit",
+    );
+
     return c.json({ error: "ERR_PLAN_LIMIT", message: result.message }, 429);
   }
 

--- a/langwatch/src/server/routes/__tests__/otel.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/otel.unit.test.ts
@@ -108,6 +108,21 @@ describe("peekCustomerTraceIds", () => {
       ]);
     });
 
+    it.each([
+      "application/json; charset=utf-8",
+      "application/json;charset=utf-8",
+      "  Application/JSON  ",
+      "APPLICATION/JSON",
+    ])(
+      "still routes through the JSON parser when content-type is %j",
+      (contentType) => {
+        const body = jsonOtlpBody([TRACE_ID_B64_1]);
+        expect(peekCustomerTraceIds(body, contentType)).toEqual([
+          TRACE_ID_HEX_1,
+        ]);
+      },
+    );
+
     it("preserves order across distinct trace_ids", () => {
       const body = jsonOtlpBody([TRACE_ID_B64_1, TRACE_ID_B64_2]);
       expect(peekCustomerTraceIds(body, "application/json")).toEqual([

--- a/langwatch/src/server/routes/__tests__/otel.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/otel.unit.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import * as root from "@opentelemetry/otlp-transformer/build/src/generated/root";
+import { classifyTokenType, peekCustomerTraceIds } from "../otel";
+
+const traceRequestType = (root as any).opentelemetry.proto.collector.trace.v1
+  .ExportTraceServiceRequest;
+
+// Two distinct 16-byte trace ids (hex) — used across the suite so we can
+// assert the function emits hex regardless of whether the input was bytes
+// or base64.
+const TRACE_ID_HEX_1 = "0bcb2eb84dd52ac9bc1496a99c733880";
+const TRACE_ID_HEX_2 = "1122334455667788aabbccddeeff0011";
+const TRACE_ID_BYTES_1 = Buffer.from(TRACE_ID_HEX_1, "hex");
+const TRACE_ID_BYTES_2 = Buffer.from(TRACE_ID_HEX_2, "hex");
+const TRACE_ID_B64_1 = TRACE_ID_BYTES_1.toString("base64");
+const TRACE_ID_B64_2 = TRACE_ID_BYTES_2.toString("base64");
+
+const SPAN_ID_HEX = "1122334455667788";
+const SPAN_ID_BYTES = Buffer.from(SPAN_ID_HEX, "hex");
+
+function bufferToArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(
+    buf.byteOffset,
+    buf.byteOffset + buf.byteLength,
+  ) as ArrayBuffer;
+}
+
+function jsonOtlpBody(traceIdsB64: string[]): ArrayBuffer {
+  // Mirrors the wire shape an SDK produces when content-type is
+  // application/json: traceId/spanId are base64-encoded strings.
+  return bufferToArrayBuffer(
+    Buffer.from(
+      JSON.stringify({
+        resourceSpans: [
+          {
+            scopeSpans: [
+              {
+                spans: traceIdsB64.map((tid) => ({
+                  traceId: tid,
+                  spanId: SPAN_ID_BYTES.toString("base64"),
+                  name: "test-span",
+                })),
+              },
+            ],
+          },
+        ],
+      }),
+      "utf-8",
+    ),
+  );
+}
+
+function protobufOtlpBody(traceIds: Buffer[]): ArrayBuffer {
+  // Use the protobuf encoder so we exercise the same decode path the
+  // production handler uses for application/x-protobuf bodies.
+  const encoded = traceRequestType
+    .encode({
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              spans: traceIds.map((tid) => ({
+                traceId: tid,
+                spanId: SPAN_ID_BYTES,
+                name: "test-span",
+              })),
+            },
+          ],
+        },
+      ],
+    })
+    .finish() as Uint8Array;
+  return bufferToArrayBuffer(Buffer.from(encoded));
+}
+
+describe("peekCustomerTraceIds", () => {
+  describe("when the body is missing or empty", () => {
+    it("returns an empty array for a zero-byte ArrayBuffer", () => {
+      const empty = new ArrayBuffer(0);
+      expect(peekCustomerTraceIds(empty, "application/x-protobuf")).toEqual([]);
+    });
+
+    it("returns an empty array when content-type is JSON and body is empty", () => {
+      const empty = new ArrayBuffer(0);
+      expect(peekCustomerTraceIds(empty, "application/json")).toEqual([]);
+    });
+  });
+
+  describe("when the body is malformed", () => {
+    it("returns an empty array for non-protobuf garbage", () => {
+      const garbage = bufferToArrayBuffer(Buffer.from([0xff, 0x00, 0xde, 0xad]));
+      expect(
+        peekCustomerTraceIds(garbage, "application/x-protobuf"),
+      ).toEqual([]);
+    });
+
+    it("returns an empty array for invalid JSON", () => {
+      const bad = bufferToArrayBuffer(Buffer.from("not-json", "utf-8"));
+      expect(peekCustomerTraceIds(bad, "application/json")).toEqual([]);
+    });
+  });
+
+  describe("when the body is well-formed JSON OTLP", () => {
+    it("decodes base64 trace_ids to lowercase hex", () => {
+      const body = jsonOtlpBody([TRACE_ID_B64_1]);
+      expect(peekCustomerTraceIds(body, "application/json")).toEqual([
+        TRACE_ID_HEX_1,
+      ]);
+    });
+
+    it("preserves order across distinct trace_ids", () => {
+      const body = jsonOtlpBody([TRACE_ID_B64_1, TRACE_ID_B64_2]);
+      expect(peekCustomerTraceIds(body, "application/json")).toEqual([
+        TRACE_ID_HEX_1,
+        TRACE_ID_HEX_2,
+      ]);
+    });
+
+    it("deduplicates trace_ids that appear on multiple spans", () => {
+      const body = jsonOtlpBody([
+        TRACE_ID_B64_1,
+        TRACE_ID_B64_1,
+        TRACE_ID_B64_2,
+      ]);
+      expect(peekCustomerTraceIds(body, "application/json")).toEqual([
+        TRACE_ID_HEX_1,
+        TRACE_ID_HEX_2,
+      ]);
+    });
+  });
+
+  describe("when the body is well-formed protobuf OTLP", () => {
+    it("decodes Uint8Array trace_ids to lowercase hex", () => {
+      const body = protobufOtlpBody([TRACE_ID_BYTES_1]);
+      expect(
+        peekCustomerTraceIds(body, "application/x-protobuf"),
+      ).toEqual([TRACE_ID_HEX_1]);
+    });
+
+    it("decodes when no content-type is supplied (defaults to protobuf path)", () => {
+      const body = protobufOtlpBody([TRACE_ID_BYTES_1]);
+      expect(peekCustomerTraceIds(body, undefined)).toEqual([TRACE_ID_HEX_1]);
+    });
+
+    it("returns multiple unique trace_ids in the order they appear", () => {
+      const body = protobufOtlpBody([TRACE_ID_BYTES_1, TRACE_ID_BYTES_2]);
+      expect(
+        peekCustomerTraceIds(body, "application/x-protobuf"),
+      ).toEqual([TRACE_ID_HEX_1, TRACE_ID_HEX_2]);
+    });
+  });
+
+  describe("when the body has nothing useful to extract", () => {
+    it("returns an empty array for OTLP with no resourceSpans", () => {
+      const body = bufferToArrayBuffer(
+        Buffer.from(JSON.stringify({}), "utf-8"),
+      );
+      expect(peekCustomerTraceIds(body, "application/json")).toEqual([]);
+    });
+
+    it("returns an empty array for spans missing traceId", () => {
+      const body = bufferToArrayBuffer(
+        Buffer.from(
+          JSON.stringify({
+            resourceSpans: [{ scopeSpans: [{ spans: [{ name: "x" }] }] }],
+          }),
+          "utf-8",
+        ),
+      );
+      expect(peekCustomerTraceIds(body, "application/json")).toEqual([]);
+    });
+  });
+
+  describe("when the request has many distinct trace_ids", () => {
+    it("respects the max cap", () => {
+      // Build 20 distinct ids, ask for 5
+      const ids = Array.from({ length: 20 }, (_, i) =>
+        Buffer.from(
+          i.toString(16).padStart(2, "0").repeat(16).slice(0, 32),
+          "hex",
+        ),
+      );
+      const body = protobufOtlpBody(ids);
+      const result = peekCustomerTraceIds(
+        body,
+        "application/x-protobuf",
+        5,
+      );
+      expect(result).toHaveLength(5);
+      // Each id must be 32 hex chars (16 bytes).
+      for (const id of result) {
+        expect(id).toMatch(/^[0-9a-f]{32}$/);
+      }
+    });
+  });
+});
+
+describe("classifyTokenType", () => {
+  describe("when given a PAT prefix", () => {
+    it("classifies pat-lw-… tokens as pat", () => {
+      expect(classifyTokenType("pat-lw-abcdef123456")).toBe("pat");
+    });
+  });
+
+  describe("when given a legacy SDK key prefix", () => {
+    it("classifies sk-lw-… tokens as legacy", () => {
+      expect(classifyTokenType("sk-lw-abcdef123456")).toBe("legacy");
+    });
+  });
+
+  describe("when given anything else", () => {
+    it("returns unknown for an arbitrary string", () => {
+      expect(classifyTokenType("abc123")).toBe("unknown");
+    });
+
+    it("returns unknown for an empty string", () => {
+      expect(classifyTokenType("")).toBe("unknown");
+    });
+
+    it("does not match a PAT prefix in the middle of the token", () => {
+      // Defensive: only the start of the string counts. This protects
+      // against pathological inputs from being misclassified.
+      expect(classifyTokenType("xpat-lw-abc")).toBe("unknown");
+    });
+  });
+});

--- a/langwatch/src/server/routes/otel.ts
+++ b/langwatch/src/server/routes/otel.ts
@@ -28,6 +28,7 @@ import {
   extractCredentials,
   patCeilingDenialResponse,
 } from "~/server/pat/auth-middleware";
+import { decodeBase64OpenTelemetryId } from "~/server/tracer/utils";
 import { createLogger } from "~/utils/logger/server";
 import { captureException } from "~/utils/posthogErrorCapture";
 
@@ -99,7 +100,7 @@ type RouteContext = {
  * `tokenType` field emitted by the unified auth middleware so on-call can
  * filter CloudWatch by SDK shape.
  */
-function classifyTokenType(token: string): "pat" | "legacy" | "unknown" {
+export function classifyTokenType(token: string): "pat" | "legacy" | "unknown" {
   if (token.startsWith("pat-lw-")) return "pat";
   if (token.startsWith("sk-lw-")) return "legacy";
   return "unknown";
@@ -255,8 +256,12 @@ async function enforcePlanLimit(
  * body is empty, malformed, or unparsable, returns an empty array. Used to
  * tag error logs (plan-limit, parse failure) so a customer who reports
  * "I sent trace_id X but it didn't appear" can be matched to the rejection.
+ *
+ * JSON-OTLP serialises trace_id as base64 strings; protobuf-OTLP decodes
+ * them as Uint8Array. `decodeBase64OpenTelemetryId` handles both — output
+ * is always lowercase hex, the same shape the rest of the platform uses.
  */
-function peekCustomerTraceIds(
+export function peekCustomerTraceIds(
   body: ArrayBuffer,
   contentType: string | undefined,
   max = 10,
@@ -276,14 +281,9 @@ function peekCustomerTraceIds(
   for (const rs of req.resourceSpans ?? []) {
     for (const ss of rs.scopeSpans ?? []) {
       for (const sp of ss.spans ?? []) {
-        const t = sp.traceId;
-        if (!t) continue;
-        const idStr =
-          typeof t === "string"
-            ? t
-            : Buffer.from(t as Uint8Array).toString("hex");
-        if (idStr) {
-          ids.add(idStr);
+        const decoded = decodeBase64OpenTelemetryId(sp.traceId);
+        if (decoded) {
+          ids.add(decoded);
           if (ids.size >= max) return Array.from(ids);
         }
       }

--- a/langwatch/src/server/routes/otel.ts
+++ b/langwatch/src/server/routes/otel.ts
@@ -267,9 +267,12 @@ export function peekCustomerTraceIds(
   max = 10,
 ): string[] {
   if (!body || body.byteLength === 0) return [];
+  // Normalise so "application/json; charset=utf-8" is recognised. The OTLP
+  // HTTP spec lets exporters append parameters and case isn't guaranteed.
+  const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
   let req: IExportTraceServiceRequest;
   try {
-    if (contentType === "application/json") {
+    if (mediaType === "application/json") {
       req = JSON.parse(Buffer.from(body).toString("utf-8"));
     } else {
       req = traceRequestType.decode(new Uint8Array(body));
@@ -466,7 +469,23 @@ app.post("/logs", async (c) => {
       }
 
       const contentType = c.req.header("content-type");
-      const body = await readBody(c.req.raw);
+
+      let body: ArrayBuffer;
+      try {
+        body = await readBody(c.req.raw);
+      } catch (error) {
+        loggerLogs.warn(
+          {
+            projectId: project.id,
+            contentEncoding: c.req.header("content-encoding") ?? null,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "OTel /logs: failed to read request body",
+        );
+        span.setStatus({ code: SpanStatusCode.ERROR, message: "Body read failed" });
+        return c.json({ error: "Unable to read body" }, 400);
+      }
+
       let logRequest: IExportLogsServiceRequest;
       try {
         if (contentType === "application/json") {
@@ -555,7 +574,23 @@ app.post("/metrics", async (c) => {
       }
 
       const contentType = c.req.header("content-type");
-      const body = await readBody(c.req.raw);
+
+      let body: ArrayBuffer;
+      try {
+        body = await readBody(c.req.raw);
+      } catch (error) {
+        loggerMetrics.warn(
+          {
+            projectId: project.id,
+            contentEncoding: c.req.header("content-encoding") ?? null,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "OTel /metrics: failed to read request body",
+        );
+        span.setStatus({ code: SpanStatusCode.ERROR, message: "Body read failed" });
+        return c.json({ error: "Unable to read body" }, 400);
+      }
+
       let metricsRequest: IExportMetricsServiceRequest;
       try {
         if (contentType === "application/json") {

--- a/langwatch/src/server/routes/otel.ts
+++ b/langwatch/src/server/routes/otel.ts
@@ -23,6 +23,7 @@ import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
 import { TokenResolver } from "~/server/pat/token-resolver";
 import {
+  collectAuthDiagnostics,
   enforcePatCeiling,
   extractCredentials,
   patCeilingDenialResponse,
@@ -84,21 +85,74 @@ app.use(loggerMiddleware());
 
 const tokenResolver = TokenResolver.create(prisma);
 
-async function authenticateAndCheckLimit(c: {
-  req: { raw: Request; header: (name: string) => string | undefined };
-}) {
+type RouteContext = {
+  req: {
+    raw: Request;
+    path: string;
+    method: string;
+    header: (name: string) => string | undefined;
+  };
+};
+
+/**
+ * Classifies a token by prefix without exposing the value. Mirrors the
+ * `tokenType` field emitted by the unified auth middleware so on-call can
+ * filter CloudWatch by SDK shape.
+ */
+function classifyTokenType(token: string): "pat" | "legacy" | "unknown" {
+  if (token.startsWith("pat-lw-")) return "pat";
+  if (token.startsWith("sk-lw-")) return "legacy";
+  return "unknown";
+}
+
+/**
+ * Resolves credentials and the active project. Logs an auth-diagnostic
+ * fingerprint on every failure path so on-call can attribute a 401 to a
+ * specific customer/SDK without needing the customer to reproduce. Mirrors
+ * the unified-auth middleware (PR #3520) — same fields, same shape, so
+ * existing CloudWatch queries work.
+ */
+async function authenticate(c: RouteContext, logger: ReturnType<typeof createLogger>) {
+  const diag = collectAuthDiagnostics(c);
   const credentials = extractCredentials((name) => c.req.header(name));
 
   if (!credentials) {
-    return { error: "Authentication token is required. Use X-Auth-Token header or Authorization: Bearer token.", status: 401 as const };
+    logger.warn(
+      diag,
+      diag.hasEmptyAuthToken
+        ? "Authentication failed: X-Auth-Token sent but empty"
+        : "Authentication failed: no auth header present",
+    );
+    return {
+      error:
+        "Authentication token is required. Use X-Auth-Token header or Authorization: Bearer token.",
+      status: 401 as const,
+    };
   }
 
-  const resolved = await tokenResolver.resolve({
-    token: credentials.token,
-    projectId: credentials.projectId,
-  });
+  let resolved;
+  try {
+    resolved = await tokenResolver.resolve({
+      token: credentials.token,
+      projectId: credentials.projectId,
+    });
+  } catch (error) {
+    logger.error(
+      { ...diag, error },
+      "Database error during authentication",
+    );
+    return { error: "Authentication service error.", status: 500 as const };
+  }
 
   if (!resolved) {
+    logger.warn(
+      {
+        ...diag,
+        tokenType: classifyTokenType(credentials.token),
+        hasProjectId: !!credentials.projectId,
+      },
+      "Authentication failed: invalid credentials",
+    );
     return { error: "Invalid auth token.", status: 401 as const };
   }
 
@@ -112,56 +166,130 @@ async function authenticateAndCheckLimit(c: {
     });
   } catch (error) {
     const denial = patCeilingDenialResponse(error);
+    logger.warn(
+      {
+        ...diag,
+        projectId: resolved.project.id,
+        tokenType: classifyTokenType(credentials.token),
+        denialStatus: denial.status,
+      },
+      "PAT permission denied for traces:create",
+    );
     return { error: denial.message, status: denial.status };
   }
 
-  const project = resolved.project;
+  return { project: resolved.project, resolved };
+}
 
-  // Check usage limits
+/**
+ * Checks usage limits for the project and returns a 429 result if exceeded.
+ * Logs `Project has reached plan limit` with `customerTraceIds` so a
+ * customer-supplied trace_id can be matched to the rejection. The check
+ * itself is wrapped in try/catch — on lookup failure we log and let the
+ * request through (same behaviour as before).
+ */
+async function enforcePlanLimit(
+  project: { id: string; teamId: string; team: { organizationId: string } },
+  customerTraceIds: string[],
+  logger: ReturnType<typeof createLogger>,
+) {
   try {
     const limitResult = await getApp().usage.checkLimit({
       teamId: project.teamId,
     });
 
-    if (limitResult.exceeded) {
-      try {
-        const activePlan = await getApp().planProvider.getActivePlan({
-          organizationId: project.team.organizationId,
-        });
-        getApp()
-          .usageLimits.notifyPlanLimitReached({
-            organizationId: project.team.organizationId,
-            planName: activePlan.name ?? "free",
-          })
-          .catch((error: unknown) => {
-            loggerTraces.error(
-              { error, projectId: project.id },
-              "Error sending plan limit notification",
-            );
-          });
-      } catch (error) {
-        loggerTraces.error(
-          { error, projectId: project.id },
-          "Error getting active plan information",
-        );
-      }
+    if (!limitResult.exceeded) return null;
 
-      return {
-        error: `ERR_PLAN_LIMIT: ${limitResult.message}`,
-        status: 429 as const,
-      };
+    try {
+      const activePlan = await getApp().planProvider.getActivePlan({
+        organizationId: project.team.organizationId,
+      });
+      getApp()
+        .usageLimits.notifyPlanLimitReached({
+          organizationId: project.team.organizationId,
+          planName: activePlan.name ?? "free",
+        })
+        .catch((error: unknown) => {
+          logger.error(
+            { error, projectId: project.id },
+            "Error sending plan limit notification",
+          );
+        });
+    } catch (error) {
+      logger.error(
+        { error, projectId: project.id },
+        "Error getting active plan information",
+      );
     }
+
+    logger.info(
+      {
+        projectId: project.id,
+        currentMonthMessagesCount: limitResult.count,
+        activePlanName: limitResult.planName,
+        maxMessagesPerMonth: limitResult.maxMessagesPerMonth,
+        customerTraceIds,
+      },
+      "Project has reached plan limit",
+    );
+
+    return {
+      error: `ERR_PLAN_LIMIT: ${limitResult.message}`,
+      status: 429 as const,
+    };
   } catch (error) {
-    loggerTraces.error(
-      { error, projectId: project.id },
+    logger.error(
+      { error, projectId: project.id, customerTraceIds },
       "Error checking trace limit",
     );
     captureException(error as Error, {
       extra: { projectId: project.id },
     });
+    return null;
   }
+}
 
-  return { project, resolved };
+/**
+ * Best-effort extraction of customer trace_ids from an OTLP traces body.
+ * Returns up to `max` unique hex-encoded trace_ids. Never throws — if the
+ * body is empty, malformed, or unparsable, returns an empty array. Used to
+ * tag error logs (plan-limit, parse failure) so a customer who reports
+ * "I sent trace_id X but it didn't appear" can be matched to the rejection.
+ */
+function peekCustomerTraceIds(
+  body: ArrayBuffer,
+  contentType: string | undefined,
+  max = 10,
+): string[] {
+  if (!body || body.byteLength === 0) return [];
+  let req: IExportTraceServiceRequest;
+  try {
+    if (contentType === "application/json") {
+      req = JSON.parse(Buffer.from(body).toString("utf-8"));
+    } else {
+      req = traceRequestType.decode(new Uint8Array(body));
+    }
+  } catch {
+    return [];
+  }
+  const ids = new Set<string>();
+  for (const rs of req.resourceSpans ?? []) {
+    for (const ss of rs.scopeSpans ?? []) {
+      for (const sp of ss.spans ?? []) {
+        const t = sp.traceId;
+        if (!t) continue;
+        const idStr =
+          typeof t === "string"
+            ? t
+            : Buffer.from(t as Uint8Array).toString("hex");
+        if (idStr) {
+          ids.add(idStr);
+          if (ids.size >= max) return Array.from(ids);
+        }
+      }
+    }
+  }
+  return Array.from(ids);
 }
 
 // ── POST /traces ─────────────────────────────────────────────────────
@@ -173,7 +301,9 @@ app.post("/traces", async (c) => {
     "TracesV1.handleTracesRequest",
     { kind: SpanKind.SERVER },
     async (span) => {
-      const authResult = await authenticateAndCheckLimit(c);
+      // Auth first — 401s/permission failures should not pay body decompression
+      // cost, and body content is irrelevant when we don't know who's calling.
+      const authResult = await authenticate(c, loggerTraces);
 
       if ("error" in authResult) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: authResult.error });
@@ -184,12 +314,54 @@ app.post("/traces", async (c) => {
       span.setAttribute("langwatch.project.id", project.id);
 
       const contentType = c.req.header("content-type");
-      const body = await readBody(c.req.raw);
+
+      let body: ArrayBuffer;
+      try {
+        body = await readBody(c.req.raw);
+      } catch (error) {
+        loggerTraces.warn(
+          {
+            projectId: project.id,
+            contentEncoding: c.req.header("content-encoding") ?? null,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "OTel /traces: failed to read request body",
+        );
+        span.setStatus({ code: SpanStatusCode.ERROR, message: "Body read failed" });
+        return c.json({ error: "Unable to read body" }, 400);
+      }
+
+      // Best-effort. If the body can't be peeked (malformed, unsupported
+      // shape, etc.), customerTraceIds stays empty — the projectId is still
+      // logged on every subsequent failure for correlation.
+      const customerTraceIds = peekCustomerTraceIds(body, contentType);
+      if (customerTraceIds.length > 0) {
+        span.setAttribute(
+          "langwatch.otel.customer_trace_ids",
+          customerTraceIds.join(","),
+        );
+      }
+
+      const limitFailure = await enforcePlanLimit(
+        project,
+        customerTraceIds,
+        loggerTraces,
+      );
+      if (limitFailure) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: limitFailure.error,
+        });
+        return c.json(
+          { message: limitFailure.error },
+          { status: limitFailure.status },
+        );
+      }
 
       const emptyPartialSuccess = { rejectedSpans: 0, errorMessage: "" };
 
       if (body.byteLength === 0) {
-        loggerTraces.debug("Received empty trace request, ignoring");
+        loggerTraces.debug({ projectId: project.id }, "Received empty trace request, ignoring");
         return c.json({
           message: "No traces to process",
           partialSuccess: emptyPartialSuccess,
@@ -219,6 +391,8 @@ app.post("/traces", async (c) => {
           loggerTraces.error(
             {
               error: jsonError,
+              projectId: project.id,
+              customerTraceIds,
               traceRequest: Buffer.from(body).toString("base64"),
             },
             "error parsing traces",
@@ -226,6 +400,7 @@ app.post("/traces", async (c) => {
           captureException(error, {
             extra: {
               projectId: project.id,
+              customerTraceIds,
               traceRequest: Buffer.from(body).toString("base64"),
               jsonError,
             },
@@ -268,7 +443,7 @@ app.post("/logs", async (c) => {
     "[POST] /api/otel/v1/logs",
     { kind: SpanKind.SERVER },
     async (span) => {
-      const authResult = await authenticateAndCheckLimit(c);
+      const authResult = await authenticate(c, loggerLogs);
 
       if ("error" in authResult) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: authResult.error });
@@ -277,6 +452,18 @@ app.post("/logs", async (c) => {
 
       const { project, resolved } = authResult;
       span.setAttribute("langwatch.project.id", project.id);
+
+      const limitFailure = await enforcePlanLimit(project, [], loggerLogs);
+      if (limitFailure) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: limitFailure.error,
+        });
+        return c.json(
+          { message: limitFailure.error },
+          { status: limitFailure.status },
+        );
+      }
 
       const contentType = c.req.header("content-type");
       const body = await readBody(c.req.raw);
@@ -302,6 +489,7 @@ app.post("/logs", async (c) => {
           loggerLogs.error(
             {
               error: jsonError,
+              projectId: project.id,
               logRequest: Buffer.from(body).toString("base64"),
             },
             "error parsing logs",
@@ -344,7 +532,7 @@ app.post("/metrics", async (c) => {
     "[POST] /api/otel/v1/metrics",
     { kind: SpanKind.SERVER },
     async (span) => {
-      const authResult = await authenticateAndCheckLimit(c);
+      const authResult = await authenticate(c, loggerMetrics);
 
       if ("error" in authResult) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: authResult.error });
@@ -353,6 +541,18 @@ app.post("/metrics", async (c) => {
 
       const { project, resolved } = authResult;
       span.setAttribute("langwatch.project.id", project.id);
+
+      const limitFailure = await enforcePlanLimit(project, [], loggerMetrics);
+      if (limitFailure) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: limitFailure.error,
+        });
+        return c.json(
+          { message: limitFailure.error },
+          { status: limitFailure.status },
+        );
+      }
 
       const contentType = c.req.header("content-type");
       const body = await readBody(c.req.raw);
@@ -378,6 +578,7 @@ app.post("/metrics", async (c) => {
           loggerMetrics.error(
             {
               error: jsonError,
+              projectId: project.id,
               metricsRequest: Buffer.from(body).toString("base64"),
             },
             "error parsing metrics",


### PR DESCRIPTION
## Summary
- Every error path on `/api/otel/v1/{traces,logs,metrics}` now logs **projectId** (when known) and the standard auth-diagnostic fingerprint (`path`, `method`, `userAgent`, `traceparent`, `forwardedFor`, `hasEmptyAuthToken`, `tokenType`) — same shape as the unified-auth middleware emits for `/api/scenario-events` (PR #3520).
- The plan-limit 429 branch now logs `"Project has reached plan limit"` with `projectId`, `count`, `planName`, `maxMessagesPerMonth` — matching `collector.ts` so existing CloudWatch queries cover both paths.
- `/traces` additionally peeks the OTLP body for customer `trace_id`s (best-effort, never throws) and emits them on the 429 log and the parse-failure log.
- Same `Project has reached plan limit` log added to the generic `blockTraceUsageExceededMiddleware`.

## Why
Live triage of a customer issue hit a wall because the OTLP error paths return silently:

- **401**: only the access log records it, no `projectId`, no IP, no key context.
- **429 (plan limit)**: returns without logging anything project-scoped. We had ~85 OTLP 429s/min sustained on prod and could not identify which tenant they belonged to.
- **400 (body parse)**: no `projectId` and no `trace_id` from the body, so a customer who says "I sent trace_id X" can't be matched to the rejection.

`collector.ts` (the legacy `/api/collector` path) already had the projectId-on-429 log. The OTel routes were the gap.

## What changed in `otel.ts`

The shared `authenticateAndCheckLimit` was split into two helpers and the `/traces` handler reordered:

1. `authenticate(c, logger)` — auth + PAT-ceiling. Logs WARN with `collectAuthDiagnostics(c)` on every 401/permission failure, plus `tokenType` (`pat` / `legacy` / `unknown` from prefix only — never the raw token).
2. `enforcePlanLimit(project, customerTraceIds, logger)` — separated out so the route can read the body, peek `trace_id`s, and pass them to the limit log.
3. `peekCustomerTraceIds(body, contentType, max=10)` — best-effort; returns `[]` on empty / malformed / unparsable body.

The `/traces` handler now flows: **auth → read body → peek trace_ids → limit check → parse body → process**. `/logs` and `/metrics` use the same auth + limit helpers but skip body-peek (different OTLP shape).

## Field shape examples

Auth-failure WARN:
```
{ path: "/api/otel/v1/traces",
  method: "POST",
  userAgent: "OTel-OTLP-Exporter-Python/1.35.0",
  traceparent: null,
  forwardedFor: "203.0.113.5",
  hasEmptyAuthToken: false,
  tokenType: "legacy",
  msg: "Authentication failed: invalid credentials" }
```

Plan-limit INFO (now resolves the "whose 429 is this?" mystery):
```
{ projectId: "project_xxxxx",
  currentMonthMessagesCount: 1234567,
  activePlanName: "ENTERPRISE",
  maxMessagesPerMonth: 999999999,
  customerTraceIds: ["aabbcc..."],
  msg: "Project has reached plan limit" }
```

## Test plan

- [ ] Probe `/api/otel/v1/traces` with no auth header — expect a WARN with `hasEmptyAuthToken: false`, no `projectId`.
- [ ] Probe with `X-Auth-Token: ""` — expect WARN with `hasEmptyAuthToken: true`.
- [ ] Probe with a bad token — expect WARN with `tokenType` set and no `projectId`.
- [ ] Probe with valid auth but malformed body — expect ERROR with `projectId` set, `customerTraceIds: []`.
- [ ] On a project that's hit the plan limit, send a real OTLP body — expect INFO `"Project has reached plan limit"` with `projectId` and `customerTraceIds`.
- [ ] Confirm happy path is unchanged (200 response, span count matches).