### PR TITLE
fix(nlpgo): bind HTTP listener before uvicorn-child to escape Lambda 10s init ceiling

### DIFF
--- a/langwatch/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
+++ b/langwatch/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getProjectLambdaArn } from "../index";
+import { getProjectLambdaArn, createLambdaClient } from "../index";
 import { LambdaClient } from "@aws-sdk/client-lambda";
 
 describe("getProjectLambdaArn", () => {
@@ -42,6 +42,17 @@ describe("getProjectLambdaArn", () => {
         .mockResolvedValueOnce({ Configuration: mockLambdaConfig });
       const result = await getProjectLambdaArn(mockProjectId);
       expect(result).toBe(mockLambdaConfig.FunctionArn);
+    });
+  });
+
+  describe("createLambdaClient", () => {
+    it("configures maxAttempts above SDK default to ride out cold-start TooManyRequests bursts", async () => {
+      const client = createLambdaClient();
+      // SDK default is 3; we override to 6. Verifies the override is wired
+      // through to the AWS SDK config so the cold-start regression that hit
+      // prod on 2026-04-28 (account-level concurrency exhaustion → "Rate
+      // Exceeded.") doesn't surface to Studio after 3 retries.
+      expect(await client.config.maxAttempts()).toBeGreaterThanOrEqual(6);
     });
   });
 

--- a/langwatch/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
+++ b/langwatch/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts
@@ -45,14 +45,16 @@ describe("getProjectLambdaArn", () => {
     });
   });
 
-  describe("createLambdaClient", () => {
-    it("configures maxAttempts above SDK default to ride out cold-start TooManyRequests bursts", async () => {
-      const client = createLambdaClient();
-      // SDK default is 3; we override to 6. Verifies the override is wired
-      // through to the AWS SDK config so the cold-start regression that hit
-      // prod on 2026-04-28 (account-level concurrency exhaustion → "Rate
-      // Exceeded.") doesn't surface to Studio after 3 retries.
-      expect(await client.config.maxAttempts()).toBeGreaterThanOrEqual(6);
+  describe("given a Lambda client", () => {
+    describe("when constructed via createLambdaClient", () => {
+      it("configures maxAttempts above SDK default to ride out cold-start TooManyRequests bursts", async () => {
+        const client = createLambdaClient();
+        // SDK default is 3; we override to 6. Verifies the override is wired
+        // through to the AWS SDK config so the cold-start regression that
+        // hit prod on 2026-04-28 (account-level concurrency exhaustion →
+        // "Rate Exceeded.") doesn't surface to Studio after 3 retries.
+        expect(await client.config.maxAttempts()).toBe(6);
+      });
     });
   });
 

--- a/langwatch/src/optimization_studio/server/lambda/index.ts
+++ b/langwatch/src/optimization_studio/server/lambda/index.ts
@@ -69,6 +69,13 @@ const parseLambdaConfig = (): LangWatchLambdaConfig => {
   }
 };
 
+// SDK default is 3 retries for retryable errors (incl. TooManyRequestsException
+// which surfaces as "Rate Exceeded."). When the per-project Lambda fleet is
+// cold-starting under a fresh image, a transient ConcurrentExecutions burst
+// can cause 3-retry windows to all land inside the saturation. Bumped to 6
+// to ride out a ~30-60s burst without surfacing the error to Studio.
+const LAMBDA_CLIENT_MAX_ATTEMPTS = 6;
+
 export const createLambdaClient = (): LambdaClient => {
   const config = parseLambdaConfig();
   return new LambdaClient({
@@ -77,6 +84,7 @@ export const createLambdaClient = (): LambdaClient => {
       accessKeyId: config.AWS_ACCESS_KEY_ID,
       secretAccessKey: config.AWS_SECRET_ACCESS_KEY,
     },
+    maxAttempts: LAMBDA_CLIENT_MAX_ATTEMPTS,
   });
 };
 

--- a/services/nlpgo/serve.go
+++ b/services/nlpgo/serve.go
@@ -59,7 +59,19 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config, pl
 		lifecycle.WithGraceful(time.Duration(cfg.Server.GracefulSeconds)*time.Second),
 		lifecycle.WithHealth(deps.Health),
 	)
-	g.Add(
+	g.Add(buildServices(deps, srv)...)
+	return g.Run(ctx)
+}
+
+// buildServices returns the lifecycle services Serve registers, in
+// registration order. Extracted from Serve so tests can assert the
+// ordering invariant directly without rebuilding the slice (which would
+// mask a Serve regression). The contract pinned by serve_test.go:
+// ListenServer("http") MUST come before Worker("uvicorn-child"), and
+// the worker startFn MUST return immediately (the inner Manager.Start
+// runs in a goroutine).
+func buildServices(deps *Deps, srv *http.Server) []lifecycle.Service {
+	return []lifecycle.Service{
 		lifecycle.Closer("otel", deps.OTel.Shutdown),
 		// HTTP listener binds $PORT first — Lambda init only needs the
 		// port to be bound, not the upstream proxy to be live. This
@@ -79,6 +91,5 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config, pl
 				}
 			}()
 		}, deps.Child.Stop),
