### PR TITLE
fix(auth): send Slack and CIO notifications on SSO auto-add signup

### DIFF
--- a/langwatch/e2e/auth-regression/better-auth-sso-smoketest.ts
+++ b/langwatch/e2e/auth-regression/better-auth-sso-smoketest.ts
@@ -120,7 +120,7 @@ async function main() {
   });
   await afterUserCreate({
     prisma,
-    user: { id: "sso_smoke_newuser1", email: "alice@google-corp.test" },
+    user: { id: "sso_smoke_newuser1", email: "alice@google-corp.test", name: "Alice" },
   });
   const alice = await prisma.organizationUser.findFirst({
     where: { userId: "sso_smoke_newuser1" },
@@ -151,7 +151,7 @@ async function main() {
   });
   await afterUserCreate({
     prisma,
-    user: { id: "sso_smoke_newuser2", email: "bob@unrelated.test" },
+    user: { id: "sso_smoke_newuser2", email: "bob@unrelated.test", name: "Bob" },
   });
   const bobOrgs = await prisma.organizationUser.findMany({
     where: { userId: "sso_smoke_newuser2" },
@@ -415,7 +415,7 @@ async function main() {
   });
   await afterUserCreate({
     prisma,
-    user: { id: "sso_smoke_mixedcase", email: "Isaac@GOOGLE-CORP.TEST" },
+    user: { id: "sso_smoke_mixedcase", email: "Isaac@GOOGLE-CORP.TEST", name: "Isaac" },
   });
   const isaacOrg = await prisma.organizationUser.findFirst({
     where: { userId: "sso_smoke_mixedcase" },
@@ -438,7 +438,7 @@ async function main() {
   try {
     await afterUserCreate({
       prisma,
-      user: { id: "sso_smoke_newuser1", email: "alice@google-corp.test" },
+      user: { id: "sso_smoke_newuser1", email: "alice@google-corp.test", name: "Alice" },
     });
   } catch (err) {
     secondAddThrew = true;

--- a/langwatch/ee/billing/nurturing/hooks/index.ts
+++ b/langwatch/ee/billing/nurturing/hooks/index.ts
@@ -1,5 +1,6 @@
 export { fireSignupNurturingCalls } from "./signupIdentification";
 export { fireInviteAcceptedNurturingCalls } from "./inviteAcceptance";
+export { fireSsoAutoAddNurturingCalls } from "./ssoAutoAdd";
 export {
   fireTeamMemberInvitedNurturing,
   fireWorkflowCreatedNurturing,

--- a/langwatch/ee/billing/nurturing/hooks/ssoAutoAdd.ts
+++ b/langwatch/ee/billing/nurturing/hooks/ssoAutoAdd.ts
@@ -1,0 +1,61 @@
+import { getApp } from "../../../../src/server/app-layer/app";
+import { captureException } from "../../../../src/utils/posthogErrorCapture";
+
+/**
+ * Identifies a user in Customer.io when they are auto-added to an
+ * organization via SSO domain matching.
+ *
+ * Fires identifyUser, groupUser, and a "joined_via_sso" event —
+ * all fire-and-forget so that Customer.io failures never block signup.
+ */
+export function fireSsoAutoAddNurturingCalls({
+  userId,
+  email,
+  name,
+  organizationId,
+  organizationName,
+}: {
+  userId: string;
+  email: string;
+  name: string | null | undefined;
+  organizationId: string;
+  organizationName: string;
+}): void {
+  const nurturing = getApp().nurturing;
+  if (!nurturing) return;
+
+  void nurturing
+    .identifyUser({
+      userId,
+      traits: {
+        email,
+        ...(name ? { name } : {}),
+        has_traces: false,
+        has_evaluations: false,
+        has_prompts: false,
+        has_simulations: false,
+        has_subscription: false,
+        createdAt: new Date().toISOString(),
+      },
+    })
+    .catch(captureException);
+
+  void nurturing
+    .groupUser({
+      userId,
+      groupId: organizationId,
+      traits: { name: organizationName },
+    })
+    .catch(captureException);
+
+  void nurturing
+    .trackEvent({
+      userId,
+      event: "joined_via_sso",
+      properties: {
+        organization_id: organizationId,
+        organization_name: organizationName,
+      },
+    })
+    .catch(captureException);
+}

--- a/langwatch/ee/billing/nurturing/types.ts
+++ b/langwatch/ee/billing/nurturing/types.ts
@@ -100,7 +100,9 @@ export type CioEventName =
   | "experiment_ran"
   | "first_prompt_created"
   | "first_simulation_ran"
-  | "joined_via_invite";
+  | "joined_via_invite"
+  | "joined_via_sso";
+>>>>>>> d28dc3ec8 (fix(auth): send Slack and CIO notifications on SSO auto-add signup)
 
 // ---------------------------------------------------------------------------
 // Batch call discriminated union

--- a/langwatch/ee/billing/nurturing/types.ts
+++ b/langwatch/ee/billing/nurturing/types.ts
@@ -102,7 +102,6 @@ export type CioEventName =
   | "first_simulation_ran"
   | "joined_via_invite"
   | "joined_via_sso";
->>>>>>> d28dc3ec8 (fix(auth): send Slack and CIO notifications on SSO auto-add signup)
 
 // ---------------------------------------------------------------------------
 // Batch call discriminated union

--- a/langwatch/src/server/better-auth/__tests__/hooks.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/hooks.test.ts
@@ -1,5 +1,15 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({
+    notifications: {
+      sendSlackSignupEvent: vi.fn().mockResolvedValue(undefined),
+    },
+    nurturing: null,
+  }),
+}));
+
 import {
   afterAccountCreate,
   afterAccountUpdate,
@@ -93,7 +103,7 @@ describe("afterUserCreate", () => {
 
       await afterUserCreate({
         prisma,
-        user: { id: "user_1", email: "new@acme.com" },
+        user: { id: "user_1", email: "new@acme.com", name: "New User" },
       });
 
       expect(prisma.organization.findUnique).toHaveBeenCalledWith({
@@ -149,7 +159,7 @@ describe("afterUserCreate", () => {
 
       await afterUserCreate({
         prisma,
-        user: { id: "user_1", email: "alice@acme.com" },
+        user: { id: "user_1", email: "alice@acme.com", name: "Alice" },
       });
 
       // Default-branch create must NOT run when invite is applied.
@@ -183,7 +193,7 @@ describe("afterUserCreate", () => {
       const prisma = makePrismaMock();
       await afterUserCreate({
         prisma,
-        user: { id: "user_1", email: "u@other.com" },
+        user: { id: "user_1", email: "u@other.com", name: "User" },
       });
       expect(prisma.organizationUser.create).not.toHaveBeenCalled();
     });
@@ -194,7 +204,7 @@ describe("afterUserCreate", () => {
       const prisma = makePrismaMock();
       await afterUserCreate({
         prisma,
-        user: { id: "user_1", email: "" },
+        user: { id: "user_1", email: "", name: "User" },
       });
       expect(prisma.organization.findUnique).not.toHaveBeenCalled();
     });
@@ -225,7 +235,7 @@ describe("afterUserCreate", () => {
       await expect(
         afterUserCreate({
           prisma,
-          user: { id: "user_1", email: "u@acme.com" },
+          user: { id: "user_1", email: "u@acme.com", name: "User" },
         }),
       ).resolves.toBeUndefined();
     });

--- a/langwatch/src/server/better-auth/hooks.ts
+++ b/langwatch/src/server/better-auth/hooks.ts
@@ -3,8 +3,11 @@ import { APIError } from "better-auth/api";
 import { generate } from "@langwatch/ksuid";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { createLogger } from "../../utils/logger/server";
+import { captureException } from "../../utils/posthogErrorCapture";
 import { isSsoProviderMatch, extractEmailDomain } from "./sso";
 import { InviteService } from "~/server/invites/invite.service";
+import { getApp } from "~/server/app-layer/app";
+import { fireSsoAutoAddNurturingCalls } from "../../../ee/billing/nurturing/hooks/ssoAutoAdd";
 
 const logger = createLogger("langwatch:better-auth:hooks");
 
@@ -102,7 +105,7 @@ export const afterUserCreate = async ({
   user,
 }: {
   prisma: PrismaClient;
-  user: { id: string; email: string };
+  user: { id: string; email: string; name: string };
 }): Promise<void> => {
   const domain = extractEmailDomain(user.email);
   if (!domain) return;
@@ -159,6 +162,22 @@ export const afterUserCreate = async ({
           ? "Applied pending invite on SSO signup"
           : "Auto-added new user to SSO organization (default MEMBER)",
       );
+
+      void getApp()
+        .notifications.sendSlackSignupEvent({
+          userName: user.name,
+          userEmail: user.email,
+          organizationName: org.name,
+        })
+        .catch(captureException);
+
+      fireSsoAutoAddNurturingCalls({
+        userId: user.id,
+        email: user.email,
+        name: user.name,
+        organizationId: org.id,
+        organizationName: org.name,
+      });
     } catch (err) {
       // P2002 (unique constraint) means another concurrent OAuth callback
       // or a retry already created this membership. Idempotent success.

--- a/langwatch/src/server/better-auth/index.ts
+++ b/langwatch/src/server/better-auth/index.ts
@@ -401,7 +401,7 @@ export const auth = betterAuth({
             user: user as { email: string; deactivatedAt?: Date | null } & Record<string, unknown>,
           }),
         after: async (user) => {
-          await afterUserCreate({ prisma, user: user as { id: string; email: string } });
+          await afterUserCreate({ prisma, user: user as { id: string; email: string; name: string } });
         },
       },
     },


### PR DESCRIPTION
## Summary

- SSO auto-add signups (`afterUserCreate` hook) bypassed `initializeOrganization`, so Slack and Customer.io notifications never fired for these users
- Adds fire-and-forget Slack + CIO notification calls after successful SSO auto-add, following the same pattern as invite acceptance (PR #3587)
- New `fireSsoAutoAddNurturingCalls` hook: CIO identify + group + `joined_via_sso` event

## Changes

| File | What |
|------|------|
| `ee/billing/nurturing/hooks/ssoAutoAdd.ts` | New hook: CIO identify + group + `joined_via_sso` event |
| `ee/billing/nurturing/hooks/index.ts` | Re-export new hook |
| `ee/billing/nurturing/types.ts` | Add `joined_via_sso` to `CioEventName` |
| `src/server/better-auth/hooks.ts` | Wire Slack + CIO calls after SSO auto-add transaction |
| `src/server/better-auth/index.ts` | Widen user type cast to include `name` |
| `src/server/better-auth/__tests__/hooks.test.ts` | Add `getApp()` mock + `name` field to test fixtures |
| `e2e/auth-regression/better-auth-sso-smoketest.ts` | Add `name` field to `afterUserCreate` calls |

## CI notes

`feature-parity` (→ `langwatch-app-complete`) fails on `main` with the same stale annotation issue (`@scenario Auth0 backend uses a separate Machine-to-Machine app for the Management API` in `passwordService.integration.test.ts:452`). Not introduced by this PR.

## Related issues

- Closes langwatch/langwatch-saas#480
- Sister fix to #3587 (invite acceptance path)

## Test plan

- [x] All 30 existing hooks unit tests pass
- [x] Typecheck clean
- [x] All CI checks green except pre-existing `feature-parity` failure on main
- [ ] Verify Slack notification fires in staging on SSO auto-add signup
- [ ] Verify Customer.io profile created with `joined_via_sso` event