### PR TITLE
fix(dev): rewrite stale localhost NEXTAUTH_URL/BASE_HOST in dev launchers (#3453)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@
 
 COMPOSE = docker compose -f compose.dev.yml
 
+# Sources scripts/lib/sanitize-dev-env.sh and rewrites stale localhost-pinned
+# NEXTAUTH_URL / BASE_HOST exports to the compose-derived APP_PORT (default
+# 5560). Real overrides like boxd-proxy URLs are left untouched. Prepended
+# to every dev `up` recipe so `make dev*` paths can't silently 403 on login
+# if a previous session leaked the env (lw#3453).
+SANITIZE_DEV_ENV = APP_PORT=$${APP_PORT:-5560} . scripts/lib/sanitize-dev-env.sh && sanitize_localhost_dev_env
+
 # Install git hooks (idempotent, runs automatically before dev targets)
 setup-hooks:
 	@git config core.hooksPath .githooks 2>/dev/null || true
@@ -44,23 +51,23 @@ service-watch:
 
 # Minimal: postgres + redis + clickhouse + app
 dev:
-	$(COMPOSE) up
+	@$(SANITIZE_DEV_ENV) && $(COMPOSE) up
 
 # + NLP service + langevals (for evaluations)
 dev-nlp:
-	$(COMPOSE) --profile nlp up
+	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile nlp up
 
 # + scenario worker + bullboard + NLP
 dev-scenarios:
-	$(COMPOSE) --profile scenarios up
+	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile scenarios up
 
 # + AI test server (for HTTP agent testing)
 dev-test:
-	$(COMPOSE) --profile test up
+	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile test up
 
 # Everything
 dev-full:
-	$(COMPOSE) --profile full up
+	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile full up
 
 # Stop all services
 down:

--- a/langwatch/scripts/__tests__/sanitize-dev-env.unit.test.ts
+++ b/langwatch/scripts/__tests__/sanitize-dev-env.unit.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for scripts/lib/sanitize-dev-env.sh — guards lw#3453 ("make
+ * quickstart" on a worktree where APP_PORT != 5560 must not 403 on login
+ * because of a stale localhost-pinned NEXTAUTH_URL inherited from a prior
+ * shell). Real proxy-style overrides (boxd, ngrok, https) must pass
+ * through untouched.
+ *
+ * The helper is bash; we drive it by sourcing it from `bash -c` and
+ * reading the resulting env.
+ */
+
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const HELPER = path.join(REPO_ROOT, "scripts/lib/sanitize-dev-env.sh");
+
+function runHelper(env: Record<string, string | undefined>): {
+  stdout: string;
+  nextauthUrl: string;
+  baseHost: string;
+  exitCode: number;
+} {
+  const exports = Object.entries(env)
+    .map(([k, v]) =>
+      v === undefined ? `unset ${k}` : `export ${k}='${v.replace(/'/g, "'\\''")}'`,
+    )
+    .join("\n");
+  const script = `
+set -e
+${exports}
+. "${HELPER}"
+sanitize_localhost_dev_env
+echo "__NEXTAUTH_URL=\${NEXTAUTH_URL:-}"
+echo "__BASE_HOST=\${BASE_HOST:-}"
+`;
+  let stdout = "";
+  let exitCode = 0;
+  try {
+    stdout = execSync("bash -s", {
+      encoding: "utf8",
+      input: script,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    exitCode = err.status ?? 1;
+    stdout = (err.stdout ?? "") + (err.stderr ?? "");
+  }
+  const nextauthUrl = stdout.match(/__NEXTAUTH_URL=(.*)/)?.[1] ?? "";
+  const baseHost = stdout.match(/__BASE_HOST=(.*)/)?.[1] ?? "";
+  return { stdout, nextauthUrl, baseHost, exitCode };
+}
+
+describe("sanitize-dev-env.sh (lw#3453)", () => {
+  describe("when stale localhost values are inherited from a prior session", () => {
+    /** @scenario sanitize rewrites stale localhost NEXTAUTH_URL to current APP_PORT */
+    it("rewrites NEXTAUTH_URL to the current APP_PORT", () => {
+      const r = runHelper({ APP_PORT: "5562", NEXTAUTH_URL: "http://localhost:5560" });
+      expect(r.exitCode).toBe(0);
+      expect(r.nextauthUrl).toBe("http://localhost:5562");
+    });
+
+    /** @scenario sanitize rewrites stale localhost BASE_HOST to current APP_PORT */
+    it("rewrites BASE_HOST to the current APP_PORT", () => {
+      const r = runHelper({ APP_PORT: "5562", BASE_HOST: "http://localhost:5560" });
+      expect(r.exitCode).toBe(0);
+      expect(r.baseHost).toBe("http://localhost:5562");
+    });
+
+    it("emits a one-line log per overwrite so users see what happened", () => {
+      const r = runHelper({ APP_PORT: "5562", NEXTAUTH_URL: "http://localhost:5560" });
+      expect(r.stdout).toMatch(/rewriting stale NEXTAUTH_URL=http:\/\/localhost:5560/);
+    });
+  });
+
+  describe("when the env var is unset", () => {
+    /** @scenario sanitize fills NEXTAUTH_URL from APP_PORT when unset */
+    it("fills NEXTAUTH_URL from APP_PORT", () => {
+      const r = runHelper({ APP_PORT: "5562", NEXTAUTH_URL: undefined });
+      expect(r.exitCode).toBe(0);
+      expect(r.nextauthUrl).toBe("http://localhost:5562");
+    });
+
+    it("fills BASE_HOST from APP_PORT", () => {
+      const r = runHelper({ APP_PORT: "5562", BASE_HOST: undefined });
+      expect(r.exitCode).toBe(0);
+      expect(r.baseHost).toBe("http://localhost:5562");
+    });
+  });
+
+  describe("when a real (non-localhost) override is exported", () => {
+    /** @scenario sanitize leaves https boxd-proxy NEXTAUTH_URL untouched */
+    it("leaves https://*.boxd.sh NEXTAUTH_URL alone (boxd proxy path)", () => {
+      const r = runHelper({
+        APP_PORT: "5562",
+        NEXTAUTH_URL: "https://langwatch-fork.boxd.sh",
+      });
+      expect(r.nextauthUrl).toBe("https://langwatch-fork.boxd.sh");
+    });
+
+    /** @scenario sanitize leaves a 127.0.0.1 NEXTAUTH_URL untouched */
+    it("leaves http://127.0.0.1:* NEXTAUTH_URL alone (treated as override)", () => {
+      const r = runHelper({
+        APP_PORT: "5562",
+        NEXTAUTH_URL: "http://127.0.0.1:5560",
+      });
+      expect(r.nextauthUrl).toBe("http://127.0.0.1:5560");
+    });
+
+    /** @scenario sanitize leaves a non-localhost http override untouched */
+    it("leaves http://abc.ngrok.io NEXTAUTH_URL alone (tunnel override)", () => {
+      const r = runHelper({
+        APP_PORT: "5562",
+        NEXTAUTH_URL: "http://abc123.ngrok.io",
+      });
+      expect(r.nextauthUrl).toBe("http://abc123.ngrok.io");
+    });
+  });
+
+  describe("when APP_PORT is not set", () => {
+    /** @scenario sanitize warns and returns nonzero when APP_PORT is unset */
+    it("warns and returns nonzero so the launcher can fail loudly", () => {
+      const r = runHelper({ APP_PORT: undefined });
+      expect(r.exitCode).not.toBe(0);
+      expect(r.stdout).toMatch(/APP_PORT/);
+    });
+  });
+
+  describe("when stale URL already matches the current port", () => {
+    /** @scenario sanitize is a noop when stale URL already matches current port */
+    it("does not log a rewrite (idempotent)", () => {
+      const r = runHelper({
+        APP_PORT: "5562",
+        NEXTAUTH_URL: "http://localhost:5562",
+      });
+      expect(r.stdout).not.toMatch(/rewriting stale/);
+      expect(r.nextauthUrl).toBe("http://localhost:5562");
+    });
+  });
+});

--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -37,6 +37,7 @@ const SPECS_ROOT = resolve(REPO_ROOT, "specs");
 const DEFAULT_TEST_ROOTS: string[] = [
   "langwatch/src",
   "langwatch/ee",
+  "langwatch/scripts",
   "mcp-server/src",
   "typescript-sdk/src",
   "python-sdk/src",

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -40,6 +40,12 @@ BULLBOARD_PORT=$(find_free_port 3000)
 AI_SERVER_PORT=$(find_free_port 3456)
 export APP_PORT BULLBOARD_PORT AI_SERVER_PORT
 
+# Strip any stale http://localhost:<oldport> exports of NEXTAUTH_URL /
+# BASE_HOST so dynamic-port worktrees don't 403 on login (lw#3453). Real
+# overrides (e.g. boxd proxy URLs) are left alone — see comment in helper.
+. "$(dirname "$0")/lib/sanitize-dev-env.sh"
+sanitize_localhost_dev_env
+
 # ---------------------------------------------------------------------------
 # Ensure .env files exist
 # ---------------------------------------------------------------------------

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -74,6 +74,12 @@ export APP_PORT=$(find_free_port 5560)
 export BULLBOARD_PORT=$(find_free_port 6380)
 export AI_SERVER_PORT=$(find_free_port 3456)
 
+# Strip any stale http://localhost:<oldport> exports of NEXTAUTH_URL /
+# BASE_HOST so dynamic-port worktrees don't 403 on login (lw#3453). Real
+# overrides (e.g. boxd proxy URLs) are left alone — see comment in helper.
+. "$(dirname "$0")/lib/sanitize-dev-env.sh"
+sanitize_localhost_dev_env
+
 # Load last choice if exists
 LAST=""
 if [ -f "$LAST_CHOICE_FILE" ]; then

--- a/scripts/lib/sanitize-dev-env.sh
+++ b/scripts/lib/sanitize-dev-env.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Sanitize stale localhost-pinned dev env vars so worktree-isolated runs
+# don't 403 when APP_PORT is dynamic (lw#3453).
+#
+# Why this exists:
+#
+# `compose.dev.yml` interpolates BASE_HOST / NEXTAUTH_URL with a fallback
+# of `http://localhost:${APP_PORT}` so dynamic-port worktrees Just Work™.
+# But the `${VAR:-default}` shell rule means an *exported* localhost URL
+# from a previous session (or a zsh helper) wins over the dynamic port,
+# and login then 403s because the cookie/CSRF origin is wrong.
+#
+# Real overrides (boxd proxy, ngrok, prod-style hostname) are NOT
+# touched — only stale `http://localhost:<port>` values get rewritten.
+#
+# Usage from the dev launcher (after APP_PORT is exported):
+#
+#   . scripts/lib/sanitize-dev-env.sh
+#   sanitize_localhost_dev_env
+#
+# Sources caller-controlled APP_PORT; emits a one-line log per overwrite.
+
+# Returns 0 if value is unset/empty or matches `http://localhost:*`,
+# 1 otherwise (real override — leave alone).
+__is_stale_localhost_url() {
+  local value="$1"
+  if [ -z "$value" ]; then
+    return 0
+  fi
+  case "$value" in
+    http://localhost:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+sanitize_localhost_dev_env() {
+  if [ -z "${APP_PORT:-}" ]; then
+    echo "WARNING: sanitize_localhost_dev_env called before APP_PORT is set" >&2
+    return 1
+  fi
+
+  local target="http://localhost:${APP_PORT}"
+
+  if __is_stale_localhost_url "${NEXTAUTH_URL:-}"; then
+    if [ -n "${NEXTAUTH_URL:-}" ] && [ "$NEXTAUTH_URL" != "$target" ]; then
+      echo "  → rewriting stale NEXTAUTH_URL=$NEXTAUTH_URL to $target"
+    fi
+    export NEXTAUTH_URL="$target"
+  fi
+
+  if __is_stale_localhost_url "${BASE_HOST:-}"; then
+    if [ -n "${BASE_HOST:-}" ] && [ "$BASE_HOST" != "$target" ]; then
+      echo "  → rewriting stale BASE_HOST=$BASE_HOST to $target"
+    fi
+    export BASE_HOST="$target"
+  fi
+}

--- a/specs/ci/dev-env-localhost-sanitize.feature
+++ b/specs/ci/dev-env-localhost-sanitize.feature
@@ -1,0 +1,64 @@
+Feature: Dev launchers strip stale localhost-pinned NEXTAUTH_URL / BASE_HOST
+  As a contributor running a second worktree on the same machine
+  I need `make quickstart` (and `make dev*`) to pick a dynamic port without 403ing on login
+  So I don't have to manually re-export NEXTAUTH_URL every time port 5560 is busy.
+
+  Background: tracking lw#3453. compose.dev.yml interpolates
+  NEXTAUTH_URL/BASE_HOST with `${VAR:-http://localhost:${APP_PORT}}` — but
+  any *exported* `http://localhost:5560` (from a prior session, zsh helper,
+  etc.) wins over the dynamic-port fallback, and login then 403s because
+  the cookie origin no longer matches the host port.
+
+  The launchers source scripts/lib/sanitize-dev-env.sh, which rewrites
+  stale localhost values to the current APP_PORT but leaves real proxy /
+  tunnel overrides (https://*.boxd.sh, ngrok URLs, 127.0.0.1, etc.) alone.
+
+  @unit
+  Scenario: sanitize rewrites stale localhost NEXTAUTH_URL to current APP_PORT
+    Given APP_PORT=5562 and the inherited NEXTAUTH_URL points at port 5560
+    When sanitize_localhost_dev_env runs
+    Then NEXTAUTH_URL is rewritten to http://localhost:5562
+
+  @unit
+  Scenario: sanitize rewrites stale localhost BASE_HOST to current APP_PORT
+    Given APP_PORT=5562 and the inherited BASE_HOST points at port 5560
+    When sanitize_localhost_dev_env runs
+    Then BASE_HOST is rewritten to http://localhost:5562
+
+  @unit
+  Scenario: sanitize fills NEXTAUTH_URL from APP_PORT when unset
+    Given APP_PORT=5562 and NEXTAUTH_URL is unset
+    When sanitize_localhost_dev_env runs
+    Then NEXTAUTH_URL is exported as http://localhost:5562
+
+  @unit
+  Scenario: sanitize leaves https boxd-proxy NEXTAUTH_URL untouched
+    Given NEXTAUTH_URL=https://langwatch-fork.boxd.sh
+    When sanitize_localhost_dev_env runs
+    Then NEXTAUTH_URL is unchanged
+
+  @unit
+  Scenario: sanitize leaves a 127.0.0.1 NEXTAUTH_URL untouched
+    Given NEXTAUTH_URL=http://127.0.0.1:5560
+    When sanitize_localhost_dev_env runs
+    Then NEXTAUTH_URL is unchanged
+
+  @unit
+  Scenario: sanitize leaves a non-localhost http override untouched
+    Given NEXTAUTH_URL=http://abc123.ngrok.io
+    When sanitize_localhost_dev_env runs
+    Then NEXTAUTH_URL is unchanged
+
+  @unit
+  Scenario: sanitize warns and returns nonzero when APP_PORT is unset
+    Given APP_PORT is unset
+    When sanitize_localhost_dev_env runs
+    Then it prints a warning that mentions APP_PORT
+    And it exits with a nonzero status
+
+  @unit
+  Scenario: sanitize is a noop when stale URL already matches current port
+    Given APP_PORT=5562 and NEXTAUTH_URL already=http://localhost:5562
+    When sanitize_localhost_dev_env runs
+    Then it does not log a "rewriting stale" line
+    And NEXTAUTH_URL is unchanged

--- a/specs/ci/dev-env-localhost-sanitize.feature
+++ b/specs/ci/dev-env-localhost-sanitize.feature
@@ -33,19 +33,19 @@ Feature: Dev launchers strip stale localhost-pinned NEXTAUTH_URL / BASE_HOST
 
   @unit
   Scenario: sanitize leaves https boxd-proxy NEXTAUTH_URL untouched
-    Given NEXTAUTH_URL=https://langwatch-fork.boxd.sh
+    Given APP_PORT=5562 and NEXTAUTH_URL=https://langwatch-fork.boxd.sh
     When sanitize_localhost_dev_env runs
     Then NEXTAUTH_URL is unchanged
 
   @unit
   Scenario: sanitize leaves a 127.0.0.1 NEXTAUTH_URL untouched
-    Given NEXTAUTH_URL=http://127.0.0.1:5560
+    Given APP_PORT=5562 and NEXTAUTH_URL=http://127.0.0.1:5560
     When sanitize_localhost_dev_env runs
     Then NEXTAUTH_URL is unchanged
 
   @unit
   Scenario: sanitize leaves a non-localhost http override untouched
-    Given NEXTAUTH_URL=http://abc123.ngrok.io
+    Given APP_PORT=5562 and NEXTAUTH_URL=http://abc123.ngrok.io
     When sanitize_localhost_dev_env runs
     Then NEXTAUTH_URL is unchanged
 


### PR DESCRIPTION
## Summary

Adds `scripts/lib/sanitize-dev-env.sh`, sourced by `scripts/dev.sh`, `scripts/dev-up.sh`, and the `make dev*` recipes, so a worktree that picks a dynamic `APP_PORT` (because 5560 is busy) can no longer 403 on login because of a stale localhost-pinned `NEXTAUTH_URL` / `BASE_HOST` inherited from a prior shell.

The helper rewrites the env var only when it's empty or matches `http://localhost:*`. Real proxy / tunnel overrides (`https://*.boxd.sh`, ngrok URLs, `http://127.0.0.1:*`, etc.) pass through untouched. Each rewrite is logged to stdout so the user sees the override.

Wired into all entry points (per AC#4): `make quickstart` (dev.sh), `make dev-up` (dev-up.sh), and the `make dev` / `dev-nlp` / `dev-scenarios` / `dev-test` / `dev-full` recipes via a `SANITIZE_DEV_ENV` Make variable.

## Test plan

- [x] `pnpm test:unit scripts/__tests__/sanitize-dev-env.unit.test.ts` — 10/10 (drives the bash helper from a real `bash -s` subshell)
- [x] `pnpm typecheck`
- [x] `pnpm check:feature-parity` — 8/8 new scenarios bound (`specs/ci/dev-env-localhost-sanitize.feature`)
- [x] `make -n dev` shows the sanitize step before `docker compose up`

## Notes

- AC#5 (origin of repo-root \`.env\`): out of scope for this PR; the issue itself flagged that the file may not even reach compose. Worth a separate investigation if it shows up again.
- AC#6 (smoke test of the actual login flow) is not part of this PR — the unit tests guard the sanitization contract; an end-to-end \`./scripts/smoke-login.sh\` would need a running stack and is best filed as a follow-up.

Closes #3453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3453