### PR TITLE
refactor(backoffice): impersonation reason field

### DIFF
--- a/langwatch/ee/admin/backoffice/__tests__/UsersView.integration.test.tsx
+++ b/langwatch/ee/admin/backoffice/__tests__/UsersView.integration.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toaster } from "~/components/ui/toaster";
+import { impersonateUser } from "../adminClient";
+import { ImpersonateDialog } from "../resources/UsersView";
+
+vi.mock("../adminClient", () => ({
+  impersonateUser: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: {
+    create: vi.fn(),
+  },
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const user = {
+  id: "user-1",
+  name: "Yoel Ernst",
+  email: "yoel@example.com",
+  image: null,
+  emailVerified: true,
+  pendingSsoSetup: false,
+  createdAt: "2026-04-01T10:00:00.000Z",
+  lastLoginAt: null,
+  deactivatedAt: null,
+  organizations: [],
+  projects: [],
+};
+
+describe("Feature: Backoffice User Impersonation Reason", () => {
+  beforeEach(() => {
+    vi.mocked(impersonateUser).mockClear();
+    vi.mocked(toaster.create).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given the ops admin has opened the impersonation dialog", () => {
+    it("shows a single-line reason field", () => {
+      render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
+        wrapper: Wrapper,
+      });
+
+      const reason = screen.getByLabelText("Reason");
+
+      expect(screen.getByText(/saved to the audit log/i)).toBeInTheDocument();
+      expect(reason.tagName).toBe("INPUT");
+    });
+
+    it("submits the reason when Enter is pressed", async () => {
+      const testingUser = userEvent.setup();
+      render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
+        wrapper: Wrapper,
+      });
+
+      await testingUser.type(screen.getByLabelText("Reason"), "support");
+      fireEvent.keyDown(screen.getByLabelText("Reason"), {
+        key: "Enter",
+        code: "Enter",
+      });
+
+      await waitFor(() => {
+        expect(impersonateUser).toHaveBeenCalledWith({
+          userIdToImpersonate: "user-1",
+          reason: "support",
+        });
+      });
+    });
+
+    it("keeps blocking empty reasons when Enter is pressed", async () => {
+      render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
+        wrapper: Wrapper,
+      });
+
+      fireEvent.keyDown(screen.getByLabelText("Reason"), {
+        key: "Enter",
+        code: "Enter",
+      });
+
+      expect(impersonateUser).not.toHaveBeenCalled();
+      expect(toaster.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Reason is required",
+          type: "error",
+        }),
+      );
+    });
+  });
+});

--- a/langwatch/ee/admin/backoffice/resources/UsersView.tsx
+++ b/langwatch/ee/admin/backoffice/resources/UsersView.tsx
@@ -2,37 +2,33 @@ import {
   Badge,
   Box,
   Button,
+  Link as ChakraLink,
   Field,
   HStack,
   Input,
-  Link as ChakraLink,
   Spacer,
   Table,
   Text,
-  Textarea,
   VStack,
   Wrap,
 } from "@chakra-ui/react";
 import { MoreVertical, Pencil, UserCheck } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useDebounce } from "use-debounce";
-import NextLink from "~/utils/compat/next-link";
 import { Dialog } from "~/components/ui/dialog";
 import { Drawer } from "~/components/ui/drawer";
 import { Menu } from "~/components/ui/menu";
 import { Switch } from "~/components/ui/switch";
 import { toaster } from "~/components/ui/toaster";
+import NextLink from "~/utils/compat/next-link";
+import { impersonateUser } from "../adminClient";
 import {
   BackofficeTable,
   EmptyCell,
   formatDate,
   formatDateTime,
 } from "../BackofficeTable";
