### PR TITLE
fix(evaluations): skip custom evaluators with no DSL so /api/evaluations/*/evaluate stops 500-ing

### DIFF
--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -564,23 +564,32 @@ export const getEvaluatorIncludingCustom = async (
     projectId,
   });
 
+  const customEntries: [string, { name: string; requiredFields: string[] }][] =
+    [];
+  for (const evaluator of availableCustomEvaluators ?? []) {
+    const dsl = evaluator.versions[0]?.dsl;
+    if (!dsl) {
+      continue;
+    }
+    const cloned = JSON.parse(JSON.stringify(dsl)) as
+      | { edges?: Edge[]; nodes?: unknown[] }
+      | undefined;
+    const { inputs } = getInputsOutputs(
+      (cloned?.edges ?? []) as Edge[],
+      (cloned?.nodes ?? []) as JsonArray as unknown[] as Node[],
+    );
+    const requiredFields = inputs
+      .map((input) => input.identifier)
+      .filter((id): id is string => typeof id === "string");
+    customEntries.push([
+      `custom/${evaluator.id}`,
+      { name: evaluator.name, requiredFields },
+    ]);
+  }
+
   const availableEvaluators = {
     ...AVAILABLE_EVALUATORS,
-    ...Object.fromEntries(
-      (availableCustomEvaluators ?? []).map((evaluator) => {
-        const { inputs } = getInputsOutputs(
-          JSON.parse(JSON.stringify(evaluator.versions[0]?.dsl))
-            ?.edges as Edge[],
-          JSON.parse(JSON.stringify(evaluator.versions[0]?.dsl))
-            ?.nodes as JsonArray as unknown[] as Node[],
-        );
-        const requiredFields = inputs.map((input) => input.identifier);
-        return [
-          `custom/${evaluator.id}`,
-          { name: evaluator.name, requiredFields },
-        ];
-      }),
-    ),
+    ...Object.fromEntries(customEntries),
   };
 
   return availableEvaluators[checkType];


### PR DESCRIPTION
## TL;DR
\`getEvaluatorIncludingCustom\` does \`JSON.parse(JSON.stringify(evaluator.versions[0]?.dsl))\` on every custom evaluator. When \`dsl\` is undefined, \`JSON.stringify(undefined) === "undefined"\` (the string), and \`JSON.parse("undefined")\` throws. **This 500's every POST to \`/api/evaluations/:evaluator/evaluate\` for any project that has a draft custom evaluator with no DSL yet** — including the status-page health-check at \`/api/health/evaluations\`.

## Repro on prod
```bash
curl -H 'Authorization: Bearer sk-lw-…' https://app.langwatch.ai/api/health/evaluations
# HTTP/2 500
# {"message":"Failed to run sample evaluation: Internal Server Error"}
```

## Stack trace (prod pod log)
```
ERROR  langwatch:api:hono  POST /api/evaluations/presidio/pii_detection/evaluate  500
SyntaxError: "undefined" is not valid JSON
    at JSON.parse (<anonymous>)
    at evaluations-legacy.ts:572:16
    at Array.map (<anonymous>)
    at getEvaluatorIncludingCustom (evaluations-legacy.ts:570:41)
    at handleEvaluatorCall (evaluations-legacy.ts:692:6)
```

## Why no real-user PII redaction broke
The per-trace PII path (`langwatch/src/server/background/workers/collector/piiCheck.ts:286`) calls the langevals Lambda **directly**, bypassing this resolver. So real customer PII redaction kept working — only the evaluations-route surface (which goes through the resolver to look up custom evaluators) was 500'ing.

## Why now
The bug ships in any project that has a custom evaluator with `versions[0].dsl == null`. That state is reachable via the Studio "create evaluator" flow when an evaluator is created and saved before its DSL has been generated. As the fleet of projects with custom evaluators grew, the chance any given project hit this rose. The status-page check uses your project's API key, so once your project picked up such a draft evaluator, the health-check started 500'ing every 5 minutes.

## Fix
Skip evaluators with no DSL in the resolver. Production happy path (custom evaluator with valid DSL) is unchanged.

## Test plan
- [x] Reproduced 500 on prod with rchaves's project token
- [x] Found stack trace pinning the failing line in production pod logs
- [x] `pnpm typecheck` clean (the pre-existing `evaluators.zod.generated.ts` error is on main, unrelated)
- [ ] After deploy: `curl -H 'Authorization: Bearer sk-lw-…' https://app.langwatch.ai/api/health/evaluations` returns 200