### PR TITLE
docs(workflows): justify @unimplemented scenarios with harness gap notes

### DIFF
--- a/specs/workflows/studio-drawer-migration.feature
+++ b/specs/workflows/studio-drawer-migration.feature
@@ -3,6 +3,12 @@ Feature: Studio Drawer Migration (Properties Panels to Drawers)
   I want to use drawers instead of right-sidebar properties panels
   So that the editing experience is consistent with evaluations-v3 and allows more space for content
 
+  # All scenarios in this file describe a UI migration on the workflow
+  # studio canvas (right-sidebar → drawer system). Need page-level
+  # workflow-studio component tests or Playwright E2E. No drawer-system
+  # studio test fixtures exist yet — all aspirational pending that
+  # harness.
+
   # Context:
   # Currently, selecting a node opens a right-sidebar properties panel with play/expand/close buttons.
   # The panel uses Framer Motion to animate between collapsed (right sidebar) and expanded (centered).

--- a/specs/workflows/studio-evaluator-node-drawer.feature
+++ b/specs/workflows/studio-evaluator-node-drawer.feature
@@ -3,6 +3,13 @@ Feature: Studio Evaluator Node Drawer
   I want evaluator nodes to use the evaluator editor drawer with local state
   So that I can edit evaluator settings without immediately affecting the global evaluator record
 
+  # All scenarios describe evaluator-node behavior on the workflow studio
+  # canvas (evaluator editor drawer, localConfig, Apply/Save/Discard).
+  # Need a studio-canvas component test against the evaluator drawer
+  # flow. The standalone EvaluatorEditorDrawer already has its own
+  # tests (`langwatch/src/components/evaluators/__tests__/`) but not
+  # in the workflow-studio context where localConfig diverges from DB.
+
   # Context:
   # After PR #1589, dragging an evaluator opens the evaluator list drawer to select/create.
   # The node then references evaluators/<id>.

--- a/specs/workflows/studio-evaluator-sidebar.feature
+++ b/specs/workflows/studio-evaluator-sidebar.feature
@@ -3,6 +3,11 @@ Feature: Studio Evaluator Sidebar Migration
   I want a simplified evaluator sidebar that uses the evaluator creation drawer
   So that I follow the same "create and name evaluators" pattern used everywhere else
 
+  # All scenarios describe sidebar UI on the optimization studio. Need
+  # a Node Selection Panel component test or Playwright E2E to drive
+  # the drag-and-drop + drawer-open flows. Aspirational pending that
+  # harness.
+
   Background:
     Given I am on the optimization studio workflow editor
     And the left sidebar (Node Selection Panel) is visible

--- a/specs/workflows/studio-llm-node-drawer.feature
+++ b/specs/workflows/studio-llm-node-drawer.feature
@@ -3,6 +3,11 @@ Feature: Studio LLM Node Drawer
   I want the LLM node to use the same drawer-based prompt editor as evaluations-v3
   So that I have a consistent editing experience and can leverage local state / save patterns
 
+  # All scenarios describe LLM-node behavior (PromptEditorDrawer, drag-and-drop,
+  # Apply/Save) on the workflow studio canvas. Need a studio-canvas component
+  # test against the prompt-editor drawer flow (no such fixture exists for
+  # the studio side; eval-v3 has its own equivalents).
+
   # Context:
   # Currently, the LLM (signature) node uses SignaturePropertiesPanel, a complex right-sidebar
   # form that syncs directly to node data via debounced setNode(). There is no concept of

--- a/specs/workflows/studio-local-state.feature
+++ b/specs/workflows/studio-local-state.feature
@@ -3,6 +3,13 @@ Feature: Studio Local State for Evaluators and Agents
   I want local (unsaved) changes that don't immediately affect the global DB record
   So that I can experiment with settings without breaking other workflows or evaluations that reference the same evaluator/agent
 
+  # All scenarios describe the local-state lifecycle (orange dot, Apply,
+  # Save, Discard, drawer-vs-DB precedence) on workflow studio nodes.
+  # Need a Workflow store + studio-canvas integration test that
+  # exercises the drawer + node localConfig roundtrip. The eval-v3
+  # patterns this is modeled on are tested in evaluations-v3 — the
+  # studio side has no equivalent harness yet.
+
   # Context:
   # Evaluators and agents in the studio are DB-backed records (evaluators/<id>, agents/<id>).
   # The same record can be referenced from multiple workflows and from evaluations-v3.

--- a/specs/workflows/workflow-management.feature
+++ b/specs/workflows/workflow-management.feature
@@ -3,6 +3,14 @@ Feature: Workflow Management UI
   I want to manage my workflows through the UI
   So that I can organize and maintain my workflow library
 
+  # All scenarios in this file describe a delete-confirmation dialog
+  # interaction on the WorkflowCard. They need a JSDOM/component test
+  # for the confirmation dialog (no such test file exists today —
+  # `CascadeArchiveDialog.test.tsx` covers a different surface).
+  # The behavioral piece (delete mutation success/failure) is covered
+  # by the Workflow REST API tests in
+  # `langwatch/src/app/api/workflows/__tests__/`.
+
   Background:
     Given I am authenticated as a project member
     And the project has existing workflows


### PR DESCRIPTION
## Summary

Phase 2 of #3458 (parity grinder) — workflows domain.

This PR is **doc-only**: 6 feature files in `specs/workflows/` get a 4-6 line header comment each, naming the missing test harness for their `@unimplemented` scenarios. No scenarios bound, no tests added — the workflow-studio canvas has no component-test fixtures yet.

The adjacent eval-v3 patterns this is modeled on are tested in `langwatch/src/evaluations-v3/__tests__/`; the studio-side equivalents don't exist.

## What changed

| Feature file | Bound | Total scenarios |
|---|---|---|
| `studio-drawer-migration.feature` | 0 | 13 |
| `studio-llm-node-drawer.feature` | 0 | 16 |
| `studio-local-state.feature` | 0 | 14 |
| `studio-evaluator-node-drawer.feature` | 0 | 9 |
| `studio-evaluator-sidebar.feature` | 0 | 7 |
| `workflow-management.feature` | 0 | 5 |

**Net `specs/workflows` `@unimplemented` count: 64 → 64 (all kept, all justified).**

## Test plan

- [x] `pnpm check:feature-parity` — passes (all @unimplemented filtered out)
- [ ] CI green (no code changed; only feature-file comments)

## Related

- Closes part of #3458
- Contract `C-2026-05-04-f114ea43` (parity grinder Phase 2)
- Sister PRs: #3773 (auth), #3774 (analytics), #3775 (agents), #3776 (evaluators), #3777 (suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)