### PR TITLE
fix(release-please): add python-sdk and skills to root exclude-paths

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -263,6 +263,8 @@
         "mcp-server",
         "langevals",
         "clickhouse-serverless",
+        "python-sdk",
+        "skills",
         ".github",
         ".cursor",
         "assets"


### PR DESCRIPTION
## Summary

Closes #3845

Adds `python-sdk` and `skills` to the `.` (langwatch root) component's `exclude-paths` array in `.github/release-please-config.json`. Both are tracked release-please components but were missing from the root's `exclude-paths`, so any `Release-As:` trailer in those subdirs was leaking into the langwatch root component (root cause of the wrong `langwatch 0.23.0` proposal in #3633).

## Diff

Exactly two strings added to one array — nothing else. Per AC#3.

```diff
       "exclude-paths": [
         "typescript-sdk",
         "sdk-go",
         "mcp-server",
         "langevals",
         "clickhouse-serverless",
+        "python-sdk",
+        "skills",
         ".github",
         ".cursor",
         "assets"
       ],
```

## Acceptance Criteria

### AC#1 — Dry-run proposes correct langwatch version (not 0.23.0)

The CI release-please workflow (`.github/workflows/release-please-sdks.yml`) is the authoritative dry-run env (it uses `RELEASE_PLEASE_TOKEN` with the proper scopes). Local dry-run via my user token failed with `Bad credentials` against the GraphQL API.

**Validation plan:** dispatch the `release-please-sdks` workflow against this branch (or merge it and watch the next `on: push` run). Expected output: a proposed `langwatch` version that is the next sensible patch from `3.2.1` (e.g. `3.2.2` or `3.3.0` depending on the conventional-commit history on `.` paths) — and **not** `0.23.0`. The shadow `python-sdk` Release-As trailer that caused #3633 will no longer leak into `.` because `python-sdk` is now in `exclude-paths`.

I'll attach the dispatch output here once CI runs, or the reviewer can trigger it.

### AC#2 — Only `.` (langwatch root) version is affected

Component versions tracked in `.github/.release-please-manifest.json`:
- `typescript-sdk`: 0.27.0 (unchanged)
- `sdk-go`: 0.2.0 (unchanged)
- `mcp-server`: 0.7.0 (unchanged)
- `langevals`: 2.2.0 (unchanged)
- `charts/clickhouse-serverless`: 0.2.0 (unchanged)
- `python-sdk`: 0.22.0 (unchanged — the change is that `python-sdk`'s Release-As no longer leaks into `.`)
- `skills`: 0.4.1 (unchanged)
- `.`: 3.2.1 → next-correct-patch (was incorrectly proposed as 0.23.0 in #3633)

This change only adjusts what the root component's commit-walker excludes; it does not touch any other component's release config.

### AC#3 — Diff is exactly one config change

```
$ git diff main..HEAD --stat
 .github/release-please-config.json | 2 ++
 1 file changed, 2 insertions(+)
```

## Test plan

- [ ] Reviewer dispatches `release-please-sdks` workflow on this branch (or after merge) and confirms the proposed `langwatch` version is sensible (not `0.23.0`).
- [ ] Reviewer confirms no other component's version moves vs. main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3845