### PR TITLE
fix(routing): preserve percent-encoding in sub-path during project slug redirect

### DIFF
--- a/langwatch/src/hooks/__tests__/resolveProjectRedirectSubPath.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/resolveProjectRedirectSubPath.unit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { resolveProjectRedirectSubPath } from "../useOrganizationTeamProject";
+
+describe("resolveProjectRedirectSubPath()", () => {
+  describe("when the pathname has a plain slug prefix", () => {
+    it("extracts the sub-path after the project slug", () => {
+      expect(
+        resolveProjectRedirectSubPath("/old-slug/messages", "old-slug")
+      ).toBe("/messages");
+    });
+
+    it("returns empty string when pathname matches the slug exactly", () => {
+      expect(
+        resolveProjectRedirectSubPath("/old-slug", "old-slug")
+      ).toBe("");
+    });
+  });
+
+  describe("when the pathname has an encoded project slug", () => {
+    it("matches %5Bproject%5D against decoded [project]", () => {
+      expect(
+        resolveProjectRedirectSubPath(
+          "/%5Bproject%5D/evaluations",
+          "[project]"
+        )
+      ).toBe("/evaluations");
+    });
+  });
+
+  describe("when the sub-path contains encoded characters", () => {
+    it("preserves %23 (hash) in the sub-path", () => {
+      expect(
+        resolveProjectRedirectSubPath(
+          "/old-slug/messages/a%23b",
+          "old-slug"
+        )
+      ).toBe("/messages/a%23b");
+    });
+
+    it("preserves %3F (question mark) in the sub-path", () => {
+      expect(
+        resolveProjectRedirectSubPath(
+          "/old-slug/messages/a%3Fb",
+          "old-slug"
+        )
+      ).toBe("/messages/a%3Fb");
+    });
+
+    it("preserves %2F (slash) in the sub-path", () => {
+      expect(
+        resolveProjectRedirectSubPath(
+          "/old-slug/messages/a%2Fb",
+          "old-slug"
+        )
+      ).toBe("/messages/a%2Fb");
+    });
+  });
+
+  describe("when pathname does not match any prefix", () => {
+    it("returns empty string", () => {
+      expect(
+        resolveProjectRedirectSubPath("/unrelated/path", "old-slug")
+      ).toBe("");
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/resolveProjectRedirectSubPath.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/resolveProjectRedirectSubPath.unit.test.ts
@@ -5,13 +5,19 @@ describe("resolveProjectRedirectSubPath()", () => {
   describe("when the pathname has a plain slug prefix", () => {
     it("extracts the sub-path after the project slug", () => {
       expect(
-        resolveProjectRedirectSubPath("/old-slug/messages", "old-slug")
+        resolveProjectRedirectSubPath({
+          pathname: "/old-slug/messages",
+          oldProject: "old-slug",
+        })
       ).toBe("/messages");
     });
 
     it("returns empty string when pathname matches the slug exactly", () => {
       expect(
-        resolveProjectRedirectSubPath("/old-slug", "old-slug")
+        resolveProjectRedirectSubPath({
+          pathname: "/old-slug",
+          oldProject: "old-slug",
+        })
       ).toBe("");
     });
   });
@@ -19,10 +25,10 @@ describe("resolveProjectRedirectSubPath()", () => {
   describe("when the pathname has an encoded project slug", () => {
     it("matches %5Bproject%5D against decoded [project]", () => {
       expect(
-        resolveProjectRedirectSubPath(
-          "/%5Bproject%5D/evaluations",
-          "[project]"
-        )
+        resolveProjectRedirectSubPath({
+          pathname: "/%5Bproject%5D/evaluations",
+          oldProject: "[project]",
+        })
       ).toBe("/evaluations");
     });
   });
@@ -30,36 +36,50 @@ describe("resolveProjectRedirectSubPath()", () => {
   describe("when the sub-path contains encoded characters", () => {
     it("preserves %23 (hash) in the sub-path", () => {
       expect(
-        resolveProjectRedirectSubPath(
-          "/old-slug/messages/a%23b",
-          "old-slug"
-        )
+        resolveProjectRedirectSubPath({
+          pathname: "/old-slug/messages/a%23b",
+          oldProject: "old-slug",
+        })
       ).toBe("/messages/a%23b");
     });
 
     it("preserves %3F (question mark) in the sub-path", () => {
       expect(
-        resolveProjectRedirectSubPath(
-          "/old-slug/messages/a%3Fb",
-          "old-slug"
-        )
+        resolveProjectRedirectSubPath({
+          pathname: "/old-slug/messages/a%3Fb",
+          oldProject: "old-slug",
+        })
       ).toBe("/messages/a%3Fb");
     });
 
     it("preserves %2F (slash) in the sub-path", () => {
       expect(
-        resolveProjectRedirectSubPath(
-          "/old-slug/messages/a%2Fb",
-          "old-slug"
-        )
+        resolveProjectRedirectSubPath({
+          pathname: "/old-slug/messages/a%2Fb",
+          oldProject: "old-slug",
+        })
       ).toBe("/messages/a%2Fb");
+    });
+  });
+
+  describe("when the slug is a prefix of a longer path segment", () => {
+    it("does not match and returns empty string", () => {
+      expect(
+        resolveProjectRedirectSubPath({
+          pathname: "/old-slugger/messages",
+          oldProject: "old-slug",
+        })
+      ).toBe("");
     });
   });
 
   describe("when pathname does not match any prefix", () => {
     it("returns empty string", () => {
       expect(
-        resolveProjectRedirectSubPath("/unrelated/path", "old-slug")
+        resolveProjectRedirectSubPath({
+          pathname: "/unrelated/path",
+          oldProject: "old-slug",
+        })
       ).toBe("");
     });
   });

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -13,6 +13,23 @@ import { api } from "../utils/api";
 import { usePublicEnv } from "./usePublicEnv";
 import { noOrgBouncerRoutes, publicRoutes, useRequiredSession } from "./useRequiredSession";
 
+/** @internal Exported for testing only */
+export function resolveProjectRedirectSubPath(
+  pathname: string,
+  oldProject: string
+): string {
+  const decodedPrefix = `/${oldProject}`;
+  const encodedPrefix = `/${encodeURIComponent(oldProject)}`;
+
+  if (pathname.startsWith(decodedPrefix)) {
+    return pathname.slice(decodedPrefix.length);
+  }
+  if (pathname.startsWith(encodedPrefix)) {
+    return pathname.slice(encodedPrefix.length);
+  }
+  return "";
+}
+
 export const useOrganizationTeamProject = (
   {
     redirectToOnboarding,
@@ -259,18 +276,14 @@ export const useOrganizationTeamProject = (
       finalProject.slug !== router.query.project
     ) {
       // Preserve the sub-path so /bad-slug/messages → /good-slug/messages
-      // Decode: browsers encode [ ] → %5B %5D, so asPath and query.project are in different encodings
+      // query.project is decoded by React Router (%5Bproject%5D → [project]),
+      // but asPath keeps percent-encoding. Match both forms, always slice from
+      // the original encoded pathname to avoid decoding characters in the sub-path.
       const url = new URL(router.asPath, window.location.origin);
-      const oldPrefix = `/${router.query.project as string}`;
-      let decodedPathname = url.pathname;
-      try {
-        decodedPathname = decodeURIComponent(url.pathname);
-      } catch {
-        // keep encoded pathname if malformed percent-encoding is present
-      }
-      const subPath = decodedPathname.startsWith(oldPrefix)
-        ? decodedPathname.slice(oldPrefix.length)
-        : "";
+      const subPath = resolveProjectRedirectSubPath(
+        url.pathname,
+        router.query.project as string
+      );
       void router.push(`/${finalProject.slug}${subPath}${url.search}`);
     }
   }, [

--- a/langwatch/src/hooks/useOrganizationTeamProject.ts
+++ b/langwatch/src/hooks/useOrganizationTeamProject.ts
@@ -14,20 +14,26 @@ import { usePublicEnv } from "./usePublicEnv";
 import { noOrgBouncerRoutes, publicRoutes, useRequiredSession } from "./useRequiredSession";
 
 /** @internal Exported for testing only */
-export function resolveProjectRedirectSubPath(
-  pathname: string,
-  oldProject: string
-): string {
+export function resolveProjectRedirectSubPath({
+  pathname,
+  oldProject,
+}: {
+  pathname: string;
+  oldProject: string;
+}): string {
   const decodedPrefix = `/${oldProject}`;
   const encodedPrefix = `/${encodeURIComponent(oldProject)}`;
 
-  if (pathname.startsWith(decodedPrefix)) {
-    return pathname.slice(decodedPrefix.length);
-  }
-  if (pathname.startsWith(encodedPrefix)) {
-    return pathname.slice(encodedPrefix.length);
-  }
-  return "";
+  const matchSegmentPrefix = (prefix: string): string | null => {
+    if (!pathname.startsWith(prefix)) return null;
+    const rest = pathname.slice(prefix.length);
+    if (rest !== "" && !rest.startsWith("/")) return null;
+    return rest;
+  };
+
+  return matchSegmentPrefix(decodedPrefix)
+    ?? matchSegmentPrefix(encodedPrefix)
+    ?? "";
 }
 
 export const useOrganizationTeamProject = (
@@ -280,10 +286,10 @@ export const useOrganizationTeamProject = (
       // but asPath keeps percent-encoding. Match both forms, always slice from
       // the original encoded pathname to avoid decoding characters in the sub-path.
       const url = new URL(router.asPath, window.location.origin);
-      const subPath = resolveProjectRedirectSubPath(
-        url.pathname,
-        router.query.project as string
-      );
+      const subPath = resolveProjectRedirectSubPath({
+        pathname: url.pathname,
+        oldProject: router.query.project as string,
+      });
       void router.push(`/${finalProject.slug}${subPath}${url.search}`);
     }
   }, [


### PR DESCRIPTION
## Summary

- Fixes the redirect logic in `useOrganizationTeamProject` that was decoding the entire URL pathname, corrupting encoded characters (`%23`→`#`, `%3F`→`?`, `%2F`→`/`) in the sub-path after the project slug
- Extracts `resolveProjectRedirectSubPath()` that matches both decoded and encoded project prefixes while always slicing from the original encoded pathname
- Adds path-segment boundary guard so `/old` doesn't false-match `/old-slug`
- Uses named object parameters per codebase convention
- The `%5Bproject%5D/evaluations` redirect from PR #3557 still works — confirmed by unit test

## Test plan

- [x] `/%5Bproject%5D/evaluations` → `/{slug}/evaluations` (PR #3557 case preserved)
- [x] `/old-slug/messages/a%23b` → `/{slug}/messages/a%23b` (`%23` not decoded to `#`)
- [x] `/old-slug/messages/a%3Fb` → `/{slug}/messages/a%3Fb` (`%3F` not decoded to `?`)
- [x] `/old-slug/messages/a%2Fb` → `/{slug}/messages/a%2Fb` (`%2F` not decoded to `/`)
- [x] `/old-slugger/messages` does NOT match when `oldProject` is `old-slug` (segment boundary guard)
- [x] Typecheck passes
- [x] 8 unit tests pass

## CI note

`feature-parity` and `langwatch-app-complete` fail on this PR, but the same failure is present on main ([run 25153346827](https://github.com/langwatch/langwatch/actions/runs/25153346827)). Root cause: stale `@scenario` annotation in `passwordService.integration.test.ts:452` referencing a scenario that no longer exists. Unrelated to this PR.

Closes #3560