### PR TITLE
fix(studio-lambda): bump per-project Lambda MemorySize 1024 → 2048 MB

### DIFF
--- a/langwatch/src/optimization_studio/server/lambda/index.ts
+++ b/langwatch/src/optimization_studio/server/lambda/index.ts
@@ -183,7 +183,18 @@ const createProjectLambda = async (
     },
     PackageType: "Image",
     Timeout: 900, // 15 minutes
-    MemorySize: 1024,
+    // 2048 MB (was 1024) gives Python multiprocessing.fork() enough RSS
+    // headroom when the bundled image runs nlpgo + uvicorn + litellm in
+    // the same container. At 1024 MB observed Max Memory Used hit
+    // 805/1024 MB mid-request on lw-dev (TEST H, 2026-04-28); fork()
+    // would fail to clone parent pages and the uvicorn worker pool
+    // crashed, cascading to /studio/* 502s. 2048 MB also doubles
+    // Lambda's allocated CPU (Lambda allocates CPU proportional to
+    // memory; ~0.58 vCPU at 1024 → ~1.17 vCPU at 2048), shaving cold-
+    // start init time too. Existing per-project Lambdas keep 1024 until
+    // a one-shot migration runs `aws lambda update-function-configuration
+    // --memory-size 2048` over each.
+    MemorySize: 2048,
     Architectures: ["arm64"],
     VpcConfig: {
       SubnetIds: config.subnet_ids,


### PR DESCRIPTION
## Summary

Per-project Lambda memory was 1024 MB. The bundled nlpgo + uvicorn + litellm image hits ~80% RSS pressure mid-request, which causes Python's `multiprocessing.fork()` to fail to clone parent pages → uvicorn worker pool crash → /studio/* 502 cascade.

Bump to 2048 MB to give fork() headroom and double allocated CPU (Lambda scales CPU proportional to memory).

## Empirical evidence (lw-dev TEST H, 2026-04-28)

```
REPORT Max Memory Used: 805 MB / 1024 MB Memory Size
[uvicorn child stderr] Exception in thread Thread-1 (_fill_pool_continuously)
panic: net/http: abort Handler
Extension.Crash
```

CPU framing — Lambda allocates CPU proportionally to memory:

| MemorySize | Allocated CPU |
|------------|---------------|
| 1024 MB    | ~0.58 vCPU    |
| 1769 MB    | ~1.00 vCPU (the threshold) |
| **2048 MB**| **~1.17 vCPU**|

So 2048 MB also shaves cold-start init time meaningfully.

## Migration for existing 26 project Lambdas

This PR only affects NEWLY-created project Lambdas. Existing 26 prod Lambdas keep 1024 MB until a one-shot migration runs:

```bash
for fn in $(aws --profile lw-prod --region eu-central-1 lambda list-functions \
    --query 'Functions[?starts_with(FunctionName, `langwatch_nlp-project_`)].FunctionName' \
    --output text); do
  aws --profile lw-prod --region eu-central-1 lambda update-function-configuration \
    --function-name "$fn" --memory-size 2048 \
    --no-cli-pager --output text > /dev/null
done

# Verification sweep — empty output means all 26 flipped successfully.
aws --profile lw-prod --region eu-central-1 lambda list-functions \
  --query 'Functions[?starts_with(FunctionName, `langwatch_nlp-project_`) && MemorySize != `2048`].[FunctionName,MemorySize]' \
  --output text
```

Reversible (swap 2048 back to 1024 to roll back). Defensive nits per CR review on this PR — output suppression to avoid pager hangs + verification sweep to catch any in-progress update that was rejected.

## Test plan

- [x] Empirical lw-dev TEST H confirmed OOM near-miss at 805/1024 MB
- [ ] Re-run lw-dev TEST H on a 2048 MB Lambda — expect Max Memory Used <1500 MB and no Thread-1 crash (Ash's lane after this lands)
- [ ] After saas PR (re-bundled image + submodule pinned to merged SHA) deploys, run migration script + dogfood real prod Studio session

## Companion changes (not in this PR)

- `services/nlpgo/adapters/proxypass/proxy.go` cold-start wait + 503 Retry-After + Recover-middleware ErrAbortHandler fix (PR #3566)
- saas Dockerfile: bundling re-roll + AWS_LWA_READINESS_CHECK_PATH=/healthz + Python preload step (saas PR opens after #3565 + #3566 merge)