### PR TITLE
fix(helm): prevent ClickHouse password drift on upgrade (#3440)

### DIFF
--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -19,9 +19,15 @@ spec:
       labels:
         {{- include "clickhouse-serverless.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: clickhouse
-      {{- with .Values.podAnnotations }}
+      {{- $authSecret := lookup "v1" "Secret" .Release.Namespace (include "clickhouse-serverless.secretName" .) }}
+      {{- if or $authSecret .Values.podAnnotations }}
       annotations:
+        {{- if $authSecret }}
+        checksum/auth-secret: {{ $authSecret.data | toJson | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       serviceAccountName: {{ include "clickhouse-serverless.serviceAccountName" . }}

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -22,11 +22,11 @@ spec:
       {{- $authSecret := lookup "v1" "Secret" .Release.Namespace (include "clickhouse-serverless.secretName" .) }}
       {{- if or $authSecret .Values.podAnnotations }}
       annotations:
-        {{- if $authSecret }}
-        checksum/auth-secret: {{ $authSecret.data | toJson | sha256sum }}
-        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if $authSecret }}
+        checksum/auth-secret: {{ $authSecret.data | toJson | sha256sum }}
         {{- end }}
       {{- end }}
     spec:

--- a/charts/langwatch/templates/clickhouse/url-secret.yaml
+++ b/charts/langwatch/templates/clickhouse/url-secret.yaml
@@ -31,13 +31,9 @@ data:
   url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | b64enc | quote }}
 {{- else if or .Release.IsInstall .Values.clickhouse.auth.password }}
   {{- $pw := .Values.clickhouse.auth.password | default (randAlphaNum 32) }}
-  {{- $cs := .Values.clickhouse.auth.clusterSecret | default "" }}
-  {{- if and (not .Release.IsInstall) (eq $cs "") }}
-    {{- fail "clickhouse.auth.clusterSecret is required on upgrade when the existing secret cannot be read via lookup. Set clickhouse.auth.clusterSecret in your values file." }}
-  {{- end }}
 stringData:
   password: {{ $pw | quote }}
-  clusterSecret: {{ $cs | default (randAlphaNum 48) | quote }}
+  clusterSecret: {{ randAlphaNum 48 | quote }}
   url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | quote }}
 {{- else }}
   {{- fail "clickhouse.auth.password is required on upgrade when the existing secret cannot be read via lookup (e.g. helm template without cluster access, restricted RBAC). Set clickhouse.auth.password in your values file." }}

--- a/charts/langwatch/templates/clickhouse/url-secret.yaml
+++ b/charts/langwatch/templates/clickhouse/url-secret.yaml
@@ -23,7 +23,9 @@ type: Opaque
 {{- if $existingSecret }}
 data:
   {{- range $key, $value := $existingSecret.data }}
+  {{- if ne $key "url" }}
   {{ $key }}: {{ $value }}
+  {{- end }}
   {{- end }}
   {{- $pw := index $existingSecret.data "password" | b64dec }}
   url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | b64enc | quote }}

--- a/charts/langwatch/templates/clickhouse/url-secret.yaml
+++ b/charts/langwatch/templates/clickhouse/url-secret.yaml
@@ -27,12 +27,14 @@ data:
   {{- end }}
   {{- $pw := index $existingSecret.data "password" | b64dec }}
   url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | b64enc | quote }}
-{{- else }}
+{{- else if or .Release.IsInstall .Values.clickhouse.auth.password }}
   {{- $pw := .Values.clickhouse.auth.password | default (randAlphaNum 32) }}
 stringData:
   password: {{ $pw | quote }}
   clusterSecret: {{ randAlphaNum 48 | quote }}
   url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | quote }}
+{{- else }}
+  {{- fail "clickhouse.auth.password is required on upgrade when the existing secret cannot be read via lookup (e.g. helm template without cluster access, restricted RBAC). Set clickhouse.auth.password in your values file." }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/langwatch/templates/clickhouse/url-secret.yaml
+++ b/charts/langwatch/templates/clickhouse/url-secret.yaml
@@ -31,9 +31,13 @@ data:
   url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | b64enc | quote }}
 {{- else if or .Release.IsInstall .Values.clickhouse.auth.password }}
   {{- $pw := .Values.clickhouse.auth.password | default (randAlphaNum 32) }}
+  {{- $cs := .Values.clickhouse.auth.clusterSecret | default "" }}
+  {{- if and (not .Release.IsInstall) (eq $cs "") }}
+    {{- fail "clickhouse.auth.clusterSecret is required on upgrade when the existing secret cannot be read via lookup. Set clickhouse.auth.clusterSecret in your values file." }}
+  {{- end }}
 stringData:
   password: {{ $pw | quote }}
