### PR TITLE
refactor(scenarios): scope DELETE /api/scenario-events to required scenarioSetId

### DIFF
--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -149,7 +149,10 @@ export const route = app.delete(
     const { project } = c.var;
     const { scenarioSetId } = c.req.valid("query");
 
-    const result = await archiveScenarioSetRuns(project.id, scenarioSetId);
+    const result = await archiveScenarioSetRuns({
+      projectId: project.id,
+      scenarioSetId,
+    });
 
     return c.json(result, 200);
   },

--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -2,6 +2,7 @@ import type { Project } from "@prisma/client";
 import { Hono } from "hono";
 import { describeRoute } from "hono-openapi";
 import { resolver, validator as zValidator } from "hono-openapi/zod";
+import { z } from "zod";
 import { getApp } from "~/server/app-layer/app";
 import { ScenarioEventType } from "~/server/scenarios/scenario-event.enums";
 import type { ScenarioEvent } from "~/server/scenarios/scenario-event.types";
@@ -121,27 +122,36 @@ app.post(
   },
 );
 
-// DELETE /api/scenario-events - Delete all events for a project
+// DELETE /api/scenario-events - Archive all simulation runs for a scenario set
 export const route = app.delete(
   "/",
   describeRoute({
-    description: "Delete all events",
+    description:
+      "Archive all simulation runs for a scenario set. Pass `scenarioSetId=default` to archive runs in the implicit default set; future SDK runs without an explicit setId will repopulate it.",
     responses: {
       ...baseResponses,
       200: {
-        description: "Events deleted successfully",
+        description: "Runs archived successfully",
         content: {
-          "application/json": { schema: resolver(responseSchemas.success) },
+          "application/json": { schema: resolver(responseSchemas.archive) },
+        },
+      },
+      400: {
+        description: "Missing or invalid scenarioSetId",
+        content: {
+          "application/json": { schema: resolver(responseSchemas.error) },
         },
       },
     },
   }),
+  zValidator("query", z.object({ scenarioSetId: z.string().min(1, "scenarioSetId query parameter is required") })),
   async (c) => {
     const { project } = c.var;
+    const { scenarioSetId } = c.req.valid("query");
 
-    await archiveAllSimulationRuns(project.id);
+    const result = await archiveScenarioSetRuns(project.id, scenarioSetId);
 
-    return c.json({ success: true }, 200);
+    return c.json(result, 200);
   },
 );
 
@@ -220,22 +230,47 @@ function isStreamingEvent(type: string): boolean {
   );
 }
 
