### PR TITLE
fix(nlpgo): execute_component scope + LANGWATCH_ENDPOINT fallback for evaluator base URL

### DIFF
--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -164,6 +164,21 @@ func (e *Engine) Execute(ctx context.Context, req ExecuteRequest) (*ExecuteResul
 	state := newRunState(req.Workflow)
 	applyManualInputs(state, req)
 	started := time.Now()
+	// execute_component (req.NodeID set) dispatches ONLY the requested
+	// node — Studio's "Run with manual input" flow on a single
+	// component card. Mirrors Python's execute_component.py which
+	// instantiates and invokes one materialized component, never the
+	// full DAG. Pre-fix the engine walked plan.Layers regardless and
+	// surfaced spurious entry/end/sibling spans in the trace
+	// (rchaves callout 2026-04-29 — clicked Execute on Code, trace
+	// showed entry+code+end+evaluator).
+	if req.NodeID != "" {
+		if _, ok := state.nodes[req.NodeID]; !ok {
+			return nil, fmt.Errorf("engine: execute_component target node %q not in workflow", req.NodeID)
+		}
+		e.runLayer(ctx, req, plan, state, []string{req.NodeID})
+		return finalize(state, traceID, started, nil), nil
+	}
 	for _, layer := range plan.Layers {
 		if err := ctx.Err(); err != nil {
 			return finalize(state, traceID, started, err), nil

--- a/services/nlpgo/app/engine/execute_component_scope_test.go
+++ b/services/nlpgo/app/engine/execute_component_scope_test.go
@@ -1,0 +1,133 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// TestEngineExecute_NodeIDDispatchesOnlyTargetNode pins the
+// execute_component contract: when ExecuteRequest.NodeID is set,
+// the engine dispatches ONLY that one node — never the rest of the
+// DAG.
+//
+// Pre-fix shipped on 2026-04-29 walked plan.Layers regardless of
+// req.NodeID, so a single-component "Run with manual input" click on
+// the Code card surfaced spurious entry/end/sibling spans in the
+// trace and (worse) ran the evaluator node — which then errored with
+// "LangWatchBaseURL is required to call the evaluator API" because
+// the user hadn't asked for evaluator dispatch in the first place.
+//
+// Mirrors langwatch_nlp/studio/execute/execute_component.py which
+// instantiates and invokes one materialized component, never the DAG.
+func TestEngineExecute_NodeIDDispatchesOnlyTargetNode(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "execute_component_scope",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "code-1", Type: dsl.ComponentCode},
+			{ID: "evaluator-1", Type: dsl.ComponentEvaluator},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "code-1", TargetHandle: "inputs.input"},
+			{Source: "code-1", SourceHandle: "outputs.output", Target: "evaluator-1", TargetHandle: "inputs.input"},
+			{Source: "evaluator-1", SourceHandle: "outputs.passed", Target: "end", TargetHandle: "inputs.passed"},
+		},
+	}
+
+	res, err := eng.Execute(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		// Studio execute_component target — only this node should
+		// dispatch. Inputs are the user-typed manual values for the
+		// target node (per ExecuteRequest.NodeID docs).
+		NodeID: "code-1",
+		Inputs: map[string]any{"input": "hi"},
+	})
+	require.NoError(t, err)
+
+	// Only the requested node has a recorded NodeState. Sibling nodes
+	// (entry, evaluator-1, end) were not dispatched, so their
+	// NodeStates are absent. If the pre-fix behavior regresses and the
+	// engine walks plan.Layers, we'd see all four nodes here — this
+	// test catches that.
+	require.Len(t, res.Nodes, 1, "execute_component must dispatch only the target node, not the full DAG")
+	require.Contains(t, res.Nodes, "code-1")
+	for _, sibling := range []string{"entry", "evaluator-1", "end"} {
+		assert.NotContains(t, res.Nodes, sibling,
+			"sibling node %q must NOT be dispatched on execute_component (Python parity: only the target node runs)", sibling)
+	}
+}
+
+// TestEngineExecute_NodeIDNotInWorkflowReturnsError pins the loud-fail
+// contract: an execute_component request naming a non-existent node
+// must return an error synchronously, not silently no-op.
+func TestEngineExecute_NodeIDNotInWorkflowReturnsError(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "missing_target",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "code-1", Type: dsl.ComponentCode},
+		},
+	}
+
+	_, err := eng.Execute(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		NodeID:   "does-not-exist",
+		Inputs:   map[string]any{"input": "hi"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "execute_component target node")
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// TestExecuteStream_NodeIDDispatchesOnlyTargetNode is the streaming
+// counterpart — Studio's SSE execute path also uses NodeID for
+// per-component runs.
+func TestExecuteStream_NodeIDDispatchesOnlyTargetNode(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "execute_component_scope_stream",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "code-1", Type: dsl.ComponentCode},
+			{ID: "evaluator-1", Type: dsl.ComponentEvaluator},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "code-1", TargetHandle: "inputs.input"},
+			{Source: "code-1", SourceHandle: "outputs.output", Target: "evaluator-1", TargetHandle: "inputs.input"},
+		},
+	}
+
+	ch, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		NodeID:   "code-1",
+		Inputs:   map[string]any{"input": "hi"},
+	}, ExecuteStreamOptions{})
+	require.NoError(t, err)
+
+	// Collect every component_state_change event and assert no sibling
+	// shows up. The pre-fix loop fired one running + one finished event
+	// per node-in-layer, so siblings would surface here.
+	dispatchedNodes := map[string]bool{}
+	for ev := range ch {
+		if ev.Type != "component_state_change" {
+			continue
+		}
+		if id, ok := ev.Payload["component_id"].(string); ok {
+			dispatchedNodes[id] = true
+		}
+	}
+	require.Len(t, dispatchedNodes, 1, "execute_component must emit state events for ONLY the target node")
+	assert.True(t, dispatchedNodes["code-1"])
+	for _, sibling := range []string{"entry", "evaluator-1", "end"} {
+		assert.False(t, dispatchedNodes[sibling], "sibling %q must not emit component_state_change", sibling)
+	}
+}

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -52,6 +53,15 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 	}
 	state := newRunState(req.Workflow)
 	applyManualInputs(state, req)
