### PR TITLE
feat(cli): tag outbound requests with langwatch-cli User-Agent

### DIFF
--- a/typescript-sdk/src/cli/commands/agents/run.ts
+++ b/typescript-sdk/src/cli/commands/agents/run.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import ora from "ora";
 import { AgentsApiService } from "@/client-sdk/services/agents/agents-api.service";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const runAgentCommand = async (
   id: string,
@@ -91,25 +90,20 @@ export const runAgentCommand = async (
 
     const runSpinner = ora(`Running agent via workflow ${workflowId}...`).start();
     try {
-      const response = await fetch(
-        `${endpoint}/api/workflows/${encodeURIComponent(workflowId)}/run`,
-        {
+      let result: Record<string, unknown>;
+      try {
+        result = (await apiRequest({
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...buildAuthHeaders({ apiKey }),
-          },
-          body: JSON.stringify(input),
-        },
-      );
-
-      if (!response.ok) {
-        const message = await formatFetchError(response);
+          path: `/api/workflows/${encodeURIComponent(workflowId)}/run`,
+          apiKey,
+          endpoint,
+          body: input,
+        })) as Record<string, unknown>;
+      } catch (httpError) {
+        const message = httpError instanceof Error ? httpError.message : String(httpError);
         runSpinner.fail(`Agent execution failed: ${message}`);
         process.exit(1);
       }
-
-      const result = await response.json() as Record<string, unknown>;
       runSpinner.succeed(`Agent "${agent.name}" executed successfully`);
 
       if (options.format === "json") {

--- a/typescript-sdk/src/cli/commands/agents/run.ts
+++ b/typescript-sdk/src/cli/commands/agents/run.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
 import { AgentsApiService } from "@/client-sdk/services/agents/agents-api.service";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -99,25 +98,13 @@ export const runAgentCommand = async (
 
     const runSpinner = createSpinner(`Running agent via workflow ${workflowId}...`).start();
     try {
-      const response = await fetch(
-        `${endpoint}/api/workflows/${encodeURIComponent(workflowId)}/run`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...buildAuthHeaders({ apiKey }),
-          },
-          body: JSON.stringify(input),
-        },
-      );
-
-      if (!response.ok) {
-        const message = await formatFetchError(response);
-        failSpinner({ spinner: runSpinner, error: new Error(message), action: "run agent" });
-        process.exit(1);
-      }
-
-      const result = await response.json() as Record<string, unknown>;
+      const result = (await apiRequest({
+        method: "POST",
+        path: `/api/workflows/${encodeURIComponent(workflowId)}/run`,
+        apiKey,
+        endpoint,
+        body: input,
+      })) as Record<string, unknown>;
       runSpinner.succeed(`Agent "${agent.name}" executed successfully`);
 
       return {

--- a/typescript-sdk/src/cli/commands/graphs/create.ts
+++ b/typescript-sdk/src/cli/commands/graphs/create.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const createGraphCommand = async (
   name: string,
@@ -29,29 +28,20 @@ export const createGraphCommand = async (
       graphDef = JSON.parse(options.graph) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/graphs`, {
+    const graph = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
+      path: "/api/graphs",
+      apiKey,
+      endpoint,
+      body: {
         name,
         graph: graphDef,
         dashboardId: options.dashboardId,
         ...(options.filters && { filters: JSON.parse(options.filters) }),
         ...(options.colSpan && { colSpan: parseInt(options.colSpan, 10) }),
         ...(options.rowSpan && { rowSpan: parseInt(options.rowSpan, 10) }),
-      }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to create graph: ${message}`);
-      process.exit(1);
-    }
-
-    const graph = await response.json() as { id: string; name: string; dashboardId: string | null };
+      },
+    })) as { id: string; name: string; dashboardId: string | null };
     spinner.succeed(`Graph "${graph.name}" created (${graph.id})`);
 
     if (options.format === "json") {

--- a/typescript-sdk/src/cli/commands/graphs/create.ts
+++ b/typescript-sdk/src/cli/commands/graphs/create.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -35,29 +34,20 @@ export const createGraphCommand = async (
       graphDef = JSON.parse(options.graph) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/graphs`, {
+    const graph = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
+      path: "/api/graphs",
+      apiKey,
+      endpoint,
+      body: {
         name,
         graph: graphDef,
         dashboardId: options.dashboardId,
         ...(options.filters && { filters: JSON.parse(options.filters) }),
         ...(options.colSpan && { colSpan: parseInt(options.colSpan, 10) }),
         ...(options.rowSpan && { rowSpan: parseInt(options.rowSpan, 10) }),
-      }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "create graph" });
-      process.exit(1);
-    }
-
-    const graph = await response.json() as { id: string; name: string; dashboardId: string | null };
+      },
+    })) as { id: string; name: string; dashboardId: string | null };
     spinner.succeed(`Graph "${graph.name}" created (${graph.id})`);
 
     return {

--- a/typescript-sdk/src/cli/commands/graphs/delete.ts
+++ b/typescript-sdk/src/cli/commands/graphs/delete.ts
@@ -1,8 +1,7 @@
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const deleteGraphCommand = async (
   id: string,
@@ -16,18 +15,19 @@ export const deleteGraphCommand = async (
   const spinner = ora(`Deleting graph "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/graphs/${encodeURIComponent(id)}`, {
-      method: "DELETE",
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
+    let result: { id: string; deleted: boolean };
+    try {
+      result = (await apiRequest({
+        method: "DELETE",
+        path: `/api/graphs/${encodeURIComponent(id)}`,
+        apiKey,
+        endpoint,
+      })) as { id: string; deleted: boolean };
+    } catch (httpError) {
+      const message = httpError instanceof Error ? httpError.message : String(httpError);
       spinner.fail(`Failed to delete graph "${id}": ${message}`);
       process.exit(1);
     }
-
-    const result = await response.json() as { id: string; deleted: boolean };
     spinner.succeed(`Graph "${id}" deleted`);
 
     if (options?.format === "json") {

--- a/typescript-sdk/src/cli/commands/graphs/delete.ts
+++ b/typescript-sdk/src/cli/commands/graphs/delete.ts
@@ -1,8 +1,7 @@
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -21,18 +20,12 @@ export const deleteGraphCommand = async (
   const spinner = createSpinner(`Deleting graph "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/graphs/${encodeURIComponent(id)}`, {
+    const result = (await apiRequest({
       method: "DELETE",
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: `delete graph "${id}"` });
-      process.exit(1);
-    }
-
-    const result = await response.json() as { id: string; deleted: boolean };
+      path: `/api/graphs/${encodeURIComponent(id)}`,
+      apiKey,
+      endpoint,
+    })) as { id: string; deleted: boolean };
     spinner.succeed(`Graph "${id}" deleted`);
 
     return {
@@ -42,7 +35,7 @@ export const deleteGraphCommand = async (
       },
     };
   } catch (error) {
-    failSpinner({ spinner, error, action: "delete graph" });
+    failSpinner({ spinner, error, action: `delete graph "${id}"` });
     process.exit(1);
   }
 };

--- a/typescript-sdk/src/cli/commands/graphs/get.ts
+++ b/typescript-sdk/src/cli/commands/graphs/get.ts
@@ -19,7 +19,7 @@ export const getGraphCommand = async (
   try {
     const graph = (await apiRequest({
       method: "GET",
-      path: `/api/graphs/${id}`,
+      path: `/api/graphs/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/graphs/get.ts
+++ b/typescript-sdk/src/cli/commands/graphs/get.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const getGraphCommand = async (
   id: string,
@@ -18,17 +17,12 @@ export const getGraphCommand = async (
   const spinner = ora(`Fetching graph "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/graphs/${id}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch graph: ${message}`);
-      process.exit(1);
-    }
-
-    const graph = (await response.json()) as {
+    const graph = (await apiRequest({
+      method: "GET",
+      path: `/api/graphs/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       name: string;
       dashboardId: string | null;

--- a/typescript-sdk/src/cli/commands/graphs/get.ts
+++ b/typescript-sdk/src/cli/commands/graphs/get.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -23,17 +22,12 @@ export const getGraphCommand = async (
   const spinner = createSpinner(`Fetching graph "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/graphs/${id}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch graph" });
-      process.exit(1);
-    }
-
-    const graph = (await response.json()) as {
+    const graph = (await apiRequest({
+      method: "GET",
+      path: `/api/graphs/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       name: string;
       dashboardId: string | null;

--- a/typescript-sdk/src/cli/commands/graphs/get.ts
+++ b/typescript-sdk/src/cli/commands/graphs/get.ts
@@ -24,7 +24,7 @@ export const getGraphCommand = async (
   try {
     const graph = (await apiRequest({
       method: "GET",
-      path: `/api/graphs/${id}`,
+      path: `/api/graphs/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/graphs/list.ts
+++ b/typescript-sdk/src/cli/commands/graphs/list.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const listGraphsCommand = async (options: {
   dashboardId?: string;
@@ -22,17 +21,12 @@ export const listGraphsCommand = async (options: {
     if (options.dashboardId) params.set("dashboardId", options.dashboardId);
     const qs = params.toString() ? `?${params}` : "";
 
-    const response = await fetch(`${endpoint}/api/graphs${qs}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch graphs: ${message}`);
-      process.exit(1);
-    }
-
-    const graphs = await response.json() as Array<{
+    const graphs = (await apiRequest({
+      method: "GET",
+      path: `/api/graphs${qs}`,
+      apiKey,
+      endpoint,
+    })) as Array<{
       id: string;
       name: string;
       dashboardId: string | null;

--- a/typescript-sdk/src/cli/commands/graphs/list.ts
+++ b/typescript-sdk/src/cli/commands/graphs/list.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -28,17 +27,12 @@ export const listGraphsCommand = async (options: {
     if (options.dashboardId) params.set("dashboardId", options.dashboardId);
     const qs = params.toString() ? `?${params}` : "";
 
-    const response = await fetch(`${endpoint}/api/graphs${qs}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch graphs" });
-      process.exit(1);
-    }
-
-    const graphs = await response.json() as Array<{
+    const graphs = (await apiRequest({
+      method: "GET",
+      path: `/api/graphs${qs}`,
+      apiKey,
+      endpoint,
+    })) as Array<{
       id: string;
       name: string;
       dashboardId: string | null;

--- a/typescript-sdk/src/cli/commands/graphs/update.ts
+++ b/typescript-sdk/src/cli/commands/graphs/update.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const updateGraphCommand = async (
   id: string,
@@ -41,22 +40,13 @@ export const updateGraphCommand = async (
       body.filters = JSON.parse(options.filters) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/graphs/${id}`, {
+    const graph = (await apiRequest({
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to update graph: ${message}`);
-      process.exit(1);
-    }
-
-    const graph = (await response.json()) as {
+      path: `/api/graphs/${id}`,
+      apiKey,
+      endpoint,
+      body,
+    })) as {
       id: string;
       name: string;
     };

--- a/typescript-sdk/src/cli/commands/graphs/update.ts
+++ b/typescript-sdk/src/cli/commands/graphs/update.ts
@@ -42,7 +42,7 @@ export const updateGraphCommand = async (
 
     const graph = (await apiRequest({
       method: "PATCH",
-      path: `/api/graphs/${id}`,
+      path: `/api/graphs/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
       body,

--- a/typescript-sdk/src/cli/commands/graphs/update.ts
+++ b/typescript-sdk/src/cli/commands/graphs/update.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -47,22 +46,13 @@ export const updateGraphCommand = async (
       body.filters = JSON.parse(options.filters) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/graphs/${id}`, {
+    const graph = (await apiRequest({
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "update graph" });
-      process.exit(1);
-    }
-
-    const graph = (await response.json()) as {
+      path: `/api/graphs/${id}`,
+      apiKey,
+      endpoint,
+      body,
+    })) as {
       id: string;
       name: string;
     };

--- a/typescript-sdk/src/cli/commands/graphs/update.ts
+++ b/typescript-sdk/src/cli/commands/graphs/update.ts
@@ -48,7 +48,7 @@ export const updateGraphCommand = async (
 
     const graph = (await apiRequest({
       method: "PATCH",
-      path: `/api/graphs/${id}`,
+      path: `/api/graphs/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
       body,

--- a/typescript-sdk/src/cli/commands/monitors/create.ts
+++ b/typescript-sdk/src/cli/commands/monitors/create.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const createMonitorCommand = async (
   name: string,
@@ -39,13 +38,12 @@ export const createMonitorCommand = async (
       parameters = JSON.parse(options.parameters) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/monitors`, {
+    const monitor = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
+      path: "/api/monitors",
+      apiKey,
+      endpoint,
+      body: {
         name,
         checkType: options.checkType,
         executionMode: options.executionMode ?? "ON_MESSAGE",
@@ -54,16 +52,8 @@ export const createMonitorCommand = async (
         level: options.level ?? "trace",
         parameters,
         preconditions: [],
-      }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to create monitor: ${message}`);
-      process.exit(1);
-    }
-
-    const monitor = (await response.json()) as {
+      },
+    })) as {
       id: string;
       name: string;
       checkType: string;

--- a/typescript-sdk/src/cli/commands/monitors/create.ts
+++ b/typescript-sdk/src/cli/commands/monitors/create.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
 import type { CommandResult } from "../../utils/output";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 /**
@@ -54,13 +53,12 @@ export const createMonitorCommand = async (
       parameters = JSON.parse(options.parameters) as Record<string, unknown>;
     }
 
-    const response = await fetch(`${endpoint}/api/monitors`, {
+    monitor = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
+      path: "/api/monitors",
+      apiKey,
+      endpoint,
+      body: {
         name,
         checkType: options.checkType,
         executionMode: options.executionMode ?? "ON_MESSAGE",
@@ -69,16 +67,8 @@ export const createMonitorCommand = async (
         level: options.level ?? "trace",
         parameters,
         preconditions: [],
-      }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "create monitor" });
-      process.exit(1);
-    }
-
-    monitor = (await response.json()) as {
+      },
+    })) as {
       id: string;
       name: string;
       checkType: string;

--- a/typescript-sdk/src/cli/commands/monitors/delete.ts
+++ b/typescript-sdk/src/cli/commands/monitors/delete.ts
@@ -1,8 +1,7 @@
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const deleteMonitorCommand = async (
   id: string,
@@ -17,18 +16,12 @@ export const deleteMonitorCommand = async (
   const spinner = ora(`Deleting monitor "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
+    const result = (await apiRequest({
       method: "DELETE",
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to delete monitor: ${message}`);
-      process.exit(1);
-    }
-
-    const result = (await response.json()) as {
+      path: `/api/monitors/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       deleted: boolean;
     };

--- a/typescript-sdk/src/cli/commands/monitors/delete.ts
+++ b/typescript-sdk/src/cli/commands/monitors/delete.ts
@@ -18,7 +18,7 @@ export const deleteMonitorCommand = async (
   try {
     const result = (await apiRequest({
       method: "DELETE",
-      path: `/api/monitors/${id}`,
+      path: `/api/monitors/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/monitors/delete.ts
+++ b/typescript-sdk/src/cli/commands/monitors/delete.ts
@@ -27,7 +27,7 @@ export const deleteMonitorCommand = async (
   try {
     result = (await apiRequest({
       method: "DELETE",
-      path: `/api/monitors/${id}`,
+      path: `/api/monitors/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/monitors/delete.ts
+++ b/typescript-sdk/src/cli/commands/monitors/delete.ts
@@ -1,9 +1,8 @@
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import type { CommandResult } from "../../utils/output";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 /**
@@ -26,18 +25,12 @@ export const deleteMonitorCommand = async (
     deleted: boolean;
   };
   try {
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
+    result = (await apiRequest({
       method: "DELETE",
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "delete monitor" });
-      process.exit(1);
-    }
-
-    result = (await response.json()) as {
+      path: `/api/monitors/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       deleted: boolean;
     };

--- a/typescript-sdk/src/cli/commands/monitors/get.ts
+++ b/typescript-sdk/src/cli/commands/monitors/get.ts
@@ -19,7 +19,7 @@ export const getMonitorCommand = async (
   try {
     const monitor = (await apiRequest({
       method: "GET",
-      path: `/api/monitors/${id}`,
+      path: `/api/monitors/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/monitors/get.ts
+++ b/typescript-sdk/src/cli/commands/monitors/get.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const getMonitorCommand = async (
   id: string,
@@ -18,17 +17,12 @@ export const getMonitorCommand = async (
   const spinner = ora(`Fetching monitor "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch monitor: ${message}`);
-      process.exit(1);
-    }
-
-    const monitor = (await response.json()) as {
+    const monitor = (await apiRequest({
+      method: "GET",
+      path: `/api/monitors/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       name: string;
       slug: string;

--- a/typescript-sdk/src/cli/commands/monitors/get.ts
+++ b/typescript-sdk/src/cli/commands/monitors/get.ts
@@ -38,7 +38,7 @@ export const getMonitorCommand = async (
   try {
     monitor = (await apiRequest({
       method: "GET",
-      path: `/api/monitors/${id}`,
+      path: `/api/monitors/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/monitors/get.ts
+++ b/typescript-sdk/src/cli/commands/monitors/get.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import type { CommandResult } from "../../utils/output";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 /**
@@ -37,17 +36,12 @@ export const getMonitorCommand = async (
     platformUrl?: string;
   };
   try {
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch monitor" });
-      process.exit(1);
-    }
-
-    monitor = (await response.json()) as {
+    monitor = (await apiRequest({
+      method: "GET",
+      path: `/api/monitors/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       name: string;
       slug: string;

--- a/typescript-sdk/src/cli/commands/monitors/list.ts
+++ b/typescript-sdk/src/cli/commands/monitors/list.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const listMonitorsCommand = async (options?: {
   format?: string;
@@ -18,17 +17,12 @@ export const listMonitorsCommand = async (options?: {
   const spinner = ora("Fetching monitors...").start();
 
   try {
-    const response = await fetch(`${endpoint}/api/monitors`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch monitors: ${message}`);
-      process.exit(1);
-    }
-
-    const monitors = (await response.json()) as Array<{
+    const monitors = (await apiRequest({
+      method: "GET",
+      path: "/api/monitors",
+      apiKey,
+      endpoint,
+    })) as Array<{
       id: string;
       name: string;
       checkType: string;

--- a/typescript-sdk/src/cli/commands/monitors/list.ts
+++ b/typescript-sdk/src/cli/commands/monitors/list.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
 import type { CommandResult } from "../../utils/output";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 /**
@@ -31,17 +30,12 @@ export const listMonitorsCommand = async (): Promise<CommandResult | void> => {
     sample: number;
   }>;
   try {
-    const response = await fetch(`${endpoint}/api/monitors`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch monitors" });
-      process.exit(1);
-    }
-
-    monitors = (await response.json()) as Array<{
+    monitors = (await apiRequest({
+      method: "GET",
+      path: "/api/monitors",
+      apiKey,
+      endpoint,
+    })) as Array<{
       id: string;
       name: string;
       checkType: string;

--- a/typescript-sdk/src/cli/commands/monitors/update.ts
+++ b/typescript-sdk/src/cli/commands/monitors/update.ts
@@ -39,7 +39,7 @@ export const updateMonitorCommand = async (
 
     const monitor = (await apiRequest({
       method: "PATCH",
-      path: `/api/monitors/${id}`,
+      path: `/api/monitors/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
       body,

--- a/typescript-sdk/src/cli/commands/monitors/update.ts
+++ b/typescript-sdk/src/cli/commands/monitors/update.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const updateMonitorCommand = async (
   id: string,
@@ -38,22 +37,13 @@ export const updateMonitorCommand = async (
       >;
     }
 
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
+    const monitor = (await apiRequest({
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to update monitor: ${message}`);
-      process.exit(1);
-    }
-
-    const monitor = (await response.json()) as {
+      path: `/api/monitors/${id}`,
+      apiKey,
+      endpoint,
+      body,
+    })) as {
       id: string;
       name: string;
       enabled: boolean;

--- a/typescript-sdk/src/cli/commands/monitors/update.ts
+++ b/typescript-sdk/src/cli/commands/monitors/update.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
 import type { CommandResult } from "../../utils/output";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 /**
@@ -49,22 +48,13 @@ export const updateMonitorCommand = async (
       >;
     }
 
-    const response = await fetch(`${endpoint}/api/monitors/${id}`, {
+    monitor = (await apiRequest({
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "update monitor" });
-      process.exit(1);
-    }
-
-    monitor = (await response.json()) as {
+      path: `/api/monitors/${id}`,
+      apiKey,
+      endpoint,
+      body,
+    })) as {
       id: string;
       name: string;
       enabled: boolean;

--- a/typescript-sdk/src/cli/commands/monitors/update.ts
+++ b/typescript-sdk/src/cli/commands/monitors/update.ts
@@ -50,7 +50,7 @@ export const updateMonitorCommand = async (
 
     monitor = (await apiRequest({
       method: "PATCH",
-      path: `/api/monitors/${id}`,
+      path: `/api/monitors/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
       body,

--- a/typescript-sdk/src/cli/commands/prompt/restore.ts
+++ b/typescript-sdk/src/cli/commands/prompt/restore.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const promptRestoreCommand = async (
   handle: string,
@@ -21,28 +20,19 @@ export const promptRestoreCommand = async (
   ).start();
 
   try {
-    const response = await fetch(
-      `${endpoint}/api/prompts/${encodeURIComponent(handle)}/versions/${encodeURIComponent(versionId)}/restore`,
-      {
+    let restored: { id: string; version: number; commitMessage: string | null };
+    try {
+      restored = (await apiRequest({
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...buildAuthHeaders({ apiKey }),
-        },
-      }
-    );
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
+        path: `/api/prompts/${encodeURIComponent(handle)}/versions/${encodeURIComponent(versionId)}/restore`,
+        apiKey,
+        endpoint,
+      })) as { id: string; version: number; commitMessage: string | null };
+    } catch (httpError) {
+      const message = httpError instanceof Error ? httpError.message : String(httpError);
       spinner.fail(`Failed to restore "${handle}" to ${versionId}: ${message}`);
       process.exit(1);
     }
-
-    const restored = (await response.json()) as {
-      id: string;
-      version: number;
-      commitMessage: string | null;
-    };
 
     spinner.succeed(
       `Restored "${handle}" — new version v${restored.version} created`

--- a/typescript-sdk/src/cli/commands/prompt/restore.ts
+++ b/typescript-sdk/src/cli/commands/prompt/restore.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -27,32 +26,12 @@ export const promptRestoreCommand = async (
   ).start();
 
   try {
-    const response = await fetch(
-      `${endpoint}/api/prompts/${encodeURIComponent(handle)}/versions/${encodeURIComponent(versionId)}/restore`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...buildAuthHeaders({ apiKey }),
-        },
-      }
-    );
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({
-        spinner,
-        error: new Error(message),
-        action: `restore "${handle}" to ${versionId}`,
-      });
-      process.exit(1);
-    }
-
-    const restored = (await response.json()) as {
-      id: string;
-      version: number;
-      commitMessage: string | null;
-    };
+    const restored = (await apiRequest({
+      method: "POST",
+      path: `/api/prompts/${encodeURIComponent(handle)}/versions/${encodeURIComponent(versionId)}/restore`,
+      apiKey,
+      endpoint,
+    })) as { id: string; version: number; commitMessage: string | null };
 
     spinner.succeed(
       `Restored "${handle}" — new version v${restored.version} created`
@@ -72,7 +51,7 @@ export const promptRestoreCommand = async (
       },
     };
   } catch (error) {
-    failSpinner({ spinner, error, action: "restore prompt" });
+    failSpinner({ spinner, error, action: `restore "${handle}" to ${versionId}` });
     process.exit(1);
   }
 };

--- a/typescript-sdk/src/cli/commands/scenarios/run.ts
+++ b/typescript-sdk/src/cli/commands/scenarios/run.ts
@@ -4,9 +4,9 @@ import {
   SuitesApiService,
   type SuiteTarget,
 } from "@/client-sdk/services/suites";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 function parseTarget(targetStr: string): SuiteTarget {
   const colonIndex = targetStr.indexOf(":");
@@ -107,40 +107,35 @@ export const runScenarioCommand = async (
       await new Promise((resolve) => setTimeout(resolve, 3000));
 
       try {
-        const statusResponse = await fetch(
-          `${endpoint}/api/scenario-events?batchRunId=${encodeURIComponent(result.batchRunId)}`,
-          {
-            method: "GET",
-            headers: buildAuthHeaders({ apiKey }),
-          },
-        );
+        const statusData = (await apiRequest({
+          method: "GET",
+          path: `/api/scenario-events?batchRunId=${encodeURIComponent(result.batchRunId)}`,
+          apiKey,
+          endpoint,
+        })) as {
+          totalCount?: number;
+          completedCount?: number;
+          passedCount?: number;
+          failedCount?: number;
+        };
 
-        if (statusResponse.ok) {
-          const statusData = await statusResponse.json() as {
-            totalCount?: number;
-            completedCount?: number;
-            passedCount?: number;
-            failedCount?: number;
-          };
+        const total = statusData.totalCount ?? result.jobCount;
+        const completedCount = statusData.completedCount ?? 0;
+        const passed = statusData.passedCount ?? 0;
+        const failed = statusData.failedCount ?? 0;
 
-          const total = statusData.totalCount ?? result.jobCount;
-          const completedCount = statusData.completedCount ?? 0;
-          const passed = statusData.passedCount ?? 0;
-          const failed = statusData.failedCount ?? 0;
+        pollSpinner.text = `Running... ${completedCount}/${total} completed (${passed} passed, ${failed} failed)`;
 
-          pollSpinner.text = `Running... ${completedCount}/${total} completed (${passed} passed, ${failed} failed)`;
-
-          if (completedCount >= total && total > 0) {
-            completed = true;
-            if (failed > 0) {
-              pollSpinner.warn(
-                `Scenario run completed: ${passed}/${total} passed, ${chalk.red(`${failed} failed`)}`,
-              );
-            } else {
-              pollSpinner.succeed(
-                `Scenario run completed: ${chalk.green(`${passed}/${total} passed`)}`,
-              );
-            }
+        if (completedCount >= total && total > 0) {
+          completed = true;
+          if (failed > 0) {
+            pollSpinner.warn(
+              `Scenario run completed: ${passed}/${total} passed, ${chalk.red(`${failed} failed`)}`,
+            );
+          } else {
+            pollSpinner.succeed(
+              `Scenario run completed: ${chalk.green(`${passed}/${total} passed`)}`,
+            );
           }
         }
       } catch {

--- a/typescript-sdk/src/cli/commands/scenarios/run.ts
+++ b/typescript-sdk/src/cli/commands/scenarios/run.ts
@@ -4,10 +4,10 @@ import {
   SuitesApiService,
   type SuiteTarget,
 } from "@/client-sdk/services/suites";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { resolveOutputFormat } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 
 function parseTarget(targetStr: string): SuiteTarget {
@@ -119,46 +119,39 @@ export const runScenarioCommand = async (
       await new Promise((resolve) => setTimeout(resolve, 3000));
 
       try {
-        const statusResponse = await fetch(
-          `${endpoint}/api/scenario-events?batchRunId=${encodeURIComponent(result.batchRunId)}`,
-          {
-            method: "GET",
-            headers: buildAuthHeaders({ apiKey }),
-          },
-        );
+        const statusData = (await apiRequest({
+          method: "GET",
+          path: `/api/scenario-events?batchRunId=${encodeURIComponent(result.batchRunId)}`,
+          apiKey,
+          endpoint,
+        })) as {
+          totalCount?: number;
+          completedCount?: number;
+          passedCount?: number;
+          failedCount?: number;
+        };
 
-        if (statusResponse.ok) {
-          const statusData = await statusResponse.json() as {
-            totalCount?: number;
-            completedCount?: number;
-            passedCount?: number;
-            failedCount?: number;
-          };
+        const total = statusData.totalCount ?? result.jobCount;
+        const completedCount = statusData.completedCount ?? 0;
+        const passed = statusData.passedCount ?? 0;
+        const failed = statusData.failedCount ?? 0;
 
-          const total = statusData.totalCount ?? result.jobCount;
-          const completedCount = statusData.completedCount ?? 0;
-          const passed = statusData.passedCount ?? 0;
-          const failed = statusData.failedCount ?? 0;
+        pollSpinner.text = `Running... ${completedCount}/${total} completed (${passed} passed, ${failed} failed)`;
 
-          pollSpinner.text = `Running... ${completedCount}/${total} completed (${passed} passed, ${failed} failed)`;
-
-          if (completedCount >= total && total > 0) {
-            completed = true;
-            if (failed > 0) {
-              pollSpinner.warn(
-                `Scenario run completed: ${passed}/${total} passed, ${chalk.red(`${failed} failed`)}`,
-              );
-              // `--wait` exists to report the verdict. Exiting 0 on a failed
-              // run hides it from every machine caller — see suites/run.ts.
-              process.exitCode = 1;
-            } else {
-              pollSpinner.succeed(
-                `Scenario run completed: ${chalk.green(`${passed}/${total} passed`)}`,
-              );
-            }
+        if (completedCount >= total && total > 0) {
+          completed = true;
+          if (failed > 0) {
+            pollSpinner.warn(
+              `Scenario run completed: ${passed}/${total} passed, ${chalk.red(`${failed} failed`)}`,
+            );
+            // `--wait` exists to report the verdict. Exiting 0 on a failed
+            // run hides it from every machine caller — see suites/run.ts.
+            process.exitCode = 1;
+          } else {
+            pollSpinner.succeed(
+              `Scenario run completed: ${chalk.green(`${passed}/${total} passed`)}`,
+            );
           }
-        } else {
-          throw new Error(`status endpoint answered ${statusResponse.status}`);
         }
       } catch {
         // Polling error — continue waiting, but bounded: a status endpoint that

--- a/typescript-sdk/src/cli/commands/secrets/create.ts
+++ b/typescript-sdk/src/cli/commands/secrets/create.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const createSecretCommand = async (
   name: string,
@@ -27,22 +26,13 @@ export const createSecretCommand = async (
   const spinner = ora(`Creating secret "${name}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets`, {
+    const secret = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({ name, value: options.value }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to create secret: ${message}`);
-      process.exit(1);
-    }
-
-    const secret = (await response.json()) as {
+      path: "/api/secrets",
+      apiKey,
+      endpoint,
+      body: { name, value: options.value },
+    })) as {
       id: string;
       name: string;
     };

--- a/typescript-sdk/src/cli/commands/secrets/create.ts
+++ b/typescript-sdk/src/cli/commands/secrets/create.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -41,22 +40,13 @@ export const createSecretCommand = async (
   const spinner = createSpinner(`Creating secret "${name}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets`, {
+    const secret = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({ name, value: options.value }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "create secret" });
-      process.exit(1);
-    }
-
-    const secret = (await response.json()) as {
+      path: "/api/secrets",
+      apiKey,
+      endpoint,
+      body: { name, value: options.value },
+    })) as {
       id: string;
       name: string;
     };

--- a/typescript-sdk/src/cli/commands/secrets/delete.ts
+++ b/typescript-sdk/src/cli/commands/secrets/delete.ts
@@ -18,7 +18,7 @@ export const deleteSecretCommand = async (
   try {
     const result = (await apiRequest({
       method: "DELETE",
-      path: `/api/secrets/${id}`,
+      path: `/api/secrets/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/secrets/delete.ts
+++ b/typescript-sdk/src/cli/commands/secrets/delete.ts
@@ -1,8 +1,7 @@
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const deleteSecretCommand = async (
   id: string,
@@ -17,18 +16,12 @@ export const deleteSecretCommand = async (
   const spinner = ora(`Deleting secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
+    const result = (await apiRequest({
       method: "DELETE",
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to delete secret: ${message}`);
-      process.exit(1);
-    }
-
-    const result = (await response.json()) as {
+      path: `/api/secrets/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       deleted: boolean;
     };

--- a/typescript-sdk/src/cli/commands/secrets/delete.ts
+++ b/typescript-sdk/src/cli/commands/secrets/delete.ts
@@ -24,7 +24,7 @@ export const deleteSecretCommand = async (
   try {
     const result = (await apiRequest({
       method: "DELETE",
-      path: `/api/secrets/${id}`,
+      path: `/api/secrets/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/secrets/delete.ts
+++ b/typescript-sdk/src/cli/commands/secrets/delete.ts
@@ -1,8 +1,7 @@
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -23,18 +22,12 @@ export const deleteSecretCommand = async (
   const spinner = createSpinner(`Deleting secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
+    const result = (await apiRequest({
       method: "DELETE",
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "delete secret" });
-      process.exit(1);
-    }
-
-    const result = (await response.json()) as {
+      path: `/api/secrets/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       deleted: boolean;
     };

--- a/typescript-sdk/src/cli/commands/secrets/get.ts
+++ b/typescript-sdk/src/cli/commands/secrets/get.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const getSecretCommand = async (
   id: string,
@@ -18,17 +17,12 @@ export const getSecretCommand = async (
   const spinner = ora(`Fetching secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch secret: ${message}`);
-      process.exit(1);
-    }
-
-    const secret = (await response.json()) as {
+    const secret = (await apiRequest({
+      method: "GET",
+      path: `/api/secrets/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       name: string;
       projectId: string;

--- a/typescript-sdk/src/cli/commands/secrets/get.ts
+++ b/typescript-sdk/src/cli/commands/secrets/get.ts
@@ -19,7 +19,7 @@ export const getSecretCommand = async (
   try {
     const secret = (await apiRequest({
       method: "GET",
-      path: `/api/secrets/${id}`,
+      path: `/api/secrets/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/secrets/get.ts
+++ b/typescript-sdk/src/cli/commands/secrets/get.ts
@@ -27,7 +27,7 @@ export const getSecretCommand = async (
   try {
     const secret = (await apiRequest({
       method: "GET",
-      path: `/api/secrets/${id}`,
+      path: `/api/secrets/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
     })) as {

--- a/typescript-sdk/src/cli/commands/secrets/get.ts
+++ b/typescript-sdk/src/cli/commands/secrets/get.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -26,17 +25,12 @@ export const getSecretCommand = async (
   const spinner = createSpinner(`Fetching secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch secret" });
-      process.exit(1);
-    }
-
-    const secret = (await response.json()) as {
+    const secret = (await apiRequest({
+      method: "GET",
+      path: `/api/secrets/${id}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       name: string;
       projectId: string;

--- a/typescript-sdk/src/cli/commands/secrets/list.ts
+++ b/typescript-sdk/src/cli/commands/secrets/list.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const listSecretsCommand = async (options?: {
   format?: string;
@@ -18,17 +17,12 @@ export const listSecretsCommand = async (options?: {
   const spinner = ora("Fetching secrets...").start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch secrets: ${message}`);
-      process.exit(1);
-    }
-
-    const secrets = (await response.json()) as Array<{
+    const secrets = (await apiRequest({
+      method: "GET",
+      path: "/api/secrets",
+      apiKey,
+      endpoint,
+    })) as Array<{
       id: string;
       name: string;
       createdAt: string;

--- a/typescript-sdk/src/cli/commands/secrets/list.ts
+++ b/typescript-sdk/src/cli/commands/secrets/list.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -24,17 +23,12 @@ export const listSecretsCommand = async (): Promise<CommandResult | void> => {
   const spinner = createSpinner("Fetching secrets...").start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch secrets" });
-      process.exit(1);
-    }
-
-    const secrets = (await response.json()) as Array<{
+    const secrets = (await apiRequest({
+      method: "GET",
+      path: "/api/secrets",
+      apiKey,
+      endpoint,
+    })) as Array<{
       id: string;
       name: string;
       createdAt: string;

--- a/typescript-sdk/src/cli/commands/secrets/update.ts
+++ b/typescript-sdk/src/cli/commands/secrets/update.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const updateSecretCommand = async (
   id: string,
@@ -18,22 +17,13 @@ export const updateSecretCommand = async (
   const spinner = ora(`Updating secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
+    const secret = (await apiRequest({
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({ value: options.value }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to update secret: ${message}`);
-      process.exit(1);
-    }
-
-    const secret = (await response.json()) as {
+      path: `/api/secrets/${id}`,
+      apiKey,
+      endpoint,
+      body: { value: options.value },
+    })) as {
       id: string;
       name: string;
     };

--- a/typescript-sdk/src/cli/commands/secrets/update.ts
+++ b/typescript-sdk/src/cli/commands/secrets/update.ts
@@ -19,7 +19,7 @@ export const updateSecretCommand = async (
   try {
     const secret = (await apiRequest({
       method: "PUT",
-      path: `/api/secrets/${id}`,
+      path: `/api/secrets/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
       body: { value: options.value },

--- a/typescript-sdk/src/cli/commands/secrets/update.ts
+++ b/typescript-sdk/src/cli/commands/secrets/update.ts
@@ -29,7 +29,7 @@ export const updateSecretCommand = async (
   try {
     const secret = (await apiRequest({
       method: "PUT",
-      path: `/api/secrets/${id}`,
+      path: `/api/secrets/${encodeURIComponent(id)}`,
       apiKey,
       endpoint,
       body: { value: options.value },

--- a/typescript-sdk/src/cli/commands/secrets/update.ts
+++ b/typescript-sdk/src/cli/commands/secrets/update.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -28,22 +27,13 @@ export const updateSecretCommand = async (
   const spinner = createSpinner(`Updating secret "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/secrets/${id}`, {
+    const secret = (await apiRequest({
       method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({ value: options.value }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "update secret" });
-      process.exit(1);
-    }
-
-    const secret = (await response.json()) as {
+      path: `/api/secrets/${id}`,
+      apiKey,
+      endpoint,
+      body: { value: options.value },
+    })) as {
       id: string;
       name: string;
     };

--- a/typescript-sdk/src/cli/commands/simulation-runs/get.ts
+++ b/typescript-sdk/src/cli/commands/simulation-runs/get.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 /**
  * Flattens Anthropic-style content (string OR array of {type:text|tool_use|tool_result|thinking})
@@ -64,21 +63,12 @@ export const getSimulationRunCommand = async (
   const spinner = ora(`Fetching simulation run "${runId}"...`).start();
 
   try {
-    const response = await fetch(
-      `${endpoint}/api/simulation-runs/${encodeURIComponent(runId)}`,
-      {
-        method: "GET",
-        headers: buildAuthHeaders({ apiKey }),
-      },
-    );
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch simulation run: ${message}`);
-      process.exit(1);
-    }
-
-    const run = await response.json() as {
+    const run = (await apiRequest({
+      method: "GET",
+      path: `/api/simulation-runs/${encodeURIComponent(runId)}`,
+      apiKey,
+      endpoint,
+    })) as {
       scenarioRunId: string;
       scenarioId: string;
       batchRunId: string;

--- a/typescript-sdk/src/cli/commands/simulation-runs/get.ts
+++ b/typescript-sdk/src/cli/commands/simulation-runs/get.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import type { CommandResult } from "../../utils/output";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 /**
@@ -66,21 +65,12 @@ export const getSimulationRunCommand = async (
   const spinner = createSpinner(`Fetching simulation run "${runId}"...`).start();
 
   try {
-    const response = await fetch(
-      `${endpoint}/api/simulation-runs/${encodeURIComponent(runId)}`,
-      {
-        method: "GET",
-        headers: buildAuthHeaders({ apiKey }),
-      },
-    );
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch simulation run" });
-      process.exit(1);
-    }
-
-    const run = await response.json() as {
+    const run = (await apiRequest({
+      method: "GET",
+      path: `/api/simulation-runs/${encodeURIComponent(runId)}`,
+      apiKey,
+      endpoint,
+    })) as {
       scenarioRunId: string;
       scenarioId: string;
       batchRunId: string;

--- a/typescript-sdk/src/cli/commands/simulation-runs/list.ts
+++ b/typescript-sdk/src/cli/commands/simulation-runs/list.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { formatRelativeTime } from "../../utils/formatting";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const listSimulationRunsCommand = async (options: {
   scenarioSetId?: string;
@@ -27,21 +26,12 @@ export const listSimulationRunsCommand = async (options: {
     if (options.batchRunId) params.set("batchRunId", options.batchRunId);
     if (options.limit) params.set("limit", options.limit);
 
-    const response = await fetch(
-      `${endpoint}/api/simulation-runs?${params.toString()}`,
-      {
-        method: "GET",
-        headers: buildAuthHeaders({ apiKey }),
-      },
-    );
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch simulation runs: ${message}`);
-      process.exit(1);
-    }
-
-    const result = await response.json() as {
+    const result = (await apiRequest({
+      method: "GET",
+      path: `/api/simulation-runs?${params.toString()}`,
+      apiKey,
+      endpoint,
+    })) as {
       runs: Array<{
         scenarioRunId: string;
         scenarioId: string;

--- a/typescript-sdk/src/cli/commands/simulation-runs/list.ts
+++ b/typescript-sdk/src/cli/commands/simulation-runs/list.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { formatRelativeTime } from "../../utils/formatting";
 import type { CommandResult } from "../../utils/output";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 export const listSimulationRunsCommand = async (options: {
@@ -28,21 +27,12 @@ export const listSimulationRunsCommand = async (options: {
     if (options.batchRunId) params.set("batchRunId", options.batchRunId);
     if (options.limit) params.set("limit", options.limit);
 
-    const response = await fetch(
-      `${endpoint}/api/simulation-runs?${params.toString()}`,
-      {
-        method: "GET",
-        headers: buildAuthHeaders({ apiKey }),
-      },
-    );
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch simulation runs" });
-      process.exit(1);
-    }
-
-    const result = await response.json() as {
+    const result = (await apiRequest({
+      method: "GET",
+      path: `/api/simulation-runs?${params.toString()}`,
+      apiKey,
+      endpoint,
+    })) as {
       runs: Array<{
         scenarioRunId: string;
         scenarioId: string;

--- a/typescript-sdk/src/cli/commands/status.ts
+++ b/typescript-sdk/src/cli/commands/status.ts
@@ -1,10 +1,10 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../utils/apiClient";
 import { checkApiKey } from "../utils/apiKey";
 import {
   createLangWatchApiClient,
 } from "@/internal/api/client";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 
 export const statusCommand = async (options?: { format?: string }): Promise<void> => {
@@ -18,20 +18,20 @@ export const statusCommand = async (options?: { format?: string }): Promise<void
   const results: Record<string, { count: number; error?: string; status?: number }> = {};
 
   async function fetchCount(url: string): Promise<{ data: unknown; error?: unknown; status?: number }> {
-    const response = await fetch(`${endpoint}${url}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-    if (!response.ok) {
-      let body: unknown;
-      try {
-        body = await response.json();
-      } catch {
-        body = undefined;
-      }
-      return { data: null, error: body ?? response.statusText, status: response.status };
+    try {
+      const data = await apiRequest({
+        method: "GET",
+        path: url,
+        apiKey,
+        endpoint,
+      });
+      return { data, error: undefined };
+    } catch (err) {
+      // apiRequest attaches the response status to the thrown error so the
+      // downstream auth-detection (`every status === 401 || 403`) keeps working.
+      const status = (err as { status?: number }).status;
+      return { data: null, error: err, status };
     }
-    const data = await response.json();
-    return { data, error: undefined };
   }
 
   // Fetch counts for all major resources in parallel

--- a/typescript-sdk/src/cli/commands/status.ts
+++ b/typescript-sdk/src/cli/commands/status.ts
@@ -1,10 +1,11 @@
 import chalk from "chalk";
 import { createSpinner } from "../utils/spinner";
+import { apiRequest } from "../utils/apiClient";
 import { checkApiKey } from "../utils/apiKey";
 import {
   createLangWatchApiClient,
 } from "@/internal/api/client";
-import { buildAuthHeaders, isPersonalAccessToken } from "@/internal/api/auth";
+import { isPersonalAccessToken } from "@/internal/api/auth";
 import { formatApiErrorMessage } from "@/client-sdk/services/_shared/format-api-error";
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import { printResult, type RawOutputFlags } from "../utils/output";
@@ -157,20 +158,20 @@ export const statusCommand = async (options?: RawOutputFlags): Promise<void> => 
   };
 
   async function fetchCount(url: string): Promise<{ data: unknown; error?: unknown; status?: number }> {
-    const response = await fetch(`${endpoint}${url}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-    if (!response.ok) {
-      let body: unknown;
-      try {
-        body = await response.json();
-      } catch {
-        body = undefined;
-      }
-      return { data: null, error: body ?? response.statusText, status: response.status };
+    try {
+      const data = await apiRequest({
+        method: "GET",
+        path: url,
+        apiKey,
+        endpoint,
+      });
+      return { data, error: undefined };
+    } catch (err) {
+      // apiRequest attaches the response status to the thrown error so the
+      // downstream auth-detection (`every status === 401 || 403`) keeps working.
+      const status = (err as { status?: number }).status;
+      return { data: null, error: err, status };
     }
-    const data = await response.json();
-    return { data, error: undefined };
   }
 
   // ── Attention-section fetchers ──────────────────────────────────────

--- a/typescript-sdk/src/cli/commands/suites/run.ts
+++ b/typescript-sdk/src/cli/commands/suites/run.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import ora from "ora";
 import { SuitesApiService } from "@/client-sdk/services/suites";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const runSuiteCommand = async (
   id: string,
@@ -82,45 +82,40 @@ export const runSuiteCommand = async (
 
       try {
         // Poll the scenario events endpoint for batch status
-        const statusResponse = await fetch(
-          `${endpoint}/api/scenario-events?batchRunId=${encodeURIComponent(result.batchRunId)}`,
-          {
-            method: "GET",
-            headers: buildAuthHeaders({ apiKey }),
-          },
-        );
+        const statusData = (await apiRequest({
+          method: "GET",
+          path: `/api/scenario-events?batchRunId=${encodeURIComponent(result.batchRunId)}`,
+          apiKey,
+          endpoint,
+        })) as {
+          totalCount?: number;
+          completedCount?: number;
+          passedCount?: number;
+          failedCount?: number;
+          status?: string;
+        };
 
-        if (statusResponse.ok) {
-          const statusData = await statusResponse.json() as {
-            totalCount?: number;
-            completedCount?: number;
-            passedCount?: number;
-            failedCount?: number;
-            status?: string;
-          };
+        const total = statusData.totalCount ?? result.jobCount;
+        const completedCount = statusData.completedCount ?? 0;
+        const passed = statusData.passedCount ?? 0;
+        const failed = statusData.failedCount ?? 0;
 
-          const total = statusData.totalCount ?? result.jobCount;
-          const completedCount = statusData.completedCount ?? 0;
-          const passed = statusData.passedCount ?? 0;
-          const failed = statusData.failedCount ?? 0;
+        const newStatus = `${completedCount}/${total} completed (${passed} passed, ${failed} failed)`;
+        if (newStatus !== lastStatus) {
+          pollSpinner.text = `Running... ${newStatus}`;
+          lastStatus = newStatus;
+        }
 
-          const newStatus = `${completedCount}/${total} completed (${passed} passed, ${failed} failed)`;
-          if (newStatus !== lastStatus) {
-            pollSpinner.text = `Running... ${newStatus}`;
-            lastStatus = newStatus;
-          }
-
-          if (completedCount >= total && total > 0) {
-            completed = true;
-            if (failed > 0) {
-              pollSpinner.warn(
-                `Suite run completed: ${passed}/${total} passed, ${chalk.red(`${failed} failed`)}`,
-              );
-            } else {
-              pollSpinner.succeed(
-                `Suite run completed: ${chalk.green(`${passed}/${total} passed`)}`,
-              );
-            }
+        if (completedCount >= total && total > 0) {
+          completed = true;
+          if (failed > 0) {
+            pollSpinner.warn(
+              `Suite run completed: ${passed}/${total} passed, ${chalk.red(`${failed} failed`)}`,
+            );
+          } else {
+            pollSpinner.succeed(
+              `Suite run completed: ${chalk.green(`${passed}/${total} passed`)}`,
+            );
           }
         }
       } catch {

--- a/typescript-sdk/src/cli/commands/suites/run.ts
+++ b/typescript-sdk/src/cli/commands/suites/run.ts
@@ -1,10 +1,10 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
 import { SuitesApiService } from "@/client-sdk/services/suites";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
 import { failSpinner } from "../../utils/spinnerError";
 import { resolveOutputFormat } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 export const runSuiteCommand = async (
@@ -109,19 +109,12 @@ export const runSuiteCommand = async (
 
       try {
         // Poll the scenario events endpoint for batch status
-        const statusResponse = await fetch(
-          `${endpoint}/api/scenario-events?batchRunId=${encodeURIComponent(result.batchRunId)}`,
-          {
-            method: "GET",
-            headers: buildAuthHeaders({ apiKey }),
-          },
-        );
-
-        if (!statusResponse.ok) {
-          throw new Error(`status endpoint answered ${statusResponse.status}`);
-        }
-
-        const statusData = await statusResponse.json() as {
+        const statusData = (await apiRequest({
+          method: "GET",
+          path: `/api/scenario-events?batchRunId=${encodeURIComponent(result.batchRunId)}`,
+          apiKey,
+          endpoint,
+        })) as {
           totalCount?: number;
           completedCount?: number;
           passedCount?: number;

--- a/typescript-sdk/src/cli/commands/traces/export.ts
+++ b/typescript-sdk/src/cli/commands/traces/export.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import ora from "ora";
 import fs from "fs";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const exportTracesCommand = async (options: {
   startDate?: string;
@@ -37,28 +36,7 @@ export const exportTracesCommand = async (options: {
   const spinner = ora(`Exporting traces (${format})...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/traces/search`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
-        query: options.query,
-        startDate,
-        endDate,
-        pageSize: Math.min(limit, 100),
-        format: "json",
-      }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Export failed: ${message}`);
-      process.exit(1);
-    }
-
-    const data = await response.json() as {
+    type ExportData = {
       traces: Array<{
         trace_id: string;
         input?: { value: string };
@@ -69,6 +47,26 @@ export const exportTracesCommand = async (options: {
       }>;
       pagination?: { totalHits?: number };
     };
+    let data: ExportData;
+    try {
+      data = (await apiRequest({
+        method: "POST",
+        path: "/api/traces/search",
+        apiKey,
+        endpoint,
+        body: {
+          query: options.query,
+          startDate,
+          endDate,
+          pageSize: Math.min(limit, 100),
+          format: "json",
+        },
+      })) as ExportData;
+    } catch (httpError) {
+      const message = httpError instanceof Error ? httpError.message : String(httpError);
+      spinner.fail(`Export failed: ${message}`);
+      process.exit(1);
+    }
 
     const traces = data.traces;
     spinner.succeed(`Exported ${traces.length} trace${traces.length !== 1 ? "s" : ""}${data.pagination?.totalHits ? ` (${data.pagination.totalHits} total)` : ""}`);

--- a/typescript-sdk/src/cli/commands/traces/export.ts
+++ b/typescript-sdk/src/cli/commands/traces/export.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
 import fs from "fs";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { createCommandEvents, type CommandEvents } from "../../telemetry/events";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import { parseOriginOption } from "./origin-filter";
@@ -58,46 +57,20 @@ export const exportTracesCommand = async (options: {
   try {
     events.started(`Exporting traces as ${format}…`);
 
-    const response = await fetch(`${endpoint}/api/traces/search`, {
+    const data = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
+      path: "/api/traces/search",
+      apiKey,
+      endpoint,
+      body: {
         query: options.query,
         startDate,
         endDate,
         pageSize: Math.min(limit, 100),
         format: "json",
         ...(originFilter ? { filters: { "traces.origin": originFilter } } : {}),
-      }),
-    });
-
-    if (!response.ok) {
-      // Read the body off a CLONE before `formatFetchError` consumes it, so the
-      // event keeps the platform's real error kind instead of degrading to one
-      // guessed from the status.
-      const body: unknown = await response
-        .clone()
-        .json()
-        .catch(() => undefined);
-
-      const message = await formatFetchError(response);
-      events.failed({
-        error: Object.assign(new Error(message), {
-          status: response.status,
-          originalError: body,
-        }),
-        message: "Trace export failed",
-      });
-      await events.flush();
-
-      failSpinner({ spinner, error: new Error(message), action: "export traces" });
-      process.exit(1);
-    }
-
-    const data = await response.json() as {
+      },
+    })) as {
       traces: ExportedTrace[];
       pagination?: { totalHits?: number };
     };

--- a/typescript-sdk/src/cli/commands/triggers/create.ts
+++ b/typescript-sdk/src/cli/commands/triggers/create.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const createTriggerCommand = async (
   name: string,
@@ -38,29 +37,20 @@ export const createTriggerCommand = async (
     const actionParams: Record<string, unknown> = {};
     if (options.slackWebhook) actionParams.slackWebhook = options.slackWebhook;
 
-    const response = await fetch(`${endpoint}/api/triggers`, {
+    const trigger = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
+      path: "/api/triggers",
+      apiKey,
+      endpoint,
+      body: {
         name,
         action: options.action,
         filters,
         actionParams,
         message: options.message,
         alertType: options.alertType,
-      }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to create trigger: ${message}`);
-      process.exit(1);
-    }
-
-    const trigger = await response.json() as { id: string; name: string; action: string; platformUrl?: string };
+      },
+    })) as { id: string; name: string; action: string; platformUrl?: string };
     spinner.succeed(`Trigger "${trigger.name}" created (${trigger.id})`);
 
     if (options.format === "json") {

--- a/typescript-sdk/src/cli/commands/triggers/create.ts
+++ b/typescript-sdk/src/cli/commands/triggers/create.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -50,29 +49,20 @@ export const createTriggerCommand = async (
     const actionParams: Record<string, unknown> = {};
     if (options.slackWebhook) actionParams.slackWebhook = options.slackWebhook;
 
-    const response = await fetch(`${endpoint}/api/triggers`, {
+    const trigger = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify({
+      path: "/api/triggers",
+      apiKey,
+      endpoint,
+      body: {
         name,
         action: options.action,
         filters,
         actionParams,
         message: options.message,
         alertType: options.alertType,
-      }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "create trigger" });
-      process.exit(1);
-    }
-
-    const trigger = await response.json() as { id: string; name: string; action: string; platformUrl?: string };
+      },
+    })) as { id: string; name: string; action: string; platformUrl?: string };
     spinner.succeed(`Trigger "${trigger.name}" created (${trigger.id})`);
 
     return {

--- a/typescript-sdk/src/cli/commands/triggers/delete.ts
+++ b/typescript-sdk/src/cli/commands/triggers/delete.ts
@@ -1,8 +1,7 @@
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const deleteTriggerCommand = async (
   id: string,
@@ -16,18 +15,19 @@ export const deleteTriggerCommand = async (
   const spinner = ora(`Deleting trigger "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
-      method: "DELETE",
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
+    let result: { id: string; deleted: boolean };
+    try {
+      result = (await apiRequest({
+        method: "DELETE",
+        path: `/api/triggers/${encodeURIComponent(id)}`,
+        apiKey,
+        endpoint,
+      })) as { id: string; deleted: boolean };
+    } catch (httpError) {
+      const message = httpError instanceof Error ? httpError.message : String(httpError);
       spinner.fail(`Failed to delete trigger "${id}": ${message}`);
       process.exit(1);
     }
-
-    const result = await response.json() as { id: string; deleted: boolean };
     spinner.succeed(`Trigger "${id}" deleted`);
 
     if (options?.format === "json") {

--- a/typescript-sdk/src/cli/commands/triggers/delete.ts
+++ b/typescript-sdk/src/cli/commands/triggers/delete.ts
@@ -1,8 +1,7 @@
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -22,18 +21,12 @@ export const deleteTriggerCommand = async (
   const spinner = createSpinner(`Deleting trigger "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
+    const result = (await apiRequest({
       method: "DELETE",
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: `delete trigger "${id}"` });
-      process.exit(1);
-    }
-
-    const result = await response.json() as { id: string; deleted: boolean };
+      path: `/api/triggers/${encodeURIComponent(id)}`,
+      apiKey,
+      endpoint,
+    })) as { id: string; deleted: boolean };
     spinner.succeed(`Trigger "${id}" deleted`);
 
     return {
@@ -44,7 +37,7 @@ export const deleteTriggerCommand = async (
       },
     };
   } catch (error) {
-    failSpinner({ spinner, error, action: "delete trigger" });
+    failSpinner({ spinner, error, action: `delete trigger "${id}"` });
     process.exit(1);
   }
 };

--- a/typescript-sdk/src/cli/commands/triggers/get.ts
+++ b/typescript-sdk/src/cli/commands/triggers/get.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const getTriggerCommand = async (
   id: string,
@@ -17,17 +16,7 @@ export const getTriggerCommand = async (
   const spinner = ora(`Fetching trigger "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch trigger "${id}": ${message}`);
-      process.exit(1);
-    }
-
-    const trigger = await response.json() as {
+    type Trigger = {
       id: string;
       name: string;
       action: string;
@@ -40,6 +29,19 @@ export const getTriggerCommand = async (
       updatedAt: string;
       platformUrl?: string;
     };
+    let trigger: Trigger;
+    try {
+      trigger = (await apiRequest({
+        method: "GET",
+        path: `/api/triggers/${encodeURIComponent(id)}`,
+        apiKey,
+        endpoint,
+      })) as Trigger;
+    } catch (httpError) {
+      const message = httpError instanceof Error ? httpError.message : String(httpError);
+      spinner.fail(`Failed to fetch trigger "${id}": ${message}`);
+      process.exit(1);
+    }
 
     spinner.succeed(`Found trigger "${trigger.name}"`);
 

--- a/typescript-sdk/src/cli/commands/triggers/get.ts
+++ b/typescript-sdk/src/cli/commands/triggers/get.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -26,17 +25,12 @@ export const getTriggerCommand = async (
   const spinner = createSpinner(`Fetching trigger "${id}"...`).start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: `fetch trigger "${id}"` });
-      process.exit(1);
-    }
-
-    const trigger = await response.json() as {
+    const trigger = (await apiRequest({
+      method: "GET",
+      path: `/api/triggers/${encodeURIComponent(id)}`,
+      apiKey,
+      endpoint,
+    })) as {
       id: string;
       name: string;
       action: string;
@@ -80,7 +74,7 @@ export const getTriggerCommand = async (
       },
     };
   } catch (error) {
-    failSpinner({ spinner, error, action: "fetch trigger" });
+    failSpinner({ spinner, error, action: `fetch trigger "${id}"` });
     process.exit(1);
   }
 };

--- a/typescript-sdk/src/cli/commands/triggers/list.ts
+++ b/typescript-sdk/src/cli/commands/triggers/list.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const listTriggersCommand = async (options?: { format?: string }): Promise<void> => {
   checkApiKey();
@@ -15,17 +14,12 @@ export const listTriggersCommand = async (options?: { format?: string }): Promis
   const spinner = ora("Fetching triggers...").start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to fetch triggers: ${message}`);
-      process.exit(1);
-    }
-
-    const triggers = await response.json() as Array<{
+    const triggers = (await apiRequest({
+      method: "GET",
+      path: "/api/triggers",
+      apiKey,
+      endpoint,
+    })) as Array<{
       id: string;
       name: string;
       action: string;

--- a/typescript-sdk/src/cli/commands/triggers/list.ts
+++ b/typescript-sdk/src/cli/commands/triggers/list.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { formatTable } from "../../utils/formatting";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -23,17 +22,12 @@ export const listTriggersCommand = async (): Promise<CommandResult | void> => {
   const spinner = createSpinner("Fetching triggers...").start();
 
   try {
-    const response = await fetch(`${endpoint}/api/triggers`, {
-      headers: buildAuthHeaders({ apiKey }),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "fetch triggers" });
-      process.exit(1);
-    }
-
-    const triggers = await response.json() as Array<{
+    const triggers = (await apiRequest({
+      method: "GET",
+      path: "/api/triggers",
+      apiKey,
+      endpoint,
+    })) as Array<{
       id: string;
       name: string;
       action: string;

--- a/typescript-sdk/src/cli/commands/triggers/update.ts
+++ b/typescript-sdk/src/cli/commands/triggers/update.ts
@@ -1,8 +1,7 @@
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const updateTriggerCommand = async (
   id: string,
@@ -33,22 +32,13 @@ export const updateTriggerCommand = async (
       process.exit(1);
     }
 
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
+    const trigger = (await apiRequest({
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to update trigger: ${message}`);
-      process.exit(1);
-    }
-
-    const trigger = await response.json() as { id: string; name: string; active: boolean };
+      path: `/api/triggers/${encodeURIComponent(id)}`,
+      apiKey,
+      endpoint,
+      body,
+    })) as { id: string; name: string; active: boolean };
     spinner.succeed(`Trigger "${trigger.name}" updated`);
 
     if (options.format === "json") {

--- a/typescript-sdk/src/cli/commands/triggers/update.ts
+++ b/typescript-sdk/src/cli/commands/triggers/update.ts
@@ -1,9 +1,8 @@
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
 import type { CommandResult } from "../../utils/output";
@@ -46,22 +45,13 @@ export const updateTriggerCommand = async (
       process.exit(1);
     }
 
-    const response = await fetch(`${endpoint}/api/triggers/${encodeURIComponent(id)}`, {
+    const trigger = (await apiRequest({
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "update trigger" });
-      process.exit(1);
-    }
-
-    const trigger = await response.json() as { id: string; name: string; active: boolean };
+      path: `/api/triggers/${encodeURIComponent(id)}`,
+      apiKey,
+      endpoint,
+      body,
+    })) as { id: string; name: string; active: boolean };
     spinner.succeed(`Trigger "${trigger.name}" updated`);
 
     return {

--- a/typescript-sdk/src/cli/commands/workflows/run.ts
+++ b/typescript-sdk/src/cli/commands/workflows/run.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const runWorkflowCommand = async (
   id: string,
@@ -23,22 +22,20 @@ export const runWorkflowCommand = async (
     const apiKey = process.env.LANGWATCH_API_KEY ?? "";
     const endpoint = process.env.LANGWATCH_ENDPOINT ?? "https://app.langwatch.ai";
 
-    const response = await fetch(`${endpoint}/api/workflows/${encodeURIComponent(id)}/run`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify(input),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
+    let result: Record<string, unknown>;
+    try {
+      result = (await apiRequest({
+        method: "POST",
+        path: `/api/workflows/${encodeURIComponent(id)}/run`,
+        apiKey,
+        endpoint,
+        body: input,
+      })) as Record<string, unknown>;
+    } catch (httpError) {
+      const message = httpError instanceof Error ? httpError.message : String(httpError);
       spinner.fail(`Workflow execution failed: ${message}`);
       process.exit(1);
     }
-
-    const result = await response.json() as Record<string, unknown>;
 
     spinner.succeed(`Workflow "${id}" executed successfully`);
 

--- a/typescript-sdk/src/cli/commands/workflows/run.ts
+++ b/typescript-sdk/src/cli/commands/workflows/run.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError, reportCommandError } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -36,22 +35,13 @@ export const runWorkflowCommand = async (
     const apiKey = process.env.LANGWATCH_API_KEY ?? "";
     const endpoint = resolveControlPlaneUrl();
 
-    const response = await fetch(`${endpoint}/api/workflows/${encodeURIComponent(id)}/run`, {
+    const result = (await apiRequest({
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...buildAuthHeaders({ apiKey }),
-      },
-      body: JSON.stringify(input),
-    });
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "run workflow" });
-      process.exit(1);
-    }
-
-    const result = await response.json() as Record<string, unknown>;
+      path: `/api/workflows/${encodeURIComponent(id)}/run`,
+      apiKey,
+      endpoint,
+      body: input,
+    })) as Record<string, unknown>;
 
     spinner.succeed(`Workflow "${id}" executed successfully`);
 

--- a/typescript-sdk/src/cli/commands/workflows/update.ts
+++ b/typescript-sdk/src/cli/commands/workflows/update.ts
@@ -1,9 +1,8 @@
 import chalk from "chalk";
 import ora from "ora";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
-import { buildAuthHeaders } from "@/internal/api/auth";
 
 export const updateWorkflowCommand = async (
   id: string,
@@ -27,25 +26,13 @@ export const updateWorkflowCommand = async (
       process.exit(1);
     }
 
-    const response = await fetch(
-      `${endpoint}/api/workflows/${encodeURIComponent(id)}`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          ...buildAuthHeaders({ apiKey }),
-        },
-        body: JSON.stringify(body),
-      },
-    );
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      spinner.fail(`Failed to update workflow: ${message}`);
-      process.exit(1);
-    }
-
-    const workflow = await response.json() as {
+    const workflow = (await apiRequest({
+      method: "PATCH",
+      path: `/api/workflows/${encodeURIComponent(id)}`,
+      apiKey,
+      endpoint,
+      body,
+    })) as {
       id: string;
       name: string;
       icon: string | null;

--- a/typescript-sdk/src/cli/commands/workflows/update.ts
+++ b/typescript-sdk/src/cli/commands/workflows/update.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 import { createSpinner } from "../../utils/spinner";
+import { apiRequest } from "../../utils/apiClient";
 import { checkApiKey } from "../../utils/apiKey";
-import { formatFetchError } from "../../utils/formatFetchError";
 import { failSpinner } from "../../utils/spinnerError";
 import { commandValidationError } from "../../utils/errorOutput";
-import { buildAuthHeaders } from "@/internal/api/auth";
 import type { CommandResult } from "../../utils/output";
 
 import { resolveControlPlaneUrl } from "@/cli/utils/governance/resolveEndpoint";
@@ -36,25 +35,13 @@ export const updateWorkflowCommand = async (
       process.exit(1);
     }
 
-    const response = await fetch(
-      `${endpoint}/api/workflows/${encodeURIComponent(id)}`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          ...buildAuthHeaders({ apiKey }),
-        },
-        body: JSON.stringify(body),
-      },
-    );
-
-    if (!response.ok) {
-      const message = await formatFetchError(response);
-      failSpinner({ spinner, error: new Error(message), action: "update workflow" });
-      process.exit(1);
-    }
-
-    const workflow = await response.json() as {
+    const workflow = (await apiRequest({
+      method: "PATCH",
+      path: `/api/workflows/${encodeURIComponent(id)}`,
+      apiKey,
+      endpoint,
+      body,
+    })) as {
       id: string;
       name: string;
       icon: string | null;

--- a/typescript-sdk/src/cli/utils/__tests__/apiClient.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/__tests__/apiClient.unit.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { apiRequest } from "../apiClient";
+
+interface CapturedCall {
+  url: string;
+  init: RequestInit;
+}
+
+describe("apiRequest()", () => {
+  const apiKey = "sk-lw-test-key";
+  const endpoint = "https://app.langwatch.ai";
+  let captured: CapturedCall;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    captured = { url: "", init: {} };
+    fetchMock = vi.fn(
+      async (url: string, init: RequestInit): Promise<Response> => {
+        captured = { url, init };
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function getHeader(name: string): string | undefined {
+    const headers = captured.init.headers as Record<string, string> | undefined;
+    if (!headers) return undefined;
+    const lower = name.toLowerCase();
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() === lower) return value;
+    }
+    return undefined;
+  }
+
+  describe("when sending any request", () => {
+    it("sets User-Agent: langwatch-cli/<version>", async () => {
+      await apiRequest({ method: "GET", path: "/api/monitors", apiKey, endpoint });
+
+      const ua = getHeader("User-Agent");
+      expect(ua).toBeDefined();
+      expect(ua).toMatch(/^langwatch-cli\//);
+    });
+
+    it("sets Authorization for sk-lw-* keys via buildAuthHeaders", async () => {
+      await apiRequest({ method: "GET", path: "/api/monitors", apiKey, endpoint });
+
+      // buildAuthHeaders lowercases the auth header key; what matters is that
+      // the Bearer token reaches the server.
+      const auth = getHeader("authorization");
+      expect(auth).toBe(`Bearer ${apiKey}`);
+    });
+
+    it("prepends the endpoint to the path", async () => {
+      await apiRequest({ method: "GET", path: "/api/monitors", apiKey, endpoint });
+      expect(captured.url).toBe("https://app.langwatch.ai/api/monitors");
+    });
+  });
+
+  describe("when called without a body", () => {
+    it("does not set Content-Type", async () => {
+      await apiRequest({ method: "GET", path: "/api/monitors", apiKey, endpoint });
+      expect(getHeader("Content-Type")).toBeUndefined();
+    });
+
+    it("does not include a body in the fetch init", async () => {
+      await apiRequest({ method: "GET", path: "/api/monitors", apiKey, endpoint });
+      expect(captured.init.body).toBeUndefined();
+    });
+  });
+
+  describe("when called with a body", () => {
+    it("sets Content-Type: application/json and JSON-stringifies the body", async () => {
+      await apiRequest({
+        method: "POST",
+        path: "/api/monitors",
+        apiKey,
+        endpoint,
+        body: { name: "x" },
+      });
+
+      expect(getHeader("Content-Type")).toBe("application/json");
+      expect(captured.init.body).toBe(JSON.stringify({ name: "x" }));
+    });
+  });
+
+  describe("when the response is 204 No Content", () => {
+    it("returns null", async () => {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+      const result = await apiRequest({
+        method: "DELETE",
+        path: "/api/monitors/abc",
+        apiKey,
+        endpoint,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("when the response is empty (content-length: 0)", () => {
+    it("returns null without parsing JSON", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response("", {
+          status: 200,
+          headers: { "content-length": "0" },
+        }),
+      );
+      const result = await apiRequest({
+        method: "GET",
+        path: "/api/monitors",
+        apiKey,
+        endpoint,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("when the response is non-2xx", () => {
+    it("throws an Error formatted via formatFetchError", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "Not allowed" }), {
+          status: 403,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      await expect(
+        apiRequest({ method: "GET", path: "/api/monitors", apiKey, endpoint }),
+      ).rejects.toThrow(/Not allowed/);
+    });
+
+    it("surfaces the status code when the body has no useful message", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response("", { status: 500 }),
+      );
+      await expect(
+        apiRequest({ method: "GET", path: "/api/monitors", apiKey, endpoint }),
+      ).rejects.toThrow(/500/);
+    });
+
+    it("attaches the response status to the thrown error", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "nope" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      try {
+        await apiRequest({
+          method: "GET",
+          path: "/api/monitors",
+          apiKey,
+          endpoint,
+        });
+        throw new Error("expected apiRequest to throw");
+      } catch (err) {
+        expect((err as { status?: number }).status).toBe(401);
+      }
+    });
+  });
+});

--- a/typescript-sdk/src/cli/utils/apiClient.ts
+++ b/typescript-sdk/src/cli/utils/apiClient.ts
@@ -1,0 +1,75 @@
+import { buildAuthHeaders } from "@/internal/api/auth";
+import { formatFetchError } from "./formatFetchError";
+
+declare const __CLI_VERSION__: string;
+
+// `__CLI_VERSION__` is replaced at build time by the tsup `define` block in
+// typescript-sdk/tsup.config.ts. Outside of a built CLI bundle (e.g. vitest)
+// the identifier doesn't exist at runtime, so we fall back to a sentinel —
+// the User-Agent stays well-formed and unit tests don't ReferenceError.
+const CLI_VERSION =
+  typeof __CLI_VERSION__ !== "undefined" ? __CLI_VERSION__ : "0.0.0-dev";
+
+const USER_AGENT = `langwatch-cli/${CLI_VERSION}`;
+
+export interface ApiRequestParams {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  /** Path under the LangWatch endpoint, including any query string (e.g. "/api/monitors?foo=bar"). */
+  path: string;
+  /** JSON-serializable request body. Omit for GET/DELETE or empty POST bodies. */
+  body?: unknown;
+  apiKey: string;
+  endpoint: string;
+}
+
+/**
+ * Single chokepoint for every CLI request to the LangWatch control plane.
+ *
+ * Tags every outbound call with `User-Agent: langwatch-cli/<version>` so the
+ * backend can attribute requests to source="cli" in the api_active_user
+ * heartbeat metric (see PR #3589 / #3591). This is the CLI mirror of
+ * `mcp-server/src/langwatch-api.ts::makeRequest`.
+ *
+ * Auth is delegated to `buildAuthHeaders` so PAT credentials still resolve
+ * via Basic auth instead of being demoted to a plain Bearer.
+ *
+ * @throws Error with the formatted server message when the response is not OK.
+ */
+export async function apiRequest({
+  method,
+  path,
+  body,
+  apiKey,
+  endpoint,
+}: ApiRequestParams): Promise<unknown> {
+  const headers: Record<string, string> = {
+    "User-Agent": USER_AGENT,
+    ...buildAuthHeaders({ apiKey }),
+  };
+
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(`${endpoint}${path}`, {
+    method,
+    headers,
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    const message = await formatFetchError(response);
+    const error = new Error(message) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+
+  if (
+    response.status === 204 ||
+    response.headers?.get("content-length") === "0"
+  ) {
+    return null;
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary

Adds a shared `apiRequest` helper at `typescript-sdk/src/cli/utils/apiClient.ts` and routes every CLI command's LangWatch API call through it. The helper sets `User-Agent: langwatch-cli/<version>` (plus `Authorization` via `buildAuthHeaders` and `Content-Type: application/json` only when there's a body), so the backend can attribute requests to `source="cli"` in the `api_active_user` heartbeat metric.

This is the CLI mirror of the MCP work in #3591 (which solved the same problem for `langwatch-mcp/<version>`).

Refs: #3589, #3591

## Behavior preserved

- Auth still routes through `buildAuthHeaders`, so `pat-lw-*` PATs continue to use Basic auth (the helper does not hard-code Bearer).
- Per-command spinner messages, exit codes, and JSON output formats are unchanged. Sites with custom error prefixes (`Export failed:`, `Workflow execution failed:`, `Agent execution failed:`, `Failed to fetch trigger \"<id>\":`, `Failed to delete trigger \"<id>\":`, `Failed to delete graph \"<id>\":`, `Failed to restore \"<handle>\" to <versionId>:`) wrap `apiRequest` in an inner try/catch so the exact text is retained.
- The `status` command's auth-detection (`every status === 401 || 403`) keeps working — the thrown error carries `status` as a property.

## Files touched

**New:**
- `typescript-sdk/src/cli/utils/apiClient.ts`
- `typescript-sdk/src/cli/utils/__tests__/apiClient.unit.test.ts` (User-Agent set, Authorization set, body→Content-Type, 204→null, content-length:0→null, non-2xx throws via `formatFetchError`, status attached to thrown error)

**Refactored to call `apiRequest`:**
- `typescript-sdk/src/cli/commands/status.ts`
- `typescript-sdk/src/cli/commands/agents/run.ts` (workflow-API path only)
- `typescript-sdk/src/cli/commands/graphs/{list,get,create,update,delete}.ts`
- `typescript-sdk/src/cli/commands/monitors/{list,get,create,update,delete}.ts`
- `typescript-sdk/src/cli/commands/prompt/restore.ts`
- `typescript-sdk/src/cli/commands/scenarios/run.ts` (poll loop)
- `typescript-sdk/src/cli/commands/secrets/{list,get,create,update,delete}.ts`
- `typescript-sdk/src/cli/commands/simulation-runs/{list,get}.ts`
- `typescript-sdk/src/cli/commands/suites/run.ts` (poll loop)
- `typescript-sdk/src/cli/commands/traces/export.ts`
- `typescript-sdk/src/cli/commands/triggers/{list,get,create,update,delete}.ts`
- `typescript-sdk/src/cli/commands/workflows/{run,update}.ts`

## Fetch sites intentionally NOT changed

- `typescript-sdk/src/cli/commands/docs.ts:55` — fetches `https://langwatch.ai/docs/*` (public docs CDN, no auth, not the API). Same exclusion the MCP work made for `create-mcp-server.ts`.
- `typescript-sdk/src/cli/commands/agents/run.ts:54` — calls a customer-configured HTTP-agent URL (not LangWatch). Skipping these matches the spec: only LangWatch-bound traffic should be tagged.

## Test plan

- [x] `pnpm typecheck` (typescript-sdk) — clean.
- [x] `pnpm test:unit` (typescript-sdk) — 1006 tests pass, including 11 new tests in `apiClient.unit.test.ts`.
- [ ] After merge: confirm a fresh CLI request shows up in PostHog with `source="cli"` (not `source="unknown"`) on the `api_active_user` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)