### PR TITLE
fix(scenarios): emit OTel span on SerializedCodeAgentAdapter timeout/error (#3438)

### DIFF
--- a/langwatch/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts
@@ -5,7 +5,58 @@
 import { AgentRole, type AgentInput } from "@langwatch/scenario";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodeAgentData } from "../../types";
-import { SerializedCodeAgentAdapter } from "../code-agent.adapter";
+
+// Capture withActiveSpan calls so the timeout/error paths can be verified.
+// (lw#3438: traced failures must always leave a span footprint.)
+const { withActiveSpanCalls } = vi.hoisted(() => {
+  const withActiveSpanCalls: Array<{
+    name: string;
+    options: { kind: number; attributes: Record<string, unknown> };
+    span: {
+      setAttribute: ReturnType<typeof vi.fn>;
+      setAttributes: ReturnType<typeof vi.fn>;
+      setStatus: ReturnType<typeof vi.fn>;
+      recordException: ReturnType<typeof vi.fn>;
+      end: ReturnType<typeof vi.fn>;
+    };
+  }> = [];
+  return { withActiveSpanCalls };
+});
+
+vi.mock("langwatch", () => ({
+  getLangWatchTracer: () => ({
+    withActiveSpan: async (
+      name: string,
+      opts: { kind: number; attributes: Record<string, unknown> },
+      fn: (span: {
+        setAttribute: ReturnType<typeof vi.fn>;
+        setAttributes: ReturnType<typeof vi.fn>;
+        setStatus: ReturnType<typeof vi.fn>;
+        recordException: ReturnType<typeof vi.fn>;
+        end: ReturnType<typeof vi.fn>;
+      }) => unknown,
+    ) => {
+      const span = {
+        setAttribute: vi.fn(),
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        recordException: vi.fn(),
+        end: vi.fn(),
+      };
+      withActiveSpanCalls.push({ name, options: opts, span });
+      try {
+        return await fn(span);
+      } catch (err) {
+        span.setStatus({ code: 2, message: (err as Error)?.message });
+        span.recordException(err as Error);
+        span.end();
+        throw err;
+      }
+    },
+  }),
+}));
+
+import { SerializedCodeAgentAdapter, SerializedCodeAgentAdapterError } from "../code-agent.adapter";
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -27,6 +78,7 @@ describe("SerializedCodeAgentAdapter", () => {
   /** NLP service /studio/execute_sync response format */
   const nlpResponse = (result: Record<string, unknown> | null) => ({
     ok: true,
+    status: 200,
     json: vi.fn().mockResolvedValue({
       trace_id: "trace_abc123",
       status: "success",
@@ -47,6 +99,7 @@ describe("SerializedCodeAgentAdapter", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    withActiveSpanCalls.length = 0;
     mockFetch.mockResolvedValue(
       nlpResponse({ output: "processed: Hello" }),
     );
@@ -461,6 +514,165 @@ describe("SerializedCodeAgentAdapter", () => {
       );
       expect(codeToEnd.sourceHandle).toBe("outputs.output");
       expect(codeToEnd.targetHandle).toBe("inputs.output");
+    });
+  });
+
+  /**
+   * Span emission on success and on failure paths.
+   *
+   * Regression for lw#3438 — customer trace had no adapter span on a hung
+   * NLP request, making the failure invisible.
+   */
+  describe("when emitting spans for the NLP request (lw#3438)", () => {
+    const findExecuteSpan = () =>
+      withActiveSpanCalls.find(
+        (c) => c.name === "SerializedCodeAgentAdapter.execute_nlp_request",
+      );
+
+    describe("when the request succeeds", () => {
+      /** @scenario code-agent adapter emits a span tagged with the request URL on success */
+      it("emits a CLIENT span tagged with the agent id and HTTP url", async () => {
+        const adapter = new SerializedCodeAgentAdapter(defaultConfig, nlpServiceUrl, apiKey);
+        await adapter.call(defaultInput);
+
+        const span = findExecuteSpan();
+        expect(span).toBeDefined();
+        expect(span!.options.attributes["scenario.agent.id"]).toBe("agent_123");
+        expect(span!.options.attributes["http.url"]).toBe(`${nlpServiceUrl}/studio/execute_sync`);
+        expect(span!.options.attributes["http.method"]).toBe("POST");
+      });
+
+      it("annotates the span with the response status code", async () => {
+        const adapter = new SerializedCodeAgentAdapter(defaultConfig, nlpServiceUrl, apiKey);
+        await adapter.call(defaultInput);
+
+        const span = findExecuteSpan();
+        const setAttrCalls = span!.span.setAttribute.mock.calls;
+        const httpStatusCall = setAttrCalls.find((c) => c[0] === "http.status_code");
+        expect(httpStatusCall?.[1]).toBe(200);
+      });
+    });
+
+    describe("when the NLP service times out before responding", () => {
+      // Fetch implementation that rejects with AbortError as soon as the
+      // controller's signal aborts. Returning the promise via async/await
+      // keeps the rejection attached to the awaited chain, avoiding spurious
+      // "unhandled rejection" warnings when fake timers drive the abort.
+      const abortAwareFetch = (signal: AbortSignal) =>
+        new Promise<Response>((_resolve, reject) => {
+          if (signal.aborted) {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+            return;
+          }
+          const onAbort = () => {
+            signal.removeEventListener("abort", onAbort);
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          };
+          signal.addEventListener("abort", onAbort);
+        });
+
+      /** @scenario code-agent adapter emits an error span with kind=timeout when the NLP service hangs */
+      it("throws SerializedCodeAgentAdapterError with kind=timeout and emits an error span", async () => {
+        mockFetch.mockImplementation(async (_url: string, opts: { signal: AbortSignal }) =>
+          abortAwareFetch(opts.signal),
+        );
+        vi.useFakeTimers();
+        try {
+          const adapter = new SerializedCodeAgentAdapter(defaultConfig, nlpServiceUrl, apiKey);
+          const callPromise = adapter.call(defaultInput);
+          // Attach the rejection handler before advancing timers so the
+          // synchronous abort doesn't surface as an unhandled rejection.
+          const settled = expect(callPromise).rejects.toBeInstanceOf(SerializedCodeAgentAdapterError);
+          await vi.advanceTimersByTimeAsync(120_001);
+          await settled;
+        } finally {
+          vi.useRealTimers();
+        }
+
+        const span = findExecuteSpan();
+        expect(span).toBeDefined();
+        const setAttrCalls = span!.span.setAttribute.mock.calls;
+        const errorKindCall = setAttrCalls.find((c) => c[0] === "error.kind");
+        expect(errorKindCall?.[1]).toBe("timeout");
+        expect(span!.span.recordException).toHaveBeenCalled();
+      });
+
+      it("the thrown error reports kind=timeout for diagnosis", async () => {
+        mockFetch.mockImplementation(async (_url: string, opts: { signal: AbortSignal }) =>
+          abortAwareFetch(opts.signal),
+        );
+        vi.useFakeTimers();
+        let captured: SerializedCodeAgentAdapterError | undefined;
+        try {
+          const adapter = new SerializedCodeAgentAdapter(defaultConfig, nlpServiceUrl, apiKey);
+          const callPromise = adapter.call(defaultInput).catch((e: SerializedCodeAgentAdapterError) => {
+            captured = e;
+          });
+          await vi.advanceTimersByTimeAsync(120_001);
+          await callPromise;
+        } finally {
+          vi.useRealTimers();
+        }
+        expect(captured?.kind).toBe("timeout");
+        expect(captured?.message).toContain("did not respond within 120000ms");
+      });
+    });
+
+    describe("when fetch fails before the response is received", () => {
+      /** @scenario code-agent adapter emits an error span with kind=fetch when the network fails */
+      it("emits an error span with kind=fetch", async () => {
+        mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+
+        const adapter = new SerializedCodeAgentAdapter(defaultConfig, nlpServiceUrl, apiKey);
+        await expect(adapter.call(defaultInput)).rejects.toBeInstanceOf(SerializedCodeAgentAdapterError);
+
+        const span = findExecuteSpan();
+        const setAttrCalls = span!.span.setAttribute.mock.calls;
+        const errorKindCall = setAttrCalls.find((c) => c[0] === "error.kind");
+        expect(errorKindCall?.[1]).toBe("fetch");
+        expect(span!.span.recordException).toHaveBeenCalled();
+      });
+    });
+
+    describe("when the NLP service returns a non-2xx response", () => {
+      /** @scenario code-agent adapter emits an error span with kind=http when the NLP service returns non-2xx */
+      it("emits an error span with kind=http and the status code", async () => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 503,
+          json: vi.fn().mockResolvedValue({ detail: "service down" }),
+          text: vi.fn().mockResolvedValue('{"detail": "service down"}'),
+        });
+
+        const adapter = new SerializedCodeAgentAdapter(defaultConfig, nlpServiceUrl, apiKey);
+        await expect(adapter.call(defaultInput)).rejects.toBeInstanceOf(SerializedCodeAgentAdapterError);
+
+        const span = findExecuteSpan();
+        const setAttrCalls = span!.span.setAttribute.mock.calls;
+        const errorKindCall = setAttrCalls.find((c) => c[0] === "error.kind");
+        const httpStatusCall = setAttrCalls.find((c) => c[0] === "http.status_code");
+        expect(errorKindCall?.[1]).toBe("http");
+        expect(httpStatusCall?.[1]).toBe(503);
+      });
+
+      it("the thrown error carries the http status code", async () => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 500,
+          json: vi.fn().mockResolvedValue({ detail: "boom" }),
+          text: vi.fn().mockResolvedValue('{"detail": "boom"}'),
+        });
+
+        const adapter = new SerializedCodeAgentAdapter(defaultConfig, nlpServiceUrl, apiKey);
+        let captured: SerializedCodeAgentAdapterError | undefined;
+        try {
+          await adapter.call(defaultInput);
+        } catch (e) {
+          captured = e as SerializedCodeAgentAdapterError;
+        }
+        expect(captured?.kind).toBe("http");
+        expect(captured?.httpStatus).toBe(500);
+      });
     });
   });
 });

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/code-agent.adapter.ts
@@ -11,12 +11,39 @@
 
 import type { AgentInput } from "@langwatch/scenario";
 import { AgentAdapter, AgentRole } from "@langwatch/scenario";
