### PR TITLE
test(evaluations-v3): bind 1 evaluator-run-rerun @unit scenario

### DIFF
--- a/langwatch/src/server/evaluations-v3/execution/__tests__/orchestrator.test.ts
+++ b/langwatch/src/server/evaluations-v3/execution/__tests__/orchestrator.test.ts
@@ -213,6 +213,7 @@ describe("orchestrator", () => {
   });
 
   describe("generateCells with evaluator-all-rows scope", () => {
+      /** @scenario "Running evaluator on all rows creates one execution per row with target output" */
       it("creates one cell per row that has a pre-computed target output", () => {
         const state = createTestState(1, 2);
         const datasetRows = createTestDataset(4);
@@ -239,6 +240,7 @@ describe("orchestrator", () => {
         expect(cells.map((c) => c.rowIndex)).toEqual([0, 1, 3]);
       });
 
+      /** @scenario "Running evaluator on all rows creates one execution per row with target output" */
       it("skips target execution for each cell", () => {
         const state = createTestState(1, 1);
         const datasetRows = createTestDataset(2);

--- a/specs/features/evaluations-v3/evaluator-run-rerun-enhancements.feature
+++ b/specs/features/evaluations-v3/evaluator-run-rerun-enhancements.feature
@@ -95,7 +95,7 @@ Feature: Evaluator Run/Rerun Enhancements
     When the user triggers "Run on all rows" for the evaluator
     Then each evaluator execution reuses the existing trace ID for its row
 
-  @unit @unimplemented
+  @unit
   Scenario: Running evaluator on all rows creates one execution per row with target output
     Given a request to run an evaluator on all rows for a target
     And pre-computed target outputs exist for some rows


### PR DESCRIPTION
## Summary

Bind the single `@unit @unimplemented` scenario in `specs/features/evaluations-v3/evaluator-run-rerun-enhancements.feature` to existing tests in `src/server/evaluations-v3/execution/__tests__/orchestrator.test.ts` via `/** @scenario "<title>" */` JSDoc + dropping the `@unimplemented` tag. Pure JSDoc — no test logic changes.

## Binding

| Scenario | Tests |
|---|---|
| Running evaluator on all rows creates one execution per row with target output | "creates one cell per row that has a pre-computed target output" AND "skips target execution for each cell" — both `it()` blocks under the `evaluator-all-rows scope` describe |

The scenario asserts two conditions (one cell per row + skips target execution), so the binding is attached to both `it()` blocks. The parity script supports multiple bindings to the same scenario.

## Net parity

+1 enforced binding (file goes from 6/7 → 7/7).

## Test plan

- [x] `pnpm test:unit src/server/evaluations-v3/execution/__tests__/orchestrator.test.ts` — 16/16 passing
- [x] `pnpm tsx scripts/check-feature-parity.ts` — exits 0; `evaluator-run-rerun-enhancements.feature` reports `7/7 scenarios bound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)