### PR TITLE
test(licensing): bind 3 subscription-limit-overrides scenarios

### DIFF
--- a/langwatch/ee/billing/__tests__/planProvider.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planProvider.unit.test.ts
@@ -251,6 +251,89 @@ describe("createSaaSPlanProvider", () => {
       });
     });
 
+    describe("when project capacity is overridden", () => {
+      /** @scenario Subscription with a project override uses that value */
+      it("returns the override value for maxProjects", async () => {
+        const subscription = {
+          plan: PlanTypes.LAUNCH,
+          status: SubscriptionStatus.ACTIVE,
+          maxProjects: 50,
+          ...Object.fromEntries(
+            NUMERIC_OVERRIDE_FIELDS.filter((f) => f !== "maxProjects").map(
+              (f) => [f, null],
+            ),
+          ),
+        };
+
+        const db = createMockDb({ findFirstResult: subscription });
+        const provider = createSaaSPlanProvider(db);
+        const plan = await provider.getActivePlan("org_1");
+
+        expect(plan.maxProjects).toBe(50);
+      });
+    });
+
+    describe("when monthly message capacity is overridden", () => {
+      /** @scenario Subscription with a monthly message override uses that value */
+      it("returns the override value for maxMessagesPerMonth", async () => {
+        const subscription = {
+          plan: PlanTypes.LAUNCH,
+          status: SubscriptionStatus.ACTIVE,
+          maxMessagesPerMonth: 500_000,
+          ...Object.fromEntries(
+            NUMERIC_OVERRIDE_FIELDS.filter(
+              (f) => f !== "maxMessagesPerMonth",
+            ).map((f) => [f, null]),
+          ),
+        };
+
+        const db = createMockDb({ findFirstResult: subscription });
+        const provider = createSaaSPlanProvider(db);
+        const plan = await provider.getActivePlan("org_1");
+
+        expect(plan.maxMessagesPerMonth).toBe(500_000);
+      });
+    });
+
+    describe("when several overrides are set together", () => {
+      /** @scenario Several overrides are applied together */
+      it("applies each override and leaves remaining fields at plan defaults", async () => {
+        const overrides = {
+          maxMembers: 20,
+          maxWorkflows: 50,
+          maxPrompts: 30,
+          maxMessagesPerMonth: 200_000,
+        };
+        const subscription = {
+          plan: PlanTypes.LAUNCH,
+          status: SubscriptionStatus.ACTIVE,
+          ...overrides,
+          ...Object.fromEntries(
+            NUMERIC_OVERRIDE_FIELDS.filter(
+              (f) => !(f in overrides),
+            ).map((f) => [f, null]),
+          ),
+        };
+
+        const db = createMockDb({ findFirstResult: subscription });
+        const provider = createSaaSPlanProvider(db);
+        const plan = await provider.getActivePlan("org_1");
+
+        expect(plan.maxMembers).toBe(20);
+        expect(plan.maxWorkflows).toBe(50);
+        expect(plan.maxPrompts).toBe(30);
+        expect(plan.maxMessagesPerMonth).toBe(200_000);
+
+        const basePlan = PLAN_LIMITS[PlanTypes.LAUNCH];
+        for (const field of NUMERIC_OVERRIDE_FIELDS) {
+          if (field in overrides) continue;
+          expect(plan[field], `expected ${field} to match plan default`).toBe(
+            basePlan[field],
+          );
+        }
+      });
+    });
+
     describe("when all overrides are null", () => {
       it("falls back to plan defaults for every field", async () => {
         const subscription = {

--- a/specs/licensing/subscription-limit-overrides.feature
+++ b/specs/licensing/subscription-limit-overrides.feature
@@ -22,13 +22,11 @@ Feature: Subscription Limit Overrides
   # Existing Overrides Still Work
   # ============================================================================
 
-  @unimplemented
   Scenario: Subscription with a project override uses that value
     Given the subscription overrides project capacity to 50
     When the plan is resolved for the organization
     Then the plan allows 50 projects
 
-  @unimplemented
   Scenario: Subscription with a monthly message override uses that value
     Given the subscription overrides monthly message capacity to 500000
     When the plan is resolved for the organization
@@ -61,7 +59,6 @@ Feature: Subscription Limit Overrides
   # Multiple Overrides Combine
   # ============================================================================
 
-  @unimplemented
   Scenario: Several overrides are applied together
     Given the subscription overrides member capacity to 20
     And the subscription overrides workflow capacity to 50


### PR DESCRIPTION
## Summary

Binds 3 `@unimplemented` scenarios in `specs/licensing/subscription-limit-overrides.feature` (1/4 → 4/4) by adding dedicated prose unit tests in `ee/billing/__tests__/planProvider.unit.test.ts` for behaviour that was previously only covered by `it.each(NUMERIC_OVERRIDE_FIELDS)` parameterized blocks (and therefore unbindable via `@scenario` JSDoc).

- **`Subscription with a project override uses that value`** — new test that mocks an active subscription with `maxProjects: 50` (other fields null) and asserts the resolved plan has `maxProjects === 50`.
- **`Subscription with a monthly message override uses that value`** — new test for `maxMessagesPerMonth: 500_000` override.
- **`Several overrides are applied together`** — new test that sets four simultaneous overrides (members/workflows/prompts/messagesPerMonth) and asserts both the override values land AND the non-overridden fields fall back to base plan defaults.

Each test uses the same mock-DB pattern as the surrounding suite. No production code changes.

## Test plan

- [x] `pnpm test:unit ee/billing/__tests__/planProvider.unit.test.ts` — 35/35 pass (was 32, +3 new)
- [x] Parity script — `subscription-limit-overrides.feature` 4/4 bound (was 1/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)