### PR TITLE
chore(billing): bind 3 @unimplemented scenarios to existing tests (#3458)

### DIFF
--- a/langwatch/ee/billing/__tests__/planProvider.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planProvider.unit.test.ts
@@ -355,6 +355,7 @@ describe("createSaaSPlanProvider", () => {
     });
 
     describe("when subscription is CANCELLED", () => {
+      /** @scenario Cancelled subscription resolves to free tier limits */
       it("resolves to free tier limits", async () => {
         // A CANCELLED subscription must not appear in active subscription query.
         // The findFirst query filters by status: ACTIVE, so cancelled subs are excluded.

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -425,6 +425,7 @@ describe("webhookService", () => {
     });
 
     describe("when subscription is already CANCELLED in DB and Stripe subscription is canceled", () => {
+      /** @scenario $0 invoice on cancellation does not reactivate a cancelled subscription */
       it("does not reactivate a cancelled subscription", async () => {
         mockStripeInstance.subscriptions.retrieve.mockResolvedValue({
           id: "sub_stripe_1",
@@ -451,6 +452,7 @@ describe("webhookService", () => {
     });
 
     describe("when subscription is ACTIVE in DB but Stripe subscription is canceled", () => {
+      /** @scenario $0 invoice on cancellation does not reactivate a cancelling subscription */
       it("does not reactivate when Stripe status is canceled", async () => {
         mockStripeInstance.subscriptions.retrieve.mockResolvedValue({
           id: "sub_stripe_1",

--- a/specs/billing/subscription-cancellation.feature
+++ b/specs/billing/subscription-cancellation.feature
@@ -9,7 +9,7 @@ Feature: Subscription cancellation revokes access and sends correct notification
     Given an organization with an active Growth Seat subscription
     And the subscription is linked to a Stripe subscription
 
-  @regression @unit @unimplemented
+  @regression @unit
   Scenario: $0 invoice on cancellation does not reactivate a cancelled subscription
     Given the subscription has been cancelled in our database
     When Stripe fires an invoice.payment_succeeded event for the cancelled subscription
@@ -17,7 +17,7 @@ Feature: Subscription cancellation revokes access and sends correct notification
     Then the webhook handler skips activation
     And no Slack notification is sent
 
-  @regression @unit @unimplemented
+  @regression @unit
   Scenario: $0 invoice on cancellation does not reactivate a cancelling subscription
     Given the subscription is still active in our database
     When Stripe fires an invoice.payment_succeeded event
@@ -25,7 +25,7 @@ Feature: Subscription cancellation revokes access and sends correct notification
     Then the webhook handler skips activation
     And no Slack notification is sent
 
-  @regression @unit @unimplemented
+  @regression @unit
   Scenario: Cancelled subscription resolves to free tier limits
     Given the subscription has been cancelled
     When the plan provider resolves the active plan for the organization


### PR DESCRIPTION
## Summary

Phase 2 unimpl-reduction for the **billing** domain (1 file, 3 scenarios — smallest possible domain). All three scenarios in `specs/billing/subscription-cancellation.feature` were already covered by existing unit tests but tagged `@unimplemented` because no `@scenario` JSDoc binding pointed back to them.

This PR adds the bindings and removes the tags. **No behavior or test logic change.**

## Bindings

| Scenario | Test |
|---|---|
| \`\$0 invoice on cancellation does not reactivate a cancelled subscription\` | \`webhookService.unit.test.ts:428\` |
| \`\$0 invoice on cancellation does not reactivate a cancelling subscription\` | \`webhookService.unit.test.ts:454\` |
| \`Cancelled subscription resolves to free tier limits\` | \`planProvider.unit.test.ts:358\` |

## Verification

- \`pnpm check:feature-parity\`: \`specs/billing/subscription-cancellation.feature 3/3 scenarios bound\`, no regressions
- \`npx vitest run\` on both files: 67/67 passing

## Test plan

- [x] Bindings verified locally via parity check
- [x] Tests pass locally
- [ ] CI green on this PR

Refs: #3458

🤖 Generated with [Claude Code](https://claude.com/claude-code)