### PR TITLE
fix(env): telemetry routing via LANGWATCH_ENDPOINT, drop localhost fallbacks

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -176,6 +176,8 @@ jobs:
       CLICKHOUSE_URL: "http://default:ci_password@localhost:8123/test_langwatch"
       CI_REDIS_URL: "redis://localhost:6379"
       CI_CLICKHOUSE_URL: "http://default:ci_password@localhost:8123/test_langwatch"
+      LANGWATCH_NLP_SERVICE: "http://localhost:5561"
+      LANGWATCH_ENDPOINT: "http://localhost:3000"
       BUILD_TIME: "true"
       CI: "true"
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -391,7 +391,6 @@ services:
       - "${AI_SERVER_PORT:-3456}:3456"
     environment:
       <<: *common-env
-      LANGWATCH_ENDPOINT: "http://app:5560/"
       # LANGWATCH_API_KEY comes from langwatch/.env via env_file below
       PINO_CONSOLE_LEVEL: "debug"
       LOG_LEVEL: "debug"

--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -108,6 +108,10 @@ REDIS_URL=""
 # LangWatch NLP service powers the optimization studio, topic clustering and sentiment analysis
 LANGWATCH_NLP_SERVICE="http://localhost:5561"
 
+# Internal service-to-service URL the worker uses to POST telemetry back to the app.
+# In Docker compose this is overridden to http://app:5560 by write-dev-overrides.sh.
+LANGWATCH_ENDPOINT="http://localhost:5560"
+
 # LangEvals powers LangWatch evaluators and guardrails: https://github.com/langwatch/langevals/
 LANGEVALS_ENDPOINT="http://localhost:5562"
 

--- a/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
+++ b/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { platformUrl } from "../platform-url";
 
-// Mutable env object so individual tests can override BASE_HOST
-const mockEnv = { BASE_HOST: "https://app.langwatch.ai" as string | undefined };
+// vi.mock factories are hoisted above top-level declarations, so the
+// mutable env object must be created via vi.hoisted to be available
+// when the mock factory runs.
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: { BASE_HOST: "https://app.langwatch.ai" as string | undefined },
+}));
 
 vi.mock("~/env.mjs", () => ({ env: mockEnv }));
 

--- a/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
+++ b/langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts
@@ -1,18 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { platformUrl } from "../platform-url";
 
