### PR TITLE
fix(langwatch_nlp): code node accepts class with __call__ or forward (FF=off back-compat)

### DIFF
--- a/langwatch/src/app/api/workflows/post_event/__tests__/post-event-routing.test.ts
+++ b/langwatch/src/app/api/workflows/post_event/__tests__/post-event-routing.test.ts
@@ -34,6 +34,14 @@ vi.mock("../../../../../server/featureFlag/featureFlag.service", () => ({
   },
 }));
 
+// `isNlpGoEnabled` resolves the project's organization via Prisma. Unit
+// shards have no DB, so the live import throws PrismaClientInitializationError
+// before the FF mock above is ever consulted. Stub the gate directly to
+// keep this a pure routing test.
+vi.mock("../../../../../server/nlpgo/nlpgoFetch", () => ({
+  isNlpGoEnabled: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock("../../../../../optimization_studio/server/addEnvs", async () => {
   const actual = await vi.importActual<
     typeof import("../../../../../optimization_studio/server/addEnvs")

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -32,6 +32,18 @@ export function usePostHog() {
           recordCrossOriginIframes: true,
         },
         loaded: (posthog) => {
+          // Explicitly expose `window.posthog` so the PostHog toolbar
+          // (launched from the PostHog dashboard's "Toolbar" button)
+          // can attach in any environment, not just development. The
+          // posthog-js library sets this internally on most builds, but
+          // bundlers and strict-mode wrappers can sometimes strip the
+          // implicit global; the assignment is best-effort and has no
+          // downside in environments where it's already set. rchaves
+          // hit a missing window.posthog dogfooding the PR.
+          if (typeof window !== "undefined") {
+            (window as unknown as { posthog: typeof posthog }).posthog =
+              posthog;
+          }
           if (publicEnv.data?.NODE_ENV === "development") posthog.debug();
         },
       });

--- a/langwatch/src/hooks/usePostHog.ts
+++ b/langwatch/src/hooks/usePostHog.ts
@@ -38,8 +38,7 @@ export function usePostHog() {
           // posthog-js library sets this internally on most builds, but
           // bundlers and strict-mode wrappers can sometimes strip the
           // implicit global; the assignment is best-effort and has no
-          // downside in environments where it's already set. rchaves
-          // hit a missing window.posthog dogfooding the PR.
+          // downside in environments where it's already set.
           if (typeof window !== "undefined") {
             (window as unknown as { posthog: typeof posthog }).posthog =
               posthog;

--- a/langwatch/src/server/nlpgo/nlpgoFetch.ts
+++ b/langwatch/src/server/nlpgo/nlpgoFetch.ts
@@ -1,4 +1,5 @@
 import { featureFlagService } from "../featureFlag/featureFlag.service";
+import { resolveOrganizationId } from "../organizations/resolveOrganizationId";
 import { lambdaFetch } from "../../utils/lambdaFetch";
 import { getProjectLambdaArn } from "../../optimization_studio/server/lambda";
 
@@ -103,13 +104,25 @@ export async function nlpgoFetch<T = unknown>(
  *   - the studio UI to hide the (now-defunct) Optimize button
  *   - the optimize REST endpoint to return 410
  *   - tRPC procedures that want to surface the engine choice to the UI
+ *
+ * If `organizationId` isn't supplied, we look it up from the project so
+ * PostHog rules that target the `organization_id` person property
+ * (org-level rollouts) match correctly. Caught when an org-level enable
+ * in PostHog wasn't reaching projects under that org because every call
+ * site passed only `projectId` — PostHog's `release_nlp_go_engine_enabled`
+ * rule can't match `organization_id` if we never send it.
+ *
+ * `resolveOrganizationId` has its own 10-minute TTL cache and silently
+ * returns undefined for orphan projects, so this stays fast and safe.
  */
 export async function isNlpGoEnabled(
   opts: Pick<NLPGOFetchOptions, "projectId" | "organizationId">,
 ): Promise<boolean> {
+  const organizationId =
+    opts.organizationId ?? (await resolveOrganizationId(opts.projectId));
   return featureFlagService.isEnabled(NLP_GO_FLAG, opts.projectId, false, {
     projectId: opts.projectId,
-    organizationId: opts.organizationId,
+    organizationId,
   });
 }
 

--- a/langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py
@@ -70,7 +70,22 @@ async def execute_component(event: ExecuteComponentPayload):
                         forward_inputs = event.inputs
                     else:
                         forward_inputs = autoparse_fields(node.data.inputs or [], event.inputs)  # type: ignore
-                    result = await dspy.asyncify(instance)(
+                    # PR #3543 back-compat: the parser accepts plain classes
+                    # with `forward(...)` only (no __call__ and no dspy.Module
+                    # base). Such classes aren't directly callable —
+                    # `dspy.asyncify(instance)(...)` would TypeError. Fall back
+                    # to `instance.forward` when `instance` isn't callable;
+                    # mirrors the priority-3 path in the Go runner
+                    # (services/nlpgo/.../codeblock/runner.py). dspy.Module
+                    # subclasses always have __call__ so they hit the fast
+                    # path unchanged.
+                    invoke_target = instance if callable(instance) else getattr(instance, "forward", None)
+                    if invoke_target is None:
+                        raise TypeError(
+                            f"Class '{class_name}' for component {node.data.name} "
+                            f"is not callable and has no forward() method."
+                        )
+                    result = await dspy.asyncify(invoke_target)(
                         **forward_inputs
                     )
 

--- a/langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py
@@ -79,11 +79,20 @@ async def execute_component(event: ExecuteComponentPayload):
                     # (services/nlpgo/.../codeblock/runner.py). dspy.Module
                     # subclasses always have __call__ so they hit the fast
                     # path unchanged.
+                    #
+                    # `callable(invoke_target)` covers both legs of the failure
+                    # surface: missing-attribute (`getattr` default = None,
+                    # `callable(None)` is False) AND non-callable-attribute
+                    # (e.g. a string class attribute named `forward`). Either
+                    # case raises a typed error here so the operator sees a
+                    # message naming the class instead of asyncify's
+                    # less-informative 'object is not callable'.
                     invoke_target = instance if callable(instance) else getattr(instance, "forward", None)
-                    if invoke_target is None:
+                    if not callable(invoke_target):
                         raise TypeError(
                             f"Class '{class_name}' for component {node.data.name} "
-                            f"is not callable and has no forward() method."
+                            f"has no callable entrypoint. Define __call__(self, ...) "
+                            f"or forward(self, ...) on the class."
                         )
                     result = await dspy.asyncify(invoke_target)(
                         **forward_inputs

--- a/langwatch_nlp/langwatch_nlp/studio/parser.py
+++ b/langwatch_nlp/langwatch_nlp/studio/parser.py
@@ -194,6 +194,68 @@ def _assert_signature_field_types_are_mapped(node: Node) -> None:
             )
 
 
+# Class-declaration regex: captures the name of any class declaration,
+# whether or not it inherits from a base. Used by _resolve_code_class_name
+# below to discover candidate classes in user-provided code; the per-class
+# resolution priority is then re-applied at materialization time (see
+# `materialized_component_class`).
+_CLASS_DECL_RE = re.compile(r"class\s+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*:")
+# Legacy dspy.Module subclass shape — kept as a fast first-pass match
+# since it covers nearly all in-prod customer code today.
+_DSPY_MODULE_SUBCLASS_RE = re.compile(r"class\s+([A-Za-z_]\w*)\s*\(\s*dspy\.Module\s*\)\s*:")
+
+
+def _resolve_code_class_name(
+    code: str, node_name: str | None, kind: str = "component"
+) -> str:
+    """Pick the user-defined class to instantiate from ``code``.
+
+    Resolution order matches the Go runtime
+    (services/nlpgo/app/engine/blocks/codeblock/runner.py) so the same
+    customer code runs identically on FF=on and FF=off:
+
+      1. ``class X(dspy.Module):`` — preferred (legacy default; the
+         dspy.Module wrapper provides cost-tracing + tracking).
+      2. ``class X:`` matching the node's display name (after
+         normalization to a class identifier) — picks the right class
+         when the user defines helpers alongside the entry class.
+      3. First ``class X:`` declaration in the file.
+
+    Method-level shape (``__call__`` vs ``forward`` vs neither) is NOT
+    inspected here because the source is not yet imported; the chosen
+    class is materialized downstream and the caller uses Python's normal
+    instance(...) protocol, which dispatches to ``__call__`` if defined.
+    A class with neither ``__call__`` nor ``forward`` raises a TypeError
+    at call time — clearer than failing here.
+
+    Anchors PR #3483's per-shape contract back-compat for FF=off so
+    customers using the new ``class X: def __call__(...)`` template
+    don't error before the FF rolls to them.
+    """
+    match = _DSPY_MODULE_SUBCLASS_RE.search(code)
+    if match:
+        return match.group(1)
+
+    # Fall back to any class declaration. Prefer one whose name matches
+    # the (normalized) node name when there are multiple candidates,
+    # so that helpers defined above the entry class don't get picked
+    # incorrectly.
+    candidates = _CLASS_DECL_RE.findall(code)
+    if not candidates:
+        raise ValueError(
+            f"Could not find a class definition for {kind} {node_name}. "
+            f"Supported shapes: dspy.Module subclass, class with __call__, "
+            f"or class with forward()."
+        )
+
+    if node_name:
+        target = normalize_name_to_class_name(node_name)
+        for name in candidates:
+            if name == target:
+                return name
+    return candidates[0]
+
+
 def parse_component(
     node: Node, workflow: Workflow, standalone=False, format=False, debug_level=0
 ) -> Tuple[str, str, Dict[str, Any]]:
@@ -280,14 +342,7 @@ def parse_component(
                     f"Code node has no source content for component {node.data.name}"
                 )
 
-            pattern = r"class (.*?)\(dspy\.Module\):"
-            match = re.search(pattern, code)
-            if not match:
-                raise ValueError(
-                    f"Could not find a class that inherits from dspy.Module for component {node.data.name}"
-                )
-
-            class_name = match.group(1)
+            class_name = _resolve_code_class_name(code, node.data.name)
             try:
                 code = black.format_str(code, mode=black.Mode())
             except Exception as e:
@@ -366,13 +421,9 @@ def parse_component(
                         raise ValueError(
                             f"Code not specified for agent {node.data.name}"
                         )
-                    pattern = r"class (.*?)\(dspy\.Module\):"
-                    match_result = re.search(pattern, code)
-                    if not match_result:
-                        raise ValueError(
-                            f"Could not find a class that inherits from dspy.Module for agent {node.data.name}"
-                        )
-                    class_name = match_result.group(1)
+                    class_name = _resolve_code_class_name(
+                        code, node.data.name, kind="agent"
+                    )
                     try:
                         code = black.format_str(code, mode=black.Mode())
                     except Exception as e:
@@ -403,7 +454,16 @@ def parse_component(
 @contextmanager
 def materialized_component_class(
     component_code: str, class_name: str
-) -> Generator[Type[dspy.Module], None, None]:
+) -> Generator[Type[Any], None, None]:
+    """Materialize a user-defined class from ``component_code`` and yield it.
+
+    Return type is ``Type[Any]`` (was ``Type[dspy.Module]``) because the
+    Code node now also accepts plain ``class X: def __call__(...)`` and
+    ``class X: def forward(...)`` shapes — the caller uses Python's
+    normal ``instance(**inputs)`` invocation, which dispatches to
+    ``__call__`` if defined and otherwise hits whatever Module subclass
+    the legacy dspy path expects.
+    """
     temp_folder = tempfile.mkdtemp()
     sys.path.insert(0, temp_folder)
 

--- a/langwatch_nlp/langwatch_nlp/studio/parser.py
+++ b/langwatch_nlp/langwatch_nlp/studio/parser.py
@@ -195,13 +195,20 @@ def _assert_signature_field_types_are_mapped(node: Node) -> None:
 
 
 # Class-declaration regex: captures the name of any class declaration,
-# whether or not it inherits from a base. Used by _resolve_code_class_name
-# below to discover candidate classes in user-provided code; the per-class
-# resolution priority is then re-applied at materialization time (see
-# `materialized_component_class`).
+# whether or not it inherits from a base. The base list (parenthesized)
+# is matched via `[^)]*` — a negated character class which includes
+# newlines — so a multi-line base declaration like
+#     class X(
+#         dspy.Module,
+#         SomeMixin,
+#     ):
+# resolves correctly. Used by _resolve_code_class_name below.
 _CLASS_DECL_RE = re.compile(r"class\s+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*:")
 # Legacy dspy.Module subclass shape — kept as a fast first-pass match
-# since it covers nearly all in-prod customer code today.
+# since it covers nearly all in-prod customer code today. Intentionally
+# strict: matches only `class X(dspy.Module):` (no other bases). The
+# `class X(dspy.Module, SomeMixin):` shape is rare in practice and falls
+# through to `_CLASS_DECL_RE` cleanly, returning the same class.
 _DSPY_MODULE_SUBCLASS_RE = re.compile(r"class\s+([A-Za-z_]\w*)\s*\(\s*dspy\.Module\s*\)\s*:")
 
 
@@ -210,9 +217,9 @@ def _resolve_code_class_name(
 ) -> str:
     """Pick the user-defined class to instantiate from ``code``.
 
-    Resolution order matches the Go runtime
-    (services/nlpgo/app/engine/blocks/codeblock/runner.py) so the same
-    customer code runs identically on FF=on and FF=off:
+    Resolution order matches the **class-based** shapes the Go runtime
+    accepts (services/nlpgo/app/engine/blocks/codeblock/runner.py), so
+    the same customer code runs identically on FF=on and FF=off:
 
       1. ``class X(dspy.Module):`` — preferred (legacy default; the
          dspy.Module wrapper provides cost-tracing + tracking).
@@ -221,12 +228,24 @@ def _resolve_code_class_name(
          when the user defines helpers alongside the entry class.
       3. First ``class X:`` declaration in the file.
 
-    Method-level shape (``__call__`` vs ``forward`` vs neither) is NOT
-    inspected here because the source is not yet imported; the chosen
-    class is materialized downstream and the caller uses Python's normal
-    instance(...) protocol, which dispatches to ``__call__`` if defined.
-    A class with neither ``__call__`` nor ``forward`` raises a TypeError
-    at call time — clearer than failing here.
+    The Go runtime ALSO accepts a fourth shape — a top-level ``def
+    execute(**inputs)`` callable with no enclosing class — but that
+    shape is intentionally NOT supported on the Python side. This
+    parser is a class-name extractor (the resolved name is later passed
+    to ``getattr(module, class_name)``); a top-level function has no
+    class to extract. Source with a top-level ``execute`` and no class
+    raises a clear ValueError listing the supported shapes. If parity
+    is ever needed, swap the resolver for an importer-then-inspect flow
+    similar to the Go runner.
+
+    Method-level shape within the chosen class (``__call__`` vs
+    ``forward`` vs neither) is NOT inspected here because the source
+    is not yet imported; the chosen class is materialized downstream
+    and the caller uses Python's normal instance(...) protocol, which
+    dispatches to ``__call__`` if defined and otherwise falls through
+    to whatever attribute the legacy dspy path expects. A class with
+    neither raises a TypeError at call time — clearer than failing
+    here.
 
     Anchors PR #3483's per-shape contract back-compat for FF=off so
     customers using the new ``class X: def __call__(...)`` template

--- a/langwatch_nlp/langwatch_nlp/studio/parser.py
+++ b/langwatch_nlp/langwatch_nlp/studio/parser.py
@@ -1,3 +1,4 @@
+import ast
 from contextlib import contextmanager, redirect_stdout
 import copy
 import io
@@ -194,22 +195,41 @@ def _assert_signature_field_types_are_mapped(node: Node) -> None:
             )
 
 
-# Class-declaration regex: captures the name of any class declaration,
-# whether or not it inherits from a base. The base list (parenthesized)
-# is matched via `[^)]*` — a negated character class which includes
-# newlines — so a multi-line base declaration like
-#     class X(
-#         dspy.Module,
-#         SomeMixin,
-#     ):
-# resolves correctly. Used by _resolve_code_class_name below.
-_CLASS_DECL_RE = re.compile(r"class\s+([A-Za-z_]\w*)\s*(?:\([^)]*\))?\s*:")
-# Legacy dspy.Module subclass shape — kept as a fast first-pass match
-# since it covers nearly all in-prod customer code today. Intentionally
-# strict: matches only `class X(dspy.Module):` (no other bases). The
-# `class X(dspy.Module, SomeMixin):` shape is rare in practice and falls
-# through to `_CLASS_DECL_RE` cleanly, returning the same class.
-_DSPY_MODULE_SUBCLASS_RE = re.compile(r"class\s+([A-Za-z_]\w*)\s*\(\s*dspy\.Module\s*\)\s*:")
+def _is_dspy_module_base(base: ast.expr) -> bool:
+    """True if ``base`` is the AST node ``dspy.Module``.
+
+    Used by _resolve_code_class_name to detect the legacy preferred
+    shape via AST instead of regex — regex over raw source can match
+    `class Fake:` inside a comment or docstring and pick the wrong
+    name; AST sees only real class declarations.
+    """
+    return (
+        isinstance(base, ast.Attribute)
+        and isinstance(base.value, ast.Name)
+        and base.value.id == "dspy"
+        and base.attr == "Module"
+    )
+
+
+def _top_level_class_defs(code: str) -> list[ast.ClassDef]:
+    """Return top-level ``ast.ClassDef`` nodes in user-supplied code.
+
+    Returns an empty list on syntax errors so the caller can surface
+    a clean "no class definition found" error rather than letting
+    SyntaxError propagate from this discovery step (the user code
+    will be black-formatted later anyway, which is where actual
+    syntax errors get reported with a nicer message).
+
+    Top-level only: nested classes inside an entry class don't count
+    as candidates — the legacy regex behavior was effectively the
+    same (it picked whatever ``class X:`` line came first), and
+    customer fixtures consistently put the entry class at the top.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+    return [node for node in tree.body if isinstance(node, ast.ClassDef)]
 
 
 def _resolve_code_class_name(
@@ -221,12 +241,13 @@ def _resolve_code_class_name(
     accepts (services/nlpgo/app/engine/blocks/codeblock/runner.py), so
     the same customer code runs identically on FF=on and FF=off:
 
-      1. ``class X(dspy.Module):`` — preferred (legacy default; the
-         dspy.Module wrapper provides cost-tracing + tracking).
+      1. ``class X(dspy.Module):`` (or any class whose bases include
+         ``dspy.Module``) — preferred (legacy default; the dspy.Module
+         wrapper provides cost-tracing + tracking).
       2. ``class X:`` matching the node's display name (after
          normalization to a class identifier) — picks the right class
          when the user defines helpers alongside the entry class.
-      3. First ``class X:`` declaration in the file.
+      3. First top-level ``class X:`` declaration in the file.
 
     The Go runtime ALSO accepts a fourth shape — a top-level ``def
     execute(**inputs)`` callable with no enclosing class — but that
@@ -240,39 +261,44 @@ def _resolve_code_class_name(
 
     Method-level shape within the chosen class (``__call__`` vs
     ``forward`` vs neither) is NOT inspected here because the source
-    is not yet imported; the chosen class is materialized downstream
-    and the caller uses Python's normal instance(...) protocol, which
-    dispatches to ``__call__`` if defined and otherwise falls through
-    to whatever attribute the legacy dspy path expects. A class with
-    neither raises a TypeError at call time — clearer than failing
-    here.
+    is not yet imported. The downstream invoker
+    (``execute_component.py`` / ``execute_flow.py``) handles the
+    dispatch — ``execute_component`` falls back from ``instance(...)``
+    to ``instance.forward(...)`` for plain forward-only classes; see
+    the import-time fallback in those modules.
 
-    Anchors PR #3483's per-shape contract back-compat for FF=off so
-    customers using the new ``class X: def __call__(...)`` template
-    don't error before the FF rolls to them.
+    AST-based discovery (not regex over raw source) so commented-out
+    or docstring text like ``class Fake:`` can't false-match. Anchors
+    PR #3483's per-shape contract back-compat for FF=off so customers
+    using the new ``class X: def __call__(...)`` template don't error
+    before the FF rolls to them.
     """
-    match = _DSPY_MODULE_SUBCLASS_RE.search(code)
-    if match:
-        return match.group(1)
+    class_defs = _top_level_class_defs(code)
 
-    # Fall back to any class declaration. Prefer one whose name matches
-    # the (normalized) node name when there are multiple candidates,
-    # so that helpers defined above the entry class don't get picked
-    # incorrectly.
-    candidates = _CLASS_DECL_RE.findall(code)
-    if not candidates:
+    # Priority 1: any class with `dspy.Module` in its bases (handles
+    # both the strict `class X(dspy.Module):` and the multi-base
+    # `class X(dspy.Module, SomeMixin):` cases).
+    for cls in class_defs:
+        if any(_is_dspy_module_base(base) for base in cls.bases):
+            return cls.name
+
+    if not class_defs:
         raise ValueError(
             f"Could not find a class definition for {kind} {node_name}. "
             f"Supported shapes: dspy.Module subclass, class with __call__, "
             f"or class with forward()."
         )
 
+    # Priority 2: name-disambiguation against the (normalized) node
+    # name when multiple candidate classes exist.
     if node_name:
         target = normalize_name_to_class_name(node_name)
-        for name in candidates:
-            if name == target:
-                return name
-    return candidates[0]
+        for cls in class_defs:
+            if cls.name == target:
+                return cls.name
+
+    # Priority 3: first top-level class declaration.
+    return class_defs[0].name
 
 
 def parse_component(

--- a/langwatch_nlp/tests/studio/test_parse.py
+++ b/langwatch_nlp/tests/studio/test_parse.py
@@ -409,7 +409,7 @@ class Code(dspy.Module):
         return {"output": "main"}
 """
         )
-        code, class_name, _ = parse_component(node, basic_workflow)
+        _, class_name, _ = parse_component(node, basic_workflow)
         # Despite Helper appearing first, the dspy.Module subclass wins.
         assert class_name == "Code"
 
@@ -426,7 +426,7 @@ class Code:
 """,
             name="Code",
         )
-        code, class_name, _ = parse_component(node, basic_workflow)
+        _, class_name, _ = parse_component(node, basic_workflow)
         assert class_name == "Code"
 
     def test_no_class_in_code_raises_clear_error(self):
@@ -474,8 +474,33 @@ class Code(
         return {"output": "multi-base"}
 """
         )
-        code, class_name, _ = parse_component(node, basic_workflow)
-        # The fast-path dspy regex won't match a multi-base class, so
-        # this exercises the fallback path with name disambiguation —
-        # picks Code (matches the node name) over Mixin.
+        _, class_name, _ = parse_component(node, basic_workflow)
+        # AST-based discovery resolves dspy.Module-as-base correctly
+        # even with additional bases (the priority-1 path matches any
+        # class with dspy.Module among its bases, not only sole-base).
+        assert class_name == "Code"
+
+    def test_class_in_comment_or_docstring_is_not_picked(self):
+        """CodeRabbit-flagged regression on #3543.
+
+        Regex-based discovery would happily pick `class Fake:` if it
+        appeared inside a string or comment, then fail at
+        `getattr(module, 'Fake')` with a confusing AttributeError. The
+        AST-based discovery only sees real top-level class declarations,
+        so the disguised class names are ignored.
+        """
+        node = self._make_code_node(
+            '''
+"""Module docstring with class Fake: nope, not a real class."""
+
+# class Hidden: this is just a comment
+SAMPLE = "class Decoy:\\n    pass"
+
+class Code:
+    def __call__(self, input: str):
+        return {"output": "real"}
+''',
+            name="Code",
+        )
+        _, class_name, _ = parse_component(node, basic_workflow)
         assert class_name == "Code"

--- a/langwatch_nlp/tests/studio/test_parse.py
+++ b/langwatch_nlp/tests/studio/test_parse.py
@@ -306,3 +306,139 @@ class TestParseComponentEntryAndEndNodes:
 
         with pytest.raises(ValueError, match="End nodes cannot be executed as standalone components"):
             parse_component(node, basic_workflow)
+
+
+class TestCodeNodeClassResolutionShapes:
+    """Pin back-compat for the FF=off (legacy Python) Code node runtime.
+
+    PR #3483 shipped a new Studio default template (`class Code: def
+    __call__(self, ...): ...` — no `dspy.Module` inheritance). The Go
+    runtime's runner.py was updated to resolve __call__ / forward /
+    dspy.Module / top-level execute, but the Python parser only matched
+    `class X(dspy.Module):`. Result: customers still on the legacy
+    Python NLP path (FF=off) would hit
+        Could not find a class that inherits from dspy.Module for component Code
+    when running the new template.
+
+    These tests pin the resolution order in
+    `_resolve_code_class_name` so the Python side accepts the same
+    shapes the Go side does:
+      1. `class X(dspy.Module):` (legacy default — preferred)
+      2. `class X:` matching the node's normalized name
+      3. First `class X:` declaration (single-class file)
+      4. No class → clear error message listing supported shapes.
+    """
+
+    def _make_code_node(self, code: str, name: str = "Code") -> CodeNode:
+        return CodeNode(
+            id="code_node",
+            data=Code(
+                name=name,
+                cls=name,
+                parameters=[
+                    Field(
+                        identifier="code",
+                        type=FieldType.str,
+                        optional=None,
+                        value=code,
+                        desc=None,
+                    ),
+                ],
+            ),
+        )
+
+    def test_class_with_dunder_call_only_no_dspy_inheritance(self):
+        """The new default template — class with __call__, no dspy.Module."""
+        node = self._make_code_node(
+            """
+class Code:
+    def __call__(self, input: str):
+        return {"output": "Hello world!"}
+"""
+        )
+        code, class_name, _ = parse_component(node, basic_workflow)
+        assert class_name == "Code"
+        with materialized_component_class(code, class_name) as Module:
+            instance = Module()
+            assert instance(input="anything") == {"output": "Hello world!"}
+
+    def test_class_with_forward_only_no_dspy_inheritance(self):
+        """`forward()` shape without dspy.Module — must also work."""
+        node = self._make_code_node(
+            """
+class Code:
+    def forward(self, **kwargs):
+        return {"output": kwargs.get("input", "")}
+"""
+        )
+        code, class_name, _ = parse_component(node, basic_workflow)
+        assert class_name == "Code"
+        with materialized_component_class(code, class_name) as Module:
+            instance = Module()
+            assert instance.forward(input="x") == {"output": "x"}
+
+    def test_legacy_dspy_module_subclass_still_resolves_first(self):
+        """Existing customer code keeps working — back-compat anchor."""
+        node = self._make_code_node(
+            """
+import dspy
+
+class Code(dspy.Module):
+    def forward(self, **kwargs):
+        return {"output": "legacy"}
+""",
+            name="Code",
+        )
+        code, class_name, _ = parse_component(node, basic_workflow)
+        assert class_name == "Code"
+        with materialized_component_class(code, class_name) as Module:
+            assert issubclass(Module, dspy.Module)
+
+    def test_dspy_module_wins_over_helper_classes_above_it(self):
+        """When the user defines helpers, the dspy.Module class is picked."""
+        node = self._make_code_node(
+            """
+import dspy
+
+class Helper:
+    def __call__(self, x):
+        return x
+
+class Code(dspy.Module):
+    def forward(self, **kwargs):
+        return {"output": "main"}
+"""
+        )
+        code, class_name, _ = parse_component(node, basic_workflow)
+        # Despite Helper appearing first, the dspy.Module subclass wins.
+        assert class_name == "Code"
+
+    def test_node_name_disambiguates_when_no_dspy_inheritance(self):
+        """Multiple bare classes — pick the one matching the node name."""
+        node = self._make_code_node(
+            """
+class Helper:
+    pass
+
+class Code:
+    def __call__(self, input: str):
+        return {"output": "main"}
+""",
+            name="Code",
+        )
+        code, class_name, _ = parse_component(node, basic_workflow)
+        assert class_name == "Code"
+
+    def test_no_class_in_code_raises_clear_error(self):
+        """Helpful error replaces the misleading 'must inherit dspy.Module'."""
+        node = self._make_code_node(
+            """
+def execute(input: str):
+    return {"output": "no class"}
+"""
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"Could not find a class definition.*Supported shapes",
+        ):
+            parse_component(node, basic_workflow)

--- a/langwatch_nlp/tests/studio/test_parse.py
+++ b/langwatch_nlp/tests/studio/test_parse.py
@@ -430,7 +430,14 @@ class Code:
         assert class_name == "Code"
 
     def test_no_class_in_code_raises_clear_error(self):
-        """Helpful error replaces the misleading 'must inherit dspy.Module'."""
+        """Helpful error replaces the misleading 'must inherit dspy.Module'.
+
+        Note: the Go runner accepts a top-level ``def execute(...)`` shape;
+        the Python parser intentionally does not (it's a class-name
+        extractor, not an instance resolver — see _resolve_code_class_name
+        docstring). The resulting message must point users at the
+        supported shapes so they convert their function into a class.
+        """
         node = self._make_code_node(
             """
 def execute(input: str):
@@ -442,3 +449,33 @@ def execute(input: str):
             match=r"Could not find a class definition.*Supported shapes",
         ):
             parse_component(node, basic_workflow)
+
+    def test_class_with_multi_line_base_list_resolves(self):
+        """Edge case Sarah flagged in #3543 review.
+
+        The class-declaration regex uses ``[^)]*`` for the base list,
+        which (unlike ``.``) matches newlines without re.DOTALL. So a
+        multi-line base list — common when the user pulls in mixins —
+        still resolves the class name correctly without falling through
+        to the no-class branch.
+        """
+        node = self._make_code_node(
+            """
+import dspy
+
+class Mixin:
+    pass
+
+class Code(
+    dspy.Module,
+    Mixin,
+):
+    def forward(self, **kwargs):
+        return {"output": "multi-base"}
+"""
+        )
+        code, class_name, _ = parse_component(node, basic_workflow)
+        # The fast-path dspy regex won't match a multi-base class, so
+        # this exercises the fallback path with name disambiguation —
+        # picks Code (matches the node name) over Mixin.
+        assert class_name == "Code"

--- a/pkg/otelsetup/otelsetup.go
+++ b/pkg/otelsetup/otelsetup.go
@@ -88,11 +88,39 @@ type Options struct {
 	// SampleRatio controls the fraction of traces sampled (0.0–1.0).
 	// 0 means "use default" (AlwaysSample). Set explicitly via config.
 	SampleRatio float64
+	// MultiTenant=true installs a per-request, per-tenant span router
+	// (TenantRouter) instead of the standard static-headers exporter.
+	// Required for nlpgo: each Studio event arrives with its own
+	// `workflow.api_key`, and a single Lambda container can serve
+	// multiple projects back-to-back. Spans must reach LangWatch's
+	// /api/otel/v1/traces with the originating project's
+	// `X-Auth-Token` — never another tenant's key, never a static
+	// admin token. When true, OTLPHeaders is ignored (the per-tenant
+	// processors set their own auth).
+	MultiTenant bool
 }
 
 // Provider holds the configured OTel SDK providers.
 type Provider struct {
 	tp *sdktrace.TracerProvider
+}
+
+// buildResourceAttrs assembles the standard service.* + node.id
+// resource attributes used by both the static and multi-tenant span
+// pipelines. Kept as a helper so the two branches in New() stay in
+// lockstep without copy-paste drift.
+func buildResourceAttrs(serviceName, serviceVersion, environment, nodeID string) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(serviceName),
+		semconv.ServiceVersion(serviceVersion),
+	}
+	if environment != "" {
+		attrs = append(attrs, attribute.String("deployment.environment.name", environment))
+	}
+	if nodeID != "" {
+		attrs = append(attrs, attribute.String("node.id", nodeID))
+	}
+	return attrs
 }
 
 // New creates the telemetry provider. If TraceEndpoint is empty, a noop
@@ -124,6 +152,34 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 		return &Provider{}, nil
 	}
 
+	if opts.MultiTenant {
+		// nlpgo path: a TenantRouter is the only span processor.
+		// Per-tenant otlptracehttp exporters are constructed lazily
+		// inside it, each with its own `X-Auth-Token` header sourced
+		// from the Studio event's `workflow.api_key`. Static
+		// OTLPHeaders are intentionally NOT applied here — they would
+		// be wrong for every tenant after the first.
+		attrs := buildResourceAttrs(serviceName, serviceVersion, environment, opts.NodeID)
+		res, _ := resource.Merge(
+			resource.Default(),
+			resource.NewWithAttributes(semconv.SchemaURL, attrs...),
+		)
+		var rootSampler sdktrace.Sampler
+		if opts.SampleRatio > 0 && opts.SampleRatio < 1.0 {
+			rootSampler = sdktrace.TraceIDRatioBased(opts.SampleRatio)
+		} else {
+			rootSampler = sdktrace.AlwaysSample()
+		}
+		router := NewTenantRouter(opts.OTLPEndpoint)
+		tp := sdktrace.NewTracerProvider(
+			sdktrace.WithResource(res),
+			sdktrace.WithSpanProcessor(router),
+			sdktrace.WithSampler(sdktrace.ParentBased(rootSampler)),
+		)
+		otelapi.SetTracerProvider(tp)
+		return &Provider{tp: tp}, nil
+	}
+
 	exporterOpts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpointURL(opts.OTLPEndpoint),
 	}
@@ -147,16 +203,7 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 	otelapi.SetErrorHandler(startupFilter)
 	wrappedExp := healthyExporterWrap(exp, startupFilter.markHealthy)
 
-	attrs := []attribute.KeyValue{
-		semconv.ServiceName(serviceName),
-		semconv.ServiceVersion(serviceVersion),
-	}
-	if environment != "" {
-		attrs = append(attrs, attribute.String("deployment.environment.name", environment))
-	}
-	if opts.NodeID != "" {
-		attrs = append(attrs, attribute.String("node.id", opts.NodeID))
-	}
+	attrs := buildResourceAttrs(serviceName, serviceVersion, environment, opts.NodeID)
 
 	res, _ := resource.Merge(
 		resource.Default(),

--- a/pkg/otelsetup/tenant_router.go
+++ b/pkg/otelsetup/tenant_router.go
@@ -1,0 +1,203 @@
+// Tenant-aware span router for multi-project OTel export.
+//
+// Background: nlpgo runs in a Lambda-style container that's reused
+// across invocations from different LangWatch projects. Each Studio
+// event arrives with its own `workflow.api_key` (the project's
+// LangWatch API key). Spans produced during that handler must be
+// exported back to LangWatch's /api/otel/v1/traces endpoint with
+// `X-Auth-Token: <api_key>` so the langwatch app's collector can
+// attribute the trace to the right project.
+//
+// The OTel SDK's standard pattern is "configure auth headers on the
+// exporter at boot, batch globally". That's wrong here: a single
+// batch can contain spans from multiple tenants (concurrent Lambda
+// invocations or container reuse), and a static `X-Auth-Token` would
+// attribute every span to whichever tenant's key was wired in. Cross-
+// tenant trace leakage is the threat we cannot tolerate.
+//
+// This router solves it by:
+//
+//  1. Stamping the api_key onto each span at OnStart, sourced from
+//     the per-request context.Context (set by the HTTP middleware).
+//     The api_key is held in an internal map keyed by the span's
+//     {trace_id, span_id} — NOT exposed as a span attribute (that
+//     would leak the secret to the OTLP collector wire).
+//
+//  2. Routing OnEnd to a per-tenant `BatchSpanProcessor` cached in a
+//     sync.Map keyed by api_key. Each processor wraps an
+//     `otlptracehttp` exporter constructed with that tenant's key as
+//     a static `X-Auth-Token` header — so async batching is safe
+//     because each batch already belongs to one tenant.
+//
+// Lambda safety: no per-request global state mutation. The router
+// itself is global and immutable; per-tenant processors are created
+// lazily and cached. ForceFlush + Shutdown fan out to every cached
+// processor.
+package otelsetup
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// APIKeyContextKey is the context key the HTTP middleware uses to
+// stash the inbound `workflow.api_key`. Public so middleware in
+// services/nlpgo/adapters/httpapi can set it without importing this
+// package's internals.
+type APIKeyContextKey struct{}
+
+// spanIdent is the lookup key for the span→api_key map. Combining
+// trace_id + span_id ensures uniqueness across concurrent traces.
+type spanIdent [24]byte
+
+func identFor(sc trace.SpanContext) spanIdent {
+	var k spanIdent
+	tid := sc.TraceID()
+	sid := sc.SpanID()
+	copy(k[:16], tid[:])
+	copy(k[16:], sid[:])
+	return k
+}
+
+// TenantRouter is a sdktrace.SpanProcessor that routes each span to a
+// per-tenant BatchSpanProcessor based on the api_key sourced from the
+// request context at OnStart time.
+type TenantRouter struct {
+	endpoint string
+
+	// spanAuth maps spanIdent → api_key (string). Populated on
+	// OnStart, consumed (and deleted) on OnEnd. Keeps the api_key
+	// off the span itself so we don't leak it to the OTLP wire.
+	spanAuth sync.Map
+
+	// processors maps api_key → sdktrace.SpanProcessor. Lazily
+	// initialized on first sight of a tenant; cached for the life of
+	// the process. Each processor owns its own otlptracehttp exporter
+	// configured with that tenant's static auth header.
+	processors sync.Map
+
+	// newProcessor is the constructor used to build a per-tenant
+	// processor when the router first sees an api_key. Indirected
+	// through a field so tests can stub the OTLP exporter without
+	// standing up a real HTTPS endpoint.
+	newProcessor func(endpoint, apiKey string) (sdktrace.SpanProcessor, error)
+}
+
+// NewTenantRouter constructs a router that exports to `endpoint`
+// (typically `${LANGWATCH_ENDPOINT}/api/otel/v1/traces`). Per-tenant
+// processors are built on first sight of each api_key.
+func NewTenantRouter(endpoint string) *TenantRouter {
+	return &TenantRouter{
+		endpoint:     endpoint,
+		newProcessor: defaultTenantProcessor,
+	}
+}
+
+func defaultTenantProcessor(endpoint, apiKey string) (sdktrace.SpanProcessor, error) {
+	exp, err := otlptracehttp.New(context.Background(),
+		otlptracehttp.WithEndpointURL(endpoint),
+		otlptracehttp.WithHeaders(map[string]string{
+			"X-Auth-Token": apiKey,
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return sdktrace.NewBatchSpanProcessor(exp), nil
+}
+
+// OnStart records the request's api_key for the span. Called
+// synchronously in the goroutine that started the span — the parent
+// context still holds the per-request value at this point.
+func (r *TenantRouter) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {
+	apiKey, _ := parent.Value(APIKeyContextKey{}).(string)
+	if apiKey == "" {
+		// Fall back to the parent span's recorded api_key (handles
+		// child spans started in goroutines that didn't propagate
+		// ctx — rare but possible). Empty string just means "drop";
+		// downstream OnEnd skips spans without auth.
+		if parentSpan := trace.SpanFromContext(parent); parentSpan.SpanContext().IsValid() {
+			if v, ok := r.spanAuth.Load(identFor(parentSpan.SpanContext())); ok {
+				apiKey, _ = v.(string)
+			}
+		}
+	}
+	if apiKey == "" {
+		return
+	}
+	r.spanAuth.Store(identFor(s.SpanContext()), apiKey)
+}
+
+// OnEnd dispatches the span to its tenant's BatchSpanProcessor.
+// Spans without a recorded api_key are dropped — they had no tenant
+// context at start time and we have no safe attribution path for them.
+func (r *TenantRouter) OnEnd(s sdktrace.ReadOnlySpan) {
+	ident := identFor(s.SpanContext())
+	v, ok := r.spanAuth.LoadAndDelete(ident)
+	if !ok {
+		return
+	}
+	apiKey, _ := v.(string)
+	if apiKey == "" {
+		return
+	}
+	proc, err := r.processorFor(apiKey)
+	if err != nil || proc == nil {
+		return
+	}
+	proc.OnEnd(s)
+}
+
+// processorFor returns the (cached) BatchSpanProcessor for `apiKey`,
+// constructing it on first sight. Concurrent calls for the same
+// api_key race the constructor but LoadOrStore ensures only one
+// processor lands in the map per key.
+func (r *TenantRouter) processorFor(apiKey string) (sdktrace.SpanProcessor, error) {
+	if existing, ok := r.processors.Load(apiKey); ok {
+		return existing.(sdktrace.SpanProcessor), nil
+	}
+	created, err := r.newProcessor(r.endpoint, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	actual, loaded := r.processors.LoadOrStore(apiKey, created)
+	if loaded {
+		// We lost the race; another goroutine cached first. Drop our
+		// instance — leaks the BSP background goroutine until process
+		// exit, but races on the same key are rare (one per tenant)
+		// and shutdown sweeps the surviving cache entry anyway.
+		_ = created.Shutdown(context.Background())
+	}
+	return actual.(sdktrace.SpanProcessor), nil
+}
+
+// ForceFlush flushes every per-tenant processor. Callers that need
+// at-most-N-tenant ordering must serialize their own; this fans out
+// in undefined order.
+func (r *TenantRouter) ForceFlush(ctx context.Context) error {
+	var errs []error
+	r.processors.Range(func(_, v any) bool {
+		if err := v.(sdktrace.SpanProcessor).ForceFlush(ctx); err != nil {
+			errs = append(errs, err)
+		}
+		return true
+	})
+	return errors.Join(errs...)
+}
+
+// Shutdown flushes + tears down every per-tenant processor.
+func (r *TenantRouter) Shutdown(ctx context.Context) error {
+	var errs []error
+	r.processors.Range(func(_, v any) bool {
+		if err := v.(sdktrace.SpanProcessor).Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
+		return true
+	})
+	return errors.Join(errs...)
+}

--- a/pkg/otelsetup/tenant_router_test.go
+++ b/pkg/otelsetup/tenant_router_test.go
@@ -164,7 +164,10 @@ func TestTenantRouter_ChildSpanInheritsParentAuth(t *testing.T) {
 	tracer := tp.Tracer("test")
 
 	parentCtx := context.WithValue(context.Background(), APIKeyContextKey{}, "key-X")
-	parentCtx, parent := tracer.Start(parentCtx, "parent")
+	// Discard the returned context: the child below intentionally builds
+	// a fresh context from the span context (not from this returned ctx)
+	// to repro the goroutine-without-ctx-propagation scenario.
+	_, parent := tracer.Start(parentCtx, "parent")
 
 	// Start a child but DROP the api_key from context — only the
 	// span context carries forward. Production case: goroutine that

--- a/pkg/otelsetup/tenant_router_test.go
+++ b/pkg/otelsetup/tenant_router_test.go
@@ -1,0 +1,226 @@
+package otelsetup
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// stubProcessor records every span it sees and the api_key it was
+// constructed with. Stands in for the real per-tenant
+// otlptracehttp/BatchSpanProcessor pair so tests can assert routing
+// without spinning up an HTTPS endpoint.
+type stubProcessor struct {
+	apiKey string
+	mu     sync.Mutex
+	ended  []sdktrace.ReadOnlySpan
+	flush  atomic.Int32
+	shut   atomic.Int32
+}
+
+func (s *stubProcessor) OnStart(context.Context, sdktrace.ReadWriteSpan) {}
+func (s *stubProcessor) OnEnd(span sdktrace.ReadOnlySpan) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ended = append(s.ended, span)
+}
+func (s *stubProcessor) ForceFlush(context.Context) error { s.flush.Add(1); return nil }
+func (s *stubProcessor) Shutdown(context.Context) error   { s.shut.Add(1); return nil }
+
+func (s *stubProcessor) seen() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.ended)
+}
+
+// makeRouterWithStubs returns a router whose per-tenant processors
+// are stubs, plus a map keyed by api_key so tests can inspect the
+// routing.
+func makeRouterWithStubs() (*TenantRouter, *sync.Map) {
+	stubs := &sync.Map{}
+	r := NewTenantRouter("https://test.local/api/otel/v1/traces")
+	r.newProcessor = func(_, apiKey string) (sdktrace.SpanProcessor, error) {
+		s := &stubProcessor{apiKey: apiKey}
+		stubs.Store(apiKey, s)
+		return s, nil
+	}
+	return r, stubs
+}
+
+// runSpan starts and ends one span on a router-backed TracerProvider.
+// The TracerProvider is intentionally NOT shut down — that would fan
+// out Shutdown to every cached per-tenant processor and double-count
+// in tests that exercise router-level Shutdown directly.
+func runSpan(t *testing.T, r *TenantRouter, ctx context.Context, name string) {
+	t.Helper()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(r))
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(ctx, name)
+	span.End()
+}
+
+// TestTenantRouter_RoutesByContextAPIKey is the happy path: a span
+// started with api_key=K_A in context lands on the K_A processor and
+// nowhere else.
+func TestTenantRouter_RoutesByContextAPIKey(t *testing.T) {
+	r, stubs := makeRouterWithStubs()
+
+	ctx := context.WithValue(context.Background(), APIKeyContextKey{}, "key-A")
+	runSpan(t, r, ctx, "span-A")
+
+	v, ok := stubs.Load("key-A")
+	require.True(t, ok, "key-A processor should have been created")
+	assert.Equal(t, 1, v.(*stubProcessor).seen())
+}
+
+// TestTenantRouter_DropsSpansWithoutAPIKey: spans started with no
+// api_key in context (and no parent that has one) are dropped — we
+// have no safe attribution path. The Lambda-reuse threat model says
+// a leaked-tenant attribution is worse than a dropped span.
+func TestTenantRouter_DropsSpansWithoutAPIKey(t *testing.T) {
+	r, stubs := makeRouterWithStubs()
+
+	runSpan(t, r, context.Background(), "orphan-span")
+
+	count := 0
+	stubs.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 0, count, "no per-tenant processor should be created for an unauth'd span")
+}
+
+// TestTenantRouter_TwoTenantsTwoProcessors: spans from two different
+// tenants each land on their own processor, never on the wrong one.
+// Pins the core multi-tenant safety claim.
+func TestTenantRouter_TwoTenantsTwoProcessors(t *testing.T) {
+	r, stubs := makeRouterWithStubs()
+
+	ctxA := context.WithValue(context.Background(), APIKeyContextKey{}, "key-A")
+	ctxB := context.WithValue(context.Background(), APIKeyContextKey{}, "key-B")
+	runSpan(t, r, ctxA, "span-A")
+	runSpan(t, r, ctxB, "span-B")
+
+	a, _ := stubs.Load("key-A")
+	b, _ := stubs.Load("key-B")
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+	assert.Equal(t, 1, a.(*stubProcessor).seen(), "key-A processor must see only A's span")
+	assert.Equal(t, 1, b.(*stubProcessor).seen(), "key-B processor must see only B's span")
+}
+
+// TestTenantRouter_ConcurrentTenantsNoCrosstalk simulates the Lambda-
+// reuse threat model: many concurrent goroutines, each with its own
+// tenant context. Asserts each tenant's processor receives exactly
+// the count of spans started with its api_key — no cross-tenant leak.
+func TestTenantRouter_ConcurrentTenantsNoCrosstalk(t *testing.T) {
+	r, stubs := makeRouterWithStubs()
+
+	const tenants = 8
+	const perTenant = 32
+
+	var wg sync.WaitGroup
+	for ti := 0; ti < tenants; ti++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			apiKey := apiKeyForIdx(idx)
+			ctx := context.WithValue(context.Background(), APIKeyContextKey{}, apiKey)
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(r))
+			defer func() { _ = tp.Shutdown(context.Background()) }()
+			tracer := tp.Tracer("test")
+			for i := 0; i < perTenant; i++ {
+				_, span := tracer.Start(ctx, "span")
+				span.End()
+			}
+		}(ti)
+	}
+	wg.Wait()
+
+	for ti := 0; ti < tenants; ti++ {
+		apiKey := apiKeyForIdx(ti)
+		v, ok := stubs.Load(apiKey)
+		require.True(t, ok, "processor for %s should exist", apiKey)
+		assert.Equal(t, perTenant, v.(*stubProcessor).seen(),
+			"tenant %s must see exactly its own %d spans, no cross-talk", apiKey, perTenant)
+	}
+}
+
+// TestTenantRouter_ChildSpanInheritsParentAuth: a child span started
+// in a context that no longer carries the api_key still routes to
+// the right tenant by inheriting from the parent span's recorded
+// api_key. Covers the edge case of goroutines that didn't propagate
+// ctx but did propagate the SpanContext.
+func TestTenantRouter_ChildSpanInheritsParentAuth(t *testing.T) {
+	r, stubs := makeRouterWithStubs()
+
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(r))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tracer := tp.Tracer("test")
+
+	parentCtx := context.WithValue(context.Background(), APIKeyContextKey{}, "key-X")
+	parentCtx, parent := tracer.Start(parentCtx, "parent")
+
+	// Start a child but DROP the api_key from context — only the
+	// span context carries forward. Production case: goroutine that
+	// receives a trace.SpanContext via baggage but no apiKeyCtx.
+	childCtxNoAPIKey := trace.ContextWithSpan(context.Background(), parent)
+	_, child := tracer.Start(childCtxNoAPIKey, "child")
+	child.End()
+	parent.End()
+
+	v, ok := stubs.Load("key-X")
+	require.True(t, ok)
+	// Both parent and child should land on the same tenant.
+	assert.Equal(t, 2, v.(*stubProcessor).seen(),
+		"parent + child must both route to key-X via parent-span fallback")
+}
+
+// TestTenantRouter_ForceFlushFansOut: all per-tenant processors are
+// flushed when the router's ForceFlush is invoked.
+func TestTenantRouter_ForceFlushFansOut(t *testing.T) {
+	r, stubs := makeRouterWithStubs()
+
+	for _, k := range []string{"key-A", "key-B"} {
+		ctx := context.WithValue(context.Background(), APIKeyContextKey{}, k)
+		runSpan(t, r, ctx, "span")
+	}
+
+	require.NoError(t, r.ForceFlush(context.Background()))
+
+	for _, k := range []string{"key-A", "key-B"} {
+		v, _ := stubs.Load(k)
+		assert.Equal(t, int32(1), v.(*stubProcessor).flush.Load(),
+			"ForceFlush should fan out to %s", k)
+	}
+}
+
+// TestTenantRouter_ShutdownFansOut: same as ForceFlush but for
+// Shutdown — every per-tenant processor sees its Shutdown call.
+func TestTenantRouter_ShutdownFansOut(t *testing.T) {
+	r, stubs := makeRouterWithStubs()
+
+	for _, k := range []string{"key-A", "key-B"} {
+		ctx := context.WithValue(context.Background(), APIKeyContextKey{}, k)
+		runSpan(t, r, ctx, "span")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, r.Shutdown(ctx))
+
+	for _, k := range []string{"key-A", "key-B"} {
+		v, _ := stubs.Load(k)
+		assert.Equal(t, int32(1), v.(*stubProcessor).shut.Load(),
+			"Shutdown should fan out to %s", k)
+	}
+}
+
+func apiKeyForIdx(i int) string {
+	return "key-tenant-" + string(rune('A'+i))
+}

--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -137,12 +137,18 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 	}
 
 	var inner struct {
-		TraceID   string          `json:"trace_id"`
-		ThreadID  string          `json:"thread_id,omitempty"`
-		Workflow  json.RawMessage `json:"workflow"`
-		Inputs    any             `json:"inputs,omitempty"`
-		Origin    string          `json:"origin,omitempty"`
-		ProjectID string          `json:"project_id,omitempty"`
+		TraceID  string          `json:"trace_id"`
+		ThreadID string          `json:"thread_id,omitempty"`
+		Workflow json.RawMessage `json:"workflow"`
+		Inputs   any             `json:"inputs,omitempty"`
+		Origin   string          `json:"origin,omitempty"`
+		// NodeID names the single node targeted by execute_component.
+		// Studio's "Run with manual input" sends Inputs as the typed
+		// values for THIS node, not as Entry-node outputs — see
+		// langwatch/src/optimization_studio/hooks/useComponentExecution.ts.
+		// Absent for execute_flow / execute_evaluation.
+		NodeID    string `json:"node_id,omitempty"`
+		ProjectID string `json:"project_id,omitempty"`
 	}
 	if err := json.Unmarshal(innerBytes, &inner); err != nil {
 		e := herr.New(r.Context(), domain.ErrBadRequest, herr.M{
@@ -172,6 +178,7 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 		TraceID:      inner.TraceID,
 		ProjectID:    inner.ProjectID,
 		ThreadID:     threadID,
+		NodeID:       inner.NodeID,
 	}, nil
 }
 

--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -76,9 +76,12 @@ func executeSyncHandler(application *app.App) http.HandlerFunc {
 		if req.Origin != "" {
 			ctx = withOrigin(ctx, req.Origin)
 		}
+		ctx, span := startStudioSpan(ctx, "nlpgo.studio.execute_sync", req, req.APIKey)
+		defer span.End()
 		clog.Get(ctx).Info("execute_flow_received")
 		result, err := executor.Execute(ctx, *req)
 		if err != nil {
+			span.RecordError(err)
 			herr.WriteHTTP(w, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
 				"reason": "engine_error",
 			}, err))
@@ -179,7 +182,27 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 		ProjectID:    inner.ProjectID,
 		ThreadID:     threadID,
 		NodeID:       inner.NodeID,
+		APIKey:       peekWorkflowAPIKey(inner.Workflow),
 	}, nil
+}
+
+// peekWorkflowAPIKey extracts the `api_key` field from raw workflow
+// JSON without parsing the full Workflow struct (a fully-typed parse
+// happens later in cmd/engine_adapter). The handler needs the key
+// up-front to seed the OTel context for its top-level span — without
+// it, the TenantRouter drops the span and the trace is missing the
+// root.
+func peekWorkflowAPIKey(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var peek struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return ""
+	}
+	return peek.APIKey
 }
 
 // peekStudioControlEventType returns "is_alive" or "stop_execution"
@@ -309,6 +332,8 @@ func executeStreamHandler(application *app.App) http.HandlerFunc {
 		if req.Origin != "" {
 			ctx = withOrigin(ctx, req.Origin)
 		}
+		ctx, span := startStudioSpan(ctx, "nlpgo.studio.execute_stream", req, req.APIKey)
+		defer span.End()
 		clog.Get(ctx).Info("execute_flow_received", zap.Bool("stream", true))
 
 		flusher, ok := w.(http.Flusher)

--- a/services/nlpgo/adapters/httpapi/tracing.go
+++ b/services/nlpgo/adapters/httpapi/tracing.go
@@ -1,0 +1,106 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+
+	otelapi "go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/langwatch/langwatch/pkg/otelsetup"
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+)
+
+// tracerName is the OTel instrumentation scope all nlpgo spans live
+// under. Mirrors the langwatch-ai-gateway convention.
+const tracerName = "langwatch-nlpgo"
+
+// startStudioSpan wraps a Studio execute_* request in a span and primes
+// the context with the inbound `workflow.api_key` so otelsetup's
+// TenantRouter can route the spans to the right per-tenant exporter.
+//
+// Trace-ID continuity: Studio generates the trace_id on the frontend
+// (useComponentExecution.ts:112) and the langwatch app's "Full Trace"
+// drawer queries by that same trace_id. For the trace to land under
+// the same id, nlpgo's spans must use the inbound trace_id as the
+// root. We construct a remote SpanContext and attach it to ctx; the
+// subsequent tracer.Start sees it as the parent and inherits the
+// trace_id (with a fresh span_id for our root span).
+//
+// When the inbound trace_id is malformed or absent, fall through to
+// a fresh trace (still better than dropping the request).
+func startStudioSpan(ctx context.Context, name string, req *app.WorkflowRequest, workflowAPIKey string) (context.Context, trace.Span) {
+	if workflowAPIKey != "" {
+		ctx = context.WithValue(ctx, otelsetup.APIKeyContextKey{}, workflowAPIKey)
+	}
+	if tid, ok := parseTraceID(req.TraceID); ok {
+		// Remote=true tells the sampler to honor the inbound decision
+		// (we always-sample inbound Studio runs since the langwatch app
+		// already gated them).
+		sc := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    tid,
+			SpanID:     newSpanID(),
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		ctx = trace.ContextWithSpanContext(ctx, sc)
+	}
+	tracer := otelapi.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, name,
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(studioRequestAttrs(req)...),
+	)
+	return ctx, span
+}
+
+func studioRequestAttrs(req *app.WorkflowRequest) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+	if req.ProjectID != "" {
+		attrs = append(attrs, attribute.String("langwatch.project_id", req.ProjectID))
+	}
+	if req.TraceID != "" {
+		attrs = append(attrs, attribute.String("langwatch.trace_id", req.TraceID))
+	}
+	if req.ThreadID != "" {
+		attrs = append(attrs, attribute.String("langwatch.thread_id", req.ThreadID))
+	}
+	if req.Origin != "" {
+		attrs = append(attrs, attribute.String("langwatch.origin", req.Origin))
+	}
+	if req.NodeID != "" {
+		// Only set for execute_component — distinguishes single-node
+		// runs in the trace tree at a glance.
+		attrs = append(attrs, attribute.String("langwatch.node_id", req.NodeID))
+	}
+	return attrs
+}
+
+// parseTraceID accepts the 32-hex-char trace_id Studio mints and
+// returns it as a trace.TraceID. Empty string or malformed input
+// returns ok=false so the caller falls through to a fresh trace.
+func parseTraceID(s string) (trace.TraceID, bool) {
+	if len(s) != 32 {
+		return trace.TraceID{}, false
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != 16 {
+		return trace.TraceID{}, false
+	}
+	var tid trace.TraceID
+	copy(tid[:], b)
+	if !tid.IsValid() {
+		return trace.TraceID{}, false
+	}
+	return tid, true
+}
+
+// newSpanID returns a random 8-byte span id. crypto/rand because
+// span_id collisions across concurrent runs would silently corrupt
+// the trace tree.
+func newSpanID() trace.SpanID {
+	var sid trace.SpanID
+	_, _ = rand.Read(sid[:])
+	return sid
+}

--- a/services/nlpgo/adapters/litellm/modelid.go
+++ b/services/nlpgo/adapters/litellm/modelid.go
@@ -18,10 +18,10 @@ import (
 // pointing to langwatch_nlp/studio/utils.py; this Go module is the third
 // echo and the TS file is the source of truth.)
 var modelAliases = map[string]string{
-	"anthropic/claude-sonnet-4":    "anthropic/claude-sonnet-4-20250514",
-	"anthropic/claude-opus-4":      "anthropic/claude-opus-4-20250514",
-	"anthropic/claude-3.5-haiku":   "anthropic/claude-3-5-haiku-20241022",
-	"anthropic/claude-3.5-sonnet":  "anthropic/claude-3-5-sonnet-20240620",
+	"anthropic/claude-sonnet-4":   "anthropic/claude-sonnet-4-20250514",
+	"anthropic/claude-opus-4":     "anthropic/claude-opus-4-20250514",
+	"anthropic/claude-3.5-haiku":  "anthropic/claude-3-5-haiku-20241022",
+	"anthropic/claude-3.5-sonnet": "anthropic/claude-3-5-sonnet-20240620",
 }
 
 // providersNeedingDotToDash is the allowlist for the dot→dash rewrite. Only

--- a/services/nlpgo/app/app.go
+++ b/services/nlpgo/app/app.go
@@ -53,6 +53,14 @@ type WorkflowRequest struct {
 	TraceID      string
 	ProjectID    string
 	ThreadID     string
+	// NodeID, when non-empty, identifies the single node the Studio
+	// "Run with manual input" flow targets. In that mode `Inputs` are
+	// fed directly into the named node (bypassing edge-based input
+	// resolution) so users can exercise a node in isolation without
+	// wiring a parent Entry → target edge first. Empty means
+	// execute_flow / execute_evaluation, where Inputs go to the Entry
+	// node and propagate via edges.
+	NodeID string
 }
 
 // WorkflowResult is the engine's response, ready for JSON serialization.

--- a/services/nlpgo/app/app.go
+++ b/services/nlpgo/app/app.go
@@ -61,6 +61,14 @@ type WorkflowRequest struct {
 	// execute_flow / execute_evaluation, where Inputs go to the Entry
 	// node and propagate via edges.
 	NodeID string
+	// APIKey is `workflow.api_key` from the inbound payload — peeked
+	// out of WorkflowJSON at decode time so the request handler can
+	// stash it on the request context before creating its top-level
+	// OTel span. Without this, the handler-level span runs before the
+	// engine_adapter parses the workflow, so the TenantRouter has no
+	// api_key in context yet and drops the span. Engine-internal spans
+	// also use it for sibling-trace correlation.
+	APIKey string
 }
 
 // WorkflowResult is the engine's response, ready for JSON serialization.

--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
@@ -65,14 +65,12 @@ func TestCodeBlock_MissingDeclaredOutput(t *testing.T) {
 }
 
 func TestCodeBlock_ExtraOutputKeysPreserved(t *testing.T) {
-	// Back-compat with legacy Python NLP path: customer code that returns
-	// extra keys (eg. `class Code: def __call__: return {"output": ...,
-	// "dspy": repr(dspy)}`) used to surface ALL keys in the Studio
-	// OUTPUTS panel, not only the declared ones. The early Go runner
-	// dropped undeclared keys silently, hiding a half of the user's
-	// dict from operator debugging — caught by rchaves on FF=on dogfood
-	// (PR #3543). The declared-output validation is preserved separately
-	// by TestCodeBlock_MissingDeclaredOutput.
+	// User code that returns extra keys (eg. `class Code: def __call__:
+	// return {"output": ..., "dspy": repr(dspy)}`) must surface ALL
+	// keys in the Studio OUTPUTS panel, not only the declared ones —
+	// operators rely on undeclared diagnostic keys for debug visibility.
+	// Declared-output validation is exercised separately by
+	// TestCodeBlock_MissingDeclaredOutput.
 	requirePython(t)
 	res, err := newExec(t).Execute(context.Background(), codeblock.Request{
 		Code:            "def execute():\n    return {'sum': 5, 'scratch': [1,2,3]}\n",
@@ -179,14 +177,12 @@ func TestCodeBlock_PlainClassWithForward(t *testing.T) {
 	assert.Equal(t, float64(42), res.Outputs["doubled"])
 }
 
-// TestCodeBlock_PlainClassWithCallable pins the new idiomatic-Python
-// default template (PR #3483 dogfood pushback): a plain class that
-// defines __call__ on itself. The runner must instantiate the class
-// and invoke __call__ via `instance(**inputs)`. Both rchaves and
-// Sarah landed on this shape over `def execute()` (free-function)
-// because helpers can live as methods inside the class without
-// polluting top-level scope, and __call__ is a built-in Python
-// convention rather than a framework lineage carryover from torch/dspy.
+// TestCodeBlock_PlainClassWithCallable pins the idiomatic-Python
+// shape: a plain class that defines __call__ on itself. The runner
+// instantiates the class and invokes __call__ via `instance(**inputs)`.
+// __call__ is a built-in Python convention (helpers can live as
+// methods on the class) so it's preferred over a free-function
+// `def execute()` template that would force helpers to top level.
 //
 // Crucial detail: the resolution check is `'__call__' in cls.__dict__`,
 // not `hasattr(cls, '__call__')`. Every class has an inherited

--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
@@ -45,7 +45,7 @@ func TestCodeBlock_HappyPath(t *testing.T) {
 func TestCodeBlock_StdoutCaptured(t *testing.T) {
 	requirePython(t)
 	res, err := newExec(t).Execute(context.Background(), codeblock.Request{
-		Code: "def execute():\n    print('hello-stdout')\n    return {'ok': True}\n",
+		Code:            "def execute():\n    print('hello-stdout')\n    return {'ok': True}\n",
 		DeclaredOutputs: []string{"ok"},
 	})
 	require.NoError(t, err)

--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
@@ -64,7 +64,15 @@ func TestCodeBlock_MissingDeclaredOutput(t *testing.T) {
 	assert.Contains(t, res.Error.Message, "missing_output: diff")
 }
 
-func TestCodeBlock_ExtraOutputDropped(t *testing.T) {
+func TestCodeBlock_ExtraOutputKeysPreserved(t *testing.T) {
+	// Back-compat with legacy Python NLP path: customer code that returns
+	// extra keys (eg. `class Code: def __call__: return {"output": ...,
+	// "dspy": repr(dspy)}`) used to surface ALL keys in the Studio
+	// OUTPUTS panel, not only the declared ones. The early Go runner
+	// dropped undeclared keys silently, hiding a half of the user's
+	// dict from operator debugging — caught by rchaves on FF=on dogfood
+	// (PR #3543). The declared-output validation is preserved separately
+	// by TestCodeBlock_MissingDeclaredOutput.
 	requirePython(t)
 	res, err := newExec(t).Execute(context.Background(), codeblock.Request{
 		Code:            "def execute():\n    return {'sum': 5, 'scratch': [1,2,3]}\n",
@@ -73,8 +81,9 @@ func TestCodeBlock_ExtraOutputDropped(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, res.Error)
 	assert.Equal(t, float64(5), res.Outputs["sum"])
-	_, hasScratch := res.Outputs["scratch"]
-	assert.False(t, hasScratch, "undeclared outputs should be dropped")
+	scratch, hasScratch := res.Outputs["scratch"]
+	assert.True(t, hasScratch, "undeclared output keys must be preserved (legacy parity)")
+	assert.Equal(t, []any{float64(1), float64(2), float64(3)}, scratch)
 }
 
 func TestCodeBlock_RaisesAreStructured(t *testing.T) {

--- a/services/nlpgo/app/engine/blocks/codeblock/runner.py
+++ b/services/nlpgo/app/engine/blocks/codeblock/runner.py
@@ -127,15 +127,12 @@ def main() -> int:
             for name in declared_outputs:
                 if name not in result:
                     raise KeyError(f"missing_output: {name}")
-            # Pass ALL keys through, not just the declared ones — legacy
-            # Python NLP path returned everything the user produced and
-            # the Studio UI surfaces extra keys ad-hoc (operator debugging,
-            # ad-hoc dict returns from `class Code: def __call__: return
-            # {"output": ..., "dspy": ...}` were visible in the OUTPUTS
-            # panel even when only "output" was declared). Filtering broke
-            # back-compat: extra keys silently disappeared in the new
-            # engine. Caught by rchaves on the FF-on dogfood. Pinned by
-            # `TestCodeBlock_PreservesUndeclaredOutputKeys`.
+            # Pass ALL keys through, not just the declared ones. The
+            # Studio UI surfaces extra keys ad-hoc — operator-debug
+            # returns like `{"output": ..., "dspy": repr(dspy)}` need
+            # the diagnostic key visible in the panel even when only
+            # "output" is on the node's declared outputs. Filtering
+            # would silently drop them.
             outputs = dict(result)
     except Exception as exc:  # noqa: BLE001 — sandbox runner intentionally catches every user-code exception so Go can render a structured error in Studio
         error = {

--- a/services/nlpgo/app/engine/blocks/codeblock/runner.py
+++ b/services/nlpgo/app/engine/blocks/codeblock/runner.py
@@ -122,10 +122,21 @@ def main() -> int:
             exec(compile(code, "<code-block>", "exec"), module_globals)
             result = _invoke_user_entrypoint(module_globals, inputs)
             result = _coerce_result(result)
+            # Validate declared outputs are present (these are wired to
+            # downstream nodes; missing them is a contract violation).
             for name in declared_outputs:
                 if name not in result:
                     raise KeyError(f"missing_output: {name}")
-                outputs[name] = result[name]
+            # Pass ALL keys through, not just the declared ones — legacy
+            # Python NLP path returned everything the user produced and
+            # the Studio UI surfaces extra keys ad-hoc (operator debugging,
+            # ad-hoc dict returns from `class Code: def __call__: return
+            # {"output": ..., "dspy": ...}` were visible in the OUTPUTS
+            # panel even when only "output" was declared). Filtering broke
+            # back-compat: extra keys silently disappeared in the new
+            # engine. Caught by rchaves on the FF-on dogfood. Pinned by
+            # `TestCodeBlock_PreservesUndeclaredOutputKeys`.
+            outputs = dict(result)
     except Exception as exc:  # noqa: BLE001 — sandbox runner intentionally catches every user-code exception so Go can render a structured error in Studio
         error = {
             "type": type(exc).__name__,

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -186,9 +186,11 @@ func (e *Engine) runLayer(ctx context.Context, req ExecuteRequest, plan *planner
 			node := state.nodes[nodeID]
 			inputs := state.resolveInputs(plan, nodeID)
 			ns := &NodeState{ID: nodeID, Status: "running", Inputs: inputs}
+			nodeCtx, span := startNodeSpan(ctx, node, req)
 			started := time.Now()
-			outputs, derr := e.dispatch(ctx, req, node, inputs, ns)
+			outputs, derr := e.dispatch(nodeCtx, req, node, inputs, ns)
 			ns.DurationMS = time.Since(started).Milliseconds()
+			endNodeSpan(span, ns, derr)
 			if derr != nil {
 				ns.Status = "error"
 				ns.Error = derr

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -80,9 +80,12 @@ func New(opts Options) *Engine {
 // ExecuteRequest is what the handler hands to the engine per call.
 type ExecuteRequest struct {
 	Workflow *dsl.Workflow
-	// Inputs, if non-nil, provide entry-node outputs explicitly and
-	// bypass dataset materialization. For dataset-driven runs leave
-	// nil and the engine reads workflow.nodes[entry].dataset.inline.
+	// Inputs, if non-nil, provide either entry-node outputs (for
+	// execute_flow / execute_evaluation, when NodeID is empty) or the
+	// target node's manual inputs (for execute_component, when NodeID
+	// names that target). The Studio "Run with manual input" flow
+	// types into a node's input panel and clicks Execute → the
+	// values land here keyed by input identifier.
 	Inputs    map[string]any
 	Origin    string
 	TraceID   string
@@ -94,6 +97,13 @@ type ExecuteRequest struct {
 	// the `X-LangWatch-Thread-Id` header so the receiving services can
 	// stamp it onto the spans they emit.
 	ThreadID string
+	// NodeID, when non-empty, signals the Studio execute_component
+	// flow: Inputs are the user-typed values for the named node, fed
+	// in directly (bypassing edge-based resolution). Empty means
+	// execute_flow / execute_evaluation, where Inputs are entry-node
+	// outputs and propagate via edges. Mirrors Python's
+	// `ExecuteComponentPayload.node_id` (langwatch_nlp/studio/app.py).
+	NodeID string
 }
 
 // ExecuteResult is what the engine returns. It mirrors the Python
@@ -152,6 +162,13 @@ func (e *Engine) Execute(ctx context.Context, req ExecuteRequest) (*ExecuteResul
 		return nil, err
 	}
 	state := newRunState(req.Workflow)
+	if req.NodeID != "" && len(req.Inputs) > 0 {
+		// execute_component: feed user-typed inputs straight into the
+		// target node, regardless of how the workflow's edges are wired.
+		// resolveInputs picks these up before walking inbound edges.
+		state.manualInputsTarget = req.NodeID
+		state.manualInputs = req.Inputs
+	}
 	started := time.Now()
 	for _, layer := range plan.Layers {
 		if err := ctx.Err(); err != nil {
@@ -227,7 +244,12 @@ func (e *Engine) runEntry(node *dsl.Node, req ExecuteRequest) (map[string]any, *
 	// means "use the workflow's dataset", not "set entry outputs to
 	// the empty map". Only honor explicit non-empty inputs as a
 	// dataset override.
-	if len(req.Inputs) > 0 {
+	//
+	// When NodeID is set (execute_component) the inputs belong to that
+	// target node, NOT to entry — runState.resolveInputs short-circuits
+	// for the target. Entry must fall through to dataset materialization
+	// here so it doesn't accidentally swallow the user's per-node typing.
+	if len(req.Inputs) > 0 && req.NodeID == "" {
 		return req.Inputs, nil
 	}
 	if node.Data.Dataset == nil || node.Data.Dataset.Inline == nil {
@@ -639,6 +661,12 @@ type runState struct {
 	// resolveInputs can rename outputs.<source_name> → inputs.<target_name>
 	// per Studio's wire convention.
 	edgesByTarget map[string][]dsl.Edge
+	// manualInputsTarget + manualInputs back the Studio
+	// execute_component flow: when manualInputsTarget == nodeID,
+	// resolveInputs returns manualInputs directly instead of walking
+	// inbound edges. Both are zero-valued for execute_flow runs.
+	manualInputsTarget string
+	manualInputs       map[string]any
 }
 
 func newRunState(w *dsl.Workflow) *runState {
@@ -702,6 +730,17 @@ func (r *runState) resolveInputs(_ *planner.Plan, id string) map[string]any {
 	// principle return a half-written upstream output map under load.
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// execute_component: return the user's manual inputs verbatim for
+	// the named target. Skips edge resolution entirely so a fresh-dragged
+	// node with no Entry→target wiring still receives the typed values.
+	// `Code.__call__()` missing-positional-arg errors traced back here.
+	if id == r.manualInputsTarget && r.manualInputs != nil {
+		copied := make(map[string]any, len(r.manualInputs))
+		for k, v := range r.manualInputs {
+			copied[k] = v
+		}
+		return copied
+	}
 	edges := r.edgesByTarget[id]
 	for _, e := range edges {
 		parentOut, ok := r.outputs[e.Source]

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -162,13 +162,7 @@ func (e *Engine) Execute(ctx context.Context, req ExecuteRequest) (*ExecuteResul
 		return nil, err
 	}
 	state := newRunState(req.Workflow)
-	if req.NodeID != "" && len(req.Inputs) > 0 {
-		// execute_component: feed user-typed inputs straight into the
-		// target node, regardless of how the workflow's edges are wired.
-		// resolveInputs picks these up before walking inbound edges.
-		state.manualInputsTarget = req.NodeID
-		state.manualInputs = req.Inputs
-	}
+	applyManualInputs(state, req)
 	started := time.Now()
 	for _, layer := range plan.Layers {
 		if err := ctx.Err(); err != nil {
@@ -645,6 +639,20 @@ func (e *Engine) runAgentWorkflow(ctx context.Context, req ExecuteRequest, node 
 		}
 	}
 	return map[string]any{"value": res.Result}, nil
+}
+
+// applyManualInputs primes runState with the inbound execute_component
+// payload's `node_id` + `inputs` so resolveInputs can short-circuit for
+// the target node. Both Execute and ExecuteStream MUST call this — the
+// streaming path forgot it once already (Bug 1, ash-detected via Studio
+// dogfood) and the symptom (Code.__call__() missing input) was bizarre.
+// Helper exists to keep that parity from drifting again.
+func applyManualInputs(state *runState, req ExecuteRequest) {
+	if req.NodeID == "" || len(req.Inputs) == 0 {
+		return
+	}
+	state.manualInputsTarget = req.NodeID
+	state.manualInputs = req.Inputs
 }
 
 // runState aggregates per-node outputs and tracks the first error

--- a/services/nlpgo/app/engine/manual_inputs_test.go
+++ b/services/nlpgo/app/engine/manual_inputs_test.go
@@ -1,0 +1,86 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// Manual-inputs override pins the Studio "Run with manual input" flow
+// (execute_component): when the user types into a node's input panel
+// and clicks Execute, those values must reach THAT node directly,
+// regardless of how the workflow's edges are wired (or whether they
+// exist at all).
+//
+// Pre-fix behavior: resolveInputs always walked inbound edges, and
+// req.Inputs was treated as Entry-node outputs. A fresh-dragged Code
+// node with no Entry→Code wiring received an empty input map → the
+// Python runner raised
+//   `Code.__call__() missing 1 required positional argument: 'input'`
+// and the Studio input field appeared to be silently dropped on
+// Execute click.
+//
+// Mirrors langwatch_nlp/studio/app.py's `payload.node_id` plumbing:
+// when node_id is set, the inputs are the target's manual values, not
+// the Entry's outputs. See ExecuteRequest.NodeID for the contract.
+func TestResolveInputs_ManualInputsForTargetNode(t *testing.T) {
+	wf := &dsl.Workflow{
+		Nodes: []dsl.Node{
+			{ID: "code-1", Type: dsl.ComponentCode},
+		},
+	}
+	state := newRunState(wf)
+	state.manualInputsTarget = "code-1"
+	state.manualInputs = map[string]any{"input": "asdf", "extra": 42}
+
+	got := state.resolveInputs(nil, "code-1")
+
+	assert.Equal(t, map[string]any{"input": "asdf", "extra": 42}, got)
+}
+
+// Other nodes in the workflow keep their normal edge-based resolution
+// even when a manualInputsTarget is set. Multi-node Studio runs would
+// break if every node received the manual inputs — only the explicit
+// target should.
+func TestResolveInputs_ManualInputsScopedToTarget(t *testing.T) {
+	wf := &dsl.Workflow{
+		Nodes: []dsl.Node{
+			{ID: "code-1", Type: dsl.ComponentCode},
+			{ID: "code-2", Type: dsl.ComponentCode},
+		},
+	}
+	state := newRunState(wf)
+	state.manualInputsTarget = "code-1"
+	state.manualInputs = map[string]any{"input": "for-code-1"}
+
+	other := state.resolveInputs(nil, "code-2")
+
+	assert.Empty(t, other, "non-target nodes must not receive manual inputs")
+}
+
+// Regression guard for caller-side mutation: the returned map must be
+// a copy, not a shared reference into runState. Otherwise a downstream
+// node executor that mutates its inputs (rare but legal) would
+// silently corrupt the original manualInputs and break a re-resolution
+// later in the same run.
+func TestResolveInputs_ManualInputsReturnsCopy(t *testing.T) {
+	wf := &dsl.Workflow{
+		Nodes: []dsl.Node{
+			{ID: "code-1", Type: dsl.ComponentCode},
+		},
+	}
+	state := newRunState(wf)
+	original := map[string]any{"input": "asdf"}
+	state.manualInputsTarget = "code-1"
+	state.manualInputs = original
+
+	got := state.resolveInputs(nil, "code-1")
+	got["input"] = "mutated"
+	got["new_key"] = "added"
+
+	assert.Equal(t, "asdf", original["input"], "mutation of returned map must not affect runState.manualInputs")
+	_, exists := original["new_key"]
+	assert.False(t, exists, "additions to returned map must not leak into runState.manualInputs")
+}

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -110,9 +110,11 @@ func (e *Engine) runLayerStream(ctx context.Context, req ExecuteRequest, plan *p
 			inputs := state.resolveInputs(plan, nodeID)
 			ns := &NodeState{ID: nodeID, Status: "running", Inputs: inputs}
 			emit(ctx, out, stateEvent(traceID, nodeID, ns))
+			nodeCtx, span := startNodeSpan(ctx, node, req)
 			started := time.Now()
-			outputs, derr := e.dispatch(ctx, req, node, inputs, ns)
+			outputs, derr := e.dispatch(nodeCtx, req, node, inputs, ns)
 			ns.DurationMS = time.Since(started).Milliseconds()
+			endNodeSpan(span, ns, derr)
 			if derr != nil {
 				ns.Status = "error"
 				ns.Error = derr

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -51,6 +51,7 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 		return nil, err
 	}
 	state := newRunState(req.Workflow)
+	applyManualInputs(state, req)
 
 	out := make(chan StreamEvent, 16)
 	go func() {

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -188,11 +188,21 @@ func stateEvent(traceID, nodeID string, ns *NodeState) StreamEvent {
 		es["error"] = ns.Error.Message
 	}
 	if ns.DurationMS > 0 {
-		// Python emits `timestamps.{started_at, finished_at}` — we don't
-		// track absolute clock-times in NodeState yet, so emit a single
-		// finished_at = now and leave started_at to the running event.
+		// Studio's ExecutionOutputPanel.tsx renders the per-component
+		// duration via `<SpanDuration>` only when BOTH
+		// `timestamps.started_at` and `timestamps.finished_at` are set
+		// (`hasTiming = started_at && finished_at`). We previously
+		// emitted only `finished_at` so the panel's "370ms · Full Trace"
+		// line silently went blank on FF=on (caught by rchaves on the
+		// dogfood). Derive started_at from finished_at − DurationMS
+		// rather than threading absolute clock-times through NodeState
+		// — the wall-clock skew between the running and finished events
+		// would be measured in microseconds anyway, and the UI only
+		// uses the diff.
+		finishedAt := time.Now().UnixMilli()
 		es["timestamps"] = map[string]any{
-			"finished_at": time.Now().UnixMilli(),
+			"started_at":  finishedAt - ns.DurationMS,
+			"finished_at": finishedAt,
 		}
 	}
 	return StreamEvent{

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -188,17 +188,14 @@ func stateEvent(traceID, nodeID string, ns *NodeState) StreamEvent {
 		es["error"] = ns.Error.Message
 	}
 	if ns.DurationMS > 0 {
-		// Studio's ExecutionOutputPanel.tsx renders the per-component
+		// Studio's ExecutionOutputPanel renders the per-component
 		// duration via `<SpanDuration>` only when BOTH
 		// `timestamps.started_at` and `timestamps.finished_at` are set
-		// (`hasTiming = started_at && finished_at`). We previously
-		// emitted only `finished_at` so the panel's "370ms · Full Trace"
-		// line silently went blank on FF=on (caught by rchaves on the
-		// dogfood). Derive started_at from finished_at − DurationMS
-		// rather than threading absolute clock-times through NodeState
-		// — the wall-clock skew between the running and finished events
-		// would be measured in microseconds anyway, and the UI only
-		// uses the diff.
+		// (`hasTiming = started_at && finished_at`). Derive started_at
+		// from finished_at − DurationMS rather than threading absolute
+		// clock-times through NodeState — the UI only uses the diff,
+		// and the wall-clock skew between the running and finished
+		// events is measured in microseconds.
 		finishedAt := time.Now().UnixMilli()
 		es["timestamps"] = map[string]any{
 			"started_at":  finishedAt - ns.DurationMS,

--- a/services/nlpgo/app/engine/stream_test.go
+++ b/services/nlpgo/app/engine/stream_test.go
@@ -60,18 +60,16 @@ func TestExecuteStream_HeartbeatExitDoesNotRaceWithClose(t *testing.T) {
 	}
 }
 
-// TestStateEvent_TimestampsHaveBothStartedAndFinished pins the fix for
-// Studio's per-component duration display going blank on FF=on.
+// TestStateEvent_TimestampsHaveBothStartedAndFinished pins both
+// timestamps on the per-component finished event so Studio's
+// ExecutionOutputPanel can render the duration line.
 //
-// ExecutionOutputPanel.tsx line 80:
+// ExecutionOutputPanel.tsx gates "<duration>ms · Full Trace" on:
 //
 //	const hasTiming = executionState.timestamps?.started_at &&
 //	                  executionState.timestamps?.finished_at;
 //
-// `hasTiming` is the gate for rendering "<duration>ms · Full Trace".
-// Without `started_at`, the line goes silent; rchaves spotted this on
-// the dogfood. The Python emitter ships both; the Go emitter previously
-// shipped only finished_at.
+// Both must be present or the line goes silent.
 func TestStateEvent_TimestampsHaveBothStartedAndFinished(t *testing.T) {
 	ns := &NodeState{
 		ID:         "code",

--- a/services/nlpgo/app/engine/stream_test.go
+++ b/services/nlpgo/app/engine/stream_test.go
@@ -59,3 +59,61 @@ func TestExecuteStream_HeartbeatExitDoesNotRaceWithClose(t *testing.T) {
 		wg.Wait()
 	}
 }
+
+// TestStateEvent_TimestampsHaveBothStartedAndFinished pins the fix for
+// Studio's per-component duration display going blank on FF=on.
+//
+// ExecutionOutputPanel.tsx line 80:
+//
+//	const hasTiming = executionState.timestamps?.started_at &&
+//	                  executionState.timestamps?.finished_at;
+//
+// `hasTiming` is the gate for rendering "<duration>ms · Full Trace".
+// Without `started_at`, the line goes silent; rchaves spotted this on
+// the dogfood. The Python emitter ships both; the Go emitter previously
+// shipped only finished_at.
+func TestStateEvent_TimestampsHaveBothStartedAndFinished(t *testing.T) {
+	ns := &NodeState{
+		ID:         "code",
+		Status:     "success",
+		DurationMS: 250,
+	}
+	ev := stateEvent("trace-x", "code", ns)
+	payload, ok := ev.Payload["execution_state"].(map[string]any)
+	if !ok {
+		t.Fatalf("execution_state missing or wrong type")
+	}
+	ts, ok := payload["timestamps"].(map[string]any)
+	if !ok {
+		t.Fatalf("timestamps map missing — UI uses it to gate the duration line")
+	}
+	startedRaw, hasStarted := ts["started_at"]
+	finishedRaw, hasFinished := ts["finished_at"]
+	if !hasStarted || !hasFinished {
+		t.Fatalf("expected both started_at and finished_at; got %v", ts)
+	}
+	started, ok := startedRaw.(int64)
+	if !ok {
+		t.Fatalf("started_at must be int64; got %T", startedRaw)
+	}
+	finished, ok := finishedRaw.(int64)
+	if !ok {
+		t.Fatalf("finished_at must be int64; got %T", finishedRaw)
+	}
+	if got := finished - started; got != ns.DurationMS {
+		t.Errorf("finished - started = %dms; want %dms (DurationMS round-trip)", got, ns.DurationMS)
+	}
+}
+
+// TestStateEvent_NoTimestampsWhenDurationZero pins the inverse: the
+// running event (status=running, DurationMS still zero) must NOT emit a
+// timestamps map, otherwise the UI's hasTiming gate would render a
+// negative duration.
+func TestStateEvent_NoTimestampsWhenDurationZero(t *testing.T) {
+	ns := &NodeState{ID: "code", Status: "running", DurationMS: 0}
+	ev := stateEvent("trace-x", "code", ns)
+	payload := ev.Payload["execution_state"].(map[string]any)
+	if _, ok := payload["timestamps"]; ok {
+		t.Errorf("running event must not include timestamps; got %v", payload["timestamps"])
+	}
+}

--- a/services/nlpgo/app/engine/tracing.go
+++ b/services/nlpgo/app/engine/tracing.go
@@ -1,0 +1,70 @@
+// Per-node OTel span helpers used by both the synchronous (Execute)
+// and streaming (ExecuteStream) paths. Spans hang off the request's
+// existing trace (set by the handler in adapters/httpapi/tracing.go)
+// so the Studio "Full Trace" drawer shows one tree rooted at the
+// langwatch-app-minted trace_id with one child per executed node.
+package engine
+
+import (
+	"context"
+
+	otelapi "go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+const tracerName = "langwatch-nlpgo"
+
+// startNodeSpan opens a span for one node's dispatch. Span name is
+// `nlpgo.node.<type>` (e.g. nlpgo.node.code, nlpgo.node.signature) so
+// trace explorers can filter to a single node kind. Attributes carry
+// the workflow-level identity (project_id / origin / thread_id) so the
+// span is queryable in isolation without joining back to the parent.
+func startNodeSpan(ctx context.Context, node *dsl.Node, req ExecuteRequest) (context.Context, trace.Span) {
+	tracer := otelapi.Tracer(tracerName)
+	attrs := []attribute.KeyValue{
+		attribute.String("langwatch.node_id", node.ID),
+		attribute.String("langwatch.node_type", string(node.Type)),
+	}
+	if req.ProjectID != "" {
+		attrs = append(attrs, attribute.String("langwatch.project_id", req.ProjectID))
+	}
+	if req.TraceID != "" {
+		attrs = append(attrs, attribute.String("langwatch.trace_id", req.TraceID))
+	}
+	if req.ThreadID != "" {
+		attrs = append(attrs, attribute.String("langwatch.thread_id", req.ThreadID))
+	}
+	if req.Origin != "" {
+		attrs = append(attrs, attribute.String("langwatch.origin", req.Origin))
+	}
+	return tracer.Start(ctx, "nlpgo.node."+string(node.Type),
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+// endNodeSpan closes a node span and stamps the dispatch outcome.
+// Error spans get the structured node-error type/message (matches the
+// `error.type` semconv shape) so trace search by error class works.
+func endNodeSpan(span trace.Span, ns *NodeState, derr *NodeError) {
+	if derr != nil {
+		span.SetStatus(codes.Error, derr.Message)
+		span.SetAttributes(
+			attribute.String("error.type", derr.Type),
+			attribute.String("error.message", derr.Message),
+		)
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	if ns != nil && ns.DurationMS > 0 {
+		span.SetAttributes(attribute.Int64("langwatch.duration_ms", ns.DurationMS))
+	}
+	if ns != nil && ns.Cost > 0 {
+		span.SetAttributes(attribute.Float64("langwatch.cost", ns.Cost))
+	}
+	span.End()
+}

--- a/services/nlpgo/app/engine/tracing_test.go
+++ b/services/nlpgo/app/engine/tracing_test.go
@@ -1,0 +1,120 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	otelapi "go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// withRecorder swaps in a sdktrace TracerProvider with a SpanRecorder
+// for the duration of the test, restoring the previous provider on
+// cleanup. Tests assert against the recorder's captured spans.
+func withRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	prev := otelapi.GetTracerProvider()
+	otelapi.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otelapi.SetTracerProvider(prev)
+	})
+	return rec
+}
+
+// TestStartNodeSpan_NameAndAttributes pins the span shape downstream
+// trace explorers depend on: the name slug encodes the node type so
+// filtering by "all code-block runs" works, and the langwatch.* attrs
+// give per-tenant + per-trace correlation without any join.
+func TestStartNodeSpan_NameAndAttributes(t *testing.T) {
+	rec := withRecorder(t)
+
+	node := &dsl.Node{ID: "code-1", Type: dsl.ComponentCode}
+	req := ExecuteRequest{
+		ProjectID: "proj_abc",
+		TraceID:   "trace_xyz",
+		ThreadID:  "thread_qq",
+		Origin:    "workflow",
+	}
+	_, span := startNodeSpan(context.Background(), node, req)
+	endNodeSpan(span, &NodeState{DurationMS: 42, Cost: 0.001}, nil)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+	got := spans[0]
+	assert.Equal(t, "nlpgo.node.code", got.Name())
+	attrs := attrMap(got.Attributes())
+	assert.Equal(t, "code-1", attrs["langwatch.node_id"])
+	assert.Equal(t, "code", attrs["langwatch.node_type"])
+	assert.Equal(t, "proj_abc", attrs["langwatch.project_id"])
+	assert.Equal(t, "trace_xyz", attrs["langwatch.trace_id"])
+	assert.Equal(t, "thread_qq", attrs["langwatch.thread_id"])
+	assert.Equal(t, "workflow", attrs["langwatch.origin"])
+	assert.Equal(t, int64(42), attrs["langwatch.duration_ms"])
+	assert.Equal(t, 0.001, attrs["langwatch.cost"])
+	assert.Equal(t, codes.Ok, got.Status().Code)
+}
+
+// TestEndNodeSpan_RecordsErrorOnDispatchFailure: when dispatch returns
+// a NodeError, the span carries error.type / error.message and a
+// codes.Error status so trace-search by failure class works.
+func TestEndNodeSpan_RecordsErrorOnDispatchFailure(t *testing.T) {
+	rec := withRecorder(t)
+
+	node := &dsl.Node{ID: "code-1", Type: dsl.ComponentCode}
+	_, span := startNodeSpan(context.Background(), node, ExecuteRequest{})
+	endNodeSpan(span, &NodeState{DurationMS: 5},
+		&NodeError{Type: "code_runner_error", Message: "boom"},
+	)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+	got := spans[0]
+	assert.Equal(t, codes.Error, got.Status().Code)
+	assert.Equal(t, "boom", got.Status().Description)
+	attrs := attrMap(got.Attributes())
+	assert.Equal(t, "code_runner_error", attrs["error.type"])
+	assert.Equal(t, "boom", attrs["error.message"])
+}
+
+// TestStartNodeSpan_NoOptionalAttrsWhenAbsent keeps the spans tight —
+// trace storage isn't free, and stamping empty-string attributes
+// pollutes filter dropdowns in trace UIs. Only the always-present
+// fields land when the request has no project/trace/etc.
+func TestStartNodeSpan_NoOptionalAttrsWhenAbsent(t *testing.T) {
+	rec := withRecorder(t)
+
+	node := &dsl.Node{ID: "x", Type: dsl.ComponentSignature}
+	_, span := startNodeSpan(context.Background(), node, ExecuteRequest{})
+	endNodeSpan(span, nil, nil)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+	attrs := attrMap(spans[0].Attributes())
+	assert.Contains(t, attrs, "langwatch.node_id")
+	assert.Contains(t, attrs, "langwatch.node_type")
+	assert.NotContains(t, attrs, "langwatch.project_id")
+	assert.NotContains(t, attrs, "langwatch.trace_id")
+	assert.NotContains(t, attrs, "langwatch.thread_id")
+	assert.NotContains(t, attrs, "langwatch.origin")
+	assert.NotContains(t, attrs, "langwatch.duration_ms")
+	assert.NotContains(t, attrs, "langwatch.cost")
+}
+
+func attrMap(kvs []attribute.KeyValue) map[string]any {
+	out := make(map[string]any, len(kvs))
+	for _, kv := range kvs {
+		out[string(kv.Key)] = kv.Value.AsInterface()
+	}
+	return out
+}

--- a/services/nlpgo/cmd/engine_adapter.go
+++ b/services/nlpgo/cmd/engine_adapter.go
@@ -37,6 +37,7 @@ func (a engineAdapter) ExecuteStream(ctx context.Context, req app.WorkflowReques
 		TraceID:   req.TraceID,
 		ProjectID: req.ProjectID,
 		ThreadID:  req.ThreadID,
+		NodeID:    req.NodeID,
 	}, engine.ExecuteStreamOptions{Heartbeat: opts.Heartbeat})
 	if err != nil {
 		ch := make(chan app.WorkflowStreamEvent, 1)
@@ -77,6 +78,7 @@ func (a engineAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (*a
 		TraceID:   req.TraceID,
 		ProjectID: req.ProjectID,
 		ThreadID:  req.ThreadID,
+		NodeID:    req.NodeID,
 	})
 	if err != nil {
 		return &app.WorkflowResult{

--- a/services/nlpgo/cmd/engine_adapter.go
+++ b/services/nlpgo/cmd/engine_adapter.go
@@ -3,10 +3,23 @@ package cmd
 import (
 	"context"
 
+	"github.com/langwatch/langwatch/pkg/otelsetup"
 	"github.com/langwatch/langwatch/services/nlpgo/app"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
 )
+
+// withWorkflowAPIKey copies the parsed workflow's api_key onto the
+// request context so otelsetup.TenantRouter can attribute every span
+// produced during this run to the right LangWatch project. Empty
+// api_key is a no-op — TenantRouter drops un-authenticated spans
+// rather than risking a wrong-tenant attribution.
+func withWorkflowAPIKey(ctx context.Context, wf *dsl.Workflow) context.Context {
+	if wf == nil || wf.APIKey == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, otelsetup.APIKeyContextKey{}, wf.APIKey)
+}
 
 // engineAdapter satisfies app.WorkflowExecutor by parsing the raw
 // workflow JSON, invoking engine.Engine, and converting the result
@@ -30,6 +43,7 @@ func (a engineAdapter) ExecuteStream(ctx context.Context, req app.WorkflowReques
 		close(ch)
 		return ch, nil
 	}
+	ctx = withWorkflowAPIKey(ctx, wf)
 	in, err := a.eng.ExecuteStream(ctx, engine.ExecuteRequest{
 		Workflow:  wf,
 		Inputs:    req.Inputs,
@@ -71,6 +85,7 @@ func (a engineAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (*a
 			},
 		}, nil
 	}
+	ctx = withWorkflowAPIKey(ctx, wf)
 	res, err := a.eng.Execute(ctx, engine.ExecuteRequest{
 		Workflow:  wf,
 		Inputs:    req.Inputs,

--- a/services/nlpgo/deps.go
+++ b/services/nlpgo/deps.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -17,6 +18,35 @@ import (
 	"github.com/langwatch/langwatch/services/nlpgo/adapters/proxypass"
 	"github.com/langwatch/langwatch/services/nlpgo/adapters/uvicornchild"
 )
+
+// configureNLPGoOTel installs nlpgo's OTel provider in multi-tenant
+// mode: every span is routed to a per-tenant exporter keyed by the
+// inbound `workflow.api_key`, so spans from project A and project B
+// can't end up in one another's traces even when the same Lambda
+// container handles both.
+//
+// Endpoint resolution mirrors the legacy Python service: read
+// `LANGWATCH_ENDPOINT` (the universal LangWatch URL env var), append
+// the OTLP traces path. Falls back to the generic `OTEL_OTLP_ENDPOINT`
+// only when LANGWATCH_ENDPOINT is unset, for environments that wire
+// OTel via the standard OTel env vars.
+func configureNLPGoOTel(ctx context.Context, cfg Config, nodeID string) (*otelsetup.Provider, error) {
+	endpoint := strings.TrimSpace(os.Getenv("LANGWATCH_ENDPOINT"))
+	if endpoint != "" {
+		endpoint = strings.TrimRight(endpoint, "/") + "/api/otel/v1/traces"
+	} else {
+		endpoint = cfg.OTel.OTLPEndpoint
+		if endpoint != "" && !strings.HasSuffix(endpoint, "/v1/traces") {
+			endpoint = strings.TrimRight(endpoint, "/") + "/v1/traces"
+		}
+	}
+	return otelsetup.New(ctx, otelsetup.Options{
+		NodeID:       nodeID,
+		OTLPEndpoint: endpoint,
+		SampleRatio:  cfg.OTel.SampleRatio,
+		MultiTenant:  true,
+	})
+}
 
 // Deps holds nlpgo's infrastructure adapters.
 type Deps struct {
@@ -37,7 +67,7 @@ func NewDeps(ctx context.Context, cfg Config) (context.Context, *Deps, error) {
 	ctx = clog.Set(ctx, logger)
 	nodeID := resolveNodeID(ctx, logger)
 
-	otelProvider, err := cfg.OTel.Configure(ctx, nodeID)
+	otelProvider, err := configureNLPGoOTel(ctx, cfg, nodeID)
 	if err != nil {
 		return ctx, nil, fmt.Errorf("otel init: %w", err)
 	}


### PR DESCRIPTION
## Summary

PR #3483 shipped a new Studio default Code template:

```python
class Code:
    def __call__(self, input: str):
        return {"output": "Hello world!"}
```

Customers still on the legacy Python NLP path (FF=off — `release_nlp_go_engine_enabled` not yet rolled to their project) hit:

```
Could not find a class that inherits from dspy.Module for component Code
```

…on every run, because Studio's new default doesn't inherit from `dspy.Module`. This PR makes the legacy Python parser shape-agnostic and lands several other fixes surfaced during dogfood.

## Fixes shipped on this branch

### 1. Parser back-compat (the headline)

`langwatch_nlp/studio/parser.py` previously regex-matched `class X(dspy.Module):`. Replaced with AST-based class discovery (`ast.parse` + `ast.ClassDef` iteration) and a 4-step resolver in `_resolve_code_class_name(code, node_name, kind)`:

1. `class X(dspy.Module):` — preferred (legacy default).
2. `class X:` matching the node's normalized class name.
3. First top-level `class X:` declaration.
4. No class found → `ValueError` listing supported shapes.

Loosened `materialized_component_class` return type from `Type[dspy.Module]` to `Type[Any]`. Mirrors the priority order used by the Go runner (`services/nlpgo/.../runner.py`).

### 2. forward() fallback in execute_component

`dspy.asyncify(instance)` calls `instance(...)` which requires `__call__`. Plain `class X: def forward(...)` (transitional shape from the dspy-rip) was TypeError'ing at call time. Added `invoke_target = instance if callable(instance) else getattr(instance, "forward", None)` with a typed error if neither is callable.

### 3. Code-block runner: pass-through extra output keys

`services/nlpgo/.../runner.py` was filtering returned keys to only the declared outputs. Operator-debug returns like `{"output": ..., "dspy": repr(dspy)}` lost the diagnostic key. Validation still asserts declared outputs are present; surfacing now passes all keys through (`outputs = dict(result)`).

### 4. Component-finished event: emit both timestamps

Studio's `ExecutionOutputPanel.tsx` gates the duration line on `started_at && finished_at`. The Go emitter only set `finished_at`, so the duration line stayed silent. Now derives `started_at = finished_at - DurationMS` so the round-trip yields the original duration.

Pinned by:
- `services/nlpgo/app/engine/stream_test.go::TestStateEvent_TimestampsHaveBothStartedAndFinished`
- `services/nlpgo/app/engine/stream_test.go::TestStateEvent_NoTimestampsWhenDurationZero` (running event must NOT emit timestamps)

### 5. Manual inputs reach the runner on FF=on (streaming path)

When the user types a manual input, Studio routes execute_component with `inputs=...`. The Go engine ignored these and reconstructed inputs from upstream edges, so single-node executions like `Code({"input": "hi"})` arrived at the runner with no `input` field and Python complained:
```
Code.__call__() missing 1 required positional argument: 'input'
```

Plumbed `manualInputsTarget` + `manualInputs` through `runState`, with a `resolveInputs` short-circuit when the dispatched node ID matches the target. Both `Execute` (sync) and `ExecuteStream` (SSE) now apply manual inputs via shared `applyManualInputs(state, req)`.

**Verified live:** ![bug 1 fixed](https://i.img402.dev/w9zt351unh.png)

### 6. PostHog feature flag plumbing

- `nlpgoFetch.isNlpGoEnabled` auto-resolves the project's organization (10-min TTL cache via `resolveOrganizationId`) so both call sites can opt out of explicit `organizationId` plumbing without losing org-level FF targeting.
- `usePostHog.ts` now sets `window.posthog = posthog` in the loaded callback so the toolbar attaches reliably.

### 7. Per-tenant OTel router (instrumentation)

Per rchaves's "SAME PR / SAME BRANCH" directive, instrumentation lands on this branch instead of a follow-up.

- `pkg/otelsetup/tenant_router.go` — per-tenant `BatchSpanProcessor` cache, side-channel `sync.Map` keyed by `{trace_id, span_id}` storing the api_key (NOT a span attribute → wire-safe, no chance of token getting persisted into the trace DB).
- `services/nlpgo/adapters/httpapi/tracing.go` — `startStudioSpan` at executeSyncHandler / executeStreamHandler entry; uses inbound `payload.trace_id` as remote SpanContext so spans share the trace root.
- `services/nlpgo/app/engine/tracing.go` — per-node `nlpgo.node.<type>` spans wrapping each dispatch in `runLayer` / `runLayerStream`; carries `duration_ms`, `cost`, `error` attributes.

Lambda-safe: warm container reuse cannot leak across tenants because the api_key is read from request context, never global state.

**Trace export verified live:** drawer renders trace data (INPUT, PROMPT TRACING, exception details), confirming spans flow nlpgo → /api/otel/v1/traces → ClickHouse → UI.

![trace export](https://i.img402.dev/ozge4068mw.png)

### 8. Test fix (CI flake → green)

`post-event-routing.test.ts` mocked `featureFlagService.isEnabled` but not `isNlpGoEnabled` itself, so `studioBackendPostEvent → isNlpGoEnabled → resolveOrganizationId → prisma.project.findUnique` ran live. Unit shards have no `DATABASE_URL`, so all 5 FF-on routing assertions failed with `PrismaClientInitializationError`. Locally green because the dev DB is up. Fixed by stubbing the gate directly.

## Test plan

- [x] `tests/studio/test_parse.py::TestCodeNodeClassResolutionShapes` — 6 tests pinning all four parser-resolution paths.
- [x] `test_class_in_comment_or_docstring_is_not_picked` — regression for the regex→AST switch (CodeRabbit catch).
- [x] Existing `test_parse_code` (dspy.Module subclass) still passes — back-compat anchor.
- [x] `services/nlpgo/.../codeblock/codeblock_test.go::TestCodeBlock_*` — runner shape coverage (legacy dspy.Module / __call__ / forward / execute / extra-keys / no-class error).
- [x] `services/nlpgo/app/engine/stream_test.go::TestStateEvent_*` — timestamps + heartbeat-vs-close race regression.
- [x] `langwatch/src/app/api/workflows/post_event/__tests__/post-event-routing.test.ts` — 5 FF-on routing pins (now CI-green with the isNlpGoEnabled stub).
- [x] Browser dogfood (FF=on): drag fresh Code → fill manual input → execute. Result panel renders output, duration, and Full Trace populated.
- [x] Browser dogfood (FF=on): Full Trace drawer shows actual span content, not the empty headers reported pre-instrumentation.

## Why this couldn't wait for FF rollout

The new code-block template is the **default** in Studio. Customers without the FF override are still on the Python path, so dragging a fresh Code block produces a broken workflow. Same-PR fix for FF=off until the FF rolls out org-wide.