### PR TITLE
revert(dev): drop tsx watch from pnpm dev — restart manually for now

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -26,7 +26,6 @@
     "dev:vite": "vite",
     "start": "./scripts/start.sh",
     "start:app": "tsx src/server.mts",
-    "start:app:watch": "tsx watch --clear-screen=false src/server.mts",
     "start:quickwit": "cd quickwit && ./quickwit run",
     "start:prepare:files": "pnpm run generate:sdk-versions && pnpm run copy:langevals-types && pnpm run types:zod:generate && pnpm run prisma:generate:typescript && pnpm run build:mcp-server",
     "build:mcp-server": "./scripts/build-mcp-server.sh",

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -33,7 +33,6 @@
     "generate:sdk-versions": "bash scripts/generate-sdk-versions.sh",
     "start:prepare:db": "pnpm run prisma:migrate && pnpm run clickhouse:migrate",
     "start:workers": "tsx --tsconfig tsconfig.workers.json src/workers.ts",
-    "start:workers:watch": "tsx watch --clear-screen=false --tsconfig tsconfig.workers.json src/workers.ts",
     "typecheck:legacy": "./node_modules/.bin/tsc --noEmit --project ./tsconfig.json",
     "typecheck": "./node_modules/.bin/tsgo --noEmit --project ./tsconfig.tsgo.json",
     "test:unit": "NODE_ENV=test PINO_LOG_LEVEL=warn vitest",

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -44,10 +44,17 @@ if [ -z "$NODE_ENV" ]; then
   RUNTIME_ENV="$RUNTIME_ENV NODE_ENV=production"
 fi
 
-# In dev, swap to `tsx watch` for the API + workers so backend file edits
+# In dev, swap to `tsx watch` for the API ONLY so backend file edits
 # auto-reload without a manual `pnpm dev` restart. Vite handles the
-# frontend's HMR; this closes the gap on the server side. Production
-# keeps plain `tsx` (single-shot, no watcher overhead).
+# frontend's HMR (it's a separate process under concurrently — the API
+# watch reload doesn't touch it). Production keeps plain `tsx`
+# (single-shot, no watcher overhead).
+#
+# Workers stay on plain `tsx` even in dev: they boot heavy state
+# (BullMQ connections, model registries, scenarios runtime) so a
+# restart on every backend save would be costly and disruptive. If
+# you're iterating on worker code specifically, restart `pnpm dev`
+# manually.
 if [[ "$NODE_ENV" = "development" ]]; then
   START_APP_COMMAND="pnpm run start:app:watch"
 else
@@ -56,11 +63,7 @@ fi
 
 START_WORKERS_COMMAND=""
 if [[ "$START_WORKERS" = "true" || "$START_WORKERS" = "1" ]]; then
-  if [[ "$NODE_ENV" = "development" ]]; then
-    START_WORKERS_COMMAND="pnpm run start:workers:watch && exit 1"
-  else
-    START_WORKERS_COMMAND="pnpm run start:workers && exit 1"
-  fi
+  START_WORKERS_COMMAND="pnpm run start:workers && exit 1"
 fi
 
 # In development, Vite runs on PORT (default 5560) and proxies /api/* to PORT+1000.

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -44,22 +44,7 @@ if [ -z "$NODE_ENV" ]; then
   RUNTIME_ENV="$RUNTIME_ENV NODE_ENV=production"
 fi
 
-# In dev, swap to `tsx watch` for the API ONLY so backend file edits
-# auto-reload without a manual `pnpm dev` restart. Vite handles the
-# frontend's HMR (it's a separate process under concurrently — the API
-# watch reload doesn't touch it). Production keeps plain `tsx`
-# (single-shot, no watcher overhead).
-#
-# Workers stay on plain `tsx` even in dev: they boot heavy state
-# (BullMQ connections, model registries, scenarios runtime) so a
-# restart on every backend save would be costly and disruptive. If
-# you're iterating on worker code specifically, restart `pnpm dev`
-# manually.
-if [[ "$NODE_ENV" = "development" ]]; then
-  START_APP_COMMAND="pnpm run start:app:watch"
-else
-  START_APP_COMMAND="pnpm run start:app"
-fi
+START_APP_COMMAND="pnpm run start:app"
 
 START_WORKERS_COMMAND=""
 if [[ "$START_WORKERS" = "true" || "$START_WORKERS" = "1" ]]; then


### PR DESCRIPTION
## Summary

The auto-watch I added in #3478 caused too many full-API restarts under fast saves — BullMQ / Prisma / ClickHouse pool churn, briefly 2x memory per reload, no good way to debounce without a custom wrapper.

The right long-term fix is lazy reload-on-request via [`@hono/vite-dev-server`](https://github.com/honojs/vite-plugins/tree/main/packages/dev-server) (Hono runs *inside* the Vite SSR process; each `/api/*` request re-imports route handlers with whatever's on disk; no restarts ever — the same pattern Next.js / Remix / SvelteKit use). That needs the API to move inside the Vite process and ship its own PR — non-trivial because of the dotenv ordering, the CSS-noop module trick, signal handlers, and worker integration.

Until then: plain `tsx` for both the API and workers, manual `pnpm dev` restart when you want to pick up backend changes. Frontend HMR via Vite is unchanged.

## Test plan

- [x] `pnpm dev` boots, both API (6560) and Vite (5560) come up, frontend HMR still works
- [x] `bash -n langwatch/scripts/start.sh` syntax-clean
- [ ] Diff vs main is exactly the inverse of the watch commits in #3478