### PR TITLE
fix: send slack and cio notifications on invite acceptance

### DIFF
--- a/langwatch/ee/billing/nurturing/hooks/index.ts
+++ b/langwatch/ee/billing/nurturing/hooks/index.ts
@@ -1,4 +1,5 @@
 export { fireSignupNurturingCalls } from "./signupIdentification";
+export { fireInviteAcceptedNurturingCalls } from "./inviteAcceptance";
 export {
   fireTeamMemberInvitedNurturing,
   fireWorkflowCreatedNurturing,

--- a/langwatch/ee/billing/nurturing/hooks/inviteAcceptance.ts
+++ b/langwatch/ee/billing/nurturing/hooks/inviteAcceptance.ts
@@ -30,7 +30,6 @@ export function fireInviteAcceptedNurturingCalls({
       traits: {
         ...(email ? { email } : {}),
         ...(name ? { name } : {}),
-        createdAt: new Date().toISOString(),
       },
     })
     .catch(captureException);

--- a/langwatch/ee/billing/nurturing/hooks/inviteAcceptance.ts
+++ b/langwatch/ee/billing/nurturing/hooks/inviteAcceptance.ts
@@ -1,0 +1,56 @@
+import { getApp } from "../../../../src/server/app-layer/app";
+import { captureException } from "../../../../src/utils/posthogErrorCapture";
+
+/**
+ * Identifies a user in Customer.io when they accept an invite and join
+ * an existing organization.
+ *
+ * Fires identifyUser, groupUser, and a "joined_via_invite" event —
+ * all fire-and-forget so that Customer.io failures never block the invite flow.
+ */
+export function fireInviteAcceptedNurturingCalls({
+  userId,
+  email,
+  name,
+  organizationId,
+  organizationName,
+}: {
+  userId: string;
+  email: string | null | undefined;
+  name: string | null | undefined;
+  organizationId: string;
+  organizationName: string;
+}): void {
+  const nurturing = getApp().nurturing;
+  if (!nurturing) return;
+
+  void nurturing
+    .identifyUser({
+      userId,
+      traits: {
+        ...(email ? { email } : {}),
+        ...(name ? { name } : {}),
+        createdAt: new Date().toISOString(),
+      },
+    })
+    .catch(captureException);
+
+  void nurturing
+    .groupUser({
+      userId,
+      groupId: organizationId,
+      traits: { name: organizationName },
+    })
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({
+      userId,
+      event: "joined_via_invite",
+      properties: {
+        organization_id: organizationId,
+        organization_name: organizationName,
+      },
+    })
+    .catch(captureException);
+}

--- a/langwatch/ee/billing/nurturing/types.ts
+++ b/langwatch/ee/billing/nurturing/types.ts
@@ -99,7 +99,8 @@ export type CioEventName =
   | "workflow_created"
   | "experiment_ran"
   | "first_prompt_created"
-  | "first_simulation_ran";
+  | "first_simulation_ran"
+  | "joined_via_invite";
 
 // ---------------------------------------------------------------------------
 // Batch call discriminated union

--- a/langwatch/src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.acceptInvite.unit.test.ts
@@ -24,6 +24,15 @@ vi.mock("../../../auditLog", () => ({
   auditLog: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("../../../app-layer/app", () => ({
+  getApp: () => ({
+    notifications: {
+      sendSlackSignupEvent: vi.fn().mockResolvedValue(undefined),
+    },
+    nurturing: null,
+  }),
+}));
+
 vi.mock("../../rbac", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../rbac")>();
   return {

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -1037,15 +1037,13 @@ export const organizationRouter = createTRPCRouter({
         });
       });
 
-      try {
-        await getApp().notifications.sendSlackSignupEvent({
+      void getApp()
+        .notifications.sendSlackSignupEvent({
           userName: session.user.name,
           userEmail: session.user.email,
           organizationName: invite.organization.name,
-        });
-      } catch (error) {
-        captureException(error);
-      }
+        })
+        .catch(captureException);
 
       fireInviteAcceptedNurturingCalls({
         userId: session.user.id,

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -20,6 +20,7 @@ import { isTeamRoleAllowedForOrganizationRole, type TeamRoleValue } from "~/util
 import { getApp } from "~/server/app-layer/app";
 import { trackServerEvent } from "~/server/posthog";
 import { fireTeamMemberInvitedNurturing } from "~/../ee/billing/nurturing/hooks/featureAdoption";
+import { fireInviteAcceptedNurturingCalls } from "~/../ee/billing/nurturing/hooks/inviteAcceptance";
 import { elasticsearchMigrate } from "../../../tasks/elasticMigrate";
 import {
   InviteService,
@@ -1034,6 +1035,24 @@ export const organizationRouter = createTRPCRouter({
           userId: session.user.id,
           invite,
         });
+      });
+
+      try {
+        await getApp().notifications.sendSlackSignupEvent({
+          userName: session.user.name,
+          userEmail: session.user.email,
+          organizationName: invite.organization.name,
+        });
+      } catch (error) {
+        captureException(error);
+      }
+
+      fireInviteAcceptedNurturingCalls({
+        userId: session.user.id,
+        email: session.user.email,
+        name: session.user.name,
+        organizationId: invite.organization.id,
+        organizationName: invite.organization.name,
       });
 
       const inviteService = InviteService.create(prisma);


### PR DESCRIPTION
## Summary

- Invite-accepted users bypassed `initializeOrganization`, so no Slack signup message or Customer.io identification was ever fired for them
- Adds fire-and-forget Slack + Customer.io notifications to the `acceptInvite` mutation, following the same pattern used in onboarding
- New `fireInviteAcceptedNurturingCalls` hook: identifies user, groups with org, tracks `joined_via_invite` event

## Changes

| File | What |
|------|------|
| `ee/billing/nurturing/hooks/inviteAcceptance.ts` | New hook: CIO identify + group + `joined_via_invite` event |
| `ee/billing/nurturing/hooks/index.ts` | Re-export new hook |
| `ee/billing/nurturing/types.ts` | Add `joined_via_invite` to `CioEventName` |
| `src/server/api/routers/organization.ts` | Wire Slack + CIO calls after `acceptInvite` transaction (fire-and-forget) |
| `organization.acceptInvite.unit.test.ts` | Add `getApp()` mock for new notification calls |

## Related issues

- Part of langwatch/langwatch-saas#479 (invite accept path — this PR)
- SSO auto-add path tracked in langwatch/langwatch-saas#480
- Backfill of existing users remains in langwatch/langwatch-saas#479

## Test plan

- [x] All 25 existing unit tests pass (onboarding, acceptInvite, signupIdentification)
- [x] Typecheck clean (no errors in changed files)
- [x] CI green (unit, integration, e2e, lint, typecheck, build)
- [ ] Verify Slack notification fires in staging when accepting an invite
- [ ] Verify Customer.io profile is created with `joined_via_invite` event in staging