### PR TITLE
chore(typescript-sdk): bind 2 SDK-level @unimplemented prompt-tag scenarios (#3458)

### DIFF
--- a/specs/typescript-sdk/cli-prompt-tags.feature
+++ b/specs/typescript-sdk/cli-prompt-tags.feature
@@ -8,12 +8,12 @@ Feature: CLI Prompt Tag Commands
 
   # --- SDK: renameTag method ---
 
-  @unit @unimplemented
+  @unit
   Scenario: renameTag calls PUT /api/prompts/tags/{tag} with new name
     When I call promptsApiService.renameTag({ tag: "old-name", name: "new-name" })
     Then the SDK sends PUT /api/prompts/tags/old-name with body { name: "new-name" }
 
-  @unit @unimplemented
+  @unit
   Scenario: Facade tags.rename delegates to renameTag
     When I call facade.tags.rename("old-name", "new-name")
     Then it delegates to promptsApiService.renameTag({ tag: "old-name", name: "new-name" })

--- a/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts-api.service.test.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts-api.service.test.ts
@@ -21,6 +21,7 @@ describe("PromptsApiService.renameTag", () => {
     } as InternalConfig);
   });
 
+  /** @scenario renameTag calls PUT /api/prompts/tags/{tag} with new name */
   it("calls PUT /api/prompts/tags/{tag} with new name", async () => {
     mockPut.mockResolvedValue({ data: undefined, error: undefined });
     await service.renameTag({ tag: "old-name", name: "new-name" });

--- a/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts.facade.unit.test.ts
+++ b/typescript-sdk/src/client-sdk/services/prompts/__tests__/prompts.facade.unit.test.ts
@@ -462,6 +462,7 @@ describe("PromptsFacade.tags.rename", () => {
   });
 
   describe("when renaming a tag", () => {
+    /** @scenario Facade tags.rename delegates to renameTag */
     it("delegates to promptsApiService.renameTag with old and new names", async () => {
       promptsApiService.renameTag.mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary

Phase 2 unimpl-reduction in \`specs/typescript-sdk/cli-prompt-tags.feature\`.

Two SDK-level scenarios already had matching tests; only \`@scenario\` JSDoc bindings were missing. The remaining 14 scenarios in the same file are CLI-level (\`langwatch prompt tag list\`, \`create\`, \`rename\` …) and require new fixture-based CLI tests, so they keep their \`@unimplemented\` tags.

## Bindings

| Scenario | Test |
|---|---|
| \`renameTag calls PUT /api/prompts/tags/{tag} with new name\` | \`prompts-api.service.test.ts:24\` |
| \`Facade tags.rename delegates to renameTag\` | \`prompts.facade.unit.test.ts:465\` |

## Verification

- \`pnpm check:feature-parity\`: 2/2 enforced cli-prompt-tags scenarios bound, no regressions

## Test plan

- [x] Bindings verified locally via parity check
- [ ] CI green on this PR

Refs: #3458

🤖 Generated with [Claude Code](https://claude.com/claude-code)