### PR TITLE
fix(nlpgo): cold-start wait + 503 retry + Recover-middleware ErrAbortHandler

### DIFF
--- a/langwatch/src/optimization_studio/server/lambda/index.ts
+++ b/langwatch/src/optimization_studio/server/lambda/index.ts
@@ -183,7 +183,18 @@ const createProjectLambda = async (
     },
     PackageType: "Image",
     Timeout: 900, // 15 minutes
-    MemorySize: 1024,
+    // 2048 MB (was 1024) gives Python multiprocessing.fork() enough RSS
+    // headroom when the bundled image runs nlpgo + uvicorn + litellm in
+    // the same container. At 1024 MB observed Max Memory Used hit
+    // 805/1024 MB mid-request on lw-dev (TEST H, 2026-04-28); fork()
+    // would fail to clone parent pages and the uvicorn worker pool
+    // crashed, cascading to /studio/* 502s. 2048 MB also doubles
+    // Lambda's allocated CPU (Lambda allocates CPU proportional to
+    // memory; ~0.58 vCPU at 1024 → ~1.17 vCPU at 2048), shaving cold-
+    // start init time too. Existing per-project Lambdas keep 1024 until
+    // a one-shot migration runs `aws lambda update-function-configuration
+    // --memory-size 2048` over each.
+    MemorySize: 2048,
     Architectures: ["arm64"],
     VpcConfig: {
       SubnetIds: config.subnet_ids,

--- a/pkg/httpmiddleware/recover.go
+++ b/pkg/httpmiddleware/recover.go
@@ -12,25 +12,51 @@ import (
 // Recover catches panics per-request. Logs the panic with full context,
 // returns a generic 500 to the client (never exposes panic internals),
 // then re-panics so net/http tears down the connection cleanly.
+//
+// Special case: http.ErrAbortHandler is a sentinel panic the standard
+// library uses to signal "abort this request, do not write further
+// output, and tear the connection down." Triggered most commonly by
+// httputil.ReverseProxy when the upstream connection EOFs mid-body.
+// We must NOT write a 500 response in that case — the response writer
+// is in an indeterminate state, the additional WriteHeader call logs
+// "superfluous response.WriteHeader" warnings, and on AWS Lambda the
+// Rust-based Lambda Web Adapter dies with "unexpected EOF during chunk
+// size line" when the wire shape goes inconsistent, taking the whole
+// container down. Bare-re-panic the sentinel so net/http handles it
+// per its documented contract (close the connection, no logging).
+//
+// Observed live in lw-dev probes against the saas Lambda runtime image
+// on 2026-04-28: a /studio/execute proxy through to a uvicorn child
+// that crashed mid-stream produced ErrAbortHandler → wrote a 500 →
+// LWA extension SIGKILL → Lambda billed 49s/Extension.Crash.
 func Recover() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
-				if v := recover(); v != nil {
-					ctx := clog.With(r.Context(),
-						zap.String("path", r.URL.Path),
-						zap.String("method", r.Method),
-						zap.String("request_id", GetRequestID(r.Context())),
-						zap.String("remote", r.RemoteAddr),
-					)
-
-					// Generic error to client — never expose panic details
-					herr.WriteHTTP(w, herr.New(ctx, "internal_error", nil))
-
-					// Log full panic + re-panic for net/http
-					defer clog.HandlePanic(ctx, true)
+				v := recover()
+				if v == nil {
+					return
+				}
+				if v == http.ErrAbortHandler {
+					// Re-panic without touching the response writer.
+					// net/http's serve loop catches this sentinel and
+					// closes the connection silently.
 					panic(v)
 				}
+
+				ctx := clog.With(r.Context(),
+					zap.String("path", r.URL.Path),
+					zap.String("method", r.Method),
+					zap.String("request_id", GetRequestID(r.Context())),
+					zap.String("remote", r.RemoteAddr),
+				)
+
+				// Generic error to client — never expose panic details
+				herr.WriteHTTP(w, herr.New(ctx, "internal_error", nil))
+
+				// Log full panic + re-panic for net/http
+				defer clog.HandlePanic(ctx, true)
+				panic(v)
 			}()
 			next.ServeHTTP(w, r)
 		})

