### PR TITLE
fix(ci): bump Go to 1.25 in sdk-go-ci to unblock otel security fix

### DIFF
--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Install dependencies
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Bumps `go-version` from `1.24` → `1.25` in both the `test` and `build` jobs of `.github/workflows/sdk-go-ci.yml`
- Required because `go.opentelemetry.io/otel` v1.43.0 (security fix for PR #3642) bumped `go.mod` minimum to Go 1.25; the old CI setting caused `GOTOOLCHAIN=local` to reject the module

## Why `sdk-python-ci` shows failing

`dorny/paths-filter` incorrectly triggers `sdk-python-ci` on `.github/workflows/sdk-go-ci.yml` changes (pre-existing paths-filter issue — not introduced here). The e2e tests then fail with OTLP read timeouts to `app.langwatch.ai`; the same failure is visible on the `main` branch right now. This is unrelated to the change in this PR.

## Test plan

- [x] `sdk-go-ci` passes with Go 1.25 (all three jobs: changes, test, build, sdk-go-complete)
- [x] All other workflow checks pass or correctly skip