-import { impersonateUser } from "../adminClient";
-import {
-  useAdminList,
-  useAdminUpdate,
-} from "../useAdminResource";
+import { useAdminList, useAdminUpdate } from "../useAdminResource";
 
 interface OrgRef {
   id: string;
@@ -44,7 +40,7 @@ interface ProjectRef {
   slug: string;
 }
 
-interface AdminUser {
+export interface AdminUser {
   id: string;
   name: string | null;
   email: string | null;
@@ -219,7 +215,7 @@ export default function UsersView() {
   );
 }
 
-function ImpersonateDialog({
+export function ImpersonateDialog({
   user,
   onClose,
 }: {
@@ -290,10 +286,15 @@ function ImpersonateDialog({
             </Text>
             <Field.Root required>
               <Field.Label>Reason</Field.Label>
-              <Textarea
-                rows={3}
+              <Input
                 value={reason}
                 onChange={(e) => setReason(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void submit();
+                  }
+                }}
                 placeholder="e.g. Debugging a stuck trace reported by support ticket #…"
                 disabled={loading}
               />
@@ -404,10 +405,7 @@ function UserEditDrawer({
             <VStack gap={4} align="stretch">
               <Field.Root>
                 <Field.Label>Name</Field.Label>
-                <Input
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                />
+                <Input value={name} onChange={(e) => setName(e.target.value)} />
               </Field.Root>
               <Field.Root>
                 <Field.Label>Email</Field.Label>

--- a/specs/features/backoffice-user-impersonation-reason.feature
+++ b/specs/features/backoffice-user-impersonation-reason.feature
@@ -1,0 +1,31 @@
+Feature: Backoffice User Impersonation Reason
+  As an ops admin
+  I want to enter an impersonation reason in a single-line field
+  So that I can quickly submit the audit reason without adding accidental line breaks
+
+  Background:
+    Given an ops admin is viewing the backoffice users page
+    And the users table includes an active user named "Yoel Ernst"
+
+  @integration
+  Scenario: Impersonation dialog asks for a single-line reason
+    When the ops admin chooses to impersonate "Yoel Ernst"
+    Then an "Impersonate user" dialog is visible
+    And the dialog explains the reason is saved to the audit log
+    And the reason field accepts a single line of text
+
+  @integration
+  Scenario: Enter submits a completed impersonation reason
+    Given the ops admin has opened the impersonation dialog for "Yoel Ernst"
+    And the reason field contains "support"
+    When the ops admin presses Enter in the reason field
+    Then impersonation is submitted for "Yoel Ernst"
+    And the submitted reason is "support"
+
+  @integration
+  Scenario: Empty reason still blocks impersonation
+    Given the ops admin has opened the impersonation dialog for "Yoel Ernst"
+    And the reason field is empty
+    When the ops admin presses Enter in the reason field
+    Then impersonation is not submitted
+    And the ops admin is told that a reason is required


### PR DESCRIPTION
## Summary
- Replace the impersonation reason textarea with a single-line input.
- Submit impersonation when Enter is pressed in the reason field.
- Add a BDD feature spec and component integration coverage for the dialog behavior.

## Verification
- PASS: `pnpm --dir langwatch exec vitest -c vitest.integration.config.ts --run ee/admin/backoffice/__tests__/UsersView.integration.test.tsx`
- PASS: `pnpm --dir langwatch exec biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false ee/admin/backoffice/resources/UsersView.tsx ee/admin/backoffice/__tests__/UsersView.integration.test.tsx`
- PASS: `pnpm --dir langwatch exec biome check --formatter-enabled=false --linter-enabled=false --assist-enabled=true ee/admin/backoffice/resources/UsersView.tsx ee/admin/backoffice/__tests__/UsersView.integration.test.tsx`
- PASS with unrelated internal analyzer warnings: `pnpm --dir langwatch exec biome check --formatter-enabled=false --linter-enabled=true --assist-enabled=false ee/admin/backoffice/resources/UsersView.tsx ee/admin/backoffice/__tests__/UsersView.integration.test.tsx`
- BLOCKED by unrelated existing/untracked test issues: `pnpm --dir langwatch typecheck` currently fails in `src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts` with missing `authorId` and stale `isEvaluator` shape errors.

## Notes
- Ran `pnpm --dir langwatch prisma:generate:typescript` before retrying typecheck to rule out stale generated Prisma client errors.