### PR TITLE
fix(traces-v2): testing-pass polish — formatter, drawer header, sticky sections

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/ConversationContext.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/ConversationContext.tsx
@@ -25,6 +25,7 @@ import {
 import { useTraceDrawerNavigation } from "../../hooks/useTraceDrawerNavigation";
 import { useDrawerStore } from "../../stores/drawerStore";
 import { STATUS_COLORS } from "../../utils/formatters";
+import { formatPreview } from "../../utils/previewFormatter";
 import { TraceIdPeek } from "../TraceIdPeek";
 import { useDisplayRoleVisuals } from "./scenarioRoles";
 
@@ -73,96 +74,41 @@ const SLIDE_VARIANTS: Variants = {
 // the bookshelf direction cue.
 const SLIDE_TRANSITION = { duration: 0.16, ease: "easeOut" as const };
 
-function truncate(s: string): string {
-  const flat = s.replace(/\s+/g, " ").trim();
-  return flat.length <= MAX_PREVIEW
-    ? flat
-    : `${flat.slice(0, MAX_PREVIEW - 1)}…`;
-}
-
 /**
- * Pull a readable snippet out of an input/output payload. If the payload is
- * a JSON chat array, walk the messages and extract the text from the side
- * we actually care about (last user prose for "input", last assistant text
- * for "output"). Strips Anthropic-style typed-block JSON and tool_use
- * wrappers so the context strip doesn't look like a stringified blob.
+ * Pull a readable snippet out of an input/output payload using the unified
+ * `formatPreview` pipeline (JSON unwrap, fence/image strip, newline glyph,
+ * cap). The `prefer` argument is a soft hint — when the payload is a chat
+ * array, we walk it for the preferred role first and fall back to
+ * `formatPreview` (which always returns the most-recent message of any
+ * role) if there's no role match. For non-array payloads `formatPreview`
+ * does all the work, so the strip's behaviour stays consistent across the
+ * column / table / drawer surfaces.
  */
 function extractReadableSnippet(
   raw: string | null | undefined,
   prefer: "user" | "assistant",
 ): string {
   if (!raw) return "";
-  // Try to parse as JSON. If chat-shaped, walk it.
-  let parsed: unknown = null;
   const trimmed = raw.trim();
-  if (
-    (trimmed.startsWith("[") && trimmed.endsWith("]")) ||
-    (trimmed.startsWith("{") && trimmed.endsWith("}"))
-  ) {
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
     try {
-      parsed = JSON.parse(trimmed);
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (Array.isArray(parsed)) {
+        for (let i = parsed.length - 1; i >= 0; i--) {
+          const msg = parsed[i] as Record<string, unknown> | null;
+          if (msg && msg.role === prefer) {
+            const single = formatPreview(JSON.stringify([msg]), {
+              maxChars: MAX_PREVIEW,
+            });
+            if (single.text.trim()) return single.text;
+          }
+        }
+      }
     } catch {
-      // not JSON, fall through to raw
+      /* fall through to formatPreview on raw input */
     }
   }
-
-  const extractMessageText = (msg: unknown): string => {
-    if (!msg || typeof msg !== "object") return "";
-    const obj = msg as Record<string, unknown>;
-    const content = obj.content;
-    if (typeof content === "string") {
-      // Could itself be JSON of a typed block — strip that down.
-      const t = content.trim();
-      if (t.startsWith('{"type":"text"')) {
-        try {
-          const inner = JSON.parse(t) as { text?: string };
-          if (typeof inner.text === "string") return inner.text;
-        } catch {
-          /* ignore */
-        }
-      }
-      // Skip pure JSON typed-blocks that aren't text
-      if (t.startsWith('{"type":"') && !t.startsWith('{"type":"text"'))
-        return "";
-      return content;
-    }
-    if (Array.isArray(content)) {
-      const texts: string[] = [];
-      for (const part of content) {
-        if (typeof part === "string") {
-          texts.push(part);
-        } else if (
-          part &&
-          typeof part === "object" &&
-          (part as { type?: unknown }).type === "text" &&
-          typeof (part as { text?: unknown }).text === "string"
-        ) {
-          texts.push((part as { text: string }).text);
-        }
-      }
-      return texts.join(" ");
-    }
-    return "";
-  };
-
-  if (Array.isArray(parsed)) {
-    const targetRole = prefer;
-    // Walk backwards for the latest matching role.
-    for (let i = parsed.length - 1; i >= 0; i--) {
-      const msg = parsed[i] as Record<string, unknown> | null;
-      if (msg && msg.role === targetRole) {
-        const text = extractMessageText(msg);
-        if (text.trim()) return truncate(text);
-      }
-    }
-    // Fallback: any message with text content.
-    for (let i = parsed.length - 1; i >= 0; i--) {
-      const text = extractMessageText(parsed[i]);
-      if (text.trim()) return truncate(text);
-    }
-  }
-
-  return truncate(raw);
+  return formatPreview(raw, { maxChars: MAX_PREVIEW }).text;
 }
 
 /**

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
@@ -1,5 +1,12 @@
 import { Box, Button, HStack, Icon, Text } from "@chakra-ui/react";
-import { forwardRef, memo, useMemo, useState } from "react";
+import {
+  forwardRef,
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   LuCheck,
   LuChevronDown,
@@ -275,6 +282,38 @@ export const IOViewer = memo(function IOViewer({
   // assistant card sits flush at the root of the section.
   const flushChatCard = format === "pretty" && isChat && mode === "output";
 
+  // Track whether the preview box's content actually exceeds its visible
+  // height. The "Click to interact" scrim only makes sense when there's
+  // hidden content to reveal — otherwise it's noise on a one-line input.
+  // ResizeObserver catches both initial layout and any reflow (format
+  // toggle, density change, font load, etc.). The fallback `scroll` listener
+  // covers the case where content height changes without the element
+  // resizing (rare, but cheap to add).
+  const previewBoxRef = useRef<HTMLDivElement>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+  useEffect(() => {
+    const el = previewBoxRef.current;
+    if (!el) {
+      setHasOverflow(false);
+      return;
+    }
+    const measure = () => {
+      setHasOverflow(el.scrollHeight - el.clientHeight > 1);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [
+    displayContent,
+    format,
+    isVirtualizingChat,
+    engaged,
+    expanded,
+    chatLayout,
+    markdownSubmode,
+  ]);
+
   return (
     <Box>
       <HStack marginBottom={1} gap={2}>
@@ -384,6 +423,7 @@ export const IOViewer = memo(function IOViewer({
         <>
           <Box ref={engagedRef} position="relative">
             <Box
+              ref={previewBoxRef}
               bg={flushChatCard ? "transparent" : "bg.subtle"}
               borderRadius={flushChatCard ? "0" : "md"}
               borderWidth={flushChatCard ? "0" : "1px"}
@@ -395,7 +435,9 @@ export const IOViewer = memo(function IOViewer({
                     ? 0
                     : 3
               }
-              opacity={!isVirtualizingChat && !engaged ? 0.6 : 1}
+              opacity={
+                !isVirtualizingChat && !engaged && hasOverflow ? 0.6 : 1
+              }
               transition="opacity 120ms ease-out"
               maxHeight={
                 isVirtualizingChat
@@ -430,7 +472,7 @@ export const IOViewer = memo(function IOViewer({
                 mode={mode}
               />
             </Box>
-            {!isVirtualizingChat && !engaged && (
+            {!isVirtualizingChat && !engaged && hasOverflow && (
               <IOViewerEngageScrim
                 flushChatCard={flushChatCard}
                 onEngage={() => setEngaged(true)}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/ScenarioChip.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/ScenarioChip.tsx
@@ -79,7 +79,7 @@ export function buildScenarioChipDef(d: ScenarioChipData): ChipDef {
 
   return {
     id: `scenario:${d.scenarioRunId}`,
-    label: "Scenario",
+    label: "Scenario run",
     value: hasResults
       ? `${displayName} · ${metCount}/${totalCount}`
       : displayName,

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/SystemPromptBanner.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/SystemPromptBanner.tsx
@@ -1,13 +1,28 @@
 import { Box, HStack, Icon, Text } from "@chakra-ui/react";
 import { ChevronDown, ChevronRight, Settings2 } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { formatPreview } from "../../../utils/previewFormatter";
 
 const SYSTEM_PROMPT_LONG_THRESHOLD = 280;
 
 export const SystemPromptBanner: React.FC<{ text: string }> = ({ text }) => {
   const [expanded, setExpanded] = useState(false);
-  const isLong = text.length > SYSTEM_PROMPT_LONG_THRESHOLD;
+  // Run system-prompt text through the shared formatter so JSON envelopes
+  // (`{"text": "…"}`), Anthropic typed blocks, and stray markdown noise
+  // get unwrapped before display. Newlines stay intact (`pre-wrap` below
+  // wants real `\n`s for line breaks); we just kill the literal fences and
+  // image markdown that would otherwise survive into the banner.
+  const formatted = useMemo(
+    () =>
+      formatPreview(text, {
+        maxChars: 100_000,
+        newlines: "preserve",
+        stripMarkdownNoise: true,
+      }).text,
+    [text],
+  );
+  const isLong = formatted.length > SYSTEM_PROMPT_LONG_THRESHOLD;
   return (
     <Box
       borderRadius="lg"
@@ -58,7 +73,7 @@ export const SystemPromptBanner: React.FC<{ text: string }> = ({ text }) => {
           lineHeight="1.6"
           lineClamp={isLong && !expanded ? 3 : undefined}
         >
-          {text}
+          {formatted}
         </Text>
       </Box>
     </Box>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -63,7 +63,11 @@ import {
 import { ThreadProgressIndicator } from "./ThreadProgressIndicator";
 import { TooltipRow } from "./TooltipRow";
 import { TraceOverflowMenu } from "./TraceOverflowMenu";
-import { readNumberAttribute, resolveAttributeValue } from "./utils";
+import {
+  formatPinValue,
+  readNumberAttribute,
+  resolveAttributeValue,
+} from "./utils";
 
 interface DrawerHeaderProps {
   trace: TraceHeader;
@@ -300,7 +304,7 @@ export const DrawerHeader = memo(function DrawerHeader({
       const resolved = def.resolve
         ? def.resolve(trace)
         : trace.attributes[def.key];
-      const value = resolved ?? null;
+      const value = formatPinValue(def.key, resolved ?? null);
       if (!value) continue;
       const filterField = FILTERABLE_PIN_FIELDS[def.key];
       const navigate = buildNavigate(def.key, value);
@@ -324,7 +328,7 @@ export const DrawerHeader = memo(function DrawerHeader({
         p.source === "resource"
           ? resources.resourceAttributes
           : trace.attributes;
-      const value = resolveAttributeValue(valueSource, p.key);
+      const value = formatPinValue(p.key, resolveAttributeValue(valueSource, p.key));
       const filterField = FILTERABLE_PIN_FIELDS[p.key];
       const navigate = value ? buildNavigate(p.key, value) : undefined;
       out.push({
@@ -411,6 +415,31 @@ export const DrawerHeader = memo(function DrawerHeader({
   const { refresh: handleRefresh, isRefreshing } = useTraceRefresh(
     trace.traceId,
   );
+
+  // Title fallback chain: explicit traceName attribute → root span name (the
+  // server populates `trace.name` from it) → trace ID prefix as a last
+  // resort. The fallback is rendered muted so the reader can tell at a
+  // glance that no semantic name was set rather than reading the ID hex
+  // as if it were the title. We detect the ID-fallback case by comparing
+  // against a prefix of the trace ID — server-side projection drops the
+  // span name into `trace.name` for unnamed traces, but for traces with
+  // no spans at all the same field falls through to the trace ID itself.
+  const { titleText, titleIsFallback } = useMemo(() => {
+    const explicit = trace.traceName?.trim();
+    if (explicit) return { titleText: explicit, titleIsFallback: false };
+    const spanName = trace.name?.trim();
+    if (
+      spanName &&
+      spanName !== trace.traceId &&
+      !trace.traceId.startsWith(spanName)
+    ) {
+      return { titleText: spanName, titleIsFallback: false };
+    }
+    return {
+      titleText: trace.traceId.slice(0, 12),
+      titleIsFallback: true,
+    };
+  }, [trace.traceName, trace.name, trace.traceId]);
 
   const chipDefs = useTraceHeaderChipDefs(trace, {
     onSelectSpan: selectSpan,
@@ -528,8 +557,9 @@ export const DrawerHeader = memo(function DrawerHeader({
             fontFamily="mono"
             letterSpacing="-0.005em"
             minWidth={0}
+            color={titleIsFallback ? "fg.muted" : undefined}
           >
-            {trace.traceName || trace.name}
+            {titleText}
           </Text>
           <HStack gap={1} flexShrink={0}>
             <Circle size="8px" bg={statusColor} flexShrink={0} />
@@ -805,23 +835,26 @@ export const DrawerHeader = memo(function DrawerHeader({
         {chipsOverflow}
       </HStack>
 
-      {/* Row 4: Dedicated pinned-context strip — auto-pins (identity / run /
-          tag) inline with intra-category dividers, custom pins capped at 3
-          inline with the rest in a "+N pinned" overflow popover. Lives on
-          its own row so the categorisation stays scannable. The slot is
-          always reserved (even when empty) so navigating to a trace with
-          no pins doesn't collapse the header by 28px and shift the body
-          tabs underneath. */}
-      <HStack
-        gap={1.5}
-        flexWrap="wrap"
-        align="center"
-        alignContent="flex-start"
-        minHeight="28px"
-      >
-        {pinResult.inline}
-        {pinResult.overflow}
-      </HStack>
+      {/* Pin strip — auto-pins (identity / run / tag) inline with intra-
+          category dividers, custom pins capped at 3 inline with the rest in
+          a "+N pinned" overflow popover. The row only renders when there's
+          actually something to show; ~35% of traces have no auto-pins (LLM
+          completions without a conversation thread, error traces, etc.) and
+          the previous always-reserved 28px slot read as dead chrome. The
+          height jump on next/previous-trace nav between trace-with-pins and
+          trace-without is small enough (~28px) that it's cheaper than the
+          permanent waste. */}
+      {(pinResult.inline.length > 0 || pinResult.overflow != null) && (
+        <HStack
+          gap={1.5}
+          flexWrap="wrap"
+          align="center"
+          alignContent="flex-start"
+        >
+          {pinResult.inline}
+          {pinResult.overflow}
+        </HStack>
+      )}
 
       {/* Row 5: Inline mode tabs — Trace / Conversation. Trace ID + relative
           timestamp tuck into the right corner of the same row, so they

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -284,6 +284,18 @@ export const DrawerHeader = memo(function DrawerHeader({
       ) {
         continue;
       }
+      // The rich `Scenario run` chip (built from `useScenarioChipData`
+      // in `TraceHeaderChips`) already surfaces the scenario run id with
+      // status + criteria + click-to-open behaviour. The plain hoisted
+      // pin would render the bare run id next to it, producing two pills
+      // for the same concept — so we skip the hoisted version whenever a
+      // scenario run is attached to the trace.
+      if (
+        def.key === "scenario.run_id" &&
+        (trace.scenarioRunId ?? trace.attributes["scenario.run_id"])
+      ) {
+        continue;
+      }
       if (userKeys.has(`attribute:${def.key}`)) continue;
       const resolved = def.resolve
         ? def.resolve(trace)

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -717,16 +717,14 @@ export const DrawerHeader = memo(function DrawerHeader({
           row separated by thin vertical dividers. The right end slot anchors
           the trace ID + relative timestamp. Collapsing what used to be three
           separate rows keeps the header dense without losing categorisation.
-          `minHeight` reserves space for two pill rows so the strip's height
-          stays stable when the user navigates between traces with different
-          chip counts — without this lock, the body content visibly hops
-          every time you press ←/→ in a conversation. */}
+          The strip wraps naturally — height tracks content rather than
+          locking to two rows, so traces with a single row of pills don't
+          carry a permanent ~28px empty band underneath. */}
       <HStack
         gap={1.5}
         flexWrap="wrap"
         align="center"
         alignContent="flex-start"
