### PR TITLE
fix(skills): publish datasets skill to langwatch/skills repo

### DIFF
--- a/skills/_publish/sync.ts
+++ b/skills/_publish/sync.ts
@@ -22,6 +22,7 @@ const FEATURE_SKILLS = [
   "prompts",
   "analytics",
   "level-up",
+  "datasets",
 ];
 
 function cleanTarget(targetDir: string): void {


### PR DESCRIPTION
## Summary

- The `datasets` skill exists locally at `skills/datasets/SKILL.mdx` but was missing from the `FEATURE_SKILLS` allowlist in `skills/_publish/sync.ts`, so the `skills-publish` workflow silently skipped it on every main push.
- As a result `npx skills add langwatch/skills/datasets` errors with `No skills found` — the directory was never copied into the published [`langwatch/skills`](https://github.com/langwatch/skills) repo (which currently only has `analytics, evaluations, level-up, prompts, recipes, scenarios, tracing`).
- One-line fix: add `"datasets"` to `FEATURE_SKILLS`.

## How the release pipeline works (for reviewers)

1. `.github/workflows/skills-publish.yml` triggers on push to `main` whenever `skills/*/SKILL.mdx`, `skills/_publish/**`, `skills/_lib/**`, `skills/_shared/*.mdx`, or `skills/version.txt` changes (this PR touches `_publish/`, so the workflow will fire on merge).
2. The job checks out `langwatch/skills` into `_skills-publish/` using `SKILLS_PUBLISH_TOKEN`.
3. Runs `pnpm sync ../_skills-publish` from `skills/`, which calls `_publish/sync.ts` — wipes the target, then for each name in `FEATURE_SKILLS` inlines the MDX partials and writes a self-contained `SKILL.md` into the target repo. Recipes are picked up automatically by directory iteration; feature skills are gated by the allowlist (this is what missed `datasets`).
4. Commits with `chore: sync skills v${version} from langwatch/langwatch` and pushes. Tags use the value in `skills/version.txt` — version bumps are handled separately by the automated `chore(main): release skills X.Y.Z` PR, so this PR does not bump the version.

After merge, the workflow run should publish `datasets/SKILL.md` to `langwatch/skills`, and `npx skills add langwatch/skills/datasets` will start working.

## Test plan

- [x] Verify the `skills-publish` workflow runs on merge and that the resulting commit on `langwatch/skills` adds a `datasets/SKILL.md`
- [x] After publish, run `npx skills add langwatch/skills/datasets -y` and confirm it installs without "No skills found"