### PR TITLE
fix(release): self-heal Chart.lock on push to main when rp PR-time sync races

### DIFF
--- a/.github/workflows/release-please-chart-lock-sync.yml
+++ b/.github/workflows/release-please-chart-lock-sync.yml
@@ -25,6 +25,19 @@ on:
     paths:
       - "charts/gateway/Chart.yaml"
       - "charts/langwatch/Chart.yaml"
+  # Self-heal on push to main. The PR-time lock-sync (above) is the
+  # primary path, but it can race-lose: if release-please bumps Chart.yaml
+  # and the rp PR is merged before the runner queue picks the workflow up,
+  # the lock-sync runs against a deleted branch and never recovers. This
+  # second trigger catches that case by regenerating Chart.lock directly
+  # on main when the on-disk gateway/Chart.yaml drifts past Chart.lock.
+  # paths-ignore on Chart.lock prevents this job's own commit from
+  # re-triggering the workflow.
+  push:
+    branches: [main]
+    paths:
+      - "charts/gateway/Chart.yaml"
+      - "charts/langwatch/Chart.yaml"
 
 permissions:
   contents: write
@@ -38,6 +51,7 @@ jobs:
     # acquire write access. Release-please-action only opens PRs from inside
     # the upstream repo, so this is the right tightening.
     if: |
+      github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.head_ref, 'release-please--branches--main--components--langwatch')
     steps:
@@ -78,4 +92,49 @@ jobs:
           fi
           git add charts/langwatch/Chart.lock
           git commit -m "chore(charts): regenerate Chart.lock for release"
+          git push
+
+  # Defense-in-depth: regenerate Chart.lock directly on main when an rp PR
+  # was merged before the PR-time lock-sync could run. Triggered by the
+  # `push: branches: [main]` filter above. GITHUB_TOKEN suffices here —
+  # we don't need to re-trigger downstream workflows because the chart
+  # CI already runs on the same push event that originally created the
+  # drift, and our follow-up push of Chart.lock will trigger another
+  # chart CI run via its own push trigger.
+  sync-main:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.12.0
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo update
+
+      - name: Regenerate Chart.lock
+        run: helm dependency update charts/langwatch
+
+      - name: Discard downloaded sub-chart archives
+        run: rm -rf charts/langwatch/charts
+
+      - name: Commit + push if Chart.lock drifted
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- charts/langwatch/Chart.lock; then
+            echo "→ Chart.lock already in sync with on-disk Chart.yaml, nothing to push"
+            exit 0
+          fi
+          git add charts/langwatch/Chart.lock
+          git commit -m "chore(charts): self-heal Chart.lock post-merge"
           git push


### PR DESCRIPTION
## Summary

Defense-in-depth for `release-please-chart-lock-sync.yml`: adds a `push: branches: [main]` trigger + `sync-main` job that regenerates Chart.lock on main when the existing PR-time sync loses a race against a fast merge.

## Why

Today's 3.2.1 release hit this race. Sequence (run [25159315642](https://github.com/langwatch/langwatch/actions/runs/25159315642)):

| Time (UTC) | Event |
|------------|-------|
| 09:59:39 | release-please updates #3605 with charts/gateway/Chart.yaml 3.2.0 → 3.2.1 → lock-sync workflow QUEUED |
| 10:01:37 | #3605 merged manually, branch deleted |
| 10:05:28 | lock-sync workflow finally STARTS (6-min runner queue) |
| 10:05:30 | `actions/checkout@v4` tries to fetch deleted PR branch → fails |
| Result | Chart.lock never regenerated. Main has gateway 3.2.1 in Chart.yaml + 3.2.0 in Chart.lock + stale digest. Every chart workflow fails: `can't get a valid version for dependency langwatch-gateway` |

Recovery required a manual `helm dependency update` + direct admin push (commit [a80c98fca](https://github.com/langwatch/langwatch/commit/a80c98fca)).

## Fix

New `sync-main` job (push trigger, GITHUB_TOKEN, paths-filter excludes Chart.lock to prevent loop):

1. Checkout main
2. `helm dependency update charts/langwatch`
3. If Chart.lock changed → commit + push to main
4. Else → exit cleanly (no-op fast path)

## Notes

- **No loop**: the workflow's own commit only touches Chart.lock, which isn't in the paths filter, so it can't re-trigger.
- **Token choice**: GITHUB_TOKEN over PAT — we don't need to re-trigger downstream workflows from main; chart CI is already running on the same push event that created the drift, and the Chart.lock follow-up will trigger another chart-CI run via its own push trigger.
- **Existing PR-time job unchanged behaviorally**; just refactored `if:` to explicitly gate on `pull_request_target` so the new push events don't fall through.

## Test plan

- [ ] Workflow YAML lints
- [ ] On next rp PR for langwatch (whenever 3.2.2 etc. is released), verify the PR-time sync still fires correctly (no regression)
- [ ] If the PR-time sync ever races again, verify `sync-main` self-heals on the post-merge push

cc @rchaves @julia