### PR TITLE
feat(scenarios): simulation_set aggregate + ArchiveSetCommand schemas (lw#3636 slice)

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/__tests__/archiveSet.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/__tests__/archiveSet.command.unit.test.ts
@@ -110,4 +110,16 @@ describe("ArchiveSetCommand (lw#3636)", () => {
       });
     });
   });
+
+  describe("given a candidate event with an empty scenarioRunIds array", () => {
+    describe("when SimulationSetArchivedEventSchema.safeParse runs", () => {
+      it("rejects the payload (empty archive is a no-op masquerading as a valid event)", () => {
+        const result = simulationSetArchivedEventDataSchema.safeParse({
+          scenarioSetId: "set-1",
+          scenarioRunIds: [],
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/__tests__/archiveSet.command.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/__tests__/archiveSet.command.unit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for ArchiveSetCommand + SimulationSetArchivedEvent (lw#3636).
+ *
+ * Covers schema parsing, command handler emit, idempotency-key
+ * collapsing, and the corresponding type guard.
+ *
+ * @see specs/event-sourcing/simulation-set-archive.feature
+ */
+
+import { describe, expect, it } from "vitest";
+import { ArchiveSetCommand } from "../commands";
+import type { TenantId } from "../../../domain/tenantId";
+import {
+  simulationSetArchivedEventDataSchema,
+  type SimulationProcessingEvent,
+} from "../schemas/events";
+import { isSimulationSetArchivedEvent } from "../schemas/typeGuards";
+
+function makeArchiveSetCommand(overrides?: {
+  tenantId?: string;
+  scenarioSetId?: string;
+  scenarioRunIds?: string[];
+  occurredAt?: number;
+}) {
+  const tenantId = overrides?.tenantId ?? "tenant-1";
+  return {
+    tenantId: tenantId as TenantId,
+    aggregateId: overrides?.scenarioSetId ?? "set-1",
+    type: "lw.simulation_set.archive" as const,
+    data: {
+      tenantId,
+      occurredAt: overrides?.occurredAt ?? 1700000000000,
+      scenarioSetId: overrides?.scenarioSetId ?? "set-1",
+      scenarioRunIds: overrides?.scenarioRunIds ?? [
+        "run-1",
+        "run-2",
+        "run-3",
+      ],
+    },
+  };
+}
+
+describe("ArchiveSetCommand (lw#3636)", () => {
+  describe("given a tenant archives a set with three runs", () => {
+    describe("when the ArchiveSetCommand handler runs", () => {
+      /** @scenario ArchiveSetCommand emits a SimulationSetArchived event with the snapshotted run ids */
+      it("emits a single SimulationSetArchived event carrying the runs", async () => {
+        const handler = new ArchiveSetCommand();
+        const events = await handler.handle(makeArchiveSetCommand());
+
+        expect(events).toHaveLength(1);
+        const [event] = events;
+        expect(event!.type).toBe("lw.simulation_set.archived");
+        expect(event!.aggregateType).toBe("simulation_set");
+        expect(event!.aggregateId).toBe("set-1");
+        expect(event!.data).toEqual({
+          scenarioSetId: "set-1",
+          scenarioRunIds: ["run-1", "run-2", "run-3"],
+        });
+      });
+    });
+  });
+
+  describe("given two ArchiveSetCommand invocations for the same scenarioSetId", () => {
+    describe("when idempotency keys are computed", () => {
+      /** @scenario ArchiveSetCommand idempotency key collapses retries on the same set */
+      it("collapses both invocations to the same idempotency key", async () => {
+        const handler = new ArchiveSetCommand();
+        const a = await handler.handle(makeArchiveSetCommand({ occurredAt: 1 }));
+        const b = await handler.handle(
+          makeArchiveSetCommand({
+            occurredAt: 2,
+            scenarioRunIds: ["run-1", "run-2", "run-3", "run-4"],
+          }),
+        );
+
+        expect(a[0]!.idempotencyKey).toBe(b[0]!.idempotencyKey);
+        expect(a[0]!.idempotencyKey).toBe("tenant-1:set-1:archiveSet");
+      });
+    });
+  });
+
+  describe("given a SimulationProcessingEvent of type lw.simulation_set.archived", () => {
+    describe("when the type guard runs", () => {
+      /** @scenario isSimulationSetArchivedEvent narrows the event type */
+      it("returns true and narrows to SimulationSetArchivedEvent", async () => {
+        const handler = new ArchiveSetCommand();
+        const [event] = await handler.handle(makeArchiveSetCommand());
+        const candidate = event as unknown as SimulationProcessingEvent;
+        expect(isSimulationSetArchivedEvent(candidate)).toBe(true);
+        if (isSimulationSetArchivedEvent(candidate)) {
+          // Type narrowing — these reads compile only when the guard works.
+          expect(candidate.data.scenarioSetId).toBe("set-1");
+          expect(candidate.data.scenarioRunIds).toHaveLength(3);
+        }
+      });
+    });
+  });
+
+  describe("given a candidate event missing the scenarioRunIds field", () => {
+    describe("when SimulationSetArchivedEventSchema.safeParse runs", () => {
+      /** @scenario SimulationSetArchivedEvent rejects payloads missing scenarioRunIds */
+      it("rejects the payload", () => {
+        const result = simulationSetArchivedEventDataSchema.safeParse({
+          scenarioSetId: "set-1",
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands.ts
@@ -8,6 +8,7 @@ import {
   simulationTextMessageEndEventDataSchema,
   simulationRunDeletedEventDataSchema,
   simulationRunCancelRequestedEventDataSchema,
+  simulationSetArchivedEventDataSchema,
 } from "./schemas/events";
 
 /**
@@ -136,4 +137,31 @@ export const DeleteRunCommand = defineCommand({
     "payload.scenarioRun.id": d.scenarioRunId,
   }),
   makeJobId: (d) => `${d.tenantId}:${d.scenarioRunId}:delete-run`,
+});
+
+/**
+ * Archive a whole scenario set in one shot. One user intent → one event,
+ * instead of N `lw.simulation_run.deleted` events for the same action.
+ *
+ * The aggregate is `simulation_set` (set-scoped); the payload carries the
+ * `scenarioRunIds` that were attached to the set at archive time so replay
+ * is deterministic.
+ *
+ * Wiring this event into the per-run fold projection (so each run's
+ * `ArchivedAt` flips in one pass) is tracked in lw#3636 follow-up — the
+ * dispatcher needs a fanout step from one set event to many run aggregates.
+ */
+export const ArchiveSetCommand = defineCommand({
+  commandType: "lw.simulation_set.archive",
+  eventType: "lw.simulation_set.archived",
+  eventVersion: "2026-05-04",
+  aggregateType: "simulation_set",
+  schema: simulationSetArchivedEventDataSchema,
+  aggregateId: (d) => d.scenarioSetId,
+  idempotencyKey: (d) => `${d.tenantId}:${d.scenarioSetId}:archiveSet`,
+  spanAttributes: (d) => ({
+    "payload.scenarioSet.id": d.scenarioSetId,
+    "payload.scenarioRun.count": d.scenarioRunIds.length,
+  }),
+  makeJobId: (d) => `${d.tenantId}:${d.scenarioSetId}:archive-set`,
 });

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/index.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/index.ts
@@ -9,6 +9,7 @@ export {
   TextMessageEndCommand,
   FinishRunCommand,
   DeleteRunCommand,
+  ArchiveSetCommand,
 } from "./commands";
 export { ComputeRunMetricsCommand } from "./commands/computeRunMetrics.command";
 export type { ComputeRunMetricsDeps } from "./commands/computeRunMetrics.command";

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/commands.ts
@@ -104,7 +104,7 @@ export type DeleteRunCommandData = z.infer<typeof deleteRunCommandDataSchema>;
 export const archiveSetCommandDataSchema = z.object({
   tenantId: z.string(),
   scenarioSetId: z.string(),
-  scenarioRunIds: z.array(z.string()),
+  scenarioRunIds: z.array(z.string()).min(1),
   occurredAt: z.number(),
 });
 export type ArchiveSetCommandData = z.infer<typeof archiveSetCommandDataSchema>;

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/commands.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/commands.ts
@@ -96,3 +96,15 @@ export const deleteRunCommandDataSchema = z.object({
   occurredAt: z.number(),
 });
 export type DeleteRunCommandData = z.infer<typeof deleteRunCommandDataSchema>;
+
+/**
+ * Bulk-archive command. One user intent collapses N runs into one event;
+ * tracks lw#3636.
+ */
+export const archiveSetCommandDataSchema = z.object({
+  tenantId: z.string(),
+  scenarioSetId: z.string(),
+  scenarioRunIds: z.array(z.string()),
+  occurredAt: z.number(),
+});
+export type ArchiveSetCommandData = z.infer<typeof archiveSetCommandDataSchema>;

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/constants.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/constants.ts
@@ -18,6 +18,14 @@ export const SIMULATION_RUN_EVENT_TYPES = {
   CANCEL_REQUESTED: "lw.simulation_run.cancel_requested",
 } as const;
 
+/**
+ * Set-scoped events. The set is the aggregate; payloads reference the
+ * runs the action applies to. See lw#3636.
+ */
+export const SIMULATION_SET_EVENT_TYPES = {
+  ARCHIVED: "lw.simulation_set.archived",
+} as const;
+
 export const SIMULATION_PROCESSING_EVENT_TYPES = [
   SIMULATION_RUN_EVENT_TYPES.QUEUED,
   SIMULATION_RUN_EVENT_TYPES.STARTED,
@@ -28,6 +36,7 @@ export const SIMULATION_PROCESSING_EVENT_TYPES = [
   SIMULATION_RUN_EVENT_TYPES.DELETED,
   SIMULATION_RUN_EVENT_TYPES.METRICS_COMPUTED,
   SIMULATION_RUN_EVENT_TYPES.CANCEL_REQUESTED,
+  SIMULATION_SET_EVENT_TYPES.ARCHIVED,
 ] as const;
 
 export type SimulationProcessingEventType =
@@ -49,6 +58,10 @@ export const SIMULATION_RUN_COMMAND_TYPES = {
   CANCEL: "lw.simulation_run.cancel",
 } as const;
 
+export const SIMULATION_SET_COMMAND_TYPES = {
+  ARCHIVE: "lw.simulation_set.archive",
+} as const;
+
 export const SIMULATION_RUN_PROCESSING_COMMAND_TYPES = [
   SIMULATION_RUN_COMMAND_TYPES.QUEUE,
   SIMULATION_RUN_COMMAND_TYPES.START,
@@ -59,6 +72,7 @@ export const SIMULATION_RUN_PROCESSING_COMMAND_TYPES = [
   SIMULATION_RUN_COMMAND_TYPES.DELETE,
   SIMULATION_RUN_COMMAND_TYPES.COMPUTE_METRICS,
   SIMULATION_RUN_COMMAND_TYPES.CANCEL,
+  SIMULATION_SET_COMMAND_TYPES.ARCHIVE,
 ] as const;
 
 export type SimulationProcessingCommandType =
@@ -77,6 +91,7 @@ export const SIMULATION_EVENT_VERSIONS = {
   DELETED: "2026-02-01",
   METRICS_COMPUTED: "2026-03-27",
   CANCEL_REQUESTED: "2026-04-06",
+  SET_ARCHIVED: "2026-05-04",
 } as const;
 
 /**

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/events.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/events.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { EventSchema } from "../../../domain/types";
-import { SIMULATION_EVENT_VERSIONS, SIMULATION_RUN_EVENT_TYPES } from "./constants";
+import {
+  SIMULATION_EVENT_VERSIONS,
+  SIMULATION_RUN_EVENT_TYPES,
+  SIMULATION_SET_EVENT_TYPES,
+} from "./constants";
 import { simulationMessageSchema, simulationResultsSchema } from "./shared";
 export type { SimulationRunStatus, SimulationVerdict } from "./shared";
 
@@ -179,6 +183,36 @@ export const SimulationRunDeletedEventSchema = EventSchema.extend({
 export type SimulationRunDeletedEvent = z.infer<typeof SimulationRunDeletedEventSchema>;
 
 /**
+ * SetArchived event — emitted when a user archives a whole scenario set.
+ * One user intent → one event carrying the affected runs, instead of N
+ * independent `lw.simulation_run.deleted` events.
+ *
+ * Aggregate is the set (`scenarioSetId`). The fold projection for
+ * `simulation_run` aggregates is currently per-run; wiring this event
+ * through the dispatcher fan-out is tracked separately — see lw#3636.
+ *
+ * Idempotency keys on `(tenantId, scenarioSetId)` so that retrying the
+ * same archive request collapses into a single event.
+ */
+export const simulationSetArchivedEventDataSchema = z.object({
+  scenarioSetId: z.string(),
+  /**
+   * Runs that belonged to the set at archive time. Snapshotted into the
+   * payload so replay produces the same projection state regardless of
+   * later run inserts/deletes.
+   */
+  scenarioRunIds: z.array(z.string()),
+});
+export type SimulationSetArchivedEventData = z.infer<typeof simulationSetArchivedEventDataSchema>;
+
+export const SimulationSetArchivedEventSchema = EventSchema.extend({
+  type: z.literal(SIMULATION_SET_EVENT_TYPES.ARCHIVED),
+  version: z.literal(SIMULATION_EVENT_VERSIONS.SET_ARCHIVED),
+  data: simulationSetArchivedEventDataSchema,
+});
+export type SimulationSetArchivedEvent = z.infer<typeof SimulationSetArchivedEventSchema>;
+
+/**
  * Union of all simulation processing event types.
  */
 export type SimulationProcessingEvent =
@@ -190,7 +224,8 @@ export type SimulationProcessingEvent =
   | SimulationRunFinishedEvent
   | SimulationRunMetricsComputedEvent
   | SimulationRunCancelRequestedEvent
-  | SimulationRunDeletedEvent;
+  | SimulationRunDeletedEvent
+  | SimulationSetArchivedEvent;
 
 export {
   isSimulationRunQueuedEvent,
@@ -202,5 +237,6 @@ export {
   isSimulationRunStartedEvent,
   isSimulationRunMetricsComputedEvent,
   isSimulationRunCancelRequestedEvent,
+  isSimulationSetArchivedEvent,
 } from "./typeGuards";
 

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/events.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/events.ts
@@ -201,7 +201,7 @@ export const simulationSetArchivedEventDataSchema = z.object({
    * payload so replay produces the same projection state regardless of
    * later run inserts/deletes.
    */
-  scenarioRunIds: z.array(z.string()),
+  scenarioRunIds: z.array(z.string()).min(1),
 });
 export type SimulationSetArchivedEventData = z.infer<typeof simulationSetArchivedEventDataSchema>;
 

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/typeGuards.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/schemas/typeGuards.ts
@@ -1,4 +1,4 @@
-import { SIMULATION_RUN_EVENT_TYPES } from "./constants";
+import { SIMULATION_RUN_EVENT_TYPES, SIMULATION_SET_EVENT_TYPES } from "./constants";
 import type {
     SimulationMessageSnapshotEvent,
     SimulationProcessingEvent,
@@ -8,6 +8,7 @@ import type {
     SimulationRunMetricsComputedEvent,
     SimulationRunQueuedEvent,
     SimulationRunStartedEvent,
+    SimulationSetArchivedEvent,
     SimulationTextMessageEndEvent,
     SimulationTextMessageStartEvent,
 } from "./events";
@@ -64,4 +65,10 @@ export function isSimulationRunDeletedEvent(
   event: SimulationProcessingEvent,
 ): event is SimulationRunDeletedEvent {
   return event.type === SIMULATION_RUN_EVENT_TYPES.DELETED;
+}
+
+export function isSimulationSetArchivedEvent(
+  event: SimulationProcessingEvent,
+): event is SimulationSetArchivedEvent {
+  return event.type === SIMULATION_SET_EVENT_TYPES.ARCHIVED;
 }

--- a/langwatch/src/server/event-sourcing/schemas/typeIdentifiers.ts
+++ b/langwatch/src/server/event-sourcing/schemas/typeIdentifiers.ts
@@ -74,6 +74,7 @@ export const AGGREGATE_TYPE_IDENTIFIERS = [
   "evaluation",
   "experiment_run",
   "simulation_run",
+  "simulation_set",
   "suite_run",
   "billing_report",
   "global",

--- a/specs/event-sourcing/simulation-set-archive.feature
+++ b/specs/event-sourcing/simulation-set-archive.feature
@@ -1,0 +1,41 @@
+Feature: One bulk-archive event per set instead of N per-run delete events
+  As an SRE who later replays history to reconstruct a customer's view
+  I need a single `lw.simulation_set.archived` event per set archive
+  So I can answer "who archived what set when?" without clustering N events
+  by setId+timestamp.
+
+  Background: tracking lw#3636. Today archiving a set fans out into N
+  `lw.simulation_run.deleted` events — one user intent producing many
+  events with no audit-time link. The new `simulation_set` aggregate
+  carries the bulk action as one event whose payload snapshots the
+  affected `scenarioRunIds`.
+
+  This slice ships only the schemas + command + type guard. Wiring the
+  event into the per-run fold projection (so each run's `ArchivedAt`
+  flips) requires a dispatcher fanout — tracked as a follow-up.
+
+  @unit
+  Scenario: ArchiveSetCommand emits a SimulationSetArchived event with the snapshotted run ids
+    Given a tenant archives a set with three runs
+    When the ArchiveSetCommand handler runs
+    Then a single event with type "lw.simulation_set.archived" is produced
+    And the event data carries the scenarioSetId
+    And the event data carries all three scenarioRunIds
+
+  @unit
+  Scenario: ArchiveSetCommand idempotency key collapses retries on the same set
+    Given two ArchiveSetCommand invocations for the same scenarioSetId
+    When idempotency keys are computed
+    Then both keys are identical
+
+  @unit
+  Scenario: isSimulationSetArchivedEvent narrows the event type
+    Given a SimulationProcessingEvent of type "lw.simulation_set.archived"
+    When the type guard runs
+    Then it returns true and the event narrows to SimulationSetArchivedEvent
+
+  @unit
+  Scenario: SimulationSetArchivedEvent rejects payloads missing scenarioRunIds
+    Given a candidate event missing the scenarioRunIds field
+    When SimulationSetArchivedEventSchema.safeParse runs
+    Then parsing fails


### PR DESCRIPTION
## Summary

Refs #3636. Schemas + command foundation for the bulk-archive-by-set work.

The current per-run path emits N `lw.simulation_run.deleted` events for one user intent ("archive this set"). The new shape: one `lw.simulation_set.archived` event whose payload snapshots the affected `scenarioRunIds`.

## Scope of this slice

This commit ships only the schemas + command + type guard. Wiring the event into the per-run fold projection (so each run's `ArchivedAt` flips in one pass) requires a dispatcher **fanout** — the dispatcher today routes one event to one aggregate; a set-scoped event needs to fan out to many `simulation_run` projections. That's the next slice and a real architectural change, so it's split out.

Until the fanout lands, the existing `DeleteRunCommand` / `SimulationRunDeletedEvent` path stays in place — **no behavior change yet**.

## Aggregate-strategy decision

A new `simulation_set` aggregate holds the bulk action.

- The set is the natural owner of "who archived me when" — replaying set events alone reconstructs admin actions without per-run noise.
- Idempotency keys collapse to `(tenantId, scenarioSetId)` — same set, same archive intent, one event regardless of retry count.
- Doesn't break the dispatcher's one-aggregate-per-command invariant (the alternate option would have).

## What changed concretely

- `AGGREGATE_TYPE_IDENTIFIERS` gains `simulation_set`.
- `SIMULATION_SET_EVENT_TYPES.ARCHIVED = "lw.simulation_set.archived"`, `SIMULATION_SET_COMMAND_TYPES.ARCHIVE = "lw.simulation_set.archive"`, `SIMULATION_EVENT_VERSIONS.SET_ARCHIVED = "2026-05-04"`.
- `simulationSetArchivedEventDataSchema` + event schema in `schemas/events.ts`.
- Type guard in `schemas/typeGuards.ts`.
- Command-side schema in `schemas/commands.ts`.
- `ArchiveSetCommand` defined via `defineCommand` with the set-scoped aggregate and idempotency key.

## Tests

4 `@unit` scenarios in `specs/event-sourcing/simulation-set-archive.feature` with matching `@scenario`-bound tests:

- ArchiveSetCommand emits a SimulationSetArchived event with the snapshotted run ids
- Idempotency key collapses retries on the same set
- `isSimulationSetArchivedEvent` narrows correctly
- Schema rejects payloads missing `scenarioRunIds`

## Test plan

- [ ] CI green (typecheck, unit, feature-parity)
- [ ] Follow-up slice: dispatcher fanout from set event → many run aggregates, then rewire `DELETE /api/scenario-events?scenarioSetId=<id>` to emit the bulk event

# Related Issue

- Resolve #3636