### PR TITLE
test(navigation): bind 5 @unimplemented child-drawer scenarios

### DIFF
--- a/langwatch/src/components/suites/__tests__/SuiteFormDrawer.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteFormDrawer.integration.test.tsx
@@ -492,6 +492,7 @@ describe("<SuiteFormDrawer/>", () => {
 
   describe("given the suite editor is open", () => {
     describe("when 'Add Scenario' is clicked", () => {
+      /** @scenario Creating a new scenario from suite editor opens as a child drawer */
       it("opens the scenario editor as a child drawer", async () => {
         const user = userEvent.setup();
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
@@ -514,6 +515,7 @@ describe("<SuiteFormDrawer/>", () => {
     });
 
     describe("when the scenario editor child drawer is closed", () => {
+      /** @scenario Closing the scenario editor child drawer returns to the suite editor */
       it("returns to suite editor with form state intact", async () => {
         const user = userEvent.setup();
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
@@ -539,6 +541,7 @@ describe("<SuiteFormDrawer/>", () => {
     });
 
     describe("when 'Add Target' is clicked", () => {
+      /** @scenario Creating a new agent from suite editor opens as a child drawer */
       it("opens the agent HTTP editor as a child drawer", async () => {
         const user = userEvent.setup();
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
@@ -561,6 +564,7 @@ describe("<SuiteFormDrawer/>", () => {
     });
 
     describe("when the agent HTTP editor child drawer is closed", () => {
+      /** @scenario Closing the agent editor child drawer returns to the suite editor */
       it("returns to suite editor with form state intact", async () => {
         const user = userEvent.setup();
         render(<SuiteFormDrawer />, { wrapper: Wrapper });
@@ -586,6 +590,7 @@ describe("<SuiteFormDrawer/>", () => {
     });
 
     describe("when form state is entered before opening a child drawer", () => {
+      /** @scenario Suite editor form state survives a child drawer round-trip */
       it("preserves suite name and scenario selections through a child drawer round-trip", async () => {
         const user = userEvent.setup();
         render(<SuiteFormDrawer />, { wrapper: Wrapper });

--- a/specs/navigation/child-drawer-nesting.feature
+++ b/specs/navigation/child-drawer-nesting.feature
@@ -62,6 +62,16 @@ Feature: Child drawers open as nested overlays instead of navigating
   # Case 3: Scenario run detail -> View Trace (regression guard)
   # Already works via local state - these verify no regression.
   # ---------------------------------------------------------------------------
+  #
+  # The two scenarios below describe the trace-details child drawer
+  # opened from inside the scenario run detail drawer. The component
+  # composition is exercised by `ScenarioRunDetailDrawer.integration
+  # .test.tsx` and the goBack() helper is covered in
+  # `TraceDetailsDrawer.integration.test.tsx` (test
+  # "calls goBack() to handle both nested and root drawer cases"),
+  # but no single test asserts the "Open Thread → child drawer
+  # mounts → close → parent visible" flow end-to-end. Cheap follow-
+  # up.
 
   @integration @unimplemented
   Scenario: Viewing a trace from scenario run detail opens as a child drawer
@@ -80,6 +90,11 @@ Feature: Child drawers open as nested overlays instead of navigating
   # ---------------------------------------------------------------------------
   # Non-drawer contexts remain unaffected
   # ---------------------------------------------------------------------------
+  #
+  # Root-level drawer behaviour is implicit in every drawer test
+  # that runs without a parent (e.g. `SuiteFormDrawer` standalone
+  # tests). No dedicated assertion exists for the "no parent
+  # drawer" branch.
 
   @integration @unimplemented
   Scenario: Opening a drawer from a page (non-drawer context) works normally
@@ -105,6 +120,12 @@ Feature: Child drawers open as nested overlays instead of navigating
   # ---------------------------------------------------------------------------
   # Keyboard interaction with stacked drawers
   # ---------------------------------------------------------------------------
+  #
+  # `NestedDrawerTyping.integration.test.tsx` covers keyboard input
+  # in nested drawers but does not specifically assert Escape-only-
+  # closes-topmost behaviour. The semantics are baked into the
+  # underlying Chakra Drawer overlay stack — adding an explicit
+  # assertion is cheap follow-up.
 
   @integration @unimplemented
   Scenario: Pressing Escape closes only the topmost child drawer

--- a/specs/navigation/home-navigation.feature
+++ b/specs/navigation/home-navigation.feature
@@ -4,6 +4,15 @@ Feature: Home Navigation
   I want consistent navigation to and from the home page
   So that I can easily access the dashboard and other features
 
+  # All 10 `@unimplemented` scenarios in this file describe page-
+  # level navigation and routing (logo click, sidebar menu items,
+  # active-page highlighting, conditional render of WelcomeLayout
+  # vs messages list, analytics alert when no traces, direct URL
+  # access). The MainMenu / sidebar components have no JSDOM render
+  # tests today, and there are no Playwright/E2E navigation tests
+  # for these routes yet. Cheap follow-up — write either a
+  # MainMenu render test or a Playwright suite under `e2e/`.
+
   Background:
     Given I am logged in
     And I have access to project "test-project"


### PR DESCRIPTION
## Summary

Phase 2 of #3458 (parity grinder) — navigation domain.

- **5 `@unimplemented` scenarios bound** to existing child-drawer integration tests
- **15 scenarios kept `@unimplemented`** — the home-navigation page-level scenarios all need a MainMenu render test or Playwright suite that doesn't exist yet.

## What changed

| Feature file | Bound | Justified |
|---|---:|---:|
| `child-drawer-nesting.feature` | 5 | 5 |
| `home-navigation.feature` | 0 | 10 |

Net `specs/navigation` `@unimplemented` count: **20 → 20 (-5 bound, 15 justified)**.

## Test plan

- [x] `pnpm check:feature-parity` passes
- [x] `pnpm typecheck` clean
- [ ] CI green

## Related

- Closes part of #3458
- Sister PRs: #3800 (settings), #3801 (background), #3802 (audit-log), #3804 (skills), #3805 (components), #3808 (setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)