### PR TITLE
test(scenarios): bind 2 model-params-error-feedback @unit scenarios

### DIFF
--- a/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts
@@ -368,6 +368,7 @@ describe("prefetchScenarioData", () => {
       };
 
       describe("when prefetching scenario data", () => {
+        /** @scenario "Prefetcher logs model params failure with reason" */
         it("returns failure with model params error", async () => {
           const deps = createMockDeps({
             promptFetcher: {
@@ -508,6 +509,7 @@ describe("prefetchScenarioData", () => {
       };
 
       describe("when prefetching scenario data", () => {
+        /** @scenario "Return success with LiteLLM params on valid configuration" */
         it("returns success with complete data", async () => {
           // The source reads process.env.LANGWATCH_ENDPOINT directly (not via env.mjs)
           const previousLangwatchEndpoint = process.env.LANGWATCH_ENDPOINT;

--- a/specs/scenarios/model-params-error-feedback.feature
+++ b/specs/scenarios/model-params-error-feedback.feature
@@ -52,7 +52,7 @@ Feature: Model params preparation error feedback
     Then it returns failure with reason "preparation_error"
     And the error message includes the original error detail
 
-  @unit @unimplemented
+  @unit
   Scenario: Return success with LiteLLM params on valid configuration
     Given a model string "openai/gpt-4" with valid format
     And the provider "openai" is enabled with a valid API key
@@ -65,7 +65,7 @@ Feature: Model params preparation error feedback
   # prefetchScenarioData must forward the reason code and actionable message
   # from the modelParamsProvider instead of a generic error.
 
-  @unit @unimplemented
+  @unit
   Scenario: Prefetcher logs model params failure with reason
     Given modelParamsProvider returns failure with reason "invalid_model_format"
     When prefetchScenarioData is called


### PR DESCRIPTION
## Summary

Bind 2 `@unit @unimplemented` scenarios in `specs/scenarios/model-params-error-feedback.feature` to existing tests in `src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts` via `/** @scenario "<title>" */` JSDoc + dropping the `@unimplemented` tag. Pure JSDoc additions — no test logic changes.

## Bindings

| Scenario | Test |
|---|---|
| Return success with LiteLLM params on valid configuration | "returns success with complete data" (asserts `result.success` + `result.data.modelParams` populated) |
| Prefetcher logs model params failure with reason | "returns failure with model params error" (asserts `result.reason` + `result.error` are forwarded from `modelParamsProvider`) |

## Skipped (still `@unimplemented`)

- **4 unit scenarios** for `modelParamsProvider.prepare()` (`Reject model string without provider prefix`, `provider not found`, `missing API key`, `missing model`, `preparation_error on unexpected exception`) — these target a provider impl with no dedicated unit test file yet.
- **3 `@integration` scenarios** (TRPC layer error surfacing) — out of scope for this `@unit` pass.

## Net parity

+2 enforced bindings.

## Test plan

- [x] `pnpm test:unit src/server/scenarios/execution/__tests__/data-prefetcher.unit.test.ts` — 23/23 passing
- [x] `pnpm tsx scripts/check-feature-parity.ts` — exits 0; `model-params-error-feedback.feature` reports `2/2 scenarios bound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)