### PR TITLE
test(prompts): bind CLI input default merge scenario

### DIFF
--- a/langwatch/src/server/prompt-config/__tests__/syncPromptAutoDetect.integration.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/syncPromptAutoDetect.integration.test.ts
@@ -183,6 +183,7 @@ describe("PromptService", () => {
 
     describe("given a new prompt that does not exist on the server", () => {
       describe("when synced with template variables", () => {
+        /** @scenario CLI hardcoded "input" default is kept only when it appears in the template */
         it("creates the prompt with auto-detected inputs merged", async () => {
           vi.spyOn(
             promptService,

--- a/specs/prompts/sync-auto-detect-variables.feature
+++ b/specs/prompts/sync-auto-detect-variables.feature
@@ -9,7 +9,7 @@ Feature: Auto-detect prompt variables during sync
 
   # --- Variable extraction (pure logic) ---
 
-  @unit @unimplemented
+  @integration
   Scenario: CLI hardcoded "input" default is kept only when it appears in the template
     Given a prompt with text "hello {{name}}"
     And the sync payload has inputs [{ identifier: "input", type: "str" }] (CLI default)


### PR DESCRIPTION
## Summary

- The 1 remaining `@unimplemented` scenario in `specs/prompts/sync-auto-detect-variables.feature` ("CLI hardcoded \"input\" default is kept only when it appears in the template") was already covered by an existing test at `syncPromptAutoDetect.integration.test.ts:187` ("creates the prompt with auto-detected inputs merged").
- Bound via `@scenario` JSDoc and re-tagged the scenario from `@unit` to `@integration` to match the binding location.
- Net `@unimplemented` Δ: -1.

## Test plan

- [x] Parity check confirms file is fully bound
- [x] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)