-async function archiveAllSimulationRuns(projectId: string): Promise<void> {
-  const app = getApp();
-  const runIds = await app.simulations.runs.getAllRunIdsForProject({ projectId });
+export async function archiveScenarioSetRuns(
+  projectId: string,
+  scenarioSetId: string,
+): Promise<{ archived: number; failed: number; scenarioSetId: string; hasMore: boolean }> {
+  const { runIds, reachedCap } = await getApp().simulations.runs.getRunIdsForSet({ projectId, scenarioSetId });
 
   const now = Date.now();
-  await Promise.all(
-    runIds.map((scenarioRunId) =>
-      getApp().simulations.deleteRun({
-        tenantId: projectId,
-        scenarioRunId,
-        occurredAt: now,
-      }),
-    ),
-  );
+  let archived = 0;
+  let failed = 0;
 
-  logger.info({ projectId, count: runIds.length }, "Dispatched archive commands for all simulation runs");
+  await pMapLimited(runIds, async (id) => {
+    try {
+      await getApp().simulations.deleteRun({
+        tenantId: projectId,
+        scenarioRunId: id,
+        occurredAt: now,
+      });
+      archived++;
+    } catch (err) {
+      failed++;
+      logger.warn({ projectId, scenarioRunId: id, err }, "Failed to dispatch deleteRun");
+    }
+  }, 8);
+
+  return { archived, failed, scenarioSetId, hasMore: reachedCap };
+}
+
+async function pMapLimited<T>(
+  items: T[],
+  fn: (item: T) => Promise<void>,
+  concurrency: number,
+): Promise<void> {
+  const executing = new Set<Promise<void>>();
+  for (const item of items) {
+    const p = fn(item).then(() => {
+      executing.delete(p);
+    });
+    executing.add(p);
+    if (executing.size >= concurrency) await Promise.race(executing);
+  }
+  await Promise.all(executing);
 }
 
 async function broadcastStreamingEvent(

--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -233,38 +233,49 @@ function isStreamingEvent(type: string): boolean {
   );
 }
 
-export async function archiveScenarioSetRuns(
-  projectId: string,
-  scenarioSetId: string,
-): Promise<{ archived: number; failed: number; scenarioSetId: string; hasMore: boolean }> {
+export async function archiveScenarioSetRuns({
+  projectId,
+  scenarioSetId,
+}: {
+  projectId: string;
+  scenarioSetId: string;
+}): Promise<{ archived: number; failed: number; scenarioSetId: string; hasMore: boolean }> {
   const { runIds, reachedCap } = await getApp().simulations.runs.getRunIdsForSet({ projectId, scenarioSetId });
 
   const now = Date.now();
   let archived = 0;
   let failed = 0;
 
-  await pMapLimited(runIds, async (id) => {
-    try {
-      await getApp().simulations.deleteRun({
-        tenantId: projectId,
-        scenarioRunId: id,
-        occurredAt: now,
-      });
-      archived++;
-    } catch (err) {
-      failed++;
-      logger.warn({ projectId, scenarioRunId: id, err }, "Failed to dispatch deleteRun");
-    }
-  }, 8);
+  await pMapLimited({
+    items: runIds,
+    concurrency: 8,
+    fn: async (id) => {
+      try {
+        await getApp().simulations.deleteRun({
+          tenantId: projectId,
+          scenarioRunId: id,
+          occurredAt: now,
+        });
+        archived++;
+      } catch (err) {
+        failed++;
+        logger.warn({ projectId, scenarioRunId: id, err }, "Failed to dispatch deleteRun");
+      }
+    },
+  });
 
   return { archived, failed, scenarioSetId, hasMore: reachedCap };
 }
 
-async function pMapLimited<T>(
-  items: T[],
-  fn: (item: T) => Promise<void>,
-  concurrency: number,
-): Promise<void> {
+async function pMapLimited<T>({
+  items,
+  fn,
+  concurrency,
+}: {
+  items: T[];
+  fn: (item: T) => Promise<void>;
+  concurrency: number;
+}): Promise<void> {
   const executing = new Set<Promise<void>>();
   for (const item of items) {
     const p = fn(item).then(() => {

--- a/langwatch/src/app/api/scenario-events/__tests__/delete-scenario-events.unit.test.ts
+++ b/langwatch/src/app/api/scenario-events/__tests__/delete-scenario-events.unit.test.ts
@@ -41,7 +41,7 @@ describe("archiveScenarioSetRuns()", () => {
       const runIds = ["run-1", "run-2", "run-3"];
       mockGetRunIdsForSet.mockResolvedValue({ runIds, reachedCap: false });
 
-      const result = await archiveScenarioSetRuns("project-a", "set-a");
+      const result = await archiveScenarioSetRuns({ projectId: "project-a", scenarioSetId: "set-a" });
 
       expect(result.archived).toBe(3);
       expect(result.failed).toBe(0);
@@ -61,7 +61,7 @@ describe("archiveScenarioSetRuns()", () => {
         .mockRejectedValueOnce(new Error("delete failed"))
         .mockResolvedValueOnce(undefined);
 
-      const result = await archiveScenarioSetRuns("project-a", "set-a");
+      const result = await archiveScenarioSetRuns({ projectId: "project-a", scenarioSetId: "set-a" });
 
       expect(result.archived).toBe(2);
       expect(result.failed).toBe(1);
@@ -73,7 +73,7 @@ describe("archiveScenarioSetRuns()", () => {
     it("returns hasMore: true", async () => {
       mockGetRunIdsForSet.mockResolvedValue({ runIds: ["run-1"], reachedCap: true });
 
-      const result = await archiveScenarioSetRuns("project-a", "set-big");
+      const result = await archiveScenarioSetRuns({ projectId: "project-a", scenarioSetId: "set-big" });
 
       expect(result.hasMore).toBe(true);
     });
@@ -83,7 +83,7 @@ describe("archiveScenarioSetRuns()", () => {
     it("returns hasMore: false", async () => {
       mockGetRunIdsForSet.mockResolvedValue({ runIds: ["run-1"], reachedCap: false });
 
-      const result = await archiveScenarioSetRuns("project-a", "set-small");
+      const result = await archiveScenarioSetRuns({ projectId: "project-a", scenarioSetId: "set-small" });
 
       expect(result.hasMore).toBe(false);
     });
@@ -112,7 +112,7 @@ describe("archiveScenarioSetRuns()", () => {
       });
 
       // Start archiving (will block until resolvers are called)
-      const archivePromise = archiveScenarioSetRuns("project-a", "set-32");
+      const archivePromise = archiveScenarioSetRuns({ projectId: "project-a", scenarioSetId: "set-32" });
 
       // Yield a macrotask tick so pMapLimited has time to start and fill
       // the first concurrency window (8 slots) before we start draining.
@@ -137,7 +137,7 @@ describe("archiveScenarioSetRuns()", () => {
     it("returns archived=0, failed=0, hasMore=false without calling deleteRun", async () => {
       mockGetRunIdsForSet.mockResolvedValue({ runIds: [], reachedCap: false });
 
-      const result = await archiveScenarioSetRuns("project-a", "ghost-set");
+      const result = await archiveScenarioSetRuns({ projectId: "project-a", scenarioSetId: "ghost-set" });
 
       expect(result.archived).toBe(0);
       expect(result.failed).toBe(0);

--- a/langwatch/src/app/api/scenario-events/__tests__/delete-scenario-events.unit.test.ts
+++ b/langwatch/src/app/api/scenario-events/__tests__/delete-scenario-events.unit.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: vi.fn(),
+}));
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { getApp } from "~/server/app-layer/app";
+import { archiveScenarioSetRuns } from "../[[...route]]/app";
+
+describe("archiveScenarioSetRuns()", () => {
+  let mockGetRunIdsForSet: Mock;
+  let mockDeleteRun: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetRunIdsForSet = vi.fn();
+    mockDeleteRun = vi.fn().mockResolvedValue(undefined);
+
+    (getApp as Mock).mockReturnValue({
+      simulations: {
+        runs: {
+          getRunIdsForSet: mockGetRunIdsForSet,
+        },
+        deleteRun: mockDeleteRun,
+      },
+    });
+  });
+
+  describe("when getRunIdsForSet returns N runs", () => {
+    it("dispatches deleteRun for each and returns archived=N, failed=0, scenarioSetId, hasMore=false", async () => {
+      const runIds = ["run-1", "run-2", "run-3"];
+      mockGetRunIdsForSet.mockResolvedValue({ runIds, reachedCap: false });
+
+      const result = await archiveScenarioSetRuns("project-a", "set-a");
+
+      expect(result.archived).toBe(3);
+      expect(result.failed).toBe(0);
+      expect(result.scenarioSetId).toBe("set-a");
+      expect(result.hasMore).toBe(false);
+      expect(mockDeleteRun).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("when one deleteRun rejects", () => {
+    it("does not short-circuit; returns archived=N-1, failed=1", async () => {
+      const runIds = ["run-1", "run-2", "run-3"];
+      mockGetRunIdsForSet.mockResolvedValue({ runIds, reachedCap: false });
+
+      mockDeleteRun
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("delete failed"))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await archiveScenarioSetRuns("project-a", "set-a");
+
+      expect(result.archived).toBe(2);
+      expect(result.failed).toBe(1);
+      expect(mockDeleteRun).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("when reachedCap is true", () => {
+    it("returns hasMore: true", async () => {
+      mockGetRunIdsForSet.mockResolvedValue({ runIds: ["run-1"], reachedCap: true });
+
+      const result = await archiveScenarioSetRuns("project-a", "set-big");
+
+      expect(result.hasMore).toBe(true);
+    });
+  });
+
+  describe("when reachedCap is false", () => {
+    it("returns hasMore: false", async () => {
+      mockGetRunIdsForSet.mockResolvedValue({ runIds: ["run-1"], reachedCap: false });
+
+      const result = await archiveScenarioSetRuns("project-a", "set-small");
+
+      expect(result.hasMore).toBe(false);
+    });
+  });
+
+  describe("when 32 ids are dispatched with concurrency 8", () => {
+    it("has at most 8 deleteRun calls in flight at once", async () => {
+      const runIds = Array.from({ length: 32 }, (_, i) => `run-${i}`);
+      mockGetRunIdsForSet.mockResolvedValue({ runIds, reachedCap: false });
+
+      let maxInFlight = 0;
+      let currentInFlight = 0;
+
+      const resolvers: Array<() => void> = [];
+
+      mockDeleteRun.mockImplementation(() => {
+        currentInFlight++;
+        if (currentInFlight > maxInFlight) maxInFlight = currentInFlight;
+
+        return new Promise<void>((resolve) => {
+          resolvers.push(() => {
+            currentInFlight--;
+            resolve();
+          });
+        });
+      });
+
+      // Start archiving (will block until resolvers are called)
+      const archivePromise = archiveScenarioSetRuns("project-a", "set-32");
+
+      // Yield a macrotask tick so pMapLimited has time to start and fill
+      // the first concurrency window (8 slots) before we start draining.
+      await new Promise<void>((r) => setTimeout(r, 0));
+
+      // Drain resolvers in round-trip loops: release all currently pending,
+      // yield, then repeat until everything is settled.
+      while (resolvers.length > 0) {
+        const batch = resolvers.splice(0, resolvers.length);
+        for (const resolve of batch) resolve();
+        await new Promise<void>((r) => setTimeout(r, 0));
+      }
+
+      await archivePromise;
+
+      expect(maxInFlight).toBeLessThanOrEqual(8);
+      expect(mockDeleteRun).toHaveBeenCalledTimes(32);
+    });
+  });
+
+  describe("when getRunIdsForSet returns an empty list", () => {
+    it("returns archived=0, failed=0, hasMore=false without calling deleteRun", async () => {
+      mockGetRunIdsForSet.mockResolvedValue({ runIds: [], reachedCap: false });
+
+      const result = await archiveScenarioSetRuns("project-a", "ghost-set");
+
+      expect(result.archived).toBe(0);
+      expect(result.failed).toBe(0);
+      expect(result.hasMore).toBe(false);
+      expect(mockDeleteRun).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -636,4 +636,136 @@ describe("SimulationClickHouseRepository (integration)", () => {
       });
     });
   });
+
+  describe("getRunIdsForSet()", () => {
+    describe("when runs exist in two scenario sets", () => {
+      it("returns only run ids matching the scenarioSetId", async () => {
+        const setA = `set-a-${nanoid()}`;
+        const setB = `set-b-${nanoid()}`;
+
+        const setAIds: string[] = [];
+        for (let i = 0; i < 3; i++) {
+          const id = `run-seta-${nanoid()}`;
+          setAIds.push(id);
+          await insertRow(ch, makeInsertRow({ ScenarioRunId: id, ScenarioSetId: setA }));
+        }
+        for (let i = 0; i < 3; i++) {
+          await insertRow(ch, makeInsertRow({ ScenarioRunId: `run-setb-${nanoid()}`, ScenarioSetId: setB }));
+        }
+
+        const result = await repo.getRunIdsForSet({ projectId: tenantId, scenarioSetId: setA });
+
+        expect(result.runIds.length).toBe(3);
+        expect(result.reachedCap).toBe(false);
+        for (const id of result.runIds) {
+          expect(setAIds).toContain(id);
+        }
+      });
+    });
+
+    describe("when scenarioSetId is \"default\"", () => {
+      it("returns rows with both ScenarioSetId = \"default\" and ScenarioSetId = \"\"", async () => {
+        // Use a unique tenant to prevent default/empty rows from other tests leaking in
+        const isolatedTenantId = `test-default-coalesce-${nanoid()}`;
+
+        const defaultIds: string[] = [];
+        const emptyIds: string[] = [];
+        const setAIds: string[] = [];
+
+        for (let i = 0; i < 2; i++) {
+          const id = `run-default-${nanoid()}`;
+          defaultIds.push(id);
+          await insertRow(ch, makeInsertRow({ TenantId: isolatedTenantId, ScenarioRunId: id, ScenarioSetId: "default" }));
+        }
+        for (let i = 0; i < 2; i++) {
+          const id = `run-empty-${nanoid()}`;
+          emptyIds.push(id);
+          await insertRow(ch, makeInsertRow({ TenantId: isolatedTenantId, ScenarioRunId: id, ScenarioSetId: "" }));
+        }
+        for (let i = 0; i < 2; i++) {
+          const id = `run-seta-${nanoid()}`;
+          setAIds.push(id);
+          await insertRow(ch, makeInsertRow({ TenantId: isolatedTenantId, ScenarioRunId: id, ScenarioSetId: `set-a-${nanoid()}` }));
+        }
+
+        const result = await repo.getRunIdsForSet({ projectId: isolatedTenantId, scenarioSetId: "default" });
+
+        expect(result.runIds.length).toBe(4);
+        expect(result.reachedCap).toBe(false);
+        const expectedIds = [...defaultIds, ...emptyIds];
+        for (const id of result.runIds) {
+          expect(expectedIds).toContain(id);
+        }
+        for (const id of setAIds) {
+          expect(result.runIds).not.toContain(id);
+        }
+      });
+    });
+
+    describe("when scenarioSetId is unknown", () => {
+      it("returns empty result with reachedCap false", async () => {
+        const ghostSet = `ghost-set-${nanoid()}`;
+
+        const result = await repo.getRunIdsForSet({ projectId: tenantId, scenarioSetId: ghostSet });
+
+        expect(result.runIds.length).toBe(0);
+        expect(result.reachedCap).toBe(false);
+      });
+    });
+
+    describe("when archived rows exist", () => {
+      it("excludes archived rows", async () => {
+        const setId = `set-archive-${nanoid()}`;
+        const activeIds: string[] = [];
+
+        for (let i = 0; i < 2; i++) {
+          const id = `run-active-${nanoid()}`;
+          activeIds.push(id);
+          await insertRow(ch, makeInsertRow({ ScenarioRunId: id, ScenarioSetId: setId, ArchivedAt: null }));
+        }
+        for (let i = 0; i < 2; i++) {
+          await insertRow(ch, makeInsertRow({
+            ScenarioRunId: `run-archived-${nanoid()}`,
+            ScenarioSetId: setId,
+            ArchivedAt: new Date(now),
+          }));
+        }
+
+        const result = await repo.getRunIdsForSet({ projectId: tenantId, scenarioSetId: setId });
+
+        expect(result.runIds.length).toBe(2);
+        for (const id of result.runIds) {
+          expect(activeIds).toContain(id);
+        }
+      });
+    });
+
+    describe("when rows exist in another project", () => {
+      it("does not return cross-project run ids", async () => {
+        const sharedSetName = `set-cross-${nanoid()}`;
+        const crossTenantId = `cross-project-${nanoid()}`;
+
+        const callerIds: string[] = [];
+        for (let i = 0; i < 2; i++) {
+          const id = `run-caller-${nanoid()}`;
+          callerIds.push(id);
+          await insertRow(ch, makeInsertRow({ ScenarioRunId: id, ScenarioSetId: sharedSetName }));
+        }
+        for (let i = 0; i < 2; i++) {
+          await insertRow(ch, makeInsertRow({
+            TenantId: crossTenantId,
+            ScenarioRunId: `run-other-${nanoid()}`,
+            ScenarioSetId: sharedSetName,
+          }));
+        }
+
+        const result = await repo.getRunIdsForSet({ projectId: tenantId, scenarioSetId: sharedSetName });
+
+        expect(result.runIds.length).toBe(2);
+        for (const id of result.runIds) {
+          expect(callerIds).toContain(id);
+        }
+      });
+    });
+  });
 });

--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -740,6 +740,49 @@ describe("SimulationClickHouseRepository (integration)", () => {
       });
     });
 
+    describe("when a stale non-archived row coexists with a newer archived row for the same run", () => {
+      // Regression for the ReplacingMergeTree(UpdatedAt) dedup gap: without
+      // dedup, an older `ArchivedAt IS NULL` version would match the filter
+      // even after the latest version archived the run, re-dispatching
+      // deletions for already-archived runs.
+      it("treats the run as archived and does not return its id", async () => {
+        const setId = `set-dedup-${nanoid()}`;
+        const archivedRunId = `run-archived-stale-${nanoid()}`;
+        const sharedBatchId = `batch-${nanoid()}`;
+
+        // Older version: ArchivedAt IS NULL, lower UpdatedAt.
+        await insertRow(ch, makeInsertRow({
+          ScenarioRunId: archivedRunId,
+          ScenarioSetId: setId,
+          BatchRunId: sharedBatchId,
+          UpdatedAt: new Date(now - 10_000),
+          ArchivedAt: null,
+        }));
+        // Newer version (same dedup key): ArchivedAt set, higher UpdatedAt.
+        await insertRow(ch, makeInsertRow({
+          ScenarioRunId: archivedRunId,
+          ScenarioSetId: setId,
+          BatchRunId: sharedBatchId,
+          UpdatedAt: new Date(now),
+          ArchivedAt: new Date(now),
+        }));
+
+        // A second, currently-active run in the same set acts as a positive
+        // control — confirms the query is otherwise wired up correctly.
+        const activeRunId = `run-active-${nanoid()}`;
+        await insertRow(ch, makeInsertRow({
+          ScenarioRunId: activeRunId,
+          ScenarioSetId: setId,
+          ArchivedAt: null,
+        }));
+
+        const result = await repo.getRunIdsForSet({ projectId: tenantId, scenarioSetId: setId });
+
+        expect(result.runIds).toContain(activeRunId);
+        expect(result.runIds).not.toContain(archivedRunId);
+      });
+    });
+
     describe("when rows exist in another project", () => {
       it("does not return cross-project run ids", async () => {
         const sharedSetName = `set-cross-${nanoid()}`;

--- a/langwatch/src/server/app-layer/simulations/repositories/__tests__/get-run-ids-for-set.unit.test.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/__tests__/get-run-ids-for-set.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  SimulationClickHouseRepository,
+  RUN_ID_CAP,
+} from "../simulation.clickhouse.repository";
+
+function makeRowsOfLength(n: number): { ScenarioRunId: string }[] {
+  return Array.from({ length: n }, (_, i) => ({ ScenarioRunId: `run-${i}` }));
+}
+
+function makeMockClientReturning(rows: { ScenarioRunId: string }[]): ClickHouseClient {
+  const jsonFn = vi.fn().mockResolvedValue(rows);
+  const queryFn = vi.fn().mockResolvedValue({ json: jsonFn });
+  return { query: queryFn } as unknown as ClickHouseClient;
+}
+
+describe("SimulationClickHouseRepository", () => {
+  describe("getRunIdsForSet()", () => {
+    describe("when N matching ids returns exactly RUN_ID_CAP", () => {
+      it("sets reachedCap to true and returns RUN_ID_CAP runIds", async () => {
+        const rows = makeRowsOfLength(RUN_ID_CAP);
+        const mockClient = makeMockClientReturning(rows);
+        const resolver = vi.fn().mockResolvedValue(mockClient);
+        const repo = new SimulationClickHouseRepository(resolver);
+
+        const result = await repo.getRunIdsForSet({
+          projectId: "project-1",
+          scenarioSetId: "set-a",
+        });
+
+        expect(result.runIds.length).toBe(RUN_ID_CAP);
+        expect(result.reachedCap).toBe(true);
+      });
+    });
+
+    describe("when N matching ids returns fewer than RUN_ID_CAP", () => {
+      it("sets reachedCap to false", async () => {
+        const rows = makeRowsOfLength(RUN_ID_CAP - 1);
+        const mockClient = makeMockClientReturning(rows);
+        const resolver = vi.fn().mockResolvedValue(mockClient);
+        const repo = new SimulationClickHouseRepository(resolver);
+
+        const result = await repo.getRunIdsForSet({
+          projectId: "project-1",
+          scenarioSetId: "set-a",
+        });
+
+        expect(result.runIds.length).toBe(RUN_ID_CAP - 1);
+        expect(result.reachedCap).toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -17,6 +17,8 @@ import type { SimulationRepository } from "./simulation.repository";
 
 const TABLE_NAME = "simulation_runs" as const;
 
+export const RUN_ID_CAP = 10000;
+
 /**
  * Returns an IN-tuple dedup predicate for simulation_runs.
  *
@@ -855,19 +857,23 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     }));
   }
 
-  async getAllRunIdsForProject({
+  async getRunIdsForSet({
     projectId,
+    scenarioSetId,
   }: {
     projectId: string;
-  }): Promise<string[]> {
+    scenarioSetId: string;
+  }): Promise<{ runIds: string[]; reachedCap: boolean }> {
     const client = await this.getClient(projectId);
+    const scenarioSetIds = expandSetIdFilter(scenarioSetId);
     const result = await client.query({
-      query: `SELECT DISTINCT ScenarioRunId FROM ${TABLE_NAME} WHERE TenantId = {tenantId:String} AND ArchivedAt IS NULL LIMIT 10000`,
-      query_params: { tenantId: projectId },
+      query: `SELECT DISTINCT ScenarioRunId FROM ${TABLE_NAME} WHERE TenantId = {tenantId:String} AND ArchivedAt IS NULL AND ScenarioSetId IN ({scenarioSetIds:Array(String)}) LIMIT ${RUN_ID_CAP}`,
+      query_params: { tenantId: projectId, scenarioSetIds },
       format: "JSONEachRow",
     });
     const rows = await result.json<{ ScenarioRunId: string }>();
-    return rows.map((r) => r.ScenarioRunId);
+    const runIds = rows.map((r) => r.ScenarioRunId);
+    return { runIds, reachedCap: runIds.length === RUN_ID_CAP };
   }
 
   async getDistinctExternalSetIds({

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -866,8 +866,20 @@ export class SimulationClickHouseRepository implements SimulationRepository {
   }): Promise<{ runIds: string[]; reachedCap: boolean }> {
     const client = await this.getClient(projectId);
     const scenarioSetIds = expandSetIdFilter(scenarioSetId);
+    // Dedup to the latest version per run before applying ArchivedAt IS NULL.
+    // simulation_runs is ReplacingMergeTree(UpdatedAt); without dedup, an
+    // older non-archived row can satisfy the filter even after the run was
+    // archived, re-dispatching deletions for already-archived runs.
     const result = await client.query({
-      query: `SELECT DISTINCT ScenarioRunId FROM ${TABLE_NAME} WHERE TenantId = {tenantId:String} AND ArchivedAt IS NULL AND ScenarioSetId IN ({scenarioSetIds:Array(String)}) LIMIT ${RUN_ID_CAP}`,
+      query: `SELECT DISTINCT ScenarioRunId
+              FROM ${TABLE_NAME}
+              WHERE TenantId = {tenantId:String}
+                AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
+                AND ArchivedAt IS NULL
+                ${simulationRunDedupPredicate(
+                  "TenantId = {tenantId:String} AND ScenarioSetId IN ({scenarioSetIds:Array(String)})",
+                )}
+              LIMIT ${RUN_ID_CAP}`,
       query_params: { tenantId: projectId, scenarioSetIds },
       format: "JSONEachRow",
     });

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.repository.ts
@@ -86,9 +86,10 @@ export interface SimulationRepository {
     sinceTimestamp?: number;
   }): Promise<AllSuitesRunDataResult>;
 
-  getAllRunIdsForProject(params: {
+  getRunIdsForSet(params: {
     projectId: string;
-  }): Promise<string[]>;
+    scenarioSetId: string;
+  }): Promise<{ runIds: string[]; reachedCap: boolean }>;
 
   /**
    * Returns distinct external (non-internal) scenario set IDs across the given projects.
@@ -144,8 +145,8 @@ export class NullSimulationRepository implements SimulationRepository {
     return { changed: true, lastUpdatedAt: 0, runs: [], scenarioSetIds: {}, hasMore: false };
   }
 
-  async getAllRunIdsForProject(): Promise<string[]> {
-    return [];
+  async getRunIdsForSet(): Promise<{ runIds: string[]; reachedCap: boolean }> {
+    return { runIds: [], reachedCap: false };
   }
 
   async getDistinctExternalSetIds(): Promise<Set<string>> {

--- a/langwatch/src/server/app-layer/simulations/simulation-run.service.ts
+++ b/langwatch/src/server/app-layer/simulations/simulation-run.service.ts
@@ -100,8 +100,11 @@ export class SimulationRunService {
     return this.repository.getRunDataForAllSuites(params);
   }
 
-  async getAllRunIdsForProject(params: { projectId: string }): Promise<string[]> {
-    return this.repository.getAllRunIdsForProject(params);
+  async getRunIdsForSet(params: {
+    projectId: string;
+    scenarioSetId: string;
+  }): Promise<{ runIds: string[]; reachedCap: boolean }> {
+    return this.repository.getRunIdsForSet(params);
   }
 
   /**

--- a/langwatch/src/server/scenarios/schemas/response-schemas.ts
+++ b/langwatch/src/server/scenarios/schemas/response-schemas.ts
@@ -91,6 +91,17 @@ const batchesSchema = z.object({
 });
 
 /**
+ * Archive operation response schema
+ * Returned by the DELETE /api/scenario-events endpoint after archiving runs for a scenario set
+ */
+export const archiveResponseSchema = z.object({
+  archived: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  scenarioSetId: z.string(),
+  hasMore: z.boolean(),
+});
+
+/**
  * Consolidated response schemas object
  * Maps response types to their corresponding Zod schemas for validation
  */
@@ -101,4 +112,5 @@ export const responseSchemas = {
   events: eventsSchema,
   batches: batchesSchema,
   runData: runDataSchema,
+  archive: archiveResponseSchema,
 };

--- a/specs/scenarios/scenario-events-set-scoped-archive.feature
+++ b/specs/scenarios/scenario-events-set-scoped-archive.feature
@@ -1,0 +1,234 @@
+Feature: Scoped DELETE /api/scenario-events
+  As an SDK or self-serve user
+  I want DELETE /api/scenario-events to require a scenario set scope
+  So that I cannot accidentally archive every simulation run in a project,
+  and so I get an honest result when the operation is partial.
+
+  # ============================================================================
+  # Integration: Required scenarioSetId query param (AC 1)
+  # ============================================================================
+
+  @integration @unimplemented
+  Scenario: DELETE without scenarioSetId returns 400
+    Given I am authenticated in project "test-project"
+    When I call DELETE /api/scenario-events with no query parameters
+    Then I receive a 400 Bad Request response
+    And the error message names "scenarioSetId" as the missing parameter
+    And no simulation runs are archived
+
+  @integration @unimplemented
+  Scenario: DELETE with empty scenarioSetId returns 400
+    Given I am authenticated in project "test-project"
+    When I call DELETE /api/scenario-events?scenarioSetId=
+    Then I receive a 400 Bad Request response
+    And the error message names "scenarioSetId" as the missing parameter
+    And no simulation runs are archived
+
+  # ============================================================================
+  # Integration: Set-scoped archive isolates other sets (AC 6)
+  # ============================================================================
+
+  @integration @unimplemented
+  Scenario: Archiving one set leaves runs in other sets untouched
+    Given I am authenticated in project "test-project"
+    And 3 un-archived simulation runs exist in scenario set "set-a"
+    And 3 un-archived simulation runs exist in scenario set "set-b"
+    When I call DELETE /api/scenario-events?scenarioSetId=set-a
+    Then the response is 200 OK
+    And the response body reports "archived" equal to 3
+    And the response body reports "failed" equal to 0
+    And the response body reports "scenarioSetId" equal to "set-a"
+    And the response body reports "hasMore" equal to false
+    And the 3 runs in scenario set "set-a" are archived
+    And the 3 runs in scenario set "set-b" remain un-archived
+
+  @integration @unimplemented
+  Scenario: Archiving an unknown scenario set succeeds with zero counts
+    Given I am authenticated in project "test-project"
+    And no simulation runs exist in scenario set "ghost-set"
+    When I call DELETE /api/scenario-events?scenarioSetId=ghost-set
+    Then the response is 200 OK
+    And the response body reports "archived" equal to 0
+    And the response body reports "failed" equal to 0
+    And the response body reports "hasMore" equal to false
+
+  # ============================================================================
+  # Integration: default set coalesces empty and "default" ScenarioSetId (AC 6)
+  # ============================================================================
+
+  @integration @unimplemented
+  Scenario: Archiving the "default" set archives both default and empty ScenarioSetId rows
+    Given I am authenticated in project "test-project"
+    And 2 un-archived simulation runs exist with ScenarioSetId "default"
+    And 2 un-archived simulation runs exist with ScenarioSetId ""
+    And 2 un-archived simulation runs exist in scenario set "set-a"
+    When I call DELETE /api/scenario-events?scenarioSetId=default
+    Then the response is 200 OK
+    And the response body reports "archived" equal to 4
+    And both the "default" and "" ScenarioSetId rows are archived
+    And the 2 runs in scenario set "set-a" remain un-archived
+
+  # ============================================================================
+  # Integration: Per-run failures are collected, not short-circuited (AC 3, AC 4)
+  # ============================================================================
+
+  @integration @unimplemented
+  Scenario: Per-run failures are reported, not short-circuited
+    Given I am authenticated in project "test-project"
+    And 5 un-archived simulation runs exist in scenario set "set-a"
+    And dispatching deleteRun fails for 2 of those runs
+    When I call DELETE /api/scenario-events?scenarioSetId=set-a
+    Then the response is 200 OK
+    And the response body reports "archived" equal to 3
+    And the response body reports "failed" equal to 2
+    And the 3 successful runs are archived
+    And each failure is logged with projectId, scenarioRunId, and error
+
+  # ============================================================================
+  # Integration: 10k cap surfaced via hasMore (AC 2, AC 4)
+  # ============================================================================
+
+  @integration @unimplemented
+  Scenario: Reaching the 10k cap reports hasMore true
+    Given I am authenticated in project "test-project"
+    And the run-id query for scenario set "big-set" is configured with a cap of 10
+    And 12 un-archived simulation runs exist in scenario set "big-set"
+    When I call DELETE /api/scenario-events?scenarioSetId=big-set
+    Then the response is 200 OK
+    And the response body reports "archived" plus "failed" equal to 10
+    And the response body reports "hasMore" equal to true
+
+  @integration @unimplemented
+  Scenario: Below the cap reports hasMore false
+    Given I am authenticated in project "test-project"
+    And 5 un-archived simulation runs exist in scenario set "small-set"
+    When I call DELETE /api/scenario-events?scenarioSetId=small-set
+    Then the response is 200 OK
+    And the response body reports "hasMore" equal to false
+
+  # ============================================================================
+  # Integration: Project isolation
+  # ============================================================================
+
+  @integration @unimplemented
+  Scenario: DELETE only archives runs in the caller's project
+    Given I am authenticated in project "project-a"
+    And 3 un-archived simulation runs exist in scenario set "set-a" in project "project-a"
+    And 3 un-archived simulation runs exist in scenario set "set-a" in project "project-b"
+    When I call DELETE /api/scenario-events?scenarioSetId=set-a
+    Then the response body reports "archived" equal to 3
+    And only the project "project-a" runs are archived
+    And the project "project-b" runs remain un-archived
+
+  # ============================================================================
+  # Integration: Unfiltered code path is removed (AC 5)
+  # ============================================================================
+
+  @integration @unimplemented
+  Scenario: Unfiltered project-wide archive endpoint no longer exists
+    Given I am authenticated in project "test-project"
+    And simulation runs exist in multiple scenario sets in the project
+    When I call DELETE /api/scenario-events with no query parameters
+    Then I receive a 400 Bad Request response
+    And no project-wide archive code path can be invoked
+    And no simulation runs are archived
+
+  # ============================================================================
+  # Integration: OpenAPI documentation (AC 7)
+  # ============================================================================
+
+  @integration @unimplemented
+  Scenario: OpenAPI documents scenarioSetId as required and the new response shape
+    Given the OpenAPI spec for the route is generated
+    When I inspect DELETE /api/scenario-events
+    Then "scenarioSetId" is documented as a required query parameter
+    And the 200 response schema includes "archived", "failed", "scenarioSetId", and "hasMore"
+    And the 400 response schema describes the missing-parameter error
+    And the description notes that "default" archives current runs for the implicit set
+    And the description notes that future SDK runs without an explicit setId will repopulate the default set
+
+  # ============================================================================
+  # Unit: Cap-reached signal from the repo (AC 2)
+  # ============================================================================
+
+  @unit @unimplemented
+  Scenario: getRunIdsForSet reports reachedCap true at exactly the cap
+    Given the repository is configured with cap N
+    And N run ids match the set filter
+    When I call getRunIdsForSet
+    Then the response includes N run ids
+    And reachedCap is true
+
+  @unit @unimplemented
+  Scenario: getRunIdsForSet reports reachedCap false below the cap
+    Given the repository is configured with cap N
+    And fewer than N run ids match the set filter
+    When I call getRunIdsForSet
+    Then the response includes fewer than N run ids
+    And reachedCap is false
+
+  # ============================================================================
+  # Unit: hasMore derivation (AC 4)
+  # ============================================================================
+
+  @unit @unimplemented
+  Scenario: hasMore is true when archived plus failed equals the cap
+    Given the cap is 10000
+    And archived equals 9990 and failed equals 10
+    When the response is built
+    Then hasMore is true
+
+  @unit @unimplemented
+  Scenario: hasMore is false when archived plus failed is below the cap
+    Given the cap is 10000
+    And archived equals 5000 and failed equals 0
+    When the response is built
+    Then hasMore is false
+
+  # ============================================================================
+  # Unit: Bounded concurrency dispatch (AC 3)
+  # ============================================================================
+
+  @unit @unimplemented
+  Scenario: Dispatch limits in-flight deleteRun calls to the configured concurrency
+    Given a concurrency limit of 8
+    And 32 run ids to dispatch
+    When the dispatch runs
+    Then no more than 8 deleteRun calls are in flight at any moment
+    And all 32 run ids are dispatched exactly once
+
+  @unit @unimplemented
+  Scenario: Dispatch does not short-circuit on a failed deleteRun
+    Given a concurrency limit of 8
+    And 4 run ids where the second one fails
+    When the dispatch runs
+    Then all 4 run ids are attempted
+    And the failure is collected, not thrown
+
+  # --- AC Coverage Map ---
+  # AC 1 ("DELETE requires scenarioSetId; missing → 400"):
+  #   - Scenario: DELETE without scenarioSetId returns 400
+  #   - Scenario: DELETE with empty scenarioSetId returns 400
+  # AC 2 ("New repo method getRunIdsForSet with expandSetIdFilter, 10k cap"):
+  #   - Scenario: Archiving the "default" set archives both default and empty ScenarioSetId rows
+  #   - Scenario: Reaching the 10k cap reports hasMore true
+  #   - Scenario: getRunIdsForSet reports reachedCap true at exactly the cap
+  #   - Scenario: getRunIdsForSet reports reachedCap false below the cap
+  # AC 3 ("Replace Promise.all with bounded-concurrency dispatch via pMapLimited"):
+  #   - Scenario: Per-run failures are reported, not short-circuited
+  #   - Scenario: Dispatch limits in-flight deleteRun calls to the configured concurrency
+  #   - Scenario: Dispatch does not short-circuit on a failed deleteRun
+  # AC 4 ("Collect per-run failures; return { archived, failed, scenarioSetId, hasMore }"):
+  #   - Scenario: Archiving one set leaves runs in other sets untouched
+  #   - Scenario: Per-run failures are reported, not short-circuited
+  #   - Scenario: Reaching the 10k cap reports hasMore true
+  #   - Scenario: Below the cap reports hasMore false
+  #   - Scenario: hasMore is true when archived plus failed equals the cap
+  #   - Scenario: hasMore is false when archived plus failed is below the cap
+  # AC 5 ("Remove the unfiltered code path entirely"):
+  #   - Scenario: Unfiltered project-wide archive endpoint no longer exists
+  # AC 6 ("Integration test: two sets in one project; default matches '' and 'default'"):
+  #   - Scenario: Archiving one set leaves runs in other sets untouched
+  #   - Scenario: Archiving the "default" set archives both default and empty ScenarioSetId rows
+  # AC 7 ("OpenAPI doc updated: required param + response shape + default note"):
+  #   - Scenario: OpenAPI documents scenarioSetId as required and the new response shape


### PR DESCRIPTION
## Why

Closes #3635

`DELETE /api/scenario-events` was unsafe and incomplete: there was no way to scope it to a single scenario set, the underlying ClickHouse query silently truncated at 10k rows while still returning `200 OK`, and the dispatch loop short-circuited on the first failure via unbounded `Promise.all`. This change scopes the endpoint to a required `scenarioSetId`, replaces the dispatch with bounded concurrency and per-run failure collection, and surfaces the truncation cap to the caller.

This is a hard break of the unfiltered `DELETE /api/scenario-events` shape — no soft-deprecation cycle. SDK clients regenerate from OpenAPI; the only response-shape consumers were the generated DELETE clients in `python-sdk` and `typescript-sdk`.

## What changed

- New repo method `getRunIdsForSet({ projectId, scenarioSetId })` returns `{ runIds, reachedCap }`. Uses `expandSetIdFilter` so `scenarioSetId=default` matches both `'default'` and legacy `''` rows. Cap kept at 10000, exposed as `RUN_ID_CAP` constant.
- `DELETE /api/scenario-events` now requires `scenarioSetId` query param via `zValidator` (missing/empty → `400`). Response shape is `{ archived, failed, scenarioSetId, hasMore }`. `hasMore` is `true` exactly when the repo hit the cap.
- Dispatch loop replaced with inlined `pMapLimited` (concurrency 8) — copied from `replayService.ts` per the issue's "no premature shared util" decision. Per-run errors are caught, counted, and logged at `warn`; the batch never short-circuits.
- Removed the unfiltered code path entirely: `archiveAllSimulationRuns` private function and `getAllRunIdsForProject` from the interface, ClickHouse repo, Null repo, and service. No backwards-compat shim.
- New `archiveResponseSchema` documents the response shape in OpenAPI; the `400` response is documented alongside `200`.

## How it works

The route's `zValidator("query", z.object({ scenarioSetId: z.string().min(1, ...) }))` rejects missing/empty values up front with a `400` carrying the standard `responseSchemas.error` shape. On a valid request, `archiveScenarioSetRuns(projectId, scenarioSetId)` queries the repo for all matching un-archived run ids (capped at 10k), then dispatches one `app.simulations.deleteRun` event per id through the inlined `pMapLimited` helper. Each dispatch is wrapped in try/catch — successes increment `archived`, failures increment `failed` and emit a `logger.warn({ projectId, scenarioRunId, err })`. The response carries the counters plus `hasMore: reachedCap`, so callers can detect a truncated batch and re-issue.

## Test plan

- `simulation.clickhouse.repository.integration.test.ts` — appended a `getRunIdsForSet()` block covering: set isolation (returns only matching rows), default coalescing (`scenarioSetId=default` matches both `default` and `''`), unknown set (empty result, `reachedCap=false`), archived rows excluded, cross-project isolation.
- `get-run-ids-for-set.unit.test.ts` — verifies `reachedCap` is exactly `true` when the row count equals `RUN_ID_CAP` and `false` below.
- `delete-scenario-events.unit.test.ts` — covers the dispatch path: success counts, failure-collection without short-circuit, `hasMore` derivation from `reachedCap`, and bounded concurrency (32 ids dispatched with concurrency 8 — never more than 8 in-flight).
- Feature file `specs/scenarios/scenario-events-set-scoped-archive.feature` — every issue AC maps to ≥1 scenario via the AC Coverage Map at the bottom.

I did not run `pnpm typecheck` / `pnpm test` locally — the worktree is missing `node_modules` (fresh checkout); CI will validate.

## Anything surprising?

- `pMapLimited` is **inlined** in `app.ts`, not imported from `replayService.ts`. Per the issue's investigation note: importing from `event-sourcing/replay/...` into `app/api/...` would create a circular layer dependency, so a one-time copy is cheaper than a premature shared util. When a third caller appears, both call sites should promote to `langwatch/src/utils/p-map-limited.ts`.
- `archiveScenarioSetRuns` is `export`ed (rather than file-private) so the route's unit test can drive it directly without standing up the full Hono auth chain. The export is a deliberate test seam, not a public API.
- SDK regeneration: the OpenAPI doc now declares `200` as `archiveResponseSchema` instead of `successSchema`. Generated clients (`python-sdk/.../delete_api_scenario_events.py`, `typescript-sdk/.../api-client.ts`) regenerate on the next SDK release. The TS CLI's `?batchRunId=…` calls in `cli/commands/{suites,scenarios}/run.ts` are GET, not DELETE — irrelevant to this break.

# Related Issue

- Resolve #3635

---

### Sweep: unbounded Promise.all over event-bus dispatch

Checked DELETE handlers across `langwatch/src/app/api/`. Two other `Promise.all` patterns exist (`prompts/app.v1.ts:691, 932`) — both iterate over user-supplied `tags` arrays (typically <10), bounded by request shape. No similar 10k+ unbounded dispatch patterns elsewhere. Clean.