-  clusterSecret: {{ randAlphaNum 48 | quote }}
+  clusterSecret: {{ $cs | default (randAlphaNum 48) | quote }}
   url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | quote }}
 {{- else }}
   {{- fail "clickhouse.auth.password is required on upgrade when the existing secret cannot be read via lookup (e.g. helm template without cluster access, restricted RBAC). Set clickhouse.auth.password in your values file." }}

--- a/charts/langwatch/tests/test-clickhouse-secret.sh
+++ b/charts/langwatch/tests/test-clickhouse-secret.sh
@@ -104,24 +104,16 @@ assert_fails_with \
   "clickhouse.auth.password is required on upgrade" \
   --is-upgrade
 
-# 4. Upgrade with password but no clusterSecret — fails
-sep; info "Test: upgrade without clusterSecret fails"
-assert_fails_with \
-  "upgrade without clusterSecret fails" \
-  "clickhouse.auth.clusterSecret is required on upgrade" \
-  --is-upgrade --set clickhouse.auth.password=UpgradePass
-
-# 5. Upgrade with both password and clusterSecret — succeeds
-sep; info "Test: upgrade with password and clusterSecret"
-OUT=$(tmpl --is-upgrade --set clickhouse.auth.password=UpgradePass --set clickhouse.auth.clusterSecret=MyClusterSecret)
+# 4. Upgrade with explicit password — succeeds
+sep; info "Test: upgrade with explicit password"
+OUT=$(tmpl --is-upgrade --set clickhouse.auth.password=UpgradePass)
 assert_contains "upgrade uses explicit password" "$OUT" "UpgradePass"
-assert_contains "upgrade uses explicit clusterSecret" "$OUT" "MyClusterSecret"
 
-# 6. Explicit password is stable across renders (no random regeneration)
+# 5. Explicit password is stable across renders (no random regeneration)
 sep; info "Test: explicit password stable across renders"
-assert_password_stable "password stable" --set clickhouse.auth.password=StablePass --set clickhouse.auth.clusterSecret=StableCS
+assert_password_stable "password stable" --set clickhouse.auth.password=StablePass
 
-# 7. URL contains the password
+# 6. URL contains the password
 sep; info "Test: URL embeds password"
 OUT=$(tmpl --set clickhouse.auth.password=UrlTestPass)
 assert_contains "URL contains password" "$OUT" "UrlTestPass"

