### PR TITLE
feat(scenarios): entry-path UX — modal gate, cache fix, error UX (#3530)

### DIFF
--- a/langwatch/src/components/IntegrationChecks.tsx
+++ b/langwatch/src/components/IntegrationChecks.tsx
@@ -13,6 +13,9 @@ export const useIntegrationChecks = () => {
     { projectId: project?.id ?? "" },
     {
       enabled: !!project,
+      // Onboarding checklist: staleTime: Infinity is fine here because
+      // refetchOnWindowFocus picks up out-of-band changes (first message
+      // synced, first workflow created, etc.) when the user returns to the tab.
       refetchOnWindowFocus: true,
       refetchOnMount: false,
       staleTime: Infinity,

--- a/langwatch/src/components/copilot-kit/TraceMessage.tsx
+++ b/langwatch/src/components/copilot-kit/TraceMessage.tsx
@@ -17,8 +17,9 @@ const TRACE_QUERY_CONFIG = {
   retry: 10,
   retryDelay: (attemptIndex: number) =>
     Math.min(2000 * 2 ** attemptIndex, 60000),
-  staleTime: Infinity, // Never consider successful data stale
-  cacheTime: Infinity, // Cache successful results indefinitely
+  // Traces are immutable once written, so caching forever is correct.
+  staleTime: Infinity,
+  cacheTime: Infinity,
 } as const;
 
 interface TraceMessageProps extends StackProps {

--- a/langwatch/src/components/evaluations/wizard/hooks/useInitialLoadExperiment.ts
+++ b/langwatch/src/components/evaluations/wizard/hooks/useInitialLoadExperiment.ts
@@ -54,6 +54,9 @@ export const useInitialLoadExperiment = () => {
       },
       {
         enabled: !!project && !!initialLoadExperimentSlug,
+        // One-shot bootstrap: result is hydrated into the Zustand wizard store
+        // (setDSL/setExperimentId/setExperimentSlug below) and the user edits
+        // from there. A background refetch would clobber unsaved edits.
         refetchOnMount: false,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,

--- a/langwatch/src/components/scenarios/ModelProviderRequiredModal.tsx
+++ b/langwatch/src/components/scenarios/ModelProviderRequiredModal.tsx
@@ -1,0 +1,61 @@
+import {
+  Box,
+  Button,
+  HStack,
+  Icon,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { AlertTriangle } from "lucide-react";
+import { Dialog } from "../ui/dialog";
+
+export interface ModelProviderRequiredModalProps {
+  open: boolean;
+  onClose: () => void;
+  onProceedAnyway: () => void;
+}
+
+export function ModelProviderRequiredModal({
+  open,
+  onClose,
+  onProceedAnyway,
+}: ModelProviderRequiredModalProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(d) => !d.open && onClose()}>
+      <Dialog.Content>
+        <Dialog.CloseTrigger />
+        <Dialog.Header>
+          <Dialog.Title>Model provider not ready</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
+          <VStack gap={4} py={4} align="center" justify="center">
+            <Box p={3} borderRadius="full" bg="orange.100" color="orange.600">
+              <Icon as={AlertTriangle} boxSize={6} />
+            </Box>
+            <Text color="fg.muted" fontSize="sm" textAlign="center">
+              Scenarios need an enabled provider with a default model to run. Configure default model provider to get started, or proceed to create a new scenario anyway.
+            </Text>
+          </VStack>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <HStack gap={2} justify="flex-end">
+            <Button variant="ghost" onClick={onProceedAnyway}>
+              Proceed anyway
+            </Button>
+            <Button colorPalette="blue" asChild>
+              <a
+                data-testid="model-provider-required-modal-configure-button"
+                href="/settings/model-providers"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: "white" }}
+              >
+                Configure model provider
+              </a>
+            </Button>
+          </HStack>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/langwatch/src/components/scenarios/ScenarioCreateModal.tsx
+++ b/langwatch/src/components/scenarios/ScenarioCreateModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { AICreateModal, type ExampleTemplate } from "../shared/AICreateModal";
+import { ModelProviderRequiredModal } from "./ModelProviderRequiredModal";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useDrawer } from "~/hooks/useDrawer";
 import { useModelProvidersSettings } from "~/hooks/useModelProvidersSettings";
@@ -91,23 +92,6 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
         throw new Error("No project selected");
       }
 
-      if (!defaultModelState.ok) {
-        if (defaultModelState.reason === "no-default") {
-          throw new Error(
-            "No default model set. Configure one in Settings → Model Providers."
-          );
-        }
-        if (defaultModelState.reason === "stale-default") {
-          throw new Error(
-            "Your default model's provider is disabled. Configure a new default in Settings → Model Providers."
-          );
-        }
-        // no-providers: AICreateModal hides the Generate button, so this is unreachable in practice
-        const _exhaustiveCheck: "no-providers" = defaultModelState.reason;
-        void _exhaustiveCheck;
-        return;
-      }
-
       try {
         const generatedData = await generateScenarioWithAI(description, project.id);
         openEditorWithData(generatedData);
@@ -116,7 +100,7 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
         throw error;
       }
     },
-    [project?.id, defaultModelState, openEditorWithData]
+    [project?.id, openEditorWithData]
   );
 
   const handleSkip = useCallback(() => {
@@ -127,7 +111,15 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
     });
   }, [openEditorWithData]);
 
