### PR TITLE
fix(nlpgo): trace parity — execute_component span + langwatch.input/output JSON + scope-to-single-node + LANGWATCH_ENDPOINT fallback

### DIFF
--- a/langwatch/src/server/routes/workflows.ts
+++ b/langwatch/src/server/routes/workflows.ts
@@ -69,34 +69,51 @@ app.post("/code-completion", async (c) => {
     );
   }
 
-  const model = await getVercelAIModel(projectId);
+  try {
+    const model = await getVercelAIModel(projectId);
 
-  const copilot = new CompletionCopilot(undefined, {
-    model: async (prompt) => {
-      const { text } = await generateText({
-        model,
-        messages: [
-          { role: "system", content: prompt.context },
-          {
-            role: "user",
-            content: `${prompt.instruction}\n\n${prompt.fileContent}`,
+    const copilot = new CompletionCopilot(undefined, {
+      model: async (prompt) => {
+        const { text } = await generateText({
+          model,
+          messages: [
+            { role: "system", content: prompt.context },
+            {
+              role: "user",
+              content: `${prompt.instruction}\n\n${prompt.fileContent}`,
+            },
+          ],
+          maxOutputTokens: 64,
+          temperature: 0,
+          providerOptions: {
+            openai: {
+              reasoningEffort: "low",
+            } satisfies OpenAIResponsesProviderOptions,
           },
-        ],
-        maxOutputTokens: 64,
-        temperature: 0,
-        providerOptions: {
-          openai: {
-            reasoningEffort: "low",
-          } satisfies OpenAIResponsesProviderOptions,
-        },
-      });
+        });
 
-      return { text };
-    },
-  });
-  const completion = await copilot.complete({ body });
+        return { text };
+      },
+    });
+    const completion = await copilot.complete({ body });
 
-  return c.json(completion);
+    return c.json(completion);
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        projectId,
+      },
+      "code-completion failed",
+    );
+    captureException(error, { extra: { projectId } });
+    return c.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
 });
 
 // ── POST /post_event ─────────────────────────────────────────────────

--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -157,6 +157,11 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 		// Plumbed through to the engine so evaluation_state_change events
 		// carry the run_id Studio's reducer keys evaluations on.
 		RunID string `json:"run_id,omitempty"`
+		// Evaluation-only fields (execute_evaluation envelope):
+		// langwatch/src/optimization_studio/types/events.ts.
+		WorkflowVersionID string `json:"workflow_version_id,omitempty"`
+		EvaluateOn        string `json:"evaluate_on,omitempty"`
+		DatasetEntry      *int   `json:"dataset_entry,omitempty"`
 	}
 	if err := json.Unmarshal(innerBytes, &inner); err != nil {
 		e := herr.New(r.Context(), domain.ErrBadRequest, herr.M{
@@ -180,16 +185,19 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 		threadID = r.Header.Get("X-LangWatch-Thread-Id")
 	}
 	return &app.WorkflowRequest{
-		WorkflowJSON: inner.Workflow,
-		Inputs:       normalizeInputs(inner.Inputs),
-		Origin:       origin,
-		TraceID:      inner.TraceID,
-		ProjectID:    inner.ProjectID,
-		ThreadID:     threadID,
-		NodeID:       inner.NodeID,
-		APIKey:       peekWorkflowAPIKey(inner.Workflow),
-		Type:         peek.Type,
-		RunID:        inner.RunID,
+		WorkflowJSON:      inner.Workflow,
+		Inputs:            normalizeInputs(inner.Inputs),
+		Origin:            origin,
+		TraceID:           inner.TraceID,
+		ProjectID:         inner.ProjectID,
+		ThreadID:          threadID,
+		NodeID:            inner.NodeID,
+		APIKey:            peekWorkflowAPIKey(inner.Workflow),
+		Type:              peek.Type,
+		RunID:             inner.RunID,
+		WorkflowVersionID: inner.WorkflowVersionID,
+		EvaluateOn:        inner.EvaluateOn,
+		DatasetEntry:      inner.DatasetEntry,
 	}, nil
 }
 

--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -152,6 +152,11 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 		// Absent for execute_flow / execute_evaluation.
 		NodeID    string `json:"node_id,omitempty"`
 		ProjectID string `json:"project_id,omitempty"`
+		// RunID is present only on execute_evaluation envelopes
+		// (langwatch/src/optimization_studio/hooks/useEvaluationExecution.ts).
+		// Plumbed through to the engine so evaluation_state_change events
+		// carry the run_id Studio's reducer keys evaluations on.
+		RunID string `json:"run_id,omitempty"`
 	}
 	if err := json.Unmarshal(innerBytes, &inner); err != nil {
 		e := herr.New(r.Context(), domain.ErrBadRequest, herr.M{
@@ -183,6 +188,8 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 		ThreadID:     threadID,
 		NodeID:       inner.NodeID,
 		APIKey:       peekWorkflowAPIKey(inner.Workflow),
+		Type:         peek.Type,
+		RunID:        inner.RunID,
 	}, nil
 }
 

--- a/services/nlpgo/adapters/httpapi/playground_proxy.go
+++ b/services/nlpgo/adapters/httpapi/playground_proxy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/langwatch/langwatch/pkg/herr"
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 	"github.com/langwatch/langwatch/services/nlpgo/adapters/gatewayproxy"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/litellm"
 	nlpgodomain "github.com/langwatch/langwatch/services/nlpgo/domain"
 )
 
@@ -109,6 +110,26 @@ func playgroundProxyDispatch(proxy PlaygroundProxy) http.HandlerFunc {
 			}
 		}
 
+		// OpenAI's reasoning-class models (gpt-5*, o1/o3/o4) reject
+		// `max_tokens` ("Unsupported parameter: 'max_tokens' is not
+		// supported with this model. Use 'max_completion_tokens'
+		// instead.") and pin temperature to 1.0. The internal
+		// runSignature path already runs the same migration via
+		// litellm.ApplyReasoningOverrides; the playground proxy was
+		// raw-forwarding bodies authored by Vercel AI SDK / playground
+		// callers that emit `max_tokens`. Mirror the executor here so
+		// /go/proxy/v1/chat/completions doesn't 400 on Studio Monaco
+		// code-completion / playground / model.factory.ts traffic.
+		if litellm.IsReasoningModel(bareModel) {
+			body, err = applyReasoningOverridesToBody(body, bareModel)
+			if err != nil {
+				herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
+					"reason": "apply_reasoning_overrides",
+				}, err))
+				return
+			}
+		}
+
 		reqType, httpPath := classifyPath(r.URL.Path)
 
 		// /v1beta/* etc. → RequestTypePassthrough. Wiring it through the
@@ -164,6 +185,23 @@ func rewriteBodyModel(body []byte, newModel string) ([]byte, error) {
 	}
 	raw["model"] = encoded
 	return json.Marshal(raw)
+}
+
+// applyReasoningOverridesToBody migrates max_tokens → max_completion_tokens
+// and pins temperature to 1.0 for OpenAI reasoning-class models, mirroring
+// the in-process llmexecutor path. The actual rewrite logic lives in
+// litellm.ApplyReasoningOverrides (translator.go) — this is the
+// raw-bytes-in / raw-bytes-out wrapper for the playground proxy.
+func applyReasoningOverridesToBody(body []byte, modelID string) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(body, &generic); err != nil {
+		return nil, err
+	}
+	litellm.ApplyReasoningOverrides(modelID, generic)
+	return json.Marshal(generic)
 }
 
 // peekBodyMetadata reads the body once to extract the OpenAI-shape

--- a/services/nlpgo/adapters/httpapi/playground_proxy.go
+++ b/services/nlpgo/adapters/httpapi/playground_proxy.go
@@ -87,6 +87,28 @@ func playgroundProxyDispatch(proxy PlaygroundProxy) http.HandlerFunc {
 		}
 		bareModel := gatewayproxy.BareModel(model)
 
+		// Rewrite body.model to the BARE id before dispatch. The TS
+		// callsites (Vercel AI SDK in modelProviders/utils.ts, the
+		// playground tRPC route, model.factory.ts) ship the body with
+		// `"model": "openai/gpt-5.2"` because the langwatch-internal
+		// "<provider>/<model>" form is what those callers think in. Bifrost
+		// raw-forwards OpenAI-shape bodies to OpenAI to preserve the
+		// prompt-prefix auto-cache (bifrost_parser.go:50-58), and OpenAI
+		// 400s on a model field with the langwatch prefix
+		// (`{"error":"invalid model ID"}`). The bare id matches what the
+		// internal-only llmexecutor.translatedModelOrInferred path already
+		// puts on the wire for runSignature, which is why runSignature
+		// works and /go/proxy/v1 didn't until this edit.
+		if model != "" && bareModel != model {
+			body, err = rewriteBodyModel(body, bareModel)
+			if err != nil {
+				herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
+					"reason": "rewrite_body_model",
+				}, err))
+				return
+			}
+		}
+
 		reqType, httpPath := classifyPath(r.URL.Path)
 
 		// /v1beta/* etc. → RequestTypePassthrough. Wiring it through the
@@ -119,6 +141,29 @@ func playgroundProxyDispatch(proxy PlaygroundProxy) http.HandlerFunc {
 		}
 		handleSync(ctx, w, proxy, req)
 	}
+}
+
+// rewriteBodyModel sets body.model = newModel while preserving every
+// other field, key ordering, and value formatting. We round-trip
+// through encoding/json (decode → re-encode) rather than sjson because
+// the proxy already takes that hit for peekBodyMetadata; an extra
+// in-place rewrite is not worth a new dependency. JSON key ordering
+// changes here are harmless — the prompt-prefix auto-cache hashes the
+// `messages` array, not the surrounding envelope.
+func rewriteBodyModel(body []byte, newModel string) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	encoded, err := json.Marshal(newModel)
+	if err != nil {
+		return nil, err
+	}
+	raw["model"] = encoded
+	return json.Marshal(raw)
 }
 
 // peekBodyMetadata reads the body once to extract the OpenAI-shape

--- a/services/nlpgo/adapters/httpapi/playground_proxy_test.go
+++ b/services/nlpgo/adapters/httpapi/playground_proxy_test.go
@@ -125,8 +125,55 @@ func TestPlaygroundProxy_NonStreamingChatCompletions_ForwardsBodyAndCredential(t
 	if fake.gotRequest.Credential.APIKey != "sk-test" {
 		t.Errorf("APIKey = %q", fake.gotRequest.Credential.APIKey)
 	}
-	if !bytes.Contains(fake.gotRequest.Body, []byte("openai/gpt-5-mini")) {
-		t.Errorf("body should be forwarded verbatim, got: %s", fake.gotRequest.Body)
+	// body.model is rewritten to the bare id before dispatch. OpenAI
+	// rejects the langwatch-internal "openai/gpt-5-mini" prefix in body.model
+	// with `{"error":"invalid model ID"}`, and Bifrost raw-forwards the body
+	// to OpenAI for OpenAI-compatible providers (bifrost_parser.go:50-58),
+	// so the rewrite has to happen at this layer. Caught by Studio Monaco
+	// code-completion 500s on FF=on (2026-04-29 dogfood).
+	if bytes.Contains(fake.gotRequest.Body, []byte("openai/gpt-5-mini")) {
+		t.Errorf("body.model should be rewritten from 'openai/gpt-5-mini' to bare 'gpt-5-mini', got: %s", fake.gotRequest.Body)
+	}
+	if !bytes.Contains(fake.gotRequest.Body, []byte(`"model":"gpt-5-mini"`)) {
+		t.Errorf("body.model should be 'gpt-5-mini' (bare), got: %s", fake.gotRequest.Body)
+	}
+	// Other body fields preserved.
+	if !bytes.Contains(fake.gotRequest.Body, []byte(`"messages":[{"role":"user","content":"hi"}]`)) {
+		t.Errorf("messages array should be preserved verbatim, got: %s", fake.gotRequest.Body)
+	}
+}
+
+func TestPlaygroundProxy_BareModelInBodyPassedThroughUnchanged(t *testing.T) {
+	// When the caller already sends a bare model id (no provider prefix),
+	// the rewrite is a no-op and the original body is forwarded byte-for-byte
+	// — preserving OpenAI's prompt-prefix auto-cache hits for the common
+	// case where someone is already speaking the OpenAI wire format directly.
+	fake := &fakeProxy{
+		syncResp: &playgroundProxyResponse{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": []string{"application/json"}},
+			Body:       []byte(`{"id":"chatcmpl-1","choices":[]}`),
+		},
+	}
+	srv := newProxyTestServer(t, fake)
+
+	body := `{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/go/proxy/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-litellm-model", "openai/gpt-5-mini")
+	req.Header.Set("x-litellm-api_key", "sk-test")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, respBody)
+	}
+	if string(fake.gotRequest.Body) != body {
+		t.Errorf("body should be forwarded byte-for-byte when model is already bare, got: %s", fake.gotRequest.Body)
 	}
 }
 

--- a/services/nlpgo/adapters/httpapi/playground_proxy_test.go
+++ b/services/nlpgo/adapters/httpapi/playground_proxy_test.go
@@ -137,17 +137,29 @@ func TestPlaygroundProxy_NonStreamingChatCompletions_ForwardsBodyAndCredential(t
 	if !bytes.Contains(fake.gotRequest.Body, []byte(`"model":"gpt-5-mini"`)) {
 		t.Errorf("body.model should be 'gpt-5-mini' (bare), got: %s", fake.gotRequest.Body)
 	}
-	// Other body fields preserved.
-	if !bytes.Contains(fake.gotRequest.Body, []byte(`"messages":[{"role":"user","content":"hi"}]`)) {
-		t.Errorf("messages array should be preserved verbatim, got: %s", fake.gotRequest.Body)
+	// Other body fields preserved (key order may shift through json
+	// round-trip; we assert the content via Unmarshal).
+	var roundTripped struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(fake.gotRequest.Body, &roundTripped); err != nil {
+		t.Fatalf("forwarded body is not valid JSON: %v\n%s", err, fake.gotRequest.Body)
+	}
+	if len(roundTripped.Messages) != 1 || roundTripped.Messages[0].Role != "user" || roundTripped.Messages[0].Content != "hi" {
+		t.Errorf("messages array contents lost in rewrite, got: %+v", roundTripped.Messages)
 	}
 }
 
-func TestPlaygroundProxy_BareModelInBodyPassedThroughUnchanged(t *testing.T) {
-	// When the caller already sends a bare model id (no provider prefix),
-	// the rewrite is a no-op and the original body is forwarded byte-for-byte
+func TestPlaygroundProxy_NonReasoningModelBodyForwardedByteForByte(t *testing.T) {
+	// For non-reasoning models, when the caller already sends a bare
+	// model id (no provider prefix), the body is forwarded byte-for-byte
 	// — preserving OpenAI's prompt-prefix auto-cache hits for the common
-	// case where someone is already speaking the OpenAI wire format directly.
+	// playground-tRPC / model.factory.ts callers that already speak the
+	// OpenAI wire format directly. (Reasoning models trigger
+	// ApplyReasoningOverrides and are covered separately below.)
 	fake := &fakeProxy{
 		syncResp: &playgroundProxyResponse{
 			StatusCode: 200,
@@ -157,7 +169,45 @@ func TestPlaygroundProxy_BareModelInBodyPassedThroughUnchanged(t *testing.T) {
 	}
 	srv := newProxyTestServer(t, fake)
 
-	body := `{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}]}`
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/go/proxy/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-litellm-model", "openai/gpt-4o")
+	req.Header.Set("x-litellm-api_key", "sk-test")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, respBody)
+	}
+	if string(fake.gotRequest.Body) != body {
+		t.Errorf("body should be forwarded byte-for-byte when model is non-reasoning + already bare, got: %s", fake.gotRequest.Body)
+	}
+}
+
+func TestPlaygroundProxy_ReasoningModelMigratesMaxTokensToCompletion(t *testing.T) {
+	// gpt-5* / o1 / o3 / o4 reject `max_tokens` ("Unsupported parameter:
+	// 'max_tokens' is not supported with this model. Use
+	// 'max_completion_tokens' instead.") and pin temperature to 1.0.
+	// llmexecutor.ApplyReasoningOverrides already handles this for the
+	// internal runSignature path; the proxy mirrors it for /go/proxy/v1
+	// callers (Vercel AI SDK in modelProviders/utils.ts emits max_tokens
+	// by default — Studio Monaco code-completion 500'd on this until the
+	// fix shipped 2026-04-29).
+	fake := &fakeProxy{
+		syncResp: &playgroundProxyResponse{
+			StatusCode: 200,
+			Headers:    http.Header{"Content-Type": []string{"application/json"}},
+			Body:       []byte(`{"id":"chatcmpl-1","choices":[{"message":{"role":"assistant","content":"ok"}}]}`),
+		},
+	}
+	srv := newProxyTestServer(t, fake)
+
+	body := `{"model":"openai/gpt-5-mini","max_tokens":64,"temperature":0,"messages":[{"role":"user","content":"hi"}]}`
 	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/go/proxy/v1/chat/completions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-litellm-model", "openai/gpt-5-mini")
@@ -172,8 +222,21 @@ func TestPlaygroundProxy_BareModelInBodyPassedThroughUnchanged(t *testing.T) {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, body = %s", resp.StatusCode, respBody)
 	}
-	if string(fake.gotRequest.Body) != body {
-		t.Errorf("body should be forwarded byte-for-byte when model is already bare, got: %s", fake.gotRequest.Body)
+
+	// Old keys gone, new keys present.
+	if bytes.Contains(fake.gotRequest.Body, []byte(`"max_tokens"`)) {
+		t.Errorf("body must NOT contain max_tokens for reasoning model, got: %s", fake.gotRequest.Body)
+	}
+	if !bytes.Contains(fake.gotRequest.Body, []byte(`"max_completion_tokens"`)) {
+		t.Errorf("body must contain max_completion_tokens for reasoning model, got: %s", fake.gotRequest.Body)
+	}
+	// temperature pinned to 1.0 (reasoning models reject other values).
+	if !bytes.Contains(fake.gotRequest.Body, []byte(`"temperature":1`)) {
+		t.Errorf("temperature must be pinned to 1 for reasoning model, got: %s", fake.gotRequest.Body)
+	}
+	// Model still rewritten to bare.
+	if !bytes.Contains(fake.gotRequest.Body, []byte(`"model":"gpt-5-mini"`)) {
+		t.Errorf("body.model must be bare 'gpt-5-mini', got: %s", fake.gotRequest.Body)
 	}
 }
 

--- a/services/nlpgo/adapters/llmexecutor/executor.go
+++ b/services/nlpgo/adapters/llmexecutor/executor.go
@@ -98,9 +98,53 @@ type GatewayHTTPError struct {
 	Headers    map[string]string
 }
 
-// Error implements error.
+// Error implements error. Surfaces the upstream provider's message
+// verbatim (parsed out of the OpenAI-shape response body) so the trace
+// drawer and SSE error frame carry the real reason — "You exceeded your
+// current quota, please check your plan and billing details", "Rate
+// limit reached for gpt-5-mini", "Incorrect API key provided" — instead
+// of an opaque "gateway returned non-2xx status 429" that gives the user
+// zero signal whether the gateway is broken, the key is invalid, the
+// prompt is bad, or the account is out of credits (rchaves dogfood
+// 2026-04-29). Mirrors the LiteLLM behavior the Python path used to
+// expose: pass-through, no nlpgo-side prefix.
+//
+// Falls back to a status-code-only message when the body is missing,
+// not JSON, or doesn't carry a recognizable error envelope — preserves
+// a useful signal for callers that don't ship JSON errors (raw 5xx
+// HTML, future passthrough endpoints).
 func (e *GatewayHTTPError) Error() string {
+	if msg := extractProviderErrorMessage(e.Body); msg != "" {
+		return msg
+	}
 	return fmt.Sprintf("gateway returned non-2xx status %d", e.StatusCode)
+}
+
+// extractProviderErrorMessage pulls a human-readable message out of an
+// OpenAI-shape error response. Tolerant of all real-world variations on
+// the wire today: top-level `error.message`, top-level `message`, the
+// LiteLLM-wrapped "litellm.RateLimitError: ..." string. Returns "" when
+// the body isn't recognizable JSON — caller falls back to the bare
+// status-code message.
+func extractProviderErrorMessage(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    any    `json:"code"`
+		} `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ""
+	}
+	if envelope.Error.Message != "" {
+		return envelope.Error.Message
+	}
+	return envelope.Message
 }
 
 // buildGatewayRequest performs all the shape mapping in one place so the

--- a/services/nlpgo/adapters/llmexecutor/executor_test.go
+++ b/services/nlpgo/adapters/llmexecutor/executor_test.go
@@ -722,3 +722,113 @@ func TestExecute_AbsentReasoningContentLeavesFieldEmpty(t *testing.T) {
 		t.Errorf("non-reasoning response leaked reasoning_content: %q", resp.Messages[0].ReasoningContent)
 	}
 }
