### PR TITLE
chore(studio): bind 3 + cull 1 @unimplemented scenarios in studio (#3458)

### DIFF
--- a/langwatch/src/optimization_studio/components/datasets/__tests__/DatasetSelection.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/datasets/__tests__/DatasetSelection.integration.test.tsx
@@ -100,6 +100,7 @@ describe("DatasetSelection", () => {
   });
 
   describe("when clicking the New dataset button", () => {
+    /** @scenario New dataset button opens the dataset creation form directly */
     it("opens addOrEditDataset drawer directly without forcing file upload", async () => {
       const user = userEvent.setup();
 
@@ -122,6 +123,7 @@ describe("DatasetSelection", () => {
       );
     });
 
+    /** @scenario Creating a dataset sets it as the active dataset */
     it("calls setIsEditing with the created dataset when onSuccess fires", async () => {
       const user = userEvent.setup();
 
@@ -145,6 +147,7 @@ describe("DatasetSelection", () => {
   });
 
   describe("when a dataset already exists on the node", () => {
+    /** @scenario New dataset button works when a dataset already exists */
     it("opens addOrEditDataset drawer, not uploadCSV", async () => {
       const user = userEvent.setup();
       const propsWithDataset = {

--- a/specs/studio/dataset-creation-regression.feature
+++ b/specs/studio/dataset-creation-regression.feature
@@ -5,19 +5,16 @@ Feature: Studio dataset creation opens the correct form
     Given the user is editing a workflow in Studio
     And the entry node is selected
 
-  @unimplemented
   Scenario: New dataset button opens the dataset creation form directly
     When the user clicks "New dataset" on the entry node
     Then the dataset creation form opens
     And the user is not forced to upload a CSV file first
 
-  @unimplemented
   Scenario: Creating a dataset sets it as the active dataset
     When the user clicks "New dataset" on the entry node
     And the user fills in the dataset name and submits
     Then the newly created dataset is set as the active dataset for the node
 
-  @unimplemented
   Scenario: New dataset button works when a dataset already exists
     Given the entry node already has a dataset assigned
     When the user clicks "New dataset" on the entry node

--- a/specs/studio/publish-not-gated.feature
+++ b/specs/studio/publish-not-gated.feature
@@ -40,13 +40,3 @@ Feature: Workflow Publish Is Not Gated By Subscription Or License
     Given the Publish component renders
     Then it must not read activePlan.canPublish to disable or hide menu items
     And it must not render a lock-icon menu item that redirects to plan management
-
-  @integration @unimplemented
-  Scenario: Workflow creation count limits still apply
-    Given my organization has reached the maximum number of workflows
-    When I try to create a new workflow
-    Then I see the workflow count limit blocker
-    And the upgrade link redirects to plan management
-    # The publish gate removal does NOT remove resource count limits.
-    # This scenario documents the existing resource-limit behavior; coverage
-    # lives in specs/licensing/enforcement-resources.feature, not here.


### PR DESCRIPTION
## Summary

Phase 2 unimpl-reduction for the **studio** domain (2 files, 4 scenarios).

### \`specs/studio/dataset-creation-regression.feature\` (BIND, 3 scenarios)

All three scenarios already had matching tests in \`DatasetSelection.integration.test.tsx\` — only \`@scenario\` JSDoc was missing.

| Scenario | Test |
|---|---|
| New dataset button opens the dataset creation form directly | line 103 |
| Creating a dataset sets it as the active dataset | line 125 |
| New dataset button works when a dataset already exists | line 148 |

### \`specs/studio/publish-not-gated.feature\` (DELETE, 1 scenario)

The scenario \`Workflow creation count limits still apply\` is **self-documented as a duplicate** by its own inline comment:

> \`# coverage lives in specs/licensing/enforcement-resources.feature, not here.\`

The remaining 4 scenarios in this file were already bound to \`Publish.gate-removed.integration.test.tsx\`.

## Verification

- \`pnpm check:feature-parity\`: 3/3 + 4/4 = 7/7 studio scenarios bound, no regressions
- \`npx vitest run\` on \`DatasetSelection.integration.test.tsx\`: 4/4 passing

## Test plan

- [x] Bindings verified locally via parity check
- [x] Tests pass locally
- [ ] CI green on this PR

Refs: #3458

🤖 Generated with [Claude Code](https://claude.com/claude-code)