### PR TITLE
fix(release): path-routed Release-As shadows for 6 polluted components

### DIFF
--- a/charts/clickhouse-serverless/.release-please-shim
+++ b/charts/clickhouse-serverless/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker — next: 0.3.0

--- a/langevals/.release-please-shim
+++ b/langevals/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker — next: 2.3.0

--- a/mcp-server/.release-please-shim
+++ b/mcp-server/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker — next: 0.8.0

--- a/python-sdk/.release-please-shim
+++ b/python-sdk/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker — next: 0.23.0

--- a/sdk-go/.release-please-shim
+++ b/sdk-go/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker — next: 0.3.0

--- a/skills/.release-please-shim
+++ b/skills/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker — next: 0.5.0

--- a/typescript-sdk/.release-please-shim
+++ b/typescript-sdk/.release-please-shim
@@ -1,0 +1,1 @@
+release-please shadow marker — next: 0.27.0


### PR DESCRIPTION
## Summary

Permanent fix for the broadcast bug from [#3615](https://github.com/langwatch/langwatch/pull/3615) (`Release-As: 3.2.1` unqualified footer in `ca9d7a923`). That footer leaks across every release-please scan and keeps regenerating wrong-version PRs for 7 components.

This PR pushes 7 path-routed commits — each touching a `.release-please-shim` file inside one component dir — with an UNqualified `Release-As: <correct-next-version>` footer. Path-routing + footer-newer-than-broadcast = each component's polluted PR retargets back to the right version.

## Per-component target

Each row = one commit in this PR.

| Component | Path | Polluted PR | Target version | Rationale |
|-----------|------|-------------|----------------|-----------|
| sdk-go | `sdk-go/` | #3620 | `0.3.0` | Pre-bug rp PR target (julia's snapshot) |
| mcp-server | `mcp-server/` | #3621 | `0.8.0` | Pre-bug rp PR target |
| charts/clickhouse-serverless | `charts/clickhouse-serverless/` | #3622 | `0.3.0` | Pre-bug rp PR target |
| skills | `skills/` | #3623 | `0.5.0` | Pre-bug rp PR target |
| **typescript-sdk** | `typescript-sdk/` | #3624 | `0.27.0` | **No pre-bug rp PR** existed — set to last released to signal "no release intended" (Option A per @rchaves) |
| python-sdk | `python-sdk/` | #3625 | `0.23.0` | Pre-bug rp PR target |
| langevals | `langevals/` | #3626 | `2.3.0` | Pre-bug rp PR target |

## Why path-routed + unqualified

We learned the hard way ([#3618](https://github.com/langwatch/langwatch/pull/3618)):
- `Release-As: <component>@<version>` qualified syntax is parsed-and-ignored by release-please-action v4 / release-please 17.1.3
- Empty commits with unqualified `Release-As:` get GLOBAL-broadcast across all components except the root one (the original bug)
- A commit that touches files inside a component's path → release-please's per-component scan walks it → unqualified `Release-As:` applies ONLY to that component

The `.release-please-shim` file exists solely to give each commit a path inside the target component's dir.

## Mechanism

For each polluted PR:
1. release-please's next scan walks commits since each component's last release tag
2. Walks include ca9d7a923's broadcast footer (`3.2.1`) AND our new shadow footer (`<target>`)
3. Latest footer wins → `<target>` is the next release version
4. PR title flips from "release X 3.2.1" back to "release X `<target>`"

For #3624 typescript-sdk specifically (Option A): `Release-As: 0.27.0` matches last-released, so release-please should close the PR cleanly (no diff to release).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, release-please-sdks workflow runs
- [ ] All 7 polluted PRs (#3620–#3626) flip to their target versions OR close
- [ ] No new wrong PRs regenerated