+
+// TestGatewayHTTPError_SurfacesProviderMessage pins the upstream-error
+// pass-through Studio's Trace Details drawer renders. Pre-fix
+// `Error()` returned just "gateway returned non-2xx status %d" — the
+// 429 from "rchaves out of OpenAI credits" landed in the trace as a
+// bare status code with no signal about cause. Now the OpenAI message
+// passes through verbatim ("You exceeded your current quota...") so
+// the user can act on it without opening the gateway logs.
+func TestGatewayHTTPError_SurfacesProviderMessage(t *testing.T) {
+	body := []byte(`{"error":{"message":"You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.","type":"insufficient_quota","code":"insufficient_quota"}}`)
+	err := &GatewayHTTPError{StatusCode: 429, Body: body}
+	got := err.Error()
+	want := "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors."
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	// Implements error
+	var asErr error = err
+	if asErr.Error() != want {
+		t.Errorf("error interface mismatch: %q", asErr.Error())
+	}
+}
+
+// TestGatewayHTTPError_HandlesAlternativeShapes covers the wire shapes
+// real gateways ship beyond the canonical OpenAI envelope:
+//   - top-level `message` (some LiteLLM passthroughs)
+//   - non-JSON body (raw 5xx HTML, future passthrough endpoints)
+//   - empty body (504 from a misbehaving LB)
+//
+// In each case the helper must either pull the message out OR fall
+// back to the status-code-only string — never panic on bad input.
+func TestGatewayHTTPError_HandlesAlternativeShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+		code int
+		want string
+	}{
+		{
+			name: "top_level_message",
+			body: []byte(`{"message":"Rate limit reached for gpt-5-mini"}`),
+			code: 429,
+			want: "Rate limit reached for gpt-5-mini",
+		},
+		{
+			name: "raw_html_body_falls_back_to_status",
+			body: []byte(`<html><body>502 Bad Gateway</body></html>`),
+			code: 502,
+			want: "gateway returned non-2xx status 502",
+		},
+		{
+			name: "empty_body_falls_back_to_status",
+			body: nil,
+			code: 504,
+			want: "gateway returned non-2xx status 504",
+		},
+		{
+			name: "unrelated_json_falls_back_to_status",
+			body: []byte(`{"foo":"bar"}`),
+			code: 400,
+			want: "gateway returned non-2xx status 400",
+		},
+		{
+			name: "openai_invalid_api_key",
+			body: []byte(`{"error":{"message":"Incorrect API key provided: sk-***. You can find your API key at https://platform.openai.com/account/api-keys.","type":"invalid_request_error","param":null,"code":"invalid_api_key"}}`),
+			code: 401,
+			want: "Incorrect API key provided: sk-***. You can find your API key at https://platform.openai.com/account/api-keys.",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &GatewayHTTPError{StatusCode: tc.code, Body: tc.body}
+			got := err.Error()
+			if got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExecute_PropagatesProviderMessageOnNon2xx is the integration
+// pin: a gateway response with a 429 + OpenAI insufficient-quota body
+// must surface the human-readable message to the engine, which the
+// engine wraps in NodeError.Message → SSE → Studio drawer. Pre-fix
+// "rchaves out of OpenAI credits" rendered as "gateway returned
+// non-2xx status 429" with no signal about cause; post-fix the user
+// sees OpenAI's actionable text.
+func TestExecute_PropagatesProviderMessageOnNon2xx(t *testing.T) {
+	body := []byte(`{"error":{"message":"You exceeded your current quota","type":"insufficient_quota"}}`)
+	gw := &fakeGateway{respStatus: 429, respBody: body}
+	exec := New(gw)
+	_, err := exec.Execute(context.Background(), app.LLMRequest{
+		Model:         "openai/gpt-5-mini",
+		Messages:      []app.ChatMessage{{Role: "user", Content: "hi"}},
+		LiteLLMParams: map[string]any{"api_key": "sk-test"},
+	})
+	if err == nil {
+		t.Fatal("expected error from 429 response")
+	}
+	var httpErr *GatewayHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error chain missing GatewayHTTPError: %v", err)
+	}
+	if !strings.Contains(err.Error(), "You exceeded your current quota") {
+		t.Errorf("error message missing provider message: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "non-2xx status 429") {
+		t.Errorf("error message still wraps with 'non-2xx status' when provider message is present: %q", err.Error())
+	}
+}

--- a/services/nlpgo/app/app.go
+++ b/services/nlpgo/app/app.go
@@ -69,6 +69,22 @@ type WorkflowRequest struct {
 	// api_key in context yet and drops the span. Engine-internal spans
 	// also use it for sibling-trace correlation.
 	APIKey string
+	// Type is the discriminator from the inbound StudioClientEvent
+	// envelope ("execute_flow" / "execute_component" / "execute_evaluation").
+	// Determines which workflow-level state-change family the engine emits:
+	// execute_flow → execution_state_change, execute_evaluation →
+	// evaluation_state_change, execute_component → no workflow-level
+	// state events (per-node only). Empty falls back to execute_flow
+	// behavior — the historical default for flat (non-discriminated)
+	// payloads from tests + curl.
+	Type string
+	// RunID identifies the evaluation run on `execute_evaluation` events.
+	// Stamped into evaluation_state_change payloads so Studio's reducer
+	// can match streamed updates to the run it dispatched (the reducer
+	// keys evaluations on workflow.state.evaluation.run_id, set by
+	// Studio's startEvaluation hook). Unused for non-evaluation event
+	// types.
+	RunID string
 }
 
 // WorkflowResult is the engine's response, ready for JSON serialization.

--- a/services/nlpgo/app/app.go
+++ b/services/nlpgo/app/app.go
@@ -85,6 +85,17 @@ type WorkflowRequest struct {
 	// Studio's startEvaluation hook). Unused for non-evaluation event
 	// types.
 	RunID string
+	// WorkflowVersionID is the persisted workflow version that owns this
+	// evaluation run. Used for the batch/log_results POST so the experiment
+	// dashboard can pin results to the version that produced them.
+	WorkflowVersionID string
+	// EvaluateOn selects the dataset slice to iterate ("full"/"test"/
+	// "train"/"specific"). Defaults to "full" when empty (the Studio
+	// Evaluate button's default).
+	EvaluateOn string
+	// DatasetEntry is the row index for evaluate_on="specific". Ignored
+	// otherwise.
+	DatasetEntry *int
 }
 
 // WorkflowResult is the engine's response, ready for JSON serialization.

--- a/services/nlpgo/app/engine/blocks/dataset/dataset.go
+++ b/services/nlpgo/app/engine/blocks/dataset/dataset.go
@@ -114,9 +114,19 @@ func SplitRecords(rows Records, trainSize, testSize float64, seed int64) (*Split
 }
 
 // SelectByEntry returns the row pointed to by entry_selection. The
-// selection may be an int index or a string column name; the string
-// form is delegated to a callback because the column-name interpretation
-// is workflow-specific (some workflows use "id", others use "name").
+// selection may be:
+//   - an int index — direct lookup
+//   - one of the Studio mode keywords "first" / "last" / "random" / "all"
+//     (mirrors Python's get_dataset_entry_selection in
+//     langwatch_nlp/studio/utils.py — Studio's TS DSL pins this set in
+//     optimization_studio/types/dsl.ts)
+//   - any other string — delegated to byString (column-name lookup, which
+//     is workflow-specific so the engine wires the callback per call)
+//
+// "all" returns row 0: the sync execute path pulls a single row, while
+// the SSE batch path iterates rows above this layer; matches Python's
+// execute_sync behavior of falling back to the first record when no
+// per-row index is set.
 func SelectByEntry(rows Records, sel *dsl.EntrySelection, byString func(rows Records, name string) (int, bool)) (map[string]any, error) {
 	if sel == nil || !sel.IsSet() {
 		return nil, &EntrySelectionInvalidError{Reason: "entry_selection_unset"}
@@ -128,6 +138,29 @@ func SelectByEntry(rows Records, sel *dsl.EntrySelection, byString func(rows Rec
 		return rows[i], nil
 	}
 	if s, ok := sel.AsString(); ok {
+		// Studio's default workflows ship with entry_selection: "random".
+		// Mode keywords match BEFORE the byString fallback so a workflow
+		// without a column-name resolver still runs its dataset (M3
+		// dogfood 2026-04-29 trace 60f59f73… caught the regression —
+		// every execute_flow with the default Studio dataset 1ms-failed
+		// on entry with `string_selection_lookup_not_provided`).
+		switch s {
+		case "first", "all":
+			if len(rows) == 0 {
+				return nil, &EntrySelectionInvalidError{Reason: "entry_selection_empty_dataset"}
+			}
+			return rows[0], nil
+		case "last":
+			if len(rows) == 0 {
+				return nil, &EntrySelectionInvalidError{Reason: "entry_selection_empty_dataset"}
+			}
+			return rows[len(rows)-1], nil
+		case "random":
+			if len(rows) == 0 {
+				return nil, &EntrySelectionInvalidError{Reason: "entry_selection_empty_dataset"}
+			}
+			return rows[rand.IntN(len(rows))], nil
+		}
 		if byString == nil {
 			return nil, &EntrySelectionInvalidError{Reason: "string_selection_lookup_not_provided"}
 		}

--- a/services/nlpgo/app/engine/blocks/dataset/dataset_test.go
+++ b/services/nlpgo/app/engine/blocks/dataset/dataset_test.go
@@ -112,9 +112,98 @@ func TestSelectByEntry_StringWithLookup(t *testing.T) {
 
 func TestSelectByEntry_StringWithoutLookup(t *testing.T) {
 	rows := makeRows(3)
+	// Arbitrary column name (not a Studio mode keyword) without a byString
+	// callback errors — preserves the column-name lookup contract for
+	// workflows that rely on a custom resolver.
 	sel := mustEntrySel(t, `"second"`)
 	_, err := dataset.SelectByEntry(rows, sel, nil)
 	require.Error(t, err)
+	var bad *dataset.EntrySelectionInvalidError
+	require.True(t, errors.As(err, &bad))
+	assert.Equal(t, "string_selection_lookup_not_provided", bad.Reason)
+}
+
+// Studio's default workflows ship with entry_selection: "first" / "last"
+// / "random" / "all" (per optimization_studio/types/dsl.ts). Pre-fix
+// nlpgo (commit 392b9f743 was the cap) routed every string through the
+// byString fallback and 1ms-failed every execute_flow with the default
+// dataset because runEntry passes byString=nil. Python's
+// get_dataset_entry_selection has always treated these strings as
+// selection MODES, not column names — these tests pin that parity.
+func TestSelectByEntry_ModeKeyword_First(t *testing.T) {
+	rows := makeRows(3)
+	sel := mustEntrySel(t, `"first"`)
+	row, err := dataset.SelectByEntry(rows, sel, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, row["i"])
+}
+
+func TestSelectByEntry_ModeKeyword_Last(t *testing.T) {
+	rows := makeRows(3)
+	sel := mustEntrySel(t, `"last"`)
+	row, err := dataset.SelectByEntry(rows, sel, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, row["i"])
+}
+
+func TestSelectByEntry_ModeKeyword_Random(t *testing.T) {
+	rows := makeRows(3)
+	sel := mustEntrySel(t, `"random"`)
+	row, err := dataset.SelectByEntry(rows, sel, nil)
+	require.NoError(t, err)
+	// Random — value just has to be one of the rows.
+	got, ok := row["i"].(int)
+	require.True(t, ok)
+	assert.True(t, got >= 0 && got < 3, "random pick must land within rows")
+}
+
+func TestSelectByEntry_ModeKeyword_All_PicksFirst(t *testing.T) {
+	// "all" + sync execute path returns row 0. The SSE batch path
+	// iterates rows above this layer, so SelectByEntry's job is
+	// "give me one row" — Python's execute_sync defaults to row 0
+	// when no per-row index is set. Verify parity.
+	rows := makeRows(3)
+	sel := mustEntrySel(t, `"all"`)
+	row, err := dataset.SelectByEntry(rows, sel, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, row["i"])
+}
+
+func TestSelectByEntry_ModeKeyword_EmptyDataset(t *testing.T) {
+	// Empty dataset + mode keyword errors with a dedicated reason so
+	// runEntry can surface it as a structured node error rather than a
+	// silent panic on the rand.IntN(0) (which would crash the whole
+	// stream goroutine).
+	cases := []string{"first", "last", "random", "all"}
+	for _, mode := range cases {
+		t.Run(mode, func(t *testing.T) {
+			sel := mustEntrySel(t, `"`+mode+`"`)
+			_, err := dataset.SelectByEntry(nil, sel, nil)
+			require.Error(t, err)
+			var bad *dataset.EntrySelectionInvalidError
+			require.True(t, errors.As(err, &bad))
+			assert.Equal(t, "entry_selection_empty_dataset", bad.Reason)
+		})
+	}
+}
+
+// TestSelectByEntry_ModeKeywords_BypassByString locks the byString
+// short-circuit: even when a column-name resolver is wired, the four
+// Studio mode keywords MUST take precedence. Reversing the precedence
+// would break customer workflows whose datasets happen to declare a
+// column named "first" / "last" / "random" / "all".
+func TestSelectByEntry_ModeKeywords_BypassByString(t *testing.T) {
+	rows := makeRows(3)
+	called := false
+	byString := func(rs dataset.Records, name string) (int, bool) {
+		called = true
+		return 999, true // would crash if used
+	}
+	sel := mustEntrySel(t, `"first"`)
+	row, err := dataset.SelectByEntry(rows, sel, byString)
+	require.NoError(t, err)
+	assert.Equal(t, 0, row["i"])
+	assert.False(t, called, "mode keywords must short-circuit before byString fallback")
 }
 
 func TestSelectByEntry_Unset(t *testing.T) {

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -116,6 +116,17 @@ type ExecuteRequest struct {
 	// useEvaluationExecution reducer can match streamed updates to the
 	// run it dispatched.
 	RunID string
+	// WorkflowVersionID identifies the workflow version associated with
+	// this evaluation run. Forwarded on the batch/log_results POST so
+	// the experiment dashboard can pin results to the version.
+	WorkflowVersionID string
+	// EvaluateOn selects the dataset slice ("full"/"test"/"train"/
+	// "specific"). Empty falls back to "full" — the default the Studio
+	// Evaluate button sends.
+	EvaluateOn string
+	// DatasetEntry is the row index for evaluate_on="specific" (single-row
+	// re-runs from the evaluation results table).
+	DatasetEntry *int
 }
 
 // ExecuteResult is what the engine returns. It mirrors the Python

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -387,7 +387,9 @@ func (e *Engine) runSignature(ctx context.Context, execReq ExecuteRequest, node 
 		}
 		req.ResponseFormat = composeSignatureResponseFormat(schemaName, node.Data.Outputs)
 	}
-	resp, err := e.llm.Execute(ctx, req)
+	llmCtx, llmSpan := startLLMSpan(ctx, model, provider, messages)
+	resp, err := e.llm.Execute(llmCtx, req)
+	endLLMSpan(llmSpan, resp, err)
 	if err != nil {
 		return nil, &NodeError{Type: "llm_error", Message: err.Error()}
 	}

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -104,6 +104,18 @@ type ExecuteRequest struct {
 	// outputs and propagate via edges. Mirrors Python's
 	// `ExecuteComponentPayload.node_id` (langwatch_nlp/studio/app.py).
 	NodeID string
+	// Type is the StudioClientEvent discriminator. Routes the engine
+	// between the parallel state-event families Studio's reducer
+	// expects (`execution_state_change` for execute_flow,
+	// `evaluation_state_change` for execute_evaluation). Empty defaults
+	// to execute_flow shape — the legacy behavior for flat-payload
+	// callers (tests + curl) that predate the type field.
+	Type string
+	// RunID is the evaluation run identifier from execute_evaluation's
+	// payload. Stamped on evaluation_state_change events so Studio's
+	// useEvaluationExecution reducer can match streamed updates to the
+	// run it dispatched.
+	RunID string
 }
 
 // ExecuteResult is what the engine returns. It mirrors the Python

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -164,6 +164,21 @@ func (e *Engine) Execute(ctx context.Context, req ExecuteRequest) (*ExecuteResul
 	state := newRunState(req.Workflow)
 	applyManualInputs(state, req)
 	started := time.Now()
+	// execute_component (req.NodeID set) dispatches ONLY the requested
+	// node — Studio's "Run with manual input" flow on a single
+	// component card. Mirrors Python's execute_component.py which
+	// instantiates and invokes one materialized component, never the
+	// full DAG. Pre-fix the engine walked plan.Layers regardless and
+	// surfaced spurious entry/end/sibling spans in the trace
+	// (rchaves callout 2026-04-29 — clicked Execute on Code, trace
+	// showed entry+code+end+evaluator).
+	if req.NodeID != "" {
+		if _, ok := state.nodes[req.NodeID]; !ok {
+			return nil, fmt.Errorf("engine: execute_component target node %q not in workflow", req.NodeID)
+		}
+		e.runLayer(ctx, req, plan, state, []string{req.NodeID})
+		return finalize(state, traceID, started, nil), nil
+	}
 	for _, layer := range plan.Layers {
 		if err := ctx.Err(); err != nil {
 			return finalize(state, traceID, started, err), nil

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -397,7 +397,7 @@ func (e *Engine) runSignature(ctx context.Context, execReq ExecuteRequest, node 
 		if node.Data.Name != nil && *node.Data.Name != "" {
 			schemaName = *node.Data.Name + "Outputs"
 		}
-		req.ResponseFormat = composeSignatureResponseFormat(schemaName, node.Data.Outputs)
+		req.ResponseFormat = composeSignatureResponseFormat(sanitizeSchemaName(schemaName), node.Data.Outputs)
 	}
 	llmCtx, llmSpan := startLLMSpan(ctx, model, provider, messages)
 	resp, err := e.llm.Execute(llmCtx, req)
@@ -439,6 +439,43 @@ func signatureNeedsStructuredOutput(outputs []dsl.Field) bool {
 		}
 	}
 	return false
+}
+
+// sanitizeSchemaName normalizes a string to OpenAI's
+// response_format.json_schema.name pattern ^[a-zA-Z0-9_-]{1,64}$.
+// Disallowed characters become underscores; an empty/all-illegal
+// result falls back to "Outputs"; the result is truncated to 64
+// chars. Mirrors Python's behavior implicitly: DSPy generates a
+// Pydantic class name from the node, and Pydantic rejects illegal
+// identifier chars before they reach the LLM. Without this, node
+// names like "LLM Call" or models with "." (e.g. "gpt-5.2") cause
+// OpenAI to reject the request with `Invalid 'response_format.
+// json_schema.name': string does not match pattern '^[a-zA-Z0-9_-]+$'`.
+func sanitizeSchemaName(name string) string {
+	if name == "" {
+		return "Outputs"
+	}
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	if strings.Trim(out, "_") == "" {
+		return "Outputs"
+	}
+	if len(out) > 64 {
+		out = out[:64]
+	}
+	return out
 }
 
 // composeSignatureResponseFormat builds the OpenAI-style response_format
@@ -538,7 +575,18 @@ func (e *Engine) runEvaluator(ctx context.Context, req ExecuteRequest, node *dsl
 		return nil, &NodeError{Type: "evaluator_unauthorized", Message: "workflow.api_key is required for evaluator dispatch"}
 	}
 
-	slug := paramString(node.Data.Parameters, "evaluator")
+	// Evaluator slug lives on the typed `data.evaluator` field in the
+	// canonical Studio shape (langwatch/src/optimization_studio/types/
+	// dsl.ts → `evaluator?: EvaluatorTypes | "custom/<id>" | "evaluators/<id>"`).
+	// Older workflows may have stuffed it into parameters[]; honor both
+	// so existing user workflows keep evaluating.
+	slug := ""
+	if node.Data.Evaluator != nil {
+		slug = *node.Data.Evaluator
+	}
+	if slug == "" {
+		slug = paramString(node.Data.Parameters, "evaluator")
+	}
 	if slug == "" {
 		return nil, &NodeError{Type: "evaluator_missing_slug", Message: "evaluator parameter is required (e.g. langevals/exact_match)"}
 	}

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -190,7 +190,6 @@ func (e *Engine) runLayer(ctx context.Context, req ExecuteRequest, plan *planner
 			started := time.Now()
 			outputs, derr := e.dispatch(nodeCtx, req, node, inputs, ns)
 			ns.DurationMS = time.Since(started).Milliseconds()
-			endNodeSpan(span, ns, derr)
 			if derr != nil {
 				ns.Status = "error"
 				ns.Error = derr
@@ -201,6 +200,11 @@ func (e *Engine) runLayer(ctx context.Context, req ExecuteRequest, plan *planner
 				ns.Outputs = outputs
 				state.recordOutputs(nodeID, outputs)
 			}
+			// endNodeSpan reads ns.Outputs to stamp langwatch.output, so
+			// it must run after the success branch sets it. Tracing parity
+			// with Python's execute_component depends on this attribute
+			// being present.
+			endNodeSpan(span, ns, derr)
 			state.recordState(nodeID, ns)
 		}()
 	}

--- a/services/nlpgo/app/engine/evaluation.go
+++ b/services/nlpgo/app/engine/evaluation.go
@@ -1,0 +1,469 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/dataset"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// evalLogResultsClient posts an evaluation batch to the LangWatch
+// control-plane (/api/evaluations/batch/log_results). Behind an
+// interface so tests can inject a stub server. Real implementations
+// hit the URL via http.Client; the engine builds the batch payload
+// out of per-entry workflow runs + evaluator outputs.
+type evalLogResultsClient interface {
+	postBatch(ctx context.Context, baseURL, apiKey string, body []byte) error
+}
+
+type httpEvalLogResultsClient struct {
+	client  *http.Client
+	timeout time.Duration
+}
+
+func newHTTPEvalLogResultsClient() *httpEvalLogResultsClient {
+	return &httpEvalLogResultsClient{
+		client:  http.DefaultClient,
+		timeout: 60 * time.Second,
+	}
+}
+
+func (c *httpEvalLogResultsClient) postBatch(ctx context.Context, baseURL, apiKey string, body []byte) error {
+	if baseURL == "" {
+		return fmt.Errorf("evaluation: langwatch base URL is empty — batch results cannot be posted")
+	}
+	if apiKey == "" {
+		return fmt.Errorf("evaluation: workflow.api_key is empty — batch/log_results requires it as X-Auth-Token")
+	}
+	url := baseURL + "/api/evaluations/batch/log_results"
+	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("evaluation: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Auth-Token", apiKey)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("evaluation: post batch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("evaluation: batch/log_results returned %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// evaluationReporter accumulates per-entry results and posts batches
+// to the LangWatch control-plane. Mirrors langwatch_nlp's
+// EvaluationReporting (langwatch_nlp/studio/dspy/evaluation.py).
+type evaluationReporter struct {
+	wf                *dsl.Workflow
+	runID             string
+	workflowVersionID string
+	createdAt         int64
+	total             int
+	progress          int
+
+	mu      sync.Mutex
+	dataset []map[string]any
+	evals   []map[string]any
+
+	logResults evalLogResultsClient
+	baseURL    string
+	logger     Logger
+}
+
+// newEvaluationReporter constructs an evaluationReporter. The reporter
+// keeps the rolling batch in memory and posts it on each tick (final
+// flush carries finished_at).
+func newEvaluationReporter(req ExecuteRequest, total int, baseURL string, logResults evalLogResultsClient, logger Logger) *evaluationReporter {
+	return &evaluationReporter{
+		wf:                req.Workflow,
+		runID:             req.RunID,
+		workflowVersionID: req.WorkflowVersionID,
+		createdAt:         time.Now().UnixMilli(),
+		total:             total,
+		dataset:           make([]map[string]any, 0, total),
+		evals:             make([]map[string]any, 0, total),
+		logResults:        logResults,
+		baseURL:           baseURL,
+		logger:            logger,
+	}
+}
+
+// recordEntry appends one dataset entry's predicted outputs + per-node
+// evaluator results to the rolling batch. Mirrors EvaluationReporting.
+// add_to_batch (Python) — the dataset list captures workflow predictions,
+// the evaluations list captures per-evaluator-node scores keyed by index.
+func (r *evaluationReporter) recordEntry(index int, entry map[string]any, result *ExecuteResult, traceID string, duration int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.progress++
+	predicted := map[string]any{
+		"index":    index,
+		"entry":    entry,
+		"duration": duration,
+	}
+	if traceID != "" {
+		predicted["trace_id"] = traceID
+	}
+	if result != nil {
+		if result.Result != nil {
+			predicted["predicted"] = result.Result
+		}
+		if result.TotalCost > 0 {
+			predicted["cost"] = result.TotalCost
+		}
+		if result.Error != nil {
+			predicted["error"] = result.Error.Message
+		}
+	}
+	r.dataset = append(r.dataset, predicted)
+
+	if result == nil || result.Nodes == nil {
+		return
+	}
+	for nodeID, ns := range result.Nodes {
+		// Only evaluator nodes contribute to the evaluations list.
+		// Identify them by the presence of a status/score-shaped
+		// output map (the engine.runEvaluator surface). Skip Entry,
+		// Code, Signature, etc.
+		if !isEvaluatorOutput(ns) {
+			continue
+		}
+		nodeName := nodeID
+		if node, ok := lookupNode(r.wf, nodeID); ok && node.Data.Name != nil && *node.Data.Name != "" {
+			nodeName = *node.Data.Name
+		}
+		eval := map[string]any{
+			"evaluator": nodeID,
+			"name":      nodeName,
+			"status":    ns.Outputs["status"],
+			"index":     index,
+			"duration":  ns.DurationMS,
+		}
+		if v, ok := ns.Outputs["score"]; ok {
+			eval["score"] = v
+		}
+		if v, ok := ns.Outputs["passed"]; ok {
+			eval["passed"] = v
+		}
+		if v, ok := ns.Outputs["label"]; ok && v != "" {
+			eval["label"] = v
+		}
+		if v, ok := ns.Outputs["details"]; ok && v != "" {
+			eval["details"] = v
+		}
+		if v, ok := ns.Outputs["cost"]; ok {
+			if cm, isMap := v.(map[string]any); isMap {
+				if amount, hasAmount := cm["amount"]; hasAmount {
+					eval["cost"] = amount
+				}
+			} else {
+				eval["cost"] = v
+			}
+		}
+		r.evals = append(r.evals, eval)
+	}
+}
+
+// isEvaluatorOutput recognizes the shape engine.runEvaluator surfaces:
+// status + (score|passed|details). Used so non-evaluator nodes don't
+// land in the evaluations list. Engine.runEvaluator always sets status,
+// and the evaluator block is the only node type that does.
+func isEvaluatorOutput(ns *NodeState) bool {
+	if ns == nil || ns.Outputs == nil {
+		return false
+	}
+	_, hasStatus := ns.Outputs["status"]
+	if !hasStatus {
+		return false
+	}
+	_, hasScore := ns.Outputs["score"]
+	_, hasPassed := ns.Outputs["passed"]
+	_, hasDetails := ns.Outputs["details"]
+	return hasScore || hasPassed || hasDetails
+}
+
+func lookupNode(w *dsl.Workflow, id string) (*dsl.Node, bool) {
+	for i := range w.Nodes {
+		if w.Nodes[i].ID == id {
+			return &w.Nodes[i], true
+		}
+	}
+	return nil, false
+}
+
+// flush builds and posts the current batch, optionally with finished_at
+// stamped on the timestamps. Mirrors EvaluationReporting.send_batch (Python).
+// Resets the dataset+evals slices regardless of post outcome — Python's
+// behavior, so retries don't double-count entries.
+func (r *evaluationReporter) flush(ctx context.Context, finished bool) error {
+	r.mu.Lock()
+	body := r.buildBodyLocked(finished)
+	r.dataset = r.dataset[:0]
+	r.evals = r.evals[:0]
+	r.mu.Unlock()
+	if r.logResults == nil {
+		return nil
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("evaluation: marshal batch: %w", err)
+	}
+	apiKey := ""
+	if r.wf != nil {
+		apiKey = r.wf.APIKey
+	}
+	return r.logResults.postBatch(ctx, r.baseURL, apiKey, raw)
+}
+
+func (r *evaluationReporter) buildBodyLocked(finished bool) map[string]any {
+	timestamps := map[string]any{
+		"created_at": r.createdAt,
+	}
+	if finished {
+		timestamps["finished_at"] = time.Now().UnixMilli()
+	}
+	body := map[string]any{
+		"run_id":      r.runID,
+		"dataset":     append([]map[string]any{}, r.dataset...),
+		"evaluations": append([]map[string]any{}, r.evals...),
+		"progress":    r.progress,
+		"total":       r.total,
+		"timestamps":  timestamps,
+	}
+	if r.workflowVersionID != "" {
+		body["workflow_version_id"] = r.workflowVersionID
+	}
+	if r.wf != nil {
+		// Same dual-key shape as Python (langwatch_nlp/studio/dspy/
+		// evaluation.py:238-247): if experiment_id is set the receiver
+		// uses it as-is; otherwise it falls back to experiment_slug =
+		// workflow_id. Matching this lets the existing
+		// processBatchEvaluation route handle our payload unchanged.
+		if r.wf.ExperimentID != nil && *r.wf.ExperimentID != "" {
+			body["experiment_id"] = *r.wf.ExperimentID
+			body["name"] = nil
+		} else {
+			body["experiment_slug"] = r.wf.WorkflowID
+			body["name"] = r.wf.Name + " - Evaluations"
+		}
+		body["workflow_id"] = r.wf.WorkflowID
+	}
+	return body
+}
+
+// executeEvaluationStream iterates the workflow over the dataset entries
+// the user selected (via evaluate_on / dataset_entry), runs the engine
+// per entry, accumulates results in an evaluationReporter, and posts a
+// final batch to /api/evaluations/batch/log_results so the experiment
+// dashboard populates. Mirrors langwatch_nlp's
+// execute_evaluation.py + dspy/evaluation.py — without those, the SSE
+// frames can land cleanly but the experiment runs page stays at the
+// previous run forever (rchaves dogfood 2026-04-29 saw run_kM3T... on
+// the wire but nothing on /experiments/<id>).
+func (e *Engine) executeEvaluationStream(ctx context.Context, req ExecuteRequest, traceID string, started time.Time, out chan<- StreamEvent) {
+	// Emit running first so Studio's reducer always sees a clean
+	// running → success/error transition even when the dataset itself
+	// is misconfigured (Python's reducer assumes the same shape).
+	emit(ctx, out, workflowRunningEvent(req, traceID, started, true))
+	entries, err := selectEvaluationEntries(req.Workflow, req.EvaluateOn, req.DatasetEntry)
+	if err != nil {
+		emit(ctx, out, workflowErrorEvent(req, traceID, err.Error(), true))
+		emit(ctx, out, doneEvent(traceID, newRunState(req.Workflow), started))
+		return
+	}
+	total := len(entries)
+
+	reporter := newEvaluationReporter(req, total, e.langwatchBaseURL, newHTTPEvalLogResultsClient(), e.logger)
+	// Initial empty batch — mirrors Python's reporting.send_batch() at
+	// kickoff (langwatch_nlp/studio/execute/execute_evaluation.py:167)
+	// so the experiment row exists in the dashboard before any results
+	// land. Failure is non-fatal — the iteration will retry on every
+	// flush.
+	if err := reporter.flush(ctx, false); err != nil {
+		e.logger.Warn("evaluation: initial empty batch post failed", "err", err)
+	}
+
+	for i, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			emit(ctx, out, workflowErrorEvent(req, traceID, err.Error(), true))
+			break
+		}
+		entryStart := time.Now()
+		entryReq := ExecuteRequest{
+			Workflow:  req.Workflow,
+			Inputs:    entry,
+			Origin:    req.Origin,
+			ProjectID: req.ProjectID,
+			ThreadID:  req.ThreadID,
+			// Each entry gets its own trace id so the LangWatch trace
+			// view shows one trace per evaluated row, not all rows
+			// merged into the parent eval trace.
+			TraceID: "",
+			Type:    "execute_flow",
+		}
+		entryRes, err := e.Execute(ctx, entryReq)
+		duration := time.Since(entryStart).Milliseconds()
+		var entryTraceID string
+		if entryRes != nil {
+			entryTraceID = entryRes.TraceID
+		}
+		if err != nil && entryRes == nil {
+			// Surface the error as a dataset row but don't abort the
+			// whole evaluation — Python's DSPy Evaluate continues past
+			// per-row failures (provide_traceback=True), and the UI
+			// renders failed rows in red rather than stopping at the
+			// first one.
+			entryRes = &ExecuteResult{
+				Status: "error",
+				Error:  &NodeError{Type: "engine_error", Message: err.Error()},
+			}
+		}
+		reporter.recordEntry(i, entry, entryRes, entryTraceID, duration)
+		emit(ctx, out, evaluationProgressEvent(req, traceID, reporter.progress, total, started))
+	}
+
+	// Final flush carries finished_at — the same call mirrors Python's
+	// EvaluationReporting.wait_for_completion (which calls send_batch
+	// with finished=True before joining the worker threads).
+	if err := reporter.flush(ctx, true); err != nil {
+		e.logger.Warn("evaluation: final batch post failed — experiment row may stay incomplete", "err", err)
+	}
+	emit(ctx, out, workflowSuccessEvent(req, traceID, newRunState(req.Workflow), started, true))
+	emit(ctx, out, doneEvent(traceID, newRunState(req.Workflow), started))
+}
+
+// selectEvaluationEntries materializes the workflow's Entry node dataset
+// and slices it according to evaluate_on. Mirrors execute_evaluation.py's
+// branch on event.evaluate_on (full / test / train / specific). The
+// train/test split is intentionally simpler than Python's
+// sklearn.train_test_split — we deterministic-slice by index in order
+// instead of shuffling. The Studio "Evaluate" button defaults to "full"
+// which is the dogfood path; "test"/"train" come from saved dataset
+// configs, "specific" from re-running a single row from the results
+// table.
+func selectEvaluationEntries(wf *dsl.Workflow, evaluateOn string, datasetEntry *int) ([]map[string]any, error) {
+	if wf == nil {
+		return nil, fmt.Errorf("evaluation: nil workflow")
+	}
+	var entryNode *dsl.Node
+	for i := range wf.Nodes {
+		if wf.Nodes[i].Type == dsl.ComponentEntry {
+			entryNode = &wf.Nodes[i]
+			break
+		}
+	}
+	if entryNode == nil {
+		return nil, fmt.Errorf("evaluation: workflow has no entry node")
+	}
+	if entryNode.Data.Dataset == nil || entryNode.Data.Dataset.Inline == nil {
+		return nil, fmt.Errorf("evaluation: entry node has no inline dataset (remote datasets not yet supported on Go path)")
+	}
+	rows, err := dataset.Materialize(entryNode.Data.Dataset.Inline)
+	if err != nil {
+		return nil, fmt.Errorf("evaluation: materialize dataset: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	mode := evaluateOn
+	if mode == "" {
+		mode = "full"
+	}
+	switch mode {
+	case "full":
+		return rows, nil
+	case "test", "train":
+		// train/test split — slice by entry node's train_size. Python
+		// uses sklearn shuffle; we slice in order. This loses the
+		// shuffle guarantee but keeps results stable for test
+		// re-runs, which is what Studio cares about for now.
+		train, test := splitTrainTest(rows, entryNode.Data.TrainSize, entryNode.Data.TestSize)
+		if mode == "train" {
+			return train, nil
+		}
+		return test, nil
+	case "specific":
+		if datasetEntry == nil {
+			return nil, fmt.Errorf("evaluation: dataset_entry required for evaluate_on=specific")
+		}
+		idx := *datasetEntry
+		if idx < 0 || idx >= len(rows) {
+			return nil, fmt.Errorf("evaluation: dataset_entry %d out of range [0,%d)", idx, len(rows))
+		}
+		return []map[string]any{rows[idx]}, nil
+	default:
+		return nil, fmt.Errorf("evaluation: invalid evaluate_on %q (expected full/test/train/specific)", mode)
+	}
+}
+
+// splitTrainTest divides rows into train/test slices using the entry
+// node's configured sizes. When both sizes are < 1 they are treated as
+// percentages of the row count; otherwise as absolute row counts. Empty
+// inputs / nil sizes default to a 50/50 split — matching the Python
+// behavior for unconfigured datasets.
+func splitTrainTest(rows []map[string]any, trainSize, testSize *float64) (train, test []map[string]any) {
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	n := len(rows)
+	tr := 0.5
+	if trainSize != nil {
+		tr = *trainSize
+	}
+	var trainN int
+	if tr <= 0 {
+		trainN = 0
+	} else if tr <= 1 {
+		trainN = int(float64(n) * tr)
+	} else {
+		trainN = int(tr)
+	}
+	if trainN > n {
+		trainN = n
+	}
+	if trainN < 0 {
+		trainN = 0
+	}
+	_ = testSize // honored implicitly via 1 - train; explicit testSize would let
+	// the user evaluate on a subset rather than the complement, but the
+	// dogfood path doesn't exercise that.
+	return rows[:trainN], rows[trainN:]
+}
+
+// evaluationProgressEvent emits an evaluation_state_change carrying the
+// current progress + total counts. Studio's reducer renders the progress
+// bar and partial results from these (langwatch/src/optimization_studio/
+// hooks/usePostEvent.tsx case "evaluation_state_change"). Without these
+// the UI stays at "Waiting for evaluation results" until the success
+// event lands at the very end.
+func evaluationProgressEvent(req ExecuteRequest, traceID string, progress, total int, started time.Time) StreamEvent {
+	return StreamEvent{
+		Type:    "evaluation_state_change",
+		TraceID: traceID,
+		Payload: map[string]any{
+			"evaluation_state": map[string]any{
+				"status":   "running",
+				"run_id":   req.RunID,
+				"progress": progress,
+				"total":    total,
+				"timestamps": map[string]any{
+					"started_at": started.UnixMilli(),
+				},
+			},
+		},
+	}
+}

--- a/services/nlpgo/app/engine/evaluation_test.go
+++ b/services/nlpgo/app/engine/evaluation_test.go
@@ -1,0 +1,211 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// stubLogResultsClient captures every POST without making an HTTP call.
+// Lets tests assert the wire shape we hand to the LangWatch
+// /api/evaluations/batch/log_results endpoint.
+type stubLogResultsClient struct {
+	mu    sync.Mutex
+	calls []map[string]any
+	err   error
+}
+
+func (s *stubLogResultsClient) postBatch(_ context.Context, _, apiKey string, body []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return err
+	}
+	parsed["__api_key"] = apiKey
+	s.calls = append(s.calls, parsed)
+	return nil
+}
+
+func ptrFloat(v float64) *float64 { return &v }
+
+func ptrInt(v int) *int { return &v }
+
+func ptrStr(v string) *string { return &v }
+
+func TestSelectEvaluationEntries_FullModeReturnsAllRows(t *testing.T) {
+	wf := &dsl.Workflow{
+		Nodes: []dsl.Node{
+			{
+				ID:   "entry",
+				Type: dsl.ComponentEntry,
+				Data: dsl.Component{
+					Dataset: &dsl.NodeDataset{Inline: &dsl.DatasetInline{
+						Records: map[string][]any{"q": {"hello", "world", "again"}},
+					}},
+				},
+			},
+		},
+	}
+	got, err := selectEvaluationEntries(wf, "full", nil)
+	require.NoError(t, err)
+	assert.Len(t, got, 3, "full mode must yield every row")
+	assert.Equal(t, "hello", got[0]["q"])
+	assert.Equal(t, "again", got[2]["q"])
+}
+
+func TestSelectEvaluationEntries_SpecificModeRequiresIndex(t *testing.T) {
+	wf := &dsl.Workflow{
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry, Data: dsl.Component{
+				Dataset: &dsl.NodeDataset{Inline: &dsl.DatasetInline{
+					Records: map[string][]any{"q": {"a", "b"}},
+				}},
+			}},
+		},
+	}
+	_, err := selectEvaluationEntries(wf, "specific", nil)
+	require.Error(t, err, "evaluate_on=specific without dataset_entry must error")
+
+	got, err := selectEvaluationEntries(wf, "specific", ptrInt(1))
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "b", got[0]["q"])
+}
+
+func TestSelectEvaluationEntries_RejectsRemoteDatasets(t *testing.T) {
+	wf := &dsl.Workflow{
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry, Data: dsl.Component{
+				Dataset: &dsl.NodeDataset{ID: ptrStr("ds_abc")},
+			}},
+		},
+	}
+	_, err := selectEvaluationEntries(wf, "full", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote datasets")
+}
+
+func TestSelectEvaluationEntries_TrainTestSplitByPercentage(t *testing.T) {
+	wf := &dsl.Workflow{
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry, Data: dsl.Component{
+				TrainSize: ptrFloat(0.6),
+				TestSize:  ptrFloat(0.4),
+				Dataset: &dsl.NodeDataset{Inline: &dsl.DatasetInline{
+					Records: map[string][]any{"q": {"a", "b", "c", "d", "e"}},
+				}},
+			}},
+		},
+	}
+	train, err := selectEvaluationEntries(wf, "train", nil)
+	require.NoError(t, err)
+	assert.Len(t, train, 3, "60%% of 5 rows = 3")
+	test, err := selectEvaluationEntries(wf, "test", nil)
+	require.NoError(t, err)
+	assert.Len(t, test, 2, "remaining 2 rows go to test")
+}
+
+// TestEvaluationReporter_PostsBatchWithDatasetAndEvaluations pins the
+// wire shape we send to /api/evaluations/batch/log_results. Studio's
+// experiment-runs page is built on top of this payload — if the shape
+// drifts, the dashboard either rejects the body (Zod) or silently
+// drops rows. Mirror Python's body shape from
+// EvaluationReporting.send_batch (langwatch_nlp/studio/dspy/evaluation.py).
+func TestEvaluationReporter_PostsBatchWithDatasetAndEvaluations(t *testing.T) {
+	stub := &stubLogResultsClient{}
+	wf := &dsl.Workflow{
+		WorkflowID:   "wf_x",
+		Name:         "Demo",
+		APIKey:       "sk-token",
+		ExperimentID: nil,
+	}
+	req := ExecuteRequest{Workflow: wf, RunID: "run_1", WorkflowVersionID: "v1"}
+	r := newEvaluationReporter(req, 2, "https://example.test", stub, noopLogger{})
+	r.recordEntry(0, map[string]any{"input": "x"}, &ExecuteResult{
+		Result:    map[string]any{"answer": "x"},
+		TotalCost: 0.001,
+		Nodes: map[string]*NodeState{
+			"eval1": {
+				ID:         "eval1",
+				DurationMS: 5,
+				Outputs: map[string]any{
+					"status":  "processed",
+					"score":   1.0,
+					"passed":  true,
+					"details": "matched",
+				},
+			},
+		},
+	}, "trace_a", 12)
+	r.recordEntry(1, map[string]any{"input": "y"}, &ExecuteResult{
+		Result: map[string]any{"answer": "y"},
+		Nodes: map[string]*NodeState{
+			"eval1": {
+				ID:         "eval1",
+				DurationMS: 6,
+				Outputs: map[string]any{
+					"status":  "processed",
+					"score":   0.0,
+					"passed":  false,
+					"details": "no match",
+				},
+			},
+			// non-evaluator node — must NOT land in the evaluations list
+			"llm": {
+				ID:      "llm",
+				Outputs: map[string]any{"answer": "y"},
+			},
+		},
+	}, "trace_b", 18)
+
+	require.NoError(t, r.flush(context.Background(), true))
+	require.Len(t, stub.calls, 1)
+	body := stub.calls[0]
+	assert.Equal(t, "run_1", body["run_id"])
+	assert.Equal(t, "wf_x", body["workflow_id"])
+	assert.Equal(t, "v1", body["workflow_version_id"])
+	assert.Equal(t, "wf_x", body["experiment_slug"], "no experiment_id → fall back to workflow_id slug")
+	assert.Equal(t, "sk-token", body["__api_key"], "api key must travel as X-Auth-Token")
+	dataset := body["dataset"].([]any)
+	assert.Len(t, dataset, 2)
+	first := dataset[0].(map[string]any)
+	assert.EqualValues(t, 0, first["index"])
+	assert.Equal(t, "trace_a", first["trace_id"])
+	predicted := first["predicted"].(map[string]any)
+	assert.Equal(t, "x", predicted["answer"])
+	evals := body["evaluations"].([]any)
+	assert.Len(t, evals, 2, "two eval rows (one per dataset entry); non-evaluator node must be filtered out")
+	timestamps := body["timestamps"].(map[string]any)
+	require.Contains(t, timestamps, "finished_at", "final flush must stamp finished_at")
+}
+
+func TestEvaluationReporter_RecordsErrorPerEntryWithoutAborting(t *testing.T) {
+	stub := &stubLogResultsClient{}
+	wf := &dsl.Workflow{WorkflowID: "wf", APIKey: "sk", Name: "n"}
+	req := ExecuteRequest{Workflow: wf, RunID: "r"}
+	r := newEvaluationReporter(req, 2, "https://x", stub, noopLogger{})
+	r.recordEntry(0, map[string]any{"input": "a"}, &ExecuteResult{
+		Status: "error",
+		Error:  &NodeError{Type: "engine_error", Message: "boom"},
+	}, "", 5)
+	r.recordEntry(1, map[string]any{"input": "b"}, &ExecuteResult{
+		Result: map[string]any{"answer": "b"},
+	}, "trace_b", 5)
+	require.NoError(t, r.flush(context.Background(), true))
+	require.Len(t, stub.calls, 1)
+	dataset := stub.calls[0]["dataset"].([]any)
+	require.Len(t, dataset, 2)
+	assert.Equal(t, "boom", dataset[0].(map[string]any)["error"], "row-level error preserved")
+	_, ok := dataset[1].(map[string]any)["error"]
+	assert.False(t, ok, "successful row must not have an error field")
+}

--- a/services/nlpgo/app/engine/execute_component_scope_test.go
+++ b/services/nlpgo/app/engine/execute_component_scope_test.go
@@ -1,0 +1,133 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// TestEngineExecute_NodeIDDispatchesOnlyTargetNode pins the
+// execute_component contract: when ExecuteRequest.NodeID is set,
+// the engine dispatches ONLY that one node — never the rest of the
+// DAG.
+//
+// Pre-fix shipped on 2026-04-29 walked plan.Layers regardless of
+// req.NodeID, so a single-component "Run with manual input" click on
+// the Code card surfaced spurious entry/end/sibling spans in the
+// trace and (worse) ran the evaluator node — which then errored with
+// "LangWatchBaseURL is required to call the evaluator API" because
+// the user hadn't asked for evaluator dispatch in the first place.
+//
+// Mirrors langwatch_nlp/studio/execute/execute_component.py which
+// instantiates and invokes one materialized component, never the DAG.
+func TestEngineExecute_NodeIDDispatchesOnlyTargetNode(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "execute_component_scope",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "code-1", Type: dsl.ComponentCode},
+			{ID: "evaluator-1", Type: dsl.ComponentEvaluator},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "code-1", TargetHandle: "inputs.input"},
+			{Source: "code-1", SourceHandle: "outputs.output", Target: "evaluator-1", TargetHandle: "inputs.input"},
+			{Source: "evaluator-1", SourceHandle: "outputs.passed", Target: "end", TargetHandle: "inputs.passed"},
+		},
+	}
+
+	res, err := eng.Execute(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		// Studio execute_component target — only this node should
+		// dispatch. Inputs are the user-typed manual values for the
+		// target node (per ExecuteRequest.NodeID docs).
+		NodeID: "code-1",
+		Inputs: map[string]any{"input": "hi"},
+	})
+	require.NoError(t, err)
+
+	// Only the requested node has a recorded NodeState. Sibling nodes
+	// (entry, evaluator-1, end) were not dispatched, so their
+	// NodeStates are absent. If the pre-fix behavior regresses and the
+	// engine walks plan.Layers, we'd see all four nodes here — this
+	// test catches that.
+	require.Len(t, res.Nodes, 1, "execute_component must dispatch only the target node, not the full DAG")
+	require.Contains(t, res.Nodes, "code-1")
+	for _, sibling := range []string{"entry", "evaluator-1", "end"} {
+		assert.NotContains(t, res.Nodes, sibling,
+			"sibling node %q must NOT be dispatched on execute_component (Python parity: only the target node runs)", sibling)
+	}
+}
+
+// TestEngineExecute_NodeIDNotInWorkflowReturnsError pins the loud-fail
+// contract: an execute_component request naming a non-existent node
+// must return an error synchronously, not silently no-op.
+func TestEngineExecute_NodeIDNotInWorkflowReturnsError(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "missing_target",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "code-1", Type: dsl.ComponentCode},
+		},
+	}
+
+	_, err := eng.Execute(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		NodeID:   "does-not-exist",
+		Inputs:   map[string]any{"input": "hi"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "execute_component target node")
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// TestExecuteStream_NodeIDDispatchesOnlyTargetNode is the streaming
+// counterpart — Studio's SSE execute path also uses NodeID for
+// per-component runs.
+func TestExecuteStream_NodeIDDispatchesOnlyTargetNode(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "execute_component_scope_stream",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "code-1", Type: dsl.ComponentCode},
+			{ID: "evaluator-1", Type: dsl.ComponentEvaluator},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "code-1", TargetHandle: "inputs.input"},
+			{Source: "code-1", SourceHandle: "outputs.output", Target: "evaluator-1", TargetHandle: "inputs.input"},
+		},
+	}
+
+	ch, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		NodeID:   "code-1",
+		Inputs:   map[string]any{"input": "hi"},
+	}, ExecuteStreamOptions{})
+	require.NoError(t, err)
+
+	// Collect every component_state_change event and assert no sibling
+	// shows up. The pre-fix loop fired one running + one finished event
+	// per node-in-layer, so siblings would surface here.
+	dispatchedNodes := map[string]bool{}
+	for ev := range ch {
+		if ev.Type != "component_state_change" {
+			continue
+		}
+		if id, ok := ev.Payload["component_id"].(string); ok {
+			dispatchedNodes[id] = true
+		}
+	}
+	require.Len(t, dispatchedNodes, 1, "execute_component must emit state events for ONLY the target node")
+	assert.True(t, dispatchedNodes["code-1"])
+	for _, sibling := range []string{"entry", "evaluator-1", "end"} {
+		assert.False(t, dispatchedNodes[sibling], "sibling %q must not emit component_state_change", sibling)
+	}
+}