+import { SpanKind } from "@opentelemetry/api";
 import { randomBytes } from "crypto";
+import { getLangWatchTracer } from "langwatch";
 import { resolveFieldMappings } from "../resolve-field-mappings";
 import type { CodeAgentData } from "../types";
 
 /** Timeout for NLP service requests (2 minutes) */
 const NLP_FETCH_TIMEOUT_MS = 120_000;
+
+/** Categories for adapter failures, surfaced as the `error.kind` span attribute. */
+type AdapterErrorKind = "timeout" | "fetch" | "http" | "nlp_error";
+
+/**
+ * Adapter-level error that always carries a structured `kind` so the parent
+ * span/trace can distinguish a timeout from a network failure or a non-2xx
+ * response from the NLP service. See lw#3438.
+ */
+export class SerializedCodeAgentAdapterError extends Error {
+  readonly kind: AdapterErrorKind;
+  readonly httpStatus?: number;
+
+  constructor(
+    message: string,
+    options: { kind: AdapterErrorKind; httpStatus?: number; cause?: unknown },
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "SerializedCodeAgentAdapterError";
+    this.kind = options.kind;
+    this.httpStatus = options.httpStatus;
+  }
+}
+
+const tracer = getLangWatchTracer("langwatch.scenarios.code-agent-adapter");
 
 /**
  * Serialized code agent adapter that uses pre-fetched configuration.
@@ -183,6 +210,12 @@ export class SerializedCodeAgentAdapter extends AgentAdapter {
    *
    * Uses execute_flow (not execute_component) because /execute_sync only
    * monitors ExecutionStateChange events, which are emitted by execute_flow.
+   *
+   * The whole call is wrapped in an OTel span so that timeouts and fetch
+   * failures always leave a footprint in the trace (lw#3438). The span's
+   * `setStatus(ERROR)` + `recordException` are handled by `withActiveSpan`,
+   * and we annotate `error.kind` + `http.status_code` so the failure mode
+   * is greppable without reading the message string.
    */
   private async executeOnNlpService(
     workflow: ReturnType<typeof this.buildWorkflow>,
@@ -200,55 +233,86 @@ export class SerializedCodeAgentAdapter extends AgentAdapter {
       },
     };
 
