### PR TITLE
test(background): un-tag 4 redis-cluster scenarios from @unimplemented

### DIFF
--- a/specs/background/redis-cluster-compatibility.feature
+++ b/specs/background/redis-cluster-compatibility.feature
@@ -11,14 +11,14 @@ Feature: BullMQ Redis Cluster Compatibility
   # Wrapping queue names in {braces} forces Redis to hash only the braced
   # portion, guaranteeing all keys for a queue land on the same slot.
 
-  @integration @unimplemented
+  @integration
   Scenario: Adding a job to a queue without a hash tag fails on Redis Cluster
     Given a Redis Cluster is running
     And a BullMQ queue named "no-hash-tag"
     When a job is added to the queue
     Then the operation fails with a CROSSSLOT error
 
-  @integration @unimplemented
+  @integration
   Scenario: Adding and processing a job succeeds when the queue name has a hash tag
     Given a Redis Cluster is running
     And a BullMQ queue named "{with_hash_tag}"
@@ -26,7 +26,7 @@ Feature: BullMQ Redis Cluster Compatibility
     When a job is added to the queue
     Then the job is processed successfully without errors
 
-  @integration @unimplemented
+  @integration
   Scenario: Background worker queues operate on Redis Cluster
     Given a Redis Cluster is running
     And the background worker queue names are loaded from configuration
@@ -54,7 +54,7 @@ Feature: BullMQ Redis Cluster Compatibility
     Then every pipeline queue name contains a hash tag
     And adding a job to each pipeline queue succeeds on the cluster
 
-  @unit @unimplemented
+  @unit
   Scenario: Every queue name produced by the system contains a hash tag
     Given all queue name sources in the codebase
     When each source produces its queue name


### PR DESCRIPTION
## Summary

These 4 scenarios in `specs/background/redis-cluster-compatibility.feature` are already bound to passing tests in `langwatch/src/server/background/__tests__/redis-cluster.integration.test.ts`. Removing `@unimplemented` lets the parity scanner enforce the bindings.

- "Adding a job to a queue without a hash tag fails on Redis Cluster"
- "Adding and processing a job succeeds when the queue name has a hash tag"
- "Background worker queues operate on Redis Cluster"
- "Every queue name produced by the system contains a hash tag"

The two event-sourcing dynamic-queue scenarios stay `@unimplemented` per the inline comment — they need `queueManager` wiring not yet present.

Net: +4 enforced parity bindings (580 → 584).

## Test plan

- [x] `npx tsx langwatch/scripts/check-feature-parity.ts` shows `4/4 scenarios bound` for this file
- [x] No code changes — the bound tests already exist and were running in CI
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)