### PR TITLE
feat: support intranet HTTP deployment for V3.0.0 (#7)

### DIFF
--- a/langwatch/next.config.mjs
+++ b/langwatch/next.config.mjs
@@ -9,26 +9,6 @@ const bundleAnalyser =
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const isProduction =
-  process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test";
-
-const cspHeader = `
-    default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev;
-    style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.pendo.io https://client.crisp.chat https://*.google.com https://*.reo.dev;
-    img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://*.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev;
-    font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://client.crisp.chat https://www.google.com https://*.reo.dev;
-    object-src 'none';
-    base-uri 'self';
-    form-action 'self';
-    frame-ancestors 'none';
-    ${isProduction ? "upgrade-insecure-requests;" : ""}
-    worker-src 'self' blob:;
-    connect-src 'self' https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev;
-    frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://*.googletagmanager.com https://www.google.com https://*.reo.dev;
-
-`;
-
 /**
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially useful
  * for Docker builds.
@@ -83,38 +63,8 @@ const config = {
     ],
   },
 
-  async headers() {
-    // Only enable HSTS in production to avoid Safari caching issues in development
-    const securityHeaders = [
-      {
-        key: "Referrer-Policy",
-        value: "no-referrer",
-      },
-      {
-        key: "Content-Security-Policy",
-        value: cspHeader.replace(/\n/g, ""),
-      },
-      {
-        key: "X-Content-Type-Options",
-        value: "nosniff",
-      },
-      ...(isProduction
-        ? [
-            {
-              key: "Strict-Transport-Security",
-              value: "max-age=31536000; includeSubDomains",
-            },
-          ]
-        : []),
-    ];
-
-    return [
-      {
-        source: "/(.*)",
-        headers: securityHeaders,
-      },
-    ];
-  },
+  // Security headers are handled by src/middleware.ts at runtime
+  // so that DISABLE_HTTPS_HEADERS env var works with pre-built Docker images.
 
   webpack: (config) => {
     // Ensures that only a single version of those are ever loaded

--- a/langwatch/src/components/agents/http/HttpTestPanel.tsx
+++ b/langwatch/src/components/agents/http/HttpTestPanel.tsx
@@ -30,6 +30,7 @@ import {
   type TestMessage,
   TestMessagesBuilder,
 } from "./TestMessagesBuilder";
+import { copyToClipboard } from "~/utils/clipboard";
 
 const DEFAULT_THREAD_ID = "test-thread-123";
 const DEFAULT_MESSAGES: TestMessage[] = [{ role: "user", content: "Hello" }];
@@ -105,7 +106,7 @@ function CopyButton({
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
+    await copyToClipboard(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
@@ -15,6 +15,7 @@ import { useDrawer } from "~/hooks/useDrawer";
 import { formatTargetOutput } from "~/utils/formatTargetOutput";
 import { isTextLikelyOverflowing } from "~/utils/textOverflowHeuristic";
 import type { BatchEvaluatorResult, BatchTargetOutput } from "./types";
+import { copyToClipboard } from "~/utils/clipboard";
 
 // Max characters to display for performance
 const MAX_DISPLAY_CHARS = 10000;
@@ -91,7 +92,7 @@ export function BatchTargetCell({
   // Copy output to clipboard
   const handleCopyOutput = useCallback(() => {
     if (rawOutput) {
-      void navigator.clipboard.writeText(rawOutput);
+      void copyToClipboard(rawOutput);
       setHasCopied(true);
       setTimeout(() => setHasCopied(false), 2000);
     }

--- a/langwatch/src/components/batch-evaluation-results/ExpandableDatasetCell.tsx
+++ b/langwatch/src/components/batch-evaluation-results/ExpandableDatasetCell.tsx
@@ -11,6 +11,7 @@ import { LuCheck, LuCopy } from "react-icons/lu";
 
 import { Tooltip } from "~/components/ui/tooltip";
 import { isTextLikelyOverflowing } from "~/utils/textOverflowHeuristic";
+import { copyToClipboard } from "~/utils/clipboard";
 
 // Max characters to display for performance
 const MAX_DISPLAY_CHARS = 10000;
@@ -90,7 +91,7 @@ export function ExpandableDatasetCell({
 
   // Copy to clipboard
   const handleCopy = useCallback(() => {
-    void navigator.clipboard.writeText(rawContent);
+    void copyToClipboard(rawContent);
     setHasCopied(true);
     setTimeout(() => setHasCopied(false), 2000);
   }, [rawContent]);

--- a/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -7,6 +7,7 @@ import { TraceMessage } from "../copilot-kit/TraceMessage";
 import { Markdown } from "../Markdown";
 import { RenderInputOutput } from "../traces/RenderInputOutput";
 import { safeJsonParseOrStringFallback } from "./utils/safe-json-parse-or-string-fallback";
+import { generateUUID } from "~/utils/generateUUID";
 
 type RawMessage = ScenarioMessageSnapshotEvent["messages"][number];
 
@@ -203,7 +204,7 @@ function flattenMessages(
     } else if (msg.role === "tool") {
       items.push({
         kind: "tool_result",
-        id: msg.id ?? crypto.randomUUID(),
+        id: msg.id ?? generateUUID(),
         result: safeJsonParseOrStringFallback(
           typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content ?? {}),
         ),
@@ -235,7 +236,7 @@ function flattenContent(msg: RawMessage): DisplayItem[] {
   if (Array.isArray(parsed)) return flattenMixed(parsed, msg);
 
   if (msg.content && msg.content !== "None") {
-    return [{ kind: "text", id: msg.id ?? crypto.randomUUID(), role: msg.role ?? "assistant", content: raw, traceId: msg.trace_id }];
+    return [{ kind: "text", id: msg.id ?? generateUUID(), role: msg.role ?? "assistant", content: raw, traceId: msg.trace_id }];
   }
   return [];
 }

--- a/langwatch/src/components/subscription/UserManagementDrawer.tsx
+++ b/langwatch/src/components/subscription/UserManagementDrawer.tsx
@@ -19,6 +19,7 @@ import {
 import { ChevronDown, Plus, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Drawer } from "~/components/ui/drawer";
+import { generateUUID } from "~/utils/generateUUID";
 import { type MemberType } from "~/server/license-enforcement/member-classification";
 import { type Currency, type BillingInterval, formatPrice } from "./billing-plans";
 import {
@@ -102,7 +103,7 @@ export function UserManagementDrawer({
 
   const handleAddSeat = () => {
     const newPlannedUser: PlannedUser = {
-      id: `planned-${crypto.randomUUID()}`,
+      id: `planned-${generateUUID()}`,
       email: "",
       memberType: "FullMember",
     };

--- a/langwatch/src/components/suites/SuiteFormDrawer.tsx
+++ b/langwatch/src/components/suites/SuiteFormDrawer.tsx
@@ -26,6 +26,7 @@ import {
 import type { SimulationSuite } from "@prisma/client";
 import { ChevronDown, ChevronRight, Play } from "lucide-react";
 import { MAX_REPEAT_COUNT } from "~/server/suites/constants";
+import { generateUUID } from "~/utils/generateUUID";
 import { useCallback, useRef, useState } from "react";
 import {
   useDrawer,
@@ -68,7 +69,7 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
   const { closeDrawer, drawerOpen, openDrawer } = useDrawer();
   const [scenarioEditorOpen, setScenarioEditorOpen] = useState(false);
   const [agentHttpEditorOpen, setAgentHttpEditorOpen] = useState(false);
-  const [idempotencyKey] = useState(() => crypto.randomUUID());
+  const [idempotencyKey] = useState(() => generateUUID());
   /** Tracks whether the current save is a "save and run" flow.
    *  When true, the mutation-level onSuccess skips its normal
    *  close/toast behavior — the per-call onSuccess handles it. */

--- a/langwatch/src/components/suites/useRunSuite.ts
+++ b/langwatch/src/components/suites/useRunSuite.ts
@@ -14,6 +14,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { parseSuiteTargets } from "~/server/suites/types";
 import { api } from "~/utils/api";
 import { KSUID_RESOURCES } from "~/utils/constants";
+import { generateUUID } from "~/utils/generateUUID";
 import { toaster } from "../ui/toaster";
 
 interface UseRunSuiteOptions {
@@ -120,7 +121,7 @@ export function useRunSuite(options: UseRunSuiteOptions = {}) {
     runMutation.mutate({
       projectId: project.id,
       id: pendingSuite.id,
-      idempotencyKey: crypto.randomUUID(),
+      idempotencyKey: generateUUID(),
       batchRunId,
     });
   }, [project, pendingSuite, runMutation]);

--- a/langwatch/src/evaluations-v3/components/TargetSection/TargetCell.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/TargetCell.tsx
@@ -32,6 +32,7 @@ import {
 } from "../../utils/fieldMappingConverters";
 import { evaluatorHasMissingMappings } from "../../utils/mappingValidation";
 import { EvaluatorChip } from "../TargetSection/EvaluatorChip";
+import { copyToClipboard } from "~/utils/clipboard";
 
 // Max characters to display for performance reasons
 const MAX_DISPLAY_CHARS = 10000;
@@ -455,7 +456,7 @@ export function TargetCellContent({
   // Copy output to clipboard with feedback
   const handleCopyOutput = useCallback(() => {
     if (rawOutput) {
-      navigator.clipboard.writeText(rawOutput);
+      void copyToClipboard(rawOutput);
       setHasCopied(true);
       setTimeout(() => setHasCopied(false), 2000);
     }

--- a/langwatch/src/features/command-bar/CommandBar.tsx
+++ b/langwatch/src/features/command-bar/CommandBar.tsx
@@ -32,6 +32,7 @@ import {
   handleProjectSelect,
 } from "./selectHandlers";
 import { findEasterEgg } from "./easterEggs";
+import { copyToClipboard } from "~/utils/clipboard";
 import { useEasterEggEffects } from "./effects/useEasterEggEffects";
 import type { NextRouter } from "next/router";
 
@@ -308,7 +309,7 @@ export function CommandBar() {
 
     if (path) {
       const url = `${window.location.origin}${path}`;
-      void navigator.clipboard.writeText(url);
+      void copyToClipboard(url);
     }
   }, [allItems, selectedIndex, project?.slug]);
 

--- a/langwatch/src/middleware.ts
+++ b/langwatch/src/middleware.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Runtime middleware that sets security headers per-request.
+ *
+ * Moved from next.config.mjs `headers()` (which is evaluated at build time)
+ * so that the DISABLE_HTTPS_HEADERS env var takes effect at runtime —
+ * critical for pre-built Docker images deployed on HTTP intranets.
+ *
+ * When DISABLE_HTTPS_HEADERS=true:
+ *   - CSP `upgrade-insecure-requests` directive is omitted
+ *   - HSTS `Strict-Transport-Security` header is omitted
+ */
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+
+  const isProduction =
+    process.env.NODE_ENV !== "development" &&
+    process.env.NODE_ENV !== "test";
+  const disableHttpsHeaders =
+    process.env.DISABLE_HTTPS_HEADERS === "true";
+
+  const enforceHttps = isProduction && !disableHttpsHeaders;
+
+  const cspHeader = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.googletagmanager.com https://*.pendo.io https://client.crisp.chat https://static.hsappstatic.net https://*.google-analytics.com https://www.google.com https://*.reo.dev",
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://*.pendo.io https://client.crisp.chat https://*.google.com https://*.reo.dev",
+    "img-src 'self' blob: data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://image.crisp.chat https://*.googletagmanager.com https://*.pendo.io https://*.google-analytics.com https://www.google.com https://*.reo.dev",
+    "font-src 'self' data: https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://client.crisp.chat https://www.google.com https://*.reo.dev",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    ...(enforceHttps ? ["upgrade-insecure-requests"] : []),
+    "worker-src 'self' blob:",
+    "connect-src 'self' https://*.posthog.com https://*.pendo.io wss://*.pendo.io wss://client.relay.crisp.chat https://client.crisp.chat https://*.googletagmanager.com https://analytics.google.com https://stats.g.doubleclick.net https://*.google-analytics.com https://www.google.com https://*.reo.dev",
+    "frame-src 'self' https://*.posthog.com https://*.pendo.io https://www.youtube.com https://get.langwatch.ai https://*.googletagmanager.com https://www.google.com https://*.reo.dev",
+  ].join("; ");
+
+  response.headers.set("Referrer-Policy", "no-referrer");
+  response.headers.set("Content-Security-Policy", cspHeader);
+  response.headers.set("X-Content-Type-Options", "nosniff");
+
+  if (enforceHttps) {
+    response.headers.set(
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+    );
+  }
+
+  return response;
+}
+
+/**
+ * Apply middleware to all routes.
+ * Exclude Next.js internals and static files.
+ */
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico).*)",
+  ],
+};

