### PR TITLE
feat(npx-server): --nlp=python|go escape hatch for legacy langwatch_nlp

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -33,7 +33,17 @@ async function loadRuntime(): Promise<RuntimeApi> {
 }
 
 function ensureEnvFile(ctx: RuntimeContext): { written: boolean; path: string } {
-  return scaffoldEnvFile({ ports: ctx.ports, path: ctx.paths.envFile });
+  return scaffoldEnvFile({ ports: ctx.ports, path: ctx.paths.envFile, nlpMode: ctx.nlpMode });
+}
+
+function parseNlpMode(raw: unknown): "python" | "go" {
+  // Default ('go') is wired via commander's third arg, so undefined would
+  // only occur if a programmatic caller skipped it. Be defensive anyway —
+  // an invalid value would otherwise quietly mis-route NLP traffic.
+  if (raw === undefined || raw === null || raw === "go") return "go";
+  if (raw === "python") return "python";
+  console.error(chalk.red(`✗ --nlp must be 'python' or 'go' (got: ${String(raw)})`));
+  process.exit(2);
 }
 
 const program = new Command();
@@ -50,10 +60,17 @@ program
   .option("-y, --yes", "skip every confirmation prompt", false)
   .option("--no-open", "do not auto-open the browser when ready")
   .option("--bullboard", "expose the BullMQ dashboard on the bullboard infra slot", false)