-describe("platformUrl", () => {
-  const originalEnv = process.env.BASE_HOST;
+// Mutable env object so individual tests can override BASE_HOST
+const mockEnv = { BASE_HOST: "https://app.langwatch.ai" as string | undefined };
 
-  afterEach(() => {
-    process.env.BASE_HOST = originalEnv;
+vi.mock("~/env.mjs", () => ({ env: mockEnv }));
+
+describe("platformUrl", () => {
+  beforeEach(() => {
+    mockEnv.BASE_HOST = "https://app.langwatch.ai";
   });
 
   describe("when BASE_HOST is set", () => {
-    beforeEach(() => {
-      process.env.BASE_HOST = "https://app.langwatch.ai";
-    });
-
     it("builds a direct page URL", () => {
       expect(
         platformUrl({ projectSlug: "my-project", path: "/datasets/ds_123" })
@@ -31,7 +30,7 @@ describe("platformUrl", () => {
     });
 
     it("strips trailing slash from BASE_HOST", () => {
-      process.env.BASE_HOST = "https://app.langwatch.ai/";
+      mockEnv.BASE_HOST = "https://app.langwatch.ai/";
       expect(
         platformUrl({ projectSlug: "test", path: "/datasets/ds_1" })
       ).toBe("https://app.langwatch.ai/test/datasets/ds_1");
@@ -40,21 +39,17 @@ describe("platformUrl", () => {
 
   describe("when BASE_HOST is not set", () => {
     beforeEach(() => {
-      delete process.env.BASE_HOST;
+      mockEnv.BASE_HOST = undefined;
     });
 
-    it("falls back to localhost:5560", () => {
+    it("returns a URL with empty base", () => {
       expect(
         platformUrl({ projectSlug: "demo", path: "/agents" })
-      ).toBe("http://localhost:5560/demo/agents");
+      ).toBe("/demo/agents");
     });
   });
 
   describe("resource URL patterns", () => {
-    beforeEach(() => {
-      process.env.BASE_HOST = "https://app.langwatch.ai";
-    });
-
     it("generates correct dataset page URL", () => {
       const url = platformUrl({ projectSlug: "p", path: "/datasets/ds_abc" });
       expect(url).toContain("/p/datasets/ds_abc");

--- a/langwatch/src/app/api/shared/platform-url.ts
+++ b/langwatch/src/app/api/shared/platform-url.ts
@@ -1,3 +1,5 @@
+import { env } from "~/env.mjs";
+
 /**
  * Builds a full platform URL for a resource so API consumers can link
  * directly to it in the LangWatch UI.
@@ -14,7 +16,7 @@ export function platformUrl({
   projectSlug: string;
   path: string;
 }): string {
-  const base = (process.env.BASE_HOST ?? "http://localhost:5560").replace(
+  const base = (env.BASE_HOST ?? "").replace(
     /\/+$/,
     "",
   );

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -117,7 +117,6 @@ export function createEnvConfig() {
       SENDGRID_API_KEY: z.string().optional(),
       LANGWATCH_NLP_SERVICE: optionalIfBuildTime(z.string().url()),
       LANGWATCH_ENDPOINT: optionalIfBuildTime(z.string().url()),
-      TOPIC_CLUSTERING_SERVICE: z.string().optional(),
       LANGEVALS_ENDPOINT: z.string().optional(),
       // S3 staging for outbound langevals POSTs is opt-in: only relevant
       // when langevals is fronted by AWS Lambda (6 MB sync-invoke cap).
@@ -316,10 +315,6 @@ export function createEnvConfig() {
       SENDGRID_API_KEY: process.env.SENDGRID_API_KEY,
       LANGWATCH_NLP_SERVICE: process.env.LANGWATCH_NLP_SERVICE,
       LANGWATCH_ENDPOINT: process.env.LANGWATCH_ENDPOINT,
-      // Temporary, ideally we want to move this to lambda too
-      TOPIC_CLUSTERING_SERVICE: process.env.TOPIC_CLUSTERING_SERVICE
-        ? process.env.TOPIC_CLUSTERING_SERVICE
-        : process.env.LANGWATCH_NLP_SERVICE,
       LANGEVALS_ENDPOINT: process.env.LANGEVALS_ENDPOINT,
       LANGEVALS_STAGING_THRESHOLD_BYTES: process.env.LANGEVALS_STAGING_THRESHOLD_BYTES,
       LANGEVALS_STAGING_TTL_SECONDS: process.env.LANGEVALS_STAGING_TTL_SECONDS,

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -115,7 +115,9 @@ export function createEnvConfig() {
       AZURE_OPENAI_KEY: z.string().optional(),
       OPENAI_API_KEY: z.string().optional(),
       SENDGRID_API_KEY: z.string().optional(),
-      LANGWATCH_NLP_SERVICE: z.string().optional(),
+      LANGWATCH_NLP_SERVICE: optionalIfBuildTime(z.string().url()),
+      LANGWATCH_ENDPOINT: optionalIfBuildTime(z.string().url()),
+      TOPIC_CLUSTERING_SERVICE: z.string().optional(),
       LANGEVALS_ENDPOINT: z.string().optional(),
       // S3 staging for outbound langevals POSTs is opt-in: only relevant
       // when langevals is fronted by AWS Lambda (6 MB sync-invoke cap).
@@ -313,6 +315,11 @@ export function createEnvConfig() {
       OPENAI_API_KEY: process.env.OPENAI_API_KEY,
       SENDGRID_API_KEY: process.env.SENDGRID_API_KEY,
       LANGWATCH_NLP_SERVICE: process.env.LANGWATCH_NLP_SERVICE,
+      LANGWATCH_ENDPOINT: process.env.LANGWATCH_ENDPOINT,
+      // Temporary, ideally we want to move this to lambda too
+      TOPIC_CLUSTERING_SERVICE: process.env.TOPIC_CLUSTERING_SERVICE
+        ? process.env.TOPIC_CLUSTERING_SERVICE
+        : process.env.LANGWATCH_NLP_SERVICE,
       LANGEVALS_ENDPOINT: process.env.LANGEVALS_ENDPOINT,
       LANGEVALS_STAGING_THRESHOLD_BYTES: process.env.LANGEVALS_STAGING_THRESHOLD_BYTES,
       LANGEVALS_STAGING_TTL_SECONDS: process.env.LANGEVALS_STAGING_TTL_SECONDS,

--- a/langwatch/src/server/experiments-v3/execution/__tests__/orchestrator.integration.test.ts
+++ b/langwatch/src/server/experiments-v3/execution/__tests__/orchestrator.integration.test.ts
@@ -25,8 +25,10 @@ import type { EvaluationV3Event, ExecutionScope } from "../types";
  * - Redis available (for abort flags)
  * - Database available for test project
  */
-// Skip when NLP service isn't available (CI or prisma-integration tests)
-const hasNlpService = !!process.env.LANGWATCH_NLP_SERVICE;
+// Skip when NLP service or OpenAI key isn't available (CI or prisma-integration tests)
+// Both are required: NLP service processes requests, OpenAI key enables the model provider.
+const hasNlpService =
+  !!process.env.LANGWATCH_NLP_SERVICE && !!process.env.OPENAI_API_KEY;
 
 describe.skipIf(!hasNlpService)("Orchestrator Integration", () => {
   let project: Project;

--- a/langwatch/src/server/experiments-v3/execution/__tests__/workflowExecution.integration.test.ts
+++ b/langwatch/src/server/experiments-v3/execution/__tests__/workflowExecution.integration.test.ts
@@ -21,8 +21,10 @@ import { buildCellWorkflow } from "../workflowBuilder";
  * - OPENAI_API_KEY in environment
  * - Database available for test project
  */
-// Skip when NLP service isn't available (CI or prisma-integration tests)
-const hasNlpService = !!process.env.LANGWATCH_NLP_SERVICE;
+// Skip when NLP service or OpenAI key isn't available (CI or prisma-integration tests)
+// Both are required: NLP service processes requests, OpenAI key enables the model provider.
+const hasNlpService =
+  !!process.env.LANGWATCH_NLP_SERVICE && !!process.env.OPENAI_API_KEY;
 
 describe.skipIf(!hasNlpService)("WorkflowExecution Integration", () => {
   let project: Project;

--- a/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
@@ -28,8 +28,9 @@ import type { ExecutionContext, TargetConfig, LiteLLMParams } from "../types";
 // Mock only env.mjs since it's a module-level import
 vi.mock("~/env.mjs", () => ({
   env: {
-    LANGWATCH_NLP_SERVICE: "http://localhost:8080",
-    BASE_HOST: "http://localhost:3000",
+    LANGWATCH_NLP_SERVICE: "http://langwatch_nlp:5561",
+    LANGWATCH_ENDPOINT: "http://app:5560",
+    // BASE_HOST no longer needed — telemetry endpoint comes from LANGWATCH_ENDPOINT
   },
 }));
 
@@ -686,42 +687,30 @@ describe("prefetchScenarioData", () => {
       describe("when prefetching scenario data", () => {
         /** @scenario "Return success with LiteLLM params on valid configuration" */
         it("returns success with complete data", async () => {
-          // The source reads process.env.LANGWATCH_ENDPOINT directly (not via env.mjs)
-          const previousLangwatchEndpoint = process.env.LANGWATCH_ENDPOINT;
-          process.env.LANGWATCH_ENDPOINT = "http://localhost:3000";
+          const deps = createMockDeps({
+            promptFetcher: {
+              getPromptByIdOrHandle: vi.fn().mockResolvedValue(promptWithModel),
+            },
+          });
 
-          try {
-            const deps = createMockDeps({
-              promptFetcher: {
-                getPromptByIdOrHandle: vi.fn().mockResolvedValue(promptWithModel),
-              },
+          const target: TargetConfig = { type: "prompt", referenceId: "prompt_123" };
+          const result = await prefetchScenarioData(defaultContext, target, deps);
+
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(result.data.context).toEqual(defaultContext);
+            expect(result.data.scenario).toEqual(defaultScenario);
+            expect(result.data.adapterData).toMatchObject({
+              type: "prompt",
+              promptId: "prompt_123",
+              systemPrompt: "You are helpful",
             });
-
-            const target: TargetConfig = { type: "prompt", referenceId: "prompt_123" };
-            const result = await prefetchScenarioData(defaultContext, target, deps);
-
-            expect(result.success).toBe(true);
-            if (result.success) {
-              expect(result.data.context).toEqual(defaultContext);
-              expect(result.data.scenario).toEqual(defaultScenario);
-              expect(result.data.adapterData).toMatchObject({
-                type: "prompt",
-                promptId: "prompt_123",
-                systemPrompt: "You are helpful",
-              });
-              expect(result.data.modelParams).toEqual(defaultModelParams);
-              expect(result.data.target).toEqual({ type: "prompt", referenceId: "prompt_123" });
-              expect(result.telemetry).toEqual({
-                endpoint: "http://localhost:3000",
-                apiKey: "test-api-key",
-              });
-            }
-          } finally {
-            if (previousLangwatchEndpoint === undefined) {
-              delete process.env.LANGWATCH_ENDPOINT;
-            } else {
-              process.env.LANGWATCH_ENDPOINT = previousLangwatchEndpoint;
-            }
+            expect(result.data.modelParams).toEqual(defaultModelParams);
+            expect(result.data.target).toEqual({ type: "prompt", referenceId: "prompt_123" });
+            expect(result.telemetry).toEqual({
+              endpoint: "http://app:5560",
+              apiKey: "test-api-key",
+            });
           }
         });
       });

--- a/langwatch/src/server/scenarios/execution/data-prefetcher.ts
+++ b/langwatch/src/server/scenarios/execution/data-prefetcher.ts
@@ -335,11 +335,11 @@ export async function prefetchScenarioData(
       modelParams: modelParamsResult.params,
       simulatorModelParams: simulatorParamsResult.params,
       judgeModelParams: judgeParamsResult.params,
-      nlpServiceUrl: env.LANGWATCH_NLP_SERVICE ?? "",
+      nlpServiceUrl: env.LANGWATCH_NLP_SERVICE,
       target,
     },
     telemetry: {
-      endpoint: env.LANGWATCH_ENDPOINT ?? "",
+      endpoint: env.LANGWATCH_ENDPOINT,
       apiKey: project.apiKey,
     },
   };

--- a/langwatch/src/server/scenarios/execution/data-prefetcher.ts
+++ b/langwatch/src/server/scenarios/execution/data-prefetcher.ts
@@ -335,11 +335,11 @@ export async function prefetchScenarioData(
       modelParams: modelParamsResult.params,
       simulatorModelParams: simulatorParamsResult.params,
       judgeModelParams: judgeParamsResult.params,
-      nlpServiceUrl: env.LANGWATCH_NLP_SERVICE ?? "http://localhost:8080",
+      nlpServiceUrl: env.LANGWATCH_NLP_SERVICE ?? "",
       target,
     },
     telemetry: {
-      endpoint: process.env.LANGWATCH_ENDPOINT!,
+      endpoint: env.LANGWATCH_ENDPOINT ?? "",
       apiKey: project.apiKey,
     },
   };

--- a/langwatch/src/server/scenarios/execution/scenario-child-process.ts
+++ b/langwatch/src/server/scenarios/execution/scenario-child-process.ts
@@ -13,7 +13,7 @@
  *
  * OTEL isolation is achieved by:
  * 1. Parent injects LANGWATCH_API_KEY (project.apiKey) and LANGWATCH_ENDPOINT
- *    (BASE_HOST) as env vars via buildChildProcessEnv in scenario.processor.ts
+ *    as env vars via buildChildProcessEnv in scenario.processor.ts
  * 2. This process imports @langwatch/scenario which calls setupObservability()
  *    at module load time, reading from those env vars
  * 3. Each child process gets its own OTEL TracerProvider
@@ -100,10 +100,14 @@ async function executeScenario(jobData: ChildProcessJobData): Promise<void> {
   } = jobData;
 
   // These are injected as env vars by the parent process (scenario.processor.ts
-  // buildChildProcessEnv). They originate from prefetchScenarioData telemetry:
-  // endpoint = BASE_HOST, apiKey = project.apiKey.
-  const langwatchEndpoint = process.env.LANGWATCH_ENDPOINT ?? "";
-  const langwatchApiKey = process.env.LANGWATCH_API_KEY ?? "";
+  // buildChildProcessEnv). They originate from prefetchScenarioData telemetry.
+  const langwatchEndpoint = process.env.LANGWATCH_ENDPOINT;
+  const langwatchApiKey = process.env.LANGWATCH_API_KEY;
+  if (!langwatchEndpoint || !langwatchApiKey) {
+    throw new Error(
+      "LANGWATCH_ENDPOINT and LANGWATCH_API_KEY must be set in child process env",
+    );
+  }
 
   const adapter = createAdapter({
     adapterData,

--- a/langwatch/src/server/scenarios/execution/scenario-child-process.ts
+++ b/langwatch/src/server/scenarios/execution/scenario-child-process.ts
@@ -12,7 +12,8 @@
  * a non-zero exit code.
  *
  * OTEL isolation is achieved by:
- * 1. Parent sets LANGWATCH_API_KEY and LANGWATCH_ENDPOINT env vars
+ * 1. Parent injects LANGWATCH_API_KEY (project.apiKey) and LANGWATCH_ENDPOINT
+ *    (BASE_HOST) as env vars via buildChildProcessEnv in scenario.processor.ts
  * 2. This process imports @langwatch/scenario which calls setupObservability()
  *    at module load time, reading from those env vars
  * 3. Each child process gets its own OTEL TracerProvider
@@ -98,14 +99,11 @@ async function executeScenario(jobData: ChildProcessJobData): Promise<void> {
     target,
   } = jobData;
 
-  const langwatchEndpoint = process.env.LANGWATCH_ENDPOINT;
-  const langwatchApiKey = process.env.LANGWATCH_API_KEY;
-  if (!langwatchEndpoint) {
-    throw new Error("LANGWATCH_ENDPOINT env var is required but not set");
-  }
-  if (!langwatchApiKey) {
-    throw new Error("LANGWATCH_API_KEY env var is required but not set");
-  }
+  // These are injected as env vars by the parent process (scenario.processor.ts
+  // buildChildProcessEnv). They originate from prefetchScenarioData telemetry:
+  // endpoint = BASE_HOST, apiKey = project.apiKey.
+  const langwatchEndpoint = process.env.LANGWATCH_ENDPOINT ?? "";
+  const langwatchApiKey = process.env.LANGWATCH_API_KEY ?? "";
 
   const adapter = createAdapter({
     adapterData,

--- a/langwatch/src/server/scenarios/simulation-runner.service.ts
+++ b/langwatch/src/server/scenarios/simulation-runner.service.ts
@@ -116,7 +116,7 @@ export class SimulationRunnerService {
 
       // For HTTP targets, use remote span judge to collect spans from the
       // user's agent. For other targets, use standard in-process judge.
-      const langwatchEndpoint = env.LANGWATCH_ENDPOINT ?? "";
+      const langwatchEndpoint = env.LANGWATCH_ENDPOINT;
       let remoteSpanJudge: RemoteSpanJudgeAgent | undefined;
       const judgeAgentInstance =
         target.type === "http"

--- a/langwatch/src/server/scenarios/simulation-runner.service.ts
+++ b/langwatch/src/server/scenarios/simulation-runner.service.ts
@@ -116,7 +116,7 @@ export class SimulationRunnerService {
 
       // For HTTP targets, use remote span judge to collect spans from the
       // user's agent. For other targets, use standard in-process judge.
-      const langwatchEndpoint = this.getLangWatchEndpoint();
+      const langwatchEndpoint = env.LANGWATCH_ENDPOINT ?? "";
       let remoteSpanJudge: RemoteSpanJudgeAgent | undefined;
       const judgeAgentInstance =
         target.type === "http"
@@ -180,14 +180,6 @@ export class SimulationRunnerService {
         "Scenario execution failed",
       );
     }
-  }
-
-  private getLangWatchEndpoint(): string {
-    const endpoint = process.env.LANGWATCH_ENDPOINT;
-    if (!endpoint) {
-      throw new Error("LANGWATCH_ENDPOINT env var is required but not set");
-    }
-    return endpoint;
   }
 
   private resolveAdapter(

--- a/scripts/lib/write-dev-overrides.sh
+++ b/scripts/lib/write-dev-overrides.sh
@@ -112,6 +112,7 @@ EOF
 DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
 REDIS_URL=redis://redis:6379
 CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch
+LANGWATCH_ENDPOINT=http://app:5560
 EOF
 
   # NLP / langevals overrides depend on which containers actually start.


### PR DESCRIPTION
## Summary

Split 5 of 5 from umbrella #3526 / draft PR #3529. Pulls in only the env-contract subset for focused review.

- Introduce dedicated `LANGWATCH_ENDPOINT` compose contract for the docker-internal worker→app URL (was being smuggled via `BASE_HOST`)
- `BASE_HOST` reverts to its real meaning — user-facing origin
- Promote `LANGWATCH_ENDPOINT` and `LANGWATCH_NLP_SERVICE` to required `url()` server-side env vars (validated at boot, optional only during `BUILD_TIME=true`)
- Drop `?? "http://localhost..."` fallbacks from production server code; env config (compose + .env) owns dev defaults, no code-side guesses

User-facing public-domain fallbacks (`?? "https://app.langwatch.ai"` in MCP / license / email) are intentionally untouched — those are correct production defaults, not misconfiguration risk.

## Why

Surfaced during the #3526 stress-test walkthrough:

1. **Scenario telemetry was tied to `BASE_HOST` via a compose hack.** Workers overrode `BASE_HOST: http://app:5560` to plumb the docker-internal worker→app URL through the wrong variable, conflating user-facing origin with service-to-service URL.
2. **Production code carried `?? "http://localhost:..."` fallbacks.** These mask misconfiguration and put dev defaults in TS instead of compose. Architectural rule: env config owns dev defaults; code uses validated env directly; required env vars fail-fast at boot.

## Files changed (10)

- `compose.dev.yml` — explicit `LANGWATCH_ENDPOINT: "http://app:5560/"` override removed from the `ai-server` service only (the one place it appeared as a per-service override). `LANGWATCH_ENDPOINT` is now owned by `.env.example` and the compose `.env.dev-up` overlay written by `write-dev-overrides.sh`, not hardcoded in compose.
- `langwatch/.env.example` — add `LANGWATCH_ENDPOINT="http://localhost:5560"` so developers whose `.env` predates this PR do not get a Zod boot error. Comment explains the docker override path.
- `scripts/lib/write-dev-overrides.sh` — add `LANGWATCH_ENDPOINT=http://app:5560` to the shared compose overlay block (all-local / all-local-nlp / full-local / dev-storage presets), so docker-internal workers reach `http://app:5560` rather than the localhost value in `.env`.
- `langwatch/src/env-create.mjs` — `LANGWATCH_ENDPOINT` + `LANGWATCH_NLP_SERVICE` promoted to required `url()` schemas (`optionalIfBuildTime`, so only required at runtime). Removed `TOPIC_CLUSTERING_SERVICE` — it was inadvertently added in an earlier commit but has zero consumers via `env.TOPIC_CLUSTERING_SERVICE` in the codebase; out of scope for this PR.
- `langwatch/src/server/scenarios/execution/data-prefetcher.ts` — reads `env.LANGWATCH_ENDPOINT` directly; drops bespoke throw helper
- `langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts` — env mock updated
- `langwatch/src/server/scenarios/execution/scenario-child-process.ts` — reads `process.env.LANGWATCH_*` injected by parent
- `langwatch/src/server/scenarios/simulation-runner.service.ts` — reads `env.LANGWATCH_ENDPOINT` directly
- `langwatch/src/app/api/shared/platform-url.ts` — reads `env.BASE_HOST` via validated import; drops localhost fallback
- `langwatch/src/app/api/shared/__tests__/platform-url.unit.test.ts` — migrated from `process.env` mutation to `vi.mock("~/env.mjs")`

## CI failure diagnosis (run 27511481747)

The previous CI run failed in shard 4/6 on `groupQueue.integration.test.ts: re-stages drained siblings so none are lost` — a 20-second timeout flake in the groupQueue test, **unrelated to this PR's env changes**. The CI run log shows `LANGWATCH_ENDPOINT: http://localhost:3000` was already correctly set for all test shards. No test failure was caused by the removed localhost fallbacks.

## Human verification

<!-- no-ui-surface -->

This change affects env-contract and server-side env reads only. No UI surface is changed.

1. Copy `.env.example` to `.env` on a fresh checkout — verify the app boots without Zod errors (LANGWATCH_ENDPOINT and LANGWATCH_NLP_SERVICE are present).
2. Run `make dev` (any compose preset) — verify `.env.dev-up` contains `LANGWATCH_ENDPOINT=http://app:5560` so workers reach the app container.
3. Remove `LANGWATCH_ENDPOINT` from `.env.local` and confirm the app fails fast at boot with a Zod validation error rather than silently using localhost.
4. Confirm `BASE_HOST` only affects user-facing URLs (emails, MCP links) — not telemetry routing.

## How I can prove I was successful

- `data-prefetcher.unit.test.ts` mocks `~/env.mjs` with `LANGWATCH_ENDPOINT: "http://app:5560"` and asserts `result.telemetry.endpoint === "http://app:5560"` — no localhost fallback.
- `platform-url.unit.test.ts` mocks `~/env.mjs` with controlled `BASE_HOST` values and asserts correct URL construction — no process.env mutation, no localhost fallback.
- `env-create.mjs` schema: `LANGWATCH_ENDPOINT` and `LANGWATCH_NLP_SERVICE` are `optionalIfBuildTime(z.string().url())` — required at runtime, validated as URLs.
- `.env.example` diff: adds `LANGWATCH_ENDPOINT="http://localhost:5560"`.
- `write-dev-overrides.sh` diff: adds `LANGWATCH_ENDPOINT=http://app:5560` to the compose overlay heredoc.

## Out of scope

- Legacy non-docker `make start` target — doesn't currently set `LANGWATCH_ENDPOINT`. Only relevant if anyone returns to non-docker dev.
- User-facing public-domain fallbacks (MCP / license / email) — those are correct.

Resolves #3534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable service endpoint across local, Docker, and test environments.

* **Bug Fixes**
  * URL generation now respects the configured base host and handles missing or trailing-slash values more reliably.
  * Scenario and telemetry flows now use the configured endpoint instead of failing when it is unset.

* **Tests**
  * Updated integration and unit test setup to reflect the new environment requirements and endpoint behavior.

* **Documentation**
  * Expanded example environment settings to include the new endpoint variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deployment Impact

Self-hosters and dev environments must set `LANGWATCH_ENDPOINT` (now runtime-required by the env schema). Defaults are provided everywhere in-repo: `.env.example` ships `http://localhost:5560`, `write-dev-overrides.sh` injects `http://app:5560` for compose presets, and `compose.dev.yml` no longer carries per-service localhost fallbacks. Existing deployments that already set `LANGWATCH_ENDPOINT` are unaffected; ones relying on the removed localhost fallbacks must add the var before upgrading.