-  const hasModelProviders = defaultModelState.ok || defaultModelState.reason !== "no-providers";
+  if (!defaultModelState.ok) {
+    return (
+      <ModelProviderRequiredModal
+        open={open}
+        onClose={onClose}
+        onProceedAnyway={() => checkAndProceed(handleSkip)}
+      />
+    );
+  }
 
   return (
     <AICreateModal
@@ -139,7 +131,6 @@ export function ScenarioCreateModal({ open, onClose }: ScenarioCreateModalProps)
       onGenerate={(desc) => checkAndProceed(() => handleGenerate(desc))}
       onSkip={() => checkAndProceed(handleSkip)}
       generatingText={GENERATING_TEXT}
-      hasModelProviders={hasModelProviders}
     />
   );
 }

--- a/langwatch/src/components/scenarios/__tests__/ScenarioCreateModal.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioCreateModal.test.tsx
@@ -126,11 +126,12 @@ describe("<ScenarioCreateModal/>", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockToasterCreate.mockClear();
-    // Reset to having providers by default
+    // Reset to having providers + a valid default model by default so the
+    // AI form renders. Tests targeting the no-default / no-providers gate
+    // override this in their own beforeEach.
     mockHasEnabledProviders = true;
     mockProviders = { openai: { enabled: true } };
-    // Reset project to default (no Azure)
-    mockProject = { id: "project-123", slug: "my-project" };
+    mockProject = { id: "project-123", slug: "my-project", defaultModel: "openai/gpt-4o-mini" };
 
     // Mock fetch for AI generation
     global.fetch = vi.fn().mockResolvedValue({
@@ -362,14 +363,17 @@ describe("<ScenarioCreateModal/>", () => {
       mockProviders = {};
     });
 
-    it("shows warning message instead of form", () => {
+    it("shows the model-provider-required modal instead of the AI form", () => {
       render(
         <ScenarioCreateModal open={true} onClose={vi.fn()} />,
         { wrapper: Wrapper }
       );
 
       const dialog = getDialogContent();
-      expect(within(dialog).getByText("No model provider configured")).toBeInTheDocument();
+      expect(within(dialog).getByText("Model provider not ready")).toBeInTheDocument();
+      expect(
+        within(dialog).getByTestId("model-provider-required-modal-configure-button")
+      ).toHaveAccessibleName("Configure model provider");
     });
 
     it("hides textarea", () => {
@@ -449,20 +453,17 @@ describe("when default model is Azure deployment not in registry", () => {
       });
     });
 
-    it("shows provider disabled error when generating because azure provider is not configured", async () => {
+    it("shows the model-provider-required modal up-front (no Generate flow)", () => {
       render(
         <ScenarioCreateModal open={true} onClose={vi.fn()} />,
         { wrapper: Wrapper }
       );
 
       const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test azure scenario" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      await waitFor(() => {
-        expect(within(dialog).getByText(/provider.*disabled|disabled.*provider/i)).toBeInTheDocument();
-      });
+      expect(within(dialog).getByText("Model provider not ready")).toBeInTheDocument();
+      expect(
+        within(dialog).getByTestId("model-provider-required-modal-configure-button")
+      ).toBeInTheDocument();
     });
   });
 });
@@ -475,14 +476,14 @@ describe("when default model is Azure and provider is NOT configured at all", ()
     mockProviders = {};
   });
 
-  it("shows No model provider configured warning", () => {
+  it("shows the model-provider-required modal", () => {
     render(
       <ScenarioCreateModal open={true} onClose={vi.fn()} />,
       { wrapper: Wrapper }
     );
 
     const dialog = getDialogContent();
-    expect(within(dialog).getByText("No model provider configured")).toBeInTheDocument();
+    expect(within(dialog).getByText("Model provider not ready")).toBeInTheDocument();
   });
 });
 
