### PR TITLE
fix(prompts): use nanoid instead of crypto.randomUUID in playground id-generators

### DIFF
--- a/langwatch/src/prompts/prompt-playground/prompt-playground-store/utils/id-generators.ts
+++ b/langwatch/src/prompts/prompt-playground/prompt-playground-store/utils/id-generators.ts
@@ -1,7 +1,9 @@
+import { nanoid } from "nanoid";
+
 export function createTabId() {
-  return `tab-${crypto.randomUUID()}`;
+  return `tab-${nanoid()}`;
 }
 
 export function createWindowId() {
-  return `window-${crypto.randomUUID()}`;
+  return `window-${nanoid()}`;
 }


### PR DESCRIPTION
## Summary
- Replaces `crypto.randomUUID()` with `nanoid()` in the prompt-playground id-generators (`createTabId`, `createWindowId`).
- Fixes `TypeError: crypto.randomUUID is not a function` thrown when creating a draft prompt from the empty-state "Create First Prompt" button.

### Why
`crypto.randomUUID()` is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) (HTTPS, `localhost`) and recent browsers. In non-secure contexts (plain HTTP deployments, older browsers, embedded webviews), `window.crypto.randomUUID` is `undefined`, so the playground store crashes on tab/window creation:

```
Uncaught (in promise) TypeError: crypto.randomUUID is not a function
    at Pvt (id-generators.ts:2)
    at addTab (DraggableTabsBrowserStore.ts:182)
    at createDraftPrompt (useCreateDraftPrompt.ts:57)
    at onClick (NoPromptsOnboardingState.tsx:27)
```

`nanoid` works in every context, is already a direct dependency (`langwatch/package.json`, `nanoid: ^5.1.11`), and is the convention used elsewhere in the codebase for opaque client-side IDs.

### Changes
| File | Change |
|---|---|
| `langwatch/src/prompts/prompt-playground/prompt-playground-store/utils/id-generators.ts` | Import `nanoid` and use it in `createTabId` / `createWindowId` instead of `crypto.randomUUID` |

### Verified
```
$ grep -rn "crypto.randomUUID" langwatch/src/prompts/prompt-playground/
(no results — both call sites migrated)
```

## Test plan
- [ ] CI passes (typecheck + unit/integration)
- [ ] Visit `/[project]/prompts` on a non-HTTPS dev origin, click **Create First Prompt** — no `crypto.randomUUID is not a function` error in the console, tab opens normally
- [ ] Tab IDs render with `tab-` prefix and window IDs with `window-` prefix