### PR TITLE
test(features): bind 5 EESubscriptionService scenarios to existing unit tests

### DIFF
--- a/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
@@ -156,6 +156,7 @@ describe("EESubscriptionService", () => {
 
   describe("updateSubscriptionItems()", () => {
     describe("when active subscription exists", () => {
+      /** @scenario EESubscriptionService updates subscription items via Stripe */
       it("updates subscription items via Stripe", async () => {
         repository.findLastNonCancelled.mockResolvedValue({
           id: "sub_db_1",
@@ -272,6 +273,7 @@ describe("EESubscriptionService", () => {
 
   describe("createOrUpdateSubscription()", () => {
     describe("when cancelling to FREE with existing subscription", () => {
+      /** @scenario EESubscriptionService cancels subscription when downgrading to free */
       it("cancels Stripe subscription and updates status via repository", async () => {
         repository.findLastNonCancelled.mockResolvedValue({
           id: "sub_db_1",
@@ -329,6 +331,7 @@ describe("EESubscriptionService", () => {
     });
 
     describe("when creating new subscription", () => {
+      /** @scenario EESubscriptionService creates checkout for new subscription */
       it("creates checkout session for new plan", async () => {
         repository.findLastNonCancelled.mockResolvedValue(null);
         repository.createPending.mockResolvedValue({ id: "sub_new" });
@@ -463,6 +466,7 @@ describe("EESubscriptionService", () => {
 
   describe("createBillingPortalSession()", () => {
     describe("when called with valid customer and base URL", () => {
+      /** @scenario EESubscriptionService creates billing portal session */
       it("creates portal session with return URL", async () => {
         stripe.billingPortal.sessions.create.mockResolvedValue({
           url: "https://billing.stripe.com/session",
@@ -500,6 +504,7 @@ describe("EESubscriptionService", () => {
 
   describe("notifyProspective()", () => {
     describe("when organization exists", () => {
+      /** @scenario EESubscriptionService notifies for prospective subscription */
       it("dispatches prospective notification", async () => {
         organizationRepository.findNameById.mockResolvedValue({
           id: "org_123",

--- a/specs/features/subscription-service-refactor.feature
+++ b/specs/features/subscription-service-refactor.feature
@@ -3,18 +3,11 @@ Feature: Subscription service refactor
   existing createSubscriptionService factory. Both coexist; the router
   continues using the old factory until Part 4.
 
-  # Parity status: 0 of 6 scenarios bound to existing tests.
-  # The remaining are tracked under #3458:
-  #   - 5 NO_TEST: behavior shipped + correct, no integration test yet exists
-  #   - 1 UPDATE: implementation diverged from the spec wording — needs scenario rewrite
-  # NO_TEST gaps:
-  #   - "EESubscriptionService updates subscription items via Stripe"
-  #   - "EESubscriptionService creates checkout for new subscription"
-  #   - "EESubscriptionService cancels subscription when downgrading to free"
-  #   - "EESubscriptionService creates billing portal session"
-  #   - "EESubscriptionService notifies for prospective subscription"
-  # UPDATE divergences:
-  #   - "New class implements the same interface as old factory"
+  # Parity status: 5 of 6 scenarios bound to existing unit tests in
+  # langwatch/ee/billing/__tests__/subscription.service.unit.test.ts.
+  # The remaining 1 @unimplemented scenario is UPDATE-class per AUDIT_MANIFEST
+  # — implementation diverged from the spec wording (no co-existence with old
+  # factory; the new class IS the service). Tracked under #3458.
 
   @unit @unimplemented
   Scenario: New class implements the same interface as old factory
@@ -22,14 +15,14 @@ Feature: Subscription service refactor
     When EESubscriptionService.create() is called with identical dependencies
     Then it returns an object satisfying the SubscriptionService interface
 
-  @unit @unimplemented
+  @unit
   Scenario: EESubscriptionService updates subscription items via Stripe
     Given an organization with an active subscription
     When updateSubscriptionItems is called with new member and trace counts
     Then the Stripe subscription is updated with calculated items
     And the method returns success true
 
-  @unit @unimplemented
+  @unit
   Scenario: EESubscriptionService creates checkout for new subscription
     Given an organization with no existing subscription
     When createOrUpdateSubscription is called with a paid plan
@@ -37,21 +30,21 @@ Feature: Subscription service refactor
     And a Stripe checkout session is created
     And the checkout URL is returned
 
-  @unit @unimplemented
+  @unit
   Scenario: EESubscriptionService cancels subscription when downgrading to free
     Given an organization with an active subscription
     When createOrUpdateSubscription is called with FREE plan
     Then the Stripe subscription is cancelled
     And the subscription status is updated to CANCELLED
 
-  @unit @unimplemented
+  @unit
   Scenario: EESubscriptionService creates billing portal session
     Given a customer ID and organization
     When createBillingPortalSession is called
     Then a Stripe billing portal session is created
     And the portal URL is returned
 
-  @unit @unimplemented
+  @unit
   Scenario: EESubscriptionService notifies for prospective subscription
     Given an existing organization
     When notifyProspective is called with plan and contact details


### PR DESCRIPTION
## Summary

The audit header on `specs/features/subscription-service-refactor.feature` was wrong — claimed \"no integration test exists yet\" but `subscription.service.unit.test.ts` already covers each EESubscriptionService method via mocked-Stripe unit tests. Adds `@scenario` JSDoc on the existing `it()` calls and removes `@unimplemented` from 5 scenarios.

| Scenario | Bound test |
|----------|------------|
| EESubscriptionService updates subscription items via Stripe | `it(\"updates subscription items via Stripe\")` line 159 |
| EESubscriptionService cancels subscription when downgrading to free | `it(\"cancels Stripe subscription and updates status via repository\")` line 275 |
| EESubscriptionService creates checkout for new subscription | `it(\"creates checkout session for new plan\")` line 332 |
| EESubscriptionService creates billing portal session | `it(\"creates portal session with return URL\")` line 466 |
| EESubscriptionService notifies for prospective subscription | `it(\"dispatches prospective notification\")` line 503 |

The 1 remaining `@unimplemented` (\"New class implements same interface as old factory\") is UPDATE-class because the old factory no longer exists to coexist with — tracked under #3458.

## Test plan

- [x] `pnpm check:feature-parity` — 5/5 scenarios bound
- [ ] CI green
- [ ] Visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)