### PR TITLE
test(skills): document 16 @unimplemented scenarios as justified gaps

### DIFF
--- a/specs/skills/skills-testing.feature
+++ b/specs/skills/skills-testing.feature
@@ -4,6 +4,21 @@ Feature: Scenario tests for skills quality assurance
   We want every skill to have scenario tests proving it works
   So that we can compound improvements with confidence and catch regressions
 
+  # All `@unimplemented` scenarios in this file describe live Claude
+  # Code-driven scenario tests under `skills/_tests/*.scenario.test.ts`
+  # (e.g. `tracing.scenario.test.ts`, `evaluations.scenario.test.ts`,
+  # `level-up.scenario.test.ts`, `analytics.scenario.test.ts`,
+  # `prompts*.scenario.test.ts`, `scenarios.scenario.test.ts`). The
+  # tests exist and are skipped in CI (`it.skipIf(isCI)`) — they
+  # spawn an actual Claude Code agent against a fixture codebase.
+  #
+  # The `check-feature-parity` script's DEFAULT_TEST_ROOTS does not
+  # include `skills/_tests/`, so JSDoc `@scenario` annotations in
+  # those files would not currently bind. Expanding the test roots
+  # is the right structural fix for this domain — tracked outside
+  # this PR. Until then, scenarios stay `@unimplemented` (with this
+  # justifying note) rather than being orphaned.
+
   Background:
     Given scenario tests live in skills/_tests/
     And fixture codebases live in skills/_tests/fixtures/


### PR DESCRIPTION
## Summary

Phase 2 of #3458 (parity grinder) — skills domain.

All 16 `@unimplemented` scenarios live in `specs/skills/skills-testing.feature`. They describe live Claude Code-driven scenario tests that already exist under `skills/_tests/*.scenario.test.ts` (e.g. `tracing.scenario.test.ts`, `evaluations.scenario.test.ts`, `level-up.scenario.test.ts`).

The catch: the parity script's `DEFAULT_TEST_ROOTS` does not include `skills/_tests/`, so any `@scenario` JSDoc added there today would not bind. Expanding the test-roots list is the right structural fix for this domain — tracked separately.

Adding a header comment so the reason is durable rather than orphaned `@unimplemented` tags.

## What changed

| Feature file | Bound | Justified |
|---|---:|---:|
| `skills-testing.feature` | 0 | 16 |

Net `specs/skills` `@unimplemented` count: **16 → 16 (0 bound, 16 justified)**.

## Test plan

- [x] `pnpm check:feature-parity` passes
- [ ] CI green

## Related

- Closes part of #3458
- Sister PRs: #3800 (settings), #3801 (background), #3802 (audit-log).
- Future work: extend `DEFAULT_TEST_ROOTS` in `check-feature-parity.ts` to include `skills/_tests/` so these tests can be bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)