-	)
-	return g.Run(ctx)
+	}
 }

--- a/services/nlpgo/serve.go
+++ b/services/nlpgo/serve.go
@@ -14,8 +14,22 @@ import (
 )
 
 // Serve wires the app into HTTP transport and lifecycle management,
-// blocking until shutdown. The uvicorn child is started first so the
-// reverse proxy is healthy when the HTTP listener starts accepting.
+// blocking until shutdown.
+//
+// Service ordering is load-bearing on AWS Lambda: the HTTP listener must
+// bind $PORT before the uvicorn-child waitHealthy poll runs, otherwise
+// the Lambda init phase (10-second hard limit) times out before the
+// adapter sees the port. With the listener up first, init completes in
+// milliseconds and the uvicorn-child startup happens in the background;
+// /go/* paths (the FF-on hot path) work immediately because they don't
+// touch the proxy, and /studio/* fall-through traffic gets a typed 503
+// from the proxy until the child reports healthy.
+//
+// Pre-fix shape registered Worker("uvicorn-child") before
+// ListenServer("http"); on Lambda this caused INIT_REPORT timeouts at
+// 9999ms and an account-level concurrency exhaustion cascade as failed
+// inits retried (~333→1000 ConcurrentExecutions during the prod incident
+// observed at 18:13 UTC after PR langwatch-saas#473 deployed).
 //
 // `playground` may be nil in test contexts that don't exercise the
 // /go/proxy/v1/* path; the handler falls back to a typed 501 in that
@@ -47,12 +61,24 @@ func Serve(ctx context.Context, application *app.App, deps *Deps, cfg Config, pl
 	)
 	g.Add(
 		lifecycle.Closer("otel", deps.OTel.Shutdown),
-		lifecycle.Worker("uvicorn-child", func(ctx context.Context) {
-			if err := deps.Child.Start(ctx); err != nil {
-				deps.Logger.Error("uvicorn_child_start_failed", zap.Error(err))
-			}
-		}, deps.Child.Stop),
+		// HTTP listener binds $PORT first — Lambda init only needs the
+		// port to be bound, not the upstream proxy to be live. This
+		// keeps init under the 10s ceiling regardless of how long the
+		// python child takes to import litellm + langwatch_nlp.
 		lifecycle.ListenServer("http", srv),
+		// Uvicorn-child starts in the background; the worker startFn
+		// returns immediately so it doesn't block the lifecycle group.
+		// Manager.Start internally polls /health and writes
+		// uvicorn_child_ready on success; until then the proxy fall-
+		// through returns a typed 503 so callers can retry instead of
+		// hanging on a stalled connection.
+		lifecycle.Worker("uvicorn-child", func(ctx context.Context) {
+			go func() {
+				if err := deps.Child.Start(ctx); err != nil {
+					deps.Logger.Error("uvicorn_child_start_failed", zap.Error(err))
+				}
+			}()
+		}, deps.Child.Stop),
 	)
 	return g.Run(ctx)
 }

