### PR TITLE
test(traces): bind 16 trace-origin-classification @unit scenarios

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
@@ -19,6 +19,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when root span has langwatch.origin", () => {
+    /** @scenario "Origin is hoisted from root span to trace summary" */
     it("hoists origin to trace summary attributes", () => {
       const span = createTestSpan({
         parentSpanId: null, // root span
@@ -34,6 +35,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when child span has langwatch.origin and root span does not", () => {
+    /** @scenario "Root span without origin preserves child span origin" */
     it("preserves child span origin value", () => {
       // Child span arrives first with origin
       const childSpan = createTestSpan({
@@ -61,6 +63,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when root span overrides child span origin", () => {
+    /** @scenario "Root span overrides child span origin when it has an opinion" */
     it("uses root span origin value", () => {
       // Child span arrives first with origin
       const childSpan = createTestSpan({
@@ -90,6 +93,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when no span sets langwatch.origin", () => {
+    /** @scenario "Traces without any origin attribute remain unset" */
     it("does not set langwatch.origin in summary attributes", () => {
       const span = createTestSpan({
         parentSpanId: null,
@@ -103,6 +107,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when black-box scenario trace propagates origin through traceparent", () => {
+    /** @scenario "Black-box scenario trace propagates origin through traceparent" */
     it("preserves root span origin through child spans", () => {
       // Root span with simulation origin
       const rootSpan = createTestSpan({
@@ -130,6 +135,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has metadata.platform = 'optimization_studio'", () => {
+    /** @scenario Projection strips metadata.platform "optimization_studio" on new traces */
     it("strips metadata.platform from hoisting", () => {
       const span = createTestSpan({
         spanAttributes: {
@@ -146,6 +152,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has metadata.platform = 'my-custom-platform'", () => {
+    /** @scenario "Projection preserves user-set metadata.platform values" */
     it("preserves user-set metadata.platform", () => {
       const span = createTestSpan({
         spanAttributes: {
@@ -160,6 +167,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has metadata.labels containing 'scenario-runner'", () => {
+    /** @scenario Projection strips metadata.labels "scenario-runner" on new traces */
     it("strips scenario-runner from labels", () => {
       const span = createTestSpan({
         spanAttributes: {
@@ -195,6 +203,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has metadata.environment = 'production'", () => {
+    /** @scenario "Projection preserves generic metadata keys like environment" */
     it("preserves generic metadata keys", () => {
       const span = createTestSpan({
         spanAttributes: {
@@ -211,6 +220,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has instrumentationScope.name = 'langwatch-evaluation'", () => {
+    /** @scenario Infer origin from instrumentationScope.name "langwatch-evaluation" */
     it("infers langwatch.origin = 'evaluation'", () => {
       const span = createTestSpan({
         instrumentationScope: { name: "langwatch-evaluation", version: null },
@@ -224,6 +234,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has instrumentationScope.name = '@langwatch/scenario'", () => {
+    /** @scenario Infer origin from instrumentationScope.name "@langwatch/scenario" */
     it("infers langwatch.origin = 'simulation'", () => {
       const span = createTestSpan({
         instrumentationScope: { name: "@langwatch/scenario", version: null },
@@ -237,6 +248,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has metadata.platform = 'optimization_studio' without langwatch.origin", () => {
+    /** @scenario Infer origin from metadata.platform "optimization_studio" */
     it("infers langwatch.origin = 'workflow'", () => {
       const span = createTestSpan({
         spanAttributes: {
@@ -251,6 +263,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has metadata.labels containing 'scenario-runner' without langwatch.origin", () => {
+    /** @scenario Infer origin from metadata.labels containing "scenario-runner" */
     it("infers langwatch.origin = 'simulation'", () => {
       const span = createTestSpan({
         spanAttributes: {
@@ -265,6 +278,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has resource attribute scenario.labels without langwatch.origin", () => {
+    /** @scenario "Infer origin from resource attribute scenario.labels" */
     it("infers langwatch.origin = 'simulation'", () => {
       const span = createTestSpan({
         resourceAttributes: {
@@ -280,6 +294,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when span has evaluation.run_id without langwatch.origin", () => {
+    /** @scenario "Infer origin from span attribute evaluation.run_id" */
     it("infers langwatch.origin = 'evaluation'", () => {
       const span = createTestSpan({
         spanAttributes: {
@@ -294,6 +309,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
   });
 
   describe("when explicit langwatch.origin is set alongside legacy markers", () => {
+    /** @scenario "Explicit langwatch.origin takes precedence over all inferred signals" */
     it("uses explicit origin over all inferred signals", () => {
       const span = createTestSpan({
         instrumentationScope: { name: "langwatch-evaluation", version: null },

--- a/specs/traces/trace-type-classification.feature
+++ b/specs/traces/trace-type-classification.feature
@@ -260,7 +260,7 @@ Feature: Trace origin classification
   # Leave generic keys (environment, etc.) untouched.
   # TODO(2027): remove this stripping code once all clients are upgraded.
 
-  @unit @unimplemented
+  @unit
   Scenario: Projection strips metadata.platform "optimization_studio" on new traces
     Given a new trace with "langwatch.origin" = "workflow"
     And metadata.platform = "optimization_studio" is set on a span
@@ -268,7 +268,7 @@ Feature: Trace origin classification
     Then the trace summary attributes contain "langwatch.origin" = "workflow"
     And the trace summary attributes do not contain "langwatch.platform"
 
-  @unit @unimplemented
+  @unit
   Scenario: Projection strips metadata.labels "scenario-runner" on new traces
     Given a new trace with "langwatch.origin" = "simulation"
     And metadata.labels contains "scenario-runner"
@@ -276,13 +276,13 @@ Feature: Trace origin classification
     Then the trace summary attributes contain "langwatch.origin" = "simulation"
     And the trace summary attributes do not contain "scenario-runner" in labels
 
-  @unit @unimplemented
+  @unit
   Scenario: Projection preserves user-set metadata.platform values
     Given a trace with metadata.platform = "my-custom-platform"
     When the fold projection processes the span
     Then the trace summary attributes contain "langwatch.platform" = "my-custom-platform"
 
-  @unit @unimplemented
+  @unit
   Scenario: Projection preserves generic metadata keys like environment
     Given a new trace with "langwatch.origin" = "workflow"
     And metadata.environment = "production" is set on a span
@@ -299,34 +299,34 @@ Feature: Trace origin classification
   # sets langwatch.origin. If the root span doesn't set it, the value
   # from child spans is preserved.
 
-  @unit @unimplemented
+  @unit
   Scenario: Origin is hoisted from root span to trace summary
     Given a trace with root span containing "langwatch.origin" = "evaluation"
     And child spans that do not contain "langwatch.origin"
     When the fold projection processes all spans
     Then the trace summary attributes contain "langwatch.origin" = "evaluation"
 
-  @unit @unimplemented
+  @unit
   Scenario: Root span overrides child span origin when it has an opinion
     Given a trace where a child span arrives first with "langwatch.origin" = "evaluation"
     And the root span arrives later with "langwatch.origin" = "simulation"
     When the fold projection processes all spans in arrival order
     Then the trace summary attributes contain "langwatch.origin" = "simulation"
 
-  @unit @unimplemented
+  @unit
   Scenario: Root span without origin preserves child span origin
     Given a trace where a child span sets "langwatch.origin" = "evaluation"
     And the root span arrives later without "langwatch.origin"
     When the fold projection processes all spans in arrival order
     Then the trace summary attributes contain "langwatch.origin" = "evaluation"
 
-  @unit @unimplemented
+  @unit
   Scenario: Traces without any origin attribute remain unset
     Given a trace where no span sets "langwatch.origin"
     When the fold projection processes all spans
     Then the trace summary attributes do not contain key "langwatch.origin"
 
-  @unit @unimplemented
+  @unit
   Scenario: Black-box scenario trace propagates origin through traceparent
     Given a scenario simulation sends a request with traceparent header
     And the root span of the trace has "langwatch.origin" = "simulation"
@@ -350,21 +350,21 @@ Feature: Trace origin classification
   #   7. span attribute evaluation.run_id present → "evaluation"
   #   8. No signal → unset (treated as "application" at query time)
 
-  @unit @unimplemented
+  @unit
   Scenario: Infer origin from instrumentationScope.name "langwatch-evaluation"
     Given a trace from an older Python SDK that does not set "langwatch.origin"
     And the root span has instrumentationScope.name = "langwatch-evaluation"
     When the fold projection processes the span
     Then the trace summary attributes contain "langwatch.origin" = "evaluation"
 
-  @unit @unimplemented
+  @unit
   Scenario: Infer origin from instrumentationScope.name "@langwatch/scenario"
     Given a trace from an older scenario tool that does not set "langwatch.origin"
     And spans have instrumentationScope.name = "@langwatch/scenario"
     When the fold projection processes the spans
     Then the trace summary attributes contain "langwatch.origin" = "simulation"
 
-  @unit @unimplemented
+  @unit
   Scenario: Infer origin from metadata.platform "optimization_studio"
     Given a trace from an older platform version
     And metadata.platform = "optimization_studio" is set
@@ -372,7 +372,7 @@ Feature: Trace origin classification
     When the fold projection processes the span
     Then the trace summary attributes contain "langwatch.origin" = "workflow"
 
-  @unit @unimplemented
+  @unit
   Scenario: Infer origin from metadata.labels containing "scenario-runner"
     Given a trace from an older platform scenario execution
     And metadata.labels contains "scenario-runner"
@@ -380,7 +380,7 @@ Feature: Trace origin classification
     When the fold projection processes the span
     Then the trace summary attributes contain "langwatch.origin" = "simulation"
 
-  @unit @unimplemented
+  @unit
   Scenario: Infer origin from resource attribute scenario.labels
     Given a trace from an older scenario tool
     And resource attributes contain "scenario.labels"
@@ -388,7 +388,7 @@ Feature: Trace origin classification
     When the fold projection processes the span
     Then the trace summary attributes contain "langwatch.origin" = "simulation"
 
-  @unit @unimplemented
+  @unit
   Scenario: Infer origin from span attribute evaluation.run_id
     Given a trace from an older SDK experiment
     And a span contains attribute "evaluation.run_id"
@@ -396,7 +396,7 @@ Feature: Trace origin classification
     When the fold projection processes the span
     Then the trace summary attributes contain "langwatch.origin" = "evaluation"
 
-  @unit @unimplemented
+  @unit
   Scenario: Explicit langwatch.origin takes precedence over all inferred signals
     Given a trace where the root span sets "langwatch.origin" = "evaluation"
     And metadata.platform = "optimization_studio" is also set


### PR DESCRIPTION
## Summary

Bind 16 `@unit @unimplemented` scenarios in `specs/traces/trace-type-classification.feature` to existing tests in `src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts` via `/** @scenario "<title>" */` JSDoc + dropping the `@unimplemented` tag. Pure JSDoc additions — no test logic changes.

## Bindings by category

### Hoisting / projection (5)

| Scenario | Test |
|---|---|
| Origin is hoisted from root span to trace summary | "hoists origin to trace summary attributes" |
| Root span overrides child span origin when it has an opinion | "uses root span origin value" |
| Root span without origin preserves child span origin | "preserves child span origin value" |
| Traces without any origin attribute remain unset | "does not set langwatch.origin in summary attributes" |
| Black-box scenario trace propagates origin through traceparent | "preserves root span origin through child spans" |

### Metadata stripping / preservation (4)

| Scenario | Test |
|---|---|
| Projection strips `metadata.platform "optimization_studio"` on new traces | "strips metadata.platform from hoisting" |
| Projection strips `metadata.labels "scenario-runner"` on new traces | "strips scenario-runner from labels" |
| Projection preserves user-set `metadata.platform` values | "preserves user-set metadata.platform" |
| Projection preserves generic metadata keys like environment | "preserves generic metadata keys" |

### Inference fallback (7)

| Scenario | Test |
|---|---|
| Infer origin from `instrumentationScope.name "langwatch-evaluation"` | "infers langwatch.origin = 'evaluation'" |
| Infer origin from `instrumentationScope.name "@langwatch/scenario"` | "infers langwatch.origin = 'simulation'" |
| Infer origin from `metadata.platform "optimization_studio"` | "infers langwatch.origin = 'workflow'" |
| Infer origin from `metadata.labels` containing `"scenario-runner"` | "infers langwatch.origin = 'simulation'" |
| Infer origin from resource attribute `scenario.labels` | "infers langwatch.origin = 'simulation'" |
| Infer origin from span attribute `evaluation.run_id` | "infers langwatch.origin = 'evaluation'" |
| Explicit `langwatch.origin` takes precedence over all inferred signals | "uses explicit origin over all inferred signals" |

## Skipped

- **19 remaining `@unit @unimplemented` scenarios** in this feature file describe SDK-side behavior (Python SDK / TypeScript SDK setting `langwatch.origin` on root spans, online-evaluation precondition filters, third-party OTEL handling) that don't map to TS unit tests in `traceSummaryOrigin.unit.test.ts`. Left as real gaps for future SDK-test coverage work.
- **All `@integration` scenarios** — out of scope for this `@unit` pass.

## Net parity

+16 enforced bindings.

## Test plan

- [x] `pnpm test:unit src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts` — 31/31 passing
- [x] `pnpm tsx scripts/check-feature-parity.ts` — exits 0; `trace-type-classification.feature` reports `16/16 scenarios bound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)