### PR TITLE
fix(evaluators): isEvaluator copy + evaluator name in traces + WrappedModule __call__

### DIFF
--- a/langwatch/src/server/agents/agent.repository.ts
+++ b/langwatch/src/server/agents/agent.repository.ts
@@ -469,6 +469,8 @@ export type AgentWithWorkflow = Agent & {
     name: string;
     icon: string | null;
     description: string | null;
+    isEvaluator: boolean;
+    isComponent: boolean;
     latestVersion: { dsl: unknown } | null;
   } | null;
 };

--- a/langwatch/src/server/agents/agent.service.ts
+++ b/langwatch/src/server/agents/agent.service.ts
@@ -180,6 +180,8 @@ export class AgentService {
           name: string;
           icon: string | null;
           description: string | null;
+          isEvaluator?: boolean;
+          isComponent?: boolean;
           latestVersion: { dsl: unknown } | null;
         };
         targetProjectId: string;
@@ -209,6 +211,8 @@ export class AgentService {
             name: source.workflow.name,
             icon: source.workflow.icon,
             description: source.workflow.description,
+            isEvaluator: source.workflow.isEvaluator,
+            isComponent: source.workflow.isComponent,
             latestVersion: source.workflow.latestVersion,
           },
           targetProjectId: input.targetProjectId,

--- a/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
@@ -88,7 +88,7 @@ describe("copyWorkflowWithDatasets", () => {
       await prisma.workflowVersion
         .deleteMany({ where: { workflowId: id, projectId } })
         .catch(() => {});
-      await prisma.workflow.delete({ where: { id } }).catch(() => {});
+      await prisma.workflow.delete({ where: { id, projectId } }).catch(() => {});
     }
   });
 

