### PR TITLE
fix(studio): strip LWA RESPONSE_STREAM prelude before forwarding SSE chunks

### DIFF
--- a/langwatch/src/optimization_studio/server/lambda/__tests__/lwa-prelude.test.ts
+++ b/langwatch/src/optimization_studio/server/lambda/__tests__/lwa-prelude.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  LWA_PRELUDE_SEPARATOR_LEN,
+  concatBytes,
+  findLWAPreludeSeparator,
+} from "../index";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/**
+ * Builds the byte shape AWS Lambda Web Adapter emits in RESPONSE_STREAM
+ * mode: a JSON prelude with statusCode + headers, then 8 zero bytes,
+ * then the response body bytes.
+ */
+function buildLWAResponse(
+  prelude: object,
+  body: string | Uint8Array,
+): Uint8Array {
+  const preludeBytes = enc.encode(JSON.stringify(prelude));
+  const sep = new Uint8Array(LWA_PRELUDE_SEPARATOR_LEN);
+  const bodyBytes = typeof body === "string" ? enc.encode(body) : body;
+  return concatBytes(concatBytes(preludeBytes, sep), bodyBytes);
+}
+
+describe("findLWAPreludeSeparator", () => {
+  it("finds the separator at the boundary between prelude JSON and SSE body", () => {
+    // Mirrors the exact prod hex-dump shape from rchaves's project_MZZ
+    // Lambda invoke (2026-04-29): prelude JSON, then 8 NULs, then the
+    // bare nlpgo control SSE body.
+    const buf = buildLWAResponse(
+      {
+        statusCode: 200,
+        headers: { "content-type": "text/event-stream" },
+        cookies: [],
+      },
+      'data: {"type":"is_alive_response"}\n\ndata: {"type":"done"}\n\n',
+    );
+    const sepIdx = findLWAPreludeSeparator(buf);
+    expect(sepIdx).toBeGreaterThan(0);
+    // The 8 bytes at sepIdx must all be zero
+    for (let j = 0; j < LWA_PRELUDE_SEPARATOR_LEN; j++) {
+      expect(buf[sepIdx + j]).toBe(0);
+    }
+    // Everything before the separator must parse as the prelude JSON
+    const prelude = JSON.parse(dec.decode(buf.slice(0, sepIdx)));
+    expect(prelude.statusCode).toBe(200);
+    // Everything after the separator must be the original body
+    expect(dec.decode(buf.slice(sepIdx + LWA_PRELUDE_SEPARATOR_LEN))).toBe(
+      'data: {"type":"is_alive_response"}\n\ndata: {"type":"done"}\n\n',
+    );
+  });
+
+  it("returns -1 when the buffer holds only part of the prelude (no separator yet)", () => {
+    // Simulates AWS splitting the prelude across multiple PayloadChunks —
+    // the strip loop must keep buffering until the separator arrives.
+    const partial = enc.encode(
+      '{"statusCode":200,"headers":{"content-type":"text/event-strea',
+    );
+    expect(findLWAPreludeSeparator(partial)).toBe(-1);
+  });
+
+  it("returns -1 for a body-only buffer that contains no 8-zero run", () => {
+    // SSE bodies are text and never contain 8 NULs — guard against
+    // false positives in the body scan.
+    const body = enc.encode(
+      'data: {"type":"is_alive_response"}\n\ndata: {"type":"done"}\n\n',
+    );
+    expect(findLWAPreludeSeparator(body)).toBe(-1);
+  });
+
+  it("recognises the separator even when followed immediately by body bytes (no padding)", () => {
+    const tightlyPacked = concatBytes(
+      enc.encode('{"statusCode":200,"headers":{},"cookies":[]}'),
+      concatBytes(new Uint8Array(LWA_PRELUDE_SEPARATOR_LEN), enc.encode("d")),
+    );
+    const sepIdx = findLWAPreludeSeparator(tightlyPacked);
+    expect(sepIdx).toBeGreaterThan(0);
+    expect(
+      dec.decode(tightlyPacked.slice(sepIdx + LWA_PRELUDE_SEPARATOR_LEN)),
+    ).toBe("d");
+  });
+});
+
+describe("concatBytes", () => {
+  it("returns a single buffer holding both inputs in order", () => {
+    const out = concatBytes(enc.encode("foo"), enc.encode("bar"));
+    expect(dec.decode(out)).toBe("foobar");
+  });
+
+  it("treats an empty left input as identity", () => {
+    const out = concatBytes(new Uint8Array(0), enc.encode("hello"));
+    expect(dec.decode(out)).toBe("hello");
+  });
+
+  it("treats an empty right input as identity", () => {
+    const out = concatBytes(enc.encode("hello"), new Uint8Array(0));
+    expect(dec.decode(out)).toBe("hello");
+  });
+});
+
+/**
+ * The end-to-end behavior of invokeLambda's strip loop is hard to unit-
+ * test because it lives inside a ReadableStream constructor that AWS
+ * SDK populates from an EventStream. Instead, we model the strip
+ * algorithm here over the same primitives the production code uses
+ * (findLWAPreludeSeparator + concatBytes) and pin the behavior on the
+ * three byte shapes that matter:
+ *
+ *   1. Prelude + body packed in ONE PayloadChunk (Go control path —
+ *      this is the prod failure mode that surfaced as "Connecting…"
+ *      forever on rchaves's FF=on project on 2026-04-29).
+ *   2. Prelude SPLIT across two PayloadChunks (rare but possible — AWS
+ *      doesn't guarantee chunk boundaries).
+ *   3. Prelude in chunk 1 alone, body in chunk 2 (legacy Python uvicorn
+ *      flush-per-event behavior — the historic happy case that masked
+ *      the bug for a long time).
+ */
+describe("LWA prelude-strip end-to-end behavior", () => {
+  /**
+   * Mirror of the strip loop in invokeLambda's ReadableStream start():
+   * accept successive chunks, return the stripped body bytes that
+   * SHOULD be enqueued downstream.
+   */
+  function stripPrelude(chunks: Uint8Array[]): Uint8Array {
+    let preludeStripped = false;
+    let preludeBuffer = new Uint8Array(0);
+    let body = new Uint8Array(0);
+    for (const chunk of chunks) {
+      let bytes = chunk;
+      if (!preludeStripped) {
+        const merged = concatBytes(preludeBuffer, bytes);
+        const sepIdx = findLWAPreludeSeparator(merged);
+        if (sepIdx === -1) {
+          preludeBuffer = merged;
+          continue;
+        }
+        bytes = merged.slice(sepIdx + LWA_PRELUDE_SEPARATOR_LEN);
+        preludeStripped = true;
+        preludeBuffer = new Uint8Array(0);
+        if (bytes.length === 0) continue;
+      }
+      body = concatBytes(body, bytes);
+    }
+    return body;
+  }
+
+  const PRELUDE = {
+    statusCode: 200,
+    headers: { "content-type": "text/event-stream" },
+    cookies: [],
+  };
+  const SSE_BODY =
+    'data: {"type":"is_alive_response"}\n\ndata: {"type":"done"}\n\n';
+
+  it("strips the prelude when prelude+body arrive in ONE chunk (the prod is_alive failure mode)", () => {
+    const fullChunk = buildLWAResponse(PRELUDE, SSE_BODY);
+    const body = stripPrelude([fullChunk]);
+    // Without the strip, downstream split("\n\n") puts the prelude JSON
+    // into events[0] and silently drops is_alive_response. With the
+    // strip, the body that downstream sees is exactly the SSE bytes.
+    expect(dec.decode(body)).toBe(SSE_BODY);
+    // And the first frame of the stripped body MUST start with "data: "
+    // so post_event/post-event.ts decodeChunk's startsWith check passes.
+    expect(dec.decode(body).startsWith("data: ")).toBe(true);
+  });
+
+  it("strips the prelude when AWS splits the prelude itself across two chunks", () => {
+    const full = buildLWAResponse(PRELUDE, SSE_BODY);
+    // Cut somewhere inside the prelude JSON (before the 8-NUL marker).
+    const cut = 30;
+    const a = full.slice(0, cut);
+    const b = full.slice(cut);
+    const body = stripPrelude([a, b]);
+    expect(dec.decode(body)).toBe(SSE_BODY);
+  });
+
+  it("strips the prelude when prelude is in chunk 1 and body in chunk 2 (uvicorn-style flush)", () => {
+    // Chunk 1: prelude + 8-NUL separator only. Chunk 2: pure SSE body.
+    const preludeBytes = enc.encode(JSON.stringify(PRELUDE));
+    const sep = new Uint8Array(LWA_PRELUDE_SEPARATOR_LEN);
+    const chunk1 = concatBytes(preludeBytes, sep);
+    const chunk2 = enc.encode(SSE_BODY);
+    const body = stripPrelude([chunk1, chunk2]);
+    expect(dec.decode(body)).toBe(SSE_BODY);
+  });
+
+  it("preserves multi-chunk body bytes verbatim once the prelude is stripped (no \\n\\n re-splitting)", () => {
+    // After the strip, downstream re-merges chunks itself. Make sure
+    // we hand off bytes as-is including any trailing partial frame.
+    const full = buildLWAResponse(PRELUDE, "data: {\"a\":1}\n\n");
+    const tail = enc.encode("data: {\"b\":2}\n\n");
+    const body = stripPrelude([full, tail]);
+    expect(dec.decode(body)).toBe(
+      'data: {"a":1}\n\ndata: {"b":2}\n\n',
+    );
+  });
+});

