### PR TITLE
fix(routing): preserve sub-path when redirecting URL-encoded project slugs

### DIFF
--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -259,10 +259,12 @@ export const useOrganizationTeamProject = (
       finalProject.slug !== router.query.project
     ) {
       // Preserve the sub-path so /bad-slug/messages → /good-slug/messages
+      // Decode pathname so that URL-encoded slugs like /%5Bproject%5D match the decoded oldPrefix
       const url = new URL(router.asPath, window.location.origin);
       const oldPrefix = `/${router.query.project as string}`;
-      const subPath = url.pathname.startsWith(oldPrefix)
-        ? url.pathname.slice(oldPrefix.length)
+      const decodedPathname = decodeURIComponent(url.pathname);
+      const subPath = decodedPathname.startsWith(oldPrefix)
+        ? decodedPathname.slice(oldPrefix.length)
         : "";
       void router.push(`/${finalProject.slug}${subPath}${url.search}`);
     }

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -262,7 +262,12 @@ export const useOrganizationTeamProject = (
       // Decode: browsers encode [ ] → %5B %5D, so asPath and query.project are in different encodings
       const url = new URL(router.asPath, window.location.origin);
       const oldPrefix = `/${router.query.project as string}`;
-      const decodedPathname = decodeURIComponent(url.pathname);
+      let decodedPathname = url.pathname;
+      try {
+        decodedPathname = decodeURIComponent(url.pathname);
+      } catch {
+        // keep encoded pathname if malformed percent-encoding is present
+      }
       const subPath = decodedPathname.startsWith(oldPrefix)
         ? decodedPathname.slice(oldPrefix.length)
         : "";

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -259,7 +259,7 @@ export const useOrganizationTeamProject = (
       finalProject.slug !== router.query.project
     ) {
       // Preserve the sub-path so /bad-slug/messages → /good-slug/messages
-      // Decode pathname so that URL-encoded slugs like /%5Bproject%5D match the decoded oldPrefix
+      // Decode: browsers encode [ ] → %5B %5D, so asPath and query.project are in different encodings
       const url = new URL(router.asPath, window.location.origin);
       const oldPrefix = `/${router.query.project as string}`;
       const decodedPathname = decodeURIComponent(url.pathname);


### PR DESCRIPTION
## Summary

- Fixes broken onboarding/email links of the form `app.langwatch.ai/[project]/evaluations`
- When a browser URL-encodes brackets (`[project]` → `%5Bproject%5D`), the sub-path redirect in `useOrganizationTeamProject` was comparing an encoded pathname against a decoded prefix — the `startsWith` check failed, sub-path was lost, and users landed on the project home instead of the intended page (e.g. `/evaluations`)
- Fix: `decodeURIComponent(url.pathname)` before the comparison so both sides are decoded, guarded in `try/catch` for malformed URIs

## Root cause

`src/hooks/useOrganizationTeamProject.ts`:
```ts
// Before
const subPath = url.pathname.startsWith(oldPrefix) ...
// url.pathname may be /%5Bproject%5D/evaluations, oldPrefix is /[project] → startsWith fails

// After
let decodedPathname = url.pathname;
try { decodedPathname = decodeURIComponent(url.pathname); } catch { }
const subPath = decodedPathname.startsWith(oldPrefix) ...  // both decoded → match works
```

## Test plan

- [x] Navigate to `app.langwatch.ai/[project]/evaluations` while logged in → should redirect to `/{slug}/evaluations`
- [x] Navigate to `app.langwatch.ai/%5Bproject%5D/evaluations` while logged in → same result
- [x] Normal slug-mismatch redirects (e.g. `/old-slug/messages` after project rename) still preserve sub-path

Supersedes #3554 (clean diff — no unrelated changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)