--- a/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.copyWorkflowWithDatasets.integration.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { nanoid } from "nanoid";
+import { getTestUser } from "~/utils/testUtils";
+import { prisma } from "~/server/db";
+import { copyWorkflowWithDatasets } from "../workflows";
+import type { Session } from "~/server/auth";
+
+describe("copyWorkflowWithDatasets", () => {
+  const sourceProjectId = "test-project-id";
+  const targetProjectId = "test-project-id-copy-wf-target";
+  const sourceWorkflowId = `test_wf_src_${nanoid(8)}`;
+  let userId: string;
+  const cleanupWorkflows: Array<{ id: string; projectId: string }> = [];
+
+  beforeAll(async () => {
+    const user = await getTestUser();
+    userId = user.id;
+
+    const teamUser = await prisma.teamUser.findFirst({
+      where: { userId: user.id },
+      include: { team: true },
+    });
+    if (!teamUser) throw new Error("Test user must have a team");
+
+    const targetExists = await prisma.project.findUnique({
+      where: { id: targetProjectId },
+    });
+    if (!targetExists) {
+      await prisma.project.create({
+        data: {
+          id: targetProjectId,
+          name: "Copy WF Target",
+          slug: "copy-wf-target",
+          apiKey: "test-api-key-copy-wf-target",
+          teamId: teamUser.team.id,
+          language: "en",
+          framework: "test",
+        },
+      });
+    }
+
+    await prisma.workflow.create({
+      data: {
+        id: sourceWorkflowId,
+        projectId: sourceProjectId,
+        name: "Source Evaluator Workflow",
+        icon: "🔍",
+        description: "An evaluator workflow",
+        isEvaluator: true,
+        isComponent: false,
+      },
+    });
+    cleanupWorkflows.push({ id: sourceWorkflowId, projectId: sourceProjectId });
+
+    await prisma.workflowVersion.create({
+      data: {
+        id: `test_wfv_${nanoid(8)}`,
+        workflowId: sourceWorkflowId,
+        projectId: sourceProjectId,
+        version: "1",
+        dsl: { nodes: [], edges: [], state: {} },
+        commitMessage: "initial",
+        authorId: userId,
+        autoSaved: false,
+      },
+    });
+
+    const version = await prisma.workflowVersion.findFirst({
+      where: { workflowId: sourceWorkflowId, projectId: sourceProjectId },
+    });
+    await prisma.workflow.update({
+      where: { id: sourceWorkflowId },
+      data: { latestVersionId: version?.id },
+    });
+  });
+
+  afterAll(async () => {
+    for (const { id, projectId } of cleanupWorkflows) {
+      await prisma.workflow
+        .update({
+          where: { id, projectId },
+          data: { latestVersionId: null, currentVersionId: null },
+        })
+        .catch(() => {});
+      await prisma.workflowVersion
+        .updateMany({ where: { workflowId: id, projectId }, data: { parentId: null } })
+        .catch(() => {});
+      await prisma.workflowVersion
+        .deleteMany({ where: { workflowId: id, projectId } })
+        .catch(() => {});
+      await prisma.workflow.delete({ where: { id } }).catch(() => {});
+    }
+  });
+
+  const getCtx = () => ({
+    prisma,
+    session: { user: { id: userId } } as Session,
+  });
+
+  describe("when source workflow is an evaluator", () => {
+    it("preserves isEvaluator on the copied workflow", async () => {
+      const source = await prisma.workflow.findUnique({
+        where: { id: sourceWorkflowId },
+        include: { latestVersion: true },
+      });
+
+      const { workflowId } = await copyWorkflowWithDatasets({
+        ctx: getCtx(),
+        workflow: {
+          id: source!.id,
+          name: source!.name,
+          icon: source!.icon,
+          description: source!.description,
+          isEvaluator: source!.isEvaluator,
+          isComponent: source!.isComponent,
+          latestVersion: source!.latestVersion,
+        },
+        targetProjectId,
+        sourceProjectId,
+      });
+      cleanupWorkflows.push({ id: workflowId, projectId: targetProjectId });
+
+      const copied = await prisma.workflow.findUnique({
+        where: { id: workflowId },
+      });
+
+      expect(copied).not.toBeNull();
+      expect(copied!.isEvaluator).toBe(true);
+      expect(copied!.isComponent).toBe(false);
+      expect(copied!.projectId).toBe(targetProjectId);
+    });
+  });
+
+  describe("when source workflow is a component", () => {
+    it("preserves isComponent on the copied workflow", async () => {
+      const componentWorkflowId = `test_wf_comp_${nanoid(8)}`;
+
+      await prisma.workflow.create({
+        data: {
+          id: componentWorkflowId,
+          projectId: sourceProjectId,
+          name: "Component Workflow",
+          icon: "🧩",
+          description: "A component",
+          isEvaluator: false,
+          isComponent: true,
+        },
+      });
+      cleanupWorkflows.push({ id: componentWorkflowId, projectId: sourceProjectId });
+
+      await prisma.workflowVersion.create({
+        data: {
+          id: `test_wfv_comp_${nanoid(8)}`,
+          workflowId: componentWorkflowId,
+          projectId: sourceProjectId,
+          version: "1",
+          dsl: { nodes: [], edges: [], state: {} },
+          commitMessage: "initial",
+          authorId: userId,
+          autoSaved: false,
+        },
+      });
+      const latestVersion = await prisma.workflowVersion.findFirst({
+        where: { workflowId: componentWorkflowId, projectId: sourceProjectId },
+      });
+      await prisma.workflow.update({
+        where: { id: componentWorkflowId },
+        data: { latestVersionId: latestVersion?.id },
+      });
+
+      const source = await prisma.workflow.findUnique({
+        where: { id: componentWorkflowId },
+        include: { latestVersion: true },
+      });
+
+      const { workflowId } = await copyWorkflowWithDatasets({
+        ctx: getCtx(),
+        workflow: {
+          id: source!.id,
+          name: source!.name,
+          icon: source!.icon,
+          description: source!.description,
+          isEvaluator: source!.isEvaluator,
+          isComponent: source!.isComponent,
+          latestVersion: source!.latestVersion,
+        },
+        targetProjectId,
+        sourceProjectId,
+      });
+      cleanupWorkflows.push({ id: workflowId, projectId: targetProjectId });
+
+      const copied = await prisma.workflow.findUnique({
+        where: { id: workflowId },
+      });
+
+      expect(copied).not.toBeNull();
+      expect(copied!.isEvaluator).toBe(false);
+      expect(copied!.isComponent).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/evaluators.ts
+++ b/langwatch/src/server/api/routers/evaluators.ts
@@ -452,6 +452,8 @@ export const evaluatorsRouter = createTRPCRouter({
             name: source.workflow.name,
             icon: source.workflow.icon,
             description: source.workflow.description,
+            isEvaluator: source.workflow.isEvaluator,
+            isComponent: source.workflow.isComponent,
             latestVersion: source.workflow.latestVersion,
           },
           targetProjectId: input.projectId,

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -1026,6 +1026,8 @@ export const experimentsRouter = createTRPCRouter({
           name: experiment.workflow.name,
           icon: experiment.workflow.icon,
           description: experiment.workflow.description,
+          isEvaluator: experiment.workflow.isEvaluator,
+          isComponent: experiment.workflow.isComponent,
           latestVersion: experiment.workflow.latestVersion,
         },
         targetProjectId: input.projectId,

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -1152,6 +1152,8 @@ export const copyWorkflowWithDatasets = async ({
     name: string;
     icon: string | null;
     description: string | null;
+    isEvaluator?: boolean;
+    isComponent?: boolean;
     latestVersion: { dsl: JsonValue } | null;
   };
   targetProjectId: string;
@@ -1247,6 +1249,8 @@ export const copyWorkflowWithDatasets = async ({
       name: workflow.name,
       icon: workflow.icon ?? "",
       description: workflow.description ?? "",
+      isEvaluator: workflow.isEvaluator ?? false,
+      isComponent: workflow.isComponent ?? false,
       copiedFromWorkflowId: copiedFromWorkflowId ?? workflow.id,
     },
   });

--- a/langwatch/src/server/app-layer/monitors/repositories/monitor.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/monitors/repositories/monitor.prisma.repository.ts
@@ -16,6 +16,7 @@ export class PrismaMonitorRepository implements MonitorRepository {
         checkType: true,
         name: true,
         threadIdleTimeout: true,
+        evaluator: { select: { name: true } },
       },
     });
   }

--- a/langwatch/src/server/app-layer/monitors/repositories/monitor.repository.ts
+++ b/langwatch/src/server/app-layer/monitors/repositories/monitor.repository.ts
@@ -3,6 +3,7 @@ export interface MonitorSummary {
   checkType: string;
   name: string;
   threadIdleTimeout: number | null;
+  evaluator: { name: string } | null;
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -78,7 +78,7 @@ function createDeps(
   return {
     monitors: {
       getEnabledOnMessageMonitors: vi.fn().mockResolvedValue([
-        { id: "mon-1", checkType: "llm/boolean", name: "Test Monitor" },
+        { id: "mon-1", checkType: "llm/boolean", name: "Test Monitor", evaluator: null },
       ]),
     } as unknown as EvaluationTriggerReactorDeps["monitors"],
     evaluation: vi.fn().mockResolvedValue(undefined),

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.unit.test.ts
@@ -63,6 +63,7 @@ function makeMonitor(overrides: Partial<MonitorSummary> = {}): MonitorSummary {
     checkType: "custom/basic",
     name: "Test Monitor",
     threadIdleTimeout: null,
+    evaluator: null,
     ...overrides,
   };
 }
@@ -163,6 +164,42 @@ describe("evaluationTrigger reactor", () => {
       expect(options).toBeDefined();
       expect(options!.deduplication!.ttlMs).toBe(DEFERRED_CHECK_DELAY_MS + 60_000);
       expect(options!.delay).toBeUndefined();
+    });
+  });
+
+  describe("when monitor has a linked evaluator", () => {
+    it("uses evaluator name instead of monitor name", async () => {
+      const monitor = makeMonitor({
+        name: "Monitor Name",
+        evaluator: { name: "Evaluator Name" },
+      });
+      const deps = createDeps();
+      vi.mocked(deps.monitors.getEnabledOnMessageMonitors).mockResolvedValue([monitor]);
+
+      const reactor = createEvaluationTriggerReactor(deps);
+      await reactor.handle(makeEvent(), makeContext());
+
+      expect(deps.evaluation).toHaveBeenCalledTimes(1);
+      const [payload] = vi.mocked(deps.evaluation).mock.calls[0]!;
+      expect(payload.evaluatorName).toBe("Evaluator Name");
+    });
+  });
+
+  describe("when monitor has no linked evaluator", () => {
+    it("falls back to monitor name", async () => {
+      const monitor = makeMonitor({
+        name: "Legacy Monitor",
+        evaluator: null,
+      });
+      const deps = createDeps();
+      vi.mocked(deps.monitors.getEnabledOnMessageMonitors).mockResolvedValue([monitor]);
+
+      const reactor = createEvaluationTriggerReactor(deps);
+      await reactor.handle(makeEvent(), makeContext());
+
+      expect(deps.evaluation).toHaveBeenCalledTimes(1);
+      const [payload] = vi.mocked(deps.evaluation).mock.calls[0]!;
+      expect(payload.evaluatorName).toBe("Legacy Monitor");
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -112,7 +112,7 @@ async function dispatchEvaluations({
         evaluationId,
         evaluatorId: monitor.id,
         evaluatorType: monitor.checkType,
-        evaluatorName: monitor.name,
+        evaluatorName: monitor.evaluator?.name ?? monitor.name,
         isGuardrail: false,
         occurredAt,
         threadIdleTimeout: monitor.threadIdleTimeout ?? undefined,

--- a/langwatch_nlp/langwatch_nlp/studio/dspy/langwatch_workflow_module.py
+++ b/langwatch_nlp/langwatch_nlp/studio/dspy/langwatch_workflow_module.py
@@ -79,6 +79,15 @@ class LangWatchWorkflowModule(ReportingModule):
             return result
 
         wrapped_module.forward = forward_with_metadata  # type: ignore
+
+        # For non-dspy.Module classes, instance() calls __call__ directly,
+        # bypassing forward. Wire __call__ through forward so the full
+        # patching chain (autoparsing, reporting, metadata) is always hit.
+        if not issubclass(wrapped_module, dspy.Module):
+            def call_via_forward(instance_self, *args, **kwargs):
+                return instance_self.forward(*args, **kwargs)
+            wrapped_module.__call__ = call_via_forward  # type: ignore
+
         return wrapped_module
 
     def run_in_parallel(self, *module_kwargs: Tuple[T, Dict[str, Any]]):

--- a/langwatch_nlp/langwatch_nlp/studio/dspy/langwatch_workflow_module.py
+++ b/langwatch_nlp/langwatch_nlp/studio/dspy/langwatch_workflow_module.py
@@ -38,7 +38,25 @@ class LangWatchWorkflowModule(ReportingModule):
 
         # Apply autoparsing and reporting to the subclass, not the original
         wrapped_module = self.with_reporting(with_autoparsing(WrappedModule), node_id)
-        wrapped_module.__forward_before_metadata__ = wrapped_module.forward  # type: ignore
+
+        # Resolve entrypoint: forward (dspy.Module convention) or __call__ (plain class).
+        # Check via __dict__ on the MRO to avoid picking up type.__call__ (metaclass)
+        # which exists on every class and would give a false positive.
+        def _has_own_method(cls, name):
+            return any(name in klass.__dict__ for klass in cls.__mro__ if klass not in (type, object))
+
+        original_method = getattr(wrapped_module, "forward", None) if _has_own_method(wrapped_module, "forward") else None
+        entrypoint_attr = "forward"
+        if not callable(original_method):
+            original_method = getattr(wrapped_module, "__call__", None) if _has_own_method(wrapped_module, "__call__") else None
+            entrypoint_attr = "__call__"
+        if not callable(original_method):
+            raise TypeError(
+                f"Class '{module.__name__}' for node {node_id} has no callable "
+                f"entrypoint. Define forward(self, ...) or __call__(self, ...)."
+            )
+
+        wrapped_module.__forward_before_metadata__ = original_method  # type: ignore
 
         def forward_with_metadata(instance_self, *args, **kwargs):
             if not run:
@@ -64,7 +82,7 @@ class LangWatchWorkflowModule(ReportingModule):
                 raise e
             return result
 
-        wrapped_module.forward = forward_with_metadata  # type: ignore
+        setattr(wrapped_module, entrypoint_attr, forward_with_metadata)
         return wrapped_module
 
     def run_in_parallel(self, *module_kwargs: Tuple[T, Dict[str, Any]]):

--- a/langwatch_nlp/langwatch_nlp/studio/dspy/langwatch_workflow_module.py
+++ b/langwatch_nlp/langwatch_nlp/studio/dspy/langwatch_workflow_module.py
@@ -36,27 +36,23 @@ class LangWatchWorkflowModule(ReportingModule):
         class WrappedModule(module):  # type: ignore
             pass
 
-        # Apply autoparsing and reporting to the subclass, not the original
-        wrapped_module = self.with_reporting(with_autoparsing(WrappedModule), node_id)
-
-        # Resolve entrypoint: forward (dspy.Module convention) or __call__ (plain class).
-        # Check via __dict__ on the MRO to avoid picking up type.__call__ (metaclass)
-        # which exists on every class and would give a false positive.
+        # For __call__-only classes (no forward method), bridge __call__ to forward
+        # so the downstream patching chain (with_autoparsing, with_reporting) works.
         def _has_own_method(cls, name):
             return any(name in klass.__dict__ for klass in cls.__mro__ if klass not in (type, object))
 
-        original_method = getattr(wrapped_module, "forward", None) if _has_own_method(wrapped_module, "forward") else None
-        entrypoint_attr = "forward"
-        if not callable(original_method):
-            original_method = getattr(wrapped_module, "__call__", None) if _has_own_method(wrapped_module, "__call__") else None
-            entrypoint_attr = "__call__"
-        if not callable(original_method):
-            raise TypeError(
-                f"Class '{module.__name__}' for node {node_id} has no callable "
-                f"entrypoint. Define forward(self, ...) or __call__(self, ...)."
-            )
+        if not _has_own_method(WrappedModule, "forward"):
+            if _has_own_method(WrappedModule, "__call__"):
+                WrappedModule.forward = WrappedModule.__call__  # type: ignore
+            else:
+                raise TypeError(
+                    f"Class '{module.__name__}' for node {node_id} has no callable "
+                    f"entrypoint. Define forward(self, ...) or __call__(self, ...)."
+                )
 
-        wrapped_module.__forward_before_metadata__ = original_method  # type: ignore
+        # Apply autoparsing and reporting to the subclass, not the original
+        wrapped_module = self.with_reporting(with_autoparsing(WrappedModule), node_id)
+        wrapped_module.__forward_before_metadata__ = wrapped_module.forward  # type: ignore
 
         def forward_with_metadata(instance_self, *args, **kwargs):
             if not run:
@@ -82,7 +78,7 @@ class LangWatchWorkflowModule(ReportingModule):
                 raise e
             return result
 
-        setattr(wrapped_module, entrypoint_attr, forward_with_metadata)
+        wrapped_module.forward = forward_with_metadata  # type: ignore
         return wrapped_module
 
     def run_in_parallel(self, *module_kwargs: Tuple[T, Dict[str, Any]]):

--- a/langwatch_nlp/tests/studio/test_wrapped_module_entrypoint.py
+++ b/langwatch_nlp/tests/studio/test_wrapped_module_entrypoint.py
@@ -1,0 +1,76 @@
+"""
+Tests for LangWatchWorkflowModule.wrapped() entrypoint resolution.
+
+Verifies that wrapped() handles classes with forward(), __call__(), or both,
+matching the same resolution order as execute_component.py and the Go runner.
+"""
+
+import dspy
+import pytest
+
+from langwatch_nlp.studio.dspy.langwatch_workflow_module import (
+    LangWatchWorkflowModule,
+)
+
+
+class ForwardOnlyModule(dspy.Module):
+    def forward(self, input: str):
+        return dspy.Prediction(output=f"forward:{input}")
+
+
+class CallOnlyClass:
+    def __call__(self, input: str):
+        return dspy.Prediction(output=f"call:{input}")
+
+
+class BothMethodsClass:
+    def forward(self, input: str):
+        return dspy.Prediction(output=f"forward:{input}")
+
+    def __call__(self, input: str):
+        return dspy.Prediction(output=f"call:{input}")
+
+
+class NeitherMethodClass:
+    pass
+
+
+class TestWrappedModuleEntrypoint:
+    def _make_workflow(self):
+        class Workflow(LangWatchWorkflowModule):
+            def forward(self, **kwargs):
+                pass
+        return Workflow()
+
+    def test_forward_only_module(self):
+        wf = self._make_workflow()
+        WrappedClass = wf.wrapped(ForwardOnlyModule, node_id="n1")
+        instance = WrappedClass()
+        result = instance(input="test")
+        assert result.output == "forward:test"
+
+    def test_call_only_class(self):
+        wf = self._make_workflow()
+        WrappedClass = wf.wrapped(CallOnlyClass, node_id="n2")
+        instance = WrappedClass()
+        result = instance(input="test")
+        assert result.output == "call:test"
+
+    def test_forward_preferred_over_call(self):
+        wf = self._make_workflow()
+        WrappedClass = wf.wrapped(BothMethodsClass, node_id="n3")
+        instance = WrappedClass()
+        result = instance(input="test")
+        assert result.output == "forward:test"
+
+    def test_neither_method_raises(self):
+        wf = self._make_workflow()
+        with pytest.raises(TypeError, match="has no callable entrypoint"):
+            wf.wrapped(NeitherMethodClass, node_id="n4")
+
+    def test_skipped_when_run_false(self):
+        wf = self._make_workflow()
+        WrappedClass = wf.wrapped(CallOnlyClass, node_id="n5", run=False)
+        instance = WrappedClass()
+        result = instance(input="test")
+        assert result.status == "skipped"


### PR DESCRIPTION
## Summary

Three fixes for evaluator bugs reported in #3572:

- **isEvaluator/isComponent preserved during workflow copy** (re-applies reverted #3573 with fixed tests). `copyWorkflowWithDatasets()` was dropping these flags, causing copied evaluator workflows to lose their identity. All four callers updated. Test now includes `projectId` in all queries for multitenancy middleware compliance.

- **Evaluator name in traces**: `evaluationTrigger` reactor was passing `monitor.name` as `evaluatorName`. For monitors linked to an Evaluator record, traces showed the monitor's name instead of the evaluator's name. Now fetches the linked evaluator's name, falls back to `monitor.name` for legacy monitors.

- **WrappedModule AttributeError**: `LangWatchWorkflowModule.wrapped()` assumed `forward()` exists. Classes using only `__call__()` (new default Code template from #3543) raised `AttributeError`. Now bridges `__call__` to `forward` before the patching chain, and wires `__call__` through `forward` for non-dspy.Module classes.

Closes #3572 (Issues 1 + 2)

## Test plan

- [x] Integration test: copied evaluator workflow preserves `isEvaluator: true`
- [x] Integration test: copied component workflow preserves `isComponent: true`
- [x] Unit test: monitor with linked evaluator uses evaluator name
- [x] Unit test: monitor without linked evaluator falls back to monitor name
- [x] Unit test: `wrapped()` with `forward()`-only class (dspy.Module)
- [x] Unit test: `wrapped()` with `__call__`-only class (plain Code node)
- [x] Unit test: `wrapped()` prefers `forward()` when both exist
- [x] Unit test: `wrapped()` raises TypeError when neither method exists
- [x] Unit test: `wrapped()` with `run=False` returns skipped result
- [x] `pnpm typecheck` clean