### PR TITLE
fix(settings): surface provider-default mismatch instead of silent no-op (#3785)

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -38,6 +38,8 @@ x-common-env: &common-env
   CLICKHOUSE_URL: http://default:langwatch@clickhouse:8123/langwatch
   LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
   LANGEVALS_ENDPOINT: http://langevals:5562
+  # Prod-like dev: IS_SAAS=true (from langwatch/.env) requires SSRF blocking.
+  BLOCK_LOCAL_HTTP_CALLS: "true"
 
 services:
   # =============================================================================

--- a/dev/docs/adr/018-form-validation-and-save.md
+++ b/dev/docs/adr/018-form-validation-and-save.md
@@ -40,6 +40,8 @@ Validation responsibility is split:
 
 A submit handler that detects an invalid cross-field state **must `return` before any mutation fires** and **must surface why** through a toast or inline error. Silent no-ops are forbidden — they are the failure mode that produced #3785.
 
+**Inputs are a separate category from action buttons.** A disabled *input* (a select with no options to pick, a date field outside its allowed range) is fine and often clearer than an enabled-but-empty one. The "no `disabled={!isValid}`" rule applies to **submit/action buttons**, where the user is choosing whether to commit. An input whose underlying domain is empty isn't hiding a constraint — there's nothing to choose. Pair the disabled input with a hint that explains *why* and *what to do* (see #3785: empty `chatOptions` → disabled `ProviderModelSelector` + "Add one in the Custom Models section above").
+
 ## Rationale
 
 ### Why not `disabled={!isValid}`

--- a/dev/docs/adr/018-form-validation-and-save.md
+++ b/dev/docs/adr/018-form-validation-and-save.md
@@ -1,0 +1,88 @@
+# ADR-018: Form Validation and Save Button Behavior
+
+**Date:** 2026-05-05
+
+**Status:** Accepted
+
+## Context
+
+LangWatch has dozens of settings, model-provider, team, role, and dialog forms. Until this point, the codebase has had a *de-facto* convention for how Save buttons interact with form validation — observable by reading the existing forms (`ChangePasswordDialog`, `RoleFormDialog`, `LLMModelCostDrawer`, `TeamForm`, `useProviderFormSubmit`, etc.) — but no written record of *why*. As a result:
+
+- New forms occasionally diverge (e.g. someone adds `disabled={!isValid}` to a Save button because it "feels" safer).
+- Reviewers have no doc to point at when nudging back toward the convention.
+- Bugs like #3785 — where a Save silently no-ops because the form's underlying state doesn't match what's displayed — are easy to introduce because the boundary between "what can be saved" and "what should be saved" is not articulated.
+
+The trigger for writing this down: while fixing #3785 (provider-default mismatch silently persisting cross-provider values), the question came up — should we *disable* the Save button when the model selection is invalid for this provider, or let the user click and surface a validation error? That question turned out to have an implicit, never-documented answer in the codebase.
+
+## Decision
+
+**Save buttons are clickable whenever the user has finished entering data. Validation runs on submit. Errors surface inline (field-level) or via toast (cross-field / backend). Save is disabled *only* while the request is in flight.**
+
+In code form:
+
+```tsx
+<Button
+  type="submit"
+  disabled={mutation.isPending}     // ✅ in-flight only
+  // disabled={!form.formState.isValid}   // ❌ never
+>
+  Save
+</Button>
+```
+
+Validation responsibility is split:
+
+| Layer | Where | Tool | Surface |
+|---|---|---|---|
+| Field-level (sync schema rules) | `react-hook-form` + `zodResolver` | Schema | `<Field.ErrorText>` inline |
+| Cross-field (one input depends on another) | Submit handler | Manual | `toaster.create({type:"error"})` + `return` before mutation |
+| Server-side (uniqueness, auth, business rules) | Mutation `onError` | tRPC error | `toaster.create({type:"error"})` |
+
+A submit handler that detects an invalid cross-field state **must `return` before any mutation fires** and **must surface why** through a toast or inline error. Silent no-ops are forbidden — they are the failure mode that produced #3785.
+
+## Rationale
+
+### Why not `disabled={!isValid}`
+
+1. **A disabled button is silent.** It tells the user "you can't proceed" without saying *why*. Users hunt for the broken field, fail, and bounce.
+
+2. **`isValid` can lie.** React-hook-form's `formState.isValid` reflects the most recent validation pass, which may not have run on every field. If validation is async (uniqueness, server-side), the button would either need to always-disable while pending (jittery) or risk being out-of-date.
+
+3. **Some users click Save *to* discover what's wrong.** Especially in long forms — they want the system to point to the broken field. A pre-disabled button removes that affordance.
+
+4. **Consistency with existing forms.** Every shipped LangWatch form follows this pattern (sample: `ChangePasswordDialog.tsx:149`, `RoleFormDialog.tsx`, `TeamForm.tsx`, `LLMModelCostDrawer.tsx`). Diverging adds cognitive load without benefit.
+
+### Why surface errors at submit time
+
+- Errors that fire on every keystroke are noisy; users haven't finished thinking yet.
+- Errors that fire only on blur miss cross-field problems (one field's validity depends on another).
+- Submit-time validation is the moment the user has *committed* — the right moment to confront them with what's wrong.
+
+### Why toasts for cross-field errors
+
+- Inline errors live at one field. Cross-field errors don't have a single home.
+- A toast pulled to the corner of the screen with a clear "Cannot save: X" title is unambiguous.
+- For especially impactful errors (e.g. #3785's "you'd persist a contradiction"), the toast can describe the *consequence*, not just the state.
+
+## Consequences
+
+- New forms that ship with `disabled={!isValid}` should be rejected in review with a link to this ADR.
+- The existing `useProviderFormSubmit` hook is the canonical example for the cross-field validation pattern (gates `updateProjectDefaultModels` mutation on provider-prefix match before firing — see #3785).
+- The design guideline (`dev/docs/design/guidelines.md` §6) summarises the rule with code patterns; this ADR captures the *why* and the alternatives considered.
+- We accept the risk that a user clicks Save on an obviously-broken form and only discovers the error after the click. In practice the click is cheap; the cost of a confusing disabled button is higher.
+
+## Alternatives considered
+
+1. **Hard-disable on `!isValid`.** Rejected because it hides reasons and conflicts with async validation; see Rationale §1-3.
+
+2. **Disable + inline reason.** "Disable the button, but render text under it explaining why." Slightly better than pure-disable, but: (a) users still can't click to see all errors at once, (b) the hint text is easy to miss, (c) requires a non-standard layout per form.
+
+3. **Mixed: disable for sync errors, allow for async.** Inconsistent — would mean the same button behaves differently depending on what's wrong. Cognitive load >> benefit.
+
+4. **Three-tier surface (inline → banner → toast).** A banner inside the form for cross-field errors, escalating to a toast only for backend errors. We may adopt this later for very long forms; for now, the toaster is consistent and visible.
+
+## References
+
+- #3785 — bug that triggered this ADR: provider-default silent no-op
+- `dev/docs/design/guidelines.md` §6 — implementation summary
+- `langwatch/src/hooks/useProviderFormSubmit.ts` — canonical implementation of cross-field submit-time validation

--- a/dev/docs/adr/README.md
+++ b/dev/docs/adr/README.md
@@ -13,6 +13,7 @@ Document **important technical and architectural decisions** — context, trade-
 | [005](./005-feature-flags.md) | Feature flags via tRPC and PostHog | Accepted |
 | [006](./006-redis-cluster-bullmq-hash-tags.md) | Redis cluster hash tags for BullMQ | Accepted |
 | [007](./007-event-sourcing-architecture.md) | Event sourcing architecture (fold/map projections) | Accepted |
+| [018](./018-form-validation-and-save.md) | Form validation and Save button behavior | Accepted |
 
 ## When to Write an ADR
 

--- a/dev/docs/design/guidelines.md
+++ b/dev/docs/design/guidelines.md
@@ -208,6 +208,57 @@ import { DashboardLayout } from "~/components/DashboardLayout";
 - Maintains navigation accessibility
 - Reduces visual noise
 
+## 6. Form Validation: Submit-then-Surface, Don't Pre-Disable
+
+Forms always allow Save to be clicked. Validation runs on submit and surfaces errors inline (field-level) and/or via toast (cross-field or backend). The Save button is disabled **only** while a request is in flight.
+
+### Why
+
+- A disabled button doesn't tell the user what's wrong. Inline errors do.
+- Users sometimes click Save expecting to discover what's missing. A pre-disabled button is silent and frustrating.
+- Async validation (uniqueness checks, server-side rules) can't always pre-compute disabled state — the button would lie about readiness.
+
+See [ADR 018](../adr/018-form-validation-and-save.md) for the full decision context.
+
+### Implementation
+
+```tsx
+<Button
+  type="submit"
+  disabled={mutation.isPending}  // ✅ in-flight only
+  // disabled={!form.formState.isValid}  // ❌ don't pre-disable
+>
+  Save
+</Button>
+```
+
+For validation:
+
+- **Field-level (sync schema rules):** Use `react-hook-form` + `zodResolver`, render inline via `<Field.ErrorText>`.
+- **Cross-field or backend-only:** Validate inside the submit handler. On failure, call `toaster.create({ type: "error", title, description })` and `return` before any mutation fires.
+- **Mutation errors:** Catch in `onError`, surface via `toaster.create({ type: "error", … })`.
+
+```tsx
+const handleSubmit = async () => {
+  // Cross-field check
+  if (useAsDefault && !defaultModel.startsWith(`${provider}/`)) {
+    toaster.create({
+      title: "Cannot save: pick a model from this provider",
+      description: "…",
+      type: "error",
+    });
+    return;
+  }
+  await mutation.mutateAsync(payload);
+};
+```
+
+### Anti-patterns
+
+- ❌ `disabled={!isValid}` — forces the user to find what's wrong without help.
+- ❌ Silent no-op on submit — appears to succeed; persists nothing or persists garbage.
+- ❌ Validation that only renders if a field is touched — invisible until the user randomly stumbles on it.
+
 ## Summary Checklist
 
 When implementing new features, verify:
@@ -218,3 +269,5 @@ When implementing new features, verify:
 - [ ] Page follows standard layout (header, title, actions)
 - [ ] Content-heavy pages use compact menu
 - [ ] Components imported from `components/ui/` where available
+- [ ] Save buttons disable only on `isPending`, never on `!isValid`
+- [ ] Validation errors surface inline or via toast; Save never silently no-ops

--- a/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
+++ b/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Button,
   Card,
@@ -410,29 +411,23 @@ export function ScenarioAIGeneration({ form }: ScenarioAIGenerationProps) {
 
 function DefaultModelErrorBanner({ children }: { children: React.ReactNode }) {
   return (
-    <VStack
-      gap={2}
-      padding={2}
-      bg="orange.50"
-      borderRadius="md"
-      fontSize="xs"
-      color="orange.700"
-      align="flex-start"
-    >
-      <HStack gap={2} align="flex-start">
-        <Icon as={AlertTriangle} boxSize={3} flexShrink={0} mt="1px" />
-        <Text>{children}</Text>
-      </HStack>
-      <Button colorPalette="blue" asChild size="sm">
-        <a
-          data-testid="scenario-ai-configure-default-model-button"
-          href="/settings/model-providers"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Configure default model
-        </a>
-      </Button>
-    </VStack>
+    <Alert.Root status="warning" fontSize="xs" alignItems="flex-start">
+      <Alert.Indicator>
+        <Icon as={AlertTriangle} boxSize={3} />
+      </Alert.Indicator>
+      <Alert.Content gap={2}>
+        <Alert.Description>{children}</Alert.Description>
+        <Button colorPalette="blue" asChild size="sm" alignSelf="flex-start">
+          <a
+            data-testid="scenario-ai-configure-default-model-button"
+            href="/settings/model-providers"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Configure default model
+          </a>
+        </Button>
+      </Alert.Content>
+    </Alert.Root>
   );
 }

--- a/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
+++ b/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
@@ -417,7 +417,13 @@ function DefaultModelErrorBanner({ children }: { children: React.ReactNode }) {
       </Alert.Indicator>
       <Alert.Content gap={2}>
         <Alert.Description>{children}</Alert.Description>
-        <Button colorPalette="blue" asChild size="sm" alignSelf="flex-start">
+        <Button
+          colorPalette="blue"
+          color="white"
+          asChild
+          size="sm"
+          alignSelf="flex-start"
+        >
           <a
             data-testid="scenario-ai-configure-default-model-button"
             href="/settings/model-providers"

--- a/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
@@ -204,14 +204,19 @@ export const DefaultProviderSection = ({
               For general tasks within LangWatch
             </Text>
             <ProviderModelSelector
-              model={
-                state.projectDefaultModel?.startsWith(`${provider.provider}/`)
-                  ? state.projectDefaultModel
-                  : (chatOptions[0] ?? "")
-              }
+              model={state.projectDefaultModel ?? ""}
               options={chatOptions}
               onChange={(model) => actions.setProjectDefaultModel(model)}
             />
+            {state.projectDefaultModel &&
+              !state.projectDefaultModel.startsWith(
+                `${provider.provider}/`,
+              ) && (
+                <Text fontSize="xs" color="orange.600" marginTop={1}>
+                  Persisted default belongs to a different provider — pick a{" "}
+                  {providerName} model to switch.
+                </Text>
+              )}
           </Field.Root>
 
           <Field.Root width="full">
@@ -220,18 +225,21 @@ export const DefaultProviderSection = ({
               For generating topic names
             </Text>
             <ProviderModelSelector
-              model={
-                state.projectTopicClusteringModel?.startsWith(
-                  `${provider.provider}/`,
-                )
-                  ? state.projectTopicClusteringModel
-                  : (chatOptions[0] ?? "")
-              }
+              model={state.projectTopicClusteringModel ?? ""}
               options={chatOptions}
               onChange={(model) =>
                 actions.setProjectTopicClusteringModel(model)
               }
             />
+            {state.projectTopicClusteringModel &&
+              !state.projectTopicClusteringModel.startsWith(
+                `${provider.provider}/`,
+              ) && (
+                <Text fontSize="xs" color="orange.600" marginTop={1}>
+                  Persisted default belongs to a different provider — pick a{" "}
+                  {providerName} model to switch.
+                </Text>
+              )}
           </Field.Root>
 
           <Field.Root width="full">

--- a/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
@@ -210,8 +210,8 @@ export const DefaultProviderSection = ({
             />
             {chatOptions.length === 0 ? (
               <Text fontSize="xs" color="fg.muted" marginTop={1}>
-                No {providerName} models available. Add a custom model below to
-                enable this.
+                No {providerName} models available. Add one in the Custom
+                Models section above to enable this.
               </Text>
             ) : (
               state.projectDefaultModel &&
@@ -219,8 +219,8 @@ export const DefaultProviderSection = ({
                 `${provider.provider}/`,
               ) && (
                 <Text fontSize="xs" color="orange.600" marginTop={1}>
-                  Persisted default belongs to a different provider — pick a{" "}
-                  {providerName} model to switch.
+                  Persisted default belongs to a different provider — pick a
+                  model from {providerName} to switch.
                 </Text>
               )
             )}
@@ -240,8 +240,8 @@ export const DefaultProviderSection = ({
             />
             {chatOptions.length === 0 ? (
               <Text fontSize="xs" color="fg.muted" marginTop={1}>
-                No {providerName} models available. Add a custom model below to
-                enable this.
+                No {providerName} models available. Add one in the Custom
+                Models section above to enable this.
               </Text>
             ) : (
               state.projectTopicClusteringModel &&
@@ -249,8 +249,8 @@ export const DefaultProviderSection = ({
                 `${provider.provider}/`,
               ) && (
                 <Text fontSize="xs" color="orange.600" marginTop={1}>
-                  Persisted default belongs to a different provider — pick a{" "}
-                  {providerName} model to switch.
+                  Persisted default belongs to a different provider — pick a
+                  model from {providerName} to switch.
                 </Text>
               )
             )}

--- a/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
@@ -208,7 +208,13 @@ export const DefaultProviderSection = ({
               options={chatOptions}
               onChange={(model) => actions.setProjectDefaultModel(model)}
             />
-            {state.projectDefaultModel &&
+            {chatOptions.length === 0 ? (
+              <Text fontSize="xs" color="fg.muted" marginTop={1}>
+                No {providerName} models available. Add a custom model below to
+                enable this.
+              </Text>
+            ) : (
+              state.projectDefaultModel &&
               !state.projectDefaultModel.startsWith(
                 `${provider.provider}/`,
               ) && (
@@ -216,7 +222,8 @@ export const DefaultProviderSection = ({
                   Persisted default belongs to a different provider — pick a{" "}
                   {providerName} model to switch.
                 </Text>
-              )}
+              )
+            )}
           </Field.Root>
 
           <Field.Root width="full">
@@ -231,7 +238,13 @@ export const DefaultProviderSection = ({
                 actions.setProjectTopicClusteringModel(model)
               }
             />
-            {state.projectTopicClusteringModel &&
+            {chatOptions.length === 0 ? (
+              <Text fontSize="xs" color="fg.muted" marginTop={1}>
+                No {providerName} models available. Add a custom model below to
+                enable this.
+              </Text>
+            ) : (
+              state.projectTopicClusteringModel &&
               !state.projectTopicClusteringModel.startsWith(
                 `${provider.provider}/`,
               ) && (
@@ -239,7 +252,8 @@ export const DefaultProviderSection = ({
                   Persisted default belongs to a different provider — pick a{" "}
                   {providerName} model to switch.
                 </Text>
-              )}
+              )
+            )}
           </Field.Root>
 
           <Field.Root width="full">

--- a/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
@@ -194,6 +194,12 @@ export const DefaultProviderSection = ({
           LangWatch features.
         </Text>
       )}
+      {state.useAsDefaultProvider && chatOptions.length === 0 && (
+        <Text fontSize="xs" color="fg.muted">
+          No {providerName} models available. Add one in the Custom Models
+          section above to enable this.
+        </Text>
+      )}
 
       {/* Default Models Selection - Only visible when toggle is enabled */}
       {state.useAsDefaultProvider && (
@@ -207,23 +213,18 @@ export const DefaultProviderSection = ({
               model={state.projectDefaultModel ?? ""}
               options={chatOptions}
               onChange={(model) => actions.setProjectDefaultModel(model)}
+              disabled={chatOptions.length === 0}
             />
-            {chatOptions.length === 0 ? (
-              <Text fontSize="xs" color="fg.muted" marginTop={1}>
-                No {providerName} models available. Add one in the Custom
-                Models section above to enable this.
-              </Text>
-            ) : (
+            {chatOptions.length > 0 &&
               state.projectDefaultModel &&
               !state.projectDefaultModel.startsWith(
                 `${provider.provider}/`,
               ) && (
                 <Text fontSize="xs" color="orange.600" marginTop={1}>
-                  Persisted default belongs to a different provider — pick a
-                  model from {providerName} to switch.
+                  Persisted default belongs to a different provider — pick a{" "}
+                  {providerName} model to switch.
                 </Text>
-              )
-            )}
+              )}
           </Field.Root>
 
           <Field.Root width="full">
@@ -237,23 +238,18 @@ export const DefaultProviderSection = ({
               onChange={(model) =>
                 actions.setProjectTopicClusteringModel(model)
               }
+              disabled={chatOptions.length === 0}
             />
-            {chatOptions.length === 0 ? (
-              <Text fontSize="xs" color="fg.muted" marginTop={1}>
-                No {providerName} models available. Add one in the Custom
-                Models section above to enable this.
-              </Text>
-            ) : (
+            {chatOptions.length > 0 &&
               state.projectTopicClusteringModel &&
               !state.projectTopicClusteringModel.startsWith(
                 `${provider.provider}/`,
               ) && (
                 <Text fontSize="xs" color="orange.600" marginTop={1}>
-                  Persisted default belongs to a different provider — pick a
-                  model from {providerName} to switch.
+                  Persisted default belongs to a different provider — pick a{" "}
+                  {providerName} model to switch.
                 </Text>
-              )
-            )}
+              )}
           </Field.Root>
 
           <Field.Root width="full">

--- a/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderDefaultSection.tsx
@@ -195,7 +195,7 @@ export const DefaultProviderSection = ({
         </Text>
       )}
       {state.useAsDefaultProvider && chatOptions.length === 0 && (
-        <Text fontSize="xs" color="fg.muted">
+        <Text fontSize="xs" color="orange.600">
           No {providerName} models available. Add one in the Custom Models
           section above to enable this.
         </Text>

--- a/langwatch/src/components/settings/ProviderModelSelector.tsx
+++ b/langwatch/src/components/settings/ProviderModelSelector.tsx
@@ -40,11 +40,13 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
   options,
   onChange,
   size = "full",
+  disabled = false,
 }: {
   model: string;
   options: string[];
   onChange: (model: string) => void;
   size?: "sm" | "md" | "full";
+  disabled?: boolean;
 }) {
   const [modelSearch, setModelSearch] = useState("");
 
@@ -168,6 +170,7 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
         setHighlightedValue(details.highlightedValue);
       }}
       size={size === "full" ? undefined : size}
+      disabled={disabled}
     >
       <Select.Trigger
         className="fix-hidden-inputs"

--- a/langwatch/src/components/settings/ProviderModelSelector.tsx
+++ b/langwatch/src/components/settings/ProviderModelSelector.tsx
@@ -207,6 +207,12 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
                 onChange={(e) => setModelSearch(e.target.value)}
                 border="none"
                 _focus={{ boxShadow: "none" }}
+                _focusVisible={{
+                  outline: "2px solid",
+                  outlineColor: "colorPalette.focusRing",
+                  outlineOffset: "1px",
+                  borderRadius: "sm",
+                }}
                 paddingX={2}
               />
             </InputGroup>

--- a/langwatch/src/components/settings/ProviderModelSelector.tsx
+++ b/langwatch/src/components/settings/ProviderModelSelector.tsx
@@ -182,14 +182,22 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
           {() => selectValueText}
         </Select.ValueText>
       </Select.Trigger>
-      <Select.Content>
+      <Select.Content padding={1}>
         <Field.Root asChild>
-          <Box position="sticky" top={0} zIndex="1">
+          <Box
+            position="sticky"
+            top={0}
+            zIndex="1"
+            background="bg.panel"
+            paddingX={1}
+            paddingY={1}
+            borderBottom="1px solid"
+            borderColor="border"
+          >
             <InputGroup
               startElement={<Search size={16} />}
               startOffset="-4px"
-              background="bg.panel"
-              width="calc(100% - 9px)"
+              width="full"
             >
               <Input
                 size="sm"
@@ -197,6 +205,9 @@ export const ProviderModelSelector = React.memo(function ProviderModelSelector({
                 type="search"
                 value={modelSearch}
                 onChange={(e) => setModelSearch(e.target.value)}
+                border="none"
+                _focus={{ boxShadow: "none" }}
+                paddingX={2}
               />
             </InputGroup>
           </Box>

--- a/langwatch/src/components/settings/__tests__/ModelProviderDefaultSection.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderDefaultSection.test.tsx
@@ -169,6 +169,40 @@ describe("<DefaultProviderSection/>", () => {
       });
     });
 
+    describe("when projectTopicClusteringModel belongs to a different provider (openai/gpt-4o-mini)", () => {
+      it("renders the orange mismatch warning under the Topic Clustering Model field", () => {
+        const state = buildState({
+          useAsDefaultProvider: true,
+          customModels: [
+            { modelId: "my-azure-deployment", displayName: "My Azure Deployment", mode: "chat" },
+          ],
+          projectDefaultModel: "azure/gpt-5-mini",
+          projectTopicClusteringModel: "openai/gpt-4o-mini",
+        });
+        const actions = buildActions();
+
+        render(
+          <Wrapper>
+            <DefaultProviderSection
+              state={state}
+              actions={actions}
+              provider={azureProvider}
+              enabledProvidersCount={2}
+              project={{ defaultModel: "azure/gpt-5-mini" }}
+              providers={{ azure: azureProvider }}
+            />
+          </Wrapper>,
+        );
+
+        // Both Default Model and Topic Clustering use the same warning text;
+        // here only topic clustering should mismatch, so exactly one warning.
+        const warnings = screen.getAllByText(
+          /Persisted default belongs to a different provider/i,
+        );
+        expect(warnings).toHaveLength(1);
+      });
+    });
+
     describe("when projectDefaultModel matches the azure prefix (azure/gpt-5-mini)", () => {
       it("does not render the mismatch warning", () => {
         const state = buildState({

--- a/langwatch/src/components/settings/__tests__/ModelProviderDefaultSection.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderDefaultSection.test.tsx
@@ -133,4 +133,127 @@ describe("<DefaultProviderSection/>", () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Regression tests — issue #3785: cross-provider default model mismatch warning
+  // ---------------------------------------------------------------------------
+
+  describe("given provider is azure, useAsDefaultProvider is true, and chatOptions has at least one azure model", () => {
+    describe("when projectDefaultModel belongs to a different provider (openai/gpt-5.2)", () => {
+      it("renders the orange mismatch warning under the Default Model field", () => {
+        const state = buildState({
+          useAsDefaultProvider: true,
+          customModels: [
+            { modelId: "my-azure-deployment", displayName: "My Azure Deployment", mode: "chat" },
+          ],
+          projectDefaultModel: "openai/gpt-5.2",
+        });
+        const actions = buildActions();
+
+        render(
+          <Wrapper>
+            <DefaultProviderSection
+              state={state}
+              actions={actions}
+              provider={azureProvider}
+              enabledProvidersCount={2}
+              project={{ defaultModel: "openai/gpt-5.2" }}
+              providers={{ azure: azureProvider }}
+            />
+          </Wrapper>,
+        );
+
+        expect(
+          screen.getByText(/Persisted default belongs to a different provider/i),
+        ).toBeTruthy();
+      });
+    });
+
+    describe("when projectDefaultModel matches the azure prefix (azure/gpt-5-mini)", () => {
+      it("does not render the mismatch warning", () => {
+        const state = buildState({
+          useAsDefaultProvider: true,
+          customModels: [
+            { modelId: "gpt-5-mini", displayName: "GPT-5 Mini", mode: "chat" },
+          ],
+          projectDefaultModel: "azure/gpt-5-mini",
+        });
+        const actions = buildActions();
+
+        render(
+          <Wrapper>
+            <DefaultProviderSection
+              state={state}
+              actions={actions}
+              provider={azureProvider}
+              enabledProvidersCount={2}
+              project={{ defaultModel: "azure/gpt-5-mini" }}
+              providers={{ azure: azureProvider }}
+            />
+          </Wrapper>,
+        );
+
+        expect(
+          screen.queryByText(/Persisted default belongs to a different provider/i),
+        ).toBeNull();
+      });
+    });
+  });
+
+  describe("given provider is azure, useAsDefaultProvider is true, and chatOptions is empty", () => {
+    describe("when the section renders", () => {
+      it("renders the empty-state hint text", () => {
+        const state = buildState({
+          useAsDefaultProvider: true,
+          customModels: [],
+          projectDefaultModel: null,
+        });
+        const actions = buildActions();
+
+        render(
+          <Wrapper>
+            <DefaultProviderSection
+              state={state}
+              actions={actions}
+              provider={azureProvider}
+              enabledProvidersCount={2}
+              project={{ defaultModel: null }}
+              providers={{ azure: azureProvider }}
+            />
+          </Wrapper>,
+        );
+
+        expect(
+          screen.getByText(/No Azure OpenAI models available/i),
+        ).toBeTruthy();
+      });
+
+      it("does not render the mismatch warning", () => {
+        const state = buildState({
+          useAsDefaultProvider: true,
+          customModels: [],
+          projectDefaultModel: "openai/gpt-5.2",
+        });
+        const actions = buildActions();
+
+        render(
+          <Wrapper>
+            <DefaultProviderSection
+              state={state}
+              actions={actions}
+              provider={azureProvider}
+              enabledProvidersCount={2}
+              project={{ defaultModel: "openai/gpt-5.2" }}
+              providers={{ azure: azureProvider }}
+            />
+          </Wrapper>,
+        );
+
+        // Warning only shows when chatOptions.length > 0 (component logic)
+        expect(
+          screen.queryByText(/Persisted default belongs to a different provider/i),
+        ).toBeNull();
+      });
+    });
+  });
 });

--- a/langwatch/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression tests for issue #3785:
+ * Provider edit drawer's Default Model dropdown silently desyncs from project state.
+ *
+ * The submit-time guard in useProviderFormSubmit fires a toast and aborts
+ * when useAsDefaultProvider is true but any selected model belongs to a
+ * different provider (prefix mismatch).
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FormSnapshot } from "../useProviderFormSubmit";
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted() ensures variables are available when vi.mock factories
+// are hoisted to the top of the file by Vitest's transform step.
+// ---------------------------------------------------------------------------
+
+const {
+  mockUpdateMutateAsync,
+  mockUpdateProjectDefaultModelsMutateAsync,
+  mockToasterCreate,
+  mockInvalidate,
+} = vi.hoisted(() => ({
+  mockUpdateMutateAsync: vi.fn().mockResolvedValue({}),
+  mockUpdateProjectDefaultModelsMutateAsync: vi.fn().mockResolvedValue({}),
+  mockToasterCreate: vi.fn(),
+  mockInvalidate: vi.fn(),
+}));
+
+vi.mock("../../utils/api", () => ({
+  api: {
+    useContext: () => ({
+      organization: {
+        getAll: {
+          invalidate: mockInvalidate,
+        },
+      },
+    }),
+    modelProvider: {
+      update: {
+        useMutation: () => ({
+          mutateAsync: mockUpdateMutateAsync,
+        }),
+      },
+    },
+    project: {
+      updateProjectDefaultModels: {
+        useMutation: () => ({
+          mutateAsync: mockUpdateProjectDefaultModelsMutateAsync,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("../../components/ui/toaster", () => ({
+  toaster: {
+    create: mockToasterCreate,
+  },
+}));
+
+// Import after mocks
+import { useProviderFormSubmit } from "../useProviderFormSubmit";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildAzureProvider() {
+  return {
+    provider: "azure",
+    enabled: true,
+    customKeys: { AZURE_OPENAI_API_KEY: "test-key" },
+    models: ["gpt-5-mini"],
+    embeddingsModels: null,
+    disabledByDefault: false,
+    deploymentMapping: null,
+    extraHeaders: [],
+  };
+}
+
+function buildSnapshot(overrides: Partial<FormSnapshot> = {}): FormSnapshot {
+  return {
+    provider: buildAzureProvider(),
+    name: "Azure OpenAI",
+    projectId: "proj-1",
+    isUsingEnvVars: true,
+    customKeys: { AZURE_OPENAI_API_KEY: "****" },
+    initialKeys: { AZURE_OPENAI_API_KEY: "****" },
+    providerKeysSchema: null,
+    extraHeaders: [],
+    customModels: [],
+    customEmbeddingsModels: [],
+    useAsDefaultProvider: true,
+    projectDefaultModel: "azure/gpt-5-mini",
+    projectTopicClusteringModel: "azure/gpt-5-mini",
+    projectEmbeddingsModel: null,
+    ...overrides,
+  };
+}
+
+function renderSubmitHook({ snapshot }: { snapshot: FormSnapshot }) {
+  return renderHook(() =>
+    useProviderFormSubmit({
+      getFormSnapshot: () => snapshot,
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useProviderFormSubmit()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given useAsDefaultProvider is true and provider is azure", () => {
+    describe("when projectDefaultModel belongs to a different provider (openai/gpt-5.2)", () => {
+      it("does not call updateProjectDefaultModels mutation", async () => {
+        const snapshot = buildSnapshot({
+          projectDefaultModel: "openai/gpt-5.2",
+          projectTopicClusteringModel: "azure/gpt-5-mini",
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockUpdateProjectDefaultModelsMutateAsync).not.toHaveBeenCalled();
+      });
+
+      it("creates an error toast", async () => {
+        const snapshot = buildSnapshot({
+          projectDefaultModel: "openai/gpt-5.2",
+          projectTopicClusteringModel: "azure/gpt-5-mini",
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockToasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "error" }),
+        );
+      });
+    });
+
+    describe("when projectTopicClusteringModel belongs to a different provider (openai/gpt-4o-mini)", () => {
+      it("does not call updateProjectDefaultModels mutation", async () => {
+        const snapshot = buildSnapshot({
+          projectDefaultModel: "azure/gpt-5-mini",
+          projectTopicClusteringModel: "openai/gpt-4o-mini",
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockUpdateProjectDefaultModelsMutateAsync).not.toHaveBeenCalled();
+      });
+
+      it("creates an error toast", async () => {
+        const snapshot = buildSnapshot({
+          projectDefaultModel: "azure/gpt-5-mini",
+          projectTopicClusteringModel: "openai/gpt-4o-mini",
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockToasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "error" }),
+        );
+      });
+    });
+
+    describe("when all models start with azure/ (no mismatch)", () => {
+      it("calls updateProjectDefaultModels mutation with the selected models", async () => {
+        const snapshot = buildSnapshot({
+          projectDefaultModel: "azure/gpt-5-mini",
+          projectTopicClusteringModel: "azure/gpt-5-mini",
+          projectEmbeddingsModel: "azure/text-embedding-3-small",
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockUpdateProjectDefaultModelsMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            projectId: "proj-1",
+            defaultModel: "azure/gpt-5-mini",
+            topicClusteringModel: "azure/gpt-5-mini",
+            embeddingsModel: "azure/text-embedding-3-small",
+          }),
+        );
+      });
+    });
+  });
+
+  describe("given useAsDefaultProvider is false", () => {
+    describe("when projectDefaultModel belongs to a different provider (openai/gpt-5.2)", () => {
+      it("does not fire the mismatch guard — submit proceeds without error toast", async () => {
+        const snapshot = buildSnapshot({
+          useAsDefaultProvider: false,
+          projectDefaultModel: "openai/gpt-5.2",
+          projectTopicClusteringModel: "openai/gpt-4o-mini",
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        // Guard only fires when useAsDefaultProvider is true
+        const errorToasts = mockToasterCreate.mock.calls.filter(
+          (call) => call[0]?.type === "error",
+        );
+        expect(errorToasts).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/useProviderFormSubmit.ts
+++ b/langwatch/src/hooks/useProviderFormSubmit.ts
@@ -3,7 +3,10 @@ import { type ZodError, z } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { toaster } from "../components/ui/toaster";
 import type { CustomModelEntry } from "../server/modelProviders/customModel.schema";
-import type { MaybeStoredModelProvider } from "../server/modelProviders/registry";
+import {
+  modelProviders,
+  type MaybeStoredModelProvider,
+} from "../server/modelProviders/registry";
 import { api } from "../utils/api";
 import {
   filterMaskedApiKeys,
@@ -177,13 +180,17 @@ export function useProviderFormSubmit({
           mismatched.push("Topic clustering model");
         }
         if (mismatched.length > 0) {
+          const providerDisplayName =
+            modelProviders[provider.provider as keyof typeof modelProviders]
+              ?.name ?? provider.provider;
           toaster.create({
-            title: "Cannot save: pick a model from this provider",
+            title:
+              mismatched.length === 1
+                ? `Cannot save: ${mismatched[0]?.toLowerCase()} is invalid`
+                : "Cannot save: default models are invalid",
             description: `${mismatched.join(" and ")} ${
               mismatched.length === 1 ? "belongs" : "belong"
-            } to a different provider. Pick a ${
-              provider.provider
-            } model${
+            } to a different provider. Pick a model from ${providerDisplayName}${
               provider.provider === "azure" ? " (or add a custom deployment)" : ""
             } before saving.`,
             type: "error",

--- a/langwatch/src/hooks/useProviderFormSubmit.ts
+++ b/langwatch/src/hooks/useProviderFormSubmit.ts
@@ -159,6 +159,42 @@ export function useProviderFormSubmit({
         }
       }
 
+      // Block save when "use as default provider" is enabled but the
+      // selected default model belongs to a different provider — otherwise
+      // updateProjectDefaultModels would silently persist a contradiction
+      // (this provider becomes the default while the model still points
+      // elsewhere). See #3785.
+      if (useAsDefaultProvider) {
+        const prefix = `${provider.provider}/`;
+        const mismatched: string[] = [];
+        if (projectDefaultModel && !projectDefaultModel.startsWith(prefix)) {
+          mismatched.push("Default model");
+        }
+        if (
+          projectTopicClusteringModel &&
+          !projectTopicClusteringModel.startsWith(prefix)
+        ) {
+          mismatched.push("Topic clustering model");
+        }
+        if (mismatched.length > 0) {
+          toaster.create({
+            title: "Cannot save: pick a model from this provider",
+            description: `${mismatched.join(" and ")} ${
+              mismatched.length === 1 ? "belongs" : "belong"
+            } to a different provider. Pick a ${
+              provider.provider
+            } model${
+              provider.provider === "azure" ? " (or add a custom deployment)" : ""
+            } before saving.`,
+            type: "error",
+            duration: 5000,
+            meta: { closable: true },
+          });
+          setIsSaving(false);
+          return;
+        }
+      }
+
       // Determine what customKeys to send
       let customKeysToSend: Record<string, unknown> | undefined;
       const userEnteredNewKey = hasUserEnteredNewApiKey(customKeys);


### PR DESCRIPTION
## Why

Closes #3785.

Opening (e.g.) the **Azure** provider drawer when the project's persisted default was `openai/gpt-5.2` showed a fake `azure/gpt-5-mini` selection in the dropdown. `ProviderModelSelector` displayed `chatOptions[0]` as a *display-only fallback* without calling `onChange`, so form state stayed at the cross-provider value. On Save, `updateProjectDefaultModels` fired with the *original* value, the server wrote it back unchanged, and the UI silently lied — twice (at save time and on revisit). The same shape affected Topic Clustering Model.

## What changed

- **Drop the silent display fallback** in `ModelProviderDefaultSection` for both Default Model and Topic Clustering dropdowns. Persisted state passes through directly; `ProviderModelSelector` already greys out unknown values, and a small inline orange warning explains *why* the displayed value belongs to a different provider.
- **Block save when the persisted default is cross-provider** in `useProviderFormSubmit`. With "use as default provider" enabled, Save now fails loud via a toast — the mutation does not fire — instead of silently persisting a contradiction. The visual warning alone wasn't enough; this gate is the real fix.
- **Disable the dropdown + show a hint when the provider has no models** (e.g. fresh Azure with no custom deployments). "No Azure OpenAI models available. Add one in the Custom Models section above to enable this."
- **Convert `ScenarioAIGeneration`'s `DefaultModelErrorBanner`** from raw `orange.50` / `orange.700` tokens to `<Alert.Root status="warning">` so the warning respects theme and dark mode. Pinned `color="white"` on the action button so its label stays legible inside the warning palette.
- **`ProviderModelSelector` polish**: padded dropdown, borderless search input with a visible `_focusVisible` ring for keyboard navigation.
- **Bake `BLOCK_LOCAL_HTTP_CALLS=true` into compose.dev's `x-common-env`** so `make dev` / `make quickstart` boots in SaaS mode without throwing the env-create.mjs guard added in #3614. Unrelated to the bug; unblocks local SaaS-mode dev (which is what we run by default).
- **ADR-018: Form validation and Save button behavior** + **`design/guidelines.md` §6**. Codifies the de-facto codebase convention (submit-then-surface, never `disabled={!isValid}`, mutation-error → toast) — triggered by the realisation while writing the validation that we had no documented answer to "should Save disable on invalid, or block-on-submit?"
- **Regression tests** (12 passing): cross-provider save guard for Default + Topic Clustering models in `useProviderFormSubmit`, mismatch warning render branches in `ModelProviderDefaultSection`.

## How it works

The fix is two-layered because either layer alone is insufficient:

1. **Layer 1 — render**: stop lying about the dropdown selection. The user sees the persisted value greyed out, with an inline warning that explains the cross-provider mismatch.
2. **Layer 2 — submit**: even if the user clicks Save without changing anything, `useProviderFormSubmit` checks `projectDefaultModel` and `projectTopicClusteringModel` against `${provider.provider}/` prefix when `useAsDefaultProvider` is true. On mismatch it fires a toast (`"Cannot save: default model is invalid"`) and `return`s before the mutation. Forbidden to silently persist a contradiction.

The ADR captures *why* the choice is "validate-on-submit, never disable Save," with the alternatives considered (hard-disable, disable + inline reason, mixed sync/async). It's the convention the rest of the codebase already follows; we just hadn't written it down.

## Test plan

- [x] Open a provider drawer where persisted default belongs to a *different* provider — dropdown shows persisted value greyed out, orange "Persisted default belongs to a different provider" hint appears below.
- [x] With the warning visible, click Save *without* picking a model. Toast errors with "Cannot save: default model is invalid" and DB is unchanged.
- [x] Pick a real model in this provider's list, Save — DB persists the new value, toast confirms success.
- [x] Open a drawer where persisted default *matches* the provider prefix — no warning, behavior unchanged.
- [x] Inspect `ScenarioAIGeneration` default-model banner in light + dark mode — Chakra warning palette renders correctly, button label stays legible.
- [x] `make quickstart` boots without the BLOCK_LOCAL_HTTP_CALLS error.
- [x] Search input in `ProviderModelSelector` shows a visible focus ring on Tab navigation.
- Tests: `pnpm test:unit src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx` (6 pass), `pnpm test:unit src/components/settings/__tests__/ModelProviderDefaultSection.test.tsx` (6 pass).

## Anything surprising?

- The compose.dev change is unrelated to the bug but ships in this PR — too small for its own PR and was blocking local dev.
- The ADR + guideline are not strictly required to ship the fix, but the question came up while writing the validation and there was nothing to point reviewers at. Worth ~200 lines of documentation.
- Replaces #3842 (closed) — that PR was on a malformed branch from a worktree placed in the wrong directory.
- One pre-existing failure on `npx-server-smoke.yml` (workflow-file issue) — not caused by this PR; same failure on `parity/features-bind-2026-05-05`, `feat/governance-platform`, etc.

### Out of scope

- Rethinking the auto-default-strategy so the project default can't drift from configured providers in the first place — tracked as kanban draft `PVTI_lADOCL9uOs4BH69Jzgr05nA`.
- Empty-state UX in the Azure dropdown when no custom deployments exist (separate visual issue).
- Back-fill of ADRs 008–017 in the README index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
