### PR TITLE
feat(simulations): inline audio player for input_audio / audio message parts

### DIFF
--- a/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -10,11 +10,31 @@ import { safeJsonParseOrStringFallback } from "./utils/safe-json-parse-or-string
 
 type RawMessage = ScenarioMessageSnapshotEvent["messages"][number];
 
-type DisplayItem =
+export type DisplayItem =
   | { kind: "text"; id: string; role: string; content: string; traceId?: string }
   | { kind: "image"; id: string; src: string; traceId?: string }
+  | {
+      kind: "audio";
+      id: string;
+      role: string;
+      src: string;
+      missing: boolean;
+      traceId?: string;
+    }
   | { kind: "tool_call"; id: string; name: string; arguments: unknown; traceId?: string }
   | { kind: "tool_result"; id: string; result: unknown; traceId?: string };
+
+/**
+ * Audio data shorter than this is treated as missing — Scenario sometimes
+ * truncates payloads when caps trigger, and a 1-byte WAV is a broken player
+ * waiting to happen. Tuned by eye; if it ever rejects a real short clip we
+ * can lower it.
+ */
+const MIN_AUDIO_BASE64_CHARS = 100;
+
+function buildAudioDataUrl(data: string, format: string | undefined): string {
+  return `data:audio/${format ?? "wav"};base64,${data}`;
+}
 
 interface ScenarioMessageRendererProps {
   messages: ScenarioMessageSnapshotEvent["messages"];
@@ -108,6 +128,37 @@ export function ScenarioMessageRenderer({
               </VStack>
             );
 
+          case "audio":
+            return (
+              <VStack
+                key={item.id}
+                align={item.role === "assistant" ? "flex-start" : "flex-end"}
+                gap={1}
+              >
+                {item.missing ? (
+                  <Box
+                    border="1px solid"
+                    borderColor="border"
+                    borderRadius="lg"
+                    paddingX={3}
+                    paddingY={2}
+                    fontSize="xs"
+                    color="fg.muted"
+                  >
+                    (audio data missing)
+                  </Box>
+                ) : (
+                  <Box maxW="320px">
+                    {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+                    <audio controls src={item.src} style={{ width: "100%" }} />
+                  </Box>
+                )}
+                {!smallerView && item.traceId && item.role === "assistant" && (
+                  <TraceMessage traceId={item.traceId} />
+                )}
+              </VStack>
+            );
+
           case "tool_call":
             return (
               <VStack key={item.id} align="flex-start" gap={2}>
@@ -175,7 +226,12 @@ export function ScenarioMessageRenderer({
 // Flatten raw scenario messages + streaming into DisplayItems
 // ---------------------------------------------------------------------------
 
-function flattenMessages(
+/**
+ * Convert raw scenario messages (and any in-flight streaming buffers) into
+ * the flat list of `DisplayItem`s the renderer iterates over. Exported for
+ * unit testing — the renderer's render path is pure once this returns.
+ */
+export function flattenMessages(
   messages: ScenarioMessageSnapshotEvent["messages"],
   streamingMessages?: StreamingMessage[],
 ): DisplayItem[] {
@@ -253,6 +309,22 @@ function flattenMixed(content: any[], msg: RawMessage): DisplayItem[] {
       items.push({ kind: "image", id: `${msg.id}-img${i}`, src: item.image_url.url, traceId: msg.trace_id });
     } else if (typeof item === "object" && item.image) {
       items.push({ kind: "image", id: `${msg.id}-img${i}`, src: item.image, traceId: msg.trace_id });
+    } else if (
+      typeof item === "object" &&
+      (item.type === "input_audio" || item.type === "audio")
+    ) {
+      const payload =
+        (item.input_audio as { data?: string; format?: string } | undefined) ??
+        (item.audio as { data?: string; format?: string } | undefined);
+      const data = payload?.data ?? "";
+      items.push({
+        kind: "audio",
+        id: `${msg.id}-aud${i}`,
+        role: msg.role ?? "user",
+        src: buildAudioDataUrl(data, payload?.format),
+        missing: data.length < MIN_AUDIO_BASE64_CHARS,
+        traceId: msg.trace_id,
+      });
     } else if (item.type === "tool_use" || item.type === "tool_call") {
       items.push({ kind: "tool_call", id: `${msg.id}-tu${i}`, name: item.name ?? item.toolName ?? "tool", arguments: item.arguments ?? item.input ?? item.args, traceId: msg.trace_id });
     } else if (item.type === "tool_result") {

--- a/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -313,9 +313,9 @@ function flattenMixed(content: any[], msg: RawMessage): DisplayItem[] {
       typeof item === "object" &&
       (item.type === "input_audio" || item.type === "audio")
     ) {
-      const payload =
-        (item.input_audio as { data?: string; format?: string } | undefined) ??
-        (item.audio as { data?: string; format?: string } | undefined);
+      const payload = (
+        item.type === "input_audio" ? item.input_audio : item.audio
+      ) as { data?: string; format?: string } | undefined;
       const data = payload?.data ?? "";
       items.push({
         kind: "audio",

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.audio.unit.test.ts
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.audio.unit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the audio-content-part flattening path in
+ * ScenarioMessageRenderer (lw#3552).
+ *
+ * @see specs/scenarios/inline-audio-player.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  flattenMessages,
+  type DisplayItem,
+} from "../ScenarioMessageRenderer";
+import type { ScenarioMessageSnapshotEvent } from "~/server/scenarios/scenario-event.types";
+
+type RawMessage = ScenarioMessageSnapshotEvent["messages"][number];
+
+const LONG_BASE64 = "U".repeat(200);
+
+function makeAudioMessage(
+  type: "input_audio" | "audio",
+  data: string,
+  format: string | undefined,
+  role: RawMessage["role"] = "user",
+): RawMessage {
+  const part: Record<string, unknown> = { type };
+  const payload: Record<string, unknown> = { data };
+  if (format !== undefined) {
+    payload.format = format;
+  }
+  part[type] = payload;
+  return {
+    id: `msg-${type}`,
+    role,
+    content: [part as unknown],
+  } as unknown as RawMessage;
+}
+
+function audioItems(items: DisplayItem[]): Extract<DisplayItem, { kind: "audio" }>[] {
+  return items.filter(
+    (i): i is Extract<DisplayItem, { kind: "audio" }> => i.kind === "audio",
+  );
+}
+
+describe("ScenarioMessageRenderer flatten — audio (lw#3552)", () => {
+  describe("given an OpenAI-style input_audio content part", () => {
+    /** @scenario detects an OpenAI-style input_audio content part */
+    it("emits a single audio entry with a wav data URL", () => {
+      const items = flattenMessages([
+        makeAudioMessage("input_audio", LONG_BASE64, "wav"),
+      ]);
+      const audio = audioItems(items);
+      expect(audio).toHaveLength(1);
+      expect(audio[0]!.src.startsWith("data:audio/wav;base64,")).toBe(true);
+      expect(audio[0]!.src.endsWith(LONG_BASE64)).toBe(true);
+      expect(audio[0]!.missing).toBe(false);
+    });
+  });
+
+  describe("given an alternate-provider audio content part", () => {
+    /** @scenario detects an alternate-provider audio content part */
+    it("emits an audio entry with the provider's format", () => {
+      const items = flattenMessages([
+        makeAudioMessage("audio", LONG_BASE64, "mp3"),
+      ]);
+      const audio = audioItems(items);
+      expect(audio).toHaveLength(1);
+      expect(audio[0]!.src.startsWith("data:audio/mp3;base64,")).toBe(true);
+    });
+  });
+
+  describe("given the SDK omits format on the audio payload", () => {
+    /** @scenario defaults format to wav when the SDK omits it */
+    it("falls back to wav in the data URL", () => {
+      const items = flattenMessages([
+        makeAudioMessage("input_audio", LONG_BASE64, undefined),
+      ]);
+      const audio = audioItems(items);
+      expect(audio).toHaveLength(1);
+      expect(audio[0]!.src.startsWith("data:audio/wav;base64,")).toBe(true);
+    });
+  });
+
+  describe("given a suspiciously short audio payload", () => {
+    /** @scenario marks suspiciously short payloads as missing */
+    it("flags the audio entry as missing", () => {
+      const items = flattenMessages([
+        makeAudioMessage("input_audio", "x", "wav"),
+      ]);
+      const audio = audioItems(items);
+      expect(audio).toHaveLength(1);
+      expect(audio[0]!.missing).toBe(true);
+    });
+  });
+
+  describe("given a mixed-content message (text + audio)", () => {
+    /** @scenario keeps text alongside audio in mixed-content messages */
+    it("emits both a text entry and an audio entry", () => {
+      const mixed = {
+        id: "msg-mixed",
+        role: "user",
+        content: [
+          { type: "text", text: "hi" },
+          {
+            type: "input_audio",
+            input_audio: { data: LONG_BASE64, format: "wav" },
+          },
+        ],
+      } as unknown as RawMessage;
+
+      const items = flattenMessages([mixed]);
+      const text = items.find((i) => i.kind === "text");
+      const audio = items.find((i) => i.kind === "audio");
+      expect(text && (text as { content: string }).content).toBe("hi");
+      expect(audio).toBeDefined();
+    });
+  });
+});

--- a/specs/scenarios/inline-audio-player.feature
+++ b/specs/scenarios/inline-audio-player.feature
@@ -1,0 +1,46 @@
+Feature: Inline audio playback in the scenario message viewer
+  As an engineer reviewing a voice-agent simulation in LangWatch
+  I need an inline player whenever a message has an `input_audio` / `audio`
+  content part
+  So I can hear what was said without copy-pasting base64 into a tool.
+
+  Background: tracking lw#3552. The Scenario SDK ships voice conversations
+  via OpenAI-style multimodal content parts (`type: "input_audio"`,
+  base64-encoded WAV). Without a player, the simulation viewer dumps the
+  entire base64 blob inline as JSON.
+
+  @unit
+  Scenario: detects an OpenAI-style input_audio content part
+    Given a message with content
+      [{type: "input_audio", input_audio: {data: "<base64>", format: "wav"}}]
+    When ScenarioMessageRenderer flattens the message
+    Then the resulting items contain a single audio entry with
+      src starting "data:audio/wav;base64,"
+
+  @unit
+  Scenario: detects an alternate-provider audio content part
+    Given a message with content
+      [{type: "audio", audio: {data: "<base64>", format: "mp3"}}]
+    When ScenarioMessageRenderer flattens the message
+    Then the resulting items contain an audio entry with
+      src starting "data:audio/mp3;base64,"
+
+  @unit
+  Scenario: defaults format to wav when the SDK omits it
+    Given a message with content
+      [{type: "input_audio", input_audio: {data: "<base64>"}}]
+    When ScenarioMessageRenderer flattens the message
+    Then the audio entry's src starts "data:audio/wav;base64,"
+
+  @unit
+  Scenario: marks suspiciously short payloads as missing
+    Given a message whose audio data field contains "x" (1 char)
+    When ScenarioMessageRenderer flattens the message
+    Then the resulting audio entry has missing=true
+
+  @unit
+  Scenario: keeps text alongside audio in mixed-content messages
+    Given a message with content
+      [{type: "text", text: "hi"}, {type: "input_audio", input_audio: {data: "<base64>", format: "wav"}}]
+    When ScenarioMessageRenderer flattens the message
+    Then the resulting items contain a text entry "hi" AND an audio entry


### PR DESCRIPTION
## Summary

Closes #3552.

Voice agents on the Scenario SDK ship messages with `input_audio` / `audio` content parts (base64-encoded WAV by default). Without a player, the simulation viewer dumps the entire base64 blob inline as JSON.

## What changed

`langwatch/src/components/simulations/ScenarioMessageRenderer.tsx`:

- Extends `DisplayItem` with an `audio` kind (`id`, `role`, `src` data URL, `missing` flag, `traceId`).
- Detects `type: "input_audio"` (OpenAI multimodal) and `type: "audio"` (alternate providers) in `flattenMixed`; pulls data from `part.input_audio.data` or `part.audio.data`; falls back to `wav` when format is omitted.
- Renders a native `<audio controls>` bound to a `data:audio/<format>;base64,<data>` URL. Suspiciously short payloads (<100 chars of base64) render an inert "(audio data missing)" placeholder instead of a broken player.
- Mixed-content messages keep both text and audio entries — the existing text/tool_call/image branches are untouched.
- Exports `flattenMessages` + `DisplayItem` so the flatten path is unit-testable without rendering Chakra.

Trace viewer audio support is intentionally out of scope here — the simulation viewer is the one explicitly named in the issue and the only place voice agents currently appear.

## Tests

5 unit scenarios in `specs/scenarios/inline-audio-player.feature` with matching `@scenario`-bound tests:

- OpenAI-style `input_audio` detection (wav)
- Alternate-provider `audio` detection (mp3)
- Format defaults to `wav` when omitted
- Short payloads marked `missing: true`
- Mixed text + audio content keeps both items

## Test plan

- [ ] CI green (typecheck, unit tests, feature-parity)
- [ ] Manual: simulation viewer renders a play/pause/seek control on a real voice scenario run

# Related Issue

- Resolve #3552