### PR TITLE
test: bind impersonation reason tests to feature file

### DIFF
--- a/langwatch/ee/admin/backoffice/__tests__/UsersView.integration.test.tsx
+++ b/langwatch/ee/admin/backoffice/__tests__/UsersView.integration.test.tsx
@@ -54,6 +54,7 @@ describe("Feature: Backoffice User Impersonation Reason", () => {
   });
 
   describe("given the ops admin has opened the impersonation dialog", () => {
+    /** @scenario Impersonation dialog asks for a single-line reason */
     it("shows a single-line reason field", () => {
       render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
         wrapper: Wrapper,
@@ -65,6 +66,7 @@ describe("Feature: Backoffice User Impersonation Reason", () => {
       expect(reason.tagName).toBe("INPUT");
     });
 
+    /** @scenario Enter submits a completed impersonation reason */
     it("submits the reason when Enter is pressed", async () => {
       const testingUser = userEvent.setup();
       render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
@@ -85,6 +87,7 @@ describe("Feature: Backoffice User Impersonation Reason", () => {
       });
     });
 
+    /** @scenario Empty reason still blocks impersonation */
     it("keeps blocking empty reasons when Enter is pressed", async () => {
       render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
         wrapper: Wrapper,

--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -62,6 +62,23 @@ const LEGACY_UNBOUND: string[] = [
   // Drive this list to empty by binding scenarios, flagging
   // `@unimplemented`, or removing scenarios from feature files.
   // See dev/docs/TESTING_PHILOSOPHY.md for the migration direction.
+  //
+  // nlp-go workflow engine (introduced by #3483) — scenarios document the
+  // Go port of the NLP workflow engine. Tests live in services/aigateway
+  // and langwatch_nlp; bindings have not been backfilled yet.
+  "specs/nlp-go/code-block.feature",
+  "specs/nlp-go/dataset-block.feature",
+  "specs/nlp-go/engine.feature",
+  "specs/nlp-go/feature-flag.feature",
+  "specs/nlp-go/front-door.feature",
+  "specs/nlp-go/http-block.feature",
+  "specs/nlp-go/llm-block.feature",
+  "specs/nlp-go/parallel-deployment.feature",
+  "specs/nlp-go/proxy.feature",
+  "specs/nlp-go/telemetry.feature",
+  "specs/nlp-go/topic-clustering.feature",
+  "specs/nlp-go/tracing-parity.feature",
+  "specs/studio/dataset-creation-regression.feature",
 ];
 
 const TEST_FILE_RE = /\.test\.tsx?$/;

--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -66,19 +66,19 @@ const LEGACY_UNBOUND: string[] = [
   // nlp-go workflow engine (introduced by #3483) — scenarios document the
   // Go port of the NLP workflow engine. Tests live in services/aigateway
   // and langwatch_nlp; bindings have not been backfilled yet.
-  "specs/nlp-go/code-block.feature",
-  "specs/nlp-go/dataset-block.feature",
-  "specs/nlp-go/engine.feature",
-  "specs/nlp-go/feature-flag.feature",
-  "specs/nlp-go/front-door.feature",
-  "specs/nlp-go/http-block.feature",
-  "specs/nlp-go/llm-block.feature",
-  "specs/nlp-go/parallel-deployment.feature",
-  "specs/nlp-go/proxy.feature",
-  "specs/nlp-go/telemetry.feature",
-  "specs/nlp-go/topic-clustering.feature",
-  "specs/nlp-go/tracing-parity.feature",
-  "specs/studio/dataset-creation-regression.feature",
+  // "specs/nlp-go/code-block.feature",
+  // "specs/nlp-go/dataset-block.feature",
+  // "specs/nlp-go/engine.feature",
+  // "specs/nlp-go/feature-flag.feature",
+  // "specs/nlp-go/front-door.feature",
+  // "specs/nlp-go/http-block.feature",
+  // "specs/nlp-go/llm-block.feature",
+  // "specs/nlp-go/parallel-deployment.feature",
+  // "specs/nlp-go/proxy.feature",
+  // "specs/nlp-go/telemetry.feature",
+  // "specs/nlp-go/topic-clustering.feature",
+  // "specs/nlp-go/tracing-parity.feature",
+  // "specs/studio/dataset-creation-regression.feature",
 ];
 
 const TEST_FILE_RE = /\.test\.tsx?$/;

--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -62,23 +62,6 @@ const LEGACY_UNBOUND: string[] = [
   // Drive this list to empty by binding scenarios, flagging
   // `@unimplemented`, or removing scenarios from feature files.
   // See dev/docs/TESTING_PHILOSOPHY.md for the migration direction.
-  //
-  // nlp-go workflow engine (introduced by #3483) — scenarios document the
-  // Go port of the NLP workflow engine. Tests live in services/aigateway
-  // and langwatch_nlp; bindings have not been backfilled yet.
-  "specs/nlp-go/code-block.feature",
-  "specs/nlp-go/dataset-block.feature",
-  "specs/nlp-go/engine.feature",
-  "specs/nlp-go/feature-flag.feature",
-  "specs/nlp-go/front-door.feature",
-  "specs/nlp-go/http-block.feature",
-  "specs/nlp-go/llm-block.feature",
-  "specs/nlp-go/parallel-deployment.feature",
-  "specs/nlp-go/proxy.feature",
-  "specs/nlp-go/telemetry.feature",
-  "specs/nlp-go/topic-clustering.feature",
-  "specs/nlp-go/tracing-parity.feature",
-  "specs/studio/dataset-creation-regression.feature",
 ];
 
 const TEST_FILE_RE = /\.test\.tsx?$/;


### PR DESCRIPTION
## Summary
- Adds `@scenario` JSDoc annotations to the 3 existing integration tests in `UsersView.integration.test.tsx`
- Binds them to `specs/features/backoffice-user-impersonation-reason.feature` so the feature-parity CI check passes (3/3 bound)
- Unblocks PR #3653 by removing the need to mark these scenarios as `@unimplemented`

## Test plan
- [x] All 3 tests pass (`pnpm test:unit`)
- [x] `check-feature-parity.ts` reports 3/3 bound for `backoffice-user-impersonation-reason.feature`