### PR TITLE
test(typescript-sdk): bind listRecords explicit pagination scenario

### DIFF
--- a/specs/features/dataset-typescript-sdk.feature
+++ b/specs/features/dataset-typescript-sdk.feature
@@ -3,11 +3,8 @@ Feature: Dataset TypeScript SDK
   I want full CRUD access to datasets and records through the SDK client
   So that I can programmatically manage datasets without using the REST API directly
 
-  # 31 of 32 scenarios are bound to integration/unit tests in
+  # 32 of 32 scenarios bound to integration/unit tests in
   # typescript-sdk/src/client-sdk/services/datasets/__tests__/.
-  # The 1 remaining @unimplemented scenario is a gap in test coverage:
-  #   - "List records with explicit pagination"
-  # Tracked under #3458.
 
   Background:
     Given a LangWatch client initialized with a valid API key
@@ -172,7 +169,7 @@ Feature: Dataset TypeScript SDK
     When I call langwatch.datasets.listRecords("my-data")
     Then I receive records with pagination metadata including total, page, limit, and totalPages
 
-  @integration @unimplemented
+  @integration
   Scenario: List records with explicit pagination
     When I call langwatch.datasets.listRecords("my-data", { page: 2, limit: 20 })
     Then the request includes page=2 and limit=20 query parameters

--- a/typescript-sdk/src/client-sdk/services/datasets/__tests__/datasets.integration.test.ts
+++ b/typescript-sdk/src/client-sdk/services/datasets/__tests__/datasets.integration.test.ts
@@ -557,6 +557,37 @@ describe("Feature: Dataset TypeScript SDK", () => {
         ).rejects.toThrow(DatasetNotFoundError);
       });
     });
+
+    describe("when called with explicit pagination", () => {
+      let capturedUrl: URL | undefined;
+
+      beforeEach(() => {
+        capturedUrl = undefined;
+        server.use(
+          http.get(
+            `${TEST_ENDPOINT}/api/dataset/:slugOrId/records`,
+            ({ request }) => {
+              capturedUrl = new URL(request.url);
+              return HttpResponse.json({
+                data: [],
+                pagination: { page: 2, limit: 20, total: 0, totalPages: 0 },
+              });
+            },
+          ),
+        );
+      });
+
+      /** @scenario "List records with explicit pagination" */
+      it("includes page and limit query parameters in the request", async () => {
+        await langwatch.datasets.listRecords("my-data", {
+          page: 2,
+          limit: 20,
+        });
+
+        expect(capturedUrl?.searchParams.get("page")).toBe("2");
+        expect(capturedUrl?.searchParams.get("limit")).toBe("20");
+      });
+    });
   });
 
   // ── Upload (unified with ifExists strategy) ────────────────────


### PR DESCRIPTION
## Summary

- Adds a new MSW-mocked integration test in `datasets.integration.test.ts` that asserts `langwatch.datasets.listRecords("my-data", { page: 2, limit: 20 })` forwards `page=2` and `limit=20` as query parameters.
- Captures the request URL via MSW's `request.url` and reads `searchParams`.
- Bound via `@scenario` JSDoc; `@unimplemented` stripped.
- Net `@unimplemented` Δ: -1.

## Test plan

- [x] Parity check shows scenario bound
- [ ] CI confirms test passes (couldn't run locally — `typescript-sdk/node_modules` not populated in this worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)