### PR TITLE
test(invites): un-skip integration suite and bind 12 @unimplemented scenarios

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/organization.invites.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/organization.invites.integration.test.ts
@@ -84,9 +84,7 @@ function makeTestPlan(overrides: Record<string, unknown> = {}) {
   };
 }
 
-// Skipped: app-layer init regression on main after es-migration refactor
-// — see langwatch/langwatch#3240.
-describe.skip("Organization Invites Integration", () => {
+describe("Organization Invites Integration", () => {
   const testNamespace = `invite-test-${nanoid(8)}`;
   let organizationId: string;
   let teamId: string;
@@ -276,6 +274,7 @@ describe.skip("Organization Invites Integration", () => {
 
   describe("createInviteRequest", () => {
     describe("when member requests invitation with ADMIN role", () => {
+      /** @scenario "Member cannot request invitation with ADMIN role" */
       it("fails with validation error", async () => {
         await expect(
           memberCaller.organization.createInviteRequest({
@@ -305,6 +304,7 @@ describe.skip("Organization Invites Integration", () => {
         expect(results[0]!.invite.status).toBe("WAITING_APPROVAL");
       });
 
+      /** @scenario "Member request sets requestedBy to the requesting user" */
       it("sets requestedBy to the requesting user's ID", async () => {
         const results = await memberCaller.organization.createInviteRequest({
           organizationId,
@@ -316,6 +316,7 @@ describe.skip("Organization Invites Integration", () => {
         expect(results[0]!.invite.requestedBy).toBe(memberUserId);
       });
 
+      /** @scenario "Invitation request has no expiration while awaiting approval" */
       it("creates invitation with null expiration", async () => {
         const results = await memberCaller.organization.createInviteRequest({
           organizationId,
@@ -327,6 +328,7 @@ describe.skip("Organization Invites Integration", () => {
         expect(results[0]!.invite.expiration).toBeNull();
       });
 
+      /** @scenario "No email is sent when a member creates an invitation request" */
       it("does not send invitation email", async () => {
         await memberCaller.organization.createInviteRequest({
           organizationId,
@@ -386,6 +388,7 @@ describe.skip("Organization Invites Integration", () => {
     });
 
     describe("when duplicate invitation exists with WAITING_APPROVAL status", () => {
+      /** @scenario "Duplicate detection across PENDING and WAITING_APPROVAL statuses" */
       it("fails with duplicate invitation error", async () => {
         // Create initial WAITING_APPROVAL invite
         await memberCaller.organization.createInviteRequest({
@@ -421,6 +424,7 @@ describe.skip("Organization Invites Integration", () => {
 
   describe("approveInvite", () => {
     describe("when admin approves a WAITING_APPROVAL invitation", () => {
+      /** @scenario "Approving an invitation sets expiration and status" */
       it("transitions status to PENDING", async () => {
         // Create WAITING_APPROVAL invite
         const results =
@@ -463,6 +467,7 @@ describe.skip("Organization Invites Integration", () => {
         expect(expiration.getTime()).toBeLessThanOrEqual(expectedMax);
       });
 
+      /** @scenario "Email is sent when admin approves an invitation request" */
       it("sends invitation email", async () => {
         const results =
           await memberCaller.organization.createInviteRequest({
@@ -486,6 +491,7 @@ describe.skip("Organization Invites Integration", () => {
     });
 
     describe("when non-admin tries to approve an invitation", () => {
+      /** @scenario "Non-admin cannot approve invitations" */
       it("fails with permission error", async () => {
         // Create WAITING_APPROVAL invite directly in DB
         const invite = await prisma.organizationInvite.create({
@@ -560,6 +566,7 @@ describe.skip("Organization Invites Integration", () => {
 
   describe("deleteInvite", () => {
     describe("when admin deletes a WAITING_APPROVAL invitation", () => {
+      /** @scenario "Deleting a WAITING_APPROVAL invitation works the same as PENDING" */
       it("removes the invitation successfully", async () => {
         // Create WAITING_APPROVAL invite
         const invite = await prisma.organizationInvite.create({
@@ -667,6 +674,7 @@ describe.skip("Organization Invites Integration", () => {
 
   describe("createInvites (admin batch)", () => {
     describe("when admin invites multiple users in a single batch", () => {
+      /** @scenario "Admin batch invite creates all records before sending any emails" */
       it("creates all invite records before sending any emails", async () => {
         const callOrder: string[] = [];
 
@@ -749,6 +757,7 @@ describe.skip("Organization Invites Integration", () => {
 
   describe("approveInvite (email failure)", () => {
     describe("when email service is unavailable during approval", () => {
+      /** @scenario "Email failure during approval does not revert the approval" */
       it("still approves the invitation", async () => {
         // Create WAITING_APPROVAL invite
         const results =
@@ -845,6 +854,7 @@ describe.skip("Organization Invites Integration", () => {
     });
 
     describe("when WAITING_APPROVAL invites count toward member limits", () => {
+      /** @scenario "WAITING_APPROVAL invites count toward license member limits" */
       it("rejects new invite when limit is reached", async () => {
         // Override the subscription handler to set a low limit
         const limitedPlan = makeTestPlan({ maxMembers: 3 });

--- a/specs/members/update-pending-invitation.feature
+++ b/specs/members/update-pending-invitation.feature
@@ -3,7 +3,7 @@ Feature: Invitation Approval Workflow
   I want to request invitations for new users
   So that admins can approve them and new collaborators can join
 
-  # The end-to-end invitation flows are partially bound to existing
+  # End-to-end invitation flows are partially bound to existing
   # JSDOM render tests:
   #   * `InvitesTable.integration.test.tsx` — Pending Approval / Invited
   #     badges + admin-only approve/reject buttons.
@@ -12,14 +12,17 @@ Feature: Invitation Approval Workflow
   #     admin does not).
   #
   # The full backend integration suite
-  # (`organization.invites.integration.test.ts`) covers the rest —
+  # (`organization.invites.integration.test.ts`) covers core
   # `createInviteRequest` validation, expiration/email semantics,
-  # admin approval transitions, license-limit enforcement — but is
-  # currently `describe.skip()` pending an app-layer init regression
-  # fix (#3240). The Playwright e2e specs under
-  # `agentic-e2e-tests/tests/members/*.spec.ts` are also `test.fixme()`
-  # for CI-flakiness reasons (#1811). Until those suites unfreeze,
-  # the remaining `@unimplemented` scenarios stay justified.
+  # admin approval transitions, license-limit enforcement, and
+  # batch / non-admin / email-failure edge cases.
+  #
+  # The Playwright e2e specs under
+  # `agentic-e2e-tests/tests/members/*.spec.ts` remain `test.fixme()`
+  # for CI-flakiness reasons (#1811), so the four `@e2e` scenarios
+  # below are still `@unimplemented`. The display-list scenarios
+  # (admin/non-admin visibility, badges) need a JSDOM render harness
+  # over the members page that does not yet exist.
 
   # ============================================================================
   # E2E: Happy Paths - Full User Workflows
@@ -63,27 +66,27 @@ Feature: Invitation Approval Workflow
   # Integration: Backend Edge Cases, Error Handling, and Rendered Components
   # ============================================================================
 
-  @integration @unimplemented
+  @integration
   Scenario: Member cannot request invitation with ADMIN role
     Given I am authenticated as a "MEMBER" of the organization
     When I request an invitation for "user@example.com" with role "ADMIN"
     Then the request fails with a validation error
     And the error indicates the role is not allowed
 
-  @integration @unimplemented
+  @integration
   Scenario: Member request sets requestedBy to the requesting user
     Given I am authenticated as a "MEMBER" of the organization
     When I request an invitation for "user@example.com" with role "MEMBER"
     Then the invitation is queued for admin approval
     And the invitation records who requested it
 
-  @integration @unimplemented
+  @integration
   Scenario: Invitation request has no expiration while awaiting approval
     Given I am authenticated as a "MEMBER" of the organization
     When I request an invitation for "user@example.com" with role "MEMBER"
     Then the invitation does not expire while waiting for admin approval
 
-  @integration @unimplemented
+  @integration
   Scenario: Approving an invitation sets expiration and status
     Given there is a "WAITING_APPROVAL" invitation for "user@example.com"
     And I am authenticated as an "ADMIN" of the organization
@@ -91,41 +94,41 @@ Feature: Invitation Approval Workflow
     Then the invitation becomes ready for the invited user to accept
     And the invitation expires after a 48-hour invite window
 
-  @integration @unimplemented
+  @integration
   Scenario: No email is sent when a member creates an invitation request
     Given I am authenticated as a "MEMBER" of the organization
     When I request an invitation for "user@example.com" with role "MEMBER"
     Then no invitation email is sent to "user@example.com"
 
-  @integration @unimplemented
+  @integration
   Scenario: Email is sent when admin approves an invitation request
     Given there is a "WAITING_APPROVAL" invitation for "user@example.com"
     And I am authenticated as an "ADMIN" of the organization
     When I approve the invitation for "user@example.com"
     Then an invitation email is sent to "user@example.com"
 
-  @integration @unimplemented
+  @integration
   Scenario: WAITING_APPROVAL invites count toward license member limits
     Given the organization has reached its member limit
     And there is a pending approval invitation
     When I invite user "new@example.com" to the organization
     Then the invitation request is rejected because the member limit was reached
 
-  @integration @unimplemented
+  @integration
   Scenario: Duplicate detection across PENDING and WAITING_APPROVAL statuses
     Given there is a "WAITING_APPROVAL" invitation for "existing@example.com"
     And I am authenticated as a "MEMBER" of the organization
     When I request an invitation for "existing@example.com" with role "MEMBER"
     Then the request fails with a duplicate invitation error
 
-  @integration @unimplemented
+  @integration
   Scenario: Admin batch invite creates all records before sending any emails
     Given I am authenticated as an "ADMIN" of the organization
     When I invite multiple users in a single batch
     Then all invite records are created atomically
     And emails are sent only after all records are persisted
 
-  @integration @unimplemented
+  @integration
   Scenario: Email failure during approval does not revert the approval
     Given there is a "WAITING_APPROVAL" invitation for "user@example.com"
     And I am authenticated as an "ADMIN" of the organization
@@ -134,14 +137,14 @@ Feature: Invitation Approval Workflow
     Then the invitation is still approved
     And the invite link is shown as fallback
 
-  @integration @unimplemented
+  @integration
   Scenario: Deleting a WAITING_APPROVAL invitation works the same as PENDING
     Given there is a "WAITING_APPROVAL" invitation for "remove@example.com"
     And I am authenticated as an "ADMIN" of the organization
     When I delete the invitation for "remove@example.com"
     Then the invitation is removed successfully
 
-  @integration @unimplemented
+  @integration
   Scenario: Non-admin cannot approve invitations
     Given there is a "WAITING_APPROVAL" invitation for "user@example.com"
     And I am authenticated as a "MEMBER" of the organization


### PR DESCRIPTION
## Summary

Phase 2 of #3458 (parity grinder) — members domain follow-up.

The integration suite at `langwatch/src/server/api/routers/__tests__/organization.invites.integration.test.ts` has been `describe.skip()`'d since the es-migration refactor introduced an app-layer init regression. PR #3008 (`issue2877/extract-invite-procedures-from`) proved the regression is fixed via commit `2546b4032` ("test(invite): re-enable integration tests — app-init regression is fixed"). That un-skip rode along with a router-rename refactor that's still in DIRTY/conflict state on its branch — meaning the un-skip itself never made it to main.

This PR lifts the un-skip onto main directly so the suite runs again, then binds 12 `@integration` scenarios from `specs/members/update-pending-invitation.feature` to the existing `it()` blocks the test file already implements.

## What's bound

- **createInviteRequest** (5 scenarios): ADMIN-role validation, requestedBy attribution, null expiration, no-email-sent semantics, duplicate detection across PENDING/WAITING_APPROVAL.
- **approveInvite** (3 scenarios): expiration+status transition, email-sent on approval, non-admin permission rejection.
- **deleteInvite** (1 scenario): WAITING_APPROVAL deletion parity with PENDING.
- **createInvites batch** (1 scenario): all records committed before any email sent.
- **approveInvite email failure** (1 scenario): approval not reverted on email failure.
- **license limits** (1 scenario): WAITING_APPROVAL invites count toward member limits.

## Spec preamble

Updated `specs/members/update-pending-invitation.feature` to drop the now-obsolete `#3240` reference (no longer the blocker — the invite suite now runs) while preserving the harness-gap notes for the remaining 4 `@e2e` (Playwright `test.fixme()` from #1811) and 5 display-list `@unimplemented` scenarios that need a JSDOM members-page harness.

## Numbers

- specs/members net `@unimplemented`: 29 → 17 (-12, all remainders justified by harness gaps).
- `pnpm check:feature-parity` reports 622/622 enforced scenarios bound across 392 files.

## Test plan
- [x] `pnpm check:feature-parity` passes locally
- [ ] CI runs `pnpm test:integration` with the un-skipped suite — should pass since the underlying app-layer init regression was confirmed fixed on PR #3008's branch
- [ ] CI typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)