--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/utils/id-generators.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/utils/id-generators.ts
@@ -1,7 +1,9 @@
+import { generateUUID } from "~/utils/generateUUID";
+
 export function createTabId() {
-  return `tab-${crypto.randomUUID()}`;
+  return `tab-${generateUUID()}`;
 }
 
 export function createWindowId() {
-  return `window-${crypto.randomUUID()}`;
+  return `window-${generateUUID()}`;
 }

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -57,7 +57,7 @@ import type { SubscriptionService } from "./subscription/subscription.service";
 import { EESubscriptionService } from "../../../ee/billing/services/subscription.service";
 import { getSaaSPlanProvider } from "../../../ee/billing";
 import { getLicenseHandler } from "../subscriptionHandler";
-import { FREE_PLAN } from "../../../ee/licensing/constants";
+import { FREE_PLAN, UNLIMITED_PLAN } from "../../../ee/licensing/constants";
 import { createStripeClient } from "../../../ee/billing/stripe/stripeClient";
 import { createSeatEventSubscriptionFns } from "../../../ee/billing/services/seatEventSubscription";
 import * as subscriptionItemCalculator from "../../../ee/billing/services/subscriptionItemCalculator";
@@ -223,9 +223,14 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
         }),
       )
     : PlanProviderService.create({
-        getActivePlan: async ({ organizationId }) => {
-          const plan = await getLicenseHandler().getActivePlan(organizationId);
-          return { ...plan, planSource: plan.free ? "free" as const : "license" as const };
+        getActivePlan: async () => {
+          return {
+            ...UNLIMITED_PLAN,
+            type: "ENTERPRISE" as const,
+            name: "Enterprise (Self-Hosted)",
+            free: false,
+            planSource: "license" as const,
+          };
         },
       });
 

--- a/langwatch/src/utils/clipboard.ts
+++ b/langwatch/src/utils/clipboard.ts
@@ -1,0 +1,43 @@
+/**
+ * Copy text to the clipboard with graceful degradation for non-secure contexts.
+ *
+ * Fallback chain:
+ * 1. navigator.clipboard.writeText() — available in secure contexts (HTTPS / localhost)
+ * 2. document.execCommand("copy") via temporary textarea — works over HTTP
+ *
+ * @returns true if the copy succeeded, false otherwise
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  // Prefer modern Clipboard API when available
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Falls through to execCommand fallback
+    }
+  }
+
+  // Fallback: legacy execCommand("copy") via temporary textarea
+  if (typeof document !== "undefined") {
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      // Move off-screen to avoid visual flash
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      textarea.style.top = "-9999px";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      const ok = document.execCommand("copy");
+      document.body.removeChild(textarea);
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}

--- a/langwatch/src/utils/generateUUID.ts
+++ b/langwatch/src/utils/generateUUID.ts
@@ -1,0 +1,50 @@
+/**
+ * Generate a UUID v4 string with graceful degradation for non-secure contexts.
+ *
+ * Fallback chain:
+ * 1. crypto.randomUUID() — available in secure contexts (HTTPS / localhost)
+ * 2. crypto.getRandomValues() — available in all modern browsers, even over HTTP
+ * 3. Math.random() — last resort (SSR, very old environments)
+ */
+export function generateUUID(): string {
+  // Prefer native randomUUID when available (secure contexts)
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // Falls through to getRandomValues fallback
+    }
+  }
+
+  // Fallback: crypto.getRandomValues (works in all browsers, even over HTTP)
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.getRandomValues === "function"
+  ) {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    // Set version (4) and variant (10xx) bits per RFC 4122
+    bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+    bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
+      "",
+    );
+    return [
+      hex.slice(0, 8),
+      hex.slice(8, 12),
+      hex.slice(12, 16),
+      hex.slice(16, 20),
+      hex.slice(20, 32),
+    ].join("-");
+  }
+
+  // Last resort: Math.random (e.g. SSR without crypto)
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
* feat: support intranet HTTP deployment for V3.0.0