--- a/langwatch/src/optimization_studio/server/lambda/index.ts
+++ b/langwatch/src/optimization_studio/server/lambda/index.ts
@@ -76,6 +76,47 @@ const parseLambdaConfig = (): LangWatchLambdaConfig => {
 // to ride out a ~30-60s burst without surfacing the error to Studio.
 const LAMBDA_CLIENT_MAX_ATTEMPTS = 6;
 
+// Lambda Web Adapter RESPONSE_STREAM mode delimits the JSON prelude
+// from the response body with 8 zero bytes. Exposed for testing.
+export const LWA_PRELUDE_SEPARATOR_LEN = 8;
+
+/** Returns the index of the first 8-zero-byte run in `buf`, or -1 if
+ *  not present. Used to locate the LWA RESPONSE_STREAM prelude/body
+ *  boundary; see invokeLambda's prelude-strip block. SSE response
+ *  bodies are text and never contain runs of 8 NULs, so a false-
+ *  positive on the body side is not a practical concern. The buffer
+ *  parameter is typed as Uint8Array<ArrayBufferLike> so AWS SDK
+ *  PayloadChunk.Payload values flow through without an extra copy. */
+export function findLWAPreludeSeparator(
+  buf: Uint8Array<ArrayBufferLike>,
+): number {
+  for (let i = 0; i + LWA_PRELUDE_SEPARATOR_LEN <= buf.length; i++) {
+    let allZero = true;
+    for (let j = 0; j < LWA_PRELUDE_SEPARATOR_LEN; j++) {
+      if (buf[i + j] !== 0) {
+        allZero = false;
+        break;
+      }
+    }
+    if (allZero) return i;
+  }
+  return -1;
+}
+
+/** Allocates a new Uint8Array containing `a` followed by `b`. The
+ *  output owns a fresh ArrayBuffer (Uint8Array<ArrayBuffer>) so
+ *  ReadableStreamDefaultController.enqueue and other strict consumers
+ *  accept it without a buffer-type mismatch. */
+export function concatBytes(
+  a: Uint8Array<ArrayBufferLike>,
+  b: Uint8Array<ArrayBufferLike>,
+): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
 export const createLambdaClient = (): LambdaClient => {
   const config = parseLambdaConfig();
   return new LambdaClient({
@@ -428,23 +469,56 @@ export const invokeLambda = async (
         try {
           let statusCode = 200;
           let errorMessage = "";
+          // Lambda Web Adapter in RESPONSE_STREAM mode prepends every
+          // streamed response with a JSON prelude (`{"statusCode":...,
+          // "headers":{...},"cookies":[]}`) followed by 8 zero bytes,
+          // and only then the body. AWS often delivers the prelude and
+          // the first body bytes inside a SINGLE PayloadChunk, so if we
+          // forward chunks raw the downstream SSE parser in
+          // post_event/post-event.ts splits on `\n\n`, sees the first
+          // segment start with `{` instead of `data: `, and silently
+          // drops it. For the Go control path
+          // (services/nlpgo/adapters/httpapi/handlers.go
+          // emitStudioControlEvent) the dropped frame IS
+          // `is_alive_response`, so Studio's heartbeat hook
+          // (usePostEvent.tsx) never flips socketStatus to "connected"
+          // and stays "Connecting…" until fetchSSE's 20s timeout fires
+          // with `name: "Timeout"` (errors.ts FetchSSETimeoutError).
+          // Strip the prelude before enqueueing — buffer across chunks
+          // in case AWS splits the prelude itself across multiple
+          // PayloadChunks (uncommon but possible).
+          let preludeStripped = false;
+          let preludeBuffer = new Uint8Array(0);
 
           for await (const chunk of EventStream) {
             if (chunk.PayloadChunk?.Payload) {
-              const payloadText = new TextDecoder().decode(
-                chunk.PayloadChunk.Payload,
-              );
-              if (statusCode < 200 || statusCode >= 300) {
-                errorMessage += payloadText;
-              }
-              if (payloadText.includes('{"statusCode":')) {
+              let payloadBytes = chunk.PayloadChunk.Payload;
+              if (!preludeStripped) {
+                const merged = concatBytes(preludeBuffer, payloadBytes);
+                const sepIdx = findLWAPreludeSeparator(merged);
+                if (sepIdx === -1) {
+                  preludeBuffer = merged;
+                  continue;
+                }
                 try {
-                  statusCode = parseInt(JSON.parse(payloadText).statusCode);
+                  const preludeText = new TextDecoder().decode(
+                    merged.slice(0, sepIdx),
+                  );
+                  statusCode = parseInt(JSON.parse(preludeText).statusCode);
                 } catch {
-                  /* this is just a safe json parse fallback */
+                  /* safe json parse fallback — keep default 200 */
+                }
+                payloadBytes = merged.slice(sepIdx + LWA_PRELUDE_SEPARATOR_LEN);
+                preludeStripped = true;
+                preludeBuffer = new Uint8Array(0);
+                if (payloadBytes.length === 0) {
+                  continue;
                 }
               }
-              controller.enqueue(chunk.PayloadChunk.Payload);
+              if (statusCode < 200 || statusCode >= 300) {
+                errorMessage += new TextDecoder().decode(payloadBytes);
+              }
+              controller.enqueue(payloadBytes);
             }
             if (chunk.InvokeComplete?.ErrorCode) {
               const error = new Error(


### PR DESCRIPTION
## Summary
- Studio FF=on heartbeats hang on "Connecting…" forever because `invokeLambda` forwards the LWA RESPONSE_STREAM prelude byte-for-byte to the downstream SSE parser, which splits on `\n\n` and silently drops the first frame (the load-bearing `is_alive_response` on the Go control path).
- Fix: buffer until the 8-zero separator is seen, parse the JSON prelude for statusCode, enqueue only the post-separator body bytes.
- 11 unit tests cover the strip helpers + three end-to-end strip-loop shapes (prelude+body in one chunk, split-prelude, uvicorn-style chunk-per-event).

## Why this surfaced now
PR #3566 + saas#478 deployed the Go-bundled Lambda image (`git-cd66f27`). The Go control path (`services/nlpgo/adapters/httpapi/handlers.go` `emitStudioControlEvent`) writes `is_alive_response` and `done` synchronously before flushing — so the entire response packs into ONE Lambda PayloadChunk. With LWA's `\x00\x00\x00\x00\x00\x00\x00\x00` prelude separator glued to the first event, `chunk.split("\n\n")` puts the prelude JSON in `events[0]` and the `is_alive_response` data line as the suffix of `events[0]` (skipped by `startsWith("data: ")`); only the trailing `done` survives.

Python `/studio/execute` is not affected in steady state because uvicorn flushes per SSE event — prelude only contaminates the cosmetic `debug` first frame, and `is_alive_response` arrives in its own later chunk.

## Repro evidence (rchaves's prod project, 2026-04-29)
Hex-dump of `aws lambda invoke … langwatch_nlp-project_MZZOfbwLOfoiXeg9KnbqF /go/studio/execute is_alive`:
```
00000110: 6f6f 6b69 6573 223a 5b5d 7d 00 00 00 00 00 00 00 00   ...cookies":[]}.........
00000120: 0064 6174 613a 207b ...                                .data: {"type":"is_alive_response"}
                                                                data: {"type":"done"}
```
Prelude JSON, 8 NULs, both SSE events — all in one PayloadChunk.

User-visible symptom: `Object { time: ..., level: 50, name: "Timeout" }` from `fetchSSE`'s `FetchSSETimeoutError` (`langwatch/src/utils/sse/errors.ts:8`) after the 20s timeout in `usePostEvent.tsx:122`.

## Test plan
- [x] `pnpm test:unit src/optimization_studio/server/lambda/__tests__/lwa-prelude.test.ts` — 11/11 green
- [x] `pnpm typecheck` — clean
- [ ] After merge + saas redeploy, dogfood Studio FF=on with rchaves's `project_MZZOfbwLOfoiXeg9KnbqF` to confirm "Connecting…" clears within ~1s