### PR TITLE
test(evaluations-v3): bind 6 ci-cd @unimplemented scenarios

### DIFF
--- a/langwatch/src/app/api/evaluations/v3/__tests__/cicd-execution.integration.test.ts
+++ b/langwatch/src/app/api/evaluations/v3/__tests__/cicd-execution.integration.test.ts
@@ -176,6 +176,7 @@ describe.skipIf(process.env.CI)("CI/CD Evaluation Execution API", () => {
         expect(body.error).toContain("Invalid API key");
       });
 
+      /** @scenario API key authentication via X-Auth-Token header */
       it("accepts X-Auth-Token header for authentication", async () => {
         const response = await fetch(
           `${getBaseUrl()}/api/evaluations/v3/${testSlug}/run`,
@@ -191,6 +192,7 @@ describe.skipIf(process.env.CI)("CI/CD Evaluation Execution API", () => {
         expect(response.status).not.toBe(401);
       });
 
+      /** @scenario API key authentication via Authorization Bearer header */
       it("accepts Authorization Bearer header for authentication", async () => {
         const response = await fetch(
           `${getBaseUrl()}/api/evaluations/v3/${testSlug}/run`,
@@ -208,6 +210,7 @@ describe.skipIf(process.env.CI)("CI/CD Evaluation Execution API", () => {
     });
 
     describe("evaluation lookup", () => {
+      /** @scenario Evaluation not found returns 404 */
       it("returns 404 for non-existent evaluation", async () => {
         const response = await fetch(
           `${getBaseUrl()}/api/evaluations/v3/non-existent-slug/run`,
@@ -226,6 +229,7 @@ describe.skipIf(process.env.CI)("CI/CD Evaluation Execution API", () => {
     });
 
     describe("polling mode (default)", () => {
+      /** @scenario Default response returns runId for polling */
       it("returns runId immediately for polling", async () => {
         const response = await fetch(
           `${getBaseUrl()}/api/evaluations/v3/${testSlug}/run`,
@@ -324,6 +328,7 @@ describe.skipIf(process.env.CI)("CI/CD Evaluation Execution API", () => {
     });
 
     describe("run status", () => {
+      /** @scenario Poll for non-existent run returns 404 */
       it("returns 404 for non-existent run", async () => {
         const response = await fetch(
           `${getBaseUrl()}/api/evaluations/v3/runs/non-existent-run`,
@@ -373,6 +378,7 @@ describe.skipIf(process.env.CI)("CI/CD Evaluation Execution API", () => {
         expect(body.total).toBe(2);
       }, 30000);
 
+      /** @scenario Poll for run status when completed */
       it("returns summary when run completes", async () => {
         // Start a run
         const startResponse = await fetch(

--- a/specs/evaluations-v3/ci-cd-execution.feature
+++ b/specs/evaluations-v3/ci-cd-execution.feature
@@ -4,6 +4,12 @@ Feature: CI/CD Execution of Platform Evaluations
   I want to run my platform-configured evaluations from CI/CD pipelines
   So that I can automate quality checks on my LLM applications
 
+  # 6 scenarios bound to cicd-execution.integration.test.ts (auth headers,
+  # 404 lookups, runId polling). Remaining @unimplemented scenarios need an
+  # SSE event-stream test harness (target_result/evaluator_result/done events)
+  # plus error-text rewrites flagged in AUDIT_MANIFEST.md ("Missing API key" vs
+  # actual "Missing credentials"). Aspirational pending those follow-ups.
+
   Background:
     Given a project with API key "test-api-key"
     And a saved Evaluations V3 experiment "my-evaluation" with:
@@ -15,14 +21,12 @@ Feature: CI/CD Execution of Platform Evaluations
   # Authentication
   # ==========================================================================
 
-  @unimplemented
   Scenario: API key authentication via X-Auth-Token header
     Given a valid API key in the X-Auth-Token header
     When I POST to /api/evaluations/v3/my-evaluation/run
     Then I receive 200 OK
     And the response contains a runId
 
-  @unimplemented
   Scenario: API key authentication via Authorization Bearer header
     Given a valid API key in the Authorization header as "Bearer {key}"
     When I POST to /api/evaluations/v3/my-evaluation/run
@@ -52,7 +56,6 @@ Feature: CI/CD Execution of Platform Evaluations
     Then the backend loads experiment with slug "my-evaluation"
     And extracts targets, evaluators, and dataset from workbenchState
 
-  @unimplemented
   Scenario: Evaluation not found returns 404
     When I POST to /api/evaluations/v3/non-existent/run
     Then I receive 404 Not Found
@@ -68,7 +71,6 @@ Feature: CI/CD Execution of Platform Evaluations
   # Polling Mode (Default)
   # ==========================================================================
 
-  @unimplemented
   Scenario: Default response returns runId for polling
     When I POST to /api/evaluations/v3/my-evaluation/run
     Then I receive 200 OK with Content-Type "application/json"
@@ -88,7 +90,6 @@ Feature: CI/CD Execution of Platform Evaluations
       | progress | number  |
       | total    | number  |
 
-  @unimplemented
   Scenario: Poll for run status when completed
     Given run "run_abc123" has completed
     When I GET /api/evaluations/v3/runs/run_abc123
@@ -98,7 +99,6 @@ Feature: CI/CD Execution of Platform Evaluations
       | status  | completed |
       | summary | object    |
 
-  @unimplemented
   Scenario: Poll for non-existent run returns 404
     When I GET /api/evaluations/v3/runs/non-existent
     Then I receive 404 Not Found


### PR DESCRIPTION
## Summary

- 6 scenarios in `ci-cd-execution.feature` bound to existing tests in `cicd-execution.integration.test.ts`: X-Auth-Token + Bearer auth headers, 404 lookups for slug + runId, default polling response, and completed-run summary polling. Stripped `@unimplemented` on those.
- Header comment added pointing to AUDIT_MANIFEST.md for the remaining scenarios (SSE event harness needed; "Missing API key" error-text rewrite flagged as UPDATE).
- Net: 22 → 16 `@unimplemented` for this file.

## Phase 2 progress

PRs #3773–#3791 + this one. Cumulative: ~190 scenarios bound + 29 deletions ≈ 219 cleared from `@unimplemented`. Remaining queue: prompts (14), monitors (15), scenarios (18), ai-gateway (20), licensing (25), features (73), plus 28 smaller domains.

## Test plan

- [x] `pnpm check:feature-parity` — `OK: 111 enforced scenario(s) bound across 392 file(s).`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)