### PR TITLE
fix(ci): repair main push checks

### DIFF
--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -246,17 +246,17 @@ jobs:
           fi
 
       - name: Probe a workflow execution end-to-end
-        # Read the secret directly in the if-check. Step-level `env:` is
-        # populated AFTER the if-check is evaluated, so `env.OPENAI_API_KEY_CI`
-        # in the condition was always empty → the step was always skipped.
-        if: ${{ secrets.OPENAI_API_KEY_CI != '' }}
         env:
           OPENAI_API_KEY_CI: ${{ secrets.OPENAI_API_KEY_CI }}
         run: |
           # Posts a minimal workflow execution that hits langwatch_nlp.
-          # If OPENAI_API_KEY_CI isn't set, this step is skipped and the
-          # smoke flow stays gateable on infrastructure alone.
+          # GitHub does not allow `secrets.*` in step `if:` expressions, so
+          # gate the optional OpenAI-backed probe inside the shell instead.
           set -e
+          if [ -z "${OPENAI_API_KEY_CI:-}" ]; then
+            echo "OPENAI_API_KEY_CI is not set; skipping OpenAI-backed probe."
+            exit 0
+          fi
           base=${RESOLVED_BASE}
           # TODO: replace with a real workflow execution once the smoke fixture lands.
           curl -fsS -X POST "http://127.0.0.1:$((base + 1))/health"

--- a/langwatch/ee/admin/backoffice/__tests__/UsersView.integration.test.tsx
+++ b/langwatch/ee/admin/backoffice/__tests__/UsersView.integration.test.tsx
@@ -54,6 +54,7 @@ describe("Feature: Backoffice User Impersonation Reason", () => {
   });
 
   describe("given the ops admin has opened the impersonation dialog", () => {
+    /** @scenario Impersonation dialog asks for a single-line reason */
     it("shows a single-line reason field", () => {
       render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
         wrapper: Wrapper,
@@ -65,6 +66,7 @@ describe("Feature: Backoffice User Impersonation Reason", () => {
       expect(reason.tagName).toBe("INPUT");
     });
 
+    /** @scenario Enter submits a completed impersonation reason */
     it("submits the reason when Enter is pressed", async () => {
       const testingUser = userEvent.setup();
       render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
@@ -85,6 +87,7 @@ describe("Feature: Backoffice User Impersonation Reason", () => {
       });
     });
 
+    /** @scenario Empty reason still blocks impersonation */
     it("keeps blocking empty reasons when Enter is pressed", async () => {
       render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
         wrapper: Wrapper,

--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -62,23 +62,6 @@ const LEGACY_UNBOUND: string[] = [
   // Drive this list to empty by binding scenarios, flagging
   // `@unimplemented`, or removing scenarios from feature files.
   // See dev/docs/TESTING_PHILOSOPHY.md for the migration direction.
-  //
-  // nlp-go workflow engine (introduced by #3483) — scenarios document the
-  // Go port of the NLP workflow engine. Tests live in services/aigateway
-  // and langwatch_nlp; bindings have not been backfilled yet.
-  "specs/nlp-go/code-block.feature",
-  "specs/nlp-go/dataset-block.feature",
-  "specs/nlp-go/engine.feature",
-  "specs/nlp-go/feature-flag.feature",
-  "specs/nlp-go/front-door.feature",
-  "specs/nlp-go/http-block.feature",
-  "specs/nlp-go/llm-block.feature",
-  "specs/nlp-go/parallel-deployment.feature",
-  "specs/nlp-go/proxy.feature",
-  "specs/nlp-go/telemetry.feature",
-  "specs/nlp-go/topic-clustering.feature",
-  "specs/nlp-go/tracing-parity.feature",
-  "specs/studio/dataset-creation-regression.feature",
 ];
 
 const TEST_FILE_RE = /\.test\.tsx?$/;


### PR DESCRIPTION
Fixes the red main push checks seen after the Dependabot merges.\n\nWhat changed:\n- Fix npx-server-smoke workflow validation by removing the invalid secrets context from a step if-expression. This was causing instant failed push runs with zero jobs/logs.\n- Bind the existing backoffice impersonation tests to their feature scenarios.\n- Remove stale LEGACY_UNBOUND entries that are now fully bound / zero-enforced and were failing feature-parity hygiene.\n\nVerified locally:\n- /home/aryansharma28/go/bin/actionlint .github/workflows/npx-server-smoke.yml .github/workflows/langwatch-app-ci.yml\n- cd langwatch && pnpm check:feature-parity\n- cd langwatch && ./node_modules/.bin/tsx scripts/check-feature-parity.ts --json => 0 unbound, 0 unknown, 0 staleLegacy\n- cd langwatch && pnpm exec vitest run ee/admin/backoffice/__tests__/UsersView.integration.test.tsx