### PR TITLE
fix(clickhouse): lazy-register backup gauges so only workers report them

### DIFF
--- a/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
@@ -416,6 +416,16 @@ describe("ClickHouse metrics", () => {
       } as unknown as ClickHouseClient;
     };
 
+    const countCallsMatching = (
+      calls: unknown[][],
+      argIndex: number,
+      needle: string,
+    ) =>
+      calls.filter((args) => {
+        const arg = args[argIndex];
+        return typeof arg === "string" && arg.includes(needle);
+      }).length;
+
     it("emits exactly one warn for repeated failures until recovery", async () => {
       const client = buildMockClient(() => true);
 
@@ -423,12 +433,11 @@ describe("ClickHouse metrics", () => {
       await metrics.collectStorageStats(client);
       await metrics.collectStorageStats(client);
 
-      // First failure warns; subsequent failures fall through to debug.
-      const backupWarnCount = loggerMocks.warn.mock.calls.filter(
-        ([, msg]: [unknown, unknown]) =>
-          typeof msg === "string" && msg.includes("system.backups"),
-      ).length;
-      expect(backupWarnCount).toBe(1);
+      // logger.warn signature is (obj, msg). First failure warns;
+      // subsequent failures fall through to debug.
+      expect(
+        countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backups"),
+      ).toBe(1);
     });
 
     it("warns again on a fresh failure after recovering", async () => {
@@ -442,17 +451,14 @@ describe("ClickHouse metrics", () => {
       shouldFail = true;
       await metrics.collectStorageStats(client); // fail → warn (#2)
 
-      const backupWarnCount = loggerMocks.warn.mock.calls.filter(
-        ([, msg]: [unknown, unknown]) =>
-          typeof msg === "string" && msg.includes("system.backups"),
-      ).length;
-      expect(backupWarnCount).toBe(2);
-
-      const recoveryInfoCount = loggerMocks.info.mock.calls.filter(
-        ([msg]: [unknown]) =>
-          typeof msg === "string" && msg.includes("recovered"),
-      ).length;
-      expect(recoveryInfoCount).toBe(1);
+      expect(
+        countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backups"),
+      ).toBe(2);
+      // logger.info("ClickHouse backup stats collection recovered ...")
+      // is called with the message as the first arg.
+      expect(
+        countCallsMatching(loggerMocks.info.mock.calls, 0, "recovered"),
+      ).toBe(1);
     });
   });
 });

--- a/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
@@ -1,6 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ClickHouseClient } from "@clickhouse/client";
 
