### PR TITLE
test: bind 10 @unimplemented scenarios across auth + model-config

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/prepareLitellmParams.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/prepareLitellmParams.unit.test.ts
@@ -58,6 +58,48 @@ describe("prepareLitellmParams", () => {
     });
   });
 
+  describe("when the model is an Anthropic Claude version with dots", () => {
+    /** @scenario "prepareLitellmParams translates Anthropic model ID" */
+    it("translates anthropic/claude-opus-4.5 to anthropic/claude-opus-4-5 in params.model", async () => {
+      const baseAnthropicProvider = {
+        provider: "anthropic" as const,
+        enabled: true,
+        customKeys: { ANTHROPIC_API_KEY: "sk-ant-test" },
+        extraHeaders: null,
+        deploymentMapping: null,
+      };
+
+      const params = await prepareLitellmParams({
+        model: "anthropic/claude-opus-4.5",
+        modelProvider: baseAnthropicProvider,
+        projectId: "project-123",
+      });
+
+      expect(params.model).toBe("anthropic/claude-opus-4-5");
+    });
+  });
+
+  describe("when the model is an OpenAI model", () => {
+    /** @scenario "prepareLitellmParams preserves OpenAI model ID" */
+    it("preserves openai/gpt-5 unchanged in params.model", async () => {
+      const baseOpenAIProvider = {
+        provider: "openai" as const,
+        enabled: true,
+        customKeys: { OPENAI_API_KEY: "sk-openai-test" },
+        extraHeaders: null,
+        deploymentMapping: null,
+      };
+
+      const params = await prepareLitellmParams({
+        model: "openai/gpt-5",
+        modelProvider: baseOpenAIProvider,
+        projectId: "project-123",
+      });
+
+      expect(params.model).toBe("openai/gpt-5");
+    });
+  });
+
   describe("when provider is azure", () => {
     it("preserves azure deployment model ID in params.model", async () => {
       const params = await prepareLitellmParams({

--- a/langwatch/src/server/better-auth/__tests__/hooks.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/hooks.test.ts
@@ -76,6 +76,7 @@ describe("beforeUserCreate", () => {
 
 describe("afterUserCreate", () => {
   describe("when the email domain matches an organization with ssoDomain", () => {
+    /** @scenario New user with matching SSO domain joins the SSO org */
     it("adds the user to the organization as a MEMBER", async () => {
       const prisma = makePrismaMock({
         organization: {
@@ -244,6 +245,7 @@ describe("beforeAccountCreate", () => {
   });
 
   describe("when the user is deactivated", () => {
+    /** @scenario Deactivated user is blocked */
     it("throws USER_DEACTIVATED", async () => {
       const prisma = makePrismaMock({
         user: {
@@ -265,6 +267,7 @@ describe("beforeAccountCreate", () => {
   });
 
   describe("when the user's email domain matches an org with correct SSO provider", () => {
+    /** @scenario Existing user with correct SSO provider auto-links */
     it("defers reconciliation to afterAccountCreate (no DB writes in before)", async () => {
       const deleteMany = vi.fn();
       const update = vi.fn();
@@ -300,6 +303,7 @@ describe("beforeAccountCreate", () => {
   });
 
   describe("when an EXISTING user's email domain matches an org with WRONG SSO provider", () => {
+    /** @scenario Existing user with wrong SSO provider gets pending flag */
     it("soft-blocks by setting pendingSsoSetup=true without throwing", async () => {
       const update = vi.fn().mockResolvedValue(undefined);
       const prisma = makePrismaMock({

--- a/langwatch/src/server/better-auth/__tests__/index.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/index.test.ts
@@ -29,6 +29,7 @@ describe("better-auth config", () => {
       expect(options?.session?.storeSessionInDatabase).toBe(true);
     });
 
+    /** @scenario Credentials-only on-prem mode */
     it("gates emailAndPassword.enabled on NEXTAUTH_PROVIDER=email", async () => {
       // Regression for iter-20 bug 16: BetterAuth's email/password routes
       // (`/sign-up/email`, `/sign-in/email`) were unconditionally enabled,

--- a/langwatch/src/server/modelProviders/__tests__/registry.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/registry.unit.test.ts
@@ -471,18 +471,21 @@ describe("Parameter Constraints", () => {
       expect(constraints?.temperature).toEqual({ min: 0, max: 1 });
     });
 
+    /** @scenario "OpenAI provider uses global defaults" */
     it("returns undefined for OpenAI models (no constraints defined)", () => {
       const constraints = getParameterConstraints("openai/gpt-4.1");
 
       expect(constraints).toBeUndefined();
     });
 
+    /** @scenario "Unknown provider returns undefined constraints" */
     it("returns undefined for unknown provider", () => {
-      const constraints = getParameterConstraints("unknown-provider/model");
+      const constraints = getParameterConstraints("unknown-provider/some-model");
 
       expect(constraints).toBeUndefined();
     });
 
+    /** @scenario "Model ID without provider prefix returns undefined" */
     it("returns undefined for model ID without provider prefix", () => {
       const constraints = getParameterConstraints("standalone-model");
 

--- a/specs/auth/phase-1-better-auth-config.feature
+++ b/specs/auth/phase-1-better-auth-config.feature
@@ -16,7 +16,6 @@ Feature: BetterAuth config (unmounted)
   # Provider selection via NEXTAUTH_PROVIDER env
   # ============================================================================
 
-  @unimplemented
   Scenario: Credentials-only on-prem mode
     Given NEXTAUTH_PROVIDER is "email"
     And AUTH0_* envs are not set
@@ -75,7 +74,6 @@ Feature: BetterAuth config (unmounted)
   # signIn guards (ported from NextAuth signIn callback)
   # ============================================================================
 
-  @unimplemented
   Scenario: Deactivated user is blocked
     Given a user exists with deactivatedAt set to yesterday
     When that user signs in via any provider
@@ -87,7 +85,6 @@ Feature: BetterAuth config (unmounted)
     When an OAuth callback returns a profile with email "b@example.com"
     Then the signin is rejected with a DIFFERENT_EMAIL_NOT_ALLOWED error
 
-  @unimplemented
   Scenario: New user with matching SSO domain joins the SSO org
     Given an organization with ssoDomain "acme.com" exists
     And no user exists with email "new@acme.com"
@@ -96,7 +93,6 @@ Feature: BetterAuth config (unmounted)
     And the user is added to the organization as a MEMBER
     And an Account row is created for the OAuth account
 
-  @unimplemented
   Scenario: Existing user with correct SSO provider auto-links
     Given an organization with ssoDomain "acme.com" and ssoProvider "google" exists
     And a user exists with email "existing@acme.com" and pendingSsoSetup=false
@@ -104,7 +100,6 @@ Feature: BetterAuth config (unmounted)
     Then the Account row is upserted
     And pendingSsoSetup remains false
 
-  @unimplemented
   Scenario: Existing user with wrong SSO provider gets pending flag
     Given an organization with ssoDomain "acme.com" and ssoProvider "okta" exists
     And a user exists with email "existing@acme.com" and pendingSsoSetup=false

--- a/specs/model-config/litellm-model-id-translation.feature
+++ b/specs/model-config/litellm-model-id-translation.feature
@@ -47,14 +47,14 @@ Feature: LiteLLM Model ID Translation
 
   # Unit Tests: Boundary Integration
 
-  @unit @unimplemented
+  @unit
   Scenario: prepareLitellmParams translates Anthropic model ID
     Given a call to prepareLitellmParams with model "anthropic/claude-opus-4.5"
     And a valid Anthropic model provider
     When the function returns
     Then params.model should be "anthropic/claude-opus-4-5"
 
-  @unit @unimplemented
+  @unit
   Scenario: prepareLitellmParams preserves OpenAI model ID
     Given a call to prepareLitellmParams with model "openai/gpt-5"
     And a valid OpenAI model provider

--- a/specs/model-config/model-parameter-constraints.feature
+++ b/specs/model-config/model-parameter-constraints.feature
@@ -9,20 +9,20 @@ Feature: Model Parameter Constraints
 
   # Unit Tests: Constraint Resolution
 
-  @unit @unimplemented
+  @unit
   Scenario: OpenAI provider uses global defaults
     Given the provider "openai" has no parameterConstraints for temperature
     When resolving constraints for model "openai/gpt-4.1"
     Then temperature constraint should be undefined
     # UI falls back to global default max 2.0 from parameterRegistry
 
-  @unit @unimplemented
+  @unit
   Scenario: Unknown provider returns undefined constraints
     Given a model ID "unknown-provider/some-model"
     When resolving constraints for that model
     Then the result should be undefined
 
-  @unit @unimplemented
+  @unit
   Scenario: Model ID without provider prefix returns undefined
     Given a model ID "standalone-model"
     When resolving constraints for that model


### PR DESCRIPTION
## Summary

Bind 10 `@unimplemented` `@unit` scenarios across two unrelated feature files to passing tests via `/** @scenario "<title>" */` JSDoc + dropping the `@unimplemented` tag. Two commits, one logical theme: "wire up parity scanner enforcement on tests that already exist."

## Commit 1 — `test(auth)`: 5 bindings (existing tests, no new code)

`specs/auth/phase-1-better-auth-config.feature` ↔ `src/server/better-auth/__tests__/`:

| Scenario | Test |
|---|---|
| Credentials-only on-prem mode | `index.test.ts` gates `emailAndPassword.enabled` on `NEXTAUTH_PROVIDER=email` |
| Deactivated user is blocked | `hooks.test.ts` `beforeAccountCreate` throws `USER_DEACTIVATED` |
| New user with matching SSO domain joins the SSO org | `hooks.test.ts` `afterUserCreate` adds MEMBER |
| Existing user with correct SSO provider auto-links | `hooks.test.ts` `beforeAccountCreate` defers reconciliation |
| Existing user with wrong SSO provider gets pending flag | `hooks.test.ts` `beforeAccountCreate` sets `pendingSsoSetup=true` |

## Commit 2 — `test(model-config)`: 5 bindings

`specs/model-config/litellm-model-id-translation.feature` (2 **new** tests in `prepareLitellmParams.unit.test.ts`):

| Scenario | Assertion |
|---|---|
| `prepareLitellmParams` translates Anthropic model ID | `anthropic/claude-opus-4.5` → `anthropic/claude-opus-4-5` in `params.model` |
| `prepareLitellmParams` preserves OpenAI model ID | `openai/gpt-5` passes through unchanged |

`specs/model-config/model-parameter-constraints.feature` (3 bindings to existing tests in `registry.unit.test.ts`, JSDoc-only):

| Scenario | Test |
|---|---|
| OpenAI provider uses global defaults | `getParameterConstraints("openai/gpt-4.1")` returns `undefined` |
| Unknown provider returns undefined constraints | `getParameterConstraints("unknown-provider/some-model")` returns `undefined` |
| Model ID without provider prefix returns undefined | `getParameterConstraints("standalone-model")` returns `undefined` |

### Skipped

- **"Translates Anthropic Claude 3.5 Sonnet model ID"** — spec expects `anthropic/claude-3-5-sonnet` but the impl correctly alias-expands to `anthropic/claude-3-5-sonnet-20240620`. Binding would mask spec/impl drift; left `@unimplemented` so the gap remains visible.
- **4 clamping scenarios** in `model-parameter-constraints.feature` — those target the Python NLP backend (`langwatch_nlp`), not TS.

## Net parity

+10 enforced bindings.

## Test plan

- [x] `pnpm test:unit src/server/better-auth/__tests__/hooks.test.ts src/server/better-auth/__tests__/index.test.ts` — passing
- [x] `pnpm test:unit src/server/api/routers/__tests__/prepareLitellmParams.unit.test.ts` — 6/6 passing
- [x] `pnpm test:unit src/server/modelProviders/__tests__/registry.unit.test.ts` — 67/67 passing
- [x] `pnpm tsx scripts/check-feature-parity.ts` — exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)