### PR TITLE
test(prompts): bind tag-name zero validation scenarios

### DIFF
--- a/langwatch/src/app/api/prompts/__tests__/prompt-tags.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/prompt-tags.integration.test.ts
@@ -180,6 +180,7 @@ describe("Prompt Tags REST API (/api/prompts/tags)", () => {
     describe("when creating a valid custom tag", () => {
       /** @scenario "Creating a custom tag" */
       /** @scenario 'Recreating "production" after deletion succeeds' */
+      /** @scenario "Accepts valid non-numeric tag during creation" */
       it("returns 201 with id and name", async () => {
         const res = await post("/api/prompts/tags", { name: "canary" });
 
@@ -191,8 +192,17 @@ describe("Prompt Tags REST API (/api/prompts/tags)", () => {
     });
 
     describe("when name is purely numeric", () => {
+      /** @scenario "Rejects zero as a tag name during creation" */
       it("returns 422", async () => {
         const res = await post("/api/prompts/tags", { name: "42" });
+
+        expect(res.status).toBe(422);
+        const body = await res.json();
+        expect(body.message).toMatch(/numeric/i);
+      });
+
+      it("rejects '0' as a numeric tag name", async () => {
+        const res = await post("/api/prompts/tags", { name: "0" });
 
         expect(res.status).toBe(422);
         const body = await res.json();

--- a/specs/prompts/shorthand-prompt-label-syntax.feature
+++ b/specs/prompts/shorthand-prompt-label-syntax.feature
@@ -5,13 +5,13 @@ Feature: Shorthand prompt tag syntax (server-side)
 
   # --- Shorthand Parsing (pure logic, no tag allowlist needed) ---
 
-  @unit @unimplemented
+  @integration
   Scenario: Rejects zero as a tag name during creation
     Given the allowed tags are "production" and "staging"
     When a user tries to create a tag named "0"
     Then the creation is rejected with a validation error
 
-  @unit @unimplemented
+  @integration
   Scenario: Accepts valid non-numeric tag during creation
     Given the allowed tags are "production" and "staging"
     When a user tries to create a tag named "production"


### PR DESCRIPTION
## Summary

- Both `@unimplemented` scenarios in `specs/prompts/shorthand-prompt-label-syntax.feature` already had matching coverage in `prompt-tags.integration.test.ts` (POST `/api/prompts/tags` 422-on-numeric, 201-on-valid).
- Added an explicit `"rejects '0'"` test next to the existing `'42'` test to exercise the specific value the scenario calls out.
- Bound via `@scenario` JSDoc; retagged scenarios from `@unit` to `@integration`.
- Net `@unimplemented` Δ: -2.

## Test plan

- [x] Parity check confirms 2/2 bound
- [ ] CI confirms tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)