### PR TITLE
test(licensing): bind subscription cancellation override-clearing scenario

### DIFF
--- a/langwatch/ee/billing/__tests__/subscription.repository.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/subscription.repository.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { PrismaSubscriptionRepository } from "../services/subscription.repository";
+import { NUMERIC_OVERRIDE_FIELDS } from "../planProvider";
+import { SubscriptionStatus } from "../planTypes";
+
+describe("PrismaSubscriptionRepository", () => {
+  let prisma: { subscription: { update: ReturnType<typeof vi.fn> } };
+  let repo: PrismaSubscriptionRepository;
+
+  beforeEach(() => {
+    prisma = {
+      subscription: {
+        update: vi.fn().mockResolvedValue({}),
+      },
+    };
+    repo = new PrismaSubscriptionRepository(prisma as unknown as PrismaClient);
+  });
+
+  describe("cancel", () => {
+    /** @scenario Cancelled subscription nullifies all override fields */
+    it("nullifies every numeric override field when cancelling a subscription", async () => {
+      await repo.cancel({ id: "sub_123" });
+
+      expect(prisma.subscription.update).toHaveBeenCalledTimes(1);
+      const call = prisma.subscription.update.mock.calls[0]?.[0] as {
+        where: { id: string };
+        data: Record<string, unknown>;
+      };
+
+      expect(call.where).toEqual({ id: "sub_123" });
+      expect(call.data.status).toBe(SubscriptionStatus.CANCELLED);
+      expect(call.data.endDate).toBeInstanceOf(Date);
+
+      for (const field of NUMERIC_OVERRIDE_FIELDS) {
+        expect(call.data[field]).toBeNull();
+      }
+    });
+  });
+});

--- a/specs/licensing/subscription-limit-overrides.feature
+++ b/specs/licensing/subscription-limit-overrides.feature
@@ -79,7 +79,6 @@ Feature: Subscription Limit Overrides
   # Cancellation Clears All Override Fields
   # ============================================================================
 
-  @unimplemented
   Scenario: Cancelled subscription nullifies all override fields
     Given the subscription had overrides for multiple limits
     When the subscription is cancelled


### PR DESCRIPTION
## Summary

Binds the last @unimplemented scenario in `subscription-limit-overrides.feature`:
**"Cancelled subscription nullifies all override fields"** (5/5 — full parity).

The existing `planProvider.unit.test.ts` parameterized `it.each` over
`NUMERIC_OVERRIDE_FIELDS` cannot bind via `@scenario` JSDoc, so this adds
a dedicated prose unit test on the actual repository method
(`PrismaSubscriptionRepository.cancel`). It mocks Prisma and asserts that
the update payload spreads `null` for every field in
`NUMERIC_OVERRIDE_FIELDS`, plus `status=CANCELLED` and an `endDate`.

This locks the cancellation contract at the data-access boundary
(complementing `webhookService.unit.test.ts` which only checks the cancel
call site).

## Test plan

- [x] `pnpm test:unit ee/billing/__tests__/subscription.repository.unit.test.ts` — 1/1 passes locally.
- [x] `pnpm exec tsx scripts/check-feature-parity.ts` — `subscription-limit-overrides.feature: 5/5 scenarios bound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)