### PR TITLE
feat(analytics): api_active_user heartbeat from auth middleware

### DIFF
--- a/langwatch/src/server/active-user/__tests__/parseClientSource.unit.test.ts
+++ b/langwatch/src/server/active-user/__tests__/parseClientSource.unit.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { parseClientSource } from "../parseClientSource";
+
+describe("parseClientSource", () => {
+  describe("when User-Agent matches the langwatch pattern", () => {
+    it("extracts mcp source and version", () => {
+      expect(parseClientSource("langwatch-mcp/0.42.1")).toEqual({
+        source: "mcp",
+        version: "0.42.1",
+      });
+    });
+
+    it("extracts cli source and version", () => {
+      expect(parseClientSource("langwatch-cli/1.0.0")).toEqual({
+        source: "cli",
+        version: "1.0.0",
+      });
+    });
+
+    it("extracts skill source", () => {
+      expect(parseClientSource("langwatch-skill/datasets@0.3.0")).toEqual({
+        source: "skill",
+        version: "datasets@0.3.0",
+      });
+    });
+
+    it("matches case-insensitively but normalizes the source label to lowercase", () => {
+      expect(parseClientSource("LangWatch-MCP/0.42.1")).toEqual({
+        source: "mcp",
+        version: "0.42.1",
+      });
+    });
+
+    it("preserves complex semver strings", () => {
+      expect(parseClientSource("langwatch-sdk-ts/2.0.0-beta.1+build.7")).toEqual({
+        source: "sdk-ts",
+        version: "2.0.0-beta.1+build.7",
+      });
+    });
+  });
+
+  describe("when User-Agent is missing or unrecognized", () => {
+    it("returns unknown for null", () => {
+      expect(parseClientSource(null)).toEqual({ source: "unknown" });
+    });
+
+    it("returns unknown for undefined", () => {
+      expect(parseClientSource(undefined)).toEqual({ source: "unknown" });
+    });
+
+    it("returns unknown for empty string", () => {
+      expect(parseClientSource("")).toEqual({ source: "unknown" });
+    });
+
+    it("returns unknown for browser user agents", () => {
+      expect(
+        parseClientSource(
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+        ),
+      ).toEqual({ source: "unknown" });
+    });
+
+    it("returns unknown for unknown langwatch product names", () => {
+      expect(parseClientSource("langwatch-future/1.0")).toEqual({
+        source: "unknown",
+      });
+    });
+
+    it("returns unknown for malformed langwatch UA without a version", () => {
+      expect(parseClientSource("langwatch-mcp/")).toEqual({ source: "unknown" });
+    });
+  });
+});

