### PR TITLE
chore(components): bind 3/5 @unimplemented scenarios in search-input (#3458)

### DIFF
--- a/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
@@ -186,6 +186,7 @@ describe("<SuiteSidebar/>", () => {
     });
 
     describe("when typing 'billing' in the search box", () => {
+      /** @scenario Suite sidebar filters suites with search icon visible */
       it("filters to only show Billing Edge", async () => {
         const user = userEvent.setup();
 

--- a/langwatch/src/components/ui/__tests__/SearchInput.integration.test.tsx
+++ b/langwatch/src/components/ui/__tests__/SearchInput.integration.test.tsx
@@ -26,6 +26,7 @@ describe("<SearchInput/>", () => {
       });
     });
 
+    /** @scenario SearchInput renders with a search icon and placeholder */
     it("renders a search icon inside the input", () => {
       expect(
         screen.getByRole("img", { name: "Search" }),

--- a/langwatch/src/components/ui/__tests__/SearchInput.unit.test.tsx
+++ b/langwatch/src/components/ui/__tests__/SearchInput.unit.test.tsx
@@ -22,6 +22,7 @@ describe("<SearchInput/>", () => {
   });
 
   describe("when typing text into the input", () => {
+    /** @scenario SearchInput forwards typed text to the onChange handler */
     it("forwards the value to the onChange callback", async () => {
       const user = userEvent.setup();
       const onChange = vi.fn();

--- a/specs/components/search-input.feature
+++ b/specs/components/search-input.feature
@@ -7,19 +7,19 @@ Feature: Standardized search input with search icon
     Given the application renders a search input field
 
   # Shared SearchInput component behavior
-  @unit @unimplemented
+  @unit
   Scenario: SearchInput forwards typed text to the onChange handler
     When I type "billing" into the SearchInput
     Then the onChange callback receives "billing"
 
-  @integration @unimplemented
+  @integration
   Scenario: SearchInput renders with a search icon and placeholder
     When the SearchInput component mounts with placeholder "Search suites..."
     Then a search icon is visible inside the input
     And the placeholder "Search suites..." is visible
 
   # Suite sidebar uses the shared SearchInput
-  @integration @unimplemented
+  @integration
   Scenario: Suite sidebar filters suites with search icon visible
     Given the suites sidebar is rendered with suites "Billing" and "Onboarding"
     When I look at the search field in the sidebar


### PR DESCRIPTION
## Summary

Phase 2 unimpl-reduction for the components/search-input feature (1 of 3 component files).

Three of the five \`@unimplemented\` scenarios in \`specs/components/search-input.feature\` already had matching tests; only the \`@scenario\` JSDoc bindings were missing. This PR adds them and removes the \`@unimplemented\` tag from those three. The remaining two scenarios (scenario picker / target picker) keep their tags — no search-icon test exists in the corresponding pickers' test files yet.

## Bindings

| Scenario | Test |
|---|---|
| \`SearchInput forwards typed text to the onChange handler\` | \`SearchInput.unit.test.tsx:25\` |
| \`SearchInput renders with a search icon and placeholder\` | \`SearchInput.integration.test.tsx:29\` |
| \`Suite sidebar filters suites with search icon visible\` | \`SuiteSidebar.integration.test.tsx:189\` |

## Still \`@unimplemented\`

- \`Scenario picker search field displays a search icon\` (no test in \`ScenarioPicker.integration.test.tsx\`)
- \`Target picker search field displays a search icon\` (no test in \`TargetPicker.unit.test.tsx\`)

## Verification

- \`pnpm check:feature-parity\`: 3/3 enforced search-input scenarios bound
- \`npx vitest run\` on the 3 affected test files: 44/44 passing

## Test plan

- [x] Bindings verified locally via parity check
- [x] Tests pass locally
- [ ] CI green on this PR

Refs: #3458

🤖 Generated with [Claude Code](https://claude.com/claude-code)