### PR TITLE
fix(evaluators): preserve evaluator config when copying workflows

### DIFF
--- a/langwatch/src/server/agents/agent.repository.ts
+++ b/langwatch/src/server/agents/agent.repository.ts
@@ -469,6 +469,8 @@ export type AgentWithWorkflow = Agent & {
     name: string;
     icon: string | null;
     description: string | null;
+    isEvaluator: boolean;
+    isComponent: boolean;
     latestVersion: { dsl: unknown } | null;
   } | null;
 };

--- a/langwatch/src/server/agents/agent.service.ts
+++ b/langwatch/src/server/agents/agent.service.ts
@@ -180,6 +180,8 @@ export class AgentService {
           name: string;
           icon: string | null;
           description: string | null;
+          isEvaluator?: boolean;
+          isComponent?: boolean;
           latestVersion: { dsl: unknown } | null;
         };
         targetProjectId: string;
@@ -209,6 +211,8 @@ export class AgentService {
             name: source.workflow.name,
             icon: source.workflow.icon,
             description: source.workflow.description,
+            isEvaluator: source.workflow.isEvaluator,
+            isComponent: source.workflow.isComponent,
             latestVersion: source.workflow.latestVersion,
           },
           targetProjectId: input.targetProjectId,

--- a/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
@@ -11,6 +11,7 @@ describe("copyWorkflowWithDatasets", () => {
   const sourceWorkflowId = `test_wf_src_${nanoid(8)}`;
   let userId: string;
   const createdWorkflowIds: string[] = [];
+  const tempSourceWorkflowIds: string[] = [];
 
   beforeAll(async () => {
     const user = await getTestUser();
@@ -77,10 +78,11 @@ describe("copyWorkflowWithDatasets", () => {
   });
 
   afterAll(async () => {
-    for (const id of createdWorkflowIds) {
+    const allIds = [sourceWorkflowId, ...createdWorkflowIds, ...tempSourceWorkflowIds];
+    for (const id of allIds) {
       await prisma.workflow
         .update({
-          where: { id, projectId: targetProjectId },
+          where: { id },
           data: { latestVersionId: null, currentVersionId: null },
         })
         .catch(() => {});
@@ -89,18 +91,6 @@ describe("copyWorkflowWithDatasets", () => {
         .catch(() => {});
       await prisma.workflow.delete({ where: { id } }).catch(() => {});
     }
-    await prisma.workflow
-      .update({
-        where: { id: sourceWorkflowId },
-        data: { latestVersionId: null, currentVersionId: null },
-      })
-      .catch(() => {});
-    await prisma.workflowVersion
-      .deleteMany({ where: { workflowId: sourceWorkflowId } })
-      .catch(() => {});
-    await prisma.workflow
-      .delete({ where: { id: sourceWorkflowId } })
-      .catch(() => {});
   });
 
   const getCtx = () => ({
@@ -145,6 +135,7 @@ describe("copyWorkflowWithDatasets", () => {
   describe("when source workflow is a component", () => {
     it("preserves isComponent on the copied workflow", async () => {
       const componentWorkflowId = `test_wf_comp_${nanoid(8)}`;
+      tempSourceWorkflowIds.push(componentWorkflowId);
       await prisma.workflow.create({
         data: {
           id: componentWorkflowId,
@@ -196,20 +187,6 @@ describe("copyWorkflowWithDatasets", () => {
         sourceProjectId,
       });
       createdWorkflowIds.push(workflowId);
-
-      // Cleanup the component source
-      await prisma.workflow
-        .update({
-          where: { id: componentWorkflowId },
-          data: { latestVersionId: null },
-        })
-        .catch(() => {});
-      await prisma.workflowVersion
-        .deleteMany({ where: { workflowId: componentWorkflowId } })
-        .catch(() => {});
-      await prisma.workflow
-        .delete({ where: { id: componentWorkflowId } })
-        .catch(() => {});
 
       const copied = await prisma.workflow.findUnique({
         where: { id: workflowId },

--- a/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
@@ -87,6 +87,9 @@ describe("copyWorkflowWithDatasets", () => {
         })
         .catch(() => {});
       await prisma.workflowVersion
+        .updateMany({ where: { workflowId: id }, data: { parentId: null } })
+        .catch(() => {});
+      await prisma.workflowVersion
         .deleteMany({ where: { workflowId: id } })
         .catch(() => {});
       await prisma.workflow.delete({ where: { id } }).catch(() => {});

--- a/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { nanoid } from "nanoid";
+import { getTestUser } from "~/utils/testUtils";
+import { prisma } from "~/server/db";
+import { copyWorkflowWithDatasets } from "../workflows";
+import type { Session } from "~/server/auth";
+
+describe("copyWorkflowWithDatasets", () => {
+  const sourceProjectId = "test-project-id";
+  const targetProjectId = "test-project-id-copy-wf-target";
+  const sourceWorkflowId = `test_wf_src_${nanoid(8)}`;
+  let userId: string;
+  const createdWorkflowIds: string[] = [];
+
+  beforeAll(async () => {
+    const user = await getTestUser();
+    userId = user.id;
+
+    const teamUser = await prisma.teamUser.findFirst({
+      where: { userId: user.id },
+      include: { team: true },
+    });
+    if (!teamUser) throw new Error("Test user must have a team");
+
+    const targetExists = await prisma.project.findUnique({
+      where: { id: targetProjectId },
+    });
+    if (!targetExists) {
+      await prisma.project.create({
+        data: {
+          id: targetProjectId,
+          name: "Copy WF Target",
+          slug: "copy-wf-target",
+          apiKey: "test-api-key-copy-wf-target",
+          teamId: teamUser.team.id,
+          language: "en",
+          framework: "test",
+        },
+      });
+    }
+
+    await prisma.workflow.create({
+      data: {
+        id: sourceWorkflowId,
+        projectId: sourceProjectId,
+        name: "Source Evaluator Workflow",
+        icon: "🔍",
+        description: "An evaluator workflow",
+        isEvaluator: true,
+        isComponent: false,
+      },
+    });
+
+    await prisma.workflowVersion.create({
+      data: {
+        id: `test_wfv_${nanoid(8)}`,
+        workflowId: sourceWorkflowId,
+        projectId: sourceProjectId,
+        version: "1",
+        dsl: { nodes: [], edges: [], state: {} },
+        commitMessage: "initial",
+        authorId: userId,
+        autoSaved: false,
+      },
+    });
+
+    await prisma.workflow.update({
+      where: { id: sourceWorkflowId },
+      data: {
+        latestVersionId: (
+          await prisma.workflowVersion.findFirst({
+            where: { workflowId: sourceWorkflowId },
+          })
+        )?.id,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    for (const id of createdWorkflowIds) {
+      await prisma.workflow
+        .update({
+          where: { id, projectId: targetProjectId },
+          data: { latestVersionId: null, currentVersionId: null },
+        })
+        .catch(() => {});
+      await prisma.workflowVersion
+        .deleteMany({ where: { workflowId: id } })
+        .catch(() => {});
+      await prisma.workflow.delete({ where: { id } }).catch(() => {});
+    }
+    await prisma.workflow
+      .update({
+        where: { id: sourceWorkflowId },
+        data: { latestVersionId: null, currentVersionId: null },
+      })
+      .catch(() => {});
+    await prisma.workflowVersion
+      .deleteMany({ where: { workflowId: sourceWorkflowId } })
+      .catch(() => {});
+    await prisma.workflow
+      .delete({ where: { id: sourceWorkflowId } })
+      .catch(() => {});
+  });
+
+  const getCtx = () => ({
+    prisma,
+    session: { user: { id: userId } } as Session,
+  });
+
+  describe("when source workflow is an evaluator", () => {
+    it("preserves isEvaluator on the copied workflow", async () => {
+      const source = await prisma.workflow.findUnique({
+        where: { id: sourceWorkflowId },
+        include: { latestVersion: true },
+      });
+
+      const { workflowId } = await copyWorkflowWithDatasets({
+        ctx: getCtx(),
+        workflow: {
+          id: source!.id,
+          name: source!.name,
+          icon: source!.icon,
+          description: source!.description,
+          isEvaluator: source!.isEvaluator,
+          isComponent: source!.isComponent,
+          latestVersion: source!.latestVersion,
+        },
+        targetProjectId,
+        sourceProjectId,
+      });
+      createdWorkflowIds.push(workflowId);
+
+      const copied = await prisma.workflow.findUnique({
+        where: { id: workflowId },
+      });
+
+      expect(copied).not.toBeNull();
+      expect(copied!.isEvaluator).toBe(true);
+      expect(copied!.isComponent).toBe(false);
+      expect(copied!.projectId).toBe(targetProjectId);
+    });
+  });
+
+  describe("when source workflow is a component", () => {
+    it("preserves isComponent on the copied workflow", async () => {
+      const componentWorkflowId = `test_wf_comp_${nanoid(8)}`;
+      await prisma.workflow.create({
+        data: {
+          id: componentWorkflowId,
+          projectId: sourceProjectId,
+          name: "Component Workflow",
+          icon: "🧩",
+          description: "A component",
+          isEvaluator: false,
+          isComponent: true,
+        },
+      });
+      await prisma.workflowVersion.create({
+        data: {
+          id: `test_wfv_comp_${nanoid(8)}`,
+          workflowId: componentWorkflowId,
+          projectId: sourceProjectId,
+          version: "1",
+          dsl: { nodes: [], edges: [], state: {} },
+          commitMessage: "initial",
+          authorId: userId,
+          autoSaved: false,
+        },
+      });
+      const latestVersion = await prisma.workflowVersion.findFirst({
+        where: { workflowId: componentWorkflowId },
+      });
+      await prisma.workflow.update({
+        where: { id: componentWorkflowId },
+        data: { latestVersionId: latestVersion?.id },
+      });
+
+      const source = await prisma.workflow.findUnique({
+        where: { id: componentWorkflowId },
+        include: { latestVersion: true },
+      });
+
+      const { workflowId } = await copyWorkflowWithDatasets({
+        ctx: getCtx(),
+        workflow: {
+          id: source!.id,
+          name: source!.name,
+          icon: source!.icon,
+          description: source!.description,
+          isEvaluator: source!.isEvaluator,
+          isComponent: source!.isComponent,
+          latestVersion: source!.latestVersion,
+        },
+        targetProjectId,
+        sourceProjectId,
+      });
+      createdWorkflowIds.push(workflowId);
+
+      // Cleanup the component source
+      await prisma.workflow
+        .update({
+          where: { id: componentWorkflowId },
+          data: { latestVersionId: null },
+        })
+        .catch(() => {});
+      await prisma.workflowVersion
+        .deleteMany({ where: { workflowId: componentWorkflowId } })
+        .catch(() => {});
+      await prisma.workflow
+        .delete({ where: { id: componentWorkflowId } })
+        .catch(() => {});
+
+      const copied = await prisma.workflow.findUnique({
+        where: { id: workflowId },
+      });
+
+      expect(copied).not.toBeNull();
+      expect(copied!.isEvaluator).toBe(false);
+      expect(copied!.isComponent).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/evaluators.ts
+++ b/langwatch/src/server/api/routers/evaluators.ts
@@ -452,6 +452,8 @@ export const evaluatorsRouter = createTRPCRouter({
             name: source.workflow.name,
             icon: source.workflow.icon,
             description: source.workflow.description,
+            isEvaluator: source.workflow.isEvaluator,
+            isComponent: source.workflow.isComponent,
             latestVersion: source.workflow.latestVersion,
           },
           targetProjectId: input.projectId,

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -1026,6 +1026,8 @@ export const experimentsRouter = createTRPCRouter({
           name: experiment.workflow.name,
           icon: experiment.workflow.icon,
           description: experiment.workflow.description,
+          isEvaluator: experiment.workflow.isEvaluator,
+          isComponent: experiment.workflow.isComponent,
           latestVersion: experiment.workflow.latestVersion,
         },
         targetProjectId: input.projectId,

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -1152,6 +1152,8 @@ export const copyWorkflowWithDatasets = async ({
     name: string;
     icon: string | null;
     description: string | null;
+    isEvaluator?: boolean;
+    isComponent?: boolean;
     latestVersion: { dsl: JsonValue } | null;
   };
   targetProjectId: string;
@@ -1247,6 +1249,8 @@ export const copyWorkflowWithDatasets = async ({
       name: workflow.name,
       icon: workflow.icon ?? "",
       description: workflow.description ?? "",
+      isEvaluator: workflow.isEvaluator ?? false,
+      isComponent: workflow.isComponent ?? false,
       copiedFromWorkflowId: copiedFromWorkflowId ?? workflow.id,
     },
   });


### PR DESCRIPTION
## Summary

- `copyWorkflowWithDatasets()` was dropping `isEvaluator` and `isComponent` flags when creating the new workflow record, causing copied evaluator workflows to lose their evaluator identity
- All four callers (workflows, evaluators, agents, experiments) now pass these flags through
- Added `isEvaluator`/`isComponent` to `AgentWithWorkflow` type so agent copy path has access to the fields

Closes #3572 (Issue 1 only — Issues 2 and 3 tracked separately)

## Test plan

- [x] Integration test: copied evaluator workflow preserves `isEvaluator: true`
- [x] Integration test: copied component workflow preserves `isComponent: true`
- [x] `pnpm typecheck` clean
- [ ] Manual: copy an evaluator workflow from one project to another, verify LLM block retains prompt/model/inputs

# Related Issue

- Resolve #3572