-    const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(),
-      NLP_FETCH_TIMEOUT_MS,
-    );
+    const url = `${this.nlpServiceUrl}/studio/execute_sync`;
 
-    try {
-      let response: Response;
-      try {
-        response = await fetch(
-          `${this.nlpServiceUrl}/studio/execute_sync`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(event),
-            signal: controller.signal,
-          },
-        );
-      } catch (fetchError) {
-        const cause = fetchError instanceof Error && "cause" in fetchError
-          ? ` (cause: ${String((fetchError as Error & { cause?: unknown }).cause)})`
-          : "";
-        throw new Error(
-          `Code execution failed: fetch to ${this.nlpServiceUrl}/studio/execute_sync failed - ${fetchError instanceof Error ? fetchError.message : String(fetchError)}${cause}`,
-        );
-      }
+    return tracer.withActiveSpan(
+      "SerializedCodeAgentAdapter.execute_nlp_request",
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          "scenario.agent.id": this.config.agentId,
+          "http.url": url,
+          "http.method": "POST",
+          "nlp.timeout_ms": NLP_FETCH_TIMEOUT_MS,
+        },
+      },
+      async (span) => {
+        const controller = new AbortController();
+        let timedOut = false;
+        const timeout = setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+        }, NLP_FETCH_TIMEOUT_MS);
 
