### PR TITLE
perf(group-queue): score-based dispatch filter to cut Redis CPU under backlog

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -616,6 +616,56 @@ describe("GroupStagingScripts", () => {
         expect(data["j1"]).toBeUndefined();
       });
     });
+
+    describe("when group is currently active", () => {
+      it("does not lower ready score below the active-until window", async () => {
+        // Seed an active job and an active-until ready score
+        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        const nowMs = 200;
+        const activeTtlSec = 60;
+        const activeUntil = nowMs + activeTtlSec * 1000;
+        await scripts.dispatch({ nowMs, activeTtlSec });
+
+        // Stage another job for the same group while it is processing
+        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }));
+
+        // Ready score must remain at activeUntil so dispatch doesn't re-pick the group
+        const ready = await inspectReadySet();
+        expect(ready).toEqual(["group-a", String(activeUntil)]);
+      });
+
+      it("still stores the new job in the group jobs zset", async () => {
+        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+
+        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }));
+
+        const jobs = await inspectGroupJobs("group-a");
+        expect(jobs).toContain("j2");
+      });
+    });
+
+    describe("when group is blocked", () => {
+      it("does not re-add a blocked group to the ready set", async () => {
+        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        await scripts.restageAndBlock({
+          groupId: "group-a",
+          newStagedJobId: "j1/r/0",
+          score: 100,
+          jobDataJson: JSON.stringify({ retry: true }),
+        });
+
+        // Sanity: group is blocked and not in ready
+        expect(await inspectBlockedSet()).toContain("group-a");
+        expect(await inspectReadySet()).toEqual([]);
+
+        // Stage a new job for the blocked group — should not reinsert it
+        await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 150 }));
+
+        expect(await inspectReadySet()).toEqual([]);
+      });
+    });
   });
 
   describe("stageBatch", () => {
@@ -995,6 +1045,54 @@ describe("GroupStagingScripts", () => {
         });
 
         expect(ok).toBe(false);
+      });
+    });
+
+    describe("when group was removed from ready (e.g. after blocking)", () => {
+      it("does not re-add the group to the ready set", async () => {
+        // Set up: group is processing a job, then gets blocked mid-flight
+        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        await scripts.restageAndBlock({
+          groupId: "group-a",
+          newStagedJobId: "j1/r/0",
+          score: 100,
+          jobDataJson: JSON.stringify({ retry: true }),
+        });
+
+        // Sanity: group is no longer in ready
+        expect(await inspectReadySet()).toEqual([]);
+
+        // Heartbeat fires after blocking — must not reinsert the blocked group
+        const ok = await scripts.refreshActiveKey({
+          groupId: "group-a",
+          stagedJobId: "j1",
+          activeTtlSec: 60,
+        });
+
+        expect(ok).toBe(true);
+        expect(await inspectReadySet()).toEqual([]);
+      });
+    });
+
+    describe("when active and in ready", () => {
+      it("refreshes ready score to nowMs + activeTtlSec*1000", async () => {
+        await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+        await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+
+        // ZADD with smaller score to simulate score drift; heartbeat should push it forward.
+        await redis.zadd(`${keyPrefix()}ready`, 200, "group-a");
+
+        const ok = await scripts.refreshActiveKey({
+          groupId: "group-a",
+          stagedJobId: "j1",
+          activeTtlSec: 120,
+        });
+
+        expect(ok).toBe(true);
+        const score = await redis.zscore(`${keyPrefix()}ready`, "group-a");
+        // Score must be in the future (nowMs + 120_000) — exact value depends on Date.now()
+        expect(Number(score)).toBeGreaterThan(Date.now());
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -94,12 +94,11 @@ describe("GroupStagingScripts", () => {
         expect(data).toEqual({ j1: payload });
       });
 
-      it("adds group to ready set with sqrt(1) score", async () => {
-        await scripts.stage(makeJob());
+      it("adds group to ready set with score = earliest pending dispatchAfter", async () => {
+        await scripts.stage(makeJob({ dispatchAfterMs: 1000 }));
 
         const ready = await inspectReadySet();
-        // sqrt(1) = 1
-        expect(ready).toEqual(["group-a", "1"]);
+        expect(ready).toEqual(["group-a", "1000"]);
       });
 
       it("pushes signal", async () => {
@@ -803,24 +802,29 @@ describe("GroupStagingScripts", () => {
         expect(jobs).toEqual([]);
       });
 
-      it("recalculates ready score or removes group", async () => {
+      it("re-scores ready set with future activeUntil after dispatch", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
         await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
 
-        await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
+        const nowMs = 300;
+        const activeTtlSec = 60;
+        await scripts.dispatch({ nowMs, activeTtlSec });
 
-        // One job left → score should be sqrt(1) = 1
+        // Group is now active → score = nowMs + activeTtlSec*1000 (suppresses redispatch)
         const ready = await inspectReadySet();
-        expect(ready).toEqual(["group-a", "1"]);
+        expect(ready).toEqual(["group-a", String(nowMs + activeTtlSec * 1000)]);
       });
 
-      it("removes group from ready set when no jobs remain", async () => {
+      it("keeps group in ready with future activeUntil score after dispatch (no pending left)", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
 
-        await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        const nowMs = 200;
+        const activeTtlSec = 60;
+        await scripts.dispatch({ nowMs, activeTtlSec });
 
+        // Group is active even though no jobs remain — completion removes it from ready.
         const ready = await inspectReadySet();
-        expect(ready).toEqual([]);
+        expect(ready).toEqual(["group-a", String(nowMs + activeTtlSec * 1000)]);
       });
 
       it("returns jobDataJson from data hash", async () => {
@@ -844,7 +848,7 @@ describe("GroupStagingScripts", () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "group-a", dispatchAfterMs: 100 }));
         await scripts.stage(makeJob({ stagedJobId: "j2", groupId: "group-b", dispatchAfterMs: 100 }));
 
-        // Dispatch from group with highest score (both have 1 job → same score, order is deterministic by ZREVRANGE)
+        // Dispatch picks groups by ZRANGEBYSCORE (lowest dispatchAfter first); both groups have the same score.
         const first = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
         expect(first).not.toBeNull();
 
@@ -911,7 +915,7 @@ describe("GroupStagingScripts", () => {
         expect(signals.length).toBeGreaterThanOrEqual(1);
       });
 
-      it("recalculates ready score if more jobs exist", async () => {
+      it("recalculates ready score from earliest pending job after completion", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
         await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
 
@@ -921,9 +925,9 @@ describe("GroupStagingScripts", () => {
           stagedJobId: dispatched.stagedJobId,
         });
 
-        // j2 still pending → ready score should be sqrt(1) = 1
+        // j2 still pending → ready score should equal j2's dispatchAfterMs (200)
         const ready = await inspectReadySet();
-        expect(ready).toContain("group-a");
+        expect(ready).toEqual(["group-a", "200"]);
       });
 
       it("removes group from ready set if no jobs remain", async () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/dispatcher.ts
@@ -118,14 +118,10 @@ export class GroupQueueDispatcher {
     }
 
     const maxJobs = Math.min(availableSlots, MAX_BATCH_SIZE);
-    const readySize = await this.params.scripts.getReadySize();
-    const randomOffset =
-      readySize > 0 ? Math.floor(Math.random() * readySize) : 0;
     const results = await this.params.scripts.dispatchBatch({
       nowMs: Date.now(),
       activeTtlSec: this.params.activeTtlSec,
       maxJobs,
-      randomOffset,
     });
 
     for (const result of results) {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -11,6 +11,8 @@ local signalKey       = KEYS[3]
 local dedupKey        = KEYS[4]
 local dataKey         = KEYS[5]
 local totalPendingKey = KEYS[6]
+local activeKey       = KEYS[7]
+local blockedKey      = KEYS[8]
 
 local stagedJobId    = ARGV[1]
 local groupId        = ARGV[2]
@@ -20,6 +22,16 @@ local dedupTtlMs     = tonumber(ARGV[5])
 local jobDataJson    = ARGV[6]
 local shouldExtend   = tonumber(ARGV[7])
 local shouldReplace  = tonumber(ARGV[8])
+
+-- Skip ready-score updates while the group is processing (active key set) or
+-- blocked. In those states the ready score is owned by REFRESH_LUA / COMPLETE_LUA
+-- (active) or by UNBLOCK (blocked). Lowering it here would re-expose the group
+-- to ZRANGEBYSCORE before the next heartbeat refreshes it.
+local function shouldUpdateReady()
+  if redis.call("EXISTS", activeKey) == 1 then return false end
+  if redis.call("SISMEMBER", blockedKey, groupId) == 1 then return false end
+  return true
+end
 
 if dedupId ~= "" and dedupTtlMs > 0 then
   local existingJobId = redis.call("GET", dedupKey)
@@ -35,7 +47,9 @@ if dedupId ~= "" and dedupTtlMs > 0 then
       end
       redis.call("SET", dedupKey, existingJobId, "PX", dedupTtlMs)
       -- Score = earliest pending dispatchAfter (LT keeps the smallest score per group)
-      redis.call("ZADD", readyKey, "LT", dispatchAfter, groupId)
+      if shouldUpdateReady() then
+        redis.call("ZADD", readyKey, "LT", dispatchAfter, groupId)
+      end
       redis.call("LPUSH", signalKey, "1")
       redis.call("LTRIM", signalKey, 0, 999)
       return 0
@@ -53,7 +67,9 @@ if dedupId ~= "" and dedupTtlMs > 0 then
 end
 
 -- Score = earliest pending dispatchAfter (LT keeps the smallest score per group)
-redis.call("ZADD", readyKey, "LT", dispatchAfter, groupId)
+if shouldUpdateReady() then
+  redis.call("ZADD", readyKey, "LT", dispatchAfter, groupId)
+end
 
 redis.call("LPUSH", signalKey, "1")
 redis.call("LTRIM", signalKey, 0, 999)
@@ -128,9 +144,16 @@ for i = 1, count do
   end
 end
 
+local blockedKey = keyPrefix .. "blocked"
 for groupId, minScore in pairs(affectedGroups) do
-  -- Score = earliest pending dispatchAfter (LT keeps the smallest)
-  redis.call("ZADD", readyKey, "LT", minScore, groupId)
+  -- Score = earliest pending dispatchAfter (LT keeps the smallest).
+  -- Skip when the group is processing or blocked — the active heartbeat /
+  -- completion / unblock paths own the score in those states. Lowering it
+  -- here would re-expose the group to ZRANGEBYSCORE before the next refresh.
+  local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+  if redis.call("EXISTS", activeKey) == 0 and redis.call("SISMEMBER", blockedKey, groupId) == 0 then
+    redis.call("ZADD", readyKey, "LT", minScore, groupId)
+  end
 end
 
 redis.call("LPUSH", signalKey, "1")
@@ -158,76 +181,87 @@ local activeUntil = nowMs + activeTtlSec * 1000
 
 -- Pull only groups whose earliest job is due now (legacy entries with score=1 also pass).
 -- Active groups carry future scores (nowMs + activeTtlSec*1000) and are excluded.
-local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", 0, 50)
-if #groups == 0 then return nil end
+-- Page through the ready zset so a head full of paused / blocked / legacy-drift
+-- entries does not cause dispatch to return nil while eligible work exists later.
+local pageSize = 200
+local scanBudget = 1000
+local offset = 0
 
-for _, groupId in ipairs(groups) do
-  if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
-    local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-    -- Defensive activeKey check — covers legacy state during migration
-    -- and the small race between ZADD ready and ZADD active.
-    local activeJob = redis.call("GET", activeKey)
-    if not activeJob then
-      local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
-      local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
+while offset < scanBudget do
+  local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", offset, pageSize)
+  if #groups == 0 then return nil end
 
-      if #results >= 2 then
-        local stagedJobId = results[1]
-        local originalScore = results[2]
+  for _, groupId in ipairs(groups) do
+    if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
+      local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+      -- Defensive activeKey check — covers legacy state during migration
+      -- and the small race between ZADD ready and ZADD active.
+      local activeJob = redis.call("GET", activeKey)
+      if not activeJob then
+        local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
+        local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
-        -- Check pause status before dequeuing
-        local paused = false
-        if hasPauses then
-          local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-          local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-          if jobDataJson then
-            local ok, data = pcall(cjson.decode, jobDataJson)
-            if ok and type(data) == "table" then
-              local p = data["__pipelineName"]
-              local t = data["__jobType"]
-              local n = data["__jobName"]
-              local pIsStr = type(p) == "string"
-              local tIsStr = type(t) == "string"
-              local nIsStr = type(n) == "string"
-              if pIsStr then
-                if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
-                elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
-                elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
+        if #results >= 2 then
+          local stagedJobId = results[1]
+          local originalScore = results[2]
+
+          -- Check pause status before dequeuing
+          local paused = false
+          if hasPauses then
+            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+            if jobDataJson then
+              local ok, data = pcall(cjson.decode, jobDataJson)
+              if ok and type(data) == "table" then
+                local p = data["__pipelineName"]
+                local t = data["__jobType"]
+                local n = data["__jobName"]
+                local pIsStr = type(p) == "string"
+                local tIsStr = type(t) == "string"
+                local nIsStr = type(n) == "string"
+                if pIsStr then
+                  if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
+                  elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
+                  elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
+                  end
                 end
               end
             end
           end
-        end
 
-        if not paused then
-          redis.call("ZREM", jobsKey, stagedJobId)
-          redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
+          if not paused then
+            redis.call("ZREM", jobsKey, stagedJobId)
+            redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
 
-          -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
-          -- If process crashes, heartbeat stops, score becomes past, group becomes dispatchable again.
-          redis.call("ZADD", readyKey, activeUntil, groupId)
+            -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
+            -- If process crashes, heartbeat stops, score becomes past, group becomes dispatchable again.
+            redis.call("ZADD", readyKey, activeUntil, groupId)
 
-          local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-          local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-          redis.call("HDEL", dataKey, stagedJobId)
+            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+            redis.call("HDEL", dataKey, stagedJobId)
 
-          return {stagedJobId, groupId, jobDataJson or "", originalScore}
-        end
-      else
-        -- Group is in ready but has no due jobs — drift cleanup.
-        local pendingCount = redis.call("ZCARD", jobsKey)
-        if pendingCount == 0 then
-          redis.call("ZREM", readyKey, groupId)
+            return {stagedJobId, groupId, jobDataJson or "", originalScore}
+          end
         else
-          -- All jobs are future-scheduled; re-score ready with earliest job's score
-          local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
-          if #nextScore >= 2 then
-            redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
+          -- Group is in ready but has no due jobs — drift cleanup.
+          local pendingCount = redis.call("ZCARD", jobsKey)
+          if pendingCount == 0 then
+            redis.call("ZREM", readyKey, groupId)
+          else
+            -- All jobs are future-scheduled; re-score ready with earliest job's score
+            local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
+            if #nextScore >= 2 then
+              redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
+            end
           end
         end
       end
     end
   end
+
+  if #groups < pageSize then return nil end
+  offset = offset + pageSize
 end
 
 return nil
@@ -249,87 +283,96 @@ local results = {}
 local dispatched = 0
 
 -- Pull only groups whose earliest job is due now. Active groups carry future
--- scores so they are naturally excluded. Over-fetch by 3x (min 30) to leave
--- headroom for blocked/paused/legacy-drift groups.
-local scanLimit = maxJobs * 3
-if scanLimit < 30 then scanLimit = 30 end
+-- scores so they are naturally excluded. Over-fetch by 3x (min 30) per page to
+-- leave headroom for blocked/paused/legacy-drift groups, then page through up
+-- to scanBudget total entries so a head full of paused/blocked groups does
+-- not starve runnable groups deeper in the zset.
+local pageSize = maxJobs * 3
+if pageSize < 30 then pageSize = 30 end
+local scanBudget = pageSize * 5
+local offset = 0
 
-local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", 0, scanLimit)
-if #groups == 0 then return results end
+while offset < scanBudget and dispatched < maxJobs do
+  local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", offset, pageSize)
+  if #groups == 0 then break end
 
-for _, groupId in ipairs(groups) do
-  if dispatched >= maxJobs then break end
+  for _, groupId in ipairs(groups) do
+    if dispatched >= maxJobs then break end
 
-  if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
-    local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-    -- Defensive activeKey check — covers legacy state during migration
-    -- and the small race between ZADD ready and ZADD active.
-    local activeJob = redis.call("GET", activeKey)
+    if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
+      local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+      -- Defensive activeKey check — covers legacy state during migration
+      -- and the small race between ZADD ready and ZADD active.
+      local activeJob = redis.call("GET", activeKey)
 
-    if not activeJob then
-      local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
-      local jobResults = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
+      if not activeJob then
+        local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
+        local jobResults = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
-      if #jobResults >= 2 then
-        local stagedJobId = jobResults[1]
-        local originalScore = jobResults[2]
+        if #jobResults >= 2 then
+          local stagedJobId = jobResults[1]
+          local originalScore = jobResults[2]
 
-        -- Check pause status before dequeuing
-        local paused = false
-        if hasPauses then
-          local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-          local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-          if jobDataJson then
-            local ok, data = pcall(cjson.decode, jobDataJson)
-            if ok and type(data) == "table" then
-              local p = data["__pipelineName"]
-              local t = data["__jobType"]
-              local n = data["__jobName"]
-              local pIsStr = type(p) == "string"
-              local tIsStr = type(t) == "string"
-              local nIsStr = type(n) == "string"
-              if pIsStr then
-                if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
-                elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
-                elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
+          -- Check pause status before dequeuing
+          local paused = false
+          if hasPauses then
+            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+            if jobDataJson then
+              local ok, data = pcall(cjson.decode, jobDataJson)
+              if ok and type(data) == "table" then
+                local p = data["__pipelineName"]
+                local t = data["__jobType"]
+                local n = data["__jobName"]
+                local pIsStr = type(p) == "string"
+                local tIsStr = type(t) == "string"
+                local nIsStr = type(n) == "string"
+                if pIsStr then
+                  if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
+                  elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
+                  elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
+                  end
                 end
               end
             end
           end
-        end
 
-        if not paused then
-          redis.call("ZREM", jobsKey, stagedJobId)
-          redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
+          if not paused then
+            redis.call("ZREM", jobsKey, stagedJobId)
+            redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
 
-          -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
-          redis.call("ZADD", readyKey, activeUntil, groupId)
+            -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
+            redis.call("ZADD", readyKey, activeUntil, groupId)
 
-          local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-          local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-          redis.call("HDEL", dataKey, stagedJobId)
+            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+            redis.call("HDEL", dataKey, stagedJobId)
 
-          results[#results + 1] = stagedJobId
-          results[#results + 1] = groupId
-          results[#results + 1] = jobDataJson or ""
-          results[#results + 1] = tostring(originalScore)
-          dispatched = dispatched + 1
-        end
-      else
-        -- Group is in ready but has no due jobs — drift cleanup.
-        local pendingCount = redis.call("ZCARD", jobsKey)
-        if pendingCount == 0 then
-          redis.call("ZREM", readyKey, groupId)
+            results[#results + 1] = stagedJobId
+            results[#results + 1] = groupId
+            results[#results + 1] = jobDataJson or ""
+            results[#results + 1] = tostring(originalScore)
+            dispatched = dispatched + 1
+          end
         else
-          -- All jobs are future-scheduled; re-score ready with earliest job's score
-          local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
-          if #nextScore >= 2 then
-            redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
+          -- Group is in ready but has no due jobs — drift cleanup.
+          local pendingCount = redis.call("ZCARD", jobsKey)
+          if pendingCount == 0 then
+            redis.call("ZREM", readyKey, groupId)
+          else
+            -- All jobs are future-scheduled; re-score ready with earliest job's score
+            local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
+            if #nextScore >= 2 then
+              redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
+            end
           end
         end
       end
     end
   end
+
+  if #groups < pageSize then break end
+  offset = offset + pageSize
 end
 
 return results
@@ -401,10 +444,12 @@ local currentActive = redis.call("GET", activeKey)
 if currentActive == stagedJobId then
   redis.call("EXPIRE", activeKey, activeTtlSec)
   -- Refresh ready-zset score so it stays "active" until heartbeat stops or completion.
-  -- If the process crashes, the heartbeat stops, and the future score stays put until
-  -- it drifts into the past, at which point dispatch picks it up (defensive activeKey
-  -- check in dispatch handles the still-alive activeKey edge case).
-  redis.call("ZADD", readyKey, nowMs + activeTtlSec * 1000, groupId)
+  -- Only update if the group is currently in ready — if RESTAGE_AND_BLOCK_LUA fired
+  -- while this heartbeat was in flight, the group has been removed and we must not
+  -- reinsert it (would violate "blocked => not in ready").
+  if redis.call("ZSCORE", readyKey, groupId) then
+    redis.call("ZADD", readyKey, nowMs + activeTtlSec * 1000, groupId)
+  end
   return 1
 end
 return 0
@@ -560,16 +605,20 @@ export class GroupStagingScripts {
 
     const dataKey = `${this.keyPrefix}group:${groupId}:data`;
     const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
+    const activeKey = `${this.keyPrefix}group:${groupId}:active`;
+    const blockedKey = `${this.keyPrefix}blocked`;
 
     const result = await this.redis.eval(
       STAGE_LUA,
-      6,
+      8,
       groupJobsKey,
       readyKey,
       signalKey,
       dedupKey,
       dataKey,
       totalPendingKey,
+      activeKey,
+      blockedKey,
       stagedJobId,
       groupId,
       String(dispatchAfterMs),

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -34,7 +34,8 @@ if dedupId ~= "" and dedupTtlMs > 0 then
         redis.call("HSET", dataKey, existingJobId, jobDataJson)
       end
       redis.call("SET", dedupKey, existingJobId, "PX", dedupTtlMs)
-      redis.call("ZADD", readyKey, 1, groupId)
+      -- Score = earliest pending dispatchAfter (LT keeps the smallest score per group)
+      redis.call("ZADD", readyKey, "LT", dispatchAfter, groupId)
       redis.call("LPUSH", signalKey, "1")
       redis.call("LTRIM", signalKey, 0, 999)
       return 0
@@ -51,7 +52,8 @@ if dedupId ~= "" and dedupTtlMs > 0 then
   redis.call("SET", dedupKey, stagedJobId, "PX", dedupTtlMs)
 end
 
-redis.call("ZADD", readyKey, 1, groupId)
+-- Score = earliest pending dispatchAfter (LT keeps the smallest score per group)
+redis.call("ZADD", readyKey, "LT", dispatchAfter, groupId)
 
 redis.call("LPUSH", signalKey, "1")
 redis.call("LTRIM", signalKey, 0, 999)
@@ -119,11 +121,16 @@ for i = 1, count do
     newStagedCount = newStagedCount + 1
   end
 
-  affectedGroups[groupId] = true
+  -- Track minimum dispatchAfter per affected group
+  local existingMin = affectedGroups[groupId]
+  if existingMin == nil or dispatchAfter < existingMin then
+    affectedGroups[groupId] = dispatchAfter
+  end
 end
 
-for groupId, _ in pairs(affectedGroups) do
-  redis.call("ZADD", readyKey, 1, groupId)
+for groupId, minScore in pairs(affectedGroups) do
+  -- Score = earliest pending dispatchAfter (LT keeps the smallest)
+  redis.call("ZADD", readyKey, "LT", minScore, groupId)
 end
 
 redis.call("LPUSH", signalKey, "1")
@@ -147,75 +154,80 @@ local nowMs        = tonumber(ARGV[2])
 local activeTtlSec = tonumber(ARGV[3])
 
 local hasPauses = redis.call("SCARD", pausedJobKey) > 0
-local scanStart = 0
-local scanEnd = 99
-local maxPasses = hasPauses and 5 or 3
+local activeUntil = nowMs + activeTtlSec * 1000
 
-for pass = 1, maxPasses do
-  local groups = redis.call("ZREVRANGE", readyKey, scanStart, scanEnd)
-  if #groups == 0 then break end
+-- Pull only groups whose earliest job is due now (legacy entries with score=1 also pass).
+-- Active groups carry future scores (nowMs + activeTtlSec*1000) and are excluded.
+local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", 0, 50)
+if #groups == 0 then return nil end
 
-  for _, groupId in ipairs(groups) do
-    if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
-      local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-      local activeJob = redis.call("GET", activeKey)
+for _, groupId in ipairs(groups) do
+  if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
+    local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+    -- Defensive activeKey check — covers legacy state during migration
+    -- and the small race between ZADD ready and ZADD active.
+    local activeJob = redis.call("GET", activeKey)
+    if not activeJob then
+      local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
+      local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
-      if not activeJob then
-        local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
-        local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
+      if #results >= 2 then
+        local stagedJobId = results[1]
+        local originalScore = results[2]
 
-        if #results >= 2 then
-          local stagedJobId = results[1]
-          local originalScore = results[2]
-
-          -- Check pause status before dequeuing
-          local paused = false
-          if hasPauses then
-            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-            if jobDataJson then
-              local ok, data = pcall(cjson.decode, jobDataJson)
-              if ok and type(data) == "table" then
-                local p = data["__pipelineName"]
-                local t = data["__jobType"]
-                local n = data["__jobName"]
-                local pIsStr = type(p) == "string"
-                local tIsStr = type(t) == "string"
-                local nIsStr = type(n) == "string"
-                if pIsStr then
-                  if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
-                  elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
-                  elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
-                  end
+        -- Check pause status before dequeuing
+        local paused = false
+        if hasPauses then
+          local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+          local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+          if jobDataJson then
+            local ok, data = pcall(cjson.decode, jobDataJson)
+            if ok and type(data) == "table" then
+              local p = data["__pipelineName"]
+              local t = data["__jobType"]
+              local n = data["__jobName"]
+              local pIsStr = type(p) == "string"
+              local tIsStr = type(t) == "string"
+              local nIsStr = type(n) == "string"
+              if pIsStr then
+                if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
+                elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
+                elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
                 end
               end
             end
           end
+        end
 
-          if not paused then
-            redis.call("ZREM", jobsKey, stagedJobId)
-            redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
+        if not paused then
+          redis.call("ZREM", jobsKey, stagedJobId)
+          redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
 
-            local pendingCount = redis.call("ZCARD", jobsKey)
-            if pendingCount > 0 then
-              redis.call("ZADD", readyKey, 1, groupId)
-            else
-              redis.call("ZREM", readyKey, groupId)
-            end
+          -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
+          -- If process crashes, heartbeat stops, score becomes past, group becomes dispatchable again.
+          redis.call("ZADD", readyKey, activeUntil, groupId)
 
-            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-            redis.call("HDEL", dataKey, stagedJobId)
+          local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+          local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+          redis.call("HDEL", dataKey, stagedJobId)
 
-            return {stagedJobId, groupId, jobDataJson or "", originalScore}
+          return {stagedJobId, groupId, jobDataJson or "", originalScore}
+        end
+      else
+        -- Group is in ready but has no due jobs — drift cleanup.
+        local pendingCount = redis.call("ZCARD", jobsKey)
+        if pendingCount == 0 then
+          redis.call("ZREM", readyKey, groupId)
+        else
+          -- All jobs are future-scheduled; re-score ready with earliest job's score
+          local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
+          if #nextScore >= 2 then
+            redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
           end
         end
       end
     end
   end
-
-  scanStart = scanEnd + 1
-  scanEnd = scanEnd + 100
 end
 
 return nil
@@ -230,93 +242,94 @@ local keyPrefix      = ARGV[1]
 local nowMs          = tonumber(ARGV[2])
 local activeTtlSec   = tonumber(ARGV[3])
 local maxJobs        = tonumber(ARGV[4])
-local randomOffset   = tonumber(ARGV[5]) or 0
 
 local hasPauses = redis.call("SCARD", pausedJobKey) > 0
-local scanWindow = maxJobs * 3
-local maxPasses = hasPauses and 5 or 3
+local activeUntil = nowMs + activeTtlSec * 1000
 local results = {}
 local dispatched = 0
-local readySize = redis.call("ZCARD", readyKey)
-local scanStart = (readySize > 0) and (randomOffset % readySize) or 0
 
-for pass = 1, maxPasses do
+-- Pull only groups whose earliest job is due now. Active groups carry future
+-- scores so they are naturally excluded. Over-fetch by 3x (min 30) to leave
+-- headroom for blocked/paused/legacy-drift groups.
+local scanLimit = maxJobs * 3
+if scanLimit < 30 then scanLimit = 30 end
+
+local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", 0, scanLimit)
+if #groups == 0 then return results end
+
+for _, groupId in ipairs(groups) do
   if dispatched >= maxJobs then break end
 
-  local scanEnd = scanStart + scanWindow - 1
-  local groups = redis.call("ZREVRANGE", readyKey, scanStart, scanEnd)
-  if #groups == 0 then break end
+  if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
+    local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+    -- Defensive activeKey check — covers legacy state during migration
+    -- and the small race between ZADD ready and ZADD active.
+    local activeJob = redis.call("GET", activeKey)
 
-  local passDispatched = 0
+    if not activeJob then
+      local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
+      local jobResults = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
-  for _, groupId in ipairs(groups) do
-    if dispatched >= maxJobs then break end
+      if #jobResults >= 2 then
+        local stagedJobId = jobResults[1]
+        local originalScore = jobResults[2]
 
-    if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
-      local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-      local activeJob = redis.call("GET", activeKey)
-
-      if not activeJob then
-        local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
-        local jobResults = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
-
-        if #jobResults >= 2 then
-          local stagedJobId = jobResults[1]
-          local originalScore = jobResults[2]
-
-          -- Check pause status before dequeuing
-          local paused = false
-          if hasPauses then
-            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-            if jobDataJson then
-              local ok, data = pcall(cjson.decode, jobDataJson)
-              if ok and type(data) == "table" then
-                local p = data["__pipelineName"]
-                local t = data["__jobType"]
-                local n = data["__jobName"]
-                local pIsStr = type(p) == "string"
-                local tIsStr = type(t) == "string"
-                local nIsStr = type(n) == "string"
-                if pIsStr then
-                  if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
-                  elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
-                  elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
-                  end
+        -- Check pause status before dequeuing
+        local paused = false
+        if hasPauses then
+          local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+          local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+          if jobDataJson then
+            local ok, data = pcall(cjson.decode, jobDataJson)
+            if ok and type(data) == "table" then
+              local p = data["__pipelineName"]
+              local t = data["__jobType"]
+              local n = data["__jobName"]
+              local pIsStr = type(p) == "string"
+              local tIsStr = type(t) == "string"
+              local nIsStr = type(n) == "string"
+              if pIsStr then
+                if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
+                elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
+                elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
                 end
               end
             end
           end
+        end
 
-          if not paused then
-            redis.call("ZREM", jobsKey, stagedJobId)
-            redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
+        if not paused then
+          redis.call("ZREM", jobsKey, stagedJobId)
+          redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
 
-            local pendingCount = redis.call("ZCARD", jobsKey)
-            if pendingCount > 0 then
-              redis.call("ZADD", readyKey, 1, groupId)
-            else
-              redis.call("ZREM", readyKey, groupId)
-            end
+          -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
+          redis.call("ZADD", readyKey, activeUntil, groupId)
 
-            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-            redis.call("HDEL", dataKey, stagedJobId)
+          local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+          local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+          redis.call("HDEL", dataKey, stagedJobId)
 
-            results[#results + 1] = stagedJobId
-            results[#results + 1] = groupId
-            results[#results + 1] = jobDataJson or ""
-            results[#results + 1] = tostring(originalScore)
-            dispatched = dispatched + 1
-            passDispatched = passDispatched + 1
+          results[#results + 1] = stagedJobId
+          results[#results + 1] = groupId
+          results[#results + 1] = jobDataJson or ""
+          results[#results + 1] = tostring(originalScore)
+          dispatched = dispatched + 1
+        end
+      else
+        -- Group is in ready but has no due jobs — drift cleanup.
+        local pendingCount = redis.call("ZCARD", jobsKey)
+        if pendingCount == 0 then
+          redis.call("ZREM", readyKey, groupId)
+        else
+          -- All jobs are future-scheduled; re-score ready with earliest job's score
+          local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
+          if #nextScore >= 2 then
+            redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
           end
         end
       end
     end
   end
-
-  if passDispatched == 0 then break end
-  scanStart = scanStart + scanWindow
 end
 
 return results
@@ -344,7 +357,14 @@ redis.call("DEL", activeKey)
 
 local pendingCount = redis.call("ZCARD", jobsKey)
 if pendingCount > 0 then
-  redis.call("ZADD", readyKey, 1, groupId)
+  -- Re-score ready with earliest pending job's dispatchAfter so dispatch sees
+  -- it again as soon as that job is due (could be past or future).
+  local nextJob = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
+  if #nextJob >= 2 then
+    redis.call("ZADD", readyKey, tonumber(nextJob[2]), groupId)
+  else
+    redis.call("ZREM", readyKey, groupId)
+  end
 else
   redis.call("ZREM", readyKey, groupId)
 end
@@ -371,12 +391,20 @@ return 1
 
 const REFRESH_LUA = `
 local activeKey    = KEYS[1]
+local readyKey     = KEYS[2]
 local stagedJobId  = ARGV[1]
 local activeTtlSec = tonumber(ARGV[2])
+local groupId      = ARGV[3]
+local nowMs        = tonumber(ARGV[4])
 
 local currentActive = redis.call("GET", activeKey)
 if currentActive == stagedJobId then
   redis.call("EXPIRE", activeKey, activeTtlSec)
+  -- Refresh ready-zset score so it stays "active" until heartbeat stops or completion.
+  -- If the process crashes, the heartbeat stops, and the future score stays put until
+  -- it drifts into the past, at which point dispatch picks it up (defensive activeKey
+  -- check in dispatch handles the still-alive activeKey edge case).
+  redis.call("ZADD", readyKey, nowMs + activeTtlSec * 1000, groupId)
   return 1
 end
 return 0
@@ -453,9 +481,10 @@ local groupDataKey = keyPrefix .. "group:" .. groupId .. ":data"
 redis.call("ZADD", groupJobsKey, dispatchAfterMs, newStagedJobId)
 redis.call("HSET", groupDataKey, newStagedJobId, jobDataJson)
 
--- 3. Update ready set score
+-- 3. Update ready set score = future dispatch time so the group becomes
+--    eligible exactly when the backoff window expires.
 local readyKey = keyPrefix .. "ready"
-redis.call("ZADD", readyKey, 1, groupId)
+redis.call("ZADD", readyKey, dispatchAfterMs, groupId)
 
 -- 4. Set active key TTL to match backoff period.
 --    While the key exists the group is locked (preserves FIFO ordering).
@@ -643,12 +672,10 @@ export class GroupStagingScripts {
     nowMs,
     activeTtlSec,
     maxJobs,
-    randomOffset,
   }: {
     nowMs: number;
     activeTtlSec: number;
     maxJobs: number;
-    randomOffset?: number;
   }): Promise<DispatchResult[]> {
     const readyKey = `${this.keyPrefix}ready`;
     const blockedKey = `${this.keyPrefix}blocked`;
@@ -664,7 +691,6 @@ export class GroupStagingScripts {
       String(nowMs),
       String(activeTtlSec),
       String(maxJobs),
-      String(randomOffset ?? 0),
     );
 
     if (!result || !Array.isArray(result) || result.length < 4) {
@@ -739,13 +765,17 @@ export class GroupStagingScripts {
     activeTtlSec: number;
   }): Promise<boolean> {
     const activeKey = `${this.keyPrefix}group:${groupId}:active`;
+    const readyKey = `${this.keyPrefix}ready`;
 
     const result = await this.redis.eval(
       REFRESH_LUA,
-      1,
+      2,
       activeKey,
+      readyKey,
       stagedJobId,
       String(activeTtlSec),
+      groupId,
+      String(Date.now()),
     );
 
     return result === 1;


### PR DESCRIPTION
## Problem

Production Redis (eu-central-1, ElastiCache `cache.m7g.xlarge`) hit **100% engine CPU at 2026-05-01 ~10:30 UTC** and stayed pegged for 30+ minutes. Memory grew from 84 MB → 2.4 GB while it was saturated.

Triggered by a heavy ingestion sweep — but the underlying reason Redis pegged (and stayed pegged after producers eased off) is that `GroupQueueProcessor`'s dispatch hot path walks the entire `ready` zset and pays multiple Redis ops per group **just to skip non-dispatchable ones**:

- All `ZADD readyKey 1 groupId` calls used a constant score, so the zset has no priority signal — `ZREVRANGE 0 99` walks groups in lex order.
- Per group: `SISMEMBER blocked` + `GET activeKey` + `ZRANGEBYSCORE jobsKey` even when the group has an active job, is delayed, or is blocked.
- 3 passes × 100 groups = up to 300 groups walked per dispatch, with 3-5 Redis ops each on negative checks. Single-threaded engine pegs.

## Fix

Encode dispatchability in the `ready` zset score and replace the ZREVRANGE-then-skip pattern with a single `ZRANGEBYSCORE readyKey -inf nowMs`.

**Score semantics on `readyKey`** (new contract):

| Group state | Score |
|---|---|
| Has dispatchable job(s) ready now | earliest pending job's `dispatchAfterMs` (past) |
| Has only future-scheduled / delayed jobs | the earliest pending job's `dispatchAfterMs` (future) |
| Has an active (processing) job | `nowMs + activeTtlSec*1000` (future, refreshed by heartbeat) |
| Blocked (after exhausted retries) | not in ready zset |
| Empty | not in ready zset |

Net effect: dispatch becomes ~O(actually-dispatchable-now) per call instead of O(readySize).

### Lua scripts

- **STAGE / STAGE_BATCH**: `ZADD readyKey "LT" dispatchAfter groupId` (preserves earliest score for the group).
- **DISPATCH / DISPATCH_BATCH**: single `ZRANGEBYSCORE readyKey -inf nowMs LIMIT 0 N` filter; on dispatch sets ready score to `activeUntil` (future) so the group is excluded until heartbeat stops or completion. Drift cleanup re-scores or removes groups with no due jobs.
- **COMPLETE**: re-scores `readyKey` with the earliest pending job's `dispatchAfter` (or removes if empty) instead of `score=1`.
- **REFRESH** (heartbeat): also pushes the ready score forward to `nowMs + activeTtlSec*1000`. Now takes `KEYS[2]=readyKey` plus `groupId`/`nowMs` ARGVs.
- **RETRY_RESTAGE**: `ZADD readyKey dispatchAfterMs groupId` (was `1`) — backoff is encoded in score.
- **RESTAGE_AND_BLOCK**: unchanged (already removes from ready).

### TS

- `dispatchBatch` drops the `randomOffset` argument (no longer needed — score-based filter is naturally bounded).
- `refreshActiveKey` now passes `readyKey` + `groupId` + `nowMs`.
- `dispatcher.ts` drops the `getReadySize()` + random-offset calculation.

## Migration safety (no data loss)

Legacy `ready` entries have score=1 (constant) from before this change. After deploy:

- `ZRANGEBYSCORE readyKey -inf nowMs` returns them as eligible (`1 < nowMs`).
- They are processed via the same defensive path (still does `SISMEMBER blocked` + `GET activeKey`).
- On dispatch/complete the score is re-written to the new model. Within minutes, all live groups have new-style scores.
- No keys are deleted, no in-flight jobs are dropped.

## Test plan

- [x] `groupQueue.retries.unit.test.ts` (9/9 pass)
- [x] `scripts.integration.test.ts` (61/61 pass — real Redis testcontainer; updated 4 score assertions)
- [x] CI runs full suite
- [x] Staging soak: deploy and observe `EngineCPUUtilization` under normal + induced backlog
- [ ] Watch `gqJobsDispatchedTotal` rate is unchanged or higher; `gq_oldest_pending_age_milliseconds` does not regress

## Out of scope (future work)

- Producer-side backpressure based on `stats:total-pending` (would prevent runaway accumulation but changes semantics — left for follow-up).
- Removing the defensive `GET activeKey` in dispatch once we're confident migration has fully drained.
- Bumping ElastiCache to a replica + MultiAZ setup so the next saturation incident has a path to no-downtime mitigation.