### PR TITLE
test(licensing): bind License-details Infinity-display scenario

### DIFF
--- a/langwatch/src/components/license/__tests__/licenseStatusUtils.unit.test.ts
+++ b/langwatch/src/components/license/__tests__/licenseStatusUtils.unit.test.ts
@@ -183,6 +183,7 @@ describe("isCorruptedLicense", () => {
 });
 
 describe("formatLimitOrUnlimited", () => {
+  /** @scenario License details card handles Infinity display */
   it("returns 'Unlimited' for Infinity", () => {
     expect(formatLimitOrUnlimited(Infinity)).toBe("Unlimited");
   });

--- a/specs/licensing/license-enforcement-refactor.feature
+++ b/specs/licensing/license-enforcement-refactor.feature
@@ -98,7 +98,7 @@ Feature: License Enforcement
     And the response should include currentMessagesPerMonth and maxMessagesPerMonth
     And the response should include currentEvaluationsCredit and maxEvaluationsCredit
 
-  @unit @unimplemented
+  @unit
   Scenario: License details card handles Infinity display
     Given an organization with UNLIMITED_PLAN
     When the license details are rendered


### PR DESCRIPTION
## Summary

- Binds spec scenario \`License details card handles Infinity display\` (specs/licensing/license-enforcement-refactor.feature) to the existing \`returns 'Unlimited' for Infinity\` unit test
- Removes \`@unimplemented\` from the spec — the behavior is already covered by the existing prose test
- Tiny: 2 files, +2/-1

## Why

Part of the parity grinder Phase 2 (#3458). The \`formatLimitOrUnlimited\` utility in \`licenseStatusUtils.ts\` is what powers the License details card's "Unlimited" rendering, and \`licenseStatusUtils.unit.test.ts\` has a clean prose test for it. No new test code needed — just adding a JSDoc \`@scenario\` binding.

## Parity gain

- \`license-enforcement-refactor.feature\`: 1/1 → 2/2 enforced scenarios bound
- Global: 615 → 616 enforced scenarios bound

## Test plan

- [x] \`pnpm check:feature-parity\` passes locally (verified \`license-enforcement-refactor.feature\` at 2/2 bound, global summary clean)
- [ ] CI runs the unit test (the binding is JSDoc-only; the test itself was already passing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)