### PR TITLE
fix(licensing): exclude archived projects from license-limit count

### DIFF
--- a/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
@@ -180,13 +180,14 @@ describe("LicenseEnforcementRepository", () => {
 
   describe("getProjectCount", () => {
     /** @scenario Counts projects across all teams */
-    it("queries projects with organization filter that traverses every team", async () => {
+    /** @scenario Counts only non-archived projects toward limit */
+    it("queries non-archived projects with organization filter that traverses every team", async () => {
       mockPrisma.project.count.mockResolvedValue(4);
 
       const result = await repository.getProjectCount(organizationId);
 
       expect(mockPrisma.project.count).toHaveBeenCalledWith({
-        where: { team: { organizationId } },
+        where: { team: { organizationId }, archivedAt: null },
       });
       expect(result).toBe(4);
     });

--- a/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
+++ b/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
@@ -129,11 +129,11 @@ export class LicenseEnforcementRepository
   }
 
   /**
-   * Counts all projects in organization.
+   * Counts non-archived projects in organization.
    */
   async getProjectCount(organizationId: string): Promise<number> {
     return this.prisma.project.count({
-      where: { team: { organizationId } },
+      where: { team: { organizationId }, archivedAt: null },
     });
   }
 

--- a/specs/licensing/enforcement-projects.feature
+++ b/specs/licensing/enforcement-projects.feature
@@ -63,7 +63,6 @@ Feature: Project Limit Enforcement with License
   # Edge Cases
   # ============================================================================
 
-  @unimplemented
   Scenario: Counts only non-archived projects toward limit
     Given the organization has a license with maxProjects 3
     And the organization has 2 active projects


### PR DESCRIPTION
## Summary

`getProjectCount` didn't filter `archivedAt`, so archived projects counted against `maxProjects` in license enforcement and against `currentProjects` in usage stats. The Project model has had `archivedAt` for a while; this fixes the count to match the documented behavior.

## Changes

- `getProjectCount` now filters `archivedAt: null`
- Existing repository unit test updated to assert the filter
- Binds "Counts only non-archived projects toward limit" scenario

## Parity impact

`enforcement-projects.feature` 3/3 → 4/4 scenarios bound.

## Test plan

- [x] `pnpm test:unit src/server/license-enforcement/` — 157 tests pass
- [x] Parity script reports 4/4 bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)