### PR TITLE
test(experiments): bind 5 slug deduplication scenarios

### DIFF
--- a/langwatch/src/server/experiments/__tests__/experiment-slug-deduplication.integration.test.ts
+++ b/langwatch/src/server/experiments/__tests__/experiment-slug-deduplication.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for ExperimentService slug deduplication.
+ * @see specs/evaluations-v3/experiment-slug-deduplication.feature
+ */
+
+import type { Project } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { getTestProject } from "~/utils/testUtils";
+import { ExperimentService } from "../experiment.service";
+
+describe("ExperimentService slug deduplication", () => {
+  let project: Project;
+  let service: ExperimentService;
+  const createdIds: string[] = [];
+
+  beforeAll(async () => {
+    project = await getTestProject("experiment-slug-dedup");
+    service = ExperimentService.create(prisma);
+  });
+
+  afterEach(async () => {
+    if (createdIds.length === 0) return;
+    await prisma.experiment.deleteMany({
+      where: { id: { in: createdIds }, projectId: project.id },
+    });
+    createdIds.length = 0;
+  });
+
+  const createExperiment = async (slug: string, name?: string) => {
+    const id = `exp_${nanoid()}`;
+    createdIds.push(id);
+    return prisma.experiment.create({
+      data: {
+        id,
+        projectId: project.id,
+        name: name ?? slug,
+        slug,
+        type: "BATCH_EVALUATION_V2",
+      },
+    });
+  };
+
+  /** @scenario New experiment gets deduplicated slug when slug conflicts with existing experiment */
+  it("appends -2 suffix when base slug already exists", async () => {
+    const baseSlug = `dedup-base-${nanoid(6)}`;
+    await createExperiment(baseSlug);
+
+    const result = await service.generateUniqueSlug({
+      baseSlug,
+      projectId: project.id,
+    });
+
+    expect(result).toBe(`${baseSlug}-2`);
+  });
+
+  /** @scenario Updating an existing experiment does not trigger slug deduplication against itself */
+  it("returns the same slug when excluding the experiment that owns it", async () => {
+    const baseSlug = `dedup-self-${nanoid(6)}`;
+    const existing = await createExperiment(baseSlug);
+
+    const result = await service.generateUniqueSlug({
+      baseSlug,
+      projectId: project.id,
+      excludeExperimentId: existing.id,
+    });
+
+    expect(result).toBe(baseSlug);
+  });
+
+  /** @scenario Multiple slug conflicts increment the suffix */
+  it("increments suffix to -3 when -2 is also taken", async () => {
+    const baseSlug = `dedup-multi-${nanoid(6)}`;
+    await createExperiment(baseSlug);
+    await createExperiment(`${baseSlug}-2`);
+
+    const result = await service.generateUniqueSlug({
+      baseSlug,
+      projectId: project.id,
+    });
+
+    expect(result).toBe(`${baseSlug}-3`);
+  });
+
+  /** @scenario Slug with no conflict returns unchanged */
+  it("returns the base slug unchanged when no conflict exists", async () => {
+    const baseSlug = `dedup-fresh-${nanoid(6)}`;
+
+    const result = await service.generateUniqueSlug({
+      baseSlug,
+      projectId: project.id,
+    });
+
+    expect(result).toBe(baseSlug);
+  });
+
+  /** @scenario Unrelated slug sharing the same prefix is not treated as a conflict */
+  it("does not treat prefix-sharing slugs as conflicts", async () => {
+    const baseSlug = `dedup-prefix-${nanoid(6)}`;
+    await createExperiment(`${baseSlug}-extended`);
+
+    const result = await service.generateUniqueSlug({
+      baseSlug,
+      projectId: project.id,
+    });
+
+    expect(result).toBe(baseSlug);
+  });
+});

--- a/specs/evaluations-v3/experiment-slug-deduplication.feature
+++ b/specs/evaluations-v3/experiment-slug-deduplication.feature
@@ -5,31 +5,31 @@ Feature: Experiment slug deduplication
   must deduplicate by appending a numeric suffix to avoid a unique constraint
   violation on (projectId, slug).
 
-  @regression @integration @unimplemented
+  @regression @integration
   Scenario: New experiment gets deduplicated slug when slug conflicts with existing experiment
     Given an experiment exists in the project with slug "my-experiment"
     When a new experiment is saved with a name that generates slug "my-experiment"
     Then the new experiment is created with slug "my-experiment-2"
 
-  @regression @integration @unimplemented
+  @regression @integration
   Scenario: Updating an existing experiment does not trigger slug deduplication against itself
     Given an experiment exists in the project with slug "my-experiment"
     When that same experiment is updated with the same name
     Then the experiment retains slug "my-experiment"
 
-  @regression @integration @unimplemented
+  @regression @integration
   Scenario: Multiple slug conflicts increment the suffix
     Given experiments exist in the project with slugs "my-experiment" and "my-experiment-2"
     When a new experiment is saved with a name that generates slug "my-experiment"
     Then the new experiment is created with slug "my-experiment-3"
 
-  @regression @integration @unimplemented
+  @regression @integration
   Scenario: Slug with no conflict returns unchanged
     Given no experiment exists in the project with the target slug
     When a new experiment is saved
     Then the slug is used as-is without a numeric suffix
 
-  @regression @integration @unimplemented
+  @regression @integration
   Scenario: Unrelated slug sharing the same prefix is not treated as a conflict
     Given an experiment exists with slug "my-exp-extended"
     When a new experiment is saved with a name that generates slug "my-exp"

--- a/specs/evaluations-v3/experiment-slug-deduplication.feature
+++ b/specs/evaluations-v3/experiment-slug-deduplication.feature
@@ -31,6 +31,6 @@ Feature: Experiment slug deduplication
 
   @regression @integration
   Scenario: Unrelated slug sharing the same prefix is not treated as a conflict
-    Given an experiment exists with slug "my-exp-extended"
+    Given an experiment exists in the project with slug "my-exp-extended"
     When a new experiment is saved with a name that generates slug "my-exp"
     Then the new experiment is created with slug "my-exp" without a suffix


### PR DESCRIPTION
## Summary

- Implements integration test for `ExperimentService.generateUniqueSlug` covering all 5 scenarios in `specs/evaluations-v3/experiment-slug-deduplication.feature`
- Removes `@unimplemented` from those scenarios
- Net @unimplemented Δ: -5 in evaluations-v3 domain

## Test plan

- [x] Test file authored at `langwatch/src/server/experiments/__tests__/experiment-slug-deduplication.integration.test.ts`
- [x] `pnpm tsx scripts/check-feature-parity.ts` passes (581 enforced scenarios bound)
- [ ] CI integration test job validates against real Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)