### PR TITLE
feat(api): list endpoints for experiments and evaluation runs

### DIFF
--- a/langwatch/src/app/api/evaluations/v3/__tests__/runs-list.integration.test.ts
+++ b/langwatch/src/app/api/evaluations/v3/__tests__/runs-list.integration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration tests for GET /api/evaluations/v3/runs?experimentSlug=...
+ *
+ * Verifies auth, query-param validation, 404 for unknown slugs, and the
+ * shape of the runs array (which may be empty for fresh experiments).
+ */
+import type { Experiment, Project } from "@prisma/client";
+import { ExperimentType } from "@prisma/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { getTestProject } from "~/utils/testUtils";
+
+describe.skipIf(process.env.CI)("GET /api/evaluations/v3/runs", () => {
+  let project: Project;
+  let experiment: Experiment;
+  const testSlug = `runs-list-test-${Date.now()}`;
+
+  const getBaseUrl = () =>
+    process.env.TEST_BASE_URL ?? "http://localhost:5560";
+
+  beforeAll(async () => {
+    project = await getTestProject("runs-list-test");
+    experiment = await prisma.experiment.create({
+      data: {
+        projectId: project.id,
+        name: "Runs List Test",
+        slug: testSlug,
+        type: ExperimentType.EVALUATIONS_V3,
+        workbenchState: { name: "Runs List Test" },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    if (experiment) {
+      await prisma.experiment
+        .delete({ where: { id: experiment.id, projectId: project.id } })
+        .catch(() => {
+          // best-effort cleanup
+        });
+    }
+  });
+
+  describe("given no api key is provided", () => {
+    describe("when calling the endpoint", () => {
+      it("rejects with 401", async () => {
+        const response = await fetch(
+          `${getBaseUrl()}/api/evaluations/v3/runs?experimentSlug=${testSlug}`,
+        );
+        expect(response.status).toBe(401);
+      });
+    });
+  });
+
+  describe("given a valid api key", () => {
+    describe("when experimentSlug is missing", () => {
+      it("rejects with 400", async () => {
+        const response = await fetch(
+          `${getBaseUrl()}/api/evaluations/v3/runs`,
+          { headers: { "X-Auth-Token": project.apiKey } },
+        );
+        expect(response.status).toBe(400);
+        const body = await response.json();
+        expect(body.error).toMatch(/experimentSlug/);
+      });
+    });
+
+    describe("when the experiment slug is unknown", () => {
+      it("returns 404", async () => {
+        const response = await fetch(
+          `${getBaseUrl()}/api/evaluations/v3/runs?experimentSlug=does-not-exist-${Date.now()}`,
+          { headers: { "X-Auth-Token": project.apiKey } },
+        );
+        expect(response.status).toBe(404);
+      });
+    });
+
+    describe("when the experiment exists", () => {
+      it("returns 200 with a runs array (possibly empty)", async () => {
+        const response = await fetch(
+          `${getBaseUrl()}/api/evaluations/v3/runs?experimentSlug=${testSlug}`,
+          { headers: { "X-Auth-Token": project.apiKey } },
+        );
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.experimentSlug).toBe(testSlug);
+        expect(body.experimentId).toBe(experiment.id);
+        expect(Array.isArray(body.runs)).toBe(true);
+        expect(body.pagination).toMatchObject({
+          page: 1,
+          pageSize: 50,
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/app/api/experiments/[[...route]]/app.ts
+++ b/langwatch/src/app/api/experiments/[[...route]]/app.ts
@@ -1,0 +1,190 @@
+/**
+ * Public REST API for experiments.
+ *
+ * Currently exposes only the list endpoint that complements the existing
+ * `/api/evaluations/v3/{slug}/run` and `/runs/{runId}` routes:
+ *
+ *   GET /api/experiments
+ *
+ * Auth: standard project API key (X-Auth-Token / Bearer / Basic).
+ *
+ * Routes go through `ExperimentService` (app-layer pattern) — no direct
+ * Prisma access here. Experiment runs are joined in via
+ * `ExperimentRunService.listRuns` so each summary includes a run count and
+ * the latest run's timestamps, matching what the dashboard already shows.
+ */
+import type { Experiment } from "@prisma/client";
+import { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import { resolver } from "hono-openapi/zod";
+import { z } from "zod";
+import { prisma } from "~/server/db";
+import { ExperimentService } from "~/server/experiments/experiment.service";
+import { ExperimentRunService } from "~/server/evaluations-v3/services/experiment-run.service";
+import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
+import { createLogger } from "~/utils/logger/server";
+import {
+  type AuthMiddlewareVariables,
+  authMiddleware,
+  handleError,
+} from "../../middleware";
+import { loggerMiddleware } from "../../middleware/logger";
+import { tracerMiddleware } from "../../middleware/tracer";
+import { baseResponses } from "../../shared/base-responses";
+
+patchZodOpenapi();
+
+const logger = createLogger("langwatch:api:experiments");
+
+type Variables = AuthMiddlewareVariables;
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
+
+const experimentSummarySchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string().nullable(),
+  type: z.string(),
+  workflowId: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  runsCount: z.number(),
+  lastRunAt: z.string().nullable(),
+});
+
+const experimentsListResponseSchema = z.object({
+  experiments: z.array(experimentSummarySchema),
+  pagination: z.object({
+    page: z.number(),
+    pageSize: z.number(),
+    totalHits: z.number(),
+    hasMore: z.boolean(),
+  }),
+});
+
+const parsePositiveInt = ({
+  value,
+  fallback,
+  max,
+}: {
+  value: string | undefined;
+  fallback: number;
+  max?: number;
+}): number => {
+  if (value === undefined) return fallback;
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return max ? Math.min(parsed, max) : parsed;
+};
+
+const toExperimentSummary = ({
+  experiment,
+  runsCount,
+  lastRunAt,
+}: {
+  experiment: Experiment;
+  runsCount: number;
+  lastRunAt: number | null;
+}) => ({
+  id: experiment.id,
+  slug: experiment.slug,
+  name: experiment.name,
+  type: experiment.type,
+  workflowId: experiment.workflowId,
+  createdAt: experiment.createdAt.toISOString(),
+  updatedAt: experiment.updatedAt.toISOString(),
+  runsCount,
+  lastRunAt: lastRunAt ? new Date(lastRunAt).toISOString() : null,
+});
+
+export const app = new Hono<{ Variables: Variables }>()
+  .basePath("/api/experiments")
+  .use(tracerMiddleware({ name: "experiments" }))
+  .use(loggerMiddleware())
+  .use(authMiddleware)
+  .onError(handleError)
+
+  .get(
+    "/",
+    describeRoute({
+      description:
+        "List experiments for the project. Includes a runs count and last-run timestamp per experiment.",
+      responses: {
+        ...baseResponses,
+        200: {
+          description: "Success",
+          content: {
+            "application/json": {
+              schema: resolver(experimentsListResponseSchema),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const project = c.get("project");
+      const page = parsePositiveInt({
+        value: c.req.query("page"),
+        fallback: 1,
+      });
+      const pageSize = parsePositiveInt({
+        value: c.req.query("pageSize"),
+        fallback: DEFAULT_PAGE_SIZE,
+        max: MAX_PAGE_SIZE,
+      });
+
+      logger.info(
+        { projectId: project.id, page, pageSize },
+        "Listing experiments",
+      );
+
+      const experimentService = ExperimentService.create(prisma);
+      const all = await experimentService.getAll({ projectId: project.id });
+
+      // Sort by updatedAt desc to match the dashboard's evaluation list.
+      const sorted = [...all].sort(
+        (a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+      );
+
+      const totalHits = sorted.length;
+      const offset = (page - 1) * pageSize;
+      const paged = sorted.slice(offset, offset + pageSize);
+
+      let runsByExperimentId: Record<
+        string,
+        Array<{ timestamps: { createdAt: number } }>
+      > = {};
+      if (paged.length > 0) {
+        const runService = ExperimentRunService.create(prisma);
+        runsByExperimentId = (await runService.listRuns({
+          projectId: project.id,
+          experimentIds: paged.map((e) => e.id),
+        })) as typeof runsByExperimentId;
+      }
+
+      const experiments = paged.map((experiment) => {
+        const runs = runsByExperimentId[experiment.id] ?? [];
+        const lastRunAt = runs.reduce<number | null>((acc, run) => {
+          const t = run.timestamps?.createdAt ?? null;
+          if (t === null) return acc;
+          return acc === null || t > acc ? t : acc;
+        }, null);
+        return toExperimentSummary({
+          experiment,
+          runsCount: runs.length,
+          lastRunAt,
+        });
+      });
+
+      return c.json({
+        experiments,
+        pagination: {
+          page,
+          pageSize,
+          totalHits,
+          hasMore: offset + paged.length < totalHits,
+        },
+      });
+    },
+  );

--- a/langwatch/src/app/api/experiments/__tests__/experiments-list.integration.test.ts
+++ b/langwatch/src/app/api/experiments/__tests__/experiments-list.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for the public experiments list endpoint.
+ *
+ * Hits the dev server (default http://localhost:5560) and asserts auth,
+ * project scoping, pagination, and the per-experiment shape.
+ */
+import type { Experiment, Project } from "@prisma/client";
+import { ExperimentType } from "@prisma/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { getTestProject } from "~/utils/testUtils";
+
+describe.skipIf(process.env.CI)("GET /api/experiments", () => {
+  let project: Project;
+  const created: Experiment[] = [];
+
+  const getBaseUrl = () =>
+    process.env.TEST_BASE_URL ?? "http://localhost:5560";
+
+  beforeAll(async () => {
+    project = await getTestProject("experiments-list-test");
+
+    const stamp = Date.now();
+    for (let index = 0; index < 3; index++) {
+      const exp = await prisma.experiment.create({
+        data: {
+          projectId: project.id,
+          name: `List Test Experiment ${index}`,
+          slug: `list-test-${stamp}-${index}`,
+          type: ExperimentType.EVALUATIONS_V3,
+          workbenchState: { name: `List Test Experiment ${index}` },
+        },
+      });
+      created.push(exp);
+    }
+  });
+
+  afterAll(async () => {
+    for (const exp of created) {
+      await prisma.experiment
+        .delete({ where: { id: exp.id, projectId: project.id } })
+        .catch(() => {
+          // best-effort cleanup
+        });
+    }
+  });
+
+  describe("given no api key is provided", () => {
+    describe("when calling the endpoint", () => {
+      it("rejects with 401", async () => {
+        const response = await fetch(`${getBaseUrl()}/api/experiments`);
+        expect(response.status).toBe(401);
+      });
+    });
+  });
+
+  describe("given a valid api key", () => {
+    describe("when calling the endpoint", () => {
+      it("returns 200 with the project's experiments", async () => {
+        const response = await fetch(`${getBaseUrl()}/api/experiments`, {
+          headers: { "X-Auth-Token": project.apiKey },
+        });
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(Array.isArray(body.experiments)).toBe(true);
+        expect(body.pagination).toBeDefined();
+        const slugs = body.experiments.map((e: { slug: string }) => e.slug);
+        for (const exp of created) {
+          expect(slugs).toContain(exp.slug);
+        }
+      });
+
+      it("exposes id, slug, name, type, runsCount, lastRunAt on each entry", async () => {
+        const response = await fetch(`${getBaseUrl()}/api/experiments`, {
+          headers: { "X-Auth-Token": project.apiKey },
+        });
+        const body = await response.json();
+        const entry = body.experiments.find(
+          (e: { slug: string }) => e.slug === created[0]!.slug,
+        );
+        expect(entry).toMatchObject({
+          id: created[0]!.id,
+          slug: created[0]!.slug,
+          name: created[0]!.name,
+          type: ExperimentType.EVALUATIONS_V3,
+        });
+        expect(typeof entry.runsCount).toBe("number");
+        expect("lastRunAt" in entry).toBe(true);
+        expect(typeof entry.createdAt).toBe("string");
+      });
+    });
+
+    describe("when paginating with pageSize=2", () => {
+      it("returns at most 2 entries and reports hasMore correctly", async () => {
+        const response = await fetch(
+          `${getBaseUrl()}/api/experiments?pageSize=2&page=1`,
+          { headers: { "X-Auth-Token": project.apiKey } },
+        );
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.experiments.length).toBeLessThanOrEqual(2);
+        expect(body.pagination.pageSize).toBe(2);
+        expect(body.pagination.page).toBe(1);
+        if (body.pagination.totalHits > 2) {
+          expect(body.pagination.hasMore).toBe(true);
+        }
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -10,6 +10,7 @@ import { app as copilotKitApp } from "../app/api/copilotkit/[[...route]]/app";
 import { app as dashboardsApp } from "../app/api/dashboards/[[...route]]/app";
 import { app as datasetApp } from "../app/api/dataset/[[...route]]/app";
 import { app as evaluatorsApp } from "../app/api/evaluators/[[...route]]/app";
+import { app as experimentsApp } from "../app/api/experiments/[[...route]]/app";
 import { app as exportTracesApp } from "../app/api/export/traces/[[...route]]/app";
 import { app as gatewayPlatformApp } from "../app/api/gateway-platform/[[...route]]/app";
 import { app as graphsApp } from "../app/api/graphs/[[...route]]/app";
@@ -74,6 +75,7 @@ export function createApiRouter() {
   api.route("/", dashboardsApp);
   api.route("/", datasetApp);
   api.route("/", evaluatorsApp);
+  api.route("/", experimentsApp);
   api.route("/", exportTracesApp);
   api.route("/", gatewayPlatformApp);
   api.route("/", graphsApp);

--- a/langwatch/src/server/routes/evaluations-v3.ts
+++ b/langwatch/src/server/routes/evaluations-v3.ts
@@ -491,6 +491,75 @@ app.post("/:slug/run", async (c) => {
   });
 });
 
+// ── GET /runs?experimentSlug=... (list runs for an experiment) ──────
+
+app.get("/runs", async (c) => {
+  const authResult = await authenticateRequest(c, "evaluations:view");
+  if ("error" in authResult) {
+    return c.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { project } = authResult;
+
+  const experimentSlug = c.req.query("experimentSlug");
+  if (!experimentSlug) {
+    return c.json(
+      {
+        error: "experimentSlug query parameter is required",
+      },
+      { status: 400 },
+    );
+  }
+
+  const pageSizeRaw = c.req.query("pageSize");
+  const pageRaw = c.req.query("page");
+  const pageSize = (() => {
+    const parsed = pageSizeRaw ? parseInt(pageSizeRaw, 10) : 50;
+    if (!Number.isFinite(parsed) || parsed <= 0) return 50;
+    return Math.min(parsed, 200);
+  })();
+  const page = (() => {
+    const parsed = pageRaw ? parseInt(pageRaw, 10) : 1;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+  })();
+
+  const experiment = await prisma.experiment.findFirst({
+    where: { projectId: project.id, slug: experimentSlug },
+    select: { id: true, slug: true },
+  });
+
+  if (!experiment) {
+    return c.json({ error: "Experiment not found" }, { status: 404 });
+  }
+
+  const experimentRunService = ExperimentRunService.create(prisma);
+  const runsByExperimentId = await experimentRunService.listRuns({
+    projectId: project.id,
+    experimentIds: [experiment.id],
+  });
+
+  const runs = runsByExperimentId[experiment.id] ?? [];
+  // Newest first to match dashboard ordering.
+  const sorted = [...runs].sort(
+    (a, b) => b.timestamps.createdAt - a.timestamps.createdAt,
+  );
+
+  const totalHits = sorted.length;
+  const offset = (page - 1) * pageSize;
+  const paged = sorted.slice(offset, offset + pageSize);
+
+  return c.json({
+    experimentId: experiment.id,
+    experimentSlug: experiment.slug,
+    runs: paged,
+    pagination: {
+      page,
+      pageSize,
+      totalHits,
+      hasMore: offset + paged.length < totalHits,
+    },
+  });
+});
+
 // ── GET /runs/:runId (poll run status) ───────────────────────────────
 
 app.get("/runs/:runId", async (c) => {

--- a/mcp-server/src/__tests__/experiment-list-tools.unit.test.ts
+++ b/mcp-server/src/__tests__/experiment-list-tools.unit.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../langwatch-api.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    makeRequest: vi.fn(),
+  };
+});
+
+import { makeRequest } from "../langwatch-api.js";
+import { handleExperimentList } from "../tools/list-experiments.js";
+import { handleEvaluationListRuns } from "../tools/list-evaluation-runs.js";
+
+const mockMakeRequest = vi.mocked(makeRequest);
+
+describe("handleExperimentList()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given experiments exist", () => {
+    describe("when invoked with default limit", () => {
+      it("renders a markdown table with each slug", async () => {
+        mockMakeRequest.mockResolvedValueOnce({
+          experiments: [
+            {
+              id: "exp_1",
+              slug: "checkout-flow",
+              name: "Checkout Flow",
+              type: "EVALUATIONS_V3",
+              workflowId: null,
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-02T00:00:00Z",
+              runsCount: 3,
+              lastRunAt: "2026-01-02T00:00:00Z",
+            },
+          ],
+          pagination: {
+            page: 1,
+            pageSize: 25,
+            totalHits: 1,
+            hasMore: false,
+          },
+        });
+
+        const out = await handleExperimentList({});
+        expect(out).toContain("# Experiments");
+        expect(out).toContain("`checkout-flow`");
+        expect(out).toContain("Checkout Flow");
+      });
+    });
+
+    describe("when invoked with limit above the cap", () => {
+      it("clamps the effective pageSize to 100", async () => {
+        mockMakeRequest.mockResolvedValueOnce({
+          experiments: [],
+          pagination: { page: 1, pageSize: 100, totalHits: 0, hasMore: false },
+        });
+
+        await handleExperimentList({ limit: 5000 });
+        const path = mockMakeRequest.mock.calls[0]![1] as string;
+        expect(path).toContain("pageSize=100");
+      });
+    });
+  });
+
+  describe("given no experiments exist", () => {
+    describe("when invoked", () => {
+      it("returns an empty-state message", async () => {
+        mockMakeRequest.mockResolvedValueOnce({
+          experiments: [],
+          pagination: { page: 1, pageSize: 25, totalHits: 0, hasMore: false },
+        });
+        const out = await handleExperimentList({});
+        expect(out).toContain("No experiments");
+      });
+    });
+  });
+});
+
+describe("handleEvaluationListRuns()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given a known experiment with runs", () => {
+    describe("when invoked", () => {
+      it("renders a markdown table with each runId", async () => {
+        mockMakeRequest.mockResolvedValueOnce({
+          experimentId: "exp_1",
+          experimentSlug: "checkout-flow",
+          runs: [
+            {
+              experimentId: "exp_1",
+              runId: "run_visible",
+              workflowVersion: null,
+              timestamps: { createdAt: 1000, updatedAt: 2000, finishedAt: 2000 },
+              summary: { evaluations: {} },
+            },
+          ],
+          pagination: {
+            page: 1,
+            pageSize: 25,
+            totalHits: 1,
+            hasMore: false,
+          },
+        });
+
+        const out = await handleEvaluationListRuns({
+          experimentSlug: "checkout-flow",
+        });
+        expect(out).toContain("# Evaluation Runs: checkout-flow");
+        expect(out).toContain("`run_visible`");
+      });
+    });
+  });
+
+  describe("given the experiment slug is unknown", () => {
+    describe("when the API throws 404", () => {
+      it("returns a graceful not-found message suggesting platform_experiment_list", async () => {
+        mockMakeRequest.mockRejectedValueOnce(
+          new Error("LangWatch API error 404: experiment not found"),
+        );
+
+        const out = await handleEvaluationListRuns({
+          experimentSlug: "does-not-exist",
+        });
+        expect(out).toContain("not found");
+        expect(out).toContain("platform_experiment_list");
+      });
+    });
+  });
+
+  describe("given the experiment exists but has no runs", () => {
+    describe("when invoked", () => {
+      it("returns an empty-state message that points at platform_run_evaluation", async () => {
+        mockMakeRequest.mockResolvedValueOnce({
+          experimentId: "exp_1",
+          experimentSlug: "support-bot",
+          runs: [],
+          pagination: { page: 1, pageSize: 25, totalHits: 0, hasMore: false },
+        });
+
+        const out = await handleEvaluationListRuns({
+          experimentSlug: "support-bot",
+        });
+        expect(out).toContain("no runs yet");
+        expect(out).toContain("platform_run_evaluation");
+      });
+    });
+  });
+});

--- a/mcp-server/src/create-mcp-server.ts
+++ b/mcp-server/src/create-mcp-server.ts
@@ -1573,6 +1573,59 @@ NOTE: Scenarios can be created two ways. Determine which approach the user needs
     })
   );
 
+  server.tool(
+    "platform_experiment_list",
+    "List experiments configured in the LangWatch project. Returns a markdown table with each experiment's slug, name, last-run timestamp, and run count. Use this to discover experiment slugs before drilling into runs with platform_evaluation_list_runs. Output is capped (default 25, max 100) to protect the agent's context window.",
+    {
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Maximum number of experiments to include (default 25, hard-capped at 100)",
+        ),
+    },
+    withToolLogging("platform_experiment_list", async (params) => {
+      requireApiKey();
+      const { handleExperimentList } = await import(
+        "./tools/list-experiments.js"
+      );
+      return {
+        content: [{ type: "text", text: await handleExperimentList(params) }],
+      };
+    })
+  );
+
+  server.tool(
+    "platform_evaluation_list_runs",
+    "List evaluation runs for a specific experiment slug. Returns a markdown table with each run's id, status, started/finished timestamps, and pass-rate summary. Use this to discover run ids before calling platform_evaluation_results. Output is capped (default 25, max 100) to protect the agent's context window.",
+    {
+      experimentSlug: z
+        .string()
+        .describe(
+          "Experiment slug from platform_experiment_list (e.g. 'checkout-flow')",
+        ),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Maximum number of runs to include (default 25, hard-capped at 100)",
+        ),
+    },
+    withToolLogging("platform_evaluation_list_runs", async (params) => {
+      requireApiKey();
+      const { handleEvaluationListRuns } = await import(
+        "./tools/list-evaluation-runs.js"
+      );
+      return {
+        content: [{ type: "text", text: await handleEvaluationListRuns(params) }],
+      };
+    })
+  );
+
   // --- Platform Dataset Tools (require API key) ---
   // These tools manage datasets on the LangWatch platform via API.
 

--- a/mcp-server/src/tools/list-evaluation-runs.ts
+++ b/mcp-server/src/tools/list-evaluation-runs.ts
@@ -1,0 +1,142 @@
+import { makeRequest } from "../langwatch-api.js";
+
+interface RunSummaryEvaluator {
+  name: string;
+  averageScore: number | null;
+  averagePassed?: number;
+}
+
+interface RunSummary {
+  evaluations: Record<string, RunSummaryEvaluator>;
+}
+
+interface ExperimentRunSummaryEntry {
+  experimentId: string;
+  runId: string;
+  workflowVersion: { id: string; version: string } | null;
+  timestamps: {
+    createdAt: number;
+    updatedAt: number;
+    finishedAt?: number | null;
+    stoppedAt?: number | null;
+  };
+  progress?: number | null;
+  total?: number | null;
+  summary: RunSummary;
+}
+
+interface EvaluationRunsListResponse {
+  experimentId: string;
+  experimentSlug: string;
+  runs: ExperimentRunSummaryEntry[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    totalHits: number;
+    hasMore: boolean;
+  };
+}
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+const formatEpoch = (epoch: number | null | undefined): string => {
+  if (!epoch || !Number.isFinite(epoch)) return "—";
+  return new Date(epoch).toISOString().replace("T", " ").slice(0, 19) + " UTC";
+};
+
+const passRate = (evaluations: RunSummary["evaluations"]): string => {
+  const entries = Object.values(evaluations ?? {});
+  if (entries.length === 0) return "—";
+  const passed = entries.filter((e) => typeof e.averagePassed === "number");
+  if (passed.length === 0) {
+    const scored = entries.filter((e) => typeof e.averageScore === "number");
+    if (scored.length === 0) return "—";
+    const avg =
+      scored.reduce((sum, e) => sum + (e.averageScore ?? 0), 0) / scored.length;
+    return `${avg.toFixed(2)} avg`;
+  }
+  const avg =
+    passed.reduce((sum, e) => sum + (e.averagePassed ?? 0), 0) / passed.length;
+  return `${(avg * 100).toFixed(0)}% pass`;
+};
+
+const runStatus = (run: ExperimentRunSummaryEntry): string => {
+  if (run.timestamps.stoppedAt) return "stopped";
+  if (run.timestamps.finishedAt) return "completed";
+  return "running";
+};
+
+export async function handleEvaluationListRuns(params: {
+  experimentSlug: string;
+  limit?: number;
+}): Promise<string> {
+  const requested =
+    typeof params.limit === "number" && params.limit > 0
+      ? params.limit
+      : DEFAULT_LIMIT;
+  const effectiveLimit = Math.min(requested, MAX_LIMIT);
+
+  const search = new URLSearchParams();
+  search.set("experimentSlug", params.experimentSlug);
+  search.set("pageSize", String(effectiveLimit));
+
+  let result: EvaluationRunsListResponse;
+  try {
+    result = (await makeRequest(
+      "GET",
+      `/api/evaluations/v3/runs?${search.toString()}`,
+    )) as EvaluationRunsListResponse;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/404|not found/i.test(message)) {
+      return [
+        `# Evaluation Runs: ${params.experimentSlug}`,
+        "",
+        "**Status**: experiment not found",
+        "",
+        `No experiment with slug \`${params.experimentSlug}\` exists in this project.`,
+        "",
+        "> Run `platform_experiment_list` to discover available experiment slugs.",
+      ].join("\n");
+    }
+    throw error;
+  }
+
+  if (result.runs.length === 0) {
+    return [
+      `# Evaluation Runs: ${result.experimentSlug}`,
+      "",
+      "_This experiment has no runs yet._",
+      "",
+      `> Trigger a run with \`platform_run_evaluation\` (slug: \`${result.experimentSlug}\`) to populate this list.`,
+    ].join("\n");
+  }
+
+  const lines: string[] = [];
+  lines.push(`# Evaluation Runs: ${result.experimentSlug}`);
+  lines.push("");
+  lines.push(
+    `Showing ${result.runs.length} of ${result.pagination.totalHits} run${result.pagination.totalHits === 1 ? "" : "s"}.`,
+  );
+  if (result.pagination.hasMore) {
+    lines.push(
+      `> More runs exist beyond this limit. Re-run with a higher \`limit\` (max ${MAX_LIMIT}) if needed.`,
+    );
+  }
+  lines.push("");
+  lines.push("| Run ID | Status | Started | Finished | Result |");
+  lines.push("|--------|--------|---------|----------|--------|");
+
+  for (const run of result.runs) {
+    lines.push(
+      `| \`${run.runId}\` | ${runStatus(run)} | ${formatEpoch(run.timestamps.createdAt)} | ${formatEpoch(run.timestamps.finishedAt ?? null)} | ${passRate(run.summary?.evaluations ?? {})} |`,
+    );
+  }
+
+  lines.push("");
+  lines.push(
+    "> Use `platform_evaluation_status <runId>` for live progress, or `platform_evaluation_results <runId>` for per-row results.",
+  );
+  return lines.join("\n");
+}

--- a/mcp-server/src/tools/list-experiments.ts
+++ b/mcp-server/src/tools/list-experiments.ts
@@ -1,0 +1,89 @@
+import { makeRequest } from "../langwatch-api.js";
+
+interface ExperimentSummary {
+  id: string;
+  slug: string;
+  name: string | null;
+  type: string;
+  workflowId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  runsCount: number;
+  lastRunAt: string | null;
+}
+
+interface ExperimentListResponse {
+  experiments: ExperimentSummary[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    totalHits: number;
+    hasMore: boolean;
+  };
+}
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+const formatTimestamp = (iso: string | null): string => {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toISOString().replace("T", " ").slice(0, 19) + " UTC";
+};
+
+export async function handleExperimentList(params: {
+  limit?: number;
+}): Promise<string> {
+  const requested =
+    typeof params.limit === "number" && params.limit > 0
+      ? params.limit
+      : DEFAULT_LIMIT;
+  const effectiveLimit = Math.min(requested, MAX_LIMIT);
+
+  const search = new URLSearchParams();
+  search.set("pageSize", String(effectiveLimit));
+
+  const result = (await makeRequest(
+    "GET",
+    `/api/experiments?${search.toString()}`,
+  )) as ExperimentListResponse;
+
+  if (result.experiments.length === 0) {
+    return [
+      "# Experiments",
+      "",
+      "_No experiments found in this project._",
+      "",
+      "> Create an experiment in the LangWatch dashboard, then re-run this tool to discover its slug.",
+    ].join("\n");
+  }
+
+  const lines: string[] = [];
+  lines.push("# Experiments");
+  lines.push("");
+  lines.push(
+    `Showing ${result.experiments.length} of ${result.pagination.totalHits} experiment${result.pagination.totalHits === 1 ? "" : "s"}.`,
+  );
+  if (result.pagination.hasMore) {
+    lines.push(
+      `> More experiments exist beyond this limit. Re-run with a higher \`limit\` (max ${MAX_LIMIT}) if needed.`,
+    );
+  }
+  lines.push("");
+  lines.push("| Slug | Name | Runs | Last Run |");
+  lines.push("|------|------|------|----------|");
+
+  for (const exp of result.experiments) {
+    const name = (exp.name ?? exp.slug).replace(/\|/g, "\\|");
+    lines.push(
+      `| \`${exp.slug}\` | ${name} | ${exp.runsCount} | ${formatTimestamp(exp.lastRunAt)} |`,
+    );
+  }
+
+  lines.push("");
+  lines.push(
+    "> Use `platform_evaluation_list_runs` with one of these slugs to see its runs.",
+  );
+  return lines.join("\n");
+}

--- a/specs/evaluations-v3/experiments-list.feature
+++ b/specs/evaluations-v3/experiments-list.feature
@@ -1,0 +1,75 @@
+@integration
+Feature: List experiments and evaluation runs via public REST API
+  As a developer using the LangWatch CLI, MCP server, or scripts
+  I want public REST endpoints that enumerate my experiments and their runs
+  So that I can discover experiment slugs and run ids without opening the dashboard
+
+  Background:
+    Given a project with a valid API key
+    And the project owns experiments "checkout-flow" and "support-bot"
+
+  # ==========================================================================
+  # GET /api/experiments
+  # ==========================================================================
+
+  Scenario: Unauthenticated request returns 401
+    Given no API key header
+    When I GET /api/experiments
+    Then I receive 401 Unauthorized
+
+  Scenario: Authenticated request lists experiments scoped to the project
+    Given a valid API key in the X-Auth-Token header
+    When I GET /api/experiments
+    Then I receive 200 OK
+    And the response contains entries for "checkout-flow" and "support-bot"
+    And each entry exposes "id", "slug", "name", "type", "createdAt", "updatedAt"
+    And no entry from another project appears
+
+  Scenario: Empty project returns an empty list
+    Given a project with no experiments
+    And a valid API key for that project
+    When I GET /api/experiments
+    Then I receive 200 OK
+    And the experiments list is empty
+
+  Scenario: Pagination returns the requested page
+    Given the project owns 60 experiments
+    When I GET /api/experiments with pageSize=25
+    Then I receive 200 OK
+    And the response contains 25 experiments
+    And the response indicates more pages remain
+
+  # ==========================================================================
+  # GET /api/evaluations/v3/runs?experimentSlug=...
+  # ==========================================================================
+
+  Scenario: Unauthenticated runs request returns 401
+    Given no API key header
+    When I GET /api/evaluations/v3/runs?experimentSlug=checkout-flow
+    Then I receive 401 Unauthorized
+
+  Scenario: Missing experimentSlug returns 400
+    Given a valid API key in the X-Auth-Token header
+    When I GET /api/evaluations/v3/runs with no query parameters
+    Then I receive 400 Bad Request
+    And the response indicates "experimentSlug" is required
+
+  Scenario: Unknown experiment slug returns 404
+    Given a valid API key in the X-Auth-Token header
+    When I GET /api/evaluations/v3/runs?experimentSlug=does-not-exist
+    Then I receive 404 Not Found
+
+  Scenario: Authenticated request returns runs for the experiment
+    Given the experiment "checkout-flow" has 3 completed runs
+    And a valid API key in the X-Auth-Token header
+    When I GET /api/evaluations/v3/runs?experimentSlug=checkout-flow
+    Then I receive 200 OK
+    And the response contains 3 runs
+    And each run exposes "runId", "experimentId", "timestamps", "summary"
+
+  Scenario: Experiment without runs returns an empty list
+    Given the experiment "support-bot" has no runs
+    And a valid API key in the X-Auth-Token header
+    When I GET /api/evaluations/v3/runs?experimentSlug=support-bot
+    Then I receive 200 OK
+    And the runs list is empty

--- a/specs/mcp-server/experiments-list-tools.feature
+++ b/specs/mcp-server/experiments-list-tools.feature
@@ -1,0 +1,49 @@
+@integration
+Feature: MCP tools for listing experiments and evaluation runs
+  As an LLM agent connected to the LangWatch MCP server
+  I want `platform_experiment_list` and `platform_evaluation_list_runs` tools
+  So that I can discover experiment slugs and run ids before drilling into results
+
+  Background:
+    Given an MCP server configured with a valid LANGWATCH_API_KEY
+
+  # ==========================================================================
+  # platform_experiment_list
+  # ==========================================================================
+
+  Scenario: Lists experiments as markdown
+    Given the project owns experiments "checkout-flow" and "support-bot"
+    When the agent invokes platform_experiment_list with no arguments
+    Then the response is markdown
+    And the response lists each experiment slug
+    And the response includes the count of runs per experiment when known
+
+  Scenario: Limit caps the number of experiments returned
+    Given the project owns 60 experiments
+    When the agent invokes platform_experiment_list with limit 10
+    Then the response includes at most 10 experiments
+    And the response notes that results were truncated
+
+  Scenario: Limit is bounded to protect agent context
+    When the agent invokes platform_experiment_list with limit 5000
+    Then the effective limit applied is 100 or lower
+
+  # ==========================================================================
+  # platform_evaluation_list_runs
+  # ==========================================================================
+
+  Scenario: Listing runs requires experimentSlug
+    When the agent invokes platform_evaluation_list_runs without experimentSlug
+    Then the call fails with a validation error mentioning "experimentSlug"
+
+  Scenario: Lists runs for a known experiment
+    Given the experiment "checkout-flow" has 2 completed runs
+    When the agent invokes platform_evaluation_list_runs with experimentSlug "checkout-flow"
+    Then the response is markdown
+    And the response lists each run id
+    And each row reports status and started/finished timestamps
+
+  Scenario: Unknown experiment slug returns a graceful not-found message
+    When the agent invokes platform_evaluation_list_runs with experimentSlug "does-not-exist"
+    Then the response indicates the experiment was not found
+    And the response suggests calling platform_experiment_list to discover slugs

--- a/specs/typescript-sdk/cli-experiments-list.feature
+++ b/specs/typescript-sdk/cli-experiments-list.feature
@@ -1,0 +1,63 @@
+@integration
+Feature: List experiments and evaluation runs from the LangWatch CLI
+  As a developer wiring CI scripts and ad-hoc queries
+  I want `langwatch experiment list` and `langwatch evaluation list-runs`
+  So that I can discover experiment slugs and run ids without opening the dashboard
+
+  Background:
+    Given LANGWATCH_API_KEY is set in the environment
+
+  # ==========================================================================
+  # langwatch experiment list
+  # ==========================================================================
+
+  Scenario: Listing experiments prints a table by default
+    Given the project owns experiments "checkout-flow" and "support-bot"
+    When I run "langwatch experiment list"
+    Then the exit code is 0
+    And the output contains the headers "Name", "Slug", "Last Run", "Runs"
+    And each owned experiment slug appears in the table
+
+  Scenario: JSON format dumps the raw payload
+    When I run "langwatch experiment list --format json"
+    Then the exit code is 0
+    And the output is valid JSON
+    And each entry has "id", "slug", "name", "type"
+
+  Scenario: Limit caps the number of rows shown
+    Given the project owns 30 experiments
+    When I run "langwatch experiment list --limit 5"
+    Then the exit code is 0
+    And at most 5 experiment rows are printed
+
+  Scenario: Missing API key prints a friendly error
+    Given LANGWATCH_API_KEY is not set
+    When I run "langwatch experiment list"
+    Then the exit code is non-zero
+    And the output mentions "LANGWATCH_API_KEY"
+
+  # ==========================================================================
+  # langwatch evaluation list-runs
+  # ==========================================================================
+
+  Scenario: Listing runs requires --experiment
+    When I run "langwatch evaluation list-runs"
+    Then the exit code is non-zero
+    And the output mentions "experiment"
+
+  Scenario: Listing runs prints a table for a known slug
+    Given the experiment "checkout-flow" has 2 completed runs
+    When I run "langwatch evaluation list-runs --experiment checkout-flow"
+    Then the exit code is 0
+    And the output contains the headers "Run ID", "Status", "Started"
+    And both run ids appear in the table
+
+  Scenario: JSON format on runs dumps the raw payload
+    When I run "langwatch evaluation list-runs --experiment checkout-flow --format json"
+    Then the exit code is 0
+    And the output is valid JSON
+
+  Scenario: Unknown experiment slug exits non-zero with a 404 message
+    When I run "langwatch evaluation list-runs --experiment does-not-exist"
+    Then the exit code is non-zero
+    And the output mentions "404" or "not found"

--- a/typescript-sdk/src/cli/commands/evaluation/__tests__/list-runs.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/evaluation/__tests__/list-runs.unit.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock(
+  "@/client-sdk/services/evaluations/evaluations-api.service",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/client-sdk/services/evaluations/evaluations-api.service")
+      >();
+    return {
+      ...actual,
+      EvaluationsApiService: vi.fn(),
+    };
+  },
+);
+
+vi.mock("../../../utils/apiKey", () => ({
+  checkApiKey: vi.fn(),
+}));
+
+vi.mock("ora", () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    warn: vi.fn(),
+    text: "",
+  }),
+}));
+
+import { EvaluationsApiService } from "@/client-sdk/services/evaluations/evaluations-api.service";
+import { evaluationListRunsCommand } from "../list-runs";
+
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+const noop = () => {
+  // suppress output during tests
+};
+
+const mockProcessExit = () => {
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new ProcessExitError(code as number);
+  });
+};
+
+describe("evaluationListRunsCommand()", () => {
+  let mockListRuns: ReturnType<typeof vi.fn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListRuns = vi.fn();
+    vi.mocked(EvaluationsApiService).mockImplementation(
+      () =>
+        ({
+          listRuns: mockListRuns,
+        }) as unknown as EvaluationsApiService,
+    );
+    logSpy = vi.spyOn(console, "log").mockImplementation(noop);
+    vi.spyOn(console, "error").mockImplementation(noop);
+    mockProcessExit();
+  });
+
+  describe("given no --experiment flag", () => {
+    describe("when invoked", () => {
+      it("exits with non-zero code", async () => {
+        await expect(evaluationListRunsCommand({})).rejects.toBeInstanceOf(
+          ProcessExitError,
+        );
+      });
+    });
+  });
+
+  describe("given an experiment slug with runs", () => {
+    describe("when format is json", () => {
+      it("emits the raw payload as JSON", async () => {
+        const payload = {
+          experimentId: "exp_1",
+          experimentSlug: "checkout-flow",
+          runs: [
+            {
+              experimentId: "exp_1",
+              runId: "run_1",
+              workflowVersion: null,
+              timestamps: { createdAt: 1, updatedAt: 2 },
+              summary: { evaluations: {} },
+            },
+          ],
+          pagination: {
+            page: 1,
+            pageSize: 50,
+            totalHits: 1,
+            hasMore: false,
+          },
+        };
+        mockListRuns.mockResolvedValue(payload);
+
+        await evaluationListRunsCommand({
+          experiment: "checkout-flow",
+          format: "json",
+        });
+
+        expect(mockListRuns).toHaveBeenCalledWith({
+          experimentSlug: "checkout-flow",
+          pageSize: 50,
+        });
+        const printed = logSpy.mock.calls.flat().join("\n");
+        expect(printed).toContain('"runId": "run_1"');
+      });
+    });
+
+    describe("when format is table", () => {
+      it("includes the run id in stdout", async () => {
+        mockListRuns.mockResolvedValue({
+          experimentId: "exp_1",
+          experimentSlug: "checkout-flow",
+          runs: [
+            {
+              experimentId: "exp_1",
+              runId: "run_visible",
+              workflowVersion: null,
+              timestamps: {
+                createdAt: Date.now() - 1000,
+                updatedAt: Date.now(),
+                finishedAt: Date.now(),
+              },
+              summary: { evaluations: {} },
+            },
+          ],
+          pagination: {
+            page: 1,
+            pageSize: 50,
+            totalHits: 1,
+            hasMore: false,
+          },
+        });
+
+        await evaluationListRunsCommand({ experiment: "checkout-flow" });
+        const printed = logSpy.mock.calls.flat().join("\n");
+        expect(printed).toContain("run_visible");
+      });
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/evaluation/list-runs.ts
+++ b/typescript-sdk/src/cli/commands/evaluation/list-runs.ts
@@ -1,0 +1,144 @@
+import chalk from "chalk";
+import ora from "ora";
+import {
+  EvaluationsApiService,
+  type ExperimentRunSummaryEntry,
+} from "@/client-sdk/services/evaluations/evaluations-api.service";
+import { checkApiKey } from "../../utils/apiKey";
+import { failSpinner } from "../../utils/spinnerError";
+import { formatTable } from "../../utils/formatting";
+
+export interface ListRunsOptions {
+  experiment?: string;
+  format?: string;
+  limit?: string;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_PAGE_SIZE = 200;
+
+const formatTimestamp = (epochMs: number | null | undefined): string => {
+  if (!epochMs || !Number.isFinite(epochMs)) return chalk.gray("—");
+  return new Date(epochMs).toLocaleString();
+};
+
+const summarizePassRate = (
+  evaluations: ExperimentRunSummaryEntry["summary"]["evaluations"],
+): string => {
+  const entries = Object.values(evaluations ?? {});
+  if (entries.length === 0) return chalk.gray("—");
+  const passEntries = entries.filter(
+    (e) => typeof e.averagePassed === "number",
+  );
+  if (passEntries.length === 0) {
+    const scoreEntries = entries.filter(
+      (e) => typeof e.averageScore === "number",
+    );
+    if (scoreEntries.length === 0) return chalk.gray("—");
+    const avg =
+      scoreEntries.reduce((sum, e) => sum + (e.averageScore ?? 0), 0) /
+      scoreEntries.length;
+    return `${avg.toFixed(2)} avg`;
+  }
+  const avg =
+    passEntries.reduce((sum, e) => sum + (e.averagePassed ?? 0), 0) /
+    passEntries.length;
+  return `${(avg * 100).toFixed(0)}% pass`;
+};
+
+const runStatus = (run: ExperimentRunSummaryEntry): string => {
+  if (run.timestamps.stoppedAt) return chalk.gray("stopped");
+  if (run.timestamps.finishedAt) return chalk.green("completed");
+  return chalk.yellow("running");
+};
+
+export const evaluationListRunsCommand = async (
+  options: ListRunsOptions = {},
+): Promise<void> => {
+  checkApiKey();
+
+  const experimentSlug = options.experiment?.trim();
+  if (!experimentSlug) {
+    console.error(
+      chalk.red(
+        "Error: --experiment <slug> is required. List experiments first with `langwatch experiment list`.",
+      ),
+    );
+    process.exit(1);
+  }
+
+  const format = options.format === "json" ? "json" : "table";
+  const limit = (() => {
+    const parsed = options.limit ? parseInt(options.limit, 10) : DEFAULT_LIMIT;
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+    return Math.min(parsed, MAX_PAGE_SIZE);
+  })();
+
+  const service = new EvaluationsApiService();
+  const spinner = ora(
+    `Fetching runs for "${experimentSlug}"...`,
+  ).start();
+
+  try {
+    const result = await service.listRuns({
+      experimentSlug,
+      pageSize: limit,
+    });
+
+    spinner.succeed(
+      `Found ${result.pagination.totalHits} run${result.pagination.totalHits === 1 ? "" : "s"} for ${chalk.cyan(experimentSlug)}`,
+    );
+
+    if (format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    if (result.runs.length === 0) {
+      console.log();
+      console.log(chalk.gray("No runs found for this experiment yet."));
+      return;
+    }
+
+    console.log();
+
+    const tableData = result.runs.map((run) => ({
+      "Run ID": run.runId,
+      Status: runStatus(run),
+      Progress:
+        typeof run.progress === "number" && typeof run.total === "number"
+          ? `${run.progress}/${run.total}`
+          : chalk.gray("—"),
+      Started: formatTimestamp(run.timestamps.createdAt),
+      Finished: formatTimestamp(run.timestamps.finishedAt),
+      Result: summarizePassRate(run.summary?.evaluations ?? {}),
+    }));
+
+    formatTable({
+      data: tableData,
+      headers: ["Run ID", "Status", "Progress", "Started", "Finished", "Result"],
+      colorMap: {
+        "Run ID": chalk.cyan,
+      },
+    });
+
+    if (result.pagination.hasMore) {
+      console.log();
+      console.log(
+        chalk.gray(
+          `Showing ${result.runs.length} of ${result.pagination.totalHits}. Increase with --limit or use --format json for full data.`,
+        ),
+      );
+    }
+
+    console.log();
+    console.log(
+      chalk.gray(
+        `Use ${chalk.cyan("langwatch evaluation status <runId>")} or ${chalk.cyan("langwatch evaluation results <runId>")} to drill into a run.`,
+      ),
+    );
+  } catch (error) {
+    failSpinner({ spinner, error, action: "list evaluation runs" });
+    process.exit(1);
+  }
+};

--- a/typescript-sdk/src/cli/commands/experiment/__tests__/list.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/experiment/__tests__/list.unit.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock(
+  "@/client-sdk/services/evaluations/evaluations-api.service",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/client-sdk/services/evaluations/evaluations-api.service")
+      >();
+    return {
+      ...actual,
+      EvaluationsApiService: vi.fn(),
+    };
+  },
+);
+
+vi.mock("../../../utils/apiKey", () => ({
+  checkApiKey: vi.fn(),
+}));
+
+vi.mock("ora", () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    warn: vi.fn(),
+    text: "",
+  }),
+}));
+
+import { EvaluationsApiService } from "@/client-sdk/services/evaluations/evaluations-api.service";
+import { experimentListCommand } from "../list";
+
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+const noop = () => {
+  // suppress output during tests
+};
+
+describe("experimentListCommand()", () => {
+  let mockListExperiments: ReturnType<typeof vi.fn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListExperiments = vi.fn();
+    vi.mocked(EvaluationsApiService).mockImplementation(
+      () =>
+        ({
+          listExperiments: mockListExperiments,
+        }) as unknown as EvaluationsApiService,
+    );
+    logSpy = vi.spyOn(console, "log").mockImplementation(noop);
+    vi.spyOn(console, "error").mockImplementation(noop);
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new ProcessExitError(code as number);
+    });
+  });
+
+  describe("given the project owns experiments", () => {
+    describe("when format is json", () => {
+      it("emits the raw payload", async () => {
+        mockListExperiments.mockResolvedValue({
+          experiments: [
+            {
+              id: "exp_1",
+              slug: "checkout-flow",
+              name: "Checkout Flow",
+              type: "EVALUATIONS_V3",
+              workflowId: null,
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-02T00:00:00Z",
+              runsCount: 3,
+              lastRunAt: "2026-01-02T00:00:00Z",
+            },
+          ],
+          pagination: {
+            page: 1,
+            pageSize: 50,
+            totalHits: 1,
+            hasMore: false,
+          },
+        });
+
+        await experimentListCommand({ format: "json" });
+        const printed = logSpy.mock.calls.flat().join("\n");
+        expect(printed).toContain('"slug": "checkout-flow"');
+      });
+    });
+
+    describe("when format is table", () => {
+      it("renders rows including the slug", async () => {
+        mockListExperiments.mockResolvedValue({
+          experiments: [
+            {
+              id: "exp_1",
+              slug: "checkout-flow",
+              name: "Checkout Flow",
+              type: "EVALUATIONS_V3",
+              workflowId: null,
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-02T00:00:00Z",
+              runsCount: 0,
+              lastRunAt: null,
+            },
+          ],
+          pagination: {
+            page: 1,
+            pageSize: 50,
+            totalHits: 1,
+            hasMore: false,
+          },
+        });
+
+        await experimentListCommand({});
+        const printed = logSpy.mock.calls.flat().join("\n");
+        expect(printed).toContain("checkout-flow");
+      });
+    });
+  });
+
+  describe("given the project has no experiments", () => {
+    describe("when called", () => {
+      it("prints an empty-state message", async () => {
+        mockListExperiments.mockResolvedValue({
+          experiments: [],
+          pagination: {
+            page: 1,
+            pageSize: 50,
+            totalHits: 0,
+            hasMore: false,
+          },
+        });
+        await experimentListCommand({});
+        const printed = logSpy.mock.calls.flat().join("\n");
+        expect(printed.toLowerCase()).toContain("no experiments");
+      });
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/experiment/list.ts
+++ b/typescript-sdk/src/cli/commands/experiment/list.ts
@@ -1,0 +1,91 @@
+import chalk from "chalk";
+import ora from "ora";
+import {
+  EvaluationsApiService,
+  type ExperimentSummary,
+} from "@/client-sdk/services/evaluations/evaluations-api.service";
+import { checkApiKey } from "../../utils/apiKey";
+import { failSpinner } from "../../utils/spinnerError";
+import { formatTable, formatRelativeTime } from "../../utils/formatting";
+
+export interface ExperimentListOptions {
+  format?: string;
+  limit?: string;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_PAGE_SIZE = 200;
+
+export const experimentListCommand = async (
+  options: ExperimentListOptions = {},
+): Promise<void> => {
+  checkApiKey();
+
+  const format = options.format === "json" ? "json" : "table";
+  const limit = (() => {
+    const parsed = options.limit ? parseInt(options.limit, 10) : DEFAULT_LIMIT;
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+    return Math.min(parsed, MAX_PAGE_SIZE);
+  })();
+
+  const service = new EvaluationsApiService();
+  const spinner = ora("Fetching experiments...").start();
+
+  try {
+    const result = await service.listExperiments({ pageSize: limit });
+    spinner.succeed(
+      `Found ${result.pagination.totalHits} experiment${result.pagination.totalHits === 1 ? "" : "s"}`,
+    );
+
+    if (format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    if (result.experiments.length === 0) {
+      console.log();
+      console.log(chalk.gray("No experiments found in this project."));
+      return;
+    }
+
+    console.log();
+
+    const tableData = result.experiments.map((exp: ExperimentSummary) => ({
+      Name: exp.name ?? exp.slug,
+      Slug: exp.slug,
+      "Last Run": exp.lastRunAt
+        ? formatRelativeTime(exp.lastRunAt)
+        : chalk.gray("—"),
+      Runs: String(exp.runsCount),
+    }));
+
+    formatTable({
+      data: tableData,
+      headers: ["Name", "Slug", "Last Run", "Runs"],
+      colorMap: {
+        Name: chalk.cyan,
+        Slug: chalk.green,
+        Runs: chalk.yellow,
+      },
+    });
+
+    if (result.pagination.hasMore) {
+      console.log();
+      console.log(
+        chalk.gray(
+          `Showing ${result.experiments.length} of ${result.pagination.totalHits}. Increase with --limit or use --format json for full data.`,
+        ),
+      );
+    }
+
+    console.log();
+    console.log(
+      chalk.gray(
+        `Use ${chalk.cyan("langwatch evaluation list-runs --experiment <slug>")} to see runs for an experiment.`,
+      ),
+    );
+  } catch (error) {
+    failSpinner({ spinner, error, action: "fetch experiments" });
+    process.exit(1);
+  }
+};

--- a/typescript-sdk/src/cli/index.ts
+++ b/typescript-sdk/src/cli/index.ts
@@ -470,6 +470,42 @@ evaluationCmd
     await impl(runId, options);
   });
 
+evaluationCmd
+  .command("list-runs")
+  .description("List evaluation runs for an experiment by slug")
+  .requiredOption("--experiment <slug>", "Experiment slug to list runs for")
+  .option("-f, --format <format>", "Output format: table (default) or json", "table")
+  .option("--limit <n>", "Maximum runs to fetch (default 50, max 200)", "50")
+  .action(
+    async (options: {
+      experiment?: string;
+      format?: string;
+      limit?: string;
+    }) => {
+      const { evaluationListRunsCommand: impl } = await import(
+        "./commands/evaluation/list-runs.js"
+      );
+      await impl(options);
+    },
+  );
+
+// Add experiment command group
+const experimentCmd = program
+  .command("experiment")
+  .description("List and inspect experiments");
+
+experimentCmd
+  .command("list")
+  .description("List experiments in the project")
+  .option("-f, --format <format>", "Output format: table (default) or json", "table")
+  .option("--limit <n>", "Maximum experiments to fetch (default 50, max 200)", "50")
+  .action(async (options: { format?: string; limit?: string }) => {
+    const { experimentListCommand: impl } = await import(
+      "./commands/experiment/list.js"
+    );
+    await impl(options);
+  });
+
 // Add workflow command group
 const workflowCmd = program
   .command("workflow")

--- a/typescript-sdk/src/client-sdk/services/evaluations/__tests__/evaluations-api-list.unit.test.ts
+++ b/typescript-sdk/src/client-sdk/services/evaluations/__tests__/evaluations-api-list.unit.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  EvaluationsApiService,
+  EvaluationsApiError,
+  type ExperimentListResponse,
+  type EvaluationRunsListResponse,
+} from "../evaluations-api.service";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("EvaluationsApiService list endpoints", () => {
+  const previousApiKey = process.env.LANGWATCH_API_KEY;
+  const previousEndpoint = process.env.LANGWATCH_ENDPOINT;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    process.env.LANGWATCH_API_KEY = "sk-lw-test";
+    process.env.LANGWATCH_ENDPOINT = "https://api.langwatch.test";
+  });
+
+  afterEach(() => {
+    if (previousApiKey === undefined) delete process.env.LANGWATCH_API_KEY;
+    else process.env.LANGWATCH_API_KEY = previousApiKey;
+    if (previousEndpoint === undefined) delete process.env.LANGWATCH_ENDPOINT;
+    else process.env.LANGWATCH_ENDPOINT = previousEndpoint;
+  });
+
+  describe("listExperiments", () => {
+    describe("given the API returns a valid payload", () => {
+      describe("when called without arguments", () => {
+        it("hits /api/experiments with no query string", async () => {
+          const payload: ExperimentListResponse = {
+            experiments: [],
+            pagination: {
+              page: 1,
+              pageSize: 50,
+              totalHits: 0,
+              hasMore: false,
+            },
+          };
+          mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(payload),
+          });
+
+          const service = new EvaluationsApiService();
+          const result = await service.listExperiments();
+
+          expect(result).toEqual(payload);
+          const url = mockFetch.mock.calls[0]![0] as string;
+          expect(url).toBe("https://api.langwatch.test/api/experiments");
+        });
+      });
+
+      describe("when called with pageSize and page", () => {
+        it("includes them in the query string", async () => {
+          mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ experiments: [], pagination: {} }),
+          });
+
+          const service = new EvaluationsApiService();
+          await service.listExperiments({ pageSize: 10, page: 2 });
+
+          const url = mockFetch.mock.calls[0]![0] as string;
+          expect(url).toContain("pageSize=10");
+          expect(url).toContain("page=2");
+        });
+      });
+    });
+
+    describe("given the API returns 401", () => {
+      describe("when called", () => {
+        it("throws EvaluationsApiError with 'list experiments' operation", async () => {
+          mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+            text: () => Promise.resolve('{"error":"Missing credentials"}'),
+          });
+
+          const service = new EvaluationsApiService();
+          const err = await service.listExperiments().catch((e) => e);
+
+          expect(err).toBeInstanceOf(EvaluationsApiError);
+          expect((err as EvaluationsApiError).operation).toBe(
+            "list experiments",
+          );
+        });
+      });
+    });
+  });
+
+  describe("listRuns", () => {
+    describe("given a valid experiment slug", () => {
+      describe("when called", () => {
+        it("hits the runs endpoint with experimentSlug query param", async () => {
+          const payload: EvaluationRunsListResponse = {
+            experimentId: "exp_1",
+            experimentSlug: "checkout-flow",
+            runs: [],
+            pagination: {
+              page: 1,
+              pageSize: 50,
+              totalHits: 0,
+              hasMore: false,
+            },
+          };
+          mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(payload),
+          });
+
+          const service = new EvaluationsApiService();
+          const result = await service.listRuns({
+            experimentSlug: "checkout-flow",
+          });
+
+          expect(result).toEqual(payload);
+          const url = mockFetch.mock.calls[0]![0] as string;
+          expect(url).toContain(
+            "/api/evaluations/v3/runs?experimentSlug=checkout-flow",
+          );
+        });
+      });
+    });
+
+    describe("given the experiment slug is unknown", () => {
+      describe("when the API returns 404", () => {
+        it("throws EvaluationsApiError mentioning the slug", async () => {
+          mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            text: () => Promise.resolve('{"error":"Experiment not found"}'),
+          });
+
+          const service = new EvaluationsApiService();
+          const err = await service
+            .listRuns({ experimentSlug: "missing" })
+            .catch((e) => e);
+
+          expect(err).toBeInstanceOf(EvaluationsApiError);
+          expect((err as EvaluationsApiError).operation).toContain("missing");
+        });
+      });
+    });
+
+    describe("given a network failure", () => {
+      describe("when fetch rejects", () => {
+        it("wraps the error as EvaluationsApiError", async () => {
+          mockFetch.mockRejectedValueOnce(new Error("ECONNRESET"));
+          const service = new EvaluationsApiService();
+          const err = await service
+            .listRuns({ experimentSlug: "checkout-flow" })
+            .catch((e) => e);
+          expect(err).toBeInstanceOf(EvaluationsApiError);
+        });
+      });
+    });
+  });
+});

