### PR TITLE
chore(npx-server): post-#3539 cleanup — restore main-only publish guard + reset root → 3.1.0

### DIFF
--- a/.github/workflows/npx-server-publish.yml
+++ b/.github/workflows/npx-server-publish.yml
@@ -43,12 +43,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # TEMP(beta.26): allow `fix/` branches so #3539 can publish beta.26 for
-    # the regen-config + zombie-port-error-message dogfood. Reverted in
-    # the same PR.
     if: |
       (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'langwatch@')) ||
-      (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/fix/')))
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     timeout-minutes: 20
 
     steps:
@@ -75,10 +72,10 @@ jobs:
           echo "langwatch/package.json version: $app_version"
           echo "release tag (if any):           $tag"
 
-          # TEMP(beta.26): warn-only lockstep so root (beta.26) + langwatch
-          # (3.1.0 GA) can drift for one publish. Reverted in the same PR.
           if [ "$pkg_version" != "$app_version" ]; then
-            echo "⚠ version drift: root=$pkg_version langwatch=$app_version (lockstep check temporarily relaxed)"
+            echo "✗ version mismatch: root=$pkg_version langwatch=$app_version"
+            echo "  release-please should keep these in lockstep — check release-please-config.json"
+            exit 1
           fi
 
           if [ "${{ github.event_name }}" = "release" ]; then
@@ -92,11 +89,15 @@ jobs:
             fi
           fi
 
-          # TEMP(beta.26): force `latest` so `npx @langwatch/server@latest`
-          # resolves to beta.26 immediately for verification.
-          # Reverted in the same PR.
-          npm_tag="latest"
-          echo "resolved npm dist-tag:          $npm_tag (forced; auto-derive temporarily disabled)"
+          # Auto-derive npm dist-tag from version: any `-` suffix (beta, rc,
+          # alpha, next, etc.) → `prerelease`; clean semver → `latest`.
+          # Same convention as scenario js (.github/workflows/javascript-publish.yml).
+          if [[ "$pkg_version" == *"-"* ]]; then
+            npm_tag="prerelease"
+          else
+            npm_tag="latest"
+          fi
+          echo "resolved npm dist-tag:          $npm_tag"
 
           echo "version=$pkg_version" >> "$GITHUB_OUTPUT"
           echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langwatch/server",
-  "version": "3.1.0-beta.26",
+  "version": "3.1.0",
   "description": "Run LangWatch locally with one command — `npx @langwatch/server`. Complete LangWatch stack: observability, evaluations, AI gateway, agent simulations.",
   "license": "Apache-2.0",
   "homepage": "https://langwatch.ai",


### PR DESCRIPTION
## Summary

PR #3539 was merged with the beta.26 TEMP commit (`c9834dd48`) still active, so main landed with:

- root `package.json` at `3.1.0-beta.26` (out of lockstep with `langwatch/package.json` at `3.1.0`)
- `npx-server-publish.yml` with `fix/*` branch allowance, warn-only lockstep, forced `@latest` dist-tag

This PR reverts those temp relaxations — the same shape as the post-beta-cleanup commits inside #3539:

- `root → 3.1.0` (lockstep restored, release-please can now bump root + langwatch in sync to 3.2.0 GA)
- workflow guard → main-only
- lockstep check → exit-1 on mismatch
- npm dist-tag → auto-derived from version suffix (`-beta` → @prerelease, clean semver → @latest)

The actual code fixes from beta.26 (regen clickhouse + redis configs on every start, decode zombie-port-conflict error messages) are kept intact — only the publish-flow temp knobs are reverted.

## Test plan
- [x] root + langwatch package.json versions in lockstep (both 3.1.0)
- [x] workflow only fires on `release` (langwatch@*) or `workflow_dispatch` from `main`
- [x] lockstep check exits 1 on mismatch
- [x] npm dist-tag auto-derives