### PR TITLE
test(licensing): bind UNLIMITED_PLAN and FREE_PLAN structure scenarios

### DIFF
--- a/langwatch/ee/licensing/__tests__/constants.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/constants.unit.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  FREE_PLAN,
   LICENSE_ERRORS,
   LICENSE_ERROR_MESSAGES,
+  UNLIMITED_PLAN,
   getUserFriendlyLicenseError,
 } from "../constants";
 
@@ -52,5 +54,34 @@ describe("getUserFriendlyLicenseError", () => {
   it("returns original error for unknown error messages", () => {
     const unknownError = "Some unknown error";
     expect(getUserFriendlyLicenseError(unknownError)).toBe(unknownError);
+  });
+});
+
+describe("UNLIMITED_PLAN", () => {
+  /** @scenario UNLIMITED_PLAN has correct structure for backward compatibility */
+  it("has the expected structural shape for self-hosted backward compatibility", () => {
+    expect(UNLIMITED_PLAN.type).toBe("OPEN_SOURCE");
+    expect(UNLIMITED_PLAN.name).toBe("Open Source");
+    expect(UNLIMITED_PLAN.free).toBe(true);
+    expect(UNLIMITED_PLAN.overrideAddingLimitations).toBe(true);
+    expect(UNLIMITED_PLAN.maxMembers).toBe(Number.MAX_SAFE_INTEGER);
+    expect(UNLIMITED_PLAN.maxProjects).toBe(Number.MAX_SAFE_INTEGER);
+    expect(UNLIMITED_PLAN.maxMessagesPerMonth).toBe(Number.MAX_SAFE_INTEGER);
+    expect(UNLIMITED_PLAN.maxWorkflows).toBe(Number.MAX_SAFE_INTEGER);
+    expect(UNLIMITED_PLAN.canPublish).toBe(true);
+  });
+});
+
+describe("FREE_PLAN", () => {
+  /** @scenario FREE_PLAN has correct limits for expired/invalid licenses */
+  it("has the expected fallback limits for expired/invalid licenses", () => {
+    expect(FREE_PLAN.type).toBe("FREE");
+    expect(FREE_PLAN.name).toBe("Free");
+    expect(FREE_PLAN.free).toBe(true);
+    expect(FREE_PLAN.maxMembers).toBe(1);
+    expect(FREE_PLAN.maxProjects).toBe(2);
+    expect(FREE_PLAN.maxMessagesPerMonth).toBe(1000);
+    expect(FREE_PLAN.maxWorkflows).toBe(3);
+    expect(FREE_PLAN.canPublish).toBe(false);
   });
 });

--- a/specs/licensing/plan-mapping.feature
+++ b/specs/licensing/plan-mapping.feature
@@ -58,34 +58,24 @@ Feature: License to PlanInfo Mapping
   # Constants: UNLIMITED_PLAN
   # ============================================================================
 
-  # KEPT @unimplemented: requires a structural assertion test for the
-  # UNLIMITED_PLAN constant exported from ee/licensing/constants.ts. The
-  # constant is currently used as a fixture in plan-router/onboarding tests
-  # but its full shape is not asserted anywhere. Cheap to add: a
-  # constants.unit.test.ts case that imports UNLIMITED_PLAN and checks
-  # every field against the literals listed below.
-  @unimplemented
+  # Limits use Number.MAX_SAFE_INTEGER (effectively unlimited and JSON-safe)
+  # rather than Infinity, which serializes to null and would break tRPC.
   Scenario: UNLIMITED_PLAN has correct structure for backward compatibility
     When I access the UNLIMITED_PLAN constant
     Then the plan type is "OPEN_SOURCE"
     And the plan name is "Open Source"
     And the plan free is true
     And the plan overrideAddingLimitations is true
-    And maxMembers is 99999
-    And maxProjects is 9999
-    And maxMessagesPerMonth is 999999999
-    And evaluationsCredit is 999999
-    And maxWorkflows is 9999
+    And maxMembers is Number.MAX_SAFE_INTEGER
+    And maxProjects is Number.MAX_SAFE_INTEGER
+    And maxMessagesPerMonth is Number.MAX_SAFE_INTEGER
+    And maxWorkflows is Number.MAX_SAFE_INTEGER
     And canPublish is true
 
   # ============================================================================
   # Constants: FREE_PLAN
   # ============================================================================
 
-  # KEPT @unimplemented: same gap as UNLIMITED_PLAN above. FREE_PLAN's full
-  # shape is not asserted directly — only piecemeal usage in licenseHandler
-  # integration tests. Add a constants.unit.test.ts case to bind this.
-  @unimplemented
   Scenario: FREE_PLAN has correct limits for expired/invalid licenses
     When I access the FREE_PLAN constant
     Then the plan type is "FREE"
@@ -94,6 +84,5 @@ Feature: License to PlanInfo Mapping
     And maxMembers is 1
     And maxProjects is 2
     And maxMessagesPerMonth is 1000
-    And evaluationsCredit is 2
     And maxWorkflows is 3
     And canPublish is false


### PR DESCRIPTION
## Summary

- Adds structural assertion tests for `UNLIMITED_PLAN` and `FREE_PLAN` constants in `ee/licensing/constants.ts`.
- Updates the spec literals in `plan-mapping.feature` to reflect the post-Infinity-fix reality: `MAX_SAFE_INTEGER` instead of `99999`/`9999`, and drops `evaluationsCredit` (which was never on the `PlanInfo` type).
- Parity: 616 → 618 enforced bound (plan-mapping.feature 6/8 → 8/8).

## Why

Iter-7 of parity-grinder Phase 2 — independent of #3851. The spec preamble explicitly said: *"Cheap to add: a constants.unit.test.ts case that imports UNLIMITED_PLAN and checks every field against the literals listed below."* That's exactly what this does, with one correction: the spec's literal sentinel values (99999, 9999) were left over from before the JSON-safety refactor that swapped them for `Number.MAX_SAFE_INTEGER`. Updated to match the actual code.

## Test plan

- [x] `pnpm check:feature-parity` — 618 enforced bound, plan-mapping 8/8
- [x] CI: `test-unit` exercises new tests against actual constant values

🤖 Generated with [Claude Code](https://claude.com/claude-code)