--- a/langwatch/src/server/active-user/__tests__/recordActiveUser.unit.test.ts
+++ b/langwatch/src/server/active-user/__tests__/recordActiveUser.unit.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import type { trackServerEvent } from "../../posthog";
+import {
+  recordActiveUser,
+  type RecordActiveUserDeps,
+} from "../recordActiveUser";
+
+type RedisLike = NonNullable<RecordActiveUserDeps["redis"]>;
+
+function makeRedis(setImpl: () => Promise<unknown>) {
+  const set = vi.fn().mockImplementation(setImpl);
+  return { set, instance: { set } as unknown as RedisLike };
+}
+
+const FROZEN_NOW = () => new Date("2026-04-29T10:00:00Z");
+
+describe("recordActiveUser", () => {
+  let trackEvent: ReturnType<typeof vi.fn> & typeof trackServerEvent;
+
+  beforeEach(() => {
+    trackEvent = vi.fn() as ReturnType<typeof vi.fn> & typeof trackServerEvent;
+  });
+
+  describe("when Redis confirms the call is the first today", () => {
+    it("fires api_active_user with userId as distinctId, source, and version", async () => {
+      const { instance: redis } = makeRedis(async () => "OK");
+
+      await recordActiveUser(
+        { userId: "u1", source: "mcp", version: "0.42.1" },
+        { redis, trackEvent, now: FROZEN_NOW },
+      );
+
+      expect(trackEvent).toHaveBeenCalledTimes(1);
+      expect(trackEvent).toHaveBeenCalledWith({
+        userId: "u1",
+        event: "api_active_user",
+        properties: { source: "mcp", version: "0.42.1" },
+      });
+    });
+
+    it("uses an active_user key keyed by userId, UTC day, and source with a 48h TTL", async () => {
+      const { set, instance: redis } = makeRedis(async () => "OK");
+
+      await recordActiveUser(
+        { userId: "u1", source: "mcp" },
+        { redis, trackEvent, now: FROZEN_NOW },
+      );
+
+      expect(set).toHaveBeenCalledWith(
+        "active_user:u1:2026-04-29:mcp",
+        "1",
+        "EX",
+        172800,
+        "NX",
+      );
+    });
+
+    it("omits version from properties when not provided", async () => {
+      const { instance: redis } = makeRedis(async () => "OK");
+
+      await recordActiveUser(
+        { userId: "u1", source: "unknown" },
+        { redis, trackEvent, now: FROZEN_NOW },
+      );
+
+      expect(trackEvent).toHaveBeenCalledWith({
+        userId: "u1",
+        event: "api_active_user",
+        properties: { source: "unknown" },
+      });
+    });
+  });
+
+  describe("when Redis indicates the heartbeat already exists for today", () => {
+    it("does not fire api_active_user", async () => {
+      const { instance: redis } = makeRedis(async () => null);
+
+      await recordActiveUser(
+        { userId: "u1", source: "mcp" },
+        { redis, trackEvent, now: FROZEN_NOW },
+      );
+
+      expect(trackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when Redis throws", () => {
+    it("fires api_active_user anyway as a graceful overcount", async () => {
+      const { instance: redis } = makeRedis(async () => {
+        throw new Error("redis down");
+      });
+
+      await recordActiveUser(
+        { userId: "u1", source: "mcp" },
+        { redis, trackEvent, now: FROZEN_NOW },
+      );
+
+      expect(trackEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("never throws to the caller", async () => {
+      const { instance: redis } = makeRedis(async () => {
+        throw new Error("redis down");
+      });
+
+      await expect(
+        recordActiveUser(
+          { userId: "u1", source: "mcp" },
+          { redis, trackEvent, now: FROZEN_NOW },
+        ),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("when redis is not configured", () => {
+    it("fires api_active_user without dedup", async () => {
+      await recordActiveUser(
+        { userId: "u1", source: "mcp" },
+        { redis: undefined, trackEvent, now: FROZEN_NOW },
+      );
+
+      expect(trackEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/langwatch/src/server/active-user/__tests__/recordActiveUser.unit.test.ts
+++ b/langwatch/src/server/active-user/__tests__/recordActiveUser.unit.test.ts
@@ -132,4 +132,24 @@ describe("recordActiveUser", () => {
       expect(trackEvent).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("when now is not provided", () => {
+    it("uses the real current date to key the Redis dedup entry", async () => {
+      const { set, instance: redis } = makeRedis(async () => "OK");
+      const expectedDay = new Date().toISOString().slice(0, 10);
+
+      await recordActiveUser(
+        { userId: "u1", source: "mcp" },
+        { redis, trackEvent },
+      );
+
+      expect(set).toHaveBeenCalledWith(
+        `active_user:u1:${expectedDay}:mcp`,
+        "1",
+        "EX",
+        172800,
+        "NX",
+      );
+    });
+  });
 });

--- a/langwatch/src/server/active-user/parseClientSource.ts
+++ b/langwatch/src/server/active-user/parseClientSource.ts
@@ -1,0 +1,35 @@
+/**
+ * Maps a User-Agent header to a coarse client-source label used by the
+ * `api_active_user` heartbeat. Recognized clients send a User-Agent of the
+ * form `langwatch-<product>/<version>`. Anything else collapses to `"unknown"`
+ * so legacy callers without the header don't break.
+ */
+
+const SOURCE_PATTERN = /^langwatch-(mcp|cli|skill|sdk-py|sdk-ts)\/(.+)$/i;
+
+export type ClientSource =
+  | "mcp"
+  | "cli"
+  | "skill"
+  | "sdk-py"
+  | "sdk-ts"
+  | "unknown";
+
+export interface ParsedClientSource {
+  source: ClientSource;
+  version?: string;
+}
+
+export function parseClientSource(
+  userAgent: string | undefined | null,
+): ParsedClientSource {
+  if (!userAgent) return { source: "unknown" };
+  const match = userAgent.match(SOURCE_PATTERN);
+  if (!match) return { source: "unknown" };
+  const [, sourceCapture, versionCapture] = match;
+  if (!sourceCapture || !versionCapture) return { source: "unknown" };
+  return {
+    source: sourceCapture.toLowerCase() as ClientSource,
+    version: versionCapture,
+  };
+}

--- a/langwatch/src/server/active-user/recordActiveUser.ts
+++ b/langwatch/src/server/active-user/recordActiveUser.ts
@@ -1,0 +1,84 @@
+import type IORedis from "ioredis";
+import type { Cluster } from "ioredis";
+import { createLogger } from "~/utils/logger/server";
+import { trackServerEvent } from "../posthog";
+import type { ClientSource } from "./parseClientSource";
+
+const logger = createLogger("langwatch:active-user");
+
+const KEY_PREFIX = "active_user:";
+
+// 48h — long enough that a request near UTC midnight in the user's tz
+// still finds yesterday's key, short enough that the dedup pool stays
+// bounded if the user is genuinely active every day.
+const TTL_SECONDS = 172_800;
+
+function buildKey(userId: string, day: string, source: string): string {
+  return `${KEY_PREFIX}${userId}:${day}:${source}`;
+}
+
+function utcDay(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
+export interface RecordActiveUserDeps {
+  redis: IORedis | Cluster | undefined;
+  trackEvent?: typeof trackServerEvent;
+  now?: () => Date;
+}
+
+export interface RecordActiveUserInput {
+  userId: string;
+  source: ClientSource;
+  version?: string;
+}
+
+/**
+ * Heartbeat capture for the `api_active_user` PostHog metric.
+ *
+ * Deduped per `(userId, UTC day, source)` via Redis `SET NX` so a power user
+ * making thousands of API calls produces at most one event per source per day.
+ *
+ * Fire-and-forget contract: never throws, never blocks the caller. On Redis
+ * outage we fire the event anyway (graceful overcount beats a silent gap).
+ * If `POSTHOG_KEY` isn't set, `trackServerEvent` no-ops.
+ */
+export async function recordActiveUser(
+  input: RecordActiveUserInput,
+  deps: RecordActiveUserDeps,
+): Promise<void> {
+  const { userId, source, version } = input;
+  const {
+    redis,
+    trackEvent = trackServerEvent,
+    now = () => new Date(),
+  } = deps;
+
+  let isFirstToday = true;
+  if (redis) {
+    try {
+      const result = await redis.set(
+        buildKey(userId, utcDay(now()), source),
+        "1",
+        "EX",
+        TTL_SECONDS,
+        "NX",
+      );
+      isFirstToday = result === "OK";
+    } catch (error) {
+      logger.warn(
+        { error, userId, source },
+        "active-user dedup unavailable; firing api_active_user as graceful overcount",
+      );
+      isFirstToday = true;
+    }
+  }
+
+  if (!isFirstToday) return;
+
+  trackEvent({
+    userId,
+    event: "api_active_user",
+    properties: { source, ...(version ? { version } : {}) },
+  });
+}

--- a/langwatch/src/server/active-user/recordActiveUser.ts
+++ b/langwatch/src/server/active-user/recordActiveUser.ts
@@ -1,0 +1,84 @@
+import type IORedis from "ioredis";
+import type { Cluster } from "ioredis";
+import { createLogger } from "@langwatch/observability";
+import { trackServerEvent } from "../posthog";
+import type { ClientSource } from "./parseClientSource";
+
+const logger = createLogger("langwatch:active-user");
+
+const KEY_PREFIX = "active_user:";
+
+// 48h — long enough that a request near UTC midnight in the user's tz
+// still finds yesterday's key, short enough that the dedup pool stays
+// bounded if the user is genuinely active every day.
+const TTL_SECONDS = 172_800;
+
+function buildKey(userId: string, day: string, source: string): string {
+  return `${KEY_PREFIX}${userId}:${day}:${source}`;
+}
+
+function utcDay(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
+export interface RecordActiveUserDeps {
+  redis: IORedis | Cluster | undefined;
+  trackEvent?: typeof trackServerEvent;
+  now?: () => Date;
+}
+
+export interface RecordActiveUserInput {
+  userId: string;
+  source: ClientSource;
+  version?: string;
+}
+
+/**
+ * Heartbeat capture for the `api_active_user` PostHog metric.
+ *
+ * Deduped per `(userId, UTC day, source)` via Redis `SET NX` so a power user
+ * making thousands of API calls produces at most one event per source per day.
+ *
+ * Fire-and-forget contract: never throws, never blocks the caller. On Redis
+ * outage we fire the event anyway (graceful overcount beats a silent gap).
+ * If `POSTHOG_KEY` isn't set, `trackServerEvent` no-ops.
+ */
+export async function recordActiveUser(
+  input: RecordActiveUserInput,
+  deps: RecordActiveUserDeps,
+): Promise<void> {
+  const { userId, source, version } = input;
+  const {
+    redis,
+    trackEvent = trackServerEvent,
+    now = () => new Date(),
+  } = deps;
+
+  let isFirstToday = true;
+  if (redis) {
+    try {
+      const result = await redis.set(
+        buildKey(userId, utcDay(now()), source),
+        "1",
+        "EX",
+        TTL_SECONDS,
+        "NX",
+      );
+      isFirstToday = result === "OK";
+    } catch (error) {
+      logger.warn(
+        { error, userId, source },
+        "active-user dedup unavailable; firing api_active_user as graceful overcount",
+      );
+      isFirstToday = true;
+    }
+  }
+
+  if (!isFirstToday) return;
+
+  trackEvent({
+    userId,
+    event: "api_active_user",
+    properties: { source, ...(version ? { version } : {}) },
+  });
+}

--- a/langwatch/src/server/api-key/auth-middleware.ts
+++ b/langwatch/src/server/api-key/auth-middleware.ts
@@ -5,6 +5,9 @@ import type { Permission } from "~/server/api/rbac";
 import { HandledError } from "@langwatch/handled-error";
 import { handledErrorResponseBody } from "~/app/api/middleware/error-handler";
 import { resolveApiKeyPermission } from "~/server/rbac/role-binding-resolver";
+import { connection } from "~/server/redis";
+import { recordActiveUser } from "~/server/active-user/recordActiveUser";
+import { parseClientSource } from "~/server/active-user/parseClientSource";
 import { getTokenType } from "./api-key-token.utils";
 import { ApiKeyPermissionDeniedError } from "./errors";
 import { type OrgResolvedToken, type ResolvedToken, TokenResolver } from "./token-resolver";
@@ -181,6 +184,24 @@ export function createUnifiedAuthMiddleware({
       c.res.status < 300
     ) {
       resolver.markUsed({ apiKeyId: resolved.apiKeyId });
+
+      // Heartbeat for the api_active_user PostHog metric. Same trigger as
+      // markUsed (API key + 2xx) so a "user is active today" follows the same
+      // truth as "this token was successfully used today". Fire-and-forget;
+      // errors are swallowed inside recordActiveUser.
+      //
+      // Ingestion keys (and any other apiKey without a userId) are skipped —
+      // the metric is user-scoped and these tokens cannot resolve to a
+      // single user, same as legacy project keys.
+      if (resolved.userId) {
+        const { source, version } = parseClientSource(
+          c.req.header("user-agent"),
+        );
+        void recordActiveUser(
+          { userId: resolved.userId, source, version },
+          { redis: connection },
+        );
+      }
     }
   };
 }

--- a/langwatch/src/server/pat/auth-middleware.ts
+++ b/langwatch/src/server/pat/auth-middleware.ts
@@ -6,6 +6,9 @@ import type { Permission } from "~/server/api/rbac";
 import { resolvePatPermission } from "~/server/rbac/role-binding-resolver";
 import { DomainError } from "~/server/app-layer/domain-error";
 import { createLogger } from "~/utils/logger/server";
+import { connection } from "~/server/redis";
+import { recordActiveUser } from "~/server/active-user/recordActiveUser";
+import { parseClientSource } from "~/server/active-user/parseClientSource";
 
 const logger = createLogger("langwatch:api:unified-auth");
 const permissionLogger = createLogger("langwatch:api:pat-ceiling");
@@ -192,6 +195,16 @@ export function createUnifiedAuthMiddleware({
       c.res.status < 300
     ) {
       resolver.markUsed({ patId: resolved.patId });
+
+      // Heartbeat for the api_active_user PostHog metric. Same trigger as
+      // markUsed (PAT + 2xx) so a "user is active today" follows the same
+      // truth as "this token was successfully used today". Fire-and-forget;
+      // errors are swallowed inside recordActiveUser.
+      const { source, version } = parseClientSource(c.req.header("user-agent"));
+      void recordActiveUser(
+        { userId: resolved.userId, source, version },
+        { redis: connection },
+      );
     }
   };
 }

--- a/mcp-server/src/langwatch-api.ts
+++ b/mcp-server/src/langwatch-api.ts
@@ -1,4 +1,7 @@
+import packageJson from "../package.json" assert { type: "json" };
 import { getConfig, requireApiKey } from "./config.js";
+
+const USER_AGENT = `langwatch-mcp/${packageJson.version}`;
 
 // --- Response types ---
 
@@ -121,6 +124,7 @@ export async function makeRequest(
   const url = getConfig().endpoint + path;
   const headers: Record<string, string> = {
     "X-Auth-Token": requireApiKey(),
+    "User-Agent": USER_AGENT,
   };
 
   if (body !== undefined) {

--- a/mcp-server/src/langwatch-api.ts
+++ b/mcp-server/src/langwatch-api.ts
@@ -2,8 +2,11 @@ import type {
   HandledErrorFault,
   SerializedReason,
 } from "@langwatch/handled-error";
+import packageJson from "../package.json" with { type: "json" };
 import { getConfig, requireApiKey } from "./config.js";
 import type { EvaluationSummary } from "./utils/format-evaluations.js";
+
+const USER_AGENT = `langwatch-mcp/${packageJson.version}`;
 
 // --- Response types ---
 
@@ -241,6 +244,7 @@ export async function makeRequest(
   const url = config.endpoint + path;
   const headers: Record<string, string> = {
     "X-Auth-Token": requireApiKey(),
+    "User-Agent": USER_AGENT,
   };
   if (config.projectId) {
     headers["X-Project-Id"] = config.projectId;

--- a/specs/analytics/api-active-user-tracking.feature
+++ b/specs/analytics/api-active-user-tracking.feature
@@ -1,0 +1,73 @@
+Feature: API active user tracking
+  As a growth analyst
+  I want every authenticated API caller to count toward Weekly Active Users
+  regardless of whether they came from the web, MCP server, CLI, or a skill
+  So that WAU/DAU/MAU reflect real product engagement across all surfaces
+  Without burning PostHog event volume on every individual API call
+
+  Background:
+    Given the unified auth middleware is mounted on a Hono route
+    And the request carries a valid PAT token resolving to a known userId
+    And PostHog is configured (POSTHOG_KEY is set)
+
+  @unit @unimplemented
+  Scenario: First successful PAT request of the day fires api_active_user
+    When the request succeeds with a 2xx response
+    And no api_active_user heartbeat exists for this (userId, day, source) in Redis
+    Then a single api_active_user PostHog event is captured
+    And distinctId equals the resolved userId
+    And properties.source matches the User-Agent (e.g. "mcp" / "cli" / "skill" / "unknown")
+    And properties.version matches the User-Agent version segment when present
+    And a Redis key active_user:<userId>:<UTC-day>:<source> is set with TTL ~48h
+
+  @unit @unimplemented
+  Scenario: Subsequent same-day same-source request does not refire
+    Given the heartbeat for (userId, day, source) already exists in Redis
+    When another successful PAT request from the same source arrives the same UTC day
+    Then no api_active_user event is captured
+    And the request completes normally
+
+  @unit @unimplemented
+  Scenario: Different sources for the same user count separately
+    Given the user already has a heartbeat for source "mcp" today
+    When the same user makes a successful request from source "cli" the same day
+    Then a single api_active_user event is captured for source "cli"
+
+  @unit @unimplemented
+  Scenario: Failed authentication does not fire
+    When the request is rejected with a 401 before reaching next()
+    Then no api_active_user event is captured
+    And no Redis heartbeat key is written
+
+  @unit @unimplemented
+  Scenario: Handler 5xx does not fire
+    When the request authenticates but the downstream handler returns 500
+    Then no api_active_user event is captured
+
+  @unit @unimplemented
+  Scenario: Legacy project tokens without userId are skipped
+    Given the request authenticates via a legacy sk-lw- project token (no userId)
+    When the request succeeds
+    Then no api_active_user event is captured
+    Because the metric is user-scoped and legacy tokens cannot resolve to a single user
+
+  @unit @unimplemented
+  Scenario: Redis outage does not break the request
+    Given Redis throws on the SET NX call
+    When the request succeeds
+    Then the request response is unaffected
+    And api_active_user fires anyway as a graceful overcount
+    And the Redis error is logged at WARN
+
+  @unit @unimplemented
+  Scenario: Missing User-Agent maps to unknown source
+    Given the request has no User-Agent header
+    When the request succeeds
+    Then properties.source equals "unknown"
+    And properties.version is absent
+
+  @unit @unimplemented
+  Scenario: MCP server outbound requests are tagged
+    Given the MCP server makes an outbound API call to the LangWatch backend
+    Then the outbound request carries User-Agent: langwatch-mcp/<package version>
+    So the backend can attribute the call to the "mcp" source


### PR DESCRIPTION
Closes #3589

## Summary
- Capture one PostHog `api_active_user` event per `(userId, UTC day, source)` on first successful PAT-authenticated request, deduped in Redis with `SET NX EX`
- Wire it from `createUnifiedAuthMiddleware` reusing the existing `markUsed` late-fire pattern (PAT + 2xx only) — same trigger as "this token was successfully used today"
- Derive `source` from `User-Agent` (`langwatch-mcp/...`, `langwatch-cli/...`, etc.); unrecognized/missing UA → `"unknown"` so legacy callers don't break
- MCP server now sets `User-Agent: langwatch-mcp/<package version>` on outbound requests so it shows up correctly

## Why this shape (vs. instrumenting MCP/CLI/skills directly)
- **One instrumentation point** for every current and future API client
- **No telemetry from user machines** in stdio MCP mode
- `userId` is already resolved by the auth middleware
- Reuses existing `trackServerEvent` in `langwatch/src/server/posthog.ts` — no new dependency
- **Bounded PostHog cost**: at most N users × M sources per day, regardless of API call volume

## Failure modes
- Redis outage → log + fire anyway (graceful overcount > silent gap)
- `POSTHOG_KEY` unset (self-hosted) → `trackServerEvent` no-ops
- Failed auth (401) and handler 5xx → no event (matches `markUsed` semantics)
- Legacy `sk-lw-` project tokens (no userId) → skipped; will be addressed when those migrate to PATs

## Test plan
- [x] `pnpm test:unit src/server/active-user` — 18 unit tests pass (parser + helper, including Redis-down and missing-Redis paths)
- [x] `pnpm test:unit src/server/pat` — existing 37 tests unchanged
- [x] `pnpm typecheck` — no new errors from this change (pre-existing errors in `saas-src/` and `error-handler.unit.test.ts` are baseline on `main`)
- [ ] Manual verification after merge: hit a PAT-authed endpoint with `User-Agent: langwatch-mcp/x.y.z`, confirm `api_active_user` event appears in PostHog with `source: "mcp"` and `version: "x.y.z"`
- [ ] Manual verification: same user calling again same day does NOT fire a second event

## Out of scope (follow-up issues to file)
- CLI / skill packages adopting `User-Agent: langwatch-cli/...` and `langwatch-skill/...` — one-line change each
- Bridging Customer.io-only `workflow_created` and `experiment_ran` events into PostHog (`langwatch/ee/billing/nurturing/hooks/featureAdoption.ts`)
- Updating the PostHog "WAU (product actions)" insight to add `api_active_user` as a series — PostHog UI change, no code

🤖 Generated with [Claude Code](https://claude.com/claude-code)