### PR TITLE
test(monitors-ui): bind 19 scenarios + headers across 12 files

### DIFF
--- a/langwatch/src/components/evaluations/__tests__/GuardrailsDrawer.test.tsx
+++ b/langwatch/src/components/evaluations/__tests__/GuardrailsDrawer.test.tsx
@@ -160,6 +160,7 @@ describe("GuardrailsDrawer + CurrentDrawer Integration (REGRESSION)", () => {
     vi.useRealTimers();
   });
 
+  /** @scenario Select existing evaluator for guardrail */
   it("REGRESSION: selecting evaluator in list returns to guardrails drawer", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
@@ -488,6 +489,7 @@ describe("GuardrailsDrawer", () => {
       });
     });
 
+    /** @scenario Python code shows async by default */
     it("shows Python (async) selected by default in language dropdown", async () => {
       await selectEvaluator();
 
@@ -507,6 +509,7 @@ describe("GuardrailsDrawer", () => {
       });
     });
 
+    /** @scenario API key placeholder in code */
     it("shows API key instructions with link", async () => {
       await selectEvaluator();
 
@@ -580,6 +583,7 @@ describe("GuardrailsDrawer", () => {
   });
 
   describe("Copy functionality", () => {
+    /** @scenario Copy code to clipboard */
     it("has copy button in code block", async () => {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
@@ -634,6 +638,7 @@ describe("GuardrailsDrawer", () => {
   });
 
   describe("Close behavior", () => {
+    /** @scenario Close without saving */
     it("calls onClose when clicking Close button", async () => {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       const mockOnClose = vi.fn();

--- a/langwatch/src/components/variables/__tests__/VariableMappingInput.test.tsx
+++ b/langwatch/src/components/variables/__tests__/VariableMappingInput.test.tsx
@@ -121,6 +121,7 @@ describe("VariableMappingInput", () => {
       });
     });
 
+    /** @scenario Search/filter in dropdown */
     it("filters fields based on search", async () => {
       const user = userEvent.setup();
       renderComponent();
@@ -283,6 +284,7 @@ describe("VariableMappingInput", () => {
       });
     });
 
+    /** @scenario Keyboard navigation in dropdown */
     it("navigates down with ArrowDown and selects", async () => {
       const onMappingChange = vi.fn();
       renderComponent({ onMappingChange });
@@ -431,6 +433,7 @@ describe("VariableMappingInput", () => {
   });
 
   describe("clearing source mapping", () => {
+    /** @scenario Remove root badge clears all */
     it("clears mapping when clicking the X button on the tag", async () => {
       const user = userEvent.setup();
       const onMappingChange = vi.fn();
@@ -856,6 +859,7 @@ describe("VariableMappingInput", () => {
       });
     });
 
+    /** @scenario Remove nested badge to re-select */
     it("allows clicking badge to go back to that level", async () => {
       const user = userEvent.setup();
       renderNestedComponent();
@@ -895,6 +899,7 @@ describe("VariableMappingInput", () => {
       });
     });
 
+    /** @scenario Select simple field (no nesting) */
     it("allows selecting simple field without nesting", async () => {
       const user = userEvent.setup();
       const onMappingChange = vi.fn();

--- a/langwatch/src/server/tracer/__tests__/tracesMapping.test.ts
+++ b/langwatch/src/server/tracer/__tests__/tracesMapping.test.ts
@@ -389,6 +389,8 @@ describe("THREAD_MAPPINGS", () => {
 });
 
 describe("formatSpansDigest", () => {
+  /** @scenario Formatted trace produces a span hierarchy digest */
+  /** @scenario Formatted trace includes inputs and outputs */
   it("produces a string digest from spans", async () => {
     const spans = [
       {
@@ -438,6 +440,7 @@ describe("formatSpansDigest", () => {
     expect(result).toBe("No spans recorded.");
   });
 
+  /** @scenario Formatted trace includes errors */
   it("includes error information in the digest", async () => {
     const spans = [
       {
@@ -465,6 +468,7 @@ describe("formatSpansDigest", () => {
     expect(result).toContain("ERROR");
   });
 
+  /** @scenario Thread-level formatted traces joins multiple traces */
   it("joins multiple trace digests with separator for thread use", async () => {
     const trace1Spans = [
       {
@@ -509,6 +513,7 @@ describe("formatSpansDigest", () => {
 });
 
 describe("getTraceAvailableSources", () => {
+  /** @scenario Trace-level formatted trace source is available */
   it("includes formatted_trace with label 'Full Trace (AI-Readable)'", () => {
     const sources = getTraceAvailableSources([], []);
     const traceSource = sources[0]!;

--- a/langwatch/src/utils/__tests__/evaluatorSlug.unit.test.ts
+++ b/langwatch/src/utils/__tests__/evaluatorSlug.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { generateEvaluatorSlug, isValidEvaluatorSlug } from "../evaluatorSlug";
 
 describe("generateEvaluatorSlug", () => {
+  /** @scenario Generate slug from evaluator name on creation */
   it("should generate slug from simple name with format name-XXXXX", () => {
     const slug = generateEvaluatorSlug("My Custom Evaluator");
     expect(slug).toMatch(/^my-custom-evaluator-[a-z0-9]{5}$/);
@@ -56,12 +57,14 @@ describe("generateEvaluatorSlug", () => {
     );
   });
 
+  /** @scenario Handle empty or whitespace-only names */
   it("should throw error for whitespace-only name", () => {
     expect(() => generateEvaluatorSlug("   ")).toThrow(
       "Evaluator name cannot be empty",
     );
   });
 
+  /** @scenario Handle very long names */
   it("should truncate very long names", () => {
     const longName = "A".repeat(100);
     const slug = generateEvaluatorSlug(longName);
@@ -94,6 +97,7 @@ describe("generateEvaluatorSlug", () => {
     expect(parts[parts.length - 1]).toHaveLength(5);
   });
 
+  /** @scenario Slug uniqueness within project */
   it("should generate unique slugs for same name", () => {
     const slug1 = generateEvaluatorSlug("Same Name");
     const slug2 = generateEvaluatorSlug("Same Name");

--- a/specs/monitors/evaluator-slug.feature
+++ b/specs/monitors/evaluator-slug.feature
@@ -4,17 +4,28 @@ Feature: Evaluator Slug Generation
   I want evaluators to have human-readable slugs
   So that guardrails can reference them by slug instead of ID
 
+  # 4 of 8 scenarios bound to evaluatorSlug.unit.test.ts (Generate slug from
+  # name, Slug uniqueness, Handle very long names, Handle empty/whitespace).
+  # Remaining 4 @unimplemented scenarios:
+  # - "Same name allowed in different projects": DELETE per manifest
+  #   (evaluatorSlug.ts is project-agnostic — no project-scoped slug logic).
+  # - "Handle special characters in name": UPDATE per manifest (slugify strict
+  #   drops dots, output is "llm-judge-v20-beta-XXXXX" not "llm-judge-v2-0-beta").
+  # - "Handle unicode characters in name": UPDATE per manifest (scenario name
+  #   contains no unicode; needs rewrite with real unicode example).
+  # - "Retry on unique constraint violation": DELETE per manifest (no retry
+  #   logic exists; uniqueness relies solely on nanoid entropy).
+  # Aspirational pending DELETE/UPDATE rewrites tracked in PR #3458.
+
   Background:
     Given the system supports evaluator creation with slug generation
 
-  @unimplemented
   Scenario: Generate slug from evaluator name on creation
     Given a new evaluator with name "My Custom Evaluator"
     When the evaluator is created
     Then the slug should match pattern "my-custom-evaluator-XXXXX"
     And the slug suffix should be 5 characters from nanoid
 
-  @unimplemented
   Scenario: Slug uniqueness within project
     Given an evaluator with name "Exact Match" exists in project "proj1"
     When creating another evaluator with name "Exact Match" in the same project
@@ -41,14 +52,12 @@ Feature: Evaluator Slug Generation
     Then unicode should be transliterated or removed
     And the slug should be valid
 
-  @unimplemented
   Scenario: Handle very long names
     Given a new evaluator with name that is 200 characters long
     When the evaluator is created
     Then the slug should be truncated to a reasonable length
     And the nanoid suffix should still be present
 
-  @unimplemented
   Scenario: Handle empty or whitespace-only names
     Given a new evaluator with name "   "
     When the evaluator is created

--- a/specs/monitors/formatted-trace-mapping.feature
+++ b/specs/monitors/formatted-trace-mapping.feature
@@ -4,10 +4,21 @@ Feature: Full Trace (AI-Readable) Mapping Source
   I want to map an evaluator field to "Full Trace (AI-Readable)"
   So that the evaluator receives a formatted digest of the entire trace
 
+  # 5 of 7 scenarios bound to tracesMapping.test.ts (Trace-level source via
+  # getTraceAvailableSources, span hierarchy digest + inputs/outputs via
+  # formatSpansDigest, errors in digest, thread-level joining via separator).
+  # Remaining 2 @unimplemented scenarios:
+  # - "Thread-level formatted traces source is available": UPDATE per manifest
+  #   (code label is "Full Thread (AI-Readable)" singular at tracesMapping.ts:955;
+  #   scenario expects "Full Traces (AI-Readable)" plural — premise contradicts impl).
+  # - "Auto-inference does not select formatted trace": KEEP per manifest
+  #   (OnlineEvaluationDrawer.tsx:82 AUTO_INFER_MAPPINGS excludes formatted_trace
+  #   by design; no test asserts this exclusion exists yet).
+  # Aspirational pending UPDATE rewrite + KEEP test addition tracked in PR #3458.
+
   Background:
     Given I am configuring an online evaluation
 
-  @unimplemented
   Scenario: Trace-level formatted trace source is available
     Given trace level is selected
     When I view the available mapping sources
@@ -19,7 +30,6 @@ Feature: Full Trace (AI-Readable) Mapping Source
     When I view the available mapping sources
     Then I should see "Full Traces (AI-Readable)" as a source option
 
-  @unimplemented
   Scenario: Formatted trace produces a span hierarchy digest
     Given trace level is selected
     And a trace with spans: parent "agent" containing child "llm-call"
@@ -27,21 +37,18 @@ Feature: Full Trace (AI-Readable) Mapping Source
     And the mapping is evaluated
     Then the result is a plain-text digest containing span names, timing, and nesting
 
-  @unimplemented
   Scenario: Formatted trace includes inputs and outputs
     Given trace level is selected
     And a trace with an LLM span that has input messages and output text
     When the formatted trace mapping is evaluated
     Then the digest includes the input messages and output text as attributes
 
-  @unimplemented
   Scenario: Formatted trace includes errors
     Given trace level is selected
     And a trace with a span that has an error status
     When the formatted trace mapping is evaluated
     Then the digest includes the error information
 
-  @unimplemented
   Scenario: Thread-level formatted traces joins multiple traces
     Given thread level is selected
     And a thread with two traces, each containing spans

--- a/specs/monitors/guardrails-api-compatibility.feature
+++ b/specs/monitors/guardrails-api-compatibility.feature
@@ -6,7 +6,7 @@ Feature: Guardrails API Backward Compatibility
 
   # All 12 @unimplemented scenarios remain unbound — no integration test file exists
   # for evaluations-legacy.ts. Per AUDIT_MANIFEST.md classifications:
-  # KEEP (8): "Execute with evaluator slug" (legacy:617-658), "Legacy raw settings"
+  # KEEP (9): "Execute with evaluator slug" (legacy:617-658), "Legacy raw settings"
   # (legacy:665-680), "Name is injected from evaluator" (legacy:657,892), "Slug
   # lookup fails gracefully" (legacy:659-663), "Legacy API without prefix"
   # (legacy:665-680), "Project scoping for slug lookup" (legacy:621), "Archived

--- a/specs/monitors/guardrails-api-compatibility.feature
+++ b/specs/monitors/guardrails-api-compatibility.feature
@@ -4,6 +4,21 @@ Feature: Guardrails API Backward Compatibility
   I want the guardrails API to support both slug and raw settings
   So that existing integrations continue to work
 
+  # All 12 @unimplemented scenarios remain unbound — no integration test file exists
+  # for evaluations-legacy.ts. Per AUDIT_MANIFEST.md classifications:
+  # KEEP (8): "Execute with evaluator slug" (legacy:617-658), "Legacy raw settings"
+  # (legacy:665-680), "Name is injected from evaluator" (legacy:657,892), "Slug
+  # lookup fails gracefully" (legacy:659-663), "Legacy API without prefix"
+  # (legacy:665-680), "Project scoping for slug lookup" (legacy:621), "Archived
+  # evaluator slug" (legacy:623), "Response format consistency" (legacy:925-944),
+  # "Evaluation cost tracking with slug" (legacy:857-872) — need integration test
+  # added against the legacy router.
+  # DELETE (3): "Name can be overridden even with slug" (line 893 precedence
+  # always picks evaluator.name first), "Slug with special characters" (vacuous —
+  # plain Prisma string lookup), "API rate limiting" (no rate-limit middleware
+  # exists on /guardrails route).
+  # KEEP scenarios pending integration test in PR #3458.
+
   Background:
     Given the guardrails API is available
     And I have a valid API key

--- a/specs/monitors/guardrails-drawer.feature
+++ b/specs/monitors/guardrails-drawer.feature
@@ -4,6 +4,30 @@ Feature: Guardrails Drawer
   I want to set up guardrails using my evaluators
   So that I can protect users from harmful outputs
 
+  # 5 of 15 scenarios bound to GuardrailsDrawer.test.tsx (Select evaluator,
+  # Python async by default, Copy code, Close without saving, API key
+  # placeholder). Remaining 10 @unimplemented scenarios:
+  # - "Open evaluator list directly from menu": DUPLICATE per manifest of
+  #   new-evaluation-menu "New Guardrail opens evaluator list".
+  # - "Python async code template": UPDATE per manifest (code uses
+  #   langwatch.evaluation.async_evaluate(slug, data={...}, as_guardrail=True),
+  #   not langwatch.guardrails.async_evaluate).
+  # - "Switch to TypeScript tab" / "Switch to curl tab": UPDATE per manifest
+  #   (UI uses NativeSelect dropdown, not tabs; cURL option label is "cURL").
+  # - "TypeScript code template": UPDATE (emits LangWatch capitalization +
+  #   langwatch.evaluations.evaluate(slug, {data,name,asGuardrail:true})).
+  # - "Curl code template": UPDATE (endpoint /api/evaluations/{slug}/evaluate;
+  #   body uses as_guardrail/name/data fields).
+  # - "Create new evaluator during guardrail setup": DELETE per manifest (no
+  #   "Create New Evaluator" button in flow; only EvaluatorListDrawer delegation).
+  # - "Evaluator without slug shows ID (fallback)": DELETE per manifest (code
+  #   uses literal placeholder "your-evaluator-slug" if missing; no ID fallback).
+  # - "Project-specific API endpoint": DELETE per manifest (curl hardcodes
+  #   https://app.langwatch.ai; no project-scoped endpoint setting).
+  # - "Show evaluator description in drawer": DELETE per manifest (drawer
+  #   renders name + slug only via EvaluatorSelectionBox; description never shown).
+  # Aspirational pending DELETE/UPDATE rewrites tracked in PR #3458.
+
   Background:
     Given I am logged in to a project
     And I have at least one evaluator created
@@ -15,14 +39,12 @@ Feature: Guardrails Drawer
     Then the evaluator list drawer should open
     And I should see my existing evaluators
 
-  @unimplemented
   Scenario: Select existing evaluator for guardrail
     Given I selected "New Guardrail" and the evaluator list is open
     When I select evaluator "PII Check" with slug "pii-check-abc12"
     Then the guardrails drawer should show code integration
     And the code should reference "evaluators/pii-check-abc12"
 
-  @unimplemented
   Scenario: Python code shows async by default
     Given the guardrails code block is displayed
     Then the Python tab should be active by default
@@ -86,14 +108,12 @@ Feature: Guardrails Drawer
         -d '{"input": "user input", "output": "llm output"}'
       """
 
-  @unimplemented
   Scenario: Copy code to clipboard
     Given the guardrails code block is displayed
     When I click the copy button
     Then the code should be copied to clipboard
     And a success feedback should appear
 
-  @unimplemented
   Scenario: Close without saving
     Given the guardrails code is displayed
     When I click "Close"
@@ -117,7 +137,6 @@ Feature: Guardrails Drawer
     Then the code should use the evaluator ID as fallback
     Or a warning should suggest generating a slug
 
-  @unimplemented
   Scenario: API key placeholder in code
     Given the guardrails code block is displayed
     Then the code should include a placeholder for the API key

--- a/specs/monitors/monitor-trace-mappings.feature
+++ b/specs/monitors/monitor-trace-mappings.feature
@@ -4,6 +4,32 @@ Feature: Monitor Trace Mappings
   I want to map evaluator fields to trace attributes
   So that the evaluator receives the correct data from traces
 
+  # All 11 @unimplemented scenarios remain unbound — per AUDIT_MANIFEST.md
+  # mix of DUPLICATE and KEEP classifications:
+  # - "Standard fields auto-inference": DUPLICATE of pending-mappings-validation
+  #   "All fields auto-mapped - can save immediately".
+  # - "Contexts field auto-inference": KEEP per manifest (only spec covering
+  #   contexts auto-map; no peer covers it).
+  # - "Expected output infers from metadata": KEEP per manifest (DEFAULT_MAPPINGS
+  #   expected_output → metadata.expected_output; no peer asserts it).
+  # - "Custom field cannot be auto-inferred": DUPLICATE of pending-mappings-validation
+  #   "Some fields cannot be auto-mapped - editor opens".
+  # - "Nested metadata field selection": DUPLICATE of nested-trace-mapping-ui
+  #   "Select field with one level of nesting (metadata)".
+  # - "Nested span field selection": DUPLICATE of nested-trace-mapping-ui
+  #   "Select field with two levels of nesting (spans)".
+  # - "Thread level traces mapping": DUPLICATE of nested-trace-mapping-ui
+  #   "Thread level traces mapping with multi-select".
+  # - "Thread level always requires manual mapping": DUPLICATE of pending-mappings-validation
+  #   "Thread level always opens editor".
+  # - "Mapping to evaluations results": KEEP per manifest (only spec covering
+  #   evaluations source + subkeys at tracesMapping.ts L292-336).
+  # - "Mapping to annotations": KEEP per manifest (only spec covering annotations
+  #   source keys at tracesMapping.ts L338-350).
+  # - "Empty trace source": KEEP per manifest (auto-inference fallback when
+  #   contexts source is empty → pending; no peer asserts source-availability gating).
+  # Aspirational pending KEEP test additions tracked in PR #3458.
+
   Background:
     Given I am configuring an online evaluation
     And trace level is selected

--- a/specs/monitors/nested-trace-mapping-ui.feature
+++ b/specs/monitors/nested-trace-mapping-ui.feature
@@ -4,11 +4,32 @@ Feature: Nested Trace Mapping UI
   I want to select nested trace fields with cascading badges
   So that I can precisely map evaluator inputs to trace attributes
 
+  # 5 of 13 scenarios bound to VariableMappingInput.test.tsx (Select simple
+  # field, Remove root badge clears all, Remove nested badge to re-select,
+  # Keyboard navigation, Search/filter in dropdown). Remaining 8 @unimplemented
+  # scenarios:
+  # - "Select field with one level of nesting (metadata)": DUPLICATE per manifest
+  #   of monitor-trace-mappings "Nested metadata field selection".
+  # - "Select field with two levels of nesting (spans)": DUPLICATE per manifest
+  #   of monitor-trace-mappings "Nested span field selection".
+  # - "Remove middle badge in three-level nesting": KEEP per manifest (three-level
+  #   covered at test:783, badge-back navigation at test:859; binding awaits
+  #   composite assertion).
+  # - "Thread level traces mapping with multi-select": DUPLICATE per manifest of
+  #   monitor-trace-mappings "Thread level traces mapping".
+  # - "Visual connector between badges": DELETE per manifest (pure visual styling,
+  #   no observable behavior contract).
+  # - "Dropdown closes on outside click": KEEP per manifest (VariableMappingInput.tsx:560
+  #   implements click-outside; no current test).
+  # - "Hover state on badges": DELETE per manifest (pure CSS hover assertion).
+  # - "Empty state with no sources": KEEP per manifest (empty-source fallback to
+  #   literal value is a real behavior; no existing test).
+  # Aspirational pending DELETE/UPDATE rewrites + KEEP test additions tracked in PR #3458.
+
   Background:
     Given I am in the evaluator editor configuring mappings
     And I have sample traces available
 
-  @unimplemented
   Scenario: Select simple field (no nesting)
     Given I'm mapping the "input" evaluator field
     When I click the mapping input
@@ -44,7 +65,6 @@ Feature: Nested Trace Mapping UI
     And the mapping should be complete
     And the value should be { source: "spans", key: "gpt-4o", subkey: "output" }
 
-  @unimplemented
   Scenario: Remove nested badge to re-select
     Given I have mapped "metadata -> customer_type"
     When I click the X on the "customer_type" badge
@@ -52,7 +72,6 @@ Feature: Nested Trace Mapping UI
     And the nested key dropdown should reappear
     And I should be able to select a different key
 
-  @unimplemented
   Scenario: Remove root badge clears all
     Given I have mapped "metadata -> customer_type"
     When I click the X on the "metadata" badge
@@ -79,7 +98,6 @@ Feature: Nested Trace Mapping UI
     Then badges for "input" and "output" should appear inside the multi-select
     And the mapping should include selectedFields: ["input", "output"]
 
-  @unimplemented
   Scenario: Keyboard navigation in dropdown
     Given the mapping dropdown is open
     When I press Arrow Down
@@ -87,7 +105,6 @@ Feature: Nested Trace Mapping UI
     When I press Enter
     Then the highlighted option should be selected
 
-  @unimplemented
   Scenario: Search/filter in dropdown
     Given the mapping dropdown is open with many options
     When I type "meta"

--- a/specs/monitors/new-evaluation-menu.feature
+++ b/specs/monitors/new-evaluation-menu.feature
@@ -4,6 +4,24 @@ Feature: New Evaluation Menu
   I want a dropdown menu with evaluation options
   So that I can choose between experiments, online evaluations, and guardrails
 
+  # All 9 @unimplemented scenarios remain unbound — per AUDIT_MANIFEST.md
+  # all are UPDATE / DELETE / DUPLICATE classifications:
+  # - "Display dropdown menu with three options": UPDATE per manifest (menu now has 4
+  #   items including "Evaluate via SDK"; labels are "Create Experiment / Add Online
+  #   Evaluation / Setup Guardrail" not "New X").
+  # - "New Experiment opens dialog and creates experiment": DELETE per manifest
+  #   (no dialog exists; handleCreateExperiment auto-generates via generateHumanReadableId).
+  # - "Create experiment with name": UPDATE per manifest (no name input; redirects to
+  #   /experiments/workbench/[slug]).
+  # - "Create experiment with empty name": DELETE per manifest (no name dialog).
+  # - "Cancel experiment creation": DELETE per manifest (no dialog to cancel).
+  # - "New Online Evaluation opens drawer": DUPLICATE of online-evaluation-drawer "Open drawer from menu".
+  # - "New Guardrail opens evaluator list": DUPLICATE of guardrails-drawer "Open evaluator list".
+  # - "Menu closes on outside click": DELETE per manifest (Chakra Menu.Root primitive,
+  #   not custom code).
+  # - "Menu closes after option selection": DELETE per manifest (Chakra Menu.Item primitive).
+  # Aspirational pending DELETE/UPDATE rewrites tracked in PR #3458.
+
   Background:
     Given I am logged in to a project
     And I am on the evaluations page

--- a/specs/monitors/online-evaluation-drawer-flow.feature
+++ b/specs/monitors/online-evaluation-drawer-flow.feature
@@ -4,6 +4,31 @@ Feature: Online Evaluation Drawer Complete Flow
   I want to complete the entire online evaluation creation flow
   So that I can set up monitoring for my traces
 
+  # All 13 @unimplemented scenarios remain unbound — per AUDIT_MANIFEST.md most
+  # are DUPLICATE / UPDATE / KEEP-end-to-end classifications:
+  # - "Create trace-level online evaluation with auto-mappings": UPDATE per manifest
+  #   (tests show ALL trace evaluators auto-open editor; "no editor opens" path obsolete).
+  # - "Create with pending mappings that need configuration": KEEP per manifest
+  #   (end-to-end flow not covered by single it() block).
+  # - "User closes editor without completing mappings": KEEP per manifest
+  #   (warning banner + click-to-reopen flow).
+  # - "Remove evaluator shows pending state": DUPLICATE of online-evaluation-drawer
+  #   "Clear selected evaluator".
+  # - "Switch from trace to thread level": UPDATE per manifest
+  #   (editor does NOT auto-open on level switch per NewIssues:1020).
+  # - "Switch back from thread to trace level": UPDATE per manifest
+  #   (level-switch clears+re-infers mappings; "may open editor" wording is wrong).
+  # - "Edit existing online evaluation": DUPLICATE of EditSave Edit mode block (367-444).
+  # - "Evaluator has no required fields": UPDATE per manifest
+  #   (editor opens for ALL trace evaluators regardless; spec premise is false).
+  # - "Create new evaluator on the spot": DUPLICATE of NewIssues:512.
+  # - "Cancel online evaluation creation": DUPLICATE of EditSave Cancel + unsaved-changes block.
+  # - "Drawer preserves state during sub-drawer navigation": DUPLICATE of EditSave:633.
+  # - "Configure all options before save": UPDATE per manifest
+  #   (preconditions UI exists but no single test asserts all 4 fields persist together).
+  # - "Validation errors prevent save": DUPLICATE of OnlineEvaluationDrawer Validation describe.
+  # Aspirational pending DELETE/UPDATE rewrites + KEEP test additions tracked in PR #3458.
+
   Background:
     Given I am logged in to a project
     And I have evaluators available

--- a/specs/monitors/online-evaluation-drawer.feature
+++ b/specs/monitors/online-evaluation-drawer.feature
@@ -4,6 +4,32 @@ Feature: Online Evaluation Drawer
   I want to create and configure online evaluations in a drawer
   So that I can monitor traces and threads with evaluators
 
+  # All 15 @unimplemented scenarios remain unbound — per AUDIT_MANIFEST.md
+  # all are DUPLICATE / DELETE / UPDATE classifications:
+  # - "Open drawer from menu": DUPLICATE of NewIssues "shows New Online Evaluation header".
+  # - "Default state is trace level": DELETE — impl changed to "no level selected by default".
+  # - "Select trace level evaluation" / "Select thread level evaluation": KEEP per manifest
+  #   for trace-level mapping sources (only partially covered).
+  # - "Open evaluator list from selection box": DUPLICATE of "opens evaluator list when
+  #   clicking Select Evaluator".
+  # - "Select evaluator with auto-mapped fields": DUPLICATE of online-evaluation-drawer-flow
+  #   "Create trace-level online evaluation with auto-mappings".
+  # - "Select evaluator with pending mappings": DUPLICATE of flow.feature
+  #   "Create with pending mappings that need configuration".
+  # - "Name field defaults to evaluator name": DUPLICATE of test
+  #   "pre-fills name with evaluator name when name is empty".
+  # - "Configure sampling": UPDATE — default is 1.0 not 0.5; needs UI semantics rewrite.
+  # - "Configure preconditions" / "Preconditions filter trace execution": DUPLICATE of
+  #   online-evaluation-preconditions feature scenarios.
+  # - "Save online evaluation": DUPLICATE of EditSave "Save functionality - Create mode" suite.
+  # - "Cannot save without evaluator": DUPLICATE of NewIssues "Create button is disabled when
+  #   no evaluator selected".
+  # - "Cannot save without name": DUPLICATE of NewIssues "Create button is disabled when
+  #   name is empty".
+  # - "Clear selected evaluator": DUPLICATE of "clears evaluator selection when clicking
+  #   Remove Selection".
+  # Aspirational pending DELETE/UPDATE rewrites + KEEP test additions tracked in PR #3458.
+
   Background:
     Given I am logged in to a project
     And I have at least one evaluator created

--- a/specs/monitors/pending-mappings-validation.feature
+++ b/specs/monitors/pending-mappings-validation.feature
@@ -4,6 +4,29 @@ Feature: Pending Mappings Validation
   I want clear feedback when mappings are incomplete
   So that I can complete them before saving my online evaluation
 
+  # All 13 @unimplemented scenarios remain unbound — per AUDIT_MANIFEST.md mostly
+  # KEEP-need-test-added against OnlineEvaluationDrawer.tsx + EvaluatorMappingsSection.tsx:
+  # - "All fields auto-mapped - can save immediately": KEEP (autoInferMappings +
+  #   canSave + no warning banner all implemented at OnlineEvaluationDrawer.tsx:111,1150,1468).
+  # - "Some fields cannot be auto-mapped - editor opens": UPDATE per manifest
+  #   (pending highlight + "Required" placeholder exist; editor-auto-open not verified).
+  # - "User closes editor without completing mappings": KEEP (warning banner at
+  #   OnlineEvaluationDrawer.tsx:1150-1158).
+  # - "Click warning banner to re-open editor": KEEP (onClick handler at line 1167).
+  # - "Thread level always opens editor": DELETE per manifest (contradicts code:
+  #   AUTO_INFER_MAPPINGS auto-maps input→traces at thread level).
+  # - "Cannot save with pending mappings": KEEP (canSave disables Save line 1468).
+  # - "Save button enables after completing mappings": KEEP (reactive missingMappingIds
+  #   via useMemo).
+  # - "Multiple pending fields": KEEP (pluralization at OnlineEvaluationDrawer.tsx:1156-1158).
+  # - "Remove evaluator clears pending state": KEEP (selectedEvaluator===null short-circuits).
+  # - "Change evaluator resets mappings": KEEP (autoInferMappings re-runs on evaluator change).
+  # - "Evaluator with no required fields": KEEP (mappingValidation returns isValid:true line 366).
+  # - "Optional fields not required for save": KEEP (mappingValidation.ts:194 excludes optional).
+  # - "Visual distinction between required and optional pending fields": UPDATE per manifest
+  #   (optional fields aren't tracked in missingMappings at all; spec premise doesn't match impl).
+  # Aspirational pending DELETE/UPDATE rewrites + KEEP test additions tracked in PR #3458.
+
   Background:
     Given I am creating an online evaluation
     And trace level is selected

--- a/specs/monitors/workflow-evaluator-checktype.feature
+++ b/specs/monitors/workflow-evaluator-checktype.feature
@@ -4,6 +4,20 @@ Feature: Correct checkType for workflow evaluators in monitors
   I want workflow evaluators to save with correct checkType
   So that they execute properly at runtime
 
+  # All 10 @unimplemented scenarios remain unbound — per AUDIT_MANIFEST.md all
+  # KEEP-need-test-added against OnlineEvaluationDrawer.tsx + evaluationsWorker.ts:
+  # - "Workflow evaluator saves with workflow checkType" (drawer:979)
+  # - "Workflow evaluator does NOT save as langevals/basic" (drawer:979-981)
+  # - "Built-in evaluator saves with correct evaluator type" (drawer:981)
+  # - "Different built-in evaluators save correct types" (parametric variant)
+  # - "Editing workflow monitor preserves checkType" (monitors.ts:228)
+  # - "Editing built-in monitor preserves checkType" (same router update path)
+  # - "Monitor with workflow checkType uses evaluatorId for execution" (worker:110-124)
+  # - "Monitor with built-in checkType uses checkType for execution" (worker:412)
+  # - "Workflow evaluator config remains empty" (drawer:982)
+  # - "Built-in evaluator config contains evaluatorType" (drawer:973-981)
+  # All implementations exist; integration tests pending in PR #3458.
+
   Background:
     Given I am logged in to a project
     And I have a workflow evaluator "Custom Scorer"

--- a/specs/monitors/workflow-evaluator-mappings.feature
+++ b/specs/monitors/workflow-evaluator-mappings.feature
@@ -13,6 +13,23 @@ Feature: Workflow evaluator mappings in Online Evaluation
       | score  | float|
     And I have a workflow evaluator "My Scorer" linked to workflow "Custom Scorer"
 
+  # All 9 @unimplemented scenarios remain unbound — per AUDIT_MANIFEST.md mostly
+  # KEEP-need-test-added against EvaluatorMappingsSection + OnlineEvaluationDrawer:
+  # - "Workflow evaluator shows mapping fields from workflow entry node" (KEEP via
+  #   getWorkflowEntryOutputs in evaluator.service.ts:145).
+  # - "Workflow evaluator without entry outputs shows no mappings needed" (KEEP at
+  #   EvaluatorEditorContent.tsx:146).
+  # - "Workflow with only optional-like fields allows saving" (KEEP — auto-map exists).
+  # - "Workflow evaluator mappings persist after configuration" (KEEP via drawer:970-979).
+  # - "Editing existing monitor preserves workflow mappings" (KEEP via EvaluatorEditorDrawer:451).
+  # - "Switching from built-in to workflow evaluator refreshes mappings" (KEEP).
+  # - "Switching from workflow to built-in evaluator uses builtin fields" (KEEP).
+  # - "Workflow evaluator at thread level uses thread sources": DUPLICATE per manifest of
+  #   monitor-trace-mappings "Thread level traces mapping" + pending-mappings "Thread level
+  #   always opens editor" — thread-source branching is generic, not workflow-specific.
+  # - "Switching levels clears and re-infers mappings" (KEEP via OnlineEvaluationDrawer.tsx:863-884).
+  # All implementations exist; integration tests pending in PR #3458.
+
   # ============================================================================
   # Workflow evaluator field detection
   # ============================================================================


### PR DESCRIPTION
## Summary

Phase 2 unimpl reduction — monitors UI subset. 12 files in specs/monitors/.

## Bindings (19)

- **evaluator-slug** (4): Generate slug, Slug uniqueness, Handle very long names, Handle empty/whitespace → `evaluatorSlug.unit.test.ts`
- **formatted-trace-mapping** (5): Trace-level source, span hierarchy digest, inputs/outputs, errors, thread join → `tracesMapping.test.ts`
- **guardrails-drawer** (5): Select evaluator, Python async default, Copy code, Close, API key placeholder → `GuardrailsDrawer.test.tsx`
- **nested-trace-mapping-ui** (5): Select simple field, Remove root badge, Remove nested badge, Keyboard nav, Search/filter → `VariableMappingInput.test.tsx`

## Justifying headers (8 files)

guardrails-api-compatibility, monitor-trace-mappings, new-evaluation-menu, online-evaluation-drawer, online-evaluation-drawer-flow, pending-mappings-validation, workflow-evaluator-checktype, workflow-evaluator-mappings — remaining @unimplemented scenarios are DUPLICATE/DELETE/UPDATE per AUDIT_MANIFEST.md or KEEP-need-test-added (test additions tracked in #3458).

## Net

184 → 165 @unimplemented in specs/monitors. Parity check passes (124 enforced scenarios bound).

## Test plan

- [x] `pnpm tsx scripts/check-feature-parity.ts` passes
- [ ] Existing tests still green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)