### PR TITLE
test(python-sdk): document 34 @unimplemented scenarios as harness-blocked

### DIFF
--- a/specs/python-sdk/async-experiment-parallelism.feature
+++ b/specs/python-sdk/async-experiment-parallelism.feature
@@ -3,6 +3,11 @@ Feature: Python SDK async-native experiment parallelism
   I want a first-class async execution mode for experiment.loop / experiment.submit
   So that singletons (gRPC channels, Firestore, ADK runners, connection pools) keep working and every item gets an isolated trace
 
+  # All `@unimplemented` scenarios in this file describe Python SDK
+  # behaviour. The check-feature-parity script only scans `*.test.ts
+  # /tsx`, so pytest cases cannot bind via JSDoc today. Cheap
+  # structural fix: extend the scanner to read pytest docstring tags.
+
   Background:
     Given a LangWatch client initialized with a valid API key
     And an experiment instance created via langwatch.experiment(slug="<slug>")

--- a/specs/python-sdk/experiment-print-summary.feature
+++ b/specs/python-sdk/experiment-print-summary.feature
@@ -3,6 +3,17 @@ Feature: Python SDK Experiment.print_summary for CI/CD parity
   I want experiment.print_summary() on SDK-driven experiments (not only on ExperimentRunResult)
   So that SDK-defined experiments can fail CI builds the same way platform experiments do
 
+  # All `@unimplemented` scenarios in this file describe Python SDK
+  # behaviour. The check-feature-parity script only scans
+  # `*.test.ts/tsx` files (`TEST_FILE_RE` in
+  # langwatch/scripts/check-feature-parity.ts) under the configured
+  # test roots, so JSDoc `@scenario` markers in `python-sdk/tests/
+  # *.py` would not be discovered. Adding a `*.py` test scanner +
+  # docstring-tag parser is the structural fix; tracked separately.
+  # Python tests for `experiment.print_summary` exist in
+  # `python-sdk/tests/` (e.g. test_experiment.py / test_examples.py)
+  # and run in the python-sdk CI suite.
+
   Background:
     Given a LangWatch client initialized with a valid API key
     And an experiment instance created via langwatch.experiment.init("ci-quality-check")

--- a/specs/python-sdk/prompt-tags.feature
+++ b/specs/python-sdk/prompt-tags.feature
@@ -3,6 +3,14 @@ Feature: Python SDK custom tag support
   I want to fetch prompts by tag and manage tag assignments
   So that I can pin my code to tagged versions and promote versions across environments
 
+  # All `@unimplemented` scenarios in this file describe Python SDK
+  # behaviour. The check-feature-parity script only scans `*.test.ts
+  # /tsx` files, so Python pytest cases under `python-sdk/tests/`
+  # cannot be bound via JSDoc today. Underlying tag-fetch tests
+  # exist in `python-sdk/tests/prompts/test_prompt.py` and
+  # `test_fetch_policies.py`. Cheap structural fix: extend the
+  # parity scanner to read pytest docstrings.
+
   Background:
     Given a LangWatch client initialized with a valid API key
 


### PR DESCRIPTION
## Summary

Phase 2 of #3458 (parity grinder) — python-sdk domain.

All 34 `@unimplemented` scenarios describe Python SDK behaviour. The parity-check script only scans `*.test.ts/tsx` files, so the existing pytest suite under `python-sdk/tests/` cannot bind via JSDoc today.

Adding a single header comment to each feature file so the reason is durable rather than orphaned `@unimplemented` tags.

## What changed

| Feature file | Bound | Justified |
|---|---:|---:|
| `experiment-print-summary.feature` | 0 | 8 |
| `prompt-tags.feature` | 0 | 15 |
| `async-experiment-parallelism.feature` | 0 | 11 |

Net `specs/python-sdk` `@unimplemented` count: **34 → 34 (0 bound, 34 justified)**.

## Future work

Cheap structural fix tracked separately: extend `langwatch/scripts/check-feature-parity.ts` to read pytest docstring tags so python-sdk and python-server scenarios can bind too.

## Test plan

- [x] `pnpm check:feature-parity` passes
- [ ] CI green

## Related

- Closes part of #3458
- Sister PRs: #3800–#3811 (settings, background, audit-log, skills, components, setup, navigation, private-dataplane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)