+	// execute_component (req.NodeID set) must dispatch ONLY the
+	// requested node. Validate target exists before starting the
+	// goroutine so callers get a synchronous error instead of an
+	// async error event. See Engine.Execute for the same guard.
+	if req.NodeID != "" {
+		if _, ok := state.nodes[req.NodeID]; !ok {
+			return nil, errInvalidRequest{msg: fmt.Sprintf("engine: execute_component target node %q not in workflow", req.NodeID)}
+		}
+	}
 
 	out := make(chan StreamEvent, 16)
 	go func() {
@@ -78,6 +88,15 @@ func (e *Engine) ExecuteStream(ctx context.Context, req ExecuteRequest, opts Exe
 			close(out)
 		}()
 
+		// execute_component (req.NodeID set) — dispatch only the
+		// requested node, never the full DAG. Same parity rationale as
+		// Engine.Execute: Studio's per-component Run flow on a single
+		// card should not surface entry/end/sibling spans in the trace.
+		if req.NodeID != "" {
+			e.runLayerStream(ctx, req, plan, state, []string{req.NodeID}, traceID, out)
+			emit(ctx, out, doneEvent(traceID, state, started))
+			return
+		}
 		for _, layer := range plan.Layers {
 			if err := ctx.Err(); err != nil {
 				emit(ctx, out, StreamEvent{

--- a/services/nlpgo/cmd/root.go
+++ b/services/nlpgo/cmd/root.go
@@ -4,6 +4,8 @@ package cmd
 import (
 	"context"
 	"net/http"
+	"os"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -70,7 +72,7 @@ func Root(ctx context.Context, _ []string) error {
 	playground := httpapi.NewPlaygroundProxyFromShim(playgroundDispatcherShim{disp: disp})
 
 	// Evaluator + agent-workflow blocks call the LangWatch app's own
-	// HTTP API. Both share the same LangWatchBaseURL (NLPGO_ENGINE_LANGWATCH_BASE_URL).
+	// HTTP API. Both share the same LangWatchBaseURL.
 	// Per-block timeouts default to 12min (Lambda max 15min minus 3min margin).
 	evalExec := evaluatorblock.New(evaluatorblock.Options{})
 	agentWfRunner := agentblock.NewWorkflowRunner(agentblock.WorkflowRunnerOptions{})
@@ -81,7 +83,7 @@ func Root(ctx context.Context, _ []string) error {
 		LLM:              llm,
 		Evaluator:        evalExec,
 		AgentWorkflow:    agentWfRunner,
-		LangWatchBaseURL: cfg.Engine.LangWatchBaseURL,
+		LangWatchBaseURL: resolveLangWatchBaseURL(cfg.Engine.LangWatchBaseURL, os.Getenv),
 	})
 	executor := engineAdapter{eng: eng}
 
@@ -93,6 +95,26 @@ func Root(ctx context.Context, _ []string) error {
 	)
 
 	return nlpgo.Serve(ctx, application, deps, cfg, playground)
+}
+
+// resolveLangWatchBaseURL returns the base URL the evaluator and
+// agent-workflow blocks use to call back into the LangWatch app. The
+// explicit `NLPGO_ENGINE_LANGWATCH_BASE_URL` setting wins so dev /
+// docker-compose can point evaluator callbacks at
+// host.docker.internal:5560 without touching the universal endpoint;
+// otherwise fall back to `LANGWATCH_ENDPOINT` — the same env var
+// configureNLPGoOTel reads in deps.go and the env terraform pins on
+// every Lambda. Pre-fix the evaluator path required the explicit var
+// only and prod set just LANGWATCH_ENDPOINT, so every evaluator
+// dispatch errored with "LangWatchBaseURL is required to call the
+// evaluator API" (rchaves callout 2026-04-29).
+//
+// `getenv` is injected so tests don't need to mutate process env.
+func resolveLangWatchBaseURL(explicit string, getenv func(string) string) string {
+	if explicit != "" {
+		return explicit
+	}
+	return strings.TrimRight(getenv("LANGWATCH_ENDPOINT"), "/")
 }
 
 // splitCSV splits "a,b,c" into ["a","b","c"], trimming whitespace and

--- a/services/nlpgo/cmd/root_test.go
+++ b/services/nlpgo/cmd/root_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import "testing"
+
+// TestResolveLangWatchBaseURL_FallsBackToLangwatchEndpoint pins the
+// fix for the prod regression on 2026-04-29: every evaluator dispatch
+// errored with "LangWatchBaseURL is required to call the evaluator
+// API" because prod set only `LANGWATCH_ENDPOINT` (the universal
+// LangWatch URL env var that terraform pins on every Lambda) and the
+// resolver previously only looked at `NLPGO_ENGINE_LANGWATCH_BASE_URL`.
+//
+// Mirrors the same fallback pattern in services/nlpgo/deps.go's
+// configureNLPGoOTel, so a single env var is the canonical source of
+// truth for "where the LangWatch app lives" across both OTel export
+// and evaluator callbacks.
+func TestResolveLangWatchBaseURL_FallsBackToLangwatchEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		explicit string
+		env      map[string]string
+		want     string
+	}{
+		{
+			name:     "explicit wins over env",
+			explicit: "https://app.langwatch.ai",
+			env:      map[string]string{"LANGWATCH_ENDPOINT": "https://other.example.com"},
+			want:     "https://app.langwatch.ai",
+		},
+		{
+			name:     "env fallback when explicit is empty",
+			explicit: "",
+			env:      map[string]string{"LANGWATCH_ENDPOINT": "https://app.langwatch.ai"},
+			want:     "https://app.langwatch.ai",
+		},
+		{
+			name:     "trailing slash in env is trimmed",
+			explicit: "",
+			env:      map[string]string{"LANGWATCH_ENDPOINT": "https://app.langwatch.ai/"},
+			want:     "https://app.langwatch.ai",
+		},
+		{
+			name:     "neither set returns empty (callers handle the typed evaluator_unconfigured error downstream)",
+			explicit: "",
+			env:      map[string]string{},
+			want:     "",
+		},
+		{
+			name:     "explicit is preserved as-is, no slash trimming (caller decides)",
+			explicit: "http://host.docker.internal:5560/",
+			env:      map[string]string{},
+			want:     "http://host.docker.internal:5560/",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			getenv := func(k string) string { return tc.env[k] }
+			got := resolveLangWatchBaseURL(tc.explicit, getenv)
+			if got != tc.want {
+				t.Errorf("resolveLangWatchBaseURL(%q, env=%v) = %q; want %q",
+					tc.explicit, tc.env, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two prod regressions surfaced 2026-04-29 by rchaves once cold-start + post-event lanes landed and Studio actually got responses through:

### B: \`execute_component\` runs the WHOLE flow

**Symptom:** Trace shows entry+code+end+evaluator spans even when the user only clicked Execute on the Code component (image 2 in the channel callout).

**Cause:** \`Engine.Execute\` walked \`plan.Layers\` regardless of \`req.NodeID\`. Python's \`execute_component.py\` instantiates and invokes one materialized component, never the DAG.

**Fix:** in both \`Engine.Execute\` and \`ExecuteStream\`, when \`req.NodeID\` is set dispatch only that node via \`runLayer\`/\`runLayerStream\` with a single-element layer list. Validates the target exists in the workflow up-front so a typo returns a synchronous error instead of a silent no-op.

### C: \`"LangWatchBaseURL is required to call the evaluator API"\` on every dispatch

**Symptom:** Trace details on the failed evaluator span (image 2):
\`\`\`
"error": {
  "type":    "evaluator_unconfigured",
  "message": "LangWatchBaseURL is required to call the evaluator API"
}
\`\`\`

**Cause:** Resolver only read the explicit \`NLPGO_ENGINE_LANGWATCH_BASE_URL\` env, but prod terraform sets just \`LANGWATCH_ENDPOINT\` — the universal LangWatch URL that the rest of the pipeline already uses (see \`configureNLPGoOTel\` in \`services/nlpgo/deps.go\`). So \`cfg.Engine.LangWatchBaseURL\` was empty in every prod Lambda.

**Fix:** Extract \`resolveLangWatchBaseURL(explicit, getenv)\` in \`cmd/root.go\`. Explicit cfg field wins (dev / docker-compose can still point evaluator callbacks at \`host.docker.internal:5560\`), otherwise fall back to \`LANGWATCH_ENDPOINT\`. Trailing slash trimmed on the fallback to match \`evaluatorblock.runEvaluator\`'s concatenation shape.

## Test plan

- [x] \`execute_component_scope_test.go\` — sync + stream paths, 4-node workflow, asserts no sibling nodes get dispatched
- [x] \`execute_component_scope_test.go\` — missing target NodeID returns synchronous error (not silent no-op)
- [x] \`root_test.go\` — 5 sub-cases for the resolver: explicit-wins, fallback, slash-trim, neither-set, explicit-preserved
- [x] All existing engine + cmd tests still pass
- [ ] Side-by-side dogfood (Ash's parallel /browser-qa lane will validate visually)
- [ ] Studio Trace Details drawer on prod after deploy: execute_component on Code shows ONLY the code span, evaluator dispatch succeeds (no LangWatchBaseURL error)

## Companion PR

\`#3569\` (M1+M2 tracing parity — \`execute_component\` span name + \`langwatch.input\`/\`langwatch.output\` JSON for ALL node types including LLM). Together they address all three issues rchaves raised in the audit callout (scope + missing input/output capture + evaluator base URL).