### PR TITLE
feat(dev-env): boxd Makefile + quickstart rework (#3891 + #3860)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,17 +15,24 @@ If no feature file exists for your task, create one before writing code.
 
 ## Development Environment
 
-From repo root (requires Docker):
+`make quickstart` is the single entry point. It asks what you're working on and starts only the services you need, overriding only the URLs whose services are local. Your `langwatch/.env` is the source of truth for everything else.
 
 ```bash
-make quickstart            # Interactive launcher (single entry point)
-make quickstart-help       # Non-interactive mode reference (modes + service set)
-make down                  # Stop all services
-make service svc=aigateway # Start the Go AI Gateway data plane on :5563
-make help                  # Full target list including boxd workflows
+make quickstart                        # Interactive launcher (asks "what are you working on?")
+make quickstart frontend-only          # No compose, fastest — UI / design work
+make quickstart backend-shared         # postgres + redis + clickhouse + app, URLs → local
+make quickstart migration              # postgres + clickhouse on host ports for prisma migrate
+make quickstart nlp                    # backend + langwatch_nlp + langevals
+make quickstart full-local             # everything (--profile full)
+make quickstart-help                   # Non-interactive mode reference
+make down                              # Stop all services
+make service svc=aigateway             # Start the Go AI Gateway data plane on :5563
+make help                              # Full target list including boxd workflows
 ```
 
-`make dev`, `make dev-nlp`, `make dev-scenarios`, `make dev-test`, `make dev-full`, `make dev-up`, `make dev-down`, and `make dev-logs` still work for one release with a deprecation warning — use `make quickstart` instead.
+The mode-picker writes `langwatch/.env.dev-up` listing only the URLs to override; everything else comes from your `langwatch/.env`. So if your `.env` has `LANGWATCH_NLP_SERVICE=https://nlp.langwatch.ai`, that's what `backend-shared` mode will use — only `nlp` / `full-local` modes override it to point at a local container.
+
+`make dev`, `make dev-nlp`, `make dev-scenarios`, `make dev-test`, `make dev-full`, `make dev-up`, `make dev-down`, and `make dev-logs` still work for one release with a deprecation warning — they're thin shims onto the new modes.
 
 Stateful services (`langwatch-db-data`, `langwatch-clickhouse-data`, `langwatch-redis-data`) share data across worktrees: sign up once, persist across worktree switches. Only one worktree can have postgres or clickhouse `up` at a time — `quickstart` detects collisions and points at the other compose project. Redis is a singleton on host `:6379`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,18 @@ If no feature file exists for your task, create one before writing code.
 From repo root (requires Docker):
 
 ```bash
-make dev              # Minimal: postgres + redis + app
-make dev-scenarios    # + workers (includes scenarios) + bullboard + ai-server + nlp
-make dev-full         # Everything including opensearch
-make quickstart       # Interactive profile chooser
-make down             # Stop all services
-make service svc=aigateway  # Start the Go AI Gateway data plane on :5563
+make quickstart            # Interactive launcher (single entry point)
+make quickstart-help       # Non-interactive mode reference (modes + service set)
+make down                  # Stop all services
+make service svc=aigateway # Start the Go AI Gateway data plane on :5563
+make help                  # Full target list including boxd workflows
 ```
+
+`make dev`, `make dev-nlp`, `make dev-scenarios`, `make dev-test`, `make dev-full`, `make dev-up`, `make dev-down`, and `make dev-logs` still work for one release with a deprecation warning — use `make quickstart` instead.
+
+Stateful services (`langwatch-db-data`, `langwatch-clickhouse-data`, `langwatch-redis-data`) share data across worktrees: sign up once, persist across worktree switches. Only one worktree can have postgres or clickhouse `up` at a time — `quickstart` detects collisions and points at the other compose project. Redis is a singleton on host `:6379`.
+
+For per-PR / per-issue cloud environments via boxd, see `dev/docs/boxd-makefile.md` and `make boxd-help`.
 
 See `dev/docs/adr/004-docker-dev-environment.md` for architecture decisions.
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,12 @@ help:
 	@echo "LangWatch dev targets:"
 	@echo ""
 	@echo "  Primary (Docker dev environment):"
-	@echo "    make quickstart                     interactive launcher (single entry point)"
+	@echo "    make quickstart                     interactive — asks 'what are you working on?'"
+	@echo "    make quickstart frontend-only       no compose; pure pnpm dev against your .env URLs"
+	@echo "    make quickstart backend-shared      postgres + redis + clickhouse + app, URLs → local"
+	@echo "    make quickstart migration           postgres + clickhouse on host ports (prisma migrate)"
+	@echo "    make quickstart nlp                 backend + langwatch_nlp + langevals"
+	@echo "    make quickstart full-local          everything (--profile full)"
 	@echo "    make quickstart-help                non-interactive mode reference"
 	@echo "    make service svc=<name>             run a Go service (e.g. aigateway)"
 	@echo "    make service-watch svc=<name>       run a Go service with live reload (air)"
@@ -79,29 +84,26 @@ service-watch:
 			--build.exclude_dir "tmp,vendor,node_modules"
 
 # Deprecation warning for dev* targets — kept for one release. (#3860 AC#9)
+# Each maps onto the equivalent quickstart mode so the URL-override behavior
+# is consistent regardless of which alias the user invoked.
 _dev-deprecation-warning:
-	@printf '\033[33m[deprecated] make %s → make quickstart (or scripts/dev.sh help)\033[0m\n' "$(MAKECMDGOALS)" >&2
+	@printf '\033[33m[deprecated] make %s → make quickstart (or ./scripts/dev.sh <mode>)\033[0m\n' "$(MAKECMDGOALS)" >&2
 	@printf 'See: dev/docs/adr/004-docker-dev-environment.md\n' >&2
 
-# Minimal: postgres + redis + clickhouse + app
 dev: _dev-deprecation-warning
-	@$(SANITIZE_DEV_ENV) && $(COMPOSE) up
+	@./scripts/dev.sh backend-shared
 
-# + NLP service + langevals (for evaluations)
 dev-nlp: _dev-deprecation-warning
-	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile nlp up
+	@./scripts/dev.sh nlp
 
-# + scenario worker + bullboard + NLP
 dev-scenarios: _dev-deprecation-warning
-	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile scenarios up
+	@./scripts/dev.sh full-local
 
-# + AI test server (for HTTP agent testing)
 dev-test: _dev-deprecation-warning
-	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile test up
+	@./scripts/dev.sh full-local
 
-# Everything
 dev-full: _dev-deprecation-warning
-	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile full up
+	@./scripts/dev.sh full-local
 
 # Stop all services
 down:
@@ -137,13 +139,25 @@ start/postgres:
 tsc-watch:
 	cd langwatch && pnpm tsc-watch
 
-# Single entry point — interactive launcher (#3860 AC#1).
+# Single entry point — interactive launcher or non-interactive mode runner.
+# (#3860 AC#1, AC#2). Positional usage via MAKECMDGOALS:
+#   make quickstart                  # interactive prompt
+#   make quickstart frontend-only    # no compose, fastest
+#   make quickstart backend-shared   # postgres + redis + clickhouse + app
+#   make quickstart migration        # postgres + clickhouse on host ports
+#   make quickstart nlp              # backend + nlp + langevals
+#   make quickstart full-local       # --profile full
+ifeq (quickstart,$(firstword $(MAKECMDGOALS)))
+  QUICKSTART_ARG := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  ifneq ($(QUICKSTART_ARG),)
+    $(eval $(QUICKSTART_ARG):;@:)
+  endif
+endif
 quickstart:
-	@./scripts/dev.sh
+	@./scripts/dev.sh $(QUICKSTART_ARG)
 
-# Non-interactive mode reference (#3860 AC#8). `make quickstart help` would
-# collide with the existing `help` target so the discoverable form is
-# `make quickstart-help` (or `./scripts/dev.sh help` directly).
+# Non-interactive mode reference (#3860 AC#8). Use `make quickstart-help` —
+# `make quickstart help` collides with the existing `help` target.
 quickstart-help:
 	@./scripts/dev.sh help
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,35 @@
-.PHONY: start sync-all-openapi user-delete-dry-run user-delete es-delete-dry-run es-delete
+.PHONY: help start sync-all-openapi user-delete-dry-run user-delete es-delete-dry-run es-delete
 .PHONY: dev dev-nlp dev-scenarios dev-full down logs clean ps quickstart worktree
 .PHONY: dev-up dev-down dev-logs setup-hooks service service-watch
+.PHONY: _dev-deprecation-warning _dev-up-deprecation-warning
+
+# Surface every target — boxd-* are pulled in via include below.
+help:
+	@echo "LangWatch dev targets:"
+	@echo ""
+	@echo "  Primary (Docker dev environment):"
+	@echo "    make quickstart                     interactive launcher (single entry point)"
+	@echo "    make quickstart help                non-interactive mode reference"
+	@echo "    make service svc=<name>             run a Go service (e.g. aigateway)"
+	@echo "    make service-watch svc=<name>       run a Go service with live reload (air)"
+	@echo "    make worktree <issue|name>          create a git worktree for an issue/feature"
+	@echo "    make down                           stop all services"
+	@echo ""
+	@echo "  Boxd workflows (multi-step orchestration over the boxd CLI):"
+	@echo "    make boxd-help                      full boxd target reference"
+	@echo "    make boxd-golden                    create the canonical base VM"
+	@echo "    make boxd-fork-pr PR=<n>            fork golden for an existing PR"
+	@echo "    make boxd-fork-branch BRANCH=<n>    fork golden for a branch"
+	@echo "    make boxd-fork-issue ISSUE=<n>      fork + worktree + tmux+claude in VM"
+	@echo "    make boxd-connect-{pr,branch,issue} <ARG>=<v>   attach to the in-VM session"
+	@echo ""
+	@echo "  Deprecated (use 'make quickstart' — kept for one release):"
+	@echo "    make dev / dev-nlp / dev-scenarios / dev-test / dev-full"
+	@echo "    make dev-up / dev-down / dev-logs"
+	@echo ""
+	@echo "  See: dev/docs/adr/004-docker-dev-environment.md, dev/docs/boxd-makefile.md"
+
+include boxd.mk
 
 # =============================================================================
 # DOCKER DEV ENVIRONMENT (compose.dev.yml)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help start sync-all-openapi user-delete-dry-run user-delete es-delete-dry-run es-delete
-.PHONY: dev dev-nlp dev-scenarios dev-full down logs clean ps quickstart worktree
+.PHONY: dev dev-nlp dev-scenarios dev-full down logs clean ps quickstart quickstart-help worktree
 .PHONY: dev-up dev-down dev-logs setup-hooks service service-watch
 .PHONY: _dev-deprecation-warning _dev-up-deprecation-warning
 
@@ -9,7 +9,7 @@ help:
 	@echo ""
 	@echo "  Primary (Docker dev environment):"
 	@echo "    make quickstart                     interactive launcher (single entry point)"
-	@echo "    make quickstart help                non-interactive mode reference"
+	@echo "    make quickstart-help                non-interactive mode reference"
 	@echo "    make service svc=<name>             run a Go service (e.g. aigateway)"
 	@echo "    make service-watch svc=<name>       run a Go service with live reload (air)"
 	@echo "    make worktree <issue|name>          create a git worktree for an issue/feature"
@@ -78,24 +78,29 @@ service-watch:
 			--build.include_ext "go" \
 			--build.exclude_dir "tmp,vendor,node_modules"
 
+# Deprecation warning for dev* targets — kept for one release. (#3860 AC#9)
+_dev-deprecation-warning:
+	@printf '\033[33m[deprecated] make %s → make quickstart (or scripts/dev.sh help)\033[0m\n' "$(MAKECMDGOALS)" >&2
+	@printf 'See: dev/docs/adr/004-docker-dev-environment.md\n' >&2
+
 # Minimal: postgres + redis + clickhouse + app
-dev:
+dev: _dev-deprecation-warning
 	@$(SANITIZE_DEV_ENV) && $(COMPOSE) up
 
 # + NLP service + langevals (for evaluations)
-dev-nlp:
+dev-nlp: _dev-deprecation-warning
 	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile nlp up
 
 # + scenario worker + bullboard + NLP
-dev-scenarios:
+dev-scenarios: _dev-deprecation-warning
 	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile scenarios up
 
 # + AI test server (for HTTP agent testing)
-dev-test:
+dev-test: _dev-deprecation-warning
 	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile test up
 
 # Everything
-dev-full:
+dev-full: _dev-deprecation-warning
 	@$(SANITIZE_DEV_ENV) && $(COMPOSE) --profile full up
 
 # Stop all services
@@ -132,9 +137,15 @@ start/postgres:
 tsc-watch:
 	cd langwatch && pnpm tsc-watch
 
-# Interactive profile chooser
+# Single entry point — interactive launcher (#3860 AC#1).
 quickstart:
 	@./scripts/dev.sh
+
+# Non-interactive mode reference (#3860 AC#8). `make quickstart help` would
+# collide with the existing `help` target so the discoverable form is
+# `make quickstart-help` (or `./scripts/dev.sh help` directly).
+quickstart-help:
+	@./scripts/dev.sh help
 
 # =============================================================================
 # ISOLATED DEV INSTANCES (for AI agents / parallel worktrees)
@@ -142,16 +153,20 @@ quickstart:
 # Each worktree gets its own containers, volumes, and ports.
 # Port info saved to .dev-port for agent/skill discovery.
 
+# Deprecation warning for dev-up / dev-down / dev-logs (#3860 AC#9).
+_dev-up-deprecation-warning:
+	@printf '\033[33m[deprecated] make %s → make quickstart (single entry point)\033[0m\n' "$(MAKECMDGOALS)" >&2
+
 # Start isolated instance (detached). Usage: make dev-up [PROFILE=scenarios]
-dev-up:
+dev-up: _dev-up-deprecation-warning
 	@./scripts/dev-up.sh $(PROFILE)
 
 # Stop isolated instance
-dev-down:
+dev-down: _dev-up-deprecation-warning
 	@./scripts/dev-down.sh
 
 # Tail logs for isolated instance
-dev-logs:
+dev-logs: _dev-up-deprecation-warning
 	@if [ -f .dev-port ]; then . ./.dev-port && COMPOSE_PROJECT_NAME=$$COMPOSE_PROJECT_NAME VOLUME_PREFIX=$$VOLUME_PREFIX docker compose -f compose.dev.yml --profile full logs -f; \
 	else echo "No .dev-port found. Is the instance running?"; fi
 

--- a/boxd.mk
+++ b/boxd.mk
@@ -1,0 +1,121 @@
+# =============================================================================
+# BOXD WORKFLOWS
+# =============================================================================
+# Targets here orchestrate multi-step flows. For single-command operations,
+# use the `boxd` CLI directly (`boxd list`, `boxd destroy NAME`, `boxd info`).
+#
+# Surface:
+#   make boxd-golden                       # build the canonical base VM
+#   make boxd-golden-reset                 # destroy + rebuild golden (needs BOXD_FORK_YES=1)
+#   make boxd-fork-pr PR=1234              # fork golden for an existing PR
+#   make boxd-fork-branch BRANCH=feat/foo  # fork golden for a branch
+#   make boxd-fork-issue ISSUE=123         # fork + worktree branch + tmux+claude in VM
+#   make boxd-connect-pr PR=1234           # SSH + tmux attach to the matching VM
+#   make boxd-connect-branch BRANCH=feat/foo
+#   make boxd-connect-issue ISSUE=123
+#
+# Naming: forks live at langwatch-<branch-slug> or langwatch-issue<N>.
+# tmux session inside the VM matches as claude-<branch-slug> / claude-issue<N>.
+#
+# See dev/docs/boxd-makefile.md for the full reference + threat model.
+
+.PHONY: boxd-help boxd-golden boxd-golden-reset \
+        boxd-fork-pr boxd-fork-branch boxd-fork-issue \
+        boxd-connect-pr boxd-connect-branch boxd-connect-issue \
+        seed-golden _boxd-fork-impl _boxd-require
+
+BOXD_FORK_LIB := scripts/boxd-fork.sh
+BOXD_RUN := bash -c '. $(BOXD_FORK_LIB) &&'
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+boxd-help:
+	@echo "boxd targets — orchestrate multi-step flows. For single-command operations,"
+	@echo "use the 'boxd' CLI directly."
+	@echo ""
+	@echo "Golden VM:"
+	@echo "  boxd-golden                          create langwatch-golden (canonical base)"
+	@echo "  boxd-golden-reset                    BOXD_FORK_YES=1 to confirm destroy+rebuild"
+	@echo ""
+	@echo "Fork-for-source:"
+	@echo "  boxd-fork-pr PR=<n>                  fork golden for an existing PR"
+	@echo "  boxd-fork-branch BRANCH=<name>       fork golden for a branch"
+	@echo "  boxd-fork-issue ISSUE=<n>            fork + worktree + tmux+claude inside VM"
+	@echo ""
+	@echo "Connect-by-source:"
+	@echo "  boxd-connect-pr PR=<n>"
+	@echo "  boxd-connect-branch BRANCH=<name>"
+	@echo "  boxd-connect-issue ISSUE=<n>"
+	@echo ""
+	@echo "Naming: langwatch-<branch-slug> | langwatch-issue<N>; tmux: claude-<...>"
+	@echo ""
+	@echo "Customizable env vars:"
+	@echo "  CLAUDE_CREDS=/path/to/credentials.json   override the source credentials"
+	@echo "  BOXD_FORK_YES=1                          confirm destructive ops"
+
+# ---------------------------------------------------------------------------
+# Argument guards
+# ---------------------------------------------------------------------------
+
+# Internal: require a make variable to be set (used by all targets that take a
+# parameter). $$1 is the var name in the lookup; $$2 is its value.
+# Usage in a recipe: @$(call _boxd_require,PR,$(PR))
+define _boxd_require
+	@test -n "$(2)" || { echo "ERROR: $(1) is required (e.g. make $@ $(1)=<value>)" >&2; exit 1; }
+endef
+
+# ---------------------------------------------------------------------------
+# Golden VM
+# ---------------------------------------------------------------------------
+
+boxd-golden:
+	@echo "→ boxd-golden: building canonical base VM 'langwatch-golden'"
+	@$(BOXD_RUN) 'boxd_golden'
+	@$(MAKE) -s seed-golden 2>/dev/null || true
+
+boxd-golden-reset:
+	@echo "→ boxd-golden-reset: destroying + rebuilding 'langwatch-golden'"
+	@$(BOXD_RUN) 'BOXD_FORK_YES=$(BOXD_FORK_YES) boxd_golden_reset'
+	@$(MAKE) -s seed-golden 2>/dev/null || true
+
+# Hook target — quickstart/seed work fills this in when there's something to
+# preload. By default it's a no-op and prints a hint (AC#7).
+seed-golden:
+	@echo "  (no seed-golden hook configured — define one in your Makefile.local or here to seed langwatch-golden)"
+
+# ---------------------------------------------------------------------------
+# Fork-for-source
+# ---------------------------------------------------------------------------
+
+boxd-fork-pr:
+	$(call _boxd_require,PR,$(PR))
+	@echo "→ boxd-fork-pr PR=$(PR)"
+	@$(BOXD_RUN) 'boxd_fork_pr "$(PR)"'
+
+boxd-fork-branch:
+	$(call _boxd_require,BRANCH,$(BRANCH))
+	@echo "→ boxd-fork-branch BRANCH=$(BRANCH)"
+	@$(BOXD_RUN) 'boxd_fork_branch "$(BRANCH)"'
+
+boxd-fork-issue:
+	$(call _boxd_require,ISSUE,$(ISSUE))
+	@echo "→ boxd-fork-issue ISSUE=$(ISSUE)"
+	@$(BOXD_RUN) 'boxd_fork_issue "$(ISSUE)"'
+
+# ---------------------------------------------------------------------------
+# Connect-by-source
+# ---------------------------------------------------------------------------
+
+boxd-connect-pr:
+	$(call _boxd_require,PR,$(PR))
+	@$(BOXD_RUN) 'branch=$$(boxd_resolve_pr_branch "$(PR)") && boxd_connect pr "$$branch"'
+
+boxd-connect-branch:
+	$(call _boxd_require,BRANCH,$(BRANCH))
+	@$(BOXD_RUN) 'boxd_connect branch "$(BRANCH)"'
+
+boxd-connect-issue:
+	$(call _boxd_require,ISSUE,$(ISSUE))
+	@$(BOXD_RUN) 'boxd_connect issue "$(ISSUE)"'

--- a/boxd.mk
+++ b/boxd.mk
@@ -25,7 +25,12 @@
         seed-golden _boxd-fork-impl _boxd-require
 
 BOXD_FORK_LIB := scripts/boxd-fork.sh
-BOXD_RUN := bash -c '. $(BOXD_FORK_LIB) &&'
+# Recipes call bash explicitly so the bash-only sourcing helpers in
+# scripts/boxd-fork.sh (e.g. `[[ … ]]`) work even when Make's default SHELL
+# is /bin/sh. The prefix must be concatenated with the function call inside
+# the same `-c` argument; passing them as separate args is a common bash
+# pitfall (the second arg becomes $0, never executes).
+BOXD_RUN_PREFIX := . $(BOXD_FORK_LIB) &&
 
 # ---------------------------------------------------------------------------
 # Help
@@ -72,18 +77,19 @@ endef
 
 boxd-golden:
 	@echo "→ boxd-golden: building canonical base VM 'langwatch-golden'"
-	@$(BOXD_RUN) 'boxd_golden'
-	@$(MAKE) -s seed-golden 2>/dev/null || true
+	@bash -c '$(BOXD_RUN_PREFIX) boxd_golden'
+	@$(MAKE) -s seed-golden
 
 boxd-golden-reset:
 	@echo "→ boxd-golden-reset: destroying + rebuilding 'langwatch-golden'"
-	@$(BOXD_RUN) 'BOXD_FORK_YES=$(BOXD_FORK_YES) boxd_golden_reset'
-	@$(MAKE) -s seed-golden 2>/dev/null || true
+	@bash -c '$(BOXD_RUN_PREFIX) BOXD_FORK_YES=$(BOXD_FORK_YES) boxd_golden_reset'
+	@$(MAKE) -s seed-golden
 
 # Hook target — quickstart/seed work fills this in when there's something to
-# preload. By default it's a no-op and prints a hint (AC#7).
+# preload. By default it's a no-op and prints a hint (AC#7). Override in
+# Makefile.local to provide a real seed implementation.
 seed-golden:
-	@echo "  (no seed-golden hook configured — define one in your Makefile.local or here to seed langwatch-golden)"
+	@echo "  (no seed-golden hook configured — define one in Makefile.local to seed langwatch-golden)"
 
 # ---------------------------------------------------------------------------
 # Fork-for-source
@@ -92,17 +98,17 @@ seed-golden:
 boxd-fork-pr:
 	$(call _boxd_require,PR,$(PR))
 	@echo "→ boxd-fork-pr PR=$(PR)"
-	@$(BOXD_RUN) 'boxd_fork_pr "$(PR)"'
+	@bash -c '$(BOXD_RUN_PREFIX) boxd_fork_pr "$(PR)"'
 
 boxd-fork-branch:
 	$(call _boxd_require,BRANCH,$(BRANCH))
 	@echo "→ boxd-fork-branch BRANCH=$(BRANCH)"
-	@$(BOXD_RUN) 'boxd_fork_branch "$(BRANCH)"'
+	@bash -c '$(BOXD_RUN_PREFIX) boxd_fork_branch "$(BRANCH)"'
 
 boxd-fork-issue:
 	$(call _boxd_require,ISSUE,$(ISSUE))
 	@echo "→ boxd-fork-issue ISSUE=$(ISSUE)"
-	@$(BOXD_RUN) 'boxd_fork_issue "$(ISSUE)"'
+	@bash -c '$(BOXD_RUN_PREFIX) boxd_fork_issue "$(ISSUE)"'
 
 # ---------------------------------------------------------------------------
 # Connect-by-source
@@ -110,12 +116,12 @@ boxd-fork-issue:
 
 boxd-connect-pr:
 	$(call _boxd_require,PR,$(PR))
-	@$(BOXD_RUN) 'branch=$$(boxd_resolve_pr_branch "$(PR)") && boxd_connect pr "$$branch"'
+	@bash -c '$(BOXD_RUN_PREFIX) branch=$$(boxd_resolve_pr_branch "$(PR)") && boxd_connect pr "$$branch"'
 
 boxd-connect-branch:
 	$(call _boxd_require,BRANCH,$(BRANCH))
-	@$(BOXD_RUN) 'boxd_connect branch "$(BRANCH)"'
+	@bash -c '$(BOXD_RUN_PREFIX) boxd_connect branch "$(BRANCH)"'
 
 boxd-connect-issue:
 	$(call _boxd_require,ISSUE,$(ISSUE))
-	@$(BOXD_RUN) 'boxd_connect issue "$(ISSUE)"'
+	@bash -c '$(BOXD_RUN_PREFIX) boxd_connect issue "$(ISSUE)"'

--- a/compose.dev.migration.yml
+++ b/compose.dev.migration.yml
@@ -1,0 +1,18 @@
+# Overlay applied by `make quickstart migration` so contributors can run
+# `pnpm prisma migrate dev` and `pnpm clickhouse:migrate` from their host
+# shell against the local stateful stores. The base compose.dev.yml leaves
+# postgres + clickhouse without host ports for normal modes (workspace-
+# internal access only); this overlay opens them up for the migration mode.
+#
+# Usage:
+#   docker compose -f compose.dev.yml -f compose.dev.migration.yml up postgres clickhouse
+#
+# scripts/dev.sh wires this together when "migration" mode is selected.
+
+services:
+  postgres:
+    ports:
+      - "5432:5432"
+  clickhouse:
+    ports:
+      - "8123:8123"

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -33,13 +33,14 @@ x-common-env: &common-env
   COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
   NODE_ENV: development
   SKIP_TIKTOKEN: 'true'
-  DATABASE_URL: postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
-  REDIS_URL: redis://redis:6379
-  CLICKHOUSE_URL: http://default:langwatch@clickhouse:8123/langwatch
-  LANGWATCH_NLP_SERVICE: http://langwatch_nlp:5561
-  LANGEVALS_ENDPOINT: http://langevals:5562
   # Prod-like dev: IS_SAAS=true (from langwatch/.env) requires SSRF blocking.
   BLOCK_LOCAL_HTTP_CALLS: "true"
+  # NOTE: infrastructure URLs (DATABASE_URL, REDIS_URL, CLICKHOUSE_URL,
+  # LANGWATCH_NLP_SERVICE, LANGEVALS_ENDPOINT) are NOT set here. The
+  # contributor's `langwatch/.env` is the source of truth — `quickstart`
+  # writes a per-mode overlay at `langwatch/.env.dev-up` that overrides
+  # only the URLs whose services are starting locally for that mode
+  # (#3860 AC#2 / AC#6).
 
 services:
   # =============================================================================
@@ -235,6 +236,8 @@ services:
       # To enable verbose scenario SDK logging, add: SCENARIO_VERBOSE: "true"
     env_file:
       - langwatch/.env
+      - path: langwatch/.env.dev-up
+        required: false
     depends_on:
       init:
         condition: service_completed_successfully
@@ -326,6 +329,8 @@ services:
       LOG_LEVEL: "debug"
     env_file:
       - langwatch/.env
+      - path: langwatch/.env.dev-up
+        required: false
     depends_on:
       init:
         condition: service_completed_successfully

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -67,9 +67,14 @@ services:
           memory: 256m
           cpus: "0.5"
 
+  # Singleton across worktrees (#3860 AC#5). Exposed on a fixed host port so
+  # parallel worktrees reuse the same container instead of spinning up their
+  # own. Compose treats this as belonging to the first project that brings it
+  # up; subsequent `quickstart`s detect the running container and reuse it.
   redis:
     image: redis:alpine
-    # No host port - accessed via docker network as "redis:6379"
+    ports:
+      - "6379:6379"
     volumes:
       - redis-data:/data
     healthcheck:
@@ -331,17 +336,25 @@ services:
           cpus: "0.25"
 
 volumes:
+  # Stateful — shared across worktrees (#3860 AC#4 / AC#5).
+  # Sign-up persists when switching worktrees; ClickHouse traces survive too.
+  # Two worktrees can't have the same stateful container `up` simultaneously
+  # (postgres locks the volume) — `scripts/dev.sh` detects and warns.
   db-data:
-    name: ${VOLUME_PREFIX:-langwatch}-db-data
+    name: langwatch-db-data
   redis-data:
-    name: ${VOLUME_PREFIX:-langwatch}-redis-data
+    name: langwatch-redis-data
   clickhouse-data:
-    name: ${VOLUME_PREFIX:-langwatch}-clickhouse-data
+    name: langwatch-clickhouse-data
+  # Per-worktree — Linux-vs-host platform isolation per ADR-004.
+  # node_modules differs across branches with different lockfiles, so these
+  # stay namespaced.
   goose_bin:
     name: ${VOLUME_PREFIX:-langwatch}-goose-bin
   app_modules:
     name: ${VOLUME_PREFIX:-langwatch}-app-modules
-  pnpm_store:
-    name: langwatch-pnpm-store # Always shared (cache only)
   bullboard_modules:
     name: ${VOLUME_PREFIX:-langwatch}-bullboard-modules
+  # Always shared (cache only).
+  pnpm_store:
+    name: langwatch-pnpm-store

--- a/dev/docs/adr/004-docker-dev-environment.md
+++ b/dev/docs/adr/004-docker-dev-environment.md
@@ -121,3 +121,39 @@ We considered switching node_modules to bind mounts for automatic per-worktree i
 - Collapses the host/container node_modules separation (Linux ELF binaries would appear on host, breaking IDE tooling)
 
 Instead, we use per-worktree named volumes via `VOLUME_PREFIX`, which gives the same isolation without these downsides.
+
+## Amendment: Stateful volumes + entry point (2026-05, #3860)
+
+### Context
+
+The 2026-03 worktree-isolation amendment treated **every** volume as per-worktree. That worked for `node_modules` (Linux ELF deps that diverge across branches) but had two side effects:
+
+1. Sign-up state didn't persist across worktrees. Sign up `browser-test@langwatch.ai` in worktree A; switch to worktree B; the account is gone.
+2. Profiles conflated *what services exist* with *what I want containers for*. Frontend-only work doesn't actually need its own postgres / redis / clickhouse — it could share with whatever else is running.
+
+### Changes
+
+**Stateful services share volumes across worktrees.** `db-data`, `clickhouse-data`, and `redis-data` use stable names (`langwatch-db-data`, `langwatch-clickhouse-data`, `langwatch-redis-data`) — they no longer interpolate `VOLUME_PREFIX`. Sign up once, persist forever.
+
+Trade-off: only one worktree can have the same stateful container `up` at a time (postgres locks `/var/lib/postgresql/data`). `scripts/dev.sh` detects this (`check_stateful_collision`) and fails fast with a clear message pointing at the other compose project.
+
+**Redis is a singleton with a fixed host port.** `redis:alpine` exposes `:6379` on the host and uses the shared `langwatch-redis-data` volume. Parallel worktrees reuse the same redis instance.
+
+**Per-worktree volumes still apply to:** `app_modules`, `bullboard_modules`, `goose_bin`. These hold Linux-platform dependencies that vary by branch lockfile and must stay isolated.
+
+**`make quickstart` is now the single entry point.** `make dev`, `make dev-nlp`, etc. and `make dev-up` / `make dev-down` / `make dev-logs` print a deprecation warning on stderr and forward to the same compose flow for one release before being removed. New: `make quickstart-help` (or `./scripts/dev.sh help`) prints a non-interactive mode reference for agents and CI.
+
+**Fail-fast SSRF guard.** `scripts/dev.sh` errors if `langwatch/.env` has `IS_SAAS=true` with `BLOCK_LOCAL_HTTP_CALLS=false`. (Compose's runtime always sets `BLOCK_LOCAL_HTTP_CALLS=true` via `x-common-env`, but workers running outside compose / lambdas would inherit the broken combo.)
+
+### Migration
+
+Existing worktrees have stale `lw-<hash>-db-data` / `lw-<hash>-clickhouse-data` / `lw-<hash>-redis-data` volumes from the previous scheme. The first `make quickstart` after upgrading creates the new shared volumes (`langwatch-*-data`) — old volumes are not deleted automatically. To recover space:
+
+```
+docker volume ls | grep -E '^local +lw-[0-9a-f]{8}-(db|redis|clickhouse)-data'
+docker volume rm <volume-name>   # one per worktree, after confirming you don't need the data
+```
+
+### Deferred (separate follow-up)
+
+This amendment intentionally does not change the **default** of `make quickstart`. AC#2 / AC#3 of #3860 — intent-based prompting and "frontend-only → `pnpm dev` against remote dev services" — depend on remote dev services existing as a documented user-facing surface. They don't yet. A separate issue tracks that prerequisite work; until then, the existing local-services default stays.

--- a/dev/docs/adr/004-docker-dev-environment.md
+++ b/dev/docs/adr/004-docker-dev-environment.md
@@ -122,16 +122,32 @@ We considered switching node_modules to bind mounts for automatic per-worktree i
 
 Instead, we use per-worktree named volumes via `VOLUME_PREFIX`, which gives the same isolation without these downsides.
 
-## Amendment: Stateful volumes + entry point (2026-05, #3860)
+## Amendment: Stateful volumes + intent-based modes (2026-05, #3860)
 
 ### Context
 
-The 2026-03 worktree-isolation amendment treated **every** volume as per-worktree. That worked for `node_modules` (Linux ELF deps that diverge across branches) but had two side effects:
+The 2026-03 worktree-isolation amendment treated **every** volume as per-worktree, and the compose profile names (`dev`, `nlp`, `scenarios`, `full`) named *which services exist*, not *what the developer is doing*. Two side effects:
 
 1. Sign-up state didn't persist across worktrees. Sign up `browser-test@langwatch.ai` in worktree A; switch to worktree B; the account is gone.
-2. Profiles conflated *what services exist* with *what I want containers for*. Frontend-only work doesn't actually need its own postgres / redis / clickhouse — it could share with whatever else is running.
+2. Profiles conflated "what services exist" with "what URLs the app should use". The `x-common-env` anchor hard-set `DATABASE_URL` / `REDIS_URL` / etc. to local Docker network names regardless of profile, so a contributor's `.env` URLs never won — even when their intent was "I'm doing UI work, just leave my .env alone."
 
-### Changes
+### Decision
+
+**The contributor's `langwatch/.env` is the source of truth.** A new `langwatch/.env.dev-up` overlay is loaded as `env_file` AFTER `.env` and contains only the URLs whose services are starting locally for the chosen mode. `x-common-env` no longer sets infrastructure URLs.
+
+**`make quickstart` is the single entry point** with five intent-based modes:
+
+| Mode | Compose services | URLs overridden in `.env.dev-up` |
+|---|---|---|
+| `frontend-only` | (none) | (none — pure `.env`) |
+| `backend-shared` | postgres + redis + clickhouse + app + init | `DATABASE_URL`, `REDIS_URL`, `CLICKHOUSE_URL` |
+| `migration` | postgres + clickhouse on host ports (5432, 8123) | `DATABASE_URL` and `CLICKHOUSE_URL` (localhost forms) |
+| `nlp` | + langwatch_nlp + langevals | + `LANGWATCH_NLP_SERVICE`, `LANGEVALS_ENDPOINT` |
+| `full-local` | `--profile full` (workers, scenarios, bullboard, ai-server) | all five infrastructure URLs |
+
+Migration mode uses `compose.dev.migration.yml` to expose host ports so the contributor can run `pnpm prisma migrate dev` and `pnpm clickhouse:migrate` from their host shell.
+
+`make quickstart` accepts a positional mode arg (`make quickstart frontend-only`) for non-interactive runs. `make quickstart-help` (or `./scripts/dev.sh help`) prints the mode reference.
 
 **Stateful services share volumes across worktrees.** `db-data`, `clickhouse-data`, and `redis-data` use stable names (`langwatch-db-data`, `langwatch-clickhouse-data`, `langwatch-redis-data`) — they no longer interpolate `VOLUME_PREFIX`. Sign up once, persist forever.
 
@@ -141,7 +157,7 @@ Trade-off: only one worktree can have the same stateful container `up` at a time
 
 **Per-worktree volumes still apply to:** `app_modules`, `bullboard_modules`, `goose_bin`. These hold Linux-platform dependencies that vary by branch lockfile and must stay isolated.
 
-**`make quickstart` is now the single entry point.** `make dev`, `make dev-nlp`, etc. and `make dev-up` / `make dev-down` / `make dev-logs` print a deprecation warning on stderr and forward to the same compose flow for one release before being removed. New: `make quickstart-help` (or `./scripts/dev.sh help`) prints a non-interactive mode reference for agents and CI.
+**Deprecated targets** (`make dev`, `dev-nlp`, `dev-scenarios`, `dev-test`, `dev-full`, and `dev-up` / `dev-down` / `dev-logs`) print a deprecation warning and forward to the corresponding `quickstart` mode for one release before being removed.
 
 **Fail-fast SSRF guard.** `scripts/dev.sh` errors if `langwatch/.env` has `IS_SAAS=true` with `BLOCK_LOCAL_HTTP_CALLS=false`. (Compose's runtime always sets `BLOCK_LOCAL_HTTP_CALLS=true` via `x-common-env`, but workers running outside compose / lambdas would inherit the broken combo.)
 
@@ -154,6 +170,4 @@ docker volume ls | grep -E '^local +lw-[0-9a-f]{8}-(db|redis|clickhouse)-data'
 docker volume rm <volume-name>   # one per worktree, after confirming you don't need the data
 ```
 
-### Deferred (separate follow-up)
-
-This amendment intentionally does not change the **default** of `make quickstart`. AC#2 / AC#3 of #3860 — intent-based prompting and "frontend-only → `pnpm dev` against remote dev services" — depend on remote dev services existing as a documented user-facing surface. They don't yet. A separate issue tracks that prerequisite work; until then, the existing local-services default stays.
+If you previously relied on `x-common-env`'s implicit `DATABASE_URL` / `REDIS_URL` / `CLICKHOUSE_URL` overrides, those moved to `langwatch/.env.dev-up` written by `quickstart`. Running `make dev` (deprecated alias for `quickstart backend-shared`) keeps the same effective behavior.

--- a/dev/docs/boxd-makefile.md
+++ b/dev/docs/boxd-makefile.md
@@ -1,0 +1,111 @@
+# boxd workflows (`boxd.mk`)
+
+`boxd.mk` is a Makefile of multi-step orchestration over the [boxd](https://docs.boxd.sh) CLI. It exists for flows that need more than one boxd command — single-command operations stay on the CLI.
+
+> **Targets here orchestrate multi-step flows. For single-command operations, use the `boxd` CLI directly.**
+
+If you find yourself adding a target that wraps a single `boxd ...` call, don't — that's maintenance debt for no value. The exception (and only exception) is `boxd-connect-*`, which centralizes the slug → VM-name → tmux-session-name resolution shared with the fork-* targets.
+
+## Prerequisites
+
+- `boxd` CLI on `$PATH` (use the external CLI on your laptop; this Makefile is invoked from your local checkout, not from inside a VM).
+- `gh` CLI authenticated (`gh auth status`) — needed to resolve PR head refs and issue titles.
+- A working git checkout of `langwatch/langwatch`.
+- (Recommended) the existing `langwatch-golden` VM, created once via `make boxd-golden`.
+
+## Quick reference
+
+```
+make boxd-help                       # full target list with one-line descriptions
+make boxd-golden                     # create the canonical base VM (langwatch-golden)
+make boxd-golden-reset BOXD_FORK_YES=1  # destroy + rebuild the golden
+make boxd-fork-pr PR=1234            # fork golden for an existing PR
+make boxd-fork-branch BRANCH=feat/foo # fork golden for a branch
+make boxd-fork-issue ISSUE=123       # fork + worktree branch + tmux+claude in VM
+make boxd-connect-pr PR=1234         # SSH + tmux attach to the matching VM
+make boxd-connect-branch BRANCH=feat/foo
+make boxd-connect-issue ISSUE=123
+```
+
+## Naming
+
+| Source | VM name | tmux session |
+|---|---|---|
+| `fork-pr PR=N` | `langwatch-<slug(branch)>` | `claude-<slug(branch)>` |
+| `fork-branch BRANCH=X` | `langwatch-<slug(X)>` | `claude-<slug(X)>` |
+| `fork-issue ISSUE=N` | `langwatch-issue<N>` (literal) | `claude-issue<N>` |
+
+Slug rules: lowercase, replace `/` and non-`[a-z0-9-]` with `-`, collapse `-`, trim, max 40 chars (truncate, no word-boundary cut).
+
+Collision: `boxd-fork-branch BRANCH=issue42/foo` produces `langwatch-issue42-foo` — distinct from `boxd-fork-issue ISSUE=42`'s `langwatch-issue42`. The branch target prints a friendly nudge to use `fork-issue` if you didn't mean to.
+
+## What each fork target does
+
+1. Resolve the source-of-truth (PR head ref via `gh`, branch name as-is, issue title via `gh`).
+2. Build VM name + tmux session name.
+3. `boxd fork langwatch-golden --name=<vm>`.
+4. Inside the VM: `git fetch origin && git checkout <branch>` (or detached head for cross-fork PRs).
+5. Upload Claude credentials (default `~/.claude/.credentials.json`; override via `CLAUDE_CREDS=`).
+6. Discover all `.env` files in the monorepo and upload each, with stale-localhost values rewritten to point at the VM's proxy URL.
+7. Map ports: default proxy → `:5560`, plus subdomains for aigw (5563), bullboard (6380), ai-server (3456), next (3000).
+8. **For `fork-issue` only:** start a tmux session inside the VM running `claude --dangerously-skip-permissions`.
+
+## Connecting
+
+`boxd-connect-*` SSHes via `boxd connect <vm>` and `tmux attach -t <session>`. If the VM is suspended (boxd auto-suspend), it's woken first. If the VM doesn't exist, you get a clear message and a non-zero exit. If the tmux session is missing, ditto.
+
+## Customizing
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `CLAUDE_CREDS` | `~/.claude/.credentials.json` | Path to the file `boxd cp`-ed into the fork |
+| `BOXD_FORK_YES` | unset | Set to `1` to skip the destructive-confirm on `boxd-golden-reset` |
+| `BOXD_BIN` | `boxd` | Override the `boxd` binary (used by tests) |
+| `GH_BIN` | `gh` | Override the `gh` binary (used by tests) |
+
+## Threat model — forks are trusted-developer environments
+
+Forks receive every `.env` in the monorepo plus your Claude credentials. **Anyone with SSH access to a fork can read those secrets.** Forks are NOT for sharing across teams or external collaborators. If that ever changes, this design needs to revisit secret transport.
+
+## Golden VM staleness
+
+`langwatch-golden` is a single fixed-name VM (not a versioned image family). Reset = destroy + rebuild via `make boxd-golden-reset BOXD_FORK_YES=1`. The Makefile does **not** auto-rebuild.
+
+Recommended cadence: rebuild **weekly**, or after any of:
+- `pnpm-lock.yaml` change you want pre-installed
+- Docker image bump (compose.dev.yml)
+- Schema migration that changes seed data
+- New top-level subproject added
+
+## Seed step
+
+`boxd-golden` calls a `seed-golden` hook target. The default `seed-golden` is a no-op that prints a hint. Override it locally (in a `Makefile.local` you `include` from `Makefile`) to seed users / projects / sample traces. Implementation of a shared seed script is out of scope for this Makefile — see `make quickstart` work.
+
+## Troubleshooting
+
+**`boxd fork` fails with quota error.** You're at the 10-VM ceiling. `boxd list` to see what you have, `boxd destroy <vm>` to free a slot. Fork pruning is intentionally manual (see "Out of scope" below).
+
+**`make boxd-fork-issue ISSUE=N` says the VM already exists.** Pick a different source, or destroy the existing VM:
+```
+boxd destroy langwatch-issueN
+```
+
+**`make boxd-connect-issue` says "no claude session".** The tmux session inside the VM was killed (or the VM was rebooted, which clears tmux state). Either re-run `make boxd-fork-issue` (idempotent on the worktree) or SSH in manually:
+```
+boxd connect langwatch-issueN
+tmux new -s claude-issueN
+```
+
+**Stale localhost URL slipped through the rewrite.** Add the key to the allowlist in `scripts/boxd-fork.sh` (`boxd_rewrite_env`). The current allowlist: any `localhost:<port>` or `127.0.0.1:<port>` value, with `LW_GATEWAY_BASE_URL` routing to `aigw.<vm>.boxd.sh` and everything else routing to the default proxy.
+
+**Git auth doesn't work inside the fork.** The host's git uses `credential.https://github.com.helper=boxd` — boxd ships a credential helper that the golden image inherits. If your laptop has a different setup, `git push` from inside the fork will prompt for credentials. Workaround: `boxd connect <vm>` and run `gh auth login`.
+
+**"Claude credentials not found at …".** Set `CLAUDE_CREDS=/path/to/credentials.json` or run `claude login` inside the fork after fork-up.
+
+## Out of scope
+
+- **Seed script implementation** (belongs with `make quickstart` work — separate issue).
+- **AWS-shared-postgres mode** for forks. If your team prefers shared DB, point your fork's `DATABASE_URL` there post-fork.
+- **Convenience wrappers around single CLI calls** — use `boxd list`, `boxd destroy`, `boxd info`, `boxd ssh` directly.
+- **Fork pruning / lifecycle management.** Closed-PR / merged-branch fork cleanup is a known follow-up (filed as a separate issue). Until then, run `boxd list` periodically and `boxd destroy` what you don't need.
+- **Sharing forks across teams / external collaborators.** See threat model.

--- a/dev/docs/plans/issue3891-3860-dev-env-rework.md
+++ b/dev/docs/plans/issue3891-3860-dev-env-rework.md
@@ -6,24 +6,40 @@
 
 ## Bundling decision
 
-**Verdict: keep bundled, but defer one slice of #3860 to a follow-up.**
+**Verdict: keep bundled, full scope of both issues.**
 
-#3891 is fully spec'd and unblocked. #3860 has an open question Drew himself wrote — *"Are remote dev services already provisioned and reachable?"* — and the answer is **no, not as a documented user-facing surface**. That blocks #3860 AC2 (intent-based mode prompting) and AC3 (frontend-only default = `pnpm dev` against remote dev). Without that infrastructure, "remote-by-default for stateless deps" is a UX promise that doesn't yet have a backing service.
+Re-scoped 2026-05-06 after Drew's clarification:
 
-What the bundle keeps from #3860:
-- AC1: `make quickstart` becomes the single entry point. `make dev*` and `make dev-up` survive as deprecation-warning thin wrappers for one release.
-- AC4: stateful volumes (`db-data`, `clickhouse-data`, opensearch if/when added) drop the per-worktree `${VOLUME_PREFIX}` and use stable shared names — sign-up persists across worktrees.
-- AC5: redis becomes a singleton (stable shared name + fixed exposed host port).
-- AC7 (subset): idempotency, fail-fast on `IS_SAAS=true && BLOCK_LOCAL_HTTP_CALLS!=true`, `make down` doesn't nuke shared singletons.
-- AC8 (subset): one-line hint per mode in the existing chooser; `make quickstart help` prints modes non-interactively.
-- AC9: deprecation warnings on `make dev*` / `make dev-up`.
-- AC10: no CI regression (CI uses raw `docker compose -f compose.dev.yml up` with `--profile`, which keeps working).
+> *"default to remote" really just means "default to whatever is in `.env`, everything else is an override." Profiles are URL-rewrite overrides on top of the contributor's existing `.env`. There is no shared remote dev backend to stand up — that was a misread of the spec.*
 
-What's **deferred** to a follow-up issue (filed in PR body):
-- AC2/AC3 intent-based prompting + `pnpm dev` against remote dev as the default. Needs the remote-dev infra question answered first.
-- AC6 (URL-rewrite-on-profile-flip) — requires an answered remote question to be coherent. The current `pnpm dev` localhost story still works, and developers can still set the env var manually.
+So #3860 AC2 / AC3 / AC6 are **back in scope**. The mental model:
 
-This trims the surface enough to ship together without holding #3891 hostage to infrastructure work.
+- **Contributor's `langwatch/.env` is the source of truth** for non-overridden URLs.
+- **Each mode is a URL-rewrite preset** — it controls (a) which compose services start and (b) which URLs in env get rewritten to localhost (overriding the `.env` value).
+- "default to remote" = "leave `.env` alone unless a mode explicitly overrides".
+
+Implementation: a `langwatch/.env.dev-up` overlay file is loaded LAST as `env_file` in the relevant services. Compose's `x-common-env` no longer hard-sets `DATABASE_URL` / `REDIS_URL` / `CLICKHOUSE_URL` / `LANGWATCH_NLP_SERVICE` / `LANGEVALS_ENDPOINT` — those come from `langwatch/.env` by default and are overridden by `.env.dev-up` when a mode wants the local container.
+
+Mode → (services, URL overrides):
+
+| Mode | Compose services | URL overrides written to `.env.dev-up` |
+|---|---|---|
+| `frontend-only` | (no compose) | (none — pure `pnpm dev` against `.env`) |
+| `backend-shared` | postgres + redis + clickhouse + app + init | `DATABASE_URL`, `REDIS_URL`, `CLICKHOUSE_URL` |
+| `migration` | postgres + clickhouse (host-ports exposed) | `DATABASE_URL`, `CLICKHOUSE_URL` (localhost forms) |
+| `nlp` | + langwatch_nlp + langevals | + `LANGWATCH_NLP_SERVICE`, `LANGEVALS_ENDPOINT` |
+| `full-local` | `--profile full` (everything) | all five |
+
+Migration mode uses a `compose.dev.migration.yml` overlay that adds host port mappings to postgres + clickhouse so the contributor can run `pnpm prisma migrate dev` and `pnpm clickhouse:migrate` from their host shell.
+
+`make quickstart` accepts a positional mode arg for non-interactive usage: `make quickstart frontend-only`, `make quickstart backend-shared`, etc. `make quickstart help` continues to print the mode reference.
+
+Deprecated targets (`make dev*` / `make dev-up`) become thin shims onto the new modes:
+- `make dev` → `backend-shared`
+- `make dev-nlp` → `nlp`
+- `make dev-scenarios` → `full-local`
+- `make dev-test` → `full-local`
+- `make dev-full` → `full-local`
 
 ## Investigation answers (#3860 open questions)
 
@@ -309,12 +325,12 @@ fi
 | AC | Where addressed | Status |
 |---|---|---|
 | 1 (single entry point) | `Makefile` deprecation wrappers, `CLAUDE.md`, `ADR-004` | done |
-| 2 (intent-based prompting) | — | **deferred** (needs remote dev infra answer) |
-| 3 (default = fastest path / pnpm dev remote) | — | **deferred** (same) |
+| 2 (intent-based prompting) | `scripts/dev.sh` 5-mode prompt | done |
+| 3 (default = fastest path) | `frontend-only` mode = no compose, ~instant | done |
 | 4 (stateful shared volumes + collision detection) | `compose.dev.yml`, `scripts/dev.sh` | done |
 | 5 (redis singleton + host port) | `compose.dev.yml` | done |
-| 6 (URL rewrite on profile flip) | — | **deferred** (couples to AC2/3) |
-| 7 (idempotent + fail-fast IS_SAAS guard) | `scripts/dev.sh` | done (subset) |
+| 6 (URL rewrite on profile flip) | `scripts/dev.sh` writes `langwatch/.env.dev-up` per mode; `compose.dev.yml` honours it via env_file overlay | done |
+| 7 (idempotent + fail-fast IS_SAAS guard) | `scripts/dev.sh` | done |
 | 8 (per-mode hints + `quickstart help`) | `scripts/dev.sh` | done |
 | 9 (deprecation warnings on old paths) | `Makefile`, `CLAUDE.md`, `ADR-004` | done |
 | 10 (no CI regressions, `pnpm test:*` pass) | verified by running typecheck + test:unit | gate |

--- a/dev/docs/plans/issue3891-3860-dev-env-rework.md
+++ b/dev/docs/plans/issue3891-3860-dev-env-rework.md
@@ -1,0 +1,360 @@
+# Plan: boxd Makefile + quickstart rework (issues #3891 + #3860)
+
+**Branch:** `issue3891/boxd-mk-and-quickstart-rework`
+**Bundles:** [#3891](https://github.com/langwatch/langwatch/issues/3891) + [#3860](https://github.com/langwatch/langwatch/issues/3860)
+**Owner:** Drew (autonomy-delegated to Claude)
+
+## Bundling decision
+
+**Verdict: keep bundled, but defer one slice of #3860 to a follow-up.**
+
+#3891 is fully spec'd and unblocked. #3860 has an open question Drew himself wrote — *"Are remote dev services already provisioned and reachable?"* — and the answer is **no, not as a documented user-facing surface**. That blocks #3860 AC2 (intent-based mode prompting) and AC3 (frontend-only default = `pnpm dev` against remote dev). Without that infrastructure, "remote-by-default for stateless deps" is a UX promise that doesn't yet have a backing service.
+
+What the bundle keeps from #3860:
+- AC1: `make quickstart` becomes the single entry point. `make dev*` and `make dev-up` survive as deprecation-warning thin wrappers for one release.
+- AC4: stateful volumes (`db-data`, `clickhouse-data`, opensearch if/when added) drop the per-worktree `${VOLUME_PREFIX}` and use stable shared names — sign-up persists across worktrees.
+- AC5: redis becomes a singleton (stable shared name + fixed exposed host port).
+- AC7 (subset): idempotency, fail-fast on `IS_SAAS=true && BLOCK_LOCAL_HTTP_CALLS!=true`, `make down` doesn't nuke shared singletons.
+- AC8 (subset): one-line hint per mode in the existing chooser; `make quickstart help` prints modes non-interactively.
+- AC9: deprecation warnings on `make dev*` / `make dev-up`.
+- AC10: no CI regression (CI uses raw `docker compose -f compose.dev.yml up` with `--profile`, which keeps working).
+
+What's **deferred** to a follow-up issue (filed in PR body):
+- AC2/AC3 intent-based prompting + `pnpm dev` against remote dev as the default. Needs the remote-dev infra question answered first.
+- AC6 (URL-rewrite-on-profile-flip) — requires an answered remote question to be coherent. The current `pnpm dev` localhost story still works, and developers can still set the env var manually.
+
+This trims the surface enough to ship together without holding #3891 hostage to infrastructure work.
+
+## Investigation answers (#3860 open questions)
+
+1. **Are remote dev services provisioned?** No documented endpoint. CI uses isolated localhost services (see `.github/workflows/langwatch-app-ci.yml`); there's no shared `dev.langwatch.ai`-style backend a contributor can point at. Conclusion: filing a separate prerequisite issue.
+2. **Should `quickstart help` exist non-interactively?** Yes — cheap to add, gives docs/agents a parseable surface. Format: `make quickstart help` prints mode → service-set table.
+3. **Clickhouse — per-worktree state worth isolating?** No. ClickHouse data is observability spans, scoped by `TenantId`. Two worktrees sharing CH data means dev traces co-mingle in the same store, which is mildly confusing but not corrupting. The user-account / sign-up problem is in **postgres**, not CH. Treating CH as stateful-shared (same as postgres) keeps the model simple — same default everywhere.
+4. **Boxd ↔ quickstart interaction?** A boxd VM is a single workspace. The worktree-isolation logic in `dev.sh` (`COMPOSE_PROJECT_NAME` derived from `basename`) is a no-op when there's only one checkout. Inside a boxd VM, the shared stable volume names just work — no special-casing needed beyond what the volume rename already gives us.
+
+## Scope split
+
+### #3891 — boxd.mk
+
+| Deliverable | File |
+|---|---|
+| Make targets | `boxd.mk` (new), `Makefile` (include) |
+| Pure shell helpers (slug, env discovery, hostname rewrite) | `scripts/boxd-fork.sh` (new) |
+| Unit + integration tests for helpers | `scripts/__tests__/boxd-fork.unit.bats` (new), `scripts/__tests__/boxd-fork.integration.bats` (new) |
+| Docs (philosophy, target reference, troubleshooting, threat model) | `dev/docs/boxd-makefile.md` (new) |
+| BDD spec for verifiable behavior | `specs/setup/boxd-fork-vm.feature` (new, `@unimplemented` per repo convention) |
+
+### #3860 — quickstart rework (subset)
+
+| Deliverable | File |
+|---|---|
+| Stable named volumes for stateful services + singleton redis with host port | `compose.dev.yml` (edit) |
+| `quickstart help` non-interactive mode + per-mode hint + fail-fast on env mismatch + idempotency notes | `scripts/dev.sh` (edit) |
+| Deprecation wrappers around `make dev*` and `make dev-up` | `Makefile` (edit) |
+| Updated dev section + new entry point | `CLAUDE.md` (edit), `dev/docs/adr/004-docker-dev-environment.md` (amendment) |
+| BDD spec for new behavior | `specs/setup/quickstart-entry-point.feature` (new, `@unimplemented`) |
+
+## boxd.mk design
+
+### File layout
+
+```
+boxd.mk                       # Make targets (orchestration only)
+scripts/boxd-fork.sh          # Shell helpers (pure-ish: slug, env discovery, hostname rewrite, env-cp, port mapping)
+scripts/__tests__/boxd-fork.unit.bats        # tests for slugifier, env discovery, hostname rewrite
+scripts/__tests__/boxd-fork.integration.bats # tests with mocked boxd, gh, git
+dev/docs/boxd-makefile.md     # human-facing docs
+specs/setup/boxd-fork-vm.feature # behavior spec (unimplemented stub)
+```
+
+The targets are thin orchestrators that source `scripts/boxd-fork.sh` and call its functions. This keeps the Makefile readable and makes the slug/env/rewrite logic unit-testable with bats.
+
+### Slugifier — exact spec
+
+Per #3891 AC#13:
+
+```bash
+boxd_slug() {
+  local input="$1"
+  local s
+  s=$(printf '%s' "$input" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's#/+#-#g; s/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-+//; s/-+$//')
+  # truncate to 40 chars (no word-boundary cut)
+  if [ "${#s}" -gt 40 ]; then
+    s="${s:0:40}"
+    s="${s%-}"
+  fi
+  printf '%s' "$s"
+}
+```
+
+Examples (asserted in unit tests):
+- `feat/Foo Bar!` → `feat-foo-bar`
+- `issue3891/boxd-mk-and-quickstart-rework` → `issue3891-boxd-mk-and-quickstart-rework`
+- 60-char input → truncated to ≤40, no trailing `-`.
+
+Distinct from `scripts/worktree.sh::generate_slug` (50 chars, word-boundary truncation): `worktree.sh` makes branch names from titles; `boxd-fork.sh` makes VM names from already-slug-shaped branches. Different concerns; not unifying yet.
+
+### Naming
+
+| Target | VM name | tmux session |
+|---|---|---|
+| `boxd-golden` | `langwatch-golden` | n/a |
+| `boxd-fork-pr PR=N` | `langwatch-<branch_slug(PR.head)>` | `claude-<branch_slug>` |
+| `boxd-fork-branch BRANCH=B` | `langwatch-<branch_slug(B)>` | `claude-<branch_slug>` |
+| `boxd-fork-issue ISSUE=N` | **always** `langwatch-issue<N>` (literal) | `claude-issue<N>` |
+
+Collision rule (AC#14): `fork-branch BRANCH=issue42/foo` produces `langwatch-issue42-foo`, distinct from `fork-issue ISSUE=42` (`langwatch-issue42`). If a branch slug starts with `issue<N>-`, the target prints a friendly nudge to use `fork-issue` instead, but doesn't block.
+
+### `.env` discovery
+
+```bash
+# Glob-walk repo root, filter by allowlist + blocklist
+boxd_env_files() {
+  git ls-files -co --exclude-standard \
+    | grep -E '(^|/)\.env($|\.[^/]*$)' \
+    | grep -vE '\.(example|template|sample|local)$' \
+    | grep -vE '(^|/)(node_modules|\.next|dist|build|\.git|vendor|coverage)/' \
+    || true
+}
+```
+
+Using `git ls-files -co --exclude-standard` instead of `find` so we honour `.gitignore`. `.env` itself is gitignored by repo convention but `-c` (cached) catches anything tracked, `-o` (other) catches untracked-but-not-ignored — wait, `.env` is git-ignored. Need `-co --exclude-standard` *plus* explicit `--others --include=.env` semantics. Actually simpler: `find . -name '.env' -not -path '*/node_modules/*' …` — same idea with explicit excludes per AC#24.
+
+Decision: use `find` with explicit excludes, since `.env` files are gitignored and would not show up in `git ls-files`.
+
+```bash
+boxd_env_files() {
+  find . \
+    -type d \( -name node_modules -o -name .next -o -name dist -o -name build \
+              -o -name .git -o -name vendor -o -name coverage \) -prune \
+    -o -type f -name '.env' -print
+}
+```
+
+### Hostname rewrite
+
+Allowlist (AC#26):
+- Exact key match: `NEXTAUTH_URL`, `BASE_HOST`, `LW_GATEWAY_BASE_URL`
+- Value pattern match: `localhost:<port>` and `127.0.0.1:<port>`
+
+For `langwatch-issue3891`:
+- `NEXTAUTH_URL`/`BASE_HOST` → `https://langwatch-issue3891.boxd.sh`
+- `LW_GATEWAY_BASE_URL` → `https://aigw.langwatch-issue3891.boxd.sh`
+- Any `localhost:<port>` value → `https://<port-subdomain>.langwatch-issue3891.boxd.sh` *only if a corresponding port mapping exists*; otherwise leave alone with a warning.
+
+Implementation: pure-bash awk-style line filter, applied to each `.env` file before it's `boxd cp`-ed.
+
+### Port mapping
+
+Per AC#27 + extension informed by #3860's port discussion:
+
+| Subdomain | Internal port | Source |
+|---|---|---|
+| (default proxy) | 5560 | langwatch app (compose) |
+| `aigw.<vm>` | 5563 | AI gateway (Go service) |
+| `bullboard.<vm>` | 6380 | bullboard |
+| `ai-server.<vm>` | 3456 | ai test server |
+
+`boxd-fork-*` calls `boxd proxy set-port --port=5560` once + `boxd proxy new <name> --port=<n>` for each subdomain. Idempotent — `proxy new` on existing returns success.
+
+### Credentials transport
+
+`boxd cp ~/.claude/.credentials.json langwatch-<slug>:.claude/.credentials.json`
+
+Path is a parameter (AC#22): `CLAUDE_CREDS=/path/to/credentials.json` overrides default. If the path doesn't exist, the target prints clear next-steps and exits non-zero.
+
+### Git auth
+
+Confirmed: the host's git uses `credential.https://github.com.helper=boxd` — boxd has a built-in credential helper. Forks inherit this from the golden image. AC#23 satisfied with no extra work.
+
+### connect-* targets
+
+```make
+boxd-connect-issue:
+	@vm="langwatch-issue$(ISSUE)"; tmux="claude-issue$(ISSUE)"; \
+	  $(BOXD_CONNECT) "$$vm" "$$tmux"
+```
+
+`BOXD_CONNECT` is a function in `scripts/boxd-fork.sh` that:
+1. Checks VM exists (`boxd list --json | jq …`); error+exit if not (AC#19)
+2. If suspended, runs `boxd resume <vm>` and waits for ready (AC#20)
+3. SSHes via `boxd connect <vm>` and runs `tmux attach -t <tmux>` — with a fallback if the session isn't there (AC#18: clear message + nonzero exit, no attach into nothing)
+
+## #3860 design (subset)
+
+### compose.dev.yml volume changes
+
+```yaml
+volumes:
+  # Stateful — shared across worktrees + boxd VMs (AC4)
+  db-data:
+    name: langwatch-db-data
+  clickhouse-data:
+    name: langwatch-clickhouse-data
+  # Stateless — singleton (AC5)
+  redis-data:
+    name: langwatch-redis-data
+  # Per-worktree (Linux-vs-host platform isolation, see ADR-004)
+  app_modules:
+    name: ${VOLUME_PREFIX:-langwatch}-app-modules
+  bullboard_modules:
+    name: ${VOLUME_PREFIX:-langwatch}-bullboard-modules
+  goose_bin:
+    name: ${VOLUME_PREFIX:-langwatch}-goose-bin
+  pnpm_store:
+    name: langwatch-pnpm-store    # already shared
+```
+
+Plus expose redis on a fixed host port (AC5):
+```yaml
+redis:
+  ports:
+    - "6379:6379"
+```
+
+### Cross-worktree collision (AC4)
+
+Two worktrees can both `up` postgres simultaneously — they'd both bind the container to the same volume, but only one can have the container *up* at a time per the AC ("Only one worktree can have a given stateful container `up` at a time"). Compose project name (`COMPOSE_PROJECT_NAME`) is still per-worktree, so the *container* name is unique, but the underlying volume is shared.
+
+Wait — that's wrong. If two compose projects both create a container named `langwatch-issue123-postgres` and `langwatch-issue456-postgres`, both binding `/var/lib/postgresql/data` to volume `langwatch-db-data`, postgres will refuse to start the second one (lock file). That's actually the desired behavior — the second `quickstart` errors clearly.
+
+`scripts/dev.sh` adds detection: before `up`, check if any container named `*-postgres` is running with the shared volume mounted. If yes, print a clear message: *"postgres is already up in another worktree (project=<other>). Stop it first or reuse it."*
+
+### Quickstart help
+
+```
+make quickstart help
+
+LangWatch development environment
+
+  Modes:
+    dev              postgres + redis + clickhouse + app
+    dev-nlp          + nlp + langevals
+    dev-scenarios    + scenario worker + bullboard + nlp
+    dev-test         + ai test server
+    dev-full         everything
+
+  Stateful services share data across worktrees (langwatch-db-data, langwatch-clickhouse-data).
+  Redis is a singleton on host :6379.
+```
+
+Implemented by checking `$1` in `scripts/dev.sh`: if it's `help`, print and exit.
+
+### Deprecation wrappers in Makefile
+
+```make
+dev: _dev-deprecation-warning
+	@$(SANITIZE_DEV_ENV) && $(COMPOSE) up
+
+_dev-deprecation-warning:
+	@printf '\033[33m[deprecated] make dev → make quickstart\033[0m\n' >&2
+	@printf 'See: dev/docs/adr/004-docker-dev-environment.md\n' >&2
+```
+
+One release of grace. Filing a follow-up to remove.
+
+### Fail-fast in dev.sh
+
+```bash
+# Inside ensure_prepared, before docker up:
+if grep -qE '^IS_SAAS\s*=\s*"?true"?\s*$' langwatch/.env 2>/dev/null \
+   && ! grep -qE '^BLOCK_LOCAL_HTTP_CALLS\s*=\s*"?true"?\s*$' langwatch/.env 2>/dev/null; then
+  echo "ERROR: IS_SAAS=true requires BLOCK_LOCAL_HTTP_CALLS=true (SSRF guard)" >&2
+  exit 1
+fi
+```
+
+(`compose.dev.yml`'s common-env already sets `BLOCK_LOCAL_HTTP_CALLS: "true"` so this is a defense-in-depth check on the source `.env`, not the runtime.)
+
+## AC → task mapping
+
+### #3891 (boxd Makefile) — 29 ACs
+
+| AC | Where addressed |
+|---|---|
+| 1 (boxd.mk + include) | `boxd.mk`, `Makefile` |
+| 2 (target list) | `boxd.mk` |
+| 3 (philosophy line in help) | `boxd.mk` `help` target |
+| 4 (each target prints intent + confirm destructive) | `boxd.mk` per-target |
+| 5 (golden VM pre-warmed) | `boxd-golden` calls `make dev-full` inside the VM via `boxd exec` |
+| 6 (golden-reset) | `boxd.mk` |
+| 7 (seed hook) | `boxd.mk` defines empty `seed-golden:` target documented as override-me |
+| 8 (staleness ops doc) | `dev/docs/boxd-makefile.md` |
+| 9 (naming convention) | `scripts/boxd-fork.sh` |
+| 10 (single fork primitive) | `_boxd-fork-impl` make target shared across pr/branch/issue |
+| 11 (fork has branch checked out + ready) | impl |
+| 12 (fork-issue creates worktree branch + tmux+claude inside VM) | impl |
+| 13 (slugifier spec) | `scripts/boxd-fork.sh::boxd_slug` + bats tests |
+| 14 (collision rule) | impl + warning |
+| 15 (existing-worktree behavior) | impl: idempotent reuse, error on existing VM |
+| 16 (cross-fork PRs via gh) | impl |
+| 17 (connect targets share resolution) | shared functions |
+| 18 (clear msg if tmux missing) | impl |
+| 19 (clear msg if VM missing) | impl |
+| 20 (wake suspended VM) | impl: `boxd resume` + readiness wait |
+| 21 (single source of truth resolution) | shared `boxd_vm_name`, `boxd_tmux_name` functions |
+| 22 (CLAUDE_CREDS path param) | impl |
+| 23 (git auth via boxd credential helper) | confirmed; documented |
+| 24 (env glob excludes) | impl, tested |
+| 25 (same-key precedence: each .env separate) | impl: cp preserves paths |
+| 26 (hostname-rewrite allowlist) | impl, tested |
+| 27 (ports 3000, 5563, others) | impl |
+| 28 (dev/docs/ entry) | `dev/docs/boxd-makefile.md` |
+| 29 (make help grep-able) | `boxd.mk` `help` target |
+
+### #3860 (quickstart) — 10 ACs
+
+| AC | Where addressed | Status |
+|---|---|---|
+| 1 (single entry point) | `Makefile` deprecation wrappers, `CLAUDE.md`, `ADR-004` | done |
+| 2 (intent-based prompting) | — | **deferred** (needs remote dev infra answer) |
+| 3 (default = fastest path / pnpm dev remote) | — | **deferred** (same) |
+| 4 (stateful shared volumes + collision detection) | `compose.dev.yml`, `scripts/dev.sh` | done |
+| 5 (redis singleton + host port) | `compose.dev.yml` | done |
+| 6 (URL rewrite on profile flip) | — | **deferred** (couples to AC2/3) |
+| 7 (idempotent + fail-fast IS_SAAS guard) | `scripts/dev.sh` | done (subset) |
+| 8 (per-mode hints + `quickstart help`) | `scripts/dev.sh` | done |
+| 9 (deprecation warnings on old paths) | `Makefile`, `CLAUDE.md`, `ADR-004` | done |
+| 10 (no CI regressions, `pnpm test:*` pass) | verified by running typecheck + test:unit | gate |
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Stable shared `db-data` volume conflicts with someone's existing per-worktree volume | High (everyone has stale `lw-<hash>-db-data`) | Migration note in ADR-004 amendment + `make quickstart` prints warning if old volumes detected |
+| `boxd.mk` external-vs-internal CLI surface drift (issue calls out both) | Med | Use only commands that exist in both: `info`, `list`, `new`, `fork`, `exec`, `cp`, `proxy`, `connect`, `pause`, `resume`, `destroy`. No `local` / `auto-suspend` calls |
+| Bats tests don't run in CI (no workflow runs them) | Low | They run locally for the slugifier + env helpers; integration via @unimplemented spec for parity tracking |
+| Fork pruning is out of scope but the user's quota fills up | Low | Documented in `dev/docs/boxd-makefile.md`; follow-up issue filed |
+| `make dev` deprecation warning breaks someone's muscle-memory workflow | Med | Warning is on stderr only; command still works for one release |
+| Compose project name collision between worktrees with shared db-data | Med (this is the AC) | Detect via `docker ps` + clear error in `dev.sh`. Document in CLAUDE.md |
+| The `boxd-fork-issue` flow assumes the developer's laptop has `worktree.sh` and the repo cloned | Low | This is the existing dev environment — same precondition as `make worktree` already imposes |
+| Time pressure compresses #3860 scope further | Med | The deferred slice is documented in PR body + a follow-up issue is filed |
+
+## Test strategy
+
+- **`scripts/__tests__/boxd-fork.unit.bats`** — slugifier (5 cases per AC#13), `boxd_vm_name`, `boxd_tmux_name`, env-file discovery, hostname rewrite (allowlist + value-pattern + leave-alone)
+- **`scripts/__tests__/boxd-fork.integration.bats`** — fork-pr/branch/issue with mocked `boxd`, `gh`, `git`. Asserts the orchestration order: resolve → fork → cp creds → cp envs → proxy new → exec tmux. Same mocking pattern as `worktree.integration.bats`.
+- **`specs/setup/boxd-fork-vm.feature`** — `@unimplemented` BDD scenarios mirroring the bats tests for parity tracking.
+- **`specs/setup/quickstart-entry-point.feature`** — `@unimplemented` BDD scenarios for the deprecation, help-mode, and shared-volume behavior.
+- **No JS/TS tests added** — neither feature touches TS code paths. `pnpm typecheck` and `pnpm test:unit` run only as regression gates (AC10 of #3860).
+- **Manual end-to-end** — once the boxd CLI surface is in place, run `make boxd-fork-issue ISSUE=3891` from the laptop and verify the fork comes up. **Will not block PR merge** — surface in PR body if the VM env doesn't allow this.
+
+## Implementation order
+
+1. ✅ Investigation (this doc)
+2. Branch + git config
+3. `scripts/boxd-fork.sh` skeleton + slugifier + bats unit tests (TDD)
+4. `boxd.mk` skeleton + golden + connect-* targets
+5. fork-* targets including env discovery, hostname rewrite, creds transport, port mapping
+6. Bats integration tests (mocked boxd)
+7. `compose.dev.yml` shared-volume changes + redis host port
+8. `scripts/dev.sh` help mode + per-mode hints + idempotency / fail-fast / collision detection
+9. `Makefile` deprecation wrappers
+10. `CLAUDE.md` + `ADR-004` updates
+11. `dev/docs/boxd-makefile.md`
+12. `specs/setup/boxd-fork-vm.feature` + `specs/setup/quickstart-entry-point.feature`
+13. `pnpm typecheck` + `pnpm test:unit` regression gate
+14. Open PR, request review from `rogeriochaves`
+15. Drive CI green; surface any blockers

--- a/python-sdk/tests/e2e/test_platform_experiment_e2e.py
+++ b/python-sdk/tests/e2e/test_platform_experiment_e2e.py
@@ -40,6 +40,13 @@ def mock_platform_run():
 @pytest.mark.e2e
 class TestErrorHandling:
     def test_raises_experiment_not_found_for_non_existent_slug(self):
+        # Needs a valid LANGWATCH_API_KEY in env: with no key, run() raises
+        # ValueError at the local pre-flight before it can hit the API to get
+        # the 404 → ExperimentNotFoundError mapping this test asserts. Skip
+        # cleanly on fork PRs / local runs without the secret (same pattern
+        # as the other e2e files, e.g. test_fetch_policies_e2e.py).
+        if not os.getenv("LANGWATCH_API_KEY"):
+            pytest.skip("LANGWATCH_API_KEY environment variable not set")
         with pytest.raises(ExperimentNotFoundError) as exc_info:
             run("non-existent-experiment-slug-12345")
         assert "non-existent-experiment-slug-12345" in str(exc_info.value)

--- a/scripts/__tests__/boxd-fork.integration.bats
+++ b/scripts/__tests__/boxd-fork.integration.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+# Integration tests for scripts/boxd-fork.sh orchestration.
+# Mocks `boxd`, `gh`, and `git` so we can verify the call sequence without
+# actually creating VMs or making network calls.
+#
+# Pattern mirrors scripts/__tests__/worktree.integration.bats: prepend a
+# mock-bin to PATH, execute the helper, grep the call log.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  MOCK_BIN="$TEST_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+
+  CALL_LOG="$TEST_DIR/calls.log"
+  : > "$CALL_LOG"
+
+  # boxd mock — records args; boxd list returns canned VMs from $TEST_DIR/vms;
+  # boxd exec records the exec'd command.
+  cat > "$MOCK_BIN/boxd" << 'MOCKEOF'
+#!/bin/bash
+echo "boxd $*" >> "$CALL_LOG"
+case "$1" in
+  list)
+    if [ -f "$TEST_DIR/vms" ]; then cat "$TEST_DIR/vms"; fi
+    exit 0
+    ;;
+  exec)
+    # boxd exec VM -- command — record but always return a benign result.
+    # If an env file lookup wants `tmux has-session`, return OK iff fixture says so.
+    case "$*" in
+      *"tmux has-session"*)
+        if [ -f "$TEST_DIR/tmux_present" ]; then echo "OK"; fi
+        ;;
+    esac
+    exit 0
+    ;;
+  fork|cp|new|destroy|resume|pause|reboot|proxy|connect|info|auto-suspend)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+MOCKEOF
+  chmod +x "$MOCK_BIN/boxd"
+
+  # gh mock — `gh issue view --jq .title` returns title from fixture.
+  cat > "$MOCK_BIN/gh" << 'MOCKEOF'
+#!/bin/bash
+echo "gh $*" >> "$CALL_LOG"
+case "$*" in
+  *"issue view"*)
+    if [ -f "$TEST_DIR/gh_title" ]; then cat "$TEST_DIR/gh_title"
+    else echo "Mock Issue Title"; fi
+    ;;
+  *"pr view"*)
+    if [ -f "$TEST_DIR/gh_pr_branch" ]; then cat "$TEST_DIR/gh_pr_branch"
+    else echo "feat/from-pr"; fi
+    ;;
+esac
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/gh"
+
+  # git mock — `git rev-parse --verify BRANCH` returns 0 iff fixture says so.
+  cat > "$MOCK_BIN/git" << 'MOCKEOF'
+#!/bin/bash
+echo "git $*" >> "$CALL_LOG"
+case "$1" in
+  rev-parse)
+    if [ -f "$TEST_DIR/branch_exists" ]; then exit 0; else exit 128; fi
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+MOCKEOF
+  chmod +x "$MOCK_BIN/git"
+
+  # worktree.sh mock — record call, succeed.
+  cat > "$MOCK_BIN/worktree.sh" << 'MOCKEOF'
+#!/bin/bash
+echo "worktree.sh $*" >> "$CALL_LOG"
+exit 0
+MOCKEOF
+  chmod +x "$MOCK_BIN/worktree.sh"
+
+  export PATH="$MOCK_BIN:$PATH"
+  export CALL_LOG TEST_DIR
+  # Point boxd-fork.sh at the mock binaries via its env-overridable hooks.
+  export BOXD_BIN="$MOCK_BIN/boxd"
+  export GH_BIN="$MOCK_BIN/gh"
+  export GIT_BIN="$MOCK_BIN/git"
+  export BOXD_FORK_REPO="langwatch/langwatch"
+  export CLAUDE_CREDS="$TEST_DIR/creds"
+  : > "$TEST_DIR/creds"
+
+  # Fixture: a fake repo root with a couple of .env files.
+  WORK_DIR="$TEST_DIR/repo"
+  mkdir -p "$WORK_DIR/langwatch" "$WORK_DIR/langwatch_nlp"
+  cat > "$WORK_DIR/langwatch/.env" <<EOF
+NEXTAUTH_URL=http://localhost:5560
+BASE_HOST=http://localhost:5560
+SOMETHING_ELSE=keep-me
+EOF
+  : > "$WORK_DIR/langwatch_nlp/.env"
+  cd "$WORK_DIR"
+
+  source "$SCRIPT_DIR/boxd-fork.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- _boxd_fork_impl orchestration ---
+
+@test "fork-issue: full happy path calls fork, cp, proxy, tmux in order" {
+  run boxd_fork_issue 4242
+  [ "$status" -eq 0 ]
+  # Expected sequence (greppable):
+  grep -q "gh issue view 4242" "$CALL_LOG"
+  grep -q "boxd fork langwatch-golden --name=langwatch-issue4242" "$CALL_LOG"
+  grep -q "boxd exec langwatch-issue4242" "$CALL_LOG"
+  grep -q "boxd cp .* langwatch-issue4242:.claude/.credentials.json" "$CALL_LOG"
+  # At least one .env was uploaded
+  grep -qE "boxd cp .* langwatch-issue4242:langwatch/langwatch/\.env" "$CALL_LOG"
+  # Ports were mapped (proxy set-port + at least one new)
+  grep -q "proxy set-port" "$CALL_LOG"
+  grep -q "proxy new aigw" "$CALL_LOG"
+  # tmux session was started inside the VM
+  grep -q "tmux new-session -d -s 'claude-issue4242'" "$CALL_LOG"
+}
+
+@test "fork-issue: errors when VM already exists (AC#15)" {
+  cat > "$TEST_DIR/vms" <<EOF
+[{"name":"langwatch-issue4242","status":"running"}]
+EOF
+  run boxd_fork_issue 4242
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists"* ]]
+}
+
+@test "fork-branch: warns when slug looks like an issue (AC#14)" {
+  run boxd_fork_branch "issue42/foo-bar"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Consider 'make boxd-fork-issue ISSUE=42'"* ]]
+  # Distinct VM name from fork-issue ISSUE=42
+  grep -q "boxd fork langwatch-golden --name=langwatch-issue42-foo-bar" "$CALL_LOG"
+}
+
+@test "fork-branch: produces langwatch-<slug> for normal branches" {
+  run boxd_fork_branch "feat/dark-mode"
+  [ "$status" -eq 0 ]
+  grep -q "boxd fork langwatch-golden --name=langwatch-feat-dark-mode" "$CALL_LOG"
+}
+
+@test "fork-pr: resolves head ref via gh and forks (AC#16)" {
+  echo "feat/from-fork" > "$TEST_DIR/gh_pr_branch"
+  run boxd_fork_pr 1234
+  [ "$status" -eq 0 ]
+  grep -q "gh pr view 1234" "$CALL_LOG"
+  grep -q "boxd fork langwatch-golden --name=langwatch-feat-from-fork" "$CALL_LOG"
+}
+
+# --- env upload + rewrite ---
+
+@test "fork: rewrites stale localhost in uploaded env" {
+  run boxd_fork_branch "feat/foo"
+  [ "$status" -eq 0 ]
+  # The uploaded .env temp file is gone post-cp, but we can verify the rewrite
+  # logic in isolation:
+  result=$(printf 'NEXTAUTH_URL=http://localhost:5560\n' \
+    | boxd_rewrite_env "langwatch-feat-foo")
+  [[ "$result" == *"langwatch-feat-foo.boxd.sh"* ]]
+}
+
+# --- connect-* ---
+
+@test "connect: errors clearly when VM does not exist (AC#19)" {
+  echo "[]" > "$TEST_DIR/vms"
+  run boxd_connect issue 4242
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "connect: errors when tmux session is missing (AC#18)" {
+  cat > "$TEST_DIR/vms" <<EOF
+[{"name":"langwatch-issue4242","status":"running"}]
+EOF
+  # tmux_present fixture not set → the tmux has-session check returns nothing
+  run boxd_connect issue 4242
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no claude session"* ]]
+}
+
+@test "connect: wakes a suspended VM before attaching (AC#20)" {
+  cat > "$TEST_DIR/vms" <<EOF
+[{"name":"langwatch-issue4242","status":"standby"}]
+EOF
+  touch "$TEST_DIR/tmux_present"
+  # boxd_connect ends in `exec` so we sub-shell it
+  ( boxd_connect issue 4242 ) >/dev/null 2>&1 || true
+  grep -q "boxd resume langwatch-issue4242" "$CALL_LOG"
+}
+
+# --- golden ---
+
+@test "golden: skips creation if VM already exists" {
+  cat > "$TEST_DIR/vms" <<EOF
+[{"name":"langwatch-golden","status":"running"}]
+EOF
+  run boxd_golden
+  [ "$status" -eq 0 ]
+  # Did NOT call `boxd new` for the existing VM
+  ! grep -q "boxd new --name=langwatch-golden" "$CALL_LOG"
+}
+
+@test "golden: creates VM when absent" {
+  echo "[]" > "$TEST_DIR/vms"
+  run boxd_golden
+  [ "$status" -eq 0 ]
+  grep -q "boxd new --name=langwatch-golden" "$CALL_LOG"
+}
+
+@test "golden-reset: refuses without BOXD_FORK_YES=1 (AC#4)" {
+  cat > "$TEST_DIR/vms" <<EOF
+[{"name":"langwatch-golden","status":"running"}]
+EOF
+  run boxd_golden_reset
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"BOXD_FORK_YES=1"* ]]
+}
+
+@test "golden-reset: destroys + recreates with BOXD_FORK_YES=1" {
+  cat > "$TEST_DIR/vms" <<EOF
+[{"name":"langwatch-golden","status":"running"}]
+EOF
+  BOXD_FORK_YES=1 run boxd_golden_reset
+  [ "$status" -eq 0 ]
+  grep -q "boxd destroy langwatch-golden" "$CALL_LOG"
+  # `boxd_vm_exists` will return false after destroy on a fresh fixture, so
+  # `boxd new` should have been called. Note: the mock list still returns the
+  # old VM, but the implementation calls `boxd new` after `boxd destroy`
+  # unconditionally for reset.
+}

--- a/scripts/__tests__/boxd-fork.unit.bats
+++ b/scripts/__tests__/boxd-fork.unit.bats
@@ -1,0 +1,216 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/boxd-fork.sh pure functions
+#
+# Behavior under test is the slugifier + naming + env-discovery + hostname-
+# rewrite logic from issue #3891. The Makefile targets in boxd.mk delegate
+# to these functions so they're testable in isolation.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  source "$SCRIPT_DIR/boxd-fork.sh"
+}
+
+# --- boxd_slug ---
+
+@test "boxd_slug: lowercases and dashes a simple title" {
+  result=$(boxd_slug "feat/Foo Bar!")
+  [ "$result" = "feat-foo-bar" ]
+}
+
+@test "boxd_slug: preserves issue<N>/<slug> shape after slashes are dashed" {
+  result=$(boxd_slug "issue3891/boxd-mk-and-quickstart-rework")
+  [ "$result" = "issue3891-boxd-mk-and-quickstart-rework" ]
+}
+
+@test "boxd_slug: strips punctuation and collapses runs of dashes" {
+  result=$(boxd_slug "Fix: user's data (broken) #123")
+  [[ "$result" =~ ^[a-z0-9-]+$ ]]
+  # No leading or trailing dash, no double dashes
+  [[ "$result" != -* ]]
+  [[ "$result" != *- ]]
+  [[ "$result" != *--* ]]
+}
+
+@test "boxd_slug: truncates to 40 chars" {
+  result=$(boxd_slug "this-is-a-very-long-branch-name-that-should-get-truncated-eventually")
+  [ "${#result}" -le 40 ]
+}
+
+@test "boxd_slug: truncated output has no trailing hyphen" {
+  result=$(boxd_slug "this-is-a-very-long-branch-name-that-should-get-truncated-eventually")
+  [[ "$result" != *- ]]
+}
+
+@test "boxd_slug: empty input produces empty output without error" {
+  result=$(boxd_slug "")
+  [ "$result" = "" ]
+}
+
+@test "boxd_slug: input that is all symbols becomes empty after trim" {
+  result=$(boxd_slug "///!!!")
+  [ "$result" = "" ]
+}
+
+# --- boxd_vm_name ---
+
+@test "boxd_vm_name: pr uses langwatch-<slug>" {
+  result=$(boxd_vm_name "pr" "feat/Foo Bar")
+  [ "$result" = "langwatch-feat-foo-bar" ]
+}
+
+@test "boxd_vm_name: branch uses langwatch-<slug>" {
+  result=$(boxd_vm_name "branch" "feat/dark-mode")
+  [ "$result" = "langwatch-feat-dark-mode" ]
+}
+
+@test "boxd_vm_name: issue always uses langwatch-issue<N> regardless of slug" {
+  # AC#14 collision rule: fork-issue uses literal langwatch-issue<N>
+  result=$(boxd_vm_name "issue" "3891")
+  [ "$result" = "langwatch-issue3891" ]
+}
+
+@test "boxd_vm_name: issue ignores any extra slug-ish input" {
+  # If callers pass "3891/whatever", the issue form still picks the number
+  result=$(boxd_vm_name "issue" "3891")
+  [ "$result" = "langwatch-issue3891" ]
+}
+
+# --- boxd_tmux_name ---
+
+@test "boxd_tmux_name: matches VM convention with claude- prefix" {
+  result=$(boxd_tmux_name "issue" "42")
+  [ "$result" = "claude-issue42" ]
+}
+
+@test "boxd_tmux_name: branch uses claude-<slug>" {
+  result=$(boxd_tmux_name "branch" "feat/dark-mode")
+  [ "$result" = "claude-feat-dark-mode" ]
+}
+
+# --- boxd_branch_issue_collision_warning ---
+
+@test "boxd_branch_issue_collision_warning: warns when slug starts with issueNNN-" {
+  run boxd_branch_issue_collision_warning "issue42-foo-bar"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"fork-issue"* ]]
+  [[ "$output" == *"42"* ]]
+}
+
+@test "boxd_branch_issue_collision_warning: silent on non-issue-shaped slug" {
+  run boxd_branch_issue_collision_warning "feat-dark-mode"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- boxd_env_files (filesystem-driven; runs in a temp dir) ---
+
+setup_env_fixture() {
+  TMP="$(mktemp -d)"
+  pushd "$TMP" > /dev/null
+  mkdir -p langwatch langwatch_nlp node_modules/foo .next dist build vendor coverage
+  : > langwatch/.env
+  : > langwatch_nlp/.env
+  : > .env
+  # Excluded by suffix
+  : > langwatch/.env.example
+  : > langwatch/.env.template
+  : > langwatch/.env.sample
+  : > langwatch/.env.local
+  # Excluded by directory
+  : > node_modules/foo/.env
+  : > .next/.env
+  : > dist/.env
+  : > build/.env
+  : > vendor/.env
+  : > coverage/.env
+}
+
+teardown_env_fixture() {
+  popd > /dev/null
+  rm -rf "$TMP"
+}
+
+@test "boxd_env_files: lists top-level .env files in monorepo subdirs" {
+  setup_env_fixture
+  result=$(boxd_env_files | sort)
+  [[ "$result" == *"./.env"* ]]
+  [[ "$result" == *"./langwatch/.env"* ]]
+  [[ "$result" == *"./langwatch_nlp/.env"* ]]
+  teardown_env_fixture
+}
+
+@test "boxd_env_files: excludes .env.example, .template, .sample, .local" {
+  setup_env_fixture
+  result=$(boxd_env_files)
+  [[ "$result" != *".example"* ]]
+  [[ "$result" != *".template"* ]]
+  [[ "$result" != *".sample"* ]]
+  [[ "$result" != *".local"* ]]
+  teardown_env_fixture
+}
+
+@test "boxd_env_files: excludes node_modules, .next, dist, build, vendor, coverage" {
+  setup_env_fixture
+  result=$(boxd_env_files)
+  [[ "$result" != *"node_modules"* ]]
+  [[ "$result" != *".next"* ]]
+  [[ "$result" != *"dist/"* ]]
+  [[ "$result" != *"build/"* ]]
+  [[ "$result" != *"vendor/"* ]]
+  [[ "$result" != *"coverage/"* ]]
+  teardown_env_fixture
+}
+
+# --- boxd_rewrite_env (hostname rewrite, allowlist + value-pattern) ---
+
+@test "boxd_rewrite_env: rewrites NEXTAUTH_URL allowlist key" {
+  result=$(printf 'NEXTAUTH_URL=http://localhost:5560\n' \
+    | boxd_rewrite_env "langwatch-issue42")
+  [ "$result" = 'NEXTAUTH_URL="https://langwatch-issue42.boxd.sh"' ]
+}
+
+@test "boxd_rewrite_env: rewrites BASE_HOST allowlist key" {
+  result=$(printf 'BASE_HOST=http://localhost:5560\n' \
+    | boxd_rewrite_env "langwatch-issue42")
+  [ "$result" = 'BASE_HOST="https://langwatch-issue42.boxd.sh"' ]
+}
+
+@test "boxd_rewrite_env: rewrites LW_GATEWAY_BASE_URL to aigw subdomain" {
+  result=$(printf 'LW_GATEWAY_BASE_URL=http://localhost:5563\n' \
+    | boxd_rewrite_env "langwatch-issue42")
+  [ "$result" = 'LW_GATEWAY_BASE_URL="https://aigw.langwatch-issue42.boxd.sh"' ]
+}
+
+@test "boxd_rewrite_env: rewrites localhost:<port> values for non-allowlist keys (matched values)" {
+  # AC#26: value pattern match also rewrites
+  result=$(printf 'OTHER_URL=http://localhost:5560\n' \
+    | boxd_rewrite_env "langwatch-issue42")
+  [[ "$result" == *"langwatch-issue42.boxd.sh"* ]]
+}
+
+@test "boxd_rewrite_env: rewrites 127.0.0.1:<port> values" {
+  result=$(printf 'OTHER_URL=http://127.0.0.1:5560\n' \
+    | boxd_rewrite_env "langwatch-issue42")
+  [[ "$result" == *"langwatch-issue42.boxd.sh"* ]]
+}
+
+@test "boxd_rewrite_env: leaves non-localhost values alone" {
+  result=$(printf 'OPENAI_API_KEY=sk-foo123\nDB_URL=postgres://u:p@db.prod:5432/x\n' \
+    | boxd_rewrite_env "langwatch-issue42")
+  [[ "$result" == *"sk-foo123"* ]]
+  [[ "$result" == *"db.prod"* ]]
+}
+
+@test "boxd_rewrite_env: leaves comments and blank lines alone" {
+  result=$(printf '# header comment\n\nKEY=value\n' \
+    | boxd_rewrite_env "langwatch-issue42")
+  [[ "$result" == *"# header comment"* ]]
+  [[ "$result" == *"KEY=value"* ]]
+}
+
+@test "boxd_rewrite_env: leaves a real boxd-proxy URL alone" {
+  result=$(printf 'NEXTAUTH_URL=https://langwatch-other.boxd.sh\n' \
+    | boxd_rewrite_env "langwatch-issue42")
+  [[ "$result" == *"langwatch-other.boxd.sh"* ]]
+}

--- a/scripts/__tests__/dev-overrides.unit.bats
+++ b/scripts/__tests__/dev-overrides.unit.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# Unit tests for write_overrides() in scripts/dev.sh — the per-mode URL
+# rewrite layer that backs `make quickstart <mode>` (#3860 AC#2 / AC#6).
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  mkdir -p "$TEST_DIR/langwatch"
+  pushd "$TEST_DIR" > /dev/null
+  source "$SCRIPT_DIR/dev.sh"
+}
+
+teardown() {
+  popd > /dev/null
+  rm -rf "$TEST_DIR"
+}
+
+@test "frontend-only writes only NEXTAUTH_PROVIDER (no infra URL overrides)" {
+  write_overrides frontend-only > /dev/null 2>&1
+  result=$(cat langwatch/.env.dev-up)
+  [[ "$result" == *"NEXTAUTH_PROVIDER=email"* ]]
+  [[ "$result" != *"DATABASE_URL"* ]]
+  [[ "$result" != *"REDIS_URL"* ]]
+  [[ "$result" != *"CLICKHOUSE_URL"* ]]
+  [[ "$result" != *"LANGWATCH_NLP_SERVICE"* ]]
+}
+
+@test "backend-shared rewrites DATABASE_URL, REDIS_URL, CLICKHOUSE_URL" {
+  write_overrides backend-shared > /dev/null 2>&1
+  result=$(cat langwatch/.env.dev-up)
+  [[ "$result" == *"DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb"* ]]
+  [[ "$result" == *"REDIS_URL=redis://redis:6379"* ]]
+  [[ "$result" == *"CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch"* ]]
+  [[ "$result" != *"LANGWATCH_NLP_SERVICE"* ]]
+  [[ "$result" != *"LANGEVALS_ENDPOINT"* ]]
+}
+
+@test "migration uses localhost host-port URLs (not docker-network names)" {
+  write_overrides migration > /dev/null 2>&1
+  result=$(cat langwatch/.env.dev-up)
+  [[ "$result" == *"DATABASE_URL=postgresql://prisma:prisma@localhost:5432/mydb"* ]]
+  [[ "$result" == *"CLICKHOUSE_URL=http://default:langwatch@localhost:8123/langwatch"* ]]
+  [[ "$result" != *"REDIS_URL"* ]]
+}
+
+@test "nlp adds LANGWATCH_NLP_SERVICE and LANGEVALS_ENDPOINT on top of backend" {
+  write_overrides nlp > /dev/null 2>&1
+  result=$(cat langwatch/.env.dev-up)
+  [[ "$result" == *"DATABASE_URL=postgresql://prisma:prisma@postgres:5432"* ]]
+  [[ "$result" == *"REDIS_URL=redis://redis:6379"* ]]
+  [[ "$result" == *"CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123"* ]]
+  [[ "$result" == *"LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561"* ]]
+  [[ "$result" == *"LANGEVALS_ENDPOINT=http://langevals:5562"* ]]
+}
+
+@test "full-local writes the same set as nlp (everything local)" {
+  write_overrides full-local > /dev/null 2>&1
+  result=$(cat langwatch/.env.dev-up)
+  [[ "$result" == *"DATABASE_URL"* ]]
+  [[ "$result" == *"REDIS_URL"* ]]
+  [[ "$result" == *"CLICKHOUSE_URL"* ]]
+  [[ "$result" == *"LANGWATCH_NLP_SERVICE"* ]]
+  [[ "$result" == *"LANGEVALS_ENDPOINT"* ]]
+}
+
+@test "write_overrides is idempotent — second call replaces, not appends" {
+  write_overrides backend-shared > /dev/null 2>&1
+  write_overrides frontend-only > /dev/null 2>&1
+  result=$(cat langwatch/.env.dev-up)
+  [[ "$result" != *"DATABASE_URL"* ]]
+  [[ "$result" == *"NEXTAUTH_PROVIDER=email"* ]]
+}

--- a/scripts/__tests__/dev-overrides.unit.bats
+++ b/scripts/__tests__/dev-overrides.unit.bats
@@ -1,25 +1,27 @@
 #!/usr/bin/env bats
-# Unit tests for write_overrides() in scripts/dev.sh — the per-mode URL
-# rewrite layer that backs `make quickstart <mode>` (#3860 AC#2 / AC#6).
+# Unit tests for write_dev_overrides() in scripts/lib/write-dev-overrides.sh
+# — the shared per-mode URL rewrite layer used by both `scripts/dev.sh`
+# (intent-based modes) and `scripts/dev-up.sh` (legacy compose-profile
+# names) (#3860 AC#2 / AC#6). Tests the helper directly to avoid coupling
+# to either launcher's prompt logic.
 
 SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 setup() {
   TEST_DIR="$(mktemp -d)"
-  mkdir -p "$TEST_DIR/langwatch"
-  pushd "$TEST_DIR" > /dev/null
-  source "$SCRIPT_DIR/dev.sh"
+  OUT="$TEST_DIR/.env.dev-up"
+  source "$SCRIPT_DIR/lib/write-dev-overrides.sh"
 }
 
 teardown() {
-  popd > /dev/null
   rm -rf "$TEST_DIR"
 }
 
+# --- intent-based mode names (scripts/dev.sh) ---
+
 @test "frontend-only writes only NEXTAUTH_PROVIDER (no infra URL overrides)" {
-  write_overrides frontend-only > /dev/null 2>&1
-  result=$(cat langwatch/.env.dev-up)
+  write_dev_overrides frontend-only "$OUT"
+  result=$(cat "$OUT")
   [[ "$result" == *"NEXTAUTH_PROVIDER=email"* ]]
   [[ "$result" != *"DATABASE_URL"* ]]
   [[ "$result" != *"REDIS_URL"* ]]
@@ -27,9 +29,9 @@ teardown() {
   [[ "$result" != *"LANGWATCH_NLP_SERVICE"* ]]
 }
 
-@test "backend-shared rewrites DATABASE_URL, REDIS_URL, CLICKHOUSE_URL" {
-  write_overrides backend-shared > /dev/null 2>&1
-  result=$(cat langwatch/.env.dev-up)
+@test "backend-shared rewrites DATABASE_URL, REDIS_URL, CLICKHOUSE_URL only" {
+  write_dev_overrides backend-shared "$OUT"
+  result=$(cat "$OUT")
   [[ "$result" == *"DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb"* ]]
   [[ "$result" == *"REDIS_URL=redis://redis:6379"* ]]
   [[ "$result" == *"CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch"* ]]
@@ -38,16 +40,16 @@ teardown() {
 }
 
 @test "migration uses localhost host-port URLs (not docker-network names)" {
-  write_overrides migration > /dev/null 2>&1
-  result=$(cat langwatch/.env.dev-up)
+  write_dev_overrides migration "$OUT"
+  result=$(cat "$OUT")
   [[ "$result" == *"DATABASE_URL=postgresql://prisma:prisma@localhost:5432/mydb"* ]]
   [[ "$result" == *"CLICKHOUSE_URL=http://default:langwatch@localhost:8123/langwatch"* ]]
   [[ "$result" != *"REDIS_URL"* ]]
 }
 
 @test "nlp adds LANGWATCH_NLP_SERVICE and LANGEVALS_ENDPOINT on top of backend" {
-  write_overrides nlp > /dev/null 2>&1
-  result=$(cat langwatch/.env.dev-up)
+  write_dev_overrides nlp "$OUT"
+  result=$(cat "$OUT")
   [[ "$result" == *"DATABASE_URL=postgresql://prisma:prisma@postgres:5432"* ]]
   [[ "$result" == *"REDIS_URL=redis://redis:6379"* ]]
   [[ "$result" == *"CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123"* ]]
@@ -55,9 +57,9 @@ teardown() {
   [[ "$result" == *"LANGEVALS_ENDPOINT=http://langevals:5562"* ]]
 }
 
-@test "full-local writes the same set as nlp (everything local)" {
-  write_overrides full-local > /dev/null 2>&1
-  result=$(cat langwatch/.env.dev-up)
+@test "full-local writes all five infrastructure URLs" {
+  write_dev_overrides full-local "$OUT"
+  result=$(cat "$OUT")
   [[ "$result" == *"DATABASE_URL"* ]]
   [[ "$result" == *"REDIS_URL"* ]]
   [[ "$result" == *"CLICKHOUSE_URL"* ]]
@@ -65,10 +67,45 @@ teardown() {
   [[ "$result" == *"LANGEVALS_ENDPOINT"* ]]
 }
 
-@test "write_overrides is idempotent — second call replaces, not appends" {
-  write_overrides backend-shared > /dev/null 2>&1
-  write_overrides frontend-only > /dev/null 2>&1
-  result=$(cat langwatch/.env.dev-up)
+@test "second call replaces (not appends) langwatch/.env.dev-up" {
+  write_dev_overrides backend-shared "$OUT"
+  write_dev_overrides frontend-only "$OUT"
+  result=$(cat "$OUT")
   [[ "$result" != *"DATABASE_URL"* ]]
   [[ "$result" == *"NEXTAUTH_PROVIDER=email"* ]]
+}
+
+# --- compose-profile mode names (scripts/dev-up.sh) — service-membership rules ---
+
+@test "scenarios profile starts langwatch_nlp but NOT langevals — overlay must respect" {
+  # langwatch_nlp is in [nlp, scenarios, full]; langevals is [nlp, full].
+  # scripts/dev-up.sh PROFILE=scenarios was previously writing both, leaving
+  # LANGEVALS_ENDPOINT pointing at a non-existent container.
+  write_dev_overrides scenarios "$OUT"
+  result=$(cat "$OUT")
+  [[ "$result" == *"LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561"* ]]
+  [[ "$result" != *"LANGEVALS_ENDPOINT"* ]]
+}
+
+@test "test profile adds no NLP / langevals URLs (ai-server only)" {
+  write_dev_overrides test "$OUT"
+  result=$(cat "$OUT")
+  [[ "$result" != *"LANGWATCH_NLP_SERVICE"* ]]
+  [[ "$result" != *"LANGEVALS_ENDPOINT"* ]]
+  # Does still set the always-on backend URLs.
+  [[ "$result" == *"DATABASE_URL"* ]]
+}
+
+@test "full profile (legacy name) sets both NLP and langevals URLs" {
+  write_dev_overrides full "$OUT"
+  result=$(cat "$OUT")
+  [[ "$result" == *"LANGWATCH_NLP_SERVICE"* ]]
+  [[ "$result" == *"LANGEVALS_ENDPOINT"* ]]
+}
+
+@test "workers profile starts langwatch_nlp (no langevals)" {
+  write_dev_overrides workers "$OUT"
+  result=$(cat "$OUT")
+  [[ "$result" == *"LANGWATCH_NLP_SERVICE"* ]]
+  [[ "$result" != *"LANGEVALS_ENDPOINT"* ]]
 }

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -467,16 +467,22 @@ EOF
   fi
   printf 'Creating golden VM %s\n' "$vm" >&2
   "$BOXD_BIN" new --name="$vm" >/dev/null
-  # Provision: install node, clone repo, install deps, run dev-full once.
+  # Provision: install Node 20 from NodeSource (apt's `nodejs` ships Node
+  # 12.x on Ubuntu 22.04 — older than corepack's 16.9.0 minimum, which
+  # would silently abort the rest of the recipe under `set -e`). Then
+  # clone repo and install deps. Errors surface (no outer `>/dev/null`).
   "$BOXD_BIN" exec "$vm" -- "
     set -e
-    sudo apt-get update -y >/dev/null 2>&1 || true
-    sudo apt-get install -y nodejs npm >/dev/null 2>&1 || true
+    if ! command -v node >/dev/null 2>&1 \\
+       || [ \"\$(node --version 2>/dev/null | cut -d. -f1 | tr -d v)\" -lt 18 ]; then
+      curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+      sudo apt-get install -y nodejs
+    fi
     if [ ! -d langwatch ]; then
       git clone https://github.com/$BOXD_FORK_REPO.git langwatch
     fi
     cd langwatch && corepack enable && pnpm -w install
-  " >/dev/null
+  "
   # Hook for seed-golden (AC#7): callable target the make file overrides.
   printf 'Done. Override the seed step by defining a seed-golden target.\n' >&2
 }

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -250,7 +250,11 @@ boxd_upload_envs() {
     boxd_rewrite_env "$vm" < "$f" > "$rewritten"
     # Preserve monorepo path under /home/boxd/langwatch (the in-VM repo path)
     target="langwatch/$rel"
-    "$BOXD_BIN" cp "$rewritten" "$vm:$target" >/dev/null
+    if ! "$BOXD_BIN" cp "$rewritten" "$vm:$target" >/dev/null; then
+      rm -f "$rewritten"
+      echo "ERROR: failed to upload $rel to $vm:$target" >&2
+      return 1
+    fi
     rm -f "$rewritten"
     printf '  uploaded %s\n' "$rel" >&2
   done < <(boxd_env_files)
@@ -269,7 +273,10 @@ WARNING: Claude credentials not found at $BOXD_CLAUDE_CREDS.
 EOF
     return 0
   fi
-  "$BOXD_BIN" cp "$BOXD_CLAUDE_CREDS" "$vm:.claude/.credentials.json" >/dev/null
+  if ! "$BOXD_BIN" cp "$BOXD_CLAUDE_CREDS" "$vm:.claude/.credentials.json" >/dev/null; then
+    echo "ERROR: failed to upload Claude credentials to $vm" >&2
+    return 1
+  fi
   printf '  uploaded Claude credentials\n' >&2
 }
 
@@ -373,9 +380,9 @@ EOF
     fi
   fi
 
-  boxd_upload_creds "$vm"
-  boxd_upload_envs "$vm"
-  boxd_map_ports "$vm"
+  boxd_upload_creds "$vm" || return 1
+  boxd_upload_envs "$vm" || return 1
+  boxd_map_ports "$vm" || return 1
 
   if [ "$start_tmux" = "1" ]; then
     # AC#12: tmux + Claude session inside the VM, named claude-<slug>/issue<N>.

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -198,11 +198,14 @@ BOXD_FORK_REPO="${BOXD_FORK_REPO:-langwatch/langwatch}"
 BOXD_CLAUDE_CREDS="${CLAUDE_CREDS:-$HOME/.claude/.credentials.json}"
 
 # boxd_vm_exists VM — true if a VM with that name exists.
+# Uses the same spacing-tolerant regex as boxd_vm_status so both functions
+# parse `boxd list --json` output consistently regardless of whether the
+# CLI compacts or pretty-prints the response.
 boxd_vm_exists() {
   local vm="${1-}"
   [ -n "$vm" ] || return 1
   "$BOXD_BIN" list --json 2>/dev/null \
-    | grep -Fq "\"name\":\"$vm\"" \
+    | grep -qE "\"name\"[[:space:]]*:[[:space:]]*\"$vm\"" \
     || return 1
 }
 
@@ -350,17 +353,24 @@ EOF
   # AC#16: for fork-pr, prefer `gh pr checkout` — it handles PRs from
   # forked repos by adding the contributor's remote automatically.
   # For branch/issue, fall back to fetch-then-checkout against origin.
+  # Fails closed: a partial fork (envs + proxies wired against the wrong
+  # branch) is worse than a hard error.
   if [ -n "$pr" ]; then
     if ! "$BOXD_BIN" exec "$vm" -- "cd langwatch && gh pr checkout '$pr' --force 2>&1" >/dev/null; then
       cat <<EOF >&2
-WARNING: 'gh pr checkout $pr' failed inside $vm. If the PR is from a fork
-         repo, the in-VM gh may not have access to it. Connect and inspect:
-           boxd connect $vm
-           cd langwatch && gh auth status && gh pr checkout $pr
+ERROR: 'gh pr checkout $pr' failed inside $vm. If the PR is from a fork
+       repo, the in-VM gh may not have access to it. Inspect with:
+         boxd connect $vm
+         cd langwatch && gh auth status && gh pr checkout $pr
+       Aborting before envs / proxies are wired against the wrong branch.
 EOF
+      return 1
     fi
   else
-    "$BOXD_BIN" exec "$vm" -- "cd langwatch && git fetch origin && git checkout '$branch' 2>/dev/null || git checkout -b '$branch' 'origin/$branch' 2>/dev/null || git checkout 'origin/$branch'" >/dev/null
+    if ! "$BOXD_BIN" exec "$vm" -- "cd langwatch && git fetch origin && git checkout '$branch' 2>/dev/null || git checkout -b '$branch' 'origin/$branch' 2>/dev/null || git checkout 'origin/$branch'" >/dev/null; then
+      echo "ERROR: failed to check out '$branch' inside $vm." >&2
+      return 1
+    fi
   fi
 
   boxd_upload_creds "$vm"
@@ -369,10 +379,13 @@ EOF
 
   if [ "$start_tmux" = "1" ]; then
     # AC#12: tmux + Claude session inside the VM, named claude-<slug>/issue<N>.
-    "$BOXD_BIN" exec "$vm" -- \
-      "tmux new-session -d -s '$tmux' 'cd langwatch && claude --dangerously-skip-permissions'" \
-      >/dev/null 2>&1 || true
-    printf '  started tmux session %s on %s\n' "$tmux" "$vm" >&2
+    if "$BOXD_BIN" exec "$vm" -- \
+        "tmux new-session -d -s '$tmux' 'cd langwatch && claude --dangerously-skip-permissions'" \
+        >/dev/null 2>&1; then
+      printf '  started tmux session %s on %s\n' "$tmux" "$vm" >&2
+    else
+      printf '  WARNING: failed to start tmux session %s on %s — start it manually after `boxd connect %s`\n' "$tmux" "$vm" "$vm" >&2
+    fi
   fi
 
   printf 'Done. Connect with:\n  make boxd-connect-%s %s=%s\n' \
@@ -398,6 +411,12 @@ boxd_fork_pr() {
     echo "ERROR: could not resolve PR #$pr via gh." >&2
     return 1
   }
+  # gh can return exit 0 with empty output on permissions edge cases —
+  # guard so we don't synthesize a degenerate VM name like `langwatch-`.
+  if [ -z "$branch" ]; then
+    echo "ERROR: gh returned an empty headRefName for PR #$pr." >&2
+    return 1
+  fi
   local slug
   slug=$(boxd_slug "$branch")
   boxd_branch_issue_collision_warning "$slug"
@@ -466,13 +485,18 @@ EOF
     return 0
   fi
   printf 'Creating golden VM %s\n' "$vm" >&2
-  "$BOXD_BIN" new --name="$vm" >/dev/null
+  if ! "$BOXD_BIN" new --name="$vm" >/dev/null; then
+    echo "ERROR: 'boxd new --name=$vm' failed." >&2
+    return 1
+  fi
   # Provision: install Node 20 from NodeSource (apt's `nodejs` ships Node
   # 12.x on Ubuntu 22.04 — older than corepack's 16.9.0 minimum, which
   # would silently abort the rest of the recipe under `set -e`). Then
-  # clone repo and install deps. Errors surface (no outer `>/dev/null`).
-  "$BOXD_BIN" exec "$vm" -- "
-    set -e
+  # clone repo and install deps. The `set -e` is INSIDE the remote shell
+  # only; we additionally check the host-side `boxd exec` exit code so
+  # provisioning failures don't slip past the success printf.
+  if ! "$BOXD_BIN" exec "$vm" -- "
+    set -euo pipefail
     if ! command -v node >/dev/null 2>&1 \\
        || [ \"\$(node --version 2>/dev/null | cut -d. -f1 | tr -d v)\" -lt 18 ]; then
       curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
@@ -482,7 +506,10 @@ EOF
       git clone https://github.com/$BOXD_FORK_REPO.git langwatch
     fi
     cd langwatch && corepack enable && pnpm -w install
-  "
+  "; then
+    echo "ERROR: provisioning $vm failed. Inspect with 'boxd connect $vm'." >&2
+    return 1
+  fi
   # Hook for seed-golden (AC#7): callable target the make file overrides.
   printf 'Done. Override the seed step by defining a seed-golden target.\n' >&2
 }

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -271,6 +271,8 @@ EOF
 }
 
 # boxd_map_ports VM — set up the standard set of proxies (AC#27).
+# Uses host-side `--vm` so we don't pay an extra `boxd exec` round-trip per
+# proxy just to invoke the in-VM CLI against itself.
 boxd_map_ports() {
   local vm="${1-}"
   [ -n "$vm" ] || { echo "VM name required" >&2; return 1; }
@@ -279,11 +281,11 @@ boxd_map_ports() {
     sub="${entry%%:*}"
     port="${entry##*:}"
     if [ "$sub" = "_default" ]; then
-      "$BOXD_BIN" exec "$vm" -- "boxd proxy set-port --port=$port" >/dev/null 2>&1 || true
+      "$BOXD_BIN" proxy set-port --port="$port" --vm "$vm" >/dev/null 2>&1 || true
       printf '  proxy: https://%s.boxd.sh -> :%s\n' "$vm" "$port" >&2
     else
       # `proxy new` errors if the subdomain already exists; that's idempotent.
-      "$BOXD_BIN" exec "$vm" -- "boxd proxy new $sub --port=$port" >/dev/null 2>&1 || true
+      "$BOXD_BIN" proxy new "$sub" --port="$port" --vm "$vm" >/dev/null 2>&1 || true
       printf '  proxy: https://%s.%s.boxd.sh -> :%s\n' "$sub" "$vm" "$port" >&2
     fi
   done
@@ -317,10 +319,11 @@ boxd_wake_if_suspended() {
 #   BRANCH     the actual git branch to check out inside the fork
 #   START_TMUX 1 to start a Claude tmux session (fork-issue), 0 otherwise
 _boxd_fork_impl() {
-  local source="$1" input="$2" user_arg="$3" branch="$4" start_tmux="${5:-0}"
-  local vm tmux
+  local source="$1" input="$2" user_arg="$3" branch="$4" start_tmux="${5:-0}" pr="${6:-}"
+  local vm tmux arg_name
   vm=$(boxd_vm_name "$source" "$input")
   tmux=$(boxd_tmux_name "$source" "$input")
+  arg_name=$(_boxd_arg_for_source "$source")
 
   printf 'Forking VM: %s (branch=%s, tmux=%s)\n' "$vm" "$branch" "$tmux" >&2
   printf '  proxies: https://%s.boxd.sh and configured subdomains\n' "$vm" >&2
@@ -331,7 +334,7 @@ _boxd_fork_impl() {
 ERROR: VM '$vm' already exists. Pick a different source or destroy it first:
          boxd destroy $vm
        Or connect to it:
-         make boxd-connect-${source%pr} ${source^^}=$input
+         make boxd-connect-${source} ${arg_name}=${user_arg}
 EOF
     return 1
   fi
@@ -342,9 +345,21 @@ EOF
     return 1
   fi
 
-  # Ensure the in-VM repo is on the right branch (AC#16: cross-fork PRs as
-  # detached head if the branch isn't local).
-  "$BOXD_BIN" exec "$vm" -- "cd langwatch && git fetch origin && git checkout '$branch' 2>/dev/null || git checkout -b '$branch' 'origin/$branch' 2>/dev/null || git checkout 'origin/$branch'" >/dev/null
+  # AC#16: for fork-pr, prefer `gh pr checkout` — it handles PRs from
+  # forked repos by adding the contributor's remote automatically.
+  # For branch/issue, fall back to fetch-then-checkout against origin.
+  if [ -n "$pr" ]; then
+    if ! "$BOXD_BIN" exec "$vm" -- "cd langwatch && gh pr checkout '$pr' --force 2>&1" >/dev/null; then
+      cat <<EOF >&2
+WARNING: 'gh pr checkout $pr' failed inside $vm. If the PR is from a fork
+         repo, the in-VM gh may not have access to it. Connect and inspect:
+           boxd connect $vm
+           cd langwatch && gh auth status && gh pr checkout $pr
+EOF
+    fi
+  else
+    "$BOXD_BIN" exec "$vm" -- "cd langwatch && git fetch origin && git checkout '$branch' 2>/dev/null || git checkout -b '$branch' 'origin/$branch' 2>/dev/null || git checkout 'origin/$branch'" >/dev/null
+  fi
 
   boxd_upload_creds "$vm"
   boxd_upload_envs "$vm"
@@ -384,7 +399,9 @@ boxd_fork_pr() {
   local slug
   slug=$(boxd_slug "$branch")
   boxd_branch_issue_collision_warning "$slug"
-  _boxd_fork_impl pr "$branch" "$pr" "$branch" 0
+  # Pass $pr as the 6th arg so _boxd_fork_impl uses `gh pr checkout` (AC#16:
+  # cross-fork PR support — gh adds the contributor's remote automatically).
+  _boxd_fork_impl pr "$branch" "$pr" "$branch" 0 "$pr"
 }
 
 # boxd_fork_branch BRANCH — fork for a branch that doesn't (yet) have a PR.

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+# scripts/boxd-fork.sh — pure-shell helpers used by boxd.mk.
+#
+# The Makefile targets in boxd.mk delegate naming, env discovery, hostname
+# rewrite, and orchestration sequencing to functions in this file so they
+# can be unit-tested with bats independent of the boxd CLI.
+#
+# Conventions:
+#   - Pure functions print to stdout, return 0/1, never `exit`.
+#   - Side-effecting functions (boxd CLI calls) live in the orchestration
+#     section at the bottom and are called from boxd.mk.
+#
+# Sourcing:
+#   . scripts/boxd-fork.sh
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Naming primitives
+# ---------------------------------------------------------------------------
+
+# boxd_slug — slugify a string per issue #3891 AC#13.
+# Lowercase, replace `/` and non-`[a-z0-9-]` with `-`, collapse repeated `-`,
+# trim leading/trailing `-`, truncate at 40 chars (no word-boundary cut).
+boxd_slug() {
+  local input="${1-}"
+  local s
+  s=$(printf '%s' "$input" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's#/+#-#g; s/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-+//; s/-+$//')
+  if [ "${#s}" -gt 40 ]; then
+    s="${s:0:40}"
+    s="${s%-}"
+  fi
+  printf '%s' "$s"
+}
+
+# boxd_vm_name SOURCE INPUT — return the VM name for the given source-of-truth.
+# SOURCE: pr | branch | issue
+# INPUT:  PR number / branch name / issue number
+#
+# Per AC#9 + AC#14:
+#   - issue → always literal `langwatch-issue<N>` (no slugifier on input)
+#   - pr / branch → `langwatch-<slug(input)>`
+boxd_vm_name() {
+  local source="${1-}" input="${2-}"
+  case "$source" in
+    issue)
+      printf 'langwatch-issue%s' "$input"
+      ;;
+    pr|branch)
+      printf 'langwatch-%s' "$(boxd_slug "$input")"
+      ;;
+    *)
+      echo "boxd_vm_name: unknown source '$source' (expected pr|branch|issue)" >&2
+      return 1
+      ;;
+  esac
+}
+
+# boxd_tmux_name SOURCE INPUT — return the tmux session name on the VM.
+# Same shape as boxd_vm_name but with `claude-` prefix instead of `langwatch-`.
+boxd_tmux_name() {
+  local source="${1-}" input="${2-}"
+  case "$source" in
+    issue)
+      printf 'claude-issue%s' "$input"
+      ;;
+    pr|branch)
+      printf 'claude-%s' "$(boxd_slug "$input")"
+      ;;
+    *)
+      echo "boxd_tmux_name: unknown source '$source' (expected pr|branch|issue)" >&2
+      return 1
+      ;;
+  esac
+}
+
+# boxd_branch_issue_collision_warning SLUG — print a friendly nudge if the
+# branch slug starts with `issue<N>-`, suggesting `fork-issue` instead.
+# Per AC#14: warn-only, doesn't error.
+boxd_branch_issue_collision_warning() {
+  local slug="${1-}"
+  if [[ "$slug" =~ ^issue([0-9]+)- ]]; then
+    local n="${BASH_REMATCH[1]}"
+    cat <<EOF >&2
+warning: branch slug '$slug' looks like it belongs to issue $n.
+         Consider 'make boxd-fork-issue ISSUE=$n' instead — that target
+         uses the canonical 'langwatch-issue$n' VM name and creates a
+         matching 'claude-issue$n' tmux session.
+EOF
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Environment file discovery and rewrite
+# ---------------------------------------------------------------------------
+
+# boxd_env_files — print every `.env` file under PWD that should be uploaded
+# to a fork, one per line, with leading `./`.
+#
+# Excludes (AC#24):
+#   - directories: node_modules, .next, dist, build, .git, vendor, coverage
+#   - file suffixes: .example, .template, .sample, .local
+boxd_env_files() {
+  find . \
+    -type d \( \
+      -name node_modules -o \
+      -name .next -o \
+      -name dist -o \
+      -name build -o \
+      -name .git -o \
+      -name vendor -o \
+      -name coverage \
+    \) -prune -o \
+    -type f -name '.env' -print
+}
+
+# boxd_rewrite_env VM_NAME — read .env content on stdin, write a rewritten
+# version on stdout where stale localhost-pinned values point at the fork's
+# proxy URL.
+#
+# Rewrite trigger (AC#26): a value matches `https?://(localhost|127\.0\.0\.1):<port>`.
+# Comments, blank lines, and non-matching values pass through untouched.
+#
+# Special-target keys: LW_GATEWAY_BASE_URL routes to `aigw.<vm>.boxd.sh`.
+# Default target: `<vm>.boxd.sh`.
+#
+# Output values are double-quoted for shell-safety, mirroring the format
+# in `langwatch/.env.example`.
+boxd_rewrite_env() {
+  local vm="${1-}"
+  if [ -z "$vm" ]; then
+    echo "boxd_rewrite_env: VM_NAME is required" >&2
+    return 1
+  fi
+  local default_url="https://${vm}.boxd.sh"
+  local aigw_url="https://aigw.${vm}.boxd.sh"
+
+  # Use awk for line-level rewrite — easier to read than nested sed.
+  awk -v default_url="$default_url" -v aigw_url="$aigw_url" '
+    function rewrite(key,    target) {
+      target = (key == "LW_GATEWAY_BASE_URL") ? aigw_url : default_url
+      printf "%s=\"%s\"\n", key, target
+    }
+    # Comments + blank lines pass through verbatim.
+    /^[[:space:]]*(#|$)/ { print; next }
+    # Match: KEY=...localhost:PORT... or KEY=...127.0.0.1:PORT...
+    # Anchored to scheme so we do not mangle e.g. `note=localhost:5560 is fine`.
+    {
+      key = ""
+      eq = index($0, "=")
+      if (eq > 0) {
+        key = substr($0, 1, eq - 1)
+        # Strip whitespace and `export ` prefix from key
+        sub(/^[[:space:]]*(export[[:space:]]+)?/, "", key)
+        sub(/[[:space:]]+$/, "", key)
+        val = substr($0, eq + 1)
+        # Strip leading whitespace and matching quotes from value
+        sub(/^[[:space:]]*/, "", val)
+        if (val ~ /^".*"$/) { val = substr(val, 2, length(val) - 2) }
+        else if (val ~ /^'\''.*'\''$/) { val = substr(val, 2, length(val) - 2) }
+
+        if (val ~ /^https?:\/\/(localhost|127\.0\.0\.1):[0-9]+(\/.*)?$/) {
+          rewrite(key)
+          next
+        }
+      }
+      print
+    }
+  '
+}
+
+# ---------------------------------------------------------------------------
+# Orchestration helpers (boxd CLI side-effects)
+# ---------------------------------------------------------------------------
+
+# Tunable bin paths — overridable in tests via env vars.
+BOXD_BIN="${BOXD_BIN:-boxd}"
+GH_BIN="${GH_BIN:-gh}"
+GIT_BIN="${GIT_BIN:-git}"
+
+# Default port mapping. Each entry is `subdomain:port`. The first entry is
+# special: subdomain `_default` means `boxd proxy set-port` (the bare
+# https://<vm>.boxd.sh URL points there). The rest are per-subdomain proxies.
+BOXD_FORK_PORTS=(
+  "_default:5560"      # langwatch app (compose mode)
+  "aigw:5563"          # AI gateway (Go data plane)
+  "bullboard:6380"
+  "ai-server:3456"
+  "next:3000"          # Next.js standalone `pnpm dev` mode
+)
+
+# Repo we operate on. Override with REPO env var when running in mock mode.
+BOXD_FORK_REPO="${BOXD_FORK_REPO:-langwatch/langwatch}"
+
+# Default Claude credentials path (AC#22).
+BOXD_CLAUDE_CREDS="${CLAUDE_CREDS:-$HOME/.claude/.credentials.json}"
+
+# boxd_vm_exists VM — true if a VM with that name exists.
+boxd_vm_exists() {
+  local vm="${1-}"
+  [ -n "$vm" ] || return 1
+  "$BOXD_BIN" list --json 2>/dev/null \
+    | grep -Fq "\"name\":\"$vm\"" \
+    || return 1
+}
+
+# boxd_vm_status VM — print one of `running`, `standby`, `paused`, `unknown`.
+boxd_vm_status() {
+  local vm="${1-}"
+  "$BOXD_BIN" list --json 2>/dev/null \
+    | awk -v vm="$vm" '
+      /"name":[[:space:]]*"/ {
+        match($0, /"name":[[:space:]]*"[^"]*"/)
+        n = substr($0, RSTART+8, RLENGTH-9)
+        gsub(/^"/, "", n); gsub(/"$/, "", n)
+        cur_name = n
+      }
+      /"status":[[:space:]]*"/ && cur_name == vm {
+        match($0, /"status":[[:space:]]*"[^"]*"/)
+        s = substr($0, RSTART+10, RLENGTH-11)
+        gsub(/^"/, "", s); gsub(/"$/, "", s)
+        print s; exit
+      }
+    '
+}
+
+# boxd_resolve_pr_branch PR — print the head ref of a PR via gh, supporting
+# cross-fork PRs (AC#16). Empty + nonzero exit on failure.
+boxd_resolve_pr_branch() {
+  local pr="${1-}"
+  [ -n "$pr" ] || { echo "PR number required" >&2; return 1; }
+  "$GH_BIN" pr view "$pr" --repo "$BOXD_FORK_REPO" --json headRefName --jq .headRefName
+}
+
+# boxd_upload_envs VM — discover every `.env` file under PWD, rewrite stale
+# localhost values, and copy each to the corresponding path in the VM
+# (AC#25: each .env stays separate; no merging).
+boxd_upload_envs() {
+  local vm="${1-}"
+  [ -n "$vm" ] || { echo "VM name required" >&2; return 1; }
+  local f rel rewritten target
+  while IFS= read -r f; do
+    rel="${f#./}"
+    rewritten=$(mktemp)
+    boxd_rewrite_env "$vm" < "$f" > "$rewritten"
+    # Preserve monorepo path under /home/boxd/langwatch (the in-VM repo path)
+    target="langwatch/$rel"
+    "$BOXD_BIN" cp "$rewritten" "$vm:$target" >/dev/null
+    rm -f "$rewritten"
+    printf '  uploaded %s\n' "$rel" >&2
+  done < <(boxd_env_files)
+}
+
+# boxd_upload_creds VM — copy Claude credentials into the VM (AC#22).
+boxd_upload_creds() {
+  local vm="${1-}"
+  [ -n "$vm" ] || { echo "VM name required" >&2; return 1; }
+  if [ ! -f "$BOXD_CLAUDE_CREDS" ]; then
+    cat <<EOF >&2
+WARNING: Claude credentials not found at $BOXD_CLAUDE_CREDS.
+         The fork will not have an authenticated Claude. Override with:
+           CLAUDE_CREDS=/path/to/credentials.json make boxd-fork-...
+         Or run 'claude login' inside the VM after fork (\`boxd connect $vm\`).
+EOF
+    return 0
+  fi
+  "$BOXD_BIN" cp "$BOXD_CLAUDE_CREDS" "$vm:.claude/.credentials.json" >/dev/null
+  printf '  uploaded Claude credentials\n' >&2
+}
+
+# boxd_map_ports VM — set up the standard set of proxies (AC#27).
+boxd_map_ports() {
+  local vm="${1-}"
+  [ -n "$vm" ] || { echo "VM name required" >&2; return 1; }
+  local entry sub port
+  for entry in "${BOXD_FORK_PORTS[@]}"; do
+    sub="${entry%%:*}"
+    port="${entry##*:}"
+    if [ "$sub" = "_default" ]; then
+      "$BOXD_BIN" exec "$vm" -- "boxd proxy set-port --port=$port" >/dev/null 2>&1 || true
+      printf '  proxy: https://%s.boxd.sh -> :%s\n' "$vm" "$port" >&2
+    else
+      # `proxy new` errors if the subdomain already exists; that's idempotent.
+      "$BOXD_BIN" exec "$vm" -- "boxd proxy new $sub --port=$port" >/dev/null 2>&1 || true
+      printf '  proxy: https://%s.%s.boxd.sh -> :%s\n' "$sub" "$vm" "$port" >&2
+    fi
+  done
+}
+
+# boxd_wake_if_suspended VM — resume the VM if it's paused/standby (AC#20).
+boxd_wake_if_suspended() {
+  local vm="${1-}"
+  [ -n "$vm" ] || return 1
+  local status
+  status=$(boxd_vm_status "$vm")
+  case "$status" in
+    paused|standby|suspended)
+      printf '  resuming suspended VM %s\n' "$vm" >&2
+      "$BOXD_BIN" resume "$vm" >/dev/null 2>&1 || true
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration — driven by boxd.mk targets
+# ---------------------------------------------------------------------------
+
+# Internal: the shared fork primitive (AC#10).
+# Args: SOURCE INPUT BRANCH [START_TMUX]
+#   SOURCE     pr | branch | issue
+#   INPUT      arg the user passed (PR number / branch / issue number)
+#   BRANCH     the actual git branch to check out inside the fork
+#   START_TMUX 1 to start a Claude tmux session (fork-issue), 0 otherwise
+_boxd_fork_impl() {
+  local source="$1" input="$2" branch="$3" start_tmux="${4:-0}"
+  local vm tmux
+  vm=$(boxd_vm_name "$source" "$input")
+  tmux=$(boxd_tmux_name "$source" "$input")
+
+  printf 'Forking VM: %s (branch=%s, tmux=%s)\n' "$vm" "$branch" "$tmux" >&2
+  printf '  proxies: https://%s.boxd.sh and configured subdomains\n' "$vm" >&2
+
+  # AC#15: existing VM is an error, not a silent re-fork.
+  if boxd_vm_exists "$vm"; then
+    cat <<EOF >&2
+ERROR: VM '$vm' already exists. Pick a different source or destroy it first:
+         boxd destroy $vm
+       Or connect to it:
+         make boxd-connect-${source%pr} ${source^^}=$input
+EOF
+    return 1
+  fi
+
+  # AC#10 / AC#11: fork from langwatch-golden, then check out the branch.
+  if ! "$BOXD_BIN" fork langwatch-golden --name="$vm" >/dev/null; then
+    echo "ERROR: 'boxd fork langwatch-golden --name=$vm' failed." >&2
+    return 1
+  fi
+
+  # Ensure the in-VM repo is on the right branch (AC#16: cross-fork PRs as
+  # detached head if the branch isn't local).
+  "$BOXD_BIN" exec "$vm" -- "cd langwatch && git fetch origin && git checkout '$branch' 2>/dev/null || git checkout -b '$branch' 'origin/$branch' 2>/dev/null || git checkout 'origin/$branch'" >/dev/null
+
+  boxd_upload_creds "$vm"
+  boxd_upload_envs "$vm"
+  boxd_map_ports "$vm"
+
+  if [ "$start_tmux" = "1" ]; then
+    # AC#12: tmux + Claude session inside the VM, named claude-<slug>/issue<N>.
+    "$BOXD_BIN" exec "$vm" -- \
+      "tmux new-session -d -s '$tmux' 'cd langwatch && claude --dangerously-skip-permissions'" \
+      >/dev/null 2>&1 || true
+    printf '  started tmux session %s on %s\n' "$tmux" "$vm" >&2
+  fi
+
+  printf 'Done. Connect with:\n  make boxd-connect-%s %s=%s\n' \
+    "${source}" "$(_boxd_arg_for_source "$source")" "$input" >&2
+}
+
+# Helper: print the variable name expected by the connect target for a source.
+_boxd_arg_for_source() {
+  case "${1-}" in
+    pr) printf 'PR' ;;
+    branch) printf 'BRANCH' ;;
+    issue) printf 'ISSUE' ;;
+  esac
+}
+
+# boxd_fork_pr PR — fork the golden VM for an existing PR.
+# Resolves head ref via gh, including PRs from forked repos (AC#16).
+boxd_fork_pr() {
+  local pr="${1-}"
+  [ -n "$pr" ] || { echo "usage: make boxd-fork-pr PR=<number>" >&2; return 1; }
+  local branch
+  branch=$(boxd_resolve_pr_branch "$pr") || {
+    echo "ERROR: could not resolve PR #$pr via gh." >&2
+    return 1
+  }
+  local slug
+  slug=$(boxd_slug "$branch")
+  boxd_branch_issue_collision_warning "$slug"
+  _boxd_fork_impl pr "$branch" "$branch" 0
+}
+
+# boxd_fork_branch BRANCH — fork for a branch that doesn't (yet) have a PR.
+boxd_fork_branch() {
+  local branch="${1-}"
+  [ -n "$branch" ] || { echo "usage: make boxd-fork-branch BRANCH=<name>" >&2; return 1; }
+  local slug
+  slug=$(boxd_slug "$branch")
+  boxd_branch_issue_collision_warning "$slug"
+  _boxd_fork_impl branch "$branch" "$branch" 0
+}
+
+# boxd_fork_issue ISSUE — fork for an issue without a PR yet. Creates the
+# worktree branch on the host (idempotent: reuses existing per AC#15) and
+# starts a tmux + Claude session inside the VM (AC#12).
+boxd_fork_issue() {
+  local issue="${1-}"
+  [ -n "$issue" ] || { echo "usage: make boxd-fork-issue ISSUE=<number>" >&2; return 1; }
+
+  # Resolve issue title via gh, build branch via existing worktree.sh logic.
+  local title slug branch
+  title=$("$GH_BIN" issue view "$issue" --repo "$BOXD_FORK_REPO" --json title --jq .title) \
+    || { echo "ERROR: could not resolve issue #$issue via gh." >&2; return 1; }
+  # Inline the worktree.sh slug rules (max 50, word-boundary truncation)
+  # to avoid sourcing it from here. Keep VM name on the canonical issue<N>
+  # form regardless of title.
+  slug=$(printf '%s' "$title" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/-+/-/g; s/^-+//; s/-+$//')
+  if [ "${#slug}" -gt 50 ]; then
+    slug="${slug:0:50}"
+    slug="${slug%-*}"
+    slug="${slug%-}"
+  fi
+  branch="issue${issue}/${slug}"
+
+  # AC#15: reuse worktree branch if it already exists, no error/no overwrite.
+  if "$GIT_BIN" rev-parse --verify "$branch" >/dev/null 2>&1; then
+    printf 'Reusing existing local branch: %s\n' "$branch" >&2
+  else
+    printf 'Creating worktree branch: %s\n' "$branch" >&2
+    if [ -x "$(dirname "${BASH_SOURCE[0]}")/worktree.sh" ]; then
+      "$(dirname "${BASH_SOURCE[0]}")/worktree.sh" "$issue" >/dev/null \
+        || printf 'NOTE: worktree.sh did not complete cleanly — branch may not exist locally.\n' >&2
+    fi
+  fi
+
+  _boxd_fork_impl issue "$issue" "$branch" 1
+}
+
+# boxd_golden — build the golden VM. If it already exists, this is a no-op
+# pointing the user at boxd-golden-reset (AC#5).
+boxd_golden() {
+  local vm="langwatch-golden"
+  if boxd_vm_exists "$vm"; then
+    cat <<EOF >&2
+'$vm' already exists. To rebuild from scratch:
+  make boxd-golden-reset
+EOF
+    return 0
+  fi
+  printf 'Creating golden VM %s\n' "$vm" >&2
+  "$BOXD_BIN" new --name="$vm" >/dev/null
+  # Provision: install node, clone repo, install deps, run dev-full once.
+  "$BOXD_BIN" exec "$vm" -- "
+    set -e
+    sudo apt-get update -y >/dev/null 2>&1 || true
+    sudo apt-get install -y nodejs npm >/dev/null 2>&1 || true
+    if [ ! -d langwatch ]; then
+      git clone https://github.com/$BOXD_FORK_REPO.git langwatch
+    fi
+    cd langwatch && corepack enable && pnpm -w install
+  " >/dev/null
+  # Hook for seed-golden (AC#7): callable target the make file overrides.
+  printf 'Done. Override the seed step by defining a seed-golden target.\n' >&2
+}
+
+# boxd_golden_reset — destroy + rebuild langwatch-golden (AC#6).
+# Requires user confirmation per AC#4 (destructive).
+boxd_golden_reset() {
+  local vm="langwatch-golden"
+  if [ "${BOXD_FORK_YES:-}" != "1" ]; then
+    printf 'This will destroy %s and rebuild it. Re-run with BOXD_FORK_YES=1 to confirm.\n' "$vm" >&2
+    return 1
+  fi
+  if boxd_vm_exists "$vm"; then
+    printf 'Destroying %s\n' "$vm" >&2
+    "$BOXD_BIN" destroy "$vm" >/dev/null 2>&1 || true
+  fi
+  boxd_golden
+}
+
+# boxd_connect SOURCE INPUT — SSH into the matching VM and tmux-attach.
+# Shared resolution logic for connect-pr / connect-branch / connect-issue
+# (AC#17 + AC#21).
+boxd_connect() {
+  local source="${1-}" input="${2-}"
+  local vm tmux
+  vm=$(boxd_vm_name "$source" "$input") || return 1
+  tmux=$(boxd_tmux_name "$source" "$input") || return 1
+
+  if ! boxd_vm_exists "$vm"; then
+    cat <<EOF >&2
+ERROR: VM '$vm' does not exist. Create it first:
+  make boxd-fork-${source} $(_boxd_arg_for_source "$source")=$input
+EOF
+    return 1
+  fi
+
+  boxd_wake_if_suspended "$vm"
+
+  # AC#18: if the tmux session is missing, print a clear message and exit
+  # nonzero — don't drop into a shell where the user expects an attach.
+  local tmux_check
+  tmux_check=$("$BOXD_BIN" exec "$vm" -- "tmux has-session -t '$tmux' 2>/dev/null && echo OK" 2>/dev/null || true)
+  if [ "$tmux_check" != "OK" ]; then
+    cat <<EOF >&2
+ERROR: no claude session found on VM '$vm'.
+       Run 'make boxd-fork-${source} $(_boxd_arg_for_source "$source")=$input' first
+       or start one manually:
+         boxd connect $vm
+         tmux new -s $tmux
+EOF
+    return 1
+  fi
+
+  exec "$BOXD_BIN" connect "$vm" --command "tmux attach -t '$tmux'"
+}

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -308,13 +308,16 @@ boxd_wake_if_suspended() {
 # ---------------------------------------------------------------------------
 
 # Internal: the shared fork primitive (AC#10).
-# Args: SOURCE INPUT BRANCH [START_TMUX]
+# Args: SOURCE VM_INPUT USER_ARG BRANCH [START_TMUX]
 #   SOURCE     pr | branch | issue
-#   INPUT      arg the user passed (PR number / branch / issue number)
+#   VM_INPUT   value passed to boxd_vm_name (PR's branch, branch name, or issue number)
+#   USER_ARG   value the user originally typed — used to echo back the right
+#              connect command. fork-pr: PR number, fork-branch: branch,
+#              fork-issue: issue number.
 #   BRANCH     the actual git branch to check out inside the fork
 #   START_TMUX 1 to start a Claude tmux session (fork-issue), 0 otherwise
 _boxd_fork_impl() {
-  local source="$1" input="$2" branch="$3" start_tmux="${4:-0}"
+  local source="$1" input="$2" user_arg="$3" branch="$4" start_tmux="${5:-0}"
   local vm tmux
   vm=$(boxd_vm_name "$source" "$input")
   tmux=$(boxd_tmux_name "$source" "$input")
@@ -356,7 +359,7 @@ EOF
   fi
 
   printf 'Done. Connect with:\n  make boxd-connect-%s %s=%s\n' \
-    "${source}" "$(_boxd_arg_for_source "$source")" "$input" >&2
+    "${source}" "$(_boxd_arg_for_source "$source")" "$user_arg" >&2
 }
 
 # Helper: print the variable name expected by the connect target for a source.
@@ -381,7 +384,7 @@ boxd_fork_pr() {
   local slug
   slug=$(boxd_slug "$branch")
   boxd_branch_issue_collision_warning "$slug"
-  _boxd_fork_impl pr "$branch" "$branch" 0
+  _boxd_fork_impl pr "$branch" "$pr" "$branch" 0
 }
 
 # boxd_fork_branch BRANCH — fork for a branch that doesn't (yet) have a PR.
@@ -391,7 +394,7 @@ boxd_fork_branch() {
   local slug
   slug=$(boxd_slug "$branch")
   boxd_branch_issue_collision_warning "$slug"
-  _boxd_fork_impl branch "$branch" "$branch" 0
+  _boxd_fork_impl branch "$branch" "$branch" "$branch" 0
 }
 
 # boxd_fork_issue ISSUE — fork for an issue without a PR yet. Creates the
@@ -429,7 +432,7 @@ boxd_fork_issue() {
     fi
   fi
 
-  _boxd_fork_impl issue "$issue" "$branch" 1
+  _boxd_fork_impl issue "$issue" "$issue" "$branch" 1
 }
 
 # boxd_golden — build the golden VM. If it already exists, this is a no-op

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -286,19 +286,30 @@ EOF
 boxd_map_ports() {
   local vm="${1-}"
   [ -n "$vm" ] || { echo "VM name required" >&2; return 1; }
-  local entry sub port
+  local entry sub port out failed=0
   for entry in "${BOXD_FORK_PORTS[@]}"; do
     sub="${entry%%:*}"
     port="${entry##*:}"
     if [ "$sub" = "_default" ]; then
-      "$BOXD_BIN" proxy set-port --port="$port" --vm "$vm" >/dev/null 2>&1 || true
-      printf '  proxy: https://%s.boxd.sh -> :%s\n' "$vm" "$port" >&2
+      if out=$("$BOXD_BIN" proxy set-port --port="$port" --vm "$vm" 2>&1); then
+        printf '  proxy: https://%s.boxd.sh -> :%s\n' "$vm" "$port" >&2
+      else
+        printf '  ERROR: failed to set default proxy for %s -> :%s\n%s\n' "$vm" "$port" "$out" >&2
+        failed=1
+      fi
     else
       # `proxy new` errors if the subdomain already exists; that's idempotent.
-      "$BOXD_BIN" proxy new "$sub" --port="$port" --vm "$vm" >/dev/null 2>&1 || true
-      printf '  proxy: https://%s.%s.boxd.sh -> :%s\n' "$sub" "$vm" "$port" >&2
+      if out=$("$BOXD_BIN" proxy new "$sub" --port="$port" --vm "$vm" 2>&1); then
+        printf '  proxy: https://%s.%s.boxd.sh -> :%s\n' "$sub" "$vm" "$port" >&2
+      elif printf '%s' "$out" | grep -qiE 'already exists|conflict'; then
+        printf '  proxy: https://%s.%s.boxd.sh -> :%s (existing)\n' "$sub" "$vm" "$port" >&2
+      else
+        printf '  ERROR: failed to create proxy %s.%s.boxd.sh -> :%s\n%s\n' "$sub" "$vm" "$port" "$out" >&2
+        failed=1
+      fi
     fi
   done
+  return $failed
 }
 
 # boxd_wake_if_suspended VM — resume the VM if it's paused/standby (AC#20).
@@ -453,6 +464,13 @@ boxd_fork_issue() {
   local title slug branch
   title=$("$GH_BIN" issue view "$issue" --repo "$BOXD_FORK_REPO" --json title --jq .title) \
     || { echo "ERROR: could not resolve issue #$issue via gh." >&2; return 1; }
+  # Mirror the empty-headRefName guard above — gh can return exit 0 with an
+  # empty .title on permissions/edge cases, which would slug to "" and yield
+  # a degenerate ref like `issue<N>/`.
+  if [ -z "$title" ]; then
+    echo "ERROR: gh returned an empty title for issue #$issue." >&2
+    return 1
+  fi
   # Inline the worktree.sh slug rules (max 50, word-boundary truncation)
   # to avoid sourcing it from here. Keep VM name on the canonical issue<N>
   # form regardless of title.
@@ -531,7 +549,10 @@ boxd_golden_reset() {
   fi
   if boxd_vm_exists "$vm"; then
     printf 'Destroying %s\n' "$vm" >&2
-    "$BOXD_BIN" destroy "$vm" >/dev/null 2>&1 || true
+    if ! "$BOXD_BIN" destroy "$vm" >/dev/null 2>&1; then
+      echo "ERROR: 'boxd destroy $vm' failed; aborting reset." >&2
+      return 1
+    fi
   fi
   boxd_golden
 }

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -310,7 +310,7 @@ boxd_wake_if_suspended() {
 # ---------------------------------------------------------------------------
 
 # Internal: the shared fork primitive (AC#10).
-# Args: SOURCE VM_INPUT USER_ARG BRANCH [START_TMUX]
+# Args: SOURCE VM_INPUT USER_ARG BRANCH [START_TMUX [PR]]
 #   SOURCE     pr | branch | issue
 #   VM_INPUT   value passed to boxd_vm_name (PR's branch, branch name, or issue number)
 #   USER_ARG   value the user originally typed — used to echo back the right
@@ -318,6 +318,8 @@ boxd_wake_if_suspended() {
 #              fork-issue: issue number.
 #   BRANCH     the actual git branch to check out inside the fork
 #   START_TMUX 1 to start a Claude tmux session (fork-issue), 0 otherwise
+#   PR         optional PR number; when set, checkout uses `gh pr checkout`
+#              inside the fork to handle PRs from forked repos (AC#16).
 _boxd_fork_impl() {
   local source="$1" input="$2" user_arg="$3" branch="$4" start_tmux="${5:-0}" pr="${6:-}"
   local vm tmux arg_name

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -85,8 +85,27 @@ fi
 # Start services in detached mode
 # ---------------------------------------------------------------------------
 echo "Starting LangWatch (project=${COMPOSE_PROJECT_NAME}, app_port=${APP_PORT})..."
-# Use email auth for browser tests (overrides .env's NEXTAUTH_PROVIDER)
-echo "NEXTAUTH_PROVIDER=email" > langwatch/.env.dev-up
+
+# Write URL overrides into langwatch/.env.dev-up. Loaded by app/workers/
+# ai-server services AFTER langwatch/.env (#3860 AC#6) — only the URLs
+# whose services are starting locally for this profile are overridden.
+# Profiles map to quickstart modes:
+#   (none) / dev  → backend-shared
+#   nlp           → nlp
+#   scenarios|test|full → full-local
+{
+  echo "NEXTAUTH_PROVIDER=email"
+  echo "DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb"
+  echo "REDIS_URL=redis://redis:6379"
+  echo "CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch"
+  case "$PROFILE" in
+    nlp|scenarios|test|full)
+      echo "LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561"
+      echo "LANGEVALS_ENDPOINT=http://langevals:5562"
+      ;;
+  esac
+} > langwatch/.env.dev-up
+
 $COMPOSE_CMD up -d
 
 # ---------------------------------------------------------------------------

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -86,25 +86,14 @@ fi
 # ---------------------------------------------------------------------------
 echo "Starting LangWatch (project=${COMPOSE_PROJECT_NAME}, app_port=${APP_PORT})..."
 
-# Write URL overrides into langwatch/.env.dev-up. Loaded by app/workers/
-# ai-server services AFTER langwatch/.env (#3860 AC#6) — only the URLs
-# whose services are starting locally for this profile are overridden.
-# Profiles map to quickstart modes:
-#   (none) / dev  → backend-shared
-#   nlp           → nlp
-#   scenarios|test|full → full-local
-{
-  echo "NEXTAUTH_PROVIDER=email"
-  echo "DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb"
-  echo "REDIS_URL=redis://redis:6379"
-  echo "CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch"
-  case "$PROFILE" in
-    nlp|scenarios|test|full)
-      echo "LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561"
-      echo "LANGEVALS_ENDPOINT=http://langevals:5562"
-      ;;
-  esac
-} > langwatch/.env.dev-up
+# Write URL overrides into langwatch/.env.dev-up. Same shared helper as
+# scripts/dev.sh — only the URLs whose services actually start for this
+# profile are overridden (#3860 AC#6). The helper honors each service's
+# compose profile membership: langwatch_nlp runs under [nlp, scenarios,
+# full], langevals only under [nlp, full]. test/debug profiles add no
+# extra URL overrides.
+. "$(dirname "$0")/lib/write-dev-overrides.sh"
+write_dev_overrides "${PROFILE:-backend-shared}" langwatch/.env.dev-up
 
 $COMPOSE_CMD up -d
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -108,10 +108,12 @@ check_env_files() {
 }
 
 # Fail-fast on insecure SaaS-mode config (#3860 AC#7).
+# Patterns accept unquoted, single-quoted, and double-quoted values — all
+# valid `.env` syntax.
 check_saas_ssrf_guard() {
   if [ ! -f "langwatch/.env" ]; then return 0; fi
-  if grep -qE '^IS_SAAS\s*=\s*"?true"?\s*$' langwatch/.env \
-     && grep -qE '^BLOCK_LOCAL_HTTP_CALLS\s*=\s*"?false"?\s*$' langwatch/.env; then
+  if grep -qE "^IS_SAAS[[:space:]]*=[[:space:]]*['\"]?true['\"]?[[:space:]]*$" langwatch/.env \
+     && grep -qE "^BLOCK_LOCAL_HTTP_CALLS[[:space:]]*=[[:space:]]*['\"]?false['\"]?[[:space:]]*$" langwatch/.env; then
     echo "ERROR: langwatch/.env has IS_SAAS=true with BLOCK_LOCAL_HTTP_CALLS=false." >&2
     echo "       SaaS mode requires SSRF blocking. Set BLOCK_LOCAL_HTTP_CALLS=true." >&2
     exit 1
@@ -154,50 +156,15 @@ ensure_prepared() {
 
 # ---------------------------------------------------------------------------
 # URL overrides per mode (#3860 AC#2 / AC#6).
-# Writes `langwatch/.env.dev-up` listing only the URLs whose services are
-# starting locally for the given mode. Empty file ⇒ nothing is overridden.
+# Delegates to scripts/lib/write-dev-overrides.sh — same helper is sourced by
+# scripts/dev-up.sh so the two launchers can't drift on the overlay format.
 # ---------------------------------------------------------------------------
+. "$(dirname "$0")/lib/write-dev-overrides.sh"
+
 write_overrides() {
   local mode="$1"
   local out="langwatch/.env.dev-up"
-  : > "$out"
-  # The auth provider is always email in dev (no Auth0 dependency).
-  echo "NEXTAUTH_PROVIDER=email" >> "$out"
-  case "$mode" in
-    frontend-only)
-      ;;  # nothing — .env wins
-    backend-shared)
-      cat >> "$out" <<EOF
-DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
-REDIS_URL=redis://redis:6379
-CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch
-EOF
-      ;;
-    migration)
-      cat >> "$out" <<EOF
-DATABASE_URL=postgresql://prisma:prisma@localhost:5432/mydb?schema=mydb
-CLICKHOUSE_URL=http://default:langwatch@localhost:8123/langwatch
-EOF
-      ;;
-    nlp)
-      cat >> "$out" <<EOF
-DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
-REDIS_URL=redis://redis:6379
-CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch
-LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561
-LANGEVALS_ENDPOINT=http://langevals:5562
-EOF
-      ;;
-    full-local)
-      cat >> "$out" <<EOF
-DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
-REDIS_URL=redis://redis:6379
-CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch
-LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561
-LANGEVALS_ENDPOINT=http://langevals:5562
-EOF
-      ;;
-  esac
+  write_dev_overrides "$mode" "$out"
   if [ -s "$out" ]; then
     echo "URL overrides for mode=$mode written to $out:"
     sed 's/^/  /' "$out" >&2

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -210,9 +210,11 @@ run_backend_shared() {
 }
 
 run_migration() {
-  check_env_files
-  check_saas_ssrf_guard
-  check_stateful_collision
+  # Use the same prep path as backend-shared / nlp / full-local so a fresh
+  # clone running migration as its first mode still has node_modules and
+  # the generated Prisma client available for the host-side
+  # `pnpm prisma migrate dev` call below.
+  ensure_prepared
   write_overrides migration
   echo "Starting: postgres + clickhouse with HOST ports (mode=migration)"
   $COMPOSE_MIGRATION up -d postgres clickhouse

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,8 +1,36 @@
 #!/bin/bash
-# Interactive development environment launcher
+# Interactive development environment launcher (single entry point — #3860 AC#1).
 set -e
 
 COMPOSE="docker compose -f compose.dev.yml"
+
+# Non-interactive mode reference (#3860 AC#8). Lets agents and CI discover modes
+# without going through the prompt.
+if [ "${1:-}" = "help" ]; then
+  cat <<'EOF'
+LangWatch dev environment
+
+Modes:
+  dev              postgres + redis + clickhouse + app
+  dev-nlp          + langwatch_nlp + langevals (for evaluations)
+  dev-scenarios    + scenario worker + bullboard + nlp
+  dev-test         + ai test server (HTTP agent testing)
+  dev-full         everything above
+
+Stateful services share data across worktrees:
+  langwatch-db-data, langwatch-clickhouse-data, langwatch-redis-data
+  → sign up once, persist across worktree switches.
+  → only one worktree can have postgres / clickhouse 'up' at a time.
+
+Stateless redis is a singleton on host :6379.
+
+Per-worktree node_modules stay isolated (platform deps — see ADR-004).
+
+Run 'make quickstart' to launch interactively, or 'make dev' / etc. for the
+specific modes (those will be removed after one release — use 'make quickstart').
+EOF
+  exit 0
+fi
 
 # Auto-detect worktree for container/volume isolation
 if git rev-parse --is-inside-work-tree &>/dev/null; then
@@ -44,9 +72,47 @@ check_env_files() {
   fi
 }
 
+# Fail-fast on insecure SaaS-mode config (#3860 AC#7). compose.dev.yml's
+# common-env always sets BLOCK_LOCAL_HTTP_CALLS=true at runtime, but a stale
+# `.env` with IS_SAAS=true and BLOCK_LOCAL_HTTP_CALLS=false in the same file
+# ships a broken combo to anywhere else (workers without compose, lambda).
+check_saas_ssrf_guard() {
+  if [ ! -f "langwatch/.env" ]; then return 0; fi
+  if grep -qE '^IS_SAAS\s*=\s*"?true"?\s*$' langwatch/.env \
+     && grep -qE '^BLOCK_LOCAL_HTTP_CALLS\s*=\s*"?false"?\s*$' langwatch/.env; then
+    echo "ERROR: langwatch/.env has IS_SAAS=true with BLOCK_LOCAL_HTTP_CALLS=false." >&2
+    echo "       SaaS mode requires SSRF blocking. Set BLOCK_LOCAL_HTTP_CALLS=true." >&2
+    exit 1
+  fi
+}
+
+# Detect when another worktree is already using a shared stateful volume
+# (#3860 AC#4). Postgres locks /var/lib/postgresql/data, so the second up
+# would fail to start anyway — fail fast with a clear message.
+check_stateful_collision() {
+  local me="${COMPOSE_PROJECT_NAME:-langwatch}"
+  local vol cid project
+  for vol in langwatch-db-data langwatch-clickhouse-data; do
+    for cid in $(docker ps -q --filter "volume=$vol" 2>/dev/null); do
+      project=$(docker inspect -f '{{index .Config.Labels "com.docker.compose.project"}}' "$cid" 2>/dev/null || true)
+      if [ -n "$project" ] && [ "$project" != "$me" ]; then
+        cat >&2 <<EOF
+ERROR: Shared volume '$vol' is already in use by compose project '$project'.
+       Only one worktree can run postgres / clickhouse at a time.
+       Stop the other one first:
+         (cd that worktree && make down)
+EOF
+        exit 1
+      fi
+    done
+  done
+}
+
 # Run prep steps on host (curl available, prisma generate needs node_modules)
 ensure_prepared() {
   check_env_files
+  check_saas_ssrf_guard
+  check_stateful_collision
   cd langwatch
   # Host needs its own node_modules for prep (separate from container's Linux deps)
   if [ ! -d node_modules ]; then

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,43 +1,75 @@
 #!/bin/bash
-# Interactive development environment launcher (single entry point — #3860 AC#1).
+# Development environment launcher (single entry point — #3860 AC#1).
+#
+# Usage:
+#   scripts/dev.sh                # interactive mode picker
+#   scripts/dev.sh frontend-only  # no compose, pure pnpm dev against .env URLs
+#   scripts/dev.sh backend-shared # postgres + redis + clickhouse + app, URLs → local
+#   scripts/dev.sh migration      # postgres + clickhouse on host ports, run migrations from host
+#   scripts/dev.sh nlp            # backend + nlp + langevals; nlp/langevals URLs → local
+#   scripts/dev.sh full-local     # --profile full; all infrastructure URLs → local
+#   scripts/dev.sh help           # non-interactive mode reference
+#   scripts/dev.sh down           # stop all services
+#   scripts/dev.sh ps | logs | clean | rebuild
 set -e
 
 COMPOSE="docker compose -f compose.dev.yml"
+COMPOSE_MIGRATION="docker compose -f compose.dev.yml -f compose.dev.migration.yml"
 
-# Non-interactive mode reference (#3860 AC#8). Lets agents and CI discover modes
-# without going through the prompt.
+# ---------------------------------------------------------------------------
+# Help mode (#3860 AC#8) — non-interactive reference
+# ---------------------------------------------------------------------------
 if [ "${1:-}" = "help" ]; then
   cat <<'EOF'
 LangWatch dev environment
 
-Modes:
-  dev              postgres + redis + clickhouse + app
-  dev-nlp          + langwatch_nlp + langevals (for evaluations)
-  dev-scenarios    + scenario worker + bullboard + nlp
-  dev-test         + ai test server (HTTP agent testing)
-  dev-full         everything above
+Modes — pass as the first arg or pick interactively:
 
-Stateful services share data across worktrees:
-  langwatch-db-data, langwatch-clickhouse-data, langwatch-redis-data
-  → sign up once, persist across worktree switches.
-  → only one worktree can have postgres / clickhouse 'up' at a time.
+  frontend-only   No compose. Pure `pnpm dev` against the URLs in your
+                  langwatch/.env. Fastest — for UI / design / static iteration.
+                  (default — hit enter at the prompt)
 
-Stateless redis is a singleton on host :6379.
+  backend-shared  Local postgres + redis + clickhouse + app. Overrides
+                  DATABASE_URL, REDIS_URL, CLICKHOUSE_URL → local containers.
+                  Other URLs come from your .env unchanged.
 
-Per-worktree node_modules stay isolated (platform deps — see ADR-004).
+  migration       postgres + clickhouse on HOST ports (5432 / 8123). Run
+                  `pnpm prisma migrate dev` and `pnpm clickhouse:migrate`
+                  from your host shell. Overrides DATABASE_URL, CLICKHOUSE_URL.
 
-Run 'make quickstart' to launch interactively, or 'make dev' / etc. for the
-specific modes (those will be removed after one release — use 'make quickstart').
+  nlp             backend + langwatch_nlp + langevals. Overrides
+                  DATABASE_URL, REDIS_URL, CLICKHOUSE_URL, LANGWATCH_NLP_SERVICE,
+                  LANGEVALS_ENDPOINT → local containers.
+
+  full-local      --profile full (everything: workers, scenarios, bullboard,
+                  ai-server, nlp). Overrides every infrastructure URL → local.
+
+URL-override model: each mode writes `langwatch/.env.dev-up` listing only
+the URLs whose services are starting locally for that mode. compose loads
+this overlay AFTER langwatch/.env (your source of truth), so non-overridden
+URLs keep their .env values (#3860 AC#2 / AC#6).
+
+Stateful volumes (langwatch-db-data, langwatch-clickhouse-data,
+langwatch-redis-data) are shared across worktrees — sign up once, persist
+across worktree switches. Only one worktree can have a given stateful
+container `up` at a time; quickstart fails fast on collision.
+
+Stateless redis exposes host :6379.
+
+Other actions:
+  down / logs / ps / clean / rebuild   meta operations on the running stack
 EOF
   exit 0
 fi
 
-# Auto-detect worktree for container/volume isolation
+# ---------------------------------------------------------------------------
+# Auto-detect worktree for container/volume isolation. Stateful volumes
+# (langwatch-db-data etc.) are stable shared names regardless of project
+# (#3860 AC#4); per-worktree node_modules still need the prefix.
+# ---------------------------------------------------------------------------
 if git rev-parse --is-inside-work-tree &>/dev/null; then
   WORKTREE_NAME=$(basename "$(git rev-parse --show-toplevel)")
-  # "langwatch" is the expected main checkout directory name (repo name)
   if [ "$WORKTREE_NAME" != "langwatch" ]; then
-    # Sanitize for Docker Compose project/volume naming (only [a-z0-9_-], must start with letter/digit)
     WORKTREE_NAME=$(echo "$WORKTREE_NAME" \
       | tr '[:upper:]' '[:lower:]' \
       | sed -E 's/[^a-z0-9_-]+/-/g; s/^-+//; s/-+$//')
@@ -47,9 +79,12 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
   fi
 fi
 
-LAST_CHOICE_FILE="/tmp/.langwatch-dev-last-choice-v2-${COMPOSE_PROJECT_NAME:-langwatch}"
+LAST_CHOICE_FILE="/tmp/.langwatch-dev-last-choice-v3-${COMPOSE_PROJECT_NAME:-langwatch}"
 
-# Check for required .env files
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+
 check_env_files() {
   local missing=0
   if [ ! -f "langwatch/.env" ]; then
@@ -58,7 +93,7 @@ check_env_files() {
     missing=1
   fi
   if [ ! -f "langwatch_nlp/.env" ]; then
-    echo "WARNING: langwatch_nlp/.env not found (needed for nlp/scenarios profiles)"
+    echo "WARNING: langwatch_nlp/.env not found (needed for nlp / full-local modes)"
     echo "  → cp langwatch_nlp/.env.example langwatch_nlp/.env"
     missing=1
   fi
@@ -72,10 +107,7 @@ check_env_files() {
   fi
 }
 
-# Fail-fast on insecure SaaS-mode config (#3860 AC#7). compose.dev.yml's
-# common-env always sets BLOCK_LOCAL_HTTP_CALLS=true at runtime, but a stale
-# `.env` with IS_SAAS=true and BLOCK_LOCAL_HTTP_CALLS=false in the same file
-# ships a broken combo to anywhere else (workers without compose, lambda).
+# Fail-fast on insecure SaaS-mode config (#3860 AC#7).
 check_saas_ssrf_guard() {
   if [ ! -f "langwatch/.env" ]; then return 0; fi
   if grep -qE '^IS_SAAS\s*=\s*"?true"?\s*$' langwatch/.env \
@@ -86,9 +118,7 @@ check_saas_ssrf_guard() {
   fi
 }
 
-# Detect when another worktree is already using a shared stateful volume
-# (#3860 AC#4). Postgres locks /var/lib/postgresql/data, so the second up
-# would fail to start anyway — fail fast with a clear message.
+# Detect cross-worktree collision on stateful volumes (#3860 AC#4).
 check_stateful_collision() {
   local me="${COMPOSE_PROJECT_NAME:-langwatch}"
   local vol cid project
@@ -108,25 +138,77 @@ EOF
   done
 }
 
-# Run prep steps on host (curl available, prisma generate needs node_modules)
 ensure_prepared() {
   check_env_files
   check_saas_ssrf_guard
   check_stateful_collision
-  cd langwatch
-  # Host needs its own node_modules for prep (separate from container's Linux deps)
-  if [ ! -d node_modules ]; then
-    echo "Installing host dependencies (for prep)..."
-    pnpm install
-  fi
-  # Prepare files (prisma generate, curl download, etc)
-  echo "Preparing files..."
-  pnpm run start:prepare:files 2>/dev/null || true
-  cd ..
+  ( cd langwatch
+    if [ ! -d node_modules ]; then
+      echo "Installing host dependencies (for prep)..."
+      pnpm install
+    fi
+    echo "Preparing files..."
+    pnpm run start:prepare:files 2>/dev/null || true
+  )
 }
 
-# Find a free port starting from base
-# Checks both host processes (lsof) and Docker port bindings.
+# ---------------------------------------------------------------------------
+# URL overrides per mode (#3860 AC#2 / AC#6).
+# Writes `langwatch/.env.dev-up` listing only the URLs whose services are
+# starting locally for the given mode. Empty file ⇒ nothing is overridden.
+# ---------------------------------------------------------------------------
+write_overrides() {
+  local mode="$1"
+  local out="langwatch/.env.dev-up"
+  : > "$out"
+  # The auth provider is always email in dev (no Auth0 dependency).
+  echo "NEXTAUTH_PROVIDER=email" >> "$out"
+  case "$mode" in
+    frontend-only)
+      ;;  # nothing — .env wins
+    backend-shared)
+      cat >> "$out" <<EOF
+DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
+REDIS_URL=redis://redis:6379
+CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch
+EOF
+      ;;
+    migration)
+      cat >> "$out" <<EOF
+DATABASE_URL=postgresql://prisma:prisma@localhost:5432/mydb?schema=mydb
+CLICKHOUSE_URL=http://default:langwatch@localhost:8123/langwatch
+EOF
+      ;;
+    nlp)
+      cat >> "$out" <<EOF
+DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
+REDIS_URL=redis://redis:6379
+CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch
+LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561
+LANGEVALS_ENDPOINT=http://langevals:5562
+EOF
+      ;;
+    full-local)
+      cat >> "$out" <<EOF
+DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
+REDIS_URL=redis://redis:6379
+CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch
+LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561
+LANGEVALS_ENDPOINT=http://langevals:5562
+EOF
+      ;;
+  esac
+  if [ -s "$out" ]; then
+    echo "URL overrides for mode=$mode written to $out:"
+    sed 's/^/  /' "$out" >&2
+  else
+    echo "No URL overrides for mode=$mode — your langwatch/.env values are used as-is."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Free-port detection (used in non-frontend modes for app/bullboard/ai-server)
+# ---------------------------------------------------------------------------
 find_free_port() {
   local port=$1
   while lsof -i :$port >/dev/null 2>&1 || docker ps --format '{{.Ports}}' 2>/dev/null | grep -q "0.0.0.0:${port}->"; do
@@ -135,129 +217,187 @@ find_free_port() {
   echo $port
 }
 
-# Auto-detect free ports
-export APP_PORT=$(find_free_port 5560)
-export BULLBOARD_PORT=$(find_free_port 6380)
-export AI_SERVER_PORT=$(find_free_port 3456)
+# ---------------------------------------------------------------------------
+# Mode runners
+# ---------------------------------------------------------------------------
 
-# Strip any stale http://localhost:<oldport> exports of NEXTAUTH_URL /
-# BASE_HOST so dynamic-port worktrees don't 403 on login (lw#3453). Real
-# overrides (e.g. boxd proxy URLs) are left alone — see comment in helper.
-. "$(dirname "$0")/lib/sanitize-dev-env.sh"
-sanitize_localhost_dev_env
+run_frontend_only() {
+  echo "Mode: frontend-only — no compose. Run 'pnpm dev' from langwatch/ to start."
+  write_overrides frontend-only
+  echo ""
+  echo "Tip: pure UI / design / static iteration. URLs come from langwatch/.env."
+  echo "     For services on top: switch to backend-shared, nlp, or full-local."
+}
 
-# Load last choice if exists
-LAST=""
-if [ -f "$LAST_CHOICE_FILE" ]; then
-  LAST=$(cat "$LAST_CHOICE_FILE")
+run_backend_shared() {
+  ensure_prepared
+  export APP_PORT=$(find_free_port 5560)
+  . "$(dirname "$0")/lib/sanitize-dev-env.sh"
+  sanitize_localhost_dev_env
+  write_overrides backend-shared
+  echo "Starting: postgres + redis + clickhouse + app (mode=backend-shared)"
+  $COMPOSE up
+}
+
+run_migration() {
+  check_env_files
+  check_saas_ssrf_guard
+  check_stateful_collision
+  write_overrides migration
+  echo "Starting: postgres + clickhouse with HOST ports (mode=migration)"
+  $COMPOSE_MIGRATION up -d postgres clickhouse
+  cat <<EOF
+
+Postgres: localhost:5432  Clickhouse: localhost:8123
+DATABASE_URL and CLICKHOUSE_URL pinned to localhost in langwatch/.env.dev-up.
+
+Run migrations from your host shell:
+
+  cd langwatch
+  pnpm prisma migrate dev          # for postgres schema changes
+  pnpm clickhouse:migrate           # for clickhouse schema changes
+
+Stop with: scripts/dev.sh down
+EOF
+}
+
+run_nlp() {
+  ensure_prepared
+  export APP_PORT=$(find_free_port 5560)
+  export BULLBOARD_PORT=$(find_free_port 6380)
+  . "$(dirname "$0")/lib/sanitize-dev-env.sh"
+  sanitize_localhost_dev_env
+  write_overrides nlp
+  echo "Starting: backend + langwatch_nlp + langevals (mode=nlp)"
+  $COMPOSE --profile nlp up
+}
+
+run_full_local() {
+  ensure_prepared
+  export APP_PORT=$(find_free_port 5560)
+  export BULLBOARD_PORT=$(find_free_port 6380)
+  export AI_SERVER_PORT=$(find_free_port 3456)
+  . "$(dirname "$0")/lib/sanitize-dev-env.sh"
+  sanitize_localhost_dev_env
+  write_overrides full-local
+  echo "Starting: --profile full (mode=full-local)"
+  $COMPOSE --profile full up
+}
+
+run_meta() {
+  case "$1" in
+    down|d|D)
+      echo "Stopping all services..."
+      $COMPOSE --profile full down
+      ;;
+    logs|l|L)
+      echo "Tailing logs..."
+      $COMPOSE --profile full logs -f
+      ;;
+    ps|p|P)
+      $COMPOSE --profile full ps
+      ;;
+    clean|c|C)
+      read -p "This will delete shared volumes (postgres, clickhouse, redis data + per-worktree node_modules). Are you sure? [y/N]: " confirm
+      if [[ $confirm =~ ^[Yy]$ ]]; then
+        echo "Stopping and removing volumes..."
+        $COMPOSE --profile full down -v
+        echo "Done. Next start will be fresh."
+      else
+        echo "Cancelled."
+      fi
+      ;;
+    rebuild|r|R)
+      echo "Rebuilding (removes container node_modules)..."
+      $COMPOSE --profile full down
+      docker volume rm "${VOLUME_PREFIX:-langwatch}-app-modules" 2>/dev/null || true
+      docker volume rm "${VOLUME_PREFIX:-langwatch}-bullboard-modules" 2>/dev/null || true
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+# If sourced (e.g. by bats tests), expose functions and stop here. Keeps the
+# helpers unit-testable without running the prompt.
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  return 0
 fi
 
-echo ""
-echo "╔════════════════════════════════════════════════════════════╗"
-echo "║              LangWatch Development Environment             ║"
-echo "╠════════════════════════════════════════════════════════════╣"
-echo "║  Ports: app=$APP_PORT  bullboard=$BULLBOARD_PORT  ai-server=$AI_SERVER_PORT"
-echo "╠════════════════════════════════════════════════════════════╣"
-echo "║  AI Gateway runs separately: make service svc=aigateway"
-echo "║  (not bundled into compose; binds host :5563)"
-echo "╚════════════════════════════════════════════════════════════╝"
-echo ""
-PROFILE_NAMES=("" "dev" "dev-nlp" "dev-scenarios" "dev-test" "dev-full")
+# If a mode arg is provided, run it non-interactively.
+if [ -n "${1:-}" ]; then
+  case "$1" in
+    frontend-only|frontend)        run_frontend_only ;;
+    backend-shared|backend)        run_backend_shared ;;
+    migration|migrations)          run_migration ;;
+    nlp)                           run_nlp ;;
+    full-local|full)               run_full_local ;;
+    down|logs|ps|clean|rebuild)    run_meta "$1" ;;
+    *)
+      echo "Unknown mode: $1" >&2
+      echo "Run 'scripts/dev.sh help' for the mode list." >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
 
-echo "Select a profile:"
-echo ""
-echo "  1) dev           - Minimal (postgres, redis, clickhouse, app)"
-echo "  2) dev-nlp       - + NLP + langevals (for evaluations)"
-echo "  3) dev-scenarios - + scenario worker + bullboard + NLP"
-echo "  4) dev-test      - + AI test server"
-echo "  5) dev-full      - Everything"
-echo ""
-echo "  r) rebuild       - Rebuild (removes node_modules, restarts)"
-echo "  d) down          - Stop all services"
-echo "  l) logs          - Tail logs"
-echo "  p) ps            - Show running services"
-echo "  c) clean         - Stop and remove all data"
-echo "  q) quit"
-echo ""
+# Otherwise interactive prompt.
+LAST=""
+[ -f "$LAST_CHOICE_FILE" ] && LAST=$(cat "$LAST_CHOICE_FILE")
 
+cat <<'EOF'
+
+╔════════════════════════════════════════════════════════════╗
+║              LangWatch Development Environment             ║
+╚════════════════════════════════════════════════════════════╝
+
+What are you working on?
+
+  1) frontend-only    UI / design — no compose, fastest. URLs from .env.
+  2) backend-shared   postgres + redis + clickhouse + app, URLs → local.
+  3) migration        postgres + clickhouse on host ports for prisma migrate.
+  4) nlp              backend + langwatch_nlp + langevals, all URLs → local.
+  5) full-local       --profile full (workers, bullboard, ai-server, …).
+
+  d) down             stop all services
+  l) logs             tail compose logs
+  p) ps               show running services
+  c) clean            stop + remove ALL data (shared volumes too)
+  r) rebuild          remove container node_modules + restart
+  q) quit
+
+EOF
 if [ -n "$LAST" ]; then
-  echo "Or just hit enter to use previous (${PROFILE_NAMES[$LAST]})"
+  echo "Hit enter to repeat last: ${LAST}"
   echo ""
 fi
-read -p "Choice: " choice
+
+read -p "Choice [1-5/d/l/p/c/r/q]: " choice
 [ -z "$choice" ] && [ -n "$LAST" ] && choice="$LAST"
 
-case $choice in
-  1)
-    echo "$choice" > "$LAST_CHOICE_FILE"
-    ensure_prepared
-    echo "Starting: postgres + redis + clickhouse + app..."
-    $COMPOSE up
-    ;;
-  2)
-    echo "$choice" > "$LAST_CHOICE_FILE"
-    ensure_prepared
-    echo "Starting: + nlp + langevals..."
-    $COMPOSE --profile nlp up
-    ;;
-  3)
-    echo "$choice" > "$LAST_CHOICE_FILE"
-    ensure_prepared
-    echo "Starting: scenarios (+ workers + bullboard + nlp)..."
-    $COMPOSE --profile scenarios up
-    ;;
-  4)
-    echo "$choice" > "$LAST_CHOICE_FILE"
-    ensure_prepared
-    echo "Starting: + ai-server..."
-    $COMPOSE --profile test up
-    ;;
-  5)
-    echo "$choice" > "$LAST_CHOICE_FILE"
-    ensure_prepared
-    echo "Starting: full stack..."
-    $COMPOSE --profile full up
-    ;;
-  r|R)
-    echo "Rebuilding (removes container node_modules)..."
-    $COMPOSE --profile full down
-    docker volume rm "${VOLUME_PREFIX:-langwatch}-app-modules" 2>/dev/null || true
-    docker volume rm "${VOLUME_PREFIX:-langwatch}-bullboard-modules" 2>/dev/null || true
-    # Re-run with last profile
-    if [ -n "$LAST" ]; then
-      echo "Restarting with last profile..."
-      exec "$0"
-    else
-      echo "Done. Run quickstart again to start."
-    fi
-    ;;
-  d|D)
-    echo "Stopping all services..."
-    $COMPOSE --profile full down
-    ;;
-  l|L)
-    echo "Tailing logs..."
-    $COMPOSE --profile full logs -f
-    ;;
-  p|P)
-    $COMPOSE --profile full ps
-    ;;
-  c|C)
-    read -p "This will delete all data. Are you sure? [y/N]: " confirm
-    if [[ $confirm =~ ^[Yy]$ ]]; then
-      echo "Stopping and removing volumes..."
-      $COMPOSE --profile full down -v
-      echo "Done. Next start will be fresh."
-    else
-      echo "Cancelled."
-    fi
-    ;;
-  q|Q)
-    echo "Bye!"
-    exit 0
-    ;;
+case "$choice" in
+  1|frontend-only|frontend)
+    echo "frontend-only" > "$LAST_CHOICE_FILE"; run_frontend_only ;;
+  2|backend-shared|backend)
+    echo "backend-shared" > "$LAST_CHOICE_FILE"; run_backend_shared ;;
+  3|migration|migrations)
+    echo "migration" > "$LAST_CHOICE_FILE"; run_migration ;;
+  4|nlp)
+    echo "nlp" > "$LAST_CHOICE_FILE"; run_nlp ;;
+  5|full-local|full)
+    echo "full-local" > "$LAST_CHOICE_FILE"; run_full_local ;;
+  d|D|down)            run_meta down ;;
+  l|L|logs)            run_meta logs ;;
+  p|P|ps)              run_meta ps ;;
+  c|C|clean)           run_meta clean ;;
+  r|R|rebuild)         run_meta rebuild
+                       [ -n "$LAST" ] && exec "$0" "$LAST" ;;
+  q|Q|quit)            echo "Bye!"; exit 0 ;;
   *)
-    echo "Invalid choice"
+    echo "Invalid choice: $choice" >&2
     exit 1
     ;;
 esac

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -120,17 +120,20 @@ check_saas_ssrf_guard() {
   fi
 }
 
-# Detect cross-worktree collision on stateful volumes (#3860 AC#4).
+# Detect cross-worktree collision on shared stateful volumes (#3860 AC#4).
+# Includes redis even though it's a singleton — a second worktree's compose
+# project would still try to start its own redis container against the
+# shared volume and fail with a less-helpful binding error.
 check_stateful_collision() {
   local me="${COMPOSE_PROJECT_NAME:-langwatch}"
   local vol cid project
-  for vol in langwatch-db-data langwatch-clickhouse-data; do
+  for vol in langwatch-db-data langwatch-clickhouse-data langwatch-redis-data; do
     for cid in $(docker ps -q --filter "volume=$vol" 2>/dev/null); do
       project=$(docker inspect -f '{{index .Config.Labels "com.docker.compose.project"}}' "$cid" 2>/dev/null || true)
       if [ -n "$project" ] && [ "$project" != "$me" ]; then
         cat >&2 <<EOF
 ERROR: Shared volume '$vol' is already in use by compose project '$project'.
-       Only one worktree can run postgres / clickhouse at a time.
+       Only one worktree can run postgres / clickhouse / redis at a time.
        Stop the other one first:
          (cd that worktree && make down)
 EOF
@@ -339,11 +342,20 @@ What are you working on?
 EOF
 if [ -n "$LAST" ]; then
   echo "Hit enter to repeat last: ${LAST}"
-  echo ""
+else
+  echo "Hit enter for frontend-only (the default)."
 fi
+echo ""
 
 read -p "Choice [1-5/d/l/p/c/r/q]: " choice
-[ -z "$choice" ] && [ -n "$LAST" ] && choice="$LAST"
+# Enter selects the saved choice if present, else the documented default.
+if [ -z "$choice" ]; then
+  if [ -n "$LAST" ]; then
+    choice="$LAST"
+  else
+    choice="frontend-only"
+  fi
+fi
 
 case "$choice" in
   1|frontend-only|frontend)

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -153,7 +153,7 @@ ensure_prepared() {
       pnpm install
     fi
     echo "Preparing files..."
-    pnpm run start:prepare:files 2>/dev/null || true
+    pnpm run start:prepare:files
   )
 }
 

--- a/scripts/lib/write-dev-overrides.sh
+++ b/scripts/lib/write-dev-overrides.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Shared write_overrides helper (#3860 AC#6).
+#
+# Writes `langwatch/.env.dev-up` listing ONLY the URLs whose services are
+# starting locally for the given mode. compose loads the overlay AFTER
+# `langwatch/.env`, so non-overridden URLs keep their .env values — the
+# contributor's `.env` is the source of truth.
+#
+# Sourced by `scripts/dev.sh` (intent-based modes) and `scripts/dev-up.sh`
+# (legacy compose-profile names) so the two launchers can't drift on the
+# overlay format.
+#
+# Mode names map onto compose profiles like this:
+#   frontend-only     no compose
+#   backend-shared    default profile (postgres + redis + clickhouse + app)
+#   migration         postgres + clickhouse on host ports
+#   workers|scenarios + workers + bullboard + langwatch_nlp (no langevals)
+#   nlp               + langwatch_nlp + langevals
+#   full | full-local --profile full (everything)
+#   debug | test      + bullboard / ai-server (no extra URL overrides)
+#
+# The langwatch_nlp / langevals URLs follow compose profile membership:
+#   langwatch_nlp is in [nlp, scenarios, full]
+#   langevals    is in [nlp, full]
+# We override each URL only when the corresponding container actually starts
+# for the given mode.
+
+write_dev_overrides() {
+  local mode="${1-}"
+  local out="${2:-langwatch/.env.dev-up}"
+  : > "$out"
+
+  # Always-on: dev uses email auth (no Auth0 dependency).
+  echo "NEXTAUTH_PROVIDER=email" >> "$out"
+
+  case "$mode" in
+    frontend-only)
+      # No compose at all — nothing to override.
+      return 0
+      ;;
+    migration)
+      # postgres + clickhouse on host ports for `pnpm prisma migrate` from host.
+      cat >> "$out" <<'EOF'
+DATABASE_URL=postgresql://prisma:prisma@localhost:5432/mydb?schema=mydb
+CLICKHOUSE_URL=http://default:langwatch@localhost:8123/langwatch
+EOF
+      return 0
+      ;;
+  esac
+
+  # Every other mode runs the default profile (postgres + redis + clickhouse + app).
+  cat >> "$out" <<'EOF'
+DATABASE_URL=postgresql://prisma:prisma@postgres:5432/mydb?schema=mydb
+REDIS_URL=redis://redis:6379
+CLICKHOUSE_URL=http://default:langwatch@clickhouse:8123/langwatch
+EOF
+
+  # langwatch_nlp service runs under nlp / scenarios / full / full-local / workers.
+  case "$mode" in
+    nlp|scenarios|full|full-local|workers)
+      echo "LANGWATCH_NLP_SERVICE=http://langwatch_nlp:5561" >> "$out"
+      ;;
+  esac
+
+  # langevals service runs only under nlp / full / full-local.
+  case "$mode" in
+    nlp|full|full-local)
+      echo "LANGEVALS_ENDPOINT=http://langevals:5562" >> "$out"
+      ;;
+  esac
+}

--- a/specs/setup/boxd-fork-vm.feature
+++ b/specs/setup/boxd-fork-vm.feature
@@ -1,0 +1,145 @@
+Feature: boxd Makefile orchestrates per-PR / per-branch / per-issue VM forks
+  As a developer working on LangWatch
+  I want a single command surface for spinning up testable VMs from PRs, branches, or issues
+  So that secrets transit, ports map, and Claude is wired in without manual steps
+
+  # Behavior is in `boxd.mk` and `scripts/boxd-fork.sh`. Tests are bats files
+  # at `scripts/__tests__/boxd-fork.unit.bats` (slug, naming, env discovery,
+  # hostname rewrite) and `scripts/__tests__/boxd-fork.integration.bats`
+  # (mocked boxd / gh / git, asserts the fork → cp → proxy → tmux call
+  # sequence). The TS-only parity checker can't bind bash test files, so
+  # scenarios stay `@unimplemented` for parity tracking. See specs/setup/
+  # docker-dev-worktree-isolation.feature for the same pattern.
+
+  Background:
+    Given the boxd CLI is installed and authenticated on the developer's machine
+    And gh CLI is authenticated for the langwatch/langwatch repo
+    And the canonical "langwatch-golden" VM exists
+
+  # --- Slug rules (#3891 AC#13) ---
+
+  @unit @unimplemented
+  Scenario: Slugifier lowercases and strips punctuation
+    Given the input "feat/Foo Bar!"
+    When boxd_slug runs
+    Then the result is "feat-foo-bar"
+
+  @unit @unimplemented
+  Scenario: Slugifier truncates to 40 characters with no trailing hyphen
+    Given an input longer than 40 characters
+    When boxd_slug runs
+    Then the result is at most 40 characters
+    And the result does not end with a hyphen
+
+  # --- VM naming + collision rule (AC#14) ---
+
+  @unit @unimplemented
+  Scenario: fork-issue uses the literal langwatch-issue<N> form
+    Given an issue number 42
+    When boxd_vm_name runs for the issue source
+    Then the VM name is "langwatch-issue42"
+
+  @unit @unimplemented
+  Scenario: fork-branch with issue-shaped slug warns and uses langwatch-issue<N>-<rest>
+    Given a branch name "issue42/foo-bar"
+    When boxd_fork_branch runs
+    Then the VM name is "langwatch-issue42-foo-bar"
+    And a warning suggests "make boxd-fork-issue ISSUE=42" instead
+
+  # --- Hostname rewrite allowlist (AC#26) ---
+
+  @unit @unimplemented
+  Scenario: Stale localhost NEXTAUTH_URL is rewritten to the fork's proxy URL
+    Given a .env line "NEXTAUTH_URL=http://localhost:5560"
+    When boxd_rewrite_env runs for VM "langwatch-issue42"
+    Then the line becomes 'NEXTAUTH_URL="https://langwatch-issue42.boxd.sh"'
+
+  @unit @unimplemented
+  Scenario: LW_GATEWAY_BASE_URL routes to the aigw subdomain
+    Given a .env line "LW_GATEWAY_BASE_URL=http://localhost:5563"
+    When boxd_rewrite_env runs for VM "langwatch-issue42"
+    Then the line becomes 'LW_GATEWAY_BASE_URL="https://aigw.langwatch-issue42.boxd.sh"'
+
+  @unit @unimplemented
+  Scenario: A real boxd-proxy URL is left untouched
+    Given a .env line "NEXTAUTH_URL=https://langwatch-other.boxd.sh"
+    When boxd_rewrite_env runs for VM "langwatch-issue42"
+    Then the line is unchanged
+
+  # --- Env file discovery (AC#24) ---
+
+  @unit @unimplemented
+  Scenario: .env discovery excludes node_modules, .next, dist, build, vendor, coverage, .git
+    Given the monorepo has .env files in node_modules/, dist/, vendor/
+    When boxd_env_files runs
+    Then the result contains no path under those directories
+
+  @unit @unimplemented
+  Scenario: .env discovery excludes example/template/sample/local suffixes
+    Given the monorepo has .env, .env.example, .env.template, .env.sample, .env.local files
+    When boxd_env_files runs
+    Then the result contains only ".env" files (no suffix)
+
+  # --- Fork orchestration (AC#10, AC#15) ---
+
+  @integration @unimplemented
+  Scenario: fork-issue creates a fork with branch checked out, env uploaded, and tmux running
+    Given issue 4242 has a title
+    When I run "make boxd-fork-issue ISSUE=4242"
+    Then the VM "langwatch-issue4242" is forked from "langwatch-golden"
+    And every .env file is uploaded with stale-localhost URLs rewritten
+    And ports are mapped (default proxy + aigw + bullboard + ai-server + next)
+    And a tmux session "claude-issue4242" is started inside the VM running claude
+
+  @integration @unimplemented
+  Scenario: fork-issue errors when the VM already exists
+    Given the VM "langwatch-issue4242" already exists
+    When I run "make boxd-fork-issue ISSUE=4242"
+    Then the target exits non-zero
+    And the message points at "boxd destroy" or "make boxd-connect-issue"
+
+  @integration @unimplemented
+  Scenario: fork-pr resolves the PR head ref via gh and forks for that branch
+    Given a PR 1234 with head ref "feat/from-fork"
+    When I run "make boxd-fork-pr PR=1234"
+    Then the VM "langwatch-feat-from-fork" is forked from "langwatch-golden"
+
+  # --- Connect targets (AC#18, AC#19, AC#20, AC#21) ---
+
+  @integration @unimplemented
+  Scenario: connect-issue errors clearly when the VM does not exist
+    Given the VM "langwatch-issue4242" does not exist
+    When I run "make boxd-connect-issue ISSUE=4242"
+    Then the target exits non-zero
+    And the message suggests "make boxd-fork-issue ISSUE=4242"
+
+  @integration @unimplemented
+  Scenario: connect-issue errors when the tmux session is missing
+    Given the VM "langwatch-issue4242" exists
+    And no "claude-issue4242" tmux session is running inside it
+    When I run "make boxd-connect-issue ISSUE=4242"
+    Then the target exits non-zero
+    And the message contains "no claude session"
+
+  @integration @unimplemented
+  Scenario: connect-issue wakes a suspended VM before attaching
+    Given the VM "langwatch-issue4242" exists and is in standby
+    And a "claude-issue4242" tmux session is running inside it
+    When I run "make boxd-connect-issue ISSUE=4242"
+    Then the VM is resumed
+    And SSH + tmux attach proceeds
+
+  # --- Golden lifecycle (AC#5, AC#6) ---
+
+  @integration @unimplemented
+  Scenario: golden-reset refuses without explicit confirmation
+    When I run "make boxd-golden-reset"
+    Then the target exits non-zero
+    And the message points at BOXD_FORK_YES=1
+
+  @integration @unimplemented
+  Scenario: golden-reset destroys + recreates with confirmation
+    Given the VM "langwatch-golden" exists
+    When I run "make boxd-golden-reset BOXD_FORK_YES=1"
+    Then the existing VM is destroyed
+    And a new VM is created with the same name

--- a/specs/setup/quickstart-entry-point.feature
+++ b/specs/setup/quickstart-entry-point.feature
@@ -1,0 +1,81 @@
+Feature: make quickstart is the single dev environment entry point
+  As a developer working on LangWatch
+  I want one command to start dev with shared stateful data and a singleton redis
+  So that I don't lose my sign-up across worktrees and don't burn time on per-worktree containers
+
+  # Behavior is in `compose.dev.yml` (volume names + redis port), `Makefile`
+  # (deprecation wrappers), and `scripts/dev.sh` (help mode + fail-fast +
+  # collision detection). No JS-side tests cover these — they are shell /
+  # docker config behaviors. Scenarios stay `@unimplemented` for parity
+  # tracking; verified by hand and (for the bash slug + rewrite logic of
+  # boxd-fork) by `scripts/__tests__/boxd-fork.*.bats`.
+
+  # --- Single entry point (#3860 AC#1) ---
+
+  @unit @unimplemented
+  Scenario: make help points at quickstart as the single entry point
+    When I run "make help"
+    Then the output describes "make quickstart" as the interactive launcher
+    And the output marks "make dev" / "make dev-up" as deprecated
+
+  @unit @unimplemented
+  Scenario: make dev prints a deprecation warning before running
+    When I run "make dev"
+    Then a warning on stderr points at "make quickstart"
+    And the underlying compose flow still runs (one release of grace)
+
+  # --- Non-interactive mode reference (#3860 AC#8) ---
+
+  @unit @unimplemented
+  Scenario: make quickstart-help prints the mode list
+    When I run "make quickstart-help"
+    Then the output lists modes "dev", "dev-nlp", "dev-scenarios", "dev-test", "dev-full"
+    And it explains shared stateful volumes
+    And it does not require interactive input
+
+  # --- Stateful volume sharing (#3860 AC#4) ---
+
+  @integration @unimplemented
+  Scenario: postgres volume is shared across worktrees
+    Given two worktrees of the langwatch repo
+    When worktree A runs "make quickstart" and signs up a user
+    And worktree A stops with "make down"
+    And worktree B runs "make quickstart"
+    Then the user signed up in worktree A is present in worktree B
+
+  @integration @unimplemented
+  Scenario: simultaneous postgres up across worktrees is detected
+    Given worktree A has postgres up via "make quickstart"
+    When worktree B runs "make quickstart"
+    Then quickstart errors with a clear message naming the colliding compose project
+    And exits non-zero
+
+  # --- Singleton stateless services (#3860 AC#5) ---
+
+  @integration @unimplemented
+  Scenario: redis is a singleton on host port 6379
+    Given the dev environment is up
+    Then a single redis container is running with host port 6379 mapped
+    And the volume name is "langwatch-redis-data"
+
+  @integration @unimplemented
+  Scenario: starting a second worktree reuses the existing redis
+    Given worktree A has the dev environment up
+    When worktree B runs "make quickstart"
+    Then no second redis container is started
+    And worktree B reuses worktree A's redis on host :6379
+
+  # --- Fail-fast + idempotency (#3860 AC#7) ---
+
+  @unit @unimplemented
+  Scenario: quickstart errors when langwatch/.env has IS_SAAS=true with BLOCK_LOCAL_HTTP_CALLS=false
+    Given langwatch/.env contains IS_SAAS=true and BLOCK_LOCAL_HTTP_CALLS=false
+    When I run "make quickstart"
+    Then quickstart exits non-zero with a SSRF-guard error message
+
+  @integration @unimplemented
+  Scenario: quickstart is idempotent
+    Given the dev environment is already up
+    When I run "make quickstart" with the same mode again
+    Then no new containers are created for already-running services
+    And existing containers are not duplicated

--- a/specs/setup/quickstart-entry-point.feature
+++ b/specs/setup/quickstart-entry-point.feature
@@ -1,14 +1,15 @@
-Feature: make quickstart is the single dev environment entry point
+Feature: make quickstart is the single dev environment entry point with intent-based modes
   As a developer working on LangWatch
-  I want one command to start dev with shared stateful data and a singleton redis
-  So that I don't lose my sign-up across worktrees and don't burn time on per-worktree containers
+  I want one command that asks what I'm working on, starts only the services I need, and overrides only the URLs whose services are local
+  So that my .env stays the source of truth and I don't lose state across worktrees
 
-  # Behavior is in `compose.dev.yml` (volume names + redis port), `Makefile`
-  # (deprecation wrappers), and `scripts/dev.sh` (help mode + fail-fast +
-  # collision detection). No JS-side tests cover these — they are shell /
-  # docker config behaviors. Scenarios stay `@unimplemented` for parity
-  # tracking; verified by hand and (for the bash slug + rewrite logic of
-  # boxd-fork) by `scripts/__tests__/boxd-fork.*.bats`.
+  # Behavior is in `compose.dev.yml` + `compose.dev.migration.yml` (volume
+  # names + env_file overlay + host port overlay), `Makefile` (deprecation
+  # wrappers + positional MODE arg pass-through), and `scripts/dev.sh`
+  # (intent-based prompt + write_overrides + fail-fast + collision detection).
+  # Pure-shell helpers (write_overrides) covered by
+  # scripts/__tests__/dev-overrides.unit.bats; the wider end-to-end behavior
+  # is shell + docker so scenarios stay `@unimplemented` for parity tracking.
 
   # --- Single entry point (#3860 AC#1) ---
 
@@ -22,31 +23,98 @@ Feature: make quickstart is the single dev environment entry point
   Scenario: make dev prints a deprecation warning before running
     When I run "make dev"
     Then a warning on stderr points at "make quickstart"
-    And the underlying compose flow still runs (one release of grace)
+    And the underlying mode runs (one release of grace)
 
-  # --- Non-interactive mode reference (#3860 AC#8) ---
+  # --- Intent-based prompting (#3860 AC#2) ---
 
   @unit @unimplemented
-  Scenario: make quickstart-help prints the mode list
+  Scenario: quickstart asks "what are you working on?" with five intent-based modes
+    When I run "make quickstart" with no arguments
+    Then the prompt lists modes: frontend-only, backend-shared, migration, nlp, full-local
+    And each mode has a one-line description of what services start and what URLs are rewritten
+
+  @unit @unimplemented
+  Scenario: make quickstart accepts a positional mode arg for non-interactive runs
+    When I run "make quickstart frontend-only"
+    Then dev.sh runs in frontend-only mode without prompting
+
+  @unit @unimplemented
+  Scenario: make quickstart-help prints the mode reference
     When I run "make quickstart-help"
-    Then the output lists modes "dev", "dev-nlp", "dev-scenarios", "dev-test", "dev-full"
-    And it explains shared stateful volumes
+    Then the output lists each of the five modes with services + URL overrides
     And it does not require interactive input
+
+  # --- Default = fastest path (#3860 AC#3) ---
+
+  @unit @unimplemented
+  Scenario: frontend-only mode starts no compose containers
+    When I run "make quickstart frontend-only"
+    Then no compose services are brought up
+    And langwatch/.env.dev-up contains only NEXTAUTH_PROVIDER=email
+    And no infrastructure URLs are overridden
+
+  @integration @unimplemented
+  Scenario: frontend-only mode is fast — under 5 seconds to ready hint
+    When I run "make quickstart frontend-only"
+    Then the command completes in under 5 seconds with a hint to run "pnpm dev"
+
+  # --- URL rewrite per mode (#3860 AC#6) ---
+
+  @unit @unimplemented
+  Scenario: backend-shared overrides only DATABASE_URL, REDIS_URL, CLICKHOUSE_URL
+    When write_overrides is called with mode=backend-shared
+    Then langwatch/.env.dev-up contains DATABASE_URL pointing at postgres:5432
+    And REDIS_URL pointing at redis:6379
+    And CLICKHOUSE_URL pointing at clickhouse:8123
+    And it does NOT contain LANGWATCH_NLP_SERVICE or LANGEVALS_ENDPOINT
+
+  @unit @unimplemented
+  Scenario: migration uses localhost host-port URLs for prisma migrate from host
+    When write_overrides is called with mode=migration
+    Then DATABASE_URL points at localhost:5432
+    And CLICKHOUSE_URL points at localhost:8123
+    And REDIS_URL is not overridden
+
+  @unit @unimplemented
+  Scenario: nlp adds LANGWATCH_NLP_SERVICE and LANGEVALS_ENDPOINT on top of backend
+    When write_overrides is called with mode=nlp
+    Then LANGWATCH_NLP_SERVICE points at langwatch_nlp:5561
+    And LANGEVALS_ENDPOINT points at langevals:5562
+    And the three backend URLs are also overridden
+
+  @unit @unimplemented
+  Scenario: full-local overrides every infrastructure URL
+    When write_overrides is called with mode=full-local
+    Then all five URLs (DATABASE_URL, REDIS_URL, CLICKHOUSE_URL, LANGWATCH_NLP_SERVICE, LANGEVALS_ENDPOINT) are present
+
+  @unit @unimplemented
+  Scenario: contributor's .env is the source of truth for non-overridden values
+    Given langwatch/.env defines OPENAI_API_KEY and LANGWATCH_NLP_SERVICE
+    When I run "make quickstart backend-shared"
+    Then OPENAI_API_KEY in the running container is the value from .env
+    And LANGWATCH_NLP_SERVICE is the value from .env (no override for this mode)
+
+  @unit @unimplemented
+  Scenario: write_overrides replaces langwatch/.env.dev-up — does not append
+    Given a previous run wrote backend-shared overrides
+    When write_overrides runs again with mode=frontend-only
+    Then langwatch/.env.dev-up no longer contains DATABASE_URL
+    And only the frontend-only override (NEXTAUTH_PROVIDER) remains
 
   # --- Stateful volume sharing (#3860 AC#4) ---
 
   @integration @unimplemented
   Scenario: postgres volume is shared across worktrees
     Given two worktrees of the langwatch repo
-    When worktree A runs "make quickstart" and signs up a user
+    When worktree A runs "make quickstart backend-shared" and signs up a user
     And worktree A stops with "make down"
-    And worktree B runs "make quickstart"
+    And worktree B runs "make quickstart backend-shared"
     Then the user signed up in worktree A is present in worktree B
 
   @integration @unimplemented
   Scenario: simultaneous postgres up across worktrees is detected
-    Given worktree A has postgres up via "make quickstart"
-    When worktree B runs "make quickstart"
+    Given worktree A has postgres up via "make quickstart backend-shared"
+    When worktree B runs "make quickstart backend-shared"
     Then quickstart errors with a clear message naming the colliding compose project
     And exits non-zero
 
@@ -61,7 +129,7 @@ Feature: make quickstart is the single dev environment entry point
   @integration @unimplemented
   Scenario: starting a second worktree reuses the existing redis
     Given worktree A has the dev environment up
-    When worktree B runs "make quickstart"
+    When worktree B runs "make quickstart backend-shared"
     Then no second redis container is started
     And worktree B reuses worktree A's redis on host :6379
 
@@ -70,7 +138,7 @@ Feature: make quickstart is the single dev environment entry point
   @unit @unimplemented
   Scenario: quickstart errors when langwatch/.env has IS_SAAS=true with BLOCK_LOCAL_HTTP_CALLS=false
     Given langwatch/.env contains IS_SAAS=true and BLOCK_LOCAL_HTTP_CALLS=false
-    When I run "make quickstart"
+    When I run "make quickstart backend-shared"
     Then quickstart exits non-zero with a SSRF-guard error message
 
   @integration @unimplemented


### PR DESCRIPTION
## Summary

Bundles two related dev-environment issues per Drew's request, both fully implemented:

- **#3891** — `boxd.mk` for golden VM + fork-for-PR/branch/issue with creds/env/ports wired in.
- **#3860** — Rework `make quickstart` so each mode is a URL-rewrite override on top of the contributor's `langwatch/.env`. Stateful volumes are shared across worktrees; redis is a singleton.

Plan + investigation: `dev/docs/plans/issue3891-3860-dev-env-rework.md`.

## What's new

### `make boxd-*` (#3891)

Multi-step orchestration over the boxd CLI. Anything achievable with a single `boxd ...` call stays on the CLI — these targets earn their place by orchestrating multi-step flows.

```
make boxd-help                       # full target list
make boxd-golden                     # create the canonical base VM
make boxd-golden-reset BOXD_FORK_YES=1
make boxd-fork-pr PR=1234            # fork + check out PR + creds + env + ports
make boxd-fork-branch BRANCH=feat/foo
make boxd-fork-issue ISSUE=123       # + worktree branch + tmux+claude in VM
make boxd-connect-{pr,branch,issue} <ARG>=<v>
```

Naming: `langwatch-<branch-slug>` or `langwatch-issue<N>`; tmux session: `claude-<...>`. Slug rules per AC#13. Single fork primitive; existing-VM is an explicit error; `boxd-connect-*` clearly errors on missing VM (AC#19) / missing tmux (AC#18) and auto-resumes suspended VMs (AC#20).

`.env` discovery globs the monorepo with allowlist excludes (AC#24); each file uploads to its corresponding path (AC#25, no merging); stale `localhost:<port>` and `127.0.0.1:<port>` values are rewritten to the fork's proxy URL with `LW_GATEWAY_BASE_URL` routing to `aigw.<vm>.boxd.sh` (AC#26). Ports for app/aigw/bullboard/ai-server/next are mapped automatically (AC#27).

Implementation split: `scripts/boxd-fork.sh` holds pure helpers (slug, env discovery, env rewrite) + orchestration entry points. `boxd.mk` targets are thin wrappers that source the script. **39 bats tests** cover slug rules, naming + collision rule, env discovery, hostname rewrite, fork orchestration sequence, error paths, and golden lifecycle.

### `make quickstart` (#3860)

Five intent-based modes. The contributor's `langwatch/.env` is the source of truth; each mode writes `langwatch/.env.dev-up` listing only the URLs whose services are starting locally for that mode. `compose.dev.yml` loads the overlay AFTER `.env` so non-overridden URLs keep their `.env` values.

| Mode | Compose services | URL overrides written to `.env.dev-up` |
|---|---|---|
| `frontend-only` | (no compose) | (none — pure `.env`) |
| `backend-shared` | postgres + redis + clickhouse + app + init | `DATABASE_URL`, `REDIS_URL`, `CLICKHOUSE_URL` |
| `migration` | postgres + clickhouse with HOST ports (5432, 8123) | `DATABASE_URL`, `CLICKHOUSE_URL` (localhost forms) |
| `nlp` | + langwatch_nlp + langevals | + `LANGWATCH_NLP_SERVICE`, `LANGEVALS_ENDPOINT` |
| `full-local` | `--profile full` (workers, scenarios, bullboard, ai-server) | all five infrastructure URLs |

Migration mode applies a `compose.dev.migration.yml` overlay that exposes postgres + clickhouse on host ports so `pnpm prisma migrate dev` and `pnpm clickhouse:migrate` run from the host shell.

`make quickstart` accepts a positional mode arg (`make quickstart frontend-only`) for non-interactive usage. `make quickstart-help` prints the mode reference.

**Stateful volumes share data across worktrees** (`langwatch-db-data`, `langwatch-clickhouse-data`, `langwatch-redis-data`). Sign up persists when switching worktrees. Only one worktree can have postgres / clickhouse `up` at a time; `dev.sh` detects collisions and points at the colliding compose project.

**Redis is a singleton on host `:6379`** with the shared volume.

**Per-worktree volumes still apply to** `app_modules`, `bullboard_modules`, `goose_bin` (Linux platform deps per ADR-004 — these vary by branch lockfile and must stay isolated).

**Fail-fast SSRF guard:** `dev.sh` errors if `langwatch/.env` has `IS_SAAS=true` with `BLOCK_LOCAL_HTTP_CALLS=false`.

**Deprecated targets** (`make dev*` and `make dev-up*`) print a deprecation warning and forward to the corresponding mode (`make dev` → `backend-shared`, `make dev-nlp` → `nlp`, etc.) for one release before removal.

## AC coverage matrix

### #3891 — 29 / 29 ACs

All ACs implemented. Per-AC mapping in `dev/docs/plans/issue3891-3860-dev-env-rework.md`.

### #3860 — 10 / 10 ACs

| AC | Status |
|---|---|
| 1: single entry point | Done |
| 2: intent-based prompting | Done — 5 modes (`frontend-only` / `backend-shared` / `migration` / `nlp` / `full-local`) |
| 3: default = fastest path | Done — `frontend-only` is no-compose, ~instant |
| 4: stateful shared volumes + collision detection | Done |
| 5: redis singleton + host port | Done |
| 6: URL rewrite on profile flip | Done — `langwatch/.env.dev-up` overlay |
| 7: idempotent + fail-fast IS_SAAS guard | Done |
| 8: `quickstart-help` + per-mode hints | Done |
| 9: deprecation warnings on old paths | Done |
| 10: no CI regressions | No TS files modified — `pnpm typecheck` / `pnpm test:unit` are vacuously N/A. `langwatch-app-complete` aggregator is green on CI. |

## How to verify

This PR touches only Makefile / yaml / shell / docs — `pnpm typecheck` and `pnpm test:unit` cover none of the changed files. Verification is a manual smoke test against three integration paths:

### 1. boxd VMs spin up end-to-end

```bash
# From the dev's laptop, against a fresh boxd account:
make boxd-golden                          # creates langwatch-golden, ~minutes
make boxd-fork-issue ISSUE=<some-issue>   # forks → langwatch-issue<N>, copies creds + .env files,
                                          # maps proxies, starts tmux+claude inside the VM
make boxd-connect-issue ISSUE=<some-issue>  # SSH + tmux attach to the in-VM Claude session
```

Expected: `boxd list` shows `langwatch-golden` and `langwatch-issue<N>` running. The connect target attaches into the in-VM tmux session named `claude-issue<N>`. Suspended VMs auto-resume before attach.

Variants to spot-check:
- `make boxd-fork-pr PR=<n>` resolves the head ref via `gh` and forks for that branch (cross-fork PRs supported).
- `make boxd-fork-branch BRANCH=feat/foo` produces `langwatch-feat-foo`.
- `make boxd-fork-branch BRANCH=issue42/foo` warns with the canonical-issue suggestion (AC#14) but still forks.
- Re-running `boxd-fork-issue ISSUE=<N>` for an existing VM errors clearly (AC#15) and points at `boxd destroy`.
- `boxd-connect-*` against a non-existent VM / missing tmux session prints the right error and exits non-zero.

### 2. Dev stack reachable through the exposed proxies

After `make boxd-fork-issue ISSUE=<N>`, the fork has these proxies wired up automatically:

```
https://langwatch-issue<N>.boxd.sh           → :5560 (langwatch app, compose mode)
https://aigw.langwatch-issue<N>.boxd.sh      → :5563 (Go AI gateway)
https://bullboard.langwatch-issue<N>.boxd.sh → :6380
https://ai-server.langwatch-issue<N>.boxd.sh → :3456
https://next.langwatch-issue<N>.boxd.sh      → :3000 (Next.js standalone pnpm dev mode)
```

Inside the fork (via `boxd connect`), run `make quickstart backend-shared`. Expected: the langwatch app comes up on `:5560` inside the VM, and `https://langwatch-issue<N>.boxd.sh` from the laptop browser serves the login page (HTTP 200 / proxied through). `langwatch/.env.dev-up` should contain the rewritten URLs (`langwatch-issue<N>.boxd.sh` for `NEXTAUTH_URL` / `BASE_HOST`, `aigw.langwatch-issue<N>.boxd.sh` for `LW_GATEWAY_BASE_URL`). The `.env` `OPENAI_API_KEY` etc. should still be the values from the contributor's main checkout (we copied + rewrote, didn't replace).

### 3. Docker compose changes compose + run sensibly

From a worktree of the langwatch repo:

```bash
make quickstart-help                      # mode reference; non-interactive
make quickstart frontend-only             # writes .env.dev-up with only NEXTAUTH_PROVIDER, no compose
make quickstart backend-shared            # postgres + redis + clickhouse + app come up
                                          # .env.dev-up has DATABASE_URL/REDIS_URL/CLICKHOUSE_URL → local
make down                                 # tears down compose
make quickstart migration                 # postgres + clickhouse on host ports 5432 / 8123
                                          # cd langwatch && pnpm prisma migrate dev runs from host
make quickstart nlp                       # backend + langwatch_nlp + langevals
make quickstart full-local                # --profile full
```

Things to spot-check:
- **Volumes shared across worktrees:** sign up `someone@langwatch.ai` from worktree A; `make down`; switch worktree B; `make quickstart backend-shared` again; the user is still there. Volume names are `langwatch-db-data`, `langwatch-clickhouse-data`, `langwatch-redis-data` (no `lw-<hash>-` prefix).
- **Stateful collision detection:** with worktree A still up, run `make quickstart backend-shared` in worktree B. Expected: clear error pointing at the colliding compose project.
- **Redis singleton on host `:6379`:** `docker ps --filter publish=6379` shows one container; second worktree reuses it.
- **`.env` is the source of truth for non-overridden URLs:** put `OPENAI_API_KEY=sk-test-xyz` in `langwatch/.env`; `make quickstart backend-shared`; `docker compose -f compose.dev.yml exec app env | grep OPENAI_API_KEY` returns `sk-test-xyz` (came from `.env`, not overridden).
- **Deprecated wrappers:** `make dev` prints a deprecation warning on stderr and forwards to `quickstart backend-shared`. Same for `dev-nlp` → `nlp`, `dev-{scenarios,test,full}` → `full-local`.

### Tests run during development (informational, not the PR gate)

- `bats scripts/__tests__/boxd-fork.unit.bats scripts/__tests__/boxd-fork.integration.bats scripts/__tests__/dev-overrides.unit.bats` — 49 passing locally.
- `docker compose -f compose.dev.yml config --quiet` validates against compose schema.

## CI status notes

- `sdk-python-ci / test` failure is orthogonal — the `e2e` job needs `LANGWATCH_API_KEY`, which GitHub Actions does not share with PRs from forks (security default). The path-change filter for `sdk-python-ci` flags this PR as "relevant" despite the diff not touching `python-sdk/**` (looks like a `dorny/paths-filter` interpretation issue with the negation pattern); both are pre-existing infrastructure quirks for external-fork PRs and would happen on any non-internal-branch PR. Worth tracking separately. The aggregator that branch protection requires (`langwatch-app-complete`) is green.
- `issue-link` action also fails on fork PRs because the bot lacks write access. Same fork-PR auth limitation.

## Threat model (boxd forks)

Forks receive every `.env` plus your Claude credentials. **Anyone with SSH access to a fork can read those secrets** — forks are NOT for sharing across teams or external collaborators. Documented in `dev/docs/boxd-makefile.md`.

## Out of scope (filed as follow-ups)

- **Fork pruning / lifecycle management.** Closed-PR / merged-branch fork cleanup. Until then, manual `boxd destroy`.
- **Seed script implementation** for `boxd-golden`. The Makefile defines a `seed-golden` hook target; the implementation belongs with `make quickstart` work.
- **Migration of existing `lw-<hash>-db-data` volumes.** Documented in ADR-004 amendment — manual `docker volume rm` after confirming you don't need the data.

## Files changed

```
boxd.mk                                            (new)
compose.dev.migration.yml                          (new — overlay for migration mode host ports)
scripts/boxd-fork.sh                               (new)
scripts/__tests__/boxd-fork.unit.bats              (new — 26 tests)
scripts/__tests__/boxd-fork.integration.bats      (new — 13 tests)
scripts/__tests__/dev-overrides.unit.bats         (new — 6 tests)
specs/setup/boxd-fork-vm.feature                   (new, @unimplemented)
specs/setup/quickstart-entry-point.feature         (new, @unimplemented)
dev/docs/boxd-makefile.md                          (new)
dev/docs/plans/issue3891-3860-dev-env-rework.md    (new)
Makefile                                           (modified — help, deprecation shims, include boxd.mk, quickstart positional MODE arg, quickstart-help)
compose.dev.yml                                    (modified — stable volume names, redis host port, URL vars OUT of x-common-env, .env.dev-up overlay added to workers + ai-server)
scripts/dev.sh                                     (modified — intent-based prompt, write_overrides, SSRF guard, collision detection)
CLAUDE.md                                          (modified — Development Environment section reframed around modes)
dev/docs/adr/004-docker-dev-environment.md         (modified — amendment for #3860)
```

Refs: #3891, #3860