### PR TITLE
refactor(ops): model OpsScope as always-defined to stop console spam (#3584)

### DIFF
--- a/langwatch/src/hooks/useOpsPermission.ts
+++ b/langwatch/src/hooks/useOpsPermission.ts
@@ -5,6 +5,16 @@ import { api } from "~/utils/api";
 // re-fetched on every drawer open and every layout mount.
 const OPS_SCOPE_STALE_TIME_MS = 5 * 60_000;
 
+/**
+ * Reports the calling user's ops access. The underlying `api.ops.getScope`
+ * is now a status probe — it always succeeds with `scope.kind === "none"`
+ * for non-ops users instead of throwing FORBIDDEN, so this hook no longer
+ * spams the console on every page load (lw#3584).
+ *
+ * Consumers should keep using `hasAccess` to gate ops UI; the discriminator
+ * is exposed via `scope.kind` for callers that want to branch on tier
+ * later (e.g. ops:view vs ops:manage if that ever lands).
+ */
 export function useOpsPermission() {
   const query = api.ops.getScope.useQuery(undefined, {
     retry: false,
@@ -12,9 +22,12 @@ export function useOpsPermission() {
     staleTime: OPS_SCOPE_STALE_TIME_MS,
   });
 
+  const scope = query.data?.scope ?? null;
+  const hasAccess = scope !== null && scope.kind !== "none";
+
   return {
-    hasAccess: query.isSuccess,
-    scope: query.data?.scope ?? null,
+    hasAccess,
+    scope,
     isLoading: query.isLoading,
   };
 }

--- a/langwatch/src/server/api/__tests__/ops-scope-resolution.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/ops-scope-resolution.unit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the OpsScope modeling change (lw#3584).
+ *
+ * - resolveOpsScope is now total: it returns `{ kind: "none" }` for non-ops
+ *   users instead of null. The middleware (`checkOpsPermission`) still
+ *   throws FORBIDDEN on `kind: "none"` so mutating endpoints stay guarded.
+ * - The `getScope` status probe bypasses the middleware so non-ops users
+ *   no longer get FORBIDDEN noise on every page load.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+// Pre-stub the admin lookup so the test isn't coupled to ADMIN_EMAILS env.
+vi.mock("../../../../ee/admin/isAdmin", () => ({
+  isAdmin: ({ email }: { email: string | null | undefined }) =>
+    email === "admin@langwatch.ai",
+}));
+
+// We import after the mock so the module sees our stubbed isAdmin.
+import { resolveOpsScope, checkOpsPermission } from "../rbac";
+
+describe("resolveOpsScope (lw#3584)", () => {
+  describe("when the caller is a non-admin user", () => {
+    /** @scenario resolveOpsScope returns kind=none for non-ops users instead of null */
+    it("returns { kind: 'none' } so the response is data, not an error", () => {
+      const scope = resolveOpsScope({
+        userId: "user-1",
+        userEmail: "person@example.com",
+        permission: "ops:view",
+        prisma: {} as unknown,
+      });
+      expect(scope).toEqual({ kind: "none" });
+    });
+  });
+
+  describe("when the caller is an admin user", () => {
+    /** @scenario resolveOpsScope returns kind=platform for admin users */
+    it("returns { kind: 'platform' }", () => {
+      const scope = resolveOpsScope({
+        userId: "admin-1",
+        userEmail: "admin@langwatch.ai",
+        permission: "ops:view",
+        prisma: {} as unknown,
+      });
+      expect(scope).toEqual({ kind: "platform" });
+    });
+  });
+});
+
+describe("checkOpsPermission middleware (lw#3584)", () => {
+  function fakeCtx(email: string | null) {
+    return {
+      session: { user: { id: "u1", email } },
+      prisma: {} as unknown,
+    } as unknown as Parameters<ReturnType<typeof checkOpsPermission>>[0]["ctx"];
+  }
+
+  /** @scenario checkOpsPermission still throws FORBIDDEN for non-ops callers */
+  it("throws FORBIDDEN when resolveOpsScope returns kind=none (default behavior)", async () => {
+    const middleware = checkOpsPermission("ops:view");
+    const next = vi.fn();
+    await expect(
+      middleware({
+        ctx: fakeCtx("person@example.com"),
+        input: undefined,
+        next,
+      } as unknown as Parameters<ReturnType<typeof checkOpsPermission>>[0]),
+    ).rejects.toThrow(/permission to access ops/);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  /** @scenario checkOpsPermission grants access for admin callers */
+  it("grants access (calls next, populates ctx.opsScope) for admin callers", async () => {
+    const middleware = checkOpsPermission("ops:view");
+    const next = vi.fn().mockResolvedValue("OK");
+    const ctx = fakeCtx("admin@langwatch.ai");
+    const result = await middleware({
+      ctx,
+      input: undefined,
+      next,
+    } as unknown as Parameters<ReturnType<typeof checkOpsPermission>>[0]);
+    expect(result).toBe("OK");
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((ctx as { opsScope?: unknown }).opsScope).toEqual({
+      kind: "platform",
+    });
+  });
+
+  /** @scenario checkOpsPermission with throwOnDeny=false populates kind=none for status probes */
+  it("with throwOnDeny=false: calls next with ctx.opsScope.kind=none for non-ops callers", async () => {
+    const middleware = checkOpsPermission("ops:view", { throwOnDeny: false });
+    const next = vi.fn().mockResolvedValue("OK");
+    const ctx = fakeCtx("person@example.com");
+    const result = await middleware({
+      ctx,
+      input: undefined,
+      next,
+    } as unknown as Parameters<ReturnType<typeof checkOpsPermission>>[0]);
+    expect(result).toBe("OK");
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((ctx as { opsScope?: unknown }).opsScope).toEqual({
+      kind: "none",
+    });
+  });
+});

--- a/langwatch/src/server/api/__tests__/ops-scope-resolution.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/ops-scope-resolution.unit.test.ts
@@ -59,7 +59,7 @@ describe("checkOpsPermission middleware (lw#3584)", () => {
 
   /** @scenario checkOpsPermission still throws FORBIDDEN for non-ops callers */
   it("throws FORBIDDEN when resolveOpsScope returns kind=none (default behavior)", async () => {
-    const middleware = checkOpsPermission("ops:view");
+    const middleware = checkOpsPermission({ permission: "ops:view" });
     const next = vi.fn();
     await expect(
       middleware({
@@ -73,7 +73,7 @@ describe("checkOpsPermission middleware (lw#3584)", () => {
 
   /** @scenario checkOpsPermission grants access for admin callers */
   it("grants access (calls next, populates ctx.opsScope) for admin callers", async () => {
-    const middleware = checkOpsPermission("ops:view");
+    const middleware = checkOpsPermission({ permission: "ops:view" });
     const next = vi.fn().mockResolvedValue("OK");
     const ctx = fakeCtx("admin@langwatch.ai");
     const result = await middleware({
@@ -90,7 +90,10 @@ describe("checkOpsPermission middleware (lw#3584)", () => {
 
   /** @scenario checkOpsPermission with throwOnDeny=false populates kind=none for status probes */
   it("with throwOnDeny=false: calls next with ctx.opsScope.kind=none for non-ops callers", async () => {
-    const middleware = checkOpsPermission("ops:view", { throwOnDeny: false });
+    const middleware = checkOpsPermission({
+      permission: "ops:view",
+      throwOnDeny: false,
+    });
     const next = vi.fn().mockResolvedValue("OK");
     const ctx = fakeCtx("person@example.com");
     const result = await middleware({

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -1070,14 +1070,23 @@ export const checkPermissionOrPubliclyShared =
 // OPS PERMISSION
 // ============================================================================
 
-export type OpsScope = { kind: "platform" };
+/**
+ * Discriminated scope every authenticated user has — `none` means "no ops
+ * access" (the honest answer for a non-ops user), `platform` means "full
+ * platform-wide access". Modeled this way so `getScope` can be a status
+ * probe that returns data instead of throwing FORBIDDEN on every page
+ * load (lw#3584).
+ */
+export type OpsScope = { kind: "none" } | { kind: "platform" };
 
 /**
- * Resolve the ops scope for a user. Returns null if the user has no ops access.
- * Shared between tRPC middleware and SSE endpoint.
+ * Resolve the ops scope for a user. Always returns a typed scope value;
+ * non-ops users get `{ kind: "none" }` instead of null. Shared between
+ * tRPC middleware (which still rejects non-ops callers via
+ * `checkOpsPermission`) and the SSE endpoint.
  *
- * Only users listed in ADMIN_EMAILS have ops access. All ops data is
- * platform-wide so no org-scoped tier exists.
+ * Only users listed in ADMIN_EMAILS get the `platform` scope. All ops
+ * data is platform-wide so no org-scoped tier exists.
  */
 export function resolveOpsScope({
   userEmail,
@@ -1086,20 +1095,21 @@ export function resolveOpsScope({
   userEmail: string | null | undefined;
   permission: Permission;
   prisma: unknown;
-}): OpsScope | null {
+}): OpsScope {
   if (isAdmin({ email: userEmail })) {
     return { kind: "platform" };
   }
 
-  return null;
+  return { kind: "none" };
 }
 
 export const checkOpsPermission =
-  (permission: Permission) =>
+  (permission: Permission, options: { throwOnDeny?: boolean } = {}) =>
   async ({
     ctx,
     next,
   }: PermissionMiddlewareParams<unknown>) => {
+    const { throwOnDeny = true } = options;
     const user = ctx.session?.user;
     if (!user) {
       throw new TRPCError({ code: "UNAUTHORIZED" });
@@ -1112,7 +1122,12 @@ export const checkOpsPermission =
       prisma: ctx.prisma,
     });
 
-    if (!opsScope) {
+    // For mutating endpoints, `kind: "none"` is a hard FORBIDDEN. For status
+    // probes that want to *report* "no access" without throwing (lw#3584
+    // — see ops.getScope), pass `{ throwOnDeny: false }` so the middleware
+    // populates `ctx.opsScope = { kind: "none" }` and the procedure handler
+    // can branch on it.
+    if (opsScope.kind === "none" && throwOnDeny) {
       throw new TRPCError({
         code: "FORBIDDEN",
         message: "You do not have permission to access ops resources",

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -1104,12 +1104,17 @@ export function resolveOpsScope({
 }
 
 export const checkOpsPermission =
-  (permission: Permission, options: { throwOnDeny?: boolean } = {}) =>
+  ({
+    permission,
+    throwOnDeny = true,
+  }: {
+    permission: Permission;
+    throwOnDeny?: boolean;
+  }) =>
   async ({
     ctx,
     next,
   }: PermissionMiddlewareParams<unknown>) => {
-    const { throwOnDeny = true } = options;
     const user = ctx.session?.user;
     if (!user) {
       throw new TRPCError({ code: "UNAUTHORIZED" });

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -10,6 +10,12 @@ import { getProjectionMetadata, getReactorMetadata } from "~/server/event-sourci
 
 const opsViewPermission = checkOpsPermission("ops:view");
 
+// Status-probe variant of the ops:view middleware — populates `ctx.opsScope`
+// (with `kind: "none"` for non-ops users) without throwing FORBIDDEN. Lets
+// `getScope` be a probe that the global menu can poll on every page load
+// without spamming the console (lw#3584).
+const opsViewProbe = checkOpsPermission("ops:view", { throwOnDeny: false });
+
 const opsManagePermission = checkOpsPermission("ops:manage");
 
 function requireOps() {
@@ -24,7 +30,18 @@ function requireOps() {
 }
 
 export const opsRouter = createTRPCRouter({
-  getScope: protectedProcedure.use(opsViewPermission).query(({ ctx }) => {
+  /**
+   * Status probe — returns the calling user's ops scope. Always succeeds for
+   * any authenticated user; non-ops users get `{ scope: { kind: "none" } }`
+   * instead of FORBIDDEN. The hook (`useOpsPermission`) derives `hasAccess`
+   * from `scope.kind !== "none"` so the global menu can hide ops UI without
+   * spamming the console with permission errors on every page load
+   * (lw#3584).
+   *
+   * The mutating ops endpoints below still go through the throw-on-deny
+   * variant of `checkOpsPermission` — only this status probe relaxes it.
+   */
+  getScope: protectedProcedure.use(opsViewProbe).query(({ ctx }) => {
     return { scope: ctx.opsScope! };
   }),
 

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -8,15 +8,18 @@ import { DASHBOARD_EVENT } from "~/server/app-layer/ops/metrics-collector";
 import type { DashboardData } from "~/server/app-layer/ops/types";
 import { getProjectionMetadata, getReactorMetadata } from "~/server/event-sourcing/pipelineRegistry";
 
-const opsViewPermission = checkOpsPermission("ops:view");
+const opsViewPermission = checkOpsPermission({ permission: "ops:view" });
 
 // Status-probe variant of the ops:view middleware — populates `ctx.opsScope`
 // (with `kind: "none"` for non-ops users) without throwing FORBIDDEN. Lets
 // `getScope` be a probe that the global menu can poll on every page load
 // without spamming the console (lw#3584).
-const opsViewProbe = checkOpsPermission("ops:view", { throwOnDeny: false });
+const opsViewProbe = checkOpsPermission({
+  permission: "ops:view",
+  throwOnDeny: false,
+});
 
-const opsManagePermission = checkOpsPermission("ops:manage");
+const opsManagePermission = checkOpsPermission({ permission: "ops:manage" });
 
 function requireOps() {
   const ops = getApp().ops;

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -45,7 +45,17 @@ export const opsRouter = createTRPCRouter({
    * variant of `checkOpsPermission` — only this status probe relaxes it.
    */
   getScope: protectedProcedure.use(opsViewProbe).query(({ ctx }) => {
-    return { scope: ctx.opsScope! };
+    // The opsViewProbe middleware (checkOpsPermission with throwOnDeny=false)
+    // always populates ctx.opsScope before calling next(). The runtime guard
+    // here is belt-and-suspenders — if it ever fires, the middleware contract
+    // has been violated and we want to know, not silently return undefined.
+    if (!ctx.opsScope) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "opsScope not populated by middleware (probable bug)",
+      });
+    }
+    return { scope: ctx.opsScope };
   }),
 
   getDashboardSnapshot: protectedProcedure

--- a/specs/rbac/ops-scope-status-probe.feature
+++ b/specs/rbac/ops-scope-status-probe.feature
@@ -1,0 +1,49 @@
+Feature: OpsScope status probe never throws FORBIDDEN
+  As any authenticated user
+  I need `api.ops.getScope` to be a status probe that returns data
+  So the global menu can hide ops UI without spamming my console with permission errors on every page load.
+
+  Background: tracking lw#3584. `useOpsPermission()` (called from
+  MainMenu, SettingsLayout, every ops shell, ...) was wrapped around
+  `api.ops.getScope`, which itself ran `checkOpsPermission` middleware
+  and threw FORBIDDEN for non-admin users. Result: every non-admin saw a
+  tRPC error in the console on every page load, even though the UI is
+  *probing* for access — "no" is the honest answer, not an error.
+
+  Now `OpsScope` is a discriminated union — every authenticated user has
+  a scope, even if that scope is `{ kind: "none" }`. The probe endpoint
+  returns the scope; the middleware-guarded mutating endpoints still
+  throw FORBIDDEN on `kind: "none"`.
+
+  @unit
+  Scenario: resolveOpsScope returns kind=none for non-ops users instead of null
+    Given a non-admin authenticated user
+    When resolveOpsScope is called
+    Then it returns `{ kind: "none" }`
+
+  @unit
+  Scenario: resolveOpsScope returns kind=platform for admin users
+    Given an admin authenticated user
+    When resolveOpsScope is called
+    Then it returns `{ kind: "platform" }`
+
+  @unit
+  Scenario: checkOpsPermission still throws FORBIDDEN for non-ops callers
+    Given the checkOpsPermission middleware wrapping a mutation
+    When a non-admin user calls the mutation
+    Then the middleware throws TRPCError code=FORBIDDEN
+    And `next` is NOT invoked
+
+  @unit
+  Scenario: checkOpsPermission grants access for admin callers
+    Given the checkOpsPermission middleware wrapping a query
+    When an admin user calls the query
+    Then `next` is invoked
+    And `ctx.opsScope.kind` is "platform"
+
+  @unit
+  Scenario: checkOpsPermission with throwOnDeny=false populates kind=none for status probes
+    Given the checkOpsPermission middleware constructed with `{ throwOnDeny: false }`
+    When a non-admin user calls the wrapped procedure
+    Then `next` is invoked
+    And `ctx.opsScope.kind` is "none"


### PR DESCRIPTION
## Summary

`useOpsPermission()` is called on every page (global menu, SettingsLayout). Its underlying `api.ops.getScope` was wrapped in `checkOpsPermission` middleware that threw FORBIDDEN for non-admin users — every non-ops user got a tRPC permission error in the console on every page load.

This change models `OpsScope` as a discriminated union — every authenticated user has a scope, even if that scope is `{ kind: "none" }`:

- `OpsScope = { kind: "none" } | { kind: "platform" }`
- `resolveOpsScope()` is now total (no nulls).
- `checkOpsPermission(perm, { throwOnDeny: false })` is the new status-probe variant — populates `ctx.opsScope = { kind: "none" }` and lets the handler return it as data.
- `ops.getScope` uses the probe variant; every other ops endpoint still throws FORBIDDEN.
- `useOpsPermission` derives `hasAccess` from `scope.kind !== "none"` instead of `query.isSuccess`.
- SSE endpoint's `if (!opsScope)` becomes `opsScope.kind === "none"`.

## Test plan

- [x] `pnpm test:unit src/server/api/__tests__/ops-scope-resolution.unit.test.ts` — 5/5
- [x] `pnpm typecheck`
- [x] `pnpm check:feature-parity` — 5/5 new scenarios bound (`specs/rbac/ops-scope-status-probe.feature`)

## Notes

- AC#3 (other `ops.*` endpoints unchanged): verified — only `getScope` switched. The `opsManagePermission`, `opsViewPermission`, all mutations and dashboard queries still go through the throw-on-deny path.
- AC#4 (hook contract preserved): `useOpsPermission()` still returns `{ hasAccess, scope, isLoading }`. All 6+ existing consumers work unchanged.
- AC#5 (no info leakage): the new shape exposes the same bit (whether the user has ops access). Both old and new shapes implicitly reveal that via 403 vs 200 / `none` vs `platform`.

Closes #3584

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3584