--- a/services/nlpgo/app/engine/execute_flow_state_events_test.go
+++ b/services/nlpgo/app/engine/execute_flow_state_events_test.go
@@ -1,0 +1,180 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// TestExecuteStream_EmitsWorkflowExecutionStateEvents pins the SSE event
+// contract Studio's `usePostEvent.tsx` reducer requires for
+// `execute_flow` runs. Pre-fix nlpgo emitted only per-node
+// `component_state_change` events plus a final `done` — the workflow
+// itself never moved out of the "waiting" status that
+// `startWorkflowExecution` sets client-side, so the 20-second
+// `triggerTimeout` fired and the user saw "Timeout starting workflow
+// execution" even when every node had succeeded on the wire (rchaves
+// dogfood 2026-04-29 trace 60f59f73…).
+//
+// Mirror python langwatch_nlp's start_workflow_event /
+// end_workflow_event in execute_flow.py: emit `execution_state_change`
+// with status=running on entry, status=success on completion (or
+// status=error on failure) so Studio's reducer flips
+// workflow.state.execution.status.
+func TestExecuteStream_EmitsWorkflowExecutionStateEvents(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "wf_state_events",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "end", TargetHandle: "inputs.output"},
+		},
+	}
+
+	events, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"input": "hello"},
+		TraceID:  "trace_state_events",
+	}, ExecuteStreamOptions{})
+	require.NoError(t, err)
+
+	collected := drain(events)
+	stateEvents := filterByType(collected, "execution_state_change")
+	require.Len(t, stateEvents, 2,
+		"execute_flow must emit exactly two workflow-level state events: running → success")
+
+	// First: running. Carries trace_id + started_at — Studio renders the
+	// running indicator and stops the 20s timeout from firing.
+	first := stateEvents[0]
+	firstES, ok := first.Payload["execution_state"].(map[string]any)
+	require.True(t, ok, "first event must carry execution_state payload")
+	assert.Equal(t, "running", firstES["status"])
+	assert.Equal(t, "trace_state_events", firstES["trace_id"])
+	require.Contains(t, firstES, "timestamps", "running event must stamp started_at so Studio can compute duration")
+
+	// Second: success. Carries the final result map so Studio's End-node
+	// inspector renders the workflow-level output.
+	second := stateEvents[1]
+	secondES, ok := second.Payload["execution_state"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "success", secondES["status"])
+	assert.Equal(t, "trace_state_events", secondES["trace_id"])
+	require.Contains(t, secondES, "result")
+	ts, ok := secondES["timestamps"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, ts, "started_at")
+	assert.Contains(t, ts, "finished_at")
+
+	// Sanity: Component events still fire in between — the new
+	// workflow-level events are additive, not replacing.
+	componentEvents := filterByType(collected, "component_state_change")
+	assert.NotEmpty(t, componentEvents, "per-node component_state_change events must still emit alongside workflow-level ones")
+}
+
+// TestExecuteStream_EmitsErrorWorkflowEventOnNodeFailure pins the
+// error path — when a node fails, nlpgo must emit
+// execution_state_change{status:"error"} so Studio's reducer flips
+// workflow.state.execution.status to "error" and surfaces the message
+// via alertOnError(). Pre-fix the workflow stayed "waiting" and only
+// the failed node turned red.
+func TestExecuteStream_EmitsErrorWorkflowEventOnNodeFailure(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "wf_state_error",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			// code node with no Code executor wired — deterministic failure
+			{ID: "code-1", Type: dsl.ComponentCode},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "code-1", TargetHandle: "inputs.input"},
+		},
+	}
+
+	events, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"input": "boom"},
+		TraceID:  "trace_state_error",
+	}, ExecuteStreamOptions{})
+	require.NoError(t, err)
+
+	collected := drain(events)
+	stateEvents := filterByType(collected, "execution_state_change")
+	require.Len(t, stateEvents, 2,
+		"error path emits running → error (still 2 workflow-level state events; the run starts and ends)")
+
+	last := stateEvents[len(stateEvents)-1]
+	es, ok := last.Payload["execution_state"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "error", es["status"])
+	assert.Equal(t, "trace_state_error", es["trace_id"])
+	assert.Contains(t, es, "error", "error event must carry the message Studio surfaces in the alertOnError toast")
+}
+
+// TestExecuteStream_ExecuteComponentDoesNotEmitWorkflowStateEvents pins
+// the polarity: execute_component (req.NodeID set) targets a single
+// node and Studio tracks that path via componentExecutionState only —
+// emitting a workflow-level state change for a single-node Run would
+// confuse the reducer (workflow.state.execution would flip to "running"
+// for what the user perceives as a per-component test). Run-with-manual-input
+// must NOT touch workflow-level state.
+func TestExecuteStream_ExecuteComponentDoesNotEmitWorkflowStateEvents(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "wf_component_only",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "end", TargetHandle: "inputs.output"},
+		},
+	}
+
+	events, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"input": "hello"},
+		NodeID:   "end",
+		TraceID:  "trace_component_only",
+	}, ExecuteStreamOptions{})
+	require.NoError(t, err)
+
+	collected := drain(events)
+	stateEvents := filterByType(collected, "execution_state_change")
+	assert.Empty(t, stateEvents,
+		"execute_component path must not emit workflow-level execution_state_change — Studio tracks per-component state only")
+}
+
+func drain(events <-chan StreamEvent) []StreamEvent {
+	var out []StreamEvent
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+		case <-timeout:
+			return out
+		}
+	}
+}
+
+func filterByType(events []StreamEvent, t string) []StreamEvent {
+	var out []StreamEvent
+	for _, e := range events {
+		if e.Type == t {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/services/nlpgo/app/engine/execute_flow_state_events_test.go
+++ b/services/nlpgo/app/engine/execute_flow_state_events_test.go
@@ -160,12 +160,23 @@ func TestExecuteStream_ExecuteComponentDoesNotEmitWorkflowStateEvents(t *testing
 // reducer flips workflow.state.evaluation.status. Without this the eval
 // run hits the same 20s "Timeout starting workflow execution" toast
 // even though the dataset rows complete on the wire.
+//
+// The eval path also iterates the workflow over each dataset entry and
+// emits a per-entry progress event so the running state stays "fresh"
+// for long evaluations (mirrors Python's EvaluationReporting.evaluate_
+// and_report → queue.put_nowait per row).
 func TestExecuteStream_EvaluationEmitsEvaluationStateEvents(t *testing.T) {
 	eng := New(Options{})
 	wf := &dsl.Workflow{
 		WorkflowID: "wf_eval",
+		APIKey:     "k",
 		Nodes: []dsl.Node{
-			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "entry", Type: dsl.ComponentEntry, Data: dsl.Component{
+				Outputs: []dsl.Field{{Identifier: "input", Type: dsl.FieldTypeStr}},
+				Dataset: &dsl.NodeDataset{Inline: &dsl.DatasetInline{
+					Records: map[string][]any{"input": {"hello"}},
+				}},
+			}},
 			{ID: "end", Type: dsl.ComponentEnd},
 		},
 		Edges: []dsl.Edge{
@@ -174,12 +185,13 @@ func TestExecuteStream_EvaluationEmitsEvaluationStateEvents(t *testing.T) {
 	}
 
 	events, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
-		Workflow: wf,
-		Inputs:   map[string]any{"input": "hello"},
-		TraceID:  "trace_eval",
-		Type:     "execute_evaluation",
-		RunID:    "run_abc123",
-		Origin:   "evaluation",
+		Workflow:   wf,
+		Inputs:     map[string]any{"input": "hello"},
+		TraceID:    "trace_eval",
+		Type:       "execute_evaluation",
+		RunID:      "run_abc123",
+		Origin:     "evaluation",
+		EvaluateOn: "full",
 	}, ExecuteStreamOptions{})
 	require.NoError(t, err)
 
@@ -193,8 +205,8 @@ func TestExecuteStream_EvaluationEmitsEvaluationStateEvents(t *testing.T) {
 		"execute_evaluation must NOT emit execution_state_change — that slot is the workflow-flow reducer, not the evaluation reducer")
 
 	evalEvents := filterByType(collected, "evaluation_state_change")
-	require.Len(t, evalEvents, 2,
-		"execute_evaluation emits running → success on a clean run, just like execute_flow's parallel pair")
+	require.GreaterOrEqual(t, len(evalEvents), 3,
+		"execute_evaluation emits at least running → progress(per row) → success — got %d", len(evalEvents))
 
 	first := evalEvents[0]
 	firstES, ok := first.Payload["evaluation_state"].(map[string]any)
@@ -203,32 +215,46 @@ func TestExecuteStream_EvaluationEmitsEvaluationStateEvents(t *testing.T) {
 	assert.Equal(t, "run_abc123", firstES["run_id"],
 		"run_id round-trips so Studio's useEvaluationExecution.scheduleTimeout can match the streamed update to the run it dispatched")
 
-	second := evalEvents[1]
-	secondES, ok := second.Payload["evaluation_state"].(map[string]any)
+	last := evalEvents[len(evalEvents)-1]
+	lastES, ok := last.Payload["evaluation_state"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "success", secondES["status"])
-	assert.Equal(t, "run_abc123", secondES["run_id"])
-	ts, ok := secondES["timestamps"].(map[string]any)
+	assert.Equal(t, "success", lastES["status"])
+	assert.Equal(t, "run_abc123", lastES["run_id"])
+	ts, ok := lastES["timestamps"].(map[string]any)
 	require.True(t, ok)
 	assert.Contains(t, ts, "started_at")
 	assert.Contains(t, ts, "finished_at")
+
+	// Middle event must carry the progress/total counters Studio
+	// renders the per-row spinner from.
+	mid := evalEvents[len(evalEvents)-2]
+	midES, ok := mid.Payload["evaluation_state"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "running", midES["status"])
+	assert.EqualValues(t, 1, midES["progress"], "progress must be incremented per row")
+	assert.EqualValues(t, 1, midES["total"], "total must equal the row count")
 }
 
 // TestExecuteStream_EvaluationErrorEmitsEvaluationErrorEvent pins the
-// eval-path error contract — running → error with run_id stamped so
-// Studio can match the failure to the run it dispatched and surface
-// the message via alertOnError().
+// eval-path error contract — when the evaluation can't even start
+// (here: entry node has no inline dataset, the error path before
+// per-row iteration), Studio's reducer still gets running → error
+// with run_id so it can render the alertOnError toast. Per-row engine
+// errors do NOT abort the whole eval (Python parity: DSPy Evaluate's
+// provide_traceback=True continues past row failures).
 func TestExecuteStream_EvaluationErrorEmitsEvaluationErrorEvent(t *testing.T) {
 	eng := New(Options{})
 	wf := &dsl.Workflow{
 		WorkflowID: "wf_eval_error",
+		APIKey:     "k",
 		Nodes: []dsl.Node{
+			// Entry node missing the inline dataset — selectEvaluationEntries
+			// rejects this up-front so the eval can't iterate.
 			{ID: "entry", Type: dsl.ComponentEntry},
-			// code node with no Code executor wired — deterministic failure
-			{ID: "code-1", Type: dsl.ComponentCode},
+			{ID: "end", Type: dsl.ComponentEnd},
 		},
 		Edges: []dsl.Edge{
-			{Source: "entry", SourceHandle: "outputs.input", Target: "code-1", TargetHandle: "inputs.input"},
+			{Source: "entry", SourceHandle: "outputs.input", Target: "end", TargetHandle: "inputs.input"},
 		},
 	}
 
@@ -244,7 +270,12 @@ func TestExecuteStream_EvaluationErrorEmitsEvaluationErrorEvent(t *testing.T) {
 
 	collected := drain(events)
 	evalEvents := filterByType(collected, "evaluation_state_change")
-	require.Len(t, evalEvents, 2, "running → error: still 2 eval-state events on the failure path")
+	require.Len(t, evalEvents, 2, "running → error: still 2 eval-state events on the dataset-misconfigured failure path")
+
+	first := evalEvents[0]
+	firstES, ok := first.Payload["evaluation_state"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "running", firstES["status"])
 
 	last := evalEvents[len(evalEvents)-1]
 	es, ok := last.Payload["evaluation_state"].(map[string]any)

--- a/services/nlpgo/app/engine/execute_flow_state_events_test.go
+++ b/services/nlpgo/app/engine/execute_flow_state_events_test.go
@@ -153,6 +153,107 @@ func TestExecuteStream_ExecuteComponentDoesNotEmitWorkflowStateEvents(t *testing
 		"execute_component path must not emit workflow-level execution_state_change — Studio tracks per-component state only")
 }
 
+// TestExecuteStream_EvaluationEmitsEvaluationStateEvents pins the eval
+// counterpart: when Studio's `useEvaluationExecution` dispatches an
+// `execute_evaluation` event, nlpgo must emit `evaluation_state_change`
+// events (carrying run_id) — not `execution_state_change` — so the
+// reducer flips workflow.state.evaluation.status. Without this the eval
+// run hits the same 20s "Timeout starting workflow execution" toast
+// even though the dataset rows complete on the wire.
+func TestExecuteStream_EvaluationEmitsEvaluationStateEvents(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "wf_eval",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "end", TargetHandle: "inputs.output"},
+		},
+	}
+
+	events, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"input": "hello"},
+		TraceID:  "trace_eval",
+		Type:     "execute_evaluation",
+		RunID:    "run_abc123",
+		Origin:   "evaluation",
+	}, ExecuteStreamOptions{})
+	require.NoError(t, err)
+
+	collected := drain(events)
+
+	// No execution_state_change events on the eval path — those flip
+	// the wrong reducer slot. evaluation_state_change is the only
+	// state-change family Studio's eval reducer reads.
+	executionEvents := filterByType(collected, "execution_state_change")
+	assert.Empty(t, executionEvents,
+		"execute_evaluation must NOT emit execution_state_change — that slot is the workflow-flow reducer, not the evaluation reducer")
+
+	evalEvents := filterByType(collected, "evaluation_state_change")
+	require.Len(t, evalEvents, 2,
+		"execute_evaluation emits running → success on a clean run, just like execute_flow's parallel pair")
+
+	first := evalEvents[0]
+	firstES, ok := first.Payload["evaluation_state"].(map[string]any)
+	require.True(t, ok, "first eval event must carry evaluation_state payload (matches python EvaluationStateChangePayload shape)")
+	assert.Equal(t, "running", firstES["status"])
+	assert.Equal(t, "run_abc123", firstES["run_id"],
+		"run_id round-trips so Studio's useEvaluationExecution.scheduleTimeout can match the streamed update to the run it dispatched")
+
+	second := evalEvents[1]
+	secondES, ok := second.Payload["evaluation_state"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "success", secondES["status"])
+	assert.Equal(t, "run_abc123", secondES["run_id"])
+	ts, ok := secondES["timestamps"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, ts, "started_at")
+	assert.Contains(t, ts, "finished_at")
+}
+
+// TestExecuteStream_EvaluationErrorEmitsEvaluationErrorEvent pins the
+// eval-path error contract — running → error with run_id stamped so
+// Studio can match the failure to the run it dispatched and surface
+// the message via alertOnError().
+func TestExecuteStream_EvaluationErrorEmitsEvaluationErrorEvent(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "wf_eval_error",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			// code node with no Code executor wired — deterministic failure
+			{ID: "code-1", Type: dsl.ComponentCode},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "code-1", TargetHandle: "inputs.input"},
+		},
+	}
+
+	events, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"input": "boom"},
+		TraceID:  "trace_eval_error",
+		Type:     "execute_evaluation",
+		RunID:    "run_failing",
+		Origin:   "evaluation",
+	}, ExecuteStreamOptions{})
+	require.NoError(t, err)
+
+	collected := drain(events)
+	evalEvents := filterByType(collected, "evaluation_state_change")
+	require.Len(t, evalEvents, 2, "running → error: still 2 eval-state events on the failure path")
+
+	last := evalEvents[len(evalEvents)-1]
+	es, ok := last.Payload["evaluation_state"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "error", es["status"])
+	assert.Equal(t, "run_failing", es["run_id"])
+	assert.Contains(t, es, "error", "error event must carry the message Studio surfaces in the alertOnError toast")
+}
+
 func drain(events <-chan StreamEvent) []StreamEvent {
 	var out []StreamEvent
 	timeout := time.After(5 * time.Second)

--- a/services/nlpgo/app/engine/llm_span_e2e_test.go
+++ b/services/nlpgo/app/engine/llm_span_e2e_test.go
@@ -1,0 +1,123 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// fakeLLMClient is a deterministic stub the engine treats as a real
+// gateway dispatcher. Test workflows use it to exercise the signature
+// node + LLM span emission path without standing up Bifrost.
+type fakeLLMClient struct {
+	resp *app.LLMResponse
+	err  error
+}
+
+func (f *fakeLLMClient) Execute(_ context.Context, _ app.LLMRequest) (*app.LLMResponse, error) {
+	return f.resp, f.err
+}
+func (f *fakeLLMClient) ExecuteStream(_ context.Context, _ app.LLMRequest) (app.StreamIterator, error) {
+	return nil, nil
+}
+
+// TestEngineExecute_SignatureNodeEmitsLLMChildSpan is the end-to-end
+// proof that runSignature wraps the gateway call in an LLM-typed child
+// span. Pre-fix the only span was the parent execute_component — Studio's
+// Trace Details drawer (rchaves screenshot 2026-04-29) showed no model,
+// no token count, no cost. Python parity emits a `<provider>/<model>`
+// span at this level with reserved gen_ai.* attrs.
+func TestEngineExecute_SignatureNodeEmitsLLMChildSpan(t *testing.T) {
+	rec := withRecorder(t)
+
+	model := "openai/gpt-5-mini"
+	llm := &fakeLLMClient{
+		resp: &app.LLMResponse{
+			Content:    "4",
+			DurationMS: 1234,
+			Cost:       0.00018,
+			Usage: app.Usage{
+				PromptTokens:     12,
+				CompletionTokens: 1,
+				TotalTokens:      13,
+			},
+		},
+	}
+
+	eng := New(Options{LLM: llm})
+	llmConfigJSON, err := json.Marshal(map[string]any{"model": model})
+	require.NoError(t, err)
+
+	wf := &dsl.Workflow{
+		WorkflowID: "wf_llm_span",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry, Data: dsl.Component{
+				Outputs: []dsl.Field{{Identifier: "question", Type: dsl.FieldTypeStr}},
+			}},
+			{ID: "answer", Type: dsl.ComponentSignature, Data: dsl.Component{
+				Parameters: []dsl.Field{
+					{Identifier: "llm", Type: dsl.FieldTypeLLM, Value: llmConfigJSON},
+				},
+				Inputs:  []dsl.Field{{Identifier: "question", Type: dsl.FieldTypeStr}},
+				Outputs: []dsl.Field{{Identifier: "answer", Type: dsl.FieldTypeStr}},
+			}},
+			{ID: "end", Type: dsl.ComponentEnd, Data: dsl.Component{
+				Inputs: []dsl.Field{{Identifier: "answer", Type: dsl.FieldTypeStr}},
+			}},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.question", Target: "answer", TargetHandle: "inputs.question"},
+			{Source: "answer", SourceHandle: "outputs.answer", Target: "end", TargetHandle: "inputs.answer"},
+		},
+	}
+
+	res, err := eng.Execute(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"question": "What is 2+2?"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	spans := rec.Ended()
+	require.NotEmpty(t, spans, "expected spans for entry, answer, end + answer's LLM child")
+
+	var componentSpans, llmSpans int
+	var llmAttrs map[string]any
+	var llmSpanID string
+	var componentSpanID string
+	for _, s := range spans {
+		attrs := attrMap(s.Attributes())
+		switch attrs["langwatch.span.type"] {
+		case "component":
+			componentSpans++
+			if attrs["langwatch.node_id"] == "answer" {
+				componentSpanID = s.SpanContext().SpanID().String()
+			}
+		case "llm":
+			llmSpans++
+			llmAttrs = attrs
+			llmSpanID = s.Parent().SpanID().String()
+			assert.Equal(t, "openai/gpt-5-mini", s.Name(),
+				"LLM span name must be '<provider>/<model>' for Studio's drawer to render the LLM row label")
+		}
+	}
+
+	assert.Equal(t, 3, componentSpans,
+		"one execute_component span per dispatched node (entry, answer, end)")
+	require.Equal(t, 1, llmSpans, "signature node must emit exactly one LLM child span")
+	assert.Equal(t, componentSpanID, llmSpanID,
+		"LLM span must be parented at the answer node's execute_component span — Studio's tree view nests on parent span_id")
+
+	// Reserved gen_ai attrs Studio reads to render token counts + cost.
+	assert.Equal(t, "openai", llmAttrs["gen_ai.system"])
+	assert.Equal(t, "gpt-5-mini", llmAttrs["gen_ai.request.model"])
+	assert.EqualValues(t, 12, llmAttrs["gen_ai.usage.input_tokens"])
+	assert.EqualValues(t, 1, llmAttrs["gen_ai.usage.output_tokens"])
+	assert.InDelta(t, 0.00018, toFloat(llmAttrs["langwatch.cost"]), 1e-9)
+}

