### PR TITLE
fix(studio): remove publish-button paywall on optimization studio

### DIFF
--- a/langwatch/src/optimization_studio/components/Publish.tsx
+++ b/langwatch/src/optimization_studio/components/Publish.tsx
@@ -3,25 +3,21 @@ import {
   Box,
   Button,
   HStack,
-  type MenuItemProps,
   Separator,
   Skeleton,
   Spacer,
-  Spinner,
   Text,
   useDisclosure,
   VStack,
 } from "@chakra-ui/react";
 import type { Dataset, DatasetRecord, Project } from "@prisma/client";
 import type { Edge } from "@xyflow/react";
-import { useRouter } from "~/utils/compat/next-router";
 import { useCallback, useState } from "react";
 import {
   ArrowUp,
   ArrowUpCircle,
   ChevronDown,
   Code,
-  Lock,
   Play,
   Share2,
   XCircle,
@@ -37,8 +33,6 @@ import { toaster } from "../../components/ui/toaster";
 import { Tooltip } from "../../components/ui/tooltip";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
-import { trackEvent } from "../../utils/tracking";
-import { usePlanManagementUrl } from "../../hooks/usePlanManagementUrl";
 import { useModelProviderKeys } from "../hooks/useModelProviderKeys";
 import { useWorkflowStore } from "../hooks/useWorkflowStore";
 import type { Workflow } from "../types/dsl";
@@ -240,7 +234,6 @@ function PublishMenu({
     project,
     allowSaveIfAutoSaveIsCurrentButNotLatest: false,
   });
-  const router = useRouter();
   const trpc = api.useContext();
 
   const publishedWorkflow = api.optimization.getPublishedWorkflow.useQuery(
@@ -325,55 +318,9 @@ function PublishMenu({
     });
   };
 
-  const { organization } = useOrganizationTeamProject();
-  const { url: planManagementUrl } = usePlanManagementUrl();
-  const usage = api.limits.getUsage.useQuery(
-    { organizationId: organization?.id ?? "" },
-    {
-      enabled: !!organization,
-    },
-  );
-
-  const planAllowsToPublish = usage.data?.activePlan.canPublish;
   const publishDisabledLabel = !publishedWorkflow.data?.version
     ? "Publish a version to enable this option"
     : undefined;
-
-  const SubscriptionMenuItem = (
-    props: MenuItemProps & {
-      tooltip?: string;
-    },
-  ) => {
-    if (!planAllowsToPublish) {
-      return (
-        <Tooltip
-          content="Subscribe to unlock publishing, click to continue"
-          positioning={{ placement: "right" }}
-        >
-          <Menu.Item
-            {...props}
-            disabled={false}
-            color="fg.subtle"
-            onClick={() => {
-              trackEvent("subscription_hook_click", {
-                projectId: project?.id,
-                hook: "studio_click_subscribe_to_publish",
-              });
-              void router.push(planManagementUrl);
-            }}
-          >
-            {usage.data ? <Lock size={16} /> : <Spinner size="sm" />}
-            {props.children}
-          </Menu.Item>
-        </Tooltip>
-      );
-    }
-    return (
-      <Tooltip content={props.tooltip} positioning={{ placement: "right" }}>
-        <Menu.Item {...props} />
-      </Tooltip>
-    );
-  };
 
   const handleExportWorkflow = async () => {
     await exportWorkflow(workflow, datasetRecords.data ?? undefined);
@@ -390,16 +337,17 @@ function PublishMenu({
           <Separator />
         </>
       )}
-      <SubscriptionMenuItem
-        tooltip={canPublish}
-        onClick={onTogglePublish}
-        disabled={!!canPublish}
-        value="publish"
-      >
-        <ArrowUp size={16} />{" "}
-        <Text textTransform="capitalize">{`Publish ${workflow_type}`}</Text>
-      </SubscriptionMenuItem>
-      <SubscriptionMenuItem
+      <Tooltip content={canPublish} positioning={{ placement: "right" }}>
+        <Menu.Item
+          onClick={onTogglePublish}
+          disabled={!!canPublish}
+          value="publish"
+        >
+          <ArrowUp size={16} />{" "}
+          <Text textTransform="capitalize">{`Publish ${workflow_type}`}</Text>
+        </Menu.Item>
+      </Tooltip>
+      <Menu.Item
         hidden={
           workflow_type === "workflow" || !publishedWorkflow.data?.isEvaluator
         }
@@ -407,9 +355,9 @@ function PublishMenu({
         value="evaluator"
       >
         <XCircle size={16} /> Unpublish Evaluator
-      </SubscriptionMenuItem>
+      </Menu.Item>
 
-      <SubscriptionMenuItem
+      <Menu.Item
         hidden={
           workflow_type === "workflow" || !publishedWorkflow.data?.isComponent
         }
@@ -417,22 +365,26 @@ function PublishMenu({
         onClick={disableAsComponent}
       >
         <XCircle size={16} /> Unpublish Component
-      </SubscriptionMenuItem>
+      </Menu.Item>
 
-      <SubscriptionMenuItem
-        tooltip={publishDisabledLabel}
-        onClick={onToggleApi}
-        disabled={!!publishDisabledLabel}
-        value="api-reference"
+      <Tooltip
+        content={publishDisabledLabel}
+        positioning={{ placement: "right" }}
       >
-        <Code size={16} /> View API Reference
-      </SubscriptionMenuItem>
-      <SubscriptionMenuItem
+        <Menu.Item
+          onClick={onToggleApi}
+          disabled={!!publishDisabledLabel}
+          value="api-reference"
+        >
+          <Code size={16} /> View API Reference
+        </Menu.Item>
+      </Tooltip>
+      <Menu.Item
         onClick={() => void handleExportWorkflow()}
         value="export-workflow"
       >
         <Share2 size={16} /> Export Workflow
-      </SubscriptionMenuItem>
+      </Menu.Item>
     </>
   );
 }

--- a/langwatch/src/optimization_studio/components/__tests__/Publish.gate-removed.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/__tests__/Publish.gate-removed.integration.test.tsx
@@ -236,6 +236,8 @@ describe("studio Publish menu", () => {
       mockCanPublish.current = false;
     });
 
+    /** @scenario Free SaaS user can open the publish menu without a paywall */
+    /** @scenario Self-hosted user without a paid license can open the publish menu without a paywall */
     it("does not render a 'Subscribe to unlock publishing' tooltip", () => {
       renderPublish();
       const tooltips = document.querySelectorAll("[data-tooltip-content]");
@@ -253,6 +255,7 @@ describe("studio Publish menu", () => {
       expect(publishItem).toBeDefined();
     });
 
+    /** @scenario Publish.tsx does not query plan.canPublish to gate the menu */
     it("does not redirect to plan management or fire subscription tracking when Publish is clicked", () => {
       renderPublish();
       const publishButton = screen.getByText(/Publish workflow/i)
@@ -279,6 +282,7 @@ describe("studio Publish menu", () => {
       mockCanPublish.current = true;
     });
 
+    /** @scenario Paid SaaS user can publish without a paywall (regression) */
     it("still renders the Publish menu without paywall (regression)", () => {
       renderPublish();
       expect(screen.getByText(/Publish workflow/i)).toBeDefined();

--- a/langwatch/src/optimization_studio/components/__tests__/Publish.gate-removed.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/__tests__/Publish.gate-removed.integration.test.tsx
@@ -251,6 +251,11 @@ describe("given the studio Publish menu is rendered", () => {
       renderPublish();
       const publishItem = screen.getByText(/Publish workflow/i);
       expect(publishItem).toBeDefined();
+      // react-feather renders <Lock /> as <svg class="feather feather-lock">,
+      // which the paywall used to inject next to the menu item children.
+      // Asserting it's absent guards against regressing the icon on its own.
+      const lockIcons = document.querySelectorAll(".feather-lock");
+      expect(lockIcons).toHaveLength(0);
     });
 
     /** @scenario Publish.tsx does not query plan.canPublish to gate the menu */

--- a/langwatch/src/optimization_studio/components/__tests__/Publish.gate-removed.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/__tests__/Publish.gate-removed.integration.test.tsx
@@ -15,13 +15,11 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockCanPublish, mockRouterPush, mockTrackEvent, mockTogglePublish } =
-  vi.hoisted(() => ({
-    mockCanPublish: { current: false as boolean },
-    mockRouterPush: vi.fn(),
-    mockTrackEvent: vi.fn(),
-    mockTogglePublish: vi.fn(),
-  }));
+const { mockCanPublish, mockRouterPush, mockTrackEvent } = vi.hoisted(() => ({
+  mockCanPublish: { current: false as boolean },
+  mockRouterPush: vi.fn(),
+  mockTrackEvent: vi.fn(),
+}));
 
 vi.mock("~/utils/compat/next-router", () => ({
   useRouter: () => ({
@@ -221,7 +219,7 @@ function renderPublish() {
   );
 }
 
-describe("studio Publish menu", () => {
+describe("given the studio Publish menu is rendered", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();

--- a/langwatch/src/optimization_studio/components/__tests__/Publish.gate-removed.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/__tests__/Publish.gate-removed.integration.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration test for the Publish menu in the optimization studio.
+ *
+ * Pins the regression: the studio Publish menu must NOT be gated by
+ * `usage.activePlan.canPublish`. No Lock icon, no "Subscribe to unlock"
+ * tooltip, no redirect to plan management — even when the active plan
+ * has canPublish=false.
+ *
+ * See specs/studio/publish-not-gated.feature.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCanPublish, mockRouterPush, mockTrackEvent, mockTogglePublish } =
+  vi.hoisted(() => ({
+    mockCanPublish: { current: false as boolean },
+    mockRouterPush: vi.fn(),
+    mockTrackEvent: vi.fn(),
+    mockTogglePublish: vi.fn(),
+  }));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    query: {},
+    push: mockRouterPush,
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1" },
+    project: { id: "proj-1", slug: "test-project", apiKey: "test-key" },
+  }),
+}));
+
+vi.mock("~/hooks/usePlanManagementUrl", () => ({
+  usePlanManagementUrl: () => ({ url: "/settings/subscription" }),
+}));
+
+vi.mock("~/utils/tracking", () => ({
+  trackEvent: mockTrackEvent,
+}));
+
+vi.mock("~/utils/api", () => {
+  const queryStub = (data: unknown) => ({
+    useQuery: () => ({ data, isLoading: false, refetch: vi.fn() }),
+  });
+  const mutationStub = () => ({
+    useMutation: () => ({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isLoading: false,
+      isPending: false,
+    }),
+  });
+  return {
+    api: {
+      useContext: () => ({
+        optimization: { getComponents: { invalidate: vi.fn() } },
+      }),
+      limits: {
+        getUsage: {
+          useQuery: () => ({
+            data: {
+              activePlan: { canPublish: mockCanPublish.current },
+            },
+            isLoading: false,
+            refetch: vi.fn(),
+          }),
+        },
+      },
+      optimization: {
+        getPublishedWorkflow: queryStub({
+          version: "1.0.0",
+          dsl: { nodes: [], edges: [], name: "Test", workflow_id: "wf-1" },
+          isComponent: false,
+          isEvaluator: false,
+        }),
+        toggleSaveAsComponent: mutationStub(),
+        toggleSaveAsEvaluator: mutationStub(),
+        disableAsComponent: mutationStub(),
+        disableAsEvaluator: mutationStub(),
+        getComponents: { invalidate: vi.fn() },
+      },
+      datasetRecord: {
+        getAll: queryStub([]),
+      },
+      workflow: {
+        publish: mutationStub(),
+        commitVersion: mutationStub(),
+      },
+    },
+  };
+});
+
+vi.mock("../../hooks/useWorkflowStore", () => ({
+  useWorkflowStore: (selector: (s: any) => any) =>
+    selector({
+      workflow_id: "wf-1",
+      workflow_type: "workflow",
+      getWorkflow: () => ({
+        workflow_id: "wf-1",
+        name: "Test Workflow",
+        nodes: [],
+        edges: [],
+        state: {},
+      }),
+      setLastCommittedWorkflow: vi.fn(),
+      setCurrentVersionId: vi.fn(),
+      currentVersionId: "v-1",
+      checkCanCommitNewVersion: () => false,
+    }),
+}));
+
+vi.mock("../../hooks/useModelProviderKeys", () => ({
+  useModelProviderKeys: () => ({
+    hasProvidersWithoutCustomKeys: false,
+    nodeProvidersWithoutCustomKeys: [],
+  }),
+}));
+
+vi.mock("../History", () => ({
+  useVersionState: () => ({
+    canSaveNewVersion: false,
+    versionToBeEvaluated: { version: "1.0.0" },
+    versions: { data: [], refetch: vi.fn() },
+  }),
+}));
+
+vi.mock("../VersionToBeUsed", () => ({
+  VersionToBeUsed: () => null,
+}));
+
+vi.mock("../AddModelProviderKey", () => ({
+  AddModelProviderKey: () => null,
+}));
+
+vi.mock("~/components/ui/menu", () => ({
+  Menu: {
+    Root: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Trigger: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Content: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Item: ({
+      children,
+      onClick,
+      hidden,
+      ...props
+    }: {
+      children?: ReactNode;
+      onClick?: () => void;
+      hidden?: boolean;
+      [key: string]: any;
+    }) =>
+      hidden ? null : (
+        <button type="button" onClick={onClick} {...props}>
+          {children}
+        </button>
+      ),
+  },
+}));
+
+vi.mock("~/components/ui/dialog", () => ({
+  Dialog: {
+    Root: ({ children, open }: { children?: ReactNode; open?: boolean }) =>
+      open ? <div>{children}</div> : null,
+    Content: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Header: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Title: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    CloseTrigger: () => <div />,
+    Body: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Footer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  },
+}));
+
+vi.mock("~/components/ui/tooltip", () => ({
+  Tooltip: ({
+    content,
+    children,
+  }: {
+    content?: ReactNode;
+    children?: ReactNode;
+  }) => (
+    <span data-tooltip-content={typeof content === "string" ? content : ""}>
+      {children}
+    </span>
+  ),
+}));
+
+vi.mock("~/components/ui/link", () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: {
+    children?: ReactNode;
+    href?: string;
+    [key: string]: any;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const { Publish } = await import("../Publish");
+
+function renderPublish() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <Publish isDisabled={false} />
+    </ChakraProvider>,
+  );
+}
+
+describe("studio Publish menu", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    mockCanPublish.current = false;
+  });
+
+  describe("when the active plan does NOT allow publishing", () => {
+    beforeEach(() => {
+      mockCanPublish.current = false;
+    });
+
+    it("does not render a 'Subscribe to unlock publishing' tooltip", () => {
+      renderPublish();
+      const tooltips = document.querySelectorAll("[data-tooltip-content]");
+      const lockTooltips = Array.from(tooltips).filter((el) =>
+        (el.getAttribute("data-tooltip-content") ?? "").includes(
+          "Subscribe to unlock publishing",
+        ),
+      );
+      expect(lockTooltips).toHaveLength(0);
+    });
+
+    it("renders the Publish workflow menu item with no lock", () => {
+      renderPublish();
+      const publishItem = screen.getByText(/Publish workflow/i);
+      expect(publishItem).toBeDefined();
+    });
+
+    it("does not redirect to plan management or fire subscription tracking when Publish is clicked", () => {
+      renderPublish();
+      const publishButton = screen.getByText(/Publish workflow/i)
+        .closest("button");
+      expect(publishButton).not.toBeNull();
+      fireEvent.click(publishButton!);
+
+      expect(mockRouterPush).not.toHaveBeenCalledWith("/settings/subscription");
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        "subscription_hook_click",
+        expect.anything(),
+      );
+    });
+
+    it("renders View API Reference and Export Workflow without paywall", () => {
+      renderPublish();
+      expect(screen.getByText(/View API Reference/i)).toBeDefined();
+      expect(screen.getByText(/Export Workflow/i)).toBeDefined();
+    });
+  });
+
+  describe("when the active plan allows publishing", () => {
+    beforeEach(() => {
+      mockCanPublish.current = true;
+    });
+
+    it("still renders the Publish menu without paywall (regression)", () => {
+      renderPublish();
+      expect(screen.getByText(/Publish workflow/i)).toBeDefined();
+      const tooltips = document.querySelectorAll("[data-tooltip-content]");
+      const lockTooltips = Array.from(tooltips).filter((el) =>
+        (el.getAttribute("data-tooltip-content") ?? "").includes(
+          "Subscribe to unlock publishing",
+        ),
+      );
+      expect(lockTooltips).toHaveLength(0);
+    });
+  });
+});

--- a/langwatch/src/server/auth0/__tests__/passwordService.integration.test.ts
+++ b/langwatch/src/server/auth0/__tests__/passwordService.integration.test.ts
@@ -449,7 +449,7 @@ describe("verifyCurrentPassword", () => {
 
 describe("changeAuth0Password", () => {
   describe("given a correct current password and valid M2M credentials", () => {
-    /** @scenario Auth0 backend uses a separate Machine-to-Machine app for the Management API */
+    /** @scenario Auth0 backend verifies the current password via Resource Owner Password Grant before updating */
     it("verifies, gets management token, and PATCHes the user's password", async () => {
       handler = (req) => {
         if (req.method === "POST" && req.path === "/oauth/token") {

--- a/specs/licensing/usage-page-navigation.feature
+++ b/specs/licensing/usage-page-navigation.feature
@@ -52,20 +52,10 @@ Feature: Plan Management Navigation
     When I see the limit warning banner
     Then the upgrade link redirects to /settings/license
 
-  # Publish feature upgrade redirect
-  @e2e @unimplemented
-  Scenario: Publish upgrade redirects to Subscription in SaaS mode
-    Given the platform is deployed in SaaS mode
-    And the organization plan does not allow publishing
-    When I try to publish from the studio
-    Then the upgrade button redirects to /settings/subscription
-
-  @e2e @unimplemented
-  Scenario: Publish upgrade redirects to License in self-hosted mode
-    Given the platform is deployed in self-hosted mode
-    And the organization plan does not allow publishing
-    When I try to publish from the studio
-    Then the upgrade button redirects to /settings/license
+  # Publish feature upgrade redirect — REMOVED.
+  # The studio publish menu is no longer gated by plan.canPublish; resource
+  # count limits (max workflows/evaluators) are the only blockers.
+  # See specs/studio/publish-not-gated.feature
 
   # Settings menu visibility
   @integration @unimplemented

--- a/specs/studio/publish-not-gated.feature
+++ b/specs/studio/publish-not-gated.feature
@@ -1,0 +1,50 @@
+Feature: Workflow Publish Is Not Gated By Subscription Or License
+  As a LangWatch user (free, paid, self-hosted, or licensed)
+  I want to publish my workflows without hitting an "upgrade to publish" wall
+  So that I can use the platform end-to-end without artificial blockers
+
+  Resource count limits (max workflows, max evaluators, max projects) still
+  apply at creation time and are the right place to surface plan limits.
+  The Publish action itself is no longer gated — once a user has gotten a
+  workflow into the studio, they can publish it.
+
+  Background:
+    Given I am authenticated as a project member
+    And I have a workflow open in the optimization studio
+
+  @integration
+  Scenario: Free SaaS user can open the publish menu without a paywall
+    Given my organization is on the FREE plan
+    When I click the "Publish" button
+    Then the dropdown shows "Publish workflow", "View API Reference" and "Export Workflow"
+    And no menu item shows a lock icon
+    And no menu item shows a "Subscribe to unlock publishing" tooltip
+
+  @integration
+  Scenario: Self-hosted user without a paid license can open the publish menu without a paywall
+    Given the platform is deployed in self-hosted mode
+    And no paid license is installed (FREE_PLAN fallback)
+    When I click the "Publish" button
+    Then the dropdown shows the publish menu items
+    And no menu item redirects to "/settings/license" on click
+    And no menu item shows a lock icon
+
+  @integration
+  Scenario: Paid SaaS user can publish without a paywall (regression)
+    Given my organization is on a paid plan
+    When I click the "Publish" button
+    Then the dropdown shows the publish menu items with no lock icon
+
+  @unit
+  Scenario: Publish.tsx does not query plan.canPublish to gate the menu
+    Given the Publish component renders
+    Then it must not read activePlan.canPublish to disable or hide menu items
+    And it must not render a lock-icon menu item that redirects to plan management
+
+  @integration
+  Scenario: Workflow creation count limits still apply
+    Given my organization has reached the maximum number of workflows
+    When I try to create a new workflow
+    Then I see the workflow count limit blocker
+    And the upgrade link redirects to plan management
+    # The publish gate removal does NOT remove resource count limits.

--- a/specs/studio/publish-not-gated.feature
+++ b/specs/studio/publish-not-gated.feature
@@ -41,10 +41,12 @@ Feature: Workflow Publish Is Not Gated By Subscription Or License
     Then it must not read activePlan.canPublish to disable or hide menu items
     And it must not render a lock-icon menu item that redirects to plan management
 
-  @integration
+  @integration @unimplemented
   Scenario: Workflow creation count limits still apply
     Given my organization has reached the maximum number of workflows
     When I try to create a new workflow
     Then I see the workflow count limit blocker
     And the upgrade link redirects to plan management
     # The publish gate removal does NOT remove resource count limits.
+    # This scenario documents the existing resource-limit behavior; coverage
+    # lives in specs/licensing/enforcement-resources.feature, not here.


### PR DESCRIPTION
## Summary

The studio Publish dropdown was wrapping every menu item in a `SubscriptionMenuItem` paywall that locked behind `usage.activePlan.canPublish`, showing a Lock icon + "Subscribe to unlock publishing" tooltip and redirecting clicks to plan management. This blocked free / unlicensed users from using the Publish menu at all (Publish, View API Reference, Export Workflow).

Resource count limits (max workflows / evaluators / projects, currently 3 each on FREE) are the right place to surface plan limits — the publish action itself shouldn't be gated. This removes the `SubscriptionMenuItem` wrapper.

## What changed

- `langwatch/src/optimization_studio/components/Publish.tsx` — strip `SubscriptionMenuItem` and the `usage.activePlan.canPublish` read; drop the now-unused `usage` query, `usePlanManagementUrl`, `useRouter`, `trackEvent`, `Lock` and `Spinner` imports. Each menu item is now a plain `Menu.Item` (with the existing `Tooltip` for the "publish disabled" hints, unchanged).
- `specs/studio/publish-not-gated.feature` — new BDD spec pinning the new behavior for FREE SaaS, self-hosted-without-license, and paid users.
- `specs/licensing/usage-page-navigation.feature` — drop the two obsolete "Publish upgrade redirects to /settings/subscription | /settings/license" scenarios; cross-reference the new studio spec.
- `Publish.gate-removed.integration.test.tsx` — RTL test that renders `Publish` with `canPublish=false` and asserts no Lock icon, no "Subscribe to unlock" tooltip, and no `/settings/subscription` redirect when Publish is clicked. Sanity-checked: the test fails on the pre-fix file (the paywall calls `router.push("/settings/subscription")` on click) and passes after the fix.

## What I deliberately did NOT touch

The backend `canPublish` plan flag (in `ee/billing/planLimits.ts`, `ee/licensing/constants.ts`, `LicenseGeneratorForm.tsx`, license schema) is left as-is. Removing it cascades into ~20 files (license-generation tests, plan templates, integration tests). The user-facing problem is the UI gate, and that's gone. A follow-up PR can purge the dead flag.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `npx vitest run Publish.gate-removed.integration.test.tsx` — 5/5 pass
- [x] Sanity check: re-applied the original (paywall) `Publish.tsx`, re-ran the test → fails as expected on the click-redirect assertion. Restored the fix → green again.
- [ ] **Manual visual verify (30s):** open the studio in your already-logged-in browser, click the **Publish** dropdown — the items should render with no Lock icon and no "Subscribe to unlock publishing" tooltip even on free / unlicensed plans.

## Why no live-browser screenshots

Spinning up a fully-authenticated dev server in this worktree (separate port + better-auth signed-cookie HMAC + NEXTAUTH_URL host mismatch) ran into a rabbit hole, and the Claude-in-Chrome extension isn't connected. I bailed on the auth bootstrap and instead wrote the RTL integration test, which is a stronger regression guard — it pins the behavior in CI, not just a one-off snapshot. Happy to take a screenshot if you want one before merging.