### PR TITLE
fix(deps): upgrade urllib3 to 2.6.3 in python-sdk (alerts #343, #331, #330)

### DIFF
--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -8898,11 +8898,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrades **urllib3** from 2.5.0 → 2.6.3 in `python-sdk/uv.lock`
- Fixes Dependabot alerts #343, #331, #330:
  - CVE-2026-21441: decompression-bomb safeguards bypassed on redirects
  - CVE-2025-66471: unbounded decompression chain
  - CVE-2025-66418: streaming API mishandles highly compressed data

### Background
urllib3 was fixed to 2.6.3 in #3657, but regressed back to 2.5.0 when subsequent lockfile regenerations (`uv lock --upgrade-package ...`) didn't preserve the urllib3 version. Dependabot correctly detected the regression and reopened the alerts.

### Changes
| File | Change |
|---|---|
| `python-sdk/uv.lock` | urllib3 2.5.0 → 2.6.3 |

## Test plan
- [ ] CI passes (lockfile-only, no code changes)