### PR TITLE
test(scenarios): bind synthetic scenario run ID format scenario

### DIFF
--- a/langwatch/src/server/scenarios/__tests__/simulation-runner.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/simulation-runner.unit.test.ts
@@ -62,6 +62,7 @@ describe("KSUID resource patterns", () => {
     const generateScenarioRunId = () =>
       generate(KSUID_RESOURCES.SCENARIO_RUN).toString();
 
+    /** @scenario Synthetic scenario run ID uses "scenariorun_" prefix with KSUID */
     it("generates IDs with scenariorun_ prefix", () => {
       const id = generateScenarioRunId();
       expect(id).toMatch(/^scenariorun_/);

--- a/specs/features/scenarios/scenario-id-format.feature
+++ b/specs/features/scenarios/scenario-id-format.feature
@@ -3,10 +3,7 @@ Feature: Scenario ID format uses full prefix and KSUID
   I want scenario IDs to use the full "scenario" prefix and KSUID generation
   So that IDs are consistent with the project's KSUID naming conventions
 
-  # Parity status: 2 of 3 scenarios bound to existing tests.
-  # The remaining 1 @unimplemented scenario describes shipped behavior
-  # that does not yet have an integration test (#3458):
-  #   - "Synthetic scenario run ID uses \"scenariorun_\" prefix with KSUID"
+  # Parity status: 3 of 3 scenarios bound to existing tests.
 
   Background:
     Given a project exists
@@ -24,7 +21,7 @@ Feature: Scenario ID format uses full prefix and KSUID
     Then it is recognized as a scenario entity
     And scenarios with the legacy "scen_" prefix are also recognized
 
-  @unit @unimplemented
+  @unit
   Scenario: Synthetic scenario run ID uses "scenariorun_" prefix with KSUID
     When a synthetic scenario run ID is generated
     Then it starts with "scenariorun_"


### PR DESCRIPTION
## Summary

- The 1 remaining `@unimplemented` scenario in `specs/features/scenarios/scenario-id-format.feature` ("Synthetic scenario run ID uses `scenariorun_` prefix with KSUID") was already covered by an existing test in `simulation-runner.unit.test.ts` lines 65-67.
- Added `@scenario` JSDoc binding and stripped the `@unimplemented` tag.
- 3/3 scenarios in this feature file now bound.
- Net `@unimplemented` Δ: -1.

## Test plan

- [x] Parity check confirms 3/3 bound (`scripts/check-feature-parity.ts`)
- [x] No code change to production paths — pure test annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)