### PR TITLE
feat(event-sourcing): add gq_blocked_groups gauge for current blocked count

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts
@@ -14,6 +14,7 @@ import {
   gqJobsExhaustedTotal,
   gqJobsNonRetryableTotal,
   gqGroupsBlockedTotal,
+  gqBlockedGroups,
 } from "../metrics";
 
 const routingLabels = {
@@ -62,6 +63,11 @@ describe("GroupQueue metrics", () => {
       const metric = register.getSingleMetric(
         "gq_oldest_pending_age_milliseconds",
       );
+      expect(metric).toBeDefined();
+    });
+
+    it("registers gq_blocked_groups gauge", () => {
+      const metric = register.getSingleMetric("gq_blocked_groups");
       expect(metric).toBeDefined();
     });
   });
@@ -191,6 +197,22 @@ describe("GroupQueue metrics", () => {
     it("sets gauge to zero when no pending jobs", () => {
       expect(() =>
         gqOldestPendingAgeMilliseconds.set({ queue_name: "test-queue" }, 0),
+      ).not.toThrow();
+    });
+  });
+
+  describe("when blocked groups gauge is set", () => {
+    it("exposes the value with the queue_name label", async () => {
+      gqBlockedGroups.set({ queue_name: "test-queue" }, 3);
+
+      const lines = await register.getSingleMetricAsString("gq_blocked_groups");
+      expect(lines).toContain('queue_name="test-queue"');
+      expect(lines).toContain("3");
+    });
+
+    it("can be reset to zero when no groups are blocked", () => {
+      expect(() =>
+        gqBlockedGroups.set({ queue_name: "test-queue" }, 0),
       ).not.toThrow();
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -4,6 +4,7 @@ import { Counter, Gauge, Histogram, register } from "prom-client";
 const metricNames = [
   "gq_active_groups",
   "gq_pending_groups",
+  "gq_blocked_groups",
   "gq_groups_blocked_total",
   "gq_jobs_staged_total",
   "gq_jobs_dispatched_total",
@@ -42,6 +43,12 @@ export const gqGroupsBlockedTotal = new Counter({
   name: "gq_groups_blocked_total",
   help: "Total number of groups that have been blocked due to exhausted retries",
   labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
+});
+
+export const gqBlockedGroups = new Gauge({
+  name: "gq_blocked_groups",
+  help: "Number of groups currently in the blocked state (jobs exhausted retries, awaiting manual unblock)",
+  labelNames: ["queue_name"] as const,
 });
 
 export const gqJobsStagedTotal = new Counter({

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
@@ -4,6 +4,7 @@ import type { Cluster } from "ioredis";
 import type { Logger } from "pino";
 import {
   gqActiveGroups,
+  gqBlockedGroups,
   gqFastqActive,
   gqFastqPending,
   gqPendingGroups,
@@ -56,14 +57,21 @@ export class GroupQueueMetricsCollector {
 
       const keyPrefix = this.params.scripts.getKeyPrefix();
       const readyKey = `${keyPrefix}ready`;
+      const blockedKey = `${keyPrefix}blocked`;
 
       const pendingGroupCount = await this.params.redisConnection.zcard(
         readyKey,
       );
+      const blockedGroupCount =
+        await this.params.redisConnection.scard(blockedKey);
 
       gqPendingGroups.set(
         { queue_name: this.params.queueName },
         pendingGroupCount,
+      );
+      gqBlockedGroups.set(
+        { queue_name: this.params.queueName },
+        blockedGroupCount,
       );
       gqActiveGroups.set(
         { queue_name: this.params.queueName },


### PR DESCRIPTION
## Summary
- Adds `gq_blocked_groups` gauge sourced from `SCARD <prefix>:blocked` in the periodic metrics collector
- Existing `gq_groups_blocked_total` is a cumulative counter — alerts that read it via `increase(...[10m])` flap green/red as transitions age out of the window even when groups remain blocked. The gauge fixes the underlying signal so a follow-up alert change can express "any groups currently blocked" cleanly
- One extra `SCARD` per queue per metrics-collection tick (cheap, O(1))

## Why
Investigating the flapping "Blocked Groups" Grafana alert in prod revealed there's no current-state metric for blocked groups. The Counter only ever moves on transition; the alert's `increase` window made it look like blocked state was clearing on its own.

## Follow-up (separate PR)
Once this is deployed and `gq_blocked_groups` shows data in Prometheus, swap the Grafana "Blocked Groups" alert query from `sum(increase(gq_groups_blocked_total[10m])) > 0` to `max(gq_blocked_groups) > 0` with a small `for` window.

## Test plan
- [x] `pnpm test:unit src/server/event-sourcing/queues/groupQueue/__tests__/metrics.unit.test.ts` (21/21)
- [ ] After deploy: confirm `gq_blocked_groups{queue_name=...}` is being scraped in Prometheus
- [ ] After deploy: trigger a blocked group (or pick existing one), verify gauge reflects current SCARD