+const promClientMocks = vi.hoisted(() => ({
+  constructedGaugeNames: [] as string[],
+}));
+
+const loggerMocks = vi.hoisted(() => ({
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => loggerMocks,
+}));
+
 // Mock prom-client
 vi.mock("prom-client", () => {
   class MockHistogram {
@@ -21,7 +36,9 @@ vi.mock("prom-client", () => {
   }
 
   class MockGauge {
-    constructor(public config: any) {}
+    constructor(public config: any) {
+      promClientMocks.constructedGaugeNames.push(config.name);
+    }
     labels(...args: string[]) {
       return { set: vi.fn() };
     }
@@ -44,6 +61,11 @@ describe("ClickHouse metrics", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    promClientMocks.constructedGaugeNames.length = 0;
+    loggerMocks.warn.mockClear();
+    loggerMocks.info.mockClear();
+    loggerMocks.debug.mockClear();
+    loggerMocks.error.mockClear();
     metrics = await import("../metrics");
   });
 
@@ -297,6 +319,140 @@ describe("ClickHouse metrics", () => {
 
     it("sets disk free bytes without throwing", () => {
       expect(() => metrics.setClickHouseDiskFreeBytes("default", 214748364800)).not.toThrow();
+    });
+  });
+
+  describe("backup gauge lazy registration", () => {
+    const BACKUP_GAUGE_NAMES = [
+      "clickhouse_backup_last_success_timestamp_seconds",
+      "clickhouse_backup_last_size_bytes",
+      "clickhouse_backup_status_total",
+    ];
+
+    it("does not construct backup gauges at module import time", () => {
+      // Module was just imported in beforeEach. None of the backup gauges
+      // should have been registered yet — they're lazily created on first
+      // use. This guards against regressing back to eager registration,
+      // which would cause non-worker pods (which never call collectStorageStats)
+      // to expose the gauges as constant 0.
+      const constructed = promClientMocks.constructedGaugeNames;
+      for (const name of BACKUP_GAUGE_NAMES) {
+        expect(constructed).not.toContain(name);
+      }
+    });
+
+    it("constructs the timestamp gauge only after the first set call", () => {
+      expect(promClientMocks.constructedGaugeNames).not.toContain(
+        "clickhouse_backup_last_success_timestamp_seconds",
+      );
+
+      metrics.setClickHouseBackupLastSuccessTimestamp(1711929600);
+
+      expect(promClientMocks.constructedGaugeNames).toContain(
+        "clickhouse_backup_last_success_timestamp_seconds",
+      );
+    });
+
+    it("constructs the size gauge only after the first set call", () => {
+      expect(promClientMocks.constructedGaugeNames).not.toContain(
+        "clickhouse_backup_last_size_bytes",
+      );
+
+      metrics.setClickHouseBackupLastSizeBytes(1073741824);
+
+      expect(promClientMocks.constructedGaugeNames).toContain(
+        "clickhouse_backup_last_size_bytes",
+      );
+    });
+
+    it("constructs the status total gauge only after the first set call", () => {
+      expect(promClientMocks.constructedGaugeNames).not.toContain(
+        "clickhouse_backup_status_total",
+      );
+
+      metrics.setClickHouseBackupStatusCount("BACKUP_CREATED", 5);
+
+      expect(promClientMocks.constructedGaugeNames).toContain(
+        "clickhouse_backup_status_total",
+      );
+    });
+
+    it("constructs each backup gauge at most once across repeated set calls", () => {
+      metrics.setClickHouseBackupLastSuccessTimestamp(1);
+      metrics.setClickHouseBackupLastSuccessTimestamp(2);
+      metrics.setClickHouseBackupLastSizeBytes(1);
+      metrics.setClickHouseBackupLastSizeBytes(2);
+      metrics.setClickHouseBackupStatusCount("BACKUP_CREATED", 1);
+      metrics.setClickHouseBackupStatusCount("BACKUP_CREATED", 2);
+
+      for (const name of BACKUP_GAUGE_NAMES) {
+        const occurrences = promClientMocks.constructedGaugeNames.filter(
+          (n) => n === name,
+        ).length;
+        expect(occurrences).toBe(1);
+      }
+    });
+  });
+
+  describe("system.backups failure logging", () => {
+    const buildMockClient = (backupShouldFail: () => boolean) => {
+      const partsResult = { json: vi.fn().mockResolvedValue({ data: [] }) };
+      const successfulBackupResult = {
+        json: vi.fn().mockResolvedValue({ data: [] }),
+      };
+      const diskResult = { json: vi.fn().mockResolvedValue({ data: [] }) };
+      return {
+        query: vi.fn(async ({ query }: { query: string }) => {
+          if (query.includes("system.parts")) return partsResult;
+          if (query.includes("system.backups")) {
+            if (backupShouldFail()) {
+              throw new Error("system.backups not found");
+            }
+            return successfulBackupResult;
+          }
+          if (query.includes("system.disks")) return diskResult;
+          return { json: vi.fn().mockResolvedValue({ data: [] }) };
+        }),
+      } as unknown as ClickHouseClient;
+    };
+
+    it("emits exactly one warn for repeated failures until recovery", async () => {
+      const client = buildMockClient(() => true);
+
+      await metrics.collectStorageStats(client);
+      await metrics.collectStorageStats(client);
+      await metrics.collectStorageStats(client);
+
+      // First failure warns; subsequent failures fall through to debug.
+      const backupWarnCount = loggerMocks.warn.mock.calls.filter(
+        ([, msg]: [unknown, unknown]) =>
+          typeof msg === "string" && msg.includes("system.backups"),
+      ).length;
+      expect(backupWarnCount).toBe(1);
+    });
+
+    it("warns again on a fresh failure after recovering", async () => {
+      let shouldFail = true;
+      const client = buildMockClient(() => shouldFail);
+
+      await metrics.collectStorageStats(client); // fail → warn (#1)
+      await metrics.collectStorageStats(client); // fail → debug (suppressed)
+      shouldFail = false;
+      await metrics.collectStorageStats(client); // recover → info
+      shouldFail = true;
+      await metrics.collectStorageStats(client); // fail → warn (#2)
+
+      const backupWarnCount = loggerMocks.warn.mock.calls.filter(
+        ([, msg]: [unknown, unknown]) =>
+          typeof msg === "string" && msg.includes("system.backups"),
+      ).length;
+      expect(backupWarnCount).toBe(2);
+
+      const recoveryInfoCount = loggerMocks.info.mock.calls.filter(
+        ([msg]: [unknown]) =>
+          typeof msg === "string" && msg.includes("recovered"),
+      ).length;
+      expect(recoveryInfoCount).toBe(1);
     });
   });
 });

--- a/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
@@ -26,6 +26,7 @@ vi.mock("prom-client", () => {
       return { set: vi.fn() };
     }
     set(value: number) {}
+    reset() {}
   }
 
   return {

--- a/langwatch/src/server/clickhouse/metrics.ts
+++ b/langwatch/src/server/clickhouse/metrics.ts
@@ -127,35 +127,54 @@ export async function executeWithMetrics<T>(
 // Backup Status Metrics
 // ============================================================================
 
-register.removeSingleMetric("clickhouse_backup_last_success_timestamp_seconds");
-const clickhouseBackupLastSuccessTimestamp = new Gauge({
-  name: "clickhouse_backup_last_success_timestamp_seconds",
-  help: "Timestamp of the last successful ClickHouse backup (Unix seconds)",
-});
+// Lazy-registered: gauges only materialize after the first successful update,
+// so non-worker pods (which never call collectStorageStats) don't pollute
+// /metrics with default-zero series. Combined with `noDataState: Alerting`,
+// a missing gauge becomes a real signal that no worker is reporting.
+let clickhouseBackupLastSuccessTimestamp: Gauge<string> | null = null;
+let clickhouseBackupLastSizeBytes: Gauge<string> | null = null;
+let clickhouseBackupStatusTotal: Gauge<"status"> | null = null;
 
-export const setClickHouseBackupLastSuccessTimestamp = (ts: number) =>
+export const setClickHouseBackupLastSuccessTimestamp = (ts: number) => {
+  if (!clickhouseBackupLastSuccessTimestamp) {
+    register.removeSingleMetric(
+      "clickhouse_backup_last_success_timestamp_seconds",
+    );
+    clickhouseBackupLastSuccessTimestamp = new Gauge({
+      name: "clickhouse_backup_last_success_timestamp_seconds",
+      help: "Timestamp of the last successful ClickHouse backup (Unix seconds)",
+    });
+  }
   clickhouseBackupLastSuccessTimestamp.set(ts);
+};
 
-register.removeSingleMetric("clickhouse_backup_last_size_bytes");
-const clickhouseBackupLastSizeBytes = new Gauge({
-  name: "clickhouse_backup_last_size_bytes",
-  help: "Size of the last successful ClickHouse backup in bytes",
-});
-
-export const setClickHouseBackupLastSizeBytes = (bytes: number) =>
+export const setClickHouseBackupLastSizeBytes = (bytes: number) => {
+  if (!clickhouseBackupLastSizeBytes) {
+    register.removeSingleMetric("clickhouse_backup_last_size_bytes");
+    clickhouseBackupLastSizeBytes = new Gauge({
+      name: "clickhouse_backup_last_size_bytes",
+      help: "Size of the last successful ClickHouse backup in bytes",
+    });
+  }
   clickhouseBackupLastSizeBytes.set(bytes);
+};
 
-register.removeSingleMetric("clickhouse_backup_status_total");
-const clickhouseBackupStatusTotal = new Gauge({
-  name: "clickhouse_backup_status_total",
-  help: "Count of ClickHouse backups by status",
-  labelNames: ["status"] as const,
-});
+const ensureBackupStatusTotal = (): Gauge<"status"> => {
+  if (!clickhouseBackupStatusTotal) {
+    register.removeSingleMetric("clickhouse_backup_status_total");
+    clickhouseBackupStatusTotal = new Gauge({
+      name: "clickhouse_backup_status_total",
+      help: "Count of ClickHouse backups by status",
+      labelNames: ["status"] as const,
+    });
+  }
+  return clickhouseBackupStatusTotal;
+};
 
 export const setClickHouseBackupStatusCount = (
   status: string,
   count: number,
-) => clickhouseBackupStatusTotal.labels(status).set(count);
+) => ensureBackupStatusTotal().labels(status).set(count);
 
 // ============================================================================
 // Disk Storage Metrics
@@ -267,7 +286,7 @@ export async function collectStorageStats(
 
       const backupRows = await backupResult.json<BackupStats>();
 
-      clickhouseBackupStatusTotal.reset();
+      ensureBackupStatusTotal().reset();
       for (const row of backupRows.data) {
         setClickHouseBackupStatusCount(row.status, parseInt(row.cnt, 10));
 
@@ -283,10 +302,9 @@ export async function collectStorageStats(
         }
       }
     } catch (backupError) {
-      // system.backups may not exist on all ClickHouse versions
-      logger.debug(
+      logger.warn(
         { error: backupError },
-        "Failed to collect ClickHouse backup stats (system.backups may not exist)",
+        "Failed to collect ClickHouse backup stats from system.backups",
       );
     }
 

--- a/langwatch/src/server/clickhouse/metrics.ts
+++ b/langwatch/src/server/clickhouse/metrics.ts
@@ -176,6 +176,10 @@ export const setClickHouseBackupStatusCount = (
   count: number,
 ) => ensureBackupStatusTotal().labels(status).set(count);
 
+// Edge-triggered: collectStorageStats runs every 15s, so we'd otherwise
+// produce 5,760 identical warns/day if system.backups is unavailable.
+let backupStatsCollectionFailing = false;
+
 // ============================================================================
 // Disk Storage Metrics
 // ============================================================================
@@ -301,11 +305,26 @@ export async function collectStorageStats(
           }
         }
       }
+
+      if (backupStatsCollectionFailing) {
+        logger.info(
+          "ClickHouse backup stats collection recovered from previous failure",
+        );
+        backupStatsCollectionFailing = false;
+      }
     } catch (backupError) {
-      logger.warn(
-        { error: backupError },
-        "Failed to collect ClickHouse backup stats from system.backups",
-      );
+      if (!backupStatsCollectionFailing) {
+        logger.warn(
+          { error: backupError },
+          "Failed to collect ClickHouse backup stats from system.backups (further failures suppressed until recovery)",
+        );
+        backupStatsCollectionFailing = true;
+      } else {
+        logger.debug(
+          { error: backupError },
+          "Failed to collect ClickHouse backup stats from system.backups",
+        );
+      }
     }
 
     // Collect per-disk storage metrics


### PR DESCRIPTION
## Summary

The `clickhouse_backup_*` gauges in `langwatch/src/server/clickhouse/metrics.ts` were registered at module load and exported by every process that imported them. Only worker pods actually run `startStorageStatsCollection`, so the `langwatch` app pods emitted these gauges as a constant `0` forever.

The **ClickHouse Backup Missing** Grafana rule masks this with a `> 0` filter, but that workaround silently degraded into `NoData` whenever worker-side gauges briefly read 0 — fresh pod start, `system.backups` query temporarily failing, etc.

On 2026-05-02, a worker rollout (replicaset `5b4b75dbc` → `5cffbc98f8`, triggered by an unrelated `LastEventOccurredAt` schema mismatch) left every worker gauge at the default `0` for ~10h. The alert auto-resolved via `noDataState: OK` with the literal `[no value]` payload — confirmed in CloudWatch and the Grafana alert history.

This PR makes those gauges **lazy-register on first successful update**, so:
- Non-worker pods never expose them.
- A missing series becomes a meaningful "no worker is reporting" signal — paired with flipping the rule to `noDataState: Alerting`, which I'll do directly in Grafana alongside the Keeper threshold change.

The inner `system.backups` failure log is also promoted from `debug` to `warn` so future silent failures of that query show up in prod CloudWatch.

## Companion Grafana changes (applied separately, not in this PR)

- **CH Keeper Errors:** `for: 0s` → `for: 5m`, threshold `> 0` → `> 50`. Stops firing on every CH pod restart / Keeper session reconnect; matches the natural deploy-burst scale (peaks ~250/10m on pod-0).
- **ClickHouse Backup Missing:** add `{job="langwatch-workers"}` selector and switch `noDataState` to `Alerting`, so a missing worker gauge pages instead of silently auto-resolving.

## Test plan

- [x] `pnpm test:unit src/server/clickhouse/__tests__/metrics.unit.test.ts` — 24/24 pass
- [ ] After deploy: confirm `/metrics` on a `langwatch` app pod no longer exposes `clickhouse_backup_last_success_timestamp_seconds`
- [ ] After deploy: confirm worker pods still expose it once the first `system.backups` query succeeds
- [ ] After deploy: apply the two Grafana rule changes and watch one full deploy cycle without paging