### PR TITLE
fix(deps): upgrade axios to 1.16.0 in langgraph example (Dependabot #884)

### DIFF
--- a/typescript-sdk/examples/langgraph/package-lock.json
+++ b/typescript-sdk/examples/langgraph/package-lock.json
@@ -1908,15 +1908,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base64-js": {
@@ -2925,9 +2925,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4139,10 +4139,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/typescript-sdk/examples/langgraph/package.json
+++ b/typescript-sdk/examples/langgraph/package.json
@@ -26,5 +26,8 @@
   "devDependencies": {
     "typescript": "^5.9.2",
     "dotenv-cli": "^10.0.0"
+  },
+  "overrides": {
+    "axios": "^1.15.0"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrades **axios** from 1.13.5 → 1.16.0 in `typescript-sdk/examples/langgraph/`
- Fixes Dependabot alert #884: unrestricted cloud metadata exfiltration via header injection chain
- axios is a **transitive optional peer dependency** (from langchain packages), not a direct dependency
- Added `overrides` field in example's `package.json` to pin `axios >= 1.15.0`

### Changes
| File | Change |
|---|---|
| `typescript-sdk/examples/langgraph/package.json` | Added `overrides.axios: "^1.15.0"` |
| `typescript-sdk/examples/langgraph/package-lock.json` | axios 1.13.5 → 1.16.0, follow-redirects 1.15.11 → 1.16.0, proxy-from-env 1.1.0 → 2.1.0 |

## Test plan
- [ ] CI passes
- [ ] Verified axios is not imported in any source code — it's a transitive optional peer dep
- [ ] This is an example project, not production code or the shipped SDK