-      if (!response.ok) {
-        let errorMessage = "";
         try {
-          const errorBody = (await response.json()) as { detail?: string };
-          errorMessage = errorBody.detail ?? JSON.stringify(errorBody);
-        } catch {
-          errorMessage = await response.text().catch(() => "");
-        }
-        throw new Error(
-          `Code execution failed: HTTP ${response.status}${errorMessage ? ` - ${errorMessage}` : ""}`,
-        );
-      }
+          let response: Response;
+          try {
+            response = await fetch(url, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(event),
+              signal: controller.signal,
+            });
+          } catch (fetchError) {
+            if (timedOut) {
+              span.setAttribute("error.kind", "timeout" satisfies AdapterErrorKind);
+              throw new SerializedCodeAgentAdapterError(
+                `Code execution failed: NLP service ${url} did not respond within ${NLP_FETCH_TIMEOUT_MS}ms (request aborted).`,
+                { kind: "timeout", cause: fetchError },
+              );
+            }
+            span.setAttribute("error.kind", "fetch" satisfies AdapterErrorKind);
+            const cause = fetchError instanceof Error && "cause" in fetchError
+              ? ` (cause: ${String((fetchError as Error & { cause?: unknown }).cause)})`
+              : "";
+            throw new SerializedCodeAgentAdapterError(
+              `Code execution failed: fetch to ${url} failed - ${fetchError instanceof Error ? fetchError.message : String(fetchError)}${cause}`,
+              { kind: "fetch", cause: fetchError },
+            );
+          }
 