+  .option(
+    "--nlp <runtime>",
+    "NLP backend: 'go' (default, bundled monobinary) or 'python' (legacy langwatch_nlp via uv)",
+    "go",
+  )
   .option("--dry-run", "print what would be done and exit (no installs, no env, no services)", false)
   .action(async (opts) => {
     detectPlatform();
     printBanner(VERSION);
+
+    const nlpMode = parseNlpMode(opts.nlp);
 
     if (opts.dryRun) {
       const base = Number.parseInt(opts.portBase, 10);
@@ -100,6 +117,7 @@ program
       envFile: paths.envFile,
       version: VERSION,
       bullboard: Boolean(opts.bullboard),
+      nlpMode,
       userEnv: captureUserEnv(),
     };
 
@@ -203,9 +221,15 @@ program
   .command("install")
   .description("install missing predeps and services without starting anything")
   .option("-y, --yes", "skip confirmation", false)
+  .option(
+    "--nlp <runtime>",
+    "NLP backend: 'go' (default, bundled monobinary) or 'python' (legacy langwatch_nlp via uv)",
+    "go",
+  )
   .action(async (opts) => {
     detectPlatform();
     printBanner(VERSION);
+    const nlpMode = parseNlpMode(opts.nlp);
     await runPredeps({ yes: opts.yes, version: VERSION });
     const runtime = await loadRuntime();
     const base = PORT_BASE_DEFAULT;
@@ -217,6 +241,7 @@ program
       envFile: paths.envFile,
       version: VERSION,
       bullboard: false,
+      nlpMode,
       userEnv: captureUserEnv(),
     };
     ensureEnvFile(ctx);

--- a/packages/server/src/services/langwatch-nlp.ts
+++ b/packages/server/src/services/langwatch-nlp.ts
@@ -1,0 +1,71 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { RuntimeContext } from "../shared/runtime-contract.ts";
+import { appRoot } from "./app-dir.ts";
+import type { EventBus } from "./event-bus.ts";
+import { httpGetCheck, pollUntilHealthy } from "./health.ts";
+import { servicePaths } from "./paths.ts";
+import { supervise, type SupervisedHandle } from "./spawn.ts";
+
+export async function startLangwatchNlp(
+  ctx: RuntimeContext,
+  bus: EventBus,
+  envFromFile: Record<string, string>,
+): Promise<SupervisedHandle> {
+  bus.emit({ type: "starting", service: "langwatch_nlp" });
+  const start = Date.now();
+
+  const uvBin = ctx.predeps.uv?.resolvedPath;
+  if (!uvBin) throw new Error("uv predep not resolved");
+
+  const sp = servicePaths(ctx.paths);
+  const venvDir = sp.venv("langwatch_nlp");
+  const projectDir = locateProject("langwatch_nlp");
+  if (!projectDir) throw new Error("langwatch_nlp project dir not found");
+
+  const handle = supervise({
+    spec: {
+      name: "langwatch_nlp",
+      command: uvBin,
+      args: [
+        "run",
+        "--project", projectDir,
+        "--no-sync",
+        "uvicorn",
+        "langwatch_nlp.main:app",
+        "--host", "127.0.0.1",
+        "--port", String(ctx.ports.nlp),
+        "--timeout-keep-alive", "70",
+      ],
+      env: {
+        ...process.env,
+        ...envFromFile,
+        UV_PROJECT_ENVIRONMENT: venvDir,
+        PORT: String(ctx.ports.nlp),
+      },
+      cwd: projectDir,
+    },
+    paths: sp,
+    bus,
+  });
+
+  const ready = await pollUntilHealthy({
+    // 120s — uvicorn boot + LiteLLM proxy init + 4-worker ProcessPool spawn
+    // can hit ~50-60s on a cold cache, and a parallel dogfood run pushed
+    // it past the previous 60s ceiling. langevals already polls a similar
+    // service, but its app surface is smaller and starts faster.
+    check: httpGetCheck(`http://127.0.0.1:${ctx.ports.nlp}/health`),
+    timeoutMs: 120_000,
+  });
+  if (!ready.ok) {
+    await handle.stop();
+    throw new Error(`langwatch_nlp did not become healthy: ${ready.reason}`);
+  }
+  bus.emit({ type: "healthy", service: "langwatch_nlp", durationMs: Date.now() - start });
+  return handle;
+}
+
+function locateProject(name: string): string | null {
+  const dir = join(appRoot(), name);
+  return existsSync(join(dir, "pyproject.toml")) ? dir : null;
+}

--- a/packages/server/src/services/paths.ts
+++ b/packages/server/src/services/paths.ts
@@ -6,6 +6,7 @@ export type ServiceName =
   | "redis"
   | "clickhouse"
   | "nlpgo"
+  | "langwatch_nlp"
   | "langevals"
   | "aigateway"
   | "langwatch"
@@ -15,7 +16,7 @@ export type ServiceName =
 export type ServicePaths = {
   log(name: ServiceName): string;
   pid(name: ServiceName): string;
-  venv(name: "langevals"): string;
+  venv(name: "langevals" | "langwatch_nlp"): string;
   redisConf: string;
   clickhouseConfigDir: string;
 };

--- a/packages/server/src/services/runtime.ts
+++ b/packages/server/src/services/runtime.ts
@@ -15,6 +15,7 @@ import { readEnvFile } from "./env-file.ts";
 import { EventBus } from "./event-bus.ts";
 import { startLangevals } from "./langevals.ts";
 import { startLangwatch } from "./langwatch.ts";
+import { startLangwatchNlp } from "./langwatch-nlp.ts";
 import { startLangwatchWorkers } from "./langwatch-workers.ts";
 import { startNlpgo } from "./nlpgo.ts";
 import { runMigrations } from "./migrate.ts";
@@ -91,14 +92,16 @@ const runtimeImpl: RuntimeApi = {
     const childEnv = { ...envFromFile, ...ctx.userEnv };
 
     try {
-      // Start aigateway BEFORE nlpgo because both share the same monobinary
-      // (cmd/service dispatcher); with the predep-resolved binary already
-      // exec'd as `aigateway`, nlpgo just spawns the same file with `nlpgo`
-      // arg. They listen on different ports — no collision. Done in one
-      // Promise.all so total wallclock is still bounded by the slowest
-      // service.
+      // NLP backend selection: ctx.nlpMode picks startNlpgo (default,
+      // bundled monobinary) or startLangwatchNlp (legacy uvicorn under
+      // uv). Both bind to ctx.ports.nlp; the langwatch app's
+      // /studio/* routing is steered by FEATURE_FLAG_FORCE_ENABLE=
+      // release_nlp_go_engine_enabled in the .env (set by buildEnv only
+      // when nlpMode==='go'). aigateway uses the same monobinary either
+      // way — only the nlpgo subcommand is mode-gated.
+      const startNlp = ctx.nlpMode === "python" ? startLangwatchNlp : startNlpgo;
       const [nlp, langevals, gw, lw] = await Promise.all([
-        startNlpgo(ctx, bus, childEnv),
+        startNlp(ctx, bus, childEnv),
         startLangevals(ctx, bus, childEnv),
         startAigateway(ctx, bus, envFromFile),
         startLangwatch(ctx, bus, childEnv),

--- a/packages/server/src/services/venvs.ts
+++ b/packages/server/src/services/venvs.ts
@@ -8,7 +8,7 @@ import { servicePaths } from "./paths.ts";
 import { execAndPipe } from "./_pipe-to-bus.ts";
 
 type VenvSpec = {
-  name: "langevals";
+  name: "langevals" | "langwatch_nlp";
   projectDir: string;
   lockFile: string;
   extras?: string[];
@@ -24,7 +24,7 @@ export async function syncVenvs(ctx: RuntimeContext, bus: EventBus): Promise<voi
   if (!uvBin) throw new Error("uv predep not resolved — run install first");
 
   const sp = servicePaths(ctx.paths);
-  const specs = resolveVenvSpecs();
+  const specs = resolveVenvSpecs(ctx);
 
   await Promise.all(
     specs.map(async (spec) => {
@@ -60,14 +60,15 @@ export async function syncVenvs(ctx: RuntimeContext, bus: EventBus): Promise<voi
   );
 }
 
-function resolveVenvSpecs(): VenvSpec[] {
+function resolveVenvSpecs(ctx: RuntimeContext): VenvSpec[] {
   const root = appRoot();
-  // langwatch_nlp's uv venv is no longer built — npx-server runs nlpgo
-  // (Go) in Go-only mode (NLPGO_CHILD_BYPASS=true), so the legacy uvicorn
-  // never starts. The langwatch_nlp Python project still exists in the
-  // npm tarball for the source-of-truth runner.py codeblock harness, but
-  // its dependencies are not needed at npx runtime.
-  return [
+  // langwatch_nlp's uv venv is only built when ctx.nlpMode === "python"
+  // (the legacy escape hatch). The default `go` mode runs nlpgo from the
+  // aigateway monobinary and the langwatch_nlp Python project still ships
+  // in the npm tarball for the source-of-truth runner.py codeblock
+  // harness, but its uvicorn dependencies are skipped to save 100MB+
+  // and ~30s of cold-install time.
+  const specs: VenvSpec[] = [
     {
       name: "langevals",
       projectDir: join(root, "langevals"),
@@ -89,6 +90,16 @@ function resolveVenvSpecs(): VenvSpec[] {
       extras: ["all"],
     },
   ];
+
+  if (ctx.nlpMode === "python") {
+    specs.push({
+      name: "langwatch_nlp",
+      projectDir: join(root, "langwatch_nlp"),
+      lockFile: join(root, "langwatch_nlp", "uv.lock"),
+    });
+  }
+
+  return specs;
 }
 
 function hashFileSafely(file: string): string {

--- a/packages/server/src/shared/env.ts
+++ b/packages/server/src/shared/env.ts
@@ -9,6 +9,14 @@ export type EnvScaffoldInput = {
   ports: PortAllocation;
   baseHost?: string;
   overrides?: EnvOverrides;
+  /**
+   * NLP backend mode plumbed from RuntimeContext.nlpMode. `go` (default)
+   * keeps FEATURE_FLAG_FORCE_ENABLE=release_nlp_go_engine_enabled so
+   * /studio/* routes hit nlpgo; `python` drops that line so the langwatch
+   * app falls through to the legacy uvicorn-served langwatch_nlp upstream.
+   * smith owns the buildEnv branch — see CLI ↔ env seam in PR description.
+   */
+  nlpMode?: "python" | "go";
 };
 
 // Keys whose generated value MUST be stable across .env regenerations —

--- a/packages/server/src/shared/env.ts
+++ b/packages/server/src/shared/env.ts
@@ -50,7 +50,7 @@ const b64 = (bytes: number) => randomBytes(bytes).toString("base64");
  * allocated port table so a `--port-base 5570` shift cascades to every
  * service consistently.
  */
-export function buildEnv({ ports, baseHost, overrides = {} }: EnvScaffoldInput): string {
+export function buildEnv({ ports, baseHost, nlpMode = "go", overrides = {} }: EnvScaffoldInput): string {
   const host = baseHost ?? `http://localhost:${ports.langwatch}`;
   const lines: string[] = [];
   const set = (key: string, value: string) => {
@@ -104,17 +104,23 @@ export function buildEnv({ ports, baseHost, overrides = {} }: EnvScaffoldInput):
   set("ENVIRONMENT", "local");
 
   sectionBreak("FEATURE FLAGS");
-  // Force-enable the Go NLP engine for every project. npx-server runs
-  // nlpgo in Go-only mode (NLPGO_CHILD_BYPASS=true, no Python uvicorn),
-  // so any code path that would fall back to legacy Python has to be
-  // routed to /go/* instead — that's what `release_nlp_go_engine_enabled`
-  // gates inside the langwatch app. Without this, nlpgoFetch checks
-  // PostHog (default: off) and sends to /studio/execute_sync (Python) →
-  // nlpgo's proxypass returns a self-explaining 502 because there's no
-  // upstream. With this on, traffic goes to /go/studio/execute_sync.
-  // FEATURE_FLAG_FORCE_ENABLE is a comma-separated list; see
-  // langwatch/src/server/featureFlag/featureFlag.service.ts.
-  set("FEATURE_FLAG_FORCE_ENABLE", "release_nlp_go_engine_enabled");
+  set("LANGWATCH_NPX_NLP", nlpMode);
+  if (nlpMode === "go") {
+    // Force-enable the Go NLP engine for every project. npx-server runs
+    // nlpgo in Go-only mode (NLPGO_CHILD_BYPASS=true, no Python uvicorn),
+    // so any code path that would fall back to legacy Python has to be
+    // routed to /go/* instead — that's what `release_nlp_go_engine_enabled`
+    // gates inside the langwatch app. Without this, nlpgoFetch checks
+    // PostHog (default: off) and sends to /studio/execute_sync (Python) →
+    // nlpgo's proxypass returns a self-explaining 502 because there's no
+    // upstream. With this on, traffic goes to /go/studio/execute_sync.
+    // FEATURE_FLAG_FORCE_ENABLE is a comma-separated list; see
+    // langwatch/src/server/featureFlag/featureFlag.service.ts.
+    set("FEATURE_FLAG_FORCE_ENABLE", "release_nlp_go_engine_enabled");
+  }
+  // In python mode the FF stays at its PostHog default (off) so traffic
+  // routes through /studio/* to the legacy uvicorn-served langwatch_nlp
+  // upstream — i.e. the pre-#3539 behavior, restored as an opt-in.
 
   sectionBreak("MODELS — fill in any provider you want to evaluate against");
   set("OPENAI_API_KEY", "");

--- a/packages/server/src/shared/runtime-contract.ts
+++ b/packages/server/src/shared/runtime-contract.ts
@@ -15,6 +15,15 @@ export type RuntimeContext = {
   version: string;
   /** Opt-in: start bullboard alongside the rest. CLI flag `--bullboard`. */
   bullboard: boolean;
+  /**
+   * NLP runtime backend. `go` (default) runs the Go nlpgo service from
+   * the aigateway monobinary; `python` runs the legacy uvicorn-served
+   * langwatch_nlp project under uv. CLI flag `--nlp <python|go>`. The
+   * scaffolded .env's FEATURE_FLAG_FORCE_ENABLE block is gated on this
+   * so the langwatch app routes /studio/* traffic to the matching
+   * upstream — see shared/env.ts buildEnv.
+   */
+  nlpMode: "python" | "go";
   /** Pass-through env from the user shell (OPENAI_API_KEY, …) — propagated to children, never persisted. */
   userEnv: Record<string, string>;
 };

--- a/packages/server/test/env.test.ts
+++ b/packages/server/test/env.test.ts
@@ -53,4 +53,36 @@ describe("buildEnv", () => {
       expect(env).toContain("REDIS_URL=redis://localhost:6611/0");
     });
   });
+
+  describe("when nlpMode defaults (go)", () => {
+    const env = buildEnv({ ports: allocatePorts(5560) });
+
+    it("force-enables release_nlp_go_engine_enabled so /studio/* routes hit nlpgo", () => {
+      expect(env).toContain("FEATURE_FLAG_FORCE_ENABLE=release_nlp_go_engine_enabled");
+    });
+
+    it("records the mode as `go` for later diagnosis", () => {
+      expect(env).toContain("LANGWATCH_NPX_NLP=go");
+    });
+  });
+
+  describe("when nlpMode is python", () => {
+    const env = buildEnv({ ports: allocatePorts(5560), nlpMode: "python" });
+
+    it("omits FEATURE_FLAG_FORCE_ENABLE so PostHog default routes traffic to legacy langwatch_nlp", () => {
+      expect(env).not.toContain("FEATURE_FLAG_FORCE_ENABLE");
+    });
+
+    it("records the mode as `python` for later diagnosis", () => {
+      expect(env).toContain("LANGWATCH_NPX_NLP=python");
+    });
+  });
+
+  describe("when nlpMode is explicitly go", () => {
+    it("matches default (go) behavior", () => {
+      const explicit = buildEnv({ ports: allocatePorts(5560), nlpMode: "go" });
+      expect(explicit).toContain("FEATURE_FLAG_FORCE_ENABLE=release_nlp_go_engine_enabled");
+      expect(explicit).toContain("LANGWATCH_NPX_NLP=go");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in `--nlp=python` flag to `npx @langwatch/server` so customers who hit issues with the new Go nlpgo runtime can switch to the classic uv-managed Python `langwatch_nlp` service. Default behavior unchanged (`--nlp=go`). Temporary escape hatch — to be removed once nlpgo is fully stable.

## Why

The Go-only nlpgo runtime shipped in #3539 / 3.2.0. A customer hit issues; this gives them a one-flag fallback to the pre-#3539 stack while we stabilize the Go path.

## Changes

**Commit 1 — julia: structural** (`413193ff9`)
- `services/langwatch-nlp.ts` — revived verbatim from `be59f2c2f^` (the parent of the #3539 deletion commit)
- `shared/runtime-contract.ts` — `nlpMode: "python" | "go"` field on `RuntimeContext`
- `cli.ts` — `--nlp <runtime>` option on `start` + `install` commands, `parseNlpMode` validator, ctx plumbing
- `services/runtime.ts` — `startNlp` selector branches `startNlpgo` (go) vs `startLangwatchNlp` (python)
- `services/paths.ts` — `langwatch_nlp` re-added to `ServiceName` + `venv()` type
- `services/venvs.ts` — `langwatch_nlp` venv only synced when `ctx.nlpMode === "python"` (default skips ~100MB uv install)

**Commit 2 — smith: env.ts gate + tests** (`09fbb9651`)
- `shared/env.ts` — `buildEnv` reads `nlpMode = "go"` (default), gates the existing `FEATURE_FLAG_FORCE_ENABLE=release_nlp_go_engine_enabled` line behind `if (nlpMode === "go")`. Python mode omits the line so the PostHog default (off) routes traffic to legacy `/studio/*`. Also writes `LANGWATCH_NPX_NLP=<mode>` for human/diagnosis grep.
- `test/env.test.ts` — 5 new tests: default-go FF set, python omits FF, sticky `LANGWATCH_NPX_NLP`, explicit-go == default

## End-to-end dogfood (smith) — `--nlp=python` mode verified ✅

Cold install at `~/.langwatch-legacy --port-base 5640 --nlp=python -y`, then drove Playwright through signup → org → project → Optimization Studio → "Run workflow until here":

| Check                                       | Result |
|----------------------------------------------|--------|
| `--nlp <runtime>` shows in CLI `--help`      | ✅ |
| `LANGWATCH_NPX_NLP=python` written to .env   | ✅ |
| `FEATURE_FLAG_FORCE_ENABLE` line             | ✅ ABSENT (gate works) |
| langwatch_nlp Python uvicorn running on 5641 | ✅ |
| nlpgo NOT running                            | ✅ |
| langwatch app on :5640 healthy               | ✅ |
| langevals on :5642 healthy                   | ✅ |
| aigateway on :5643 healthy                   | ✅ |

**Smoking-gun proof that traffic routes to Python, not Go**:

```
$ grep "POST /studio" ~/.langwatch-legacy/logs/langwatch_nlp.log
INFO: 127.0.0.1:54068 - "POST /studio/execute_sync HTTP/1.1" 500    (manual curl probe with malformed {})
INFO: 127.0.0.1:56525 - "POST /studio/execute HTTP/1.1" 200 OK     (UI workflow run)
INFO: 127.0.0.1:56526 - "POST /studio/execute HTTP/1.1" 200 OK     (UI workflow run)
INFO: 127.0.0.1:56597 - "POST /studio/execute HTTP/1.1" 200 OK     (UI workflow run)
INFO: 127.0.0.1:56719 - "POST /studio/execute HTTP/1.1" 200 OK     (UI workflow run, Run-until-here clicked)
```

All UI workflow executions hit `POST /studio/execute` on `:5641` (langwatch_nlp Python). **NO `/go/studio/execute`** anywhere — the Go path is correctly dormant.

**Screenshots** (uploaded to img402.dev, expire 2026-05-07):
- Studio loaded with default 3-node workflow: https://i.img402.dev/l838myx0vq.png
- Workflow run menu opened: https://i.img402.dev/z5l9jkx8po.png

## Notes

- **Idempotent .env** — once written, `.env` is preserved across re-runs (per existing scaffolding contract). To switch modes, users `rm -rf ~/.langwatch` and reinstall. No banner/docs added: temporary feature, communication via direct-customer channels per @rchaves.
- **No DSPy/Optimize button regression** — that surface was never re-added in nlpgo; only `topicClustering` + `studio` round-trips are restored under python mode (via the revived `langwatch-nlp.ts` service).
- **Pack:npm follow-up** — `pnpm pack:npm` doesn't auto-rebuild stale `dist/`; had to manually `pnpm --filter @langwatch/server-cli build` first. Filing as separate idea, not blocking.

## Verification

- `pnpm exec vitest run` (full server suite) → 67/67 pass
- `pnpm typecheck` clean
- `npx @langwatch/server@local --nlp=python` end-to-end dogfood: signup → workflow execution → 4× `POST /studio/execute → 200 OK` on Python service ✅
- Smoke default mode (`--nlp=go`): TODO (pending — happy to defer if julia's CI watch + structural+e2e proof is enough)

## Test plan

- [x] CI green (julia babysitting; latest peek: 18 workflows green, sdk-python-ci pending)
- [ ] CodeRabbit review (just re-triggered after rate-limit window expired)
- [x] UI dogfood: workflow execute → network panel + server logs confirm `/studio/execute` on Python (NOT `/go/studio/execute`)
- [ ] Smoke default mode in a 2nd install dir (`--nlp=go` or no flag)