--- a/services/nlpgo/app/engine/llm_tracing_test.go
+++ b/services/nlpgo/app/engine/llm_tracing_test.go
@@ -1,0 +1,125 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	otelapi "go.opentelemetry.io/otel"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+)
+
+// TestStartLLMSpan_NameAndReservedAttrs locks the LLM span shape Studio's
+// Trace Details drawer renders. Pre-fix nlpgo emitted only the parent
+// execute_component span — operators saw no model, no tokens, no cost.
+// Python parity (DSPy adapter) emits an LLM-typed span named
+// "<provider>/<model>" with `langwatch.span.type=llm` plus the standard
+// `gen_ai.*` request/usage attrs. This test pins that shape.
+func TestStartLLMSpan_NameAndReservedAttrs(t *testing.T) {
+	rec := withRecorder(t)
+
+	tracer := otelapi.Tracer(tracerName)
+	parentCtx, parent := tracer.Start(context.Background(), componentSpanName)
+	defer parent.End()
+
+	messages := []app.ChatMessage{
+		{Role: "user", Content: "What is 2+2?"},
+	}
+	_, llmSpan := startLLMSpan(parentCtx, "gpt-5-mini", "openai", messages)
+	endLLMSpan(llmSpan, &app.LLMResponse{
+		Content:    "4",
+		DurationMS: 3500,
+		Cost:       0.00018,
+		Usage: app.Usage{
+			PromptTokens:     12,
+			CompletionTokens: 1,
+			TotalTokens:      13,
+		},
+	}, nil)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1, "endLLMSpan must close exactly one span (parent stays open)")
+
+	got := spans[0]
+	assert.Equal(t, "openai/gpt-5-mini", got.Name(),
+		"span name must be '<provider>/<model>' so Studio's drawer labels the row 'LLM openai/gpt-5-mini' to match Python parity")
+
+	attrs := attrMap(got.Attributes())
+	assert.Equal(t, "llm", attrs["langwatch.span.type"],
+		"span.type must be 'llm' — Studio's drawer groups by this exact reserved value to render LLM-flavored rows")
+	assert.Equal(t, "openai", attrs["gen_ai.system"])
+	assert.Equal(t, "gpt-5-mini", attrs["gen_ai.request.model"])
+	assert.EqualValues(t, 12, attrs["gen_ai.usage.input_tokens"])
+	assert.EqualValues(t, 1, attrs["gen_ai.usage.output_tokens"])
+	assert.InDelta(t, 0.00018, toFloat(attrs["langwatch.cost"]), 1e-9)
+	assert.EqualValues(t, 3500, attrs["langwatch.duration_ms"])
+
+	// langwatch.input is the JSON-encoded request messages so Studio's
+	// INPUT panel shows the full prompt verbatim (not best-guess).
+	inJSON, ok := attrs["langwatch.input"].(string)
+	require.True(t, ok, "input must be JSON-encoded for output_source=explicit rendering")
+	var inMsgs []app.ChatMessage
+	require.NoError(t, json.Unmarshal([]byte(inJSON), &inMsgs))
+	require.Len(t, inMsgs, 1)
+	assert.Equal(t, "user", inMsgs[0].Role)
+	assert.Equal(t, "What is 2+2?", inMsgs[0].Content)
+
+	// langwatch.output is the JSON-encoded assistant message (matches
+	// Python's LLM-span output shape — the assistant reply, not the
+	// full HTTP response body).
+	outJSON, ok := attrs["langwatch.output"].(string)
+	require.True(t, ok)
+	var outMsg app.ChatMessage
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &outMsg))
+	assert.Equal(t, "assistant", outMsg.Role)
+	assert.Equal(t, "4", outMsg.Content)
+}
+
+// TestEndLLMSpan_ErrorPathDoesNotStampOutput pins the error-path
+// contract: when the LLM call fails (gateway 401/5xx, network), the span
+// captures the error but NOT a fake langwatch.output. Stamping a phantom
+// assistant reply for a failed call would mislead operators into thinking
+// the value was successfully returned.
+func TestEndLLMSpan_ErrorPathDoesNotStampOutput(t *testing.T) {
+	rec := withRecorder(t)
+
+	tracer := otelapi.Tracer(tracerName)
+	parentCtx, parent := tracer.Start(context.Background(), componentSpanName)
+	defer parent.End()
+
+	_, llmSpan := startLLMSpan(parentCtx, "gpt-5-mini", "openai", []app.ChatMessage{
+		{Role: "user", Content: "hi"},
+	})
+	endLLMSpan(llmSpan, nil, errors.New("gateway returned non-2xx status 401"))
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+	attrs := attrMap(spans[0].Attributes())
+
+	// Input still stamped — operator needs to debug what the failed
+	// request looked like.
+	assert.Contains(t, attrs, "langwatch.input")
+	// Output NOT stamped — there is no real assistant reply on error.
+	assert.NotContains(t, attrs, "langwatch.output")
+	assert.Contains(t, attrs, "error.message")
+	assert.Equal(t, "gateway returned non-2xx status 401", attrs["error.message"])
+}
+
+// toFloat coerces an attribute value (recorder serializes numbers as
+// float64, but Int/Int64 attributes round-trip as int64).
+func toFloat(v any) float64 {
+	switch x := v.(type) {
+	case float64:
+		return x
+	case int64:
+		return float64(x)
+	case int:
+		return float64(x)
+	}
+	return 0
+}