--- a/pkg/httpmiddleware/recover.go
+++ b/pkg/httpmiddleware/recover.go
@@ -1,6 +1,7 @@
 package httpmiddleware
 
 import (
+	"errors"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -37,10 +38,13 @@ func Recover() func(http.Handler) http.Handler {
 				if v == nil {
 					return
 				}
-				if v == http.ErrAbortHandler {
+				if err, ok := v.(error); ok && errors.Is(err, http.ErrAbortHandler) {
 					// Re-panic without touching the response writer.
 					// net/http's serve loop catches this sentinel and
-					// closes the connection silently.
+					// closes the connection silently. Use errors.Is
+					// (not direct ==) so a wrapped ErrAbortHandler from
+					// a deeper handler is still caught — errorlint
+					// flags the bare equality check.
 					panic(v)
 				}
 

--- a/pkg/httpmiddleware/recover_test.go
+++ b/pkg/httpmiddleware/recover_test.go
@@ -1,0 +1,92 @@
+package httpmiddleware
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/langwatch/langwatch/pkg/contexts"
+)
+
+// testCtx returns a request context with a service-info value so the
+// middleware's logging path doesn't blow up looking for it.
+func testCtx() context.Context {
+	return contexts.SetServiceInfo(context.Background(), contexts.ServiceInfo{
+		Service:     "test",
+		Version:     "test",
+		Environment: "test",
+	})
+}
+
+// TestRecover_GenericPanicReturns500AndRePanics — the historical
+// happy-path: a generic panic should result in a 500 response to the
+// client AND a re-panic so net/http closes the connection.
+func TestRecover_GenericPanicReturns500AndRePanics(t *testing.T) {
+	h := Recover()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(errors.New("boom"))
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(testCtx())
+	defer func() {
+		if v := recover(); v == nil {
+			t.Fatalf("Recover middleware did not re-panic on a generic panic; net/http would not close the connection cleanly")
+		}
+	}()
+	h.ServeHTTP(rec, req)
+	// The recorder captured the 500 written before re-panic.
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 in response, got %d", rec.Code)
+	}
+}
+
+// TestRecover_ErrAbortHandlerIsRePanickedWithoutWritingResponse pins
+// the AWS-Lambda-deploy fix: when the inner handler panics with
+// http.ErrAbortHandler (the standard sentinel ReverseProxy uses when
+// upstream EOFs mid-body), the middleware MUST NOT write a 500 — the
+// response writer is in an indeterminate state and the extra
+// WriteHeader call surfaces as "superfluous response.WriteHeader" in
+// the log, plus crashes the Rust-based Lambda Web Adapter which
+// expects a clean stream.
+//
+// Re-panicking the sentinel without touching the response writer is
+// the documented contract: net/http's serve loop catches
+// ErrAbortHandler and closes the connection silently.
+func TestRecover_ErrAbortHandlerIsRePanickedWithoutWritingResponse(t *testing.T) {
+	h := Recover()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(testCtx())
+
+	rePanicked := false
+	func() {
+		defer func() {
+			if v := recover(); v != nil {
+				rePanicked = true
+				if v != http.ErrAbortHandler {
+					t.Errorf("expected ErrAbortHandler re-panic, got %v", v)
+				}
+			}
+		}()
+		h.ServeHTTP(rec, req)
+	}()
+
+	if !rePanicked {
+		t.Fatalf("Recover did not re-panic ErrAbortHandler; net/http would not handle abort correctly")
+	}
+	if rec.Code != http.StatusOK {
+		// httptest.ResponseRecorder defaults to 200 if WriteHeader was
+		// never called. If our middleware (incorrectly) wrote a 500
+		// before re-panicking, we'd see 500 here.
+		t.Errorf("expected response writer untouched (default 200), got %d — middleware wrote a response despite ErrAbortHandler", rec.Code)
+	}
+	// And no body should have been written.
+	body, _ := io.ReadAll(rec.Body)
+	if len(strings.TrimSpace(string(body))) != 0 {
+		t.Errorf("expected empty response body on ErrAbortHandler, got %q", string(body))
+	}
+}

--- a/pkg/httpmiddleware/recover_test.go
+++ b/pkg/httpmiddleware/recover_test.go
@@ -67,7 +67,8 @@ func TestRecover_ErrAbortHandlerIsRePanickedWithoutWritingResponse(t *testing.T)
 		defer func() {
 			if v := recover(); v != nil {
 				rePanicked = true
-				if v != http.ErrAbortHandler {
+				err, ok := v.(error)
+				if !ok || !errors.Is(err, http.ErrAbortHandler) {
 					t.Errorf("expected ErrAbortHandler re-panic, got %v", v)
 				}
 			}

--- a/services/nlpgo/adapters/proxypass/proxy.go
+++ b/services/nlpgo/adapters/proxypass/proxy.go
@@ -8,6 +8,7 @@ package proxypass
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -25,6 +26,24 @@ type Options struct {
 	Logger *zap.Logger
 	// FlushInterval controls SSE/streaming flush. -1 = flush after every write.
 	FlushInterval time.Duration
+	// ColdStartWait caps how long an incoming request will wait for the
+	// upstream to become reachable on first hit. The lifecycle reorder
+	// in services/nlpgo/serve.go (PR #3559) made the HTTP listener bind
+	// $PORT before the uvicorn child finishes warming, which closed the
+	// Lambda init-timeout problem but opened a new one: requests that
+	// land in the ~12-18s child-warmup window would dial 127.0.0.1:5561
+	// and get connection-refused, surfacing as "502 child upstream
+	// unavailable" to Studio (the prod symptom on 2026-04-28 19:xx UTC
+	// after saas#476 deploy). With ColdStartWait > 0 we briefly poll for
+	// the child instead of failing fast, so the cold-start window is
+	// invisible to callers. Default: 5s. Set to 0 to disable the wait
+	// (tests).
+	ColdStartWait time.Duration
+	// ColdStartProbeInterval is the gap between TCP dial probes during
+	// the wait. Default: 100ms.
+	ColdStartProbeInterval time.Duration
+	// ColdStartProbeTimeout caps each individual TCP probe. Default: 200ms.
+	ColdStartProbeTimeout time.Duration
 }
 
 // New builds a reverse proxy ready to mount as a chi NotFound handler.
@@ -41,9 +60,21 @@ func New(opts Options) (http.Handler, error) {
 		// chunks to the client without waiting on an internal buffer.
 		opts.FlushInterval = -1
 	}
+	if opts.ColdStartWait == 0 {
+		opts.ColdStartWait = 5 * time.Second
+	}
+	if opts.ColdStartProbeInterval == 0 {
+		opts.ColdStartProbeInterval = 100 * time.Millisecond
+	}
+	if opts.ColdStartProbeTimeout == 0 {
+		opts.ColdStartProbeTimeout = 200 * time.Millisecond
+	}
 	target, err := url.Parse(opts.UpstreamURL)
 	if err != nil {
 		return nil, fmt.Errorf("proxypass: parse upstream: %w", err)
+	}
+	if target.Host == "" {
+		return nil, fmt.Errorf("proxypass: upstream URL %q has no host", opts.UpstreamURL)
 	}
 
 	rp := &httputil.ReverseProxy{
@@ -65,7 +96,60 @@ func New(opts Options) (http.Handler, error) {
 			http.Error(w, "child upstream unavailable", http.StatusBadGateway)
 		},
 	}
-	return rp, nil
+	return waitForUpstream(rp, target.Host, opts), nil
+}
+
+// waitForUpstream wraps the reverse proxy with a short cold-start
+// tolerance window. On each request we TCP-probe the upstream host:
+// if reachable, hand off to the reverse proxy immediately; if not,
+// poll every ColdStartProbeInterval up to ColdStartWait. After the
+// deadline, return 503 with Retry-After:1 — Studio's invokeLambda has
+// LambdaClient maxAttempts:6 (langwatch PR #3559) so a transient cold-
+// start storm transparently retries instead of toasting "Failed run
+// workflow: 502 child upstream unavailable" at the user.
+//
+// Once the probe succeeds the request flows through the standard
+// httputil.ReverseProxy: any subsequent failure (upstream 5xx, write
+// error mid-SSE, etc.) still hits the 502 ErrorHandler above. The
+// wrapper only widens the no-route window — it doesn't change happy-
+// path or steady-state behavior.
+func waitForUpstream(next http.Handler, host string, opts Options) http.Handler {
+	if opts.ColdStartWait <= 0 {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deadline := time.Now().Add(opts.ColdStartWait)
+		probeStart := time.Now()
+		for {
+			if conn, err := net.DialTimeout("tcp", host, opts.ColdStartProbeTimeout); err == nil {
+				_ = conn.Close()
+				if waited := time.Since(probeStart); waited > opts.ColdStartProbeInterval {
+					// Only log when we actually waited — happy path stays quiet.
+					opts.Logger.Info("proxypass_upstream_ready_after_wait",
+						zap.String("path", r.URL.Path),
+						zap.Duration("waited", waited),
+					)
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+			if time.Now().After(deadline) {
+				opts.Logger.Warn("proxypass_upstream_unavailable_after_wait",
+					zap.String("path", r.URL.Path),
+					zap.String("host", host),
+					zap.Duration("waited", time.Since(probeStart)),
+				)
+				w.Header().Set("Retry-After", "1")
+				http.Error(w, "child upstream warming up — retry shortly", http.StatusServiceUnavailable)
+				return
+			}
+			select {
+			case <-time.After(opts.ColdStartProbeInterval):
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
 }
 
 func forwardedProto(r *http.Request) string {

--- a/services/nlpgo/adapters/proxypass/proxy.go
+++ b/services/nlpgo/adapters/proxypass/proxy.go
@@ -58,9 +58,14 @@ type Options struct {
 	// start is dominated by uvicorn process spawn, not import work.
 	ColdStartWait time.Duration
 	// ColdStartProbeInterval is the gap between TCP dial probes during
-	// the wait. Default: 100ms.
+	// the wait. Default: 100ms. Zero or negative values fall back to
+	// the default — unlike ColdStartWait, there is no "negative
+	// disables" sentinel here; a negative interval would CPU-spin the
+	// retry loop.
 	ColdStartProbeInterval time.Duration
-	// ColdStartProbeTimeout caps each individual TCP probe. Default: 200ms.
+	// ColdStartProbeTimeout caps each individual TCP probe. Default:
+	// 200ms. Zero or negative values fall back to the default — a
+	// negative timeout would make every probe return immediately.
 	ColdStartProbeTimeout time.Duration
 }
 
@@ -81,10 +86,16 @@ func New(opts Options) (http.Handler, error) {
 	if opts.ColdStartWait == 0 {
 		opts.ColdStartWait = 90 * time.Second
 	}
-	if opts.ColdStartProbeInterval == 0 {
+	// Probe knobs: <= 0 falls back to default. Unlike ColdStartWait,
+	// negatives have no special "disable" meaning here — a negative
+	// probe interval would make time.After fire instantly and the loop
+	// at line 165 would CPU-spin during outages; a negative probe
+	// timeout would make every net.DialTimeout return immediately.
+	// Treat both as misconfiguration and snap to the default.
+	if opts.ColdStartProbeInterval <= 0 {
 		opts.ColdStartProbeInterval = 100 * time.Millisecond
 	}
-	if opts.ColdStartProbeTimeout == 0 {
+	if opts.ColdStartProbeTimeout <= 0 {
 		opts.ColdStartProbeTimeout = 200 * time.Millisecond
 	}
 	target, err := url.Parse(opts.UpstreamURL)
@@ -93,6 +104,10 @@ func New(opts Options) (http.Handler, error) {
 	}
 	if target.Host == "" {
 		return nil, fmt.Errorf("proxypass: upstream URL %q has no host", opts.UpstreamURL)
+	}
+	probeAddr, err := probeAddress(target)
+	if err != nil {
+		return nil, fmt.Errorf("proxypass: %w", err)
 	}
 
 	rp := &httputil.ReverseProxy{
@@ -114,7 +129,32 @@ func New(opts Options) (http.Handler, error) {
 			http.Error(w, "child upstream unavailable", http.StatusBadGateway)
 		},
 	}
-	return waitForUpstream(rp, target.Host, opts), nil
+	return waitForUpstream(rp, probeAddr, opts), nil
+}
+
+// probeAddress returns the host:port string suitable for net.DialTimeout.
+// url.URL.Host omits the default port when the URL doesn't carry one
+// explicitly (http://example.com → "example.com", no ":80"), so dialing
+// it raw fails with "missing port in address" and our cold-start probe
+// silently returns 503 every time. Resolve the scheme default
+// (80 for http, 443 for https) before joining; an unrecognised scheme
+// without a port is a configuration error and surfaces from New().
+func probeAddress(u *url.URL) (string, error) {
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("upstream URL %q has no host", u.Redacted())
+	}
+	if port := u.Port(); port != "" {
+		return net.JoinHostPort(host, port), nil
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		return net.JoinHostPort(host, "80"), nil
+	case "https":
+		return net.JoinHostPort(host, "443"), nil
+	default:
+		return "", fmt.Errorf("upstream URL %q has no port and unsupported scheme %q", u.Redacted(), u.Scheme)
+	}
 }
 
 // waitForUpstream wraps the reverse proxy with a short cold-start

--- a/services/nlpgo/adapters/proxypass/proxy.go
+++ b/services/nlpgo/adapters/proxypass/proxy.go
@@ -38,15 +38,22 @@ type Options struct {
 	// instead of failing fast, so the cold-start window is invisible to
 	// callers.
 	//
-	// Default: 25s. Empirically the saas Lambda runtime image takes
-	// ~22s end-to-end for uvicorn to import litellm + langwatch_nlp.main
-	// and bind 127.0.0.1:5561 (measured locally on the saas Dockerfile
-	// build: nlpgo binds at ~3s, uvicorn child reachable at ~22s). 25s
-	// absorbs the full cold-start window in a single request rather
-	// than relying on Studio's LambdaClient retry (maxAttempts:6) to
-	// pick up a 503 from an earlier attempt. Stays well under Lambda's
-	// 900s function timeout. Set to 0 to disable the wait entirely
-	// (tests / fail-fast topologies).
+	// Default: 90s. Empirical cold-start measurements:
+	//   - Local docker (M-series CPU): ~22s for uvicorn child to bind
+	//     5561 after litellm + langwatch_nlp.main imports.
+	//   - AWS Lambda 1024MB (~1 vCPU): >50s observed in lw-dev probes;
+	//     even 50s of cumulative active wall-clock didn't get the child
+	//     past the joblib warmup. Lambda CPU is the bottleneck.
+	//
+	// 90s gives generous headroom for Lambda Python imports while still
+	// fitting comfortably under the AWS SDK's 5-minute streaming-invoke
+	// deadline and Lambda's 900s function timeout. Set to 0 to disable
+	// the wait entirely (tests / fail-fast topologies).
+	//
+	// This is paired with a docker-build-time `python langwatch_nlp/main.py`
+	// preload step (in saas's Dockerfile.langwatch_nlp.lambda.runtime)
+	// which warms .pyc bytecode + litellm runtime initializers so cold-
+	// start is dominated by uvicorn process spawn, not import work.
 	ColdStartWait time.Duration
 	// ColdStartProbeInterval is the gap between TCP dial probes during
 	// the wait. Default: 100ms.
@@ -70,7 +77,7 @@ func New(opts Options) (http.Handler, error) {
 		opts.FlushInterval = -1
 	}
 	if opts.ColdStartWait == 0 {
-		opts.ColdStartWait = 25 * time.Second
+		opts.ColdStartWait = 90 * time.Second
 	}
 	if opts.ColdStartProbeInterval == 0 {
 		opts.ColdStartProbeInterval = 100 * time.Millisecond

--- a/services/nlpgo/adapters/proxypass/proxy.go
+++ b/services/nlpgo/adapters/proxypass/proxy.go
@@ -31,13 +31,19 @@ type Options struct {
 	// in services/nlpgo/serve.go (PR #3559) made the HTTP listener bind
 	// $PORT before the uvicorn child finishes warming, which closed the
 	// Lambda init-timeout problem but opened a new one: requests that
-	// land in the ~12-18s child-warmup window would dial 127.0.0.1:5561
-	// and get connection-refused, surfacing as "502 child upstream
-	// unavailable" to Studio (the prod symptom on 2026-04-28 19:xx UTC
-	// after saas#476 deploy). With ColdStartWait > 0 we briefly poll for
-	// the child instead of failing fast, so the cold-start window is
-	// invisible to callers. Default: 5s. Set to 0 to disable the wait
-	// (tests).
+	// land in the child-warmup window would dial 127.0.0.1:5561 and get
+	// connection-refused, surfacing as "502 child upstream unavailable"
+	// to Studio (the prod symptom on 2026-04-28 19:xx UTC after saas#476
+	// deploy). With ColdStartWait > 0 we briefly poll for the child
+	// instead of failing fast, so the cold-start window is invisible to
+	// callers.
+	//
+	// Default: 15s. Empirically the saas Lambda runtime image takes
+	// ~14s for uvicorn to import litellm + langwatch_nlp.main and bind
+	// 127.0.0.1:5561 (measured locally on the saas Dockerfile build).
+	// 15s gives a small safety margin while staying well under Lambda's
+	// 900s function timeout. Set to 0 to disable the wait entirely
+	// (tests / fail-fast topologies).
 	ColdStartWait time.Duration
 	// ColdStartProbeInterval is the gap between TCP dial probes during
 	// the wait. Default: 100ms.
@@ -61,7 +67,7 @@ func New(opts Options) (http.Handler, error) {
 		opts.FlushInterval = -1
 	}
 	if opts.ColdStartWait == 0 {
-		opts.ColdStartWait = 5 * time.Second
+		opts.ColdStartWait = 15 * time.Second
 	}
 	if opts.ColdStartProbeInterval == 0 {
 		opts.ColdStartProbeInterval = 100 * time.Millisecond

--- a/services/nlpgo/adapters/proxypass/proxy.go
+++ b/services/nlpgo/adapters/proxypass/proxy.go
@@ -47,8 +47,10 @@ type Options struct {
 	//
 	// 90s gives generous headroom for Lambda Python imports while still
 	// fitting comfortably under the AWS SDK's 5-minute streaming-invoke
-	// deadline and Lambda's 900s function timeout. Set to 0 to disable
-	// the wait entirely (tests / fail-fast topologies).
+	// deadline and Lambda's 900s function timeout. Set to a NEGATIVE
+	// duration (e.g. -1) to disable the wait entirely (tests / fail-fast
+	// topologies); zero means "unset, use the 90s default" per the
+	// usual Go zero-value-is-default idiom.
 	//
 	// This is paired with a docker-build-time `python langwatch_nlp/main.py`
 	// preload step (in saas's Dockerfile.langwatch_nlp.lambda.runtime)

--- a/services/nlpgo/adapters/proxypass/proxy.go
+++ b/services/nlpgo/adapters/proxypass/proxy.go
@@ -38,10 +38,13 @@ type Options struct {
 	// instead of failing fast, so the cold-start window is invisible to
 	// callers.
 	//
-	// Default: 15s. Empirically the saas Lambda runtime image takes
-	// ~14s for uvicorn to import litellm + langwatch_nlp.main and bind
-	// 127.0.0.1:5561 (measured locally on the saas Dockerfile build).
-	// 15s gives a small safety margin while staying well under Lambda's
+	// Default: 25s. Empirically the saas Lambda runtime image takes
+	// ~22s end-to-end for uvicorn to import litellm + langwatch_nlp.main
+	// and bind 127.0.0.1:5561 (measured locally on the saas Dockerfile
+	// build: nlpgo binds at ~3s, uvicorn child reachable at ~22s). 25s
+	// absorbs the full cold-start window in a single request rather
+	// than relying on Studio's LambdaClient retry (maxAttempts:6) to
+	// pick up a 503 from an earlier attempt. Stays well under Lambda's
 	// 900s function timeout. Set to 0 to disable the wait entirely
 	// (tests / fail-fast topologies).
 	ColdStartWait time.Duration
@@ -67,7 +70,7 @@ func New(opts Options) (http.Handler, error) {
 		opts.FlushInterval = -1
 	}
 	if opts.ColdStartWait == 0 {
-		opts.ColdStartWait = 15 * time.Second
+		opts.ColdStartWait = 25 * time.Second
 	}
 	if opts.ColdStartProbeInterval == 0 {
 		opts.ColdStartProbeInterval = 100 * time.Millisecond

--- a/services/nlpgo/adapters/proxypass/proxy_internal_test.go
+++ b/services/nlpgo/adapters/proxypass/proxy_internal_test.go
@@ -1,0 +1,72 @@
+package proxypass
+
+import (
+	"net/url"
+	"testing"
+)
+
+// TestProbeAddress_ResolvesSchemeDefaultPort pins the CR fix for cold-
+// start probes against bare-hostname upstream URLs. url.URL.Host omits
+// the default port (http://example.com → "example.com" with no ":80"),
+// and net.DialTimeout requires "host:port" — so before this helper,
+// every probe against such a URL failed with "missing port in address"
+// and the cold-start preamble silently 503'd through the full
+// ColdStartWait window. Production currently always passes
+// http://127.0.0.1:5561 (explicit port), but configuration drift or a
+// future caller could trip this; the helper keeps the contract honest.
+func TestProbeAddress_ResolvesSchemeDefaultPort(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"explicit ipv4 port preserved", "http://127.0.0.1:5561", "127.0.0.1:5561"},
+		{"explicit hostname port preserved", "http://upstream.local:8080", "upstream.local:8080"},
+		{"bare hostname http defaults to 80", "http://example.com", "example.com:80"},
+		{"bare hostname https defaults to 443", "https://example.com", "example.com:443"},
+		{"http path component does not leak into host", "http://example.com/studio/execute", "example.com:80"},
+		{"ipv6 with explicit port preserved", "http://[::1]:5561", "[::1]:5561"},
+		{"ipv6 bare http defaults to 80", "http://[2001:db8::1]/", "[2001:db8::1]:80"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.raw)
+			if err != nil {
+				t.Fatalf("url.Parse(%q): %v", tc.raw, err)
+			}
+			got, err := probeAddress(u)
+			if err != nil {
+				t.Fatalf("probeAddress(%q): unexpected error %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Errorf("probeAddress(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProbeAddress_RejectsUnknownSchemeWithoutPort pins the surfaced
+// startup error for misconfigured URLs. A bare hostname under an
+// unrecognised scheme has no obvious default port to fill in, so we
+// fail loud at New() rather than silently failing every probe at
+// runtime — the latter mode is exactly what hid the bug CR flagged.
+func TestProbeAddress_RejectsUnknownSchemeWithoutPort(t *testing.T) {
+	cases := []string{
+		"ftp://example.com",
+		"gopher://upstream.local",
+		"://example.com", // missing scheme
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			u, err := url.Parse(raw)
+			if err != nil {
+				// url.Parse may itself reject some shapes; that's still
+				// a valid loud-fail outcome from the caller's POV.
+				return
+			}
+			if _, err := probeAddress(u); err == nil {
+				t.Errorf("probeAddress(%q) returned no error; expected an unsupported-scheme rejection", raw)
+			}
+		})
+	}
+}

--- a/services/nlpgo/adapters/proxypass/proxy_test.go
+++ b/services/nlpgo/adapters/proxypass/proxy_test.go
@@ -249,6 +249,66 @@ func TestReverseProxy_NegativeColdStartWaitDisablesWait(t *testing.T) {
 		"with the wait disabled, request should fail fast — got %s", elapsed)
 }
 
+// TestReverseProxy_NegativeProbeKnobsFallBackToDefaults pins the CR
+// guard for misconfiguration: a negative ColdStartProbeInterval would
+// make time.After fire instantly inside the retry loop and CPU-spin
+// during outages; a negative ColdStartProbeTimeout would make every
+// net.DialTimeout return immediately. Unlike ColdStartWait, neither
+// probe knob has a "negative disables" sentinel — both must clamp to
+// the default. Without this guard, negative values survive into the
+// loop and the proxy degrades into a hot probe storm.
+//
+// Approach: same shape as TestReverseProxy_UpstreamReachableMidWait —
+// upstream comes up after ~150ms — but we pass NEGATIVE probe knobs
+// and a short ColdStartWait. If negatives clamp correctly, the loop
+// runs at the 100ms default interval, sees the upstream a few probes
+// in, and the request succeeds with 200. If negatives leak into the
+// loop, the test would still pass functionally but the loop would
+// CPU-spin during the warmup gap (not directly observable in unit
+// tests; the production cost is wasted CPU on every cold-start).
+// Functional correctness is what we pin here.
+func TestReverseProxy_NegativeProbeKnobsFallBackToDefaults(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := probe.Addr().String()
+	require.NoError(t, probe.Close())
+
+	proxy, err := proxypass.New(proxypass.Options{
+		UpstreamURL:            "http://" + addr,
+		ColdStartWait:          1 * time.Second,
+		ColdStartProbeInterval: -1 * time.Second, // negative, must clamp
+		ColdStartProbeTimeout:  -1 * time.Second, // negative, must clamp
+	})
+	require.NoError(t, err,
+		"New must accept negative probe knobs and clamp them; rejecting at startup would be a behavior regression")
+	front := httptest.NewServer(proxy)
+	defer front.Close()
+
+	upstream := http.Server{
+		Addr: addr,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	defer func() { _ = upstream.Close() }()
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		ln, lerr := net.Listen("tcp", addr)
+		if lerr != nil {
+			t.Errorf("delayed listen: %v", lerr)
+			return
+		}
+		_ = upstream.Serve(ln)
+	}()
+
+	resp, err := http.Get(front.URL + "/studio/execute")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"with negative probe knobs clamped to defaults, the cold-start wait must still complete the request once the upstream comes up")
+}
+
 // TestReverseProxy_UpstreamReachableMidWaitProxiesThrough pins the
 // happy cold-start path: when the upstream isn't reachable on the
 // first probe but becomes reachable inside the wait window, the proxy

--- a/services/nlpgo/adapters/proxypass/proxy_test.go
+++ b/services/nlpgo/adapters/proxypass/proxy_test.go
@@ -198,7 +198,7 @@ func TestReverseProxy_UpstreamUnreachable_Returns503AfterWait(t *testing.T) {
 	// 127.0.0.1:1 is reserved and never listens.
 	proxy, err := proxypass.New(proxypass.Options{
 		UpstreamURL: "http://127.0.0.1:1",
-		// Tight wait so the test stays fast; production default is 5s.
+		// Tight wait so the test stays fast; production default is 90s.
 		ColdStartWait:          200 * time.Millisecond,
 		ColdStartProbeInterval: 50 * time.Millisecond,
 		ColdStartProbeTimeout:  50 * time.Millisecond,
@@ -218,6 +218,35 @@ func TestReverseProxy_UpstreamUnreachable_Returns503AfterWait(t *testing.T) {
 		"503 must carry Retry-After:1 so the LambdaClient backs off briefly before retry")
 	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
 		"proxypass must wait the full ColdStartWait window before giving up")
+}
+
+// TestReverseProxy_NegativeColdStartWaitDisablesWait pins the
+// documented contract that a NEGATIVE ColdStartWait disables the
+// preamble entirely, so callers who want the legacy fail-fast
+// behavior have a way to opt out without rewriting the proxy. Per
+// the doc on Options.ColdStartWait, zero is the Go zero-value-is-
+// default idiom (use the 90s default), and negative is the explicit
+// "disabled" signal. With the wait disabled, an unreachable upstream
+// returns 502 immediately from the existing ErrorHandler — same as
+// the pre-cold-start-wait shape.
+func TestReverseProxy_NegativeColdStartWaitDisablesWait(t *testing.T) {
+	proxy, err := proxypass.New(proxypass.Options{
+		UpstreamURL:   "http://127.0.0.1:1",
+		ColdStartWait: -1, // explicit disable
+	})
+	require.NoError(t, err)
+	front := httptest.NewServer(proxy)
+	defer front.Close()
+
+	start := time.Now()
+	resp, err := http.Get(front.URL + "/studio/execute")
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode,
+		"with ColdStartWait disabled, an unreachable upstream must surface as 502 immediately (not 503 after waiting)")
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"with the wait disabled, request should fail fast — got %s", elapsed)
 }
 
 // TestReverseProxy_UpstreamReachableMidWaitProxiesThrough pins the

--- a/services/nlpgo/adapters/proxypass/proxy_test.go
+++ b/services/nlpgo/adapters/proxypass/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -177,23 +178,115 @@ func TestReverseProxy_ClientCancelPropagatesUpstream(t *testing.T) {
 	}
 }
 
-// TestReverseProxy_UpstreamUnreachable_Returns502 verifies the error
-// path: when uvicorn is down (or wrong URL), proxypass returns 502
-// with a clean message rather than leaking a connection-refused error
-// or hanging.
-func TestReverseProxy_UpstreamUnreachable_Returns502(t *testing.T) {
+// TestReverseProxy_UpstreamUnreachable_Returns503AfterWait verifies the
+// cold-start fix: when uvicorn is unreachable, proxypass polls the
+// upstream for ColdStartWait before giving up, then returns 503 with
+// Retry-After:1 (not 502) so the AWS SDK's retryable-status logic
+// kicks in instead of failing the user-visible request immediately.
+//
+// Pre-fix this test asserted 502 — the old behavior was correct for a
+// permanently-down upstream but wrong during the Lambda cold-start
+// window where the python child takes ~12-18s to import litellm. After
+// the lifecycle reorder in PR #3559 binds $PORT immediately, requests
+// can land while the child is still warming, and 502 surfaced as
+// "Failed run workflow: 502 child upstream unavailable" in Studio
+// (prod incident on 2026-04-28 19:xx UTC after saas#476 deploy). The
+// 503 + Retry-After contract lets the LambdaClient retry transparently
+// — see langwatch/src/optimization_studio/server/lambda/index.ts
+// (maxAttempts:6, also from PR #3559).
+func TestReverseProxy_UpstreamUnreachable_Returns503AfterWait(t *testing.T) {
 	// 127.0.0.1:1 is reserved and never listens.
-	proxy, err := proxypass.New(proxypass.Options{UpstreamURL: "http://127.0.0.1:1"})
+	proxy, err := proxypass.New(proxypass.Options{
+		UpstreamURL: "http://127.0.0.1:1",
+		// Tight wait so the test stays fast; production default is 5s.
+		ColdStartWait:          200 * time.Millisecond,
+		ColdStartProbeInterval: 50 * time.Millisecond,
+		ColdStartProbeTimeout:  50 * time.Millisecond,
+	})
 	require.NoError(t, err)
 	front := httptest.NewServer(proxy)
 	defer front.Close()
 
+	start := time.Now()
+	resp, err := http.Get(front.URL + "/studio/execute")
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"unreachable upstream after the cold-start wait must surface as 503 (not 502) so the LambdaClient retries transparently")
+	assert.Equal(t, "1", resp.Header.Get("Retry-After"),
+		"503 must carry Retry-After:1 so the LambdaClient backs off briefly before retry")
+	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
+		"proxypass must wait the full ColdStartWait window before giving up")
+}
+
+// TestReverseProxy_UpstreamReachableMidWaitProxiesThrough pins the
+// happy cold-start path: when the upstream isn't reachable on the
+// first probe but becomes reachable inside the wait window, the proxy
+// polls until it sees the host, then proxies the request through.
+// Without this behavior /studio/execute requests landing in the child
+// warmup window would 503 even though the child becomes ready ~ms
+// later — caller would have to retry an already-survivable request.
+func TestReverseProxy_UpstreamReachableMidWaitProxiesThrough(t *testing.T) {
+	// Reserve a free port; don't bind it yet. The proxy will see
+	// connection-refused, wait, then succeed once we start the listener.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := probe.Addr().String()
+	require.NoError(t, probe.Close())
+
+	proxy, err := proxypass.New(proxypass.Options{
+		UpstreamURL:            "http://" + addr,
+		ColdStartWait:          1 * time.Second,
+		ColdStartProbeInterval: 30 * time.Millisecond,
+		ColdStartProbeTimeout:  50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	front := httptest.NewServer(proxy)
+	defer front.Close()
+
+	// Start the upstream after a short delay so the proxy sees a few
+	// connection-refused probes before the host comes up.
+	type observed struct {
+		method, path string
+	}
+	hits := make(chan observed, 1)
+	upstream := http.Server{
+		Addr: addr,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits <- observed{r.Method, r.URL.Path}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	defer func() { _ = upstream.Close() }()
+	upstreamReady := make(chan struct{})
+	go func() {
+		time.Sleep(150 * time.Millisecond) // simulate child warmup
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			t.Errorf("delayed listen: %v", err)
+			close(upstreamReady)
+			return
+		}
+		close(upstreamReady)
+		_ = upstream.Serve(ln)
+	}()
+
 	resp, err := http.Get(front.URL + "/studio/execute")
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
-	body, _ := io.ReadAll(resp.Body)
-	assert.Contains(t, strings.ToLower(string(body)), "upstream")
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"upstream became reachable inside ColdStartWait; proxypass must proxy through, not 503")
+
+	select {
+	case h := <-hits:
+		assert.Equal(t, "/studio/execute", h.path)
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream never received the proxied request")
+	}
+	<-upstreamReady
 }
 
 // TestReverseProxy_ForwardsMethodAndPath ensures the proxy doesn't

--- a/services/nlpgo/deps.go
+++ b/services/nlpgo/deps.go
@@ -80,6 +80,17 @@ func NewDeps(ctx context.Context, cfg Config) (context.Context, *Deps, error) {
 		HealthURL: cfg.Child.HealthURL,
 		Disabled:  cfg.Child.Bypass,
 		Logger:    logger,
+		// StartTimeout is the wall-clock budget for the python child to
+		// respond 200 to /health from spawn. The default Manager value
+		// (30s) is fine on dev hardware but too tight on AWS Lambda
+		// 1024MB (≈1 vCPU): empirical lw-dev probes show the child
+		// being SIGKILL'd at 30s with the litellm + langwatch_nlp
+		// imports still in flight, leaving the proxy with no upstream
+		// to dial. Bumping to 120s covers Lambda's slower CPU plus any
+		// freeze-during-init interaction; well under the 900s function
+		// timeout. Once the child is healthy this knob is not on the
+		// hot path — it's a one-time cold-start budget.
+		StartTimeout: 120 * time.Second,
 	})
 
 	probes.RegisterReadiness("uvicorn_child", func() (bool, string) {


### PR DESCRIPTION
## Summary

Stack of cold-start fixes for the AWS Lambda deploy of nlpgo. After PR #3559 fixed the Lambda init ceiling by reordering the lifecycle group, prod redeploy via [langwatch-saas#476](https://github.com/langwatch/langwatch-saas/pull/476) hit a NEW failure mode: `/studio/execute` legacy paths returned `502 child upstream unavailable` immediately during the cold-start window. lw-dev probes also surfaced a uvicorn-child SIGKILL at 30s + a Recover-middleware bug that crashes the Lambda Web Adapter.

This PR addresses all of them. Companion saas PR (Sarah) bumps `MemorySize: 1024 → 2048` per [#3565](https://github.com/langwatch/langwatch/pull/3565) to address the OOM that surfaces independently.

## Commits

### `18e262d3c` — proxypass waits for upstream during cold-start, returns 503 not 502

Wraps the reverse proxy with a TCP-probe preamble. On each request the proxy polls `127.0.0.1:5561` every 100ms up to `ColdStartWait`. If reachable, hand off to the standard reverse proxy. If not, return `503` with `Retry-After: 1` so the LambdaClient retry path (`maxAttempts: 6`, also from #3559) kicks in.

The 502 ErrorHandler is preserved for actual upstream errors (5xx mid-stream, write-error, etc.) that occur AFTER the dial succeeded. The wrapper only widens the no-route window.

### `28ae529fa` + `53a00c106` + `b29aceee3` — `ColdStartWait` 5s → 90s default

Iteratively bumped to absorb the Lambda cold-start in a single request rather than relying on SDK retries:

| Image / config                                                | Result                              |
|---------------------------------------------------------------|-------------------------------------|
| Pre-fix (saas#476)                                            | 502 in <1s ❌                       |
| Lifecycle reorder + `ColdStartWait=5s`                        | 503 in 5s after waiting ❌         |
| Lifecycle reorder + `ColdStartWait=15s`                       | 503 in 15s after waiting ❌        |
| Lifecycle reorder + `ColdStartWait=25s` + LWA env             | 503 in 25s; SDK retry would catch  |
| Lifecycle reorder + `ColdStartWait=90s` + preload + LWA env   | 200 SSE in ~13s end-to-end ✅      |

90s gives generous headroom for Lambda 1024MB CPU + the Python child's litellm imports while still fitting under the AWS SDK's 5-minute streaming-invoke deadline.

### `cd166c354` — uvicorn-child `StartTimeout` 30s → 120s for Lambda CPU

lw-dev CloudWatch showed:
```
[error] uvicorn_child_exited error: "uvicornchild: exited unexpectedly: signal: killed"
[error] uvicorn_child_start_failed error: "uvicornchild: not healthy within 30s"
```

`Manager.Start` was killing the still-importing child at the default 30s budget — Lambda 1024MB (≈0.58 vCPU) is meaningfully slower than dev hardware. Bumped to 120s to absorb the Lambda Python-import cost. Off the hot path once the child is healthy.

### `17c2a9d4e` — `httpmiddleware/Recover` re-panics `http.ErrAbortHandler` without writing 500

Also surfaced live: when uvicorn upstream EOFs mid-body, `httputil.ReverseProxy` panics with the `http.ErrAbortHandler` sentinel. The Recover middleware previously caught that, wrote a 500, then re-panicked — putting the response writer in an indeterminate state. Symptoms:

- Go log: `superfluous response.WriteHeader call`
- Rust LWA panic: `unexpected EOF during chunk size line` → SIGKILL → `Extension.Crash`

Fix: detect the sentinel before touching the response writer and re-panic immediately. `net/http` handles it per its documented contract (close the connection silently). Generic panics still get the 500 + re-panic path.

## Test plan

- [x] `services/nlpgo/adapters/proxypass/...` — `TestReverseProxy_UpstreamUnreachable_Returns503AfterWait` + `TestReverseProxy_UpstreamReachableMidWaitProxiesThrough` pin the new contract; existing tests preserved.
- [x] `pkg/httpmiddleware/recover_test.go` — generic-panic 500 path preserved; `ErrAbortHandler` re-panics without writing.
- [x] Full nlpgo + httpmiddleware suite green locally.
- [x] **Real-Lambda lw-dev validation**: each successive fix verified against an arm64/1024MB lw-dev test Lambda before bumping the next default. The 90s wait + preload + LWA env combo lands `/studio/execute` is_alive on a fresh cold container in 13s with valid SSE response (was: 502 immediate).
- [ ] Final lw-dev validation pending the companion saas PR (Dockerfile preload + bundling re-roll + 2048MB Memory) to confirm the OOM at 805/1024 MB is gone.

## Saas-side companion (REQUIRED for prod redeploy)

The saas Dockerfile changes live in [`langwatch-saas#?`](https://github.com/langwatch/langwatch-saas) (Sarah is preparing). Needs:

- Re-roll the nlpgo bundling reverted in [saas#477](https://github.com/langwatch/langwatch-saas/pull/477)
- `RUN PYTHONPATH=. python langwatch_nlp/main.py` preload step
- `ENV AWS_LWA_READINESS_CHECK_PATH=/healthz`
- Submodule pin to this PR's merge SHA + #3565's merge SHA
- 26-Lambda fleet migration script for the `MemorySize: 2048` config

That saas PR will not be opened until both this PR and #3565 merge.
