### PR TITLE
fix(ci): split OpenAI keys per workflow + drop sdk examples to gpt-5-mini

### DIFF
--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run tests
         working-directory: langevals
         env:
-          OPENAI_API_KEY: ${{ secrets.PYTHON_SDK_OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.LANGEVALS_OPENAI_API_KEY }}
           AZURE_API_KEY: ${{ secrets.PYTHON_SDK_AZURE_OPENAI_API_KEY }}
           AZURE_API_BASE: ${{ secrets.PYTHON_SDK_AZURE_OPENAI_ENDPOINT }}
           AZURE_CONTENT_SAFETY_ENDPOINT: ${{ secrets.LANGEVALS_AZURE_CONTENT_SAFETY_ENDPOINT }}

--- a/.github/workflows/langwatch-nlp-ci.yml
+++ b/.github/workflows/langwatch-nlp-ci.yml
@@ -134,7 +134,7 @@ jobs:
         if: github.actor != 'dependabot[bot]' || github.event_name == 'pull_request_target'
         working-directory: langwatch_nlp
         env:
-          OPENAI_API_KEY: ${{ secrets.PYTHON_SDK_OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.LANGWATCH_NLP_OPENAI_API_KEY }}
           AZURE_OPENAI_ENDPOINT: ${{ secrets.PYTHON_SDK_AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY: ${{ secrets.PYTHON_SDK_AZURE_OPENAI_API_KEY }}
         run: make test-integration

--- a/python-sdk/examples/cli/guaranteed_availability_with_cli.py
+++ b/python-sdk/examples/cli/guaranteed_availability_with_cli.py
@@ -125,7 +125,7 @@ def main():
 
             print(f"   Model: {prompt.model}")  # from the prompt data itself
             assert (
-                prompt.model == "openai/gpt-5"
+                prompt.model == "openai/gpt-5-mini"
             ), "Prompt model should be openai/gpt-4o-mini"
 
             # 5. Test compile the prompt

--- a/python-sdk/examples/cli/guaranteed_availability_with_cli.py
+++ b/python-sdk/examples/cli/guaranteed_availability_with_cli.py
@@ -125,8 +125,8 @@ def main():
 
             print(f"   Model: {prompt.model}")  # from the prompt data itself
             assert (
-                prompt.model == "openai/gpt-5-mini"
-            ), "Prompt model should be openai/gpt-4o-mini"
+                prompt.model == "openai/gpt-5"
+            ), "Prompt model should match the langwatch CLI's default (openai/gpt-5 — see typescript-sdk/src/cli/commands/create.ts)"
 
             # 5. Test compile the prompt
             print("\n5️⃣ Test compile the prompt")

--- a/python-sdk/examples/custom_evaluation_bot.py
+++ b/python-sdk/examples/custom_evaluation_bot.py
@@ -20,7 +20,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",
@@ -45,7 +45,7 @@ async def main(message: cl.Message):
 @langwatch.span(type="evaluation")
 def useful_message_evaluation(question: str, answer: str):
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/documentation/openai_langwatch.py
+++ b/python-sdk/examples/documentation/openai_langwatch.py
@@ -15,7 +15,7 @@ async def get_openai_chat_response(user_prompt: str):
 
     # All calls made with 'client' will now be automatically captured as spans
     response = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[{"role": "user", "content": user_prompt}],
     )
     completion = response.choices[0].message.content

--- a/python-sdk/examples/evaluation_manual_call.py
+++ b/python-sdk/examples/evaluation_manual_call.py
@@ -20,7 +20,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/generic_bot_span_low_level.py
+++ b/python-sdk/examples/generic_bot_span_low_level.py
@@ -23,7 +23,7 @@ async def main(message: cl.Message):
             input=message.content,
         ) as span:
             with span.span(
-                type="llm", input=message.content, model="openai/gpt-5"
+                type="llm", input=message.content, model="openai/gpt-5-mini"
             ) as nested_span:
                 time.sleep(1)  # generating the message...
                 generated_message = "Hello there! How can I help from low level?"

