### PR TITLE
test(licensing): bind 2 role-upgrade scenarios via license-limit-guard tests

### DIFF
--- a/langwatch/src/server/license-enforcement/__tests__/license-limit-guard.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-limit-guard.unit.test.ts
@@ -130,6 +130,7 @@ describe("assertMemberTypeLimitNotExceeded", () => {
   });
 
   describe("when changeType is lite-to-full", () => {
+    /** @scenario Allows upgrade from Lite Member to full member when under limit */
     it("allows change when under limit", async () => {
       const mockRepo = createMockRepo(3); // 3 members, limit is 5
       const limits = createLimits(5);
@@ -160,6 +161,7 @@ describe("assertMemberTypeLimitNotExceeded", () => {
       expect(mockNotifyResourceLimitReached).not.toHaveBeenCalled();
     });
 
+    /** @scenario Blocks upgrade from Lite Member to full member when at member limit */
     it("throws when at limit", async () => {
       const mockRepo = createMockRepo(5); // 5 members, limit is 5
       const limits = createLimits(5);

--- a/specs/licensing/enforcement-members.feature
+++ b/specs/licensing/enforcement-members.feature
@@ -277,7 +277,6 @@ Feature: Member Limit Enforcement with License
   # Role Update Limit Checks
   # ============================================================================
 
-  @unimplemented
   Scenario: Blocks upgrade from Lite Member to full member when at member limit
     Given the organization has 3 Full Members
     And the organization has 1 Lite Member user "lite@example.com"
@@ -286,7 +285,6 @@ Feature: Member Limit Enforcement with License
     Then the request fails with FORBIDDEN
     And the error message contains "member limit reached"
 
-  @unimplemented
   Scenario: Allows upgrade from Lite Member to full member when under limit
     Given the organization has 2 Full Members
     And the organization has 1 Lite Member user "lite@example.com"


### PR DESCRIPTION
## Summary
- Binds 2 @unimplemented scenarios from `specs/licensing/enforcement-members.feature` to existing prose unit tests in `license-limit-guard.unit.test.ts`
- Both scenarios exercise the role-change limit guard with \`lite-to-full\` changeType — the test names ("allows change when under limit", "throws when at limit") map 1:1 to the spec
- Continues parity grinder Phase 2 (#3458). Builds on iter-1 #3803 and iter-2 #3810.

## Bindings

| Scenario | Test |
|----------|------|
| Allows upgrade from Lite Member to full member when under limit | \`assertMemberTypeLimitNotExceeded > when changeType is lite-to-full > allows change when under limit\` |
| Blocks upgrade from Lite Member to full member when at member limit | \`assertMemberTypeLimitNotExceeded > when changeType is lite-to-full > throws when at limit\` |

The third role-update scenario ("Blocks custom role change that would exceed full member limit") remains @unimplemented because it requires permission-array introspection coupled to limit checks, not just \`changeType\` — no existing test exercises that specific path.

## Test plan
- [x] \`pnpm check:feature-parity\` — both scenarios now pass
- [x] No behavioral changes — only JSDoc comments added; \`@unimplemented\` tags removed from feature
- [x] Diff is 2 + / 2 - across 2 files (~700 chars total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)