### PR TITLE
test(features): implement 4 unit tests for trace-limit-upgrade-message parity

### DIFF
--- a/langwatch/src/server/app-layer/usage/__tests__/limit-message.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/limit-message.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildLimitMessage } from "../limit-message";
+
+vi.mock("~/env.mjs", () => ({
+  env: {
+    IS_SAAS: true,
+    BASE_HOST: undefined,
+  },
+}));
+
+const envMock = await vi.hoisted(async () => {
+  const mod = await import("~/env.mjs");
+  return mod.env as { IS_SAAS: boolean; BASE_HOST: string | undefined };
+});
+
+describe("buildLimitMessage", () => {
+  beforeEach(() => {
+    envMock.IS_SAAS = true;
+    envMock.BASE_HOST = undefined;
+  });
+
+  /** @scenario Free-tier org on SaaS told to upgrade with correct unit */
+  it("tells a free-tier SaaS org to upgrade with the events unit", () => {
+    envMock.IS_SAAS = true;
+    const message = buildLimitMessage({
+      isFree: true,
+      limit: 50000,
+      usageUnit: "events",
+    });
+    expect(message).toContain("Free limit of 50000 events reached");
+    expect(message).toContain(
+      "upgrade your plan at https://app.langwatch.ai/settings/subscription",
+    );
+  });
+
+  /** @scenario Free-tier org on self-hosted told to buy a license */
+  it("tells a free-tier self-hosted org to buy a license at the configured base host", () => {
+    envMock.IS_SAAS = false;
+    envMock.BASE_HOST = "https://my-langwatch.example.com";
+    const message = buildLimitMessage({
+      isFree: true,
+      limit: 50000,
+      usageUnit: "events",
+    });
+    expect(message).toContain("Free limit of 50000 events reached");
+    expect(message).toContain(
+      "buy a license at https://my-langwatch.example.com/settings/license",
+    );
+  });
+
+  /** @scenario Paid TIERED org on SaaS told to upgrade with traces unit */
+  it("tells a paid SaaS org to upgrade with the traces unit", () => {
+    envMock.IS_SAAS = true;
+    const message = buildLimitMessage({
+      isFree: false,
+      limit: 10000,
+      usageUnit: "traces",
+    });
+    expect(message).toContain("Monthly limit of 10000 traces reached");
+    expect(message).toContain(
+      "upgrade your plan at https://app.langwatch.ai/settings/subscription",
+    );
+  });
+
+  /** @scenario Paid TIERED org on self-hosted told to buy a license */
+  it("tells a paid self-hosted org to buy a license at the configured base host", () => {
+    envMock.IS_SAAS = false;
+    envMock.BASE_HOST = "https://my-langwatch.example.com";
+    const message = buildLimitMessage({
+      isFree: false,
+      limit: 10000,
+      usageUnit: "traces",
+    });
+    expect(message).toContain("Monthly limit of 10000 traces reached");
+    expect(message).toContain(
+      "buy a license at https://my-langwatch.example.com/settings/license",
+    );
+  });
+});

--- a/langwatch/src/server/app-layer/usage/limit-message.ts
+++ b/langwatch/src/server/app-layer/usage/limit-message.ts
@@ -1,0 +1,40 @@
+import { env } from "~/env.mjs";
+import type { UsageUnit } from "./usage-meter-policy";
+
+/**
+ * Builds the human-readable limit message for 429 responses.
+ *
+ * Format: "{prefix} limit of {limit} {unit} reached. To increase your limits, {action}"
+ * - prefix: "Free" for free-tier orgs, "Monthly" for paid orgs
+ * - unit: "events" or "traces" based on the meter decision
+ * - action: SaaS users are told to upgrade; self-hosted users are told to buy a license
+ */
+export function buildLimitMessage({
+  isFree,
+  limit,
+  usageUnit,
+}: {
+  isFree: boolean;
+  limit: number;
+  usageUnit: UsageUnit;
+}): string {
+  const prefix = isFree ? "Free" : "Monthly";
+  const base = `${prefix} limit of ${limit} ${usageUnit} reached`;
+  const upgradeUrl = buildUpgradeUrl();
+
+  return `${base}. To increase your limits, ${upgradeUrl}`;
+}
+
+/**
+ * Returns the upgrade call-to-action based on deployment mode.
+ * SaaS: "upgrade your plan at https://app.langwatch.ai/settings/subscription"
+ * Self-hosted: "buy a license at {BASE_HOST}/settings/license"
+ */
+export function buildUpgradeUrl(): string {
+  if (env.IS_SAAS) {
+    return "upgrade your plan at https://app.langwatch.ai/settings/subscription";
+  }
+
+  const baseHost = env.BASE_HOST ?? "https://app.langwatch.ai";
+  return `buy a license at ${baseHost}/settings/license`;
+}

--- a/langwatch/src/server/app-layer/usage/usage.service.ts
+++ b/langwatch/src/server/app-layer/usage/usage.service.ts
@@ -9,8 +9,8 @@ import {
   type MeterDecision,
   type UsageUnit,
 } from "./usage-meter-policy";
+import { buildLimitMessage } from "./limit-message";
 import { OrganizationRepository } from "../../repositories/organization.repository";
-import { env } from "~/env.mjs";
 import { ScenarioSetLimitExceededError } from "./errors";
 import type { SimulationRunService } from "../simulations/simulation-run.service";
 import { UNLIMITED_MESSAGES } from "../../../../ee/billing/planLimits";
