### PR TITLE
fix(security): upgrade jupyter-server to 2.18.2

### DIFF
--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -2766,7 +2766,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-server"
-version = "2.16.0"
+version = "2.18.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2778,7 +2778,7 @@ dependencies = [
     { name = "jupyter-server-terminals" },
     { name = "nbconvert" },
     { name = "nbformat" },
-    { name = "overrides" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
     { name = "prometheus-client" },
     { name = "pywinpty", marker = "(python_full_version >= '3.11' and os_name == 'nt' and sys_platform == 'darwin') or (python_full_version >= '3.11' and os_name == 'nt' and sys_platform == 'linux') or (os_name == 'nt' and platform_machine != 'aarch64' and sys_platform == 'linux') or (os_name == 'nt' and sys_platform != 'darwin' and sys_platform != 'linux')" },
@@ -2789,9 +2789,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/c8/ba2bbcd758c47f1124c4ca14061e8ce60d9c6fd537faee9534a95f83521a/jupyter_server-2.16.0.tar.gz", hash = "sha256:65d4b44fdf2dcbbdfe0aa1ace4a842d4aaf746a2b7b168134d5aaed35621b7f6", size = 728177, upload-time = "2025-05-12T16:44:46.245Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/15/1eacb0fcb79ef86e8a0a79a708e6ad7435f6f223097dd29a4ce861fabc44/jupyter_server-2.18.2.tar.gz", hash = "sha256:06b4f40d8a7a00bb39d5216859c81374a0e7cfefe6d8a5a7facc5a5c37c679a7", size = 753177, upload-time = "2026-05-06T07:04:36.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/1f/5ebbced977171d09a7b0c08a285ff9a20aafb9c51bde07e52349ff1ddd71/jupyter_server-2.16.0-py3-none-any.whl", hash = "sha256:3d8db5be3bc64403b1c65b400a1d7f4647a5ce743f3b20dbdefe8ddb7b55af9e", size = 386904, upload-time = "2025-05-12T16:44:43.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/50/ecf4f70d65bdb7519b28a33d1b2fee8a4b4ba1ae1a92f15d97e877c5de21/jupyter_server-2.18.2-py3-none-any.whl", hash = "sha256:fa5e46539ded65791838035a2b6001f13e54d5f64b8b3752eb1e91fdd641a5b8", size = 391907, upload-time = "2026-05-06T07:04:34.014Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrades `jupyter-server` from 2.16.0 → 2.18.2 in `python-sdk/uv.lock` to resolve two high-severity Dependabot alerts
- **CVE-2026-35397** (#998): Path traversal via incorrect `startswith()` root directory check allows access to sibling directories
- **CVE-2026-40110** (#999): CORS origin validation bypass via `re.match()` in `allow_origin_pat`

## Risk Assessment

**Safe upgrade — examples-only, lockfile-only change:**

| Factor | Detail |
|--------|--------|
| **Where is jupyter-server used?** | Transitive dep of `jupyterlab` and `jupyter`, both in the `examples` dependency group |
| **Production code affected?** | No — SDK source only has a `_is_notebook()` detection utility using `IPython.get_ipython()`, no jupyter imports |
| **Pinned versions?** | `jupyterlab>=4.5.6` has a `# security` comment (prior CVE fix pattern), no compatibility pin. `jupyter-server` is not directly specified |
| **What changed?** | Only `python-sdk/uv.lock` — 4 lines (version + hashes) |

Closes https://github.com/langwatch/langwatch/security/dependabot/998
Closes https://github.com/langwatch/langwatch/security/dependabot/999

## Test plan

- [ ] CI passes (lockfile-only change, no code changes)
- [ ] Verify Dependabot alerts 998 and 999 auto-close after merge