--- a/python-sdk/examples/guardrails.py
+++ b/python-sdk/examples/guardrails.py
@@ -36,7 +36,7 @@ async def main(message: cl.Message):
         return
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/guardrails_without_tracing.py
+++ b/python-sdk/examples/guardrails_without_tracing.py
@@ -28,7 +28,7 @@ async def main(message: cl.Message):
         return
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/haystack_bot.py
+++ b/python-sdk/examples/haystack_bot.py
@@ -99,7 +99,7 @@ class TrackedOpenAIGenerator(OpenAIGenerator):
 
 
 llm = TrackedOpenAIGenerator(
-    api_key=Secret.from_token(os.environ["OPENAI_API_KEY"]), model="gpt-5"
+    api_key=Secret.from_token(os.environ["OPENAI_API_KEY"]), model="gpt-5-mini"
 )
 
 rag_pipeline = Pipeline()

--- a/python-sdk/examples/langchain_bot_with_memory.py
+++ b/python-sdk/examples/langchain_bot_with_memory.py
@@ -28,7 +28,7 @@ async def on_chat_start():
             ("human", "{input}"),
         ]
     )
-    llm = ChatOpenAI(temperature=1, model="gpt-5", max_tokens=4096)
+    llm = ChatOpenAI(temperature=1, model="gpt-5-mini", max_tokens=4096)
     runnable = prompt | llm
 
     cl.user_session.set("runnable", runnable)

--- a/python-sdk/examples/langchain_rag_bot.py
+++ b/python-sdk/examples/langchain_rag_bot.py
@@ -45,7 +45,7 @@ async def on_chat_start():
     # )
 
     tools = [retriever_tool]