--- a/services/nlpgo/serve_test.go
+++ b/services/nlpgo/serve_test.go
@@ -1,0 +1,116 @@
+package nlpgo
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/langwatch/langwatch/pkg/lifecycle"
+)
+
+// TestServe_ListenerBindsBeforeBlockingChild pins the contract that
+// keeps nlpgo deployable on AWS Lambda: when Serve registers its
+// services, the HTTP listener must bind $PORT before the uvicorn-child
+// readiness wait runs.
+//
+// Background: in the prod incident on 2026-04-28 the previous shape
+// registered Worker("uvicorn-child") BEFORE ListenServer("http"). The
+// worker's startFn called Manager.Start synchronously, which blocks in
+// waitHealthy polling the python child for ~12-18s. Lambda's init phase
+// has a hard 10s ceiling — port never bound, init timed out, AWS
+// retried inits, retry storm pinned ConcurrentExecutions to the
+// account-level 1000 cap, and every Studio is_alive heartbeat surfaced
+// "Rate Exceeded." in the toast.
+//
+// The fix in serve.go does two things:
+//   1. Register ListenServer("http") BEFORE Worker("uvicorn-child").
+//   2. Wrap the worker's startFn body in a `go func() { ... }()` so
+//      Manager.Start runs in the background. The lifecycle group's
+//      synchronous Service.Start returns instantly and the listener
+//      starts as the next step.
+//
+// This test recreates the same registration shape using a worker that
+// would block forever (simulating an unreachable child) and asserts the
+// listener binds within a tight deadline. Without BOTH parts of the
+// fix, the deadline expires.
+func TestServe_ListenerBindsBeforeBlockingChild(t *testing.T) {
+	// Pick a free port — bind, get the address, close so the lifecycle
+	// listener can take it. There's a tiny race window with another
+	// process on the host but on CI workers it's negligible.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	addr := probe.Addr().String()
+	_ = probe.Close()
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+		ReadHeaderTimeout: time.Second,
+	}
+
+	var childStartCalled atomic.Bool
+	// blockingStartFn simulates the ORIGINAL bad shape — a Worker whose
+	// startFn body blocks on a child that never becomes healthy. The
+	// fix wraps the inner block in a goroutine so the startFn itself
+	// returns immediately. We replicate the FIXED shape here; if a
+	// future refactor regresses by removing the goroutine wrap, the
+	// listener-bind deadline below will fail.
+	nonBlockingStartFn := func(ctx context.Context) {
+		go func() {
+			childStartCalled.Store(true)
+			// Simulate Manager.waitHealthy on an unreachable upstream.
+			<-ctx.Done()
+		}()
+	}
+
+	g := lifecycle.New(lifecycle.WithGraceful(time.Second))
+	g.Add(
+		// Mirror serve.go ordering exactly: listener first, then worker.
+		lifecycle.ListenServer("http", srv),
+		lifecycle.Worker("uvicorn-child", nonBlockingStartFn, func() {}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- g.Run(ctx) }()
+
+	// 100ms is comfortably under Lambda's 10s init budget while still
+	// catching slow-start regressions. Local hosts dial loopback in
+	// well under 10ms.
+	deadline := time.Now().Add(100 * time.Millisecond)
+	bound := false
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 20*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			bound = true
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !bound {
+		t.Fatalf("http listener not bound at %s within 100ms — Lambda init phase would time out", addr)
+	}
+
+	// Cancel + drain the lifecycle goroutine so the test exits cleanly.
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("lifecycle.Run did not return within 2s after cancel")
+	}
+
+	// Sanity: the worker DID start (in the background) — proves we are
+	// testing the right shape (a Worker that the group considers
+	// "started" but whose inner work continues asynchronously).
+	if !childStartCalled.Load() {
+		t.Fatalf("worker startFn was never invoked; test would not catch a regression")
+	}
+}