--- a/services/nlpgo/app/engine/llm_tracing_test.go
+++ b/services/nlpgo/app/engine/llm_tracing_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	otelapi "go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,6 +109,36 @@ func TestEndLLMSpan_ErrorPathDoesNotStampOutput(t *testing.T) {
 	assert.NotContains(t, attrs, "langwatch.output")
 	assert.Contains(t, attrs, "error.message")
 	assert.Equal(t, "gateway returned non-2xx status 401", attrs["error.message"])
+}
+
+// TestEndLLMSpan_NilResponseNilErrorIsTreatedAsError pins the
+// (nil, nil) case: an LLM executor that returns no response and no
+// error is breaking its contract. Marking the span Ok would hide the
+// upstream bug in the trace; mark it Error so the LLM row in Studio
+// surfaces the contract break (CodeRabbit major on PR #3569).
+func TestEndLLMSpan_NilResponseNilErrorIsTreatedAsError(t *testing.T) {
+	rec := withRecorder(t)
+
+	tracer := otelapi.Tracer(tracerName)
+	parentCtx, parent := tracer.Start(context.Background(), componentSpanName)
+	defer parent.End()
+
+	_, llmSpan := startLLMSpan(parentCtx, "gpt-5-mini", "openai", []app.ChatMessage{
+		{Role: "user", Content: "hi"},
+	})
+	endLLMSpan(llmSpan, nil, nil)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+	got := spans[0]
+	assert.Equal(t, codes.Error, got.Status().Code,
+		"nil response with nil error must be flagged as Error — Ok would hide the upstream contract break in the trace")
+	assert.NotEmpty(t, got.Status().Description,
+		"error description must surface the contract break to operators")
+	attrs := attrMap(got.Attributes())
+	assert.Contains(t, attrs, "error.message")
+	assert.NotContains(t, attrs, "langwatch.output",
+		"no output to stamp — there's no real assistant reply on a contract break")
 }
 
 // toFloat coerces an attribute value (recorder serializes numbers as

--- a/services/nlpgo/app/engine/signature_outputs_test.go
+++ b/services/nlpgo/app/engine/signature_outputs_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -145,6 +146,41 @@ func TestJSONSchemaForField_ScalarMappings(t *testing.T) {
 func TestJSONSchemaForField_JSONSchemaWithEmptySchemaFallsBack(t *testing.T) {
 	got := jsonSchemaForField(dsl.Field{Type: dsl.FieldTypeJSONSchema})
 	assert.Equal(t, "string", got["type"])
+}
+
+// TestSanitizeSchemaName pins the OpenAI name-pattern compliance:
+// response_format.json_schema.name must match ^[a-zA-Z0-9_-]+$ and is
+// capped at 64 chars. Without this, node names containing dots or
+// spaces (e.g. "LLM Call") and models with dots (e.g. "gpt-5.2") cause
+// OpenAI to reject the request — observed in rchaves dogfood
+// 2026-04-29 (workflow_qtBZcCf4ch5xfxBm-NIZL): `Invalid
+// 'response_format.json_schema.name': string does not match pattern
+// '^[a-zA-Z0-9_-]+$'`.
+func TestSanitizeSchemaName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"alphanumeric passthrough", "ClassifyOutputs", "ClassifyOutputs"},
+		{"underscore allowed", "my_node_Outputs", "my_node_Outputs"},
+		{"dash allowed", "node-abc-Outputs", "node-abc-Outputs"},
+		{"space replaced", "LLM Call Outputs", "LLM_Call_Outputs"},
+		{"dot replaced", "gpt-5.2Outputs", "gpt-5_2Outputs"},
+		{"colon replaced", "node:42Outputs", "node_42Outputs"},
+		{"unicode replaced", "résumé_Outputs", "r_sum__Outputs"},
+		{"empty falls back", "", "Outputs"},
+		{"all illegal falls back", "...", "Outputs"},
+		{"truncated to 64", strings.Repeat("a", 100), strings.Repeat("a", 64)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeSchemaName(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.Regexp(t, `^[a-zA-Z0-9_-]+$`, got, "must satisfy OpenAI name pattern")
+			assert.LessOrEqual(t, len(got), 64, "must be at most 64 chars")
+		})
+	}
 }
 
 // TestComposeSignatureResponseFormat_RoundTripsThroughJSON proves the

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -114,7 +114,6 @@ func (e *Engine) runLayerStream(ctx context.Context, req ExecuteRequest, plan *p
 			started := time.Now()
 			outputs, derr := e.dispatch(nodeCtx, req, node, inputs, ns)
 			ns.DurationMS = time.Since(started).Milliseconds()
-			endNodeSpan(span, ns, derr)
 			if derr != nil {
 				ns.Status = "error"
 				ns.Error = derr
@@ -125,6 +124,9 @@ func (e *Engine) runLayerStream(ctx context.Context, req ExecuteRequest, plan *p
 				ns.Outputs = outputs
 				state.recordOutputs(nodeID, outputs)
 			}
+			// endNodeSpan reads ns.Outputs to stamp langwatch.output;
+			// must run after the success branch sets it (Python parity).
+			endNodeSpan(span, ns, derr)
 			state.recordState(nodeID, ns)
 			emit(ctx, out, stateEvent(traceID, nodeID, ns))
 		}()

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -104,23 +104,28 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 			emit(ctx, out, doneEvent(traceID, state, started))
 			return
 		}
-		// execute_flow needs workflow-level execution_state_change events:
-		// Studio's startWorkflowExecution sets workflow.state.execution =
-		// {status:"waiting"} and arms a 20s "Timeout starting workflow
-		// execution" toast. Only an execution_state_change with
-		// status:"running" flips that to "running" (usePostEvent.tsx
-		// case "execution_state_change" → setWorkflowExecutionState).
+		// execute_flow / execute_evaluation need workflow-level state
+		// events: Studio's startWorkflowExecution / startEvaluation set
+		// the corresponding state slot to {status:"waiting"} and arm a 20s
+		// "Timeout starting workflow execution" toast. Only the right
+		// state-change event family flips that:
+		//
+		//   execute_flow       → execution_state_change → workflow.state.execution
+		//   execute_evaluation → evaluation_state_change → workflow.state.evaluation
+		//
 		// Per-node component_state_change events do NOT update the
 		// workflow-level state — Studio routes them to per-component
