### PR TITLE
fix(workflows): strip per-node execution_state before persisting

### DIFF
--- a/langwatch/src/optimization_studio/utils/dslUtils.ts
+++ b/langwatch/src/optimization_studio/utils/dslUtils.ts
@@ -1,6 +1,7 @@
 import type { Node } from "@xyflow/react";
 import type { z } from "zod";
-import type { workflowJsonSchema } from "../types/dsl";
+import type { Component, workflowJsonSchema } from "../types/dsl";
+import { mergeLocalConfigsIntoDsl } from "./mergeLocalConfigs";
 
 export const clearDsl = (
   dsl: z.infer<typeof workflowJsonSchema>,
@@ -34,6 +35,26 @@ export const clearDsl = (
     }),
     state: includeExecutionStates ? dsl.state : undefined,
   };
+};
+
+/**
+ * Single chokepoint for all pre-save transforms before persisting a workflow version.
+ * Composes: merge local configs → strip per-node execution_state → clear top-level state → deep clone.
+ */
+export const prepareDslForPersistence = (
+  dsl: z.infer<typeof workflowJsonSchema>,
+): z.infer<typeof workflowJsonSchema> => {
+  const merged = {
+    ...dsl,
+    nodes: mergeLocalConfigsIntoDsl(dsl.nodes as Node<Component>[]) as any,
+    state: {},
+  };
+
+  for (const node of merged.nodes) {
+    delete (node as Node).data.execution_state;
+  }
+
+  return JSON.parse(JSON.stringify(merged));
 };
 
 export const hasDSLChanged = (

--- a/langwatch/src/optimization_studio/utils/dslUtils.ts
+++ b/langwatch/src/optimization_studio/utils/dslUtils.ts
@@ -44,17 +44,23 @@ export const clearDsl = (
 export const prepareDslForPersistence = (
   dsl: z.infer<typeof workflowJsonSchema>,
 ): z.infer<typeof workflowJsonSchema> => {
-  const merged = {
-    ...dsl,
-    nodes: mergeLocalConfigsIntoDsl(dsl.nodes as Node<Component>[]) as any,
-    state: {},
-  };
+  const mergedNodes = mergeLocalConfigsIntoDsl(
+    dsl.nodes as Node<Component>[],
+  );
 
-  for (const node of merged.nodes) {
-    delete (node as Node).data.execution_state;
-  }
+  const cleanedNodes = mergedNodes.map((node) => {
+    const { execution_state, ...dataRest } =
+      node.data as Record<string, unknown>;
+    return { ...node, data: dataRest };
+  });
 
-  return JSON.parse(JSON.stringify(merged));
+  return JSON.parse(
+    JSON.stringify({
+      ...dsl,
+      nodes: cleanedNodes,
+      state: {},
+    }),
+  );
 };
 
 export const hasDSLChanged = (

--- a/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/workflows.saveOrCommit.integration.test.ts
@@ -121,6 +121,33 @@ describe("saveOrCommitWorkflowVersion", () => {
     });
   });
 
+  describe("when nodes have execution_state", () => {
+    it("strips execution_state from persisted nodes", async () => {
+      const dsl = buildDsl({
+        instructions: "You are a helpful assistant.",
+        messages: [{ role: "user", content: "{{input}}" }],
+        executionState: {
+          status: "success",
+          trace_id: "trace_123",
+          span_id: "span_456",
+          timestamps: { started_at: 1000, finished_at: 2000 },
+        },
+      });
+
+      const version = await saveOrCommitWorkflowVersion({
+        ctx: getCtx(),
+        input: { projectId, workflowId, dsl },
+        autoSaved: false,
+        commitMessage: "test execution_state stripping",
+      });
+
+      const savedDsl = version.dsl as any;
+      for (const node of savedDsl.nodes) {
+        expect(node.data.execution_state).toBeUndefined();
+      }
+    });
+  });
+
   describe("when a signature node has NO localPromptConfig", () => {
     it("preserves parameters as-is", async () => {
       const dsl = buildDsl({
@@ -158,10 +185,12 @@ function buildDsl({
   instructions,
   messages,
   localPromptConfig,
+  executionState,
 }: {
   instructions: string;
   messages: Array<{ role: string; content: string }>;
   localPromptConfig?: any;
+  executionState?: any;
 }) {
   versionCounter++;
   return {
@@ -203,6 +232,7 @@ function buildDsl({
             },
           ],
           localPromptConfig,
+          execution_state: executionState,
         },
       },
     ],

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -11,10 +11,10 @@ import {
   type Workflow,
   workflowJsonSchema,
 } from "../../../optimization_studio/types/dsl";
-import { mergeLocalConfigsIntoDsl } from "../../../optimization_studio/utils/mergeLocalConfigs";
 import { migrateDSLVersion } from "../../../optimization_studio/types/migrate";
 import {
   clearDsl,
+  prepareDslForPersistence,
   recursiveAlphabeticallySortedKeys,
 } from "../../../optimization_studio/utils/dslUtils";
 import type { Unpacked } from "../../../utils/types";
@@ -1310,16 +1310,7 @@ export const saveOrCommitWorkflowVersion = async ({
   const [versionMajor] = (latestVersion?.version ?? "0.0").split(".");
   const nextVersion = `${parseInt(versionMajor ?? "0") + 1}`;
 
-  // Cast required: input.dsl.nodes is z.array(z.any()) from the Zod schema,
-  // while mergeLocalConfigsIntoDsl expects Node<Component>[]. The Zod schema
-  // uses z.any() for nodes because the DSL node types are too polymorphic
-  // for a single Zod discriminated union.
-  const dslWithMergedConfigs = {
-    ...input.dsl,
-    nodes: mergeLocalConfigsIntoDsl(input.dsl.nodes as any) as any,
-    state: {},
-  };
-  const dslWithoutStates = JSON.parse(JSON.stringify(dslWithMergedConfigs));
+  const dslWithoutStates = prepareDslForPersistence(input.dsl);
   const data = {
     commitMessage,
     authorId: ctx.session.user.id,


### PR DESCRIPTION
## Summary
- Extract `prepareDslForPersistence()` as single chokepoint for all pre-save transforms in workflow persistence
- Strips per-node `execution_state` (trace_id, span_id, timestamps, error, cost) before persisting to database
- Previously only top-level `state` was cleared; per-node ephemeral data leaked into JSONB
- Uses destructuring (not `delete`) to avoid mutating the caller's input

## Changes
- **`dslUtils.ts`**: Add `prepareDslForPersistence()` composing: merge local configs → strip execution_state → clear state → deep clone
- **`workflows.ts`**: Replace manual transform block in `saveOrCommitWorkflowVersion` with single `prepareDslForPersistence()` call, remove unused `mergeLocalConfigsIntoDsl` import
- **`workflows.saveOrCommit.integration.test.ts`**: Add regression test proving execution_state is stripped from persisted nodes

## Test plan
- [x] Regression test fails without fix (execution_state persisted)
- [x] Regression test passes with fix (execution_state stripped)
- [x] Existing localPromptConfig merge tests still pass (3/3)
- [x] TypeScript typecheck passes
- [x] CI green (2 pre-existing failures on main: feature-parity, npx-server-smoke)

Closes #3455