### PR TITLE
fix(ci): remove secrets.* from step-level if in npx-server-smoke

### DIFF
--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -246,17 +246,20 @@ jobs:
           fi
 
       - name: Probe a workflow execution end-to-end
-        # Read the secret directly in the if-check. Step-level `env:` is
-        # populated AFTER the if-check is evaluated, so `env.OPENAI_API_KEY_CI`
-        # in the condition was always empty → the step was always skipped.
-        if: ${{ secrets.OPENAI_API_KEY_CI != '' }}
+        # `secrets.*` is not valid in a step-level `if:` expression — only
+        # env/inputs/github/runner/steps/matrix contexts are allowed there.
+        # Gate inside the shell instead.
         env:
           OPENAI_API_KEY_CI: ${{ secrets.OPENAI_API_KEY_CI }}
         run: |
           # Posts a minimal workflow execution that hits langwatch_nlp.
-          # If OPENAI_API_KEY_CI isn't set, this step is skipped and the
-          # smoke flow stays gateable on infrastructure alone.
+          # Skip when OPENAI_API_KEY_CI isn't set so the smoke stays
+          # gateable on infrastructure alone.
           set -e
+          if [ -z "${OPENAI_API_KEY_CI:-}" ]; then
+            echo "OPENAI_API_KEY_CI not set — skipping OpenAI-backed probe."
+            exit 0
+          fi
           base=${RESOLVED_BASE}
           # TODO: replace with a real workflow execution once the smoke fixture lands.
           curl -fsS -X POST "http://127.0.0.1:$((base + 1))/health"


### PR DESCRIPTION
## Summary

- The `npx-server-smoke.yml` workflow had `if: ${{ secrets.OPENAI_API_KEY_CI != '' }}` at step level. GitHub Actions only allows `env`, `inputs`, `github`, `runner`, `steps`, and `matrix` contexts in step-level `if:` — **not** `secrets.*`.
- GitHub's validator started enforcing this after the two recent Dependabot merges, causing instant 0-second failures on every push with "Invalid workflow file".
- Fix: drop the step-level `if:`, expose the secret as a step `env` var, and short-circuit inside the shell script when it's empty.

## Test plan

- [ ] CI passes on this PR (no 0s workflow validation failure)
- [ ] Smoke tests run normally (no YAML parse error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)