### PR TITLE
test(licensing): bind 2 enforcement-resources scenarios via existing tests

### DIFF
--- a/langwatch/src/server/license-enforcement/__tests__/license-enforcement.service.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-enforcement.service.unit.test.ts
@@ -194,7 +194,8 @@ describe("LicenseEnforcementService", () => {
       );
     });
 
-    it("includes current and max in LimitExceededError", async () => {
+    /** @scenario Blocks prompt creation when at limit */
+    it("includes current, max, and prompts label in LimitExceededError", async () => {
       vi.mocked(mockRepository.getPromptCount).mockResolvedValue(5);
 
       try {
@@ -206,6 +207,7 @@ describe("LicenseEnforcementService", () => {
         expect(limitError.limitType).toBe("prompts");
         expect(limitError.current).toBe(5);
         expect(limitError.max).toBe(5);
+        expect(limitError.message).toContain("maximum number of prompts");
       }
     });
 
@@ -250,7 +252,8 @@ describe("LicenseEnforcementService", () => {
       expect(mockRepository.getProjectCount).toHaveBeenCalledWith("org-456");
     });
 
-    it("throws LimitExceededError when limit is reached", async () => {
+    /** @scenario Blocks team creation when at limit */
+    it("throws LimitExceededError mentioning teams when team limit is reached", async () => {
       vi.mocked(mockRepository.getTeamCount).mockResolvedValue(5);
 
       await expect(
@@ -258,7 +261,7 @@ describe("LicenseEnforcementService", () => {
           organizationId: "org-123",
           limitType: "teams",
         })
-      ).rejects.toThrow(LimitExceededError);
+      ).rejects.toThrow(/maximum number of teams/);
     });
 
     it("does not throw when limit is not exceeded", async () => {

--- a/specs/licensing/enforcement-resources.feature
+++ b/specs/licensing/enforcement-resources.feature
@@ -92,7 +92,7 @@ Feature: Resource Limit Enforcement (Workflows, Prompts, Evaluators, Scenarios, 
     When I create a prompt in project "proj-789"
     Then the prompt is created successfully
 
-  @integration @unimplemented
+  @integration
   Scenario: Blocks prompt creation when at limit
     Given the organization has a license with maxPrompts 3
     And the organization has 3 prompts across all projects
@@ -181,7 +181,7 @@ Feature: Resource Limit Enforcement (Workflows, Prompts, Evaluators, Scenarios, 
     When I create a team in the organization
     Then the team is created successfully
 
-  @integration @unimplemented
+  @integration
   Scenario: Blocks team creation when at limit
     Given the organization has a license with maxTeams 3
     And the organization has 3 teams


### PR DESCRIPTION
## Summary

Binds 2 `@unimplemented` scenarios in `specs/licensing/enforcement-resources.feature` (6/6 → 8/8 of bindable count) by attaching `@scenario` JSDoc to existing tests that already exercise the exact resource type and behavior.

- **`Blocks prompt creation when at limit`** → existing `enforceLimit("prompts")` at-limit test in `license-enforcement.service.unit.test.ts`. Renamed and extended to also assert the error message contains `"maximum number of prompts"`, matching the spec text.
- **`Blocks team creation when at limit`** → existing `enforceLimitByOrganization({limitType: "teams"})` at-limit test. Renamed and tightened to assert the error message matches `/maximum number of teams/`, matching the spec text.

Both pre-existing tests already exercised the right behaviour with the right resource. The change adds the `@scenario` annotation for the parity gate AND tightens each assertion so the test actually verifies the error-message portion the spec promises (`error message contains "maximum number of <resource>"`).

## Why these scenarios specifically (and not the others in the file)?

Most other resource-type @unimplemented in this file are covered behaviourally by the parameterized `it.each(limitTypeTests)` block — but parameterized cases cannot bind via JSDoc. Only `prompts` and `teams` happened to also have dedicated single-name `it()` tests; those are the ones binding here. Workflow-copy / per-resource UI / expired-license-FREE-tier scenarios remain `@unimplemented` pending dedicated tests or harnesses (documented in the file's preamble).

## Test plan

- [x] `pnpm test:unit src/server/license-enforcement/__tests__/license-enforcement.service.unit.test.ts` — 29/29 pass
- [x] Parity script — `enforcement-resources.feature` 8/8 bound (was 6/6)
- [x] Asserted text matches actual `LimitExceededError.message` template (`LIMIT_TYPE_LABELS["prompts"] === "prompts"`, `["teams"] === "teams"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)