--- a/typescript-sdk/src/client-sdk/services/evaluations/evaluations-api.service.ts
+++ b/typescript-sdk/src/client-sdk/services/evaluations/evaluations-api.service.ts
@@ -3,6 +3,8 @@ import {
   createLangWatchApiClient,
   type LangwatchApiClient,
 } from "@/internal/api/client";
+import { buildAuthHeaders } from "@/internal/api/auth";
+import { DEFAULT_ENDPOINT } from "@/internal/constants";
 import { type InternalConfig } from "@/client-sdk/types";
 import {
   extractStatusFromResponse,
@@ -18,6 +20,77 @@ export interface EvaluationRunStartResponse {
 
 export type EvaluationRunStatusResponse =
   paths["/api/evaluations/v3/runs/{runId}"]["get"]["responses"]["200"]["content"]["application/json"];
+
+/**
+ * Summary entry returned by `GET /api/experiments`. Mirrors
+ * `experimentSummarySchema` from the control-plane Hono route. Hand-written
+ * because the route is not yet exposed via the generated OpenAPI types.
+ */
+export interface ExperimentSummary {
+  id: string;
+  slug: string;
+  name: string | null;
+  type: string;
+  workflowId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  runsCount: number;
+  lastRunAt: string | null;
+}
+
+export interface ExperimentListPagination {
+  page: number;
+  pageSize: number;
+  totalHits: number;
+  hasMore: boolean;
+}
+
+export interface ExperimentListResponse {
+  experiments: ExperimentSummary[];
+  pagination: ExperimentListPagination;
+}
+
+/**
+ * Per-run entry returned by `GET /api/evaluations/v3/runs?experimentSlug=...`.
+ * Mirrors `ExperimentRun` from the control plane.
+ */
+export interface ExperimentRunSummaryEntry {
+  experimentId: string;
+  runId: string;
+  workflowVersion: {
+    id: string;
+    version: string;
+    commitMessage: string;
+    author: { name: string | null; image: string | null } | null;
+  } | null;
+  timestamps: {
+    createdAt: number;
+    updatedAt: number;
+    finishedAt?: number | null;
+    stoppedAt?: number | null;
+  };
+  progress?: number | null;
+  total?: number | null;
+  summary: {
+    datasetCost?: number;
+    evaluationsCost?: number;
+    datasetAverageCost?: number;
+    datasetAverageDuration?: number;
+    evaluationsAverageCost?: number;
+    evaluationsAverageDuration?: number;
+    evaluations: Record<
+      string,
+      { name: string; averageScore: number | null; averagePassed?: number }
+    >;
+  };
+}
+
+export interface EvaluationRunsListResponse {
+  experimentId: string;
+  experimentSlug: string;
+  runs: ExperimentRunSummaryEntry[];
+  pagination: ExperimentListPagination;
+}
 
 export class EvaluationsApiError extends Error {
   constructor(
@@ -64,5 +137,120 @@ export class EvaluationsApiService {
     );
     if (error) this.handleApiError(`get run status for "${runId}"`, error);
     return data;
+  }
+
+  /**
+   * List experiments for the current project.
+   *
+   * Hits `GET /api/experiments` directly via fetch (not the typed
+   * `apiClient`) because the route is not yet declared in the generated
+   * OpenAPI `paths`.
+   */
+  async listExperiments({
+    pageSize,
+    page,
+  }: {
+    pageSize?: number;
+    page?: number;
+  } = {}): Promise<ExperimentListResponse> {
+    const apiKey = process.env.LANGWATCH_API_KEY ?? "";
+    const endpoint = process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT;
+    const projectId = process.env.LANGWATCH_PROJECT_ID;
+    const search = new URLSearchParams();
+    if (pageSize !== undefined) search.set("pageSize", String(pageSize));
+    if (page !== undefined) search.set("page", String(page));
+    const qs = search.toString();
+    const url = `${endpoint}/api/experiments${qs ? `?${qs}` : ""}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "GET",
+        headers: {
+          ...buildAuthHeaders({ apiKey, projectId }),
+          "content-type": "application/json",
+        },
+      });
+    } catch (error) {
+      this.handleApiError("list experiments", error);
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      let parsed: unknown = text;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        // keep raw text
+      }
+      const fauxError = {
+        response: { status: response.status },
+        data: parsed,
+      };
+      this.handleApiError("list experiments", fauxError);
+    }
+
+    return (await response.json()) as ExperimentListResponse;
+  }
+
+  /**
+   * List evaluation runs for an experiment slug.
+   *
+   * Hits `GET /api/evaluations/v3/runs?experimentSlug=...` directly via
+   * fetch because the route is not yet declared in the generated OpenAPI.
+   */
+  async listRuns({
+    experimentSlug,
+    pageSize,
+    page,
+  }: {
+    experimentSlug: string;
+    pageSize?: number;
+    page?: number;
+  }): Promise<EvaluationRunsListResponse> {
+    const apiKey = process.env.LANGWATCH_API_KEY ?? "";
+    const endpoint = process.env.LANGWATCH_ENDPOINT ?? DEFAULT_ENDPOINT;
+    const projectId = process.env.LANGWATCH_PROJECT_ID;
+    const search = new URLSearchParams();
+    search.set("experimentSlug", experimentSlug);
+    if (pageSize !== undefined) search.set("pageSize", String(pageSize));
+    if (page !== undefined) search.set("page", String(page));
+    const url = `${endpoint}/api/evaluations/v3/runs?${search.toString()}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "GET",
+        headers: {
+          ...buildAuthHeaders({ apiKey, projectId }),
+          "content-type": "application/json",
+        },
+      });
+    } catch (error) {
+      this.handleApiError(
+        `list runs for experiment "${experimentSlug}"`,
+        error,
+      );
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      let parsed: unknown = text;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        // keep raw text
+      }
+      const fauxError = {
+        response: { status: response.status },
+        data: parsed,
+      };
+      this.handleApiError(
+        `list runs for experiment "${experimentSlug}"`,
+        fauxError,
+      );
+    }
+
+    return (await response.json()) as EvaluationRunsListResponse;
   }
 }


