### PR TITLE
fix(deps): upgrade authlib to 1.6.11 (CVE: JWK Header Injection)

### DIFF
--- a/langevals/uv.lock
+++ b/langevals/uv.lock
@@ -333,14 +333,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.6"
+version = "1.6.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrades `authlib` from 1.6.6 to 1.6.11 in `langevals/uv.lock`
- Fixes Dependabot alert #592 (critical severity)
- **CVE: JWK Header Injection** — allows an attacker to forge arbitrary JWT tokens that pass signature verification by embedding their own public key in the JWT `jwk` header field

## Impact assessment
- `authlib` is a **transitive dependency** pulled in by `arize-phoenix` (used in `langevals/notebooks/`)
- **Not used directly** in any LangWatch production code — no Python file imports authlib
- `langevals-notebook` is a non-publishable workspace member (`package = false`) used for development notebooks only
- The lock file change is minimal: only the authlib version and hashes updated

## Risk: **None**
- Lock file only — no code changes
- Transitive dependency used by arize-phoenix internally
- No direct authlib API usage in the codebase

## Test plan
- [x] `uv lock --upgrade-package authlib` resolves cleanly
- [x] Only `langevals/uv.lock` changed (3 lines)
- [ ] CI green