### PR TITLE
test(licensing): bind maxMembersLite-optional schema scenario

### DIFF
--- a/langwatch/ee/licensing/__tests__/validation.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/validation.unit.test.ts
@@ -5,6 +5,7 @@ import {
   validateLicense,
   verifySignature,
 } from "../validation";
+import { LicensePlanLimitsSchema } from "../types";
 import {
   BASE_LICENSE,
   VALID_LICENSE_KEY,
@@ -16,6 +17,29 @@ import {
   GARBAGE_DATA,
 } from "./fixtures/testLicenses";
 import { TEST_PUBLIC_KEY, WRONG_PUBLIC_KEY } from "./fixtures/testKeys";
+
+describe("LicensePlanLimitsSchema", () => {
+  /** @scenario License schema accepts maxMembersLite as optional field */
+  it("accepts a license payload with maxMembersLite set to 5", () => {
+    const payload = {
+      type: "PRO",
+      name: "Pro",
+      maxMembers: 5,
+      maxMembersLite: 5,
+      maxProjects: 10,
+      maxMessagesPerMonth: 50000,
+      maxWorkflows: 25,
+      canPublish: true,
+    };
+
+    const result = LicensePlanLimitsSchema.safeParse(payload);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxMembersLite).toBe(5);
+    }
+  });
+});
 
 describe("parseLicenseKey", () => {
   /** @scenario Parses valid base64-encoded license key */

--- a/specs/licensing/license-enforcement-refactor.feature
+++ b/specs/licensing/license-enforcement-refactor.feature
@@ -20,7 +20,7 @@ Feature: License Enforcement
   # maxMembersLite in License Schema
   # ============================================================================
 
-  @unit @unimplemented
+  @unit
   Scenario: License schema accepts maxMembersLite as optional field
     Given a license payload with maxMembersLite set to 5
     When the license is validated


### PR DESCRIPTION
## Summary

- Adds schema-acceptance test for `LicensePlanLimitsSchema` confirming `maxMembersLite` parses correctly when set to 5.
- Binds the spec scenario `License schema accepts maxMembersLite as optional field` via JSDoc.
- Parity: 616 → 617 enforced bound.

## Why

Iter-6 of parity-grinder Phase 2 — independent of #3851. Closes one more @unimplemented in `specs/licensing/license-enforcement-refactor.feature`.

## Test plan

- [x] `pnpm check:feature-parity` — 617 enforced bound
- [x] CI: `test-unit` will exercise the new test against `LicensePlanLimitsSchema.safeParse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)