### PR TITLE
test(model-config): bind 8 unified-reasoning-form @unit scenarios

### DIFF
--- a/langwatch/src/prompts/utils/__tests__/llmPromptConfigUtils.test.ts
+++ b/langwatch/src/prompts/utils/__tests__/llmPromptConfigUtils.test.ts
@@ -3,12 +3,15 @@ import { PromptScope } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 import type { VersionedPrompt } from "~/server/prompt-config";
 import {
+  formValuesToTriggerSaveVersionParams,
   nodeDataToLocalPromptConfig,
   promptConfigFormValuesToOptimizationStudioNodeData,
   safeOptimizationStudioNodeDataToPromptConfigFormInitialValues,
   versionedPromptToPromptConfigFormValues,
   versionedPromptToPromptConfigFormValuesWithSystemMessage,
 } from "../llmPromptConfigUtils";
+import { buildDefaultFormValues } from "../buildDefaultFormValues";
+import { formSchema } from "~/prompts/schemas/form-schema";
 
 describe("safeOptimizationStudioNodeDataToPromptConfigFormInitialValues", () => {
   describe("when LLM value is an object", () => {
@@ -370,6 +373,30 @@ describe("versionedPromptToPromptConfigFormValues", () => {
       expect(result.handle).toBeNull();
     });
   });
+
+  describe("when prompt has reasoning set", () => {
+    /** @scenario "versionedPromptToPromptConfigFormValues maps reasoning correctly" */
+    it("maps reasoning 'high' onto form values llm.reasoning", () => {
+      const prompt = createMockPrompt("test-prompt");
+      prompt.reasoning = "high";
+
+      const result = versionedPromptToPromptConfigFormValues(prompt);
+
+      expect(result.version.configData.llm.reasoning).toBe("high");
+    });
+  });
+
+  describe("when prompt has no reasoning", () => {
+    /** @scenario "versionedPromptToPromptConfigFormValues handles missing reasoning" */
+    it("leaves form values llm.reasoning undefined", () => {
+      const prompt = createMockPrompt("test-prompt");
+      // reasoning intentionally not set
+
+      const result = versionedPromptToPromptConfigFormValues(prompt);
+
+      expect(result.version.configData.llm.reasoning).toBeUndefined();
+    });
+  });
 });
 
 describe("versionedPromptToPromptConfigFormValuesWithSystemMessage", () => {
@@ -708,6 +735,75 @@ describe("nodeDataToLocalPromptConfig()", () => {
 
       expect(result).not.toBeUndefined();
       expect(result!.messages).toEqual([{ role: "system", content: "" }]);
+    });
+  });
+});
+
+describe("formValuesToTriggerSaveVersionParams", () => {
+  describe("when form values include reasoning", () => {
+    /** @scenario "formValuesToTriggerSaveVersionParams includes reasoning" */
+    it("propagates reasoning 'high' and omits legacy provider-specific fields", () => {
+      const formValues = buildDefaultFormValues({
+        version: { configData: { llm: { reasoning: "high" } } },
+      });
+
+      const result = formValuesToTriggerSaveVersionParams(formValues);
+
+      expect(result.reasoning).toBe("high");
+      // Unified field is the canonical sink; legacy provider-specific
+      // names must not leak through.
+      expect(result).not.toHaveProperty("reasoningEffort");
+      expect(result).not.toHaveProperty("thinkingLevel");
+      expect(result).not.toHaveProperty("effort");
+    });
+  });
+
+  describe("when form values omit reasoning", () => {
+    /** @scenario "formValuesToTriggerSaveVersionParams handles undefined reasoning" */
+    it("returns reasoning undefined and no legacy fields", () => {
+      const formValues = buildDefaultFormValues();
+
+      const result = formValuesToTriggerSaveVersionParams(formValues);
+
+      expect(result.reasoning).toBeUndefined();
+      expect(result).not.toHaveProperty("reasoningEffort");
+    });
+  });
+});
+
+describe("formSchema reasoning validation", () => {
+  describe("when llm.reasoning is set to a valid value", () => {
+    /** @scenario "Form schema accepts reasoning field with valid value" */
+    it("accepts 'high'", () => {
+      const values = buildDefaultFormValues({
+        version: { configData: { llm: { reasoning: "high" } } },
+      });
+      expect(formSchema.safeParse(values).success).toBe(true);
+    });
+
+    /** @scenario Form schema accepts reasoning field with "low" value */
+    it("accepts 'low'", () => {
+      const values = buildDefaultFormValues({
+        version: { configData: { llm: { reasoning: "low" } } },
+      });
+      expect(formSchema.safeParse(values).success).toBe(true);
+    });
+
+    /** @scenario Form schema accepts reasoning field with "medium" value */
+    it("accepts 'medium'", () => {
+      const values = buildDefaultFormValues({
+        version: { configData: { llm: { reasoning: "medium" } } },
+      });
+      expect(formSchema.safeParse(values).success).toBe(true);
+    });
+  });
+
+  describe("when llm.reasoning is not set", () => {
+    /** @scenario "Form schema accepts undefined reasoning" */
+    it("accepts undefined reasoning", () => {
+      const values = buildDefaultFormValues();
+      expect(formSchema.safeParse(values).success).toBe(true);
+      expect(values.version.configData.llm.reasoning).toBeUndefined();
     });
   });
 });

