### PR TITLE
fix(scenarios,nav): repair F11 save-and-run redirect race and F12 hydration warnings

### DIFF
--- a/langwatch/src/components/MainMenu.tsx
+++ b/langwatch/src/components/MainMenu.tsx
@@ -179,7 +179,7 @@ export const MainMenu = React.memo(function MainMenu({
               paddingTop={3}
               paddingBottom={1}
             >
-              {showExpanded ? "Evaluate" : <div>&nbsp;</div>}
+              {showExpanded ? "Evaluate" : <>&nbsp;</>}
             </Text>
 
             <CollapsibleMenuGroup
@@ -246,7 +246,7 @@ export const MainMenu = React.memo(function MainMenu({
               paddingTop={3}
               paddingBottom={1}
             >
-              {showExpanded ? "Library" : <div>&nbsp;</div>}
+              {showExpanded ? "Library" : <>&nbsp;</>}
             </Text>
 
             <PageMenuLink
@@ -310,7 +310,7 @@ export const MainMenu = React.memo(function MainMenu({
                     textTransform="uppercase"
                     color="gray.500"
                   >
-                    {showExpanded ? "Gateway" : <div>&nbsp;</div>}
+                    {showExpanded ? "Gateway" : <>&nbsp;</>}
                   </Text>
                   {showExpanded && (
                     <Badge
@@ -491,7 +491,7 @@ const OpsSection = ({ showExpanded }: { showExpanded: boolean }) => {
         paddingTop={3}
         paddingBottom={1}
       >
-        {showExpanded ? "Ops" : <div>&nbsp;</div>}
+        {showExpanded ? "Ops" : <>&nbsp;</>}
       </Text>
       <SideMenuLink
         icon={Activity}

--- a/langwatch/src/components/__tests__/MainMenu.hydration.unit.test.ts
+++ b/langwatch/src/components/__tests__/MainMenu.hydration.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment node
+ *
+ * Source-level guard for lw#3586 F12: MainMenu's compact-mode placeholders
+ * MUST NOT render `<div>&nbsp;</div>` inside Chakra `<Text>` (which renders
+ * a `<p>`), because `<div>` cannot be a descendant of `<p>` and React flags
+ * it as a hydration error in dev. The fix uses Fragments instead.
+ *
+ * A source-text check is enough here because the offending pattern is
+ * unambiguous and the fix is a 4-character substitution; a render test
+ * would require the full nav store / chakra wiring for marginal extra
+ * confidence.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("MainMenu placeholders (lw#3586 F12)", () => {
+  /** @scenario MainMenu compact-mode placeholders use Fragments not divs to avoid hydration warnings */
+  it("does not render <div>&nbsp;</div> inside <Text> (would hydration-warn)", () => {
+    const file = readFileSync(
+      path.join(__dirname, "..", "MainMenu.tsx"),
+      "utf8",
+    );
+    expect(file).not.toMatch(/<div>&nbsp;<\/div>/);
+  });
+
+  it("uses Fragment <>&nbsp;</> for compact placeholders", () => {
+    const file = readFileSync(
+      path.join(__dirname, "..", "MainMenu.tsx"),
+      "utf8",
+    );
+    expect(file).toMatch(/<>&nbsp;<\/>/);
+  });
+});

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -270,7 +270,14 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
 
       try {
         await form.handleSubmit(async (data) => {
-          const savedScenario = await handleSave(data);
+          // skipTransition: don't open the edit-mode drawer mid-save — we're
+          // navigating away to /simulations next, so the create→edit URL push
+          // would race with our redirect (lw#3586 F11). The whole `await` is
+          // also why the redirect itself MUST be the only router.push that
+          // fires after — `onClose()` does its own router.push inside
+          // closeDrawer, and back-to-back router.push calls get coalesced
+          // (the cleanup push wins, the redirect gets dropped silently).
+          const savedScenario = await handleSave(data, { skipTransition: true });
           if (!savedScenario) return;
 
           // Persist the target selection for this scenario
@@ -282,8 +289,10 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
           // Fire the run — no callbacks, simulations page picks up via SSE
           void runScenario({ scenarioId: savedScenario.id, target, batchRunId });
 
-          // Close drawer and navigate to simulations page
-          onClose();
+          // Navigate to simulations — drawer closes implicitly via route change.
+          // Intentionally NOT calling onClose() here: closeDrawer() does its
+          // own router.push to strip drawer.* params, which would race with
+          // this redirect and silently win (lw#3586 F11).
           void router.push(`/${project.slug}/simulations?pendingBatch=${batchRunId}`);
         })();
       } catch (error) {
@@ -296,7 +305,7 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
         });
       }
     },
-    [handleSave, project?.id, project?.slug, persistTarget, runScenario, formInstance, onClose, router, utils, openDrawer],
+    [handleSave, project?.id, project?.slug, persistTarget, runScenario, formInstance, router, utils, openDrawer],
   );
   const handleSaveWithoutRunning = useCallback(async () => {
     const form = formInstance;

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.integration.test.tsx
@@ -429,43 +429,140 @@ describe("<ScenarioFormDrawer/>", () => {
   });
 
   describe("when user clicks save-and-run", () => {
-    beforeEach(() => {
-      mocks.mockDrawerParams = { scenarioId: "existing-scenario-id" };
-      mocks.mockGetByIdData = {
-        id: "existing-scenario-id",
-        name: "Refund Flow",
-        situation: "User requests a refund",
-        criteria: ["Agent acknowledges the issue"],
-        labels: [],
-      };
-      mocks.mockUpdateMutateAsync.mockResolvedValue({
-        id: "existing-scenario-id",
-        name: "Refund Flow",
-        situation: "User requests a refund",
-        criteria: ["Agent acknowledges the issue"],
-        labels: [],
+    describe("from edit mode (existing scenario)", () => {
+      beforeEach(() => {
+        mocks.mockDrawerParams = { scenarioId: "existing-scenario-id" };
+        mocks.mockGetByIdData = {
+          id: "existing-scenario-id",
+          name: "Refund Flow",
+          situation: "User requests a refund",
+          criteria: ["Agent acknowledges the issue"],
+          labels: [],
+        };
+        mocks.mockUpdateMutateAsync.mockResolvedValue({
+          id: "existing-scenario-id",
+          name: "Refund Flow",
+          situation: "User requests a refund",
+          criteria: ["Agent acknowledges the issue"],
+          labels: [],
+        });
+        mocks.mockRunScenario.mockResolvedValue(undefined);
       });
-      mocks.mockRunScenario.mockResolvedValue(undefined);
+
+      /** @scenario save-and-run navigates to /simulations from edit mode */
+      it("navigates to /simulations with the new pendingBatch query param", async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+
+        render(<ScenarioFormDrawer open={true} onClose={onClose} />, { wrapper: Wrapper });
+
+        const saveAndRunButton = screen.getByTestId("save-and-run-button");
+        await user.click(saveAndRunButton);
+
+        await waitFor(() => {
+          expect(mocks.mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+        });
+
+        await waitFor(() => {
+          expect(mocks.mockRouterPush).toHaveBeenCalledWith(
+            expect.stringMatching(/^\/my-project\/simulations\?pendingBatch=/),
+          );
+        });
+      });
+
+      /** @scenario save-and-run does not call onClose so closeDrawer's router.push can't race the redirect */
+      it("does NOT call onClose (lw#3586 — closeDrawer's router.push would race the redirect)", async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+
+        render(<ScenarioFormDrawer open={true} onClose={onClose} />, { wrapper: Wrapper });
+
+        const saveAndRunButton = screen.getByTestId("save-and-run-button");
+        await user.click(saveAndRunButton);
+
+        await waitFor(() => {
+          expect(mocks.mockRouterPush).toHaveBeenCalled();
+        });
+        expect(onClose).not.toHaveBeenCalled();
+      });
+
+      /** @scenario save-and-run fires exactly one router.push (the simulations redirect) */
+      it("fires exactly one router.push (the simulations redirect)", async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+
+        render(<ScenarioFormDrawer open={true} onClose={onClose} />, { wrapper: Wrapper });
+
+        await user.click(screen.getByTestId("save-and-run-button"));
+
+        await waitFor(() => {
+          expect(mocks.mockRouterPush).toHaveBeenCalled();
+        });
+        expect(mocks.mockRouterPush).toHaveBeenCalledTimes(1);
+        const arg = mocks.mockRouterPush.mock.calls[0]![0] as string;
+        expect(arg).toMatch(/^\/my-project\/simulations\?pendingBatch=/);
+      });
     });
 
-    it("closes the drawer and navigates to simulations page", async () => {
-      const user = userEvent.setup();
-      const onClose = vi.fn();
-
-      render(<ScenarioFormDrawer open={true} onClose={onClose} />, { wrapper: Wrapper });
-
-      const saveAndRunButton = screen.getByTestId("save-and-run-button");
-      await user.click(saveAndRunButton);
-
-      await waitFor(() => {
-        expect(mocks.mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+    describe("from create mode (new scenario)", () => {
+      beforeEach(() => {
+        mocks.mockDrawerParams = {};
+        mocks.mockGetByIdData = null;
+        mocks.mockComplexProps = {
+          initialFormData: {
+            name: "Refund Request Test",
+            situation: "User requests a refund",
+            criteria: ["Agent acknowledges the issue"],
+            labels: [],
+          },
+        };
+        mocks.mockCreateMutateAsync.mockResolvedValue({
+          id: "new-scenario-id",
+          name: "Refund Request Test",
+          situation: "User requests a refund",
+          criteria: ["Agent acknowledges the issue"],
+          labels: [],
+        });
+        mocks.mockRunScenario.mockResolvedValue(undefined);
       });
 
-      // Drawer closes and navigates to simulations page with pending batch
-      expect(onClose).toHaveBeenCalled();
-      expect(mocks.mockRouterPush).toHaveBeenCalledWith(
-        expect.stringMatching(/^\/my-project\/simulations\?pendingBatch=/),
-      );
+      /** @scenario save-and-run navigates to /simulations from create mode */
+      it("navigates to /simulations with the new pendingBatch query param", async () => {
+        const user = userEvent.setup();
+
+        render(<ScenarioFormDrawer open={true} />, { wrapper: Wrapper });
+
+        const saveAndRunButton = screen.getByTestId("save-and-run-button");
+        await user.click(saveAndRunButton);
+
+        await waitFor(() => {
+          expect(mocks.mockCreateMutateAsync).toHaveBeenCalledTimes(1);
+        });
+
+        await waitFor(() => {
+          expect(mocks.mockRouterPush).toHaveBeenCalledWith(
+            expect.stringMatching(/^\/my-project\/simulations\?pendingBatch=/),
+          );
+        });
+      });
+
+      /** @scenario save-and-run from create mode does not transition to edit-mode URL */
+      it("does NOT transition the URL to /scenarios/<id> mid-save (lw#3586 F11 — would race the redirect)", async () => {
+        const user = userEvent.setup();
+
+        render(<ScenarioFormDrawer open={true} />, { wrapper: Wrapper });
+
+        await user.click(screen.getByTestId("save-and-run-button"));
+
+        await waitFor(() => {
+          expect(mocks.mockRouterPush).toHaveBeenCalled();
+        });
+        // Only the simulations redirect — no edit-mode transition push.
+        expect(mocks.mockRouterPush).toHaveBeenCalledTimes(1);
+        expect(mocks.mockRouterPush.mock.calls[0]![0]).toMatch(
+          /^\/my-project\/simulations\?pendingBatch=/,
+        );
+      });
     });
   });
 

--- a/specs/navigation/main-menu-compact-placeholders.feature
+++ b/specs/navigation/main-menu-compact-placeholders.feature
@@ -1,0 +1,17 @@
+Feature: MainMenu compact-mode placeholders avoid hydration warnings
+  As a developer
+  I need MainMenu's collapsed-sidebar section labels to be valid HTML
+  So the React hydration warning "<div> cannot be a descendant of <p>" stays out of the console.
+
+  Background: tracking lw#3586 F12. Chakra `<Text>` renders a `<p>`, and
+  four section-label placeholders (`Evaluate`, `Library`, `Gateway`, `Ops`)
+  rendered `<div>&nbsp;</div>` inside that `<Text>` for the compact state.
+  React flagged this as invalid nesting. The fix replaces them with
+  Fragments matching the existing `Observe` placeholder pattern.
+
+  @unit
+  Scenario: MainMenu compact-mode placeholders use Fragments not divs to avoid hydration warnings
+    Given the MainMenu source file
+    When scanned for the `<div>&nbsp;</div>` pattern
+    Then the pattern is not present
+    And Fragment-based `<>&nbsp;</>` placeholders are present

--- a/specs/scenarios/save-and-run-redirect.feature
+++ b/specs/scenarios/save-and-run-redirect.feature
@@ -1,0 +1,48 @@
+Feature: Save-and-run from the scenario form drawer redirects to /simulations on first click
+  As a user composing a new scenario
+  I need "Save and Run" to take me straight to /simulations
+  So I can watch the run start without manually navigating away from a stale form URL.
+
+  Background: tracking lw#3586 F11. Two competing `router.push` calls used
+  to fire after a successful save (closeDrawer's drawer-param cleanup vs
+  the simulations redirect). Back-to-back router.push calls get coalesced
+  — the cleanup push won and the redirect was silently dropped. The drawer
+  also transitioned create → edit-mode mid-save, adding a third competing
+  push.
+
+  The fix: pass `skipTransition: true` to handleSave (no create→edit URL
+  push) and drop the `onClose()` call (the simulations route swap closes
+  the drawer implicitly). After the fix exactly one router.push fires:
+  the redirect itself.
+
+  @integration
+  Scenario: save-and-run navigates to /simulations from edit mode
+    Given an existing scenario open in the form drawer
+    When the user clicks Save and Run
+    Then router.push is called with /<projectSlug>/simulations?pendingBatch=<id>
+
+  @integration
+  Scenario: save-and-run does not call onClose so closeDrawer's router.push can't race the redirect
+    Given an existing scenario open in the form drawer
+    And an `onClose` prop is provided
+    When the user clicks Save and Run
+    Then `onClose` is NOT called
+
+  @integration
+  Scenario: save-and-run fires exactly one router.push (the simulations redirect)
+    Given an existing scenario open in the form drawer
+    When the user clicks Save and Run
+    Then router.push is called exactly once
+    And the single push targets /<projectSlug>/simulations
+
+  @integration
+  Scenario: save-and-run navigates to /simulations from create mode
+    Given the form drawer is open without a scenarioId (create mode)
+    When the user clicks Save and Run
+    Then router.push is called with /<projectSlug>/simulations?pendingBatch=<id>
+
+  @integration
+  Scenario: save-and-run from create mode does not transition to edit-mode URL
+    Given the form drawer is open without a scenarioId (create mode)
+    When the user clicks Save and Run
+    Then router.push is called exactly once (no edit-mode URL transition)


### PR DESCRIPTION
## Summary

Two findings split out of the #3526 stress-test umbrella:

**F11 — Save-and-Run did not redirect to /simulations on the first click.** Two competing `router.push` calls fired after a successful save (`closeDrawer()`'s drawer-param cleanup vs the simulations redirect); the cleanup push won and the redirect was silently dropped. A second smaller race: create-mode → edit-mode URL transition also competed.

Fix in `ScenarioFormDrawer.tsx`:
- Drop the `onClose()` call — the `/simulations` route swap closes the drawer implicitly.
- Pass `skipTransition: true` to `handleSave()` so the create→edit transition doesn't fight the redirect.

**F12 — `<div> cannot be a descendant of <p>` hydration warnings.** Four section-label placeholders in `MainMenu.tsx` rendered `<div>&nbsp;</div>` inside Chakra `<Text>` (which renders a `<p>`).

Fix: replaced all 4 with `<>&nbsp;</>` (Fragment), matching the existing Observe pattern.

## Test plan

- [x] `pnpm test:unit src/components/scenarios/__tests__/ScenarioFormDrawer.integration.test.tsx` — 19/19 (5 new save-and-run tests, both create and edit mode)
- [x] `pnpm test:unit src/components/__tests__/MainMenu.hydration.unit.test.ts` — 2/2 (source-text guard so F12 can't regress)
- [x] `pnpm typecheck`
- [x] `pnpm check:feature-parity` — 5/5 + 1/1 new scenarios bound

Closes #3586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3586