### PR TITLE
test(licensing): bind 2 enforcement-projects scenarios

### DIFF
--- a/langwatch/src/server/license-enforcement/__tests__/license-enforcement.service.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-enforcement.service.unit.test.ts
@@ -261,7 +261,8 @@ describe("LicenseEnforcementService", () => {
       ).rejects.toThrow(LimitExceededError);
     });
 
-    it("does not throw when limit is not exceeded", async () => {
+    /** @scenario Allows project creation when under limit */
+    it("does not throw when project count is below project limit", async () => {
       vi.mocked(mockRepository.getProjectCount).mockResolvedValue(2);
 
       await expect(
@@ -270,6 +271,18 @@ describe("LicenseEnforcementService", () => {
           limitType: "projects",
         })
       ).resolves.toBeUndefined();
+    });
+
+    /** @scenario Blocks project creation when over limit */
+    it("throws LimitExceededError when project count exceeds project limit", async () => {
+      vi.mocked(mockRepository.getProjectCount).mockResolvedValue(11);
+
+      await expect(
+        service.enforceLimitByOrganization({
+          organizationId: "org-123",
+          limitType: "projects",
+        })
+      ).rejects.toThrow(LimitExceededError);
     });
 
     it("does not require user parameter", async () => {

--- a/specs/licensing/enforcement-projects.feature
+++ b/specs/licensing/enforcement-projects.feature
@@ -22,14 +22,12 @@ Feature: Project Limit Enforcement with License
   # License-Based Project Limits
   # ============================================================================
 
-  @unimplemented
   Scenario: Allows project creation when under limit
     Given the organization has a license with maxProjects 5
     And the organization has 3 projects
     When I create a project named "New Project"
     Then the project is created successfully
 
-  @unimplemented
   Scenario: Blocks project creation when over limit
     Given the organization has a license with maxProjects 2
     And the organization has 3 projects


### PR DESCRIPTION
## Summary

Binds 2 `@unimplemented` scenarios in `specs/licensing/enforcement-projects.feature` (0/2 → 2/2):

- **`Allows project creation when under limit`** → existing `enforceLimitByOrganization({limitType: "projects"})` no-throw test; renamed for clarity, added `@scenario` JSDoc.
- **`Blocks project creation when over limit`** → new test that mocks `getProjectCount` above `maxProjects` and asserts `LimitExceededError` is thrown.

## Test plan

- [x] `pnpm test:unit src/server/license-enforcement/__tests__/license-enforcement.service.unit.test.ts` — 30/30 pass (was 29, +1 new)
- [x] Parity script — `enforcement-projects.feature` 2/2 bound (was 0/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)