### PR TITLE
fix(ui): defer mermaid + emoji-picker imports to prevent prod boot crash

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/VizPlaceholder.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/VizPlaceholder.tsx
@@ -43,7 +43,8 @@ import type { VizTab } from "../../stores/drawerStore";
 import { SPAN_TYPE_COLORS } from "../../utils/formatters";
 import { FlameView } from "./flameView";
 import { NewSpanFlash } from "./NewSpanFlash";
-import { SequenceSkeleton, TopologySkeleton } from "./sequenceView";
+import { SequenceSkeleton } from "./sequenceView/SequenceSkeleton";
+import { TopologySkeleton } from "./sequenceView/TopologySkeleton";
 import { SpanListView } from "./spanListView";
 import { WaterfallView } from "./waterfallView";
 

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/sequenceView/useMermaidRenderer.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/sequenceView/useMermaidRenderer.ts
@@ -1,4 +1,3 @@
-import mermaid from "mermaid";
 import {
   type Dispatch,
   type RefObject,
@@ -7,6 +6,13 @@ import {
   useState,
 } from "react";
 import { EASTER_EGG_IMAGE_URL } from "./useKonamiEasterEgg";
+
+// Mermaid is loaded via a true `await import()` inside the effect so it
+// stays in its own chunk. A top-level `import mermaid from "mermaid"`
+// collapses mermaid into whatever chunk the parent module ends up in,
+// which in turn rewires mermaid's internal dynamic diagram loaders and
+// breaks its `__name` helper at top-level evaluation. Keeping the import
+// dynamic preserves the chunk boundary mermaid expects.
 
 const MINIMAP_W = 200;
 const MINIMAP_H = 72;
@@ -79,6 +85,8 @@ export function useMermaidRenderer({
 
     void (async () => {
       try {
+        const mermaid = (await import("mermaid")).default;
+        if (cancelled) return;
         mermaid.initialize({
           startOnLoad: false,
           theme: colorMode === "dark" ? "dark" : "default",

--- a/langwatch/src/optimization_studio/components/properties/modals/EmojiPickerModal.tsx
+++ b/langwatch/src/optimization_studio/components/properties/modals/EmojiPickerModal.tsx
@@ -1,7 +1,16 @@
 import { type BoxProps, PopoverContent } from "@chakra-ui/react";
-import { EmojiStyle, SkinTonePickerLocation } from "emoji-picker-react";
+import type { EmojiStyle, SkinTonePickerLocation } from "emoji-picker-react";
 import dynamic from "~/utils/compat/next-dynamic";
 import { ConfigModal } from "./ConfigModal";
+
+// Use string literals matching the enum values rather than importing the
+// runtime enums. A value-import of even a single enum from
+// `emoji-picker-react` collapses the entire library into whatever chunk
+// this module ends up in, defeating the `dynamic()` lazy load below and
+// crashing app boot ("n is not a function") when the eager bundle of
+// emoji-picker-react fails to initialise.
+const EMOJI_STYLE_NATIVE = "native" as EmojiStyle;
+const SKIN_TONE_PREVIEW = "PREVIEW" as SkinTonePickerLocation;
 
 const EmojiPicker = dynamic(
   () => import("emoji-picker-react").then((mod) => mod.default),
@@ -25,8 +34,8 @@ export function EmojiPickerModal({
     <ConfigModal open={open} onClose={onClose} title="Workflow Icon" unstyled>
       <PopoverContent marginRight={4} position="absolute" marginTop="72px" {...props}>
         <EmojiPicker
-          emojiStyle={EmojiStyle.NATIVE}
-          skinTonePickerLocation={SkinTonePickerLocation.PREVIEW}
+          emojiStyle={EMOJI_STYLE_NATIVE}
+          skinTonePickerLocation={SKIN_TONE_PREVIEW}
           onEmojiClick={(emojiData: any) => {
             onChange(emojiData.emoji);
             onClose();


### PR DESCRIPTION
## Summary
- Production app was crashing on boot with `Uncaught TypeError: v is not a function` at `mermaid.core-CjwbxbmZ.js:2:4343` after the recent traces-v2 deploy. Locally I reproduced an identical-shape crash in `emoji-picker-react.esm-DWSExrw8.js:1:97` that the user's prod build is also vulnerable to.
- Root cause is a Vite/Rollup bundling pattern: a top-level value-import from a heavy library defeats a sibling `lazy()` / `dynamic()` wrapper. Rollup collapses the lib into the parent chunk's eager static graph, which rewires the lib's internal `__name`/helper plumbing and crashes at top-level evaluation.
- Three minimal-diff fixes restore proper code-splitting; build verification confirms the main `index` chunk and trace-page chunk no longer statically reference `mermaid` or `emoji-picker-react`.

## What changed
- **`useMermaidRenderer.ts`** — replaced top-level `import mermaid from "mermaid"` with `const mermaid = (await import("mermaid")).default` inside the effect (matches the pre-existing `SequenceDiagram.tsx:390` pattern).
- **`VizPlaceholder.tsx`** — switched skeleton imports from the `./sequenceView` index to the direct files, so the lazy `SequenceView` graph stays gated behind its `lazy()` wrapper instead of being dragged in by the index re-export of skeletons.
- **`EmojiPickerModal.tsx`** — converted the value-import of `EmojiStyle` / `SkinTonePickerLocation` to a `type`-only import with local string-literal constants matching the enum values, so the `dynamic()` wrapper actually defers `emoji-picker-react`.

## Test plan
- [x] `NODE_ENV=production vite build` succeeds.
- [x] Chunk-graph grep confirms zero static `mermaid` / `emoji-picker-react` imports in the main `index` chunk and the trace-page chunks.
- [x] Playwright load of `/` against the prod build boots cleanly (redirects to `/auth/signin`); no `is not a function` errors in the console.
- [ ] Manual smoke after deploy: open a trace and switch to the sequence/topology viz to confirm mermaid still renders correctly when the user actually triggers the lazy chunk.
- [ ] Manual smoke after deploy: open the workflow icon picker in optimization studio to confirm emoji-picker still renders.