--- a/charts/langwatch/tests/test-clickhouse-secret.sh
+++ b/charts/langwatch/tests/test-clickhouse-secret.sh
@@ -75,8 +75,8 @@ assert_contains() {
 assert_password_stable() {
   local label="$1"; shift
   local pw1 pw2
-  pw1=$(tmpl "$@" | grep '^\s*password:' | head -1 | sed 's/.*password: *//' | tr -d '"')
-  pw2=$(tmpl "$@" | grep '^\s*password:' | head -1 | sed 's/.*password: *//' | tr -d '"')
+  pw1=$(tmpl "$@" | grep -E '^[[:space:]]*password:' | head -1 | sed 's/.*password: *//' | tr -d '"')
+  pw2=$(tmpl "$@" | grep -E '^[[:space:]]*password:' | head -1 | sed 's/.*password: *//' | tr -d '"')
   if [[ "$pw1" == "$pw2" ]]; then
     pass "$label"
     PASSED=$((PASSED + 1))
@@ -104,16 +104,24 @@ assert_fails_with \
   "clickhouse.auth.password is required on upgrade" \
   --is-upgrade
 
-# 4. Upgrade with explicit password — succeeds
-sep; info "Test: upgrade with explicit password"
-OUT=$(tmpl --is-upgrade --set clickhouse.auth.password=UpgradePass)
+# 4. Upgrade with password but no clusterSecret — fails
+sep; info "Test: upgrade without clusterSecret fails"
+assert_fails_with \
+  "upgrade without clusterSecret fails" \
+  "clickhouse.auth.clusterSecret is required on upgrade" \
+  --is-upgrade --set clickhouse.auth.password=UpgradePass
+
+# 5. Upgrade with both password and clusterSecret — succeeds
+sep; info "Test: upgrade with password and clusterSecret"
+OUT=$(tmpl --is-upgrade --set clickhouse.auth.password=UpgradePass --set clickhouse.auth.clusterSecret=MyClusterSecret)
 assert_contains "upgrade uses explicit password" "$OUT" "UpgradePass"
+assert_contains "upgrade uses explicit clusterSecret" "$OUT" "MyClusterSecret"
 
-# 5. Explicit password is stable across renders (no random regeneration)
+# 6. Explicit password is stable across renders (no random regeneration)
 sep; info "Test: explicit password stable across renders"
-assert_password_stable "password stable" --set clickhouse.auth.password=StablePass
+assert_password_stable "password stable" --set clickhouse.auth.password=StablePass --set clickhouse.auth.clusterSecret=StableCS
 
-# 6. URL contains the password
+# 7. URL contains the password
 sep; info "Test: URL embeds password"
 OUT=$(tmpl --set clickhouse.auth.password=UrlTestPass)
 assert_contains "URL contains password" "$OUT" "UrlTestPass"

--- a/charts/langwatch/tests/test-clickhouse-secret.sh
+++ b/charts/langwatch/tests/test-clickhouse-secret.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Template-level regression tests for ClickHouse password secret (#3440).
+#
+# Verifies that the url-secret.yaml template handles install/upgrade
+# correctly and never generates random passwords on upgrade without
+# explicit password.
+#
+# Requirements: helm (no cluster needed)
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RELEASE="test"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}[INFO]${NC}  $*"; }
+pass()  { echo -e "${GREEN}[PASS]${NC}  $*"; }
+fail()  { echo -e "${RED}[FAIL]${NC}  $*" >&2; exit 1; }
+sep()   { echo -e "\n${CYAN}────────────────────────────────────────────────${NC}"; }
+
+tmpl() {
+  helm template "$RELEASE" "$CHART_DIR" \
+    --set autogen.enabled=true \
+    --show-only templates/clickhouse/url-secret.yaml \
+    "$@" 2>&1
+}
+
+PASSED=0
+FAILED=0
+
+assert_renders() {
+  local label="$1"; shift
+  local out
+  if out=$(tmpl "$@"); then
+    if echo "$out" | grep -q 'kind: Secret'; then
+      pass "$label"
+      PASSED=$((PASSED + 1))
+    else
+      fail "$label: rendered but no Secret found"
+    fi
+  else
+    echo "$out"
+    fail "$label: template failed to render"
+  fi
+}
+
+assert_fails_with() {
+  local label="$1" expected_msg="$2"; shift 2
+  local out
+  if out=$(tmpl "$@" 2>&1); then
+    fail "$label: expected template to fail but it succeeded"
+  else
+    if echo "$out" | grep -qF "$expected_msg"; then
+      pass "$label"
+      PASSED=$((PASSED + 1))
+    else
+      echo "$out"
+      fail "$label: template failed but with unexpected error (expected: $expected_msg)"
+    fi
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    pass "$label"
+    PASSED=$((PASSED + 1))
+  else
+    fail "$label: expected to find '$needle'"
+  fi
+}
+
+assert_password_stable() {
+  local label="$1"; shift
+  local pw1 pw2
+  pw1=$(tmpl "$@" | grep '^\s*password:' | head -1 | sed 's/.*password: *//' | tr -d '"')
+  pw2=$(tmpl "$@" | grep '^\s*password:' | head -1 | sed 's/.*password: *//' | tr -d '"')
+  if [[ "$pw1" == "$pw2" ]]; then
+    pass "$label"
+    PASSED=$((PASSED + 1))
+  else
+    fail "$label: password not stable across renders ('$pw1' vs '$pw2')"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+sep; info "Suite: ClickHouse url-secret.yaml template tests (#3440)"
+
+# 1. Fresh install without explicit password — generates random password
+sep; info "Test: fresh install generates password"
+assert_renders "install renders Secret"
+
+# 2. Fresh install with explicit password — uses it
+sep; info "Test: fresh install with explicit password"
+OUT=$(tmpl --set clickhouse.auth.password=MyExplicitPass)
+assert_contains "install uses explicit password" "$OUT" "MyExplicitPass"
+
+# 3. Upgrade without explicit password — fails with helpful error
+sep; info "Test: upgrade without password fails"
+assert_fails_with \
+  "upgrade without password fails" \
+  "clickhouse.auth.password is required on upgrade" \
+  --is-upgrade
+
+# 4. Upgrade with explicit password — succeeds
+sep; info "Test: upgrade with explicit password"
+OUT=$(tmpl --is-upgrade --set clickhouse.auth.password=UpgradePass)
+assert_contains "upgrade uses explicit password" "$OUT" "UpgradePass"
+
+# 5. Explicit password is stable across renders (no random regeneration)
+sep; info "Test: explicit password stable across renders"
+assert_password_stable "password stable" --set clickhouse.auth.password=StablePass
+
+# 6. URL contains the password
+sep; info "Test: URL embeds password"
+OUT=$(tmpl --set clickhouse.auth.password=UrlTestPass)
+assert_contains "URL contains password" "$OUT" "UrlTestPass"
+assert_contains "URL targets clickhouse service" "$OUT" "test-clickhouse:8123/langwatch"
+
+sep
+echo -e "\n${GREEN}All $PASSED tests passed.${NC}"

--- a/charts/langwatch/tests/test-clickhouse-secret.sh
+++ b/charts/langwatch/tests/test-clickhouse-secret.sh
@@ -29,7 +29,6 @@ tmpl() {
 }
 
 PASSED=0
-FAILED=0
 
 assert_renders() {
   local label="$1"; shift

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1396,8 +1396,10 @@ clickhouse:
   ## and passes it to the subchart via auth.existingSecret. This ensures the full connection URL
   ## (with embedded credentials) is stored as a Kubernetes Secret, never interpolated in manifests.
   auth:
-    ## @param clickhouse.auth.password [string] ClickHouse password (auto-generated when empty).
+    ## @param clickhouse.auth.password [string] ClickHouse password (auto-generated on install, required on upgrade without cluster access).
     password: ""
+    ## @param clickhouse.auth.clusterSecret [string] ClickHouse inter-node cluster secret (auto-generated on install, required on upgrade without cluster access).
+    clusterSecret: ""
     ## @param clickhouse.auth.existingSecret [string] Name of existing secret containing the password. Supports tpl expressions.
     existingSecret: '{{ printf "%s-clickhouse" .Release.Name }}'
     ## @extra clickhouse.auth.secretKeys Key mappings for existing secret.

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1398,8 +1398,6 @@ clickhouse:
   auth:
     ## @param clickhouse.auth.password [string] ClickHouse password (auto-generated on install, required on upgrade without cluster access).
     password: ""
-    ## @param clickhouse.auth.clusterSecret [string] ClickHouse inter-node cluster secret (auto-generated on install, required on upgrade without cluster access).
-    clusterSecret: ""
     ## @param clickhouse.auth.existingSecret [string] Name of existing secret containing the password. Supports tpl expressions.
     existingSecret: '{{ printf "%s-clickhouse" .Release.Name }}'
     ## @extra clickhouse.auth.secretKeys Key mappings for existing secret.


### PR DESCRIPTION
## Problem

After upgrading the Helm chart (e.g. 3.0.0 → 3.1.0), the app fails to connect to ClickHouse with `REQUIRED_PASSWORD`. Two compounding defects:

1. **`url-secret.yaml` regenerates a random password on every render** when `lookup` returns nil (GitOps controllers, `helm template`, restricted RBAC). The app pod restarts with the new password, but ClickHouse keeps the old one.
2. **The ClickHouse StatefulSet has no checksum annotation**, so it never restarts to pick up secret changes.

Also fixed: the existing-secret branch emitted a duplicate `url` YAML key (once from range loop, once recalculated), which strict parsers (kubeval, OPA) would reject.

## Changes

### `charts/langwatch/templates/clickhouse/url-secret.yaml`
- Guard random password generation behind `Release.IsInstall`: fresh installs auto-generate, upgrades without cluster access fail with a clear error requiring `clickhouse.auth.password`
- Exclude `url` from the range loop when preserving existing secret data, preventing duplicate YAML keys

### `charts/clickhouse-serverless/templates/statefulset.yaml`
- Add `checksum/auth-secret` pod annotation (via `lookup`) so ClickHouse pods auto-restart when the auth secret changes
- Render the checksum after `podAnnotations` so the computed value always wins over user-provided duplicates

### `charts/langwatch/tests/test-clickhouse-secret.sh`
- Template-level regression tests: install, upgrade-without-password (error), upgrade-with-password (success), password stability, URL embedding
- Uses POSIX `[[:space:]]` for grep portability

## E2E Verification (minikube)

Tested full upgrade path on minikube: 3.0.0 (from registry) → upgrade.

| Check | Result |
|-------|--------|
| Password fingerprint pre-upgrade | `f11361df0a5c04e38eb78c7cccbf5b60` |
| Password fingerprint post-upgrade | `f11361df0a5c04e38eb78c7cccbf5b60` |
| ClickHouse auth after upgrade | `auth_works` |
| `trace_summaries` count | 23 rows (no data loss) |
| `stored_spans` count | 23 rows (no data loss) |

**Note:** The normal `helm upgrade` path (with cluster access) preserves passwords via `lookup`. Our fix adds the safety net for when `lookup` fails (GitOps/ArgoCD, restricted RBAC). End-to-end ArgoCD testing tracked in #3602.

## Test plan
- [x] `helm template` (install) renders Secret with auto-generated password
- [x] `helm template --is-upgrade` without explicit password → fails with clear error
- [x] `helm template --is-upgrade --set clickhouse.auth.password=X` → renders correctly
- [x] Explicit password is stable across renders (no random regeneration)
- [x] URL contains the correct password and service endpoint
- [x] Full chart template renders without errors
- [x] `charts/langwatch/tests/test-clickhouse-secret.sh` — 7/7 tests pass
- [x] E2E: minikube 3.0.0 → upgrade, no password drift, no data loss

Closes #3440