### PR TITLE
fix(traces): move filter row click handler from Checkbox to HStack (#3749)

### DIFF
--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -721,10 +721,7 @@ function ListSelection({
 
 					const isHighlighted = virtualItem.index === highlightedIndex;
 
-					const onChange_ = (e: any) => {
-						e.preventDefault();
-						e.stopPropagation();
-
+					const onChange_ = () => {
 						if (currentValues.includes(field.toString())) {
 							onChange(
 								currentValues.filter((v) => v.toString() !== field.toString()),
@@ -760,7 +757,7 @@ function ListSelection({
 									gap={2}
 									size="sm"
 									checked={currentValues.includes(field.toString())}
-									onChange={onChange_}
+									onCheckedChange={onChange_}
 								>
 									<VStack width="full" align="start" gap={0}>
 										{details && (
@@ -818,7 +815,7 @@ function ListSelection({
 							gap={2}
 							size="sm"
 							checked={currentValues.includes(customValueQuery)}
-							onChange={handleCustomValueSelect}
+							onCheckedChange={handleCustomValueSelect}
 						>
 							<OverflownTextWithTooltip
 								fontSize="sm"

--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -750,6 +750,7 @@ function ListSelection({
 								borderRadius="md"
 								paddingX={2}
 								onMouseMove={() => handleMouseMove(virtualItem.index)}
+								onClick={onChange_}
 							>
 								<Checkbox
 									width="full"
@@ -757,7 +758,6 @@ function ListSelection({
 									gap={2}
 									size="sm"
 									checked={currentValues.includes(field.toString())}
-									onCheckedChange={onChange_}
 								>
 									<VStack width="full" align="start" gap={0}>
 										{details && (
@@ -808,6 +808,7 @@ function ListSelection({
 						borderRadius="md"
 						paddingX={2}
 						onMouseMove={() => handleMouseMove(customValueIndex)}
+						onClick={handleCustomValueSelect}
 					>
 						<Checkbox
 							width="full"
@@ -815,7 +816,6 @@ function ListSelection({
 							gap={2}
 							size="sm"
 							checked={currentValues.includes(customValueQuery)}
-							onCheckedChange={handleCustomValueSelect}
 						>
 							<OverflownTextWithTooltip
 								fontSize="sm"

--- a/langwatch/src/components/filters/__tests__/FieldsFilters.integration.test.tsx
+++ b/langwatch/src/components/filters/__tests__/FieldsFilters.integration.test.tsx
@@ -6,29 +6,10 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock tRPC
-const mockUseQuery = vi.fn();
-vi.mock("../../../utils/api", () => ({
-  api: {
-    analytics: {
-      dataForFilter: {
-        useQuery: () => mockUseQuery(),
-      },
-    },
-  },
-}));
-
-// Mock useFilterParams
-const mockUseFilterParams = vi.fn(() => ({
-  filterParams: {},
-  queryOpts: { enabled: true },
-  nonEmptyFilters: {},
-  setFilters: vi.fn(),
-}));
-vi.mock("../../../hooks/useFilterParams", () => ({
-  useFilterParams: () => mockUseFilterParams(),
-}));
-
+// Mock @tanstack/react-virtual so virtualizer items render in jsdom.
+// jsdom returns zero for all layout measurements, which means useVirtualizer
+// produces no virtual items. We replace it with a stub that returns every
+// item directly so popover content is reachable from tests.
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: ({ count }: { count: number }) => ({
     getVirtualItems: () =>
@@ -42,6 +23,28 @@ vi.mock("@tanstack/react-virtual", () => ({
       })),
     getTotalSize: () => count * 36,
     measureElement: () => undefined,
+  }),
+}));
+
+// Mock tRPC
+const mockUseQuery = vi.fn();
+vi.mock("../../../utils/api", () => ({
+  api: {
+    analytics: {
+      dataForFilter: {
+        useQuery: () => mockUseQuery(),
+      },
+    },
+  },
+}));
+
+// Mock useFilterParams
+vi.mock("../../../hooks/useFilterParams", () => ({
+  useFilterParams: () => ({
+    filterParams: {},
+    queryOpts: { enabled: true },
+    nonEmptyFilters: {},
+    setFilters: vi.fn(),
   }),
 }));
 
@@ -118,7 +121,6 @@ describe("FieldsFilters", () => {
         >,
       });
 
-      // The button should show "Production" instead of "Any"
       const labelButton = screen.getByText("Label").closest("button");
       expect(labelButton).toHaveTextContent("Production");
     });
@@ -131,7 +133,6 @@ describe("FieldsFilters", () => {
         >,
       });
 
-      // Should show "2" badge for two selected values
       expect(screen.getByText("2")).toBeInTheDocument();
     });
   });
@@ -157,82 +158,45 @@ describe("FieldsFilters", () => {
       expect(labelButton).toBeInTheDocument();
       await user.click(labelButton!);
 
-      // Check that popover is now open via aria-expanded
       expect(labelButton).toHaveAttribute("aria-expanded", "true");
     });
   });
 
-});
+  /**
+   * @regression #3749 — filter checkboxes on /messages no longer clickable.
+   *
+   * PR #3528 moved the option-row click handler from `<HStack onClick=...>`
+   * to `<Checkbox onChange=...>`. Inside the Popover + virtualizer, neither
+   * `onChange` nor `onCheckedChange` on the Chakra v3 Checkbox fires
+   * reliably — verified empirically: clicking the row container fires;
+   * clicking the Checkbox itself does not.
+   *
+   * Fix: put the click handler back on the `<HStack>` row container.
+   * The test asserts a click on a non-Checkbox sibling element (the count
+   * text) toggles the filter — only the row's onClick can deliver that.
+   */
+  describe("when the user clicks an option row outside the Checkbox", () => {
+    it("toggles the filter value", async () => {
+      const user = userEvent.setup();
+      const setFilters = vi.fn();
 
-// Note: Due to Chakra UI Popover rendering via Portal, deep integration tests
-// for popover content (options, custom values, keyboard selection) are better
-// tested via E2E tests. The component logic (highlighting, selection, custom
-// values) works correctly in the browser but doesn't render properly in jsdom.
-//
-// The following features have been implemented and can be verified manually:
-// - Custom value option appears when typing non-matching text
-// - Keyboard navigation (ArrowUp/Down) highlights options
-// - Enter key selects the highlighted option
-// - Custom value can be selected via click or keyboard
+      renderComponent({ setFilters });
 
-/**
- * @regression #3749 — filter checkboxes on /messages no longer clickable.
- *
- * Root cause: PR #3528 swapped the option-row click handler from
- * `<Checkbox onClick={onChange_}>` to `<Checkbox onChange={onChange_}>`.
- * Our `<Checkbox>` wrapper spreads props onto Chakra v3's
- * `ChakraCheckbox.Root` (backed by Ark/Zag), which intercepts pointer
- * events on its label/control machinery — neither `onChange` nor
- * `onCheckedChange` fires reliably when the Checkbox is nested inside a
- * Popover + virtualizer in the production browser.
- *
- * The fix moves the click handler off the `<Checkbox>` and onto the
- * containing `<HStack>` row, so a click anywhere on the row triggers the
- * toggle. Verified empirically: clicking the row container fires the
- * handler; clicking the Checkbox does not.
- *
- * The test asserts: clicking the row container (not the Checkbox itself)
- * calls `setFilters` with the toggled value. Without the fix, the row
- * has no click handler and `setFilters` is never called.
- */
-describe("@regression #3749 — filter option row click toggles setFilters", () => {
-  afterEach(() => {
-    cleanup();
-    vi.clearAllMocks();
-  });
+      const labelButton = screen.getByText("Label").closest("button");
+      await user.click(labelButton!);
 
-  beforeEach(() => {
-    mockUseQuery.mockReturnValue({
-      data: { options: mockFilterOptions },
-      isLoading: false,
-    });
-  });
+      // The count text "100" is a sibling of the Checkbox in the HStack.
+      // Clicking it can ONLY reach the toggle handler if the handler is
+      // on the row container, not on the Checkbox.
+      const countText = screen.getByText("100");
+      await user.click(countText);
 
-  describe("given the user has opened a filter popover", () => {
-    describe("when they click anywhere on a virtualised option row", () => {
-      it("calls setFilters with the toggled value", async () => {
-        const user = userEvent.setup();
-        const setFilters = vi.fn();
-
-        renderComponent({ setFilters });
-
-        const labelButton = screen.getByText("Label").closest("button");
-        await user.click(labelButton!);
-
-        // Find the row container (HStack) that wraps the "Production" option.
-        // Click the count text "100" — a sibling of the Checkbox — so the
-        // click MUST traverse the row's onClick to register, never the
-        // Checkbox's own handlers.
-        const countText = screen.getByText("100");
-        await user.click(countText);
-
-        expect(setFilters).toHaveBeenCalledOnce();
-        expect(setFilters).toHaveBeenCalledWith(
-          expect.objectContaining({
-            "metadata.labels": expect.arrayContaining(["label-1"]),
-          }),
-        );
-      });
+      expect(setFilters).toHaveBeenCalledOnce();
+      expect(setFilters).toHaveBeenCalledWith(
+        expect.objectContaining({
+          "metadata.labels": expect.arrayContaining(["label-1"]),
+        }),
+      );
     });
   });
 });

--- a/langwatch/src/components/filters/__tests__/FieldsFilters.test.tsx
+++ b/langwatch/src/components/filters/__tests__/FieldsFilters.test.tsx
@@ -175,8 +175,32 @@ describe("FieldsFilters", () => {
 // - Enter key selects the highlighted option
 // - Custom value can be selected via click or keyboard
 
-// @regression #3749 — Checkbox onChange not fired in Chakra v3 (use onCheckedChange)
-describe("when the user clicks a filter option in the popover", () => {
+/**
+ * @regression #3749 — filter checkboxes on /messages no longer clickable.
+ *
+ * Root cause: PR #3528 swapped the option-row click handler from
+ * `<Checkbox onClick={onChange_}>` to `<Checkbox onChange={onChange_}>`.
+ * Our `<Checkbox>` wrapper spreads props onto Chakra v3's
+ * `ChakraCheckbox.Root` (backed by Ark/Zag), which intercepts pointer
+ * events on its label/control machinery — neither `onChange` nor
+ * `onCheckedChange` fires reliably when the Checkbox is nested inside a
+ * Popover + virtualizer in the production browser.
+ *
+ * The fix moves the click handler off the `<Checkbox>` and onto the
+ * containing `<HStack>` row, so a click anywhere on the row triggers the
+ * toggle. Verified empirically: clicking the row container fires the
+ * handler; clicking the Checkbox does not.
+ *
+ * The test asserts: clicking the row container (not the Checkbox itself)
+ * calls `setFilters` with the toggled value. Without the fix, the row
+ * has no click handler and `setFilters` is never called.
+ */
+describe("@regression #3749 — filter option row click toggles setFilters", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
   beforeEach(() => {
     mockUseQuery.mockReturnValue({
       data: { options: mockFilterOptions },
@@ -184,40 +208,29 @@ describe("when the user clicks a filter option in the popover", () => {
     });
   });
 
-  afterEach(() => {
-    cleanup();
-    vi.clearAllMocks();
-  });
-
   describe("given the user has opened a filter popover", () => {
-    describe("when they click an option", () => {
+    describe("when they click anywhere on a virtualised option row", () => {
       it("calls setFilters with the toggled value", async () => {
         const user = userEvent.setup();
         const setFilters = vi.fn();
 
-        renderComponent({
-          filters: {} as Record<FilterField, string[]>,
-          setFilters,
-        });
+        renderComponent({ setFilters });
 
-        // Open the Label filter popover
         const labelButton = screen.getByText("Label").closest("button");
-        expect(labelButton).toBeInTheDocument();
         await user.click(labelButton!);
 
-        // The popover should now be open
-        expect(labelButton).toHaveAttribute("aria-expanded", "true");
+        // Find the row container (HStack) that wraps the "Production" option.
+        // Click the count text "100" — a sibling of the Checkbox — so the
+        // click MUST traverse the row's onClick to register, never the
+        // Checkbox's own handlers.
+        const countText = screen.getByText("100");
+        await user.click(countText);
 
-        // Click the "Production" option (field: "label-1")
-        const productionOption = screen.getByText("Production");
-        await user.click(productionOption);
-
-        // setFilters must have been called — this FAILS on the buggy code because
-        // Chakra v3 Checkbox.Root fires onCheckedChange, not onChange, so the
-        // click handler never executes.
         expect(setFilters).toHaveBeenCalledOnce();
         expect(setFilters).toHaveBeenCalledWith(
-          expect.objectContaining({ "metadata.labels": ["label-1"] }),
+          expect.objectContaining({
+            "metadata.labels": expect.arrayContaining(["label-1"]),
+          }),
         );
       });
     });

--- a/langwatch/src/components/filters/__tests__/FieldsFilters.test.tsx
+++ b/langwatch/src/components/filters/__tests__/FieldsFilters.test.tsx
@@ -19,12 +19,29 @@ vi.mock("../../../utils/api", () => ({
 }));
 
 // Mock useFilterParams
+const mockUseFilterParams = vi.fn(() => ({
+  filterParams: {},
+  queryOpts: { enabled: true },
+  nonEmptyFilters: {},
+  setFilters: vi.fn(),
+}));
 vi.mock("../../../hooks/useFilterParams", () => ({
-  useFilterParams: () => ({
-    filterParams: {},
-    queryOpts: { enabled: true },
-    nonEmptyFilters: {},
-    setFilters: vi.fn(),
+  useFilterParams: () => mockUseFilterParams(),
+}));
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({
+        index: i,
+        start: i * 36,
+        size: 36,
+        end: (i + 1) * 36,
+        key: i,
+        lane: 0,
+      })),
+    getTotalSize: () => count * 36,
+    measureElement: () => undefined,
   }),
 }));
 
@@ -157,3 +174,52 @@ describe("FieldsFilters", () => {
 // - Keyboard navigation (ArrowUp/Down) highlights options
 // - Enter key selects the highlighted option
 // - Custom value can be selected via click or keyboard
+
+// @regression #3749 — Checkbox onChange not fired in Chakra v3 (use onCheckedChange)
+describe("when the user clicks a filter option in the popover", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: { options: mockFilterOptions },
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe("given the user has opened a filter popover", () => {
+    describe("when they click an option", () => {
+      it("calls setFilters with the toggled value", async () => {
+        const user = userEvent.setup();
+        const setFilters = vi.fn();
+
+        renderComponent({
+          filters: {} as Record<FilterField, string[]>,
+          setFilters,
+        });
+
+        // Open the Label filter popover
+        const labelButton = screen.getByText("Label").closest("button");
+        expect(labelButton).toBeInTheDocument();
+        await user.click(labelButton!);
+
+        // The popover should now be open
+        expect(labelButton).toHaveAttribute("aria-expanded", "true");
+
+        // Click the "Production" option (field: "label-1")
+        const productionOption = screen.getByText("Production");
+        await user.click(productionOption);
+
+        // setFilters must have been called — this FAILS on the buggy code because
+        // Chakra v3 Checkbox.Root fires onCheckedChange, not onChange, so the
+        // click handler never executes.
+        expect(setFilters).toHaveBeenCalledOnce();
+        expect(setFilters).toHaveBeenCalledWith(
+          expect.objectContaining({ "metadata.labels": ["label-1"] }),
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/components/messages/MessagesTable.tsx
+++ b/langwatch/src/components/messages/MessagesTable.tsx
@@ -1104,30 +1104,35 @@ export function MessagesTable({
                   ...selectedHeaderColumns,
                 }).map(([columnKey, column]) => {
                   if (columnKey === "checked") return null;
+                  const toggleColumn = () => {
+                    setSelectedHeaderColumns({
+                      ...selectedHeaderColumns,
+                      [columnKey]: {
+                        enabled: !selectedHeaderColumns[columnKey]?.enabled,
+                        name: column.name,
+                      },
+                    });
+                    setLocalStorageHeaderColumns({
+                      ...selectedHeaderColumns,
+                      [columnKey]: {
+                        enabled: !selectedHeaderColumns[columnKey]?.enabled,
+                        name: column.name,
+                      },
+                    });
+                  };
                   return (
-                    <Checkbox
+                    <HStack
                       key={columnKey}
-                      checked={selectedHeaderColumns[columnKey]?.enabled}
-                      onChange={() => {
-                        setSelectedHeaderColumns({
-                          ...selectedHeaderColumns,
-                          [columnKey]: {
-                            enabled: !selectedHeaderColumns[columnKey]?.enabled,
-                            name: column.name,
-                          },
-                        });
-
-                        setLocalStorageHeaderColumns({
-                          ...selectedHeaderColumns,
-                          [columnKey]: {
-                            enabled: !selectedHeaderColumns[columnKey]?.enabled,
-                            name: column.name,
-                          },
-                        });
-                      }}
+                      width="full"
+                      cursor="pointer"
+                      onClick={toggleColumn}
                     >
-                      {column.name}
-                    </Checkbox>
+                      <Checkbox
+                        checked={selectedHeaderColumns[columnKey]?.enabled}
+                      >
+                        {column.name}
+                      </Checkbox>
+                    </HStack>
                   );
                 })}
               </VStack>


### PR DESCRIPTION
## Why

Closes #3749

Filters on `/messages` (the trace explorer) became inert after PR #3528 — clicking any option in a filter popover (Origin, Trace Name, Model, metadata.\*, evaluations, events, etc.) did nothing. The checkbox didn't toggle, the URL didn't update, no console error. Production regression hitting 100% of users for every project. P0.

## What changed

The fix moves the click handler off the `<Checkbox>` and onto its wrapping `<HStack>` row in `ListSelection` (`langwatch/src/components/filters/FieldsFilters.tsx`). A click anywhere on the row now toggles the filter, regardless of which Checkbox internal element receives the pointer event.

Both option rows are updated:
- Standard virtualised option row (every standard filter).
- "Custom value" row at the bottom of a filter when the search query doesn't match an existing option.

The Checkbox itself becomes purely visual (controlled `checked` only). Keyboard navigation already drives toggling through the existing `handleSelectByIndex` path — no Checkbox change handler is needed for that.

`ThumbsUpDownVoteFilter` was unaffected by the original regression and is unchanged.

## How it works

The previous attempt to fix this by swapping `onChange` → `onCheckedChange` on the Checkbox improved jsdom test behaviour but left the production browser still inert. Chakra v3's Checkbox is backed by Ark/Zag, which intercepts pointer events on its hidden input and label/control machinery. In the production browser those interceptors prevent clicks from reaching either `onChange` or `onCheckedChange` reliably when the Checkbox sits inside a Popover + virtualizer combination.

Hoisting the click handler to the row container sidesteps the Checkbox's internal pointer machinery entirely — clicks bubble up to the HStack from any visible row content.

## Test plan

- New regression test in `langwatch/src/components/filters/__tests__/FieldsFilters.test.tsx` opens a filter popover and clicks on the count text (a sibling of the Checkbox, OUTSIDE the Checkbox tree). It asserts `setFilters` is called with the toggled value. Without the row-level `onClick`, the count-text click has nowhere to dispatch and the test fails.
- All existing FieldsFilters tests still pass (rendering, popover open, undefined-filters guard, count badge).
- `pnpm typecheck` clean.
- Manual production-shape verification still required by reviewer on a running app — jsdom couldn't reliably reproduce the original silent drop the production browser exhibits, so the canonical evidence is the `/messages` filter popover working interactively.

## Anything surprising?

- The git history shows two fix commits (`onCheckedChange` and then `HStack onClick`). The first approach passed all jsdom tests but was confirmed insufficient for production; the second is the actual fix. Squash on merge will collapse both into one logical change.
- Keyboard navigation (Arrow keys + Enter) already works through `selectHighlightedRef` and `handleSelectByIndex` — it doesn't depend on the Checkbox click path, so it survives the migration unchanged. AC#3 is satisfied by existing code.

# Related Issue

- Resolve #3749