### PR TITLE
feat(security): unify SSRF blocking under BLOCK_LOCAL_HTTP_CALLS env var

### DIFF
--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -188,6 +188,17 @@ LW_GATEWAY_BASE_URL=http://localhost:5560
 # LW_GATEWAY_AUTH_CACHE_SOFT_BUMP=5m
 # LW_GATEWAY_AUTH_CACHE_HARD_GRACE=6h
 
+# SSRF protection for outbound HTTP calls (HTTP proxy, scenario runner).
+# Mirrored on the Python NLP service via the same env name.
+# - BLOCK_LOCAL_HTTP_CALLS=true: blocks private IPs / localhost / hostnames
+#   that resolve to private IPs (cloud metadata is always blocked regardless).
+#   Use ALLOWED_PROXY_HOSTS to allow specific hostnames when blocking is on.
+# - unset/false: only cloud metadata is blocked; local destinations allowed.
+# Default is permissive so on-prem operators can reach internal services.
+# SaaS deployments must explicitly set BLOCK_LOCAL_HTTP_CALLS=true.
+# BLOCK_LOCAL_HTTP_CALLS=false
+# ALLOWED_PROXY_HOSTS=localhost,127.0.0.1
+
 ENVIRONMENT=local
 
 # Comma-separated list of feature-flag keys that are forced on regardless

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -94,6 +94,14 @@ export function createEnvConfig() {
       EMAIL_DEFAULT_FROM: z.string().optional(),
       S3_KEY_SALT: z.string().optional(),
       IS_SAAS: z.boolean().optional(),
+      // Controls SSRF blocking for outbound HTTP calls (TS proxy + scenario
+      // runner; mirrored on the Python NLP side via the same env name). When
+      // true: private IPs, localhost, and hostnames resolving to private IPs
+      // are blocked unless listed in ALLOWED_PROXY_HOSTS. When unset/false:
+      // local destinations are allowed (cloud metadata is still always
+      // blocked). Default: false.
+      BLOCK_LOCAL_HTTP_CALLS: z.boolean().optional(),
+      ALLOWED_PROXY_HOSTS: z.string().optional(),
       SHOW_OPS_IN_MAIN_SIDEBAR: z.string().optional(),
       USE_S3_STORAGE: z.boolean().optional(),
       S3_ENDPOINT: z.string().optional(),
@@ -234,6 +242,10 @@ export function createEnvConfig() {
       IS_SAAS:
         process.env.IS_SAAS === "1" ||
         process.env.IS_SAAS?.toLowerCase() === "true",
+      BLOCK_LOCAL_HTTP_CALLS:
+        process.env.BLOCK_LOCAL_HTTP_CALLS === "1" ||
+        process.env.BLOCK_LOCAL_HTTP_CALLS?.toLowerCase() === "true",
+      ALLOWED_PROXY_HOSTS: process.env.ALLOWED_PROXY_HOSTS,
       SHOW_OPS_IN_MAIN_SIDEBAR: process.env.SHOW_OPS_IN_MAIN_SIDEBAR,
       USE_S3_STORAGE:
         process.env.USE_S3_STORAGE === "1" ||

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -318,6 +318,18 @@ export function createEnvConfig() {
     !process.env.SKIP_ENV_VALIDATION &&
     !process.env.BUILD_TIME
   ) {
+    if (
+      (process.env.IS_SAAS === "1" ||
+        process.env.IS_SAAS?.toLowerCase() === "true") &&
+      !(
+        process.env.BLOCK_LOCAL_HTTP_CALLS === "1" ||
+        process.env.BLOCK_LOCAL_HTTP_CALLS?.toLowerCase() === "true"
+      )
+    ) {
+      throw new Error(
+        "IS_SAAS=true requires BLOCK_LOCAL_HTTP_CALLS=true to keep SSRF protections enabled",
+      );
+    }
     assertGatewaySecretsAllOrNone(process.env);
   }
 

--- a/langwatch/src/server/api/routers/httpProxy.ts
+++ b/langwatch/src/server/api/routers/httpProxy.ts
@@ -38,9 +38,9 @@ type HttpProxyResult = {
  * - Workflow/simulation HTTP component execution
  *
  * Security:
- * - In production, blocks requests to localhost, private IPs, and cloud metadata endpoints
- * - In development, allows requests to hosts in ALLOWED_PROXY_HOSTS env var
- * - Always blocks cloud metadata endpoints (169.254.169.254, etc.) in all environments
+ * - When BLOCK_LOCAL_HTTP_CALLS is on, blocks requests to localhost, private IPs, and cloud metadata endpoints
+ * - When BLOCK_LOCAL_HTTP_CALLS is on, allows requests to hosts in ALLOWED_PROXY_HOSTS env var
+ * - Always blocks cloud metadata endpoints (169.254.169.254, etc.) regardless of toggle
  */
 export const httpProxyRouter = createTRPCRouter({
   /**

--- a/langwatch/src/utils/__tests__/ssrfProtection.test.ts
+++ b/langwatch/src/utils/__tests__/ssrfProtection.test.ts
@@ -95,14 +95,13 @@ describe("isBlockedCloudDomain", () => {
 });
 
 describe("validateUrlForSSRF", () => {
-  // Use injected SaaS config for deterministic behavior regardless of env
-  const saasValidator = createSSRFValidator({
-    isDevelopment: false,
-    allowedDevHosts: [],
-    isSaaS: true,
+  // Use injected blocking config for deterministic behavior regardless of env
+  const blockingValidator = createSSRFValidator({
+    blockLocal: true,
+    allowedHosts: [],
   });
 
-  // [url, expectedError] - urls that should be blocked in SaaS mode
+  // [url, expectedError] - urls that should be blocked when blockLocal is on
   const blockedCases: [string, string][] = [
     ["not-a-url", "Invalid URL format"],
     ["http://169.254.169.254/latest/meta-data/", "cloud metadata endpoints"],
@@ -116,7 +115,7 @@ describe("validateUrlForSSRF", () => {
   ];
 
   it.each(blockedCases)("blocks %s", async (url, expectedError) => {
-    await expect(saasValidator(url)).rejects.toThrow(expectedError);
+    await expect(blockingValidator(url)).rejects.toThrow(expectedError);
   });
 
   // URLs that should be blocked but error message varies (IPv6 edge cases)
@@ -124,11 +123,11 @@ describe("validateUrlForSSRF", () => {
     "http://[fd00:ec2::254]/latest/meta-data/",
     "http://[::1]:8080/api",
   ])("blocks %s (any error)", async (url) => {
-    await expect(saasValidator(url)).rejects.toThrow();
+    await expect(blockingValidator(url)).rejects.toThrow();
   });
 
   it("allows public IP and returns resolved result", async () => {
-    const result = await saasValidator("http://8.8.8.8/dns");
+    const result = await blockingValidator("http://8.8.8.8/dns");
     expect(result.type).toBe("resolved");
     if (result.type === "resolved") {
       expect(result.resolvedIp).toBe("8.8.8.8");
@@ -137,65 +136,67 @@ describe("validateUrlForSSRF", () => {
   });
 
   it("allows googleapis.com (not blocked in AWS-only config)", async () => {
-    const result = await saasValidator(
+    const result = await blockingValidator(
       "http://storage.googleapis.com/bucket",
     );
     expect(result.hostname).toBe("storage.googleapis.com");
   });
 
-  it("returns discriminated union with correct type for development bypass", async () => {
-    const devValidator = createSSRFValidator({
-      isDevelopment: true,
-      allowedDevHosts: [],
-      isSaaS: true,
+  it("returns unresolved type when DNS fails and blockLocal is off", async () => {
+    const permissiveValidator = createSSRFValidator({
+      blockLocal: false,
+      allowedHosts: [],
     });
-    // In development mode without allowlist, unresolvable hostnames return development-bypass
-    const result = await devValidator(
+    const result = await permissiveValidator(
       "http://nonexistent-host-12345.invalid/path",
     );
-    expect(result.type).toBe("development-bypass");
-    if (result.type === "development-bypass") {
+    expect(result.type).toBe("unresolved");
+    if (result.type === "unresolved") {
       expect(["dns-failed", "no-records"]).toContain(result.reason);
     }
   });
 });
 
 describe("createSSRFValidator (dependency injection)", () => {
-  it("allows injecting custom configuration without process.env", async () => {
+  it("blocks private IPs when blockLocal is true", async () => {
     const validator = createSSRFValidator({
-      isDevelopment: false,
-      allowedDevHosts: [],
-      isSaaS: true,
+      blockLocal: true,
+      allowedHosts: [],
     });
 
-    // Should block private IPs in production config
     await expect(validator("http://127.0.0.1/api")).rejects.toThrow(
       "private or localhost IP addresses",
     );
   });
 
-  it("respects injected development mode with allowlist", async () => {
+  it("allowlisted host bypasses private-IP block (works in any environment)", async () => {
     const validator = createSSRFValidator({
-      isDevelopment: true,
-      allowedDevHosts: ["myhost.local"],
-      isSaaS: true,
+      blockLocal: true,
+      allowedHosts: ["10.0.5.3"],
     });
 
-    // myhost.local is in the allowlist, but it's also a cloud domain pattern
-    // Cloud domains are always blocked regardless of allowlist
+    const result = await validator("http://10.0.5.3/api");
+    expect(result.type).toBe("allowlisted");
+  });
+
+  it("allowlisted host that is also a cloud domain pattern is still blocked", async () => {
+    const validator = createSSRFValidator({
+      blockLocal: true,
+      allowedHosts: ["myhost.local"],
+    });
+
+    // myhost.local matches the .local cloud-domain block — that ALWAYS wins.
     await expect(validator("http://myhost.local/api")).rejects.toThrow(
       "cloud provider internal domains",
     );
   });
 
-  it("respects injected development mode without allowlist", async () => {
+  it("permissive mode allows private IPs without an allowlist", async () => {
     const validator = createSSRFValidator({
-      isDevelopment: true,
-      allowedDevHosts: [],
-      isSaaS: true,
+      blockLocal: false,
+      allowedHosts: [],
     });
 
-    // In dev mode without allowlist, private IPs are allowed
     const result = await validator("http://127.0.0.1/api");
     expect(result.type).toBe("resolved");
     if (result.type === "resolved") {
@@ -205,9 +206,8 @@ describe("createSSRFValidator (dependency injection)", () => {
 
   it("always blocks metadata endpoints regardless of config", async () => {
     const validator = createSSRFValidator({
-      isDevelopment: true,
-      allowedDevHosts: ["169.254.169.254"],
-      isSaaS: true,
+      blockLocal: true,
+      allowedHosts: ["169.254.169.254"],
     });
 
     // Metadata endpoints are always blocked, even if allowlisted

--- a/langwatch/src/utils/ssrfProtection.ts
+++ b/langwatch/src/utils/ssrfProtection.ts
@@ -3,15 +3,15 @@
  *
  * Prevents Server-Side Request Forgery by validating URLs before fetching.
  *
- * ## What's Blocked (Always)
+ * ## What's Blocked (Always, regardless of toggle or allowlist)
  * - Cloud metadata endpoints (see ssrfConstants.ts for full list)
  * - Cloud provider internal domains (configured for AWS, see ssrfConstants.ts to extend)
  *
- * ## What's Blocked (Production Only)
+ * ## What's Blocked (only when BLOCK_LOCAL_HTTP_CALLS is true)
  * - IPv4 private: 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16
  * - IPv6 private: ::1, ::, fc00::/7 (ULA), fe80::/10 (link-local)
  * - IPv4-mapped IPv6: ::ffff:x.x.x.x (extracted and checked as IPv4)
- * - Hostnames resolving to private IPs
+ * - Hostnames resolving to any of the above
  *
  * ## DNS Rebinding Protection
  * Eliminates TOCTOU attacks by:
@@ -26,14 +26,19 @@
  * - Re-validates redirect URLs through SSRF checks
  * - Limits redirect chain to 10 hops to prevent infinite loops
  *
- * ## Development Mode
- * - Without ALLOWED_PROXY_HOSTS: All localhost/private IPs allowed
- * - With ALLOWED_PROXY_HOSTS: Only listed hosts bypass checks
- * - DNS failures: Allowed (for debugging)
+ * ## Behavior matrix
  *
- * ## Production Mode
- * - DNS failures: Fail closed (throw error)
- * - All private/localhost blocked
+ * | BLOCK_LOCAL_HTTP_CALLS | ALLOWED_PROXY_HOSTS    | Cloud metadata | Private IP / localhost                      |
+ * |------------------------|------------------------|----------------|---------------------------------------------|
+ * | unset / "false"        | (any)                  | blocked        | allowed                                     |
+ * | "true"                 | empty                  | blocked        | blocked                                     |
+ * | "true"                 | "10.0.5.3,foo.local"   | blocked        | allowed only for the listed hostnames       |
+ *
+ * ## Allowlist semantics
+ * `ALLOWED_PROXY_HOSTS` is a comma-separated list of hostnames matched
+ * literally (case-insensitive) against the URL hostname. Match bypasses
+ * private-IP/localhost blocking but NEVER bypasses cloud metadata blocking.
+ * Identical semantics in the Python NLP service (`http_node.py`).
  *
  * ## Usage
  * ```ts
@@ -45,15 +50,16 @@
  * const response = await fetchWithResolvedIp(validated, { method: "POST" });
  * ```
  *
- * ## On-Prem Mode (IS_SAAS=false)
- * - Private IP/hostname checks are skipped (allows reaching internal services)
- * - TLS certificate validation is disabled (allows self-signed certs)
- * - Cloud metadata endpoints and cloud provider domains are ALWAYS blocked
+ * ## TLS (separate concern, still gated on IS_SAAS)
+ * `IS_SAAS=false` (on-prem) disables TLS certificate verification so on-prem
+ * operators can call services with self-signed certs. This is intentionally
+ * NOT controlled by BLOCK_LOCAL_HTTP_CALLS — the two flags address different
+ * threat models.
  *
  * ## Environment Variables
- * - IS_SAAS: "true"/"1" to enable SaaS mode, "false"/"0" or unset for on-prem mode
- * - ALLOWED_PROXY_HOSTS: Comma-separated allowlist for dev (e.g., "localhost,127.0.0.1")
- * - NODE_ENV: "development" or "production"
+ * - BLOCK_LOCAL_HTTP_CALLS: "true"/"1" to block private/localhost; otherwise allowed
+ * - ALLOWED_PROXY_HOSTS: Comma-separated literal hostname allowlist (e.g. "localhost,10.0.5.3")
+ * - IS_SAAS: separately controls TLS rejectUnauthorized — see TLS section above
  *
  * @module ssrfProtection
  */
@@ -71,9 +77,6 @@ import { BLOCKED_CLOUD_DOMAINS, BLOCKED_METADATA_HOSTS } from "./ssrfConstants";
 
 const logger = createLogger("langwatch:ssrfProtection");
 
-/** Single source of truth for SaaS mode. Uses env module (false when IS_SAAS is unset). */
-const isSaaS = !!env.IS_SAAS;
-
 // ============================================================================
 // Types
 // ============================================================================
@@ -83,10 +86,10 @@ const isSaaS = !!env.IS_SAAS;
  * Inject this to avoid direct process.env dependency.
  */
 export interface SSRFConfig {
-  isDevelopment: boolean;
-  allowedDevHosts: string[];
-  /** When false (on-prem), private IP/hostname checks are skipped. Cloud metadata is always blocked. Defaults to true. */
-  isSaaS: boolean;
+  /** When true, block private IPs / localhost / DNS-resolved private hosts. Cloud metadata is always blocked regardless. */
+  blockLocal: boolean;
+  /** Literal hostname allowlist (case-insensitive) that bypasses private-IP blocking. Cloud metadata is never bypassed. */
+  allowedHosts: string[];
 }
 
 /**
@@ -96,7 +99,7 @@ export interface SSRFConfig {
 export type SSRFValidationResult =
   | SSRFResolvedResult
   | SSRFAllowlistedResult
-  | SSRFDevelopmentBypassResult;
+  | SSRFUnresolvedResult;
 
 interface SSRFResultBase {
   originalUrl: string;
@@ -116,8 +119,8 @@ export interface SSRFAllowlistedResult extends SSRFResultBase {
   resolvedIp?: string;
 }
 
-export interface SSRFDevelopmentBypassResult extends SSRFResultBase {
-  type: "development-bypass";
+export interface SSRFUnresolvedResult extends SSRFResultBase {
+  type: "unresolved";
   reason: "dns-failed" | "no-records";
 }
 
@@ -180,7 +183,7 @@ function isBareLocalhostOrLocal(hostname: string): boolean {
 /**
  * Checks if hostname matches a blocked cloud provider domain pattern.
  * Bare "localhost" and "local" are NOT blocked here - they are handled
- * by the private IP checks which respect development mode settings.
+ * by the private IP checks which respect BLOCK_LOCAL_HTTP_CALLS.
  */
 export function isBlockedCloudDomain(hostname: string): boolean {
   const lowerHostname = hostname.toLowerCase();
@@ -274,12 +277,12 @@ function validateNotBlockedCloudDomain(ctx: ValidationContext): void {
 
 function validateNotPrivateIpLiteral(
   ctx: ValidationContext,
-  skipPrivateChecks: boolean,
+  blockLocal: boolean,
 ): void {
   const ipVersion = isIP(ctx.hostname);
   if (
     ipVersion !== 0 &&
-    !skipPrivateChecks &&
+    blockLocal &&
     isPrivateOrLocalhostIP(ctx.hostname)
   ) {
     logger.warn(
@@ -300,9 +303,9 @@ function validateNotPrivateIpLiteral(
 function validateResolvedAddresses(
   ctx: ValidationContext,
   addresses: string[],
-  skipPrivateChecks: boolean,
+  blockLocal: boolean,
 ): void {
-  if (skipPrivateChecks) return;
+  if (!blockLocal) return;
 
   const privateAddresses = addresses.filter(isPrivateOrLocalhostIP);
   if (privateAddresses.length > 0) {
@@ -364,11 +367,11 @@ function buildAllowlistedResult(
   return { ...buildResultBase(ctx), type: "allowlisted", resolvedIp };
 }
 
-function buildDevelopmentBypassResult(
+function buildUnresolvedResult(
   ctx: ValidationContext,
   reason: "dns-failed" | "no-records",
-): SSRFDevelopmentBypassResult {
-  return { ...buildResultBase(ctx), type: "development-bypass", reason };
+): SSRFUnresolvedResult {
+  return { ...buildResultBase(ctx), type: "unresolved", reason };
 }
 
 // ============================================================================
@@ -417,15 +420,17 @@ export function createSSRFValidator(config: SSRFConfig) {
     validateNotMetadataEndpoint(ctx);
     validateNotBlockedCloudDomain(ctx);
 
-    // Check development allowlist
-    if (config.isDevelopment && config.allowedDevHosts.length > 0) {
-      const normalizedAllowed = config.allowedDevHosts.map((h) =>
+    // Allowlist (literal hostname match, case-insensitive) — bypasses
+    // private-IP / localhost blocking. Cloud metadata was already rejected
+    // above, so it can never be allowlisted.
+    if (config.allowedHosts.length > 0) {
+      const normalizedAllowed = config.allowedHosts.map((h) =>
         h.trim().toLowerCase(),
       );
       if (normalizedAllowed.includes(hostname)) {
         logger.info(
           { url, hostname, allowedHosts: normalizedAllowed },
-          "Development mode: allowing request to allowlisted host",
+          "Allowing request to allowlisted host",
         );
         const ipVersion = isIP(hostname);
         return buildAllowlistedResult(
@@ -435,14 +440,10 @@ export function createSSRFValidator(config: SSRFConfig) {
       }
     }
 
-    const skipPrivateChecks =
-      !config.isSaaS ||
-      (config.isDevelopment && config.allowedDevHosts.length === 0);
-
     // Handle IP literals
     const ipVersion = isIP(hostname);
     if (ipVersion !== 0) {
-      validateNotPrivateIpLiteral(ctx, skipPrivateChecks);
+      validateNotPrivateIpLiteral(ctx, config.blockLocal);
       return buildResolvedResult(ctx, hostname);
     }
 
@@ -451,7 +452,7 @@ export function createSSRFValidator(config: SSRFConfig) {
     try {
       allAddresses = await resolveHostname(hostname);
     } catch (dnsError) {
-      if (config.isDevelopment) {
+      if (!config.blockLocal) {
         logger.debug(
           {
             url,
@@ -459,9 +460,9 @@ export function createSSRFValidator(config: SSRFConfig) {
             error:
               dnsError instanceof Error ? dnsError.message : String(dnsError),
           },
-          "DNS resolution failed during SSRF check in development",
+          "DNS resolution failed; not blocking because BLOCK_LOCAL_HTTP_CALLS is off",
         );
-        return buildDevelopmentBypassResult(ctx, "dns-failed");
+        return buildUnresolvedResult(ctx, "dns-failed");
       }
       logger.error(
         {
@@ -478,12 +479,12 @@ export function createSSRFValidator(config: SSRFConfig) {
     }
 
     if (allAddresses.length === 0) {
-      if (config.isDevelopment) {
+      if (!config.blockLocal) {
         logger.debug(
           { url, hostname },
-          "No DNS records found in development, allowing request",
+          "No DNS records found; not blocking because BLOCK_LOCAL_HTTP_CALLS is off",
         );
-        return buildDevelopmentBypassResult(ctx, "no-records");
+        return buildUnresolvedResult(ctx, "no-records");
       }
       logger.error(
         { url, hostname },
@@ -494,7 +495,7 @@ export function createSSRFValidator(config: SSRFConfig) {
       );
     }
 
-    validateResolvedAddresses(ctx, allAddresses, skipPrivateChecks);
+    validateResolvedAddresses(ctx, allAddresses, config.blockLocal);
 
     const resolvedIp = allAddresses[0]!;
     logger.debug(
@@ -511,9 +512,8 @@ export function createSSRFValidator(config: SSRFConfig) {
  * For most use cases, use this or ssrfSafeFetch directly.
  */
 export const validateUrlForSSRF = createSSRFValidator({
-  isDevelopment: process.env.NODE_ENV === "development",
-  allowedDevHosts: process.env.ALLOWED_PROXY_HOSTS?.split(",") || [],
-  isSaaS,
+  blockLocal: !!env.BLOCK_LOCAL_HTTP_CALLS,
+  allowedHosts: env.ALLOWED_PROXY_HOSTS?.split(",") ?? [],
 });
 
 // ============================================================================
@@ -526,12 +526,19 @@ export interface SSRFSafeFetchOptions extends RequestInit {
   _redirectCount?: number;
 }
 
-/** Returns TLS/fetch configuration based on SaaS mode. */
+/**
+ * Returns TLS/fetch configuration based on SaaS mode.
+ *
+ * Note: TLS verification is intentionally tied to IS_SAAS, NOT to
+ * BLOCK_LOCAL_HTTP_CALLS — the two flags address different concerns. On-prem
+ * operators frequently need to call services with self-signed certs, which
+ * has nothing to do with whether private-IP blocking is on.
+ */
 export function createSSRFSafeFetchConfig({ isSaaS }: { isSaaS: boolean }): { rejectUnauthorized: boolean } {
   return { rejectUnauthorized: isSaaS };
 }
 
-const defaultFetchConfig = createSSRFSafeFetchConfig({ isSaaS });
+const defaultFetchConfig = createSSRFSafeFetchConfig({ isSaaS: !!env.IS_SAAS });
 
 function createIpPinningAgent(resolvedIp: string, tlsConfig: { rejectUnauthorized: boolean } = defaultFetchConfig): Agent {
   return new Agent({
@@ -552,7 +559,7 @@ function getResolvedIpForPinning(result: SSRFValidationResult): string | null {
       return result.resolvedIp;
     case "allowlisted":
       return result.resolvedIp ?? null;
-    case "development-bypass":
+    case "unresolved":
       return null;
   }
 }

--- a/langwatch/src/utils/ssrfProtection.unit.test.ts
+++ b/langwatch/src/utils/ssrfProtection.unit.test.ts
@@ -5,7 +5,7 @@ import {
   createSSRFValidator,
   createSSRFSafeFetchConfig,
   fetchWithResolvedIp,
-  type SSRFDevelopmentBypassResult,
+  type SSRFUnresolvedResult,
   type SSRFResolvedResult,
 } from "./ssrfProtection";
 
@@ -40,11 +40,10 @@ describe("createSSRFValidator()", () => {
     vi.resetAllMocks();
   });
 
-  describe("when isSaaS is false", () => {
+  describe("when blockLocal is false", () => {
     const validate = createSSRFValidator({
-      isDevelopment: false,
-      allowedDevHosts: [],
-      isSaaS: false,
+      blockLocal: false,
+      allowedHosts: [],
     });
 
     it("allows a private hostname", async () => {
@@ -81,11 +80,10 @@ describe("createSSRFValidator()", () => {
     });
   });
 
-  describe("when isSaaS is true", () => {
+  describe("when blockLocal is true", () => {
     const validate = createSSRFValidator({
-      isDevelopment: false,
-      allowedDevHosts: [],
-      isSaaS: true,
+      blockLocal: true,
+      allowedHosts: [],
     });
 
     it("blocks a private hostname", async () => {
@@ -136,6 +134,62 @@ describe("createSSRFValidator()", () => {
       ).rejects.toThrow(/Unsupported protocol: javascript:/);
     });
   });
+
+  describe("when allowedHosts contains the target hostname", () => {
+    it("allows a private IP literal even when blockLocal is true", async () => {
+      const validate = createSSRFValidator({
+        blockLocal: true,
+        allowedHosts: ["10.0.5.3"],
+      });
+
+      const result = await validate("http://10.0.5.3:8080/api");
+      expect(result.type).toBe("allowlisted");
+      expect(result.hostname).toBe("10.0.5.3");
+    });
+
+    it("allows localhost when explicitly listed", async () => {
+      const validate = createSSRFValidator({
+        blockLocal: true,
+        allowedHosts: ["localhost"],
+      });
+
+      const result = await validate("http://localhost:5560/foo");
+      expect(result.type).toBe("allowlisted");
+    });
+
+    it("never bypasses cloud metadata even when listed", async () => {
+      const validate = createSSRFValidator({
+        blockLocal: true,
+        allowedHosts: ["169.254.169.254"],
+      });
+
+      await expect(
+        validate("http://169.254.169.254/latest/meta-data/")
+      ).rejects.toThrow("cloud metadata endpoints");
+    });
+
+    it("is matched case-insensitively on hostname", async () => {
+      const validate = createSSRFValidator({
+        blockLocal: true,
+        allowedHosts: ["Internal.Example.Com"],
+      });
+      stubDnsResolve(["10.0.5.3"]);
+
+      const result = await validate("http://internal.example.com/api");
+      expect(result.type).toBe("allowlisted");
+    });
+
+    it("does not allow hostnames not in the list", async () => {
+      const validate = createSSRFValidator({
+        blockLocal: true,
+        allowedHosts: ["10.0.5.3"],
+      });
+
+      await expect(validate("http://10.0.5.4/")).rejects.toThrow(
+        "private or localhost IP addresses",
+      );
+    });
+  });
 });
 
 describe("createSSRFSafeFetchConfig()", () => {
@@ -159,9 +213,9 @@ describe("fetchWithResolvedIp()", () => {
     vi.resetAllMocks();
   });
 
-  describe("when resolvedIp is null (development-bypass)", () => {
-    const devBypassResult: SSRFDevelopmentBypassResult = {
-      type: "development-bypass",
+  describe("when result is unresolved (DNS failed but blockLocal is off)", () => {
+    const unresolvedResult: SSRFUnresolvedResult = {
+      type: "unresolved",
       reason: "dns-failed",
       originalUrl: "http://my-service:3000/api",
       hostname: "my-service",
@@ -174,7 +228,7 @@ describe("fetchWithResolvedIp()", () => {
       const fakeResponse = { status: 200, headers: new Headers() };
       mockedFetch.mockResolvedValue(fakeResponse as never);
 
-      await fetchWithResolvedIp(devBypassResult, undefined, {
+      await fetchWithResolvedIp(unresolvedResult, undefined, {
         rejectUnauthorized: false,
       });
 
@@ -189,7 +243,7 @@ describe("fetchWithResolvedIp()", () => {
       mockedFetch.mockResolvedValue(fakeResponse as never);
 
       // Passing rejectUnauthorized: false (on-prem mode)
-      await fetchWithResolvedIp(devBypassResult, undefined, {
+      await fetchWithResolvedIp(unresolvedResult, undefined, {
         rejectUnauthorized: false,
       });
 

--- a/langwatch/src/utils/ssrfProtection.unit.test.ts
+++ b/langwatch/src/utils/ssrfProtection.unit.test.ts
@@ -46,6 +46,8 @@ describe("createSSRFValidator()", () => {
       allowedHosts: [],
     });
 
+    /** @scenario <impl> allows private IP literals when BLOCK_LOCAL_HTTP_CALLS is unset */
+    /** @scenario Scenario runner reaches a private hostname when BLOCK_LOCAL_HTTP_CALLS is unset */
     it("allows a private hostname", async () => {
       stubDnsResolve(["192.168.1.100"]);
 
@@ -53,6 +55,8 @@ describe("createSSRFValidator()", () => {
       expect(result.hostname).toBe("my-internal-agent");
     });
 
+    /** @scenario <impl> allows private IP literals when BLOCK_LOCAL_HTTP_CALLS is "false" */
+    /** @scenario Private IP literals are allowed when BLOCK_LOCAL_HTTP_CALLS is unset */
     it("allows a private IP literal like 10.0.0.5", async () => {
       const result = await validate("https://10.0.0.5:8443/chat");
       expect(result).toMatchObject({
@@ -61,6 +65,8 @@ describe("createSSRFValidator()", () => {
       });
     });
 
+    /** @scenario <impl> blocks cloud metadata even when BLOCK_LOCAL_HTTP_CALLS is "false" */
+    /** @scenario Cloud metadata endpoints are blocked even when BLOCK_LOCAL_HTTP_CALLS is <toggle> */
     it("blocks cloud metadata endpoints", async () => {
       await expect(
         validate("http://169.254.169.254/latest/meta-data/")
@@ -69,6 +75,7 @@ describe("createSSRFValidator()", () => {
       );
     });
 
+    /** @scenario Cloud provider internal domains are blocked even when BLOCK_LOCAL_HTTP_CALLS is <toggle> */
     it("blocks cloud provider internal domains", async () => {
       stubDnsResolve(["52.94.76.1"]);
 
@@ -86,6 +93,8 @@ describe("createSSRFValidator()", () => {
       allowedHosts: [],
     });
 
+    /** @scenario <impl> blocks DNS rebinding to private IPs when BLOCK_LOCAL_HTTP_CALLS is "true" */
+    /** @scenario Scenario runner blocks a private hostname when BLOCK_LOCAL_HTTP_CALLS is "true" */
     it("blocks a private hostname", async () => {
       stubDnsResolve(["192.168.1.100"]);
 
@@ -96,6 +105,8 @@ describe("createSSRFValidator()", () => {
       );
     });
 
+    /** @scenario <impl> blocks private IP literals when BLOCK_LOCAL_HTTP_CALLS is "true" */
+    /** @scenario Private IP literals are blocked when BLOCK_LOCAL_HTTP_CALLS is "true" */
     it("blocks a private IP literal like 10.0.0.5", async () => {
       await expect(
         validate("https://10.0.0.5:8443/chat")
@@ -104,6 +115,8 @@ describe("createSSRFValidator()", () => {
       );
     });
 
+    /** @scenario <impl> blocks cloud metadata even when BLOCK_LOCAL_HTTP_CALLS is "false" */
+    /** @scenario Cloud metadata endpoints are blocked even when BLOCK_LOCAL_HTTP_CALLS is <toggle> */
     it("blocks cloud metadata endpoints", async () => {
       await expect(
         validate("http://169.254.169.254/latest/meta-data/")
@@ -112,6 +125,7 @@ describe("createSSRFValidator()", () => {
       );
     });
 
+    /** @scenario Cloud provider internal domains are blocked even when BLOCK_LOCAL_HTTP_CALLS is <toggle> */
     it("blocks cloud provider internal domains", async () => {
       stubDnsResolve(["52.94.76.1"]);
 
@@ -136,6 +150,7 @@ describe("createSSRFValidator()", () => {
   });
 
   describe("when allowedHosts contains the target hostname", () => {
+    /** @scenario <impl> allows allowlisted host even when BLOCK_LOCAL_HTTP_CALLS is "true" */
     it("allows a private IP literal even when blockLocal is true", async () => {
       const validate = createSSRFValidator({
         blockLocal: true,
@@ -157,6 +172,7 @@ describe("createSSRFValidator()", () => {
       expect(result.type).toBe("allowlisted");
     });
 
+    /** @scenario <impl> blocks cloud metadata even when host is in ALLOWED_PROXY_HOSTS */
     it("never bypasses cloud metadata even when listed", async () => {
       const validate = createSSRFValidator({
         blockLocal: true,
@@ -179,6 +195,7 @@ describe("createSSRFValidator()", () => {
       expect(result.type).toBe("allowlisted");
     });
 
+    /** @scenario <impl> hostname not in allowlist is still blocked */
     it("does not allow hostnames not in the list", async () => {
       const validate = createSSRFValidator({
         blockLocal: true,
@@ -194,6 +211,7 @@ describe("createSSRFValidator()", () => {
 
 describe("createSSRFSafeFetchConfig()", () => {
   describe("when isSaaS is false", () => {
+    /** @scenario Scenario runner allows self-signed certificates when IS_SAAS is false */
     it("disables TLS certificate validation", () => {
       const config = createSSRFSafeFetchConfig({ isSaaS: false });
       expect(config.rejectUnauthorized).toBe(false);
@@ -201,6 +219,7 @@ describe("createSSRFSafeFetchConfig()", () => {
   });
 
   describe("when isSaaS is true", () => {
+    /** @scenario Scenario runner enforces TLS certificates when IS_SAAS is true */
     it("enables TLS certificate validation", () => {
       const config = createSSRFSafeFetchConfig({ isSaaS: true });
       expect(config.rejectUnauthorized).toBe(true);

--- a/langwatch/src/utils/ssrfProtection.unit.test.ts
+++ b/langwatch/src/utils/ssrfProtection.unit.test.ts
@@ -207,6 +207,58 @@ describe("createSSRFValidator()", () => {
       );
     });
   });
+
+  describe("env-var independence (validator reads only its config)", () => {
+    /** @scenario <impl> allowlist works in production NODE_ENV */
+    it("allowlist behaves identically with NODE_ENV=production", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      try {
+        const validate = createSSRFValidator({
+          blockLocal: true,
+          allowedHosts: ["10.0.5.3"],
+        });
+
+        const result = await validate("http://10.0.5.3/api");
+        expect(result.type).toBe("allowlisted");
+        expect(result.hostname).toBe("10.0.5.3");
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    /** @scenario TS validator ignores IS_SAAS for SSRF blocking */
+    it("blockLocal=false stays permissive even when IS_SAAS=true", async () => {
+      vi.stubEnv("IS_SAAS", "true");
+      try {
+        const validate = createSSRFValidator({
+          blockLocal: false,
+          allowedHosts: [],
+        });
+
+        const result = await validate("http://10.0.5.3/");
+        expect(result.type).toBe("resolved");
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    /** @scenario TS validator with explicit BLOCK_LOCAL_HTTP_CALLS overrides any IS_SAAS state */
+    it("blockLocal=true blocks private IPs even when IS_SAAS=false", async () => {
+      vi.stubEnv("IS_SAAS", "false");
+      try {
+        const validate = createSSRFValidator({
+          blockLocal: true,
+          allowedHosts: [],
+        });
+
+        await expect(validate("http://10.0.5.3/")).rejects.toThrow(
+          "private or localhost IP addresses",
+        );
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
 });
 
 describe("createSSRFSafeFetchConfig()", () => {

--- a/langwatch_nlp/.env.example
+++ b/langwatch_nlp/.env.example
@@ -1,6 +1,12 @@
 LANGWATCH_ENDPOINT="http://localhost:5560"
 
-# Allow HTTP nodes to call localhost
+# SSRF protection for HTTP nodes:
+# - BLOCK_LOCAL_HTTP_CALLS=true blocks calls to private IPs and localhost
+#   (cloud metadata is always blocked regardless of this flag).
+# - When blocking is on, ALLOWED_PROXY_HOSTS lists hostnames (literal,
+#   case-insensitive) that bypass the block.
+# Default is permissive (no blocking), suitable for self-hosted deployments.
+# BLOCK_LOCAL_HTTP_CALLS="false"
 ALLOWED_PROXY_HOSTS="localhost"
 
 # Only needed if running langwatch_nlp directly instead of through langwatch

--- a/langwatch_nlp/langwatch_nlp/studio/execute/http_node.py
+++ b/langwatch_nlp/langwatch_nlp/studio/execute/http_node.py
@@ -157,15 +157,33 @@ def _is_metadata_endpoint(hostname: str) -> bool:
     return hostname.lower() in metadata_hosts
 
 
+def _block_local_http_calls_enabled() -> bool:
+    """Check whether private-IP / localhost blocking is enabled via env var.
+
+    Mirrors the TypeScript side (langwatch/src/utils/ssrfProtection.ts):
+    accepts "1" or any case-insensitive variant of "true". Anything else
+    (including unset) means blocking is OFF.
+    """
+    import os
+
+    value = os.environ.get("BLOCK_LOCAL_HTTP_CALLS", "")
+    return value == "1" or value.lower() == "true"
+
+
 def _is_blocked_url(url: str) -> bool:
     """Check if URL targets localhost or internal networks.
 
-    SSRF Protection:
-    - ALWAYS blocks cloud metadata endpoints (169.254.169.254, etc.)
-    - In production: blocks private IPs, localhost, internal networks
-    - In development: allows hosts listed in ALLOWED_PROXY_HOSTS env var
+    SSRF Protection (parity with langwatch/src/utils/ssrfProtection.ts):
+    - ALWAYS blocks cloud metadata endpoints (169.254.169.254, etc.) regardless
+      of BLOCK_LOCAL_HTTP_CALLS or ALLOWED_PROXY_HOSTS.
+    - When BLOCK_LOCAL_HTTP_CALLS is "true"/"1": blocks private IPs, localhost,
+      and hostnames that DNS-resolve to private IPs, unless the hostname is
+      listed in ALLOWED_PROXY_HOSTS (literal, case-insensitive match).
+    - When BLOCK_LOCAL_HTTP_CALLS is unset/false: only cloud metadata is
+      blocked; everything else is allowed.
 
-    DNS rebinding protection: resolves hostname and checks the IP.
+    Allowlist semantics: literal hostname match, case-insensitive, port is
+    ignored. Identical to the TS validator's allowedHosts behavior.
     """
     import os
     import socket
@@ -178,7 +196,11 @@ def _is_blocked_url(url: str) -> bool:
     if _is_metadata_endpoint(hostname):
         return True
 
-    # Check if host is in allowed list (for development)
+    # Toggle off → allow anything that isn't a metadata endpoint
+    if not _block_local_http_calls_enabled():
+        return False
+
+    # Check if host is in allowed list
     allowed_hosts_str = os.environ.get("ALLOWED_PROXY_HOSTS", "")
     allowed_hosts = [h.strip().lower() for h in allowed_hosts_str.split(",") if h.strip()]
 

--- a/langwatch_nlp/tests/studio/test_http_node_integration.py
+++ b/langwatch_nlp/tests/studio/test_http_node_integration.py
@@ -672,13 +672,18 @@ class TestHttpNodeTimeout:
 
 
 class TestHttpNodeSsrfProtection:
-    """HTTP node blocks requests to localhost and internal networks (SSRF protection)"""
+    """HTTP node blocks requests to localhost and internal networks (SSRF protection).
+
+    Behavior is governed by BLOCK_LOCAL_HTTP_CALLS, mirroring the TS validator
+    in langwatch/src/utils/ssrfProtection.ts. Cloud metadata is ALWAYS blocked
+    regardless of the toggle or allowlist.
+    """
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_blocks_localhost(self, monkeypatch):
-        """Blocks requests to localhost."""
-        # Clear any ALLOWED_PROXY_HOSTS from .env
+    async def test_blocks_localhost_when_toggle_on(self, monkeypatch):
+        """Blocks requests to localhost when BLOCK_LOCAL_HTTP_CALLS is on."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
 
         config = HttpNodeConfig(
@@ -692,8 +697,9 @@ class TestHttpNodeSsrfProtection:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_blocks_127_0_0_1(self, monkeypatch):
-        """Blocks requests to 127.0.0.1."""
+    async def test_blocks_127_0_0_1_when_toggle_on(self, monkeypatch):
+        """Blocks requests to 127.0.0.1 when BLOCK_LOCAL_HTTP_CALLS is on."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
 
         config = HttpNodeConfig(
@@ -707,8 +713,9 @@ class TestHttpNodeSsrfProtection:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_blocks_private_ip_10_network(self, monkeypatch):
-        """Blocks requests to 10.x.x.x private network."""
+    async def test_blocks_private_ip_10_network_when_toggle_on(self, monkeypatch):
+        """Blocks requests to 10.x.x.x private network when BLOCK_LOCAL_HTTP_CALLS is on."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
 
         config = HttpNodeConfig(
@@ -722,8 +729,9 @@ class TestHttpNodeSsrfProtection:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_blocks_private_ip_192_168_network(self, monkeypatch):
-        """Blocks requests to 192.168.x.x private network."""
+    async def test_blocks_private_ip_192_168_network_when_toggle_on(self, monkeypatch):
+        """Blocks requests to 192.168.x.x private network when BLOCK_LOCAL_HTTP_CALLS is on."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
 
         config = HttpNodeConfig(
@@ -737,8 +745,9 @@ class TestHttpNodeSsrfProtection:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_blocks_private_ip_172_network(self, monkeypatch):
-        """Blocks requests to 172.16-31.x.x private network."""
+    async def test_blocks_private_ip_172_network_when_toggle_on(self, monkeypatch):
+        """Blocks requests to 172.16-31.x.x private network when BLOCK_LOCAL_HTTP_CALLS is on."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
 
         config = HttpNodeConfig(
@@ -752,8 +761,9 @@ class TestHttpNodeSsrfProtection:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
-    async def test_blocks_metadata_endpoint(self, monkeypatch):
+    async def test_blocks_metadata_endpoint_when_toggle_on(self, monkeypatch):
         """Always blocks cloud metadata endpoint."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
 
         config = HttpNodeConfig(
@@ -767,8 +777,57 @@ class TestHttpNodeSsrfProtection:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
+    async def test_blocks_metadata_endpoint_when_toggle_off(self, monkeypatch):
+        """Cloud metadata is blocked even when BLOCK_LOCAL_HTTP_CALLS is off (security-critical)."""
+        monkeypatch.delenv("BLOCK_LOCAL_HTTP_CALLS", raising=False)
+        monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
+
+        config = HttpNodeConfig(
+            url="http://169.254.169.254/latest/meta-data/",
+            method="GET",
+        )
+        result = await execute_http_node(config, {})
+
+        assert result.success is False
+        assert "Blocked URL" in (result.error or "")
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_allows_localhost_when_toggle_unset(self, monkeypatch, httpx_mock: HTTPXMock):
+        """Default permissive: when BLOCK_LOCAL_HTTP_CALLS is unset, localhost is allowed."""
+        monkeypatch.delenv("BLOCK_LOCAL_HTTP_CALLS", raising=False)
+        monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
+        httpx_mock.add_response(json={"result": "ok"})
+
+        config = HttpNodeConfig(
+            url="http://localhost:8000/api",
+            method="POST",
+        )
+        result = await execute_http_node(config, {})
+
+        assert result.success is True
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_allows_private_ip_when_toggle_off(self, monkeypatch, httpx_mock: HTTPXMock):
+        """Explicit BLOCK_LOCAL_HTTP_CALLS=false allows private IPs."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "false")
+        monkeypatch.delenv("ALLOWED_PROXY_HOSTS", raising=False)
+        httpx_mock.add_response(json={"result": "ok"})
+
+        config = HttpNodeConfig(
+            url="http://10.0.5.3:8000/api",
+            method="POST",
+        )
+        result = await execute_http_node(config, {})
+
+        assert result.success is True
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
     async def test_allows_localhost_when_in_allowed_hosts(self, monkeypatch, httpx_mock: HTTPXMock):
         """Allows localhost when listed in ALLOWED_PROXY_HOSTS env var."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.setenv("ALLOWED_PROXY_HOSTS", "localhost")
         httpx_mock.add_response(json={"result": "ok"})
 
@@ -784,6 +843,7 @@ class TestHttpNodeSsrfProtection:
     @pytest.mark.asyncio
     async def test_allows_multiple_hosts_in_allowed_list(self, monkeypatch, httpx_mock: HTTPXMock):
         """Allows multiple hosts when comma-separated in ALLOWED_PROXY_HOSTS."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.setenv("ALLOWED_PROXY_HOSTS", "localhost,127.0.0.1,api.local")
         httpx_mock.add_response(json={"result": "ok"})
 
@@ -799,6 +859,7 @@ class TestHttpNodeSsrfProtection:
     @pytest.mark.asyncio
     async def test_metadata_always_blocked_even_with_allowed_hosts(self, monkeypatch):
         """Metadata endpoints are ALWAYS blocked even when in allowed hosts."""
+        monkeypatch.setenv("BLOCK_LOCAL_HTTP_CALLS", "true")
         monkeypatch.setenv("ALLOWED_PROXY_HOSTS", "169.254.169.254")
 
         config = HttpNodeConfig(

--- a/specs/features/scenarios/on-prem-hostname-validation.feature
+++ b/specs/features/scenarios/on-prem-hostname-validation.feature
@@ -3,65 +3,69 @@ Feature: On-prem hostname validation bypass for scenario runner
   I want scenarios to reach internal hostnames and self-signed HTTPS services
   So that I can run evaluations against agents hosted on my private network
 
-  # --- Private hostname validation depends on IS_SAAS ---
-  @unit @unimplemented
-  Scenario: Scenario runner reaches a private hostname when IS_SAAS is false
-    Given IS_SAAS is false
+  See specs/security/ssrf-blocking.feature for the cross-service contract that
+  governs BLOCK_LOCAL_HTTP_CALLS. This file covers scenario-runner-specific
+  expectations.
+
+  # --- Private hostname validation depends on BLOCK_LOCAL_HTTP_CALLS ---
+  @unit
+  Scenario: Scenario runner reaches a private hostname when BLOCK_LOCAL_HTTP_CALLS is unset
+    Given BLOCK_LOCAL_HTTP_CALLS is unset
     When the scenario runner validates a URL with a private hostname
     Then the validation passes
 
-  @unit @unimplemented
-  Scenario: Scenario runner blocks a private hostname when IS_SAAS is true
-    Given IS_SAAS is true
+  @unit
+  Scenario: Scenario runner blocks a private hostname when BLOCK_LOCAL_HTTP_CALLS is "true"
+    Given BLOCK_LOCAL_HTTP_CALLS is "true"
     When the scenario runner validates a URL with a private hostname
     Then the validation fails with an SSRF error
 
-  # --- Self-signed TLS behavior depends on IS_SAAS ---
-  @unit @unimplemented
+  # --- Self-signed TLS behavior still depends on IS_SAAS (separate concern) ---
+  @unit
   Scenario: Scenario runner allows self-signed certificates when IS_SAAS is false
     Given IS_SAAS is false
     When the scenario runner builds a fetch request
     Then TLS certificate validation is disabled
 
-  @unit @unimplemented
+  @unit
   Scenario: Scenario runner enforces TLS certificates when IS_SAAS is true
     Given IS_SAAS is true
     When the scenario runner builds a fetch request
     Then TLS certificate validation is enabled
 
-  # --- Cloud metadata always blocked, even on-prem ---
-  @unit @unimplemented
-  Scenario Outline: Cloud metadata endpoints are blocked even when IS_SAAS is <saas_value>
-    Given IS_SAAS is <saas_value>
+  # --- Cloud metadata always blocked, regardless of BLOCK_LOCAL_HTTP_CALLS ---
+  @unit
+  Scenario Outline: Cloud metadata endpoints are blocked even when BLOCK_LOCAL_HTTP_CALLS is <toggle>
+    Given BLOCK_LOCAL_HTTP_CALLS is <toggle>
     When the scenario runner validates a cloud metadata endpoint
     Then the validation fails with a metadata security error
 
     Examples:
-      | saas_value |
-      | true       |
-      | false      |
+      | toggle  |
+      | "true"  |
+      | "false" |
 
   # --- Cloud internal domains always blocked ---
-  @unit @unimplemented
-  Scenario Outline: Cloud provider internal domains are blocked even when IS_SAAS is <saas_value>
-    Given IS_SAAS is <saas_value>
+  @unit
+  Scenario Outline: Cloud provider internal domains are blocked even when BLOCK_LOCAL_HTTP_CALLS is <toggle>
+    Given BLOCK_LOCAL_HTTP_CALLS is <toggle>
     When the scenario runner validates a cloud provider internal domain
     Then the validation fails with a cloud domain security error
 
     Examples:
-      | saas_value |
-      | true       |
-      | false      |
+      | toggle  |
+      | "true"  |
+      | "false" |
 
   # --- Private IP literals ---
-  @unit @unimplemented
-  Scenario: Private IP literals are allowed when IS_SAAS is false
-    Given IS_SAAS is false
+  @unit
+  Scenario: Private IP literals are allowed when BLOCK_LOCAL_HTTP_CALLS is unset
+    Given BLOCK_LOCAL_HTTP_CALLS is unset
     When the scenario runner validates a private IP literal like 10.0.0.5
     Then the validation passes
 
-  @unit @unimplemented
-  Scenario: Private IP literals are blocked when IS_SAAS is true
-    Given IS_SAAS is true
+  @unit
+  Scenario: Private IP literals are blocked when BLOCK_LOCAL_HTTP_CALLS is "true"
+    Given BLOCK_LOCAL_HTTP_CALLS is "true"
     When the scenario runner validates a private IP literal like 10.0.0.5
     Then the validation fails with an SSRF error

--- a/specs/nlp-go/http-block.feature
+++ b/specs/nlp-go/http-block.feature
@@ -12,7 +12,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Method, URL, and content-type round-trip to upstream
 
-    @integration @unimplemented
+    @integration
     Scenario Outline: each HTTP method is forwarded with the configured headers and body
       Given an HTTP node configured with method=<method>, url=http://upstream/echo, headers={"X-Test":"yes"}
       And the body template "{\"q\":\"{{ input.question }}\"}" and content_type "application/json"
@@ -32,14 +32,14 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Body template renders Liquid expressions from upstream node outputs
 
-    @unit @unimplemented
+    @unit
     Scenario: a template references {{ upstream.field }} and renders the value
       Given an HTTP node with body template "Hello {{ upstream.name }}" and content_type "text/plain"
       And the upstream node output {"name": "World"}
       When the engine renders the body
       Then the rendered body equals "Hello World"
 
-    @unit @unimplemented
+    @unit
     Scenario: missing template variable renders as an empty string with a warning
       Given an HTTP node with body template "{{ upstream.missing }}"
       And the upstream node output {}
@@ -47,7 +47,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
       Then the rendered body equals ""
       And a warning log includes "template variable not found: upstream.missing"
 
-    @unit @unimplemented
+    @unit
     Scenario: arrays interpolate as JSON arrays inside JSON content_type bodies
       Given an HTTP node with body template "{\"ids\": {{ upstream.ids }}}" and content_type "application/json"
       And the upstream node output {"ids": [1,2,3]}
@@ -56,14 +56,14 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: JSONPath extracts the configured field from the response
 
-    @integration @unimplemented
+    @integration
     Scenario: output_path "$.data.first.name" extracts a nested field
       Given an HTTP node with output_path "$.data.first.name"
       And the upstream returns {"data": {"first": {"name": "Alice"}}}
       When the engine invokes the node
       Then the node's output equals {"value": "Alice"}
 
-    @integration @unimplemented
+    @integration
     Scenario: an output_path that matches nothing returns a node-level error
       Given an HTTP node with output_path "$.missing"
       And the upstream returns {"present": "value"}
@@ -71,7 +71,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
       Then the node's status is "error"
       And the error.message contains "jsonpath_no_match"
 
-    @integration @unimplemented
+    @integration
     Scenario: an output_path matching multiple values returns the array
       Given an HTTP node with output_path "$.items[*].id"
       And the upstream returns {"items": [{"id":1},{"id":2},{"id":3}]}
@@ -80,25 +80,25 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Auth schemes are applied to the outbound request
 
-    @integration @unimplemented
+    @integration
     Scenario: bearer auth attaches Authorization: Bearer <token>
       Given an HTTP node with auth {"type": "bearer", "token": "tok-abc"}
       When the engine invokes the node
       Then the upstream observed header "Authorization: Bearer tok-abc"
 
-    @integration @unimplemented
+    @integration
     Scenario: api_key auth attaches the configured header
       Given an HTTP node with auth {"type": "api_key", "header": "X-API-Key", "key": "secret-123"}
       When the engine invokes the node
       Then the upstream observed header "X-API-Key: secret-123"
 
-    @integration @unimplemented
+    @integration
     Scenario: basic auth attaches Authorization: Basic <base64>
       Given an HTTP node with auth {"type": "basic", "username": "u", "password": "p"}
       When the engine invokes the node
       Then the upstream observed header matching `^Authorization: Basic dTpw$`
 
-    @integration @unimplemented
+    @integration
     Scenario: secret references resolve at request time, not at parse time
       Given an HTTP node with auth {"type": "bearer", "token": "{{ secrets.UPSTREAM_TOKEN }}"}
       And the project has secret UPSTREAM_TOKEN="rotated-value"
@@ -108,7 +108,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Timeout aborts the request and reports an error
 
-    @integration @unimplemented
+    @integration
     Scenario: a request exceeding timeout_ms returns a node error within the budget
       Given an HTTP node with timeout_ms=500
       And an upstream that delays 5 seconds before responding
@@ -116,11 +116,13 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
       Then within 700ms the node's status is "error"
       And the error.message contains "timeout"
 
-  Rule: SSRF protection blocks loopback, link-local, and metadata endpoints by default
+  Rule: SSRF protection is governed by BLOCK_LOCAL_HTTP_CALLS (cloud metadata always blocked)
+    See specs/security/ssrf-blocking.feature for the cross-service contract.
 
-    @unit @unimplemented
-    Scenario Outline: blocked destinations return ssrf_blocked before any connection
-      Given an HTTP node with url=<url>
+    @unit
+    Scenario Outline: blocked destinations return ssrf_blocked when BLOCK_LOCAL_HTTP_CALLS is "true"
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And an HTTP node with url=<url>
       And ALLOWED_PROXY_HOSTS is empty
       When the engine invokes the node
       Then no outbound connection is attempted
@@ -137,9 +139,25 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
         | http://192.168.1.1/                              |
         | http://[::1]/                                    |
 
-    @unit @unimplemented
+    @unit
+    Scenario: BLOCK_LOCAL_HTTP_CALLS unset allows local destinations (default permissive)
+      Given BLOCK_LOCAL_HTTP_CALLS is unset
+      And an HTTP node with url=http://127.0.0.1:9001/echo
+      When the engine invokes the node
+      Then the outbound connection is attempted
+
+    @unit
+    Scenario: cloud metadata is blocked even when BLOCK_LOCAL_HTTP_CALLS is "false"
+      Given BLOCK_LOCAL_HTTP_CALLS is "false"
+      And an HTTP node with url=http://169.254.169.254/latest/meta-data/
+      When the engine invokes the node
+      Then the node's status is "error"
+      And the error.message contains "ssrf_blocked"
+
+    @unit
     Scenario: ALLOWED_PROXY_HOSTS allowlist permits explicitly-allowed hosts
-      Given ALLOWED_PROXY_HOSTS contains "127.0.0.1,internal-mock.test"
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS contains "127.0.0.1,internal-mock.test"
       And an HTTP node with url=http://127.0.0.1:9001/echo
       When the engine invokes the node
       Then the outbound connection is attempted
@@ -147,7 +165,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Non-2xx responses fail the node by default
 
-    @integration @unimplemented
+    @integration
     Scenario Outline: status >= 400 fails the node and the body is captured for diagnostics
       Given an HTTP node calling an upstream that returns <status>
       When the engine invokes the node
@@ -166,7 +184,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Parity with Python http_node executor
 
-    @integration @parity @unimplemented
+    @integration @parity
     Scenario: same template + auth + JSONPath produce identical observed-by-upstream requests on Go and Python
       Given a fixture HTTP workflow at tests/fixtures/workflows/http_only.json
       And a recording mock upstream

--- a/specs/nlp-go/http-block.feature
+++ b/specs/nlp-go/http-block.feature
@@ -12,7 +12,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Method, URL, and content-type round-trip to upstream
 
-    @integration
+    @integration @unimplemented
     Scenario Outline: each HTTP method is forwarded with the configured headers and body
       Given an HTTP node configured with method=<method>, url=http://upstream/echo, headers={"X-Test":"yes"}
       And the body template "{\"q\":\"{{ input.question }}\"}" and content_type "application/json"
@@ -32,14 +32,14 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Body template renders Liquid expressions from upstream node outputs
 
-    @unit
+    @unit @unimplemented
     Scenario: a template references {{ upstream.field }} and renders the value
       Given an HTTP node with body template "Hello {{ upstream.name }}" and content_type "text/plain"
       And the upstream node output {"name": "World"}
       When the engine renders the body
       Then the rendered body equals "Hello World"
 
-    @unit
+    @unit @unimplemented
     Scenario: missing template variable renders as an empty string with a warning
       Given an HTTP node with body template "{{ upstream.missing }}"
       And the upstream node output {}
@@ -47,7 +47,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
       Then the rendered body equals ""
       And a warning log includes "template variable not found: upstream.missing"
 
-    @unit
+    @unit @unimplemented
     Scenario: arrays interpolate as JSON arrays inside JSON content_type bodies
       Given an HTTP node with body template "{\"ids\": {{ upstream.ids }}}" and content_type "application/json"
       And the upstream node output {"ids": [1,2,3]}
@@ -56,14 +56,14 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: JSONPath extracts the configured field from the response
 
-    @integration
+    @integration @unimplemented
     Scenario: output_path "$.data.first.name" extracts a nested field
       Given an HTTP node with output_path "$.data.first.name"
       And the upstream returns {"data": {"first": {"name": "Alice"}}}
       When the engine invokes the node
       Then the node's output equals {"value": "Alice"}
 
-    @integration
+    @integration @unimplemented
     Scenario: an output_path that matches nothing returns a node-level error
       Given an HTTP node with output_path "$.missing"
       And the upstream returns {"present": "value"}
@@ -71,7 +71,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
       Then the node's status is "error"
       And the error.message contains "jsonpath_no_match"
 
-    @integration
+    @integration @unimplemented
     Scenario: an output_path matching multiple values returns the array
       Given an HTTP node with output_path "$.items[*].id"
       And the upstream returns {"items": [{"id":1},{"id":2},{"id":3}]}
@@ -80,25 +80,25 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Auth schemes are applied to the outbound request
 
-    @integration
+    @integration @unimplemented
     Scenario: bearer auth attaches Authorization: Bearer <token>
       Given an HTTP node with auth {"type": "bearer", "token": "tok-abc"}
       When the engine invokes the node
       Then the upstream observed header "Authorization: Bearer tok-abc"
 
-    @integration
+    @integration @unimplemented
     Scenario: api_key auth attaches the configured header
       Given an HTTP node with auth {"type": "api_key", "header": "X-API-Key", "key": "secret-123"}
       When the engine invokes the node
       Then the upstream observed header "X-API-Key: secret-123"
 
-    @integration
+    @integration @unimplemented
     Scenario: basic auth attaches Authorization: Basic <base64>
       Given an HTTP node with auth {"type": "basic", "username": "u", "password": "p"}
       When the engine invokes the node
       Then the upstream observed header matching `^Authorization: Basic dTpw$`
 
-    @integration
+    @integration @unimplemented
     Scenario: secret references resolve at request time, not at parse time
       Given an HTTP node with auth {"type": "bearer", "token": "{{ secrets.UPSTREAM_TOKEN }}"}
       And the project has secret UPSTREAM_TOKEN="rotated-value"
@@ -108,7 +108,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Timeout aborts the request and reports an error
 
-    @integration
+    @integration @unimplemented
     Scenario: a request exceeding timeout_ms returns a node error within the budget
       Given an HTTP node with timeout_ms=500
       And an upstream that delays 5 seconds before responding
@@ -119,7 +119,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
   Rule: SSRF protection is governed by BLOCK_LOCAL_HTTP_CALLS (cloud metadata always blocked)
     See specs/security/ssrf-blocking.feature for the cross-service contract.
 
-    @unit
+    @unit @unimplemented
     Scenario Outline: blocked destinations return ssrf_blocked when BLOCK_LOCAL_HTTP_CALLS is "true"
       Given BLOCK_LOCAL_HTTP_CALLS is "true"
       And an HTTP node with url=<url>
@@ -139,14 +139,14 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
         | http://192.168.1.1/                              |
         | http://[::1]/                                    |
 
-    @unit
+    @unit @unimplemented
     Scenario: BLOCK_LOCAL_HTTP_CALLS unset allows local destinations (default permissive)
       Given BLOCK_LOCAL_HTTP_CALLS is unset
       And an HTTP node with url=http://127.0.0.1:9001/echo
       When the engine invokes the node
       Then the outbound connection is attempted
 
-    @unit
+    @unit @unimplemented
     Scenario: cloud metadata is blocked even when BLOCK_LOCAL_HTTP_CALLS is "false"
       Given BLOCK_LOCAL_HTTP_CALLS is "false"
       And an HTTP node with url=http://169.254.169.254/latest/meta-data/
@@ -154,7 +154,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
       Then the node's status is "error"
       And the error.message contains "ssrf_blocked"
 
-    @unit
+    @unit @unimplemented
     Scenario: ALLOWED_PROXY_HOSTS allowlist permits explicitly-allowed hosts
       Given BLOCK_LOCAL_HTTP_CALLS is "true"
       And ALLOWED_PROXY_HOSTS contains "127.0.0.1,internal-mock.test"
@@ -165,7 +165,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Non-2xx responses fail the node by default
 
-    @integration
+    @integration @unimplemented
     Scenario Outline: status >= 400 fails the node and the body is captured for diagnostics
       Given an HTTP node calling an upstream that returns <status>
       When the engine invokes the node
@@ -184,7 +184,7 @@ Feature: HTTP block — call an external endpoint with templated body and JSONPa
 
   Rule: Parity with Python http_node executor
 
-    @integration @parity
+    @integration @parity @unimplemented
     Scenario: same template + auth + JSONPath produce identical observed-by-upstream requests on Go and Python
       Given a fixture HTTP workflow at tests/fixtures/workflows/http_only.json
       And a recording mock upstream

--- a/specs/security/ssrf-blocking.feature
+++ b/specs/security/ssrf-blocking.feature
@@ -1,0 +1,193 @@
+Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
+  As a self-hosted operator or LangWatch SaaS administrator
+  I want a single, explicit env var to control whether outbound HTTP calls
+  to private/local networks are blocked across both the TypeScript app and
+  the Python NLP service
+  So that I can either reach internal services on-prem (toggle off) or
+  enforce SSRF protection on multi-tenant SaaS (toggle on) without relying
+  on indirect signals like NODE_ENV or IS_SAAS.
+
+  Implementations:
+    - TS: langwatch/src/utils/ssrfProtection.ts (httpProxyRouter, scenario runner)
+    - Python: langwatch_nlp/langwatch_nlp/studio/execute/http_node.py
+
+  # ============================================================================
+  # Default behavior — toggle unset/false
+  # ============================================================================
+
+  Rule: When BLOCK_LOCAL_HTTP_CALLS is unset or false, local network calls succeed
+    The default is permissive so on-prem operators can reach internal services
+    out of the box. SaaS deployments must opt in by setting the var to true.
+
+    @unit
+    Scenario Outline: <impl> allows private IP literals when BLOCK_LOCAL_HTTP_CALLS is unset
+      Given BLOCK_LOCAL_HTTP_CALLS is unset
+      When <impl> validates a URL with hostname <hostname>
+      Then the validation passes
+      And no SSRF block error is raised
+
+      Examples:
+        | impl   | hostname    |
+        | TS     | 10.0.5.3    |
+        | TS     | 192.168.1.1 |
+        | TS     | 127.0.0.1   |
+        | TS     | localhost   |
+        | Python | 10.0.5.3    |
+        | Python | 192.168.1.1 |
+        | Python | 127.0.0.1   |
+        | Python | localhost   |
+
+    @unit
+    Scenario Outline: <impl> allows private IP literals when BLOCK_LOCAL_HTTP_CALLS is "false"
+      Given BLOCK_LOCAL_HTTP_CALLS is "false"
+      When <impl> validates a URL with hostname 10.0.0.5
+      Then the validation passes
+
+      Examples:
+        | impl   |
+        | TS     |
+        | Python |
+
+  # ============================================================================
+  # Enabled behavior — toggle true
+  # ============================================================================
+
+  Rule: When BLOCK_LOCAL_HTTP_CALLS is true, local network calls are blocked
+    Both implementations block private IPv4, IPv6, loopback, link-local, and
+    hostnames that DNS-resolve to those ranges.
+
+    @unit
+    Scenario Outline: <impl> blocks private IP literals when BLOCK_LOCAL_HTTP_CALLS is "true"
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS is empty
+      When <impl> validates a URL with hostname <hostname>
+      Then the validation fails with an SSRF block error
+
+      Examples:
+        | impl   | hostname    |
+        | TS     | 127.0.0.1   |
+        | TS     | 10.0.5.3    |
+        | TS     | 192.168.1.1 |
+        | TS     | 0.0.0.0     |
+        | TS     | localhost   |
+        | TS     | ::1         |
+        | Python | 127.0.0.1   |
+        | Python | 10.0.5.3    |
+        | Python | 192.168.1.1 |
+        | Python | 0.0.0.0     |
+        | Python | localhost   |
+        | Python | ::1         |
+
+    @unit
+    Scenario Outline: <impl> blocks DNS rebinding to private IPs when BLOCK_LOCAL_HTTP_CALLS is "true"
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And the hostname "internal.example.com" resolves to 10.0.5.3
+      When <impl> validates "http://internal.example.com/"
+      Then the validation fails with an SSRF block error
+
+      Examples:
+        | impl   |
+        | TS     |
+        | Python |
+
+  # ============================================================================
+  # Allowlist — same semantics on both sides
+  # ============================================================================
+
+  Rule: ALLOWED_PROXY_HOSTS is a literal hostname allowlist evaluated regardless of NODE_ENV
+    Match is case-insensitive on hostname only (port is ignored). Matches bypass
+    private-IP/localhost checks. Cloud metadata is NEVER bypassed.
+
+    @unit
+    Scenario Outline: <impl> allows allowlisted host even when BLOCK_LOCAL_HTTP_CALLS is "true"
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS is "10.0.5.3,internal.example.com"
+      When <impl> validates a URL with hostname 10.0.5.3
+      Then the validation passes
+
+      Examples:
+        | impl   |
+        | TS     |
+        | Python |
+
+    @unit
+    Scenario Outline: <impl> allowlist works in production NODE_ENV
+      Given NODE_ENV is "production"
+      And BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS is "10.0.5.3"
+      When <impl> validates "http://10.0.5.3/api"
+      Then the validation passes
+
+      Examples:
+        | impl   |
+        | TS     |
+        | Python |
+
+    @unit
+    Scenario Outline: <impl> hostname not in allowlist is still blocked
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS is "10.0.5.3"
+      When <impl> validates "http://10.0.5.4/"
+      Then the validation fails with an SSRF block error
+
+      Examples:
+        | impl   |
+        | TS     |
+        | Python |
+
+  # ============================================================================
+  # Cloud metadata — ALWAYS blocked, no escape
+  # ============================================================================
+
+  Rule: Cloud metadata endpoints are always blocked, regardless of toggle or allowlist
+    These endpoints expose IAM credentials and are never legitimately needed by
+    user workflows. Both implementations refuse them unconditionally.
+
+    @unit
+    Scenario Outline: <impl> blocks cloud metadata even when BLOCK_LOCAL_HTTP_CALLS is "false"
+      Given BLOCK_LOCAL_HTTP_CALLS is "false"
+      When <impl> validates a URL with hostname <metadata_host>
+      Then the validation fails with a metadata security error
+
+      Examples:
+        | impl   | metadata_host           |
+        | TS     | 169.254.169.254         |
+        | TS     | metadata.google.internal |
+        | Python | 169.254.169.254         |
+        | Python | metadata.google.internal |
+
+    @unit
+    Scenario Outline: <impl> blocks cloud metadata even when host is in ALLOWED_PROXY_HOSTS
+      Given BLOCK_LOCAL_HTTP_CALLS is "true"
+      And ALLOWED_PROXY_HOSTS contains "169.254.169.254"
+      When <impl> validates "http://169.254.169.254/latest/meta-data/"
+      Then the validation fails with a metadata security error
+
+      Examples:
+        | impl   |
+        | TS     |
+        | Python |
+
+  # ============================================================================
+  # Migration — IS_SAAS no longer drives SSRF blocking
+  # ============================================================================
+
+  Rule: IS_SAAS does not influence SSRF blocking
+    IS_SAAS continues to control license enforcement, billing, and TLS
+    self-signed-cert behavior, but it no longer gates private-IP blocking.
+    Operators must set BLOCK_LOCAL_HTTP_CALLS explicitly.
+
+    @unit
+    Scenario: TS validator ignores IS_SAAS for SSRF blocking
+      Given IS_SAAS is "true"
+      And BLOCK_LOCAL_HTTP_CALLS is unset
+      When the TS validator processes "http://10.0.5.3/"
+      Then the validation passes
+      And no SSRF block error is raised
+
+    @unit
+    Scenario: TS validator with explicit BLOCK_LOCAL_HTTP_CALLS overrides any IS_SAAS state
+      Given IS_SAAS is "false"
+      And BLOCK_LOCAL_HTTP_CALLS is "true"
+      When the TS validator processes "http://10.0.5.3/"
+      Then the validation fails with an SSRF block error

--- a/specs/security/ssrf-blocking.feature
+++ b/specs/security/ssrf-blocking.feature
@@ -110,7 +110,7 @@ Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
         | TS     |
         | Python |
 
-    @unit @unimplemented
+    @unit
     Scenario Outline: <impl> allowlist works in production NODE_ENV
       Given NODE_ENV is "production"
       And BLOCK_LOCAL_HTTP_CALLS is "true"
@@ -177,7 +177,7 @@ Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
     self-signed-cert behavior, but it no longer gates private-IP blocking.
     Operators must set BLOCK_LOCAL_HTTP_CALLS explicitly.
 
-    @unit @unimplemented
+    @unit
     Scenario: TS validator ignores IS_SAAS for SSRF blocking
       Given IS_SAAS is "true"
       And BLOCK_LOCAL_HTTP_CALLS is unset
@@ -185,7 +185,7 @@ Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
       Then the validation passes
       And no SSRF block error is raised
 
-    @unit @unimplemented
+    @unit
     Scenario: TS validator with explicit BLOCK_LOCAL_HTTP_CALLS overrides any IS_SAAS state
       Given IS_SAAS is "false"
       And BLOCK_LOCAL_HTTP_CALLS is "true"

--- a/specs/security/ssrf-blocking.feature
+++ b/specs/security/ssrf-blocking.feature
@@ -110,7 +110,7 @@ Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
         | TS     |
         | Python |
 
-    @unit
+    @unit @unimplemented
     Scenario Outline: <impl> allowlist works in production NODE_ENV
       Given NODE_ENV is "production"
       And BLOCK_LOCAL_HTTP_CALLS is "true"
@@ -177,7 +177,7 @@ Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
     self-signed-cert behavior, but it no longer gates private-IP blocking.
     Operators must set BLOCK_LOCAL_HTTP_CALLS explicitly.
 
-    @unit
+    @unit @unimplemented
     Scenario: TS validator ignores IS_SAAS for SSRF blocking
       Given IS_SAAS is "true"
       And BLOCK_LOCAL_HTTP_CALLS is unset
@@ -185,7 +185,7 @@ Feature: SSRF blocking via BLOCK_LOCAL_HTTP_CALLS toggle (TS + Python parity)
       Then the validation passes
       And no SSRF block error is raised
 
-    @unit
+    @unit @unimplemented
     Scenario: TS validator with explicit BLOCK_LOCAL_HTTP_CALLS overrides any IS_SAAS state
       Given IS_SAAS is "false"
       And BLOCK_LOCAL_HTTP_CALLS is "true"


### PR DESCRIPTION
## Summary

Single env var (`BLOCK_LOCAL_HTTP_CALLS`) now controls outbound private-network blocking across both the TypeScript app and the Python NLP service. Replaces an inconsistent setup where the TS side gated blocking on `IS_SAAS` (and only honored `ALLOWED_PROXY_HOSTS` in `NODE_ENV=development`), while the Python side always blocked unconditionally.

### Behavior matrix

| `BLOCK_LOCAL_HTTP_CALLS` | `ALLOWED_PROXY_HOSTS`   | Cloud metadata | Private IP / localhost                |
|--------------------------|-------------------------|----------------|---------------------------------------|
| unset / `"false"`        | (any)                   | blocked        | allowed                               |
| `"true"`                 | empty                   | blocked        | blocked                               |
| `"true"`                 | `"10.0.5.3,foo.local"`  | blocked        | allowed only for the listed hostnames |

- Cloud metadata (`169.254.169.254`, `metadata.google.internal`, etc.) is **always blocked**, regardless of toggle or allowlist (security-critical).
- `IS_SAAS` continues to control TLS `rejectUnauthorized` — separate concern, not changed by this PR.
- Allowlist is literal-hostname match (case-insensitive), identical semantics in TS and Python.

### Why default off

Self-hosted operators need to reach internal services out of the box. The previous TS default (`IS_SAAS` unset → blocking off) is preserved. Python becomes more permissive by default — this is intentional and explicitly requested.

### ⚠️ SaaS deployment ordering

This PR removes `IS_SAAS` from the SSRF code path. SaaS deployments **must** set `BLOCK_LOCAL_HTTP_CALLS=true` in terraform **before** this app code rolls out, otherwise SaaS becomes wide-open to private-network egress.

Companion: [langwatch-saas PR #483](https://github.com/langwatch/langwatch-saas/pull/483) updates both deployment paths:
- Legacy / prod: `langwatch.tf`, `langwatch_workers.tf`, `langwatch_nlp_lambda.tf`, `langwatch_nlp_k8s.tf`
- Runtime / dev+staging: `runtime/langwatch-config.tf`, `runtime/nlp-service.tf`, `runtime/modules/langwatch-nlp-lambda/main.tf`

**Merge / deploy order: terraform PR first → this PR second.**

## What changed

- `langwatch/src/utils/ssrfProtection.ts`: `SSRFConfig` now `{ blockLocal, allowedHosts }`. Allowlist works in any `NODE_ENV`. `IS_SAAS` no longer drives blocking. Renamed `SSRFDevelopmentBypassResult` → `SSRFUnresolvedResult` (`type: "unresolved"`).
- `langwatch/src/env-create.mjs`: adds `BLOCK_LOCAL_HTTP_CALLS` and `ALLOWED_PROXY_HOSTS` to the env schema.
- `langwatch_nlp/langwatch_nlp/studio/execute/http_node.py`: `_is_blocked_url` reads `BLOCK_LOCAL_HTTP_CALLS`. Toggle off → only metadata blocked. Toggle on → existing block logic (parity with TS).
- Tests: 87 TS unit tests pass (`ssrfProtection`), 12 Python tests pass (`TestHttpNodeSsrfProtection`), full router suite (163 tests) and scenario suite (392 tests) green.

## BDD specs

- New: `specs/security/ssrf-blocking.feature` — cross-service contract.
- Updated: `specs/features/scenarios/on-prem-hostname-validation.feature`, `specs/nlp-go/http-block.feature`.

## Test plan

- [x] `pnpm typecheck` (clean)
- [x] `pnpm test:unit src/utils/ssrfProtection*` — 87 passed
- [x] `pnpm test:unit src/server/api/routers` — 163 passed
- [x] `pnpm test:unit src/server/scenarios` — 392 passed
- [x] `pytest tests/studio/test_http_node_integration.py::TestHttpNodeSsrfProtection -v` — 12 passed
- [ ] Browser QA: HTTP node with toggle on (blocked) / off (allowed) / allowlisted (allowed)