--- a/specs/model-config/unified-reasoning-form.feature
+++ b/specs/model-config/unified-reasoning-form.feature
@@ -4,32 +4,32 @@ Feature: Unified Reasoning Form Field
   So that I have a consistent experience across all providers
 
   # Form Schema Validation
-  @unit @unimplemented
+  @unit
   Scenario: Form schema accepts reasoning field with valid value
     Given a prompt config form
     When I set llm.reasoning to "high"
     Then the form should validate successfully
 
-  @unit @unimplemented
+  @unit
   Scenario: Form schema accepts reasoning field with "low" value
     Given a prompt config form
     When I set llm.reasoning to "low"
     Then the form should validate successfully
 
-  @unit @unimplemented
+  @unit
   Scenario: Form schema accepts reasoning field with "medium" value
     Given a prompt config form
     When I set llm.reasoning to "medium"
     Then the form should validate successfully
 
-  @unit @unimplemented
+  @unit
   Scenario: Form schema accepts undefined reasoning
     Given a prompt config form
     When I do not set llm.reasoning
     Then the form should validate successfully
 
   # Form to Save Params Conversion
-  @unit @unimplemented
+  @unit
   Scenario: formValuesToTriggerSaveVersionParams includes reasoning
     Given form values with llm.reasoning "high"
     When converting to save params
@@ -38,7 +38,7 @@ Feature: Unified Reasoning Form Field
     And the result should NOT include thinkingLevel
     And the result should NOT include effort
 
-  @unit @unimplemented
+  @unit
   Scenario: formValuesToTriggerSaveVersionParams handles undefined reasoning
     Given form values with no llm.reasoning set
     When converting to save params
@@ -46,13 +46,13 @@ Feature: Unified Reasoning Form Field
     And the result should NOT include reasoningEffort
 
   # Versioned Prompt to Form Values Conversion
-  @unit @unimplemented
+  @unit
   Scenario: versionedPromptToPromptConfigFormValues maps reasoning correctly
     Given a versioned prompt with reasoning "high"
     When converting to form values
     Then the form should have llm.reasoning "high"
 
-  @unit @unimplemented
+  @unit
   Scenario: versionedPromptToPromptConfigFormValues handles missing reasoning
     Given a versioned prompt with no reasoning
     When converting to form values


### PR DESCRIPTION
## Summary

Add 8 new unit tests in `langwatch/src/prompts/utils/__tests__/llmPromptConfigUtils.test.ts` that exercise `unified-reasoning-form.feature` behavior end-to-end. Unlike the prior parity PRs in this thread (#3848, #3855), these are **real new tests**, not JSDoc bindings to existing tests.

## What this verifies

The feature file describes an end-to-end conversion contract: form values → save params → versioned prompt → form values. Each conversion step must preserve the canonical `reasoning` field and avoid leaking legacy provider-specific names (`reasoningEffort`, `thinkingLevel`, `effort`).

### `formValuesToTriggerSaveVersionParams` (2 tests)

| Scenario | What the test asserts |
|---|---|
| includes reasoning | `reasoning: "high"` in form → `reasoning: "high"` in result; `reasoningEffort` / `thinkingLevel` / `effort` are NOT present |
| handles undefined reasoning | unset reasoning → `result.reasoning === undefined`; no legacy fields |

### `versionedPromptToPromptConfigFormValues` (2 tests)

| Scenario | What the test asserts |
|---|---|
| maps reasoning correctly | `prompt.reasoning = "high"` → `result.version.configData.llm.reasoning === "high"` |
| handles missing reasoning | unset prompt.reasoning → `result.version.configData.llm.reasoning === undefined` |

### `formSchema` reasoning validation (4 tests)

| Scenario | What the test asserts |
|---|---|
| accepts valid value | `'high'` parses successfully |
| accepts `"low"` | `'low'` parses successfully |
| accepts `"medium"` | `'medium'` parses successfully |
| accepts undefined | unset reasoning still parses successfully |

## Skipped

- **`Form values round-trip preserves reasoning`** — `@integration` scope, not `@unit`. Out of band for this `@unit` pass.

## Net parity

+8 enforced bindings.

## Test plan

- [x] `pnpm test:unit src/prompts/utils/__tests__/llmPromptConfigUtils.test.ts` — 39/39 passing (was 31)
- [x] `pnpm tsx scripts/check-feature-parity.ts` — exits 0; `unified-reasoning-form.feature` reports `8/8 scenarios bound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)