### PR TITLE
fix(auth): replace TeamUser queries with RoleBinding for post-migration users

### DIFF
--- a/langwatch/src/app/api/secrets/[[...route]]/app.ts
+++ b/langwatch/src/app/api/secrets/[[...route]]/app.ts
@@ -222,15 +222,22 @@ export const app = new Hono<{ Variables: Variables }>()
 
       const encryptedValue = encrypt(body.value);
 
-      // API key auth has no user context — use first team member as owner
-      const binding = await prisma.roleBinding.findFirst({
-        where: {
-          scopeType: RoleBindingScopeType.TEAM,
-          scopeId: project.teamId,
-          userId: { not: null },
-        },
-        select: { userId: true },
+      const team = await prisma.team.findUnique({
+        where: { id: project.teamId },
+        select: { organizationId: true },
       });
+
+      const binding = team
+        ? await prisma.roleBinding.findFirst({
+            where: {
+              organizationId: team.organizationId,
+              scopeType: RoleBindingScopeType.TEAM,
+              scopeId: project.teamId,
+              userId: { not: null },
+            },
+            select: { userId: true },
+          })
+        : null;
       const userId = binding?.userId ?? "system";
 
       const secret = await prisma.projectSecret.create({

--- a/langwatch/src/app/api/secrets/[[...route]]/app.ts
+++ b/langwatch/src/app/api/secrets/[[...route]]/app.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { describeRoute } from "hono-openapi";
 import { resolver, validator as zValidator } from "hono-openapi/zod";
 import { z } from "zod";
+import { RoleBindingScopeType } from "@prisma/client";
 import { prisma } from "~/server/db";
 import { encrypt } from "~/utils/encryption";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
@@ -222,11 +223,15 @@ export const app = new Hono<{ Variables: Variables }>()
       const encryptedValue = encrypt(body.value);
 
       // API key auth has no user context — use first team member as owner
-      const teamUser = await prisma.teamUser.findFirst({
-        where: { teamId: project.teamId },
+      const binding = await prisma.roleBinding.findFirst({
+        where: {
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: project.teamId,
+          userId: { not: null },
+        },
         select: { userId: true },
       });
-      const userId = teamUser?.userId ?? "system";
+      const userId = binding?.userId ?? "system";
 
       const secret = await prisma.projectSecret.create({
         data: {

--- a/langwatch/src/app/api/secrets/__tests__/secrets-rolebinding.unit.test.ts
+++ b/langwatch/src/app/api/secrets/__tests__/secrets-rolebinding.unit.test.ts
@@ -1,0 +1,154 @@
+import { RoleBindingScopeType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    projectSecret: {
+      count: vi.fn().mockResolvedValue(0),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn(),
+    },
+    roleBinding: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("~/utils/encryption", () => ({
+  encrypt: vi.fn().mockReturnValue("encrypted-value"),
+}));
+
+vi.mock("~/utils/extend-zod-openapi", () => ({
+  patchZodOpenapi: vi.fn(),
+}));
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("../../middleware", async () => {
+  return {
+    authMiddleware: async (c: any, next: any) => {
+      c.set("project", {
+        id: "project-1",
+        teamId: "team-1",
+        name: "Test Project",
+      });
+      await next();
+    },
+    handleError: (err: any, c: any) => {
+      return c.json({ error: err.message }, 500);
+    },
+  };
+});
+
+vi.mock("../../middleware/logger", () => ({
+  loggerMiddleware: () => async (_c: any, next: any) => {
+    await next();
+  },
+}));
+
+vi.mock("../../middleware/tracer", () => ({
+  tracerMiddleware: () => async (_c: any, next: any) => {
+    await next();
+  },
+}));
+
+import { prisma } from "~/server/db";
+import { app } from "../[[...route]]/app";
+
+describe("secrets API fallback owner lookup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (prisma.projectSecret.count as any).mockResolvedValue(0);
+    (prisma.projectSecret.findFirst as any).mockResolvedValue(null);
+    (prisma.projectSecret.create as any).mockResolvedValue({
+      id: "secret-1",
+      projectId: "project-1",
+      name: "MY_SECRET",
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+    });
+  });
+
+  describe("when team has only RoleBinding users (no TeamUser rows)", () => {
+    beforeEach(() => {
+      (prisma.roleBinding.findFirst as any).mockResolvedValue({
+        userId: "user-rolebinding-only",
+      });
+    });
+
+    it("queries roleBinding with team scope for fallback owner", async () => {
+      const res = await app.request("/api/secrets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "MY_SECRET",
+          value: "secret-value",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(prisma.roleBinding.findFirst).toHaveBeenCalledWith({
+        where: {
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: "team-1",
+          userId: { not: null },
+        },
+        select: { userId: true },
+      });
+    });
+
+    it("uses the roleBinding userId as secret owner", async () => {
+      await app.request("/api/secrets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "MY_SECRET",
+          value: "secret-value",
+        }),
+      });
+
+      expect(prisma.projectSecret.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            createdById: "user-rolebinding-only",
+            updatedById: "user-rolebinding-only",
+          }),
+        })
+      );
+    });
+  });
+
+  describe("when no RoleBinding users exist for the team", () => {
+    beforeEach(() => {
+      (prisma.roleBinding.findFirst as any).mockResolvedValue(null);
+    });
+
+    it("falls back to system as owner", async () => {
+      await app.request("/api/secrets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "MY_SECRET",
+          value: "secret-value",
+        }),
+      });
+
+      expect(prisma.projectSecret.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            createdById: "system",
+            updatedById: "system",
+          }),
+        })
+      );
+    });
+  });
+});