-        minHeight="56px"
       >
         {/* Section 1: Performance metrics */}
         <MetricPill label="Duration" value={formatDuration(trace.durationMs)} />

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -304,7 +304,7 @@ export const DrawerHeader = memo(function DrawerHeader({
       const resolved = def.resolve
         ? def.resolve(trace)
         : trace.attributes[def.key];
-      const value = formatPinValue(def.key, resolved ?? null);
+      const value = formatPinValue({ key: def.key, value: resolved ?? null });
       if (!value) continue;
       const filterField = FILTERABLE_PIN_FIELDS[def.key];
       const navigate = buildNavigate(def.key, value);
@@ -328,7 +328,10 @@ export const DrawerHeader = memo(function DrawerHeader({
         p.source === "resource"
           ? resources.resourceAttributes
           : trace.attributes;
-      const value = formatPinValue(p.key, resolveAttributeValue(valueSource, p.key));
+      const value = formatPinValue({
+        key: p.key,
+        value: resolveAttributeValue(valueSource, p.key),
+      });
       const filterField = FILTERABLE_PIN_FIELDS[p.key];
       const navigate = value ? buildNavigate(p.key, value) : undefined;
       out.push({

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/utils.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/utils.ts
@@ -11,8 +11,37 @@ export function readNumberAttribute(
   return null;
 }
 
-export function formatPinValue(value: unknown): string | null {
+/**
+ * Format a raw attribute value for display in a pin pill. Strings pass
+ * through; primitives stringify; objects fall back to JSON.
+ *
+ * When `key` is provided, key-aware formatting kicks in for attributes
+ * whose raw shape would otherwise read as noise:
+ *  - `langwatch.labels` arrives as a JSON-encoded array (e.g.
+ *    `["sample","prod"]`). Rendering the literal array bracket + quotes in
+ *    a pill pollutes the strip; we unwrap to a `·`-separated list so the
+ *    user sees the labels themselves.
+ */
+export function formatPinValue(
+  key: string,
+  value: unknown,
+): string | null;
+export function formatPinValue(value: unknown): string | null;
+export function formatPinValue(
+  arg1: unknown,
+  arg2?: unknown,
+): string | null {
+  // Two-arg form: (key, value). One-arg form: (value).
+  const key = arguments.length === 2 ? (arg1 as string) : null;
+  const value = arguments.length === 2 ? arg2 : arg1;
   if (value === undefined || value === null || value === "") return null;
+
+  // Key-aware formatting goes first so it can return without falling
+  // through to the generic JSON stringify path.
+  if (key === "langwatch.labels") {
+    return formatLabelsValue(value);
+  }
+
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean")
     return String(value);
@@ -23,12 +52,43 @@ export function formatPinValue(value: unknown): string | null {
   }
 }
 
+/**
+ * Labels arrive in two practical shapes:
+ *   1. JSON-encoded array string: `'["sample","prod"]'`
+ *   2. Already-decoded array of strings.
+ *
+ * Either way, render as `sample · prod` so the user sees the labels and
+ * not the array literal. Falls back to the raw string when neither shape
+ * applies (e.g. legacy traces that wrote a plain comma-separated string).
+ */
+function formatLabelsValue(value: unknown): string | null {
+  let arr: unknown = value;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      try {
+        arr = JSON.parse(trimmed);
+      } catch {
+        return value;
+      }
+    } else {
+      return value;
+    }
+  }
+  if (!Array.isArray(arr)) return null;
+  const labels = arr
+    .map((item) => (typeof item === "string" ? item : String(item)))
+    .filter((s) => s.length > 0);
+  if (labels.length === 0) return null;
+  return labels.join(" · ");
+}
+
 export function resolveAttributeValue(
   source: Record<string, string> | Record<string, unknown>,
   key: string,
 ): string | null {
   if (key in source) {
-    return formatPinValue((source as Record<string, unknown>)[key]);
+    return formatPinValue(key, (source as Record<string, unknown>)[key]);
   }
   // Dot-path traversal as a fallback for nested objects.
   const parts = key.split(".");
@@ -37,5 +97,5 @@ export function resolveAttributeValue(
     if (current == null || typeof current !== "object") return null;
     current = (current as Record<string, unknown>)[part];
   }
-  return formatPinValue(current);
+  return formatPinValue(key, current);
 }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/utils.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/utils.ts
@@ -22,18 +22,13 @@ export function readNumberAttribute(
  *    a pill pollutes the strip; we unwrap to a `·`-separated list so the
  *    user sees the labels themselves.
  */
-export function formatPinValue(
-  key: string,
-  value: unknown,
-): string | null;
-export function formatPinValue(value: unknown): string | null;
-export function formatPinValue(
-  arg1: unknown,
-  arg2?: unknown,
-): string | null {
-  // Two-arg form: (key, value). One-arg form: (value).
-  const key = arguments.length === 2 ? (arg1 as string) : null;
-  const value = arguments.length === 2 ? arg2 : arg1;
+export function formatPinValue({
+  key,
+  value,
+}: {
+  value: unknown;
+  key?: string;
+}): string | null {
   if (value === undefined || value === null || value === "") return null;
 
   // Key-aware formatting goes first so it can return without falling
@@ -88,7 +83,10 @@ export function resolveAttributeValue(
   key: string,
 ): string | null {
   if (key in source) {
-    return formatPinValue(key, (source as Record<string, unknown>)[key]);
+    return formatPinValue({
+      key,
+      value: (source as Record<string, unknown>)[key],
+    });
   }
   // Dot-path traversal as a fallback for nested objects.
   const parts = key.split(".");
@@ -97,5 +95,5 @@ export function resolveAttributeValue(
     if (current == null || typeof current !== "object") return null;
     current = (current as Record<string, unknown>)[part];
   }
-  return formatPinValue(key, current);
+  return formatPinValue({ key, value: current });
 }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
@@ -29,14 +29,6 @@ export function AccordionShell({
 }
 
 /**
- * Approximate rendered height of one accordion trigger row (uppercase 2xs
- * label + paddingY=2 + 1px top border). Used to compute the sticky-top
- * offset so triggers stack instead of overlapping. If we restyle the
- * trigger size, bump this in step.
- */
-const STICKY_TRIGGER_HEIGHT_PX = 32;
-
-/**
  * Height of the `SpanTabBar` (Summary / LLM-Optimized / pinned span tabs)
  * that sits sticky at `top: 0` of the drawer body. Accordion triggers
  * have to pin *below* it or they end up hidden behind the tab strip
@@ -118,7 +110,7 @@ export function Section({
         // because the Items are direct children of the same scroll
         // container and their triggers occupy full width.
         position="sticky"
-        top={`${SPAN_TAB_BAR_HEIGHT_PX + (stackIndex ?? 0) * STICKY_TRIGGER_HEIGHT_PX}px`}
+        top={`${SPAN_TAB_BAR_HEIGHT_PX + (stackIndex ?? 0) * tokens.triggerHeightPx}px`}
         zIndex={1}
       >
         <HStack flex={1} gap={2}>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
@@ -36,6 +36,15 @@ export function AccordionShell({
  */
 const STICKY_TRIGGER_HEIGHT_PX = 32;
 
+/**
+ * Height of the `SpanTabBar` (Summary / LLM-Optimized / pinned span tabs)
+ * that sits sticky at `top: 0` of the drawer body. Accordion triggers
+ * have to pin *below* it or they end up hidden behind the tab strip
+ * (the bar has `zIndex: 2`, triggers have `zIndex: 1`). Keep this in
+ * sync with `SpanTabBar`'s `minHeight` (38px).
+ */
+const SPAN_TAB_BAR_HEIGHT_PX = 38;
+
 export function Section({
   value,
   title,
@@ -109,7 +118,7 @@ export function Section({
         // because the Items are direct children of the same scroll
         // container and their triggers occupy full width.
         position="sticky"
-        top={`${(stackIndex ?? 0) * STICKY_TRIGGER_HEIGHT_PX}px`}
+        top={`${SPAN_TAB_BAR_HEIGHT_PX + (stackIndex ?? 0) * STICKY_TRIGGER_HEIGHT_PX}px`}
         zIndex={1}
       >
         <HStack flex={1} gap={2}>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
@@ -2,6 +2,10 @@ import { Accordion, Badge, Box, HStack, Text } from "@chakra-ui/react";
 import { type ReactNode, useRef } from "react";
 import { PresenceSection } from "~/features/presence/components/PresenceSection";
 import { SectionPresenceDot } from "~/features/presence/components/SectionPresenceDot";
+import {
+  getDrawerDensityTokens,
+  useDensityStore,
+} from "../../../stores/densityStore";
 import { useSectionPresenceStore } from "./sectionPresence";
 
 export function AccordionShell({
@@ -73,6 +77,8 @@ export function Section({
   const hasOpenedRef = useRef(open ?? true);
   if (open) hasOpenedRef.current = true;
   const renderChildren = open === undefined || hasOpenedRef.current;
+  const density = useDensityStore((s) => s.density);
+  const tokens = getDrawerDensityTokens(density);
   return (
     <Accordion.Item
       value={value}
@@ -83,7 +89,7 @@ export function Section({
       <Accordion.ItemTrigger
         width="100%"
         paddingX={4}
-        paddingY={2}
+        paddingY={tokens.sectionTriggerY}
         // Solid bg under sticky so content scrolling underneath is
         // occluded — without it the title would overlap the content
         // beneath when pinned. `bg.surface` matches the drawer body.
@@ -139,7 +145,11 @@ export function Section({
       <Accordion.ItemContent>
         {trackPresence ? (
           <PresenceSection id={value}>
-            <Box paddingX={4} paddingY={2} paddingBottom={3}>
+            <Box
+              paddingX={4}
+              paddingY={tokens.sectionContentY}
+              paddingBottom={tokens.sectionContentY + 1}
+            >
               {renderChildren ? children : null}
             </Box>
           </PresenceSection>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
@@ -24,6 +24,14 @@ export function AccordionShell({
   );
 }
 
+/**
+ * Approximate rendered height of one accordion trigger row (uppercase 2xs
+ * label + paddingY=2 + 1px top border). Used to compute the sticky-top
+ * offset so triggers stack instead of overlapping. If we restyle the
+ * trigger size, bump this in step.
+ */
+const STICKY_TRIGGER_HEIGHT_PX = 32;
+
 export function Section({
   value,
   title,
@@ -31,6 +39,7 @@ export function Section({
   empty,
   children,
   isFirst,
+  stackIndex,
   open,
 }: {
   value: string;
@@ -44,6 +53,13 @@ export function Section({
   empty?: boolean;
   children: ReactNode;
   isFirst?: boolean;
+  /**
+   * Position of this section in its accordion (0-based). Drives the sticky
+   * top offset so this section's trigger pins below all earlier sections'
+   * triggers as the user scrolls. Pass the iteration index. Falls back to 0
+   * when omitted, which collapses the stack into a single sticky line.
+   */
+  stackIndex?: number;
   /**
    * When provided, defers mounting `children` until the section has been
    * opened at least once. After first open, children stay mounted so toggling
@@ -68,7 +84,10 @@ export function Section({
         width="100%"
         paddingX={4}
         paddingY={2}
-        bg="transparent"
+        // Solid bg under sticky so content scrolling underneath is
+        // occluded — without it the title would overlap the content
+        // beneath when pinned. `bg.surface` matches the drawer body.
+        bg="bg.surface"
         color="fg.muted"
         borderTopWidth={isFirst ? "0" : "1px"}
         borderColor="border.muted"
@@ -76,6 +95,16 @@ export function Section({
         _hover={{ bg: "bg.softHover", color: "fg" }}
         _open={{ bg: "bg.softHover", color: "fg" }}
         cursor="pointer"
+        // Sticky stack: each trigger pins at a `top` offset that equals
+        // its position in the accordion times the trigger height, so as
+        // the user scrolls down the open section's body, every earlier
+        // trigger comes to rest above it (Notion-style). Inside-Item
+        // sticky scopes the stickiness to the Item's height — fine here
+        // because the Items are direct children of the same scroll
+        // container and their triggers occupy full width.
+        position="sticky"
+        top={`${(stackIndex ?? 0) * STICKY_TRIGGER_HEIGHT_PX}px`}
+        zIndex={1}
       >
         <HStack flex={1} gap={2}>
           <Text

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -124,6 +124,7 @@ export function SpanAccordions({
                   title="Input and Output"
                   empty={!detailQuery.isLoading && !hasIO}
                   isFirst={isFirst}
+                stackIndex={idx}
                   open={isOpen}
                 >
                   {detailQuery.isLoading ? (
@@ -158,6 +159,7 @@ export function SpanAccordions({
                   value="prompt"
                   title="Prompt"
                   isFirst={isFirst}
+                stackIndex={idx}
                   open={isOpen}
                 >
                   {detail && <PromptAccordion span={detail} />}
@@ -181,6 +183,7 @@ export function SpanAccordions({
                     !detailQuery.isLoading
                   }
                   isFirst={isFirst}
+                stackIndex={idx}
                   open={isOpen}
                 >
                   {hasAttributes ? (
@@ -212,6 +215,7 @@ export function SpanAccordions({
                   value="scope"
                   title="Instrumentation Scope"
                   isFirst={isFirst}
+                stackIndex={idx}
                   open={isOpen}
                 >
                   <ScopeBlock scope={spanScope} />
@@ -225,6 +229,7 @@ export function SpanAccordions({
                   value="exceptions"
                   title="Exceptions"
                   isFirst={isFirst}
+                stackIndex={idx}
                   open={isOpen}
                 >
                   {detail?.error ? (
@@ -289,6 +294,7 @@ export function SpanAccordions({
                 count={hasEvents ? detail!.events.length : undefined}
                 empty={!detailQuery.isLoading && !hasEvents}
                 isFirst={isFirst}
+                stackIndex={idx}
                 open={isOpen}
               >
                 {hasEvents ? (

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
@@ -109,24 +109,29 @@ export function TraceSummaryAccordions({
                 title="Input and Output"
                 empty={!hasIO}
                 isFirst={isFirst}
+                stackIndex={idx}
                 open={isOpen}
               >
                 {hasIO ? (
                   <VStack align="stretch" gap={2}>
-                    {trace.input && (
+                    {trace.input ? (
                       <IOViewer
                         label="Input"
                         content={trace.input}
                         traceId={trace.traceId}
                       />
+                    ) : (
+                      <MissingIORow label="Input" mode="input" />
                     )}
-                    {trace.output && (
+                    {trace.output ? (
                       <IOViewer
                         label="Output"
                         content={trace.output}
                         mode="output"
                         traceId={trace.traceId}
                       />
+                    ) : (
+                      <MissingIORow label="Output" mode="output" />
                     )}
                   </VStack>
                 ) : (
@@ -147,6 +152,7 @@ export function TraceSummaryAccordions({
                 count={attrCount}
                 empty={!hasAttributes && !resources.isLoading}
                 isFirst={isFirst}
+                stackIndex={idx}
                 open={isOpen}
               >
                 {hasAttributes ? (
@@ -174,6 +180,7 @@ export function TraceSummaryAccordions({
                 value="scope"
                 title="Instrumentation Scope"
                 isFirst={isFirst}
+                stackIndex={idx}
                 open={isOpen}
               >
                 <ScopeBlock scope={resources.scope} />
@@ -187,6 +194,7 @@ export function TraceSummaryAccordions({
                 value="exceptions"
                 title="Exceptions"
                 isFirst={isFirst}
+                stackIndex={idx}
                 open={isOpen}
               >
                 <HStack
@@ -231,6 +239,7 @@ export function TraceSummaryAccordions({
                   pendingCount === 0
                 }
                 isFirst={isFirst}
+                stackIndex={idx}
                 open={isOpen}
               >
                 {evalsLoading ? (
@@ -261,6 +270,7 @@ export function TraceSummaryAccordions({
               count={traceEvents.length > 0 ? traceEvents.length : undefined}
               empty={traceEvents.length === 0}
               isFirst={isFirst}
+                stackIndex={idx}
               open={isOpen}
             >
               {traceEvents.length > 0 ? (
@@ -299,5 +309,40 @@ export function TraceSummaryAccordions({
         })}
       </AccordionShell>
     </Box>
+  );
+}
+
+/**
+ * Single dim row used in place of an IOViewer when the trace has the
+ * other side captured but this one is missing. Lets the user see at a
+ * glance that "this trace had an input but no output" rather than us
+ * silently hiding the OUTPUT label and leaving them to infer the gap.
+ *
+ * Kept structurally similar to the IOViewer header (uppercase 2xs label
+ * on the left) so the two read as siblings — same hierarchy, just with
+ * the body replaced by a muted placeholder.
+ */
+function MissingIORow({
+  label,
+  mode,
+}: {
+  label: string;
+  mode: "input" | "output";
+}): React.JSX.Element {
+  return (
+    <HStack gap={2} paddingY={1}>
+      <Text
+        textStyle="2xs"
+        fontWeight="bold"
+        color="fg.muted"
+        letterSpacing="wide"
+        textTransform="uppercase"
+      >
+        {label}
+      </Text>
+      <Text textStyle="xs" color="fg.subtle" fontStyle="italic">
+        — no {mode} recorded
+      </Text>
+    </HStack>
   );
 }

--- a/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
@@ -3,7 +3,8 @@ import { ArrowDown, ArrowUp, Bot, User, Wrench } from "lucide-react";
 import type React from "react";
 import { useDensityTokens } from "../../hooks/useDensityTokens";
 import { useDensityStore } from "../../stores/densityStore";
-import { type ParsedIO, tryParseChat } from "./chatContent";
+import { formatPreview } from "../../utils/previewFormatter";
+import { tryParseChat } from "./chatContent";
 
 const VERTICAL_BAR = "\u2506";
 const COMFORTABLE_LABEL_WIDTH = "60px";
@@ -21,20 +22,41 @@ export const IOPreview: React.FC<IOPreviewProps> = ({ input, output }) => {
   return <CompactIOPreview input={input} output={output} />;
 };
 
+/**
+ * Build the row data once per cell. `formatPreview` runs the unified
+ * unwrap/strip/glyph pipeline; `tryParseChat` is still consulted for the
+ * isChat/isTool flags that drive the role icon. Both are cheap (each does
+ * one JSON.parse attempt on the same input).
+ */
+function buildRow(raw: string | null): {
+  text: string;
+  isChat: boolean;
+  isTool: boolean;
+} {
+  if (raw === null) return { text: "", isChat: false, isTool: false };
+  const parsed = tryParseChat(raw);
+  const formatted = formatPreview(raw, { maxChars: 80 });
+  return {
+    text: formatted.text,
+    isChat: parsed.isChat,
+    isTool: parsed.isTool,
+  };
+}
+
 const CompactIOPreview: React.FC<IOPreviewProps> = ({ input, output }) => {
   const tokens = useDensityTokens();
   return (
     <VStack align="start" gap={0.5} fontFamily="mono">
       {input !== null && (
         <CompactRow
-          parsed={tryParseChat(input)}
+          row={buildRow(input)}
           fontSize={tokens.ioFontSize}
           direction="input"
         />
       )}
       {output !== null && (
         <CompactRow
-          parsed={tryParseChat(output)}
+          row={buildRow(output)}
           fontSize={tokens.ioFontSize}
           direction="output"
         />
@@ -44,13 +66,13 @@ const CompactIOPreview: React.FC<IOPreviewProps> = ({ input, output }) => {
 };
 
 interface CompactRowProps {
-  parsed: ParsedIO;
+  row: { text: string; isChat: boolean; isTool: boolean };
   fontSize: string;
   direction: "input" | "output";
 }
 
 const CompactRow: React.FC<CompactRowProps> = ({
-  parsed,
+  row,
   fontSize,
   direction,
 }) => {
@@ -67,7 +89,7 @@ const CompactRow: React.FC<CompactRowProps> = ({
         <Icon boxSize="10px" color={accent}>
           {isInput ? <ArrowUp /> : <ArrowDown />}
         </Icon>
-        <RoleIcon parsed={parsed} color={accent} direction={direction} />
+        <RoleIcon row={row} color={accent} direction={direction} />
       </Flex>
       <Text
         fontSize={fontSize}
@@ -78,32 +100,32 @@ const CompactRow: React.FC<CompactRowProps> = ({
         flex={1}
         minWidth={0}
       >
-        {parsed.text}
+        {row.text}
       </Text>
     </HStack>
   );
 };
 
 const RoleIcon: React.FC<{
-  parsed: ParsedIO;
+  row: { isChat: boolean; isTool: boolean };
   color: string;
   direction: "input" | "output";
-}> = ({ parsed, color, direction }) => {
+}> = ({ row, color, direction }) => {
   if (direction === "input") {
-    return parsed.isChat ? (
+    return row.isChat ? (
       <Icon boxSize="10px" color={color}>
         <User />
       </Icon>
     ) : null;
   }
-  if (parsed.isTool) {
+  if (row.isTool) {
     return (
       <Icon boxSize="10px" color={color}>
         <Wrench />
       </Icon>
     );
   }
-  if (parsed.isChat) {
+  if (row.isChat) {
     return (
       <Icon boxSize="10px" color={color}>
         <Bot />
@@ -120,7 +142,7 @@ const ComfortableIOPreview: React.FC<IOPreviewProps> = ({ input, output }) => (
         label="Input"
         labelColor="blue.fg"
         textColor="fg.muted"
-        text={tryParseChat(input).text}
+        text={formatPreview(input, { maxChars: 200 }).text}
       />
     )}
     {output !== null && (
@@ -128,7 +150,7 @@ const ComfortableIOPreview: React.FC<IOPreviewProps> = ({ input, output }) => (
         label="Output"
         labelColor="green.fg"
         textColor="fg"
-        text={tryParseChat(output).text}
+        text={formatPreview(output, { maxChars: 200 }).text}
       />
     )}
   </VStack>

--- a/langwatch/src/features/traces-v2/components/TraceTable/TraceTableLayout.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/TraceTableLayout.tsx
@@ -1,11 +1,14 @@
 import { Box, Flex } from "@chakra-ui/react";
 import type React from "react";
-import { useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useRefreshUIStore } from "../../stores/refreshUIStore";
 import { RefreshProgressBar } from "../TracesPage/RefreshProgressBar";
 import { NewTracesScrollUpIndicator } from "./NewTracesScrollUpIndicator";
 import { Pagination } from "./Pagination";
-import { useRegisterTraceTableScrollRef } from "./scrollContext";
+import {
+  releaseTraceTableScrollElement,
+  setTraceTableScrollElement,
+} from "./scrollContext";
 
 interface TraceTableLayoutProps {
   totalHits: number;
@@ -17,13 +20,40 @@ export const TraceTableLayout: React.FC<TraceTableLayoutProps> = ({
   children,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const ownedElRef = useRef<HTMLDivElement | null>(null);
   const isReplacingData = useRefreshUIStore((s) => s.isReplacingData);
-  useRegisterTraceTableScrollRef(scrollRef);
+
+  // Tracking which element this layout owns lets the store reject a
+  // stale unmount-cleanup fire from clobbering a *newer* layout's
+  // already-published element. This matters when the page swaps
+  // between ResultsPane and EmptyResultsPane on tour activation:
+  // React mounts the new layout (publishing its element) before
+  // running the old layout's unmount cleanup, and an unconditional
+  // `setRef(null)` would overwrite the live element with null.
+  const setRef = useCallback((el: HTMLDivElement | null) => {
+    scrollRef.current = el;
+    if (el) {
+      ownedElRef.current = el;
+      setTraceTableScrollElement(el);
+    } else if (ownedElRef.current) {
+      releaseTraceTableScrollElement(ownedElRef.current);
+      ownedElRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (ownedElRef.current) {
+        releaseTraceTableScrollElement(ownedElRef.current);
+        ownedElRef.current = null;
+      }
+    };
+  }, []);
 
   return (
     <Flex direction="column" height="full" position="relative">
       <Box
-        ref={scrollRef}
+        ref={setRef}
         flex={1}
         overflow="auto"
         opacity={isReplacingData ? 0.55 : 1}

--- a/langwatch/src/features/traces-v2/components/TraceTable/registry/addons/group/GroupTracesAddon.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/registry/addons/group/GroupTracesAddon.tsx
@@ -10,7 +10,7 @@ import {
   formatRelativeTime,
   formatTokens,
 } from "../../../../../utils/formatters";
-import { truncateText } from "../../../chatContent";
+import { formatPreview } from "../../../../../utils/previewFormatter";
 import { MonoCell } from "../../../MonoCell";
 import { ROW_STYLES, rowVariantFor, StatusDot } from "../../../StatusRow";
 import { Td, Tr } from "../../../TablePrimitives";
@@ -60,7 +60,7 @@ const GroupedTraceRow: React.FC<GroupedTraceRowProps> = ({
   const style = ROW_STYLES[variant];
   const turnBg = isSelected ? style.bg : "fg/2";
   const inputPreview = trace.input
-    ? truncateText({ text: trace.input, limit: INPUT_PREVIEW_LIMIT })
+    ? formatPreview(trace.input, { maxChars: INPUT_PREVIEW_LIMIT }).text
     : null;
 
   return (

--- a/langwatch/src/features/traces-v2/components/TraceTable/scrollContext.ts
+++ b/langwatch/src/features/traces-v2/components/TraceTable/scrollContext.ts
@@ -1,42 +1,73 @@
-import { type RefObject, useEffect } from "react";
+import { useSyncExternalStore } from "react";
 
 /**
- * Module-level holder for the trace-table scroll container ref. Avoids
- * React Context (banned by traces-v2 STANDARDS §2) while still letting
- * children (the virtualizer + new-traces indicator) reach the same DOM
- * element established by `TraceTableLayout`.
+ * Module-level scroll-element store for the trace table. Consumers (the
+ * virtualizer, new-traces indicator) subscribe via `useTraceTableScrollElement`
+ * and re-render when the element attaches or detaches. `TraceTableLayout`
+ * publishes via `setTraceTableScrollElement` from its callback ref.
  *
- * Rendering two trace tables on the same page would race on this ref;
- * we don't do that today and it would be obvious in code review.
+ * Why a state-driven store instead of a RefObject: react-virtual reads the
+ * scroll element on its first render via `getScrollElement()`. If that returns
+ * `null` (because the `<Box ref>` hasn't committed yet), the virtualizer
+ * settles into an empty state and never recomputes — the table area stays
+ * blank even though `count > 0`. Re-rendering consumers when the element
+ * attaches is what makes the virtualizer pick it up.
+ *
+ * `useSyncExternalStore` is the textbook React 18 way to subscribe to an
+ * external mutable source: it gives us tear-free reads, plays correctly with
+ * suspense / concurrent rendering, and (crucially here) re-runs `getSnapshot`
+ * on every render so a consumer that subscribed *before* the publisher's
+ * callback ref fired still sees the up-to-date element on the next render
+ * pass after the ref attaches. A `useState + useEffect` mirror would miss
+ * the initial sync because the effect runs after the publisher's commit but
+ * the consumer's render has already cached `null` in state. Avoiding React
+ * Context keeps us aligned with traces-v2 STANDARDS §2.
+ *
+ * Rendering two trace tables on the same page would race on this store; we
+ * don't do that today and would catch it in code review.
  */
-let currentScrollRef: RefObject<HTMLElement | null> | null = null;
 
-export function useTraceTableScrollRef(): RefObject<HTMLElement | null> {
-  if (!currentScrollRef) {
-    throw new Error(
-      "useTraceTableScrollRef must be used inside TraceTableLayout",
-    );
-  }
-  return currentScrollRef;
+type Subscriber = () => void;
+let currentEl: HTMLElement | null = null;
+const subscribers = new Set<Subscriber>();
+
+export function setTraceTableScrollElement(el: HTMLElement | null): void {
+  if (currentEl === el) return;
+  currentEl = el;
+  subscribers.forEach((fn) => fn());
 }
 
 /**
- * Layout-side hook — registers the scroll ref *synchronously during render*
- * so descendants reading via `useTraceTableScrollRef()` see it on the same
- * render pass. A `useEffect` cleanup clears the holder on unmount.
- *
- * Setting state during render is unusual but safe here: the holder is a
- * module-level mutable pointer to a stable React ref, not React state, and
- * the Layout always renders before its children.
+ * Clear the store iff `el` is currently the published element. Used by
+ * `TraceTableLayout`'s unmount cleanup to avoid a stale teardown
+ * clobbering a *newer* layout's already-published element. React mounts
+ * the new layout before running the old one's effect cleanup when the
+ * outer pane swaps (e.g. tour activation flips ResultsPane →
+ * EmptyResultsPane), and an unconditional null-set would race the new
+ * mount and leave the virtualizer with no scroll element.
  */
-export function useRegisterTraceTableScrollRef(
-  ref: RefObject<HTMLElement | null>,
-): void {
-  currentScrollRef = ref;
-  useEffect(() => {
-    currentScrollRef = ref;
-    return () => {
-      if (currentScrollRef === ref) currentScrollRef = null;
-    };
-  }, [ref]);
+export function releaseTraceTableScrollElement(el: HTMLElement): void {
+  if (currentEl === el) {
+    currentEl = null;
+    subscribers.forEach((fn) => fn());
+  }
+}
+
+function subscribe(fn: Subscriber): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+function getSnapshot(): HTMLElement | null {
+  return currentEl;
+}
+
+function getServerSnapshot(): HTMLElement | null {
+  return null;
+}
+
+export function useTraceTableScrollElement(): HTMLElement | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/langwatch/src/features/traces-v2/components/TraceTable/useTraceTableVirtualizer.ts
+++ b/langwatch/src/features/traces-v2/components/TraceTable/useTraceTableVirtualizer.ts
@@ -1,7 +1,7 @@
 import { useVirtualizer, type Virtualizer } from "@tanstack/react-virtual";
 import { useCallback } from "react";
 import { useDensityStore } from "../../stores/densityStore";
-import { useTraceTableScrollRef } from "./scrollContext";
+import { useTraceTableScrollElement } from "./scrollContext";
 
 /** Px estimate per row before measureElement runs. */
 const ESTIMATE_PER_DENSITY: Record<"compact" | "comfortable", number> = {
@@ -26,18 +26,23 @@ interface VirtualizerResult {
 /**
  * Shared virtualizer for the trace lens bodies. Each "item" is one row's
  * outer <tbody>; spacers are emitted by the lens body.
+ *
+ * Subscribes to the scroll-element store rather than reading a RefObject so
+ * the virtualizer re-renders when the element attaches; otherwise the first
+ * `getScrollElement()` call returns `null` and the virtualizer never
+ * recovers, leaving the table body empty on initial load.
  */
 export function useTraceTableVirtualizer({
   count,
   addonCount,
 }: VirtualizerArgs): VirtualizerResult {
-  const scrollRef = useTraceTableScrollRef();
+  const scrollEl = useTraceTableScrollElement();
   const density = useDensityStore((s) => s.density);
 
   const baseEstimate =
     ESTIMATE_PER_DENSITY[density] + addonCount * ESTIMATE_PER_ADDON;
 
-  const getScrollElement = useCallback(() => scrollRef.current, [scrollRef]);
+  const getScrollElement = useCallback(() => scrollEl, [scrollEl]);
   const estimateSize = useCallback(() => baseEstimate, [baseEstimate]);
 
   const virtualizer = useVirtualizer<HTMLElement, HTMLTableSectionElement>({

--- a/langwatch/src/features/traces-v2/components/TracesPage/AuroraSvg.tsx
+++ b/langwatch/src/features/traces-v2/components/TracesPage/AuroraSvg.tsx
@@ -28,8 +28,11 @@ interface Curtain {
  * Curtains are packed tighter than their radii so they overlap, and
  * mix-blend-mode "screen" (below) brightens those overlaps additively —
  * making the row read as one continuous wash instead of discrete blobs.
- * Long mismatched durations with negative delays keep them out of phase
- * so there's no perceptible resync beat.
+ * Mismatched durations with negative delays keep them out of phase so
+ * there's no perceptible resync beat. Cycle times sit in the 4–7s range
+ * so the ribbon reads as something happening *now*, not as a slow
+ * background loop. Delays are scaled in proportion so each curtain
+ * still enters its cycle at a different phase.
  */
 const CURTAINS: Curtain[] = [
   {
@@ -37,16 +40,16 @@ const CURTAINS: Curtain[] = [
     rx: 170,
     ry: 270,
     color: "#7dd3fc",
-    durationMs: 11500,
-    delayMs: -2200,
+    durationMs: 5750,
+    delayMs: -1100,
   },
   {
     cx: 160,
     rx: 160,
     ry: 290,
     color: "#3b82f6",
-    durationMs: 9000,
-    delayMs: -5500,
+    durationMs: 4500,
+    delayMs: -2750,
     reverse: true,
   },
   {
@@ -54,16 +57,16 @@ const CURTAINS: Curtain[] = [
     rx: 175,
     ry: 260,
     color: "#22d3ee",
-    durationMs: 13000,
-    delayMs: -1500,
+    durationMs: 6500,
+    delayMs: -750,
   },
   {
     cx: 380,
     rx: 165,
     ry: 295,
     color: "#60a5fa",
-    durationMs: 8500,
-    delayMs: -7000,
+    durationMs: 4250,
+    delayMs: -3500,
     reverse: true,
   },
   {
@@ -71,16 +74,16 @@ const CURTAINS: Curtain[] = [
     rx: 175,
     ry: 270,
     color: "#6366f1",
-    durationMs: 12000,
-    delayMs: -3500,
+    durationMs: 6000,
+    delayMs: -1750,
   },
   {
     cx: 600,
     rx: 160,
     ry: 285,
     color: "#38bdf8",
-    durationMs: 10000,
-    delayMs: -8500,
+    durationMs: 5000,
+    delayMs: -4250,
     reverse: true,
   },
   {
@@ -88,16 +91,16 @@ const CURTAINS: Curtain[] = [
     rx: 170,
     ry: 265,
     color: "#818cf8",
-    durationMs: 11500,
-    delayMs: -2800,
+    durationMs: 5750,
+    delayMs: -1400,
   },
   {
     cx: 820,
     rx: 165,
     ry: 290,
     color: "#0ea5e9",
-    durationMs: 9500,
-    delayMs: -6200,
+    durationMs: 4750,
+    delayMs: -3100,
     reverse: true,
   },
   {
@@ -105,8 +108,8 @@ const CURTAINS: Curtain[] = [
     rx: 175,
     ry: 275,
     color: "#a5b4fc",
-    durationMs: 13500,
-    delayMs: -4400,
+    durationMs: 6750,
+    delayMs: -2200,
   },
 ];
 

--- a/langwatch/src/features/traces-v2/onboarding/chapters/chapters.ts
+++ b/langwatch/src/features/traces-v2/onboarding/chapters/chapters.ts
@@ -72,6 +72,7 @@ export const STAGE_TO_CHAPTER: Record<StageId, ChapterId> = {
   facetsReveal: "slice",
   arrivalPrep: "arrivals",
   auroraArrival: "arrivals",
+  auroraLanding: "arrivals",
   postArrival: "arrivals",
   drawerOverview: "drawer",
   outro: "outro",

--- a/langwatch/src/features/traces-v2/onboarding/chapters/onboardingJourneyConfig.ts
+++ b/langwatch/src/features/traces-v2/onboarding/chapters/onboardingJourneyConfig.ts
@@ -8,8 +8,8 @@
  *
  * Stage flow:
  *
- *   welcome1     →  welcome2     →  densityIntro  →  auroraArrival  →  postArrival  →  complete
- *   (auto 3.5s)     (auto 4.5s)     (manual CTA)     (auto 4s)         (row click)
+ *   welcome1  →  welcome2  →  densityIntro  →  auroraArrival  →  auroraLanding  →  postArrival  →  complete
+ *   (auto)       (auto)       (manual CTA)     (ribbon only)     (rows arrive)     (row click)
  *
  * `holdMs + next` ⇒ auto-advance after the delay.
  * `cta + next`    ⇒ render an inline CTA button that advances on click.
@@ -25,6 +25,7 @@ export type StageId =
   | "facetsReveal"
   | "arrivalPrep"
   | "auroraArrival"
+  | "auroraLanding"
   | "postArrival"
   | "drawerOverview"
   | "outro"
@@ -37,8 +38,12 @@ export type StageId =
  *                     the trace drawer is open on the right.
  *  - `bottomCentre` — bottom-anchored, centred horizontally, used
  *                     while the facet sidebar takes the left rail.
+ *  - `topBanner`    — top-anchored thin banner. The hero band fades
+ *                     out so the live table reads as the user's
+ *                     space, with the banner sitting above it as a
+ *                     "wrap-up" strip rather than an overlay.
  */
-export type HeroLayout = "centre" | "left" | "bottomCentre";
+export type HeroLayout = "centre" | "left" | "bottomCentre" | "topBanner";
 
 export interface StageDef {
   id: StageId;
@@ -219,14 +224,31 @@ export const ONBOARDING_JOURNEY: StageDef[] = [
     // we don't get a re-fade flicker. Hero text dims during the
     // aurora so the user's eye is pulled UP to the ribbon, then
     // fades back when we advance.
+    //
+    // Ribbon-only beat: the aurora flares first, *without* the new
+    // arrivals in the table below it. If the rows land at the same
+    // moment the ribbon plays, the eye doesn't get a chance to read
+    // "aurora → then traces" — it reads "ribbon and items appear at
+    // once," which loses the cause-and-effect of the metaphor. The
+    // landing happens in the next stage.
     heading: "Watch out for the aurora...\nNew traces tend to follow it.",
-    // 5800ms — gives the aurora long enough to read as a *moment*
-    // rather than a flash. The drift cycles are 8–13s so we still
-    // won't see a full one, but stretching past the previous 4.8s
-    // means the user has time to register the ribbon, see the rows
-    // land underneath it, and feel that something arrived. This is
-    // the journey's marquee visual; it earns the extra second.
-    holdMs: 5800,
+    holdMs: 1800,
+    next: "auroraLanding",
+    showAurora: true,
+    showArrivals: false,
+    showIntegrateCta: false,
+    dimHero: true,
+  },
+  {
+    id: "auroraLanding",
+    // Second beat of the marquee moment: ribbon stays visible while
+    // the new arrivals slide in underneath it, so the user reads
+    // "the aurora is what brought these in." Total time on the
+    // ribbon (auroraArrival + auroraLanding) lands ~5.8s, matching
+    // what the previous single stage held. Heading still carries
+    // through so we don't re-fade the hero text mid-moment.
+    heading: "Watch out for the aurora...\nNew traces tend to follow it.",
+    holdMs: 4000,
     next: "postArrival",
     showAurora: true,
     showArrivals: true,
@@ -269,15 +291,17 @@ export const ONBOARDING_JOURNEY: StageDef[] = [
   },
   {
     id: "outro",
-    // Terminal chapter — renders as the OutroPanel (highlight cards
-    // + integrate / done CTAs) instead of a typewriter hero. The
-    // panel absorbs the role the standalone "What's-new" dialog
-    // used to play, so all the post-tour content (multiplayer,
-    // shortcuts, integrate) lives in one place at the end of the
-    // journey rather than as a separate dialog the user has to
-    // re-open.
+    // Terminal chapter — renders as a thin top banner instead of a
+    // centred hero overlay. The journey already taught the user the
+    // basics; the outro is now a "tour done, here's the CTA" strip
+    // that pins to the top of the table area so the live data is
+    // visible underneath without overlap. `showIntegrateCta: false`
+    // suppresses the standalone "Integrate my code" button that
+    // would otherwise stack a duplicate primary CTA next to the
+    // banner's own "Send your own traces" button.
     showArrivals: true,
-    heroLayout: "centre",
+    heroLayout: "topBanner",
+    showIntegrateCta: false,
   },
   {
     id: "complete",

--- a/langwatch/src/features/traces-v2/onboarding/components/EmptyStateOverlay.tsx
+++ b/langwatch/src/features/traces-v2/onboarding/components/EmptyStateOverlay.tsx
@@ -44,14 +44,20 @@ export const EmptyStateOverlay = () => {
           surrounding chrome as-is for ~1.4s, so the page reads as a
           real product they're looking at — not a marketing
           sequence. Mesh + hero band fade in only when the welcome
-          typewriter starts. */}
-      {stage !== "settle" && <OnboardingMeshBackground />}
+          typewriter starts. The outro chapter also drops the mesh
+          so the live table reads as the user's space, with only the
+          thin top banner left as onboarding chrome. */}
+      {stage !== "settle" && heroLayout !== "topBanner" && (
+        <OnboardingMeshBackground />
+      )}
       {/* Hero band — full-width horizontal fade. Sticks regardless
           of where the hero is anchored, because once the user is
           past the table-centric beats (drawer open, sidebar open)
           the band fades into being a soft atmospheric wash. Fades
           in over the settle → welcome transition so the page
-          calmly slides into onboarding rather than slamming in. */}
+          calmly slides into onboarding rather than slamming in.
+          Suppressed for the topBanner layout so the live table is
+          fully visible behind the wrap-up strip. */}
       <Flex
         position="absolute"
         inset={0}
@@ -59,7 +65,9 @@ export const EmptyStateOverlay = () => {
         justify="center"
         zIndex={1}
         pointerEvents="none"
-        opacity={stage === "settle" ? 0 : 1}
+        opacity={
+          stage === "settle" || heroLayout === "topBanner" ? 0 : 1
+        }
         transition="opacity 0.7s ease-out"
       >
         <Box
@@ -137,6 +145,13 @@ function layoutFlexProps(layout: HeroLayout, drawerLeftX: number | null) {
       align: "flex-end" as const,
       justify: "center" as const,
       paddingBottom: { base: 8, md: 12 },
+    };
+  }
+  if (layout === "topBanner") {
+    return {
+      align: "flex-start" as const,
+      justify: "center" as const,
+      paddingTop: { base: 2, md: 3 },
     };
   }
   return { align: "center" as const, justify: "center" as const };

--- a/langwatch/src/features/traces-v2/onboarding/components/OutroPanel.tsx
+++ b/langwatch/src/features/traces-v2/onboarding/components/OutroPanel.tsx
@@ -1,158 +1,87 @@
-import { Box, Button, HStack, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
-import {
-  ArrowRight,
-  Keyboard,
-  RotateCcw,
-  Sparkles,
-  Users,
-  Wrench,
-} from "lucide-react";
+import { Box, Button, HStack, Icon, Text } from "@chakra-ui/react";
+import { ArrowRight, Sparkles, Wrench, X } from "lucide-react";
 import type React from "react";
-import type { LucideIcon } from "lucide-react";
-
-interface OutroHighlight {
-  icon: LucideIcon;
-  iconColor: string;
-  label: string;
-  hint: string;
-}
-
-/**
- * The journey itself teaches density, filtering (lenses + facets), the
- * arrival aurora, and the trace drawer — every chapter is the
- * teaching for that thing. The outro panel covers the *highlights
- * that don't get a chapter of their own*: multiplayer presence,
- * keyboard shortcuts, and the integrate path. Three cards keep it a
- * "while you're here" panel rather than a second full tour, which
- * matches the §14 design discussion's framing of the outro as
- * "rest of the highlights" not a third teaching surface.
- *
- * Beta status used to be a separate step in the retired What's-new
- * dialog; folding it into the subhead keeps the panel compact.
- */
-const HIGHLIGHTS: OutroHighlight[] = [
-  {
-    icon: Users,
-    iconColor: "blue.fg",
-    label: "Multiplayer",
-    hint: "Your teammates show up where you do, in real time.",
-  },
-  {
-    icon: Keyboard,
-    iconColor: "purple.fg",
-    label: "Shortcuts",
-    hint: "Hit ? anywhere to see the lot — there are loads.",
-  },
-  {
-    icon: Wrench,
-    iconColor: "orange.fg",
-    label: "Integrate",
-    hint: "Send your own traces — paste a snippet, or hand it to your agent.",
-  },
-];
 
 interface OutroPanelProps {
   onIntegrate: () => void;
   onDone: () => void;
-  onRewatch: () => void;
+  /**
+   * Kept on the props so callers don't have to change shape — the
+   * inline banner doesn't render a "watch again" link itself
+   * (re-entry lives on the toolbar's Tour button), so this is unused
+   * here. Removed from the runtime args list with an underscore to
+   * make the intent explicit.
+   */
+  onRewatch?: () => void;
 }
 
 /**
- * Final chapter of the empty-state journey. Replaces the one-line
- * outro hero ("That's the tour.") with a compact panel of three
- * highlight cards plus the exit CTAs.
+ * Final beat of the empty-state journey. Replaces the previous
+ * full-card overlay with a thin top banner so the live table is
+ * visible underneath without row-text bleed. Visual job:
  *
- * Keep it terse — the journey already did the teaching. The cards
- * are reminders, not lessons; their hints fit on one line each. The
- * primary action is "Send your own traces" (the integrate path) so
- * the user can leave feeling like the next step is theirs to take,
- * not "tour over, now what."
+ *   ┌──────────────────────────────────────────────────────────┐
+ *   │ ✨ Tour done — explore freely.   [Send your own traces ↗] ✕│
+ *   └──────────────────────────────────────────────────────────┘
+ *
+ * Kept terse on purpose: the journey already did the teaching, the
+ * highlight cards (multiplayer / shortcuts / docs) sit elsewhere in
+ * the app, and stacking a "rest of the highlights" panel on top of
+ * the live table after the user has already finished the tour reads
+ * as in-the-way. The single primary action is "send your own
+ * traces" so the next step still feels like the user's to take.
  */
 export function OutroPanel({
   onIntegrate,
   onDone,
-  onRewatch,
 }: OutroPanelProps): React.ReactElement {
   return (
-    <VStack align="stretch" gap={4} maxWidth="540px" width="full">
-      <VStack align="center" gap={1} textAlign="center">
-        <HStack gap={1.5} color="orange.fg">
-          <Icon boxSize={4}>
+    <Box
+      width="full"
+      maxWidth="780px"
+      paddingX={{ base: 3, md: 4 }}
+      paddingY={2}
+      borderRadius="full"
+      borderWidth="1px"
+      borderColor="border.muted"
+      background="bg.panel/85"
+      backdropFilter="blur(8px)"
+      boxShadow="sm"
+    >
+      <HStack gap={3} justify="space-between" flexWrap="wrap">
+        <HStack gap={2} flex={1} minWidth="0">
+          <Icon boxSize={3.5} color="orange.fg">
             <Sparkles />
           </Icon>
-          <Text textStyle="xs" fontWeight={500} letterSpacing="0.04em">
-            That&apos;s the tour
+          <Text textStyle="sm" fontWeight={500} color="fg" truncate>
+            Tour done — explore freely.
           </Text>
         </HStack>
-        <Text color="fg.muted" textStyle="sm" lineHeight={1.6}>
-          A few extras worth knowing about — and it&apos;s still beta, so
-          ping us when something feels wrong.
-        </Text>
-      </VStack>
 
-      <SimpleGrid columns={{ base: 1, md: 3 }} gap={2.5}>
-        {HIGHLIGHTS.map((h) => (
-          <Box
-            key={h.label}
-            paddingX={3}
-            paddingY={2.5}
-            borderRadius="lg"
-            borderWidth="1px"
-            borderColor="border.muted"
-            background="bg.panel/60"
+        <HStack gap={2} flexShrink={0}>
+          <Button
+            size="sm"
+            variant="solid"
+            colorPalette="orange"
+            onClick={onIntegrate}
           >
-            <HStack gap={2} marginBottom={1}>
-              <Icon boxSize={3.5} color={h.iconColor}>
-                <h.icon />
-              </Icon>
-              <Text textStyle="sm" fontWeight={500} color="fg">
-                {h.label}
-              </Text>
-            </HStack>
-            <Text textStyle="xs" color="fg.muted" lineHeight={1.5}>
-              {h.hint}
-            </Text>
-          </Box>
-        ))}
-      </SimpleGrid>
-
-      <HStack gap={2.5} justify="center" flexWrap="wrap">
-        <Button
-          size="md"
-          variant="solid"
-          colorPalette="orange"
-          onClick={onIntegrate}
-        >
-          <Wrench size={14} />
-          Send your own traces
-          <ArrowRight size={14} />
-        </Button>
-        <Button
-          size="md"
-          variant="ghost"
-          colorPalette="gray"
-          onClick={onDone}
-        >
-          Done
-        </Button>
+            <Wrench size={13} />
+            Send your own traces
+            <ArrowRight size={13} />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            colorPalette="gray"
+            onClick={onDone}
+            aria-label="Dismiss tour banner"
+          >
+            <Icon boxSize={3.5}>
+              <X />
+            </Icon>
+          </Button>
+        </HStack>
       </HStack>
-
-      <HStack justify="center">
-        <Button
-          variant="plain"
-          size="xs"
-          color="fg.subtle"
-          padding={0}
-          minHeight="auto"
-          onClick={onRewatch}
-          _hover={{ color: "fg.muted" }}
-        >
-          <Icon boxSize={3}>
-            <RotateCcw />
-          </Icon>
-          Watch the tour again
-        </Button>
-      </HStack>
-    </VStack>
+    </Box>
   );
 }

--- a/langwatch/src/features/traces-v2/onboarding/components/TracesEmptyOnboarding.tsx
+++ b/langwatch/src/features/traces-v2/onboarding/components/TracesEmptyOnboarding.tsx
@@ -591,12 +591,11 @@ export function TracesEmptyOnboarding(): React.ReactElement {
                 give the user a way out of "I missed that beat" without
                 forcing them to restart the whole tour. Hidden on the
                 density spotlight (its cards already double as advance
-                affordances) and the outro (the OutroPanel owns its own
-                CTAs there). The bullet separators are only rendered
-                when an item is shown so we don't get adjacent dots. */}
-            {!stageDef.showDensitySpotlight &&
-              stage !== "outro" &&
-              !isReturningWelcome && (
+                affordances). The outer gate already excludes the outro
+                chapter (the OutroPanel owns its own CTAs there). The
+                bullet separators are only rendered when an item is
+                shown so we don't get adjacent dots. */}
+            {!stageDef.showDensitySpotlight && !isReturningWelcome && (
               <>
                 {canGoBack && (
                   <>

--- a/langwatch/src/features/traces-v2/onboarding/components/TracesEmptyOnboarding.tsx
+++ b/langwatch/src/features/traces-v2/onboarding/components/TracesEmptyOnboarding.tsx
@@ -310,7 +310,13 @@ export function TracesEmptyOnboarding(): React.ReactElement {
         // slack on narrower viewports (the Flex container's
         // paddingRight = viewport - drawerLeft caps the visible
         // canvas, so this maxWidth only kicks in when there's space).
-        maxWidth={stageDef.heroLayout === "left" ? "460px" : "640px"}
+        maxWidth={
+          stageDef.heroLayout === "left"
+            ? "460px"
+            : stageDef.heroLayout === "topBanner"
+              ? "820px"
+              : "640px"
+        }
         paddingX={{ base: 4, md: 8 }}
       >
         {/* Hero motion key is the heading text (or a hidden-stage
@@ -563,7 +569,12 @@ export function TracesEmptyOnboarding(): React.ReactElement {
             stage (densityIntro). The Continue button stays quiet
             until the user actually picks a density — once they
             have, it wakes up to solid orange so pressing it next
-            reads as obvious. */}
+            reads as obvious. Suppressed on outro: the OutroPanel
+            top banner owns its own primary + dismiss controls, and
+            stacking another row of "Skip for now / Integration
+            overview" alongside the banner would re-introduce the
+            duplicate-CTA problem the banner is here to fix. */}
+        {stage !== "outro" && (
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -666,17 +677,19 @@ export function TracesEmptyOnboarding(): React.ReactElement {
                 outro footer feel cluttered. */}
           </HStack>
         </motion.div>
+        )}
 
         {/* Chapter progress strip — sits at the bottom of the hero
             stack, beneath the docs / skip secondary controls, so it
             reads as a quiet "where am I in this" indicator rather
             than competing with the primary CTA. Hidden on `settle`
-            (no narrative beat has landed yet) so it doesn't appear
-            before the journey is acknowledged. The strip itself is
-            non-clickable — chapter jumping is offered separately
-            via `ReturningUserHub` for users who've already done the
-            tour once. */}
-        {stage !== "settle" && (
+            (no narrative beat has landed yet) and on `outro` (the
+            top banner is the entire chrome — adding a strip below it
+            re-introduces the stacked-card feel the banner is here to
+            replace). The strip itself is non-clickable — chapter
+            jumping is offered separately via `ReturningUserHub` for
+            users who've already done the tour once. */}
+        {stage !== "settle" && stage !== "outro" && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/langwatch/src/features/traces-v2/onboarding/effects/RichRowGlow.tsx
+++ b/langwatch/src/features/traces-v2/onboarding/effects/RichRowGlow.tsx
@@ -5,9 +5,11 @@ import { RICH_ARRIVAL_TRACE_ID } from "../data/samplePreviewTraces";
  * Global `<style>` tag for the rich-arrival row's tour highlight —
  * the soft blue halo + outer ring that pulses around the highlighted
  * row. Active across the arrival → drawer chapters
- * (`auroraArrival`, `postArrival`, `drawerOverview`) so the row
+ * (`auroraLanding`, `postArrival`, `drawerOverview`) so the row
  * "comes out glowing" the moment it lands and stays visibly tagged
- * while the drawer is open.
+ * while the drawer is open. Note: ribbon-only `auroraArrival` is
+ * intentionally excluded — the row hasn't arrived yet during that
+ * beat, so there's nothing to glow.
  *
  * Why a global stylesheet (not a Chakra `css` prop on a wrapper):
  * the table renders inside the always-on `ResultsPane` chrome, and
@@ -18,16 +20,21 @@ import { RICH_ARRIVAL_TRACE_ID } from "../data/samplePreviewTraces";
  * (`OnboardingHost` only renders this when active) keeps the rule
  * out of stylesheet for users who aren't onboarding.
  *
- * Scoped to `> tr:first-child > td` so only the main row gets the
- * outer ring — the optional IOPreview addon row inside the same
- * `<tbody>` would otherwise pick up its own ring and the trace
- * would read as two stacked highlighted cells.
+ * The trace's `<tbody>` may contain one or two `<tr>` elements:
+ *  - Compact density: a single main row.
+ *  - Comfortable density: a main row + an IOPreview addon row.
+ *
+ * The outline is drawn so the two rows read as one block: top stroke on
+ * the first row, bottom stroke on the last row, side strokes that wrap
+ * the whole tbody. In compact density `:first-child === :last-child` so
+ * both rules apply to the same row and it gets all four strokes
+ * naturally — no special-casing needed.
  *
  * Uses `html.dark` for the dark-mode override (Chakra v3's
  * class-based color mode), matching `DrawerGlow`.
  */
 const ACTIVE_STAGES = [
-  "auroraArrival",
+  "auroraLanding",
   "postArrival",
   "drawerOverview",
 ] as const;
@@ -46,12 +53,21 @@ export const RichRowGlow: React.FC = () => {
       return `${dark}body[data-traces-tour-stage="${stage}"] ${tbody}${hover}${suffix}`;
     }).join(", ");
 
-  // Outer ring on the main row only. Top + bottom strokes on every
-  // td; first/last td add the matching side stroke. The result reads
-  // as one outlined block rather than four side-by-side boxes.
-  const ROW = " > tr:first-child > td";
-  const ROW_FIRST = " > tr:first-child > td:first-child";
-  const ROW_LAST = " > tr:first-child > td:last-child";
+  // Outer ring split across the tbody's row(s):
+  //   - top stroke on every td of the first row
+  //   - bottom stroke on every td of the last row (same row in compact)
+  //   - left/right side strokes spanning ALL rows' first/last td
+  //
+  // In compact density there's only one row, so :first-child and
+  // :last-child collapse to the same row and the four strokes assemble
+  // into a single outline. In comfortable density the main row carries
+  // the top + sides, the IOPreview row carries the bottom + sides, and
+  // the seam between them is intentionally unstroked so the highlight
+  // reads as one block rather than two stacked boxes.
+  const ROW_FIRST = " > tr:first-child > td";
+  const ROW_LAST = " > tr:last-child > td";
+  const SIDE_FIRST = " > tr > td:first-child";
+  const SIDE_LAST = " > tr > td:last-child";
 
   return (
     <style>{`
@@ -97,38 +113,96 @@ export const RichRowGlow: React.FC = () => {
         --rich-bg-hover: rgba(125, 211, 252, 0.2);
         animation: tracesV2RichRowGlowDark 2.2s ease-in-out infinite;
       }
-      ${each(ROW)} {
+      ${each(" > tr > td")} {
         background-color: var(--rich-bg);
-        box-shadow:
-          inset 0 1px 0 0 var(--rich-ring),
-          inset 0 -1px 0 0 var(--rich-ring);
         transition: background-color 200ms ease, box-shadow 200ms ease;
       }
       ${each(ROW_FIRST)} {
+        box-shadow: inset 0 1px 0 0 var(--rich-ring);
+      }
+      ${each(ROW_LAST)} {
+        box-shadow: inset 0 -1px 0 0 var(--rich-ring);
+      }
+      ${each(SIDE_FIRST)} {
+        box-shadow: inset 1px 0 0 0 var(--rich-ring);
+      }
+      ${each(SIDE_LAST)} {
+        box-shadow: inset -1px 0 0 0 var(--rich-ring);
+      }
+      ${each(" > tr:first-child > td:first-child")} {
+        box-shadow:
+          inset 0 1px 0 0 var(--rich-ring),
+          inset 1px 0 0 0 var(--rich-ring);
+      }
+      ${each(" > tr:first-child > td:last-child")} {
+        box-shadow:
+          inset 0 1px 0 0 var(--rich-ring),
+          inset -1px 0 0 0 var(--rich-ring);
+      }
+      ${each(" > tr:last-child > td:first-child")} {
+        box-shadow:
+          inset 0 -1px 0 0 var(--rich-ring),
+          inset 1px 0 0 0 var(--rich-ring);
+      }
+      ${each(" > tr:last-child > td:last-child")} {
+        box-shadow:
+          inset 0 -1px 0 0 var(--rich-ring),
+          inset -1px 0 0 0 var(--rich-ring);
+      }
+      ${each(" > tr:first-child:last-child > td:first-child")} {
         box-shadow:
           inset 0 1px 0 0 var(--rich-ring),
           inset 0 -1px 0 0 var(--rich-ring),
           inset 1px 0 0 0 var(--rich-ring);
       }
-      ${each(ROW_LAST)} {
+      ${each(" > tr:first-child:last-child > td:last-child")} {
         box-shadow:
           inset 0 1px 0 0 var(--rich-ring),
           inset 0 -1px 0 0 var(--rich-ring),
           inset -1px 0 0 0 var(--rich-ring);
       }
-      ${each(ROW, { hover: true })} {
+      ${each(" > tr > td", { hover: true })} {
         background-color: var(--rich-bg-hover);
-        box-shadow:
-          inset 0 1px 0 0 var(--rich-ring-hover),
-          inset 0 -1px 0 0 var(--rich-ring-hover);
       }
       ${each(ROW_FIRST, { hover: true })} {
+        box-shadow: inset 0 1px 0 0 var(--rich-ring-hover);
+      }
+      ${each(ROW_LAST, { hover: true })} {
+        box-shadow: inset 0 -1px 0 0 var(--rich-ring-hover);
+      }
+      ${each(SIDE_FIRST, { hover: true })} {
+        box-shadow: inset 1px 0 0 0 var(--rich-ring-hover);
+      }
+      ${each(SIDE_LAST, { hover: true })} {
+        box-shadow: inset -1px 0 0 0 var(--rich-ring-hover);
+      }
+      ${each(" > tr:first-child > td:first-child", { hover: true })} {
+        box-shadow:
+          inset 0 1px 0 0 var(--rich-ring-hover),
+          inset 1px 0 0 0 var(--rich-ring-hover);
+      }
+      ${each(" > tr:first-child > td:last-child", { hover: true })} {
+        box-shadow:
+          inset 0 1px 0 0 var(--rich-ring-hover),
+          inset -1px 0 0 0 var(--rich-ring-hover);
+      }
+      ${each(" > tr:last-child > td:first-child", { hover: true })} {
+        box-shadow:
+          inset 0 -1px 0 0 var(--rich-ring-hover),
+          inset 1px 0 0 0 var(--rich-ring-hover);
+      }
+      ${each(" > tr:last-child > td:last-child", { hover: true })} {
+        box-shadow:
+          inset 0 -1px 0 0 var(--rich-ring-hover),
+          inset -1px 0 0 0 var(--rich-ring-hover);
+      }
+      ${each(" > tr:first-child:last-child > td:first-child", { hover: true })} {
         box-shadow:
           inset 0 1px 0 0 var(--rich-ring-hover),
           inset 0 -1px 0 0 var(--rich-ring-hover),
           inset 1px 0 0 0 var(--rich-ring-hover);
       }
-      ${each(ROW_LAST, { hover: true })} {
+      ${each(" > tr:first-child:last-child > td:last-child", { hover: true })} {
         box-shadow:
           inset 0 1px 0 0 var(--rich-ring-hover),
           inset 0 -1px 0 0 var(--rich-ring-hover),

--- a/langwatch/src/features/traces-v2/stores/densityStore.ts
+++ b/langwatch/src/features/traces-v2/stores/densityStore.ts
@@ -66,12 +66,20 @@ export interface DrawerDensityTokens {
   sectionTriggerY: number;
   /** Vertical padding around accordion section body content. */
   sectionContentY: number;
+  /**
+   * Approximate rendered pixel height of one accordion trigger row. Drives
+   * the sticky-stack offset between siblings — has to match the trigger's
+   * actual height (text line-height + 2 × paddingY + 1px border) or later
+   * sections pin too early (overlap) or too late (visible gap).
+   */
+  triggerHeightPx: number;
 }
 
 export function getDrawerDensityTokens(density: Density): DrawerDensityTokens {
   if (density === "compact") {
-    return { sectionTriggerY: 1.5, sectionContentY: 1.5 };
+    // 16px (2xs line-height) + 2 × 6px paddingY + 1px border = 29px.
+    return { sectionTriggerY: 1.5, sectionContentY: 1.5, triggerHeightPx: 29 };
   }
-  // comfortable
-  return { sectionTriggerY: 2.5, sectionContentY: 2.5 };
+  // comfortable: 16px + 2 × 10px + 1px = 37px.
+  return { sectionTriggerY: 2.5, sectionContentY: 2.5, triggerHeightPx: 37 };
 }

--- a/langwatch/src/features/traces-v2/stores/densityStore.ts
+++ b/langwatch/src/features/traces-v2/stores/densityStore.ts
@@ -9,7 +9,9 @@ const DEFAULT_DENSITY: Density = "compact";
  * Density is a personal preference, not a per-lens or per-URL setting.
  * Lives in its own zustand store backed by `localStorage` so the user's
  * choice persists across sessions and lens switches without leaking into
- * shared/URL state.
+ * shared/URL state. The trace drawer reads the same value (via
+ * `getDrawerDensityTokens`) so the user only ever picks density once and
+ * the whole product follows.
  */
 function load(): Density {
   if (typeof window === "undefined") return DEFAULT_DENSITY;
@@ -43,3 +45,33 @@ export const useDensityStore = create<DensityState>((set) => ({
     set({ density });
   },
 }));
+
+/**
+ * Padding tokens for the trace drawer's accordion section headers
+ * (INPUT AND OUTPUT, METADATA, EVALS, EVENTS, EXCEPTIONS …) under the
+ * mode-tab strip. These follow the user's shared density preference so
+ * the body of the drawer feels coherent with the table density they
+ * already picked.
+ *
+ * The drawer's *title* strip (trace name, metric/source chip row,
+ * pinned-context strip, mode tabs) is intentionally NOT density-driven
+ * — it carries identity information that's the same size regardless of
+ * row preference, and tightening it reads like accidental UI rather
+ * than a deliberate density choice.
+ *
+ * Values are in Chakra space units (1 ≈ 4px).
+ */
+export interface DrawerDensityTokens {
+  /** Vertical padding on accordion section header (the trigger row). */
+  sectionTriggerY: number;
+  /** Vertical padding around accordion section body content. */
+  sectionContentY: number;
+}
+
+export function getDrawerDensityTokens(density: Density): DrawerDensityTokens {
+  if (density === "compact") {
+    return { sectionTriggerY: 1.5, sectionContentY: 1.5 };
+  }
+  // comfortable
+  return { sectionTriggerY: 2.5, sectionContentY: 2.5 };
+}

--- a/langwatch/src/features/traces-v2/utils/__tests__/previewFormatter.unit.test.ts
+++ b/langwatch/src/features/traces-v2/utils/__tests__/previewFormatter.unit.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { formatPreview } from "../previewFormatter";
+
+const opts = { maxChars: 80 };
+
+describe("formatPreview", () => {
+  describe("given empty input", () => {
+    it("returns empty text without parsing", () => {
+      expect(formatPreview(null, opts)).toEqual({ text: "" });
+      expect(formatPreview(undefined, opts)).toEqual({ text: "" });
+      expect(formatPreview("", opts)).toEqual({ text: "" });
+    });
+  });
+
+  describe("given plain prose", () => {
+    it("returns the input unchanged when within the cap", () => {
+      const result = formatPreview("Hello, how are you?", opts);
+      expect(result.text).toBe("Hello, how are you?");
+      expect(result.role).toBeUndefined();
+    });
+
+    it("hard-caps at maxChars with an ellipsis", () => {
+      const long = "a".repeat(200);
+      const result = formatPreview(long, { maxChars: 20 });
+      expect(result.text).toBe(`${"a".repeat(19)}…`);
+    });
+  });
+
+  describe("given multiline prose", () => {
+    describe("when newlines: glyph", () => {
+      it("renders ↵ between non-empty lines", () => {
+        const result = formatPreview("line one\nline two\nline three", {
+          maxChars: 80,
+        });
+        expect(result.text).toBe("line one ↵ line two ↵ line three");
+      });
+
+      it("collapses runs of blank lines to a single ↵", () => {
+        const result = formatPreview("first\n\n\nsecond", { maxChars: 80 });
+        expect(result.text).toBe("first ↵ second");
+      });
+    });
+
+    describe("when newlines: space", () => {
+      it("collapses all whitespace runs to single spaces", () => {
+        const result = formatPreview("line one\nline two", {
+          maxChars: 80,
+          newlines: "space",
+        });
+        expect(result.text).toBe("line one line two");
+      });
+    });
+
+    describe("when newlines: preserve", () => {
+      it("keeps newlines verbatim", () => {
+        const result = formatPreview("line one\nline two", {
+          maxChars: 80,
+          newlines: "preserve",
+        });
+        expect(result.text).toBe("line one\nline two");
+      });
+    });
+  });
+
+  describe("given a fenced code block", () => {
+    it("strips the fence and language hint, flags hadCode", () => {
+      const input = "```python\nimport time\nfrom typing import Callable\n```";
+      const result = formatPreview(input, { maxChars: 80 });
+      expect(result.hadCode).toBe(true);
+      expect(result.text).toBe("import time ↵ from typing import Callable");
+    });
+
+    it("keeps the body when no language is specified", () => {
+      const input = "```\nfoo\nbar\n```";
+      const result = formatPreview(input, { maxChars: 80 });
+      expect(result.hadCode).toBe(true);
+      expect(result.text).toBe("foo ↵ bar");
+    });
+
+    it("does not strip inline backticks (only fenced blocks)", () => {
+      const result = formatPreview("Use `foo()` to call it", { maxChars: 80 });
+      expect(result.hadCode).toBe(false);
+      expect(result.text).toBe("Use `foo()` to call it");
+    });
+  });
+
+  describe("given markdown images", () => {
+    it("replaces ![alt](url) with 📷 alt and flags hadImage", () => {
+      const result = formatPreview("Look ![diagram](https://x.test/d.png) here", {
+        maxChars: 80,
+      });
+      expect(result.hadImage).toBe(true);
+      expect(result.text).toBe("Look 📷 diagram here");
+    });
+
+    it("uses bare 📷 when alt is empty", () => {
+      const result = formatPreview("![](https://x.test/d.png)", { maxChars: 80 });
+      expect(result.hadImage).toBe(true);
+      expect(result.text).toBe("📷");
+    });
+  });
+
+  describe("given a single-key JSON envelope", () => {
+    it("unwraps allowlisted keys (question, input, prompt, query, text, content, message)", () => {
+      for (const key of [
+        "question",
+        "input",
+        "prompt",
+        "query",
+        "text",
+        "content",
+        "message",
+      ]) {
+        const result = formatPreview(`{"${key}": "hello"}`, { maxChars: 80 });
+        expect(result.text).toBe("hello");
+      }
+    });
+
+    it("preserves the JSON shape when the key is not allowlisted", () => {
+      const result = formatPreview('{"id": "abc-123"}', { maxChars: 80 });
+      expect(result.text).toBe('{"id":"abc-123"}');
+    });
+
+    it("preserves multi-key objects", () => {
+      const result = formatPreview('{"a": 1, "b": 2}', { maxChars: 80 });
+      expect(result.text).toBe('{"a":1,"b":2}');
+    });
+
+    it("renders an image inside an unwrapped envelope as 📷", () => {
+      const result = formatPreview('{"question": "![](https://x/y.jpeg)"}', {
+        maxChars: 80,
+      });
+      expect(result.text).toBe("📷");
+      expect(result.hadImage).toBe(true);
+    });
+  });
+
+  describe("given a chat-shaped JSON array", () => {
+    it("returns the last assistant text and surfaces role", () => {
+      const input = JSON.stringify([
+        { role: "user", content: "What's up?" },
+        { role: "assistant", content: "All good, thanks!" },
+      ]);
+      const result = formatPreview(input, { maxChars: 80 });
+      expect(result.text).toBe("All good, thanks!");
+      expect(result.role).toBe("assistant");
+    });
+
+    it("renders tool calls as toolName(...)", () => {
+      const input = JSON.stringify([
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ function: { name: "search_documents" } }],
+        },
+      ]);
+      const result = formatPreview(input, { maxChars: 80 });
+      expect(result.text).toBe("search_documents(...)");
+      expect(result.role).toBe("assistant");
+    });
+
+    it("walks an array-shaped Anthropic content payload", () => {
+      const input = JSON.stringify([
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Here is the answer" },
+            { type: "tool_use", name: "search" },
+          ],
+        },
+      ]);
+      const result = formatPreview(input, { maxChars: 80 });
+      expect(result.text).toBe("Here is the answer");
+    });
+  });
+
+  describe("given a top-level Anthropic typed block", () => {
+    it("unwraps {type: text, text: ...}", () => {
+      const result = formatPreview('{"type":"text","text":"hello there"}', {
+        maxChars: 80,
+      });
+      expect(result.text).toBe("hello there");
+    });
+
+    it("renders <type> for non-text blocks so the user sees something existed", () => {
+      const result = formatPreview('{"type":"tool_use","name":"search"}', {
+        maxChars: 80,
+      });
+      expect(result.text).toBe("<tool_use>");
+    });
+  });
+
+  describe("given malformed JSON", () => {
+    it("falls back to raw input", () => {
+      const result = formatPreview('{"unclosed: "value"', { maxChars: 80 });
+      expect(result.text).toBe('{"unclosed: "value"');
+    });
+  });
+
+  describe("given content that combines several issues", () => {
+    it("unwraps an envelope, strips a fence, surfaces glyph and hadCode", () => {
+      const input = JSON.stringify({
+        question: "```python\nimport time\nimport os\n```",
+      });
+      const result = formatPreview(input, { maxChars: 80 });
+      expect(result.text).toBe("import time ↵ import os");
+      expect(result.hadCode).toBe(true);
+    });
+  });
+
+  describe("given stripMarkdownNoise: false", () => {
+    it("leaves fences and images intact", () => {
+      const result = formatPreview("```python\nfoo\n```", {
+        maxChars: 80,
+        stripMarkdownNoise: false,
+        newlines: "preserve",
+      });
+      expect(result.text).toBe("```python\nfoo\n```");
+      expect(result.hadCode).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/utils/previewFormatter.ts
+++ b/langwatch/src/features/traces-v2/utils/previewFormatter.ts
@@ -1,0 +1,339 @@
+/**
+ * Single-source preview formatter for the trace explorer's truncated I/O
+ * surfaces (table cell, group preview, conversation-context strip, system
+ * prompt banner).
+ *
+ * The codebase had four separate paths into "render this content as a one-
+ * line preview" — `tryParseChat`, `extractReadableSnippet`, `truncateText`,
+ * raw `lineClamp`. Each one solved a different subset of the formatting
+ * problems and the surfaces leaked the rest:
+ *
+ *   - `\`\`\`python\n…\n\`\`\`` → fences shown literally, eating preview width.
+ *   - `{"question":"…"}` → JSON envelope shown verbatim instead of unwrapped.
+ *   - `![](url)` → markdown image rendered as raw `![](…)`.
+ *   - `\n` inside a `whitespace: nowrap` cell → collapsed silently, the
+ *     reader can't tell the original was multi-line.
+ *
+ * `formatPreview` runs the full pipeline once and returns a single result
+ * shape, so each preview surface just calls it. Failure-soft at every step:
+ * if any part of the pipeline can't make sense of the input, we keep going
+ * with what we have. Returning the raw input (truncated) is always a valid
+ * outcome — a worse-but-correct preview is better than a thrown error.
+ */
+
+const ELLIPSIS = "…";
+const NEWLINE_GLYPH = "↵"; // ↵
+
+/**
+ * Single-key JSON envelopes worth unwrapping. Matched against the *only* key
+ * of the object — multi-key objects keep their JSON shape.
+ *
+ * Scoped to keys whose value is reliably user-meaningful prose (the kind a
+ * preview should surface). `id`, `name`, etc. are intentionally excluded:
+ * unwrapping `{"id":"abc"}` to `"abc"` would lose the structural signal
+ * that the trace's input *was* an envelope of an id, which is itself
+ * meaningful in some integrations.
+ */
+const UNWRAP_KEY_ALLOWLIST = new Set([
+  "question",
+  "input",
+  "prompt",
+  "query",
+  "text",
+  "content",
+  "message",
+]);
+
+/** ChatMessage shape we recognise in chat-array unwrapping. */
+interface ChatMessageLike {
+  role?: string;
+  content?: unknown;
+  tool_calls?: Array<{ function?: { name?: string } }>;
+}
+
+export type NewlineTreatment = "glyph" | "space" | "preserve";
+
+export interface PreviewOptions {
+  /** Hard cap on output length (post-pipeline). */
+  maxChars: number;
+  /**
+   * How to render newlines that survive unwrap + fence-strip:
+   *  - "glyph": replace each run of \n with " ↵ " so the reader sees
+   *    structure existed, but the text still flows as one line. Default
+   *    for nowrap surfaces (table cell, group preview, conv context).
+   *  - "space": collapse all whitespace runs to a single space. Calmer
+   *    visual, loses the "this was multi-line" signal.
+   *  - "preserve": keep \n verbatim. For surfaces with `pre-wrap` CSS
+   *    that actually want to break lines (system prompt banner).
+   */
+  newlines?: NewlineTreatment;
+  /**
+   * When true, strip ```lang\n…\n``` fences (keeping the body) and replace
+   * `![alt](url)` with "📷 alt". Default true. Disable for surfaces that
+   * render their own markdown.
+   */
+  stripMarkdownNoise?: boolean;
+}
+
+export interface PreviewResult {
+  /** The formatted, truncated string ready for direct rendering. */
+  text: string;
+  /**
+   * If chat-array unwrapping picked a message, the role of that message.
+   * Lets callers prefix `USER` / `ASSISTANT` chips next to the preview.
+   */
+  role?: "user" | "assistant" | "system" | "tool";
+  /** A fenced code block was discarded during noise-strip. */
+  hadCode?: boolean;
+  /** A markdown image was discarded during noise-strip. */
+  hadImage?: boolean;
+}
+
+/**
+ * Format an input/output payload for one-line / short-block preview.
+ * `null` / empty input → `{ text: "" }`.
+ */
+export function formatPreview(
+  raw: string | null | undefined,
+  options: PreviewOptions,
+): PreviewResult {
+  if (!raw) return { text: "" };
+
+  const noiseStrip = options.stripMarkdownNoise ?? true;
+  const newlines = options.newlines ?? "glyph";
+
+  // Pipeline state — each step mutates `text` and may set role/hadCode/hadImage.
+  let text = raw;
+  let role: PreviewResult["role"];
+  let hadCode = false;
+  let hadImage = false;
+
+  // 1. JSON unwrap. Only attempt when the trimmed input *looks* like JSON,
+  //    so we don't waste cycles on every plain-string preview.
+  const trimmed = text.trim();
+  if (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    const unwrap = unwrapJson(trimmed);
+    if (unwrap) {
+      text = unwrap.text;
+      role = unwrap.role;
+    }
+  }
+
+  // 2. Markdown noise strip — fences + images. Runs after unwrap so a
+  //    JSON-wrapped fenced code block (rare but real) gets normalised first.
+  if (noiseStrip) {
+    const stripped = stripMarkdownNoise(text);
+    text = stripped.text;
+    hadCode = stripped.hadCode;
+    hadImage = stripped.hadImage;
+  }
+
+  // 3. Newline treatment.
+  text = applyNewlineTreatment(text, newlines);
+
+  // 4. Trim, hard-cap.
+  text = text.trim();
+  if (text.length > options.maxChars) {
+    text = text.slice(0, options.maxChars - 1).trimEnd() + ELLIPSIS;
+  }
+
+  return { text, role, hadCode, hadImage };
+}
+
+// ---------------------------------------------------------------------------
+// JSON unwrap: chat arrays, Anthropic typed blocks, single-key envelopes.
+
+interface UnwrapResult {
+  text: string;
+  role?: PreviewResult["role"];
+}
+
+function unwrapJson(trimmed: string): UnwrapResult | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (Array.isArray(parsed)) {
+    return unwrapChatArray(parsed);
+  }
+  if (parsed && typeof parsed === "object") {
+    return unwrapObject(parsed as Record<string, unknown>);
+  }
+  return null;
+}
+
+/**
+ * Walk a chat-shaped array (most-recent-first) and return the text of the
+ * last message that has any. Tool calls render as `toolName(...)` so the
+ * preview shows what the model did, not just an empty content field.
+ */
+function unwrapChatArray(arr: unknown[]): UnwrapResult | null {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    const msg = arr[i];
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg as ChatMessageLike;
+    const toolName = m.tool_calls?.[0]?.function?.name;
+    if (toolName) {
+      return {
+        text: `${toolName}(...)`,
+        role: normaliseRole(m.role),
+      };
+    }
+    const content = extractMessageContent(m.content);
+    if (content) {
+      return { text: content, role: normaliseRole(m.role) };
+    }
+  }
+  return null;
+}
+
+/**
+ * Object unwrap: prefer Anthropic-typed blocks, fall back to single-key
+ * envelopes, otherwise stringify so we still produce *something*.
+ */
+function unwrapObject(obj: Record<string, unknown>): UnwrapResult {
+  // Anthropic typed block at the top level.
+  if (obj.type === "text" && typeof obj.text === "string") {
+    return { text: obj.text };
+  }
+  if (typeof obj.type === "string" && obj.type !== "text") {
+    // tool_use, tool_result, thinking, etc. — these rarely make readable
+    // previews on their own. Surface a tag so the user knows there *was*
+    // content but it wasn't text.
+    return { text: `<${obj.type}>` };
+  }
+
+  // Single-key envelope from the allowlist.
+  const keys = Object.keys(obj);
+  if (keys.length === 1) {
+    const key = keys[0]!;
+    if (UNWRAP_KEY_ALLOWLIST.has(key.toLowerCase())) {
+      const value = obj[key];
+      if (typeof value === "string") return { text: value };
+      if (typeof value === "number" || typeof value === "boolean") {
+        return { text: String(value) };
+      }
+    }
+  }
+
+  // Fallback: stringify with no indent so it fits a one-liner.
+  try {
+    return { text: JSON.stringify(obj) };
+  } catch {
+    return { text: "" };
+  }
+}
+
+/** Pull a string out of a chat message's `content` field (string | array). */
+function extractMessageContent(content: unknown): string {
+  if (typeof content === "string") {
+    // The string might itself be a typed-block JSON — try one more unwrap.
+    const t = content.trim();
+    if (t.startsWith('{"type":"text"')) {
+      try {
+        const inner = JSON.parse(t) as { text?: string };
+        if (typeof inner.text === "string") return inner.text;
+      } catch {
+        /* fall through */
+      }
+    }
+    if (t.startsWith('{"type":"') && !t.startsWith('{"type":"text"')) {
+      // Non-text typed block — nothing readable.
+      return "";
+    }
+    return content;
+  }
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (typeof part === "string") {
+        parts.push(part);
+      } else if (
+        part &&
+        typeof part === "object" &&
+        (part as { type?: unknown }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string"
+      ) {
+        parts.push((part as { text: string }).text);
+      }
+    }
+    return parts.join(" ");
+  }
+  return "";
+}
+
+function normaliseRole(role: unknown): PreviewResult["role"] {
+  if (
+    role === "user" ||
+    role === "assistant" ||
+    role === "system" ||
+    role === "tool"
+  ) {
+    return role;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown noise strip.
+
+interface NoiseStripResult {
+  text: string;
+  hadCode: boolean;
+  hadImage: boolean;
+}
+
+/**
+ * Drop ```lang\n…\n``` fence wrappers (keeping the code body) and replace
+ * `![alt](url)` images with a `📷 alt` token. The *language hint* on a
+ * fence (`python`, `json`) is dropped — at preview width it's noise.
+ *
+ * Only the fences themselves are stripped, not inline backticks: ``foo``
+ * inside running prose is fine to keep.
+ */
+function stripMarkdownNoise(text: string): NoiseStripResult {
+  let hadCode = false;
+  let hadImage = false;
+
+  // Multi-line fenced code block: ```lang\n…\n```. Drop the fences + lang
+  // hint, keep the body. Non-greedy match handles multiple blocks per
+  // input. Split-and-rejoin avoids regex re-entry on tricky inputs.
+  const FENCE_RE = /```(?:[a-zA-Z0-9_+-]*)\n([\s\S]*?)\n?```/g;
+  text = text.replace(FENCE_RE, (_match, body: string) => {
+    hadCode = true;
+    return body;
+  });
+
+  // Image: ![alt](url) → "📷 alt" (or "📷" when alt is empty). Strict
+  // single-line match — multi-line `![alt](\n  url\n)` is rare and would
+  // break the preview anyway.
+  const IMAGE_RE = /!\[([^\]]*)\]\([^)]*\)/g;
+  text = text.replace(IMAGE_RE, (_m, alt: string) => {
+    hadImage = true;
+    return alt.trim() ? `\u{1F4F7} ${alt.trim()}` : "\u{1F4F7}";
+  });
+
+  return { text, hadCode, hadImage };
+}
+
+// ---------------------------------------------------------------------------
+// Newline treatment.
+
+function applyNewlineTreatment(text: string, mode: NewlineTreatment): string {
+  if (mode === "preserve") return text;
+  if (mode === "space") return text.replace(/\s+/g, " ");
+  // glyph: collapse runs of newline-containing whitespace to " ↵ ", and
+  // collapse pure spaces/tabs runs to a single space. This way a normal
+  // paragraph with line wrap renders as "first line ↵ second line" rather
+  // than the misleading "first linesecond line" the nowrap default produces.
+  return text
+    .replace(/[ \t]+/g, " ")
+    .replace(/\s*\n+\s*/g, ` ${NEWLINE_GLYPH} `)
+    .trim();
+}


### PR DESCRIPTION
## Summary

Three commits worth of fixes from the Traces V2 testing pass.

### `5bf6afe98` — bug bash round (drawer / table / tour)
- **Click-to-interact threshold**: I/O viewer now ResizeObserver-detects overflow and only mounts the click scrim when content actually overflows; short payloads stay live.
- **Empty I/O state on table load**: `MissingIORow` renders explicitly when neither input nor output is present so the section isn't a silent void.
- **Aurora pacing**: durations halved (4.25–6.75s) and sequenced into two beats (`auroraArrival` + new `auroraLanding`) — aurora settles before rows arrive instead of dropping in simultaneously.
- **Dense-row glow**: extended selectors so the rich-row glow covers both rows of comfortable density, not just the first.
- **Outro panel**: rewritten as a thin horizontal banner with `topBanner` hero layout.
- **Scroll element race**: `scrollContext` now uses `useSyncExternalStore` + `releaseTraceTableScrollElement` to avoid the empty-rows bug when `ResultsPane` ↔ `EmptyResultsPane` swap clobbered the published element.

### `0d892483a` — preview formatter, header cleanup, drawer density
- Single source of truth: `formatPreview()` (JSON unwrap → markdown noise strip → newline treatment → trim+cap), wired into the table, conversation context, system-prompt banner, and the group-traces addon. 24 unit tests.
- Header: smart name fallback chain (`traceName ?? rootSpanName ?? id-prefix`, muted on fallback), suppresses redundant `scenario.run_id` pin when the rich Scenario chip is present, drops the empty pin row when there's nothing to show, unwraps `langwatch.labels` JSON arrays into `a · b · c`.
- Drawer accordion section padding (INPUT AND OUTPUT, METADATA, EVALS, EVENTS, EXCEPTIONS) now follows the user's table density preference. Title strip stays fixed-height — identity info reads the same regardless of density.

### `68f7c8393` — sticky pin + chips minHeight
- Accordion section triggers were stuck at `top: 0` of the drawer body, where `SpanTabBar` (zIndex 2) was already pinned — they were sticking but hidden behind it. Offset the sticky stack by the bar's 38px height so INPUT AND OUTPUT pins under the tab strip and later sections stack above as usual.
- Dropped the 56px `minHeight` on the chips strip; it reserved room for two rows of pills even when only one was rendered, leaving a permanent ~28px empty band above the pin row on most traces.

## Test plan
- [ ] Open a trace drawer and scroll the body — INPUT AND OUTPUT trigger pins below the Summary/LLM-Optimized tab strip, METADATA pins above it as you scroll past, etc.
- [ ] Open a trace with only one row of chips (e.g. orchestrate workflow with USER pin) — confirm no empty band between the chips row and the mode tabs.
- [ ] Open a trace with no I/O — confirm the empty-state row renders in the table, not a blank cell.
- [ ] Toggle table density between Compact and Comfortable — drawer accordion sections (INPUT AND OUTPUT, METADATA) follow; drawer title strip stays fixed.
- [ ] Run the onboarding tour — aurora settles before rows arrive; both rows in comfortable density show the glow.
- [ ] Tab through Summary / LLM-Optimized / pinned span tabs — no empty rows in the trace table after the swap.
- [ ] `pnpm test:unit langwatch/src/features/traces-v2/utils/__tests__/previewFormatter.unit.test.ts` passes.