### PR TITLE
fix(release-please): correct clickhouse-serverless exclude-path to charts/

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -262,7 +262,7 @@
         "sdk-go",
         "mcp-server",
         "langevals",
-        "clickhouse-serverless",
+        "charts/clickhouse-serverless",
         "python-sdk",
         "skills",
         ".github",


### PR DESCRIPTION
## Summary

Follow-up to #3866 (closes #3845 properly).

The shim file for the `charts/clickhouse-serverless` package lives at `charts/clickhouse-serverless/.release-please-shim`, but the langwatch root component's `exclude-paths` entry was just `"clickhouse-serverless"` — which matches the unrelated **top-level** `clickhouse-serverless/` Go service directory, not the chart. So every shadow `Release-As:` trailer pushed for that component (most recently `0.3.0`) leaked into the langwatch root commit walk.

This is the same bug class as #3845: `exclude-paths` filters by **literal filesystem path**, not package/component name.

## Diff

```diff
       "exclude-paths": [
         "typescript-sdk",
         "sdk-go",
         "mcp-server",
         "langevals",
-        "clickhouse-serverless",
+        "charts/clickhouse-serverless",
         "python-sdk",
         "skills",
         ".github",
         ".cursor",
         "assets"
       ],
```

## Why we know this is the cause

After #3866 merged, the `release langwatch` PR #3633 went from proposing `0.23.0` → `0.3.0`. The `0.23.0` was python-sdk's shadow leaking; we fixed that. The new `0.3.0` matches the `Release-As: 0.3.0` footer in commit `f30310999` — the `chore(clickhouse-serverless): single-footer shadow Release-As 0.3.0` shadow shim. That shim only changes `charts/clickhouse-serverless/.release-please-shim`, which the broken exclude-paths entry never matched.

```
$ git show --stat f30310999
chore(clickhouse-serverless): single-footer shadow Release-As 0.3.0

 charts/clickhouse-serverless/.release-please-shim | 2 +-
```

## Validation plan

Same as #3866 — local dry-run hits the known release-please/fine-grained-PAT incompatibility (401 on the GraphQL release iterator). After merge, the next `release-please-sdks` push run on `main` should:

1. Update PR #3633 (the `langwatch` autorelease) to a version derived from `3.2.1` (e.g. `3.2.2` or `3.3.0`), **not** `0.3.0`.
2. Leave the other 7 component PRs unchanged (typescript-sdk@0.27.0, python-sdk@0.23.0, sdk-go@0.3.0, mcp-server@0.8.0, langevals@2.3.0, skills@0.5.0, clickhouse-serverless@0.3.0).

If the langwatch root PR still proposes `0.3.0` after merge, there's a deeper release-please path-matching quirk we haven't accounted for and we'll need to investigate further.

## Test plan

- [ ] After merge, watch the next `release-please-sdks` workflow run on main.
- [ ] Confirm PR #3633 now proposes a sensible `langwatch` version (`3.2.x` / `3.x.0`).
- [ ] Confirm no other component PRs change.

Refs #3845

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3845