### PR TITLE
fix(clickhouse): IN-tuple dedup on hot projection state reads

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -166,39 +166,47 @@ export class EvaluationRunClickHouseRepository
       // Do not "simplify" to `ORDER BY UpdatedAt DESC LIMIT 1`: with many
       // unmerged versions per (TenantId, EvaluationId) it forces the engine
       // to read every version *with* the heavy columns just to sort them in
-      // memory. See dev/docs/best_practices/clickhouse-queries.md.
+      // memory.
+      //
+      // Outer SELECT references columns via the `t.` alias because the
+      // SELECT projects `toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAt`
+      // (and similar for Created/Archived/Scheduled/Started/CompletedAt).
+      // Without the alias the IN-tuple's `UpdatedAt` could resolve to the
+      // projected UInt64 alias instead of the raw DateTime64 column and the
+      // type comparison would break. See
+      // dev/docs/best_practices/clickhouse-queries.md.
       const result = await client.query({
         query: `
           SELECT
-            ProjectionId,
-            TenantId,
-            EvaluationId,
-            Version,
-            EvaluatorId,
-            EvaluatorType,
-            EvaluatorName,
-            TraceId,
-            IsGuardrail,
-            Status,
-            Score,
-            Passed,
-            Label,
-            Details,
-            Inputs,
-            Error,
-            ErrorDetails,
-            toUnixTimestamp64Milli(CreatedAt) AS CreatedAt,
-            toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAt,
-            toUnixTimestamp64Milli(ArchivedAt) AS ArchivedAt,
-            toUnixTimestamp64Milli(ScheduledAt) AS ScheduledAt,
-            toUnixTimestamp64Milli(StartedAt) AS StartedAt,
-            toUnixTimestamp64Milli(CompletedAt) AS CompletedAt,
-            CostId,
-            LastProcessedEventId
-          FROM ${TABLE_NAME}
-          WHERE TenantId = {tenantId:String}
-            AND EvaluationId = {evaluationId:String}
-            AND (TenantId, EvaluationId, UpdatedAt) IN (
+            t.ProjectionId AS ProjectionId,
+            t.TenantId AS TenantId,
+            t.EvaluationId AS EvaluationId,
+            t.Version AS Version,
+            t.EvaluatorId AS EvaluatorId,
+            t.EvaluatorType AS EvaluatorType,
+            t.EvaluatorName AS EvaluatorName,
+            t.TraceId AS TraceId,
+            t.IsGuardrail AS IsGuardrail,
+            t.Status AS Status,
+            t.Score AS Score,
+            t.Passed AS Passed,
+            t.Label AS Label,
+            t.Details AS Details,
+            t.Inputs AS Inputs,
+            t.Error AS Error,
+            t.ErrorDetails AS ErrorDetails,
+            toUnixTimestamp64Milli(t.CreatedAt) AS CreatedAt,
+            toUnixTimestamp64Milli(t.UpdatedAt) AS UpdatedAt,
+            toUnixTimestamp64Milli(t.ArchivedAt) AS ArchivedAt,
+            toUnixTimestamp64Milli(t.ScheduledAt) AS ScheduledAt,
+            toUnixTimestamp64Milli(t.StartedAt) AS StartedAt,
+            toUnixTimestamp64Milli(t.CompletedAt) AS CompletedAt,
+            t.CostId AS CostId,
+            t.LastProcessedEventId AS LastProcessedEventId
+          FROM ${TABLE_NAME} AS t
+          WHERE t.TenantId = {tenantId:String}
+            AND t.EvaluationId = {evaluationId:String}
+            AND (t.TenantId, t.EvaluationId, t.UpdatedAt) IN (
               SELECT TenantId, EvaluationId, max(UpdatedAt)
               FROM ${TABLE_NAME}
               WHERE TenantId = {tenantId:String}

--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -158,6 +158,15 @@ export class EvaluationRunClickHouseRepository
 
     try {
       const client = await this.resolveClient(tenantId);
+      // IN-tuple dedup over the ReplacingMergeTree: the inner SELECT scans
+      // only (TenantId, EvaluationId, UpdatedAt) — small, sparse — to find
+      // the latest version, then the outer SELECT pulls the heavy columns
+      // (Inputs, Details, Error, ErrorDetails — ZSTD(3)) for that one row.
+      //
+      // Do not "simplify" to `ORDER BY UpdatedAt DESC LIMIT 1`: with many
+      // unmerged versions per (TenantId, EvaluationId) it forces the engine
+      // to read every version *with* the heavy columns just to sort them in
+      // memory. See dev/docs/best_practices/clickhouse-queries.md.
       const result = await client.query({
         query: `
           SELECT
@@ -189,7 +198,13 @@ export class EvaluationRunClickHouseRepository
           FROM ${TABLE_NAME}
           WHERE TenantId = {tenantId:String}
             AND EvaluationId = {evaluationId:String}
-          ORDER BY UpdatedAt DESC
+            AND (TenantId, EvaluationId, UpdatedAt) IN (
+              SELECT TenantId, EvaluationId, max(UpdatedAt)
+              FROM ${TABLE_NAME}
+              WHERE TenantId = {tenantId:String}
+                AND EvaluationId = {evaluationId:String}
+              GROUP BY TenantId, EvaluationId
+            )
           LIMIT 1
         `,
         query_params: { tenantId, evaluationId },

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -174,50 +174,56 @@ export class TraceSummaryClickHouseRepository implements TraceSummaryRepository 
       // read every version *with* the heavy columns just to sort them in
       // memory. Called per-event during the trace-summary projection apply,
       // so a 100× read amplification compounds fast under load.
-      // See dev/docs/best_practices/clickhouse-queries.md.
+      //
+      // Outer SELECT references columns via the `t.` alias because the
+      // SELECT projects `toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAt`
+      // (and similar for Created/OccurredAt). Without the alias the
+      // IN-tuple's `UpdatedAt` could resolve to the projected UInt64 alias
+      // instead of the raw DateTime64 column and the type comparison would
+      // break. See dev/docs/best_practices/clickhouse-queries.md.
       const result = await client.query({
         query: `
           SELECT
-            ProjectionId,
-            TenantId,
-            TraceId,
-            Version,
-            Attributes,
-            toUnixTimestamp64Milli(OccurredAt) AS OccurredAt,
-            toUnixTimestamp64Milli(CreatedAt) AS CreatedAt,
-            toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAt,
-            ComputedIOSchemaVersion,
-            ComputedInput,
-            ComputedOutput,
-            TimeToFirstTokenMs,
-            TimeToLastTokenMs,
-            TotalDurationMs,
-            TokensPerSecond,
-            SpanCount,
-            ContainsErrorStatus,
-            ContainsOKStatus,
-            ErrorMessage,
-            Models,
-            TotalCost,
-            TokensEstimated,
-            TotalPromptTokenCount,
-            TotalCompletionTokenCount,
-            OutputFromRootSpan,
-            OutputSpanEndTimeMs,
-            BlockedByGuardrail,
-            TopicId,
-            SubTopicId,
-            AnnotationIds,
-            HasAnnotation,
-            ScenarioRoleCosts,
-            ScenarioRoleLatencies,
-            TraceName,
-            ScenarioRoleSpans,
-            SpanCosts
-          FROM ${TABLE_NAME}
-          WHERE TenantId = {tenantId:String}
-            AND TraceId = {traceId:String}
-            AND (TenantId, TraceId, UpdatedAt) IN (
+            t.ProjectionId AS ProjectionId,
+            t.TenantId AS TenantId,
+            t.TraceId AS TraceId,
+            t.Version AS Version,
+            t.Attributes AS Attributes,
+            toUnixTimestamp64Milli(t.OccurredAt) AS OccurredAt,
+            toUnixTimestamp64Milli(t.CreatedAt) AS CreatedAt,
+            toUnixTimestamp64Milli(t.UpdatedAt) AS UpdatedAt,
+            t.ComputedIOSchemaVersion AS ComputedIOSchemaVersion,
+            t.ComputedInput AS ComputedInput,
+            t.ComputedOutput AS ComputedOutput,
+            t.TimeToFirstTokenMs AS TimeToFirstTokenMs,
+            t.TimeToLastTokenMs AS TimeToLastTokenMs,
+            t.TotalDurationMs AS TotalDurationMs,
+            t.TokensPerSecond AS TokensPerSecond,
+            t.SpanCount AS SpanCount,
+            t.ContainsErrorStatus AS ContainsErrorStatus,
+            t.ContainsOKStatus AS ContainsOKStatus,
+            t.ErrorMessage AS ErrorMessage,
+            t.Models AS Models,
+            t.TotalCost AS TotalCost,
+            t.TokensEstimated AS TokensEstimated,
+            t.TotalPromptTokenCount AS TotalPromptTokenCount,
+            t.TotalCompletionTokenCount AS TotalCompletionTokenCount,
+            t.OutputFromRootSpan AS OutputFromRootSpan,
+            t.OutputSpanEndTimeMs AS OutputSpanEndTimeMs,
+            t.BlockedByGuardrail AS BlockedByGuardrail,
+            t.TopicId AS TopicId,
+            t.SubTopicId AS SubTopicId,
+            t.AnnotationIds AS AnnotationIds,
+            t.HasAnnotation AS HasAnnotation,
+            t.ScenarioRoleCosts AS ScenarioRoleCosts,
+            t.ScenarioRoleLatencies AS ScenarioRoleLatencies,
+            t.TraceName AS TraceName,
+            t.ScenarioRoleSpans AS ScenarioRoleSpans,
+            t.SpanCosts AS SpanCosts
+          FROM ${TABLE_NAME} AS t
+          WHERE t.TenantId = {tenantId:String}
+            AND t.TraceId = {traceId:String}
+            AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
               SELECT TenantId, TraceId, max(UpdatedAt)
               FROM ${TABLE_NAME}
               WHERE TenantId = {tenantId:String}

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -164,6 +164,17 @@ export class TraceSummaryClickHouseRepository implements TraceSummaryRepository 
 
     try {
       const client = await this.resolveClient(tenantId);
+      // IN-tuple dedup over the ReplacingMergeTree: the inner SELECT scans
+      // only (TenantId, TraceId, UpdatedAt) — small, sparse — to find the
+      // latest version, then the outer SELECT pulls the heavy columns
+      // (ComputedInput, ComputedOutput, Attributes, etc.) for that one row.
+      //
+      // Do not "simplify" to `ORDER BY UpdatedAt DESC LIMIT 1`: with many
+      // unmerged versions per (TenantId, TraceId) it forces the engine to
+      // read every version *with* the heavy columns just to sort them in
+      // memory. Called per-event during the trace-summary projection apply,
+      // so a 100× read amplification compounds fast under load.
+      // See dev/docs/best_practices/clickhouse-queries.md.
       const result = await client.query({
         query: `
           SELECT
@@ -206,7 +217,13 @@ export class TraceSummaryClickHouseRepository implements TraceSummaryRepository 
           FROM ${TABLE_NAME}
           WHERE TenantId = {tenantId:String}
             AND TraceId = {traceId:String}
-          ORDER BY UpdatedAt DESC
+            AND (TenantId, TraceId, UpdatedAt) IN (
+              SELECT TenantId, TraceId, max(UpdatedAt)
+              FROM ${TABLE_NAME}
+              WHERE TenantId = {tenantId:String}
+                AND TraceId = {traceId:String}
+              GROUP BY TenantId, TraceId
+            )
           LIMIT 1
         `,
         query_params: { tenantId, traceId },


### PR DESCRIPTION
## Summary

Hot-fix for the 2026-05-01 ingestion incident. Two repository methods read the latest version of a projection row from ReplacingMergeTree tables using `ORDER BY UpdatedAt DESC LIMIT 1`. Under load this is the wrong shape: with many unmerged versions per `(TenantId, key)`, the engine reads **every version with the heavy columns** into memory just to sort by `UpdatedAt`.

CloudWatch slow-query logs over 30 min × 8 worker pods during the incident:

| Pattern | Count | Avg read | Avg duration | Cumulative time |
|---|---|---|---|---|
| `tenantId, traceId` (`trace_summaries`) | **3,329** | 0.13 MB | 2,263 ms | **~7,500 sec** |
| `tenantId, evaluationId` (`evaluation_runs`) | 357 | **5.85 MB** | 577 ms | ~210 sec |

These two queries were the dominant CH read load during the incident. The trace-summary one is called *per-event* during the projection apply, so the read amplification compounds with ingestion volume.

## Fix

Both queries switched to the IN-tuple dedup pattern documented in `dev/docs/best_practices/clickhouse-queries.md`:

```sql
SELECT <columns…>
FROM <table>
WHERE TenantId = {tenantId:String}
  AND <key> = {key:String}
  AND (TenantId, <key>, UpdatedAt) IN (
    SELECT TenantId, <key>, max(UpdatedAt)
    FROM <table>
    WHERE TenantId = {tenantId:String}
      AND <key> = {key:String}
    GROUP BY TenantId, <key>
  )
LIMIT 1
```

The inner SELECT reads only the sparse `(key…, UpdatedAt)` tuple — granular and fast even with thousands of unmerged versions. The outer SELECT then reads the heavy columns (`ComputedInput`, `ComputedOutput`, `Attributes`, `Inputs`, `Details`, `Error`, `ErrorDetails` — all ZSTD(3)) for the single matching row.

Files:
- `langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts` — `getByTraceId`
- `langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts` — `getByEvaluationId`

## Behavior parity

The IN-tuple form returns the same row as `ORDER BY UpdatedAt DESC LIMIT 1` — the row with the maximum `UpdatedAt` for the matched key. If multiple rows share the same `max(UpdatedAt)` (vanishingly rare with millisecond precision), the outer `LIMIT 1` picks one deterministically per ClickHouse's standard ordering. Same behavior as before.

## Test plan

- [ ] CI green
- [ ] Existing `trace-summary` and `evaluation-run` integration tests pass (they use behaviour-level assertions on the returned record, not on query text)
- [ ] Post-deploy: watch `EngineCPUUtilization` on prod ElastiCache and worker CloudWatch slow-query logs — expect the `tenantId, traceId` and `tenantId, evaluationId` slow-query lines to drop to near-zero, and `completedPerSec` to track ingestion rate without bursts.

## Follow-ups (separate PR)

A sweep across the remaining ReplacingMergeTree repos for the same anti-pattern. Candidates flagged in initial grep:
- `langwatch/src/server/traces/repositories/span-storage.clickhouse.repository.ts`
- `langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts`
- `langwatch/src/server/evaluations/clickhouse-evaluation.service.ts`
- `langwatch/src/server/evaluations-v3/services/clickhouse-experiment-run.service.ts`
- Other tables with `ENGINE = ReplacingMergeTree` (`experiment_runs`, `simulation_runs`, `billable_events`, `suite_runs`)