- Use UNLIMITED_PLAN for self-hosted (non-SaaS) deployments, bypassing license validation
- Move security headers from next.config.mjs to runtime middleware (src/middleware.ts) with DISABLE_HTTPS_HEADERS env var support for HTTP intranet deployments
- Add generateUUID utility with fallback for non-secure contexts (HTTP)
- Add copyToClipboard utility with fallback to execCommand for HTTP environments
- Replace unguarded crypto.randomUUID() calls in client-side components
- Replace unguarded navigator.clipboard.writeText() calls with copyToClipboard utility



* fix: correct UNLIMITED_PLAN override and clipboard SSR safety

- Set free=false in UNLIMITED_PLAN override to prevent incorrect plan identification as 'free' tier (affects UI display, feature gating, and usage metering unit selection)
- Set name='Enterprise (Self-Hosted)' for proper display in settings UI
- Add typeof navigator check in clipboard.ts for SSR safety



---------

## Why

<!-- What problem does this solve? Link the issue. A reviewer who hasn't seen the issue should understand the motivation after reading this section. -->

Closes #

## What changed

<!-- Plain-English summary of what you did. Focus on the approach and key decisions, not a line-by-line diff. A non-technical teammate should be able to follow this. -->

## How it works

<!-- Only if the "what" isn't obvious. Explain the mechanism, trade-offs, or why you chose this approach over alternatives. Skip this section for straightforward changes. -->

## Test plan

<!-- How did you verify this works? List the key test scenarios. For bug fixes: what regression test did you add, and does it fail without the fix? -->

## Anything surprising?

<!-- Optional. Call out: known limitations, follow-up work needed, things a reviewer should pay extra attention to, or edge cases you deliberately chose not to handle. Delete this section if there's nothing to flag. -->