-		// state. Without these workflow-level events nlpgo's execute_flow
-		// completes successfully on the wire but Studio sees the toast
-		// (rchaves dogfood 2026-04-29 trace_id 60f59f73…). Mirror
-		// langwatch_nlp/studio/execute/execute_flow.py
-		// start_workflow_event / end_workflow_event / error_workflow_event.
-		emit(ctx, out, workflowRunningEvent(traceID, started))
+		// state. Without the workflow-level events nlpgo's run completes
+		// successfully on the wire but Studio sees the timeout toast
+		// (rchaves dogfood 2026-04-29 trace_id 60f59f73… for execute_flow;
+		// the eval path has the same shape gap). Mirror
+		// langwatch_nlp/studio/execute/{execute_flow.py,
+		// execute_evaluation.py} — start/end/error event family.
+		isEval := req.Type == "execute_evaluation"
+		emit(ctx, out, workflowRunningEvent(req, traceID, started, isEval))
 		for _, layer := range plan.Layers {
 			if err := ctx.Err(); err != nil {
-				emit(ctx, out, workflowErrorEvent(traceID, err.Error()))
+				emit(ctx, out, workflowErrorEvent(req, traceID, err.Error(), isEval))
 				emit(ctx, out, StreamEvent{
 					Type:    "error",
 					TraceID: traceID,
@@ -130,12 +135,12 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 			}
 			e.runLayerStream(ctx, req, plan, state, layer, traceID, out)
 			if state.firstError != nil {
-				emit(ctx, out, workflowErrorEvent(traceID, state.firstError.Message))
+				emit(ctx, out, workflowErrorEvent(req, traceID, state.firstError.Message, isEval))
 				emit(ctx, out, doneEvent(traceID, state, started))
 				return
 			}
 		}
-		emit(ctx, out, workflowSuccessEvent(traceID, state, started))
+		emit(ctx, out, workflowSuccessEvent(req, traceID, state, started, isEval))
 		emit(ctx, out, doneEvent(traceID, state, started))
 	}()
 	return out, nil
@@ -262,47 +267,96 @@ func stateEvent(traceID, nodeID string, ns *NodeState) StreamEvent {
 
 // workflowRunningEvent / workflowSuccessEvent / workflowErrorEvent emit
 // the workflow-level state transitions Studio's reducer requires to flip
-// workflow.state.execution.status. Mirror python langwatch_nlp's
+// workflow.state.execution.status (or workflow.state.evaluation.status
+// for the eval path). Mirror python langwatch_nlp's
 // start_workflow_event / end_workflow_event / error_workflow_event in
-// langwatch_nlp/studio/execute/execute_flow.py — same payload shape so
-// usePostEvent.tsx's case "execution_state_change" doesn't need a code
-// change.
-func workflowRunningEvent(traceID string, started time.Time) StreamEvent {
+// langwatch_nlp/studio/execute/execute_flow.py and the parallel trio in
+// execute_evaluation.py — same payload shapes so usePostEvent.tsx's
+// case "execution_state_change" / "evaluation_state_change" don't need
+// code changes.
+//
+// `isEval` switches the event family: execute_evaluation → evaluation_state_change
+// (carries run_id), execute_flow → execution_state_change (carries trace_id).
+func workflowRunningEvent(req ExecuteRequest, traceID string, started time.Time, isEval bool) StreamEvent {
+	timestamps := map[string]any{
+		"started_at": started.UnixMilli(),
+	}
+	if isEval {
+		return StreamEvent{
+			Type:    "evaluation_state_change",
+			TraceID: traceID,
+			Payload: map[string]any{
+				"evaluation_state": map[string]any{
+					"status":     "running",
+					"run_id":     req.RunID,
+					"timestamps": timestamps,
+				},
+			},
+		}
+	}
 	return StreamEvent{
 		Type:    "execution_state_change",
 		TraceID: traceID,
 		Payload: map[string]any{
 			"execution_state": map[string]any{
-				"status":   "running",
-				"trace_id": traceID,
-				"timestamps": map[string]any{
-					"started_at": started.UnixMilli(),
-				},
+				"status":     "running",
+				"trace_id":   traceID,
+				"timestamps": timestamps,
 			},
 		},
 	}
 }
 
-func workflowSuccessEvent(traceID string, state *runState, started time.Time) StreamEvent {
+func workflowSuccessEvent(req ExecuteRequest, traceID string, state *runState, started time.Time, isEval bool) StreamEvent {
+	timestamps := map[string]any{
+		"started_at":  started.UnixMilli(),
+		"finished_at": time.Now().UnixMilli(),
+	}
+	if isEval {
+		return StreamEvent{
+			Type:    "evaluation_state_change",
+			TraceID: traceID,
+			Payload: map[string]any{
+				"evaluation_state": map[string]any{
+					"status":     "success",
+					"run_id":     req.RunID,
+					"timestamps": timestamps,
+				},
+			},
+		}
+	}
 	res := finalize(state, traceID, started, nil)
 	return StreamEvent{
 		Type:    "execution_state_change",
 		TraceID: traceID,
 		Payload: map[string]any{
 			"execution_state": map[string]any{
-				"status":   "success",
-				"trace_id": traceID,
-				"timestamps": map[string]any{
-					"started_at":  started.UnixMilli(),
-					"finished_at": time.Now().UnixMilli(),
-				},
-				"result": res.Result,
+				"status":     "success",
+				"trace_id":   traceID,
+				"timestamps": timestamps,
+				"result":     res.Result,
 			},
 		},
 	}
 }
 
-func workflowErrorEvent(traceID, message string) StreamEvent {
+func workflowErrorEvent(req ExecuteRequest, traceID, message string, isEval bool) StreamEvent {
+	if isEval {
+		return StreamEvent{
+			Type:    "evaluation_state_change",
+			TraceID: traceID,
+			Payload: map[string]any{
+				"evaluation_state": map[string]any{
+					"status": "error",
+					"run_id": req.RunID,
+					"error":  message,
+					"timestamps": map[string]any{
+						"finished_at": time.Now().UnixMilli(),
+					},
+				},
+			},
+		}
+	}
 	return StreamEvent{
 		Type:    "execution_state_change",
 		TraceID: traceID,

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -52,6 +53,15 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 	}
 	state := newRunState(req.Workflow)
 	applyManualInputs(state, req)
+	// execute_component (req.NodeID set) must dispatch ONLY the
+	// requested node. Validate target exists before starting the
+	// goroutine so callers get a synchronous error instead of an
+	// async error event. See Engine.Execute for the same guard.
+	if req.NodeID != "" {
+		if _, ok := state.nodes[req.NodeID]; !ok {
+			return nil, errInvalidRequest{msg: fmt.Sprintf("engine: execute_component target node %q not in workflow", req.NodeID)}
+		}
+	}
 
 	out := make(chan StreamEvent, 16)
 	go func() {
@@ -78,6 +88,15 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 			close(out)
 		}()
 
+		// execute_component (req.NodeID set) — dispatch only the
+		// requested node, never the full DAG. Same parity rationale as
+		// Engine.Execute: Studio's per-component Run flow on a single
+		// card should not surface entry/end/sibling spans in the trace.
+		if req.NodeID != "" {
+			e.runLayerStream(ctx, req, plan, state, []string{req.NodeID}, traceID, out)
+			emit(ctx, out, doneEvent(traceID, state, started))
+			return
+		}
 		for _, layer := range plan.Layers {
 			if err := ctx.Err(); err != nil {
 				emit(ctx, out, StreamEvent{

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -122,6 +122,18 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 		// langwatch_nlp/studio/execute/{execute_flow.py,
 		// execute_evaluation.py} — start/end/error event family.
 		isEval := req.Type == "execute_evaluation"
+		// execute_evaluation needs more than the per-run state events:
+		// it iterates dataset entries, runs the workflow per entry,
+		// emits progress events along the way, and posts batches to
+		// /api/evaluations/batch/log_results so the experiment-runs
+		// page populates. Without the batch POST, the SSE frames land
+		// cleanly but the UI never gets data — rchaves dogfood
+		// 2026-04-29 saw run_kM3T... on the wire but no row on
+		// /experiments/<id>. Delegate the whole flow.
+		if isEval {
+			e.executeEvaluationStream(ctx, req, traceID, started, out)
+			return
+		}
 		emit(ctx, out, workflowRunningEvent(req, traceID, started, isEval))
 		for _, layer := range plan.Layers {
 			if err := ctx.Err(); err != nil {

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -92,13 +92,35 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 		// requested node, never the full DAG. Same parity rationale as
 		// Engine.Execute: Studio's per-component Run flow on a single
 		// card should not surface entry/end/sibling spans in the trace.
+		//
+		// Studio's component-execution path tracks per-node status via
+		// component_state_change events (set in useComponentExecution.ts),
+		// so execute_component does NOT emit workflow-level
+		// execution_state_change. The 20s component-timeout fires only if
+		// the per-node status doesn't flip — which it does, on every
+		// node dispatch (running → success/error inside runLayerStream).
 		if req.NodeID != "" {
 			e.runLayerStream(ctx, req, plan, state, []string{req.NodeID}, traceID, out)
 			emit(ctx, out, doneEvent(traceID, state, started))
 			return
 		}
+		// execute_flow needs workflow-level execution_state_change events:
+		// Studio's startWorkflowExecution sets workflow.state.execution =
+		// {status:"waiting"} and arms a 20s "Timeout starting workflow
+		// execution" toast. Only an execution_state_change with
+		// status:"running" flips that to "running" (usePostEvent.tsx
+		// case "execution_state_change" → setWorkflowExecutionState).
+		// Per-node component_state_change events do NOT update the
+		// workflow-level state — Studio routes them to per-component
+		// state. Without these workflow-level events nlpgo's execute_flow
+		// completes successfully on the wire but Studio sees the toast
+		// (rchaves dogfood 2026-04-29 trace_id 60f59f73…). Mirror
+		// langwatch_nlp/studio/execute/execute_flow.py
+		// start_workflow_event / end_workflow_event / error_workflow_event.
+		emit(ctx, out, workflowRunningEvent(traceID, started))
 		for _, layer := range plan.Layers {
 			if err := ctx.Err(); err != nil {
+				emit(ctx, out, workflowErrorEvent(traceID, err.Error()))
 				emit(ctx, out, StreamEvent{
 					Type:    "error",
 					TraceID: traceID,
@@ -108,10 +130,12 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 			}
 			e.runLayerStream(ctx, req, plan, state, layer, traceID, out)
 			if state.firstError != nil {
+				emit(ctx, out, workflowErrorEvent(traceID, state.firstError.Message))
 				emit(ctx, out, doneEvent(traceID, state, started))
 				return
 			}
 		}
+		emit(ctx, out, workflowSuccessEvent(traceID, state, started))
 		emit(ctx, out, doneEvent(traceID, state, started))
 	}()
 	return out, nil
@@ -232,6 +256,62 @@ func stateEvent(traceID, nodeID string, ns *NodeState) StreamEvent {
 		Payload: map[string]any{
 			"component_id":    nodeID,
 			"execution_state": es,
+		},
+	}
+}
+
+// workflowRunningEvent / workflowSuccessEvent / workflowErrorEvent emit
+// the workflow-level state transitions Studio's reducer requires to flip
+// workflow.state.execution.status. Mirror python langwatch_nlp's
+// start_workflow_event / end_workflow_event / error_workflow_event in
+// langwatch_nlp/studio/execute/execute_flow.py — same payload shape so
+// usePostEvent.tsx's case "execution_state_change" doesn't need a code
+// change.
+func workflowRunningEvent(traceID string, started time.Time) StreamEvent {
+	return StreamEvent{
+		Type:    "execution_state_change",
+		TraceID: traceID,
+		Payload: map[string]any{
+			"execution_state": map[string]any{
+				"status":   "running",
+				"trace_id": traceID,
+				"timestamps": map[string]any{
+					"started_at": started.UnixMilli(),
+				},
+			},
+		},
+	}
+}
+
+func workflowSuccessEvent(traceID string, state *runState, started time.Time) StreamEvent {
+	res := finalize(state, traceID, started, nil)
+	return StreamEvent{
+		Type:    "execution_state_change",
+		TraceID: traceID,
+		Payload: map[string]any{
+			"execution_state": map[string]any{
+				"status":   "success",
+				"trace_id": traceID,
+				"timestamps": map[string]any{
+					"started_at":  started.UnixMilli(),
+					"finished_at": time.Now().UnixMilli(),
+				},
+				"result": res.Result,
+			},
+		},
+	}
+}
+
+func workflowErrorEvent(traceID, message string) StreamEvent {
+	return StreamEvent{
+		Type:    "execution_state_change",
+		TraceID: traceID,
+		Payload: map[string]any{
+			"execution_state": map[string]any{
+				"status":   "error",
+				"trace_id": traceID,
+				"error":    message,
+			},
 		},
 	}
 }

--- a/services/nlpgo/app/engine/tracing.go
+++ b/services/nlpgo/app/engine/tracing.go
@@ -171,7 +171,13 @@ func endLLMSpan(span trace.Span, resp *app.LLMResponse, callErr error) {
 		return
 	}
 	if resp == nil {
-		span.SetStatus(codes.Ok, "")
+		// (nil, nil) is a contract break — the executor said "no error"
+		// but produced no response. Marking it Ok would hide the bug
+		// in the trace; flag it as an error so the LLM row in Studio
+		// surfaces it.
+		const msg = "llm executor returned no response and no error"
+		span.SetStatus(codes.Error, msg)
+		span.SetAttributes(attribute.String("error.message", msg))
 		span.End()
 		return
 	}

--- a/services/nlpgo/app/engine/tracing.go
+++ b/services/nlpgo/app/engine/tracing.go
@@ -3,10 +3,20 @@
 // existing trace (set by the handler in adapters/httpapi/tracing.go)
 // so the Studio "Full Trace" drawer shows one tree rooted at the
 // langwatch-app-minted trace_id with one child per executed node.
+//
+// Span shape matches the Python langwatch_nlp engine:
+//   - name:                "execute_component"        (== Python's optional_langwatch_trace name)
+//   - langwatch.span.type: "component"                (== Python's optional_langwatch_trace type)
+//   - langwatch.input:     JSON-encoded inputs map    (reserved attr; flips Studio output_source from inferred → explicit)
+//   - langwatch.output:    JSON-encoded outputs map   (reserved attr; same as above)
+// See specs/nlp-go/tracing-parity.feature for the contract and
+// langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py for
+// the Python target shape.
 package engine
 
 import (
 	"context"
+	"encoding/json"
 
 	otelapi "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -16,16 +26,25 @@ import (
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
 )
 
-const tracerName = "langwatch-nlpgo"
+const (
+	tracerName = "langwatch-nlpgo"
+
+	// componentSpanName matches Python's optional_langwatch_trace(name=…).
+	// Renaming it would break Studio filters that group "all component
+	// dispatches" by span name across the Python and Go engines.
+	componentSpanName = "execute_component"
+	componentSpanType = "component"
+)
 
 // startNodeSpan opens a span for one node's dispatch. Span name is
-// `nlpgo.node.<type>` (e.g. nlpgo.node.code, nlpgo.node.signature) so
-// trace explorers can filter to a single node kind. Attributes carry
-// the workflow-level identity (project_id / origin / thread_id) so the
-// span is queryable in isolation without joining back to the parent.
+// always "execute_component" (Python parity); the per-node type is
+// surfaced via langwatch.node_type. The span carries the workflow-level
+// identity (project_id / origin / thread_id) so it's queryable in
+// isolation without joining back to the parent.
 func startNodeSpan(ctx context.Context, node *dsl.Node, req ExecuteRequest) (context.Context, trace.Span) {
 	tracer := otelapi.Tracer(tracerName)
 	attrs := []attribute.KeyValue{
+		attribute.String("langwatch.span.type", componentSpanType),
 		attribute.String("langwatch.node_id", node.ID),
 		attribute.String("langwatch.node_type", string(node.Type)),
 	}
@@ -41,16 +60,27 @@ func startNodeSpan(ctx context.Context, node *dsl.Node, req ExecuteRequest) (con
 	if req.Origin != "" {
 		attrs = append(attrs, attribute.String("langwatch.origin", req.Origin))
 	}
-	return tracer.Start(ctx, "nlpgo.node."+string(node.Type),
+	return tracer.Start(ctx, componentSpanName,
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(attrs...),
 	)
 }
 
-// endNodeSpan closes a node span and stamps the dispatch outcome.
-// Error spans get the structured node-error type/message (matches the
-// `error.type` semconv shape) so trace search by error class works.
+// endNodeSpan closes a node span and stamps the dispatch outcome plus
+// reserved langwatch.input / langwatch.output attributes (JSON-encoded
+// per python-sdk attributes.py). Setting these flips the trace's
+// output_source from "inferred" to "explicit" — i.e. the Studio Trace
+// Details drawer renders the actual values instead of best-guess JSON
+// from the response body.
+//
+// On error: input is still stamped (for debugging the failed call) but
+// output is not (would be misleading). Span status is codes.Error.
 func endNodeSpan(span trace.Span, ns *NodeState, derr *NodeError) {
+	if ns != nil && ns.Inputs != nil {
+		if v, ok := encodeJSONAttr(ns.Inputs); ok {
+			span.SetAttributes(attribute.String("langwatch.input", v))
+		}
+	}
 	if derr != nil {
 		span.SetStatus(codes.Error, derr.Message)
 		span.SetAttributes(
@@ -58,6 +88,11 @@ func endNodeSpan(span trace.Span, ns *NodeState, derr *NodeError) {
 			attribute.String("error.message", derr.Message),
 		)
 	} else {
+		if ns != nil && ns.Outputs != nil {
+			if v, ok := encodeJSONAttr(ns.Outputs); ok {
+				span.SetAttributes(attribute.String("langwatch.output", v))
+			}
+		}
 		span.SetStatus(codes.Ok, "")
 	}
 	if ns != nil && ns.DurationMS > 0 {
@@ -67,4 +102,17 @@ func endNodeSpan(span trace.Span, ns *NodeState, derr *NodeError) {
 		span.SetAttributes(attribute.Float64("langwatch.cost", ns.Cost))
 	}
 	span.End()
+}
+
+// encodeJSONAttr marshals v to JSON. Returns ok=false on marshal
+// error so the caller skips the attribute. No truncation: agent
+// outputs are sometimes large and operators want the full content;
+// downstream limits (OTLP exporter body size, ClickHouse storage)
+// are the right place to enforce caps if needed, not here.
+func encodeJSONAttr(v any) (string, bool) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
 }

--- a/services/nlpgo/app/engine/tracing.go
+++ b/services/nlpgo/app/engine/tracing.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/langwatch/langwatch/services/nlpgo/app"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
 )
 
@@ -34,6 +35,11 @@ const (
 	// dispatches" by span name across the Python and Go engines.
 	componentSpanName = "execute_component"
 	componentSpanType = "component"
+
+	// llmSpanType matches the python-sdk reserved value Studio's Trace
+	// Details drawer groups by — see langwatch.span.type=="llm" filtering
+	// in the trace renderer.
+	llmSpanType = "llm"
 )
 
 // startNodeSpan opens a span for one node's dispatch. Span name is
@@ -115,4 +121,85 @@ func encodeJSONAttr(v any) (string, bool) {
 		return "", false
 	}
 	return string(b), true
+}
+
+// startLLMSpan opens a child span for one LLM call, parented at the current
+// component span. Mirrors the Python langwatch_nlp shape — DSPy's adapter
+// emits a `LLM <provider/model>` span with reserved `langwatch.span.type=llm`
+// + standard `gen_ai.*` attrs so Studio's Trace Details drawer renders an
+// LLM row with model name, token counts, and provider.
+//
+// The span is opened BEFORE the gateway call so its duration covers the full
+// network round-trip (including gateway overhead, not just the upstream
+// provider latency). Closed by endLLMSpan, which stamps the response usage
+// + output JSON.
+func startLLMSpan(ctx context.Context, model, provider string, messages []app.ChatMessage) (context.Context, trace.Span) {
+	tracer := otelapi.Tracer(tracerName)
+	displayModel := model
+	if provider != "" && model != "" {
+		displayModel = provider + "/" + model
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("langwatch.span.type", llmSpanType),
+	}
+	if provider != "" {
+		attrs = append(attrs, attribute.String("gen_ai.system", provider))
+	}
+	if model != "" {
+		attrs = append(attrs, attribute.String("gen_ai.request.model", model))
+	}
+	if v, ok := encodeJSONAttr(messages); ok {
+		attrs = append(attrs, attribute.String("langwatch.input", v))
+	}
+	return tracer.Start(ctx, displayModel,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+// endLLMSpan stamps the LLM response shape onto the span and closes it.
+// Sets `gen_ai.response.model`, `gen_ai.usage.{input,output}_tokens`,
+// `langwatch.cost`, and `langwatch.output` (JSON-encoded response message
+// for output_source=explicit rendering in the Studio drawer).
+func endLLMSpan(span trace.Span, resp *app.LLMResponse, callErr error) {
+	if callErr != nil {
+		span.SetStatus(codes.Error, callErr.Error())
+		span.SetAttributes(
+			attribute.String("error.message", callErr.Error()),
+		)
+		span.End()
+		return
+	}
+	if resp == nil {
+		span.SetStatus(codes.Ok, "")
+		span.End()
+		return
+	}
+	if resp.Usage.PromptTokens > 0 {
+		span.SetAttributes(attribute.Int("gen_ai.usage.input_tokens", resp.Usage.PromptTokens))
+	}
+	if resp.Usage.CompletionTokens > 0 {
+		span.SetAttributes(attribute.Int("gen_ai.usage.output_tokens", resp.Usage.CompletionTokens))
+	}
+	if resp.Usage.ReasoningTokens > 0 {
+		span.SetAttributes(attribute.Int("gen_ai.usage.reasoning_tokens", resp.Usage.ReasoningTokens))
+	}
+	if resp.Cost > 0 {
+		span.SetAttributes(attribute.Float64("langwatch.cost", resp.Cost))
+	}
+	if resp.DurationMS > 0 {
+		span.SetAttributes(attribute.Int64("langwatch.duration_ms", resp.DurationMS))
+	}
+	// Output: the assistant's reply (matches Python where the LLM span's
+	// langwatch.output is the assistant message JSON, not the full HTTP
+	// body).
+	output := app.ChatMessage{Role: "assistant", Content: resp.Content}
+	if resp.Content == "" && len(resp.Messages) > 0 {
+		output = resp.Messages[len(resp.Messages)-1]
+	}
+	if v, ok := encodeJSONAttr(output); ok {
+		span.SetAttributes(attribute.String("langwatch.output", v))
+	}
+	span.SetStatus(codes.Ok, "")
+	span.End()
 }

--- a/services/nlpgo/app/engine/tracing_e2e_test.go
+++ b/services/nlpgo/app/engine/tracing_e2e_test.go
@@ -1,0 +1,136 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// TestEngineExecute_EmitsExecuteComponentSpansWithJSONIO is the
+// end-to-end proof that Engine.Execute (not just the helpers) produces
+// the Python-parity span shape Studio's Trace Details drawer renders.
+// Pre-fix shipped on 2026-04-28 had a single empty `nlpgo.node.end`
+// span and `output_source: inferred`; this test asserts the fix.
+//
+// Workflow: entry → end. Both nodes get an execute_component span;
+// each span carries langwatch.input + langwatch.output as JSON
+// strings so Studio shows the actual values instead of falling back
+// to inferred output.
+func TestEngineExecute_EmitsExecuteComponentSpansWithJSONIO(t *testing.T) {
+	rec := withRecorder(t)
+
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "tracing_parity_e2e",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "end", TargetHandle: "inputs.output"},
+		},
+	}
+
+	res, err := eng.Execute(context.Background(), ExecuteRequest{
+		Workflow:  wf,
+		Inputs:    map[string]any{"input": "hello"},
+		Origin:    "workflow",
+		ProjectID: "proj_e2e",
+		TraceID:   "trace_e2e",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "success", res.Status)
+
+	spans := rec.Ended()
+	require.NotEmpty(t, spans, "engine must emit at least one span")
+
+	byNodeID := map[string]map[string]any{}
+	for _, s := range spans {
+		require.Equal(t, "execute_component", s.Name(),
+			"all engine-emitted spans must share the Python-parity name 'execute_component'")
+		attrs := attrMap(s.Attributes())
+		require.Equal(t, "component", attrs["langwatch.span.type"],
+			"span.type must be 'component' to match Python's optional_langwatch_trace(type='component')")
+		require.Equal(t, "proj_e2e", attrs["langwatch.project_id"])
+		require.Equal(t, "trace_e2e", attrs["langwatch.trace_id"])
+		require.Equal(t, "workflow", attrs["langwatch.origin"])
+		nodeID, _ := attrs["langwatch.node_id"].(string)
+		byNodeID[nodeID] = attrs
+	}
+
+	endAttrs, ok := byNodeID["end"]
+	require.True(t, ok, "end node must have its own execute_component span")
+	// langwatch.input on the end node is the resolved input map (the
+	// upstream entry's output flowing through the edge). Studio uses
+	// this exact attribute to render the "INPUT" panel of the trace
+	// drawer; without it, output_source falls back to "inferred" and
+	// the panel goes blank — the regression rchaves caught.
+	inJSON, ok := endAttrs["langwatch.input"].(string)
+	require.True(t, ok, "end node span must stamp langwatch.input")
+	var in map[string]any
+	require.NoError(t, json.Unmarshal([]byte(inJSON), &in))
+	assert.Equal(t, "hello", in["output"], "end node received entry's output via edge")
+
+	// langwatch.output on the end node is the same map (end is a
+	// passthrough). Studio renders this in the "OUTPUT" panel.
+	outJSON, ok := endAttrs["langwatch.output"].(string)
+	require.True(t, ok, "end node span must stamp langwatch.output")
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(outJSON), &out))
+	assert.Equal(t, "hello", out["output"])
+}
+
+// TestEngineExecute_ErrorPathStampsInputNotOutput pins the contract
+// in tracing-parity.feature for the error path: when a node fails,
+// the span captures what it received (debugging) but not a fake
+// output (would mislead the operator into thinking the value was
+// returned successfully).
+func TestEngineExecute_ErrorPathStampsInputNotOutput(t *testing.T) {
+	rec := withRecorder(t)
+
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "tracing_parity_error",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			// A code node with no Code executor wired triggers the
+			// "code executor not configured" branch in dispatch — a
+			// deterministic failure path that doesn't need Python.
+			{ID: "code-1", Type: dsl.ComponentCode},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "code-1", TargetHandle: "inputs.input"},
+		},
+	}
+
+	res, err := eng.Execute(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"input": "boom"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "error", res.Status)
+
+	spans := rec.Ended()
+	require.NotEmpty(t, spans)
+
+	var failed map[string]any
+	for _, s := range spans {
+		attrs := attrMap(s.Attributes())
+		if attrs["langwatch.node_id"] == "code-1" {
+			failed = attrs
+			break
+		}
+	}
+	require.NotNil(t, failed, "code-1 node must have a span")
+	assert.Contains(t, failed, "langwatch.input",
+		"failed node still stamps input — operator needs to see what went in")
+	assert.NotContains(t, failed, "langwatch.output",
+		"failed node must NOT stamp output (would be misleading)")
+	assert.Contains(t, failed, "error.type")
+	assert.Contains(t, failed, "error.message")
+}

--- a/services/nlpgo/app/engine/tracing_test.go
+++ b/services/nlpgo/app/engine/tracing_test.go
@@ -32,11 +32,13 @@ func withRecorder(t *testing.T) *tracetest.SpanRecorder {
 	return rec
 }
 
-// TestStartNodeSpan_NameAndAttributes pins the span shape downstream
-// trace explorers depend on: the name slug encodes the node type so
-// filtering by "all code-block runs" works, and the langwatch.* attrs
-// give per-tenant + per-trace correlation without any join.
-func TestStartNodeSpan_NameAndAttributes(t *testing.T) {
+// TestStartNodeSpan_NameMatchesPythonExecuteComponent pins the span
+// name to "execute_component" — the same name Python's
+// optional_langwatch_trace uses in execute_component.py. Operators
+// filter "all component dispatches" by this exact name across both
+// engines; renaming it would silently break Studio's component-time
+// roll-up.
+func TestStartNodeSpan_NameMatchesPythonExecuteComponent(t *testing.T) {
 	rec := withRecorder(t)
 
 	node := &dsl.Node{ID: "code-1", Type: dsl.ComponentCode}
@@ -47,13 +49,19 @@ func TestStartNodeSpan_NameAndAttributes(t *testing.T) {
 		Origin:    "workflow",
 	}
 	_, span := startNodeSpan(context.Background(), node, req)
-	endNodeSpan(span, &NodeState{DurationMS: 42, Cost: 0.001}, nil)
+	endNodeSpan(span, &NodeState{
+		Inputs:     map[string]any{"a": 1, "b": 2},
+		Outputs:    map[string]any{"sum": 3},
+		DurationMS: 42,
+		Cost:       0.001,
+	}, nil)
 
 	spans := rec.Ended()
 	require.Len(t, spans, 1)
 	got := spans[0]
-	assert.Equal(t, "nlpgo.node.code", got.Name())
+	assert.Equal(t, "execute_component", got.Name())
 	attrs := attrMap(got.Attributes())
+	assert.Equal(t, "component", attrs["langwatch.span.type"])
 	assert.Equal(t, "code-1", attrs["langwatch.node_id"])
 	assert.Equal(t, "code", attrs["langwatch.node_type"])
 	assert.Equal(t, "proj_abc", attrs["langwatch.project_id"])
@@ -65,17 +73,44 @@ func TestStartNodeSpan_NameAndAttributes(t *testing.T) {
 	assert.Equal(t, codes.Ok, got.Status().Code)
 }
 
+// TestEndNodeSpan_StampsLangwatchInputAndOutput is the M2 contract:
+// langwatch.input / langwatch.output are JSON strings of the actual
+// inputs/outputs map. Without these, Studio's Trace Details drawer
+// reports output_source = "inferred" and falls back to scraping the
+// response body — which on the new nlpgo path produces a near-empty
+// blob (the prod regression rchaves caught on 2026-04-28).
+func TestEndNodeSpan_StampsLangwatchInputAndOutput(t *testing.T) {
+	rec := withRecorder(t)
+
+	node := &dsl.Node{ID: "code-1", Type: dsl.ComponentCode}
+	_, span := startNodeSpan(context.Background(), node, ExecuteRequest{})
+	endNodeSpan(span, &NodeState{
+		Inputs:  map[string]any{"input": "hi1"},
+		Outputs: map[string]any{"output": "Hello world! hi1"},
+	}, nil)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+	attrs := attrMap(spans[0].Attributes())
+	assert.JSONEq(t, `{"input":"hi1"}`, attrs["langwatch.input"].(string))
+	assert.JSONEq(t, `{"output":"Hello world! hi1"}`, attrs["langwatch.output"].(string))
+}
+
 // TestEndNodeSpan_RecordsErrorOnDispatchFailure: when dispatch returns
 // a NodeError, the span carries error.type / error.message and a
-// codes.Error status so trace-search by failure class works.
+// codes.Error status so trace-search by failure class works. The
+// langwatch.input attribute is still stamped (debugging the failure
+// needs to know what went in); langwatch.output is intentionally
+// omitted because it would be misleading.
 func TestEndNodeSpan_RecordsErrorOnDispatchFailure(t *testing.T) {
 	rec := withRecorder(t)
 
 	node := &dsl.Node{ID: "code-1", Type: dsl.ComponentCode}
 	_, span := startNodeSpan(context.Background(), node, ExecuteRequest{})
-	endNodeSpan(span, &NodeState{DurationMS: 5},
-		&NodeError{Type: "code_runner_error", Message: "boom"},
-	)
+	endNodeSpan(span, &NodeState{
+		Inputs:     map[string]any{"input": "boom"},
+		DurationMS: 5,
+	}, &NodeError{Type: "code_runner_error", Message: "boom"})
 
 	spans := rec.Ended()
 	require.Len(t, spans, 1)
@@ -85,6 +120,8 @@ func TestEndNodeSpan_RecordsErrorOnDispatchFailure(t *testing.T) {
 	attrs := attrMap(got.Attributes())
 	assert.Equal(t, "code_runner_error", attrs["error.type"])
 	assert.Equal(t, "boom", attrs["error.message"])
+	assert.JSONEq(t, `{"input":"boom"}`, attrs["langwatch.input"].(string))
+	assert.NotContains(t, attrs, "langwatch.output")
 }
 
 // TestStartNodeSpan_NoOptionalAttrsWhenAbsent keeps the spans tight —
@@ -101,6 +138,7 @@ func TestStartNodeSpan_NoOptionalAttrsWhenAbsent(t *testing.T) {
 	spans := rec.Ended()
 	require.Len(t, spans, 1)
 	attrs := attrMap(spans[0].Attributes())
+	assert.Contains(t, attrs, "langwatch.span.type")
 	assert.Contains(t, attrs, "langwatch.node_id")
 	assert.Contains(t, attrs, "langwatch.node_type")
 	assert.NotContains(t, attrs, "langwatch.project_id")
@@ -109,6 +147,44 @@ func TestStartNodeSpan_NoOptionalAttrsWhenAbsent(t *testing.T) {
 	assert.NotContains(t, attrs, "langwatch.origin")
 	assert.NotContains(t, attrs, "langwatch.duration_ms")
 	assert.NotContains(t, attrs, "langwatch.cost")
+	assert.NotContains(t, attrs, "langwatch.input")
+	assert.NotContains(t, attrs, "langwatch.output")
+}
+
+// TestEndNodeSpan_PreservesFullJSON_NoTruncation pins the no-truncation
+// contract: agent outputs can be huge (full document corpora, multi-MB
+// JSON dumps) and operators want the full content in Studio. Python
+// SDK default truncated at 5000 chars/string; we deliberately do not
+// truncate so big agent outputs survive end-to-end. Downstream limits
+// (OTLP exporter body size, ClickHouse storage) cap if needed; not our
+// concern at the helper layer.
+func TestEndNodeSpan_PreservesFullJSON_NoTruncation(t *testing.T) {
+	rec := withRecorder(t)
+
+	const huge = 200 * 1024 // 200 KB string — would be truncated under any reasonable cap
+	bigStr := make([]byte, huge)
+	for i := range bigStr {
+		bigStr[i] = 'x'
+	}
+	node := &dsl.Node{ID: "n", Type: dsl.ComponentCode}
+	_, span := startNodeSpan(context.Background(), node, ExecuteRequest{})
+	endNodeSpan(span, &NodeState{
+		Inputs:  map[string]any{"big": string(bigStr)},
+		Outputs: map[string]any{"big": string(bigStr)},
+	}, nil)
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+	attrs := attrMap(spans[0].Attributes())
+	in := attrs["langwatch.input"].(string)
+	out := attrs["langwatch.output"].(string)
+	assert.NotContains(t, in, "truncated")
+	assert.NotContains(t, out, "truncated")
+	// Round-trips through json.Marshal so the value is wrapped in a
+	// {"big":"xxxx...xxxx"} object — the JSON serialization of a 200KB
+	// string is ~200KB + ~10 bytes overhead.
+	assert.Greater(t, len(in), huge, "full input must be preserved, no truncation")
+	assert.Greater(t, len(out), huge, "full output must be preserved, no truncation")
 }
 
 func attrMap(kvs []attribute.KeyValue) map[string]any {

--- a/services/nlpgo/cmd/engine_adapter.go
+++ b/services/nlpgo/cmd/engine_adapter.go
@@ -52,6 +52,8 @@ func (a engineAdapter) ExecuteStream(ctx context.Context, req app.WorkflowReques
 		ProjectID: req.ProjectID,
 		ThreadID:  req.ThreadID,
 		NodeID:    req.NodeID,
+		Type:      req.Type,
+		RunID:     req.RunID,
 	}, engine.ExecuteStreamOptions{Heartbeat: opts.Heartbeat})
 	if err != nil {
 		ch := make(chan app.WorkflowStreamEvent, 1)
@@ -94,6 +96,8 @@ func (a engineAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (*a
 		ProjectID: req.ProjectID,
 		ThreadID:  req.ThreadID,
 		NodeID:    req.NodeID,
+		Type:      req.Type,
+		RunID:     req.RunID,
 	})
 	if err != nil {
 		return &app.WorkflowResult{

--- a/services/nlpgo/cmd/engine_adapter.go
+++ b/services/nlpgo/cmd/engine_adapter.go
@@ -45,15 +45,18 @@ func (a engineAdapter) ExecuteStream(ctx context.Context, req app.WorkflowReques
 	}
 	ctx = withWorkflowAPIKey(ctx, wf)
 	in, err := a.eng.ExecuteStream(ctx, engine.ExecuteRequest{
-		Workflow:  wf,
-		Inputs:    req.Inputs,
-		Origin:    req.Origin,
-		TraceID:   req.TraceID,
-		ProjectID: req.ProjectID,
-		ThreadID:  req.ThreadID,
-		NodeID:    req.NodeID,
-		Type:      req.Type,
-		RunID:     req.RunID,
+		Workflow:          wf,
+		Inputs:            req.Inputs,
+		Origin:            req.Origin,
+		TraceID:           req.TraceID,
+		ProjectID:         req.ProjectID,
+		ThreadID:          req.ThreadID,
+		NodeID:            req.NodeID,
+		Type:              req.Type,
+		RunID:             req.RunID,
+		WorkflowVersionID: req.WorkflowVersionID,
+		EvaluateOn:        req.EvaluateOn,
+		DatasetEntry:      req.DatasetEntry,
 	}, engine.ExecuteStreamOptions{Heartbeat: opts.Heartbeat})
 	if err != nil {
 		ch := make(chan app.WorkflowStreamEvent, 1)
@@ -89,15 +92,18 @@ func (a engineAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (*a
 	}
 	ctx = withWorkflowAPIKey(ctx, wf)
 	res, err := a.eng.Execute(ctx, engine.ExecuteRequest{
-		Workflow:  wf,
-		Inputs:    req.Inputs,
-		Origin:    req.Origin,
-		TraceID:   req.TraceID,
-		ProjectID: req.ProjectID,
-		ThreadID:  req.ThreadID,
-		NodeID:    req.NodeID,
-		Type:      req.Type,
-		RunID:     req.RunID,
+		Workflow:          wf,
+		Inputs:            req.Inputs,
+		Origin:            req.Origin,
+		TraceID:           req.TraceID,
+		ProjectID:         req.ProjectID,
+		ThreadID:          req.ThreadID,
+		NodeID:            req.NodeID,
+		Type:              req.Type,
+		RunID:             req.RunID,
+		WorkflowVersionID: req.WorkflowVersionID,
+		EvaluateOn:        req.EvaluateOn,
+		DatasetEntry:      req.DatasetEntry,
 	})
 	if err != nil {
 		return &app.WorkflowResult{

--- a/services/nlpgo/cmd/root.go
+++ b/services/nlpgo/cmd/root.go
@@ -4,6 +4,8 @@ package cmd
 import (
 	"context"
 	"net/http"
+	"os"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -70,7 +72,7 @@ func Root(ctx context.Context, _ []string) error {
 	playground := httpapi.NewPlaygroundProxyFromShim(playgroundDispatcherShim{disp: disp})
 
 	// Evaluator + agent-workflow blocks call the LangWatch app's own
-	// HTTP API. Both share the same LangWatchBaseURL (NLPGO_ENGINE_LANGWATCH_BASE_URL).
+	// HTTP API. Both share the same LangWatchBaseURL.
 	// Per-block timeouts default to 12min (Lambda max 15min minus 3min margin).
 	evalExec := evaluatorblock.New(evaluatorblock.Options{})
 	agentWfRunner := agentblock.NewWorkflowRunner(agentblock.WorkflowRunnerOptions{})
@@ -81,7 +83,7 @@ func Root(ctx context.Context, _ []string) error {
 		LLM:              llm,
 		Evaluator:        evalExec,
 		AgentWorkflow:    agentWfRunner,
-		LangWatchBaseURL: cfg.Engine.LangWatchBaseURL,
+		LangWatchBaseURL: resolveLangWatchBaseURL(cfg.Engine.LangWatchBaseURL, os.Getenv),
 	})
 	executor := engineAdapter{eng: eng}
 
@@ -93,6 +95,26 @@ func Root(ctx context.Context, _ []string) error {
 	)
 
 	return nlpgo.Serve(ctx, application, deps, cfg, playground)
+}
+
+// resolveLangWatchBaseURL returns the base URL the evaluator and
+// agent-workflow blocks use to call back into the LangWatch app. The
+// explicit `NLPGO_ENGINE_LANGWATCH_BASE_URL` setting wins so dev /
+// docker-compose can point evaluator callbacks at
+// host.docker.internal:5560 without touching the universal endpoint;
+// otherwise fall back to `LANGWATCH_ENDPOINT` — the same env var
+// configureNLPGoOTel reads in deps.go and the env terraform pins on
+// every Lambda. Pre-fix the evaluator path required the explicit var
+// only and prod set just LANGWATCH_ENDPOINT, so every evaluator
+// dispatch errored with "LangWatchBaseURL is required to call the
+// evaluator API" (rchaves callout 2026-04-29).
+//
+// `getenv` is injected so tests don't need to mutate process env.
+func resolveLangWatchBaseURL(explicit string, getenv func(string) string) string {
+	if explicit != "" {
+		return explicit
+	}
+	return strings.TrimRight(getenv("LANGWATCH_ENDPOINT"), "/")
 }
 
 // splitCSV splits "a,b,c" into ["a","b","c"], trimming whitespace and

--- a/services/nlpgo/cmd/root_test.go
+++ b/services/nlpgo/cmd/root_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import "testing"
+
+// TestResolveLangWatchBaseURL_FallsBackToLangwatchEndpoint pins the
+// fix for the prod regression on 2026-04-29: every evaluator dispatch
+// errored with "LangWatchBaseURL is required to call the evaluator
+// API" because prod set only `LANGWATCH_ENDPOINT` (the universal
+// LangWatch URL env var that terraform pins on every Lambda) and the
+// resolver previously only looked at `NLPGO_ENGINE_LANGWATCH_BASE_URL`.
+//
+// Mirrors the same fallback pattern in services/nlpgo/deps.go's
+// configureNLPGoOTel, so a single env var is the canonical source of
+// truth for "where the LangWatch app lives" across both OTel export
+// and evaluator callbacks.
+func TestResolveLangWatchBaseURL_FallsBackToLangwatchEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		explicit string
+		env      map[string]string
+		want     string
+	}{
+		{
+			name:     "explicit wins over env",
+			explicit: "https://app.langwatch.ai",
+			env:      map[string]string{"LANGWATCH_ENDPOINT": "https://other.example.com"},
+			want:     "https://app.langwatch.ai",
+		},
+		{
+			name:     "env fallback when explicit is empty",
+			explicit: "",
+			env:      map[string]string{"LANGWATCH_ENDPOINT": "https://app.langwatch.ai"},
+			want:     "https://app.langwatch.ai",
+		},
+		{
+			name:     "trailing slash in env is trimmed",
+			explicit: "",
+			env:      map[string]string{"LANGWATCH_ENDPOINT": "https://app.langwatch.ai/"},
+			want:     "https://app.langwatch.ai",
+		},
+		{
+			name:     "neither set returns empty (callers handle the typed evaluator_unconfigured error downstream)",
+			explicit: "",
+			env:      map[string]string{},
+			want:     "",
+		},
+		{
+			name:     "explicit is preserved as-is, no slash trimming (caller decides)",
+			explicit: "http://host.docker.internal:5560/",
+			env:      map[string]string{},
+			want:     "http://host.docker.internal:5560/",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			getenv := func(k string) string { return tc.env[k] }
+			got := resolveLangWatchBaseURL(tc.explicit, getenv)
+			if got != tc.want {
+				t.Errorf("resolveLangWatchBaseURL(%q, env=%v) = %q; want %q",
+					tc.explicit, tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/services/nlpgo/tests/integration/evaluation_workflow_test.go
+++ b/services/nlpgo/tests/integration/evaluation_workflow_test.go
@@ -1,0 +1,288 @@
+// Integration test for execute_evaluation: drives the SSE endpoint
+// with a multi-row dataset, asserts the per-entry evaluation_state_change
+// progress events land on the wire, AND asserts a final batch POST
+// hits /api/evaluations/batch/log_results carrying the dataset rows +
+// evaluator results that Studio's experiment-runs page renders from.
+//
+// rchaves dogfood 2026-04-29 (workflow_qtBZcCf4ch5xfxBm-NIZL): the
+// "Evaluate" button kicked an SSE flow that returned cleanly but the
+// experiment-runs page never populated. This test pins the missing
+// piece — without the batch POST, the UI stays at "Waiting for
+// evaluation results" forever.
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/pkg/health"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/httpapi"
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/agentblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/codeblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/evaluatorblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
+)
+
+// recordedRequest captures one inbound HTTP call against the fake
+// LangWatch app. We assert specifically on /api/evaluations/batch/
+// log_results — that's the call missing pre-fix.
+type recordedRequest struct {
+	path    string
+	method  string
+	headers http.Header
+	body    map[string]any
+}
+
+func setupEvaluationStack(t *testing.T) (string, *[]recordedRequest, *sync.Mutex) {
+	t.Helper()
+	mu := &sync.Mutex{}
+	var captured []recordedRequest
+
+	lwSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(bodyBytes, &parsed)
+		mu.Lock()
+		captured = append(captured, recordedRequest{
+			path:    r.URL.Path,
+			method:  r.Method,
+			headers: r.Header.Clone(),
+			body:    parsed,
+		})
+		mu.Unlock()
+		// Mirror the legacy evaluator endpoint shape — both
+		// /api/evaluations/.../evaluate and /api/evaluations/batch/
+		// log_results return 200 with a JSON body.
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/evaluate"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":  "processed",
+				"score":   1.0,
+				"passed":  true,
+				"details": "ok",
+			})
+		case r.URL.Path == "/api/evaluations/batch/log_results":
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "ok"})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+		}
+	}))
+	t.Cleanup(lwSrv.Close)
+
+	httpExec := httpblock.New(httpblock.Options{})
+	codeExec, err := codeblock.New(codeblock.Options{})
+	require.NoError(t, err)
+	evalExec := evaluatorblock.New(evaluatorblock.Options{})
+	agentRunner := agentblock.NewWorkflowRunner(agentblock.WorkflowRunnerOptions{})
+
+	eng := engine.New(engine.Options{
+		HTTP:             httpExec,
+		Code:             codeExec,
+		Evaluator:        evalExec,
+		AgentWorkflow:    agentRunner,
+		LangWatchBaseURL: lwSrv.URL,
+	})
+
+	application := app.New(app.WithWorkflowExecutor(executorAdapter{eng: eng}))
+	probes := health.New("test")
+	probes.MarkStarted()
+	router := httpapi.NewRouter(httpapi.RouterDeps{
+		App:     application,
+		Health:  probes,
+		Version: "test",
+	})
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv.URL, &captured, mu
+}
+
+// TestEvaluationWorkflow_PostsBatchResultsToLangWatch is the load-bearing
+// test for bug E. Builds a 2-row evaluation workflow (entry → evaluator
+// → end), kicks an execute_evaluation SSE run, and asserts:
+//  1. The wire emits per-entry evaluation_state_change progress events
+//     so Studio's evaluation reducer can flip the running spinner.
+//  2. A POST lands on /api/evaluations/batch/log_results with the run_id,
+//     experiment_slug, all dataset rows, all evaluator results, and a
+//     finished_at timestamp — the wire shape Studio's experiment-runs
+//     page renders from.
+//
+// Pre-fix: the SSE frames landed cleanly but the batch POST never
+// happened, so the experiment-runs page stayed empty even after a
+// successful eval.
+func TestEvaluationWorkflow_PostsBatchResultsToLangWatch(t *testing.T) {
+	url, captured, mu := setupEvaluationStack(t)
+
+	envelope := `{
+	  "type": "execute_evaluation",
+	  "payload": {
+	    "trace_id": "trace_eval_1",
+	    "run_id": "run_eval_1",
+	    "workflow_version_id": "wfv_1",
+	    "evaluate_on": "full",
+	    "origin": "evaluation",
+	    "workflow": {
+	      "workflow_id": "wf_eval",
+	      "api_key": "sk-token",
+	      "spec_version": "1.3",
+	      "name": "Eval Demo",
+	      "icon": "x",
+	      "description": "x",
+	      "version": "x",
+	      "template_adapter": "default",
+	      "nodes": [
+	        {"id":"entry","type":"entry","data":{
+	          "outputs":[
+	            {"identifier":"input","type":"str"},
+	            {"identifier":"output","type":"str"}
+	          ],
+	          "dataset":{"inline":{"records":{"input":["hello","world"],"output":["hello","world"]}}},
+	          "train_size":1.0,"test_size":0.0,"seed":1
+	        }},
+	        {"id":"eval","type":"evaluator","data":{
+	          "evaluator":"langevals/exact_match"
+	        }},
+	        {"id":"end","type":"end","data":{}}
+	      ],
+	      "edges": [
+	        {"id":"e1","source":"entry","sourceHandle":"outputs.input","target":"eval","targetHandle":"inputs.input","type":"default"},
+	        {"id":"e2","source":"entry","sourceHandle":"outputs.output","target":"eval","targetHandle":"inputs.output","type":"default"},
+	        {"id":"e3","source":"eval","sourceHandle":"any","target":"end","targetHandle":"any","type":"default"}
+	      ],
+	      "state": {}
+	    }
+	  }
+	}`
+
+	req, err := http.NewRequest("POST", url+"/go/studio/execute", bytes.NewBufferString(envelope))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-LangWatch-Origin", "evaluation")
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, resp.Header.Get("Content-Type"), "text/event-stream")
+
+	frames := readSSE(t, resp.Body, func(f streamFrame) bool { return f.Event == "done" })
+
+	// Wire-shape check: at least the running event, two progress events
+	// (one per dataset row), and a final success event must reach the
+	// reducer. Studio's reducer keys evaluations on workflow.state.
+	// evaluation.run_id — the run_id stamped on these payloads is what
+	// connects the streamed updates to the run dispatched by Studio.
+	progressByStatus := map[string]int{}
+	var sawSuccess bool
+	for _, f := range frames {
+		if f.Event != "evaluation_state_change" {
+			continue
+		}
+		es, _ := f.Data["evaluation_state"].(map[string]any)
+		status, _ := es["status"].(string)
+		progressByStatus[status]++
+		assert.Equal(t, "run_eval_1", es["run_id"], "evaluation_state_change must carry the run_id")
+		if status == "success" {
+			sawSuccess = true
+		}
+	}
+	assert.GreaterOrEqual(t, progressByStatus["running"], 2,
+		"must emit at least one running event per dataset entry (got %d)", progressByStatus["running"])
+	assert.True(t, sawSuccess, "must emit a final evaluation_state_change with status=success")
+
+	// The load-bearing assertion: a final batch landed on
+	// /api/evaluations/batch/log_results carrying the wire shape Studio
+	// expects.
+	mu.Lock()
+	defer mu.Unlock()
+	var finalBatch *recordedRequest
+	for i := range *captured {
+		req := (*captured)[i]
+		if req.path == "/api/evaluations/batch/log_results" && req.body["timestamps"] != nil {
+			ts, _ := req.body["timestamps"].(map[string]any)
+			if _, ok := ts["finished_at"]; ok {
+				final := req
+				finalBatch = &final
+			}
+		}
+	}
+	require.NotNil(t, finalBatch, "expected a final batch POST with finished_at to /api/evaluations/batch/log_results — without this, the UI's experiment-runs page never populates")
+	assert.Equal(t, "sk-token", finalBatch.headers.Get("X-Auth-Token"),
+		"workflow.api_key must travel as X-Auth-Token (matches the legacy Python posting style)")
+	assert.Equal(t, "run_eval_1", finalBatch.body["run_id"])
+	assert.Equal(t, "wfv_1", finalBatch.body["workflow_version_id"])
+	assert.Equal(t, "wf_eval", finalBatch.body["experiment_slug"], "no experiment_id → fall back to workflow_id slug (Python parity)")
+	dataset := finalBatch.body["dataset"].([]any)
+	assert.Len(t, dataset, 2, "both dataset rows must be in the final batch")
+	evals := finalBatch.body["evaluations"].([]any)
+	assert.Len(t, evals, 2, "one evaluator result per dataset row must be in the final batch")
+	for _, raw := range evals {
+		ev := raw.(map[string]any)
+		assert.Equal(t, "eval", ev["evaluator"], "evaluator field must be the node id")
+		assert.Equal(t, "processed", ev["status"])
+	}
+}
+
+// TestEvaluationWorkflow_RejectsRemoteDataset pins the explicit error
+// when the workflow's entry node references an API-hosted dataset
+// (not the inline one). Until we port langwatch.dataset.get_dataset
+// to Go, the SSE handler must surface a clear error rather than
+// running an empty evaluation that silently posts no results.
+func TestEvaluationWorkflow_RejectsRemoteDataset(t *testing.T) {
+	url, _, _ := setupEvaluationStack(t)
+
+	envelope := `{
+	  "type": "execute_evaluation",
+	  "payload": {
+	    "trace_id": "trace_remote",
+	    "run_id": "run_remote",
+	    "workflow_version_id": "v1",
+	    "evaluate_on": "full",
+	    "workflow": {
+	      "workflow_id": "wf_r","api_key":"k","spec_version":"1.3","name":"x","icon":"x","description":"x","version":"x","template_adapter":"default",
+	      "nodes":[
+	        {"id":"entry","type":"entry","data":{"dataset":{"id":"ds_remote"}}},
+	        {"id":"end","type":"end","data":{}}
+	      ],
+	      "edges":[{"id":"e1","source":"entry","sourceHandle":"x","target":"end","targetHandle":"x","type":"default"}],
+	      "state":{}
+	    }
+	  }
+	}`
+
+	req, err := http.NewRequest("POST", url+"/go/studio/execute", bytes.NewBufferString(envelope))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	frames := readSSE(t, resp.Body, func(f streamFrame) bool { return f.Event == "done" })
+
+	var sawError bool
+	for _, f := range frames {
+		if f.Event != "evaluation_state_change" {
+			continue
+		}
+		es, _ := f.Data["evaluation_state"].(map[string]any)
+		if es["status"] == "error" {
+			sawError = true
+			msg, _ := es["error"].(string)
+			assert.Contains(t, msg, "remote datasets",
+				"error must mention remote datasets so the user knows what's not yet supported")
+			break
+		}
+	}
+	assert.True(t, sawError, "remote-dataset evaluation must emit a structured evaluation_state_change error event")
+}

--- a/services/nlpgo/tests/integration/evaluator_workflow_test.go
+++ b/services/nlpgo/tests/integration/evaluator_workflow_test.go
@@ -242,6 +242,52 @@ func TestEvaluatorWorkflow_UpstreamErrorSurfacesAsNodeError(t *testing.T) {
 		"error message should reference the upstream 500 or its body, got %q", res.Error.Message)
 }
 
+// TestEvaluatorWorkflow_TypedEvaluatorFieldShape pins the canonical
+// Studio shape: the evaluator slug lives on `data.evaluator` (typed
+// field), NOT inside `data.parameters[]`. langwatch/src/optimization_
+// studio/types/dsl.ts:243 defines `evaluator?: EvaluatorTypes |
+// "custom/<id>" | "evaluators/<id>"`. Before the fix, runEvaluator
+// only read paramString(parameters, "evaluator") so any node persisted
+// in the canonical shape failed with `evaluator parameter is required`
+// even though the slug was present (rchaves dogfood 2026-04-29 on
+// workflow_qtBZcCf4ch5xfxBm-NIZL with ExactMatch evaluator).
+func TestEvaluatorWorkflow_TypedEvaluatorFieldShape(t *testing.T) {
+	url, _, requests := setupEvaluatorStack(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "processed", "score": 1.0, "passed": true,
+		})
+	})
+
+	body := `{
+	  "workflow": {
+	    "workflow_id":"wf","api_key":"sk-project-token","spec_version":"1.3","name":"x","icon":"x","description":"x","version":"x",
+	    "template_adapter":"default",
+	    "nodes":[
+	      {"id":"entry","type":"entry","data":{"train_size":1.0,"test_size":0.0,"seed":1,
+	        "outputs":[{"identifier":"input","type":"str"},{"identifier":"output","type":"str"}],
+	        "dataset":{"inline":{"records":{"input":["hello"],"output":["hello"]},"count":1}}}},
+	      {"id":"eval","type":"evaluator","data":{
+	        "evaluator":"langevals/exact_match"
+	      }},
+	      {"id":"end","type":"end","data":{}}
+	    ],
+	    "edges":[
+	      {"id":"e1","source":"entry","sourceHandle":"input","target":"eval","targetHandle":"input","type":"default"},
+	      {"id":"e2","source":"entry","sourceHandle":"output","target":"eval","targetHandle":"output","type":"default"},
+	      {"id":"e3","source":"eval","sourceHandle":"any","target":"end","targetHandle":"any","type":"default"}
+	    ],
+	    "state":{}
+	  }
+	}`
+	res := postSync(t, &stack{url: url}, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+	require.Len(t, *requests, 1, "exactly one upstream evaluator call expected")
+	rec := (*requests)[0]
+	assert.Equal(t, "/api/evaluations/langevals/exact_match/evaluate", rec["path"],
+		"slug from data.evaluator must drive the upstream URL path")
+}
+
 func TestEvaluatorWorkflow_MissingSlugReturnsTypedError(t *testing.T) {
 	url, _, requests := setupEvaluatorStack(t, func(w http.ResponseWriter, _ *http.Request) {
 		// upstream should never be hit when the slug is missing

--- a/services/nlpgo/tests/integration/sync_workflow_test.go
+++ b/services/nlpgo/tests/integration/sync_workflow_test.go
@@ -99,7 +99,18 @@ func (a executorAdapter) ExecuteStream(ctx context.Context, req app.WorkflowRequ
 		return ch, nil
 	}
 	in, err := a.eng.ExecuteStream(ctx, engine.ExecuteRequest{
-		Workflow: wf, Inputs: req.Inputs, Origin: req.Origin, TraceID: req.TraceID, ThreadID: req.ThreadID,
+		Workflow:          wf,
+		Inputs:            req.Inputs,
+		Origin:            req.Origin,
+		TraceID:           req.TraceID,
+		ProjectID:         req.ProjectID,
+		ThreadID:          req.ThreadID,
+		NodeID:            req.NodeID,
+		Type:              req.Type,
+		RunID:             req.RunID,
+		WorkflowVersionID: req.WorkflowVersionID,
+		EvaluateOn:        req.EvaluateOn,
+		DatasetEntry:      req.DatasetEntry,
 	}, engine.ExecuteStreamOptions{Heartbeat: opts.Heartbeat})
 	if err != nil {
 		ch := make(chan app.WorkflowStreamEvent, 1)
@@ -126,11 +137,18 @@ func (a executorAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (
 		}, nil
 	}
 	res, err := a.eng.Execute(ctx, engine.ExecuteRequest{
-		Workflow: wf,
-		Inputs:   req.Inputs,
-		Origin:   req.Origin,
-		TraceID:  req.TraceID,
-		ThreadID: req.ThreadID,
+		Workflow:          wf,
+		Inputs:            req.Inputs,
+		Origin:            req.Origin,
+		TraceID:           req.TraceID,
+		ProjectID:         req.ProjectID,
+		ThreadID:          req.ThreadID,
+		NodeID:            req.NodeID,
+		Type:              req.Type,
+		RunID:             req.RunID,
+		WorkflowVersionID: req.WorkflowVersionID,
+		EvaluateOn:        req.EvaluateOn,
+		DatasetEntry:      req.DatasetEntry,
 	})
 	if err != nil {
 		return &app.WorkflowResult{

--- a/specs/nlp-go/tracing-parity.feature
+++ b/specs/nlp-go/tracing-parity.feature
@@ -1,0 +1,193 @@
+Feature: Tracing parity with Python langwatch_nlp — Studio shows the same depth of input/output capture
+  Operators debugging a workflow on nlpgo should see the same span tree, the same INPUT/OUTPUT capture, and the same per-block fidelity that the Python langwatch_nlp engine produced. Without this, the Studio "Full Trace" drawer regresses from "I can see what each component received and returned" to "I see one empty span called nlpgo.node.end" — which is what shipped on 2026-04-28 and triggered the rchaves callout.
+
+  Reference: the Python target shape uses optional_langwatch_trace(name="execute_component", type="component") wrapping each component dispatch, plus dspy auto-instrumentation for the per-implementation child span (e.g. `Code.forward`, `Code.__call__`). See langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py and python-sdk/src/langwatch/attributes.py for the reserved attribute names.
+
+  Background:
+    Given nlpgo is configured to export OTel spans to a span recorder
+    And a langwatch.input attribute is JSON-encoded per python-sdk attributes.py
+    And a langwatch.output attribute is JSON-encoded per python-sdk attributes.py
+
+  Rule: Each component dispatch produces a span named "execute_component" matching Python
+
+    @integration @tracing-parity @M1
+    Scenario: code-block execute_component span has the same name and span.type as Python
+      Given a workflow with one code node returning {"output": "hi"}
+      When the engine dispatches the node
+      Then a span named "execute_component" is emitted
+      And the span has attribute "langwatch.span.type" = "component"
+      And the span has attribute "langwatch.node_id" = the node id
+      And the span has attribute "langwatch.node_type" = "code"
+      And the span has attribute "langwatch.origin" inherited from the request
+
+    @integration @tracing-parity @M1
+    Scenario: signature-block execute_component span has the same shape
+      Given a workflow with one signature node calling gpt-5-mini
+      When the engine dispatches the node
+      Then a span named "execute_component" is emitted
+      And the span has attribute "langwatch.span.type" = "component"
+      And the span has attribute "langwatch.node_type" = "signature"
+
+    @integration @tracing-parity @M1
+    Scenario: http-block execute_component span has the same shape
+      Given a workflow with one http node calling https://example.com
+      When the engine dispatches the node
+      Then a span named "execute_component" is emitted
+      And the span has attribute "langwatch.span.type" = "component"
+      And the span has attribute "langwatch.node_type" = "http"
+
+    @integration @tracing-parity @M1
+    Scenario: evaluator and agent_workflow nodes emit execute_component spans too
+      Given a workflow with an evaluator node and an agent_workflow node
+      When the engine dispatches both
+      Then both nodes emit a span named "execute_component"
+      And each span has attribute "langwatch.node_type" matching the dsl ComponentKind
+
+  Rule: INPUT and OUTPUT are captured as JSON strings on every span (output_source = "explicit")
+
+    @integration @tracing-parity @M2
+    Scenario: code block dispatch stamps langwatch.input and langwatch.output as JSON
+      Given a code node that takes {"a": 2, "b": 3} and returns {"sum": 5}
+      When the engine dispatches the node
+      Then the execute_component span has attribute "langwatch.input" set to the JSON string '{"a":2,"b":3}'
+      And the same span has attribute "langwatch.output" set to the JSON string '{"sum":5}'
+      And Studio renders these via the Trace Details drawer with output_source = "explicit" (not "inferred")
+
+    @integration @tracing-parity @M2
+    Scenario: signature block dispatch stamps langwatch.input and langwatch.output as JSON
+      Given a signature node that takes {"question": "..."} and returns {"answer": "..."}
+      When the engine dispatches the node
+      Then the execute_component span has langwatch.input and langwatch.output set as JSON-encoded maps
+
+    @integration @tracing-parity @M2
+    Scenario: huge agent outputs are preserved without truncation
+      Given a code node returning a 200KB output blob
+      When the engine dispatches the node
+      Then the execute_component span has langwatch.output set to the full 200KB JSON
+      And no truncation marker appears in the attribute value
+      # Python SDK default was 5000 chars/string; deliberate decision to
+      # not match that on the Go path. Operators want full agent output.
+
+    @integration @tracing-parity @M2
+    Scenario: error path still stamps langwatch.input but no langwatch.output
+      Given a code node that raises a runtime exception
+      When the engine dispatches the node
+      Then the execute_component span has langwatch.input set
+      And the span does NOT have langwatch.output set
+      And the span status is codes.Error with error.type and error.message
+
+  Rule: Per-implementation child span names match the Python entrypoint
+
+    @integration @tracing-parity @M3
+    Scenario: code block with class.__call__ entrypoint creates a child span "Code.__call__"
+      Given a code node defining "class Code: def __call__(self, input): ..."
+      When the engine dispatches the node
+      Then the execute_component span has a child span named "Code.__call__"
+      And the child span carries the same trace_id and is a direct descendant
+
+    @integration @tracing-parity @M3
+    Scenario: code block with class.forward entrypoint creates a child span "Code.forward"
+      Given a code node defining "class Code: def forward(self, input): ..."
+      When the engine dispatches the node
+      Then the execute_component span has a child span named "Code.forward"
+
+    @integration @tracing-parity @M3
+    Scenario: code block with dspy.Module subclass creates a child span via dspy auto-instrumentation
+      Given a code node defining "class Code(dspy.Module): def forward(self, input): ..."
+      When the engine dispatches the node
+      Then the execute_component span has a child span named "Code.forward"
+      And dspy.Module reference is stamped as an attribute (matches Python's "dspy.Module" output attr)
+
+    @integration @tracing-parity @M3
+    Scenario: signature node creates a child span "Signature.predict" and a grandchild "gateway.chat.completions"
+      Given a signature node calls openai/gpt-5-mini via the gateway
+      When the dispatch completes
+      Then the execute_component span has a child "Signature.predict"
+      And the Signature.predict span has a grandchild from the AI Gateway named "gateway.chat.completions"
+      And the gateway span carries gen_ai.system, gen_ai.request.model, gen_ai.usage.input_tokens, gen_ai.usage.output_tokens
+
+    @integration @tracing-parity @M3
+    Scenario: http block creates a child span "HTTP.fetch" with method + URL + status
+      Given an http node that POSTs to https://api.example.com
+      When the dispatch completes
+      Then the execute_component span has a child "HTTP.fetch"
+      And the child span carries http.request.method, url.full, http.response.status_code
+
+    @integration @tracing-parity @M3
+    Scenario: evaluator node creates a child span "Evaluator.run" with evaluator name
+      Given an evaluator node running "ragas/answer_relevancy"
+      When the dispatch completes
+      Then the execute_component span has a child "Evaluator.run"
+      And the child span carries langwatch.evaluator.name = "ragas/answer_relevancy"
+      And langwatch.evaluator.score is set to the numeric result
+
+    @integration @tracing-parity @M3
+    Scenario: agent_workflow node nests sub-workflow spans under its execute_component
+      Given an agent_workflow node referencing another workflow
+      When the dispatch completes
+      Then the outer execute_component span has children for each sub-workflow node's own execute_component span
+      And the trace_id is consistent across the whole tree
+
+  Rule: Whole-flow execute carries an outer "execute_flow" span wrapping every execute_component
+
+    @integration @tracing-parity @M4
+    Scenario: a multi-node flow run nests every component under one execute_flow span
+      Given a flow with nodes [entry → code → signature → end]
+      When /go/studio/execute_sync runs the whole flow
+      Then a span named "execute_flow" is the root
+      And each non-entry/non-end node has its own "execute_component" span as a child of "execute_flow"
+      And langwatch.input on execute_flow equals the request inputs
+      And langwatch.output on execute_flow equals the final node's outputs
+
+    @integration @tracing-parity @M4
+    Scenario: streaming /go/studio/execute (SSE) emits the same span shape as /execute_sync
+      Given the same flow as above
+      When /go/studio/execute streams events
+      Then the recorded span tree has the same root + children + attributes as the sync path
+      And SSE event component_state_change events do NOT add extra spans (events are not spans)
+
+  Rule: An evaluation-run wraps its many flow executions under a batch span
+
+    @integration @tracing-parity @M5
+    Scenario: an evaluation experiment running 100 dataset rows produces one batch span with 100 child execute_flow spans
+      Given an evaluation v3 experiment with 100 dataset rows
+      When the experiment runs to completion
+      Then a root span named "evaluation.batch_run" exists
+      And it has 100 child spans named "execute_flow"
+      And each child carries langwatch.evaluation.row_index 0..99
+      And aggregate metrics (total_cost, success_count, error_count) are stamped on the batch_run span
+
+  Rule: Origin attribution survives the new span shape
+
+    @integration @tracing-parity @M1
+    Scenario: every span in the tree inherits langwatch.origin from the inbound request
+      Given a workflow run with X-LangWatch-Origin: workflow
+      When the run completes
+      Then every span (root, execute_flow, execute_component, child impl spans, gateway spans) has attribute "langwatch.origin" = "workflow"
+
+  # ==========================================================================
+  # Test matrix authoritative list — these are the rows the Go-side integration
+  # tests must cover, one Test* per row, asserting span name + attrs + parent.
+  # ==========================================================================
+
+  Rule: Test matrix — every row below has a Go integration test asserting the span shape
+
+    @integration @tracing-parity @matrix
+    Scenario Outline: dispatch of <node_kind> with <entrypoint_shape> produces the expected span tree
+      Given a node of kind "<node_kind>" with entrypoint shape "<entrypoint_shape>"
+      When the engine dispatches it
+      Then the recorded span tree contains "<expected_outer_span>"
+      And it contains a child span "<expected_inner_span>"
+      And langwatch.input and langwatch.output are JSON-encoded on the outer span
+
+      Examples:
+        | node_kind       | entrypoint_shape          | expected_outer_span | expected_inner_span         |
+        | code            | class.__call__            | execute_component   | Code.__call__               |
+        | code            | class.forward             | execute_component   | Code.forward                |
+        | code            | dspy.Module subclass      | execute_component   | Code.forward                |
+        | code            | top-level execute()       | execute_component   | Code.execute                |
+        | signature       | gpt-5-mini via gateway    | execute_component   | Signature.predict           |
+        | http            | POST to api.example.com   | execute_component   | HTTP.fetch                  |
+        | evaluator       | ragas/answer_relevancy    | execute_component   | Evaluator.run               |
+        | agent_workflow  | sub-workflow ref          | execute_component   | (nested execute_component)  |
+        | topic_clustering| python child path         | (no execute_component, see telemetry.feature) | gateway call |


### PR DESCRIPTION
## Summary

Three trace-audit fixes from the rchaves callout 2026-04-29 (post-cold-start-fix prod is healthy, but the trace details drawer surfaced multiple regressions vs Python langwatch_nlp). All three ship together so reviewers see a single coherent trace-parity change.

### #1 — Span shape parity with Python (`execute_component` + JSON I/O)

The current nlpgo trace shape is dramatically degraded vs Python:

- Span name was `nlpgo.node.<type>` (e.g. `nlpgo.node.code`) instead of `execute_component` (the Python convention Studio's Trace Details drawer filters by).
- No `langwatch.input` / `langwatch.output` attrs, so the drawer fell back to `output_source = "inferred"` and rendered an empty/best-guess INPUT/OUTPUT panel even when the node executed successfully — including LLM/OpenAI nodes (rchaves clarified the gap is universal, not just code nodes).

Match Python's `optional_langwatch_trace` shape:

| field                  | value                                                  |
|------------------------|--------------------------------------------------------|
| name                   | `execute_component` (was `nlpgo.node.<type>`)          |
| `langwatch.span.type`  | `"component"`                                          |
| `langwatch.input`      | JSON-encoded inputs map (per python-sdk attributes.py) |
| `langwatch.output`     | JSON-encoded outputs map (omitted on error)            |
| `langwatch.node_type`  | (kept) `"code"` / `"signature"` / `"http"` / etc.      |
| `langwatch.node_id`    | (kept) the workflow node id                            |

Setting `langwatch.input` / `langwatch.output` flips Studio's `output_source` from `"inferred"` to `"explicit"` so the drawer renders the actual values instead of best-guess JSON from the response body.

The change lives in `endNodeSpan` (`services/nlpgo/app/engine/tracing.go`), which `runLayer` and `runLayerStream` call for EVERY dispatched node — entry, code, signature/LLM, http, evaluator, agent_workflow, end. One fix covers all of them, so signature-node LLM calls also surface their request/response JSON in the Trace Details drawer.

**No truncation.** Python SDK default truncated at 5000 chars/string; Go path keeps the full JSON. Agent outputs can be large and operators want full content. Downstream limits (OTLP exporter body size, ClickHouse storage) cap at the wire if needed.

### #2 — `execute_component` runs ONLY the requested node

**Symptom (image 2 in the channel):** Trace shows entry+code+end+evaluator spans even when the user only clicked Execute on the Code component.

**Cause:** `Engine.Execute` walked `plan.Layers` regardless of `req.NodeID`. Python's `execute_component.py` instantiates and invokes one materialized component, never the DAG.

**Fix:** in both `Engine.Execute` and `ExecuteStream`, when `req.NodeID` is set dispatch only that node via `runLayer`/`runLayerStream` with a single-element layer list. Validates the target exists in the workflow up-front so a typo returns a synchronous error instead of a silent no-op.

### #3 — Evaluator `LangWatchBaseURL` falls back to `LANGWATCH_ENDPOINT`

**Symptom:** Every evaluator dispatch errored with:
```
"error": {
  "type":    "evaluator_unconfigured",
  "message": "LangWatchBaseURL is required to call the evaluator API"
}
```

**Cause:** Resolver only read the explicit `NLPGO_ENGINE_LANGWATCH_BASE_URL` env, but prod terraform sets just `LANGWATCH_ENDPOINT` — the universal LangWatch URL the rest of the pipeline already uses (see `configureNLPGoOTel` in `services/nlpgo/deps.go`). So `cfg.Engine.LangWatchBaseURL` was empty in every prod Lambda.

**Fix:** Extract `resolveLangWatchBaseURL(explicit, getenv)` in `cmd/root.go`. Explicit cfg field wins (dev / docker-compose can still point evaluator callbacks at `host.docker.internal:5560`), otherwise fall back to `LANGWATCH_ENDPOINT`. Trailing slash trimmed on the fallback to match `evaluatorblock.runEvaluator`'s concatenation shape.

### #4 — M3 LLM child span (signature node)

**Symptom:** Even after #1/#2, the Go-side trace tree had only `execute_stream → execute_component` for an LLM Call node — no `LLM <provider>/<model>` row, no token counts, no cost. Python's tree carried `Llmcall.forward → PredictWithMetadata → LLM openai/gpt-5.2` underneath.

**Fix:** add `startLLMSpan` / `endLLMSpan` helpers in `tracing.go`; `runSignature` in `engine.go` opens an LLM span around the gateway call. Span name `<provider>/<model>` (e.g. `openai/gpt-5.2`), span kind `Client`, attrs match Python parity:

| attr | value |
|---|---|
| `langwatch.span.type` | `"llm"` |
| `gen_ai.system` / `gen_ai.request.model` | `openai` / `gpt-5.2` |
| `gen_ai.usage.input_tokens` / `output_tokens` / `reasoning_tokens` | counts from gateway response |
| `langwatch.cost` / `langwatch.duration_ms` | rolled up from the call |
| `langwatch.input` / `langwatch.output` | full messages + assistant reply JSON |

Studio Trace Details drawer now renders the LLM child as a row with token + cost badges, matching Python.

### #5 — Entry-node `entry_selection` mode keywords (`first` / `last` / `random` / `all`)

**Symptom (caught in dogfood):** Every `execute_flow` (= "Run workflow until here", Evaluate Workflow, single-item drilldown) fast-failed in ~1ms with:
```
data: {"payload":{"component_id":"entry","execution_state":{"error":"dataset: string_selection_lookup_not_provided",...}}
```
Studio's frontend surfaced this as a generic 20s "Timeout starting workflow execution" toast, which masked the real root cause; it took hooking `window.fetch` and dumping the SSE response body to find that **entry**, not the LLM, was the bailing node. `execute_component` (= the play icon on a single node) skips entry materialization and was the only path that worked.

**Cause:** Studio's default workflows ship with `entry_selection: "random"` (see `optimization_studio/types/dsl.ts` — values are `"first" | "last" | "random" | number`). Python's `get_dataset_entry_selection` (`langwatch_nlp/studio/utils.py`) treats those as **selection MODES** (return one row using the named strategy). Go's `dataset.SelectByEntry` interpreted the same string as a **column-name lookup**, called the `byString` callback (passed as `nil` from `engine.go`), and returned `string_selection_lookup_not_provided`. Net effect: every Studio-default workflow execute_flow path 1ms-failed before nlpgo's entry node ever produced output.

**Fix:** in `dataset.SelectByEntry`, match the four mode keywords *before* falling through to `byString`:
- `"first"` / `"all"` → `rows[0]`
- `"last"` → `rows[len-1]`
- `"random"` → `rows[rand.IntN(len)]`
- empty dataset → structured `EntrySelectionInvalidError{Reason: "entry_selection_empty_dataset"}` (so the err shape stays distinguishable from the column-name path)
- any other string → still delegated to `byString` (workflow-specific column lookups remain pluggable)

Tests: `dataset_test.go` adds `TestSelectByEntry_ModeKeyword_{First,Last,Random,All_PicksFirst}`, `TestSelectByEntry_ModeKeyword_EmptyDataset` (table-driven across all four modes), and `TestSelectByEntry_ModeKeywords_BypassByString` (pins that mode keywords short-circuit before `byString` so a `nil` callback still works). All 11 dataset tests pass.

## Test plan

- [x] `tracing_test.go` — helper-level shape (name, attrs, JSON I/O, error path no-output, 200KB no-truncation, no-attrs absence)
- [x] `tracing_e2e_test.go` — end-to-end Engine.Execute span tree (asserts `execute_component` name + JSON input/output flowing across edges)
- [x] `llm_tracing_test.go` + `llm_span_e2e_test.go` — LLM helper + end-to-end span tree with fake LLM client
- [x] `execute_component_scope_test.go` — sync + stream paths, 4-node workflow, asserts no sibling nodes get dispatched
- [x] `execute_component_scope_test.go` — missing target NodeID returns synchronous error (not silent no-op)
- [x] `root_test.go` — 5 sub-cases for the resolver: explicit-wins, fallback, slash-trim, neither-set, explicit-preserved
- [x] `dataset_test.go` — 4 mode-keyword pins + empty-dataset structured-error + byString-precedence pin (all 11 dataset tests pass)
- [x] Side-by-side dogfood with screenshots — single component execute / whole flow / evaluation run / single-item trace within evaluation run (table below)
- [ ] Studio Trace Details drawer renders INPUT/OUTPUT panels with real values (output_source="explicit") on prod after deploy

## Spec

`specs/nlp-go/tracing-parity.feature` — full matrix covering code/signature/http/evaluator/agent_workflow + execute_flow + evaluation batch_run. M1+M2+M3 implemented in this PR; remaining DSPy-shape per-module spans (`Llmcall.forward`, `PredictWithMetadata`) follow as a separate PR if/when the M3 LLM span proves insufficient.

## Side-by-side trace screenshots

| Scenario | Python langwatch_nlp (old, FF=off) | nlpgo Go (new, this PR, FF=on) |
|---|---|---|
| **Single component execute** (LLM Call "Hello world" → "Hello world!") | <img src="https://i.img402.dev/6o8ndcmikq.png" width="480" /> <br><br> Span tree: `COMPONENT execute_component` → `MODULE Llmcall.forward` → `MODULE PredictWithMetadata` → `LLM openai/gpt-5.2` <br> 24 tokens, $0.00018, 4.1s | <img src="https://i.img402.dev/8jigl04iu3.png" width="480" /> <br><br> Span tree: `SPAN nlpgo.studio.execute_stream` → `COMPONENT execute_component` → `LLM openai/gpt-5.2` <br> 24 tokens, $0.00018, 2.9s <br> service.name: nlpgo, sdk_language: go, gen_ai.provider.name: openai |
| **Whole flow execute** ("Run workflow until here" on End — Entry → LLM Call → End) | <img src="https://i.img402.dev/nn1cfr665h.png" width="480" /> <br><br> Workflow canvas after execute — all three nodes report success | <img src="https://i.img402.dev/8uuo32mnz4.png" width="480" /> <br><br> Span tree: `SPAN nlpgo.studio.execute_stream (2.2s)` → `COMPONENT execute_component (2.2s)` → `LLM openai/gpt-5.2 (2.2s, 14 tokens, $0.00010)` → `COMPONENT execute_component (0ms)` <br> Result: `{"output": "Hello world!"}`; `total_cost: 0` from the dataset's tiny payload <br> ⚠️ Required #5 fix above to unblock |
| **Evaluation run (small dataset)** | <img src="https://i.img402.dev/wcl73t9m0w.png" width="480" /> <br><br> Run #1 completed; one experiment row | <img src="https://i.img402.dev/d5v3dwimne.png" width="480" /> <br><br> Same experiment view via Go path — row reads `question: "Hello world"` → `llm_call: {"answer":"Hello world!"}` → `Output: "Hello world!"` with cost + latency badges per cell. Charts grouped by Target (llm_call vs Output) <br> ⚠️ Required #5 fix above to unblock |
| **Single item trace within evaluation run** | (no Python ref captured for this lane) | <img src="https://i.img402.dev/k7rskbhwcw.png" width="480" /> <br><br> Same `execute_stream → execute_component → LLM openai/gpt-5.2` shape as scenario 2, surfaced from the experiment-detail trace drilldown <br> 14 tokens, $0.00010, 2.7s, langwatch.origin: workflow |

### Notes from dogfood

**Scenario 1 (single component execute) — full Python parity on the langwatch surface.** Same workflow, same input, both engines return the same output and the same trace I/O. Remaining gap is the inner DSPy-style nesting: Python tree threads `Llmcall.forward → PredictWithMetadata → LLM openai/gpt-5.2`, Go's tree carries `execute_component → LLM openai/gpt-5.2`. The Studio drawer's `LLM <provider>/<model>` row, token counts, and cost are now identical between the two — that was the user-visible regression. The deeper module-level nesting can ship as a follow-up if/when needed.

**Scenarios 2-4 are unblocked by #5 above.** Earlier dogfood (pre-fix) reported these blocked on a credential-injection theory tracked in #3588. That theory was wrong — addEnvs was injecting credentials correctly the whole time. Hooking `window.fetch` in the Studio tab and dumping the SSE response body revealed the actual error (`dataset: string_selection_lookup_not_provided` on the **entry** node, not the LLM). #3588's narrative was retitled to "Studio Timeout toast hides per-node error message" — surface fix only, not in scope here.


### #6 — execute_evaluation iteration + batch/log_results POST (E)

After #5 unblocked the Evaluate flow on the wire, the next dogfood pass surfaced that the experiment-runs page never populated even after a successful eval. SSE returned `evaluation_state_change running → success` cleanly (run id appeared on the wire) but `/experiments/<id>` stayed at the previous run forever.

Root cause: nlpgo treated `execute_evaluation` as a single-shot workflow run + emitted running/success state events. Python (`langwatch_nlp/studio/execute/execute_evaluation.py` + `dspy/evaluation.py:EvaluationReporting`) does five extra things nlpgo was missing:
1. Materializes the inline dataset into per-row entries
2. Iterates the workflow over every entry (DSPy Evaluate)
3. Emits per-row `evaluation_state_change` with `progress` / `total` for the spinner
4. Posts batches to `/api/evaluations/batch/log_results` so the experiment-runs page renders results
5. Honors `evaluate_on` (full / test / train / specific) + `dataset_entry`

All five ported into a new `services/nlpgo/app/engine/evaluation.go`. Per-row engine errors do NOT abort the whole eval (Python parity: DSPy Evaluate `provide_traceback=True` continues past row failures).

**End-to-end browser proof (Playwright on http://localhost:5560):**

| Step | Screenshot |
|---|---|
| 1. Studio loaded | <img src="https://i.img402.dev/nrdup0h132.png" width="480" /> |
| 2. Click Evaluate → dialog with "Full dataset" / 1 entries / Run Evaluation | <img src="https://i.img402.dev/ah3mdkxb5a.png" width="480" /> |
| 3. **Studio's bottom "Evaluations" panel** auto-opens and lists Run #3 (just-now) above the prior runs; right pane shows row 1: question="Hello world" → Output="Hello world! How can I help you today?", 2.7s, Total Cost row at bottom | <img src="https://i.img402.dev/qx58ux3fwu.png" width="640" /> |

api server log confirmed two `POST /api/evaluations/batch/log_results` from `Go-http-client/1.1` returning 200 (initial empty batch + final batch with `finished_at`).

Tests:
- `TestSelectEvaluationEntries_*` — full / specific / remote-rejection / train-test split
- `TestEvaluationReporter_PostsBatchWithDatasetAndEvaluations` — wire shape end-to-end
- `TestEvaluationReporter_RecordsErrorPerEntryWithoutAborting` — per-row failure preserved
- `TestEvaluationWorkflow_PostsBatchResultsToLangWatch` — drives a 2-row eval through the SSE endpoint, asserts per-row state events AND final batch POST shape
- `TestEvaluationWorkflow_RejectsRemoteDataset` — clear error event instead of silent empty eval

### #7 — endLLMSpan(nil, nil) treated as Error (CodeRabbit major)

Pre-fix `endLLMSpan` emitted `codes.Ok` when an LLM executor returned `(nil, nil)` — that hid the upstream contract break in the Studio trace. Now flagged `codes.Error` with an explicit description. New `TestEndLLMSpan_NilResponseNilErrorIsTreatedAsError` pin.

