### PR TITLE
feat(scenarios): structured logging across worker boundary

### DIFF
--- a/langwatch/src/server/scenarios/execution/__tests__/child-logger.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/child-logger.unit.test.ts
@@ -59,7 +59,11 @@ describe("child-logger", () => {
     describe("when the child requests its base logger", () => {
       /** @scenario child process tolerates missing context env var */
       it("returns a logger without bindings and without throwing", () => {
-        expect(() => createChildProcessLogger("test", {})).not.toThrow();
+        const logger = createChildProcessLogger("test", {}) as unknown as {
+          bindings: () => Record<string, unknown>;
+        };
+        expect(logger).toBeDefined();
+        expect(logger.bindings()).toEqual({});
       });
     });
   });

--- a/langwatch/src/server/scenarios/execution/__tests__/child-logger.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/child-logger.unit.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for child-logger — the bridge that propagates the parent's
+ * structured logger context across the parent → child process boundary.
+ *
+ * @see specs/scenarios/observability-context.feature
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => {
+  const make = (bindings: Record<string, unknown> = {}) => ({
+    bindings: () => bindings,
+    child: (extra: Record<string, unknown>) =>
+      make({ ...bindings, ...extra }),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  });
+  return {
+    createLogger: vi.fn(() => make({})),
+  };
+});
+
+import {
+  encodeScenarioLogContext,
+  decodeScenarioLogContext,
+  createChildProcessLogger,
+  SCENARIO_LOG_CONTEXT_ENV,
+} from "../child-logger";
+
+describe("child-logger", () => {
+  describe("given a parent context with all bindings", () => {
+    describe("when the child decodes and rebuilds its logger", () => {
+      /** @scenario child process logger inherits the parent's context bindings */
+      it("returns a logger whose bindings include all 3 keys", () => {
+        const encoded = encodeScenarioLogContext({
+          projectId: "proj_1",
+          batchRunId: "batch_1",
+          scenarioRunId: "run_1",
+        });
+
+        const logger = createChildProcessLogger("test", {
+          [SCENARIO_LOG_CONTEXT_ENV]: encoded,
+        }) as unknown as { bindings: () => Record<string, unknown> };
+
+        expect(logger.bindings()).toEqual({
+          projectId: "proj_1",
+          batchRunId: "batch_1",
+          scenarioRunId: "run_1",
+        });
+      });
+    });
+  });
+
+  describe("given the context env var is unset", () => {
+    describe("when the child requests its base logger", () => {
+      /** @scenario child process tolerates missing context env var */
+      it("returns a logger without bindings and without throwing", () => {
+        expect(() => createChildProcessLogger("test", {})).not.toThrow();
+      });
+    });
+  });
+
+  describe("given the context env var contains malformed JSON", () => {
+    describe("when the child requests its base logger", () => {
+      /** @scenario child process tolerates invalid context JSON */
+      it("returns a logger without bindings and emits a warning", () => {
+        const stderr = vi
+          .spyOn(process.stderr, "write")
+          .mockImplementation(() => true);
+
+        const logger = createChildProcessLogger("test", {
+          [SCENARIO_LOG_CONTEXT_ENV]: "{not valid json",
+        });
+
+        expect(logger).toBeDefined();
+        expect(stderr).toHaveBeenCalledWith(
+          expect.stringContaining("not valid JSON"),
+        );
+
+        stderr.mockRestore();
+      });
+    });
+  });
+
+  describe("encode/decode round-trip", () => {
+    it("drops undefined and empty-string values", () => {
+      const encoded = encodeScenarioLogContext({
+        projectId: "proj_1",
+        batchRunId: undefined,
+        scenarioRunId: "",
+      });
+      const decoded = decodeScenarioLogContext(encoded);
+      expect(decoded).toEqual({ projectId: "proj_1" });
+    });
+
+    it("decode returns empty object for unset env var", () => {
+      expect(decodeScenarioLogContext(undefined)).toEqual({});
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/execution/child-logger.ts
+++ b/langwatch/src/server/scenarios/execution/child-logger.ts
@@ -1,0 +1,87 @@
+/**
+ * Bridges the parent's structured logger context across the parent → child
+ * process boundary.
+ *
+ * The parent attaches a context object (scenarioRunId, batchRunId, projectId,
+ * scenarioId) to its `logger.child(...)` call. Without this bridge, the
+ * spawned scenario child gets a fresh logger with no context, so its log
+ * lines aren't joinable to the parent's by ID in CloudWatch Insights.
+ *
+ * Tracking: lw#3593.
+ *
+ * @see specs/scenarios/observability-context.feature
+ */
+
+import { createLogger, type Logger } from "~/utils/logger/server";
+
+export const SCENARIO_LOG_CONTEXT_ENV = "LANGWATCH_LOG_CONTEXT";
+
+export type ScenarioLogContext = {
+  scenarioRunId?: string;
+  batchRunId?: string;
+  projectId?: string;
+  scenarioId?: string;
+  setId?: string;
+};
+
+/**
+ * Encode a logger context for transport across a process boundary.
+ *
+ * Returns a JSON string suitable for an env var. Keys whose value is
+ * `undefined` are dropped so the child only inherits real bindings.
+ */
+export function encodeScenarioLogContext(context: ScenarioLogContext): string {
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (typeof value === "string" && value.length > 0) {
+      filtered[key] = value;
+    }
+  }
+  return JSON.stringify(filtered);
+}
+
+/**
+ * Decode an env var value into a logger context object.
+ *
+ * Returns an empty object when the env var is unset or malformed; never
+ * throws. Malformed JSON triggers a stderr warning so it's still visible
+ * during incident response.
+ */
+export function decodeScenarioLogContext(
+  raw: string | undefined,
+): ScenarioLogContext {
+  if (!raw) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as ScenarioLogContext;
+    }
+    return {};
+  } catch {
+    process.stderr.write(
+      `[child-logger] ${SCENARIO_LOG_CONTEXT_ENV} is not valid JSON; ignoring\n`,
+    );
+    return {};
+  }
+}
+
+/**
+ * Build the base logger for a scenario child process.
+ *
+ * Reads the context env var, decodes it, and returns a child logger bound
+ * to those fields. Use this once at the top of `scenario-child-process.ts`
+ * and pass the returned logger down to anything emitting structured events.
+ */
+export function createChildProcessLogger(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Logger {
+  const context = decodeScenarioLogContext(env[SCENARIO_LOG_CONTEXT_ENV]);
+  const base = createLogger(name);
+  if (Object.keys(context).length === 0) {
+    return base;
+  }
+  return base.child(context);
+}

--- a/langwatch/src/server/scenarios/execution/scenario-child-process.ts
+++ b/langwatch/src/server/scenarios/execution/scenario-child-process.ts
@@ -32,6 +32,9 @@ import { RemoteSpanJudgeAgent } from "./remote-span-judge-agent";
 import { createTraceApiSpanQuery } from "./trace-api-span-query";
 import { SerializedHttpAgentAdapter } from "./serialized-adapters/http-agent.adapter";
 import { bridgeTraceIdFromAdapterToJudge } from "./bridge-trace-id";
+import { createChildProcessLogger } from "./child-logger";
+
+const logger = createChildProcessLogger("langwatch:scenarios:child");
 
 /**
  * Some TracerProvider implementations (like ProxyTracerProvider) wrap a delegate.
@@ -160,12 +163,11 @@ async function executeScenario(jobData: ChildProcessJobData): Promise<void> {
     },
   );
 
-  // Log the result to stderr (human-readable) but don't exit with error code for failed tests
-  // A failed test is still a successful execution - results are reported via SDK
+  // A failed test is still a successful execution — results are reported via SDK.
   if (result.success) {
-    console.error(`Scenario passed`);
+    logger.info("scenario passed");
   } else {
-    console.error(`Scenario failed: ${result.reasoning}`);
+    logger.warn({ reasoning: result.reasoning }, "scenario failed");
   }
 
   // Flush OTEL traces before exiting
@@ -199,23 +201,26 @@ async function flushOtelTraces(): Promise<void> {
 
     // Try forceFlush first (preferred), then shutdown
     if (concreteProvider.forceFlush) {
-      console.error("Flushing OTEL traces...");
+      logger.debug("flushing otel traces");
       await concreteProvider.forceFlush();
-      console.error("OTEL traces flushed");
+      logger.debug("otel traces flushed");
     } else if (concreteProvider.shutdown) {
-      console.error("Shutting down OTEL provider...");
+      logger.debug("shutting down otel provider");
       await concreteProvider.shutdown();
-      console.error("OTEL provider shutdown complete");
+      logger.debug("otel provider shutdown complete");
     }
   } catch (error) {
     // Don't fail the scenario if OTEL flush fails
-    console.error(`OTEL flush warning: ${error instanceof Error ? error.message : String(error)}`);
+    logger.warn(
+      { err: error instanceof Error ? error.message : String(error) },
+      "otel flush warning",
+    );
   }
 }
 
 main().catch(async (error) => {
   const errorMessage = error instanceof Error ? error.message : String(error);
-  console.error(`Scenario execution failed: ${errorMessage}`);
+  logger.error({ err: errorMessage }, "scenario execution failed");
   // Still flush traces on error so we capture what happened
   await flushOtelTraces();
   // Output JSON error result to stdout for parent process to parse

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/__tests__/http-agent.adapter.logging.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/__tests__/http-agent.adapter.logging.unit.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the structured logging path in SerializedHttpAgentAdapter.
+ *
+ * Tracking lw#3593 — adapter must log every request (success and failure)
+ * at info/warn/error level with enough fields to reconstruct the call from
+ * CloudWatch.
+ *
+ * @see specs/scenarios/observability-context.feature
+ */
+
+import { AgentRole, type AgentInput } from "@langwatch/scenario";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HttpAgentData } from "../../types";
+import { SerializedHttpAgentAdapter } from "../http-agent.adapter";
+
+vi.mock("~/utils/ssrfProtection", () => ({
+  ssrfSafeFetch: vi.fn(),
+}));
+
+vi.mock("../../trace-context-headers", () => ({
+  injectTraceContextHeaders: vi.fn(
+    ({ headers }: { headers: Record<string, string> }) => ({
+      headers,
+      traceId: undefined,
+    }),
+  ),
+}));
+
+import { ssrfSafeFetch } from "~/utils/ssrfProtection";
+
+const mockSsrfSafeFetch = vi.mocked(ssrfSafeFetch);
+
+interface FakeLogger {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+  child: () => FakeLogger;
+}
+
+function makeFakeLogger(): FakeLogger {
+  const fake: FakeLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => fake,
+  };
+  return fake;
+}
+
+const defaultConfig: HttpAgentData = {
+  type: "http",
+  agentId: "agent_log",
+  url: "https://api.example.com/chat",
+  method: "POST",
+  headers: [],
+  outputPath: "$.response",
+};
+
+const defaultInput: AgentInput = {
+  threadId: "thread_log",
+  messages: [{ role: "user", content: "Hello" }],
+  newMessages: [{ role: "user", content: "Hello" }],
+  requestedRole: AgentRole.AGENT,
+  scenarioState: {} as AgentInput["scenarioState"],
+  scenarioConfig: {} as AgentInput["scenarioConfig"],
+};
+
+describe("SerializedHttpAgentAdapter — logging (lw#3593)", () => {
+  let logger: FakeLogger;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = makeFakeLogger();
+  });
+
+  describe("given the upstream returns 200", () => {
+    describe("when the adapter executes a request", () => {
+      /** @scenario HTTP adapter logs successful calls with url, method, status, latency */
+      it("emits an info entry with url, method, statusCode, durationMs", async () => {
+        mockSsrfSafeFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: vi.fn().mockResolvedValue({ response: "ok" }),
+          text: vi.fn().mockResolvedValue("ok"),
+        } as unknown as Awaited<ReturnType<typeof ssrfSafeFetch>>);
+
+        const adapter = new SerializedHttpAgentAdapter(
+          defaultConfig,
+          logger as unknown as ConstructorParameters<
+            typeof SerializedHttpAgentAdapter
+          >[1],
+        );
+
+        await adapter.call(defaultInput);
+
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: "https://api.example.com/chat",
+            method: "POST",
+            statusCode: 200,
+            durationMs: expect.any(Number),
+          }),
+          "http call ok",
+        );
+      });
+    });
+  });
+
+  describe("given the upstream returns 503 with a body", () => {
+    describe("when the adapter executes a request", () => {
+      /** @scenario HTTP adapter logs non-2xx responses with body preview */
+      it("emits a warn entry with statusCode and a responseBodyPreview", async () => {
+        mockSsrfSafeFetch.mockResolvedValue({
+          ok: false,
+          status: 503,
+          statusText: "Service Unavailable",
+          headers: new Headers({ "content-type": "text/plain" }),
+          json: vi.fn(),
+          text: vi.fn().mockResolvedValue("upstream busy"),
+        } as unknown as Awaited<ReturnType<typeof ssrfSafeFetch>>);
+
+        const adapter = new SerializedHttpAgentAdapter(
+          defaultConfig,
+          logger as unknown as ConstructorParameters<
+            typeof SerializedHttpAgentAdapter
+          >[1],
+        );
+
+        await expect(adapter.call(defaultInput)).rejects.toThrow(/HTTP 503/);
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: "https://api.example.com/chat",
+            method: "POST",
+            statusCode: 503,
+            durationMs: expect.any(Number),
+            responseBodyPreview: expect.stringContaining("upstream busy"),
+          }),
+          "http call failed",
+        );
+      });
+    });
+  });
+
+  describe("given the network call rejects with ECONNREFUSED", () => {
+    describe("when the adapter executes a request", () => {
+      /** @scenario HTTP adapter logs network failures with error class */
+      it("emits an error entry with errorClass and message", async () => {
+        mockSsrfSafeFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+        const adapter = new SerializedHttpAgentAdapter(
+          defaultConfig,
+          logger as unknown as ConstructorParameters<
+            typeof SerializedHttpAgentAdapter
+          >[1],
+        );
+
+        await expect(adapter.call(defaultInput)).rejects.toThrow(
+          "ECONNREFUSED",
+        );
+
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: "https://api.example.com/chat",
+            method: "POST",
+            errorClass: "Error",
+            message: "ECONNREFUSED",
+          }),
+          "http call failed",
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/http-agent.adapter.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/http-agent.adapter.ts
@@ -101,7 +101,7 @@ export class SerializedHttpAgentAdapter extends AgentAdapter {
   ): Promise<unknown> {
     const method = this.config.method.toUpperCase();
     const startedAt = Date.now();
-    let response: Response;
+    let response: Awaited<ReturnType<typeof ssrfSafeFetch>>;
     try {
       response = await ssrfSafeFetch(url, {
         method,

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/http-agent.adapter.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/http-agent.adapter.ts
@@ -17,6 +17,22 @@ import {
 } from "../http-template-engine";
 import { injectTraceContextHeaders } from "../trace-context-headers";
 import type { HttpAgentData } from "../types";
+import { createChildProcessLogger } from "../child-logger";
+import type { Logger } from "~/utils/logger/server";
+
+/**
+ * Truncate a response body for log inclusion. Long bodies are useless in
+ * CloudWatch and explode log volume; the prefix is enough to spot the
+ * upstream's failure mode.
+ */
+const RESPONSE_BODY_PREVIEW_CHARS = 512;
+
+function previewResponseBody(body: string): string {
+  if (body.length <= RESPONSE_BODY_PREVIEW_CHARS) {
+    return body;
+  }
+  return `${body.slice(0, RESPONSE_BODY_PREVIEW_CHARS)}…`;
+}
 
 /**
  * Serialized HTTP agent adapter that uses pre-fetched configuration.
@@ -26,12 +42,15 @@ export class SerializedHttpAgentAdapter extends AgentAdapter {
   role = AgentRole.AGENT;
 
   private readonly config: HttpAgentData;
+  private readonly logger: Logger;
   private capturedTraceId: string | undefined;
 
-  constructor(config: HttpAgentData) {
+  constructor(config: HttpAgentData, logger?: Logger) {
     super();
     this.name = "SerializedHttpAgentAdapter";
     this.config = config;
+    this.logger =
+      logger ?? createChildProcessLogger("langwatch:scenarios:http-adapter");
   }
 
   /** Returns the trace ID captured during the most recent HTTP request. */
@@ -81,15 +100,57 @@ export class SerializedHttpAgentAdapter extends AgentAdapter {
     body: string,
   ): Promise<unknown> {
     const method = this.config.method.toUpperCase();
-    const response = await ssrfSafeFetch(url, {
-      method,
-      headers,
-      body: method !== "GET" ? body : undefined,
-    });
+    const startedAt = Date.now();
+    let response: Response;
+    try {
+      response = await ssrfSafeFetch(url, {
+        method,
+        headers,
+        body: method !== "GET" ? body : undefined,
+      });
+    } catch (error) {
+      const errorClass =
+        error instanceof Error ? error.constructor.name : typeof error;
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        {
+          url,
+          method,
+          errorClass,
+          message,
+          durationMs: Date.now() - startedAt,
+        },
+        "http call failed",
+      );
+      throw error;
+    }
+
+    const durationMs = Date.now() - startedAt;
 
     if (!response.ok) {
+      const responseBody = await response.text().catch(() => "");
+      this.logger.warn(
+        {
+          url,
+          method,
+          statusCode: response.status,
+          durationMs,
+          responseBodyPreview: previewResponseBody(responseBody),
+        },
+        "http call failed",
+      );
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
+
+    this.logger.info(
+      {
+        url,
+        method,
+        statusCode: response.status,
+        durationMs,
+      },
+      "http call ok",
+    );
 
     const contentType = response.headers.get("content-type");
     if (contentType?.includes("application/json")) {

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/http-agent.adapter.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/http-agent.adapter.ts
@@ -128,7 +128,10 @@ export class SerializedHttpAgentAdapter extends AgentAdapter {
     const durationMs = Date.now() - startedAt;
 
     if (!response.ok) {
-      const responseBody = await response.text().catch(() => "");
+      const responseBody =
+        typeof response.text === "function"
+          ? await response.text().catch(() => "")
+          : "";
       this.logger.warn(
         {
           url,

--- a/langwatch/src/server/scenarios/execution/serialized-adapters/http-agent.adapter.ts
+++ b/langwatch/src/server/scenarios/execution/serialized-adapters/http-agent.adapter.ts
@@ -35,6 +35,20 @@ function previewResponseBody(body: string): string {
 }
 
 /**
+ * Strip query string before logging. URL templates can interpolate
+ * user-supplied secrets (?api_key=…, ?access_token=…) and CloudWatch
+ * persists every log line — drop the query so credentials don't leak.
+ */
+function redactUrlForLogs(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Serialized HTTP agent adapter that uses pre-fetched configuration.
  * No database access required.
  */
@@ -101,6 +115,7 @@ export class SerializedHttpAgentAdapter extends AgentAdapter {
   ): Promise<unknown> {
     const method = this.config.method.toUpperCase();
     const startedAt = Date.now();
+    const loggedUrl = redactUrlForLogs(url);
     let response: Awaited<ReturnType<typeof ssrfSafeFetch>>;
     try {
       response = await ssrfSafeFetch(url, {
@@ -114,7 +129,7 @@ export class SerializedHttpAgentAdapter extends AgentAdapter {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(
         {
-          url,
+          url: loggedUrl,
           method,
           errorClass,
           message,
@@ -134,7 +149,7 @@ export class SerializedHttpAgentAdapter extends AgentAdapter {
           : "";
       this.logger.warn(
         {
-          url,
+          url: loggedUrl,
           method,
           statusCode: response.status,
           durationMs,
@@ -147,7 +162,7 @@ export class SerializedHttpAgentAdapter extends AgentAdapter {
 
     this.logger.info(
       {
-        url,
+        url: loggedUrl,
         method,
         statusCode: response.status,
         durationMs,

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -38,6 +38,10 @@ import { CHILD_PROCESS, SCENARIO_WORKER } from "./scenario.constants";
 import { ScenarioFailureHandler, type FailureEventParams } from "./scenario-failure-handler";
 import { ScenarioService } from "./scenario.service";
 import { resolveChildProcessSpawn } from "./execution/child-process-spawn";
+import {
+  encodeScenarioLogContext,
+  SCENARIO_LOG_CONTEXT_ENV,
+} from "./execution/child-logger";
 
 // ============================================================================
 // Dependency Interfaces (Dependency Inversion Principle)
@@ -316,11 +320,19 @@ async function spawnScenarioChildProcess(
     };
 
     const otelResourceAttrs = buildOtelResourceAttributes(childProcessData.scenario.labels);
+    const logContext = encodeScenarioLogContext({
+      scenarioRunId: jobData.scenarioRunId,
+      batchRunId,
+      projectId,
+      scenarioId,
+      setId,
+    });
     const childEnv = buildChildProcessEnv({
       LANGWATCH_API_KEY: telemetry.apiKey,
       LANGWATCH_ENDPOINT: telemetry.endpoint,
       SCENARIO_HEADLESS: "true",
       OTEL_RESOURCE_ATTRIBUTES: otelResourceAttrs,
+      [SCENARIO_LOG_CONTEXT_ENV]: logContext,
     });
 
     const packageRoot = path.resolve(__dirname, "../../..");

--- a/specs/scenarios/observability-context.feature
+++ b/specs/scenarios/observability-context.feature
@@ -1,0 +1,59 @@
+Feature: Scenario worker logs carry the parent's logger context
+  As an SRE diagnosing a failing scenario run from CloudWatch Insights
+  I need every log line emitted by the worker (parent + child + adapter)
+  So I can grep one scenarioRunId and reconstruct the full lifecycle
+  without reading multi-line stderr blobs.
+
+  Background: tracking lw#3593. Three concrete gaps surfaced during a
+  recent investigation:
+    1. http-agent.adapter.ts had zero logging on either path.
+    2. scenario-child-process.ts used console.error (unstructured).
+    3. The parent's logger.child({ scenarioRunId, batchRunId, projectId })
+       didn't cross the parent → child boundary.
+
+  The fix: serialize the parent's context to env, rebuild the child's
+  base logger from it, and replace console.error with structured logs.
+  The HTTP adapter logs every call (success or failure) at info level.
+
+  @unit
+  Scenario: child process logger inherits the parent's context bindings
+    Given the parent serializes context {projectId, batchRunId, scenarioRunId}
+      into the LANGWATCH_LOG_CONTEXT env var
+    When the child reads the env var
+    Then createChildLogger returns a logger whose bindings include all 3 keys
+
+  @unit
+  Scenario: child process tolerates missing context env var
+    Given LANGWATCH_LOG_CONTEXT is unset
+    When the child requests its base logger
+    Then a logger is returned without bindings and without throwing
+
+  @unit
+  Scenario: child process tolerates invalid context JSON
+    Given LANGWATCH_LOG_CONTEXT contains malformed JSON
+    When the child requests its base logger
+    Then a logger is returned without bindings and a warning is emitted
+
+  @unit
+  Scenario: HTTP adapter logs successful calls with url, method, status, latency
+    Given a SerializedHttpAgentAdapter pointed at a server that returns 200
+    When the adapter executes a request
+    Then the logger receives an "http call ok" info entry
+      with fields {url, method, statusCode, durationMs}
+
+  @unit
+  Scenario: HTTP adapter logs non-2xx responses with body preview
+    Given a SerializedHttpAgentAdapter pointed at a server that returns 503
+      with response body "upstream busy"
+    When the adapter executes a request
+    Then the logger receives an "http call failed" warn entry
+      with fields {url, method, statusCode, durationMs, responseBodyPreview}
+      and the preview contains "upstream busy"
+
+  @unit
+  Scenario: HTTP adapter logs network failures with error class
+    Given a SerializedHttpAgentAdapter where ssrfSafeFetch throws "ECONNREFUSED"
+    When the adapter executes a request
+    Then the logger receives an "http call failed" error entry
+      with fields {url, method, errorClass}
+      and errorClass equals "Error"


### PR DESCRIPTION
## Summary

Closes #3593.

Three observability gaps surfaced during a recent investigation:

1. `http-agent.adapter.ts` had zero logging on either path. On non-2xx it threw `HTTP {status}: {statusText}` and discarded url, response body, latency.
2. `scenario-child-process.ts` used `console.error`; stderr arrived at the parent as a multi-line blob inside one log event, not searchable JSON.
3. The parent's `logger.child({ scenarioRunId, batchRunId, projectId })` didn't cross the parent → child process boundary, so even structured child logs would have been unjoinable to parent events.

## What changed

- **`execution/child-logger.ts` (new):** `encodeScenarioLogContext` serializes the context to `LANGWATCH_LOG_CONTEXT` env, `decodeScenarioLogContext` rebuilds it on the child side; `createChildProcessLogger` returns a base logger bound to those fields. Tolerates missing/malformed input — never throws.
- **Wires the env var** into `buildChildProcessEnv` in `scenario.processor.ts` so every child inherits its parent's bindings.
- **Replaces `console.error`** in `scenario-child-process.ts` with the new logger (info/warn/debug/error as appropriate).
- **Adds structured logging** to `SerializedHttpAgentAdapter`:
  - `info "http call ok"` with `{url, method, statusCode, durationMs}`
  - `warn "http call failed"` with `{..., responseBodyPreview}` on non-2xx (body truncated to 512 chars)
  - `error "http call failed"` with `{..., errorClass, message}` on rejection

  Adapter accepts an optional logger for testability; defaults derive from the env-bound child logger so production wires the context through automatically.

## Tests

6 unit scenarios in `specs/scenarios/observability-context.feature` with matching `@scenario`-bound tests:

- `child-logger.unit.test.ts` — context bindings, missing env var, malformed JSON, encode/decode round-trip
- `http-agent.adapter.logging.unit.test.ts` — 200 success, 503 with body preview, ECONNREFUSED with errorClass

## Test plan

- [ ] CI green (typecheck, unit tests, feature-parity)
- [ ] Spot-check CloudWatch in staging: filter `@message like /<runId>/` returns parent + child + adapter events for one scenario run

# Related Issue

- Resolve #3593