### PR DESCRIPTION
## Summary

Adds the two missing public REST list endpoints so API-key clients (CLI, MCP, scripts) can enumerate experiments and runs without opening the dashboard:

- `GET /api/experiments` — list project experiments (id, slug, name, type, run count, last-run timestamp).
- `GET /api/evaluations/v3/runs?experimentSlug=<slug>` — list runs for an experiment.

Plus the matching consumers:

- TypeScript SDK: `EvaluationsApiService.listExperiments` / `listRuns`.
- CLI: `langwatch experiment list` and `langwatch evaluation list-runs --experiment <slug>` (table + JSON output, `--limit` clamping).
- MCP: `platform_experiment_list` and `platform_evaluation_list_runs` (markdown, default 25 / max 100 to protect context window).

Both endpoints reuse existing services (`ExperimentService.getAll`, `ExperimentRunService.listRuns`) — no direct Prisma access from routes. Both filter by project and return camelCase pagination shapes (`page`, `pageSize`, `totalHits`, `hasMore`). SDK types are hand-written because these routes are not yet exposed via the generated OpenAPI paths (same pattern PR #3886 used for `getRunResults`).

This completes the discovery chain `list experiments → list runs → fetch results`, where the final step is provided by #3886.

Refs #3885.

## Test plan

- [x] Backend typecheck green (`pnpm typecheck` in `langwatch/`).
- [x] SDK typecheck green (`pnpm typecheck` in `typescript-sdk/`).
- [x] MCP typecheck green (`tsc --noEmit` in `mcp-server/`).
- [x] New SDK + CLI unit tests pass end-to-end (12/12) — `evaluations-api-list.unit.test.ts`, `evaluation/list-runs.unit.test.ts`, `experiment/list.unit.test.ts`.
- [x] New MCP unit tests pass end-to-end (6/6) — `experiment-list-tools.unit.test.ts`.
- [x] Full SDK + MCP suites green for everything not pre-existing-broken (1192/1210 SDK; 343/344 MCP — failures are pre-existing OpenAI / harness issues unrelated to these changes).
- [x] Full backend `pnpm test:unit` green (16321/16322 — only pre-existing `sanitize-dev-env` flake fails).
- [x] Live HTTP probe of both endpoints against a local dev server with the new code mounted: `GET /api/experiments` → 200 with project-scoped experiments; `GET /api/evaluations/v3/runs?experimentSlug=...` → 200 (or 404 for unknown slug, 400 for missing slug, 401 unauthenticated).
- [x] CLI live dogfood against local dev server: `langwatch experiment list` (table + JSON), `langwatch evaluation list-runs --experiment <slug>` (table + JSON + 404 path with non-zero exit).
- [ ] Hosted dogfood against `app.langwatch.ai` — **not possible until merged + deployed** (the new endpoints return 404 on the production host since they don't exist there yet).
- [ ] End-to-end chain with `evaluation results <runId>` from PR #3886 — **blocked on zero completed runs in the local DB** (only experiment present has 0 runs in ClickHouse). Once #3886 lands and this PR ships, the chain can be exercised against a project that has completed runs.

## Live dogfood readout

Endpoints verified against a local dev server (Docker app on :5560) using a real project key from the local Postgres:

```
GET /api/experiments?pageSize=5
→ 200 { experiments: [{ id, slug: "epic-ancient-nova", name, type, runsCount: 0, lastRunAt: null, ... }], pagination: {...} }

GET /api/evaluations/v3/runs?experimentSlug=epic-ancient-nova
→ 200 { experimentId, experimentSlug, runs: [], pagination: {...} }

GET /api/evaluations/v3/runs?experimentSlug=does-not-exist
→ 404 { error: "Experiment not found" }

GET /api/evaluations/v3/runs (no slug)
→ 400 { error: "experimentSlug query parameter is required" }

GET /api/experiments  (no auth)
→ 401 { error: "Missing credentials" }
```

CLI table output renders cleanly for both commands; `--format json` dumps the full payload; unknown slug exits non-zero with a wrapped 404 message. The lowest-scoring-evaluator readout from PR #3886 is **deferred** until completed runs exist in the same environment as the new endpoints.

## Related

Direct precursor: #3886 (adds `GET /runs/:runId/results` + SDK + CLI + MCP). This PR completes the `list → runs → results` chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)