### PR TITLE
fix(health-checks): wrap PII sample in a list so /api/health/evaluations stops 500-ing

### DIFF
--- a/langwatch/src/server/routes/health-checks.ts
+++ b/langwatch/src/server/routes/health-checks.ts
@@ -201,10 +201,17 @@ app.get("/evaluations", async (c) => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          data: {
-            input:
-              "Hello, my name is John Canary and my email is canary@langwatch.ai.",
-          },
+          // langevals presidio expects `data` as a LIST of items — see the
+          // production caller in workers/collector/piiCheck.ts:293. Sending
+          // a bare object here returns 422 "Input should be a valid list"
+          // from the Lambda, which the route serialises as a 500 to Studio
+          // ("Failed to run sample evaluation: Internal Server Error").
+          data: [
+            {
+              input:
+                "Hello, my name is John Canary and my email is canary@langwatch.ai.",
+            },
+          ],
           settings: {
             entities: {
               email_address: true,


### PR DESCRIPTION
## Summary
- `GET /api/health/evaluations` 500's with `Failed to run sample evaluation: Internal Server Error` because it sends `data: {input: "…"}` to the presidio PII Lambda, which expects `data` as a **list** of items (`data: [{input: "…"}]`).
- Bug existed since the Vite/Hono migration (#3170, 670b4fd8b) — the file's only commit. No regression triggered it; the endpoint just hadn't been exercised in prod recently.
- Fix: wrap the sample in a list, mirroring the canonical caller at `langwatch/src/server/background/workers/collector/piiCheck.ts:293` which has always sent the correct shape.

## Direct Lambda repro
On `presidio-evaluator-lambda` (prod, image `hash-722586b`):

```bash
# WRONG (current health-checks shape) → 422
{"data":{"input":"Hello, my name is John Canary…"}, "settings":{…}}
# {"detail":[{"type":"list_type","loc":["body","data"],"msg":"Input should be a valid list",…}]}

# CORRECT (piiCheck.ts shape) → 200 with PII results
{"data":[{"input":"Hello, my name is John Canary…"}], "settings":{…}}
# [{"status":"processed","score":2.0,"passed":false,"details":"PII detected: EMAIL_ADDRESS … PERSON …",…}]
```

## Why no real user impact
`piiCheck.ts:293` (the worker-side caller hit by every span ingestion) has always sent the correct list shape and works fine. Lambda metrics show 0 errors over the last 10 min; ~150-350 invocations/min steady. The 500 only surfaces from the self-test endpoint at `/api/health/evaluations`.

## Test plan
- [x] Direct Lambda invoke on prod confirms list shape returns 200 with proper EMAIL_ADDRESS + PERSON detection
- [x] No new typecheck errors (pre-existing failure in `evaluators.zod.generated.ts` is on main, unrelated)
- [ ] After deploy: `curl -H "X-Auth-Token: <project-key>" https://app.langwatch.ai/api/health/evaluations` returns 200 instead of 500