### PR TITLE
fix(rbac): restore project creation for team members

### DIFF
--- a/langwatch/src/server/api/__tests__/rbac.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac.test.ts
@@ -170,7 +170,7 @@ describe("RBAC Permission System", () => {
         true,
       );
       expect(teamRoleHasPermission(TeamUserRole.MEMBER, "project:create")).toBe(
-        false,
+        true,
       );
       expect(teamRoleHasPermission(TeamUserRole.MEMBER, "project:delete")).toBe(
         false,
@@ -414,8 +414,8 @@ describe("RBAC Permission System", () => {
         expect(canCreate(TeamUserRole.ADMIN, Resources.PROJECT)).toBe(true);
       });
 
-      it("returns false for MEMBER role on project resource", () => {
-        expect(canCreate(TeamUserRole.MEMBER, Resources.PROJECT)).toBe(false);
+      it("returns true for MEMBER role on project resource", () => {
+        expect(canCreate(TeamUserRole.MEMBER, Resources.PROJECT)).toBe(true);
       });
 
       it("returns false for VIEWER role on project resource", () => {
@@ -470,7 +470,7 @@ describe("RBAC Permission System", () => {
         const permissions = getTeamRolePermissions(TeamUserRole.MEMBER);
         expect(permissions).toContain("project:view");
         expect(permissions).toContain("project:update");
-        expect(permissions).not.toContain("project:create");
+        expect(permissions).toContain("project:create");
         expect(permissions).not.toContain("project:delete");
         expect(permissions).not.toContain("project:manage");
         expect(permissions).toContain("workflows:view");
@@ -635,7 +635,7 @@ describe("RBAC Permission System", () => {
       // Should have limited project permissions
       expect(memberPermissions).toContain("project:view");
       expect(memberPermissions).toContain("project:update");
-      expect(memberPermissions).not.toContain("project:create");
+      expect(memberPermissions).toContain("project:create");
       expect(memberPermissions).not.toContain("project:delete");
       expect(memberPermissions).not.toContain("project:manage");
     });

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -164,6 +164,7 @@ const TEAM_ROLE_PERMISSIONS: Record<TeamUserRole, Permission[]> = {
   [TeamUserRole.MEMBER]: [
     // Projects
     "project:view",
+    "project:create",
     "project:update",
     // Analytics
     "analytics:view",

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -97,7 +97,7 @@ export const projectRouter = createTRPCRouter({
     .use(skipPermissionCheckProjectCreation)
     .use(({ ctx, input, next }) => {
       if (input.teamId) {
-        return checkTeamPermission("organization:manage")({
+        return checkTeamPermission("project:create")({
           ctx,
           input: { ...input, teamId: input.teamId },
           next,


### PR DESCRIPTION
Closes #3581

## Summary

- **Regression from #724:** The RBAC migration changed the project creation permission from team-level (`TEAM_CREATE_NEW_PROJECTS`) to org-level (`organization:manage`), blocking all non-org-admin users from creating projects
- **Fix:** Add `project:create` to MEMBER team permissions and change the backend check from `organization:manage` to `project:create`
- Team membership enforcement is implicit through the RoleBinding lookup — no extra check needed

### Changes

| File | Change |
|------|--------|
| `src/server/api/rbac.ts` | Add `project:create` to `TEAM_ROLE_PERMISSIONS[MEMBER]` |
| `src/server/api/routers/project.ts:100` | Change `checkTeamPermission("organization:manage")` → `checkTeamPermission("project:create")` |
| `src/server/api/__tests__/rbac.test.ts` | Update 3 assertions to expect MEMBER has `project:create` |

### Permission flow after fix

| Scenario | Result | Why |
|----------|--------|-----|
| MEMBER creates project in own team | Allowed | TEAM-scoped MEMBER binding has `project:create` |
| MEMBER creates project in foreign team | Denied | No TEAM-scoped binding; ORG MEMBER only has `organization:view` |
| Org ADMIN creates project in any team | Allowed | ORG-scoped ADMIN binding bypasses all checks |

## Test plan

- [x] RBAC unit tests updated and passing (51 pass, 0 fail)
- [x] Typecheck passes
- [x] CI green (all test suites pass)
- [ ] MEMBER in own team can create a project (manual verification)
- [ ] MEMBER in foreign team is denied (manual verification)
- [ ] Org ADMIN can still create projects in any team (no regression)