-    model = ChatOpenAI(model="gpt-5", streaming=True)
+    model = ChatOpenAI(model="gpt-5-mini", streaming=True)
 
     agent = create_agent(
         model=model,

--- a/python-sdk/examples/openai_bot.py
+++ b/python-sdk/examples/openai_bot.py
@@ -22,7 +22,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/openai_bot_disable_trace.py
+++ b/python-sdk/examples/openai_bot_disable_trace.py
@@ -21,7 +21,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/openai_bot_function_call.py
+++ b/python-sdk/examples/openai_bot_function_call.py
@@ -30,7 +30,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",
@@ -71,7 +71,7 @@ async def main(message: cl.Message):
     weather = get_weather(weather_call["city"])
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/openai_bot_max_string_length.py
+++ b/python-sdk/examples/openai_bot_max_string_length.py
@@ -19,7 +19,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/openai_bot_max_string_length_none.py
+++ b/python-sdk/examples/openai_bot_max_string_length_none.py
@@ -22,7 +22,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/openai_bot_otel_metrics.py
+++ b/python-sdk/examples/openai_bot_otel_metrics.py
@@ -42,7 +42,7 @@ time_to_first_token_hist = meter.create_histogram(
 async def do_call_llm(content: str, msg):
     start_time = time.time()
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",
@@ -85,5 +85,5 @@ def record_first_token_latency(milliseconds: float):
     seconds = milliseconds / 1000.0
     print(f"Record first token latency: {seconds} seconds")
     time_to_first_token_hist.record(
-        seconds, attributes={"model": "gpt-5", "request.status": "success"}
+        seconds, attributes={"model": "gpt-5-mini", "request.status": "success"}
     )

--- a/python-sdk/examples/openai_bot_rag.py
+++ b/python-sdk/examples/openai_bot_rag.py
@@ -55,7 +55,7 @@ async def main(message: cl.Message):
     contexts = rag_retrieval(message.content)
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/openai_bot_sampling_rate.py
+++ b/python-sdk/examples/openai_bot_sampling_rate.py
@@ -21,7 +21,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/opentelemetry/openinference_haystack.py
+++ b/python-sdk/examples/opentelemetry/openinference_haystack.py
@@ -48,7 +48,7 @@ Answer:
 retriever = InMemoryBM25Retriever(document_store=document_store)
 prompt_builder = PromptBuilder(template=prompt_template)
 llm = OpenAIGenerator(
-    api_key=Secret.from_token(os.environ["OPENAI_API_KEY"]), model="gpt-5"
+    api_key=Secret.from_token(os.environ["OPENAI_API_KEY"]), model="gpt-5-mini"
 )
 
 rag_pipeline = Pipeline()

--- a/python-sdk/examples/opentelemetry/openinference_openai_bot.py
+++ b/python-sdk/examples/opentelemetry/openinference_openai_bot.py
@@ -31,7 +31,7 @@ async def main(message: cl.Message):
         metadata={"foo": "bar"},
     ):
         completion = client.chat.completions.create(
-            model="gpt-5",
+            model="gpt-5-mini",
             messages=[
                 {
                     "role": "system",

--- a/python-sdk/examples/opentelemetry/openllmetry_openai_bot.py
+++ b/python-sdk/examples/opentelemetry/openllmetry_openai_bot.py
@@ -26,7 +26,7 @@ async def main(message: cl.Message):
     )
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",

--- a/python-sdk/examples/sanity/setup_example.py
+++ b/python-sdk/examples/sanity/setup_example.py
@@ -42,7 +42,7 @@ class Question(BaseModel):
 
 def stream_openai_response(question: str):
     response = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[{"role": "user", "content": question}],
         stream=True,
         stream_options={"include_usage": True},

--- a/python-sdk/examples/span_evaluation.py
+++ b/python-sdk/examples/span_evaluation.py
@@ -33,7 +33,7 @@ class GetBioInfoList(BaseModel):
 
 async def extract_structured_user_bios(user_bios: list[str]) -> GetBioInfoList:
     completion = client.beta.chat.completions.parse(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",
@@ -53,7 +53,7 @@ async def extract_structured_user_bios(user_bios: list[str]) -> GetBioInfoList:
         output=str(get_bio_info_list),
         contexts=user_bios,
         settings={
-            "model": "openai/gpt-5",
+            "model": "openai/gpt-5-mini",
             "embeddings_model": "openai/text-embedding-ada-002",
             "max_tokens": 2048,
         },
@@ -71,7 +71,7 @@ async def generate_and_execute_code(
     msg: cl.Message, question: str, bio_info_list: GetBioInfoList
 ) -> tuple[str, str]:
     completion = client.beta.chat.completions.parse(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "system",
@@ -156,7 +156,7 @@ async def answer_user(
     result: str,
 ):
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5-mini",
         messages=[
             {
                 "role": "user",
@@ -211,7 +211,7 @@ async def main(message: cl.Message):
         output=answer,
         expected_output="Rogerio",
         settings={
-            "model": "openai/gpt-5",
+            "model": "openai/gpt-5-mini",
             "embeddings_model": "openai/text-embedding-ada-002",
             "max_tokens": 2048,
         },


### PR DESCRIPTION
## Why

The OpenAI usage for the key labeled \`langwatch-nlp-ci\` was ~\$14/day, with **gpt-5 (full) output alone at \$13.94**. My first hypothesis was a gpt-5-mini reasoning-token issue — that turned out to be wrong (closed #3638).

Two real problems:

1. **Three workflows shared one OpenAI key.** \`PYTHON_SDK_OPENAI_API_KEY\` was wired into \`sdk-python-ci\`, \`langevals-ci\`, **and** \`langwatch-nlp-ci\`. The dashboard label was effectively a lie — it was the sum of all three jobs.
2. **\`python-sdk/examples/*\` hardcoded \`model=\"gpt-5\"\`.** \`sdk-python-ci\` runs \`make test-examples\` which imports each example and executes its \`main()\`. With ~23 examples × multiple PR runs/day at \$10/1M output, this is where the money went.

## What

**Secret split** (set via \`gh secret set\`, ready before this merges):
- \`sdk-python-ci\` → \`PYTHON_SDK_OPENAI_API_KEY\` (rotated to fresh key)
- \`langevals-ci\` → \`LANGEVALS_OPENAI_API_KEY\` (new)
- \`langwatch-nlp-ci\` → \`LANGWATCH_NLP_OPENAI_API_KEY\` (new)

The previously shared key will be revoked after merge.

**Examples downgraded to gpt-5-mini** across all 23 files. Per the CLAUDE.md rule, \`gpt-5-mini\` is the standard model for fixtures/docs; nothing in these examples requires flagship reasoning.

## Expected impact

- OpenAI dashboard will show per-workflow spend (no more \"is it nlp or sdk?\" detective work).
- \`PYTHON_SDK_OPENAI_API_KEY\` (where \`test-examples\` lives) drops ~5–10× from the model swap. \`gpt-5-mini\` output is \$2/1M vs \$10/1M for gpt-5.
- \`LANGWATCH_NLP_OPENAI_API_KEY\` and \`LANGEVALS_OPENAI_API_KEY\` should each show cents/day, isolated from the noisy sdk runs.

## Test plan

- [ ] Merge → next sdk-python-ci run pulls the rotated key + new gpt-5-mini examples.
- [ ] Watch OpenAI dashboard for 24h; \`langwatch-nlp-ci\` and \`langevals-ci\` keys should each be <\$1/day.
- [ ] Revoke the old shared key after first successful CI run on each workflow confirms the rotation took.