### PR TITLE
test(auth): bind 4 isSsoProviderMatch scenarios in phase-1-better-auth

### DIFF
--- a/langwatch/src/server/better-auth/__tests__/sso.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/sso.test.ts
@@ -3,6 +3,7 @@ import { extractEmailDomain, isSsoProviderMatch } from "../sso";
 
 describe("isSsoProviderMatch", () => {
   describe("when the org has no ssoProvider", () => {
+    /** @scenario isSsoProviderMatch — org without ssoProvider */
     it("returns false even if the account looks like a match", () => {
       expect(
         isSsoProviderMatch(
@@ -14,6 +15,7 @@ describe("isSsoProviderMatch", () => {
   });
 
   describe("when the org ssoProvider matches the account providerId", () => {
+    /** @scenario isSsoProviderMatch — direct provider name match */
     it("returns true for a direct provider name match", () => {
       expect(
         isSsoProviderMatch(
@@ -25,6 +27,7 @@ describe("isSsoProviderMatch", () => {
   });
 
   describe("when the org ssoProvider is an Auth0 connection prefix", () => {
+    /** @scenario isSsoProviderMatch — Auth0 prefix match */
     it("returns true when providerAccountId starts with the prefix", () => {
       expect(
         isSsoProviderMatch(
@@ -77,6 +80,7 @@ describe("isSsoProviderMatch", () => {
   });
 
   describe("when the wrong provider is used", () => {
+    /** @scenario isSsoProviderMatch — wrong provider rejected */
     it("returns false", () => {
       expect(
         isSsoProviderMatch(

--- a/specs/auth/phase-1-better-auth-config.feature
+++ b/specs/auth/phase-1-better-auth-config.feature
@@ -43,28 +43,24 @@ Feature: BetterAuth config (unmounted)
   # SSO domain + provider matching (ported from NextAuth signIn callback)
   # ============================================================================
 
-  @unimplemented
   Scenario: isSsoProviderMatch — Auth0 prefix match
     Given an organization with ssoProvider "waad|acme-azure-connection"
     And an OAuth account with providerId "auth0" and providerAccountId "waad|acme-azure-connection|user-123"
     When I call isSsoProviderMatch(org, account)
     Then it returns true
 
-  @unimplemented
   Scenario: isSsoProviderMatch — direct provider name match
     Given an organization with ssoProvider "google"
     And an OAuth account with providerId "google" and providerAccountId "google-id-123"
     When I call isSsoProviderMatch(org, account)
     Then it returns true
 
-  @unimplemented
   Scenario: isSsoProviderMatch — wrong provider rejected
     Given an organization with ssoProvider "okta"
     And an OAuth account with providerId "google" and providerAccountId "google-id-123"
     When I call isSsoProviderMatch(org, account)
     Then it returns false
 
-  @unimplemented
   Scenario: isSsoProviderMatch — org without ssoProvider
     Given an organization with ssoProvider null
     And any OAuth account


### PR DESCRIPTION
## Summary

Bind the 4 `@unimplemented` `isSsoProviderMatch` scenarios in `specs/auth/phase-1-better-auth-config.feature` to existing tests in `langwatch/src/server/better-auth/__tests__/sso.test.ts`:

- "isSsoProviderMatch — Auth0 prefix match"
- "isSsoProviderMatch — direct provider name match"
- "isSsoProviderMatch — wrong provider rejected"
- "isSsoProviderMatch — org without ssoProvider"

The feature already has `@unit` at the feature level so the scenarios inherit the tag (no per-scenario tag needed). All 4 scenarios are now bound to passing tests.

Net: +4 enforced parity bindings.

## Test plan

- [x] `npx tsx langwatch/scripts/check-feature-parity.ts` shows `4/4 scenarios bound`
- [x] All 12 tests in sso.test.ts pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)