@@ -541,9 +542,11 @@ describe("given azure is the only enabled provider and project.defaultModel is a
 });
 
 describe("given azure is the only enabled provider and project.defaultModel is null", () => {
-  describe("when user clicks Generate with AI", () => {
+  // null defaultModel → getDefaultModelState returns { ok: false, reason: "no-default" }
+  // The modal must show the same "Configure model provider" UI it shows for no-providers,
+  // so the user can self-recover instead of hitting a dead-end error.
+  describe("when the modal opens", () => {
     beforeEach(() => {
-      // null defaultModel → getDefaultModelState returns { ok: false, reason: "no-default" }
       mockProject = { id: "p1", slug: "proj", defaultModel: undefined };
       mockHasEnabledProviders = true;
       mockProviders = { azure: { enabled: true }, openai: { enabled: false } };
@@ -554,65 +557,48 @@ describe("given azure is the only enabled provider and project.defaultModel is n
       });
     });
 
+    it("shows the Configure model provider footer button", () => {
+      render(
+        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(
+        within(dialog).getByTestId("model-provider-required-modal-configure-button")
+      ).toHaveAccessibleName("Configure model provider");
+    });
+
+    it("does not render the description textarea or Generate button", () => {
+      render(
+        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(within(dialog).queryByRole("textbox")).not.toBeInTheDocument();
+      expect(within(dialog).queryByRole("button", { name: /generate with ai/i })).not.toBeInTheDocument();
+    });
+
     it("does not call generateScenarioWithAI", async () => {
       render(
         <ScenarioCreateModal open={true} onClose={vi.fn()} />,
         { wrapper: Wrapper }
       );
 
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test missing default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      // Wait briefly to allow any async state to settle
+      // Nothing the user can do in the modal triggers a generation.
       await waitFor(() => {
-        // fetch must NOT have been called — no valid default model
         expect(global.fetch).not.toHaveBeenCalled();
-      });
-    });
-
-    it("renders an error state with a message not containing API keys not configured", async () => {
-      render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test missing default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      // Wait for the error state to appear (any error), then assert on the message
-      await waitFor(() => {
-        expect(within(dialog).getByText(/something went wrong/i)).toBeInTheDocument();
-      });
-      // The error message must NOT be the misleading "API keys not configured" text
-      expect(within(dialog).queryByText(/api keys not configured/i)).not.toBeInTheDocument();
-    });
-
-    it("renders an error mentioning default model", async () => {
-      render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test missing default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      await waitFor(() => {
-        expect(within(dialog).getByText(/default model/i)).toBeInTheDocument();
       });
     });
   });
 });
 
 describe("given azure is the only enabled provider and project.defaultModel is openai/gpt-5.2 (stale)", () => {
-  describe("when user clicks Generate with AI", () => {
+  // Stale default → getDefaultModelState returns { ok: false, reason: "stale-default" }
+  // Same contract as no-default: surface the recovery affordance, suppress generation.
+  describe("when the modal opens", () => {
     beforeEach(() => {
-      // Stale default: openai provider is disabled → getDefaultModelState returns { ok: false, reason: "stale-default" }
       mockProject = { id: "p1", slug: "proj", defaultModel: "openai/gpt-5.2" };
       mockHasEnabledProviders = true;
       mockProviders = { azure: { enabled: true }, openai: { enabled: false } };
@@ -623,54 +609,37 @@ describe("given azure is the only enabled provider and project.defaultModel is o
       });
     });
 
+    it("shows the Configure model provider footer button", () => {
+      render(
+        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(
+        within(dialog).getByTestId("model-provider-required-modal-configure-button")
+      ).toHaveAccessibleName("Configure model provider");
+    });
+
+    it("does not render the description textarea or Generate button", () => {
+      render(
+        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
+        { wrapper: Wrapper }
+      );
+
+      const dialog = getDialogContent();
+      expect(within(dialog).queryByRole("textbox")).not.toBeInTheDocument();
+      expect(within(dialog).queryByRole("button", { name: /generate with ai/i })).not.toBeInTheDocument();
+    });
+
     it("does not call generateScenarioWithAI", async () => {
       render(
         <ScenarioCreateModal open={true} onClose={vi.fn()} />,
         { wrapper: Wrapper }
       );
 
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test stale default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
       await waitFor(() => {
         expect(global.fetch).not.toHaveBeenCalled();
-      });
-    });
-
-    it("renders an error state with a message not containing API keys not configured", async () => {
-      render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test stale default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      // Wait for the error state to appear (any error), then assert on the message
-      await waitFor(() => {
-        expect(within(dialog).getByText(/something went wrong/i)).toBeInTheDocument();
-      });
-      // The error message must NOT be the misleading "API keys not configured" text
-      expect(within(dialog).queryByText(/api keys not configured/i)).not.toBeInTheDocument();
-    });
-
-    it("renders an error mentioning the provider is disabled", async () => {
-      render(
-        <ScenarioCreateModal open={true} onClose={vi.fn()} />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      const textarea = within(dialog).getByRole("textbox");
-      fireEvent.change(textarea, { target: { value: "Test stale default" } });
-      fireEvent.click(within(dialog).getByRole("button", { name: /generate with ai/i }));
-
-      await waitFor(() => {
-        expect(within(dialog).getByText(/provider.*disabled|disabled.*provider/i)).toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/scenarios/utils/__tests__/classifyGenerationError.test.ts
+++ b/langwatch/src/components/scenarios/utils/__tests__/classifyGenerationError.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { classifyGenerationError } from "../classifyGenerationError";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Minimal TRPCClientError-shaped object (without importing the real class). */
+function makeTrpcError(message: string, dataMessage?: string): Error & { data?: { message?: string } } {
+  const err = new Error(message) as Error & { data?: { message?: string } };
+  if (dataMessage !== undefined) {
+    err.data = { message: dataMessage };
+  }
+  return err;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("classifyGenerationError", () => {
+  // ── config tier ────────────────────────────────────────────────────────────
+
+  describe("given an error matching /no default model/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("No default model set for this project"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+      expect(result.copy).toContain("no default model");
+    });
+  });
+
+  describe("given an error matching /no.*provider/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("No provider found for this project"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  describe("given an error matching /provider.*not.*configured/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("Provider is not configured"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  describe("given an error matching /stale/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("Stale provider reference detected"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+      expect(result.copy).toContain("provider is disabled");
+    });
+  });
+
+  describe("given an error matching /provider.*disabled/", () => {
+    it("returns config tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("The provider has been disabled"));
+
+      expect(result.tier).toBe("config");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  // ── auth tier ──────────────────────────────────────────────────────────────
+
+  describe("given an Error with message matching /invalid api key/", () => {
+    it("returns auth tier with configure CTA", () => {
+      const result = classifyGenerationError(new Error("Invalid API key provided"));
+
+      expect(result.tier).toBe("auth");
+      expect(result.cta).toBe("configure");
+      expect(result.copy).toContain("API key");
+    });
+  });
+
+  describe("given an error matching /authentication/", () => {
+    it("returns auth tier", () => {
+      const result = classifyGenerationError(new Error("Authentication failed"));
+
+      expect(result.tier).toBe("auth");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  describe("given an error matching /unauthorized/", () => {
+    it("returns auth tier", () => {
+      const result = classifyGenerationError(new Error("401 Unauthorized"));
+
+      expect(result.tier).toBe("auth");
+      expect(result.cta).toBe("configure");
+    });
+  });
+
+  // ── rate-limit tier ────────────────────────────────────────────────────────
+
+  describe("given an error matching /rate limit/", () => {
+    it("returns rate-limit tier with configure-and-retry CTA", () => {
+      const result = classifyGenerationError(new Error("You have exceeded the rate limit"));
+
+      expect(result.tier).toBe("rate-limit");
+      expect(result.cta).toBe("configure-and-retry");
+    });
+  });
+
+  describe("given an error matching /quota/", () => {
+    it("returns rate-limit tier", () => {
+      const result = classifyGenerationError(new Error("Quota exceeded for this period"));
+
+      expect(result.tier).toBe("rate-limit");
+      expect(result.cta).toBe("configure-and-retry");
+    });
+  });
+
+  // ── timeout tier ───────────────────────────────────────────────────────────
+
+  describe("given an error matching /timeout/", () => {
+    it("returns timeout tier with retry CTA", () => {
+      const result = classifyGenerationError(new Error("The request timed out"));
+
+      expect(result.tier).toBe("timeout");
+      expect(result.cta).toBe("retry");
+    });
+  });
+
+  // ── unknown tier ───────────────────────────────────────────────────────────
+
+  describe("given an Error with an unrecognised message", () => {
+    it("returns unknown tier with retry-or-skip CTA and preserves raw message", () => {
+      const result = classifyGenerationError(new Error("Unexpected internal server error"));
+
+      expect(result.tier).toBe("unknown");
+      expect(result.cta).toBe("retry-or-skip");
+      if (result.tier === "unknown") {
+        expect(result.rawMessage).toBe("Unexpected internal server error");
+      }
+    });
+  });
+
+  // ── input shape variants ───────────────────────────────────────────────────
+
+  describe("given a TRPCClientError shape with data.message", () => {
+    it("extracts message from data.message", () => {
+      const err = makeTrpcError("Outer wrapper message", "Invalid API key from provider");
+      const result = classifyGenerationError(err);
+
+      // data.message takes priority — matches auth tier
+      expect(result.tier).toBe("auth");
+    });
+  });
+
+  describe("given a TRPCClientError shape without data.message", () => {
+    it("falls back to error.message", () => {
+      const err = makeTrpcError("Invalid API key from error.message");
+      const result = classifyGenerationError(err);
+
+      expect(result.tier).toBe("auth");
+    });
+  });
+
+  describe("given a plain string error", () => {
+    it("treats the string as the message", () => {
+      const result = classifyGenerationError("rate limit exceeded");
+
+      expect(result.tier).toBe("rate-limit");
+    });
+  });
+
+  describe("given an unknown non-Error value", () => {
+    it("returns unknown tier with string-coerced raw message", () => {
+      const result = classifyGenerationError({ code: 500 });
+
+      expect(result.tier).toBe("unknown");
+      if (result.tier === "unknown") {
+        expect(result.rawMessage).toBe("[object Object]");
+      }
+    });
+  });
+
+  describe("given case-insensitive matching", () => {
+    it("matches INVALID API KEY in upper case", () => {
+      const result = classifyGenerationError(new Error("INVALID API KEY"));
+
+      expect(result.tier).toBe("auth");
+    });
+  });
+});

--- a/langwatch/src/components/scenarios/utils/classifyGenerationError.ts
+++ b/langwatch/src/components/scenarios/utils/classifyGenerationError.ts
@@ -1,0 +1,115 @@
+/**
+ * Classifies a generation error into a tier with tailored copy and a recovery CTA.
+ *
+ * Tier-1: known error shapes → specific, actionable copy.
+ * Tier-2 (unknown): generic copy + raw backend message verbatim.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type GenerationErrorClass =
+  | { tier: "config"; cta: "configure"; copy: string }
+  | { tier: "auth"; cta: "configure"; copy: string }
+  | { tier: "rate-limit"; cta: "configure-and-retry"; copy: string }
+  | { tier: "timeout"; cta: "retry"; copy: string }
+  | { tier: "unknown"; cta: "retry-or-skip"; copy: string; rawMessage: string };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Message extraction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extracts a plain string message from an arbitrary unknown error value.
+ *
+ * Handles:
+ * - Error instances (including TRPCClientError, which extends Error)
+ * - Plain strings
+ * - Everything else via String()
+ */
+function extractMessage(error: unknown): string {
+  if (typeof error === "string") return error;
+
+  if (error instanceof Error) {
+    // TRPCClientError stores the server message in error.message already,
+    // but also exposes data.message on some shapes. Prefer data.message when present.
+    const trpcLike = error as Error & {
+      data?: { message?: string };
+    };
+    if (trpcLike.data?.message) {
+      return trpcLike.data.message;
+    }
+    return error.message;
+  }
+
+  return String(error);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classifier
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maps a generation error to a classified tier with tailored copy and a recovery CTA.
+ *
+ * Regex matching is performed case-insensitively against the extracted message string.
+ */
+export function classifyGenerationError(error: unknown): GenerationErrorClass {
+  const message = extractMessage(error);
+
+  if (/no default model/i.test(message)) {
+    return {
+      tier: "config",
+      cta: "configure",
+      copy: "Your project has no default model configured. Set one to continue.",
+    };
+  }
+
+  if (/no.*provider|provider.*not.*configured/i.test(message)) {
+    return {
+      tier: "config",
+      cta: "configure",
+      copy: "No model provider is configured. Add one to continue.",
+    };
+  }
+
+  if (/stale|provider.*disabled/i.test(message)) {
+    return {
+      tier: "config",
+      cta: "configure",
+      copy: "The configured default model's provider is disabled. Reconfigure to continue.",
+    };
+  }
+
+  if (/invalid api key|authentication|unauthorized/i.test(message)) {
+    return {
+      tier: "auth",
+      cta: "configure",
+      copy: "There was a problem reaching your model provider. Check your provider configuration and that your API key is correct.",
+    };
+  }
+
+  if (/rate limit|quota/i.test(message)) {
+    return {
+      tier: "rate-limit",
+      cta: "configure-and-retry",
+      copy: "Rate limit reached on your provider. Wait a moment or check your provider's usage settings.",
+    };
+  }
+
+  if (/timeout|timed out/i.test(message)) {
+    return {
+      tier: "timeout",
+      cta: "retry",
+      copy: "The generation request timed out. Try again — the backend may be slow.",
+    };
+  }
+
+  return {
+    tier: "unknown",
+    cta: "retry-or-skip",
+    copy: "Something went wrong while generating your scenario.",
+    rawMessage: message,
+  };
+}

--- a/langwatch/src/components/shared/AICreateModal.tsx
+++ b/langwatch/src/components/shared/AICreateModal.tsx
@@ -1,16 +1,17 @@
 import {
   Box,
   Button,
+  Code,
   HStack,
   Icon,
-  Link,
   Spinner,
   Text,
   Textarea,
   VStack,
 } from "@chakra-ui/react";
-import { AlertCircle, AlertTriangle, Sparkles } from "lucide-react";
+import { AlertCircle, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { classifyGenerationError } from "../scenarios/utils/classifyGenerationError";
 import { Dialog } from "../ui/dialog";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -39,8 +40,6 @@ export interface AICreateModalProps {
   onSkip: () => void;
   /** Text shown during generation (default: "Generating...") */
   generatingText?: string;
-  /** Whether model providers are configured (default: true) */
-  hasModelProviders?: boolean;
 }
 
 type ModalState = "idle" | "generating" | "error";
@@ -67,11 +66,10 @@ export function AICreateModal({
   onGenerate,
   onSkip,
   generatingText = DEFAULT_GENERATING_TEXT,
-  hasModelProviders = true,
 }: AICreateModalProps) {
   const [description, setDescription] = useState("");
   const [modalState, setModalState] = useState<ModalState>("idle");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [capturedError, setCapturedError] = useState<unknown>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Clear timeout on unmount or when state changes
@@ -88,7 +86,7 @@ export function AICreateModal({
     if (open) {
       setDescription("");
       setModalState("idle");
-      setErrorMessage("");
+      setCapturedError(null);
     }
   }, [open]);
 
@@ -112,7 +110,7 @@ export function AICreateModal({
 
     // Action is proceeding - show generating state
     setModalState("generating");
-    setErrorMessage("");
+    setCapturedError(null);
 
     // Set up timeout
     const timeoutPromise = new Promise<never>((_, reject) => {
@@ -124,10 +122,9 @@ export function AICreateModal({
     try {
       await Promise.race([generationPromise, timeoutPromise]);
     } catch (error) {
+      console.error("[AICreateModal] generation error:", error);
       setModalState("error");
-      setErrorMessage(
-        error instanceof Error ? error.message : "An unexpected error occurred"
-      );
+      setCapturedError(error);
     } finally {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -164,11 +161,7 @@ export function AICreateModal({
           <Dialog.Title>{title}</Dialog.Title>
         </Dialog.Header>
         <Dialog.Body>
-          {!hasModelProviders && (
-            <NoModelProvidersWarning />
-          )}
-
-          {hasModelProviders && modalState === "idle" && (
+          {modalState === "idle" && (
             <IdleState
               description={description}
               placeholder={placeholder}
@@ -178,18 +171,12 @@ export function AICreateModal({
             />
           )}
 
-          {hasModelProviders && modalState === "generating" && <GeneratingState text={generatingText} />}
+          {modalState === "generating" && <GeneratingState text={generatingText} />}
 
-          {hasModelProviders && modalState === "error" && (
-            <ErrorState errorMessage={errorMessage} />
-          )}
+          {modalState === "error" && <ErrorState error={capturedError} />}
         </Dialog.Body>
         <Dialog.Footer>
-          {!hasModelProviders && (
-            <NoModelProvidersFooter />
-          )}
-
-          {hasModelProviders && modalState === "idle" && (
+          {modalState === "idle" && (
             <IdleFooter
               onSkip={handleSkip}
               onGenerate={handleGenerate}
@@ -197,8 +184,12 @@ export function AICreateModal({
             />
           )}
 
-{hasModelProviders && modalState === "error" && (
-            <ErrorFooter onSkip={handleSkip} onTryAgain={handleTryAgain} />
+          {modalState === "error" && (
+            <ErrorFooter
+              error={capturedError}
+              onSkip={handleSkip}
+              onTryAgain={handleTryAgain}
+            />
           )}
         </Dialog.Footer>
       </Dialog.Content>
@@ -272,25 +263,36 @@ function GeneratingState({ text }: GeneratingStateProps) {
 }
 
 interface ErrorStateProps {
-  errorMessage: string;
+  error: unknown;
 }
 
-function ErrorState({ errorMessage }: ErrorStateProps) {
+function ErrorState({ error }: ErrorStateProps) {
+  const classified = classifyGenerationError(error);
+
   return (
     <VStack gap={4} py={4}>
-      <Box
-        p={3}
-        borderRadius="full"
-        bg="red.100"
-        color="red.600"
-      >
+      <Box p={3} borderRadius="full" bg="red.100" color="red.600">
         <Icon as={AlertCircle} boxSize={6} />
       </Box>
       <VStack gap={1}>
         <Text fontWeight="semibold">Something went wrong</Text>
         <Text color="fg.muted" fontSize="sm" textAlign="center">
-          {errorMessage}
+          {classified.copy}
         </Text>
+        {classified.tier === "unknown" && classified.rawMessage && (
+          <Code
+            fontSize="xs"
+            mt={2}
+            px={2}
+            py={1}
+            borderRadius="md"
+            whiteSpace="pre-wrap"
+            wordBreak="break-word"
+            maxW="100%"
+          >
+            {classified.rawMessage}
+          </Code>
+        )}
       </VStack>
     </VStack>
   );
@@ -321,66 +323,45 @@ function IdleFooter({ onSkip, onGenerate, isGenerateDisabled }: IdleFooterProps)
 }
 
 interface ErrorFooterProps {
+  error: unknown;
   onSkip: () => void;
   onTryAgain: () => void;
 }
 
-function ErrorFooter({ onSkip, onTryAgain }: ErrorFooterProps) {
+function ErrorFooter({ error, onSkip, onTryAgain }: ErrorFooterProps) {
+  const classified = classifyGenerationError(error);
+
+  const showConfigure =
+    classified.cta === "configure" || classified.cta === "configure-and-retry";
+  const showRetry =
+    classified.cta === "retry" ||
+    classified.cta === "configure-and-retry" ||
+    classified.cta === "retry-or-skip";
+
   return (
     <HStack gap={2} justify="flex-end">
       <Button variant="ghost" onClick={onSkip}>
         I'll write it myself
       </Button>
-      <Button colorPalette="blue" onClick={onTryAgain}>
-        Try again
-      </Button>
-    </HStack>
-  );
-}
-
-function NoModelProvidersWarning() {
-  return (
-    <VStack gap={4} py={8} align="center" justify="center">
-      <Box
-        p={3}
-        borderRadius="full"
-        bg="orange.100"
-        color="orange.600"
-      >
-        <Icon as={AlertTriangle} boxSize={6} />
-      </Box>
-      <VStack gap={1}>
-        <Text fontWeight="semibold">No model provider configured</Text>
-        <Text color="fg.muted" fontSize="sm" textAlign="center">
-          Scenarios require a model provider to run. Please configure one to get started.{" "}
-          <Link
+      {showConfigure && (
+        <Button colorPalette="blue" asChild>
+          <a
+            data-testid="error-configure-model-provider-button"
             href="/settings/model-providers"
             target="_blank"
             rel="noopener noreferrer"
-            color="blue.500"
-            fontWeight="medium"
+            style={{ color: "white" }}
           >
             Configure model provider
-          </Link>
-        </Text>
-      </VStack>
-    </VStack>
-  );
-}
-
-function NoModelProvidersFooter() {
-  return (
-    <HStack gap={2} justify="flex-end">
-      <Button colorPalette="blue" asChild>
-        <a
-          data-testid="ai-create-modal-configure-model-provider-button"
-          href="/settings/model-providers"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Configure model provider
-        </a>
-      </Button>
+          </a>
+        </Button>
+      )}
+      {showRetry && (
+        <Button colorPalette="blue" onClick={onTryAgain}>
+          Try again
+        </Button>
+      )}
     </HStack>
   );
 }
+

--- a/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
+++ b/langwatch/src/components/shared/__tests__/AICreateModal.test.tsx
@@ -606,206 +606,178 @@ describe("<AICreateModal/>", () => {
     });
   });
 
-  describe("when hasModelProviders is false", () => {
-    it("displays warning message", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
+  // ─────────────────────────────────────────────────────────────────────────
+  // Error classifier integration
+  // ─────────────────────────────────────────────────────────────────────────
 
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).getByText("No model provider configured")
-      ).toBeInTheDocument();
-    });
+  describe("given an auth-shape error", () => {
+    describe("when ErrorState renders", () => {
+      it("shows the Configure model provider button", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("Invalid API key provided by the provider"));
 
-    it("does not render textarea", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(within(dialog).queryByRole("textbox")).not.toBeInTheDocument();
-    });
-
-    it("does not render Generate with AI button", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).queryByRole("button", { name: /generate with ai/i })
-      ).not.toBeInTheDocument();
-    });
-
-    it("does not render example template pills", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(within(dialog).queryByText("Customer Support")).not.toBeInTheDocument();
-      expect(within(dialog).queryByText("RAG Q&A")).not.toBeInTheDocument();
-      expect(within(dialog).queryByText("Tool-calling Agent")).not.toBeInTheDocument();
-    });
-
-    it("does not render I'll write it myself button", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).queryByRole("button", { name: /i'll write it myself/i })
-      ).not.toBeInTheDocument();
-    });
-
-    it("renders link to model provider settings", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={false}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      // Filter out the footer CTA by its test id so we assert the inline body
-      // link regardless of DOM order.
-      const links = within(dialog).getAllByRole("link", { name: /model provider/i });
-      const inlineLinks = links.filter(
-        (link) =>
-          link.getAttribute("data-testid") !==
-          "ai-create-modal-configure-model-provider-button",
-      );
-      expect(inlineLinks).toHaveLength(1);
-      expect(inlineLinks[0]).toHaveAttribute("href", "/settings/model-providers");
-    });
-
-    describe("footer Configure model provider button", () => {
-      function getFooterConfigureButton(dialog: HTMLElement) {
-        return within(dialog).getByTestId(
-          "ai-create-modal-configure-model-provider-button",
-        );
-      }
-
-      it("shows primary Configure model provider button in footer", () => {
         render(
           <AICreateModal
             open={true}
             onClose={vi.fn()}
             title="Create new scenario"
             exampleTemplates={defaultExampleTemplates}
-            onGenerate={vi.fn()}
+            onGenerate={onGenerate}
             onSkip={vi.fn()}
-            hasModelProviders={false}
           />,
           { wrapper: Wrapper }
         );
 
         const dialog = getDialogContent();
-        const button = getFooterConfigureButton(dialog);
-        expect(button).toBeInTheDocument();
-        expect(button).toHaveAccessibleName("Configure model provider");
-        expect(button).toHaveAttribute("href", "/settings/model-providers");
-        expect(button).toHaveAttribute("target", "_blank");
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          expect(
+            within(dialog).getByTestId("error-configure-model-provider-button")
+          ).toBeInTheDocument();
+        });
       });
 
-      it("footer button uses rel noopener noreferrer", () => {
+      it("shows tailored copy about API key", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("Invalid API key provided"));
+
         render(
           <AICreateModal
             open={true}
             onClose={vi.fn()}
             title="Create new scenario"
             exampleTemplates={defaultExampleTemplates}
-            onGenerate={vi.fn()}
+            onGenerate={onGenerate}
             onSkip={vi.fn()}
-            hasModelProviders={false}
           />,
           { wrapper: Wrapper }
         );
 
         const dialog = getDialogContent();
-        const button = getFooterConfigureButton(dialog);
-        const rel = button.getAttribute("rel") ?? "";
-        expect(rel).toContain("noopener");
-        expect(rel).toContain("noreferrer");
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          expect(within(dialog).getByText(/api key/i)).toBeInTheDocument();
+        });
       });
     });
-
   });
 
-  describe("when hasModelProviders is true", () => {
-    it("does not display warning message", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={true}
-        />,
-        { wrapper: Wrapper }
-      );
+  describe("given an unknown error", () => {
+    describe("when ErrorState renders", () => {
+      it("shows the raw error message verbatim", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("Completely unexpected server meltdown 42"));
 
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).queryByText(/no model provider/i)
-      ).not.toBeInTheDocument();
+        render(
+          <AICreateModal
+            open={true}
+            onClose={vi.fn()}
+            title="Create new scenario"
+            exampleTemplates={defaultExampleTemplates}
+            onGenerate={onGenerate}
+            onSkip={vi.fn()}
+          />,
+          { wrapper: Wrapper }
+        );
+
+        const dialog = getDialogContent();
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          expect(
+            within(dialog).getByText("Completely unexpected server meltdown 42")
+          ).toBeInTheDocument();
+        });
+      });
+
+      it("does not show Configure model provider button", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("Completely unexpected server meltdown 42"));
+
+        render(
+          <AICreateModal
+            open={true}
+            onClose={vi.fn()}
+            title="Create new scenario"
+            exampleTemplates={defaultExampleTemplates}
+            onGenerate={onGenerate}
+            onSkip={vi.fn()}
+          />,
+          { wrapper: Wrapper }
+        );
+
+        const dialog = getDialogContent();
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          expect(
+            within(dialog).queryByTestId("error-configure-model-provider-button")
+          ).not.toBeInTheDocument();
+        });
+      });
     });
+  });
 
+  describe("given a config-shape error", () => {
+    describe("when Configure is clicked", () => {
+      it("links to settings/model-providers in a new tab", async () => {
+        const onGenerate = vi
+          .fn()
+          .mockRejectedValue(new Error("No default model configured for this project"));
+
+        render(
+          <AICreateModal
+            open={true}
+            onClose={vi.fn()}
+            title="Create new scenario"
+            exampleTemplates={defaultExampleTemplates}
+            onGenerate={onGenerate}
+            onSkip={vi.fn()}
+          />,
+          { wrapper: Wrapper }
+        );
+
+        const dialog = getDialogContent();
+        const textarea = within(dialog).getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Test description" } });
+        fireEvent.click(
+          within(dialog).getByRole("button", { name: /generate with ai/i })
+        );
+
+        await waitFor(() => {
+          const configureBtn = within(dialog).getByTestId(
+            "error-configure-model-provider-button"
+          );
+          expect(configureBtn).toHaveAttribute("href", "/settings/model-providers");
+          expect(configureBtn).toHaveAttribute("target", "_blank");
+        });
+      });
+    });
+  });
+
+  describe("when rendered with default props", () => {
     it("renders textarea", () => {
       render(
         <AICreateModal
@@ -815,7 +787,6 @@ describe("<AICreateModal/>", () => {
           exampleTemplates={defaultExampleTemplates}
           onGenerate={vi.fn()}
           onSkip={vi.fn()}
-          hasModelProviders={true}
         />,
         { wrapper: Wrapper }
       );
@@ -833,7 +804,6 @@ describe("<AICreateModal/>", () => {
           exampleTemplates={defaultExampleTemplates}
           onGenerate={vi.fn()}
           onSkip={vi.fn()}
-          hasModelProviders={true}
         />,
         { wrapper: Wrapper }
       );
@@ -853,7 +823,6 @@ describe("<AICreateModal/>", () => {
           exampleTemplates={defaultExampleTemplates}
           onGenerate={vi.fn()}
           onSkip={vi.fn()}
-          hasModelProviders={true}
         />,
         { wrapper: Wrapper }
       );
@@ -862,28 +831,6 @@ describe("<AICreateModal/>", () => {
       expect(within(dialog).getByText("Customer Support")).toBeInTheDocument();
       expect(within(dialog).getByText("RAG Q&A")).toBeInTheDocument();
       expect(within(dialog).getByText("Tool-calling Agent")).toBeInTheDocument();
-    });
-
-    it("does not show Configure model provider button in footer", () => {
-      render(
-        <AICreateModal
-          open={true}
-          onClose={vi.fn()}
-          title="Create new scenario"
-          exampleTemplates={defaultExampleTemplates}
-          onGenerate={vi.fn()}
-          onSkip={vi.fn()}
-          hasModelProviders={true}
-        />,
-        { wrapper: Wrapper }
-      );
-
-      const dialog = getDialogContent();
-      expect(
-        within(dialog).queryByTestId(
-          "ai-create-modal-configure-model-provider-button",
-        )
-      ).not.toBeInTheDocument();
     });
   });
 });

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -56,7 +56,12 @@ export const useOrganizationTeamProject = (
     { isDemo: isDemo },
     {
       enabled: !!session.data || !isPublicRoute,
-      staleTime: keepFetching ? undefined : Infinity,
+      // Small reference query that drives load-bearing client state (current
+      // project incl. defaultModel). Cheap to refetch — prefer freshness over
+      // a "cache forever" default. Background refetch on focus picks up edits
+      // made via SDK, API, or another tab.
+      staleTime: keepFetching ? 0 : 30_000,
+      refetchOnWindowFocus: true,
       refetchInterval: keepFetching ? 5_000 : undefined,
     },
   );

--- a/langwatch/src/hooks/usePublicEnv.ts
+++ b/langwatch/src/hooks/usePublicEnv.ts
@@ -4,6 +4,8 @@ export const usePublicEnv = () => {
   return api.publicEnv.useQuery(
     {},
     {
+      // Server env vars don't change while the app is open — caching forever
+      // is correct. Server restart gives the user a new bundle anyway.
       staleTime: Infinity,
       refetchOnMount: false,
       refetchOnWindowFocus: false,

--- a/langwatch/src/optimization_studio/hooks/useLoadWorkflow.ts
+++ b/langwatch/src/optimization_studio/hooks/useLoadWorkflow.ts
@@ -11,7 +11,13 @@ export const useLoadWorkflow = () => {
   const { project } = useOrganizationTeamProject();
   const workflow = api.workflow.getById.useQuery(
     { workflowId: workflowId ?? "", projectId: project?.id ?? "" },
-    { enabled: !!project && !!workflowId, staleTime: Infinity },
+    {
+      enabled: !!project && !!workflowId,
+      // One-shot bootstrap for the studio editor. The result feeds the
+      // Zustand workflow store and AutoSave writes back from there — a
+      // background refetch would clobber unsaved edits.
+      staleTime: Infinity,
+    },
   );
 
   return { workflow };


### PR DESCRIPTION
## Summary

Split 1 of 5 from umbrella **#3526** / draft PR **#3529**. Cherry-picks the entry-path UX subset (**F1**, **F4**, **F5**) into a focused PR for review. Code already validated end-to-end in the umbrella; this PR is for review-sized review.

Closes #3530.

## What's in here

### F1 — Modal dead-end fix
- New `ModelProviderRequiredModal` with secondary **Proceed anyway** + primary **Configure model provider** (links to `/settings/model-providers`, `target=_blank`).
- `ScenarioCreateModal` renders the new modal up-front when `defaultModelState.ok === false` (covers `no-providers`, `no-default`, `stale-default`) instead of letting the user click Generate and hit a misleading error.
- `AICreateModal`: dropped `hasModelProviders` prop and `NoModelProvidersWarning` / `NoModelProvidersFooter` subcomponents — the gate now lives one level up where it belongs.

### F4 — `useOrganizationTeamProject` cache fix
- Replaced `staleTime: Infinity` with `staleTime: 30_000` + `refetchOnWindowFocus: true` so cross-tab / SDK mutations to `project` (including `defaultModel`) surface on focus instead of being permanently cached.
- Audited 5 other `Infinity` callsites — left as-is, each with a one-line justification:
  - `IntegrationChecks.tsx` — onboarding checklist; `refetchOnWindowFocus` already picks up out-of-band changes.
  - `TraceMessage.tsx` — traces are immutable once written; cache forever is correct.
  - `useInitialLoadExperiment.ts` / `useLoadWorkflow.ts` — one-shot Zustand bootstraps; a background refetch would clobber unsaved edits.
  - `usePublicEnv.ts` — server env vars don't change while the app is open.

### F5 — Error UX
- New `classifyGenerationError` util maps backend errors → tier-1 known classes (`config` / `auth` / `rate-limit` / `timeout`) with tailored copy + CTA.
- Unknown errors render the raw backend message verbatim (no more "Something went wrong" + stale frontend pre-flight string).
- Config-shape errors surface a primary **Configure model provider** button alongside Try again.
- Frontend `console.error`s the raw error; backend already logs the original.

## Out of scope (intentional)

- **F2** server-side `getResolvedDefaultModel` resolver (split 2). `ScenarioCreateModal` still reads `project.defaultModel` directly; the resolved-default tRPC consumer call lands in split 2. **Partial-file overlap** on `ScenarioCreateModal.tsx` between split 1 and split 2 is intentional, not a conflict — the gate logic and the tRPC consumer are independent concerns.
- **F3** provider drawer save-flow (separate split).
- **F6** / **F8** scenario editor data-loss (separate split).
- **F10** env-contract sweep (separate split).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] Targeted vitest passes:
  - `langwatch/src/components/scenarios/utils/__tests__/classifyGenerationError.test.ts`
  - `langwatch/src/components/scenarios/__tests__/ScenarioCreateModal.test.tsx`
  - `langwatch/src/components/shared/__tests__/AICreateModal.test.tsx`
- [ ] Manual smoke before un-drafting:
  - [ ] No-providers project → ModelProviderRequiredModal appears, Configure CTA opens settings in new tab, Proceed anyway opens the editor with empty form.
  - [ ] Stale-default project → same modal.
  - [ ] Happy path with valid default model → AI form unchanged.
  - [ ] Cross-tab: edit `project.defaultModel` from tab B; tab A picks up the change on focus (≤30s).
  - [ ] Trigger a generation error (e.g. invalid API key) → ErrorState surfaces the configure CTA + tailored copy; unknown errors show raw message verbatim.

## Notes for review

- The umbrella's test file had two unrelated stale assertions that referenced the pre-split copy and one regex that didn't match the test message ("timed out" vs `/timeout/`). Updated to match new behavior + extended the timeout regex to also match "timed out" (real-world phrasing); no new tests added.
- After cherry-pick, ran `pnpm start:prepare:files` to regenerate Prisma + generated types; pre-existing typecheck noise on `main` (Prisma agent / `types.generated`) clears once those files are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3530