### PR TITLE
test(analytics): bind 18 ClickHouse + chart-rendering @unit scenarios

### DIFF
--- a/langwatch/src/server/analytics/__tests__/registry.unit.test.ts
+++ b/langwatch/src/server/analytics/__tests__/registry.unit.test.ts
@@ -4,6 +4,7 @@ import { analyticsMetrics } from "../registry";
 describe("analyticsMetrics", () => {
   describe("event_details", () => {
     describe("when calling aggregation()", () => {
+      /** @scenario "Event details and event score metrics use distinct aggregation keys" */
       it("produces a key containing 'event_details', not 'event_score'", () => {
         const result = analyticsMetrics.events.event_details.aggregation(
           0,
@@ -34,6 +35,7 @@ describe("analyticsMetrics", () => {
   });
 
   describe("evaluation_pass_rate", () => {
+    /** @scenario "Evaluation pass rate displays as percentage" */
     it("uses percentage format", () => {
       expect(analyticsMetrics.evaluations.evaluation_pass_rate.format).toBe(
         "0%",

--- a/langwatch/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
@@ -237,6 +237,7 @@ describe("column-pruning", () => {
     });
 
     describe("when requesting performance.tokens_per_second", () => {
+      /** @scenario "Tokens per second metric resolves duration from stored spans" */
       it("includes DurationMs in the stored_spans subquery", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,

--- a/langwatch/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/column-pruning.test.ts
@@ -32,6 +32,7 @@ describe("column-pruning", () => {
 
   describe("trace dedup subquery column pruning", () => {
     describe("when requesting trace_count metric", () => {
+      /** @scenario "Trace dedup subquery selects only columns required by the query" */
       it("does not use SELECT * in the dedup subquery", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -83,6 +84,7 @@ describe("column-pruning", () => {
     });
 
     describe("when requesting total_cost grouped by metadata.user_id", () => {
+      /** @scenario "Dedup subquery includes groupBy columns when grouping is active" */
       it("includes the column mapped to metadata.user_id", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -116,6 +118,7 @@ describe("column-pruning", () => {
     });
 
     describe("when requesting trace_count filtered by metadata.labels", () => {
+      /** @scenario "Dedup subquery includes filter columns when filters are active" */
       it("includes the column mapped to metadata.labels", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -137,6 +140,7 @@ describe("column-pruning", () => {
 
   describe("evaluation runs subquery column pruning", () => {
     describe("when referencing an evaluation metric", () => {
+      /** @scenario "Evaluation runs subquery selects only needed evaluation columns" */
       it("does not use SELECT * in the evaluation_runs subquery", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -175,6 +179,7 @@ describe("column-pruning", () => {
     });
 
     describe("when grouping by evaluations.evaluation_passed", () => {
+      /** @scenario "Evaluation runs subquery adapts columns to groupBy field" */
       it("includes the Passed column", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -195,6 +200,7 @@ describe("column-pruning", () => {
 
   describe("stored spans JOIN column pruning", () => {
     describe("when grouping by metadata.span_type", () => {
+      /** @scenario "Stored spans JOIN selects only needed span columns" */
       it("does not include wide span columns like Input and Output", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -213,6 +219,7 @@ describe("column-pruning", () => {
     });
 
     describe("when grouping by events.event_type", () => {
+      /** @scenario "Stored spans JOIN adapts columns to event-based grouping" */
       it("includes the Events.Name column", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -318,6 +325,7 @@ describe("column-pruning", () => {
 
   describe("query correctness after pruning", () => {
     describe("when building a timeseries query for trace_count", () => {
+      /** @scenario "Pruned query generates syntactically valid SQL" */
       it("generates syntactically valid SQL", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -341,6 +349,7 @@ describe("column-pruning", () => {
     });
 
     describe("when building a CTE query for arrayJoin grouping", () => {
+      /** @scenario "Pruned CTE query for arrayJoin grouping preserves metric accuracy" */
       it("selects only needed columns in the CTE inner query", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,

--- a/langwatch/src/server/analytics/clickhouse/__tests__/memory-safety.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/memory-safety.test.ts
@@ -107,6 +107,7 @@ describe("memory-safety", () => {
     }
 
     describe("when generating SQL for any groupBy that touches stored_spans", () => {
+      /** @scenario "Analytics queries access SpanAttributes only via key extraction" */
       it("does not include bare SpanAttributes in the outermost SELECT", () => {
         const result = buildTimeseriesQuery({
           ...baseInput,
@@ -155,6 +156,7 @@ describe("memory-safety", () => {
     );
 
     describe("when the topic counting query SQL is inspected", () => {
+      /** @scenario "Topic and field-discovery queries access only specific attributes" */
       it("does not select the full SpanAttributes Map column", () => {
         expect(getTopicCountsBody).not.toBeNull();
         expect(getTopicCountsBody![0]).not.toContain("SpanAttributes");
@@ -168,6 +170,7 @@ describe("memory-safety", () => {
     });
 
     describe("when the field discovery query SQL is inspected", () => {
+      /** @scenario "Topic and field-discovery queries access only specific attributes" */
       it("does not select the full SpanAttributes Map column", () => {
         expect(getDistinctFieldNamesBody).not.toBeNull();
         expect(getDistinctFieldNamesBody![0]).not.toContain("SpanAttributes");
@@ -200,6 +203,7 @@ describe("memory-safety", () => {
     );
 
     describe("when the topic counting query SQL is inspected", () => {
+      /** @scenario "Topic counting query includes a LIMIT clause" */
       it("includes a LIMIT clause followed by a number", () => {
         expect(getTopicCountsBody).not.toBeNull();
         expect(getTopicCountsBody![0]).toMatch(/\bLIMIT\s+\d+/);
@@ -226,6 +230,7 @@ describe("memory-safety", () => {
     );
 
     describe("when the field discovery query SQL is inspected", () => {
+      /** @scenario "Field discovery query includes a LIMIT clause" */
       it("span names query includes a LIMIT clause followed by a number", () => {
         expect(getDistinctFieldNamesBody).not.toBeNull();
         // The body contains two queries (span names + metadata keys).
@@ -282,6 +287,7 @@ describe("memory-safety", () => {
        * passes clickhouse_settings. This reads the source file and checks
        * that all query() invocations include the settings parameter.
        */
+      /** @scenario "All query execution paths include memory safety settings" */
       it("passes clickhouse_settings to every .query() call in clickhouse-analytics.service.ts", () => {
         const servicePath = path.resolve(
           __dirname,
@@ -340,6 +346,7 @@ describe("memory-safety", () => {
   // -------------------------------------------------------------------------
   describe("metric prefix column-pruning test coverage", () => {
     describe("when comparing metric-translator prefixes to column-pruning tests", () => {
+      /** @scenario "Every metric prefix in metric-translator has a column-pruning test" */
       it("has at least one column-pruning test for every registered metric prefix", () => {
         // Extract metric prefixes from metric-translator.ts by reading the source
         const translatorPath = path.resolve(

--- a/specs/analytics/chart-rendering.feature
+++ b/specs/analytics/chart-rendering.feature
@@ -32,7 +32,7 @@ Feature: Analytics Chart Rendering
   # Pass rate formatting
   # ---------------------------------------------------------------------------
 
-  @unit @unimplemented
+  @unit
   Scenario: Evaluation pass rate displays as percentage
     Given a chart showing evaluation pass rate data
     When the chart renders the Y-axis and tooltips
@@ -72,7 +72,7 @@ Feature: Analytics Chart Rendering
   # Event metrics coexistence
   # ---------------------------------------------------------------------------
 
-  @unit @unimplemented
+  @unit
   Scenario: Event details and event score metrics use distinct aggregation keys
     Given a dashboard with both event score and event details metrics
     When both metrics query the same event key and subkey
@@ -82,7 +82,7 @@ Feature: Analytics Chart Rendering
   # Tokens per second metric completeness
   # ---------------------------------------------------------------------------
 
-  @unit @unimplemented
+  @unit
   Scenario: Tokens per second metric resolves duration from stored spans
     Given an analytics query for the performance tokens per second metric
     When the ClickHouse query is built

--- a/specs/analytics/clickhouse-column-pruning.feature
+++ b/specs/analytics/clickhouse-column-pruning.feature
@@ -15,21 +15,21 @@ Feature: ClickHouse Analytics Column Pruning
   # Trace summaries deduplication subquery
   # ---------------------------------------------------------------------------
 
-  @unit @unimplemented
+  @unit
   Scenario: Trace dedup subquery selects only columns required by the query
     When an analytics query requests the "trace_count" metric
     Then the trace_summaries dedup subquery does not use SELECT *
     And the dedup subquery selects the identity columns needed for deduplication
     And the dedup subquery selects only the metric columns referenced by the query
 
-  @unit @unimplemented
+  @unit
   Scenario: Dedup subquery includes groupBy columns when grouping is active
     When an analytics query requests "total_cost" grouped by "metadata.user_id"
     Then the dedup subquery includes the column mapped to "metadata.user_id"
     And the dedup subquery includes the column mapped to "total_cost"
     And no other payload columns appear in the dedup subquery
 
-  @unit @unimplemented
+  @unit
   Scenario: Dedup subquery includes filter columns when filters are active
     When an analytics query requests "trace_count" filtered by "metadata.labels"
     Then the dedup subquery includes the column mapped to "metadata.labels"
@@ -39,13 +39,13 @@ Feature: ClickHouse Analytics Column Pruning
   # Evaluation runs subquery JOIN
   # ---------------------------------------------------------------------------
 
-  @unit @unimplemented
+  @unit
   Scenario: Evaluation runs subquery selects only needed evaluation columns
     When an analytics query references an evaluation metric like "evaluations.score"
     Then the evaluation_runs subquery does not use SELECT *
     And the evaluation_runs subquery selects only the columns needed for the JOIN key and the referenced metric
 
-  @unit @unimplemented
+  @unit
   Scenario: Evaluation runs subquery adapts columns to groupBy field
     When an analytics query groups by "evaluations.evaluation_passed"
     Then the evaluation_runs subquery includes the "Passed" column
@@ -55,13 +55,13 @@ Feature: ClickHouse Analytics Column Pruning
   # Stored spans JOIN
   # ---------------------------------------------------------------------------
 
-  @unit @unimplemented
+  @unit
   Scenario: Stored spans JOIN selects only needed span columns
     When an analytics query groups by "metadata.span_type"
     Then the stored_spans source selects only the columns needed for the JOIN key and the span type attribute
     And wide columns like Input and Output are excluded from the stored_spans source
 
-  @unit @unimplemented
+  @unit
   Scenario: Stored spans JOIN adapts columns to event-based grouping
     When an analytics query groups by "events.event_type"
     Then the stored_spans source includes the Events.Name column
@@ -71,7 +71,7 @@ Feature: ClickHouse Analytics Column Pruning
   # Query correctness after pruning
   # ---------------------------------------------------------------------------
 
-  @unit @unimplemented
+  @unit
   Scenario: Pruned query generates syntactically valid SQL
     When an analytics timeseries query is built for "trace_count" over a date range
     Then the generated SQL is syntactically valid
@@ -81,7 +81,7 @@ Feature: ClickHouse Analytics Column Pruning
     When an analytics timeseries query is built for "trace_count" over a date range
     Then every column alias referenced in SELECT, GROUP BY, and ORDER BY is available from the pruned sources
 
-  @unit @unimplemented
+  @unit
   Scenario: Pruned CTE query for arrayJoin grouping preserves metric accuracy
     When an analytics query requests "trace_count" grouped by "metadata.labels"
     Then the CTE inner query selects only identity, period, date, group key, and metric columns

--- a/specs/analytics/clickhouse-memory-safety.feature
+++ b/specs/analytics/clickhouse-memory-safety.feature
@@ -16,36 +16,36 @@ Feature: ClickHouse Query Memory Safety Regression Tests
   # Layer 1: SQL structure assertions (unit tests, no DB)
   # ---------------------------------------------------------------------------
 
-  @unit @unimplemented
+  @unit
   Scenario: Analytics queries access SpanAttributes only via key extraction
     When any builder-generated analytics query produces SQL
     Then the outermost SELECT clause never includes a bare "SpanAttributes" column
     And SpanAttributes is only accessed via specific key extraction like SpanAttributes['key']
 
-  @unit @unimplemented
+  @unit
   Scenario: Topic and field-discovery queries access only specific attributes
     When the topic counting query SQL is inspected
     Then the SQL does not select the full SpanAttributes Map column
     When the field discovery query SQL is inspected
     Then the SQL does not select the full SpanAttributes Map column
 
-  @unit @unimplemented
+  @unit
   Scenario: Topic counting query includes a LIMIT clause
     When the topic counting query SQL is inspected
     Then the SQL includes a LIMIT clause
 
-  @unit @unimplemented
+  @unit
   Scenario: Field discovery query includes a LIMIT clause
     When the field discovery query SQL is inspected
     Then the SQL includes a LIMIT clause
 
-  @unit @unimplemented
+  @unit
   Scenario: All query execution paths include memory safety settings
     When each ClickHouse query execution call in the analytics service is inspected
     Then every call passes clickhouse_settings
     And clickhouse_settings contains max_bytes_before_external_group_by
 
-  @unit @unimplemented
+  @unit
   Scenario: Every metric prefix in metric-translator has a column-pruning test
     Given the set of all metric prefixes registered in metric-translator
     And the set of all metric prefixes covered by column-pruning tests


### PR DESCRIPTION
## Summary

Bind 18 `@unit @unimplemented` scenarios across three related analytics feature files to passing tests via `/** @scenario "<title>" */` JSDoc + dropping the `@unimplemented` tag. Pure JSDoc additions — no test logic changes.

## Commit 1 — `column-pruning.feature`: 9 bindings

`specs/analytics/clickhouse-column-pruning.feature` ↔ `src/server/analytics/clickhouse/__tests__/column-pruning.test.ts`:

| Scenario | Test |
|---|---|
| Trace dedup subquery selects only columns required... | does not use `SELECT *` in the dedup subquery |
| Dedup subquery includes groupBy columns | includes `Attributes` for `metadata.user_id` grouping |
| Dedup subquery includes filter columns | includes `Attributes` for `metadata.labels` filter |
| Evaluation runs subquery selects only needed columns | does not use `SELECT *` in `evaluation_runs` |
| Evaluation runs subquery adapts to groupBy | includes `Passed` column for `evaluation_passed` |
| Stored spans JOIN selects only needed columns | excludes `ss.Input` / `ss.Output` |
| Stored spans JOIN adapts to event-based grouping | includes `Events.Name` |
| Pruned query generates valid SQL | structural `SELECT`/`FROM`/`WHERE` checks |
| Pruned CTE for arrayJoin | CTE selects only identity, period, group_key, metric |

## Commit 2 — `memory-safety.feature`: 6 bindings

`specs/analytics/clickhouse-memory-safety.feature` ↔ `src/server/analytics/clickhouse/__tests__/memory-safety.test.ts`:

| Scenario | Test |
|---|---|
| Analytics queries access SpanAttributes only via key extraction | groupBy test asserting bare `SpanAttributes` never in outermost `SELECT` |
| Topic and field-discovery queries access only specific attributes | bound to BOTH topic-counting and field-discovery tests |
| Topic counting query includes a LIMIT clause | LIMIT regex on `getTopicCounts` body |
| Field discovery query includes a LIMIT clause | LIMIT count on `getDistinctFieldNames` body |
| All query execution paths include memory safety settings | every `.query()` call has `clickhouse_settings` |
| Every metric prefix has a column-pruning test | cross-source check of metric-translator vs column-pruning.test |

## Commit 3 — `chart-rendering.feature`: 3 bindings

`specs/analytics/chart-rendering.feature` ↔ existing analytics unit tests:

| Scenario | Test |
|---|---|
| Evaluation pass rate displays as percentage | `registry.unit.test.ts` asserts `evaluation_pass_rate.format === "0%"` |
| Event details and event score metrics use distinct aggregation keys | `registry.unit.test.ts` asserts the aggregation key contains `event_details`, not `event_score` |
| Tokens per second metric resolves duration from stored spans | `column-pruning.test.ts` asserts `DurationMs` in `stored_spans` subquery |

## Skipped

- **`column-pruning` "Pruned query resolves all column references from pruned sources"** — needs SQL parsing not in current tests.
- **5 chart-rendering scenarios** (graph-type switching, color alignment, semantic tokens, filter re-render, current-period-without-comparison) — UI-side, no backing TS unit tests.
- **All `@integration` and `@regression @integration` scenarios** — out of scope for this `@unit` pass.

## Net parity

+18 enforced bindings (615 → 633).

## Test plan

- [x] `pnpm test:unit src/server/analytics/clickhouse/__tests__/column-pruning.test.ts` — 21/21 passing
- [x] `pnpm test:unit src/server/analytics/clickhouse/__tests__/memory-safety.test.ts` — 14/14 passing
- [x] `pnpm test:unit src/server/analytics/__tests__/registry.unit.test.ts` — 3/3 passing
- [x] `pnpm tsx scripts/check-feature-parity.ts` — exits 0; all three files report fully bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)