--- a/services/nlpgo/serve_test.go
+++ b/services/nlpgo/serve_test.go
@@ -4,42 +4,113 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/langwatch/langwatch/pkg/lifecycle"
+	"github.com/langwatch/langwatch/pkg/otelsetup"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/uvicornchild"
 )
 
-// TestServe_ListenerBindsBeforeBlockingChild pins the contract that
-// keeps nlpgo deployable on AWS Lambda: when Serve registers its
-// services, the HTTP listener must bind $PORT before the uvicorn-child
-// readiness wait runs.
+// TestBuildServices_RegistersListenerBeforeUvicornChild pins the
+// registration order Serve uses on AWS Lambda. The HTTP listener must
+// be registered (and therefore started) before the uvicorn-child
+// Worker, otherwise the lifecycle group blocks on Manager.waitHealthy
+// (~12-18s for litellm + langwatch_nlp imports) before $PORT binds and
+// Lambda's 10s init ceiling fires.
 //
-// Background: in the prod incident on 2026-04-28 the previous shape
-// registered Worker("uvicorn-child") BEFORE ListenServer("http"). The
-// worker's startFn called Manager.Start synchronously, which blocks in
-// waitHealthy polling the python child for ~12-18s. Lambda's init phase
-// has a hard 10s ceiling — port never bound, init timed out, AWS
-// retried inits, retry storm pinned ConcurrentExecutions to the
-// account-level 1000 cap, and every Studio is_alive heartbeat surfaced
-// "Rate Exceeded." in the toast.
+// This test calls Serve's actual buildServices helper, so a regression
+// that swaps the order back inside serve.go fails this test directly.
 //