@@ -272,40 +272,3 @@ export class UsageService {
 
 }
 
-/**
- * Builds the human-readable limit message for 429 responses.
- *
- * Format: "{prefix} limit of {limit} {unit} reached. To increase your limits, {action}"
- * - prefix: "Free" for free-tier orgs, "Monthly" for paid orgs
- * - unit: "events" or "traces" based on the meter decision
- * - action: SaaS users are told to upgrade; self-hosted users are told to buy a license
- */
-function buildLimitMessage({
-  isFree,
-  limit,
-  usageUnit,
-}: {
-  isFree: boolean;
-  limit: number;
-  usageUnit: UsageUnit;
-}): string {
-  const prefix = isFree ? "Free" : "Monthly";
-  const base = `${prefix} limit of ${limit} ${usageUnit} reached`;
-  const upgradeUrl = buildUpgradeUrl();
-
-  return `${base}. To increase your limits, ${upgradeUrl}`;
-}
-
-/**
- * Returns the upgrade call-to-action based on deployment mode.
- * SaaS: "upgrade your plan at https://app.langwatch.ai/settings/subscription"
- * Self-hosted: "buy a license at {BASE_HOST}/settings/license"
- */
-function buildUpgradeUrl(): string {
-  if (env.IS_SAAS) {
-    return "upgrade your plan at https://app.langwatch.ai/settings/subscription";
-  }
-
-  const baseHost = env.BASE_HOST ?? "https://app.langwatch.ai";
-  return `buy a license at ${baseHost}/settings/license`;
-}

--- a/specs/features/trace-limit-upgrade-message.feature
+++ b/specs/features/trace-limit-upgrade-message.feature
@@ -7,16 +7,11 @@ Feature: Usage limit 429 message includes upgrade instructions
   # Free tier counts "events", paid TIERED counts "traces".
   # The message must reflect the actual usage unit being counted.
 
-  # 0 of 4 scenarios are bound — all are UPDATE-class per AUDIT_MANIFEST.
-  # Production message formatting diverges from scenario assertions
-  # (e.g., "Free limit of 50000 events" vs "Free plan limit of"). Scenarios need
-  # rewriting to match actual strings in limit-message.ts (tracked under #3458):
-  #   - "Free-tier org on SaaS told to upgrade with correct unit"
-  #   - "Free-tier org on self-hosted told to buy a license"
-  #   - "Paid TIERED org on SaaS told to upgrade with traces unit"
-  #   - "Paid TIERED org on self-hosted told to buy a license"
+  # All 4 scenarios are bound to limit-message.unit.test.ts via @scenario JSDoc.
+  # The buildLimitMessage helper was extracted from usage.service.ts into
+  # langwatch/src/server/app-layer/usage/limit-message.ts to make it directly
+  # testable without spinning up the full UsageService.
 
-  @unimplemented
   Scenario: Free-tier org on SaaS told to upgrade with correct unit
     Given a free-tier organization that has exceeded 50000 events
     And the platform is running in SaaS mode
@@ -24,7 +19,6 @@ Feature: Usage limit 429 message includes upgrade instructions
     Then the message contains "Free limit of 50000 events reached"
     And the message contains "upgrade your plan at https://app.langwatch.ai/settings/subscription"
 
-  @unimplemented
   Scenario: Free-tier org on self-hosted told to buy a license
     Given a free-tier organization that has exceeded 50000 events
     And the platform is running in self-hosted mode
@@ -33,7 +27,6 @@ Feature: Usage limit 429 message includes upgrade instructions
     Then the message contains "Free limit of 50000 events reached"
     And the message contains "buy a license at https://my-langwatch.example.com/settings/license"
 
-  @unimplemented
   Scenario: Paid TIERED org on SaaS told to upgrade with traces unit
     Given a paid TIERED organization that has exceeded 10000 traces
     And the platform is running in SaaS mode
@@ -41,7 +34,6 @@ Feature: Usage limit 429 message includes upgrade instructions
     Then the message contains "Monthly limit of 10000 traces reached"
     And the message contains "upgrade your plan at https://app.langwatch.ai/settings/subscription"
 
-  @unimplemented
   Scenario: Paid TIERED org on self-hosted told to buy a license
     Given a paid TIERED organization that has exceeded 10000 traces
     And the platform is running in self-hosted mode


### PR DESCRIPTION
## Summary

Extracts `buildLimitMessage` and `buildUpgradeUrl` from `usage.service.ts` into a dedicated `limit-message.ts` module so they can be unit-tested directly without spinning up the full UsageService. Adds 4 unit tests, one per scenario in `trace-limit-upgrade-message.feature`:

- Free-tier org on SaaS told to upgrade with correct unit
- Free-tier org on self-hosted told to buy a license
- Paid TIERED org on SaaS told to upgrade with traces unit
- Paid TIERED org on self-hosted told to buy a license

## Refactor

The extraction is behavior-preserving — `usage.service.ts` still calls the same functions, just imported instead of inline.

## Test plan

- [x] 4 new tests pass: `pnpm vitest run src/server/app-layer/usage/__tests__/limit-message.unit.test.ts`
- [x] 19 existing usage.service tests still pass
- [x] `pnpm check:feature-parity` — 4/4 scenarios bound in trace-limit-upgrade-message
- [ ] CI green
- [ ] Visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)