-      const result = (await response.json()) as {
-        trace_id: string;
-        status: string;
-        result: Record<string, unknown> | null;
-      };
-      return this.extractOutput(result.result);
-    } finally {
-      clearTimeout(timeout);
-    }
+          span.setAttribute("http.status_code", response.status);
+
+          if (!response.ok) {
+            let errorMessage = "";
+            try {
+              const errorBody = (await response.json()) as { detail?: string };
+              errorMessage = errorBody.detail ?? JSON.stringify(errorBody);
+            } catch {
+              errorMessage = await response.text().catch(() => "");
+            }
+            span.setAttribute("error.kind", "http" satisfies AdapterErrorKind);
+            throw new SerializedCodeAgentAdapterError(
+              `Code execution failed: HTTP ${response.status}${errorMessage ? ` - ${errorMessage}` : ""}`,
+              { kind: "http", httpStatus: response.status },
+            );
+          }
+
+          const result = (await response.json()) as {
+            trace_id: string;
+            status: string;
+            result: Record<string, unknown> | null;
+          };
+          span.setAttribute("nlp.status", result.status);
+          if (result.trace_id) {
+            span.setAttribute("nlp.trace_id", result.trace_id);
+          }
+          return this.extractOutput(result.result);
+        } finally {
+          clearTimeout(timeout);
+        }
+      },
+    );
   }
 
   /**

--- a/specs/scenarios/serialized-adapter-error-tracing.feature
+++ b/specs/scenarios/serialized-adapter-error-tracing.feature
@@ -1,0 +1,38 @@
+Feature: Serialized adapters always emit a span footprint on failure
+  As a developer debugging a hung scenario run in LangWatch Observability
+  I need every adapter call — even failing ones — to leave a span behind
+  So I can tell timeout from network failure from server error without reading stderr.
+
+  Background: tracking lw#3438. Customer trace showed only the simulator span
+  on a hung run; the adapter span was absent because the failure path didn't
+  touch the tracer. Each adapter now wraps its outbound NLP request in a span
+  whose `error.kind` attribute distinguishes the failure mode.
+
+  @unit
+  Scenario: code-agent adapter emits a span tagged with the request URL on success
+    Given a SerializedCodeAgentAdapter with a healthy NLP service
+    When the adapter's `call` resolves
+    Then a span named "SerializedCodeAgentAdapter.execute_nlp_request" exists
+    And the span has attributes "http.url", "http.method", "scenario.agent.id", "http.status_code"
+
+  @unit
+  Scenario: code-agent adapter emits an error span with kind=timeout when the NLP service hangs
+    Given a SerializedCodeAgentAdapter pointed at an unresponsive NLP service
+    When the adapter's `call` is awaited past the fetch timeout
+    Then it rejects with SerializedCodeAgentAdapterError carrying kind=timeout
+    And the emitted span recorded the exception
+    And the span has attribute "error.kind"="timeout"
+
+  @unit
+  Scenario: code-agent adapter emits an error span with kind=fetch when the network fails
+    Given a SerializedCodeAgentAdapter where fetch rejects synchronously
+    When the adapter's `call` is awaited
+    Then it rejects with SerializedCodeAgentAdapterError carrying kind=fetch
+    And the span has attribute "error.kind"="fetch"
+
+  @unit
+  Scenario: code-agent adapter emits an error span with kind=http when the NLP service returns non-2xx
+    Given a SerializedCodeAgentAdapter where the NLP service returns HTTP 503
+    When the adapter's `call` is awaited
+    Then it rejects with SerializedCodeAgentAdapterError carrying kind=http and httpStatus=503
+    And the span has attributes "error.kind"="http" and "http.status_code"=503


### PR DESCRIPTION
## Summary

- Wraps `SerializedCodeAgentAdapter.executeOnNlpService` in a dedicated `SerializedCodeAgentAdapter.execute_nlp_request` CLIENT span so timeouts and fetch failures always leave a footprint in the trace (lw#3438).
- Distinguishes failure modes via an `error.kind` span attribute (`timeout` | `fetch` | `http`) and a typed `SerializedCodeAgentAdapterError` with `kind` + `httpStatus`.
- Adds `specs/scenarios/serialized-adapter-error-tracing.feature` plus 5 new unit tests covering success / timeout / fetch failure / HTTP non-2xx.

## Test plan

- [x] `pnpm test:unit src/server/scenarios/execution/serialized-adapters/__tests__/code-agent.adapter.unit.test.ts` — 33/33
- [x] `pnpm typecheck`
- [x] `pnpm check:feature-parity` — 4/4 new scenarios bound

Closes #3438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3438