### PR TITLE
fix(filters): cancel useDebounceValue on FieldsFilter unmount (CI flake)

### DIFF
--- a/langwatch/src/components/filters/FieldsFilters.tsx
+++ b/langwatch/src/components/filters/FieldsFilters.tsx
@@ -178,6 +178,15 @@ function FieldsFilter({
 
 	const searchRef = React.useRef<HTMLInputElement | null>(null);
 	const [query, setQuery] = useDebounceValue("", 300);
+	// Cancel pending debounced setState on unmount. Without this, a trailing
+	// fire after teardown (e.g. in vitest workers tearing down jsdom) calls
+	// setState on an unmounted tree → "ReferenceError: window is not defined"
+	// inside react-dom's debounced scheduler.
+	useEffect(() => {
+		return () => {
+			setQuery.cancel();
+		};
+	}, [setQuery]);
 	const [immediateQuery, setImmediateQuery] = useState("");
 	const { open, setOpen } = useDisclosure();
 	const current = filters?.[filterId] ?? [];


### PR DESCRIPTION
## Summary

The `useDebounceValue("", 300)` setter in `FieldsFilters` retained a trailing timer past component unmount. In vitest workers tearing down jsdom, the trailing setState fired against an unmounted tree, hitting react-dom's scheduler which assumes `window` exists — producing `ReferenceError: window is not defined` as an Unhandled Error and failing `langwatch-app-ci > test-integration` intermittently.

## How I found it

Reproduced on PR #3781 across two retriggers (audio-player feature, no React changes). The test that originates the trailing fire is `SeriesFiltersDrawer.integration.test.tsx` (mounts SeriesFiltersDrawer → FieldsFilters → useDebounceValue).

Stack from the failing job:
```
ReferenceError: window is not defined
  ❯ resolveUpdatePriority react-dom-client.development.js:1308:7
  ❯ requestUpdateLane     react-dom-client.development.js:16345:11
  ❯ dispatchSetState      react-dom-client.development.js:9126:14
  ❯ invokeFunc            lodash.debounce/index.js:160:19
  ❯ trailingEdge          lodash.debounce/index.js:207:14
This error originated in "src/components/__tests__/SeriesFiltersDrawer.integration.test.tsx"
```

## Fix

Cancel the debounced setter in a `useEffect` cleanup so trailing fires can't outlive the component.

```diff
 const [query, setQuery] = useDebounceValue("", 300);
+useEffect(() => {
+  return () => {
+    setQuery.cancel();
+  };
+}, [setQuery]);
```

`DebouncedState<T>` from `usehooks-ts` extends `ControlFunctions` which exposes `cancel`.

## Test plan

- [ ] CI green on this branch (verifies the fix doesn't break anything)
- [ ] PR #3781's CI re-run after this lands stops flaking on `SeriesFiltersDrawer`