-// The fix in serve.go does two things:
-//   1. Register ListenServer("http") BEFORE Worker("uvicorn-child").
-//   2. Wrap the worker's startFn body in a `go func() { ... }()` so
-//      Manager.Start runs in the background. The lifecycle group's
-//      synchronous Service.Start returns instantly and the listener
-//      starts as the next step.
-//
-// This test recreates the same registration shape using a worker that
-// would block forever (simulating an unreachable child) and asserts the
-// listener binds within a tight deadline. Without BOTH parts of the
-// fix, the deadline expires.
+// Pre-fix incident: PR langwatch-saas#473 deploy on 2026-04-28 hit
+// "INIT_REPORT Init Duration: 9999.10ms Status: timeout" on every
+// per-project Lambda; failed inits retried, ConcurrentExecutions
+// pinned at the 1000 account cap, and AWS surfaced "Rate Exceeded."
+// to Studio's toast.
+func TestBuildServices_RegistersListenerBeforeUvicornChild(t *testing.T) {
+	deps := newTestDeps(t)
+	srv := &http.Server{Addr: "127.0.0.1:0", ReadHeaderTimeout: time.Second}
+
+	services := buildServices(deps, srv)
+
+	// Find indices by service name (the lifecycle.Service interface's
+	// String() method is the registered name).
+	idx := map[string]int{}
+	for i, s := range services {
+		idx[s.String()] = i
+	}
+	listenerIdx, ok := idx["http"]
+	if !ok {
+		t.Fatalf("expected 'http' lifecycle service in buildServices output; got names %v", names(services))
+	}
+	childIdx, ok := idx["uvicorn-child"]
+	if !ok {
+		t.Fatalf("expected 'uvicorn-child' lifecycle service in buildServices output; got names %v", names(services))
+	}
+	if listenerIdx >= childIdx {
+		t.Fatalf("Lambda init regression: 'http' listener (idx %d) must be registered before 'uvicorn-child' worker (idx %d). "+
+			"Lifecycle services start sequentially via svc.Start(ctx); a blocking child Start would prevent $PORT bind "+
+			"within Lambda's 10s init ceiling. Service order: %v", listenerIdx, childIdx, names(services))
+	}
+}
+
+// TestBuildServices_UvicornChildWorkerDoesNotBlockStart pins the
+// second half of the cold-start fix: even with the right ordering,
+// if Worker("uvicorn-child")'s startFn synchronously waits on the
+// child's health, the lifecycle group still blocks before reaching
+// the listener (because the worker is registered after closer "otel"
+// and lifecycle.Run starts services in order). The fix wraps the
+// inner Manager.Start in a `go func()` so the startFn returns
+// immediately. This test reaches into the worker's Service.Start and
+// asserts it returns quickly even when given a context that would
+// keep a synchronous child blocked indefinitely.
+func TestBuildServices_UvicornChildWorkerDoesNotBlockStart(t *testing.T) {
+	deps := newTestDeps(t)
+	srv := &http.Server{Addr: "127.0.0.1:0", ReadHeaderTimeout: time.Second}
+
+	services := buildServices(deps, srv)
+	var worker lifecycle.Service
+	for _, s := range services {
+		if s.String() == "uvicorn-child" {
+			worker = s
+			break
+		}
+	}
+	if worker == nil {
+		t.Fatalf("uvicorn-child worker not registered; got names %v", names(services))
+	}
+
+	// Run Start with a context that will never be cancelled until we
+	// say so. If startFn synchronously blocks (the regression we want
+	// to catch), Start won't return and the deadline below fires.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() { done <- worker.Start(ctx) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("worker.Start returned err: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Lambda init regression: uvicorn-child worker.Start did not return within 100ms. " +
+			"Wrap the inner Manager.Start call in a `go func()` so the lifecycle group's synchronous " +
+			"Service.Start returns immediately and the next service (the http listener) starts.")
+	}
+}
+
+// TestServe_ListenerBindsBeforeBlockingChild is the runtime sibling of
+// the buildServices ordering test: it boots a real lifecycle.Group
+// with the Serve-registered services and asserts the http listener
+// has bound $PORT within a Lambda-safe deadline (100ms — far under
+// the 10s init ceiling) even when the uvicorn-child worker is
+// configured around a child that never becomes healthy. Together with
+// the buildServices test above, both arms of the fix are pinned:
+// (1) registration order, (2) non-blocking worker startFn.
 func TestServe_ListenerBindsBeforeBlockingChild(t *testing.T) {
-	// Pick a free port — bind, get the address, close so the lifecycle
-	// listener can take it. There's a tiny race window with another
-	// process on the host but on CI workers it's negligible.
 	probe, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("probe listen: %v", err)
@@ -47,43 +118,21 @@ func TestServe_ListenerBindsBeforeBlockingChild(t *testing.T) {
 	addr := probe.Addr().String()
 	_ = probe.Close()
 
+	deps := newTestDeps(t)
 	srv := &http.Server{
 		Addr:              addr,
 		Handler:           http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
 		ReadHeaderTimeout: time.Second,
 	}
 
-	var childStartCalled atomic.Bool
-	// blockingStartFn simulates the ORIGINAL bad shape — a Worker whose
-	// startFn body blocks on a child that never becomes healthy. The
-	// fix wraps the inner block in a goroutine so the startFn itself
-	// returns immediately. We replicate the FIXED shape here; if a
-	// future refactor regresses by removing the goroutine wrap, the
-	// listener-bind deadline below will fail.
-	nonBlockingStartFn := func(ctx context.Context) {
-		go func() {
-			childStartCalled.Store(true)
-			// Simulate Manager.waitHealthy on an unreachable upstream.
-			<-ctx.Done()
-		}()
-	}
-
 	g := lifecycle.New(lifecycle.WithGraceful(time.Second))
-	g.Add(
-		// Mirror serve.go ordering exactly: listener first, then worker.
-		lifecycle.ListenServer("http", srv),
-		lifecycle.Worker("uvicorn-child", nonBlockingStartFn, func() {}),
-	)
+	g.Add(buildServices(deps, srv)...)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-
 	runDone := make(chan error, 1)
 	go func() { runDone <- g.Run(ctx) }()
 
-	// 100ms is comfortably under Lambda's 10s init budget while still
-	// catching slow-start regressions. Local hosts dial loopback in
-	// well under 10ms.
 	deadline := time.Now().Add(100 * time.Millisecond)
 	bound := false
 	for time.Now().Before(deadline) {
@@ -99,18 +148,43 @@ func TestServe_ListenerBindsBeforeBlockingChild(t *testing.T) {
 		t.Fatalf("http listener not bound at %s within 100ms — Lambda init phase would time out", addr)
 	}
 
-	// Cancel + drain the lifecycle goroutine so the test exits cleanly.
 	cancel()
 	select {
 	case <-runDone:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("lifecycle.Run did not return within 2s after cancel")
 	}
+}
 
-	// Sanity: the worker DID start (in the background) — proves we are
-	// testing the right shape (a Worker that the group considers
-	// "started" but whose inner work continues asynchronously).
-	if !childStartCalled.Load() {
-		t.Fatalf("worker startFn was never invoked; test would not catch a regression")
+// newTestDeps builds a Deps with stubs for the cold-start tests.
+// The uvicorn-child Manager is configured Disabled=true so its Start
+// returns immediately — the test isn't exercising the child, only the
+// registration shape that wraps it. OTel is constructed via
+// otelsetup.New with empty OTLPEndpoint, which returns a noop Provider
+// whose Shutdown is safe to invoke during lifecycle teardown.
+func newTestDeps(t *testing.T) *Deps {
+	t.Helper()
+	child := uvicornchild.New(uvicornchild.Options{
+		Disabled:  true,
+		Logger:    zap.NewNop(),
+		HealthURL: "http://127.0.0.1:1/never-healthy",
+	})
+	otelProvider, err := otelsetup.New(context.Background(), otelsetup.Options{})
+	if err != nil {
+		t.Fatalf("otelsetup.New: %v", err)
+	}
+	return &Deps{
+		Logger: zap.NewNop(),
+		OTel:   otelProvider,
+		Child:  child,
 	}
 }
+
+func names(services []lifecycle.Service) []string {
+	out := make([]string, 0, len(services))
+	for _, s := range services {
+		out = append(out, s.String())
+	}
+	return out
+}
+

--- a/services/nlpgo/serve_test.go
+++ b/services/nlpgo/serve_test.go
@@ -2,8 +2,10 @@ package nlpgo
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
+	"runtime"
 	"testing"
 	"time"
 
@@ -125,7 +127,10 @@ func TestServe_ListenerBindsBeforeBlockingChild(t *testing.T) {
 		ReadHeaderTimeout: time.Second,
 	}
 
-	g := lifecycle.New(lifecycle.WithGraceful(time.Second))
+	// Generous graceful window because the test's blocking sleep child
+	// can take longer than 1s to be killed by Manager.Stop. The
+	// listener-bind assertion fires long before this window matters.
+	g := lifecycle.New(lifecycle.WithGraceful(5 * time.Second))
 	g.Add(buildServices(deps, srv)...)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -150,25 +155,49 @@ func TestServe_ListenerBindsBeforeBlockingChild(t *testing.T) {
 
 	cancel()
 	select {
-	case <-runDone:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("lifecycle.Run did not return within 2s after cancel")
+	case err := <-runDone:
+		// lifecycle.Run returns nil on graceful cancel, or an error
+		// wrapping context.Canceled if cancel propagated through a
+		// child Start. Either is fine; surface anything else.
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("lifecycle.Run returned unexpected error: %v", err)
+		}
+	case <-time.After(7 * time.Second):
+		t.Fatalf("lifecycle.Run did not return within 7s after cancel")
 	}
 }
 
-// newTestDeps builds a Deps with stubs for the cold-start tests.
-// The uvicorn-child Manager is configured Disabled=true so its Start
-// returns immediately — the test isn't exercising the child, only the
-// registration shape that wraps it. OTel is constructed via
-// otelsetup.New with empty OTLPEndpoint, which returns a noop Provider
-// whose Shutdown is safe to invoke during lifecycle teardown.
+// newTestDeps builds a Deps whose uvicorn-child Manager will BLOCK in
+// Start until the test's deferred Stop fires. This is load-bearing for
+// the regression tests: with Disabled=true the inner Manager.Start
+// would return immediately, masking a hypothetical regression where
+// the worker startFn dropped the `go func()` wrap and called
+// Manager.Start synchronously. By forcing the child to block, the
+// "doesn't block" assertion only holds if the goroutine wrap is in
+// place.
+//
+// Implementation: spawn a long-running `sleep` binary as the child
+// process and point HealthURL at a closed port — Manager.waitHealthy
+// will poll until StartTimeout elapses. We set StartTimeout to 5s,
+// well over the test's 100ms deadline, so a regression deterministically
+// trips the deadline.
+//
+// OTel is constructed via otelsetup.New with empty OTLPEndpoint, which
+// returns a noop Provider whose Shutdown is safe to invoke during
+// lifecycle teardown.
 func newTestDeps(t *testing.T) *Deps {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("regression test relies on POSIX `sleep` binary; not exercised on Windows")
+	}
 	child := uvicornchild.New(uvicornchild.Options{
-		Disabled:  true,
-		Logger:    zap.NewNop(),
-		HealthURL: "http://127.0.0.1:1/never-healthy",
+		Command:      "sleep",
+		Args:         []string{"3600"},
+		HealthURL:    "http://127.0.0.1:1/never-healthy",
+		StartTimeout: 5 * time.Second,
+		Logger:       zap.NewNop(),
 	})
+	t.Cleanup(child.Stop) // kills the sleep child after the test
 	otelProvider, err := otelsetup.New(context.Background(), otelsetup.Options{})
 	if err != nil {
 		t.Fatalf("otelsetup.New: %v", err)


### PR DESCRIPTION
## Summary

Hot-fix for the prod incident on 2026-04-28 at ~18:13 UTC after deploying [langwatch-saas#473](https://github.com/langwatch/langwatch-saas/pull/473) (which bundled the nlpgo Go binary into the saas-side Lambda runtime image).

Symptoms (FF-on accounts):
- Studio toast: **"Rate Exceeded."**
- ConcurrentExecutions metric pinned at the account-level **1000** ceiling for the duration of the incident
- CloudWatch on every per-project Lambda: `INIT_REPORT Init Duration: 9999.10 ms  Phase: init  Status: timeout`

Saas#473 was reverted in [#474](https://github.com/langwatch/langwatch-saas/pull/474) as immediate mitigation. This PR is the monorepo half of the redeploy fix — see "Saas-side companion" below.

## Root cause

`services/nlpgo/serve.go` registered lifecycle services in this order:

1. `Closer("otel")` — no-op start
2. `Worker("uvicorn-child")` — `Manager.Start` synchronously polls `/health` until the python child is reachable (~12-18s, dominated by litellm + langwatch_nlp imports)
3. `ListenServer("http")` — binds `$PORT`

`pkg/lifecycle/group.go` starts services sequentially via `svc.Start(ctx)`, so the HTTP listener didn't bind `$PORT` until uvicorn-child returned. On AWS Lambda the **init phase has a hard 10-second ceiling**. Every cold start failed init at ~10s. AWS retried inits, the retry storm pinned account-level concurrency to the 1000 cap, and `InvokeWithResponseStreamCommand` callers in langwatch-app started getting `TooManyRequestsException` — bubbled to Studio as the "Rate Exceeded." toast.

## Fix

Two commits, both load-bearing:

### `9cea81a00` + `8e82785fc` — `fix(nlpgo): bind HTTP listener before uvicorn-child`

1. Reorder so `ListenServer("http")` registers **before** `Worker("uvicorn-child")`. The listener binds in milliseconds and Lambda init completes well under the 10s ceiling.
2. Wrap the worker startFn body in a `go func()` so `Manager.Start` runs in the background. The lifecycle group's synchronous `Service.Start` returns instantly so the next service starts.
3. Extract the lifecycle service slice into a `buildServices(deps, srv)` helper so the regression tests call the same code Serve runs at boot. Without the helper, tests rebuilding the slice with the right ordering hardcoded would mask a `Serve` regression.

`/go/*` paths are unaffected — the Go engine handles `is_alive`, `execute_*`, etc. without touching the proxy. `/studio/*` fall-through to uvicorn proxy returns the existing typed `502 child upstream unavailable` on connection-refused while the child is still warming up. Short-lived window.

### `18af1e2cf` — `fix(studio-lambda): bump LambdaClient maxAttempts from 3 to 6`

Belt-and-suspenders. AWS SDK default of 3 retries with exponential backoff fits inside ~10s — long enough that during a saturation window like the one we just had, retries can fall entirely inside the bad period. Bumping to 6 attempts (~50s of backoff) lets future cold-start storms ride out transparently instead of toasting users.

## lw-dev empirical validation

Built `Dockerfile.langwatch_nlp.lambda.runtime` locally with the saas bundling diff + this branch as submodule, pushed to the lw-dev `langwatch-dev-nlp-lambda-ecr` repo, deployed a throwaway test Lambda, ran `aws lambda invoke`, captured `INIT_REPORT` from CloudWatch:

| Image / config                                                            | Init Duration | Status         |
|---------------------------------------------------------------------------|---------------|----------------|
| Pre-fix (saas#473 broken bundling)                                        | 9999.10 ms    | TIMEOUT (prod) |
| Lifecycle reorder ONLY (no env var)                                       | 9996-9999 ms  | TIMEOUT ❌     |
| Lifecycle reorder + `AWS_LWA_READINESS_CHECK_PATH=/healthz`               | **416.60 ms** | ✅ SUCCESS     |

End-to-end on the SUCCESS row:
- Wall-clock cold-start invoke: 1057 ms (init + first request)
- `POST /go/studio/execute {"type":"is_alive"}` returns 200 SSE: `data: {"type":"is_alive_response"} … data: {"type":"done"}`

## Saas-side companion (REQUIRED for prod redeploy)

The reorder alone is **insufficient**. Lambda Web Adapter's default readiness probe path is `/`, which falls through nlpgo's chi router to the not-yet-ready uvicorn ChildProxy → connection refused → LWA never sees a 200 within the 10s init budget. The companion saas PR must add:

```dockerfile
ENV AWS_LWA_READINESS_CHECK_PATH=/healthz
```

`/healthz` is served by nlpgo itself (registered at `services/nlpgo/adapters/httpapi/router.go:65`) and answers as soon as the listener binds. Sarah is preparing that saas PR with:
- Re-roll of the nlpgo bundling (mirror the reverted [saas#473](https://github.com/langwatch/langwatch-saas/pull/473))
- New `ENV AWS_LWA_READINESS_CHECK_PATH=/healthz`
- Submodule bump to this PR's merge commit on main

## Test plan

- [x] `services/nlpgo/serve_test.go::TestBuildServices_RegistersListenerBeforeUvicornChild` — fails on a `Serve` regression that swaps Worker before ListenServer.
- [x] `services/nlpgo/serve_test.go::TestBuildServices_UvicornChildWorkerDoesNotBlockStart` — fails on a regression that drops the `go func()` wrap.
- [x] `services/nlpgo/serve_test.go::TestServe_ListenerBindsBeforeBlockingChild` — runtime sibling driving `lifecycle.Group` end-to-end.
- [x] `langwatch/src/optimization_studio/server/lambda/__tests__/getProjectLambdaArn.test.ts` — pins `maxAttempts: 6` on the SDK config.
- [x] `go test ./services/nlpgo/...` green locally.
- [x] **Real-Lambda validation in lw-dev** (table above) confirms init goes from 9999 ms TIMEOUT to 416 ms SUCCESS with the reorder + LWA env var combination.

## Why we're not asking for an AWS quota bump

The 1000 ceiling wasn't hit because we needed 1000 slots — it was hit because every failed init held a slot for ~10s while it died, then AWS retried, multiplying the backlog. Pre-deploy steady-state was 11-16 concurrent. Once init completes in milliseconds (this PR + the saas env var), each invocation only holds a slot for the time it serves a request — back to baseline, with 60×+ headroom under the existing 1000 quota.