### PR TITLE
test(settings): document 5 @unimplemented scenarios as justified gaps

### DIFF
--- a/specs/settings/change-password-auth0.feature
+++ b/specs/settings/change-password-auth0.feature
@@ -98,6 +98,19 @@ Feature: Change password from /settings/authentication
     And the server does NOT call the Management API
     And the tRPC mutation throws UNAUTHORIZED with message "Current password is incorrect"
 
+  # The two `@unimplemented` scenarios below describe behaviour that is
+  # implemented in the source but has no asserting test:
+  #   * AUTH0_CLIENT_ID/SECRET fallback path:
+  #     `passwordService.ts` reads
+  #     `env.AUTH0_MGMT_CLIENT_ID ?? env.AUTH0_CLIENT_ID` (and the secret
+  #     mirror), but the existing
+  #     `passwordService.integration.test.ts` only mocks
+  #     `AUTH0_CLIENT_ID/SECRET` and does not assert which env var the
+  #     service picked. A binding test would need to vary the env
+  #     surface between two test runs.
+  #   * Rate limit (5/15min) — implemented in the `user.changePassword`
+  #     tRPC mutation against a Redis-backed limiter; no router-level
+  #     integration test exercises the limiter today.
   @integration @unimplemented
   Scenario: Auth0 backend falls back to AUTH0_CLIENT_ID/SECRET when the M2M vars are absent
     Given AUTH0_MGMT_CLIENT_ID and AUTH0_MGMT_CLIENT_SECRET are not set
@@ -128,6 +141,14 @@ Feature: Change password from /settings/authentication
     And the server logs the grant-misconfig error
     And I see an error toast telling an administrator to enable the Password grant
 
+  # The email-mode end-to-end flow (router-level test that wires
+  # together password verification + Prisma update + session revoke)
+  # has no integration test today. The pieces are tested individually:
+  #   * `revokeOtherSessionsForUser` — `revokeSessions.test.ts`
+  #   * BetterAuth credential update — covered by `auth.test.ts` paths
+  # but no test exercises the `user.changePassword` mutation in email
+  # mode end-to-end. Leaving `@unimplemented` until the router test
+  # exists.
   @regression @integration @unimplemented
   Scenario: Email-provider mode continues to verify the current password and revoke other sessions
     Given the tenant runs on NEXTAUTH_PROVIDER="email"

--- a/specs/settings/decompose-model-provider-form-hook.feature
+++ b/specs/settings/decompose-model-provider-form-hook.feature
@@ -3,6 +3,15 @@ Feature: Decompose useModelProviderForm hook into focused sub-hooks
   I want the hook logic organized into single-responsibility sub-hooks
   So that each concern is independently testable and the code is easier to navigate
 
+  # The two `@refactor @integration @unimplemented` scenarios below are
+  # acceptance criteria for a not-yet-started refactor (the hook
+  # decomposition itself). They intentionally remain `@unimplemented`
+  # — they assert the *result* of work that has not been done. The
+  # rest of this file (the `@refactor`-only scenarios) describes the
+  # target architecture and is also aspirational, not bound to tests.
+  # Existing coverage of the current monolithic hook lives in
+  # `useModelProviderForm.integration.test.tsx`.
+
   Background:
     Given the useModelProviderForm hook returns [state, actions]
     And two consumer components depend on the public API


### PR DESCRIPTION
## Summary

Phase 2 of #3458 (parity grinder) — settings domain.

All 5 `@unimplemented` scenarios describe behaviour that's either implemented but untested, or acceptance criteria for an unstarted refactor. Adding header comments so the reason is durable (rather than orphaned `@unimplemented` tags).

## What changed

| Feature file | Bound | Justified |
|---|---:|---:|
| `change-password-auth0.feature` | 0 | 3 |
| `decompose-model-provider-form-hook.feature` | 0 | 2 |
| `llm-model-cost-drawer-error-handling.feature` | n/a | 0 (clean) |

Net `specs/settings` `@unimplemented` count: **5 → 5 (0 — all justified)**.

## Test plan

- [x] `pnpm check:feature-parity` — passes
- [ ] CI green

## Related

- Closes part of #3458
- Sister PRs in the misc-domains slice (one per domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)