### PR TITLE
fix(charts): `helm dep update` so release-please rp branches don't fail CI

### DIFF
--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "charts/langwatch/**"
       - "charts/clickhouse-serverless/**"
+      - "charts/gateway/**"
       - "charts/lib/**"
       - ".github/workflows/langwatch-chart.yml"
   push:
@@ -12,6 +13,7 @@ on:
     paths:
       - "charts/langwatch/**"
       - "charts/clickhouse-serverless/**"
+      - "charts/gateway/**"
       - "charts/lib/**"
       - ".github/workflows/langwatch-chart.yml"
 
@@ -55,7 +57,13 @@ jobs:
           version: v3.12.0
       - run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
       - run: helm repo add langwatch https://langwatch.github.io/langwatch
-      - run: helm dependency build .
+      # `update` instead of `build`: regenerates Chart.lock from current
+      # on-disk Chart.yaml. release-please bumps the local file:// gateway
+      # sub-chart version on every release but cannot recompute the
+      # sha256 digest in Chart.lock — so `build` (strict lock-vs-disk
+      # check) fails on every release-please PR. `update` is equivalent
+      # since prometheus is hard-pinned in Chart.yaml at 25.27.0.
+      - run: helm dependency update .
       - name: "helm template (${{ matrix.name }})"
         run: helm template lw . ${{ matrix.flags }} > /dev/null
 


### PR DESCRIPTION
## Summary

Chart workflow CI fails on every release-please PR (e.g. #3393 for langwatch 3.2.0) with:

```
Save error occurred: can't get a valid version for dependency langwatch-gateway
Error: can't get a valid version for dependency langwatch-gateway
```

## Why

release-please bumps `charts/gateway/Chart.yaml` `$.version` via `extra-files` on every release, but it cannot recompute the sha256 `digest` in `charts/langwatch/Chart.lock`. `helm dependency build` is strict about lock-vs-on-disk version match, so every rp PR is doomed.

## Fix

Swap `helm dependency build` → `helm dependency update` in the `lint-template` job. `update` regenerates the lock + digest from the current Chart.yaml. `Chart.lock` stays in repo for offline `helm install` / local-dev determinism — it's just always overwritten in CI.

Also adds `charts/gateway/**` to `paths:` filter so gateway-only changes trigger umbrella validation.

## Note on `feature-parity` job

PR #3393 also fails the `feature-parity` check (162 unbound `@scenario` annotations from #3298). That's a separate issue with broader scope — rchaves is force-merging #3393 to bypass it, with binding work tracked as follow-up.

## Test plan

- [ ] Chart CI re-runs green on this branch (lint-template jobs)
- [ ] After merge, re-run release-please PR #3393 — verify chart jobs go green
- [ ] After 3.2.0 ships, re-confirm `helm dep update` worked end-to-end on the next release-please cycle