### PR TITLE
fix(nlp-ci): cap gpt-5-mini reasoning tokens in integration tests

### DIFF
--- a/langwatch_nlp/tests/studio/test_workflow_parse_and_execution.py
+++ b/langwatch_nlp/tests/studio/test_workflow_parse_and_execution.py
@@ -41,6 +41,11 @@ llm_field = Field(
         model="gpt-5-mini",
         temperature=0.0,
         max_tokens=100,
+        # reasoning="minimal" caps gpt-5-mini's reasoning tokens in CI. Without it,
+        # `get_corrected_llm_params` bumps max_tokens to 16000 (DSPy minimum for
+        # reasoning models) and default-medium reasoning bills multi-thousand
+        # output tokens per call at $2/1M, dominating the OpenAI bill.
+        reasoning="minimal",
     ),
     desc=None,
 )
@@ -983,7 +988,7 @@ def test_parse_workflow_with_default_llm():
 
     workflow = copy.deepcopy(simple_workflow)
     workflow.default_llm = LLMConfig(
-        model="gpt-5-mini", temperature=0.0, max_tokens=100
+        model="gpt-5-mini", temperature=0.0, max_tokens=100, reasoning="minimal"
     )
 
     generate_query_node = next(
@@ -1303,7 +1308,12 @@ def test_proposes_instructions_with_grounded_proposer():
         from dspy.propose.grounded_proposer import GroundedProposer
 
         proposer = GroundedProposer(
-            prompt_model=dspy.LM(model="openai/gpt-5-mini"),
+            prompt_model=dspy.LM(
+                model="openai/gpt-5-mini",
+                max_tokens=16000,
+                temperature=1.0,
+                reasoning_effort="minimal",
+            ),
             program=instance,
             trainset=[],
         )


### PR DESCRIPTION
## Why

`langwatch-nlp-ci` was burning ~\$12.86/day on OpenAI while every other CI key on the same org sat at <\$1. The integration suite uses `gpt-5-mini` per the CLAUDE.md rule, so this looked surprising at first.

The cause is mechanical:

- `gpt-5-mini` is a reasoning model.
- `get_corrected_llm_params` (`langwatch_nlp/studio/utils.py:432`) auto-bumps `max_tokens` from the test fixture's `100` up to `16000` (DSPy's required minimum for reasoning models). The fixture's budget is silently overridden.
- Default `reasoning_effort` is `"medium"`, so each call emits multi-thousand reasoning tokens at \$2.00/1M output.
- Across ~12 PR/main runs/day × ~10–20 LLM calls/run, that lines up with the \$12.86/day we're seeing.

## What

Set `reasoning="minimal"` on:

- The shared `llm_field` fixture used by every active `@pytest.mark.integration` test in `test_workflow_parse_and_execution.py`.
- The two `LLMConfig`/`dspy.LM` instances built inline in xfail-but-still-executed tests in the same file (`test_parse_workflow_with_default_llm`, `test_proposes_instructions_with_grounded_proposer`).

`reasoning` is the canonical field on `LLMConfig`; `normalize_reasoning_from_provider_fields` + `map_reasoning_to_provider` translate it to `reasoning_effort=minimal` on the LiteLLM call (verified locally — `dspy.LM` ends up with `temperature=1.0, max_tokens=16000, reasoning_effort=minimal`).

Model choice is unchanged — still `gpt-5-mini` per CLAUDE.md. Only the reasoning depth is dialed down for these CI tests, where the assertions check workflow plumbing (e.g. \"Paris\" appears in output) and don't need medium-effort reasoning.

## Expected impact

Reasoning tokens drop from multi-K to ~0 per call. Bill should fall ~10–20×, in line with the other CI keys.

## Test plan

- [ ] Local: `pytest --collect-only` collects all 17 tests cleanly (verified).
- [ ] Local: `LLMConfig(... reasoning="minimal")` round-trips through `node_llm_config_to_dspy_lm` to `reasoning_effort=minimal` (verified).
- [ ] On merge: watch the next 24h on the OpenAI dashboard for `langwatch-nlp-ci` — should drop from ~\$12/day to ~cents.