### PR TITLE
test(features): implement 5 unit tests for pricing-model-aware-free-plan parity

### DIFF
--- a/langwatch/src/server/app-layer/usage/__tests__/usage-meter-policy.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage-meter-policy.unit.test.ts
@@ -205,6 +205,69 @@ describe("resolveUsageMeter", () => {
   });
 });
 
+describe("counting unit by organization profile", () => {
+  /** @scenario Free TIERED organization counts each span toward the limit */
+  it("counts each span (events unit) for a free TIERED organization", () => {
+    const decision = resolveUsageMeter({
+      pricingModel: PricingModel.TIERED,
+      isFree: true,
+      hasValidLicenseOverride: false,
+      clickhouseAvailable: true,
+    });
+
+    expect(decision.usageUnit).toBe("events");
+  });
+
+  /** @scenario Free SEAT_EVENT organization counts each span toward the limit */
+  it("counts each span (events unit) for a free SEAT_EVENT organization", () => {
+    const decision = resolveUsageMeter({
+      pricingModel: PricingModel.SEAT_EVENT,
+      isFree: true,
+      hasValidLicenseOverride: false,
+      clickhouseAvailable: true,
+    });
+
+    expect(decision.usageUnit).toBe("events");
+  });
+
+  /** @scenario Paid TIERED organization counts each trace as one unit */
+  it("counts each trace (traces unit) for a paid TIERED organization", () => {
+    const decision = resolveUsageMeter({
+      pricingModel: PricingModel.TIERED,
+      isFree: false,
+      hasValidLicenseOverride: false,
+      clickhouseAvailable: true,
+    });
+
+    expect(decision.usageUnit).toBe("traces");
+  });
+
+  /** @scenario Paid SEAT_EVENT organization counts each span toward the limit */
+  it("counts each span (events unit) for a paid SEAT_EVENT organization", () => {
+    const decision = resolveUsageMeter({
+      pricingModel: PricingModel.SEAT_EVENT,
+      isFree: false,
+      hasValidLicenseOverride: false,
+      clickhouseAvailable: true,
+    });
+
+    expect(decision.usageUnit).toBe("events");
+  });
+
+  /** @scenario Licensed organization respects its own counting rule */
+  it("uses the license-specified counting unit for a licensed organization", () => {
+    const decision = resolveUsageMeter({
+      pricingModel: PricingModel.SEAT_EVENT,
+      licenseUsageUnit: "traces",
+      isFree: true,
+      hasValidLicenseOverride: true,
+      clickhouseAvailable: true,
+    });
+
+    expect(decision.usageUnit).toBe("traces");
+  });
+});
+
 describe("normalizeUsageUnit", () => {
   it("normalizes 'events' to events", () => {
     expect(normalizeUsageUnit("events")).toBe("events");

--- a/specs/features/pricing-model-aware-free-plan.feature
+++ b/specs/features/pricing-model-aware-free-plan.feature
@@ -7,15 +7,15 @@ Feature: Unified FREE plan experience
     Given the platform is running in SaaS mode
 
   # 6 of 12 scenarios are bound to existing tests in langwatch/ee/billing/__tests__/planProvider.unit.test.ts.
-  # The remaining 6 @unimplemented scenarios are UPDATE-class per AUDIT_MANIFEST
-  # — no span/trace counting tests exist in planLimits.unit.test.ts yet — and need
-  # tests written before binding (tracked under #3458):
-  #   - "Free TIERED organization counts each span toward the limit"
-  #   - "Free SEAT_EVENT organization counts each span toward the limit"
-  #   - "Paid TIERED organization counts each trace as one unit"
-  #   - "Paid SEAT_EVENT organization counts each span toward the limit"
-  #   - "Licensed organization respects its own counting rule"
+  # 5 counting-unit scenarios are now bound in
+  # langwatch/src/server/app-layer/usage/__tests__/usage-meter-policy.unit.test.ts
+  # (the "counting unit by organization profile" describe block).
+  #
+  # NoTest gap (1 scenario remains @unimplemented):
   #   - "Self-hosted free organization is never blocked"
+  #     UsageService.checkLimit has no IS_SAAS short-circuit — it still returns
+  #     exceeded: true on self-hosted when limits are hit. The scenario describes
+  #     behaviour that is not yet implemented in the service layer.
 
   # ============================================================================
   # Event Limits
@@ -73,31 +73,31 @@ Feature: Unified FREE plan experience
   # Usage counting — free tier counts every span as one unit
   # ============================================================================
 
-  @unit @unimplemented
+  @unit
   Scenario: Free TIERED organization counts each span toward the limit
     Given a free organization originally on the TIERED pricing model
     When a trace with 5 spans is ingested
     Then 5 units are counted toward the monthly limit
 
-  @unit @unimplemented
+  @unit
   Scenario: Free SEAT_EVENT organization counts each span toward the limit
     Given a free organization on the SEAT_EVENT pricing model
     When a trace with 5 spans is ingested
     Then 5 units are counted toward the monthly limit
 
-  @unit @unimplemented
+  @unit
   Scenario: Paid TIERED organization counts each trace as one unit
     Given a paid organization on the TIERED pricing model
     When a trace with 5 spans is ingested
     Then 1 unit is counted toward the monthly limit
 
-  @unit @unimplemented
+  @unit
   Scenario: Paid SEAT_EVENT organization counts each span toward the limit
     Given a paid organization on the SEAT_EVENT pricing model
     When a trace with 5 spans is ingested
     Then 5 units are counted toward the monthly limit
 
-  @unit @unimplemented
+  @unit
   Scenario: Licensed organization respects its own counting rule
     Given an organization with an active license that specifies trace-based counting
     When a trace with 5 spans is ingested


### PR DESCRIPTION
## Summary

Implements REAL unit tests (not just `@scenario` JSDoc bindings) for 5 scenarios in `specs/features/pricing-model-aware-free-plan.feature`. Adds a new \"counting unit by organization profile\" describe block to `usage-meter-policy.unit.test.ts` where each test maps verbatim to a scenario title.

| Scenario | Mapping |
|----------|---------|
| Free TIERED organization counts each span toward the limit | `isFree=true, TIERED → events` |
| Free SEAT_EVENT organization counts each span toward the limit | `isFree=true, SEAT_EVENT → events` |
| Paid TIERED organization counts each trace as one unit | `isFree=false, TIERED → traces` |
| Paid SEAT_EVENT organization counts each span toward the limit | `isFree=false, SEAT_EVENT → events` |
| Licensed organization respects its own counting rule | license override wins over pricing model |

## Deferred

- `Self-hosted free organization is never blocked` stays `@unimplemented` because `UsageService.checkLimit` has no `IS_SAAS` short-circuit. Documented as a NoTest gap in the feature header.

## Test plan

- [x] `pnpm vitest run src/server/app-layer/usage/__tests__/usage-meter-policy.unit.test.ts` — 27 tests pass
- [x] `pnpm check:feature-parity` — 302 enforced bound (incl. 5 new)
- [ ] CI green
- [ ] Visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)