### PR TITLE
fix(release): path-routed Release-As 3.2.1 to retarget #3605 (langwatch root)

### DIFF
--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -198,3 +198,10 @@ ENVIRONMENT=local
 # `release_ui_ai_gateway_menu_enabled` on the team's local envs + staging.
 # Checked BEFORE the PostHog call, so it's network-free.
 FEATURE_FLAG_FORCE_ENABLE=release_ui_ai_gateway_menu_enabled
+
+# npx-server (`npx @langwatch/server`) marker — written by the CLI on
+# install to record which NLP runtime was selected via the `--nlp` flag
+# (`go` default, or `python` for the legacy escape hatch). Read for
+# diagnosis only; the actual upstream routing is gated by the FF block
+# above. See packages/server/src/cli.ts (#3613).
+# LANGWATCH_NPX_NLP=go


### PR DESCRIPTION
## TL;DR

Path-routed \`Release-As: 3.2.1\` footer on a commit that touches a file under
the langwatch root component path (\`langwatch/.env.example\`). release-please-action
v4 reads file paths to scope footers to specific components — empty commits
broadcast (the bug from PR #3615), file-touching commits route correctly.

## Why this is needed

- PR #3615's \`ca9d7a923\` used an unqualified \`Release-As: 3.2.1\` on an empty
  commit. release-please-action v4 broadcast it to every NON-root component,
  inverse of intent.
- PR #3618's qualified-syntax footers (\`Release-As: langwatch@3.2.1\`) didn't
  work either — the v4 parser ignores \`<component>@<version>\` syntax entirely.
- This commit modifies a file under \`langwatch/\` (part of root component since
  not in the umbrella's \`exclude-paths\`), so release-please's per-component
  walk for \`.\` includes this commit and applies the \`Release-As: 3.2.1\` footer.

## What also happened

The 7 incorrectly retargeted component PRs (\`#3617 typescript-sdk\`,
\`#3484 skills\`, \`#3398 mcp-server\`, \`#3407 python-sdk\`,
\`#3037 clickhouse-serverless\`, \`#1936 sdk-go\`, \`#1597 langevals\`) have
all been closed via \`gh pr close\`. They'll regenerate organically when
their components have real pending releases.

## Bonus content (justifies a real change, not just a marker file)

The diff documents the \`LANGWATCH_NPX_NLP\` env var added in #3613 (the
\`--nlp=python|go\` escape hatch) so self-hosters reading the .env template
can see it. Real, useful doc.

## Expected outcome on merge

1. Push to main triggers \`release-please-sdks.yml\`.
2. release-please walks the \`.\` (root) component, sees this commit's
   \`Release-As: 3.2.1\` footer, applies it.
3. PR #3605 retargets \`3.3.0\` → \`3.2.1\`.
4. Merging #3605 ships **3.2.1**.

## Tech debt acknowledged

\`ca9d7a923\`'s broadcast footer stays in main's history forever. Until each
component cuts its next real release (clearing it from the scan window),
release-please will try to re-create wrongly-versioned PRs for those 7
components. Recovery is identical to this PR's recipe: a path-routed
\`Release-As:\` shadow when the time comes.

## Refs

- The bug: #3615 (broadcasting), #3618 (failed qualified-syntax fix)
- Workflow run that did the original damage: 25155512822
- Closed polluted PRs: #3617 #3484 #3398 #3407 #3037 #1936 #1597