### PR TITLE
fix(clickhouse): match lastEventOccurredAt column casing to actual schema

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -268,7 +268,7 @@ export class EvaluationRunClickHouseRepository
             toUnixTimestamp64Milli(CompletedAt) AS CompletedAt,
             CostId,
             LastProcessedEventId,
-            toUnixTimestamp64Milli(LastEventOccurredAt) AS LastEventOccurredAt
+            toUnixTimestamp64Milli(lastEventOccurredAt) AS lastEventOccurredAt
           FROM ${TABLE_NAME}
           WHERE TenantId = {tenantId:String}
             AND ScheduledAt >= now() - INTERVAL 7 DAY

--- a/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-summary.clickhouse.repository.ts
@@ -18,7 +18,7 @@ const logger = createLogger(
 type ClickHouseSummaryWriteRecord = Omit<
   WithDateWrites<
     ClickHouseSummaryRecord,
-    "OccurredAt" | "CreatedAt" | "UpdatedAt" | "LastEventOccurredAt"
+    "OccurredAt" | "CreatedAt" | "UpdatedAt" | "lastEventOccurredAt"
   >,
   "Events.Timestamp"
 > & {
@@ -34,7 +34,7 @@ interface ClickHouseSummaryRecord extends TraceSummaryFieldsBase {
   "Events.Timestamp": string[];
   "Events.Name": string[];
   "Events.Attributes": Record<string, string>[];
-  LastEventOccurredAt: number;
+  lastEventOccurredAt: number;
 }
 
 export class TraceSummaryClickHouseRepository
@@ -324,7 +324,7 @@ export class TraceSummaryClickHouseRepository
       occurredAt: record.OccurredAt,
       createdAt: record.CreatedAt,
       updatedAt: record.UpdatedAt,
-      lastEventOccurredAt: Number(record.LastEventOccurredAt ?? 0),
+      lastEventOccurredAt: Number(record.lastEventOccurredAt ?? 0),
     };
   }
 
@@ -343,7 +343,7 @@ export class TraceSummaryClickHouseRepository
       OccurredAt: new Date(data.occurredAt),
       CreatedAt: new Date(data.createdAt),
       UpdatedAt: new Date(data.updatedAt),
-      LastEventOccurredAt: data.lastEventOccurredAt
+      lastEventOccurredAt: data.lastEventOccurredAt
         ? new Date(data.lastEventOccurredAt)
         : new Date(0),
       ComputedIOSchemaVersion: data.computedIOSchemaVersion,


### PR DESCRIPTION
## Summary

- Migration `00015` created the `lastEventOccurredAt` column with **camelCase** on `evaluation_runs` and `trace_summaries`, while the other 3 tables (`simulation_runs`, `experiment_runs`, `suite_runs`) correctly used **PascalCase**
- The query code and TS types referenced `LastEventOccurredAt` (PascalCase), but ClickHouse is case-sensitive — causing `Unknown expression` errors on `evaluation_runs.findByTraceId` and silent data loss on `trace_summaries` writes
- Fixed the code to match the actual column casing (`lastEventOccurredAt`) in both repositories

## Test plan

- [x] Typecheck passes
- [ ] Verify `findByTraceId` no longer throws on `evaluation_runs`
- [ ] Verify `trace_summaries` `lastEventOccurredAt` values are correctly persisted after writes