--- a/langwatch/src/app/api/secrets/__tests__/secrets-rolebinding.unit.test.ts
+++ b/langwatch/src/app/api/secrets/__tests__/secrets-rolebinding.unit.test.ts
@@ -8,6 +8,9 @@ vi.mock("~/server/db", () => ({
       findFirst: vi.fn().mockResolvedValue(null),
       create: vi.fn(),
     },
+    team: {
+      findUnique: vi.fn(),
+    },
     roleBinding: {
       findFirst: vi.fn(),
     },
@@ -39,6 +42,9 @@ vi.mock("../../middleware", async () => {
         teamId: "team-1",
         name: "Test Project",
       });
+      await next();
+    },
+    requirePermission: () => async (_c: any, next: any) => {
       await next();
     },
     handleError: (err: any, c: any) => {
@@ -75,6 +81,9 @@ describe("secrets API fallback owner lookup", () => {
       createdAt: new Date("2026-01-01"),
       updatedAt: new Date("2026-01-01"),
     });
+    (prisma.team as any).findUnique.mockResolvedValue({
+      organizationId: "org-1",
+    });
   });
 
   describe("when team has only RoleBinding users (no TeamUser rows)", () => {
@@ -97,6 +106,7 @@ describe("secrets API fallback owner lookup", () => {
       expect(res.status).toBe(201);
       expect(prisma.roleBinding.findFirst).toHaveBeenCalledWith({
         where: {
+          organizationId: "org-1",
           scopeType: RoleBindingScopeType.TEAM,
           scopeId: "team-1",
           userId: { not: null },

--- a/langwatch/src/server/api/__tests__/role-api.test.ts
+++ b/langwatch/src/server/api/__tests__/role-api.test.ts
@@ -1,4 +1,4 @@
-import { TeamUserRole } from "@prisma/client";
+import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RoleService } from "../../role";
 import {
@@ -328,6 +328,13 @@ describe("RoleService Tests", () => {
       );
 
       expect(result).toEqual({ success: true });
+      expect(mockPrisma.roleBinding.findFirst).toHaveBeenCalledWith({
+        where: {
+          userId: "user-123",
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: "team-123",
+        },
+      });
       expect(mockPrisma.roleBinding.deleteMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({ userId: "user-123", scopeType: "TEAM", scopeId: "team-123" }),
@@ -398,9 +405,13 @@ describe("RoleService Tests", () => {
       await expect(
         roleService.assignRoleToUser("user-123", "team-123", "role-123"),
       ).rejects.toThrow(UserNotTeamMemberError);
-      await expect(
-        roleService.assignRoleToUser("user-123", "team-123", "role-123"),
-      ).rejects.toThrow("User is not a member of the specified team");
+      expect(mockPrisma.roleBinding.findFirst).toHaveBeenCalledWith({
+        where: {
+          userId: "user-123",
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: "team-123",
+        },
+      });
     });
   });
 

--- a/langwatch/src/server/api/__tests__/role-api.test.ts
+++ b/langwatch/src/server/api/__tests__/role-api.test.ts
@@ -29,6 +29,7 @@ const mockPrisma = {
     update: vi.fn(),
   },
   roleBinding: {
+    findFirst: vi.fn(),
     deleteMany: vi.fn(),
     create: vi.fn(),
   },
@@ -315,7 +316,7 @@ describe("RoleService Tests", () => {
       mockPrisma.customRole.findUnique.mockResolvedValue(mockCustomRole);
       mockPrisma.team.findUnique.mockResolvedValue(mockTeam);
       mockPrisma.team.findUniqueOrThrow.mockResolvedValue(mockTeam);
-      mockPrisma.teamUser.findUnique.mockResolvedValue(mockTeamUser);
+      mockPrisma.roleBinding.findFirst.mockResolvedValue(mockTeamUser);
       mockPrisma.roleBinding.deleteMany.mockResolvedValue({ count: 0 });
       mockPrisma.roleBinding.create.mockResolvedValue({});
       mockPrisma.teamUser.update.mockResolvedValue({});
@@ -392,7 +393,7 @@ describe("RoleService Tests", () => {
 
       mockPrisma.customRole.findUnique.mockResolvedValue(mockCustomRole);
       mockPrisma.team.findUnique.mockResolvedValue(mockTeam);
-      mockPrisma.teamUser.findUnique.mockResolvedValue(null);
+      mockPrisma.roleBinding.findFirst.mockResolvedValue(null);
 
       await expect(
         roleService.assignRoleToUser("user-123", "team-123", "role-123"),

--- a/langwatch/src/server/api/__tests__/role-api.test.ts
+++ b/langwatch/src/server/api/__tests__/role-api.test.ts
@@ -308,7 +308,7 @@ describe("RoleService Tests", () => {
         organizationId: "org-123",
       };
 
-      const mockTeamUser = {
+      const mockBinding = {
         userId: "user-123",
         teamId: "team-123",
       };
@@ -316,7 +316,7 @@ describe("RoleService Tests", () => {
       mockPrisma.customRole.findUnique.mockResolvedValue(mockCustomRole);
       mockPrisma.team.findUnique.mockResolvedValue(mockTeam);
       mockPrisma.team.findUniqueOrThrow.mockResolvedValue(mockTeam);
-      mockPrisma.roleBinding.findFirst.mockResolvedValue(mockTeamUser);
+      mockPrisma.roleBinding.findFirst.mockResolvedValue(mockBinding);
       mockPrisma.roleBinding.deleteMany.mockResolvedValue({ count: 0 });
       mockPrisma.roleBinding.create.mockResolvedValue({});
       mockPrisma.teamUser.update.mockResolvedValue({});
@@ -331,6 +331,7 @@ describe("RoleService Tests", () => {
       expect(mockPrisma.roleBinding.findFirst).toHaveBeenCalledWith({
         where: {
           userId: "user-123",
+          organizationId: "org-123",
           scopeType: RoleBindingScopeType.TEAM,
           scopeId: "team-123",
         },
@@ -408,6 +409,7 @@ describe("RoleService Tests", () => {
       expect(mockPrisma.roleBinding.findFirst).toHaveBeenCalledWith({
         where: {
           userId: "user-123",
+          organizationId: "org-123",
           scopeType: RoleBindingScopeType.TEAM,
           scopeId: "team-123",
         },

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -1,4 +1,4 @@
-import { AlertType, TriggerAction } from "@prisma/client";
+import { AlertType, RoleBindingScopeType, TriggerAction } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -60,9 +60,11 @@ export const automationRouter = createTRPCRouter({
         throw new Error(`Project with id ${input.projectId} not found`);
       }
 
-      const teamMembers = await ctx.prisma.teamUser.findMany({
+      const teamBindings = await ctx.prisma.roleBinding.findMany({
         where: {
-          teamId: project.teamId,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: project.teamId,
+          userId: { not: null },
         },
         include: {
           user: true,
@@ -88,7 +90,9 @@ export const automationRouter = createTRPCRouter({
           });
         }
       } else if (input.action === TriggerAction.SEND_EMAIL) {
-        const teamEmails = teamMembers.map((user) => user.user.email);
+        const teamEmails = teamBindings
+          .filter((b) => b.user !== null)
+          .map((b) => b.user!.email);
 
         if (input.actionParams.members) {
           input.actionParams.members.map((email: string) => {

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -53,6 +53,7 @@ export const automationRouter = createTRPCRouter({
         },
         select: {
           teamId: true,
+          team: { select: { organizationId: true } },
         },
       });
 
@@ -62,6 +63,7 @@ export const automationRouter = createTRPCRouter({
 
       const teamBindings = await ctx.prisma.roleBinding.findMany({
         where: {
+          organizationId: project.team.organizationId,
           scopeType: RoleBindingScopeType.TEAM,
           scopeId: project.teamId,
           userId: { not: null },
@@ -91,8 +93,7 @@ export const automationRouter = createTRPCRouter({
         }
       } else if (input.action === TriggerAction.SEND_EMAIL) {
         const teamEmails = teamBindings
-          .filter((b) => b.user !== null)
-          .map((b) => b.user!.email);
+          .flatMap((b) => (b.user ? [b.user.email] : []));
 
         if (input.actionParams.members) {
           input.actionParams.members.map((email: string) => {

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -1149,20 +1149,19 @@ export const organizationRouter = createTRPCRouter({
             });
           }
 
-          const currentTeamUser = await prisma.teamUser.findUnique({
+          const currentBinding = await prisma.roleBinding.findFirst({
             where: {
-              userId_teamId: {
-                userId: input.userId,
-                teamId: input.teamId,
-              },
+              userId: input.userId,
+              scopeType: RoleBindingScopeType.TEAM,
+              scopeId: input.teamId,
             },
-            select: { assignedRoleId: true },
+            select: { customRoleId: true },
           });
 
-          const oldPermissions = currentTeamUser?.assignedRoleId
+          const oldPermissions = currentBinding?.customRoleId
             ? await (async () => {
                 const role = await prisma.customRole.findUnique({
-                  where: { id: currentTeamUser.assignedRoleId! },
+                  where: { id: currentBinding.customRoleId! },
                   select: { permissions: true },
                 });
                 return role?.permissions as string[] | undefined;

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -1152,8 +1152,10 @@ export const organizationRouter = createTRPCRouter({
           const currentBinding = await prisma.roleBinding.findFirst({
             where: {
               userId: input.userId,
+              organizationId: team.organizationId,
               scopeType: RoleBindingScopeType.TEAM,
               scopeId: input.teamId,
+              customRoleId: { not: null },
             },
             select: { customRoleId: true },
           });

--- a/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
@@ -51,6 +51,9 @@ const createMockPrisma = () => ({
   teamUser: {
     findMany: vi.fn().mockResolvedValue([]),
   },
+  roleBinding: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
   customRole: {
     findMany: vi.fn().mockResolvedValue([]),
   },
@@ -229,8 +232,8 @@ describe("LicenseEnforcementRepository", () => {
         { userId: "u1", role: OrganizationUserRole.EXTERNAL },
       ]);
       mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([
-        { userId: "u1", assignedRoleId: "role-1" },
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { userId: "u1", customRoleId: "role-1" },
       ]);
       mockPrisma.customRole.findMany.mockResolvedValue([
         { id: "role-1", permissions: ["project:view", "project:manage"] },
@@ -247,8 +250,8 @@ describe("LicenseEnforcementRepository", () => {
         { userId: "u1", role: OrganizationUserRole.EXTERNAL },
       ]);
       mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([
-        { userId: "u1", assignedRoleId: "role-1" },
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { userId: "u1", customRoleId: "role-1" },
       ]);
       mockPrisma.customRole.findMany.mockResolvedValue([
         { id: "role-1", permissions: ["project:view", "analytics:view"] },
@@ -351,7 +354,7 @@ describe("LicenseEnforcementRepository", () => {
         { userId: "u1", role: OrganizationUserRole.EXTERNAL },
       ]);
       mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([]); // No team assignment
+      mockPrisma.roleBinding.findMany.mockResolvedValue([]); // No team assignment
       mockPrisma.customRole.findMany.mockResolvedValue([]);
       mockPrisma.organizationInvite.findMany.mockResolvedValue([]);
 
@@ -406,8 +409,8 @@ describe("LicenseEnforcementRepository", () => {
         { userId: "u1", role: OrganizationUserRole.EXTERNAL },
       ]);
       mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([
-        { userId: "u1", assignedRoleId: null },
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { userId: "u1", customRoleId: null },
       ]);
       mockPrisma.customRole.findMany.mockResolvedValue([]);
       mockPrisma.organizationInvite.findMany.mockResolvedValue([]);
@@ -422,8 +425,8 @@ describe("LicenseEnforcementRepository", () => {
         { userId: "u1", role: OrganizationUserRole.EXTERNAL },
       ]);
       mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([
-        { userId: "u1", assignedRoleId: "role-1" },
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { userId: "u1", customRoleId: "role-1" },
       ]);
       mockPrisma.customRole.findMany.mockResolvedValue([
         { id: "role-1", permissions: ["project:view", "analytics:view"] },
@@ -440,8 +443,8 @@ describe("LicenseEnforcementRepository", () => {
         { userId: "u1", role: OrganizationUserRole.EXTERNAL },
       ]);
       mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([
-        { userId: "u1", assignedRoleId: "role-1" },
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { userId: "u1", customRoleId: "role-1" },
       ]);
       mockPrisma.customRole.findMany.mockResolvedValue([
         { id: "role-1", permissions: ["project:view", "project:manage"] },
@@ -557,7 +560,7 @@ describe("LicenseEnforcementRepository", () => {
         { userId: "u1", role: OrganizationUserRole.EXTERNAL },
       ]);
       mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([]); // No team assignment
+      mockPrisma.roleBinding.findMany.mockResolvedValue([]); // No team assignment
       mockPrisma.customRole.findMany.mockResolvedValue([]);
       mockPrisma.organizationInvite.findMany.mockResolvedValue([]);
 
@@ -571,8 +574,8 @@ describe("LicenseEnforcementRepository", () => {
         { userId: "u1", role: OrganizationUserRole.EXTERNAL },
       ]);
       mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
-      mockPrisma.teamUser.findMany.mockResolvedValue([
-        { userId: "u1", assignedRoleId: null },
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { userId: "u1", customRoleId: null },
       ]);
       mockPrisma.customRole.findMany.mockResolvedValue([]);
       mockPrisma.organizationInvite.findMany.mockResolvedValue([

--- a/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
+++ b/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
@@ -3,6 +3,7 @@ import {
   OrganizationUserRole,
   type Prisma,
   type PrismaClient,
+  RoleBindingScopeType,
 } from "@prisma/client";
 import { getCurrentMonthStart } from "../utils/dateUtils";
 import {
@@ -245,21 +246,23 @@ export class LicenseEnforcementRepository
       return new Map();
     }
 
-    const teamUsers = await this.prisma.teamUser.findMany({
+    const teamIds = teams.map((t) => t.id);
+    const bindings = await this.prisma.roleBinding.findMany({
       where: {
-        teamId: { in: teams.map((t) => t.id) },
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: { in: teamIds },
         userId: { in: externalUserIds },
       },
-      select: { userId: true, assignedRoleId: true },
+      select: { userId: true, customRoleId: true },
     });
 
     const userPermissionsMap = new Map<string, string[]>();
-    for (const tu of teamUsers) {
-      if (tu.assignedRoleId) {
-        const permissions = customRoleMap.get(tu.assignedRoleId);
+    for (const binding of bindings) {
+      if (binding.customRoleId && binding.userId) {
+        const permissions = customRoleMap.get(binding.customRoleId);
         if (permissions) {
-          const existing = userPermissionsMap.get(tu.userId) ?? [];
-          userPermissionsMap.set(tu.userId, [...existing, ...permissions]);
+          const existing = userPermissionsMap.get(binding.userId) ?? [];
+          userPermissionsMap.set(binding.userId, [...existing, ...permissions]);
         }
       }
     }

--- a/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
+++ b/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
@@ -249,6 +249,7 @@ export class LicenseEnforcementRepository
     const teamIds = teams.map((t) => t.id);
     const bindings = await this.prisma.roleBinding.findMany({
       where: {
+        organizationId,
         scopeType: RoleBindingScopeType.TEAM,
         scopeId: { in: teamIds },
         userId: { in: externalUserIds },

--- a/langwatch/src/server/role/__tests__/role-service-rolebinding.unit.test.ts
+++ b/langwatch/src/server/role/__tests__/role-service-rolebinding.unit.test.ts
@@ -1,0 +1,101 @@
+import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RoleService } from "../role.service";
+import {
+  RoleOrganizationMismatchError,
+  UserNotTeamMemberError,
+} from "../errors";
+
+const mockTx = {
+  roleBinding: {
+    deleteMany: vi.fn(),
+    create: vi.fn(),
+  },
+};
+
+const mockPrisma = {
+  team: {
+    findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
+  },
+  roleBinding: {
+    findFirst: vi.fn(),
+  },
+  customRole: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  $transaction: vi.fn((cb: (tx: any) => Promise<any>) => cb(mockTx)),
+} as any;
+
+describe("RoleService.assignRoleToUser", () => {
+  let service: RoleService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new RoleService(mockPrisma);
+  });
+
+  describe("when user has RoleBinding but no TeamUser row", () => {
+    beforeEach(() => {
+      mockPrisma.customRole.findUnique.mockResolvedValue({
+        id: "role-1",
+        organizationId: "org-1",
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        organizationId: "org-1",
+      });
+      mockPrisma.roleBinding.findFirst.mockResolvedValue({
+        userId: "user-rolebinding-only",
+        role: TeamUserRole.MEMBER,
+      });
+      mockPrisma.team.findUniqueOrThrow.mockResolvedValue({
+        organizationId: "org-1",
+      });
+    });
+
+    it("allows role assignment via RoleBinding membership check", async () => {
+      await expect(
+        service.assignRoleToUser("user-rolebinding-only", "team-1", "role-1")
+      ).resolves.toEqual({ success: true });
+    });
+
+    it("queries roleBinding with team scope for membership", async () => {
+      await service.assignRoleToUser(
+        "user-rolebinding-only",
+        "team-1",
+        "role-1"
+      );
+
+      expect(mockPrisma.roleBinding.findFirst).toHaveBeenCalledWith({
+        where: {
+          userId: "user-rolebinding-only",
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: "team-1",
+        },
+      });
+    });
+  });
+
+  describe("when user has no RoleBinding for the team", () => {
+    beforeEach(() => {
+      mockPrisma.customRole.findUnique.mockResolvedValue({
+        id: "role-1",
+        organizationId: "org-1",
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        organizationId: "org-1",
+      });
+      mockPrisma.roleBinding.findFirst.mockResolvedValue(null);
+    });
+
+    it("throws UserNotTeamMemberError", async () => {
+      await expect(
+        service.assignRoleToUser("user-nobody", "team-1", "role-1")
+      ).rejects.toThrow(UserNotTeamMemberError);
+    });
+  });
+});

--- a/langwatch/src/server/role/__tests__/role-service-rolebinding.unit.test.ts
+++ b/langwatch/src/server/role/__tests__/role-service-rolebinding.unit.test.ts
@@ -1,10 +1,7 @@
 import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RoleService } from "../role.service";
-import {
-  RoleOrganizationMismatchError,
-  UserNotTeamMemberError,
-} from "../errors";
+import { UserNotTeamMemberError } from "../errors";
 
 const mockTx = {
   roleBinding: {

--- a/langwatch/src/server/role/__tests__/role-service-rolebinding.unit.test.ts
+++ b/langwatch/src/server/role/__tests__/role-service-rolebinding.unit.test.ts
@@ -70,6 +70,7 @@ describe("RoleService.assignRoleToUser", () => {
       expect(mockPrisma.roleBinding.findFirst).toHaveBeenCalledWith({
         where: {
           userId: "user-rolebinding-only",
+          organizationId: "org-1",
           scopeType: RoleBindingScopeType.TEAM,
           scopeId: "team-1",
         },

--- a/langwatch/src/server/role/role.service.ts
+++ b/langwatch/src/server/role/role.service.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from "@prisma/client";
+import { type PrismaClient, RoleBindingScopeType } from "@prisma/client";
 import {
   RoleDuplicateNameError,
   RoleInUseError,
@@ -97,18 +97,17 @@ export class RoleService {
 
   async assignRoleToUser(userId: string, teamId: string, customRoleId: string) {
     // Business rule: Validate all entities exist and belong together
-    const [customRole, team, teamUser] = await Promise.all([
+    const [customRole, team, binding] = await Promise.all([
       this.repository.findById(customRoleId),
       this.prisma.team.findUnique({
         where: { id: teamId },
         select: { organizationId: true },
       }),
-      this.prisma.teamUser.findUnique({
+      this.prisma.roleBinding.findFirst({
         where: {
-          userId_teamId: {
-            userId,
-            teamId,
-          },
+          userId,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: teamId,
         },
       }),
     ]);
@@ -125,7 +124,7 @@ export class RoleService {
       throw new RoleOrganizationMismatchError();
     }
 
-    if (!teamUser) {
+    if (!binding) {
       throw new UserNotTeamMemberError();
     }
 

--- a/langwatch/src/server/role/role.service.ts
+++ b/langwatch/src/server/role/role.service.ts
@@ -96,19 +96,11 @@ export class RoleService {
   }
 
   async assignRoleToUser(userId: string, teamId: string, customRoleId: string) {
-    // Business rule: Validate all entities exist and belong together
-    const [customRole, team, binding] = await Promise.all([
+    const [customRole, team] = await Promise.all([
       this.repository.findById(customRoleId),
       this.prisma.team.findUnique({
         where: { id: teamId },
         select: { organizationId: true },
-      }),
-      this.prisma.roleBinding.findFirst({
-        where: {
-          userId,
-          scopeType: RoleBindingScopeType.TEAM,
-          scopeId: teamId,
-        },
       }),
     ]);
 
@@ -123,6 +115,15 @@ export class RoleService {
     if (customRole.organizationId !== team.organizationId) {
       throw new RoleOrganizationMismatchError();
     }
+
+    const binding = await this.prisma.roleBinding.findFirst({
+      where: {
+        userId,
+        organizationId: team.organizationId,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: teamId,
+      },
+    });
 
     if (!binding) {
       throw new UserNotTeamMemberError();


### PR DESCRIPTION
## Summary

After the BetterAuth migration, new users only get `RoleBinding` rows — no legacy `TeamUser` rows. Five production queries still used `teamUser.findFirst/findUnique/findMany`, meaning post-migration users were silently invisible to those code paths.

**Fixed queries:**
- `role.service.ts` — membership check in `assignRoleToUser` now uses `roleBinding.findFirst` with TEAM scope + `organizationId`
- `secrets/app.ts` — API-key fallback owner lookup now queries `roleBinding` with `organizationId` defense-in-depth
- `organization.ts` — LITE_MEMBER custom role lookup now uses `roleBinding.findFirst` with `customRoleId: { not: null }` and `organizationId`
- `automations.ts` — team member enumeration for email alerts now queries `roleBinding` with `organizationId`
- `license-enforcement.repository.ts` — permission mapping for external users now uses `roleBinding` with `organizationId`

**Not changed (intentional):**
- `rbac.ts` fallback paths (lines ~629, ~879) — backward-compat for pre-migration users, guarded by "try RoleBinding first" logic
- All `teamUser` writes/deletes — cleanup operations that correctly target legacy rows
- Schema/type definitions and test setup fixtures

## Review feedback addressed
- Added `organizationId` predicate to all RoleBinding queries (defense-in-depth, aligns with canonical query pattern)
- Replaced `!` non-null assertion with `flatMap` pattern in automations.ts
- Narrowed organization.ts binding query with `customRoleId: { not: null }` to avoid non-deterministic results
- Renamed `mockTeamUser` → `mockBinding` in role-api test
- Pushed back on SecretsService extraction and RoleBindingRepository (pre-existing tech debt / premature abstraction for a bug fix)

## Test plan
- [x] New unit tests for RoleBinding membership check in `assignRoleToUser` (3 tests)
- [x] New unit tests for secrets fallback owner via RoleBinding (3 tests)
- [x] Updated license-enforcement repository tests to use `roleBinding.findMany` mocks
- [x] Updated role-api tests with `roleBinding.findFirst` mocks and predicate assertions
- [x] All assertions verify `organizationId` + `scopeType: TEAM` + `scopeId` query shape
- [x] Typecheck passes
- [x] CI: test-unit (1-4), test-integration (1-4), lint, build all pass. `test-unit (3)` and `test-integration (3)` fail on codecov upload (pre-existing on main)