### PR TITLE
feat(langy): v2 backend — persistence, project memory, L6 retrieval, rate limit

### DIFF
--- a/langwatch/prisma/migrations/20260508153928_langy_memory/migration.sql
+++ b/langwatch/prisma/migrations/20260508153928_langy_memory/migration.sql
@@ -1,0 +1,87 @@
+-- Langy assistant tables — see specs/assistant/memory-design.md §3
+
+-- LangyConversation
+CREATE TABLE "LangyConversation" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT,
+    "isShared" BOOLEAN NOT NULL DEFAULT false,
+    "sharedAt" TIMESTAMP(3),
+    "sharedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "LangyConversation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "LangyConversation_projectId_userId_updatedAt_idx" ON "LangyConversation"("projectId", "userId", "updatedAt");
+CREATE INDEX "LangyConversation_projectId_isShared_updatedAt_idx" ON "LangyConversation"("projectId", "isShared", "updatedAt");
+CREATE INDEX "LangyConversation_deletedAt_idx" ON "LangyConversation"("deletedAt");
+
+-- LangyMessage
+CREATE TABLE "LangyMessage" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "parts" JSONB NOT NULL,
+    "tokenCount" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LangyMessage_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "LangyMessage_conversationId_createdAt_idx" ON "LangyMessage"("conversationId", "createdAt");
+CREATE INDEX "LangyMessage_projectId_idx" ON "LangyMessage"("projectId");
+
+-- LangyProjectMemory
+CREATE TABLE "LangyProjectMemory" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "contentSummary" TEXT,
+    "contentVersion" INTEGER NOT NULL DEFAULT 1,
+    "generatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "refreshedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastEditorId" TEXT,
+
+    CONSTRAINT "LangyProjectMemory_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "LangyProjectMemory_projectId_key" ON "LangyProjectMemory"("projectId");
+CREATE INDEX "LangyProjectMemory_projectId_idx" ON "LangyProjectMemory"("projectId");
+
+-- LangyProjectMemoryHistory
+CREATE TABLE "LangyProjectMemoryHistory" (
+    "id" TEXT NOT NULL,
+    "projectMemoryId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "contentVersion" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "changedById" TEXT,
+    "changeReason" TEXT,
+    "changedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LangyProjectMemoryHistory_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "LangyProjectMemoryHistory_projectMemoryId_changedAt_idx" ON "LangyProjectMemoryHistory"("projectMemoryId", "changedAt");
+CREATE INDEX "LangyProjectMemoryHistory_projectId_idx" ON "LangyProjectMemoryHistory"("projectId");
+
+-- LangyUserPreferences
+CREATE TABLE "LangyUserPreferences" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "mode" TEXT NOT NULL DEFAULT 'non_expert',
+    "dismissedSuggestionKinds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LangyUserPreferences_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "LangyUserPreferences_userId_projectId_key" ON "LangyUserPreferences"("userId", "projectId");
+CREATE INDEX "LangyUserPreferences_projectId_idx" ON "LangyUserPreferences"("projectId");

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -1800,3 +1800,85 @@ model GatewayCacheRule {
     @@index([organizationId, archivedAt, priority])
     @@index([organizationId, enabled, priority])
 }
+
+// ============================================================================
+// Langy assistant — see specs/assistant/memory-design.md §3
+// ============================================================================
+
+model LangyConversation {
+    id          String    @id @default(cuid())
+    projectId   String
+    userId      String
+    title       String?
+    isShared    Boolean   @default(false)
+    sharedAt    DateTime?
+    sharedById  String?
+    createdAt   DateTime  @default(now())
+    updatedAt   DateTime  @updatedAt
+    deletedAt   DateTime?
+
+    messages    LangyMessage[]
+
+    @@index([projectId, userId, updatedAt])
+    @@index([projectId, isShared, updatedAt])
+    @@index([deletedAt])
+}
+
+model LangyMessage {
+    id             String   @id @default(cuid())
+    conversationId String
+    projectId      String
+    role           String
+    parts          Json
+    tokenCount     Int?
+    createdAt      DateTime @default(now())
+
+    conversation   LangyConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+
+    @@index([conversationId, createdAt])
+    @@index([projectId])
+}
+
+model LangyProjectMemory {
+    id             String   @id @default(cuid())
+    projectId      String   @unique
+    content        String   @db.Text
+    contentSummary String?  @db.Text
+    contentVersion Int      @default(1)
+    generatedAt    DateTime @default(now())
+    refreshedAt    DateTime @default(now())
+    lastEditorId   String?
+
+    history        LangyProjectMemoryHistory[]
+
+    @@index([projectId])
+}
+
+model LangyProjectMemoryHistory {
+    id              String   @id @default(cuid())
+    projectMemoryId String
+    projectId       String
+    contentVersion  Int
+    content         String   @db.Text
+    changedById     String?
+    changeReason    String?
+    changedAt       DateTime @default(now())
+
+    projectMemory   LangyProjectMemory @relation(fields: [projectMemoryId], references: [id], onDelete: Cascade)
+
+    @@index([projectMemoryId, changedAt])
+    @@index([projectId])
+}
+
+model LangyUserPreferences {
+    id                       String   @id @default(cuid())
+    userId                   String
+    projectId                String
+    mode                     String   @default("non_expert")
+    dismissedSuggestionKinds String[] @default([])
+    createdAt                DateTime @default(now())
+    updatedAt                DateTime @updatedAt
+
+    @@unique([userId, projectId])
+    @@index([projectId])
+}

--- a/langwatch/specs/assistant/langy-workbench-sidebar.feature
+++ b/langwatch/specs/assistant/langy-workbench-sidebar.feature
@@ -1,6 +1,6 @@
-Feature: Sage assistant sidebar in the experiment workbench
+Feature: Langy assistant sidebar in the experiment workbench
   As a user working inside the experiment workbench
-  I want to chat with an in-product AI assistant named Sage
+  I want to chat with an in-product AI assistant named Langy
   So that I can understand, find, and plan with evaluators without leaving the page
 
   Background:
@@ -13,16 +13,16 @@ Feature: Sage assistant sidebar in the experiment workbench
   # ---------------------------------------------------------------------------
 
   @integration
-  Scenario: Opening Sage reveals an empty chat panel
-    When I open the Sage assistant
+  Scenario: Opening Langy reveals an empty chat panel
+    When I open the Langy assistant
     Then a right-side chat panel appears
-    And the panel shows a welcome message from Sage
+    And the panel shows a welcome message from Langy
     And my workbench content remains visible and usable
 
   @integration
-  Scenario: Closing Sage collapses the panel
-    Given the Sage panel is open
-    When I close the Sage panel
+  Scenario: Closing Langy collapses the panel
+    Given the Langy panel is open
+    When I close the Langy panel
     Then the panel is no longer visible
     And the workbench reclaims the full width
 
@@ -32,9 +32,9 @@ Feature: Sage assistant sidebar in the experiment workbench
 
   @integration
   Scenario: Asking which evaluators exist in my project
-    Given the Sage panel is open
+    Given the Langy panel is open
     When I ask "what evaluators do I have available?"
-    Then Sage replies with a list that includes each of my project's evaluators by name
+    Then Langy replies with a list that includes each of my project's evaluators by name
     And each evaluator in the list has a short one-line description
     And evaluators from other projects are not mentioned
 
@@ -44,22 +44,22 @@ Feature: Sage assistant sidebar in the experiment workbench
 
   @integration
   Scenario: Asking for details about a specific evaluator
-    Given the Sage panel is open
+    Given the Langy panel is open
     And my project has an evaluator named "Answer Relevancy"
     When I ask "how does Answer Relevancy work?"
-    Then Sage's reply describes what the evaluator measures
-    And Sage's reply lists the inputs the evaluator expects
+    Then Langy's reply describes what the evaluator measures
+    And Langy's reply lists the inputs the evaluator expects
 
   # ---------------------------------------------------------------------------
   # Suggesting an evaluator for a goal
   # ---------------------------------------------------------------------------
 
   @integration
-  Scenario: Asking Sage to suggest an evaluator for a goal
-    Given the Sage panel is open
+  Scenario: Asking Langy to suggest an evaluator for a goal
+    Given the Langy panel is open
     When I describe my goal: "I want to measure hallucinations in a RAG pipeline"
-    Then Sage proposes one or more evaluators that fit the goal
-    And Sage explains why each suggestion fits
+    Then Langy proposes one or more evaluators that fit the goal
+    And Langy explains why each suggestion fits
     And each suggestion references an evaluator that exists in my project or in the built-in catalog
 
   # ---------------------------------------------------------------------------
@@ -67,30 +67,30 @@ Feature: Sage assistant sidebar in the experiment workbench
   # ---------------------------------------------------------------------------
 
   @integration
-  Scenario: Sage proposes an action but does not execute it
-    Given the Sage panel is open
+  Scenario: Langy proposes an action but does not execute it
+    Given the Langy panel is open
     When I ask "run Answer Relevancy on my current experiment"
-    Then Sage does not modify the experiment
-    And Sage's reply explains the steps I would take to run that evaluator myself
+    Then Langy does not modify the experiment
+    And Langy's reply explains the steps I would take to run that evaluator myself
 
   # ---------------------------------------------------------------------------
   # Project isolation
   # ---------------------------------------------------------------------------
 
   @integration
-  Scenario: Sage only sees the current project's data
+  Scenario: Langy only sees the current project's data
     Given I belong to multiple projects
     And another project of mine has an evaluator named "Secret Eval"
-    When I ask Sage "list every evaluator I have"
-    Then Sage's reply does not mention "Secret Eval"
+    When I ask Langy "list every evaluator I have"
+    Then Langy's reply does not mention "Secret Eval"
 
   # ---------------------------------------------------------------------------
   # Authorization
   # ---------------------------------------------------------------------------
 
   @integration
-  Scenario: A user without evaluation view permission cannot use Sage
+  Scenario: A user without evaluation view permission cannot use Langy
     Given my role in the project does not grant evaluation view permission
-    When I try to open the Sage assistant
+    When I try to open the Langy assistant
     Then the assistant is unavailable
     And I see a message explaining I need evaluation access

--- a/langwatch/specs/assistant/sage-workbench-sidebar.feature
+++ b/langwatch/specs/assistant/sage-workbench-sidebar.feature
@@ -1,0 +1,96 @@
+Feature: Sage assistant sidebar in the experiment workbench
+  As a user working inside the experiment workbench
+  I want to chat with an in-product AI assistant named Sage
+  So that I can understand, find, and plan with evaluators without leaving the page
+
+  Background:
+    Given I am signed in with access to a project
+    And I am viewing an experiment in the workbench
+    And my project has at least one custom evaluator and several built-in evaluators available
+
+  # ---------------------------------------------------------------------------
+  # Opening and closing the sidebar
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Opening Sage reveals an empty chat panel
+    When I open the Sage assistant
+    Then a right-side chat panel appears
+    And the panel shows a welcome message from Sage
+    And my workbench content remains visible and usable
+
+  @integration
+  Scenario: Closing Sage collapses the panel
+    Given the Sage panel is open
+    When I close the Sage panel
+    Then the panel is no longer visible
+    And the workbench reclaims the full width
+
+  # ---------------------------------------------------------------------------
+  # Listing evaluators
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Asking which evaluators exist in my project
+    Given the Sage panel is open
+    When I ask "what evaluators do I have available?"
+    Then Sage replies with a list that includes each of my project's evaluators by name
+    And each evaluator in the list has a short one-line description
+    And evaluators from other projects are not mentioned
+
+  # ---------------------------------------------------------------------------
+  # Explaining a specific evaluator
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Asking for details about a specific evaluator
+    Given the Sage panel is open
+    And my project has an evaluator named "Answer Relevancy"
+    When I ask "how does Answer Relevancy work?"
+    Then Sage's reply describes what the evaluator measures
+    And Sage's reply lists the inputs the evaluator expects
+
+  # ---------------------------------------------------------------------------
+  # Suggesting an evaluator for a goal
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Asking Sage to suggest an evaluator for a goal
+    Given the Sage panel is open
+    When I describe my goal: "I want to measure hallucinations in a RAG pipeline"
+    Then Sage proposes one or more evaluators that fit the goal
+    And Sage explains why each suggestion fits
+    And each suggestion references an evaluator that exists in my project or in the built-in catalog
+
+  # ---------------------------------------------------------------------------
+  # Read-only boundary (v1 does not take actions on the user's behalf)
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Sage proposes an action but does not execute it
+    Given the Sage panel is open
+    When I ask "run Answer Relevancy on my current experiment"
+    Then Sage does not modify the experiment
+    And Sage's reply explains the steps I would take to run that evaluator myself
+
+  # ---------------------------------------------------------------------------
+  # Project isolation
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Sage only sees the current project's data
+    Given I belong to multiple projects
+    And another project of mine has an evaluator named "Secret Eval"
+    When I ask Sage "list every evaluator I have"
+    Then Sage's reply does not mention "Secret Eval"
+
+  # ---------------------------------------------------------------------------
+  # Authorization
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: A user without evaluation view permission cannot use Sage
+    Given my role in the project does not grant evaluation view permission
+    When I try to open the Sage assistant
+    Then the assistant is unavailable
+    And I see a message explaining I need evaluation access

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -38,6 +38,12 @@ import { findCurrentRoute, projectRoutes, type Route } from "../utils/routes";
 import { trackEvent } from "../utils/tracking";
 import { AnnouncementBanner } from "./AnnouncementBanner";
 import { CurrentDrawer } from "./CurrentDrawer";
+import { LangyProvider, useLangy } from "./langy/LangyContext";
+import {
+  LangyDrawer,
+  LANGY_DOCKED_OFFSET,
+  LANGY_TRANSITION,
+} from "./langy/LangySidebar";
 import { FullLogo } from "./icons/FullLogo";
 import { LogoIcon } from "./icons/LogoIcon";
 import { LoadingScreen } from "./LoadingScreen";
@@ -358,13 +364,14 @@ export const DashboardLayout = ({
     router.pathname.startsWith("/[project]/analytics");
   const showSavedViews = isTracesOrAnalyticsPage;
 
+  const isProjectRoute =
+    router.pathname === "/[project]" ||
+    router.pathname.startsWith("/[project]/");
+  const showLangy = !publicPage && userIsPartOfTeam && isProjectRoute;
+
   return (
-    <Box
-      width="full"
-      minHeight="100vh"
-      background="bg.page"
-      overflowX={["auto", "auto", "hidden"]}
-    >
+    <LangyProvider>
+      <LangyShiftedRoot showLangy={showLangy}>
       <Head>
         <title>
           LangWatch{project ? ` - ${project.name}` : ""}
@@ -801,10 +808,48 @@ export const DashboardLayout = ({
         </Box>
       </HStack>
       <GlobalUpgradeModal />
-    </Box>
+    </LangyShiftedRoot>
+    </LangyProvider>
   );
 };
 
+function LangyShiftedRoot({
+  showLangy,
+  children,
+}: {
+  showLangy: boolean;
+  children: React.ReactNode;
+}) {
+  const { isOpen } = useLangy();
+  const shifted = showLangy && isOpen;
+  return (
+    <>
+      <Box
+        width="full"
+        minHeight="100vh"
+        background="bg.page"
+        overflowX={["auto", "auto", "hidden"]}
+        paddingRight={shifted ? `${LANGY_DOCKED_OFFSET}px` : 0}
+        transition={`padding-right ${LANGY_TRANSITION}`}
+      >
+        {children}
+      </Box>
+      {showLangy && <LangyDrawerConnected />}
+    </>
+  );
+}
+
+function LangyDrawerConnected() {
+  const { isOpen, setIsOpen, proposalHandlers, experimentSlug } = useLangy();
+  return (
+    <LangyDrawer
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      proposalHandlers={proposalHandlers}
+      experimentSlug={experimentSlug}
+    />
+  );
+}
 
 function GlobalUpgradeModal() {
   const { isOpen, variant, close } = useUpgradeModalStore();

--- a/langwatch/src/components/langy/LangyContext.tsx
+++ b/langwatch/src/components/langy/LangyContext.tsx
@@ -1,0 +1,90 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { ProposalHandlers } from "./LangySidebar";
+
+interface LangyContextValue {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  proposalHandlers: ProposalHandlers;
+  experimentSlug: string | undefined;
+  registerHandlers: (
+    handlers: ProposalHandlers,
+    opts?: { experimentSlug?: string },
+  ) => void;
+  clearHandlers: () => void;
+}
+
+const LangyContext = createContext<LangyContextValue | null>(null);
+
+export function LangyProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [proposalHandlers, setProposalHandlers] = useState<ProposalHandlers>(
+    {},
+  );
+  const [experimentSlug, setExperimentSlug] = useState<string | undefined>();
+
+  const registerHandlers = useCallback(
+    (handlers: ProposalHandlers, opts?: { experimentSlug?: string }) => {
+      setProposalHandlers(handlers);
+      setExperimentSlug(opts?.experimentSlug);
+    },
+    [],
+  );
+
+  const clearHandlers = useCallback(() => {
+    setProposalHandlers({});
+    setExperimentSlug(undefined);
+  }, []);
+
+  const value = useMemo<LangyContextValue>(
+    () => ({
+      isOpen,
+      setIsOpen,
+      proposalHandlers,
+      experimentSlug,
+      registerHandlers,
+      clearHandlers,
+    }),
+    [
+      isOpen,
+      proposalHandlers,
+      experimentSlug,
+      registerHandlers,
+      clearHandlers,
+    ],
+  );
+
+  return <LangyContext.Provider value={value}>{children}</LangyContext.Provider>;
+}
+
+export function useLangy(): LangyContextValue {
+  const ctx = useContext(LangyContext);
+  if (!ctx) {
+    throw new Error("useLangy must be used inside <LangyProvider>");
+  }
+  return ctx;
+}
+
+/**
+ * Optional hook for pages that want to expose page-specific proposal
+ * handlers (e.g. the experiments workbench). Handlers register on mount
+ * and clear on unmount, so other pages get a chat-only Langy.
+ */
+export function useRegisterLangyHandlers(
+  handlers: ProposalHandlers,
+  opts?: { experimentSlug?: string },
+) {
+  const { registerHandlers, clearHandlers } = useLangy();
+  const slug = opts?.experimentSlug;
+  useEffect(() => {
+    registerHandlers(handlers, { experimentSlug: slug });
+    return () => clearHandlers();
+  }, [handlers, slug, registerHandlers, clearHandlers]);
+}

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -33,8 +33,8 @@ const SAMPLE_PROMPTS = [
   "Suggest an evaluator for measuring RAG hallucinations",
 ];
 
-export interface SageProposal {
-  sageProposal: true;
+export interface LangyProposal {
+  langyProposal: true;
   kind: string;
   summary: string;
   rationale?: string;
@@ -56,15 +56,15 @@ export type ProposalHandlers = Record<
   (payload: Record<string, unknown>) => Promise<AppliedOutcome>
 >;
 
-interface SageDrawerProps {
+interface LangyDrawerProps {
   proposalHandlers?: ProposalHandlers;
   experimentSlug?: string;
 }
 
-export function SageDrawer({
+export function LangyDrawer({
   proposalHandlers,
   experimentSlug,
-}: SageDrawerProps) {
+}: LangyDrawerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const handleRef = useRef<HTMLButtonElement>(null);
@@ -84,12 +84,12 @@ export function SageDrawer({
 
   return (
     <>
-      <SageHandle
+      <LangyHandle
         ref={handleRef}
         isOpen={isOpen}
         onToggle={() => setIsOpen((v) => !v)}
       />
-      <SagePanel
+      <LangyPanel
         ref={panelRef}
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
@@ -100,16 +100,16 @@ export function SageDrawer({
   );
 }
 
-const SageHandle = forwardRef<
+const LangyHandle = forwardRef<
   HTMLButtonElement,
   { isOpen: boolean; onToggle: () => void }
->(function SageHandle({ isOpen, onToggle }, ref) {
+>(function LangyHandle({ isOpen, onToggle }, ref) {
   return (
     <Box
       ref={ref}
       as="button"
       onClick={onToggle}
-      aria-label={isOpen ? "Close Sage" : "Open Sage"}
+      aria-label={isOpen ? "Close Langy" : "Open Langy"}
       position="fixed"
       right={isOpen ? `${DRAWER_WIDTH}px` : 0}
       top="50%"
@@ -146,14 +146,14 @@ const SageHandle = forwardRef<
             transform: "rotate(180deg)",
           }}
         >
-          SAGE
+          LANGY
         </Text>
       </VStack>
     </Box>
   );
 });
 
-const SagePanel = forwardRef<
+const LangyPanel = forwardRef<
   HTMLDivElement,
   {
     isOpen: boolean;
@@ -161,7 +161,7 @@ const SagePanel = forwardRef<
     proposalHandlers?: ProposalHandlers;
     experimentSlug?: string;
   }
->(function SagePanel(
+>(function LangyPanel(
   { isOpen, onClose, proposalHandlers, experimentSlug },
   ref,
 ) {
@@ -184,7 +184,7 @@ const SagePanel = forwardRef<
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const transport = useMemo(
-    () => new DefaultChatTransport({ api: "/api/sage/chat" }),
+    () => new DefaultChatTransport({ api: "/api/langy/chat" }),
     [],
   );
   const { messages, sendMessage, stop, status } = useChat({
@@ -192,7 +192,7 @@ const SagePanel = forwardRef<
     onError: (error) => {
       if (isHandledByGlobalHandler(error)) return;
       toaster.create({
-        title: "Sage error",
+        title: "Langy error",
         description: error.message,
         type: "error",
         duration: 5000,
@@ -219,7 +219,7 @@ const SagePanel = forwardRef<
 
   const applyProposal = async (
     proposalId: string,
-    proposal: SageProposal,
+    proposal: LangyProposal,
   ) => {
     if (applyingProposals.has(proposalId)) return;
     if (proposalId in appliedOutcomes) return;
@@ -353,7 +353,7 @@ function PanelHeader({ onClose }: { onClose: () => void }) {
       </Box>
       <VStack align="start" gap={0}>
         <Text fontSize="sm" fontWeight="600" color="fg">
-          Sage
+          Langy
         </Text>
         <Text fontSize="xs" color="fg.muted">
           Propose &amp; apply
@@ -363,7 +363,7 @@ function PanelHeader({ onClose }: { onClose: () => void }) {
       <IconButton
         size="xs"
         variant="ghost"
-        aria-label="Close Sage"
+        aria-label="Close Langy"
         onClick={onClose}
       >
         <LuX size={14} />
@@ -395,7 +395,7 @@ function ThinkingIndicator({ messages }: { messages: UIMessage[] }) {
       alignSelf="flex-start"
     >
       <Spinner size="xs" colorPalette="blue" />
-      <Text>Sage is {label}…</Text>
+      <Text>Langy is {label}…</Text>
     </HStack>
   );
 }
@@ -427,7 +427,7 @@ function Composer({
       <HStack gap={2}>
         <Input
           placeholder={
-            isBusy ? "Sage is working…" : "Ask Sage or describe what you want…"
+            isBusy ? "Langy is working…" : "Ask Langy or describe what you want…"
           }
           value={input}
           onChange={(e) => onInputChange(e.target.value)}
@@ -474,7 +474,7 @@ function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
     <VStack align="stretch" gap={3} paddingTop={2}>
       <VStack align="start" gap={1}>
         <Text fontSize="sm" fontWeight="600" color="fg">
-          Hey, I&apos;m Sage.
+          Hey, I&apos;m Langy.
         </Text>
         <Text fontSize="xs" color="fg.muted" lineHeight="1.55">
           I can propose evaluators, help you pick the right one for your
@@ -532,7 +532,7 @@ function MessageContent({
   >;
   discardedProposals: Set<string>;
   applyingProposals: Set<string>;
-  onApply: (proposalId: string, proposal: SageProposal) => Promise<void>;
+  onApply: (proposalId: string, proposal: LangyProposal) => Promise<void>;
   onDiscard: (proposalId: string) => void;
 }) {
   const isUser = message.role === "user";
@@ -615,7 +615,7 @@ function ProposalCard({
   onApply,
   onDiscard,
 }: {
-  proposal: SageProposal;
+  proposal: LangyProposal;
   appliedOutcome?: { href?: string; label?: string; onOpen?: () => void };
   isDiscarded: boolean;
   isApplying: boolean;
@@ -636,8 +636,8 @@ function ProposalCard({
           ? "Deleting…"
           : "Applying…"
         : destructive
-          ? "Sage wants to delete"
-          : "Sage proposes";
+          ? "Langy wants to delete"
+          : "Langy proposes";
   const accentPalette = isApplied
     ? destructive
       ? "gray"
@@ -774,12 +774,12 @@ function ProposalCard({
 
 function extractProposals(
   message: UIMessage,
-): Array<{ id: string; proposal: SageProposal }> {
-  const result: Array<{ id: string; proposal: SageProposal }> = [];
+): Array<{ id: string; proposal: LangyProposal }> {
+  const result: Array<{ id: string; proposal: LangyProposal }> = [];
   for (const part of message.parts) {
     if (!part.type?.startsWith("tool-")) continue;
     const output = (part as { output?: unknown }).output;
-    if (!isSageProposal(output)) continue;
+    if (!isLangyProposal(output)) continue;
     const id =
       (part as { toolCallId?: string }).toolCallId ??
       `${message.id}:${result.length}`;
@@ -788,11 +788,11 @@ function extractProposals(
   return result;
 }
 
-function isSageProposal(value: unknown): value is SageProposal {
+function isLangyProposal(value: unknown): value is LangyProposal {
   if (!value || typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
   return (
-    v.sageProposal === true &&
+    v.langyProposal === true &&
     typeof v.kind === "string" &&
     typeof v.summary === "string"
   );

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -10,7 +10,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
-import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   LuArrowRight,
   LuCheck,
@@ -26,6 +26,15 @@ import { isHandledByGlobalHandler } from "~/utils/trpcError";
 
 const DRAWER_WIDTH = 420;
 const HANDLE_WIDTH = 26;
+const PANEL_GUTTER = 16;
+
+/**
+ * Total horizontal space the Langy panel occupies when docked open
+ * (panel width + the right-side gutter). Page layouts can use this
+ * to shift content out of the way with a matching transition.
+ */
+export const LANGY_DOCKED_OFFSET = DRAWER_WIDTH + PANEL_GUTTER;
+export const LANGY_TRANSITION = "360ms cubic-bezier(0.32, 0.72, 0, 1)";
 
 const SAMPLE_PROMPTS = [
   "Summarize my current experiment",
@@ -59,38 +68,33 @@ export type ProposalHandlers = Record<
 interface LangyDrawerProps {
   proposalHandlers?: ProposalHandlers;
   experimentSlug?: string;
+  /**
+   * Controlled open state. When provided, the parent owns visibility —
+   * which is what enables the surrounding layout to shift in lockstep.
+   * If omitted, the drawer manages its own state (overlay-style).
+   */
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function LangyDrawer({
   proposalHandlers,
   experimentSlug,
+  isOpen: isOpenProp,
+  onOpenChange,
 }: LangyDrawerProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const panelRef = useRef<HTMLDivElement>(null);
-  const handleRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const onPointerDown = (event: PointerEvent) => {
-      const target = event.target as Node | null;
-      if (!target) return;
-      if (panelRef.current?.contains(target)) return;
-      if (handleRef.current?.contains(target)) return;
-      setIsOpen(false);
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    return () => document.removeEventListener("pointerdown", onPointerDown);
-  }, [isOpen]);
+  const isControlled = isOpenProp !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = isControlled ? isOpenProp : internalOpen;
+  const setIsOpen = (next: boolean) => {
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
 
   return (
     <>
-      <LangyHandle
-        ref={handleRef}
-        isOpen={isOpen}
-        onToggle={() => setIsOpen((v) => !v)}
-      />
+      <LangyHandle isOpen={isOpen} onToggle={() => setIsOpen(!isOpen)} />
       <LangyPanel
-        ref={panelRef}
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         proposalHandlers={proposalHandlers}
@@ -100,18 +104,20 @@ export function LangyDrawer({
   );
 }
 
-const LangyHandle = forwardRef<
-  HTMLButtonElement,
-  { isOpen: boolean; onToggle: () => void }
->(function LangyHandle({ isOpen, onToggle }, ref) {
+function LangyHandle({
+  isOpen,
+  onToggle,
+}: {
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
   return (
     <Box
-      ref={ref}
       as="button"
       onClick={onToggle}
       aria-label={isOpen ? "Close Langy" : "Open Langy"}
       position="fixed"
-      right={isOpen ? `${DRAWER_WIDTH}px` : 0}
+      right={isOpen ? `${DRAWER_WIDTH + PANEL_GUTTER / 2}px` : 0}
       top="50%"
       transform="translateY(-50%)"
       width={`${HANDLE_WIDTH}px`}
@@ -126,8 +132,8 @@ const LangyHandle = forwardRef<
       borderColor="border.emphasized"
       borderRightWidth={0}
       boxShadow="sm"
-      color="fg.muted"
-      transition="right 360ms cubic-bezier(0.32, 0.72, 0, 1), transform 180ms ease, color 180ms ease, background 180ms ease"
+      color={isOpen ? "blue.fg" : "fg.muted"}
+      transition={`right ${LANGY_TRANSITION}, transform 180ms ease, color 180ms ease, background 180ms ease`}
       _hover={{
         transform: "translate(-2px, -50%)",
         color: "blue.fg",
@@ -151,20 +157,19 @@ const LangyHandle = forwardRef<
       </VStack>
     </Box>
   );
-});
+}
 
-const LangyPanel = forwardRef<
-  HTMLDivElement,
-  {
-    isOpen: boolean;
-    onClose: () => void;
-    proposalHandlers?: ProposalHandlers;
-    experimentSlug?: string;
-  }
->(function LangyPanel(
-  { isOpen, onClose, proposalHandlers, experimentSlug },
-  ref,
-) {
+function LangyPanel({
+  isOpen,
+  onClose,
+  proposalHandlers,
+  experimentSlug,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  proposalHandlers?: ProposalHandlers;
+  experimentSlug?: string;
+}) {
   const { project } = useOrganizationTeamProject();
   const projectId = project?.id;
 
@@ -274,7 +279,6 @@ const LangyPanel = forwardRef<
 
   return (
     <Box
-      ref={ref}
       position="fixed"
       top={2}
       right={2}
@@ -282,17 +286,20 @@ const LangyPanel = forwardRef<
       width={`${DRAWER_WIDTH}px`}
       zIndex={1500}
       borderRadius="lg"
-      background="bg.surface/80"
-      backdropFilter="blur(25px)"
+      background="bg.surface/85"
+      backdropFilter="blur(28px) saturate(140%)"
       borderWidth="1px"
       borderColor="border.emphasized"
-      boxShadow="lg"
-      transition="transform 360ms cubic-bezier(0.32, 0.72, 0, 1), opacity 200ms ease"
+      boxShadow="0 24px 60px -20px rgba(15, 23, 42, 0.35), 0 8px 20px -8px rgba(15, 23, 42, 0.2)"
+      transition={`transform ${LANGY_TRANSITION}, opacity 220ms ease`}
       transform={
-        isOpen ? "translateX(0)" : `translateX(calc(${DRAWER_WIDTH}px + 16px))`
+        isOpen
+          ? "translateX(0)"
+          : `translateX(calc(${DRAWER_WIDTH}px + ${PANEL_GUTTER}px))`
       }
       opacity={isOpen ? 1 : 0}
       pointerEvents={isOpen ? "auto" : "none"}
+      aria-hidden={!isOpen}
     >
       <VStack gap={0} align="stretch" height="full">
         <PanelHeader onClose={onClose} />
@@ -328,7 +335,7 @@ const LangyPanel = forwardRef<
       </VStack>
     </Box>
   );
-});
+}
 
 function PanelHeader({ onClose }: { onClose: () => void }) {
   return (

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -38,6 +38,7 @@ export interface SageProposal {
   kind: string;
   summary: string;
   rationale?: string;
+  destructive?: boolean;
   payload: Record<string, unknown>;
 }
 
@@ -622,15 +623,36 @@ function ProposalCard({
   onDiscard: () => void;
 }) {
   const isApplied = !!appliedOutcome;
+  const destructive = !!proposal.destructive;
   const faded = isDiscarded;
   const statusLabel = isApplied
-    ? "Applied"
+    ? destructive
+      ? "Done"
+      : "Applied"
     : isDiscarded
       ? "Discarded"
       : isApplying
-        ? "Applying…"
-        : "Sage proposes";
-  const accentPalette = isApplied ? "green" : "blue";
+        ? destructive
+          ? "Deleting…"
+          : "Applying…"
+        : destructive
+          ? "Sage wants to delete"
+          : "Sage proposes";
+  const accentPalette = isApplied
+    ? destructive
+      ? "gray"
+      : "green"
+    : destructive
+      ? "red"
+      : "blue";
+  const borderTone = isApplied
+    ? destructive
+      ? "border.emphasized"
+      : "green.emphasized"
+    : destructive
+      ? "red.emphasized"
+      : "blue.emphasized";
+  const primaryButtonLabel = destructive ? "Delete" : "Apply";
   const openHref = appliedOutcome?.href;
   const onOpen = appliedOutcome?.onOpen;
   const openLabel = appliedOutcome?.label ?? "Open";
@@ -652,7 +674,7 @@ function ProposalCard({
       borderRadius="lg"
       background="bg.panel"
       borderWidth="1px"
-      borderColor={isApplied ? "green.emphasized" : "blue.emphasized"}
+      borderColor={borderTone}
       boxShadow="sm"
       opacity={faded ? 0.75 : 1}
       cursor={hasOpen ? "pointer" : "default"}
@@ -705,13 +727,13 @@ function ProposalCard({
           <HStack gap={2} paddingTop={1}>
             <Button
               size="xs"
-              colorPalette="blue"
+              colorPalette={destructive ? "red" : "blue"}
               onClick={onApply}
               disabled={isApplying}
               loading={isApplying}
             >
               <LuCheck size={12} />
-              Apply
+              {primaryButtonLabel}
             </Button>
             <Button
               size="xs"
@@ -719,7 +741,7 @@ function ProposalCard({
               onClick={onDiscard}
               disabled={isApplying}
             >
-              Discard
+              {destructive ? "Cancel" : "Discard"}
             </Button>
           </HStack>
         )}
@@ -767,11 +789,11 @@ function extractProposals(
 }
 
 function isSageProposal(value: unknown): value is SageProposal {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
   return (
-    !!value &&
-    typeof value === "object" &&
-    (value as Record<string, unknown>).sageProposal === true &&
-    typeof (value as Record<string, unknown>).kind === "string" &&
-    typeof (value as Record<string, unknown>).summary === "string"
+    v.sageProposal === true &&
+    typeof v.kind === "string" &&
+    typeof v.summary === "string"
   );
 }

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -42,8 +42,12 @@ export interface SageProposal {
 }
 
 export type AppliedOutcome = {
-  href?: string;
+  /** Label for the "open" affordance. Defaults to "Open". */
   label?: string;
+  /** If provided, clicking the applied card triggers this (e.g. openDrawer). */
+  onOpen?: () => void;
+  /** Fallback link target if no onOpen is provided. */
+  href?: string;
 } | void;
 
 export type ProposalHandlers = Record<
@@ -165,7 +169,10 @@ const SagePanel = forwardRef<
 
   const [input, setInput] = useState("");
   const [appliedOutcomes, setAppliedOutcomes] = useState<
-    Record<string, { href?: string; label?: string }>
+    Record<
+      string,
+      { href?: string; label?: string; onOpen?: () => void }
+    >
   >({});
   const [discardedProposals, setDiscardedProposals] = useState<Set<string>>(
     new Set(),
@@ -518,7 +525,10 @@ function MessageContent({
   onDiscard,
 }: {
   message: UIMessage;
-  appliedOutcomes: Record<string, { href?: string; label?: string }>;
+  appliedOutcomes: Record<
+    string,
+    { href?: string; label?: string; onOpen?: () => void }
+  >;
   discardedProposals: Set<string>;
   applyingProposals: Set<string>;
   onApply: (proposalId: string, proposal: SageProposal) => Promise<void>;
@@ -605,7 +615,7 @@ function ProposalCard({
   onDiscard,
 }: {
   proposal: SageProposal;
-  appliedOutcome?: { href?: string; label?: string };
+  appliedOutcome?: { href?: string; label?: string; onOpen?: () => void };
   isDiscarded: boolean;
   isApplying: boolean;
   onApply: () => void;
@@ -622,7 +632,19 @@ function ProposalCard({
         : "Sage proposes";
   const accentPalette = isApplied ? "green" : "blue";
   const openHref = appliedOutcome?.href;
+  const onOpen = appliedOutcome?.onOpen;
   const openLabel = appliedOutcome?.label ?? "Open";
+  const hasOpen = !!onOpen || !!openHref;
+
+  const triggerOpen = () => {
+    if (onOpen) {
+      onOpen();
+      return;
+    }
+    if (openHref) {
+      window.location.href = openHref;
+    }
+  };
 
   return (
     <Box
@@ -633,16 +655,16 @@ function ProposalCard({
       borderColor={isApplied ? "green.emphasized" : "blue.emphasized"}
       boxShadow="sm"
       opacity={faded ? 0.75 : 1}
-      cursor={openHref ? "pointer" : "default"}
+      cursor={hasOpen ? "pointer" : "default"}
       onClick={(e) => {
-        if (!openHref) return;
+        if (!hasOpen) return;
         const target = e.target as HTMLElement;
         if (target.closest("a, button")) return;
-        window.location.href = openHref;
+        triggerOpen();
       }}
       transition="border-color 150ms ease, box-shadow 150ms ease"
       _hover={
-        openHref
+        hasOpen
           ? { borderColor: "green.fg", boxShadow: "md" }
           : undefined
       }
@@ -701,19 +723,26 @@ function ProposalCard({
             </Button>
           </HStack>
         )}
-        {isApplied && openHref && (
+        {isApplied && hasOpen && (
           <HStack gap={2} paddingTop={1}>
-            <Button
-              size="xs"
-              variant="outline"
-              colorPalette="green"
-              asChild
-            >
-              <a href={openHref}>
+            {onOpen ? (
+              <Button
+                size="xs"
+                variant="outline"
+                colorPalette="green"
+                onClick={triggerOpen}
+              >
                 {openLabel}
                 <LuArrowRight size={12} />
-              </a>
-            </Button>
+              </Button>
+            ) : openHref ? (
+              <Button size="xs" variant="outline" colorPalette="green" asChild>
+                <a href={openHref}>
+                  {openLabel}
+                  <LuArrowRight size={12} />
+                </a>
+              </Button>
+            ) : null}
           </HStack>
         )}
       </VStack>

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -1,0 +1,730 @@
+import { useChat } from "@ai-sdk/react";
+import {
+  Box,
+  Button,
+  HStack,
+  IconButton,
+  Input,
+  Spinner,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { DefaultChatTransport, type UIMessage } from "ai";
+import { useEffect, useRef, useState } from "react";
+import {
+  LuArrowRight,
+  LuCheck,
+  LuSend,
+  LuSparkles,
+  LuX,
+} from "react-icons/lu";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { Markdown } from "~/components/Markdown";
+import { toaster } from "~/components/ui/toaster";
+import { isHandledByGlobalHandler } from "~/utils/trpcError";
+
+const DRAWER_WIDTH = 420;
+const HANDLE_WIDTH = 28;
+
+const SYSTEM_FONT_STACK =
+  '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "Inter", "Segoe UI", Roboto, sans-serif';
+
+const SAMPLE_PROMPTS = [
+  "What evaluators do I have available?",
+  "Suggest an evaluator for measuring RAG hallucinations and add it to my workbench",
+  "List my prompts and datasets",
+];
+
+export interface SageProposal {
+  sageProposal: true;
+  kind: string;
+  summary: string;
+  rationale?: string;
+  payload: Record<string, unknown>;
+}
+
+export type ProposalHandlers = Record<
+  string,
+  (payload: Record<string, unknown>) => Promise<void>
+>;
+
+interface SageDrawerProps {
+  proposalHandlers?: ProposalHandlers;
+}
+
+export function SageDrawer({ proposalHandlers }: SageDrawerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <SageHandle isOpen={isOpen} onToggle={() => setIsOpen((v) => !v)} />
+      <SagePanel
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        proposalHandlers={proposalHandlers}
+      />
+    </>
+  );
+}
+
+function SageHandle({
+  isOpen,
+  onToggle,
+}: {
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Box
+      as="button"
+      onClick={onToggle}
+      aria-label={isOpen ? "Close Sage" : "Open Sage"}
+      position="fixed"
+      right={isOpen ? `${DRAWER_WIDTH}px` : 0}
+      top="50%"
+      transform="translateY(-50%)"
+      width={`${HANDLE_WIDTH}px`}
+      height="96px"
+      zIndex={1600}
+      cursor="pointer"
+      borderTopLeftRadius="18px"
+      borderBottomLeftRadius="18px"
+      borderTopRightRadius={0}
+      borderBottomRightRadius={0}
+      style={{
+        background:
+          "linear-gradient(135deg, rgba(167, 139, 250, 0.95), rgba(124, 58, 237, 0.95))",
+        backdropFilter: "blur(20px) saturate(180%)",
+        WebkitBackdropFilter: "blur(20px) saturate(180%)",
+        boxShadow:
+          "-8px 0 32px rgba(124, 58, 237, 0.28), inset 1px 0 0 rgba(255,255,255,0.2)",
+        border: "1px solid rgba(255,255,255,0.18)",
+        borderRight: "none",
+        transition:
+          "right 360ms cubic-bezier(0.32, 0.72, 0, 1), transform 220ms ease, box-shadow 220ms ease",
+      }}
+      _hover={{
+        transform: "translate(-3px, -50%)",
+      }}
+    >
+      <VStack gap={1} height="full" justify="center" color="white">
+        <LuSparkles size={14} />
+        <Text
+          fontSize="10px"
+          fontWeight="semibold"
+          letterSpacing="0.12em"
+          style={{
+            writingMode: "vertical-rl",
+            textOrientation: "mixed",
+            transform: "rotate(180deg)",
+            fontFamily: SYSTEM_FONT_STACK,
+          }}
+        >
+          SAGE
+        </Text>
+      </VStack>
+    </Box>
+  );
+}
+
+function SagePanel({
+  isOpen,
+  onClose,
+  proposalHandlers,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  proposalHandlers?: ProposalHandlers;
+}) {
+  const { project } = useOrganizationTeamProject();
+  const projectId = project?.id;
+
+  const [input, setInput] = useState("");
+  const [appliedProposals, setAppliedProposals] = useState<Set<string>>(
+    new Set(),
+  );
+  const [discardedProposals, setDiscardedProposals] = useState<Set<string>>(
+    new Set(),
+  );
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({ api: "/api/sage/chat" }),
+    onError: (error) => {
+      if (isHandledByGlobalHandler(error)) return;
+      toaster.create({
+        title: "Sage error",
+        description: error.message,
+        type: "error",
+        duration: 5000,
+        meta: { closable: true },
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [messages, status]);
+
+  const isBusy = status === "submitted" || status === "streaming";
+
+  const send = async (text: string) => {
+    if (!text.trim() || !projectId || isBusy) return;
+    setInput("");
+    await sendMessage(
+      { role: "user", parts: [{ type: "text", text }] },
+      { body: { projectId } },
+    );
+  };
+
+  const applyProposal = async (
+    proposalId: string,
+    proposal: SageProposal,
+  ) => {
+    const handler = proposalHandlers?.[proposal.kind];
+    if (!handler) {
+      toaster.create({
+        title: "Cannot apply",
+        description: `No handler for '${proposal.kind}' on this page.`,
+        type: "error",
+        duration: 5000,
+        meta: { closable: true },
+      });
+      return;
+    }
+    try {
+      await handler(proposal.payload);
+      setAppliedProposals((prev) => new Set(prev).add(proposalId));
+      toaster.create({
+        title: "Applied",
+        description: proposal.summary,
+        type: "success",
+        duration: 3000,
+        meta: { closable: true },
+      });
+    } catch (error) {
+      if (isHandledByGlobalHandler(error)) return;
+      toaster.create({
+        title: "Failed to apply",
+        description: error instanceof Error ? error.message : "Unknown error",
+        type: "error",
+        duration: 5000,
+        meta: { closable: true },
+      });
+    }
+  };
+
+  const discardProposal = (proposalId: string) => {
+    setDiscardedProposals((prev) => new Set(prev).add(proposalId));
+  };
+
+  return (
+    <Box
+      position="fixed"
+      top={0}
+      right={0}
+      height="100vh"
+      width={`${DRAWER_WIDTH}px`}
+      zIndex={1500}
+      style={{
+        transform: isOpen ? "translateX(0)" : `translateX(${DRAWER_WIDTH}px)`,
+        transition: "transform 360ms cubic-bezier(0.32, 0.72, 0, 1)",
+        background:
+          "linear-gradient(180deg, rgba(252, 251, 255, 0.82) 0%, rgba(245, 243, 255, 0.78) 100%)",
+        backdropFilter: "blur(40px) saturate(180%)",
+        WebkitBackdropFilter: "blur(40px) saturate(180%)",
+        borderLeft: "1px solid rgba(124, 58, 237, 0.1)",
+        boxShadow:
+          "-32px 0 60px rgba(15, 23, 42, 0.12), inset 1px 0 0 rgba(255,255,255,0.6)",
+        borderTopLeftRadius: "24px",
+        borderBottomLeftRadius: "24px",
+        fontFamily: SYSTEM_FONT_STACK,
+      }}
+    >
+      <VStack gap={0} align="stretch" height="full">
+        <PanelHeader onClose={onClose} />
+        <Box ref={scrollRef} flex={1} overflowY="auto" paddingX={5} paddingY={4}>
+          {messages.length === 0 ? (
+            <EmptyState onPick={(prompt) => void send(prompt)} />
+          ) : (
+            <VStack gap={4} align="stretch">
+              {messages.map((message) => (
+                <MessageContent
+                  key={message.id}
+                  message={message}
+                  appliedProposals={appliedProposals}
+                  discardedProposals={discardedProposals}
+                  onApply={applyProposal}
+                  onDiscard={discardProposal}
+                />
+              ))}
+              {isBusy && <ThinkingIndicator messages={messages} />}
+            </VStack>
+          )}
+        </Box>
+        <Composer
+          input={input}
+          onInputChange={setInput}
+          onSend={() => void send(input)}
+          disabled={isBusy || !projectId}
+          canSend={!!input.trim() && !isBusy && !!projectId}
+        />
+      </VStack>
+    </Box>
+  );
+}
+
+function PanelHeader({ onClose }: { onClose: () => void }) {
+  return (
+    <HStack
+      paddingX={5}
+      paddingY={4}
+      borderBottom="1px solid"
+      borderColor="rgba(124, 58, 237, 0.08)"
+      gap={3}
+    >
+      <Box
+        width="32px"
+        height="32px"
+        borderRadius="10px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        color="white"
+        style={{
+          background:
+            "linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%)",
+          boxShadow:
+            "0 6px 20px rgba(124, 58, 237, 0.35), inset 0 1px 0 rgba(255,255,255,0.4)",
+        }}
+      >
+        <LuSparkles size={16} />
+      </Box>
+      <VStack align="start" gap={0}>
+        <Text
+          fontSize="15px"
+          fontWeight="600"
+          letterSpacing="-0.01em"
+          color="gray.900"
+        >
+          Sage
+        </Text>
+        <Text fontSize="11px" color="gray.500" letterSpacing="0.02em">
+          Propose &amp; apply
+        </Text>
+      </VStack>
+      <Box flex={1} />
+      <IconButton
+        size="sm"
+        variant="ghost"
+        aria-label="Close Sage"
+        onClick={onClose}
+        borderRadius="10px"
+      >
+        <LuX size={16} />
+      </IconButton>
+    </HStack>
+  );
+}
+
+function ThinkingIndicator({ messages }: { messages: UIMessage[] }) {
+  const last = messages.at(-1);
+  const activeTool =
+    last?.role === "assistant"
+      ? last.parts.findLast((part) => part.type?.startsWith("tool-"))
+      : undefined;
+  const label = activeTool?.type
+    ? activeTool.type.replace(/^tool-/, "").replace(/_/g, " ")
+    : "thinking";
+
+  return (
+    <HStack
+      color="gray.500"
+      fontSize="12px"
+      paddingX={3}
+      paddingY={2}
+      borderRadius="12px"
+      style={{
+        background: "rgba(255, 255, 255, 0.5)",
+        backdropFilter: "blur(10px)",
+        WebkitBackdropFilter: "blur(10px)",
+        border: "1px solid rgba(124, 58, 237, 0.08)",
+        alignSelf: "flex-start",
+      }}
+    >
+      <Spinner size="xs" colorPalette="purple" />
+      <Text>Sage is {label}…</Text>
+    </HStack>
+  );
+}
+
+function Composer({
+  input,
+  onInputChange,
+  onSend,
+  disabled,
+  canSend,
+}: {
+  input: string;
+  onInputChange: (v: string) => void;
+  onSend: () => void;
+  disabled: boolean;
+  canSend: boolean;
+}) {
+  return (
+    <Box
+      paddingX={4}
+      paddingY={4}
+      borderTop="1px solid"
+      borderColor="rgba(124, 58, 237, 0.08)"
+    >
+      <HStack
+        gap={2}
+        paddingX={2}
+        paddingY={2}
+        borderRadius="14px"
+        style={{
+          background: "rgba(255, 255, 255, 0.75)",
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)",
+          border: "1px solid rgba(124, 58, 237, 0.12)",
+          boxShadow: "0 1px 3px rgba(15, 23, 42, 0.04)",
+        }}
+      >
+        <Input
+          placeholder="Ask Sage or describe what you want…"
+          value={input}
+          onChange={(e) => onInputChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              onSend();
+            }
+          }}
+          disabled={disabled}
+          size="sm"
+          variant="outline"
+          border="none"
+          _focus={{ outline: "none", boxShadow: "none" }}
+          _focusVisible={{ outline: "none", boxShadow: "none" }}
+          fontSize="13px"
+          color="gray.800"
+        />
+        <IconButton
+          size="sm"
+          aria-label="Send"
+          onClick={onSend}
+          disabled={!canSend}
+          borderRadius="10px"
+          style={{
+            background: canSend
+              ? "linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%)"
+              : "rgba(124, 58, 237, 0.15)",
+            color: "white",
+            boxShadow: canSend
+              ? "0 4px 12px rgba(124, 58, 237, 0.35)"
+              : "none",
+            transition: "all 200ms ease",
+          }}
+        >
+          <LuSend size={14} />
+        </IconButton>
+      </HStack>
+    </Box>
+  );
+}
+
+function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
+  return (
+    <VStack align="stretch" gap={4} paddingTop={4}>
+      <VStack align="start" gap={2}>
+        <Text
+          fontSize="15px"
+          fontWeight="600"
+          color="gray.900"
+          letterSpacing="-0.01em"
+        >
+          Hey, I&apos;m Sage.
+        </Text>
+        <Text fontSize="13px" color="gray.600" lineHeight="1.55">
+          I can propose evaluators, help you pick the right one for your
+          experiment, and (soon) touch prompts and datasets. Try:
+        </Text>
+      </VStack>
+      <VStack align="stretch" gap={2}>
+        {SAMPLE_PROMPTS.map((prompt) => (
+          <Box
+            key={prompt}
+            as="button"
+            textAlign="left"
+            padding={3}
+            borderRadius="12px"
+            cursor="pointer"
+            style={{
+              background: "rgba(255, 255, 255, 0.7)",
+              backdropFilter: "blur(12px)",
+              WebkitBackdropFilter: "blur(12px)",
+              border: "1px solid rgba(124, 58, 237, 0.1)",
+              transition: "all 180ms ease",
+            }}
+            _hover={{
+              transform: "translateY(-1px)",
+            }}
+            onClick={() => onPick(prompt)}
+          >
+            <HStack gap={2} align="flex-start">
+              <Box color="purple.500" paddingTop="2px">
+                <LuArrowRight size={12} />
+              </Box>
+              <Text fontSize="12.5px" color="gray.700" lineHeight="1.4">
+                {prompt}
+              </Text>
+            </HStack>
+          </Box>
+        ))}
+      </VStack>
+    </VStack>
+  );
+}
+
+function MessageContent({
+  message,
+  appliedProposals,
+  discardedProposals,
+  onApply,
+  onDiscard,
+}: {
+  message: UIMessage;
+  appliedProposals: Set<string>;
+  discardedProposals: Set<string>;
+  onApply: (proposalId: string, proposal: SageProposal) => Promise<void>;
+  onDiscard: (proposalId: string) => void;
+}) {
+  const isUser = message.role === "user";
+  const textParts = message.parts
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+
+  const proposals = extractProposals(message);
+
+  if (!textParts && proposals.length === 0) return null;
+
+  return (
+    <VStack align="stretch" gap={2} width="full">
+      {textParts && (
+        <Box
+          width="full"
+          display="flex"
+          justifyContent={isUser ? "flex-end" : "flex-start"}
+        >
+          <Box
+            maxWidth="88%"
+            paddingX="14px"
+            paddingY="10px"
+            borderRadius={isUser ? "16px 16px 4px 16px" : "16px 16px 16px 4px"}
+            style={
+              isUser
+                ? {
+                    background:
+                      "linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%)",
+                    color: "white",
+                    boxShadow: "0 4px 14px rgba(124, 58, 237, 0.25)",
+                  }
+                : {
+                    background: "rgba(255, 255, 255, 0.78)",
+                    backdropFilter: "blur(12px)",
+                    WebkitBackdropFilter: "blur(12px)",
+                    border: "1px solid rgba(124, 58, 237, 0.08)",
+                    boxShadow: "0 1px 3px rgba(15, 23, 42, 0.04)",
+                  }
+            }
+          >
+            {isUser ? (
+              <Text fontSize="13px" whiteSpace="pre-wrap" lineHeight="1.5">
+                {textParts}
+              </Text>
+            ) : (
+              <Box
+                fontSize="13px"
+                color="gray.800"
+                lineHeight="1.55"
+                css={{
+                  "& p": { margin: 0 },
+                  "& p + p": { marginTop: "6px" },
+                  "& ul, & ol": {
+                    paddingLeft: "18px",
+                    margin: "4px 0",
+                  },
+                  "& code": {
+                    fontSize: "12px",
+                    padding: "1px 5px",
+                    borderRadius: "4px",
+                    background: "rgba(124, 58, 237, 0.08)",
+                  },
+                }}
+              >
+                <Markdown>{textParts}</Markdown>
+              </Box>
+            )}
+          </Box>
+        </Box>
+      )}
+      {proposals.map(({ id, proposal }) => (
+        <ProposalCard
+          key={id}
+          proposal={proposal}
+          isApplied={appliedProposals.has(id)}
+          isDiscarded={discardedProposals.has(id)}
+          onApply={() => void onApply(id, proposal)}
+          onDiscard={() => onDiscard(id)}
+        />
+      ))}
+    </VStack>
+  );
+}
+
+function ProposalCard({
+  proposal,
+  isApplied,
+  isDiscarded,
+  onApply,
+  onDiscard,
+}: {
+  proposal: SageProposal;
+  isApplied: boolean;
+  isDiscarded: boolean;
+  onApply: () => void;
+  onDiscard: () => void;
+}) {
+  const faded = isApplied || isDiscarded;
+  const statusLabel = isApplied
+    ? "Applied"
+    : isDiscarded
+      ? "Discarded"
+      : "Sage proposes";
+  return (
+    <Box
+      padding={4}
+      borderRadius="16px"
+      opacity={faded ? 0.7 : 1}
+      style={{
+        background: isApplied
+          ? "linear-gradient(135deg, rgba(220, 252, 231, 0.85), rgba(240, 253, 244, 0.85))"
+          : "linear-gradient(135deg, rgba(250, 245, 255, 0.88), rgba(243, 232, 255, 0.88))",
+        backdropFilter: "blur(16px) saturate(180%)",
+        WebkitBackdropFilter: "blur(16px) saturate(180%)",
+        border: isApplied
+          ? "1px solid rgba(34, 197, 94, 0.25)"
+          : "1px solid rgba(124, 58, 237, 0.18)",
+        boxShadow: isApplied
+          ? "0 4px 14px rgba(34, 197, 94, 0.12)"
+          : "0 6px 20px rgba(124, 58, 237, 0.12)",
+        transition: "all 200ms ease",
+      }}
+    >
+      <VStack align="stretch" gap={2}>
+        <HStack gap={2}>
+          <Box
+            width="22px"
+            height="22px"
+            borderRadius="7px"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            color="white"
+            style={{
+              background: isApplied
+                ? "linear-gradient(135deg, #4ade80, #22c55e)"
+                : "linear-gradient(135deg, #a78bfa, #7c3aed)",
+            }}
+          >
+            {isApplied ? <LuCheck size={12} /> : <LuSparkles size={12} />}
+          </Box>
+          <Text
+            fontSize="10.5px"
+            fontWeight="600"
+            letterSpacing="0.08em"
+            textTransform="uppercase"
+            color={isApplied ? "green.700" : "purple.700"}
+          >
+            {statusLabel}
+          </Text>
+        </HStack>
+        <Text
+          fontSize="13.5px"
+          fontWeight="600"
+          color="gray.900"
+          letterSpacing="-0.005em"
+        >
+          {proposal.summary}
+        </Text>
+        {proposal.rationale && (
+          <Text fontSize="12px" color="gray.600" lineHeight="1.5">
+            {proposal.rationale}
+          </Text>
+        )}
+        {!isApplied && !isDiscarded && (
+          <HStack gap={2} paddingTop={1}>
+            <Button
+              size="xs"
+              onClick={onApply}
+              borderRadius="10px"
+              paddingX={3}
+              height="28px"
+              style={{
+                background: "linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%)",
+                color: "white",
+                boxShadow: "0 4px 12px rgba(124, 58, 237, 0.3)",
+                fontSize: "12px",
+                fontWeight: 600,
+              }}
+            >
+              <LuCheck size={12} />
+              Apply
+            </Button>
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={onDiscard}
+              borderRadius="10px"
+              paddingX={3}
+              height="28px"
+              color="gray.600"
+              fontSize="12px"
+            >
+              Discard
+            </Button>
+          </HStack>
+        )}
+      </VStack>
+    </Box>
+  );
+}
+
+function extractProposals(
+  message: UIMessage,
+): Array<{ id: string; proposal: SageProposal }> {
+  const result: Array<{ id: string; proposal: SageProposal }> = [];
+  for (const part of message.parts) {
+    if (!part.type?.startsWith("tool-")) continue;
+    const output = (part as { output?: unknown }).output;
+    if (!isSageProposal(output)) continue;
+    const id =
+      (part as { toolCallId?: string }).toolCallId ??
+      `${message.id}:${result.length}`;
+    result.push({ id, proposal: output });
+  }
+  return result;
+}
+
+function isSageProposal(value: unknown): value is SageProposal {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as Record<string, unknown>).sageProposal === true &&
+    typeof (value as Record<string, unknown>).kind === "string" &&
+    typeof (value as Record<string, unknown>).summary === "string"
+  );
+}

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -10,7 +10,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
-import { useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import {
   LuArrowRight,
   LuCheck,
@@ -51,11 +51,31 @@ interface SageDrawerProps {
 
 export function SageDrawer({ proposalHandlers }: SageDrawerProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const handleRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (panelRef.current?.contains(target)) return;
+      if (handleRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [isOpen]);
 
   return (
     <>
-      <SageHandle isOpen={isOpen} onToggle={() => setIsOpen((v) => !v)} />
+      <SageHandle
+        ref={handleRef}
+        isOpen={isOpen}
+        onToggle={() => setIsOpen((v) => !v)}
+      />
       <SagePanel
+        ref={panelRef}
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         proposalHandlers={proposalHandlers}
@@ -64,15 +84,13 @@ export function SageDrawer({ proposalHandlers }: SageDrawerProps) {
   );
 }
 
-function SageHandle({
-  isOpen,
-  onToggle,
-}: {
-  isOpen: boolean;
-  onToggle: () => void;
-}) {
+const SageHandle = forwardRef<
+  HTMLButtonElement,
+  { isOpen: boolean; onToggle: () => void }
+>(function SageHandle({ isOpen, onToggle }, ref) {
   return (
     <Box
+      ref={ref}
       as="button"
       onClick={onToggle}
       aria-label={isOpen ? "Close Sage" : "Open Sage"}
@@ -117,17 +135,16 @@ function SageHandle({
       </VStack>
     </Box>
   );
-}
+});
 
-function SagePanel({
-  isOpen,
-  onClose,
-  proposalHandlers,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  proposalHandlers?: ProposalHandlers;
-}) {
+const SagePanel = forwardRef<
+  HTMLDivElement,
+  {
+    isOpen: boolean;
+    onClose: () => void;
+    proposalHandlers?: ProposalHandlers;
+  }
+>(function SagePanel({ isOpen, onClose, proposalHandlers }, ref) {
   const { project } = useOrganizationTeamProject();
   const projectId = project?.id;
 
@@ -213,6 +230,7 @@ function SagePanel({
 
   return (
     <Box
+      ref={ref}
       position="fixed"
       top={2}
       right={2}
@@ -230,6 +248,7 @@ function SagePanel({
         isOpen ? "translateX(0)" : `translateX(calc(${DRAWER_WIDTH}px + 16px))`
       }
       opacity={isOpen ? 1 : 0}
+      pointerEvents={isOpen ? "auto" : "none"}
     >
       <VStack gap={0} align="stretch" height="full">
         <PanelHeader onClose={onClose} />
@@ -262,7 +281,7 @@ function SagePanel({
       </VStack>
     </Box>
   );
-}
+});
 
 function PanelHeader({ onClose }: { onClose: () => void }) {
   return (

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -10,7 +10,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
-import { forwardRef, useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
 import {
   LuArrowRight,
   LuCheck,
@@ -164,10 +164,17 @@ const SagePanel = forwardRef<
   const [discardedProposals, setDiscardedProposals] = useState<Set<string>>(
     new Set(),
   );
+  const [applyingProposals, setApplyingProposals] = useState<Set<string>>(
+    new Set(),
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  const transport = useMemo(
+    () => new DefaultChatTransport({ api: "/api/sage/chat" }),
+    [],
+  );
   const { messages, sendMessage, status } = useChat({
-    transport: new DefaultChatTransport({ api: "/api/sage/chat" }),
+    transport,
     onError: (error) => {
       if (isHandledByGlobalHandler(error)) return;
       toaster.create({
@@ -200,6 +207,9 @@ const SagePanel = forwardRef<
     proposalId: string,
     proposal: SageProposal,
   ) => {
+    if (applyingProposals.has(proposalId)) return;
+    if (appliedProposals.has(proposalId)) return;
+    if (discardedProposals.has(proposalId)) return;
     const handler = proposalHandlers?.[proposal.kind];
     if (!handler) {
       toaster.create({
@@ -211,6 +221,7 @@ const SagePanel = forwardRef<
       });
       return;
     }
+    setApplyingProposals((prev) => new Set(prev).add(proposalId));
     try {
       await handler(proposal.payload);
       setAppliedProposals((prev) => new Set(prev).add(proposalId));
@@ -222,13 +233,20 @@ const SagePanel = forwardRef<
         meta: { closable: true },
       });
     } catch (error) {
-      if (isHandledByGlobalHandler(error)) return;
-      toaster.create({
-        title: "Failed to apply",
-        description: error instanceof Error ? error.message : "Unknown error",
-        type: "error",
-        duration: 5000,
-        meta: { closable: true },
+      if (!isHandledByGlobalHandler(error)) {
+        toaster.create({
+          title: "Failed to apply",
+          description: error instanceof Error ? error.message : "Unknown error",
+          type: "error",
+          duration: 5000,
+          meta: { closable: true },
+        });
+      }
+    } finally {
+      setApplyingProposals((prev) => {
+        const next = new Set(prev);
+        next.delete(proposalId);
+        return next;
       });
     }
   };
@@ -272,6 +290,7 @@ const SagePanel = forwardRef<
                   message={message}
                   appliedProposals={appliedProposals}
                   discardedProposals={discardedProposals}
+                  applyingProposals={applyingProposals}
                   onApply={applyProposal}
                   onDiscard={discardProposal}
                 />
@@ -465,12 +484,14 @@ function MessageContent({
   message,
   appliedProposals,
   discardedProposals,
+  applyingProposals,
   onApply,
   onDiscard,
 }: {
   message: UIMessage;
   appliedProposals: Set<string>;
   discardedProposals: Set<string>;
+  applyingProposals: Set<string>;
   onApply: (proposalId: string, proposal: SageProposal) => Promise<void>;
   onDiscard: (proposalId: string) => void;
 }) {
@@ -537,6 +558,7 @@ function MessageContent({
           proposal={proposal}
           isApplied={appliedProposals.has(id)}
           isDiscarded={discardedProposals.has(id)}
+          isApplying={applyingProposals.has(id)}
           onApply={() => void onApply(id, proposal)}
           onDiscard={() => onDiscard(id)}
         />
@@ -549,12 +571,14 @@ function ProposalCard({
   proposal,
   isApplied,
   isDiscarded,
+  isApplying,
   onApply,
   onDiscard,
 }: {
   proposal: SageProposal;
   isApplied: boolean;
   isDiscarded: boolean;
+  isApplying: boolean;
   onApply: () => void;
   onDiscard: () => void;
 }) {
@@ -563,7 +587,9 @@ function ProposalCard({
     ? "Applied"
     : isDiscarded
       ? "Discarded"
-      : "Sage proposes";
+      : isApplying
+        ? "Applying…"
+        : "Sage proposes";
   const accentPalette = isApplied ? "green" : "blue";
 
   return (
@@ -610,11 +636,22 @@ function ProposalCard({
         )}
         {!isApplied && !isDiscarded && (
           <HStack gap={2} paddingTop={1}>
-            <Button size="xs" colorPalette="blue" onClick={onApply}>
+            <Button
+              size="xs"
+              colorPalette="blue"
+              onClick={onApply}
+              disabled={isApplying}
+              loading={isApplying}
+            >
               <LuCheck size={12} />
               Apply
             </Button>
-            <Button size="xs" variant="ghost" onClick={onDiscard}>
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={onDiscard}
+              disabled={isApplying}
+            >
               Discard
             </Button>
           </HStack>

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -41,9 +41,14 @@ export interface SageProposal {
   payload: Record<string, unknown>;
 }
 
+export type AppliedOutcome = {
+  href?: string;
+  label?: string;
+} | void;
+
 export type ProposalHandlers = Record<
   string,
-  (payload: Record<string, unknown>) => Promise<void>
+  (payload: Record<string, unknown>) => Promise<AppliedOutcome>
 >;
 
 interface SageDrawerProps {
@@ -159,9 +164,9 @@ const SagePanel = forwardRef<
   const projectId = project?.id;
 
   const [input, setInput] = useState("");
-  const [appliedProposals, setAppliedProposals] = useState<Set<string>>(
-    new Set(),
-  );
+  const [appliedOutcomes, setAppliedOutcomes] = useState<
+    Record<string, { href?: string; label?: string }>
+  >({});
   const [discardedProposals, setDiscardedProposals] = useState<Set<string>>(
     new Set(),
   );
@@ -209,7 +214,7 @@ const SagePanel = forwardRef<
     proposal: SageProposal,
   ) => {
     if (applyingProposals.has(proposalId)) return;
-    if (appliedProposals.has(proposalId)) return;
+    if (proposalId in appliedOutcomes) return;
     if (discardedProposals.has(proposalId)) return;
     const handler = proposalHandlers?.[proposal.kind];
     if (!handler) {
@@ -224,8 +229,11 @@ const SagePanel = forwardRef<
     }
     setApplyingProposals((prev) => new Set(prev).add(proposalId));
     try {
-      await handler(proposal.payload);
-      setAppliedProposals((prev) => new Set(prev).add(proposalId));
+      const outcome = await handler(proposal.payload);
+      setAppliedOutcomes((prev) => ({
+        ...prev,
+        [proposalId]: outcome ?? {},
+      }));
       toaster.create({
         title: "Applied",
         description: proposal.summary,
@@ -289,7 +297,7 @@ const SagePanel = forwardRef<
                 <MessageContent
                   key={message.id}
                   message={message}
-                  appliedProposals={appliedProposals}
+                  appliedOutcomes={appliedOutcomes}
                   discardedProposals={discardedProposals}
                   applyingProposals={applyingProposals}
                   onApply={applyProposal}
@@ -503,14 +511,14 @@ function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
 
 function MessageContent({
   message,
-  appliedProposals,
+  appliedOutcomes,
   discardedProposals,
   applyingProposals,
   onApply,
   onDiscard,
 }: {
   message: UIMessage;
-  appliedProposals: Set<string>;
+  appliedOutcomes: Record<string, { href?: string; label?: string }>;
   discardedProposals: Set<string>;
   applyingProposals: Set<string>;
   onApply: (proposalId: string, proposal: SageProposal) => Promise<void>;
@@ -577,7 +585,7 @@ function MessageContent({
         <ProposalCard
           key={id}
           proposal={proposal}
-          isApplied={appliedProposals.has(id)}
+          appliedOutcome={appliedOutcomes[id]}
           isDiscarded={discardedProposals.has(id)}
           isApplying={applyingProposals.has(id)}
           onApply={() => void onApply(id, proposal)}
@@ -590,20 +598,21 @@ function MessageContent({
 
 function ProposalCard({
   proposal,
-  isApplied,
+  appliedOutcome,
   isDiscarded,
   isApplying,
   onApply,
   onDiscard,
 }: {
   proposal: SageProposal;
-  isApplied: boolean;
+  appliedOutcome?: { href?: string; label?: string };
   isDiscarded: boolean;
   isApplying: boolean;
   onApply: () => void;
   onDiscard: () => void;
 }) {
-  const faded = isApplied || isDiscarded;
+  const isApplied = !!appliedOutcome;
+  const faded = isDiscarded;
   const statusLabel = isApplied
     ? "Applied"
     : isDiscarded
@@ -612,6 +621,8 @@ function ProposalCard({
         ? "Applying…"
         : "Sage proposes";
   const accentPalette = isApplied ? "green" : "blue";
+  const openHref = appliedOutcome?.href;
+  const openLabel = appliedOutcome?.label ?? "Open";
 
   return (
     <Box
@@ -622,6 +633,19 @@ function ProposalCard({
       borderColor={isApplied ? "green.emphasized" : "blue.emphasized"}
       boxShadow="sm"
       opacity={faded ? 0.75 : 1}
+      cursor={openHref ? "pointer" : "default"}
+      onClick={(e) => {
+        if (!openHref) return;
+        const target = e.target as HTMLElement;
+        if (target.closest("a, button")) return;
+        window.location.href = openHref;
+      }}
+      transition="border-color 150ms ease, box-shadow 150ms ease"
+      _hover={
+        openHref
+          ? { borderColor: "green.fg", boxShadow: "md" }
+          : undefined
+      }
     >
       <VStack align="stretch" gap={2}>
         <HStack gap={2}>
@@ -674,6 +698,21 @@ function ProposalCard({
               disabled={isApplying}
             >
               Discard
+            </Button>
+          </HStack>
+        )}
+        {isApplied && openHref && (
+          <HStack gap={2} paddingTop={1}>
+            <Button
+              size="xs"
+              variant="outline"
+              colorPalette="green"
+              asChild
+            >
+              <a href={openHref}>
+                {openLabel}
+                <LuArrowRight size={12} />
+              </a>
             </Button>
           </HStack>
         )}

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -16,6 +16,7 @@ import {
   LuCheck,
   LuSend,
   LuSparkles,
+  LuSquare,
   LuX,
 } from "react-icons/lu";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -173,7 +174,7 @@ const SagePanel = forwardRef<
     () => new DefaultChatTransport({ api: "/api/sage/chat" }),
     [],
   );
-  const { messages, sendMessage, status } = useChat({
+  const { messages, sendMessage, stop, status } = useChat({
     transport,
     onError: (error) => {
       if (isHandledByGlobalHandler(error)) return;
@@ -303,7 +304,9 @@ const SagePanel = forwardRef<
           input={input}
           onInputChange={setInput}
           onSend={() => void send(input)}
-          disabled={isBusy || !projectId}
+          onStop={() => void stop()}
+          isBusy={isBusy}
+          disabled={!projectId}
           canSend={!!input.trim() && !isBusy && !!projectId}
         />
       </VStack>
@@ -385,12 +388,16 @@ function Composer({
   input,
   onInputChange,
   onSend,
+  onStop,
+  isBusy,
   disabled,
   canSend,
 }: {
   input: string;
   onInputChange: (v: string) => void;
   onSend: () => void;
+  onStop: () => void;
+  isBusy: boolean;
   disabled: boolean;
   canSend: boolean;
 }) {
@@ -403,30 +410,44 @@ function Composer({
     >
       <HStack gap={2}>
         <Input
-          placeholder="Ask Sage or describe what you want…"
+          placeholder={
+            isBusy ? "Sage is working…" : "Ask Sage or describe what you want…"
+          }
           value={input}
           onChange={(e) => onInputChange(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
-              onSend();
+              if (!isBusy) onSend();
             }
           }}
-          disabled={disabled}
+          disabled={disabled || isBusy}
           size="sm"
           variant="outline"
           borderColor="border.emphasized"
           background="bg.panel"
         />
-        <IconButton
-          size="sm"
-          colorPalette="blue"
-          aria-label="Send"
-          onClick={onSend}
-          disabled={!canSend}
-        >
-          <LuSend size={14} />
-        </IconButton>
+        {isBusy ? (
+          <IconButton
+            size="sm"
+            colorPalette="red"
+            variant="outline"
+            aria-label="Stop"
+            onClick={onStop}
+          >
+            <LuSquare size={12} />
+          </IconButton>
+        ) : (
+          <IconButton
+            size="sm"
+            colorPalette="blue"
+            aria-label="Send"
+            onClick={onSend}
+            disabled={!canSend}
+          >
+            <LuSend size={14} />
+          </IconButton>
+        )}
       </HStack>
     </Box>
   );

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -24,10 +24,7 @@ import { toaster } from "~/components/ui/toaster";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
 
 const DRAWER_WIDTH = 420;
-const HANDLE_WIDTH = 28;
-
-const SYSTEM_FONT_STACK =
-  '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", "Inter", "Segoe UI", Roboto, sans-serif';
+const HANDLE_WIDTH = 26;
 
 const SAMPLE_PROMPTS = [
   "What evaluators do I have available?",
@@ -84,40 +81,35 @@ function SageHandle({
       top="50%"
       transform="translateY(-50%)"
       width={`${HANDLE_WIDTH}px`}
-      height="96px"
+      height="84px"
       zIndex={1600}
       cursor="pointer"
-      borderTopLeftRadius="18px"
-      borderBottomLeftRadius="18px"
-      borderTopRightRadius={0}
-      borderBottomRightRadius={0}
-      style={{
-        background:
-          "linear-gradient(135deg, rgba(167, 139, 250, 0.95), rgba(124, 58, 237, 0.95))",
-        backdropFilter: "blur(20px) saturate(180%)",
-        WebkitBackdropFilter: "blur(20px) saturate(180%)",
-        boxShadow:
-          "-8px 0 32px rgba(124, 58, 237, 0.28), inset 1px 0 0 rgba(255,255,255,0.2)",
-        border: "1px solid rgba(255,255,255,0.18)",
-        borderRight: "none",
-        transition:
-          "right 360ms cubic-bezier(0.32, 0.72, 0, 1), transform 220ms ease, box-shadow 220ms ease",
-      }}
+      borderTopLeftRadius="lg"
+      borderBottomLeftRadius="lg"
+      background="bg.surface/80"
+      backdropFilter="blur(25px)"
+      borderWidth="1px"
+      borderColor="border.emphasized"
+      borderRightWidth={0}
+      boxShadow="sm"
+      color="fg.muted"
+      transition="right 360ms cubic-bezier(0.32, 0.72, 0, 1), transform 180ms ease, color 180ms ease, background 180ms ease"
       _hover={{
-        transform: "translate(-3px, -50%)",
+        transform: "translate(-2px, -50%)",
+        color: "blue.fg",
+        background: "bg.panel/90",
       }}
     >
-      <VStack gap={1} height="full" justify="center" color="white">
+      <VStack gap={1.5} height="full" justify="center">
         <LuSparkles size={14} />
         <Text
           fontSize="10px"
-          fontWeight="semibold"
+          fontWeight="600"
           letterSpacing="0.12em"
           style={{
             writingMode: "vertical-rl",
             textOrientation: "mixed",
             transform: "rotate(180deg)",
-            fontFamily: SYSTEM_FONT_STACK,
           }}
         >
           SAGE
@@ -222,33 +214,30 @@ function SagePanel({
   return (
     <Box
       position="fixed"
-      top={0}
-      right={0}
-      height="100vh"
+      top={2}
+      right={2}
+      bottom={2}
       width={`${DRAWER_WIDTH}px`}
       zIndex={1500}
-      style={{
-        transform: isOpen ? "translateX(0)" : `translateX(${DRAWER_WIDTH}px)`,
-        transition: "transform 360ms cubic-bezier(0.32, 0.72, 0, 1)",
-        background:
-          "linear-gradient(180deg, rgba(252, 251, 255, 0.82) 0%, rgba(245, 243, 255, 0.78) 100%)",
-        backdropFilter: "blur(40px) saturate(180%)",
-        WebkitBackdropFilter: "blur(40px) saturate(180%)",
-        borderLeft: "1px solid rgba(124, 58, 237, 0.1)",
-        boxShadow:
-          "-32px 0 60px rgba(15, 23, 42, 0.12), inset 1px 0 0 rgba(255,255,255,0.6)",
-        borderTopLeftRadius: "24px",
-        borderBottomLeftRadius: "24px",
-        fontFamily: SYSTEM_FONT_STACK,
-      }}
+      borderRadius="lg"
+      background="bg.surface/80"
+      backdropFilter="blur(25px)"
+      borderWidth="1px"
+      borderColor="border.emphasized"
+      boxShadow="lg"
+      transition="transform 360ms cubic-bezier(0.32, 0.72, 0, 1), opacity 200ms ease"
+      transform={
+        isOpen ? "translateX(0)" : `translateX(calc(${DRAWER_WIDTH}px + 16px))`
+      }
+      opacity={isOpen ? 1 : 0}
     >
       <VStack gap={0} align="stretch" height="full">
         <PanelHeader onClose={onClose} />
-        <Box ref={scrollRef} flex={1} overflowY="auto" paddingX={5} paddingY={4}>
+        <Box ref={scrollRef} flex={1} overflowY="auto" paddingX={4} paddingY={4}>
           {messages.length === 0 ? (
             <EmptyState onPick={(prompt) => void send(prompt)} />
           ) : (
-            <VStack gap={4} align="stretch">
+            <VStack gap={3} align="stretch">
               {messages.map((message) => (
                 <MessageContent
                   key={message.id}
@@ -278,51 +267,40 @@ function SagePanel({
 function PanelHeader({ onClose }: { onClose: () => void }) {
   return (
     <HStack
-      paddingX={5}
-      paddingY={4}
-      borderBottom="1px solid"
-      borderColor="rgba(124, 58, 237, 0.08)"
+      paddingX={4}
+      paddingY={3}
+      borderBottomWidth="1px"
+      borderColor="border.muted"
       gap={3}
     >
       <Box
-        width="32px"
-        height="32px"
-        borderRadius="10px"
+        width="28px"
+        height="28px"
+        borderRadius="md"
         display="flex"
         alignItems="center"
         justifyContent="center"
-        color="white"
-        style={{
-          background:
-            "linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%)",
-          boxShadow:
-            "0 6px 20px rgba(124, 58, 237, 0.35), inset 0 1px 0 rgba(255,255,255,0.4)",
-        }}
+        background="blue.subtle"
+        color="blue.fg"
       >
-        <LuSparkles size={16} />
+        <LuSparkles size={14} />
       </Box>
       <VStack align="start" gap={0}>
-        <Text
-          fontSize="15px"
-          fontWeight="600"
-          letterSpacing="-0.01em"
-          color="gray.900"
-        >
+        <Text fontSize="sm" fontWeight="600" color="fg">
           Sage
         </Text>
-        <Text fontSize="11px" color="gray.500" letterSpacing="0.02em">
+        <Text fontSize="xs" color="fg.muted">
           Propose &amp; apply
         </Text>
       </VStack>
       <Box flex={1} />
       <IconButton
-        size="sm"
+        size="xs"
         variant="ghost"
         aria-label="Close Sage"
         onClick={onClose}
-        borderRadius="10px"
       >
-        <LuX size={16} />
+        <LuX size={14} />
       </IconButton>
     </HStack>
   );
@@ -340,20 +318,17 @@ function ThinkingIndicator({ messages }: { messages: UIMessage[] }) {
 
   return (
     <HStack
-      color="gray.500"
-      fontSize="12px"
+      color="fg.muted"
+      fontSize="xs"
       paddingX={3}
       paddingY={2}
-      borderRadius="12px"
-      style={{
-        background: "rgba(255, 255, 255, 0.5)",
-        backdropFilter: "blur(10px)",
-        WebkitBackdropFilter: "blur(10px)",
-        border: "1px solid rgba(124, 58, 237, 0.08)",
-        alignSelf: "flex-start",
-      }}
+      borderRadius="md"
+      background="bg.subtle"
+      borderWidth="1px"
+      borderColor="border.muted"
+      alignSelf="flex-start"
     >
-      <Spinner size="xs" colorPalette="purple" />
+      <Spinner size="xs" colorPalette="blue" />
       <Text>Sage is {label}…</Text>
     </HStack>
   );
@@ -374,24 +349,12 @@ function Composer({
 }) {
   return (
     <Box
-      paddingX={4}
-      paddingY={4}
-      borderTop="1px solid"
-      borderColor="rgba(124, 58, 237, 0.08)"
+      paddingX={3}
+      paddingY={3}
+      borderTopWidth="1px"
+      borderColor="border.muted"
     >
-      <HStack
-        gap={2}
-        paddingX={2}
-        paddingY={2}
-        borderRadius="14px"
-        style={{
-          background: "rgba(255, 255, 255, 0.75)",
-          backdropFilter: "blur(12px)",
-          WebkitBackdropFilter: "blur(12px)",
-          border: "1px solid rgba(124, 58, 237, 0.12)",
-          boxShadow: "0 1px 3px rgba(15, 23, 42, 0.04)",
-        }}
-      >
+      <HStack gap={2}>
         <Input
           placeholder="Ask Sage or describe what you want…"
           value={input}
@@ -405,28 +368,15 @@ function Composer({
           disabled={disabled}
           size="sm"
           variant="outline"
-          border="none"
-          _focus={{ outline: "none", boxShadow: "none" }}
-          _focusVisible={{ outline: "none", boxShadow: "none" }}
-          fontSize="13px"
-          color="gray.800"
+          borderColor="border.emphasized"
+          background="bg.panel"
         />
         <IconButton
           size="sm"
+          colorPalette="blue"
           aria-label="Send"
           onClick={onSend}
           disabled={!canSend}
-          borderRadius="10px"
-          style={{
-            background: canSend
-              ? "linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%)"
-              : "rgba(124, 58, 237, 0.15)",
-            color: "white",
-            boxShadow: canSend
-              ? "0 4px 12px rgba(124, 58, 237, 0.35)"
-              : "none",
-            transition: "all 200ms ease",
-          }}
         >
           <LuSend size={14} />
         </IconButton>
@@ -437,17 +387,12 @@ function Composer({
 
 function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
   return (
-    <VStack align="stretch" gap={4} paddingTop={4}>
-      <VStack align="start" gap={2}>
-        <Text
-          fontSize="15px"
-          fontWeight="600"
-          color="gray.900"
-          letterSpacing="-0.01em"
-        >
+    <VStack align="stretch" gap={3} paddingTop={2}>
+      <VStack align="start" gap={1}>
+        <Text fontSize="sm" fontWeight="600" color="fg">
           Hey, I&apos;m Sage.
         </Text>
-        <Text fontSize="13px" color="gray.600" lineHeight="1.55">
+        <Text fontSize="xs" color="fg.muted" lineHeight="1.55">
           I can propose evaluators, help you pick the right one for your
           experiment, and (soon) touch prompts and datasets. Try:
         </Text>
@@ -458,26 +403,26 @@ function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
             key={prompt}
             as="button"
             textAlign="left"
-            padding={3}
-            borderRadius="12px"
+            paddingX={3}
+            paddingY="10px"
+            borderRadius="md"
             cursor="pointer"
-            style={{
-              background: "rgba(255, 255, 255, 0.7)",
-              backdropFilter: "blur(12px)",
-              WebkitBackdropFilter: "blur(12px)",
-              border: "1px solid rgba(124, 58, 237, 0.1)",
-              transition: "all 180ms ease",
-            }}
+            background="bg.panel"
+            borderWidth="1px"
+            borderColor="border.muted"
+            boxShadow="2xs"
+            transition="background 150ms ease, border-color 150ms ease"
             _hover={{
-              transform: "translateY(-1px)",
+              background: "bg.subtle",
+              borderColor: "border.emphasized",
             }}
             onClick={() => onPick(prompt)}
           >
             <HStack gap={2} align="flex-start">
-              <Box color="purple.500" paddingTop="2px">
+              <Box color="blue.fg" paddingTop="2px">
                 <LuArrowRight size={12} />
               </Box>
-              <Text fontSize="12.5px" color="gray.700" lineHeight="1.4">
+              <Text fontSize="xs" color="fg" lineHeight="1.5">
                 {prompt}
               </Text>
             </HStack>
@@ -521,47 +466,34 @@ function MessageContent({
         >
           <Box
             maxWidth="88%"
-            paddingX="14px"
-            paddingY="10px"
-            borderRadius={isUser ? "16px 16px 4px 16px" : "16px 16px 16px 4px"}
-            style={
-              isUser
-                ? {
-                    background:
-                      "linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%)",
-                    color: "white",
-                    boxShadow: "0 4px 14px rgba(124, 58, 237, 0.25)",
-                  }
-                : {
-                    background: "rgba(255, 255, 255, 0.78)",
-                    backdropFilter: "blur(12px)",
-                    WebkitBackdropFilter: "blur(12px)",
-                    border: "1px solid rgba(124, 58, 237, 0.08)",
-                    boxShadow: "0 1px 3px rgba(15, 23, 42, 0.04)",
-                  }
-            }
+            paddingX={3}
+            paddingY={2}
+            borderRadius="md"
+            borderTopRightRadius={isUser ? "sm" : "md"}
+            borderTopLeftRadius={isUser ? "md" : "sm"}
+            background={isUser ? "blue.solid" : "bg.panel"}
+            color={isUser ? "white" : "fg"}
+            borderWidth={isUser ? 0 : "1px"}
+            borderColor="border.muted"
+            boxShadow="2xs"
           >
             {isUser ? (
-              <Text fontSize="13px" whiteSpace="pre-wrap" lineHeight="1.5">
+              <Text fontSize="sm" whiteSpace="pre-wrap" lineHeight="1.5">
                 {textParts}
               </Text>
             ) : (
               <Box
-                fontSize="13px"
-                color="gray.800"
+                fontSize="sm"
                 lineHeight="1.55"
                 css={{
                   "& p": { margin: 0 },
                   "& p + p": { marginTop: "6px" },
-                  "& ul, & ol": {
-                    paddingLeft: "18px",
-                    margin: "4px 0",
-                  },
+                  "& ul, & ol": { paddingLeft: "18px", margin: "4px 0" },
                   "& code": {
                     fontSize: "12px",
                     padding: "1px 5px",
                     borderRadius: "4px",
-                    background: "rgba(124, 58, 237, 0.08)",
+                    background: "bg.subtle",
                   },
                 }}
               >
@@ -604,96 +536,57 @@ function ProposalCard({
     : isDiscarded
       ? "Discarded"
       : "Sage proposes";
+  const accentPalette = isApplied ? "green" : "blue";
+
   return (
     <Box
-      padding={4}
-      borderRadius="16px"
-      opacity={faded ? 0.7 : 1}
-      style={{
-        background: isApplied
-          ? "linear-gradient(135deg, rgba(220, 252, 231, 0.85), rgba(240, 253, 244, 0.85))"
-          : "linear-gradient(135deg, rgba(250, 245, 255, 0.88), rgba(243, 232, 255, 0.88))",
-        backdropFilter: "blur(16px) saturate(180%)",
-        WebkitBackdropFilter: "blur(16px) saturate(180%)",
-        border: isApplied
-          ? "1px solid rgba(34, 197, 94, 0.25)"
-          : "1px solid rgba(124, 58, 237, 0.18)",
-        boxShadow: isApplied
-          ? "0 4px 14px rgba(34, 197, 94, 0.12)"
-          : "0 6px 20px rgba(124, 58, 237, 0.12)",
-        transition: "all 200ms ease",
-      }}
+      padding={3}
+      borderRadius="lg"
+      background="bg.panel"
+      borderWidth="1px"
+      borderColor={isApplied ? "green.emphasized" : "blue.emphasized"}
+      boxShadow="sm"
+      opacity={faded ? 0.75 : 1}
     >
       <VStack align="stretch" gap={2}>
         <HStack gap={2}>
           <Box
-            width="22px"
-            height="22px"
-            borderRadius="7px"
+            width="20px"
+            height="20px"
+            borderRadius="sm"
             display="flex"
             alignItems="center"
             justifyContent="center"
-            color="white"
-            style={{
-              background: isApplied
-                ? "linear-gradient(135deg, #4ade80, #22c55e)"
-                : "linear-gradient(135deg, #a78bfa, #7c3aed)",
-            }}
+            background={`${accentPalette}.subtle`}
+            color={`${accentPalette}.fg`}
           >
             {isApplied ? <LuCheck size={12} /> : <LuSparkles size={12} />}
           </Box>
           <Text
-            fontSize="10.5px"
+            fontSize="10px"
             fontWeight="600"
             letterSpacing="0.08em"
             textTransform="uppercase"
-            color={isApplied ? "green.700" : "purple.700"}
+            color={`${accentPalette}.fg`}
           >
             {statusLabel}
           </Text>
         </HStack>
-        <Text
-          fontSize="13.5px"
-          fontWeight="600"
-          color="gray.900"
-          letterSpacing="-0.005em"
-        >
+        <Text fontSize="sm" fontWeight="600" color="fg">
           {proposal.summary}
         </Text>
         {proposal.rationale && (
-          <Text fontSize="12px" color="gray.600" lineHeight="1.5">
+          <Text fontSize="xs" color="fg.muted" lineHeight="1.5">
             {proposal.rationale}
           </Text>
         )}
         {!isApplied && !isDiscarded && (
           <HStack gap={2} paddingTop={1}>
-            <Button
-              size="xs"
-              onClick={onApply}
-              borderRadius="10px"
-              paddingX={3}
-              height="28px"
-              style={{
-                background: "linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%)",
-                color: "white",
-                boxShadow: "0 4px 12px rgba(124, 58, 237, 0.3)",
-                fontSize: "12px",
-                fontWeight: 600,
-              }}
-            >
+            <Button size="xs" colorPalette="blue" onClick={onApply}>
               <LuCheck size={12} />
               Apply
             </Button>
-            <Button
-              size="xs"
-              variant="ghost"
-              onClick={onDiscard}
-              borderRadius="10px"
-              paddingX={3}
-              height="28px"
-              color="gray.600"
-              fontSize="12px"
-            >
+            <Button size="xs" variant="ghost" onClick={onDiscard}>
               Discard
             </Button>
           </HStack>

--- a/langwatch/src/components/sage/SageSidebar.tsx
+++ b/langwatch/src/components/sage/SageSidebar.tsx
@@ -27,9 +27,9 @@ const DRAWER_WIDTH = 420;
 const HANDLE_WIDTH = 26;
 
 const SAMPLE_PROMPTS = [
-  "What evaluators do I have available?",
-  "Suggest an evaluator for measuring RAG hallucinations and add it to my workbench",
-  "List my prompts and datasets",
+  "Summarize my current experiment",
+  "Which rows are failing and why?",
+  "Suggest an evaluator for measuring RAG hallucinations",
 ];
 
 export interface SageProposal {
@@ -47,9 +47,13 @@ export type ProposalHandlers = Record<
 
 interface SageDrawerProps {
   proposalHandlers?: ProposalHandlers;
+  experimentSlug?: string;
 }
 
-export function SageDrawer({ proposalHandlers }: SageDrawerProps) {
+export function SageDrawer({
+  proposalHandlers,
+  experimentSlug,
+}: SageDrawerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const handleRef = useRef<HTMLButtonElement>(null);
@@ -79,6 +83,7 @@ export function SageDrawer({ proposalHandlers }: SageDrawerProps) {
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         proposalHandlers={proposalHandlers}
+        experimentSlug={experimentSlug}
       />
     </>
   );
@@ -143,8 +148,12 @@ const SagePanel = forwardRef<
     isOpen: boolean;
     onClose: () => void;
     proposalHandlers?: ProposalHandlers;
+    experimentSlug?: string;
   }
->(function SagePanel({ isOpen, onClose, proposalHandlers }, ref) {
+>(function SagePanel(
+  { isOpen, onClose, proposalHandlers, experimentSlug },
+  ref,
+) {
   const { project } = useOrganizationTeamProject();
   const projectId = project?.id;
 
@@ -183,7 +192,7 @@ const SagePanel = forwardRef<
     setInput("");
     await sendMessage(
       { role: "user", parts: [{ type: "text", text }] },
-      { body: { projectId } },
+      { body: { projectId, experimentSlug } },
     );
   };
 

--- a/langwatch/src/instrumentation.node.ts
+++ b/langwatch/src/instrumentation.node.ts
@@ -13,6 +13,7 @@ import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-node";
 import { setupObservability } from "langwatch/observability/node";
 
 const explicitEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+const langwatchTracingEnabled = !!process.env.LANGWATCH_API_KEY;
 
 const spanProcessors = [] as Array<BatchSpanProcessor>;
 const logRecordProcessors = [] as Array<BatchLogRecordProcessor>;
@@ -40,9 +41,13 @@ if (explicitEndpoint) {
 	}
 }
 
-if (spanProcessors.length > 0 || logRecordProcessors.length > 0) {
+if (
+	spanProcessors.length > 0 ||
+	logRecordProcessors.length > 0 ||
+	langwatchTracingEnabled
+) {
 	setupObservability({
-		langwatch: "disabled",
+		langwatch: langwatchTracingEnabled ? undefined : "disabled",
 		attributes: {
 			"service.name": "langwatch-backend",
 			"deployment.environment": process.env.ENVIRONMENT,

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -67,6 +67,7 @@ export default function ExperimentsWorkbenchPage() {
 
   const proposalHandlers = useMemo<ProposalHandlers>(() => {
     const projectId = project?.id;
+    const projectSlug = project?.slug;
     if (!projectId) return {} as ProposalHandlers;
     return {
       "evaluators.create": async (payload) => {
@@ -82,6 +83,12 @@ export default function ExperimentsWorkbenchPage() {
           config,
         });
         await utils.evaluators.getAll.invalidate({ projectId });
+        return projectSlug
+          ? {
+              href: `/${projectSlug}/evaluations`,
+              label: "Open evaluators",
+            }
+          : undefined;
       },
       "workbench.addEvaluator": async (payload) => {
         const { dbEvaluatorId, evaluatorType, name, fields } = payload as {
@@ -119,6 +126,9 @@ export default function ExperimentsWorkbenchPage() {
           data: { handle, messages, model, temperature, maxTokens },
         });
         await utils.prompts.getAllPromptsForProject.invalidate({ projectId });
+        return projectSlug
+          ? { href: `/${projectSlug}/prompts`, label: "Open prompt" }
+          : undefined;
       },
       "prompts.update": async (payload) => {
         const { id, commitMessage, messages, model, temperature, maxTokens } =
@@ -142,6 +152,9 @@ export default function ExperimentsWorkbenchPage() {
           },
         });
         await utils.prompts.getAllPromptsForProject.invalidate({ projectId });
+        return projectSlug
+          ? { href: `/${projectSlug}/prompts`, label: "Open prompt" }
+          : undefined;
       },
       "datasets.create": async (payload) => {
         const { name, columnTypes, initialRows } = payload as {
@@ -149,7 +162,7 @@ export default function ExperimentsWorkbenchPage() {
           columnTypes: { name: string; type: string }[];
           initialRows?: Record<string, unknown>[];
         };
-        await upsertDataset.mutateAsync({
+        const created = await upsertDataset.mutateAsync({
           projectId,
           name,
           columnTypes: columnTypes as never,
@@ -163,6 +176,9 @@ export default function ExperimentsWorkbenchPage() {
             : {}),
         });
         await utils.dataset.getAll.invalidate({ projectId });
+        return projectSlug && created?.id
+          ? { href: `/${projectSlug}/datasets/${created.id}`, label: "Open dataset" }
+          : undefined;
       },
       "datasets.addRows": async (payload) => {
         const { datasetId, rows } = payload as {
@@ -175,6 +191,9 @@ export default function ExperimentsWorkbenchPage() {
           entries: rows.map((row) => ({ id: nanoid(), ...row })) as never,
         });
         await utils.dataset.getAll.invalidate({ projectId });
+        return projectSlug
+          ? { href: `/${projectSlug}/datasets/${datasetId}`, label: "Open dataset" }
+          : undefined;
       },
     };
   }, [

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -46,6 +46,10 @@ export default function ExperimentsWorkbenchPage() {
     }));
 
   const createEvaluator = api.evaluators.create.useMutation();
+  const createPrompt = api.prompts.create.useMutation();
+  const updatePrompt = api.prompts.update.useMutation();
+  const upsertDataset = api.dataset.upsert.useMutation();
+  const createDatasetRecords = api.datasetRecord.create.useMutation();
   const utils = api.useContext();
   const { execute: executeEvaluation } = useExecuteEvaluation();
 
@@ -101,8 +105,89 @@ export default function ExperimentsWorkbenchPage() {
         // header.
         void executeEvaluation({ type: "full" });
       },
+      "prompts.create": async (payload) => {
+        const { handle, messages, model, temperature, maxTokens } =
+          payload as {
+            handle: string;
+            messages: { role: "system" | "user" | "assistant"; content: string }[];
+            model?: string;
+            temperature?: number;
+            maxTokens?: number;
+          };
+        await createPrompt.mutateAsync({
+          projectId,
+          data: { handle, messages, model, temperature, maxTokens },
+        });
+        await utils.prompts.getAllPromptsForProject.invalidate({ projectId });
+      },
+      "prompts.update": async (payload) => {
+        const { id, commitMessage, messages, model, temperature, maxTokens } =
+          payload as {
+            id: string;
+            commitMessage: string;
+            messages?: { role: "system" | "user" | "assistant"; content: string }[];
+            model?: string;
+            temperature?: number;
+            maxTokens?: number;
+          };
+        await updatePrompt.mutateAsync({
+          projectId,
+          id,
+          data: {
+            commitMessage,
+            ...(messages ? { messages } : {}),
+            ...(model ? { model } : {}),
+            ...(temperature !== undefined ? { temperature } : {}),
+            ...(maxTokens !== undefined ? { maxTokens } : {}),
+          },
+        });
+        await utils.prompts.getAllPromptsForProject.invalidate({ projectId });
+      },
+      "datasets.create": async (payload) => {
+        const { name, columnTypes, initialRows } = payload as {
+          name: string;
+          columnTypes: { name: string; type: string }[];
+          initialRows?: Record<string, unknown>[];
+        };
+        await upsertDataset.mutateAsync({
+          projectId,
+          name,
+          columnTypes: columnTypes as never,
+          ...(initialRows && initialRows.length > 0
+            ? {
+                datasetRecords: initialRows.map((row) => ({
+                  id: nanoid(),
+                  entry: row,
+                })) as never,
+              }
+            : {}),
+        });
+        await utils.dataset.getAll.invalidate({ projectId });
+      },
+      "datasets.addRows": async (payload) => {
+        const { datasetId, rows } = payload as {
+          datasetId: string;
+          rows: Record<string, unknown>[];
+        };
+        await createDatasetRecords.mutateAsync({
+          projectId,
+          datasetId,
+          entries: rows.map((row) => ({ id: nanoid(), ...row })) as never,
+        });
+        await utils.dataset.getAll.invalidate({ projectId });
+      },
     };
-  }, [project?.id, createEvaluator, utils, addEvaluator, executeEvaluation]);
+  }, [
+    project?.id,
+    createEvaluator,
+    createPrompt,
+    updatePrompt,
+    upsertDataset,
+    createDatasetRecords,
+    utils,
+    addEvaluator,
+    executeEvaluation,
+  ]);
 
   // Warm up lambda instances in the background (invisible to user)
   useLambdaWarmup();

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -22,6 +22,7 @@ import { useEvaluationsV3Store } from "~/evaluations-v3/hooks/useEvaluationsV3St
 import { useExecuteEvaluation } from "~/evaluations-v3/hooks/useExecuteEvaluation";
 import { useLambdaWarmup } from "~/evaluations-v3/hooks/useLambdaWarmup";
 import { useSavedDatasetLoader } from "~/evaluations-v3/hooks/useSavedDatasetLoader";
+import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 
@@ -52,6 +53,7 @@ export default function ExperimentsWorkbenchPage() {
   const createDatasetRecords = api.datasetRecord.create.useMutation();
   const utils = api.useContext();
   const { execute: executeEvaluation } = useExecuteEvaluation();
+  const { openDrawer } = useDrawer();
 
   // Enable autosave for evaluation state - this also handles loading existing experiments
   const {
@@ -76,19 +78,24 @@ export default function ExperimentsWorkbenchPage() {
           type: "evaluator" | "workflow";
           config: Record<string, unknown>;
         };
-        await createEvaluator.mutateAsync({
+        const created = await createEvaluator.mutateAsync({
           projectId,
           name,
           type,
           config,
         });
         await utils.evaluators.getAll.invalidate({ projectId });
-        return projectSlug
-          ? {
-              href: `/${projectSlug}/evaluations`,
-              label: "Open evaluators",
-            }
-          : undefined;
+        const evaluatorType = (created?.config as {
+          evaluatorType?: string;
+        } | null)?.evaluatorType;
+        return {
+          label: "Edit evaluator",
+          onOpen: () =>
+            openDrawer("evaluatorEditor", {
+              evaluatorId: created.id,
+              evaluatorType,
+            }),
+        };
       },
       "workbench.addEvaluator": async (payload) => {
         const { dbEvaluatorId, evaluatorType, name, fields } = payload as {
@@ -198,6 +205,7 @@ export default function ExperimentsWorkbenchPage() {
     };
   }, [
     project?.id,
+    project?.slug,
     createEvaluator,
     createPrompt,
     updatePrompt,
@@ -206,6 +214,7 @@ export default function ExperimentsWorkbenchPage() {
     utils,
     addEvaluator,
     executeEvaluation,
+    openDrawer,
   ]);
 
   // Warm up lambda instances in the background (invisible to user)

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -36,15 +36,23 @@ export default function ExperimentsWorkbenchPage() {
   const { project } = useOrganizationTeamProject();
   const slug = router.query.slug as string | undefined;
 
-  const { name, setName, datasets, reset, autosaveStatus, addEvaluator } =
-    useEvaluationsV3Store((state) => ({
-      name: state.name,
-      setName: state.setName,
-      datasets: state.datasets,
-      reset: state.reset,
-      autosaveStatus: state.ui.autosaveStatus,
-      addEvaluator: state.addEvaluator,
-    }));
+  const {
+    name,
+    setName,
+    datasets,
+    reset,
+    autosaveStatus,
+    addEvaluator,
+    removeEvaluator,
+  } = useEvaluationsV3Store((state) => ({
+    name: state.name,
+    setName: state.setName,
+    datasets: state.datasets,
+    reset: state.reset,
+    autosaveStatus: state.ui.autosaveStatus,
+    addEvaluator: state.addEvaluator,
+    removeEvaluator: state.removeEvaluator,
+  }));
 
   const createEvaluator = api.evaluators.create.useMutation();
   const updateEvaluator = api.evaluators.update.useMutation();
@@ -126,6 +134,14 @@ export default function ExperimentsWorkbenchPage() {
         const { id } = payload as { id: string };
         await deleteEvaluator.mutateAsync({ projectId, id });
         await utils.evaluators.getAll.invalidate({ projectId });
+        // Drop any workbench columns that referenced the archived evaluator
+        // so the table reflects the delete immediately.
+        const current = useEvaluationsV3Store.getState().evaluators;
+        for (const entry of current) {
+          if (entry.dbEvaluatorId === id) {
+            useEvaluationsV3Store.getState().removeEvaluator(entry.id);
+          }
+        }
         return undefined;
       },
       "workbench.addEvaluator": async (payload) => {
@@ -246,6 +262,7 @@ export default function ExperimentsWorkbenchPage() {
     createDatasetRecords,
     utils,
     addEvaluator,
+    removeEvaluator,
     executeEvaluation,
     openDrawer,
   ]);

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -47,6 +47,8 @@ export default function ExperimentsWorkbenchPage() {
     }));
 
   const createEvaluator = api.evaluators.create.useMutation();
+  const updateEvaluator = api.evaluators.update.useMutation();
+  const deleteEvaluator = api.evaluators.delete.useMutation();
   const createPrompt = api.prompts.create.useMutation();
   const updatePrompt = api.prompts.update.useMutation();
   const upsertDataset = api.dataset.upsert.useMutation();
@@ -96,6 +98,35 @@ export default function ExperimentsWorkbenchPage() {
               evaluatorType,
             }),
         };
+      },
+      "evaluators.update": async (payload) => {
+        const { id, name, config, evaluatorType } = payload as {
+          id: string;
+          name?: string;
+          config: Record<string, unknown>;
+          evaluatorType?: string;
+        };
+        await updateEvaluator.mutateAsync({
+          projectId,
+          id,
+          ...(name ? { name } : {}),
+          config,
+        });
+        await utils.evaluators.getAll.invalidate({ projectId });
+        return {
+          label: "Edit evaluator",
+          onOpen: () =>
+            openDrawer("evaluatorEditor", {
+              evaluatorId: id,
+              evaluatorType,
+            }),
+        };
+      },
+      "evaluators.delete": async (payload) => {
+        const { id } = payload as { id: string };
+        await deleteEvaluator.mutateAsync({ projectId, id });
+        await utils.evaluators.getAll.invalidate({ projectId });
+        return undefined;
       },
       "workbench.addEvaluator": async (payload) => {
         const { dbEvaluatorId, evaluatorType, name, fields } = payload as {
@@ -207,6 +238,8 @@ export default function ExperimentsWorkbenchPage() {
     project?.id,
     project?.slug,
     createEvaluator,
+    updateEvaluator,
+    deleteEvaluator,
     createPrompt,
     updatePrompt,
     upsertDataset,

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -96,7 +96,10 @@ export default function ExperimentsWorkbenchPage() {
         });
       },
       "workbench.run": async () => {
-        await executeEvaluation({ type: "full" });
+        // Fire-and-forget: the eval run can take minutes. Apply should
+        // confirm immediately; progress is visible in the workbench
+        // header.
+        void executeEvaluation({ type: "full" });
       },
     };
   }, [project?.id, createEvaluator, utils, addEvaluator, executeEvaluation]);

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -19,6 +19,7 @@ import { TableSettingsMenu } from "~/evaluations-v3/components/TableSettingsMenu
 import { UndoRedo } from "~/evaluations-v3/components/UndoRedo";
 import { useAutosaveEvaluationsV3 } from "~/evaluations-v3/hooks/useAutosaveEvaluationsV3";
 import { useEvaluationsV3Store } from "~/evaluations-v3/hooks/useEvaluationsV3Store";
+import { useExecuteEvaluation } from "~/evaluations-v3/hooks/useExecuteEvaluation";
 import { useLambdaWarmup } from "~/evaluations-v3/hooks/useLambdaWarmup";
 import { useSavedDatasetLoader } from "~/evaluations-v3/hooks/useSavedDatasetLoader";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -46,6 +47,7 @@ export default function ExperimentsWorkbenchPage() {
 
   const createEvaluator = api.evaluators.create.useMutation();
   const utils = api.useContext();
+  const { execute: executeEvaluation } = useExecuteEvaluation();
 
   // Enable autosave for evaluation state - this also handles loading existing experiments
   const {
@@ -93,8 +95,11 @@ export default function ExperimentsWorkbenchPage() {
           localEvaluatorConfig: { name },
         });
       },
+      "workbench.run": async () => {
+        await executeEvaluation({ type: "full" });
+      },
     };
-  }, [project?.id, createEvaluator, utils, addEvaluator]);
+  }, [project?.id, createEvaluator, utils, addEvaluator, executeEvaluation]);
 
   // Warm up lambda instances in the background (invisible to user)
   useLambdaWarmup();
@@ -214,7 +219,10 @@ export default function ExperimentsWorkbenchPage() {
         </Box>
       </VStack>
 
-      <SageDrawer proposalHandlers={proposalHandlers} />
+      <SageDrawer
+        proposalHandlers={proposalHandlers}
+        experimentSlug={slug}
+      />
 
       {/* Load saved dataset records - renders nothing, just triggers fetches */}
       <SavedDatasetLoaders datasets={datasets} />

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -1,8 +1,13 @@
 import { Alert, Box, HStack, Spacer, VStack } from "@chakra-ui/react";
+import { nanoid } from "nanoid";
 import { useRouter } from "~/utils/compat/next-router";
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { DashboardLayout } from "~/components/DashboardLayout";
+import {
+  SageDrawer,
+  type ProposalHandlers,
+} from "~/components/sage/SageSidebar";
 import { LoadingScreen } from "~/components/LoadingScreen";
 import { AutosaveStatus } from "~/evaluations-v3/components/AutosaveStatus";
 import { EditableHeading } from "~/evaluations-v3/components/EditableHeading";
@@ -17,6 +22,7 @@ import { useEvaluationsV3Store } from "~/evaluations-v3/hooks/useEvaluationsV3St
 import { useLambdaWarmup } from "~/evaluations-v3/hooks/useLambdaWarmup";
 import { useSavedDatasetLoader } from "~/evaluations-v3/hooks/useSavedDatasetLoader";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { api } from "~/utils/api";
 
 /**
  * Experiments Workbench Page
@@ -28,14 +34,18 @@ export default function ExperimentsWorkbenchPage() {
   const { project } = useOrganizationTeamProject();
   const slug = router.query.slug as string | undefined;
 
-  const { name, setName, datasets, reset, autosaveStatus } =
+  const { name, setName, datasets, reset, autosaveStatus, addEvaluator } =
     useEvaluationsV3Store((state) => ({
       name: state.name,
       setName: state.setName,
       datasets: state.datasets,
       reset: state.reset,
       autosaveStatus: state.ui.autosaveStatus,
+      addEvaluator: state.addEvaluator,
     }));
+
+  const createEvaluator = api.evaluators.create.useMutation();
+  const utils = api.useContext();
 
   // Enable autosave for evaluation state - this also handles loading existing experiments
   const {
@@ -48,6 +58,43 @@ export default function ExperimentsWorkbenchPage() {
 
   // Track loading state for saved datasets
   const { isLoading: isLoadingDatasets } = useSavedDatasetLoader();
+
+  const proposalHandlers = useMemo<ProposalHandlers>(() => {
+    const projectId = project?.id;
+    if (!projectId) return {} as ProposalHandlers;
+    return {
+      "evaluators.create": async (payload) => {
+        const { name, type, config } = payload as {
+          name: string;
+          type: "evaluator" | "workflow";
+          config: Record<string, unknown>;
+        };
+        await createEvaluator.mutateAsync({
+          projectId,
+          name,
+          type,
+          config,
+        });
+        await utils.evaluators.getAll.invalidate({ projectId });
+      },
+      "workbench.addEvaluator": async (payload) => {
+        const { dbEvaluatorId, evaluatorType, name, fields } = payload as {
+          dbEvaluatorId: string;
+          evaluatorType: string;
+          name: string;
+          fields: { identifier: string; type: string; optional?: boolean }[];
+        };
+        addEvaluator({
+          id: `evaluator_${nanoid()}`,
+          evaluatorType: evaluatorType as never,
+          inputs: fields as never,
+          dbEvaluatorId,
+          mappings: {},
+          localEvaluatorConfig: { name },
+        });
+      },
+    };
+  }, [project?.id, createEvaluator, utils, addEvaluator]);
 
   // Warm up lambda instances in the background (invisible to user)
   useLambdaWarmup();
@@ -166,6 +213,8 @@ export default function ExperimentsWorkbenchPage() {
           </Box>
         </Box>
       </VStack>
+
+      <SageDrawer proposalHandlers={proposalHandlers} />
 
       {/* Load saved dataset records - renders nothing, just triggers fetches */}
       <SavedDatasetLoaders datasets={datasets} />

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -1,15 +1,11 @@
 import { Alert, Box, HStack, Spacer, VStack } from "@chakra-ui/react";
 import { nanoid } from "nanoid";
 import { useRouter } from "~/utils/compat/next-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 
 import { DashboardLayout } from "~/components/DashboardLayout";
-import {
-  LangyDrawer,
-  LANGY_DOCKED_OFFSET,
-  LANGY_TRANSITION,
-  type ProposalHandlers,
-} from "~/components/langy/LangySidebar";
+import { useRegisterLangyHandlers } from "~/components/langy/LangyContext";
+import type { ProposalHandlers } from "~/components/langy/LangySidebar";
 import { LoadingScreen } from "~/components/LoadingScreen";
 import { AutosaveStatus } from "~/evaluations-v3/components/AutosaveStatus";
 import { EditableHeading } from "~/evaluations-v3/components/EditableHeading";
@@ -37,7 +33,6 @@ export default function ExperimentsWorkbenchPage() {
   const router = useRouter();
   const { project } = useOrganizationTeamProject();
   const slug = router.query.slug as string | undefined;
-  const [isLangyOpen, setIsLangyOpen] = useState(false);
 
   const {
     name,
@@ -270,6 +265,8 @@ export default function ExperimentsWorkbenchPage() {
     openDrawer,
   ]);
 
+  useRegisterLangyHandlers(proposalHandlers, { experimentSlug: slug });
+
   // Warm up lambda instances in the background (invisible to user)
   useLambdaWarmup();
 
@@ -341,8 +338,6 @@ export default function ExperimentsWorkbenchPage() {
         gap={0}
         align="stretch"
         overflow="hidden"
-        paddingRight={isLangyOpen ? `${LANGY_DOCKED_OFFSET}px` : 0}
-        transition={`padding-right ${LANGY_TRANSITION}`}
       >
         {/* Header */}
         <HStack paddingX={6} paddingY={3} flexShrink={0}>
@@ -389,13 +384,6 @@ export default function ExperimentsWorkbenchPage() {
           </Box>
         </Box>
       </VStack>
-
-      <LangyDrawer
-        proposalHandlers={proposalHandlers}
-        experimentSlug={slug}
-        isOpen={isLangyOpen}
-        onOpenChange={setIsLangyOpen}
-      />
 
       {/* Load saved dataset records - renders nothing, just triggers fetches */}
       <SavedDatasetLoaders datasets={datasets} />

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -5,9 +5,9 @@ import { useEffect, useMemo, useState } from "react";
 
 import { DashboardLayout } from "~/components/DashboardLayout";
 import {
-  SageDrawer,
+  LangyDrawer,
   type ProposalHandlers,
-} from "~/components/sage/SageSidebar";
+} from "~/components/langy/LangySidebar";
 import { LoadingScreen } from "~/components/LoadingScreen";
 import { AutosaveStatus } from "~/evaluations-v3/components/AutosaveStatus";
 import { EditableHeading } from "~/evaluations-v3/components/EditableHeading";
@@ -385,7 +385,7 @@ export default function ExperimentsWorkbenchPage() {
         </Box>
       </VStack>
 
-      <SageDrawer
+      <LangyDrawer
         proposalHandlers={proposalHandlers}
         experimentSlug={slug}
       />

--- a/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
+++ b/langwatch/src/pages/[project]/experiments/workbench/[slug].tsx
@@ -6,6 +6,8 @@ import { useEffect, useMemo, useState } from "react";
 import { DashboardLayout } from "~/components/DashboardLayout";
 import {
   LangyDrawer,
+  LANGY_DOCKED_OFFSET,
+  LANGY_TRANSITION,
   type ProposalHandlers,
 } from "~/components/langy/LangySidebar";
 import { LoadingScreen } from "~/components/LoadingScreen";
@@ -35,6 +37,7 @@ export default function ExperimentsWorkbenchPage() {
   const router = useRouter();
   const { project } = useOrganizationTeamProject();
   const slug = router.query.slug as string | undefined;
+  const [isLangyOpen, setIsLangyOpen] = useState(false);
 
   const {
     name,
@@ -338,6 +341,8 @@ export default function ExperimentsWorkbenchPage() {
         gap={0}
         align="stretch"
         overflow="hidden"
+        paddingRight={isLangyOpen ? `${LANGY_DOCKED_OFFSET}px` : 0}
+        transition={`padding-right ${LANGY_TRANSITION}`}
       >
         {/* Header */}
         <HStack paddingX={6} paddingY={3} flexShrink={0}>
@@ -388,6 +393,8 @@ export default function ExperimentsWorkbenchPage() {
       <LangyDrawer
         proposalHandlers={proposalHandlers}
         experimentSlug={slug}
+        isOpen={isLangyOpen}
+        onOpenChange={setIsLangyOpen}
       />
 
       {/* Load saved dataset records - renders nothing, just triggers fetches */}

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -30,6 +30,7 @@ import { app as evaluationsV3App } from "./routes/evaluations-v3";
 import { app as gatewayInternalApp } from "./routes/gateway-internal";
 import { app as healthChecksApp } from "./routes/health-checks";
 import { app as otelApp } from "./routes/otel";
+import { app as sageApp } from "./routes/sage";
 import { app as playgroundApp } from "./routes/playground";
 import { app as scenarioGenerateApp } from "./routes/scenario-generate";
 import { app as scimApp } from "./routes/scim";
@@ -93,6 +94,7 @@ export function createApiRouter() {
   api.route("/", gatewayInternalApp);
   api.route("/", otelApp);
   api.route("/", playgroundApp);
+  api.route("/", sageApp);
   api.route("/", scenarioGenerateApp);
   api.route("/", scimApp);
   api.route("/", webhooksApp);

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -30,7 +30,7 @@ import { app as evaluationsV3App } from "./routes/evaluations-v3";
 import { app as gatewayInternalApp } from "./routes/gateway-internal";
 import { app as healthChecksApp } from "./routes/health-checks";
 import { app as otelApp } from "./routes/otel";
-import { app as sageApp } from "./routes/sage";
+import { app as langyApp } from "./routes/langy";
 import { app as playgroundApp } from "./routes/playground";
 import { app as scenarioGenerateApp } from "./routes/scenario-generate";
 import { app as scimApp } from "./routes/scim";
@@ -94,7 +94,7 @@ export function createApiRouter() {
   api.route("/", gatewayInternalApp);
   api.route("/", otelApp);
   api.route("/", playgroundApp);
-  api.route("/", sageApp);
+  api.route("/", langyApp);
   api.route("/", scenarioGenerateApp);
   api.route("/", scimApp);
   api.route("/", webhooksApp);

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -28,6 +28,7 @@ import {
 } from "../../license-enforcement";
 import { captureException } from "~/utils/posthogErrorCapture";
 import { generateApiKey } from "../../utils/apiKeyGenerator";
+import { enqueueLangyBootstrap } from "../../background/queues/langyBootstrapQueue";
 import {
   checkOrganizationPermission,
   checkProjectPermission,
@@ -222,6 +223,10 @@ export const projectRouter = createTRPCRouter({
           capturedOutputVisibility:
             ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
         },
+      });
+
+      void enqueueLangyBootstrap(project.id).catch((error) => {
+        captureException(error);
       });
 
       return { success: true, projectSlug: project.slug };

--- a/langwatch/src/server/background/queues/constants.ts
+++ b/langwatch/src/server/background/queues/constants.ts
@@ -40,3 +40,15 @@ export const USAGE_STATS_QUEUE = {
   JOB: "usage_stats",
 } as const;
 
+/** Langy bootstrap queue - generates project memory at project creation. */
+export const LANGY_BOOTSTRAP_QUEUE = {
+  NAME: makeQueueName("langy_bootstrap"),
+  JOB: "langy_bootstrap",
+} as const;
+
+/** Langy retention queue - daily hard-delete sweep of soft-deleted convos. */
+export const LANGY_RETENTION_QUEUE = {
+  NAME: makeQueueName("langy_retention"),
+  JOB: "langy_retention",
+} as const;
+

--- a/langwatch/src/server/background/queues/langyBootstrapQueue.ts
+++ b/langwatch/src/server/background/queues/langyBootstrapQueue.ts
@@ -1,0 +1,39 @@
+import type { ConnectionOptions } from "bullmq";
+import { connection } from "../../redis";
+import {
+  type LangyBootstrapJob,
+  runLangyBootstrapJob,
+} from "../workers/langyBootstrapWorker";
+import { LANGY_BOOTSTRAP_QUEUE } from "./constants";
+import { QueueWithFallback } from "./queueWithFallback";
+
+export { LANGY_BOOTSTRAP_QUEUE } from "./constants";
+
+export const langyBootstrapQueue = new QueueWithFallback<
+  LangyBootstrapJob,
+  void,
+  string
+>(LANGY_BOOTSTRAP_QUEUE.NAME, runLangyBootstrapJob, {
+  connection: connection as ConnectionOptions,
+  defaultJobOptions: {
+    backoff: {
+      type: "exponential",
+      delay: 5000,
+    },
+    attempts: 3,
+    removeOnComplete: {
+      age: 0,
+    },
+    removeOnFail: {
+      age: 60 * 60 * 24 * 7, // 7 days
+    },
+  },
+});
+
+export const enqueueLangyBootstrap = async (projectId: string) => {
+  return await langyBootstrapQueue.add(
+    LANGY_BOOTSTRAP_QUEUE.JOB,
+    { projectId },
+    { jobId: `langy_bootstrap_${projectId}` },
+  );
+};

--- a/langwatch/src/server/background/queues/langyRetentionQueue.ts
+++ b/langwatch/src/server/background/queues/langyRetentionQueue.ts
@@ -1,0 +1,46 @@
+import type { ConnectionOptions } from "bullmq";
+import { connection } from "../../redis";
+import {
+  type LangyRetentionJob,
+  runLangyRetentionJob,
+} from "../workers/langyRetentionWorker";
+import { LANGY_RETENTION_QUEUE } from "./constants";
+import { QueueWithFallback } from "./queueWithFallback";
+import { createLogger } from "../../../utils/logger/server";
+
+export { LANGY_RETENTION_QUEUE } from "./constants";
+
+const logger = createLogger("langwatch:langyRetentionQueue");
+
+export const langyRetentionQueue = new QueueWithFallback<
+  LangyRetentionJob,
+  void,
+  string
+>(LANGY_RETENTION_QUEUE.NAME, runLangyRetentionJob, {
+  connection: connection as ConnectionOptions,
+  defaultJobOptions: {
+    attempts: 1,
+    removeOnComplete: { age: 0 },
+    removeOnFail: { age: 60 * 60 * 24 * 7 },
+  },
+});
+
+/**
+ * Schedule the daily retention sweep. Runs at 03:00 UTC.
+ */
+export const scheduleLangyRetention = async () => {
+  if (!connection) {
+    logger.info("no redis connection, skipping langy retention schedule");
+    return;
+  }
+  return await langyRetentionQueue.add(
+    LANGY_RETENTION_QUEUE.JOB,
+    { scheduledAt: Date.now() },
+    {
+      jobId: "langy_retention_daily",
+      repeat: {
+        pattern: "0 3 * * *",
+      },
+    },
+  );
+};

--- a/langwatch/src/server/background/worker.ts
+++ b/langwatch/src/server/background/worker.ts
@@ -48,6 +48,11 @@ import { SCENARIO_WORKER } from "../scenarios/scenario.constants";
 import { getScenarioExecutionHandle } from "../app-layer/presets";
 import { monitoredQueues } from "./queues";
 import { startUsageStatsWorker } from "./workers/usageStatsWorker";
+import { startLangyBootstrapWorker } from "./workers/langyBootstrapWorker";
+import {
+  startLangyRetentionWorker,
+} from "./workers/langyRetentionWorker";
+import { scheduleLangyRetention } from "./queues/langyRetentionQueue";
 
 const logger = createLogger("langwatch:workers");
 
@@ -163,6 +168,9 @@ export const start = async (
     const topicClusteringWorker = startTopicClusteringWorker();
     const trackEventsWorker = startTrackEventsWorker();
     const usageStatsWorker = startUsageStatsWorker();
+    const langyBootstrapWorker = startLangyBootstrapWorker();
+    const langyRetentionWorker = startLangyRetentionWorker();
+    void scheduleLangyRetention().catch(() => undefined);
     const metricsServer = startMetricsServer();
 
     // Register all closeables for graceful shutdown
@@ -171,6 +179,8 @@ export const start = async (
     registerCloseable("topicClustering", topicClusteringWorker);
     registerCloseable("trackEvents", trackEventsWorker);
     registerCloseable("usageStats", usageStatsWorker);
+    registerCloseable("langyBootstrap", langyBootstrapWorker);
+    registerCloseable("langyRetention", langyRetentionWorker);
     registerCloseable("scenario", scenarioProcessor);
     registerCloseable("metricsServer", {
       close: () =>

--- a/langwatch/src/server/background/workers/langyBootstrapWorker.ts
+++ b/langwatch/src/server/background/workers/langyBootstrapWorker.ts
@@ -91,7 +91,16 @@ export async function runLangyBootstrapJob(
 
     let content: string;
     try {
-      const model = await getVercelAIModel(projectId, FALLBACK_MODEL);
+      // Spec: project's configured default LLM; fallback gpt-5-mini if none.
+      // getVercelAIModel(projectId) uses project default with its own
+      // fallback (DEFAULT_MODEL). If neither resolves, we retry with
+      // gpt-5-mini explicitly.
+      let model;
+      try {
+        model = await getVercelAIModel(projectId);
+      } catch {
+        model = await getVercelAIModel(projectId, FALLBACK_MODEL);
+      }
       const result = await generateText({
         model,
         system: BOOTSTRAP_PROMPT,

--- a/langwatch/src/server/background/workers/langyBootstrapWorker.ts
+++ b/langwatch/src/server/background/workers/langyBootstrapWorker.ts
@@ -1,0 +1,198 @@
+import { type Job, Worker } from "bullmq";
+import { BullMQOtel } from "bullmq-otel";
+import { generateText } from "ai";
+import { withJobContext } from "../../context/asyncContext";
+import { createLogger } from "../../../utils/logger/server";
+import {
+  captureException,
+  withScope,
+} from "../../../utils/posthogErrorCapture";
+import {
+  getJobProcessingCounter,
+  getJobProcessingDurationHistogram,
+  recordJobWaitDuration,
+} from "../../metrics";
+import { connection } from "../../redis";
+import { prisma } from "../../db";
+import { LANGY_BOOTSTRAP_QUEUE } from "../queues/constants";
+import { LangyProjectMemoryService } from "../../services/langy";
+import { getVercelAIModel } from "../../modelProviders/utils";
+import { TiktokenClient } from "../../app-layer/clients/tokenizer/tiktoken.client";
+
+const logger = createLogger("langwatch:workers:langyBootstrapWorker");
+
+const FALLBACK_MODEL = "openai/gpt-5-mini";
+const TARGET_TOKEN_CAP = 2000;
+
+export type LangyBootstrapJob = {
+  projectId: string;
+};
+
+const BOOTSTRAP_PROMPT = `You are bootstrapping a project memory file for the LangWatch assistant "Langy".
+
+Read the snapshot of the project below (evaluators, prompts, recent traces). Produce a concise markdown brief that helps Langy understand:
+- What this project appears to do (one sentence)
+- Key evaluators in use and what they check
+- Notable prompts and their purpose
+- Anything unusual or noteworthy in recent activity
+
+Keep it under 1500 tokens. Use plain language. No code blocks unless essential. Do not invent facts.`;
+
+async function gatherProjectSnapshot(projectId: string) {
+  const [project, evaluators, prompts, datasets] = await Promise.all([
+    prisma.project.findUnique({
+      where: { id: projectId },
+      select: { name: true, language: true, framework: true, defaultModel: true },
+    }),
+    prisma.evaluator.findMany({
+      where: { projectId },
+      select: { name: true, slug: true, type: true },
+      take: 50,
+    }),
+    prisma.llmPromptConfig.findMany({
+      where: { projectId },
+      select: { handle: true, name: true },
+      take: 50,
+    }),
+    prisma.dataset.findMany({
+      where: { projectId, archivedAt: null },
+      select: { name: true, slug: true },
+      take: 50,
+    }),
+  ]);
+
+  return { project, evaluators, prompts, datasets };
+}
+
+export async function runLangyBootstrapJob(
+  job: Job<LangyBootstrapJob, void, string>,
+) {
+  const { projectId } = job.data;
+  recordJobWaitDuration(job, "langy_bootstrap");
+  getJobProcessingCounter("langy_bootstrap", "processing").inc();
+  const start = Date.now();
+
+  try {
+    const memoryService = LangyProjectMemoryService.create(prisma);
+
+    const existing = await memoryService.getById({ projectId });
+    if (existing) {
+      logger.info({ projectId }, "project memory already exists, skipping bootstrap");
+      return;
+    }
+
+    const snapshot = await gatherProjectSnapshot(projectId);
+    if (!snapshot.project) {
+      logger.warn({ projectId }, "project not found, skipping langy bootstrap");
+      return;
+    }
+
+    const userMessage = `Project snapshot (JSON):\n\n${JSON.stringify(snapshot, null, 2)}`;
+
+    let content: string;
+    try {
+      const model = await getVercelAIModel(projectId, FALLBACK_MODEL);
+      const result = await generateText({
+        model,
+        system: BOOTSTRAP_PROMPT,
+        messages: [{ role: "user", content: userMessage }],
+      });
+      content = result.text.trim();
+    } catch (error) {
+      logger.warn(
+        { projectId, error: error instanceof Error ? error.message : String(error) },
+        "LLM bootstrap failed, writing minimal starter memory",
+      );
+      content = renderMinimalStarter(snapshot);
+    }
+
+    const tokenizer = new TiktokenClient();
+    const tokens = await tokenizer.countTokens(FALLBACK_MODEL, content);
+    const contentSummary =
+      tokens && tokens > TARGET_TOKEN_CAP
+        ? content.slice(0, Math.floor((TARGET_TOKEN_CAP / tokens) * content.length))
+        : null;
+
+    await memoryService.writeNewVersion({
+      projectId,
+      content,
+      contentSummary,
+      changeReason: "auto_bootstrap",
+      changedById: null,
+    });
+
+    getJobProcessingCounter("langy_bootstrap", "completed").inc();
+    getJobProcessingDurationHistogram("langy_bootstrap").observe(Date.now() - start);
+  } catch (error) {
+    getJobProcessingCounter("langy_bootstrap", "failed").inc();
+    logger.error({ jobId: job.id, error }, "failed to bootstrap langy project memory");
+    await withScope(async (scope) => {
+      scope.setTag?.("worker", "langyBootstrap");
+      scope.setExtra?.("job", job.data);
+      captureException(error);
+    });
+    throw error;
+  }
+}
+
+function renderMinimalStarter(snapshot: Awaited<ReturnType<typeof gatherProjectSnapshot>>) {
+  const lines: string[] = [];
+  lines.push(`# ${snapshot.project?.name ?? "Project"} — Langy memory`);
+  lines.push("");
+  lines.push("(Auto-generated starter memory. Edit me in Settings → Langy.)");
+  lines.push("");
+  if (snapshot.evaluators.length > 0) {
+    lines.push("## Evaluators");
+    for (const e of snapshot.evaluators.slice(0, 10)) {
+      lines.push(`- ${e.name} (${e.type})`);
+    }
+    lines.push("");
+  }
+  if (snapshot.prompts.length > 0) {
+    lines.push("## Prompts");
+    for (const p of snapshot.prompts.slice(0, 10)) {
+      lines.push(`- ${p.name ?? p.handle}`);
+    }
+    lines.push("");
+  }
+  if (snapshot.datasets.length > 0) {
+    lines.push("## Datasets");
+    for (const d of snapshot.datasets.slice(0, 10)) {
+      lines.push(`- ${d.name}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export const startLangyBootstrapWorker = () => {
+  if (!connection) {
+    logger.info("no redis connection, skipping langy bootstrap worker");
+    return;
+  }
+
+  const worker = new Worker<LangyBootstrapJob, void, string>(
+    LANGY_BOOTSTRAP_QUEUE.NAME,
+    withJobContext(runLangyBootstrapJob),
+    {
+      connection,
+      concurrency: 2,
+      telemetry: new BullMQOtel(LANGY_BOOTSTRAP_QUEUE.NAME),
+    },
+  );
+
+  worker.on("ready", () => {
+    logger.info("langy bootstrap worker active, waiting for jobs!");
+  });
+
+  worker.on("failed", async (job, err) => {
+    logger.error({ jobId: job?.id, error: err.message }, "langy bootstrap job failed");
+    getJobProcessingCounter("langy_bootstrap", "failed").inc();
+    await withScope((scope) => {
+      scope.setTag?.("worker", "langyBootstrap");
+      scope.setExtra?.("job", job?.data);
+      captureException(err);
+    });
+  });
+
+  return worker;
+};

--- a/langwatch/src/server/background/workers/langyRetentionWorker.ts
+++ b/langwatch/src/server/background/workers/langyRetentionWorker.ts
@@ -1,0 +1,76 @@
+import { type Job, Worker } from "bullmq";
+import { BullMQOtel } from "bullmq-otel";
+import { withJobContext } from "../../context/asyncContext";
+import { createLogger } from "../../../utils/logger/server";
+import {
+  captureException,
+  withScope,
+} from "../../../utils/posthogErrorCapture";
+import {
+  getJobProcessingCounter,
+  recordJobWaitDuration,
+} from "../../metrics";
+import { connection } from "../../redis";
+import { prisma } from "../../db";
+import { LANGY_RETENTION_QUEUE } from "../queues/constants";
+import { LangyConversationService } from "../../services/langy";
+
+const logger = createLogger("langwatch:workers:langyRetentionWorker");
+
+export const LANGY_HARD_DELETE_AFTER_DAYS = 90;
+
+export type LangyRetentionJob = {
+  scheduledAt: number;
+};
+
+export async function runLangyRetentionJob(
+  job: Job<LangyRetentionJob, void, string>,
+) {
+  recordJobWaitDuration(job, "langy_retention");
+  getJobProcessingCounter("langy_retention", "processing").inc();
+  try {
+    const cutoff = new Date(
+      Date.now() - LANGY_HARD_DELETE_AFTER_DAYS * 24 * 60 * 60 * 1000,
+    );
+    const service = LangyConversationService.create(prisma);
+    const result = await service.hardDeleteOlderThan({ cutoff });
+    logger.info({ ...result, cutoff }, "langy retention sweep complete");
+    getJobProcessingCounter("langy_retention", "completed").inc();
+  } catch (error) {
+    getJobProcessingCounter("langy_retention", "failed").inc();
+    logger.error({ jobId: job.id, error }, "langy retention sweep failed");
+    await withScope(async (scope) => {
+      scope.setTag?.("worker", "langyRetention");
+      captureException(error);
+    });
+    throw error;
+  }
+}
+
+export const startLangyRetentionWorker = () => {
+  if (!connection) {
+    logger.info("no redis connection, skipping langy retention worker");
+    return;
+  }
+  const worker = new Worker<LangyRetentionJob, void, string>(
+    LANGY_RETENTION_QUEUE.NAME,
+    withJobContext(runLangyRetentionJob),
+    {
+      connection,
+      concurrency: 1,
+      telemetry: new BullMQOtel(LANGY_RETENTION_QUEUE.NAME),
+    },
+  );
+  worker.on("ready", () => {
+    logger.info("langy retention worker active");
+  });
+  worker.on("failed", async (job, err) => {
+    logger.error({ jobId: job?.id, error: err.message }, "retention job failed");
+    getJobProcessingCounter("langy_retention", "failed").inc();
+    await withScope((scope) => {
+      scope.setTag?.("worker", "langyRetention");
+      captureException(err);
+    });
+  });
+  return worker;
+};

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -84,7 +84,9 @@ type JobType =
   | "usage_stats"
   | "usage_reporting"
   | "event_sourcing"
-  | "scenario";
+  | "scenario"
+  | "langy_bootstrap"
+  | "langy_retention";
 
 type JobStatus = "processing" | "completed" | "failed";
 

--- a/langwatch/src/server/middleware/rate-limit-langy.ts
+++ b/langwatch/src/server/middleware/rate-limit-langy.ts
@@ -1,0 +1,46 @@
+import { connection } from "../redis";
+
+export const LANGY_MESSAGES_PER_MINUTE = 30;
+export const LANGY_TOOL_CALLS_PER_MESSAGE = 8;
+
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  retryAfterSeconds?: number;
+};
+
+/**
+ * Sliding-window-ish rate limit using Redis INCR + EXPIRE on a per-minute key.
+ * No-ops (always allows) when Redis is unavailable to keep dev/test usable.
+ */
+export async function checkLangyMessageRateLimit({
+  userId,
+  projectId,
+  limit = LANGY_MESSAGES_PER_MINUTE,
+}: {
+  userId: string;
+  projectId: string;
+  limit?: number;
+}): Promise<RateLimitResult> {
+  if (!connection) {
+    return { allowed: true, remaining: limit };
+  }
+  const bucket = Math.floor(Date.now() / 60_000);
+  const key = `langy:rl:msg:${projectId}:${userId}:${bucket}`;
+  const count = await (connection as { incr: (k: string) => Promise<number> }).incr(key);
+  if (count === 1) {
+    await (
+      connection as { expire: (k: string, s: number) => Promise<number> }
+    ).expire(key, 65);
+  }
+  const remaining = Math.max(0, limit - count);
+  if (count > limit) {
+    const nextBucket = (bucket + 1) * 60_000;
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterSeconds: Math.max(1, Math.ceil((nextBucket - Date.now()) / 1000)),
+    };
+  }
+  return { allowed: true, remaining };
+}

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -245,7 +245,6 @@ app.post("/langy/chat", async (c) => {
   }
 
   const conversationService = LangyConversationService.create(prisma);
-  const messageService = LangyMessageService.create(prisma);
   const preferencesService = LangyUserPreferencesService.create(prisma);
 
   const conversation = await conversationService.ensureConversation({
@@ -1235,9 +1234,17 @@ app.post("/langy/chat", async (c) => {
         const assistantMessages = response.messages.filter(
           (m) => m.role === "assistant" || m.role === "tool",
         );
-        const parts = assistantMessages.flatMap((m) =>
-          Array.isArray(m.content) ? m.content : [],
-        );
+        const parts = assistantMessages.flatMap((m) => {
+          if (typeof m.content === "string") {
+            return m.content
+              ? [{ type: "text", text: m.content, role: m.role }]
+              : [];
+          }
+          if (Array.isArray(m.content)) {
+            return m.content.map((c) => ({ ...c, role: m.role }));
+          }
+          return [];
+        });
         await persistAssistantMessage({
           conversationId: conversation.id,
           projectId,

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -1,12 +1,10 @@
 /**
- * Hono route for the SAGE assistant.
+ * Hono route for the Langy assistant.
  *
- * POST /api/sage/chat — streams an AI chat response with access to
+ * POST /api/langy/chat — streams an AI chat response with access to
  * read-only evaluator tools scoped to the caller's project.
  *
- * SAGE = Scenarios, Analysis, Guidance, Evaluation.
- *
- * v1 is read-only: Sage proposes actions, it does not run evaluators,
+ * v1 is read-only: Langy proposes actions, it does not run evaluators,
  * mutate experiments, or modify project state.
  */
 import {
@@ -36,11 +34,11 @@ import { parseEvaluationResult } from "~/utils/evaluationResults";
 import { createLogger } from "~/utils/logger/server";
 import type { NextRequestShim as any } from "./types";
 
-const logger = createLogger("langwatch:api:sage");
+const logger = createLogger("langwatch:api:langy");
 
-const SAGE_MODEL = "openai/gpt-5";
+const LANGY_MODEL = "openai/gpt-5";
 
-const SAGE_SYSTEM_PROMPT = `You are Sage, the in-product AI assistant for LangWatch. You live in a right-side sidebar inside the experiment workbench. The name stands for Scenarios, Analysis, Guidance, Evaluation.
+const LANGY_SYSTEM_PROMPT = `You are Langy, the in-product AI assistant for LangWatch. You live in a right-side sidebar inside the experiment workbench.
 
 ## What you can do
 - **Read** the project's evaluators, prompts, and datasets. Use these tools autonomously whenever they help you answer.
@@ -85,10 +83,10 @@ const SAGE_SYSTEM_PROMPT = `You are Sage, the in-product AI assistant for LangWa
 - Mention the chosen model briefly in your reply so the user can catch it before applying.`;
 
 export const app = new Hono().basePath("/api");
-app.use(tracerMiddleware({ name: "sage" }));
+app.use(tracerMiddleware({ name: "langy" }));
 app.use(loggerMiddleware());
 
-app.post("/sage/chat", async (c) => {
+app.post("/langy/chat", async (c) => {
   const session = await getServerAuthSession({ req: c.req.raw as any });
   if (!session) {
     return c.json(
@@ -114,7 +112,7 @@ app.post("/sage/chat", async (c) => {
   );
   if (!hasPermission) {
     return c.json(
-      { error: "You do not have permission to use Sage for this project." },
+      { error: "You do not have permission to use Langy for this project." },
       { status: 403 },
     );
   }
@@ -440,7 +438,7 @@ app.post("/sage/chat", async (c) => {
             ? mergedSettings.model
             : undefined;
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "evaluators.create",
           summary: `Create evaluator "${name}" (${evaluatorType})`,
           rationale: chosenModel
@@ -570,7 +568,7 @@ app.post("/sage/chat", async (c) => {
         rationale,
       }) => {
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "prompts.create",
           summary: `Create prompt "${handle}"`,
           rationale,
@@ -626,7 +624,7 @@ app.post("/sage/chat", async (c) => {
           return { error: `No prompt found with id '${id}'.` };
         }
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "prompts.update",
           summary: `Update prompt "${(existing as { handle?: string }).handle ?? id}"`,
           rationale,
@@ -673,7 +671,7 @@ app.post("/sage/chat", async (c) => {
       }),
       execute: async ({ name, columns, initialRows, rationale }) => {
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "datasets.create",
           summary: `Create dataset "${name}"${
             initialRows?.length ? ` with ${initialRows.length} row(s)` : ""
@@ -709,7 +707,7 @@ app.post("/sage/chat", async (c) => {
           return { error: `No dataset found with id '${datasetId}'.` };
         }
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "datasets.addRows",
           summary: `Add ${rows.length} row(s) to "${dataset.name}"`,
           rationale,
@@ -754,7 +752,7 @@ app.post("/sage/chat", async (c) => {
         if (name && name !== evaluator.name) changedFields.push("name");
         if (settings) changedFields.push(...Object.keys(settings));
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "evaluators.update",
           summary: `Update evaluator "${evaluator.name}"${
             changedFields.length ? ` (${changedFields.join(", ")})` : ""
@@ -790,7 +788,7 @@ app.post("/sage/chat", async (c) => {
           return { error: `No project evaluator with slug '${slug}'.` };
         }
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "evaluators.delete",
           destructive: true,
           summary: `Archive evaluator "${evaluator.name}"`,
@@ -815,7 +813,7 @@ app.post("/sage/chat", async (c) => {
       }),
       execute: async ({ rationale }) => {
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "workbench.run",
           summary: "Run the evaluation on all targets and evaluators",
           rationale,
@@ -846,7 +844,7 @@ app.post("/sage/chat", async (c) => {
           (enriched.config as { evaluatorType?: string } | null)
             ?.evaluatorType ?? `custom/${enriched.slug}`;
         return {
-          sageProposal: true,
+          langyProposal: true,
           kind: "workbench.addEvaluator",
           summary: `Add "${enriched.name}" to this workbench`,
           rationale,
@@ -861,25 +859,25 @@ app.post("/sage/chat", async (c) => {
     }),
   };
 
-  const model = await getVercelAIModel(projectId, SAGE_MODEL);
+  const model = await getVercelAIModel(projectId, LANGY_MODEL);
 
   const result = streamText({
     model,
-    system: SAGE_SYSTEM_PROMPT,
+    system: LANGY_SYSTEM_PROMPT,
     messages: convertToModelMessages(messages),
     tools,
     stopWhen: stepCountIs(8),
     maxRetries: 2,
     experimental_telemetry: {
       isEnabled: true,
-      functionId: "sage.chat",
+      functionId: "langy.chat",
       metadata: {
         "langwatch.project_id": projectId,
         "langwatch.user_id": session.user.id,
       },
     },
     onError: (error) => {
-      logger.error({ error }, "error in sage chat stream");
+      logger.error({ error }, "error in langy chat stream");
     },
   });
 

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -860,11 +860,12 @@ app.post("/langy/chat", async (c) => {
   };
 
   const model = await getVercelAIModel(projectId, LANGY_MODEL);
+  const modelMessages = await convertToModelMessages(messages);
 
   const result = streamText({
     model,
     system: LANGY_SYSTEM_PROMPT,
-    messages: convertToModelMessages(messages),
+    messages: modelMessages,
     tools,
     stopWhen: stepCountIs(8),
     maxRetries: 2,

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -9,6 +9,7 @@
  */
 import {
   convertToModelMessages,
+  generateText,
   stepCountIs,
   streamText,
   tool,
@@ -32,11 +33,112 @@ import { getVercelAIModel } from "~/server/modelProviders/utils";
 import { PromptService } from "~/server/prompt-config/prompt.service";
 import { parseEvaluationResult } from "~/utils/evaluationResults";
 import { createLogger } from "~/utils/logger/server";
+import { auditLog } from "~/server/auditLog";
+import { TiktokenClient } from "~/server/app-layer/clients/tokenizer/tiktoken.client";
+import {
+  LangyConversationService,
+  LangyMessageService,
+  LangyProjectMemoryService,
+  LangyUserPreferencesService,
+} from "~/server/services/langy";
+import { ConversationToolIdSet } from "~/server/services/langy/toolIdValidator";
+import {
+  LANGY_TOOL_CALLS_PER_MESSAGE,
+  checkLangyMessageRateLimit,
+} from "~/server/middleware/rate-limit-langy";
+import { esClient, TRACE_INDEX } from "~/server/elasticsearch";
 import type { NextRequestShim as any } from "./types";
 
 const logger = createLogger("langwatch:api:langy");
 
-const LANGY_MODEL = "openai/gpt-5";
+const LANGY_FALLBACK_MODEL = "openai/gpt-5-mini";
+
+function buildSystemPrompt(opts: {
+  projectMemory: string | null;
+  mode: string;
+}): string {
+  const segments = [LANGY_SYSTEM_PROMPT];
+  if (opts.mode === "expert") {
+    segments.push(
+      "\n## Mode: expert\n- Be terse. Drop confirmations the user did not ask for. Skip restating the question. Use jargon freely.",
+    );
+  } else {
+    segments.push(
+      "\n## Mode: non-expert\n- Default to plain language. Confirm before destructive actions. Prefer visual summaries over JSON.",
+    );
+  }
+  if (opts.projectMemory) {
+    segments.push(
+      `\n## Project memory\n${opts.projectMemory}\n\nUse this memory as context. If something here is wrong, the user can edit it in Settings → Langy.`,
+    );
+  }
+  return segments.join("\n");
+}
+
+async function loadInjectableProjectMemory(
+  projectId: string,
+): Promise<string | null> {
+  const service = LangyProjectMemoryService.create(prisma);
+  const memory = await service.getById({ projectId });
+  if (!memory) return null;
+  return memory.contentSummary ?? memory.content;
+}
+
+function extractAssistantText(
+  parts: Array<Record<string, unknown>> | undefined,
+): string {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .map((p) => (typeof p?.text === "string" ? (p.text as string) : ""))
+    .filter(Boolean)
+    .join("\n");
+}
+
+async function persistAssistantMessage(opts: {
+  conversationId: string;
+  projectId: string;
+  parts: unknown;
+  text: string;
+  model: string;
+}) {
+  const tokenizer = new TiktokenClient();
+  const tokenCount = (await tokenizer.countTokens(opts.model, opts.text)) ?? null;
+  const messageService = LangyMessageService.create(prisma);
+  await messageService.append({
+    conversationId: opts.conversationId,
+    projectId: opts.projectId,
+    role: "assistant",
+    parts: opts.parts ?? [],
+    tokenCount,
+  });
+  const conversationService = LangyConversationService.create(prisma);
+  await conversationService.touch({
+    id: opts.conversationId,
+    projectId: opts.projectId,
+  });
+}
+
+async function persistUserMessage(opts: {
+  conversationId: string;
+  projectId: string;
+  message: UIMessage;
+  model: string;
+}) {
+  const text =
+    Array.isArray(opts.message.parts) && opts.message.parts.length
+      ? extractAssistantText(opts.message.parts as Array<Record<string, unknown>>)
+      : "";
+  const tokenizer = new TiktokenClient();
+  const tokenCount = (await tokenizer.countTokens(opts.model, text)) ?? null;
+  const messageService = LangyMessageService.create(prisma);
+  await messageService.append({
+    conversationId: opts.conversationId,
+    projectId: opts.projectId,
+    role: "user",
+    parts: opts.message.parts ?? [],
+    tokenCount,
+  });
+}
 
 const LANGY_SYSTEM_PROMPT = `You are Langy, the in-product AI assistant for LangWatch. You live in a right-side sidebar inside the experiment workbench.
 
@@ -95,10 +197,16 @@ app.post("/langy/chat", async (c) => {
     );
   }
 
-  const { messages, projectId, experimentSlug } = (await c.req.json()) as {
+  const {
+    messages,
+    projectId,
+    experimentSlug,
+    conversationId: requestedConversationId,
+  } = (await c.req.json()) as {
     messages: UIMessage[];
     projectId: string;
     experimentSlug?: string;
+    conversationId?: string | null;
   };
 
   if (!projectId) {
@@ -117,8 +225,73 @@ app.post("/langy/chat", async (c) => {
     );
   }
 
+  const rl = await checkLangyMessageRateLimit({
+    userId: session.user.id,
+    projectId,
+  });
+  if (!rl.allowed) {
+    return c.json(
+      {
+        error: "Too many messages. Please slow down.",
+        retryAfterSeconds: rl.retryAfterSeconds,
+      },
+      {
+        status: 429,
+        headers: rl.retryAfterSeconds
+          ? { "Retry-After": String(rl.retryAfterSeconds) }
+          : undefined,
+      },
+    );
+  }
+
+  const conversationService = LangyConversationService.create(prisma);
+  const messageService = LangyMessageService.create(prisma);
+  const preferencesService = LangyUserPreferencesService.create(prisma);
+
+  const conversation = await conversationService.ensureConversation({
+    projectId,
+    userId: session.user.id,
+    conversationId: requestedConversationId ?? null,
+    title:
+      messages[0] && extractAssistantText(messages[0].parts as any)
+        ? extractAssistantText(messages[0].parts as any).slice(0, 80)
+        : null,
+  });
+
+  const lastUserMessage = messages[messages.length - 1];
+  const projectMemory = await loadInjectableProjectMemory(projectId);
+  const prefs = await preferencesService.getById({
+    userId: session.user.id,
+    projectId,
+  });
+
+  let model;
+  try {
+    model = await getVercelAIModel(projectId);
+  } catch (error) {
+    return c.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "No model configured for this project.",
+      },
+      { status: 409 },
+    );
+  }
+
+  if (lastUserMessage?.role === "user") {
+    await persistUserMessage({
+      conversationId: conversation.id,
+      projectId,
+      message: lastUserMessage,
+      model: LANGY_FALLBACK_MODEL,
+    });
+  }
+
   const evaluatorService = EvaluatorService.create(prisma);
   const promptService = new PromptService(prisma);
+  const seenIds = new ConversationToolIdSet();
 
   const tools = {
     list_evaluators: tool({
@@ -140,6 +313,8 @@ app.post("/langy/chat", async (c) => {
             projectId,
           });
           for (const e of projectEvaluators) {
+            seenIds.record("evaluator_id", e.id);
+            seenIds.record("evaluator_slug", e.slug);
             items.push({
               source: "project",
               id: e.id,
@@ -155,6 +330,7 @@ app.post("/langy/chat", async (c) => {
           for (const [evaluatorType, def] of Object.entries(
             AVAILABLE_EVALUATORS,
           )) {
+            seenIds.record("evaluator_type", evaluatorType);
             items.push({
               source: "built_in",
               evaluatorType,
@@ -198,6 +374,8 @@ app.post("/langy/chat", async (c) => {
               error: `No project evaluator found with slug '${slug}'.`,
             };
           }
+          seenIds.record("evaluator_id", evaluator.id);
+          seenIds.record("evaluator_slug", evaluator.slug);
           const enriched = await evaluatorService.enrichWithFields(evaluator);
           return {
             source: "project",
@@ -249,6 +427,10 @@ app.post("/langy/chat", async (c) => {
           projectId,
           version: "latest",
         });
+        for (const p of prompts as Array<Record<string, unknown>>) {
+          seenIds.record("prompt_id", p.id as string);
+          seenIds.record("prompt_handle", p.handle as string);
+        }
         return {
           items: prompts.map((p: Record<string, unknown>) => ({
             id: p.id,
@@ -271,6 +453,7 @@ app.post("/langy/chat", async (c) => {
           orderBy: { updatedAt: "desc" },
           include: { _count: { select: { datasetRecords: true } } },
         });
+        for (const d of datasets) seenIds.record("dataset_id", d.id);
         return {
           items: datasets.map((d) => ({
             id: d.id,
@@ -412,6 +595,11 @@ app.post("/langy/chat", async (c) => {
           ),
       }),
       execute: async ({ name, evaluatorType, settings, rationale }) => {
+        if (!seenIds.has("evaluator_type", evaluatorType)) {
+          return {
+            error: `Evaluator type '${evaluatorType}' was not surfaced by list_evaluators in this conversation. Call list_evaluators('built_in') and reference one of those types.`,
+          };
+        }
         const def =
           AVAILABLE_EVALUATORS[
             evaluatorType as keyof typeof AVAILABLE_EVALUATORS
@@ -734,6 +922,11 @@ app.post("/langy/chat", async (c) => {
         rationale: z.string(),
       }),
       execute: async ({ slug, name, settings, rationale }) => {
+        if (!seenIds.has("evaluator_slug", slug)) {
+          return {
+            error: `Evaluator slug '${slug}' was not surfaced by list_evaluators in this conversation. Call list_evaluators first.`,
+          };
+        }
         const evaluator = await evaluatorService.getBySlug({ slug, projectId });
         if (!evaluator) {
           return { error: `No project evaluator with slug '${slug}'.` };
@@ -783,6 +976,11 @@ app.post("/langy/chat", async (c) => {
           ),
       }),
       execute: async ({ slug, rationale }) => {
+        if (!seenIds.has("evaluator_slug", slug)) {
+          return {
+            error: `Evaluator slug '${slug}' was not surfaced by list_evaluators in this conversation.`,
+          };
+        }
         const evaluator = await evaluatorService.getBySlug({ slug, projectId });
         if (!evaluator) {
           return { error: `No project evaluator with slug '${slug}'.` };
@@ -832,6 +1030,11 @@ app.post("/langy/chat", async (c) => {
         rationale: z.string(),
       }),
       execute: async ({ slug, rationale }) => {
+        if (!seenIds.has("evaluator_slug", slug)) {
+          return {
+            error: `Evaluator slug '${slug}' was not surfaced by list_evaluators in this conversation.`,
+          };
+        }
         const evaluator = await evaluatorService.getBySlug({
           slug,
           projectId,
@@ -857,17 +1060,163 @@ app.post("/langy/chat", async (c) => {
         };
       },
     }),
+
+    search_traces: tool({
+      description:
+        "Lazy semantic-ish search over recent traces in this project. Use when the user asks to 'find traces' matching a description (errors, hallucinations, latency). Returns a small list of trace ids with brief context. Tool result is per-turn only — do not persist or recall ids across conversations.",
+      inputSchema: z.object({
+        query: z
+          .string()
+          .min(1)
+          .describe("Free-text query (e.g. 'hallucinations', 'rag failures')."),
+        limit: z.number().int().min(1).max(20).default(10),
+      }),
+      execute: async ({ query, limit }) => {
+        try {
+          const client = await esClient({ projectId });
+          const result = await client.search({
+            index: TRACE_INDEX.alias,
+            size: limit,
+            body: {
+              query: {
+                bool: {
+                  must: [
+                    { term: { project_id: projectId } },
+                    {
+                      multi_match: {
+                        query,
+                        fields: [
+                          "input.value^2",
+                          "output.value",
+                          "metadata.user_id",
+                          "metadata.thread_id",
+                          "error.message",
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+              sort: [{ "timestamps.started_at": { order: "desc" } }],
+            },
+          });
+          const hits = (result.hits?.hits ?? []) as Array<{
+            _id: string;
+            _source?: Record<string, unknown>;
+          }>;
+          return {
+            items: hits.map((h) => ({
+              traceId: h._id,
+              startedAt:
+                (h._source as { timestamps?: { started_at?: number } } | undefined)
+                  ?.timestamps?.started_at ?? null,
+              snippet:
+                (h._source as { input?: { value?: string } } | undefined)?.input
+                  ?.value?.slice(0, 200) ?? null,
+            })),
+          };
+        } catch (error) {
+          logger.warn(
+            { error: error instanceof Error ? error.message : error },
+            "search_traces failed",
+          );
+          return { items: [], error: "search_traces is unavailable right now." };
+        }
+      },
+    }),
+
+    search_prompts: tool({
+      description:
+        "Search prompts in this project by handle/name keyword. Use when looking for an existing prompt to reference or update.",
+      inputSchema: z.object({
+        query: z.string().min(1),
+        limit: z.number().int().min(1).max(20).default(10),
+      }),
+      execute: async ({ query, limit }) => {
+        const rows = await prisma.llmPromptConfig.findMany({
+          where: {
+            projectId,
+            OR: [
+              { handle: { contains: query, mode: "insensitive" } },
+              { name: { contains: query, mode: "insensitive" } },
+            ],
+          },
+          orderBy: { updatedAt: "desc" },
+          take: limit,
+        });
+        for (const r of rows) {
+          seenIds.record("prompt_id", r.id);
+          seenIds.record("prompt_handle", r.handle);
+        }
+        return {
+          items: rows.map((r) => ({
+            id: r.id,
+            handle: r.handle,
+            name: r.name ?? r.handle,
+          })),
+        };
+      },
+    }),
+
+    search_past_runs: tool({
+      description:
+        "Search past evaluation runs (BatchEvaluation) for this project, optionally filtered by experiment slug or workflow id, ordered by recency.",
+      inputSchema: z.object({
+        experimentSlug: z.string().optional(),
+        workflowId: z.string().optional(),
+        limit: z.number().int().min(1).max(20).default(10),
+      }),
+      execute: async ({ experimentSlug, workflowId: _workflowId, limit }) => {
+        const where: Record<string, unknown> = { projectId };
+        if (experimentSlug) {
+          const exp = await prisma.experiment.findFirst({
+            where: { projectId, slug: experimentSlug },
+            select: { id: true },
+          });
+          if (!exp) return { items: [], error: "experiment not found" };
+          where.experimentId = exp.id;
+        }
+        const rows = await prisma.batchEvaluation.findMany({
+          where,
+          orderBy: { createdAt: "desc" },
+          take: limit,
+          select: {
+            id: true,
+            experimentId: true,
+            createdAt: true,
+            status: true,
+            score: true,
+            passed: true,
+            evaluation: true,
+          },
+        });
+        return {
+          items: rows.map((r) => ({
+            id: r.id,
+            experimentId: r.experimentId,
+            createdAt: r.createdAt,
+            status: r.status,
+            score: r.score,
+            passed: r.passed,
+            evaluation: r.evaluation,
+          })),
+        };
+      },
+    }),
   };
 
-  const model = await getVercelAIModel(projectId, LANGY_MODEL);
+  const systemPrompt = buildSystemPrompt({
+    projectMemory,
+    mode: prefs.mode,
+  });
   const modelMessages = await convertToModelMessages(messages);
 
   const result = streamText({
     model,
-    system: LANGY_SYSTEM_PROMPT,
+    system: systemPrompt,
     messages: modelMessages,
     tools,
-    stopWhen: stepCountIs(8),
+    stopWhen: stepCountIs(LANGY_TOOL_CALLS_PER_MESSAGE),
     maxRetries: 2,
     experimental_telemetry: {
       isEnabled: true,
@@ -875,17 +1224,400 @@ app.post("/langy/chat", async (c) => {
       metadata: {
         "langwatch.project_id": projectId,
         "langwatch.user_id": session.user.id,
+        "langy.conversation_id": conversation.id,
       },
     },
     onError: (error) => {
       logger.error({ error }, "error in langy chat stream");
     },
+    onFinish: async ({ text, response }) => {
+      try {
+        const assistantMessages = response.messages.filter(
+          (m) => m.role === "assistant" || m.role === "tool",
+        );
+        const parts = assistantMessages.flatMap((m) =>
+          Array.isArray(m.content) ? m.content : [],
+        );
+        await persistAssistantMessage({
+          conversationId: conversation.id,
+          projectId,
+          parts,
+          text,
+          model: LANGY_FALLBACK_MODEL,
+        });
+      } catch (error) {
+        logger.error({ error }, "failed to persist langy assistant message");
+      }
+    },
   });
 
   const response = result.toUIMessageStreamResponse();
+  const headers = new Headers(response.headers);
+  headers.set("x-langy-conversation-id", conversation.id);
   return new Response(response.body, {
     status: response.status,
-    headers: response.headers,
+    headers,
+  });
+});
+
+// ============================================================================
+// Conversation management
+// ============================================================================
+
+async function requireSessionAndPermission(c: any, projectId: string | undefined) {
+  const session = await getServerAuthSession({ req: c.req.raw as any });
+  if (!session) return { error: c.json({ error: "Unauthorized" }, { status: 401 }) };
+  if (!projectId) return { error: c.json({ error: "Missing projectId" }, { status: 400 }) };
+  const ok = await hasProjectPermission(
+    { prisma, session },
+    projectId,
+    "evaluations:view",
+  );
+  if (!ok) return { error: c.json({ error: "Forbidden" }, { status: 403 }) };
+  return { session };
+}
+
+async function requireProjectAdmin(session: Awaited<ReturnType<typeof getServerAuthSession>>, projectId: string) {
+  if (!session) return false;
+  return await hasProjectPermission(
+    { prisma, session },
+    projectId,
+    "project:manage",
+  );
+}
+
+app.get("/langy/conversations", async (c) => {
+  const projectId = c.req.query("projectId");
+  const guard = await requireSessionAndPermission(c, projectId);
+  if (guard.error) return guard.error;
+  const limit = Number(c.req.query("limit") ?? "50");
+  const service = LangyConversationService.create(prisma);
+  const conversations = await service.getAll({
+    projectId: projectId!,
+    userId: guard.session!.user.id,
+    limit: Math.min(Math.max(limit, 1), 100),
+  });
+  return c.json({ conversations });
+});
+
+app.get("/langy/conversations/:id", async (c) => {
+  const projectId = c.req.query("projectId");
+  const guard = await requireSessionAndPermission(c, projectId);
+  if (guard.error) return guard.error;
+  const id = c.req.param("id");
+  const convService = LangyConversationService.create(prisma);
+  const conv = await convService.getById({
+    id,
+    projectId: projectId!,
+    userId: guard.session!.user.id,
+  });
+  if (!conv) return c.json({ error: "Not found" }, { status: 404 });
+  const msgService = LangyMessageService.create(prisma);
+  const messages = await msgService.getAllByConversation({
+    conversationId: conv.id,
+    projectId: projectId!,
+  });
+  return c.json({ conversation: conv, messages });
+});
+
+app.patch("/langy/conversations/:id", async (c) => {
+  const body = (await c.req.json()) as {
+    projectId: string;
+    title?: string | null;
+    isShared?: boolean;
+  };
+  const guard = await requireSessionAndPermission(c, body.projectId);
+  if (guard.error) return guard.error;
+  const id = c.req.param("id");
+  const service = LangyConversationService.create(prisma);
+  try {
+    const updated = await service.updateById({
+      id,
+      projectId: body.projectId,
+      userId: guard.session!.user.id,
+      title: body.title,
+      isShared: body.isShared,
+    });
+    if (body.isShared !== undefined) {
+      await auditLog({
+        userId: guard.session!.user.id,
+        projectId: body.projectId,
+        action: body.isShared
+          ? "langy.conversation.share"
+          : "langy.conversation.unshare",
+        args: { conversationId: id },
+      });
+    }
+    return c.json({ conversation: updated });
+  } catch {
+    return c.json({ error: "Not found or not owned" }, { status: 404 });
+  }
+});
+
+app.delete("/langy/conversations/:id", async (c) => {
+  const projectId = c.req.query("projectId");
+  const guard = await requireSessionAndPermission(c, projectId);
+  if (guard.error) return guard.error;
+  const id = c.req.param("id");
+  const service = LangyConversationService.create(prisma);
+  const ok = await service.deleteById({
+    id,
+    projectId: projectId!,
+    userId: guard.session!.user.id,
+  });
+  if (!ok) return c.json({ error: "Not found or not owned" }, { status: 404 });
+  return c.json({ success: true });
+});
+
+// ============================================================================
+// Project memory
+// ============================================================================
+
+const PROJECT_MEMORY_REFRESH_PROMPT = `You are regenerating a project memory file for the LangWatch assistant Langy.
+
+Read the snapshot of the project state below (evaluators, prompts, datasets) and produce a concise, plain-language markdown brief covering:
+- What this project does (one sentence)
+- Active evaluators and what they check
+- Notable prompts and their purpose
+- Anything unusual worth noting
+
+Keep under 1500 tokens. No invented facts.`;
+
+app.get("/langy/project-memory", async (c) => {
+  const projectId = c.req.query("projectId");
+  const guard = await requireSessionAndPermission(c, projectId);
+  if (guard.error) return guard.error;
+  const service = LangyProjectMemoryService.create(prisma);
+  const memory = await service.getById({ projectId: projectId! });
+  return c.json({ memory });
+});
+
+app.put("/langy/project-memory", async (c) => {
+  const body = (await c.req.json()) as { projectId: string; content: string };
+  const guard = await requireSessionAndPermission(c, body.projectId);
+  if (guard.error) return guard.error;
+  const isAdmin = await requireProjectAdmin(guard.session!, body.projectId);
+  if (!isAdmin) {
+    return c.json(
+      { error: "Editing project memory requires project admin." },
+      { status: 403 },
+    );
+  }
+  const service = LangyProjectMemoryService.create(prisma);
+  const memory = await service.writeNewVersion({
+    projectId: body.projectId,
+    content: body.content,
+    changedById: guard.session!.user.id,
+    changeReason: "user_edit",
+  });
+  await auditLog({
+    userId: guard.session!.user.id,
+    projectId: body.projectId,
+    action: "langy.project_memory.edit",
+    args: { contentVersion: memory.contentVersion },
+  });
+  return c.json({ memory });
+});
+
+app.post("/langy/project-memory/refresh", async (c) => {
+  const body = (await c.req.json()) as { projectId: string };
+  const guard = await requireSessionAndPermission(c, body.projectId);
+  if (guard.error) return guard.error;
+  const isAdmin = await requireProjectAdmin(guard.session!, body.projectId);
+  if (!isAdmin) {
+    return c.json(
+      { error: "Refreshing project memory requires project admin." },
+      { status: 403 },
+    );
+  }
+
+  let model;
+  try {
+    model = await getVercelAIModel(body.projectId);
+  } catch (error) {
+    return c.json(
+      {
+        error:
+          error instanceof Error ? error.message : "No model configured.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const [project, evaluators, prompts, datasets] = await Promise.all([
+    prisma.project.findUnique({
+      where: { id: body.projectId },
+      select: { name: true, language: true, framework: true },
+    }),
+    prisma.evaluator.findMany({
+      where: { projectId: body.projectId },
+      select: { name: true, slug: true, type: true },
+      take: 50,
+    }),
+    prisma.llmPromptConfig.findMany({
+      where: { projectId: body.projectId },
+      select: { handle: true, name: true },
+      take: 50,
+    }),
+    prisma.dataset.findMany({
+      where: { projectId: body.projectId, archivedAt: null },
+      select: { name: true, slug: true },
+      take: 50,
+    }),
+  ]);
+
+  const snapshot = JSON.stringify(
+    { project, evaluators, prompts, datasets },
+    null,
+    2,
+  );
+
+  const stream = streamText({
+    model,
+    system: PROJECT_MEMORY_REFRESH_PROMPT,
+    messages: [
+      {
+        role: "user",
+        content: `Project snapshot (JSON):\n\n${snapshot}`,
+      },
+    ],
+    onFinish: async ({ text }) => {
+      try {
+        const memoryService = LangyProjectMemoryService.create(prisma);
+        await memoryService.writeNewVersion({
+          projectId: body.projectId,
+          content: text,
+          changeReason: "user_refresh",
+          changedById: guard.session!.user.id,
+        });
+        await auditLog({
+          userId: guard.session!.user.id,
+          projectId: body.projectId,
+          action: "langy.project_memory.refresh",
+        });
+      } catch (error) {
+        logger.error({ error }, "failed to persist refreshed project memory");
+      }
+    },
+    onError: (error) => {
+      logger.error({ error }, "project memory refresh stream errored");
+    },
+  });
+
+  return stream.toUIMessageStreamResponse();
+});
+
+// ============================================================================
+// Preferences
+// ============================================================================
+
+app.get("/langy/preferences", async (c) => {
+  const projectId = c.req.query("projectId");
+  const guard = await requireSessionAndPermission(c, projectId);
+  if (guard.error) return guard.error;
+  const service = LangyUserPreferencesService.create(prisma);
+  const prefs = await service.getById({
+    userId: guard.session!.user.id,
+    projectId: projectId!,
+  });
+  return c.json({ preferences: prefs });
+});
+
+app.put("/langy/preferences", async (c) => {
+  const body = (await c.req.json()) as {
+    projectId: string;
+    mode?: "non_expert" | "expert";
+    dismissedSuggestionKinds?: string[];
+  };
+  const guard = await requireSessionAndPermission(c, body.projectId);
+  if (guard.error) return guard.error;
+  const service = LangyUserPreferencesService.create(prisma);
+  let prefs = await service.getById({
+    userId: guard.session!.user.id,
+    projectId: body.projectId,
+  });
+  if (body.mode) {
+    prefs = await service.setMode({
+      userId: guard.session!.user.id,
+      projectId: body.projectId,
+      mode: body.mode,
+    });
+  }
+  if (body.dismissedSuggestionKinds) {
+    prefs = await service.setDismissedSuggestionKinds({
+      userId: guard.session!.user.id,
+      projectId: body.projectId,
+      kinds: body.dismissedSuggestionKinds,
+    });
+  }
+  return c.json({ preferences: prefs });
+});
+
+// ============================================================================
+// Memory clear-all + GDPR export
+// ============================================================================
+
+app.delete("/langy/memory", async (c) => {
+  const projectId = c.req.query("projectId");
+  const guard = await requireSessionAndPermission(c, projectId);
+  if (guard.error) return guard.error;
+  const userId = guard.session!.user.id;
+  const convService = LangyConversationService.create(prisma);
+  const prefService = LangyUserPreferencesService.create(prisma);
+  const result = await convService.clearAllForUser({
+    projectId: projectId!,
+    userId,
+  });
+  await prefService.resetForUser({ projectId: projectId!, userId });
+  await auditLog({
+    userId,
+    projectId: projectId!,
+    action: "langy.memory.clear_all",
+    args: { deletedCount: result.deletedCount },
+  });
+  return c.json({ deletedCount: result.deletedCount });
+});
+
+app.get("/langy/memory/export", async (c) => {
+  const projectId = c.req.query("projectId");
+  const guard = await requireSessionAndPermission(c, projectId);
+  if (guard.error) return guard.error;
+  const userId = guard.session!.user.id;
+  const convService = LangyConversationService.create(prisma);
+  const conversations = await convService.getAll({
+    projectId: projectId!,
+    userId,
+    limit: 1000,
+  });
+  const msgService = LangyMessageService.create(prisma);
+  const conversationsWithMessages = await Promise.all(
+    conversations
+      .filter((c) => c.isOwn)
+      .map(async (c) => ({
+        conversation: c,
+        messages: await msgService.getAllByConversation({
+          conversationId: c.id,
+          projectId: projectId!,
+        }),
+      })),
+  );
+  const prefService = LangyUserPreferencesService.create(prisma);
+  const preferences = await prefService.getById({
+    userId,
+    projectId: projectId!,
+  });
+  await auditLog({
+    userId,
+    projectId: projectId!,
+    action: "langy.memory.export",
+    args: { conversationCount: conversationsWithMessages.length },
+  });
+  return c.json({
+    exportedAt: new Date().toISOString(),
+    projectId,
+    userId,
+    conversations: conversationsWithMessages,
+    preferences,
   });
 });
 

--- a/langwatch/src/server/routes/sage.ts
+++ b/langwatch/src/server/routes/sage.ts
@@ -44,7 +44,7 @@ const SAGE_SYSTEM_PROMPT = `You are Sage, the in-product AI assistant for LangWa
 
 ## What you can do
 - **Read** the project's evaluators, prompts, and datasets. Use these tools autonomously whenever they help you answer.
-- **Propose changes** that the user can apply with one click — creating evaluators, adding them to the workbench, and (later) prompts/datasets. You never mutate state yourself. Every "propose_*" tool returns a card; the user clicks Apply to commit.
+- **Propose changes** that the user can apply with one click — creating/updating evaluators and prompts, creating datasets and appending rows, adding evaluators to the workbench, and running the experiment. You never mutate state yourself. Every "propose_*" tool returns a card; the user clicks Apply to commit.
 
 ## Ground rules
 - Never fabricate names, IDs, or slugs. Only reference entities your tools returned.
@@ -68,6 +68,16 @@ const SAGE_SYSTEM_PROMPT = `You are Sage, the in-product AI assistant for LangWa
 
 ## Running experiments
 - Use **propose_run_workbench** when the user asks to run/evaluate/execute the experiment. Before proposing, call get_workbench_state and sanity-check that there's at least one target and at least one evaluator. If mappings look missing, note that in your reply so the user knows a run might fail validation.
+
+## Prompts
+- Call get_prompt_details before proposing an update so you know which fields are already set. Only include fields you actually want to change.
+- propose_update_prompt requires a commitMessage — make it specific ("add safety system message" beats "updated prompt").
+- When proposing a brand-new prompt, pick a handle that reflects intent and slug-conventions (kebab-case).
+
+## Datasets
+- Before propose_add_dataset_rows, call get_dataset_details so your row values line up with the declared column types — mismatches will fail validation.
+- propose_create_dataset can include initialRows so the dataset lands with seed data in a single Apply.
+- When the user asks for "N examples", generate the actual row values inline in the tool call. Don't ask them to specify each one unless the domain is ambiguous.
 
 ## Evaluator models
 - propose_create_evaluator auto-fills settings from the evaluator's defaults, using the **project's default model** for any \`model\` field. You do NOT need to pass settings.model unless the user explicitly asked for a specific one.
@@ -443,6 +453,269 @@ app.post("/sage/chat", async (c) => {
               evaluatorType,
               settings: mergedSettings,
             },
+          },
+        };
+      },
+    }),
+
+    get_prompt_details: tool({
+      description:
+        "Fetch the full config for a single prompt by handle or id: model, temperature, maxTokens, message templates, and declared inputs/outputs.",
+      inputSchema: z.object({
+        idOrHandle: z
+          .string()
+          .describe("The prompt id or handle, as returned by list_prompts."),
+      }),
+      execute: async ({ idOrHandle }) => {
+        const prompt = await promptService.getPromptByIdOrHandle({
+          idOrHandle,
+          projectId,
+        });
+        if (!prompt) {
+          return { error: `No prompt found with id or handle '${idOrHandle}'.` };
+        }
+        const p = prompt as Record<string, unknown>;
+        return {
+          id: p.id,
+          handle: p.handle,
+          scope: p.scope,
+          model: p.model,
+          temperature: p.temperature,
+          maxTokens: p.maxTokens,
+          messages: p.messages,
+          inputs: p.inputs,
+          outputs: p.outputs,
+          version: p.version,
+        };
+      },
+    }),
+
+    get_dataset_details: tool({
+      description:
+        "Fetch a dataset's schema and a sample of its rows so you can understand its content before proposing additions or changes.",
+      inputSchema: z.object({
+        datasetId: z
+          .string()
+          .describe("The dataset id as returned by list_datasets."),
+        sampleRowLimit: z.number().int().min(0).max(20).default(5),
+      }),
+      execute: async ({ datasetId, sampleRowLimit }) => {
+        const dataset = await prisma.dataset.findFirst({
+          where: { id: datasetId, projectId, archivedAt: null },
+          include: { _count: { select: { datasetRecords: true } } },
+        });
+        if (!dataset) {
+          return { error: `No dataset found with id '${datasetId}'.` };
+        }
+        const sampleRows =
+          sampleRowLimit > 0
+            ? await prisma.datasetRecord.findMany({
+                where: { datasetId, projectId },
+                orderBy: { createdAt: "asc" },
+                take: sampleRowLimit,
+                select: { id: true, entry: true },
+              })
+            : [];
+        return {
+          id: dataset.id,
+          slug: dataset.slug,
+          name: dataset.name,
+          columnTypes: dataset.columnTypes,
+          rowCount: dataset._count.datasetRecords,
+          sampleRows,
+        };
+      },
+    }),
+
+    propose_create_prompt: tool({
+      description:
+        "Propose creating a new prompt in the project. Returns a card the user approves to commit. The handle must be unique within the project; use kebab-case or snake_case.",
+      inputSchema: z.object({
+        handle: z
+          .string()
+          .min(1)
+          .max(80)
+          .describe(
+            "Unique, URL-safe prompt handle (e.g. 'rag-qa', 'support-triage').",
+          ),
+        messages: z
+          .array(
+            z.object({
+              role: z.enum(["system", "user", "assistant"]),
+              content: z.string(),
+            }),
+          )
+          .min(1)
+          .describe("Chat-style message templates that define the prompt."),
+        model: z
+          .string()
+          .optional()
+          .describe(
+            "Optional model override (e.g. 'openai/gpt-4.1-mini'). Omit to fall back to the project default.",
+          ),
+        temperature: z.number().min(0).max(2).optional(),
+        maxTokens: z.number().int().positive().optional(),
+        rationale: z
+          .string()
+          .describe(
+            "One short sentence explaining why this prompt fits the user's goal.",
+          ),
+      }),
+      execute: async ({
+        handle,
+        messages,
+        model,
+        temperature,
+        maxTokens,
+        rationale,
+      }) => {
+        return {
+          sageProposal: true,
+          kind: "prompts.create",
+          summary: `Create prompt "${handle}"`,
+          rationale,
+          payload: {
+            handle,
+            messages,
+            model,
+            temperature,
+            maxTokens,
+          },
+        };
+      },
+    }),
+
+    propose_update_prompt: tool({
+      description:
+        "Propose updating an existing prompt by creating a new version. A commitMessage is required. Call get_prompt_details first so you only send fields you actually want to change.",
+      inputSchema: z.object({
+        id: z
+          .string()
+          .describe("The prompt id (not handle), as returned by list_prompts."),
+        commitMessage: z
+          .string()
+          .min(1)
+          .describe("Short description of what this revision changes."),
+        messages: z
+          .array(
+            z.object({
+              role: z.enum(["system", "user", "assistant"]),
+              content: z.string(),
+            }),
+          )
+          .optional(),
+        model: z.string().optional(),
+        temperature: z.number().min(0).max(2).optional(),
+        maxTokens: z.number().int().positive().optional(),
+        rationale: z.string(),
+      }),
+      execute: async ({
+        id,
+        commitMessage,
+        messages,
+        model,
+        temperature,
+        maxTokens,
+        rationale,
+      }) => {
+        const existing = await promptService.getPromptByIdOrHandle({
+          idOrHandle: id,
+          projectId,
+        });
+        if (!existing) {
+          return { error: `No prompt found with id '${id}'.` };
+        }
+        return {
+          sageProposal: true,
+          kind: "prompts.update",
+          summary: `Update prompt "${(existing as { handle?: string }).handle ?? id}"`,
+          rationale,
+          payload: {
+            id,
+            commitMessage,
+            messages,
+            model,
+            temperature,
+            maxTokens,
+          },
+        };
+      },
+    }),
+
+    propose_create_dataset: tool({
+      description:
+        "Propose creating a new dataset with a schema (column names + types) and optional seed rows you author inline. Use this before propose_add_dataset_rows if the dataset does not yet exist.",
+      inputSchema: z.object({
+        name: z.string().min(1).max(120),
+        columns: z
+          .array(
+            z.object({
+              name: z.string().min(1),
+              type: z.enum([
+                "string",
+                "boolean",
+                "number",
+                "date",
+                "list",
+                "json",
+              ]),
+            }),
+          )
+          .min(1)
+          .describe("Schema: column name + value type."),
+        initialRows: z
+          .array(z.record(z.unknown()))
+          .optional()
+          .describe(
+            "Optional seed rows. Each row is an object mapping column name to value. Keep values consistent with declared column types.",
+          ),
+        rationale: z.string(),
+      }),
+      execute: async ({ name, columns, initialRows, rationale }) => {
+        return {
+          sageProposal: true,
+          kind: "datasets.create",
+          summary: `Create dataset "${name}"${
+            initialRows?.length ? ` with ${initialRows.length} row(s)` : ""
+          }`,
+          rationale,
+          payload: {
+            name,
+            columnTypes: columns,
+            initialRows: initialRows ?? [],
+          },
+        };
+      },
+    }),
+
+    propose_add_dataset_rows: tool({
+      description:
+        "Propose appending rows to an existing dataset. Each row is an object mapping column name to value. Values must be consistent with the dataset's column types (call get_dataset_details first to confirm).",
+      inputSchema: z.object({
+        datasetId: z.string(),
+        rows: z
+          .array(z.record(z.unknown()))
+          .min(1)
+          .max(50)
+          .describe("Up to 50 rows; each row is { columnName: value }."),
+        rationale: z.string(),
+      }),
+      execute: async ({ datasetId, rows, rationale }) => {
+        const dataset = await prisma.dataset.findFirst({
+          where: { id: datasetId, projectId, archivedAt: null },
+          select: { id: true, name: true, slug: true },
+        });
+        if (!dataset) {
+          return { error: `No dataset found with id '${datasetId}'.` };
+        }
+        return {
+          sageProposal: true,
+          kind: "datasets.addRows",
+          summary: `Add ${rows.length} row(s) to "${dataset.name}"`,
+          rationale,
+          payload: {
+            datasetId,
+            rows,
           },
         };
       },

--- a/langwatch/src/server/routes/sage.ts
+++ b/langwatch/src/server/routes/sage.ts
@@ -721,6 +721,88 @@ app.post("/sage/chat", async (c) => {
       },
     }),
 
+    propose_update_evaluator: tool({
+      description:
+        "Propose updating an existing project evaluator's name or settings. Call get_evaluator_details first so you only override what you actually want to change. Settings are merged over the evaluator's current config.",
+      inputSchema: z.object({
+        slug: z.string().describe("Slug of the project evaluator to update."),
+        name: z.string().min(1).max(255).optional(),
+        settings: z
+          .record(z.unknown())
+          .optional()
+          .describe(
+            "Partial settings to merge over the evaluator's current settings object.",
+          ),
+        rationale: z.string(),
+      }),
+      execute: async ({ slug, name, settings, rationale }) => {
+        const evaluator = await evaluatorService.getBySlug({ slug, projectId });
+        if (!evaluator) {
+          return { error: `No project evaluator with slug '${slug}'.` };
+        }
+        const currentConfig =
+          (evaluator.config as Record<string, unknown> | null) ?? {};
+        const currentSettings =
+          (currentConfig.settings as Record<string, unknown> | undefined) ?? {};
+        const mergedConfig: Record<string, unknown> = {
+          ...currentConfig,
+          ...(settings
+            ? { settings: { ...currentSettings, ...settings } }
+            : {}),
+        };
+        const changedFields: string[] = [];
+        if (name && name !== evaluator.name) changedFields.push("name");
+        if (settings) changedFields.push(...Object.keys(settings));
+        return {
+          sageProposal: true,
+          kind: "evaluators.update",
+          summary: `Update evaluator "${evaluator.name}"${
+            changedFields.length ? ` (${changedFields.join(", ")})` : ""
+          }`,
+          rationale,
+          payload: {
+            id: evaluator.id,
+            evaluatorType: (currentConfig as { evaluatorType?: string })
+              .evaluatorType,
+            ...(name ? { name } : {}),
+            config: mergedConfig,
+          },
+        };
+      },
+    }),
+
+    propose_delete_evaluator: tool({
+      description:
+        "Propose archiving (soft-deleting) an existing project evaluator. This is a destructive action — only propose it when the user explicitly asks. Existing workbench references to this evaluator will break once archived.",
+      inputSchema: z.object({
+        slug: z
+          .string()
+          .describe("Slug of the project evaluator to archive."),
+        rationale: z
+          .string()
+          .describe(
+            "Why the user wants to delete this evaluator, or a short confirmation of what they asked.",
+          ),
+      }),
+      execute: async ({ slug, rationale }) => {
+        const evaluator = await evaluatorService.getBySlug({ slug, projectId });
+        if (!evaluator) {
+          return { error: `No project evaluator with slug '${slug}'.` };
+        }
+        return {
+          sageProposal: true,
+          kind: "evaluators.delete",
+          destructive: true,
+          summary: `Archive evaluator "${evaluator.name}"`,
+          rationale,
+          payload: {
+            id: evaluator.id,
+            name: evaluator.name,
+          },
+        };
+      },
+    }),
+
     propose_run_workbench: tool({
       description:
         "Propose running the current experiment (kicks off all target × evaluator cells). Returns a proposal card the user clicks Apply to execute. Use this when the user asks to 'run', 'evaluate', 'execute', or 'kick off' the experiment.",

--- a/langwatch/src/server/routes/sage.ts
+++ b/langwatch/src/server/routes/sage.ts
@@ -1,0 +1,404 @@
+/**
+ * Hono route for the SAGE assistant.
+ *
+ * POST /api/sage/chat — streams an AI chat response with access to
+ * read-only evaluator tools scoped to the caller's project.
+ *
+ * SAGE = Scenarios, Analysis, Guidance, Evaluation.
+ *
+ * v1 is read-only: Sage proposes actions, it does not run evaluators,
+ * mutate experiments, or modify project state.
+ */
+import {
+  convertToModelMessages,
+  stepCountIs,
+  streamText,
+  tool,
+  type UIMessage,
+} from "ai";
+import { Hono } from "hono";
+import { z } from "zod";
+import { loggerMiddleware } from "~/app/api/middleware/logger";
+import { tracerMiddleware } from "~/app/api/middleware/tracer";
+import { hasProjectPermission } from "~/server/api/rbac";
+import { getServerAuthSession } from "~/server/auth";
+import { prisma } from "~/server/db";
+import { AVAILABLE_EVALUATORS } from "~/server/evaluations/evaluators.generated";
+import {
+  getEvaluatorDefaultSettings,
+  getEvaluatorDefinitions,
+} from "~/server/evaluations/getEvaluator";
+import { EvaluatorService } from "~/server/evaluators/evaluator.service";
+import { getVercelAIModel } from "~/server/modelProviders/utils";
+import { PromptService } from "~/server/prompt-config/prompt.service";
+import { createLogger } from "~/utils/logger/server";
+import type { NextRequestShim as any } from "./types";
+
+const logger = createLogger("langwatch:api:sage");
+
+const SAGE_MODEL = "openai/gpt-5";
+
+const SAGE_SYSTEM_PROMPT = `You are Sage, the in-product AI assistant for LangWatch. You live in a right-side sidebar inside the experiment workbench. The name stands for Scenarios, Analysis, Guidance, Evaluation.
+
+## What you can do
+- **Read** the project's evaluators, prompts, and datasets. Use these tools autonomously whenever they help you answer.
+- **Propose changes** that the user can apply with one click — creating evaluators, adding them to the workbench, and (later) prompts/datasets. You never mutate state yourself. Every "propose_*" tool returns a card; the user clicks Apply to commit.
+
+## Ground rules
+- Never fabricate names, IDs, or slugs. Only reference entities your tools returned.
+- When asked to "do" something, propose it via the relevant propose_* tool. Say "I'll propose this for you to approve" rather than "I did it".
+- One proposal per turn unless the user explicitly asked for multiple. Don't spam cards.
+
+## Tone
+- Informative, not over-helpful. Curate — do not enumerate.
+- "What do I have?" → surface **at most 3–5** most relevant items, grouped by category if useful. Never paste the full catalog.
+- Prefer 1–3 short bullets. No filler openers ("Great question!", "Sure!"). No closing offers unless the user is likely to need more.
+- If the honest answer needs more than 5 items, summarize + offer drill-down instead of listing everything.
+- When recommending, pick the single best match first, then at most two alternatives, each in one line.
+
+## Tool use
+- Before talking about the user's evaluators/prompts/datasets, call the matching list_* tool with 'project' scope first.
+- Use list_evaluators 'built_in' or 'all' only when suggesting new evaluators from the catalog.
+- After a tool call, synthesize — don't regurgitate the raw list.
+
+## Evaluator models
+- propose_create_evaluator auto-fills settings from the evaluator's defaults, using the **project's default model** for any \`model\` field. You do NOT need to pass settings.model unless the user explicitly asked for a specific one.
+- If the user wants to choose a model, ask them which and then pass it in settings.model when proposing.
+- Mention the chosen model briefly in your reply so the user can catch it before applying.`;
+
+export const app = new Hono().basePath("/api");
+app.use(tracerMiddleware({ name: "sage" }));
+app.use(loggerMiddleware());
+
+app.post("/sage/chat", async (c) => {
+  const session = await getServerAuthSession({ req: c.req.raw as any });
+  if (!session) {
+    return c.json(
+      { error: "You must be logged in to access this endpoint." },
+      { status: 401 },
+    );
+  }
+
+  const { messages, projectId } = (await c.req.json()) as {
+    messages: UIMessage[];
+    projectId: string;
+  };
+
+  if (!projectId) {
+    return c.json({ error: "Missing projectId" }, { status: 400 });
+  }
+
+  const hasPermission = await hasProjectPermission(
+    { prisma, session },
+    projectId,
+    "evaluations:view",
+  );
+  if (!hasPermission) {
+    return c.json(
+      { error: "You do not have permission to use Sage for this project." },
+      { status: 403 },
+    );
+  }
+
+  const evaluatorService = EvaluatorService.create(prisma);
+  const promptService = new PromptService(prisma);
+
+  const tools = {
+    list_evaluators: tool({
+      description:
+        "Lists evaluators available to the caller's project. Returns both the custom project evaluators and the built-in catalog. Use this before suggesting or explaining any evaluator.",
+      inputSchema: z.object({
+        scope: z
+          .enum(["project", "built_in", "all"])
+          .default("all")
+          .describe(
+            "Which set to return: the user's project evaluators, the built-in catalog, or both.",
+          ),
+      }),
+      execute: async ({ scope }) => {
+        const items: Array<Record<string, unknown>> = [];
+
+        if (scope === "project" || scope === "all") {
+          const projectEvaluators = await evaluatorService.getAllWithFields({
+            projectId,
+          });
+          for (const e of projectEvaluators) {
+            items.push({
+              source: "project",
+              id: e.id,
+              slug: e.slug,
+              name: e.name,
+              type: e.type,
+              inputs: e.fields.map((f) => f.identifier),
+            });
+          }
+        }
+
+        if (scope === "built_in" || scope === "all") {
+          for (const [evaluatorType, def] of Object.entries(
+            AVAILABLE_EVALUATORS,
+          )) {
+            items.push({
+              source: "built_in",
+              evaluatorType,
+              name: def.name,
+              description: def.description,
+              category: def.category,
+              isGuardrail: def.isGuardrail,
+              requiredFields: def.requiredFields,
+              optionalFields: def.optionalFields,
+            });
+          }
+        }
+
+        return { items };
+      },
+    }),
+
+    get_evaluator_details: tool({
+      description:
+        "Fetches details for a single evaluator, either by project slug (for custom project evaluators) or by built-in type key (for catalog entries). Provide exactly one of `slug` or `evaluatorType`.",
+      inputSchema: z.object({
+        slug: z
+          .string()
+          .optional()
+          .describe("Project evaluator slug for custom evaluators."),
+        evaluatorType: z
+          .string()
+          .optional()
+          .describe(
+            "Built-in evaluator type key, for example 'ragas/answer_relevancy'.",
+          ),
+      }),
+      execute: async ({ slug, evaluatorType }) => {
+        if (slug) {
+          const evaluator = await evaluatorService.getBySlug({
+            slug,
+            projectId,
+          });
+          if (!evaluator) {
+            return {
+              error: `No project evaluator found with slug '${slug}'.`,
+            };
+          }
+          const enriched = await evaluatorService.enrichWithFields(evaluator);
+          return {
+            source: "project",
+            id: enriched.id,
+            slug: enriched.slug,
+            name: enriched.name,
+            type: enriched.type,
+            fields: enriched.fields,
+            outputFields: enriched.outputFields,
+          };
+        }
+
+        if (evaluatorType) {
+          const def =
+            AVAILABLE_EVALUATORS[
+              evaluatorType as keyof typeof AVAILABLE_EVALUATORS
+            ];
+          if (!def) {
+            return {
+              error: `No built-in evaluator with type '${evaluatorType}'.`,
+            };
+          }
+          return {
+            source: "built_in",
+            evaluatorType,
+            name: def.name,
+            description: def.description,
+            category: def.category,
+            isGuardrail: def.isGuardrail,
+            requiredFields: def.requiredFields,
+            optionalFields: def.optionalFields,
+            result: def.result,
+            docsUrl: def.docsUrl,
+          };
+        }
+
+        return {
+          error: "Provide either 'slug' or 'evaluatorType'.",
+        };
+      },
+    }),
+
+    list_prompts: tool({
+      description:
+        "Lists the prompts defined in the caller's project. Returns handle, name, model, and a short preview.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        const prompts = await promptService.getAllPrompts({
+          projectId,
+          version: "latest",
+        });
+        return {
+          items: prompts.map((p: Record<string, unknown>) => ({
+            id: p.id,
+            handle: p.handle,
+            name: p.name ?? p.handle,
+            model: p.model,
+            scope: p.scope,
+          })),
+        };
+      },
+    }),
+
+    list_datasets: tool({
+      description:
+        "Lists the datasets in the caller's project with their column schema and row count.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        const datasets = await prisma.dataset.findMany({
+          where: { projectId, archivedAt: null },
+          orderBy: { updatedAt: "desc" },
+          include: { _count: { select: { datasetRecords: true } } },
+        });
+        return {
+          items: datasets.map((d) => ({
+            id: d.id,
+            slug: d.slug,
+            name: d.name,
+            columnTypes: d.columnTypes,
+            rowCount: d._count.datasetRecords,
+          })),
+        };
+      },
+    }),
+
+    propose_create_evaluator: tool({
+      description:
+        "Propose creating a new evaluator in the project. The user will see a preview card and click Apply to commit. Use this when the user asks for a new evaluator that doesn't yet exist.",
+      inputSchema: z.object({
+        name: z
+          .string()
+          .min(1)
+          .max(255)
+          .describe("Human-readable evaluator name shown in the UI."),
+        evaluatorType: z
+          .string()
+          .describe(
+            "The built-in evaluator type key, e.g. 'ragas/answer_relevancy'. Must match one you found via list_evaluators('built_in').",
+          ),
+        settings: z
+          .record(z.unknown())
+          .optional()
+          .describe(
+            "Optional settings override. Leave empty to use defaults from the evaluator definition.",
+          ),
+        rationale: z
+          .string()
+          .describe(
+            "One short sentence explaining why this evaluator fits the user's goal.",
+          ),
+      }),
+      execute: async ({ name, evaluatorType, settings, rationale }) => {
+        const def =
+          AVAILABLE_EVALUATORS[
+            evaluatorType as keyof typeof AVAILABLE_EVALUATORS
+          ];
+        if (!def) {
+          return {
+            error: `No built-in evaluator with type '${evaluatorType}'. Use list_evaluators('built_in') first.`,
+          };
+        }
+        const project = await prisma.project.findUnique({
+          where: { id: projectId },
+          select: { defaultModel: true, embeddingsModel: true },
+        });
+        const defaults = getEvaluatorDefaultSettings(
+          getEvaluatorDefinitions(evaluatorType),
+          project ?? undefined,
+        ) as Record<string, unknown>;
+        const mergedSettings: Record<string, unknown> = {
+          ...defaults,
+          ...(settings ?? {}),
+        };
+        const chosenModel =
+          typeof mergedSettings.model === "string"
+            ? mergedSettings.model
+            : undefined;
+        return {
+          sageProposal: true,
+          kind: "evaluators.create",
+          summary: `Create evaluator "${name}" (${evaluatorType})`,
+          rationale: chosenModel
+            ? `${rationale} Uses ${chosenModel} (project default).`
+            : rationale,
+          payload: {
+            name,
+            type: "evaluator" as const,
+            config: {
+              evaluatorType,
+              settings: mergedSettings,
+            },
+          },
+        };
+      },
+    }),
+
+    propose_add_evaluator_to_workbench: tool({
+      description:
+        "Propose adding an existing project evaluator as a column in the current experiment workbench. Only works for evaluators that already exist in the project (use propose_create_evaluator first if needed).",
+      inputSchema: z.object({
+        slug: z
+          .string()
+          .describe("Slug of the existing project evaluator to add."),
+        rationale: z.string(),
+      }),
+      execute: async ({ slug, rationale }) => {
+        const evaluator = await evaluatorService.getBySlug({
+          slug,
+          projectId,
+        });
+        if (!evaluator) {
+          return { error: `No project evaluator with slug '${slug}'.` };
+        }
+        const enriched = await evaluatorService.enrichWithFields(evaluator);
+        const evalType =
+          (enriched.config as { evaluatorType?: string } | null)
+            ?.evaluatorType ?? `custom/${enriched.slug}`;
+        return {
+          sageProposal: true,
+          kind: "workbench.addEvaluator",
+          summary: `Add "${enriched.name}" to this workbench`,
+          rationale,
+          payload: {
+            dbEvaluatorId: enriched.id,
+            evaluatorType: evalType,
+            name: enriched.name,
+            fields: enriched.fields,
+          },
+        };
+      },
+    }),
+  };
+
+  const model = await getVercelAIModel(projectId, SAGE_MODEL);
+
+  const result = streamText({
+    model,
+    system: SAGE_SYSTEM_PROMPT,
+    messages: convertToModelMessages(messages),
+    tools,
+    stopWhen: stepCountIs(8),
+    maxRetries: 2,
+    experimental_telemetry: {
+      isEnabled: true,
+      functionId: "sage.chat",
+      metadata: {
+        "langwatch.project_id": projectId,
+        "langwatch.user_id": session.user.id,
+      },
+    },
+    onError: (error) => {
+      logger.error({ error }, "error in sage chat stream");
+    },
+  });
+
+  const response = result.toUIMessageStreamResponse();
+  return new Response(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+});

--- a/langwatch/src/server/routes/sage.ts
+++ b/langwatch/src/server/routes/sage.ts
@@ -23,6 +23,7 @@ import { tracerMiddleware } from "~/app/api/middleware/tracer";
 import { hasProjectPermission } from "~/server/api/rbac";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
+import { persistedEvaluationsV3StateSchema } from "~/evaluations-v3/types/persistence";
 import { AVAILABLE_EVALUATORS } from "~/server/evaluations/evaluators.generated";
 import {
   getEvaluatorDefaultSettings,
@@ -31,6 +32,7 @@ import {
 import { EvaluatorService } from "~/server/evaluators/evaluator.service";
 import { getVercelAIModel } from "~/server/modelProviders/utils";
 import { PromptService } from "~/server/prompt-config/prompt.service";
+import { parseEvaluationResult } from "~/utils/evaluationResults";
 import { createLogger } from "~/utils/logger/server";
 import type { NextRequestShim as any } from "./types";
 
@@ -57,9 +59,15 @@ const SAGE_SYSTEM_PROMPT = `You are Sage, the in-product AI assistant for LangWa
 - When recommending, pick the single best match first, then at most two alternatives, each in one line.
 
 ## Tool use
-- Before talking about the user's evaluators/prompts/datasets, call the matching list_* tool with 'project' scope first.
+- When the user asks about "my experiment", "this experiment", the results, or what's configured in the workbench, call **get_workbench_state** first. That tool is authoritative for what's actually on screen.
+- To investigate failures or underperformance, use **find_failing_rows**. Report the pattern (what inputs fail, which evaluator flagged them) rather than dumping the raw list.
+- Before talking about the user's evaluators/prompts/datasets at the project level (not the workbench), call the matching list_* tool with 'project' scope first.
 - Use list_evaluators 'built_in' or 'all' only when suggesting new evaluators from the catalog.
 - After a tool call, synthesize — don't regurgitate the raw list.
+- Workbench state reflects the last autosave, which usually lags the UI by a second or two. If the user says "I just added X", call get_workbench_state anyway — it'll usually be there.
+
+## Running experiments
+- Use **propose_run_workbench** when the user asks to run/evaluate/execute the experiment. Before proposing, call get_workbench_state and sanity-check that there's at least one target and at least one evaluator. If mappings look missing, note that in your reply so the user knows a run might fail validation.
 
 ## Evaluator models
 - propose_create_evaluator auto-fills settings from the evaluator's defaults, using the **project's default model** for any \`model\` field. You do NOT need to pass settings.model unless the user explicitly asked for a specific one.
@@ -79,9 +87,10 @@ app.post("/sage/chat", async (c) => {
     );
   }
 
-  const { messages, projectId } = (await c.req.json()) as {
+  const { messages, projectId, experimentSlug } = (await c.req.json()) as {
     messages: UIMessage[];
     projectId: string;
+    experimentSlug?: string;
   };
 
   if (!projectId) {
@@ -266,6 +275,108 @@ app.post("/sage/chat", async (c) => {
       },
     }),
 
+    get_workbench_state: tool({
+      description:
+        "Inspect the current experiment workbench: what datasets, targets, and evaluators are configured, plus summary statistics from the last run (pass/fail/error counts per target). Call this before answering any question about the current experiment's setup or results.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        if (!experimentSlug) {
+          return {
+            error:
+              "No experiment is currently open. The caller did not pass experimentSlug.",
+          };
+        }
+        const experiment = await prisma.experiment.findFirst({
+          where: { projectId, slug: experimentSlug },
+        });
+        if (!experiment) {
+          return { error: `No experiment found with slug '${experimentSlug}'.` };
+        }
+        if (!experiment.workbenchState) {
+          return {
+            experimentName: experiment.name ?? experimentSlug,
+            message:
+              "This experiment has no saved workbench state yet. It hasn't been configured or nothing has autosaved.",
+          };
+        }
+        const parsed = persistedEvaluationsV3StateSchema.safeParse(
+          experiment.workbenchState,
+        );
+        if (!parsed.success) {
+          return {
+            error: "Failed to parse workbench state.",
+            details: parsed.error.message,
+          };
+        }
+        const state = parsed.data;
+        return summarizeWorkbenchState(state);
+      },
+    }),
+
+    find_failing_rows: tool({
+      description:
+        "Return rows from the current workbench where an evaluator reported a failed or error status. Use this to investigate why an experiment is underperforming. Returns at most `limit` rows with their input values and which evaluators flagged them.",
+      inputSchema: z.object({
+        evaluatorSlug: z
+          .string()
+          .optional()
+          .describe(
+            "Optional: restrict to a single evaluator by its project slug. Omit to scan all evaluators.",
+          ),
+        targetId: z
+          .string()
+          .optional()
+          .describe("Optional: restrict to a single target id."),
+        limit: z.number().int().min(1).max(20).default(10),
+      }),
+      execute: async ({ evaluatorSlug, targetId, limit }) => {
+        if (!experimentSlug) {
+          return { error: "No experiment is currently open." };
+        }
+        const experiment = await prisma.experiment.findFirst({
+          where: { projectId, slug: experimentSlug },
+        });
+        if (!experiment?.workbenchState) {
+          return {
+            error: `Experiment '${experimentSlug}' has no results yet.`,
+          };
+        }
+        const parsed = persistedEvaluationsV3StateSchema.safeParse(
+          experiment.workbenchState,
+        );
+        if (!parsed.success) {
+          return { error: "Failed to parse workbench state." };
+        }
+        const state = parsed.data;
+        let evaluatorIdFilter: string | undefined;
+        if (evaluatorSlug) {
+          const dbEval = await evaluatorService.getBySlug({
+            slug: evaluatorSlug,
+            projectId,
+          });
+          if (!dbEval) {
+            return {
+              error: `No project evaluator with slug '${evaluatorSlug}'.`,
+            };
+          }
+          const match = state.evaluators.find(
+            (e) => e.dbEvaluatorId === dbEval.id,
+          );
+          if (!match) {
+            return {
+              error: `Evaluator '${evaluatorSlug}' is not in this workbench.`,
+            };
+          }
+          evaluatorIdFilter = match.id;
+        }
+        return findFailingRows(state, {
+          evaluatorIdFilter,
+          targetIdFilter: targetId,
+          limit,
+        });
+      },
+    }),
+
     propose_create_evaluator: tool({
       description:
         "Propose creating a new evaluator in the project. The user will see a preview card and click Apply to commit. Use this when the user asks for a new evaluator that doesn't yet exist.",
@@ -337,6 +448,27 @@ app.post("/sage/chat", async (c) => {
       },
     }),
 
+    propose_run_workbench: tool({
+      description:
+        "Propose running the current experiment (kicks off all target × evaluator cells). Returns a proposal card the user clicks Apply to execute. Use this when the user asks to 'run', 'evaluate', 'execute', or 'kick off' the experiment.",
+      inputSchema: z.object({
+        rationale: z
+          .string()
+          .describe(
+            "One short sentence explaining why running now makes sense (e.g. 'all mappings look configured, ready to run').",
+          ),
+      }),
+      execute: async ({ rationale }) => {
+        return {
+          sageProposal: true,
+          kind: "workbench.run",
+          summary: "Run the evaluation on all targets and evaluators",
+          rationale,
+          payload: {},
+        };
+      },
+    }),
+
     propose_add_evaluator_to_workbench: tool({
       description:
         "Propose adding an existing project evaluator as a column in the current experiment workbench. Only works for evaluators that already exist in the project (use propose_create_evaluator first if needed).",
@@ -402,3 +534,196 @@ app.post("/sage/chat", async (c) => {
     headers: response.headers,
   });
 });
+
+type ParsedState = ReturnType<
+  typeof persistedEvaluationsV3StateSchema.parse
+>;
+
+function summarizeWorkbenchState(state: ParsedState) {
+  const datasets = state.datasets.map((d) => ({
+    id: d.id,
+    type: d.type,
+    columns: (d.columns ?? []).map((c) =>
+      typeof c === "string" ? c : (c as { name?: string }).name,
+    ),
+    ...("datasetId" in d && d.datasetId ? { datasetId: d.datasetId } : {}),
+  }));
+
+  const targets = state.targets.map((t) => {
+    const local = (t as Record<string, unknown>).localTargetConfig as
+      | { name?: string }
+      | undefined;
+    return {
+      id: t.id,
+      type: (t as { type?: string }).type,
+      name: local?.name ?? t.id,
+    };
+  });
+
+  const evaluators = state.evaluators.map((e) => ({
+    id: e.id,
+    evaluatorType: e.evaluatorType,
+    name: e.localEvaluatorConfig?.name ?? e.id,
+    dbEvaluatorId: e.dbEvaluatorId,
+  }));
+
+  const results = state.results
+    ? summarizePerTargetResults(state)
+    : null;
+
+  return {
+    experimentName: state.name,
+    activeDatasetId: state.activeDatasetId,
+    datasets,
+    targets,
+    evaluators,
+    results,
+  };
+}
+
+function summarizePerTargetResults(state: ParsedState) {
+  const results = state.results;
+  if (!results) return null;
+  const summary: Array<{
+    targetId: string;
+    rowsEvaluated: number;
+    errors: number;
+    perEvaluator: Array<{
+      evaluatorId: string;
+      evaluatorName: string;
+      passed: number;
+      failed: number;
+      processed: number;
+      error: number;
+      skipped: number;
+      pending: number;
+    }>;
+  }> = [];
+  const evaluatorNameById = Object.fromEntries(
+    state.evaluators.map((e) => [e.id, e.localEvaluatorConfig?.name ?? e.id]),
+  );
+  for (const [targetId, outputs] of Object.entries(results.targetOutputs)) {
+    const rowCount = outputs.length;
+    const targetErrors = results.errors[targetId] ?? [];
+    const errors = targetErrors.filter(Boolean).length;
+    const perEvaluator: typeof summary[number]["perEvaluator"] = [];
+    const evalResults = results.evaluatorResults[targetId] ?? {};
+    for (const [evaluatorId, cells] of Object.entries(evalResults)) {
+      const counts = {
+        passed: 0,
+        failed: 0,
+        processed: 0,
+        error: 0,
+        skipped: 0,
+        pending: 0,
+      };
+      for (let i = 0; i < rowCount; i++) {
+        const parsed = parseEvaluationResult(cells[i]);
+        if (parsed.status === "running") continue;
+        if (parsed.status in counts) {
+          counts[parsed.status as keyof typeof counts]++;
+        }
+      }
+      perEvaluator.push({
+        evaluatorId,
+        evaluatorName: evaluatorNameById[evaluatorId] ?? evaluatorId,
+        ...counts,
+      });
+    }
+    summary.push({
+      targetId,
+      rowsEvaluated: rowCount,
+      errors,
+      perEvaluator,
+    });
+  }
+  return summary;
+}
+
+function findFailingRows(
+  state: ParsedState,
+  opts: {
+    evaluatorIdFilter?: string;
+    targetIdFilter?: string;
+    limit: number;
+  },
+) {
+  const results = state.results;
+  if (!results) return { rows: [], total: 0 };
+
+  const evaluatorNameById = Object.fromEntries(
+    state.evaluators.map((e) => [e.id, e.localEvaluatorConfig?.name ?? e.id]),
+  );
+  const inlineDatasets = Object.fromEntries(
+    state.datasets
+      .filter((d) => d.type === "inline")
+      .map((d) => [d.id, d as { id: string; columns?: unknown; records?: Record<string, unknown[]> }]),
+  );
+
+  type FailingRow = {
+    targetId: string;
+    rowIndex: number;
+    inputs?: Record<string, unknown>;
+    failingEvaluators: Array<{
+      evaluatorId: string;
+      evaluatorName: string;
+      status: string;
+      details?: string;
+    }>;
+  };
+  const rows: FailingRow[] = [];
+  let total = 0;
+
+  for (const [targetId, evalResults] of Object.entries(
+    results.evaluatorResults,
+  )) {
+    if (opts.targetIdFilter && targetId !== opts.targetIdFilter) continue;
+    const rowCount = results.targetOutputs[targetId]?.length ?? 0;
+    for (let i = 0; i < rowCount; i++) {
+      const failing: FailingRow["failingEvaluators"] = [];
+      for (const [evaluatorId, cells] of Object.entries(evalResults)) {
+        if (opts.evaluatorIdFilter && evaluatorId !== opts.evaluatorIdFilter)
+          continue;
+        const parsed = parseEvaluationResult(cells[i]);
+        if (parsed.status === "failed" || parsed.status === "error") {
+          failing.push({
+            evaluatorId,
+            evaluatorName: evaluatorNameById[evaluatorId] ?? evaluatorId,
+            status: parsed.status,
+            details: parsed.details,
+          });
+        }
+      }
+      if (failing.length === 0) continue;
+      total++;
+      if (rows.length >= opts.limit) continue;
+      // Try to attach input values from an inline dataset if available
+      const inputs = extractRowInputs(inlineDatasets, i);
+      rows.push({ targetId, rowIndex: i, inputs, failingEvaluators: failing });
+    }
+  }
+
+  return { rows, total };
+}
+
+function extractRowInputs(
+  inlineDatasets: Record<
+    string,
+    { records?: Record<string, unknown[]> }
+  >,
+  rowIndex: number,
+): Record<string, unknown> | undefined {
+  for (const dataset of Object.values(inlineDatasets)) {
+    if (!dataset.records) continue;
+    const row: Record<string, unknown> = {};
+    let hasAny = false;
+    for (const [column, cells] of Object.entries(dataset.records)) {
+      if (rowIndex < cells.length) {
+        row[column] = cells[rowIndex];
+        hasAny = true;
+      }
+    }
+    if (hasAny) return row;
+  }
+  return undefined;
+}

--- a/langwatch/src/server/services/langy/LangyConversationService.ts
+++ b/langwatch/src/server/services/langy/LangyConversationService.ts
@@ -1,0 +1,262 @@
+import type { LangyConversation, PrismaClient } from "@prisma/client";
+
+export type ConversationListItem = {
+  id: string;
+  title: string | null;
+  isShared: boolean;
+  isOwn: boolean;
+  updatedAt: Date;
+  messageCount: number;
+};
+
+export class LangyConversationRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById({
+    id,
+    projectId,
+  }: {
+    id: string;
+    projectId: string;
+  }): Promise<LangyConversation | null> {
+    return await this.prisma.langyConversation.findFirst({
+      where: { id, projectId, deletedAt: null },
+    });
+  }
+
+  async findAllForUser({
+    projectId,
+    userId,
+    limit,
+  }: {
+    projectId: string;
+    userId: string;
+    limit: number;
+  }) {
+    return await this.prisma.langyConversation.findMany({
+      where: {
+        projectId,
+        deletedAt: null,
+        OR: [{ userId }, { isShared: true }],
+      },
+      orderBy: { updatedAt: "desc" },
+      take: limit,
+      include: { _count: { select: { messages: true } } },
+    });
+  }
+
+  async create({
+    projectId,
+    userId,
+    title,
+  }: {
+    projectId: string;
+    userId: string;
+    title?: string | null;
+  }): Promise<LangyConversation> {
+    return await this.prisma.langyConversation.create({
+      data: { projectId, userId, title: title ?? null },
+    });
+  }
+
+  async update({
+    id,
+    projectId,
+    data,
+  }: {
+    id: string;
+    projectId: string;
+    data: Partial<{
+      title: string | null;
+      isShared: boolean;
+      sharedAt: Date | null;
+      sharedById: string | null;
+    }>;
+  }) {
+    return await this.prisma.langyConversation.updateMany({
+      where: { id, projectId },
+      data,
+    });
+  }
+
+  async softDelete({ id, projectId }: { id: string; projectId: string }) {
+    return await this.prisma.langyConversation.updateMany({
+      where: { id, projectId, deletedAt: null },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  async softDeleteAllForUser({
+    projectId,
+    userId,
+  }: {
+    projectId: string;
+    userId: string;
+  }) {
+    return await this.prisma.langyConversation.updateMany({
+      where: { projectId, userId, deletedAt: null },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  async hardDeleteOlderThan({
+    projectId,
+    cutoff,
+  }: {
+    projectId?: string;
+    cutoff: Date;
+  }) {
+    return await this.prisma.langyConversation.deleteMany({
+      where: {
+        ...(projectId ? { projectId } : {}),
+        deletedAt: { not: null, lt: cutoff },
+      },
+    });
+  }
+
+  async touch({ id, projectId }: { id: string; projectId: string }) {
+    return await this.prisma.langyConversation.updateMany({
+      where: { id, projectId },
+      data: { updatedAt: new Date() },
+    });
+  }
+}
+
+export class LangyConversationService {
+  constructor(private readonly repository: LangyConversationRepository) {}
+
+  static create(prisma: PrismaClient): LangyConversationService {
+    return new LangyConversationService(new LangyConversationRepository(prisma));
+  }
+
+  async getById({
+    id,
+    projectId,
+    userId,
+  }: {
+    id: string;
+    projectId: string;
+    userId: string;
+  }): Promise<LangyConversation | null> {
+    const conv = await this.repository.findById({ id, projectId });
+    if (!conv) return null;
+    if (conv.userId !== userId && !conv.isShared) return null;
+    return conv;
+  }
+
+  async getAll({
+    projectId,
+    userId,
+    limit = 50,
+  }: {
+    projectId: string;
+    userId: string;
+    limit?: number;
+  }): Promise<ConversationListItem[]> {
+    const rows = await this.repository.findAllForUser({
+      projectId,
+      userId,
+      limit,
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      isShared: r.isShared,
+      isOwn: r.userId === userId,
+      updatedAt: r.updatedAt,
+      messageCount: r._count.messages,
+    }));
+  }
+
+  async ensureConversation({
+    projectId,
+    userId,
+    conversationId,
+    title,
+  }: {
+    projectId: string;
+    userId: string;
+    conversationId?: string | null;
+    title?: string | null;
+  }): Promise<LangyConversation> {
+    if (conversationId) {
+      const existing = await this.getById({
+        id: conversationId,
+        projectId,
+        userId,
+      });
+      if (existing && existing.userId === userId) return existing;
+    }
+    return await this.repository.create({ projectId, userId, title });
+  }
+
+  async deleteById({
+    id,
+    projectId,
+    userId,
+  }: {
+    id: string;
+    projectId: string;
+    userId: string;
+  }): Promise<boolean> {
+    const conv = await this.getById({ id, projectId, userId });
+    if (!conv || conv.userId !== userId) return false;
+    const result = await this.repository.softDelete({ id, projectId });
+    return result.count > 0;
+  }
+
+  async updateById({
+    id,
+    projectId,
+    userId,
+    title,
+    isShared,
+  }: {
+    id: string;
+    projectId: string;
+    userId: string;
+    title?: string | null;
+    isShared?: boolean;
+  }) {
+    const conv = await this.getById({ id, projectId, userId });
+    if (!conv || conv.userId !== userId) {
+      throw new Error("conversation not found or not owned");
+    }
+    const data: Parameters<LangyConversationRepository["update"]>[0]["data"] = {};
+    if (title !== undefined) data.title = title;
+    if (isShared !== undefined) {
+      data.isShared = isShared;
+      data.sharedAt = isShared ? new Date() : null;
+      data.sharedById = isShared ? userId : null;
+    }
+    await this.repository.update({ id, projectId, data });
+    return await this.repository.findById({ id, projectId });
+  }
+
+  async clearAllForUser({
+    projectId,
+    userId,
+  }: {
+    projectId: string;
+    userId: string;
+  }) {
+    const result = await this.repository.softDeleteAllForUser({
+      projectId,
+      userId,
+    });
+    return { deletedCount: result.count };
+  }
+
+  async hardDeleteOlderThan({
+    cutoff,
+  }: {
+    cutoff: Date;
+  }): Promise<{ deletedCount: number }> {
+    const result = await this.repository.hardDeleteOlderThan({ cutoff });
+    return { deletedCount: result.count };
+  }
+
+  async touch({ id, projectId }: { id: string; projectId: string }) {
+    await this.repository.touch({ id, projectId });
+  }
+}

--- a/langwatch/src/server/services/langy/LangyConversationService.ts
+++ b/langwatch/src/server/services/langy/LangyConversationService.ts
@@ -100,15 +100,20 @@ export class LangyConversationRepository {
   }
 
   async hardDeleteOlderThan({
-    projectId,
     cutoff,
   }: {
-    projectId?: string;
     cutoff: Date;
   }) {
+    // Multi-tenancy guard requires projectId (or projectId.in) in WHERE.
+    // Project is exempt from the guard — enumerate projects, then sweep
+    // each one's soft-deleted conversations in a batched IN clause.
+    const projects = await this.prisma.project.findMany({
+      select: { id: true },
+    });
+    if (projects.length === 0) return { count: 0 };
     return await this.prisma.langyConversation.deleteMany({
       where: {
-        ...(projectId ? { projectId } : {}),
+        projectId: { in: projects.map((p) => p.id) },
         deletedAt: { not: null, lt: cutoff },
       },
     });

--- a/langwatch/src/server/services/langy/LangyMessageService.ts
+++ b/langwatch/src/server/services/langy/LangyMessageService.ts
@@ -1,0 +1,82 @@
+import type { LangyMessage, PrismaClient } from "@prisma/client";
+
+export type MessageRole = "user" | "assistant" | "tool" | "system";
+
+export type CreateMessageInput = {
+  conversationId: string;
+  projectId: string;
+  role: MessageRole;
+  parts: unknown;
+  tokenCount?: number | null;
+};
+
+export class LangyMessageRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findAllByConversation({
+    conversationId,
+    projectId,
+  }: {
+    conversationId: string;
+    projectId: string;
+  }) {
+    return await this.prisma.langyMessage.findMany({
+      where: { conversationId, projectId },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  async create(input: CreateMessageInput): Promise<LangyMessage> {
+    return await this.prisma.langyMessage.create({
+      data: {
+        conversationId: input.conversationId,
+        projectId: input.projectId,
+        role: input.role,
+        parts: input.parts as never,
+        tokenCount: input.tokenCount ?? null,
+      },
+    });
+  }
+
+  async createMany(inputs: CreateMessageInput[]) {
+    if (inputs.length === 0) return { count: 0 };
+    return await this.prisma.langyMessage.createMany({
+      data: inputs.map((i) => ({
+        conversationId: i.conversationId,
+        projectId: i.projectId,
+        role: i.role,
+        parts: i.parts as never,
+        tokenCount: i.tokenCount ?? null,
+      })),
+    });
+  }
+}
+
+export class LangyMessageService {
+  constructor(private readonly repository: LangyMessageRepository) {}
+
+  static create(prisma: PrismaClient): LangyMessageService {
+    return new LangyMessageService(new LangyMessageRepository(prisma));
+  }
+
+  async getAllByConversation({
+    conversationId,
+    projectId,
+  }: {
+    conversationId: string;
+    projectId: string;
+  }): Promise<LangyMessage[]> {
+    return await this.repository.findAllByConversation({
+      conversationId,
+      projectId,
+    });
+  }
+
+  async append(input: CreateMessageInput): Promise<LangyMessage> {
+    return await this.repository.create(input);
+  }
+
+  async appendMany(inputs: CreateMessageInput[]) {
+    return await this.repository.createMany(inputs);
+  }
+}

--- a/langwatch/src/server/services/langy/LangyProjectMemoryService.ts
+++ b/langwatch/src/server/services/langy/LangyProjectMemoryService.ts
@@ -1,0 +1,193 @@
+import type { LangyProjectMemory, PrismaClient } from "@prisma/client";
+
+export type ChangeReason = "auto_bootstrap" | "auto_refresh" | "user_edit" | "user_refresh";
+
+export class LangyProjectMemoryRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById({ projectId }: { projectId: string }) {
+    return await this.prisma.langyProjectMemory.findFirst({
+      where: { projectId },
+    });
+  }
+
+  async upsert({
+    projectId,
+    content,
+    contentSummary,
+    lastEditorId,
+  }: {
+    projectId: string;
+    content: string;
+    contentSummary?: string | null;
+    lastEditorId?: string | null;
+  }) {
+    const existing = await this.prisma.langyProjectMemory.findFirst({
+      where: { projectId },
+    });
+    if (existing) {
+      return await this.prisma.langyProjectMemory.update({
+        where: { id: existing.id },
+        data: {
+          content,
+          contentSummary: contentSummary ?? null,
+          contentVersion: existing.contentVersion + 1,
+          refreshedAt: new Date(),
+          lastEditorId: lastEditorId ?? null,
+        },
+      });
+    }
+    return await this.prisma.langyProjectMemory.create({
+      data: {
+        projectId,
+        content,
+        contentSummary: contentSummary ?? null,
+        contentVersion: 1,
+        lastEditorId: lastEditorId ?? null,
+      },
+    });
+  }
+
+  async deleteByProjectId({ projectId }: { projectId: string }) {
+    return await this.prisma.langyProjectMemory.deleteMany({
+      where: { projectId },
+    });
+  }
+}
+
+export class LangyProjectMemoryService {
+  constructor(
+    private readonly repository: LangyProjectMemoryRepository,
+    private readonly historyService: LangyProjectMemoryHistoryService,
+  ) {}
+
+  static create(prisma: PrismaClient): LangyProjectMemoryService {
+    return new LangyProjectMemoryService(
+      new LangyProjectMemoryRepository(prisma),
+      LangyProjectMemoryHistoryService.create(prisma),
+    );
+  }
+
+  async getById({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<LangyProjectMemory | null> {
+    return await this.repository.findById({ projectId });
+  }
+
+  async writeNewVersion({
+    projectId,
+    content,
+    contentSummary,
+    changedById,
+    changeReason,
+  }: {
+    projectId: string;
+    content: string;
+    contentSummary?: string | null;
+    changedById?: string | null;
+    changeReason: ChangeReason;
+  }): Promise<LangyProjectMemory> {
+    const memory = await this.repository.upsert({
+      projectId,
+      content,
+      contentSummary,
+      lastEditorId: changedById,
+    });
+    await this.historyService.append({
+      projectMemoryId: memory.id,
+      projectId,
+      contentVersion: memory.contentVersion,
+      content,
+      changedById,
+      changeReason,
+    });
+    return memory;
+  }
+
+  async isStale({
+    projectId,
+    olderThanDays = 30,
+  }: {
+    projectId: string;
+    olderThanDays?: number;
+  }): Promise<boolean> {
+    const memory = await this.getById({ projectId });
+    if (!memory) return false;
+    const cutoff = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
+    return memory.refreshedAt.getTime() < cutoff;
+  }
+
+  async deleteByProjectId({ projectId }: { projectId: string }) {
+    await this.repository.deleteByProjectId({ projectId });
+  }
+}
+
+export class LangyProjectMemoryHistoryRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(input: {
+    projectMemoryId: string;
+    projectId: string;
+    contentVersion: number;
+    content: string;
+    changedById?: string | null;
+    changeReason?: string | null;
+  }) {
+    return await this.prisma.langyProjectMemoryHistory.create({
+      data: {
+        projectMemoryId: input.projectMemoryId,
+        projectId: input.projectId,
+        contentVersion: input.contentVersion,
+        content: input.content,
+        changedById: input.changedById ?? null,
+        changeReason: input.changeReason ?? null,
+      },
+    });
+  }
+
+  async findAll({
+    projectMemoryId,
+    projectId,
+  }: {
+    projectMemoryId: string;
+    projectId: string;
+  }) {
+    return await this.prisma.langyProjectMemoryHistory.findMany({
+      where: { projectMemoryId, projectId },
+      orderBy: { changedAt: "desc" },
+    });
+  }
+}
+
+export class LangyProjectMemoryHistoryService {
+  constructor(private readonly repository: LangyProjectMemoryHistoryRepository) {}
+
+  static create(prisma: PrismaClient): LangyProjectMemoryHistoryService {
+    return new LangyProjectMemoryHistoryService(
+      new LangyProjectMemoryHistoryRepository(prisma),
+    );
+  }
+
+  async append(input: {
+    projectMemoryId: string;
+    projectId: string;
+    contentVersion: number;
+    content: string;
+    changedById?: string | null;
+    changeReason: ChangeReason;
+  }) {
+    return await this.repository.create(input);
+  }
+
+  async getAll({
+    projectMemoryId,
+    projectId,
+  }: {
+    projectMemoryId: string;
+    projectId: string;
+  }) {
+    return await this.repository.findAll({ projectMemoryId, projectId });
+  }
+}

--- a/langwatch/src/server/services/langy/LangyProjectMemoryService.ts
+++ b/langwatch/src/server/services/langy/LangyProjectMemoryService.ts
@@ -26,8 +26,8 @@ export class LangyProjectMemoryRepository {
       where: { projectId },
     });
     if (existing) {
-      return await this.prisma.langyProjectMemory.update({
-        where: { id: existing.id },
+      await this.prisma.langyProjectMemory.updateMany({
+        where: { id: existing.id, projectId },
         data: {
           content,
           contentSummary: contentSummary ?? null,
@@ -36,6 +36,9 @@ export class LangyProjectMemoryRepository {
           lastEditorId: lastEditorId ?? null,
         },
       });
+      return (await this.prisma.langyProjectMemory.findFirst({
+        where: { projectId },
+      }))!;
     }
     return await this.prisma.langyProjectMemory.create({
       data: {

--- a/langwatch/src/server/services/langy/LangyUserPreferencesService.ts
+++ b/langwatch/src/server/services/langy/LangyUserPreferencesService.ts
@@ -1,0 +1,119 @@
+import type { LangyUserPreferences, PrismaClient } from "@prisma/client";
+
+export type LangyMode = "non_expert" | "expert";
+
+export class LangyUserPreferencesRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById({
+    userId,
+    projectId,
+  }: {
+    userId: string;
+    projectId: string;
+  }) {
+    return await this.prisma.langyUserPreferences.findFirst({
+      where: { userId, projectId },
+    });
+  }
+
+  async upsert({
+    userId,
+    projectId,
+    mode,
+    dismissedSuggestionKinds,
+  }: {
+    userId: string;
+    projectId: string;
+    mode?: LangyMode;
+    dismissedSuggestionKinds?: string[];
+  }) {
+    return await this.prisma.langyUserPreferences.upsert({
+      where: { userId_projectId: { userId, projectId } },
+      create: {
+        userId,
+        projectId,
+        mode: mode ?? "non_expert",
+        dismissedSuggestionKinds: dismissedSuggestionKinds ?? [],
+      },
+      update: {
+        ...(mode !== undefined ? { mode } : {}),
+        ...(dismissedSuggestionKinds !== undefined
+          ? { dismissedSuggestionKinds }
+          : {}),
+      },
+    });
+  }
+
+  async deleteByUserAndProject({
+    userId,
+    projectId,
+  }: {
+    userId: string;
+    projectId: string;
+  }) {
+    return await this.prisma.langyUserPreferences.deleteMany({
+      where: { userId, projectId },
+    });
+  }
+}
+
+export class LangyUserPreferencesService {
+  constructor(private readonly repository: LangyUserPreferencesRepository) {}
+
+  static create(prisma: PrismaClient): LangyUserPreferencesService {
+    return new LangyUserPreferencesService(
+      new LangyUserPreferencesRepository(prisma),
+    );
+  }
+
+  async getById({
+    userId,
+    projectId,
+  }: {
+    userId: string;
+    projectId: string;
+  }): Promise<LangyUserPreferences> {
+    const existing = await this.repository.findById({ userId, projectId });
+    if (existing) return existing;
+    return await this.repository.upsert({ userId, projectId });
+  }
+
+  async setMode({
+    userId,
+    projectId,
+    mode,
+  }: {
+    userId: string;
+    projectId: string;
+    mode: LangyMode;
+  }): Promise<LangyUserPreferences> {
+    return await this.repository.upsert({ userId, projectId, mode });
+  }
+
+  async setDismissedSuggestionKinds({
+    userId,
+    projectId,
+    kinds,
+  }: {
+    userId: string;
+    projectId: string;
+    kinds: string[];
+  }): Promise<LangyUserPreferences> {
+    return await this.repository.upsert({
+      userId,
+      projectId,
+      dismissedSuggestionKinds: kinds,
+    });
+  }
+
+  async resetForUser({
+    userId,
+    projectId,
+  }: {
+    userId: string;
+    projectId: string;
+  }) {
+    await this.repository.deleteByUserAndProject({ userId, projectId });
+  }
+}

--- a/langwatch/src/server/services/langy/LangyUserPreferencesService.ts
+++ b/langwatch/src/server/services/langy/LangyUserPreferencesService.ts
@@ -28,19 +28,32 @@ export class LangyUserPreferencesRepository {
     mode?: LangyMode;
     dismissedSuggestionKinds?: string[];
   }) {
-    return await this.prisma.langyUserPreferences.upsert({
-      where: { userId_projectId: { userId, projectId } },
-      create: {
+    // Avoid Prisma's compound-unique upsert because the multi-tenancy
+    // middleware only recognizes `projectId` (or specific compound keys)
+    // in `where`. Do an explicit find → update / create.
+    const existing = await this.prisma.langyUserPreferences.findFirst({
+      where: { userId, projectId },
+    });
+    if (existing) {
+      await this.prisma.langyUserPreferences.updateMany({
+        where: { id: existing.id, projectId },
+        data: {
+          ...(mode !== undefined ? { mode } : {}),
+          ...(dismissedSuggestionKinds !== undefined
+            ? { dismissedSuggestionKinds }
+            : {}),
+        },
+      });
+      return (await this.prisma.langyUserPreferences.findFirst({
+        where: { userId, projectId },
+      }))!;
+    }
+    return await this.prisma.langyUserPreferences.create({
+      data: {
         userId,
         projectId,
         mode: mode ?? "non_expert",
         dismissedSuggestionKinds: dismissedSuggestionKinds ?? [],
-      },
-      update: {
-        ...(mode !== undefined ? { mode } : {}),
-        ...(dismissedSuggestionKinds !== undefined
-          ? { dismissedSuggestionKinds }
-          : {}),
       },
     });
   }

--- a/langwatch/src/server/services/langy/__tests__/LangyConversationService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyConversationService.unit.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LangyConversationRepository,
+  LangyConversationService,
+} from "../LangyConversationService";
+
+function makeRepo(overrides?: Partial<LangyConversationRepository>) {
+  const repo = {
+    findById: vi.fn(),
+    findAllForUser: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    softDelete: vi.fn(),
+    softDeleteAllForUser: vi.fn(),
+    hardDeleteOlderThan: vi.fn(),
+    touch: vi.fn(),
+    ...overrides,
+  } as unknown as LangyConversationRepository;
+  return repo;
+}
+
+describe("LangyConversationService", () => {
+  describe("given a conversation owned by another user in the same project", () => {
+    describe("when getById is called by a non-owner without share", () => {
+      it("returns null to prevent cross-user leakage", async () => {
+        const repo = makeRepo({
+          findById: vi.fn().mockResolvedValue({
+            id: "c1",
+            projectId: "p1",
+            userId: "bob",
+            isShared: false,
+          }),
+        });
+        const svc = new LangyConversationService(repo);
+        const result = await svc.getById({
+          id: "c1",
+          projectId: "p1",
+          userId: "alice",
+        });
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when the conversation is shared", () => {
+      it("returns the conversation to non-owners in the same project", async () => {
+        const conv = {
+          id: "c1",
+          projectId: "p1",
+          userId: "bob",
+          isShared: true,
+        };
+        const repo = makeRepo({
+          findById: vi.fn().mockResolvedValue(conv),
+        });
+        const svc = new LangyConversationService(repo);
+        const result = await svc.getById({
+          id: "c1",
+          projectId: "p1",
+          userId: "alice",
+        });
+        expect(result).toEqual(conv);
+      });
+    });
+  });
+
+  describe("given a delete is requested by a non-owner", () => {
+    it("does not delete and returns false", async () => {
+      const repo = makeRepo({
+        findById: vi.fn().mockResolvedValue({
+          id: "c1",
+          projectId: "p1",
+          userId: "bob",
+          isShared: true,
+        }),
+        softDelete: vi.fn().mockResolvedValue({ count: 1 }),
+      });
+      const svc = new LangyConversationService(repo);
+      const result = await svc.deleteById({
+        id: "c1",
+        projectId: "p1",
+        userId: "alice",
+      });
+      expect(result).toBe(false);
+      expect(repo.softDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when ensureConversation is called with no id", () => {
+    it("creates a new conversation scoped to projectId and userId", async () => {
+      const repo = makeRepo({
+        create: vi
+          .fn()
+          .mockResolvedValue({ id: "new", projectId: "p1", userId: "alice" }),
+      });
+      const svc = new LangyConversationService(repo);
+      await svc.ensureConversation({
+        projectId: "p1",
+        userId: "alice",
+      });
+      expect(repo.create).toHaveBeenCalledWith({
+        projectId: "p1",
+        userId: "alice",
+        title: undefined,
+      });
+    });
+  });
+
+  describe("when clearAllForUser is called", () => {
+    it("soft-deletes all the user's conversations and returns the count", async () => {
+      const repo = makeRepo({
+        softDeleteAllForUser: vi.fn().mockResolvedValue({ count: 7 }),
+      });
+      const svc = new LangyConversationService(repo);
+      const result = await svc.clearAllForUser({
+        projectId: "p1",
+        userId: "alice",
+      });
+      expect(result.deletedCount).toBe(7);
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/__tests__/LangyProjectMemoryService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyProjectMemoryService.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LangyProjectMemoryHistoryService,
+  LangyProjectMemoryRepository,
+  LangyProjectMemoryService,
+} from "../LangyProjectMemoryService";
+
+function makeService() {
+  const repo = {
+    findById: vi.fn(),
+    upsert: vi.fn().mockResolvedValue({
+      id: "m1",
+      projectId: "p1",
+      content: "x",
+      contentVersion: 2,
+      refreshedAt: new Date(),
+    }),
+    deleteByProjectId: vi.fn(),
+  } as unknown as LangyProjectMemoryRepository;
+  const history = {
+    append: vi.fn(),
+    getAll: vi.fn(),
+  } as unknown as LangyProjectMemoryHistoryService;
+  return {
+    service: new LangyProjectMemoryService(repo, history),
+    repo,
+    history,
+  };
+}
+
+describe("LangyProjectMemoryService", () => {
+  describe("when writeNewVersion is called", () => {
+    it("upserts the memory and appends a history row", async () => {
+      const { service, history, repo } = makeService();
+      await service.writeNewVersion({
+        projectId: "p1",
+        content: "hello",
+        changeReason: "user_edit",
+        changedById: "u1",
+      });
+      expect(repo.upsert).toHaveBeenCalledWith({
+        projectId: "p1",
+        content: "hello",
+        contentSummary: undefined,
+        lastEditorId: "u1",
+      });
+      expect(history.append).toHaveBeenCalledWith({
+        projectMemoryId: "m1",
+        projectId: "p1",
+        contentVersion: 2,
+        content: "hello",
+        changedById: "u1",
+        changeReason: "user_edit",
+      });
+    });
+  });
+
+  describe("given a memory refreshed 31 days ago", () => {
+    describe("when isStale is checked", () => {
+      it("returns true", async () => {
+        const { service, repo } = makeService();
+        (repo.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
+          refreshedAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000),
+        });
+        expect(await service.isStale({ projectId: "p1" })).toBe(true);
+      });
+    });
+  });
+
+  describe("given no memory exists", () => {
+    it("isStale returns false", async () => {
+      const { service, repo } = makeService();
+      (repo.findById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      expect(await service.isStale({ projectId: "p1" })).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/__tests__/LangyUserPreferencesService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyUserPreferencesService.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LangyUserPreferencesRepository,
+  LangyUserPreferencesService,
+} from "../LangyUserPreferencesService";
+
+function makeService() {
+  const repo = {
+    findById: vi.fn(),
+    upsert: vi.fn(),
+    deleteByUserAndProject: vi.fn(),
+  } as unknown as LangyUserPreferencesRepository;
+  return { service: new LangyUserPreferencesService(repo), repo };
+}
+
+describe("LangyUserPreferencesService", () => {
+  describe("when getById is called for a user with no row", () => {
+    it("creates a default-mode row", async () => {
+      const { service, repo } = makeService();
+      (repo.findById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (repo.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({
+        userId: "u1",
+        projectId: "p1",
+        mode: "non_expert",
+        dismissedSuggestionKinds: [],
+      });
+      const prefs = await service.getById({ userId: "u1", projectId: "p1" });
+      expect(prefs.mode).toBe("non_expert");
+      expect(repo.upsert).toHaveBeenCalledWith({
+        userId: "u1",
+        projectId: "p1",
+      });
+    });
+  });
+
+  describe("when setMode is called", () => {
+    it("upserts the new mode", async () => {
+      const { service, repo } = makeService();
+      (repo.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({
+        userId: "u1",
+        projectId: "p1",
+        mode: "expert",
+      });
+      await service.setMode({
+        userId: "u1",
+        projectId: "p1",
+        mode: "expert",
+      });
+      expect(repo.upsert).toHaveBeenCalledWith({
+        userId: "u1",
+        projectId: "p1",
+        mode: "expert",
+      });
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/index.ts
+++ b/langwatch/src/server/services/langy/index.ts
@@ -1,0 +1,22 @@
+export {
+  LangyConversationService,
+  LangyConversationRepository,
+} from "./LangyConversationService";
+export type { ConversationListItem } from "./LangyConversationService";
+export {
+  LangyMessageService,
+  LangyMessageRepository,
+} from "./LangyMessageService";
+export type { CreateMessageInput, MessageRole } from "./LangyMessageService";
+export {
+  LangyProjectMemoryService,
+  LangyProjectMemoryRepository,
+  LangyProjectMemoryHistoryService,
+  LangyProjectMemoryHistoryRepository,
+} from "./LangyProjectMemoryService";
+export type { ChangeReason } from "./LangyProjectMemoryService";
+export {
+  LangyUserPreferencesService,
+  LangyUserPreferencesRepository,
+} from "./LangyUserPreferencesService";
+export type { LangyMode } from "./LangyUserPreferencesService";

--- a/langwatch/src/server/services/langy/toolIdValidator.ts
+++ b/langwatch/src/server/services/langy/toolIdValidator.ts
@@ -1,0 +1,46 @@
+/**
+ * Conversation-scoped ID set tracker for Langy tool calls.
+ *
+ * Tools that LIST or DETAIL entities (evaluators, prompts, datasets) record
+ * the IDs/slugs they returned. Tools that ACT on a specific id/slug check it
+ * was previously seen — preventing the LLM from referencing fabricated IDs.
+ */
+
+export type SeenIdKind =
+  | "evaluator_id"
+  | "evaluator_slug"
+  | "evaluator_type"
+  | "prompt_id"
+  | "prompt_handle"
+  | "dataset_id";
+
+export class ConversationToolIdSet {
+  private readonly seen = new Map<SeenIdKind, Set<string>>();
+
+  record(kind: SeenIdKind, id: string | undefined | null) {
+    if (!id) return;
+    let set = this.seen.get(kind);
+    if (!set) {
+      set = new Set();
+      this.seen.set(kind, set);
+    }
+    set.add(String(id));
+  }
+
+  recordMany(kind: SeenIdKind, ids: Array<string | undefined | null>) {
+    for (const id of ids) this.record(kind, id);
+  }
+
+  has(kind: SeenIdKind, id: string | undefined | null): boolean {
+    if (!id) return false;
+    return this.seen.get(kind)?.has(String(id)) ?? false;
+  }
+
+  /**
+   * Returns true if any of the kinds contain the given id.
+   * Useful for slugs/handles that may have been recorded under multiple kinds.
+   */
+  hasAny(kinds: SeenIdKind[], id: string | undefined | null): boolean {
+    return kinds.some((k) => this.has(k, id));
+  }
+}

--- a/specs/assistant/PRD.md
+++ b/specs/assistant/PRD.md
@@ -1,0 +1,493 @@
+# Langy v2 — Product Requirements Doc
+
+> Status: **Draft for alignment**
+> Owner: aryan@langwatch.ai
+> Last updated: 2026-05-06
+> Related PR: [#3211 — feat(sage): in-product AI assistant with propose-apply pattern](https://github.com/langwatch/langwatch/pull/3211)
+
+This doc defines the vision, scope, and non-goals for Langy v2. The behavioral
+contract lives in `specs/assistant/*.feature`. Implementation lives in
+`langwatch/src/components/langy/` and `langwatch/src/server/routes/langy.ts`.
+
+---
+
+## 1. Vision
+
+Langy is the AI assistant for LangWatch. Its job is to make the platform easy
+to use and easy to implement for people who are not LLM engineers. It helps
+non-technical users understand what is happening in their LLM systems, make
+the right changes safely (via propose-apply), and get nudged toward the next
+useful step.
+
+Langy is a **single-loop agent** with a curated tool surface. It is not a
+multi-agent orchestrator. It is not a general-purpose chatbot. It is a
+LangWatch-shaped colleague that knows the product cold and explains it in
+plain language.
+
+North-star reference: PostHog AI. One agent, many surfaces, streamed visibility
+into every tool call, project-level memory file, evals driven by real
+production traces (not synthetic suites).
+
+**Engineers are not the primary user of Langy.** Engineers will reach for the
+MCP server, the CLI, or Claude Code in their editor. Langy must remain useful
+to them, but is not optimized for them. Wherever a design tension emerges
+between "fast for engineers" and "approachable for non-technical users",
+Langy resolves toward the latter.
+
+---
+
+## 2. Personas
+
+| Persona | Rank | Why they use Langy |
+|---|---|---|
+| **PM / non-technical operator** | Primary | Drive LangWatch without writing code — understand traces, set up evaluators, run experiments, ship LLM features safely. Needs plain-language explanations, no jargon, no JSON. |
+| **Founder / solo dev** | Secondary | Onboarding to LangWatch for the first time, needs Langy to teach the platform as they go |
+| **LLM Ops engineer** | Tertiary | Quick spot-checks inside the product. For deep work they use the MCP server, CLI, or Claude Code in their editor — not Langy. |
+
+**Implications of putting non-technical operators first** (these flow into
+goals, tool design, and UX in later sections):
+
+- Plain-language tone: no "evaluator schema", "tool call", "tRPC mutation", "tracing span"
+- Proposal cards explain *what will change for the user* before any config detail
+- Errors are written for humans ("I couldn't find that experiment") not stack traces
+- Langy actively *teaches* LangWatch concepts as it works (a glossary tool / inline definitions)
+- Read-only safety net matters more — non-technical users are more vulnerable to bad mutations, so destructive proposals require an extra confirmation
+- Visual output beats text dumps — tables, charts, before/after diffs, not JSON
+- Engineers' workflows (MCP, CLI, Claude Code) are explicit non-goals here
+
+---
+
+## 2a. Design principles
+
+Tiebreakers when the team disagrees. Read these before any non-trivial design call.
+
+1. **Trust above all.** The minimum trust bar of the product is sacred. A bad answer
+   that looks confident is worse than no answer. A misleading chart is worse than no
+   chart. Anything that erodes trust takes precedence over speed, polish, or
+   ambition.
+2. **Plain language by default; expert mode is one toggle away.** Default to
+   explanation, confirmations, visual output. A single toggle flips Langy into
+   expert mode: terse, raw, fewer confirmations. Engineers stay in flow; non-
+   technical users stay safe.
+3. **Propose, never apply unilaterally.** Mutations always go through a proposal
+   the user must accept. Destructive proposals require an extra confirmation.
+4. **Reuse, don't rebuild.** Charts come from the existing analytics components.
+   Mutations go through existing services. Auth/permissions go through existing
+   middleware. Langy is a new surface, not a parallel platform.
+5. **Single loop, not multi-agent.** One agent keeps full context and switches
+   modes (PostHog's lesson). Sub-agents are a non-goal.
+6. **Memory must be visible and editable.** Anything Langy remembers must be
+   inspectable on a settings page with one-click delete. Hidden memory is hostile.
+7. **Dogfood with engineers.** PostHog's quality compounds because engineers use
+   their own AI daily. We do the same. Non-technical UX rises *because* technical
+   bar is met, not in spite of it.
+8. **Lenses must never lie.** When v3 ships generative views, accuracy of the
+   visualization is the gating criterion. A wrong lens kills trust faster than a
+   wrong sentence.
+
+---
+
+## 3. Current state (v1, what's on this branch)
+
+- Mounted globally on all `/[project]/*` routes via `DashboardLayout`
+- Hono route at `/api/langy/chat`, Vercel AI SDK `streamText`, hardcoded `openai/gpt-5`
+- 17 tools: read state (evaluators, prompts, datasets, workbench, failing rows) + 10 `propose_*` mutations
+- Propose-apply pattern: tool returns a `LangyProposal`; UI shows Apply/Discard; per-page handlers map to tRPC mutations
+- No conversation persistence; no project memory; no proactive suggestions
+- All queries scoped by `projectId`; `hasProjectPermission(... "evaluations:view")` gate at route entry
+- **No tests exist for the feature.** A spec was claimed to exist but does not.
+
+---
+
+## 4. Goals (v2)
+
+1. **Memory: cross-session conversation history (L3) + project knowledge file (L4).** Editable, scoped per-user-per-project.
+2. **Post-turn inline proactive suggestions.** Langy emits an optional "next step" chip at the end of each assistant turn (see §7). No background worker.
+3. **Mode toggle.** Default = non-expert (plain language, confirmations, visual). Expert = terse, raw, fewer confirmations. Destructive ops always confirm regardless of mode. Per-user preference, persisted.
+4. **Default-provider integration.** Langy uses the project's configured default LLM provider — no hardcoded fallback. If no model is configured, the route returns a clear "configure a model first" error.
+5. **OSS-included with BYO keys.** Langy ships in self-hosted LangWatch. Customers bring their own API credentials, same as the rest of the platform.
+6. **Self-observability (dogfood).** Every Langy LLM call is itself a trace in a dedicated LangWatch project. We dogfood our own observability on our own product.
+7. **Evaluation harness.** A way to replay real Langy traces and grade them. Weekly review ritual ("Traces Hour").
+8. **Tests.** Every scenario in `specs/assistant/*.feature` has a binding test.
+9. **Framework migration to Mastra** — gain sessions, memory, workflows, evals natively. Keep the 17 tools.
+10. **Hardening** — rate limit, tool-output validation, structured error surfaces.
+
+## 5. Non-goals (v2)
+
+- ❌ **Lenses / generative UI** — deferred to v3 (see §10)
+- ❌ Multi-agent orchestration / sub-agents (PostHog's lesson — single loop)
+- ❌ Episodic memory (auto-extracted "facts about the user") — defer to v3
+- ❌ Pre-injecting semantic retrieval — make it a tool the agent calls
+- ❌ Gemini/Vertex/ADK migration
+- ❌ Voice / multimodal input
+- ❌ Public API for Langy (it stays first-party)
+
+---
+
+## 6. Memory model
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  Tier  │ Description                              │ v1 │ v2 │ v3+      │
+├────────┼──────────────────────────────────────────┼────┼────┼──────────┤
+│  L1    │ Within-turn (system prompt + tool calls) │ ✅ │ ✅ │ ✅       │
+│  L2    │ Within-conversation history              │ ✅ │ ✅ │ ✅       │
+│  L3    │ Cross-session history (per user/project) │ ❌ │ ✅ │ ✅       │
+│  L4    │ Project knowledge file (editable)        │ ❌ │ ✅ │ ✅       │
+│  L5    │ Episodic memory (auto-extracted facts)   │ ❌ │ ❌ │ explore  │
+│  L6    │ Semantic retrieval (lazy, tool-driven)   │ ❌ │ ✅ │ ✅       │
+│  L7    │ Per-project vector embeddings            │ ❌ │ ❌ │ deferred │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### L3 — cross-session conversation history
+
+- Persist `(projectId, userId, conversationId, messages, createdAt, updatedAt)`
+- **Scoped per-user** — one user's chats are never visible to another user, even
+  in the same project. We may relax to per-team in v3+; for v2 we do not mix.
+- **Opt-in "share this conversation with the team"** per-conversation toggle —
+  when on, makes a single conversation visible to other members of the project.
+  Off by default. Sharing a conversation is logged (audit trail).
+- New chat by default; "Recent" list opens a picker (your own + any explicitly
+  shared with you).
+- Conversations are soft-deletable; hard-delete after 90 days of no activity
+  (configurable).
+- Stored in Postgres alongside other project data (no new infra).
+
+### L4 — project knowledge file
+
+- One file per project: `LangyProjectMemory`
+- **Auto-generated as a background job at project-creation time.** By the time
+  the user first opens Langy, the file is already there. No visible "let me
+  learn about this project" UX. The magic is in showing up prepared.
+- Initial generation reads project state (evaluators, prompts, sample traces if
+  any) and produces a thin starter doc. It improves as data accumulates.
+- **Refresh** happens on user request (button in settings) or when the file is
+  older than 30 days (non-blocking banner offers refresh). User-initiated
+  refresh **streams** the regeneration — the user sees Langy compose the new
+  doc in real time, builds trust.
+- Auto-bootstrap is **silent** (no streaming UI). User-initiated refresh is
+  **streaming** (visible composition).
+- **Always editable** in a settings page — the user is the source of truth.
+  Markdown editor.
+- Always injected into the system prompt. Token budget cap: **≤2k tokens for v2**.
+  If longer, summarized on read with a cheap model; user always sees the full
+  file in settings.
+- **Cap revisit trigger:** raise to 4k if (a) median project memory regularly
+  exceeds 80% of the 2k cap, or (b) users repeatedly ask Langy to remember
+  things that won't fit. Revisit decision at v2.5.
+
+### L6 — semantic retrieval (lazy)
+
+- New tools: `search_traces`, `search_prompts`, `search_past_runs`
+- Backed by existing Postgres + ClickHouse data via filtered queries
+- Agent decides when to call. Do not pre-inject.
+
+### L7 — per-project vector embeddings (NOT YET IMPLEMENTED, future)
+
+> **Status: deferred. Captured here so we don't paint v2 into a corner.**
+
+A future version of Langy may store **per-project vector embeddings** over
+project artifacts (traces, prompts, evaluators, datasets, conversations) so
+that semantic similarity search becomes a real tool rather than a keyword
+filter. This unlocks:
+
+- "Find traces that look like this failing one" (true semantic similarity)
+- "Recall what this user asked about last quarter" (episodic memory L5)
+- "Compare projects" (cross-project retrieval, with consent)
+
+Why deferred:
+- Adds infra (pgvector, Weaviate, Qdrant, or similar)
+- Embedding model choice and chunking strategy are real engineering work
+- Quality bar must be earned (a wrong vector match is a confidence trap)
+- Current data scale doesn't yet justify it
+
+Pre-conditions for re-evaluation:
+- L4 project memory regularly exceeds 4k tokens
+- Users start asking time-spanning recall questions ("what did I tell you 3
+  months ago about X?")
+- We have the eng bandwidth to support a new infra component
+
+When we ship this, the design will be: per-project (one namespace per
+projectId), with multitenancy enforced at query time, and never crossing
+projects unless an explicit cross-project consent exists. Spec to be written
+in a follow-up PRD.
+
+### Memory budget rule
+
+Pinned (system prompt + L4) + recalled (tool results) ≤ 15% of context.
+If exceeded, summarize before injecting.
+
+### Privacy & safety
+
+- Settings page: "What Langy remembers about this project"
+- One-click clear (per-conversation, per-project, per-user)
+- L3/L4 never crosses project or organization boundaries
+- All memory writes pass through the same permission middleware as the rest of the app
+
+---
+
+## 7. Proactive suggestions (post-turn inline)
+
+**Architecture:** suggestions are produced **inline by the chat agent at the
+end of each assistant turn**. There is no separate cron worker, no background
+loop, no "suggestions" table. The agent emits a structured "next step" block
+as the last part of its response.
+
+**Why this is the right shape:**
+- The agent already has full context (the question, the answer, the project
+  memory) — it is the best-positioned thing in the system to know what's next.
+- No new infra. No drift between agent's view and worker's view.
+- Cheaper: one LLM call produces both answer and suggestion.
+- Smarter: suggestions are conversational, not generic ("you said X, so try Y"
+  rather than a templated nudge).
+
+**Output shape:**
+
+After answering, Langy may emit zero or one suggestion of the form:
+
+```json
+{
+  "kind": "suggestion",
+  "label": "Add a hallucination evaluator",
+  "rationale": "3 rows in this experiment look like fabrications.",
+  "actionKind": "open_proposal" | "open_url" | "ask_followup",
+  "payload": { ... }
+}
+```
+
+**UI:** rendered as a single dismissible chip beneath the assistant message.
+Click → triggers the action. Dismiss → records the kind in
+`LangyUserPreferences.dismissedSuggestionKinds`.
+
+**Rules:**
+- Zero or one per turn (never two)
+- Suggestions are *suggestions*, not commands — clicking one does not
+  auto-apply, it opens the relevant proposal or page
+- Dismissible, with "don't show this kind again" memory
+- The agent is instructed (via system prompt) to skip suggestions when:
+  - The conversation is in active troubleshooting (don't interrupt)
+  - The previous turn already resulted in an applied proposal
+  - The user explicitly said "stop suggesting things"
+
+**Out of scope (deferred):** page-context proactive nudges that fire without
+a user message ("you opened the workbench and 3 rows are failing — want help?").
+That would require a different trigger (page view) and re-introduces a
+worker-shaped problem. Revisit in v3 alongside lenses if signal demands it.
+
+---
+
+## 8. Architecture & framework
+
+### Decision: Mastra, not Google ADK
+
+- ADK-JS is real but Google-flavored; most value (Vertex Agent Engine, Cloud Trace, A2UI) is GCP-locked. We deploy to our own K8s.
+- ADK-Python adds a TS↔Python boundary for features Mastra has natively in TS.
+- Mastra: TS-native, sessions/memory/evals/workflows on top of the same Vercel AI SDK primitives we already use.
+
+### Target topology
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Browser (Next.js)                                               │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  LangyContext + LangySidebar                               │ │
+│  │  - chat UI, proposal cards, stop button                    │ │
+│  │  - per-page proposal handlers                              │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                          │ POST /api/langy/chat (SSE)            │
+└──────────────────────────┼───────────────────────────────────────┘
+                           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  langwatch (Hono route in Next.js)                               │
+│  - auth + projectId + permissions guard                          │
+│  - delegate to Mastra agent                                      │
+└──────────────────────────┬───────────────────────────────────────┘
+                           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Mastra agent: "langy"                                           │
+│  - tools (17 → grow over time)                                   │
+│  - memory: Postgres-backed sessions + project memory file        │
+│  - evals harness (replay traces)                                 │
+└──────────────────────────┬───────────────────────────────────────┘
+                           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Provider via getVercelAIModel(projectId, model)                 │
+│  - default: project-configured model, fallback openai/gpt-5      │
+└──────────────────────────────────────────────────────────────────┘
+
+(separate process, cron-driven)
+┌──────────────────────────────────────────────────────────────────┐
+│  langy-suggestions worker                                        │
+│  - per-project tick: scan recent state → produce 0-1 suggestion  │
+│  - writes to Postgres; UI polls or subscribes                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+K8s deployment is a *milestone*, not a v2 requirement. The Mastra agent runs
+in-process inside the Next.js app for v2; we extract it to its own service
+when (a) we need it scaled independently, or (b) it gets in the way of the
+main app's deploy cadence.
+
+---
+
+## 8a. Lenses (v3 — captured here so the v2 design does not paint us into a corner)
+
+A **lens** is an ephemeral, agent-rendered view of LangWatch data tailored to the
+current question. Langy uses *existing* LangWatch analytics components (charts,
+tables, trace lists) and assembles them as a one-shot view inside the chat.
+
+### Examples
+
+| Lens | Trigger | What renders |
+|---|---|---|
+| Trace lens | "Show failing traces last hour" | Filtered trace list + summary stats |
+| Evaluator preview | "If I added this evaluator, what would my last 100 traces look like?" | Side-by-side: current vs hypothetical |
+| Comparison | "Compare prompt v2 vs v3" | Diff + metric deltas |
+| Cohort | "Show me Stripe's traces from this week" | Filtered slice |
+| Health | "Is anything breaking right now?" | Langy picks the relevant charts itself |
+
+### Rendering rules
+
+- Lenses render **inside the chat panel**. The chat expands horizontally to fit
+  the lens; the conversation stays visible above. The user can scroll back to
+  prior messages without losing the lens.
+- Lenses **reuse existing analytics components** — no parallel chart system.
+- Lenses are **ephemeral by default** (they vanish when the conversation is closed).
+- "Pin this lens" is an explicit one-click action that saves the lens.
+
+### Save model — open question for v3
+
+Two options, decision deferred:
+
+- **(a) Per-section pinned lenses** — lens saved to the section it relates to
+  (experiments has its own pinned lenses, evaluations has its own, traces has
+  its own). Matches existing "saved view" patterns. Discoverable in context.
+  *Recommended.*
+- **(b) Global Lenses page** — separate top-level area for pinned lenses.
+  Simpler conceptually, but adds a new navigation primitive and divorces the
+  lens from where it's useful.
+
+### What lenses are NOT
+
+- Not workspaces. A lens answers one question.
+- Not mutations. A lens shows; it never changes data.
+- Not infinite. A lens has a token / row budget. If the slice is too big, Langy
+  asks the user to narrow it.
+
+### Why deferred
+
+Lenses are generative UI. That is materially harder than chat: every lens type
+is a new surface, accuracy of the visualization is the trust bar, and bad
+lenses kill trust faster than bad sentences. We earn the right to ship lenses
+by getting memory and proactive suggestions solid first.
+
+---
+
+## 9. Safety & multitenancy
+
+- Every tool reads/writes through the existing service layer (no direct Prisma in tools)
+- `projectId` filter on every query (CLAUDE.md rule, enforced)
+- Tool output validation: if the agent passes back an evaluator ID it didn't receive from a `list_*` tool in this conversation, reject
+- Rate limit per (userId, projectId): N messages per minute, M tool calls per message (`stepCountIs(8)` already exists; pair with a Redis counter)
+- Destructive proposals (delete, archive) require an explicit confirmation step in the UI — already in place via `destructive: true` flag
+
+---
+
+## 10. Evaluation strategy
+
+- Every Langy conversation is a trace in LangWatch (dogfood)
+- Weekly **Traces Hour**: 30 min reviewing 10 random conversations from the past week, tag failure modes
+- Failure modes feed back as scenarios in `specs/assistant/*.feature`
+- Synthetic evals are nice-to-have, not the primary signal (PostHog's lesson)
+
+---
+
+## 11. Phasing
+
+### v2
+
+**Phase 1 — Foundations (test what already exists)**
+- Write `.feature` files for the v1 baseline behavior ✅ (done in this PRD round)
+- Bind tests to baseline scenarios; CI green
+- No new behavior
+
+**Phase 2 — Memory**
+- L3 cross-session conversation history (UI + storage)
+- L4 project memory file (init flow + edit page + injection)
+- Settings page for "what Langy remembers" with one-click delete
+- Lazy semantic retrieval tools (search_traces, search_prompts, search_past_runs)
+
+**Phase 3 — Mode toggle + hardening**
+- Per-user expert/non-expert preference
+- Tone + confirmation rules per mode
+- Rate limits, model-per-project, tool-output validation
+
+**Phase 4 — Mastra migration**
+- Move agent loop into Mastra
+- Reuse memory primitives from Mastra where they fit
+- Keep all 17 tools intact
+
+**Phase 5 — Post-turn inline suggestions**
+- System-prompt instruction to emit zero-or-one suggestion at end of turn
+- UI: dismissible chip beneath each assistant message
+- Dismissal memory in `LangyUserPreferences.dismissedSuggestionKinds`
+- (No worker, no cron — entirely inside the chat loop)
+
+**Phase 6 — Eval harness**
+- Trace replay
+- Traces Hour ritual
+
+### v3
+
+**Phase 7 — Lenses (generative UI)**
+- Inline rendering inside expanding chat panel
+- Reuse existing analytics components
+- Pin/save model (per-section vs global — decide at start of v3)
+- Trust gate: accuracy benchmarks before public ship
+
+**Phase 8 — Episodic memory** (only if v2 memory is solid and there's signal it's needed)
+
+K8s extraction of the agent loop: only when justified by independent scaling
+needs or deploy-cadence friction. Not before.
+
+---
+
+## 12. Open questions (need your input)
+
+All v2-scope questions are answered. Captured in §13.
+
+Decisions made through this PRD discussion:
+- ~~Vision framing~~ → "AI assistant for LangWatch", PM-first with expert toggle
+- ~~Lenses scope~~ → v3, render in-chat with expanding panel, reuse analytics
+- ~~Mode toggle~~ → yes, v2; destructive ops confirm regardless of mode
+- ~~Dogfood approach~~ → engineers first (PostHog model)
+- ~~Buyer profile~~ → mix of all three; Langy must demo well to all
+- ~~Per-user vs per-project memory~~ → per-user, with opt-in conversation share
+- ~~L4 size cap~~ → 2k for v2; revisit trigger documented in §6
+- ~~Default model~~ → project's configured default; clear error if none
+- ~~Proactive suggestion shape~~ → post-turn inline, no worker
+- ~~OSS / self-hosted~~ → included, BYO API keys
+- ~~Self-observability~~ → yes, dogfood Langy on Langy
+
+---
+
+## 13. Non-decisions captured (for posterity)
+
+- We considered Google ADK and rejected it — see §8
+- We considered LangGraph-JS and deferred — only revisit if we need durable resumable branching workflows
+- We considered episodic (L5) memory and deferred to v3
+- We considered making Langy multi-agent and rejected — single loop, switch_mode-style scaling
+- We considered lenses for v2 and deferred to v3 — memory + proactive must be solid first
+- We considered global "Lenses" navigation and lean toward per-section pinned lenses (decision deferred to v3 kickoff)
+- We considered building Langy primarily for engineers and rejected — engineers use MCP/CLI/Claude Code; Langy targets non-technical operators with an expert-mode escape hatch
+
+---
+
+## 14. References
+
+- PostHog AI architecture: https://posthog.com/handbook/engineering/ai/architecture
+- PostHog: 8 learnings from 1 year of agents: https://posthog.com/blog/8-learnings-from-1-year-of-agents-posthog-ai
+- PostHog: building AI features: https://posthog.com/newsletter/building-ai-features
+- Google ADK: https://adk.dev/
+- Mastra: https://mastra.ai

--- a/specs/assistant/README.md
+++ b/specs/assistant/README.md
@@ -1,0 +1,64 @@
+# Langy — assistant specs
+
+The full specification for **Langy**, LangWatch's in-product AI assistant.
+
+> If you only have 5 minutes, read [`PRD.md`](./PRD.md) §1, §2, §2a, §4.
+
+## Document map
+
+| Doc | What it answers | Read when |
+|---|---|---|
+| [`PRD.md`](./PRD.md) | Why Langy exists, who it's for, what v2 ships, what we're explicitly NOT building, design principles | First. Always. |
+| [`memory-design.md`](./memory-design.md) | How memory is built — schema, data flow, multitenancy, retention, GDPR, threat model | When working on memory or answering a privacy/security question |
+| [`architecture.md`](./architecture.md) | How the pieces fit — sequence diagrams, API contracts, component boundaries, state | When designing or implementing a Langy change |
+| [`implementation-plan.md`](./implementation-plan.md) | What we build, in what order, broken into PR-sized chunks | When picking up work for a Langy phase |
+| [`langy-baseline.feature`](./langy-baseline.feature) | Behavior contract for the v1 already on this branch | Before any v2 work — we test what exists first |
+| [`langy-memory.feature`](./langy-memory.feature) | Behavior contract for L3 + L4 + L6 memory | When implementing or testing memory |
+| [`langy-proactive.feature`](./langy-proactive.feature) | Behavior contract for post-turn suggestions | When implementing or testing suggestions |
+
+## How to use this doc set
+
+1. **Read the PRD first.** Everything else assumes you've internalized the
+   vision, principles, and non-goals.
+2. **`.feature` files are the requirements.** Per LangWatch convention, tests
+   bind to scenarios. Edit them carefully.
+3. **The other markdown docs are reference**, not specifications. They explain
+   *how* — implementation may diverge if a better design appears, but the
+   `.feature` files and the PRD are the contract.
+4. **Decisions go in PRD §13 (non-decisions captured) and the relevant doc's
+   decision log** — not in chat or commit messages. If a decision isn't in the
+   docs, it doesn't exist.
+5. **Open questions live at the bottom of each doc.** Don't sprinkle "TBD" in
+   the body — hoist it to the open-questions section so it's visible.
+
+## Conventions
+
+- Markdown for prose, tables, diagrams (mermaid)
+- Gherkin for behavior contracts (`.feature` files)
+- File names are kebab-case; section numbers stable once published
+- Decision logs at the bottom of each doc, dated, with rationale
+- Last-updated stamps at the top of every doc — keep them current
+
+## Where the code lives
+
+| Surface | Path |
+|---|---|
+| Chat UI | `langwatch/src/components/langy/` |
+| Chat route | `langwatch/src/server/routes/langy.ts` |
+| (Future) memory service | `langwatch/src/server/services/langy/` |
+| Layout integration | `langwatch/src/components/DashboardLayout.tsx` |
+| Tests | `langwatch/src/server/routes/__tests__/langy.*.test.ts` (and component tests under `langwatch/src/components/langy/__tests__/`) |
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **Langy** | The in-product AI assistant for LangWatch. (Was called "Sage" earlier on this branch.) |
+| **Lens** | An ephemeral, agent-rendered view of LangWatch data inside the chat panel. v3 feature. |
+| **Proposal** | A change Langy suggests (create/update/delete). User must click Apply for it to take effect. |
+| **L1–L7** | The seven memory tiers, defined in `memory-design.md` §2 and PRD §6. |
+| **Project memory (L4)** | The editable markdown doc that summarizes a project; always injected into the system prompt. |
+| **Mode toggle** | Per-user preference between non-expert (default, plain language) and expert (terse, raw). |
+| **Bootstrap** | The auto-generation of project memory when a project is created. Silent. |
+| **Refresh** | User-initiated regeneration of project memory. Streamed visibly. |
+| **Post-turn suggestion** | A "next step" chip Langy may emit at the end of any assistant response. |

--- a/specs/assistant/architecture.md
+++ b/specs/assistant/architecture.md
@@ -1,0 +1,416 @@
+# Langy architecture — deep spec
+
+> Companion to `PRD.md` and `memory-design.md`. The PRD says *what*. The memory
+> doc says *how memory is stored*. This doc says *how the pieces fit and
+> communicate*.
+>
+> Status: **Draft for review.**
+> Last updated: 2026-05-06
+
+## 1. Topology
+
+```mermaid
+flowchart TD
+  subgraph Browser
+    UI[LangySidebar React]
+    Ctx[LangyContext provider]
+    Layout[DashboardLayout]
+    Layout --> Ctx --> UI
+  end
+
+  subgraph NextJSApp[Next.js app]
+    direction TB
+    Hono[Hono routes /api/langy/*]
+    SvcConv[LangyConversationService]
+    SvcMem[LangyProjectMemoryService]
+    SvcPref[LangyUserPreferencesService]
+    Agent[Agent runtime: Vercel AI SDK in v2 → Mastra in v2.5]
+    Tools[Langy tool registry — 17 tools]
+    Hono --> SvcConv
+    Hono --> SvcMem
+    Hono --> SvcPref
+    Hono --> Agent
+    Agent --> Tools
+    Tools --> SvcEval[(EvaluatorService)]
+    Tools --> SvcPrompt[(PromptService)]
+    Tools --> SvcDataset[(DatasetService)]
+    Tools --> SvcWorkbench[(WorkbenchService)]
+    Tools --> SvcSearch[search_traces / search_prompts / search_past_runs]
+  end
+
+  subgraph Storage
+    PG[(Postgres)]
+    CH[(ClickHouse)]
+  end
+
+  subgraph External
+    LLM[LLM provider — project's configured default]
+  end
+
+  UI -- POST /api/langy/chat SSE --> Hono
+  SvcConv --> PG
+  SvcMem --> PG
+  SvcPref --> PG
+  SvcEval --> PG
+  SvcPrompt --> PG
+  SvcDataset --> PG
+  SvcWorkbench --> PG
+  SvcSearch --> CH
+  Agent <--> LLM
+
+  subgraph Bootstrap[Project-creation hook]
+    Hook[Project created]
+    Worker[bootstrapLangyProjectMemory job]
+    Hook --> Worker --> SvcMem
+    Worker -. summary LLM call .-> LLM
+  end
+
+  subgraph Observability
+    SelfTrace[LangWatch dogfood project]
+  end
+  Agent -. emits trace .-> SelfTrace
+```
+
+## 2. Component boundaries
+
+| Component | Responsibility | Does NOT do |
+|---|---|---|
+| **LangySidebar / LangyContext** | Render chat, propagate page-level proposal handlers, manage local UI state | Tool execution, persistence, routing |
+| **Hono routes** | Auth, permissions, rate limiting, request → service → response orchestration | Business logic, direct Prisma calls |
+| **Services** (`Langy*Service`) | All read/write to Langy tables; multitenancy enforcement; transaction boundaries | HTTP, streaming |
+| **Agent runtime** | LLM call, streaming, tool dispatch, message assembly | Persistence (it calls services for that) |
+| **Tools** | Domain operations — list evaluators, propose changes, search | Cross-cutting concerns (auth, logging — those are in the route layer) |
+| **Bootstrap worker** | Generate project memory at project creation | Anything user-facing |
+
+The CLAUDE.md rule applies: **routes call services, never repositories;
+services call repositories, never each other directly without crossing
+boundaries cleanly.**
+
+## 3. API contracts
+
+### 3.1 Chat
+
+```
+POST /api/langy/chat
+Content-Type: application/json
+
+Request body:
+{
+  "conversationId": string | null,    // null → create a new conversation
+  "messages": UIMessage[],            // Vercel AI SDK shape
+  "projectId": string,
+  "experimentSlug": string | null,    // optional page context
+  "userMode": "non_expert" | "expert" // from LangyUserPreferences, sent for visibility
+}
+
+Response: SSE stream (Vercel AI SDK toUIMessageStreamResponse)
+
+Errors:
+- 401 Unauthorized — no session
+- 403 Forbidden — missing project permission
+- 409 Conflict — no model configured for project ("configure a model first")
+- 429 Too Many Requests — rate limit exceeded
+- 500 Internal Server Error — model call failed
+```
+
+### 3.2 Conversation listing
+
+```
+GET /api/langy/conversations?projectId=...&limit=50&cursor=...
+
+Response:
+{
+  "conversations": [
+    {
+      "id": string,
+      "title": string,
+      "isShared": boolean,
+      "isOwn": boolean,
+      "updatedAt": string (ISO),
+      "messageCount": number
+    }
+  ],
+  "nextCursor": string | null
+}
+```
+
+### 3.3 Conversation detail
+
+```
+GET /api/langy/conversations/:id?projectId=...
+
+403 if not owner and not shared.
+
+Response:
+{
+  "conversation": LangyConversation,
+  "messages": LangyMessage[]
+}
+```
+
+### 3.4 Conversation mutations
+
+```
+POST   /api/langy/conversations           // create (usually called implicitly by /chat)
+DELETE /api/langy/conversations/:id       // soft delete
+PATCH  /api/langy/conversations/:id       // toggle isShared, edit title
+```
+
+### 3.5 Project memory
+
+```
+GET   /api/langy/project-memory?projectId=...
+PUT   /api/langy/project-memory           // user edit
+POST  /api/langy/project-memory/refresh   // streaming SSE — user-initiated refresh
+```
+
+### 3.6 User preferences
+
+```
+GET /api/langy/preferences?projectId=...
+PUT /api/langy/preferences                // mode toggle, dismissed kinds
+```
+
+## 4. Sequence diagrams
+
+### 4.1 Send a message (turn lifecycle)
+
+```mermaid
+sequenceDiagram
+  participant U as User (browser)
+  participant H as Hono route
+  participant S as Services
+  participant A as Agent runtime
+  participant T as Tools
+  participant L as LLM provider
+  participant DB as Postgres
+
+  U->>H: POST /api/langy/chat (SSE)
+  H->>H: auth + permission + rate limit
+  H->>S: ensureConversation(projectId, userId, conversationId?)
+  S->>DB: insert/load LangyConversation
+  S-->>H: conversationId
+  H->>S: persistUserMessage(...)
+  S->>DB: insert LangyMessage(role=user)
+  H->>S: loadProjectMemory(projectId)
+  S->>DB: select LangyProjectMemory
+  H->>S: loadUserPrefs(userId, projectId)
+  H->>A: streamChat({ system, memory, prefs, messages })
+  A->>L: streamText(...)
+  L-->>A: token stream
+  loop tool calls
+    A->>T: execute tool
+    T->>S: domain query/proposal
+    S->>DB: read
+    T-->>A: tool result
+    A->>L: continue with result
+    L-->>A: more tokens
+  end
+  A-->>H: stream chunks
+  H-->>U: SSE chunks
+  A->>S: persistAssistantMessage(parts) on stream end
+  S->>DB: insert LangyMessage(role=assistant) + tool messages
+  A-->>L: emit Langy trace to dogfood project (async)
+```
+
+### 4.2 Project memory bootstrap (project creation)
+
+```mermaid
+sequenceDiagram
+  participant Sys as Project lifecycle hook
+  participant W as bootstrapLangyProjectMemory worker
+  participant S as Services
+  participant L as LLM (gpt-5-mini)
+  participant DB as Postgres
+
+  Sys->>W: enqueue(projectId)
+  W->>S: gatherProjectState(projectId)
+  S->>DB: list evaluators, prompts, sample 50 traces
+  S-->>W: snapshot
+  W->>L: summarize(snapshot, bootstrapPrompt)
+  L-->>W: markdown summary
+  W->>W: enforce 2k token cap
+  W->>S: createProjectMemory(projectId, content, "auto_bootstrap")
+  S->>DB: insert LangyProjectMemory + history row
+```
+
+### 4.3 Project memory refresh (user-initiated, streaming)
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant H as Hono route
+  participant S as Services
+  participant L as LLM
+  participant DB as Postgres
+
+  U->>H: POST /api/langy/project-memory/refresh
+  H->>H: auth + project:admin permission
+  H->>S: gatherProjectState(projectId)
+  S->>DB: snapshot
+  H->>L: streamText(refreshPrompt, snapshot)
+  loop streaming
+    L-->>H: tokens
+    H-->>U: SSE chunks (user watches doc compose)
+  end
+  H->>S: appendVersion(projectMemoryId, content, "user_refresh")
+  S->>DB: insert LangyProjectMemoryHistory + update LangyProjectMemory
+  H-->>U: stream end (final doc)
+```
+
+### 4.4 Apply a proposal
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant UI as LangySidebar
+  participant H as Hono route (existing tRPC mutation)
+  participant S as Domain service (Evaluator/Prompt/Dataset)
+  participant DB as Postgres
+
+  U->>UI: click Apply on proposal card
+  UI->>UI: lookup handler in proposalHandlers[kind]
+  UI->>H: tRPC mutation (createEvaluator / updatePrompt / etc.)
+  H->>H: auth + projectId + permission
+  H->>S: domain operation
+  S->>DB: write
+  S-->>H: result
+  H-->>UI: success or error
+  UI->>UI: transition card to "Applied" state with link
+```
+
+## 5. State machines
+
+### 5.1 Conversation states
+
+```
+┌─────────┐  user opens new chat  ┌────────┐  user closes/leaves  ┌──────────┐
+│ none    │ ────────────────────► │ active │ ────────────────────►│ inactive │
+└─────────┘                       └────────┘                       └──────────┘
+                                       │ user deletes
+                                       ▼
+                                  ┌─────────┐  90 days   ┌──────────┐
+                                  │ deleted │ ─────────► │ purged   │
+                                  └─────────┘            └──────────┘
+```
+
+### 5.2 Project memory states
+
+```
+┌──────────┐  project created     ┌──────────────┐  user edits       ┌────────┐
+│ none     │ ───────────────────► │ bootstrapped │ ────────────────► │ edited │
+└──────────┘                      └──────┬───────┘                   └────┬───┘
+                                         │ 30 days                        │
+                                         ▼                                ▼
+                                    ┌─────────┐  user clicks refresh  ┌──────────┐
+                                    │ stale   │ ────────────────────► │refreshed │
+                                    └─────────┘                       └──────────┘
+```
+
+### 5.3 Proposal lifecycle (existing v1, captured for completeness)
+
+```
+emitted by tool → proposed → (apply) → applying → applied
+                       │
+                       └─→ (discard) → discarded
+```
+
+## 6. Multitenancy enforcement (the three layers)
+
+| Layer | What enforces | Where |
+|---|---|---|
+| 1. Permission middleware | `hasProjectPermission(userId, projectId, capability)` returns 403 if missing | All `/api/langy/*` routes |
+| 2. Service layer guard | Every Prisma query includes `projectId` in WHERE | `Langy*Service` methods |
+| 3. Authorization at read | For per-user data: `userId` match OR `isShared` flag | `LangyConversationService.findById` |
+
+Anti-patterns blocked at code-review:
+- Routes calling Prisma directly
+- Services with methods that take only `id` (no `projectId`)
+- Frontend accepting raw IDs without going through the service layer
+
+## 7. Token budgeting per turn
+
+```
+┌───────────────────────────────────────────────────────────┐
+│  CONTEXT WINDOW (model-dependent, e.g. 128k-1M)           │
+│  ┌─────────────────────────────────────────────────────┐ │
+│  │ System prompt (identity + rules)        ~2k tokens  │ │  pinned
+│  │ Project memory (L4, summarized to cap)  ≤2k tokens  │ │  pinned
+│  │ User preferences (mode, etc.)           ~50 tokens  │ │  pinned
+│  ├─────────────────────────────────────────────────────┤ │
+│  │ Conversation history (sliding window)   variable    │ │  managed
+│  │   - if total budget exceeded:                       │ │
+│  │   - oldest 50% summarized into a [summary] block    │ │
+│  │   - replaced inline                                 │ │
+│  ├─────────────────────────────────────────────────────┤ │
+│  │ Tool results (current turn only, never persisted)   │ │  ephemeral
+│  ├─────────────────────────────────────────────────────┤ │
+│  │ Assistant response (output)                         │ │  output
+│  └─────────────────────────────────────────────────────┘ │
+└───────────────────────────────────────────────────────────┘
+
+Pinned + managed ≤ 80% of model window. Output reserve ≥ 20%.
+If pinned alone > 15% of window: log warning, alert engineering.
+```
+
+## 8. Observability
+
+Every Langy LLM call emits a LangWatch trace into the **dogfood project**
+(separate dedicated project for Langy's own observability). Trace fields:
+
+- `langy.conversation_id`
+- `langy.user_id` (hashed)
+- `langy.project_id` (hashed)
+- `langy.user_mode` (`non_expert` | `expert`)
+- `langy.injected_memory_tokens`
+- `langy.tools_called` (list)
+- `langy.suggestion_kind` (if emitted)
+- `langy.error` (if any)
+
+This is the foundation of the Traces Hour ritual. We dogfood our own product
+on our own product.
+
+## 9. Failure handling
+
+| Failure | What the user sees | What happens |
+|---|---|---|
+| LLM provider 5xx | "Langy is having trouble — try again" | Trace logged with error; retry once with exponential backoff |
+| Tool throws | Tool call result includes `error` field; LLM is told it failed and decides what to do | Logged; rate-limited if same tool fails repeatedly in a turn |
+| Apply mutation fails | Proposal card shows error toast; card stays in "Proposed" state | User can retry or edit |
+| Bootstrap worker fails | Project memory remains absent; first chat triggers a silent retry; if it fails twice, surfaces a settings banner | Logged with the error; ops alert |
+| Conversation persistence fails | User sees a warning that "this conversation may not be saved" | Stream continues; we attempt to persist on retry |
+| No model configured | 409 with structured error: "configure a model first" | UI redirects to model settings page |
+
+## 10. Testing strategy
+
+| Layer | What we test | Where |
+|---|---|---|
+| Component (UI) | LangySidebar opens, proposal cards render, dismissal works | `langwatch/src/components/langy/__tests__/*.integration.test.tsx` |
+| Route | Auth, permissions, rate limit, request/response shape | `langwatch/src/server/routes/__tests__/langy.*.test.ts` |
+| Service | Multitenancy enforcement, deletion semantics, retention | `langwatch/src/server/services/langy/__tests__/*.unit.test.ts` |
+| Tool | Each tool's input/output shape; project isolation | Service-layer tests (tools are thin wrappers) |
+| BDD | All scenarios in `*.feature` are bound to passing tests | Vitest + scenario binding |
+| Eval (Traces Hour) | Real conversation traces graded weekly | Dogfood project |
+
+## 11. Open architecture questions
+
+1. **Where does the agent runtime live?** v2 = in-process inside Next.js. v2.5
+   = Mastra in-process. v3 = consider extracting to a Hono service if the
+   deploy cadence of the main app starts conflicting with Langy iteration speed.
+2. **Streaming protocol.** Stick with Vercel AI SDK's UI message stream. When
+   migrating to Mastra, ensure compatibility (Mastra builds on the same primitives).
+3. **Pgvector?** Defer to v3 (L7 in PRD §6). Architecture above is unchanged
+   when added — it would slot into the search tools.
+4. **Rate-limit scope.** Per-user-per-project? Per-org? Both? Default proposal:
+   per-user-per-project, with an org-level burst cap.
+
+## 12. Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-06 | In-process Next.js for v2; revisit extraction at v3 | Avoid premature service split; deploy cadence is fine for now |
+| 2026-05-06 | Mastra over Google ADK and LangGraph-JS | TS-native, lightest migration, no GCP lock-in |
+| 2026-05-06 | Bootstrap as a background job, not lazy-on-first-open | "Magic of being prepared" UX outweighs eager-job complexity |
+| 2026-05-06 | Streaming for user-initiated refresh, silent for auto-bootstrap | Streaming where the user is watching; silent where they aren't |
+| 2026-05-06 | Suggestions inline in chat turn, no worker | Smarter and lighter than cron; agent has full context already |
+| 2026-05-06 | Self-observability via dedicated dogfood project | Dogfood is our primary eval signal |

--- a/specs/assistant/implementation-plan.md
+++ b/specs/assistant/implementation-plan.md
@@ -1,0 +1,336 @@
+# Langy v2 — implementation plan
+
+> Companion to `PRD.md`, `memory-design.md`, `architecture.md`.
+> The PRD says *what*. The architecture says *how it fits*.
+> This doc says *what we build, in what order, in what PR*.
+>
+> Status: **Draft for review.**
+> Last updated: 2026-05-06
+
+## How to read this doc
+
+Each phase below is a vertical slice of work. Inside each phase, **PRs are
+ordered**: do PR-N before PR-N+1 within the phase. Across phases, you can
+parallelize where dependencies don't bind.
+
+For each PR:
+- **Goal** — what is true after this merges
+- **Files** — the concrete touch list
+- **Tests** — what must pass (binds to `.feature` scenarios where applicable)
+- **Verification** — how you know it works (manual + automated)
+- **Risks** — what could go wrong; mitigations
+
+A PR is too big if it can't be reviewed in 30 minutes. Split it.
+
+---
+
+## Phase 0 — Cleanup & alignment (1 PR, ~half a day)
+
+**Goal:** the branch is named, the spec is canonical, the v1 code is unchanged
+but understood. We are ready to test what already exists.
+
+### PR-0.1: Spec alignment + dead-code audit
+
+- **Files:**
+  - `specs/assistant/*` (already drafted in this session — review and merge)
+  - `langwatch/src/components/langy/*` — note any TODOs/unused exports
+  - `langwatch/src/server/routes/langy.ts` — confirm tool surface vs PRD §3
+
+- **Outcome:** PRD and `.feature` files are merged on a feature branch off
+  `feat/sage-assistant`. No code changes yet.
+
+- **Verification:** spec docs render correctly on GitHub; team review on PRD.
+
+---
+
+## Phase 1 — Foundations: test what exists (3 PRs, ~3-5 days)
+
+**Goal:** every scenario in `langy-baseline.feature` has a passing test.
+This is the regression net before we change anything.
+
+### PR-1.1: Test infra for Langy
+
+- **Goal:** test scaffolding exists (factories, helpers, fixtures).
+- **Files:**
+  - `langwatch/src/server/routes/__tests__/langy.test-utils.ts` — request helpers
+  - `langwatch/src/components/langy/__tests__/test-utils.tsx` — render helpers, mocked LangyContext
+  - Test fixtures for fake project + evaluators + prompts
+- **Tests:** none yet (this is infra)
+- **Verification:** `pnpm test:unit` runs the (empty) Langy test suite without errors.
+
+### PR-1.2: Bind unit/integration tests to baseline scenarios
+
+- **Goal:** `langy-baseline.feature` scenarios pass.
+- **Files:**
+  - `langwatch/src/server/routes/__tests__/langy.chat.integration.test.ts` — auth, permission gate, project isolation, tool call surface
+  - `langwatch/src/components/langy/__tests__/LangySidebar.integration.test.tsx` — open/close, proposal card render, Apply/Discard
+  - `langwatch/src/components/langy/__tests__/ProposalCard.integration.test.tsx` — destructive variant, Applied state
+- **Tests:** every `langy-baseline.feature` scenario bound
+- **Verification:** `pnpm test:integration` green; spec coverage = 100%.
+- **Risks:** existing v1 code may not be testable as-is (e.g., hardcoded model). Mitigation: add minimal seams (env override for model in tests) without changing prod behavior.
+
+### PR-1.3: Self-observability scaffolding
+
+- **Goal:** every Langy LLM call emits a trace to a dogfood project.
+- **Files:**
+  - `langwatch/src/server/routes/langy.ts` — wrap streamText with trace export
+  - `langwatch/src/server/observability/langy-tracer.ts` — new helper
+  - Config: dogfood project ID and API key in env
+- **Tests:** unit test that asserts a trace is emitted on a happy-path call
+- **Verification:** local run shows a Langy trace in the dogfood project.
+
+---
+
+## Phase 2 — Memory (5 PRs, ~2 weeks)
+
+**Goal:** L3 (cross-session history), L4 (project memory), and L6 (lazy
+retrieval) all working end-to-end. `langy-memory.feature` scenarios pass.
+
+### PR-2.1: Schema + migrations
+
+- **Goal:** the four tables exist in dev and migrations are reviewed.
+- **Files:**
+  - `langwatch/prisma/schema.prisma` — add `LangyConversation`, `LangyMessage`, `LangyProjectMemory`, `LangyProjectMemoryHistory`, `LangyUserPreferences`
+  - `langwatch/prisma/migrations/<timestamp>_langy_memory/migration.sql`
+- **Tests:** schema-level — Prisma client compiles; multitenancy middleware enforces `projectId` on Langy models.
+- **Verification:** `pnpm start:prepare:files` regenerates types; CI green.
+- **Risks:** schema drift if someone changes during review. Mitigation: rebase often.
+
+### PR-2.2: LangyConversationService + LangyMessageService + tests
+
+- **Goal:** create/list/load/delete conversations and messages, with multitenancy enforced.
+- **Files:**
+  - `langwatch/src/server/services/langy/LangyConversationService.ts`
+  - `langwatch/src/server/services/langy/LangyMessageService.ts`
+  - `langwatch/src/server/services/langy/index.ts`
+  - Unit tests under `__tests__/`
+- **Tests:** binds `langy-memory.feature` scenarios:
+  - "Conversation history is scoped per user within a project"
+  - "Conversation history never crosses projects"
+  - "Delete a conversation"
+  - "Idle conversations are hard-deleted after 90 days" (cron unit-tested in 2.5)
+- **Verification:** unit tests green.
+
+### PR-2.3: Conversation routes + UI integration
+
+- **Goal:** Langy chat persists messages and supports a Recent list.
+- **Files:**
+  - `langwatch/src/server/routes/langy.ts` — wire chat to `LangyConversationService` + `LangyMessageService`
+  - `langwatch/src/server/routes/langy-conversations.ts` — new GET/PATCH/DELETE routes
+  - `langwatch/src/components/langy/RecentConversations.tsx` — new
+  - `langwatch/src/components/langy/LangySidebar.tsx` — wire Recent panel
+- **Tests:** binds:
+  - "Conversation history persists across page reloads"
+  - "Start a new conversation"
+  - "View recent conversations"
+- **Verification:** manual: send messages, reload, verify persistence; run `pnpm test:integration`.
+
+### PR-2.4: LangyProjectMemoryService + bootstrap worker
+
+- **Goal:** project memory bootstraps automatically when a project is created.
+- **Files:**
+  - `langwatch/src/server/services/langy/LangyProjectMemoryService.ts`
+  - `langwatch/src/server/workers/bootstrapLangyProjectMemory.ts`
+  - Hook into project-creation flow (find existing hook in `langwatch/src/server/services/projects/...`)
+  - System-prompt update in `langwatch/src/server/routes/langy.ts` to inject project memory
+- **Tests:** binds:
+  - "First-time project memory init"
+  - "Project memory is injected into every conversation"
+  - "Project memory token budget is enforced"
+- **Verification:** create a fresh project; within 30s, `LangyProjectMemory` row exists; first chat shows Langy already knowing the project.
+- **Risks:** worker fails silently. Mitigation: ops alert on bootstrap failure; fallback re-attempt on first chat open.
+
+### PR-2.5: Project memory edit + refresh + settings UI
+
+- **Goal:** users can view, edit, and refresh project memory.
+- **Files:**
+  - `langwatch/src/server/routes/langy-project-memory.ts` — GET, PUT, POST refresh (SSE streaming)
+  - `langwatch/src/pages/[project]/settings/langy.tsx` — new settings page
+  - Markdown editor component (reuse existing if present, otherwise add a simple one)
+- **Tests:** binds:
+  - "Edit project memory"
+  - "Stale project memory prompts a refresh"
+  - "View what Langy remembers about me in this project"
+  - "Clear all my Langy memory in this project"
+- **Verification:** manual end-to-end on the settings page.
+
+### PR-2.6: Lazy retrieval tools (L6)
+
+- **Goal:** `search_traces`, `search_prompts`, `search_past_runs` exist and work.
+- **Files:**
+  - `langwatch/src/server/routes/langy.ts` — register three new tools
+  - Backed by existing services (TraceService, PromptService, etc.) with new search methods if not present
+- **Tests:** binds:
+  - "Langy retrieves traces via tool, not pre-injection"
+- **Verification:** ask Langy "find traces with hallucinations"; tool is called; tool result feeds the answer.
+
+---
+
+## Phase 3 — Mode toggle + hardening (3 PRs, ~1 week)
+
+**Goal:** non-expert/expert toggle works; rate-limit + tool-output validation in place.
+
+### PR-3.1: User preferences
+
+- **Goal:** `LangyUserPreferences` row managed; mode toggle in UI.
+- **Files:**
+  - `LangyUserPreferencesService` + tests
+  - `langwatch/src/server/routes/langy-preferences.ts`
+  - `LangySidebar` toggle UI
+  - System prompt in chat route reads `mode` and adjusts tone rules
+- **Tests:**
+  - mode persists across sessions
+  - mode flips system-prompt instructions
+- **Verification:** toggle expert mode; Langy responses get tighter; refresh page; mode persists.
+
+### PR-3.2: Rate limiting
+
+- **Goal:** per-user-per-project rate limit; per-message tool-call cap.
+- **Files:**
+  - `langwatch/src/server/middleware/rate-limit-langy.ts` — new
+  - Wire into `/api/langy/chat`
+  - Use existing Redis if present
+- **Tests:** rate-limit unit + integration; ensure 429 with structured error.
+- **Verification:** flood the route, get throttled.
+
+### PR-3.3: Tool-output validation + structured errors
+
+- **Goal:** the agent cannot reference IDs it didn't receive from a `list_*` tool in this conversation; routes return structured errors.
+- **Files:**
+  - `langwatch/src/server/routes/langy.ts` — wrap tool registration with a validator
+  - Conversation-scoped ID set tracked in agent state
+- **Tests:**
+  - tool with hallucinated ID → graceful error result, not crash
+  - structured error envelope on all 4xx/5xx
+- **Verification:** intentional hallucinated ID test passes.
+
+---
+
+## Phase 4 — Mastra migration (3 PRs, ~1.5 weeks)
+
+**Goal:** the agent loop is owned by Mastra; tools and memory plumbing reuse v2 services.
+
+### PR-4.1: Mastra spike behind a feature flag
+
+- **Goal:** Mastra runs the agent for a small % of internal users; A/B against Vercel AI SDK path.
+- **Files:**
+  - `langwatch/package.json` — add Mastra
+  - `langwatch/src/server/services/langy/mastra-agent.ts` — new agent definition with the 17 tools
+  - Feature flag wired into `/api/langy/chat`
+- **Tests:** Mastra path emits the same SSE shape as the legacy path; integration test parity.
+- **Verification:** flag flip; engineers dogfood for a week.
+- **Risks:** Mastra version compatibility / SSE protocol drift. Mitigation: pin Mastra version; feature-flag rollback.
+
+### PR-4.2: Memory primitives via Mastra
+
+- **Goal:** Mastra session/memory abstractions back the L3/L4 reads (still persisting to our Postgres tables via service-layer adapters).
+- **Files:** `mastra-agent.ts` updated; adapter functions to bridge Mastra memory ↔ `LangyConversationService` / `LangyProjectMemoryService`.
+- **Tests:** parity with PR-2 tests on the Mastra path.
+- **Verification:** flag-flipped users see no behavioral change.
+
+### PR-4.3: Cut over + remove legacy path
+
+- **Goal:** Mastra is the only path. Delete the Vercel AI SDK direct usage.
+- **Files:** remove legacy code in `langy.ts`; flag retired.
+- **Tests:** all existing tests still pass.
+- **Verification:** internal soak; then customer rollout.
+
+---
+
+## Phase 5 — Post-turn inline suggestions (2 PRs, ~3-4 days)
+
+**Goal:** Langy emits a one-chip suggestion at the end of relevant turns.
+
+### PR-5.1: System-prompt instruction + structured output
+
+- **Goal:** Langy emits an optional structured `suggestion` part at the end of a response.
+- **Files:**
+  - System prompt update in `langy.ts` (or Mastra agent)
+  - Output validator that ensures at most one suggestion of valid kind
+  - Suggestion type defined in shared types
+- **Tests:**
+  - "Langy emits at most one suggestion per turn"
+  - "Suggestion is part of the same turn, not a follow-up"
+  - "No suggestion when the previous turn applied a proposal"
+- **Verification:** drive Langy through a few flows; observe suggestions appearing where expected.
+
+### PR-5.2: UI rendering + dismissal
+
+- **Goal:** suggestion chips render below assistant messages; Apply/Dismiss/Don't-show-again work.
+- **Files:**
+  - `langwatch/src/components/langy/SuggestionChip.tsx` — new
+  - `LangySidebar.tsx` — render chip below assistant messages
+  - `LangyUserPreferencesService` — wire `dismissedSuggestionKinds`
+- **Tests:**
+  - "Click suggestion to act"
+  - "Dismiss a suggestion"
+  - "Don't show this kind again"
+- **Verification:** manual; suggestions appear, dismissals stick.
+
+---
+
+## Phase 6 — Eval harness + Traces Hour ritual (2 PRs, ~1 week)
+
+**Goal:** real Langy traces can be replayed and graded; weekly ritual runs.
+
+### PR-6.1: Trace replay
+
+- **Goal:** an internal tool that takes a stored Langy conversation and re-runs it against the current agent.
+- **Files:**
+  - `langwatch/src/server/services/langy/replay.ts` — new
+  - CLI script under `langwatch/scripts/langy-replay.ts`
+- **Tests:** unit test on the replay function.
+- **Verification:** run the script on a known conversation; output diff.
+
+### PR-6.2: Traces Hour dashboard
+
+- **Goal:** internal page surfacing 10 random recent Langy conversations for review.
+- **Files:**
+  - `langwatch/src/pages/_internal/langy-traces-hour.tsx`
+  - Sampling logic in `LangyConversationService`
+- **Tests:** sampling is deterministic per seed.
+- **Verification:** team uses it weekly; failure modes captured as new `.feature` scenarios.
+
+---
+
+## Cross-cutting work
+
+These don't fit neatly in a phase but happen alongside:
+
+- **Audit logging** — wire each mutation to the existing audit-log infra (start in PR-2.2; complete by PR-2.5).
+- **Backup/restore drill** — run a deletion + restore drill once memory is live; verify hard-delete propagates within 30 days.
+- **Docs** — update `dev/docs/` with a Langy section linking to `specs/assistant/`.
+- **CHANGELOG** — every Langy phase entry merged.
+
+## Estimated total
+
+≈ **6-8 weeks** for all of v2 if one engineer is full-time on it. Roughly:
+- Phase 0+1: 1 week
+- Phase 2: 2 weeks
+- Phase 3: 1 week
+- Phase 4: 1.5 weeks
+- Phase 5: 0.5 week
+- Phase 6: 1 week
+- Slack/review/integration: 0.5-1 week
+
+If two engineers work on it, Phase 4 (Mastra migration) blocks parallelism
+because everything funnels through the agent runtime.
+
+## Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-06 | Test the v1 baseline before any new behavior | Regression net beats clever new code |
+| 2026-05-06 | Mastra migration in Phase 4 (after memory ships on the existing path) | Don't migrate runtime and add features simultaneously |
+| 2026-05-06 | Bootstrap as a project-creation hook, not lazy first-open | UX magic of being prepared |
+| 2026-05-06 | Phase 5 is post-turn only; no worker | Architectural simplification |
+| 2026-05-06 | Phase 6 dogfood ritual is shipped as a real feature | Eval signal compounds; only happens if it's a feature, not a calendar reminder |
+
+## Open questions
+
+1. Who does the design pass on the Recent conversations UI and the settings
+   page? Worth pairing with a designer before PR-2.3.
+2. Is there an existing project-creation hook (Phase 2.4 dependency)? If not,
+   that becomes a sub-task within PR-2.4.
+3. Can we get internal usage on Mastra via a flag for at least 2 weeks before
+   cutover? Affects Phase 4 timeline.

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -1,0 +1,115 @@
+@unimplemented
+Feature: Langy in-product AI assistant — baseline (v1)
+  As a user of LangWatch
+  I want an in-product AI assistant that can read project state and propose changes
+  So that I can operate my LLM systems without leaving the product
+
+  # Behavioral contract for the v1 baseline that already exists on this branch.
+  # Tests should bind to these scenarios before any new behavior is added.
+
+  Background:
+    Given I am authenticated
+    And I have access to project "demo"
+
+  # ============================================================================
+  # Mounting and visibility
+  # ============================================================================
+
+  Scenario: Langy is available on every project page
+    When I navigate to any "/[project]/*" route in project "demo"
+    Then the Langy handle is visible
+    And Langy is not visible on public or ops routes
+
+  Scenario: Open Langy from the handle
+    Given Langy is closed
+    When I click the Langy handle
+    Then the Langy panel opens docked on the right
+    And the page content shifts left to make room
+
+  Scenario: Close Langy by clicking outside
+    Given the Langy panel is open
+    When I click outside the panel
+    Then the panel closes
+    And page content returns to full width
+
+  # ============================================================================
+  # Project isolation
+  # ============================================================================
+
+  Scenario: Tool calls are scoped to the active project
+    Given I am viewing project "demo"
+    When Langy lists evaluators
+    Then it returns only evaluators belonging to "demo"
+    And no evaluator from another project is included
+
+  Scenario: Permission gate at chat entry
+    Given I do not have "evaluations:view" permission for project "demo"
+    When I send a message to Langy in project "demo"
+    Then the request is rejected with a 403
+
+  # ============================================================================
+  # Read-only tools (information retrieval)
+  # ============================================================================
+
+  Scenario: Ask Langy what evaluators exist
+    Given evaluators "RagFaithfulness" and "Toxicity" exist in "demo"
+    When I ask "what evaluators are configured?"
+    Then Langy lists "RagFaithfulness" and "Toxicity"
+    And Langy does not fabricate evaluator names
+
+  Scenario: Ask Langy why rows are failing
+    Given experiment "exp1" has 3 rows failing the "Toxicity" evaluator
+    When I ask Langy "which rows are failing and why?"
+    Then Langy returns the 3 rows with the failing evaluator named
+
+  # ============================================================================
+  # Propose-apply pattern
+  # ============================================================================
+
+  Scenario: Propose creating an evaluator without applying it
+    When I ask Langy "suggest an evaluator for hallucinations"
+    Then Langy proposes a new evaluator
+    And the proposal is shown as a card with "Apply" and "Discard" buttons
+    And no evaluator is created until I click "Apply"
+
+  Scenario: Apply a proposed evaluator
+    Given Langy has proposed creating evaluator "Hallucination v1"
+    When I click "Apply"
+    Then evaluator "Hallucination v1" is created in "demo"
+    And the proposal card transitions to "Applied" state
+    And the card shows a link to open the new evaluator
+
+  Scenario: Discard a proposal
+    Given Langy has proposed creating evaluator "X"
+    When I click "Discard"
+    Then no evaluator is created
+    And the proposal is dismissed
+
+  Scenario: Destructive proposals are visually distinct
+    When Langy proposes archiving an evaluator
+    Then the proposal card is rendered with the destructive variant
+    And the action requires explicit confirmation before applying
+
+  # ============================================================================
+  # Streaming and cancellation
+  # ============================================================================
+
+  Scenario: Stream responses token by token
+    When I send a message
+    Then Langy renders tokens as they arrive
+    And tool calls are visible as they execute
+
+  Scenario: Stop an in-flight generation
+    Given Langy is generating a response
+    When I click "Stop"
+    Then generation halts
+    And the partial response is preserved
+
+  # ============================================================================
+  # Read-only boundary (v1)
+  # ============================================================================
+
+  Scenario: Langy never mutates data without a proposal
+    When Langy decides an evaluator should change
+    Then it must call a "propose_*" tool
+    And it must not directly call a mutation

--- a/specs/assistant/langy-memory.feature
+++ b/specs/assistant/langy-memory.feature
@@ -1,0 +1,124 @@
+@unimplemented
+Feature: Langy memory
+  As a user of LangWatch
+  I want Langy to remember relevant context across conversations
+  So that I do not have to re-explain my project every time I open it
+
+  # See specs/assistant/PRD.md §6 for the memory tier model.
+  # In-scope here: L3 (cross-session conversation history) and L4 (project memory file).
+  # Out of scope: L5 (episodic auto-extracted facts).
+
+  Background:
+    Given I am authenticated as "alice@example.com"
+    And I have access to project "demo"
+
+  # ============================================================================
+  # L3 — cross-session conversation history
+  # ============================================================================
+
+  Scenario: Conversation history persists across page reloads
+    Given I have an open Langy conversation with 5 messages
+    When I reload the page
+    Then the same conversation reopens with all 5 messages
+
+  Scenario: Start a new conversation
+    Given I have an existing Langy conversation
+    When I click "New chat"
+    Then a fresh conversation is opened with no prior messages
+    And the previous conversation remains in my recent list
+
+  Scenario: View recent conversations
+    Given I have 3 prior Langy conversations in project "demo"
+    When I open the recent list
+    Then I see the 3 conversations ordered by last activity
+
+  Scenario: Conversation history is scoped per user within a project
+    Given user "bob@example.com" has Langy conversations in project "demo"
+    And I am authenticated as "alice@example.com" in project "demo"
+    When I open my recent list
+    Then I see only my own conversations
+    And Bob's conversations are not visible
+
+  Scenario: Conversation history never crosses projects
+    Given I have Langy conversations in project "demo"
+    When I switch to project "other"
+    Then my "demo" conversations are not visible in "other"
+
+  Scenario: Delete a conversation
+    Given I have a Langy conversation
+    When I delete it
+    Then it no longer appears in my recent list
+    And its messages are no longer used as context for future conversations
+
+  Scenario: Idle conversations are hard-deleted after 90 days
+    Given a conversation has had no activity for 91 days
+    When the retention sweep runs
+    Then the conversation and its messages are permanently removed
+
+  # ============================================================================
+  # L4 — project memory file
+  # ============================================================================
+
+  Scenario: First-time project memory init
+    Given project "demo" has no Langy project memory
+    When I open Langy for the first time in "demo"
+    Then Langy offers to initialize project memory
+    When I accept and answer the onboarding questions
+    Then a project memory file is created
+    And it summarizes the project's evaluators, prompts, and main concerns
+
+  Scenario: Project memory is injected into every conversation
+    Given project "demo" has a project memory file
+    When I send a new message in any Langy conversation in "demo"
+    Then the project memory is included in the system context
+    And Langy answers consistently with that memory
+
+  Scenario: Edit project memory
+    Given project "demo" has a project memory file
+    When I open the project memory settings page
+    Then I can read and edit the memory text
+    When I save my edits
+    Then subsequent conversations use the edited memory
+
+  Scenario: Stale project memory prompts a refresh
+    Given project "demo"'s memory file is older than 30 days
+    When I open Langy
+    Then a non-blocking banner offers to refresh project memory
+
+  Scenario: Project memory token budget is enforced
+    Given project "demo"'s memory file would exceed 2k tokens
+    When the memory is injected
+    Then it is summarized to fit the 2k cap
+    And the user can see the summarized version
+
+  Scenario: Project memory does not cross project boundaries
+    Given project "demo" has a project memory file
+    When I open Langy in project "other"
+    Then "demo"'s memory is not used
+
+  # ============================================================================
+  # Privacy controls
+  # ============================================================================
+
+  Scenario: View what Langy remembers about me in this project
+    When I open the Langy memory settings page
+    Then I see my conversation history
+    And I see the project memory file
+    And I have one-click delete for each
+
+  Scenario: Clear all my memory in this project
+    Given I have conversations and contributed to the project memory
+    When I click "Clear my Langy memory"
+    Then my conversations are deleted
+    And my contributions to project memory are removed
+    And the project memory file remains for other users
+
+  # ============================================================================
+  # Lazy semantic retrieval (L6)
+  # ============================================================================
+
+  Scenario: Langy retrieves traces via tool, not pre-injection
+    When I ask Langy "find traces with hallucinations"
+    Then Langy calls the search_traces tool
+    And the tool result is included only for that turn
+    And the system prompt does not pre-include trace data

--- a/specs/assistant/langy-proactive.feature
+++ b/specs/assistant/langy-proactive.feature
@@ -1,0 +1,109 @@
+@unimplemented
+Feature: Langy post-turn inline suggestions
+  As a user of LangWatch
+  I want Langy to suggest a useful next step after answering my question
+  So that I am nudged toward valuable actions without losing momentum
+
+  # See specs/assistant/PRD.md §7.
+  # Suggestions are produced INLINE by the chat agent at the end of each
+  # assistant turn. There is no separate cron worker. The agent emits zero or
+  # one structured "next step" block alongside its response.
+
+  Background:
+    Given I am authenticated
+    And I have access to project "demo"
+
+  # ============================================================================
+  # Production rules
+  # ============================================================================
+
+  Scenario: Langy emits at most one suggestion per turn
+    When I send a message and Langy responds
+    Then the response contains zero or one suggestion
+    And it never contains two or more
+
+  Scenario: Suggestion is part of the same turn, not a follow-up
+    When Langy responds with a suggestion
+    Then the suggestion arrives in the same streamed response as the answer
+    And no second LLM call is made to produce it
+
+  # ============================================================================
+  # Display rules
+  # ============================================================================
+
+  Scenario: Suggestion renders as a dismissible chip below the assistant message
+    Given Langy emitted a suggestion
+    Then the chip is visible beneath the assistant message
+    And the chip shows a label and a short rationale
+
+  Scenario: Click suggestion to act
+    Given a suggestion of kind "open_proposal" is visible
+    When I click it
+    Then the relevant proposal flow opens
+    And no mutation has occurred yet
+
+  Scenario: Click suggestion of kind open_url
+    Given a suggestion of kind "open_url" is visible
+    When I click it
+    Then I am navigated to the suggested page in the same project
+
+  Scenario: Click suggestion of kind ask_followup
+    Given a suggestion of kind "ask_followup" is visible
+    When I click it
+    Then the suggested follow-up question is sent as my next message
+
+  Scenario: Dismiss a suggestion
+    Given a suggestion is visible
+    When I click "Dismiss"
+    Then the chip is hidden
+    And the assistant message remains
+
+  Scenario: "Don't show this kind again"
+    Given a suggestion of kind "rerun-stale-experiment" is visible
+    When I click "Don't show this kind again"
+    Then the kind is appended to my LangyUserPreferences.dismissedSuggestionKinds
+    And no future turn produces a suggestion of this kind for me in this project
+    Until I re-enable it from settings
+
+  # ============================================================================
+  # Suppression rules (when Langy SHOULD NOT suggest anything)
+  # ============================================================================
+
+  Scenario: No suggestion when the previous turn applied a proposal
+    Given my previous turn applied a proposal
+    When I send a follow-up message
+    Then Langy's response contains no suggestion
+    # Reason: avoid suggestion fatigue immediately after the user just acted.
+
+  Scenario: No suggestion when actively troubleshooting
+    Given the conversation contains a stack trace or explicit error from the user
+    When Langy responds
+    Then no suggestion is emitted
+    # Reason: don't interrupt diagnosis with a nudge.
+
+  Scenario: User asks Langy to stop suggesting
+    When I tell Langy "stop suggesting things"
+    Then no further suggestions are emitted in this conversation
+    And this preference persists for the remainder of the conversation
+
+  Scenario: Dismissed kinds do not reappear
+    Given I have dismissed kind "rerun-stale-experiment"
+    When Langy would otherwise emit a suggestion of that kind
+    Then it emits no suggestion in that turn
+
+  # ============================================================================
+  # Privacy and safety
+  # ============================================================================
+
+  Scenario: Suggestions never auto-apply
+    Given any suggestion is visible
+    Then no mutation has occurred
+    And clicking the suggestion opens a flow that requires explicit user action
+
+  Scenario: Suggestions never reference data from another project
+    Given I am working in project "demo"
+    Then no suggestion references entities from project "other"
+
+  Scenario: Suggestions never reference another user's private conversation
+    Given another user "bob" has a private conversation in project "demo"
+    Then no suggestion in my conversation references content from bob's chat

--- a/specs/assistant/memory-design.md
+++ b/specs/assistant/memory-design.md
@@ -1,0 +1,508 @@
+# Langy memory — technical design, safety, and GDPR
+
+> Companion doc to `specs/assistant/PRD.md`. The PRD says *what* memory does
+> and which tiers ship. This doc says *how* it is built, *where* the data
+> lives, *who* can see it, and *how* we satisfy GDPR and similar regimes.
+>
+> Status: **Draft for review.** No code written yet.
+> Owner: aryan@langwatch.ai
+> Last updated: 2026-05-06
+
+## 1. Why this doc exists
+
+Memory is the most privacy-sensitive thing Langy does. Conversations may
+contain PII (customer names, email addresses, internal data). Project memory
+records the user's stated goals and pain points. Both are durable and both
+will eventually be subject to subject-access requests, deletion requests, and
+audits. Getting the data model and the controls right *before* writing code
+is cheaper than retrofitting them later.
+
+This doc is the source of truth for: schema, data flow, multitenancy
+enforcement, deletion semantics, retention, GDPR rights, and threat model.
+
+## 2. Scope
+
+In scope:
+- L3 (cross-session conversation history)
+- L4 (project memory file)
+- L6 (lazy semantic retrieval — tool-only, no persistence beyond what already exists)
+
+Not in scope here (covered in PRD §6):
+- L1, L2 (in-turn / in-conversation, ephemeral, no special storage)
+- L5 (episodic auto-extracted facts) — deferred
+- L7 (per-project vector embeddings) — deferred; see future-design section §11
+
+---
+
+## 3. Data model (Prisma)
+
+```prisma
+// One row per Langy conversation.
+model LangyConversation {
+  id              String    @id @default(cuid())
+  projectId       String                              // multitenancy guard
+  userId          String                              // owner of this conversation
+  title           String?                             // auto-generated from first user message
+  isShared        Boolean   @default(false)           // opt-in team-share toggle
+  sharedAt        DateTime?                           // null when unshared
+  sharedById      String?                             // userId who shared (audit)
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  deletedAt       DateTime?                           // soft delete; cron hard-deletes after 90d
+
+  messages        LangyMessage[]
+
+  @@index([projectId, userId, updatedAt])
+  @@index([projectId, isShared, updatedAt])           // for "shared with me" queries
+  @@index([deletedAt])                                // for retention cron
+}
+
+// One row per message in a conversation.
+model LangyMessage {
+  id              String    @id @default(cuid())
+  conversationId  String
+  projectId       String                              // denormalized for fast multitenancy filtering
+  role            String                              // "user" | "assistant" | "tool"
+  parts           Json                                // Vercel AI SDK message parts
+  tokenCount      Int?                                // for budget enforcement
+  createdAt       DateTime  @default(now())
+
+  conversation    LangyConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+
+  @@index([conversationId, createdAt])
+  @@index([projectId])
+}
+
+// One row per project.
+model LangyProjectMemory {
+  id              String    @id @default(cuid())
+  projectId       String    @unique
+  content         String    @db.Text                  // markdown, full version
+  contentSummary  String?   @db.Text                  // summarized for injection if content > 2k tokens
+  contentVersion  Int       @default(1)
+  generatedAt     DateTime  @default(now())
+  refreshedAt     DateTime  @default(now())           // last regenerate or edit
+  lastEditorId    String?                             // null if auto-generated, else userId
+
+  history         LangyProjectMemoryHistory[]
+
+  @@index([projectId])
+}
+
+// Append-only history for project memory edits — supports diff view + audit + rollback.
+model LangyProjectMemoryHistory {
+  id              String    @id @default(cuid())
+  projectMemoryId String
+  contentVersion  Int
+  content         String    @db.Text
+  changedById     String?                             // null if system-generated
+  changeReason    String?                             // "auto_bootstrap" | "auto_refresh" | "user_edit"
+  changedAt       DateTime  @default(now())
+
+  projectMemory   LangyProjectMemory @relation(fields: [projectMemoryId], references: [id], onDelete: Cascade)
+
+  @@index([projectMemoryId, changedAt])
+}
+
+// Per-user-per-project preferences.
+model LangyUserPreferences {
+  id              String    @id @default(cuid())
+  userId          String
+  projectId       String
+  mode            String    @default("non_expert")    // "non_expert" | "expert"
+  dismissedSuggestionKinds String[]                   // for proactive suggestions
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@unique([userId, projectId])
+}
+```
+
+### Choices and why
+
+| Choice | Reason |
+|---|---|
+| Postgres, not Redis or vector store | Memory is small, structured, durable, queryable. Postgres matches the rest of LangWatch. |
+| `projectId` denormalized on `LangyMessage` | Saves a join on every multitenancy check. Matches existing LangWatch convention. |
+| Soft delete with 90-day hard delete | Supports "Undo delete", aligns with retention policy. |
+| `LangyProjectMemoryHistory` separate table | Audit trail + rollback support without bloating the main row. |
+| No memory opt-out flag | We do not offer a "use Langy without memory" mode. Right-to-object (Art 21) is satisfied by deletion + the right to stop using Langy. Memory is core to the product. |
+
+---
+
+## 4. Data flow
+
+### 4.1 Write path — sending a message
+
+```
+Browser (LangySidebar)
+   │
+   │ POST /api/langy/chat  { messages, projectId, conversationId? }
+   ▼
+Hono route /api/langy/chat
+   │
+   ├─► Auth: requireSession()
+   ├─► Permission: hasProjectPermission(userId, projectId, "evaluations:view")
+   ├─► Rate limit: per (userId, projectId), N msgs/min
+   │
+   ├─► If conversationId is null: create LangyConversation (projectId, userId)
+   │
+   ├─► Persist user message → LangyMessage (role=user)
+   │
+   ├─► Build prompt:
+   │       1. system prompt (hardcoded identity + rules)
+   │       2. inject LangyProjectMemory.contentSummary (or content if ≤2k)
+   │       3. inject LangyUserPreferences (mode, etc.)
+   │       4. recent N messages from this conversation
+   │       5. (lazy retrieval results come in later, via tool calls)
+   │
+   ├─► streamText() via Vercel AI SDK
+   │       - tool calls happen here
+   │       - tool results stream back; never persisted to memory
+   │
+   ├─► On stream end: persist assistant message + tool messages → LangyMessage[]
+   │
+   ▼
+Browser receives SSE stream, renders tokens + tool calls + proposals
+```
+
+### 4.2 Read path — opening a conversation
+
+```
+Browser opens conversation X
+   │
+   │ GET /api/langy/conversations/{id}
+   ▼
+Hono route
+   │
+   ├─► Auth + projectId + permission check
+   │
+   ├─► Authorization check (this is the per-user privacy guard):
+   │       conversation.userId == session.userId
+   │       OR (conversation.isShared AND conversation.projectId == session.projectId)
+   │   → if neither: 403
+   │
+   ├─► Load conversation + messages
+   │
+   ▼
+Browser renders conversation
+```
+
+**Critical:** the authorization check at read time is what prevents user-to-user
+leakage within a project. A bug here is a P0 incident. It must be tested in
+`langy-memory.feature` *and* in a unit test on the route handler.
+
+### 4.3 Project memory — bootstrap
+
+```
+Project created (existing project lifecycle hook)
+   │
+   ▼
+Enqueue background job: bootstrapLangyProjectMemory(projectId)
+   │
+   ▼
+Worker
+   │
+   ├─► Load project state: list_evaluators, list_prompts, sample 50 recent traces
+   │
+   ├─► Render bootstrap prompt → LLM (gpt-5-mini, cheap)
+   │
+   ├─► LLM returns markdown summary
+   │
+   ├─► Truncate or summarize if > 2k tokens
+   │
+   ├─► INSERT LangyProjectMemory (changeReason="auto_bootstrap")
+   │
+   ▼
+Done. User opens Langy later → memory is already there.
+```
+
+### 4.4 Project memory — refresh (user-initiated)
+
+```
+User clicks "Refresh project memory" in settings
+   │
+   │ POST /api/langy/project-memory/refresh
+   ▼
+Hono route
+   │
+   ├─► Auth + projectId + permission check ("project:admin" required)
+   │
+   ├─► Stream the LLM regeneration directly to the browser (SSE)
+   │       - user watches tokens compose the new doc
+   │
+   ├─► On stream end: append to LangyProjectMemoryHistory, update LangyProjectMemory
+   │
+   ▼
+Browser shows new doc + diff vs prior version
+```
+
+### 4.5 Project memory — refresh (auto-stale, non-blocking)
+
+```
+Banner appears: "Project memory is 30+ days old. Refresh?"
+   │
+   │ User clicks Refresh → same flow as 4.4
+   │
+   │ User dismisses → banner stays dismissed for 7 days, then re-appears
+```
+
+### 4.6 Lazy retrieval (L6) — no persistence
+
+```
+LLM decides to call search_traces({query: "..."}) tool
+   │
+   ▼
+Tool handler: ClickHouse / Postgres filtered query
+   │
+   ├─► Multitenancy: TenantId = projectId enforced in query
+   │
+   ▼
+Returns rows → injected as tool result message → discarded after this turn
+```
+
+---
+
+## 5. Multitenancy enforcement
+
+Three layers, all required:
+
+1. **Permission middleware (route entry).** Every Langy route runs through
+   `hasProjectPermission(userId, projectId, capability)` before any handler
+   logic. Without this, the route returns 403.
+2. **Service layer.** All Prisma queries that touch `LangyConversation`,
+   `LangyMessage`, `LangyProjectMemory` MUST include `projectId` in the WHERE
+   clause. The CLAUDE.md project rule is enforced by middleware that rejects
+   queries on project-level models without `projectId`.
+3. **Authorization at read.** For per-user data (conversations), the query
+   must additionally check `userId == session.userId OR (isShared AND
+   sharedWithSameProject)`.
+
+Anti-patterns to reject in code review:
+- `prisma.langyConversation.findUnique({ where: { id } })` ❌ — missing projectId + userId
+- `prisma.langyMessage.findMany({ where: { conversationId } })` ❌ — missing projectId
+- Any service method that takes `conversationId` without also taking `projectId` from session ❌
+
+---
+
+## 6. Deletion semantics
+
+| Action | What happens immediately | What happens later |
+|---|---|---|
+| User deletes a single conversation | `deletedAt` set; conversation hidden from UI | Cron hard-deletes after 90 days |
+| User clicks "Clear all my Langy memory in this project" | All their conversations soft-deleted; their `LangyUserPreferences` reset | Hard-delete after 90 days; project memory unaffected (it's shared) |
+| User account deleted (org-level action) | All `LangyConversation` and `LangyUserPreferences` for that userId soft-deleted across all projects | Hard-delete cron sweep within 30 days (faster timeline for account deletion) |
+| Project deleted | Cascade-delete all Langy data for that projectId | Within 30 days for full hard-delete |
+| Organization deleted (full erasure request) | All Langy data across all org projects soft-deleted, then hard-deleted within 30 days | Backups purged on next backup cycle (≤30 days, see §8) |
+| GDPR Art 17 erasure request from end-user | Same as "user account deleted" but with formal logging | Confirmation email; backup purge tracked |
+
+Soft delete is internal only — to the user, "delete" means gone. Soft delete
+exists so that *we* can recover from accidental bulk deletes and to give a
+short undo window. It is never exposed as a "trash" UI.
+
+---
+
+## 7. Retention
+
+| Data | Hot retention | Cold / hard-delete |
+|---|---|---|
+| `LangyMessage` (active) | While conversation exists | n/a |
+| `LangyConversation` (soft-deleted) | 90 days from `deletedAt` | Hard-deleted by cron |
+| `LangyProjectMemory` | While project exists | Cascade-deleted with project |
+| `LangyProjectMemoryHistory` | 1 year (rolling) | Older versions pruned monthly |
+| `LangyUserPreferences` | While user × project relationship exists | Hard-deleted on user removal from project |
+| Backups (Postgres) | 30 days | Backup rotation purges deleted data within 30 days |
+
+Retention timers run as a daily cron job. The job logs counts of records
+deleted per category for ops visibility.
+
+---
+
+## 8. GDPR + similar regimes
+
+LangWatch processes data on behalf of customers (controller). Customers' end
+users are data subjects. Langy specifically holds:
+
+- Conversations (potentially PII-bearing free text)
+- Project memory (operator-stated goals, project shape)
+- User preferences (mode, opt-out flag)
+
+### 8.1 Lawful basis
+
+Most likely **legitimate interest** (Art 6(1)(f)) — Langy is a product feature
+that helps the user operate LangWatch. Documented in privacy notice. User has
+right to object (§8.4).
+
+If a customer's contract requires it, basis can be **contract performance**
+(Art 6(1)(b)) — Langy is part of the service the customer purchased.
+
+### 8.2 Data subject rights
+
+| Right | Article | How Langy supports it |
+|---|---|---|
+| Access | Art 15 | Settings page exposes all stored data; "Export my Langy data" produces JSON archive |
+| Rectification | Art 16 | Project memory is editable. Conversations are not editable but can be deleted. |
+| Erasure | Art 17 | One-click "Clear all my Langy memory in this project"; full erasure on account deletion |
+| Restriction of processing | Art 18 | Satisfied via deletion (user can clear memory at any time) |
+| Data portability | Art 20 | "Export my Langy data" produces JSON archive |
+| Object | Art 21 | Satisfied via deletion + the user's right to stop using Langy. We do not offer a "use Langy without memory" mode — memory is core to the product. |
+| Automated decision-making | Art 22 | Langy never makes automated decisions with legal/significant effect; propose-apply pattern keeps the human in the loop |
+
+### 8.3 Subprocessors
+
+Conversations and project memory are processed by the LLM provider configured
+for the project (default: OpenAI). This must be:
+- Declared in the LangWatch DPA / subprocessors list
+- Covered by SCCs (Standard Contractual Clauses) if data leaves EU
+- Subject to an Art 28 processor agreement
+
+**Special note:** OpenAI's ZDR (Zero Data Retention) terms or equivalent
+should be enabled for Langy traffic if the customer is EU-regulated. This is
+operationally enforceable — we add a `langwatch-feature: langy` header to
+outbound LLM calls and the provider routes accordingly.
+
+### 8.4 Data minimization
+
+- We do NOT store tool call results (lazy retrieval) — they're transient.
+- We do NOT store the user's IP, device fingerprint, or location alongside conversations.
+- We do NOT auto-extract PII from conversations into structured fields (would create new processing surface; defer L5).
+- Conversation `title` is auto-generated from the first message — if the first
+  message contains PII, the title will too. This is an acceptable trade for
+  usability; user can edit/delete the title.
+
+### 8.5 Storage limitation
+
+- 90-day hard delete on soft-deleted conversations
+- 30-day backup retention
+- 1-year rolling retention for memory edit history
+
+### 8.6 Cross-border transfer
+
+LangWatch does not restrict the LLM provider list based on the customer's
+data residency. The customer chooses any model their project is configured
+with — including non-EU providers, even on EU deployments. This is a
+deliberate product decision: forcing a provider list undermines the
+"any model" flexibility that LangWatch sells.
+
+Compliance is handled at the **contract layer** (DPA, SCCs with each
+subprocessor) rather than the **product layer** (forced restriction).
+Customers who require EU-only processing must contractually pick EU-region
+providers themselves; we surface that information but do not enforce it.
+
+### 8.7 Audit logging
+
+We log **mutations and access events**, not reads. Reads are too noisy and
+expensive to log at row level; mutations + sensitive access events are
+sufficient for incident response.
+
+Logged events:
+- Conversation create / delete / share / unshare
+- Project memory bootstrap / refresh / edit / rollback
+- User preferences changes (mode toggle, etc.)
+- Memory exports (Art 15)
+- Erasure events (Art 17)
+- Settings page access (sensitive — user is viewing what's stored)
+
+Logs go to the existing LangWatch audit log infrastructure
+(`specs/audit-log/`), retained per existing policy.
+
+### 8.8 Data location
+
+Langy memory lives in the same Postgres instance as the rest of the project's
+data. If the customer is on an EU-only deployment, Langy data is EU-only too.
+No separate datastore = no new transfer surface.
+
+---
+
+## 9. Threat model
+
+| Threat | Mitigation |
+|---|---|
+| Bob in Project A reads Alice's conversations in Project A | Per-user authorization at read; tested in `langy-memory.feature` |
+| User in Org A reads conversations from Org B | `projectId` filter + permission middleware (existing) |
+| Deleted conversation resurfaces in LLM output via project memory | Project memory is regenerated only on user action; v2 has no auto-extraction |
+| Backup contains deleted user's data forever | 30-day backup rotation, documented; tested in DR drill |
+| Malicious user prompts Langy to leak another user's conversation | Conversations are not in the prompt context unless it's the current user's; LLM cannot retrieve them |
+| Tool call result contains PII that gets stored as part of the assistant message | Persisted assistant message contains the LLM's *response*, which may reference tool data — same surface as today's chat. Acceptable; user can delete. |
+| Project memory contains a hallucinated fact that misleads future conversations | (1) auto-bootstrap shows draft, (2) user edits anytime, (3) stale banner at 30 days, (4) edit history allows rollback |
+| LLM provider is breached | Subprocessor breach notification clauses in DPA; we notify customers within 72h per Art 33 |
+| Insider access to Postgres bypasses all controls | DB access logged; SOC2 control; row-level encryption is *not* in scope for v2 |
+
+---
+
+## 10. Operational considerations
+
+- **Metrics.** Track per-project: conversation count, message count, project
+  memory token size, refresh frequency, opt-out rate. Watch for outliers.
+- **Cost ceiling.** Project memory injection costs tokens on every turn. Cap
+  at 2k tokens; alert if any project's effective injected memory exceeds
+  budget repeatedly.
+- **Observability.** Every Langy LLM call is itself a LangWatch trace
+  (dogfood). The trace includes which memory tiers were injected.
+- **Backup & DR.** Memory is backed up alongside Postgres. RTO/RPO matches
+  the rest of LangWatch.
+- **Migration.** When we move agent execution to Mastra (PRD phase 4),
+  memory storage stays in Postgres unchanged. Mastra reads/writes via the
+  same service layer.
+
+---
+
+## 11. Future: per-project vector embeddings (L7)
+
+This section captures the design *intent* so that v2 doesn't paint v3 into a
+corner.
+
+### Approach when we ship it
+
+- **pgvector** (Postgres extension) is the most likely choice — keeps everything
+  in one DB, no new infra, sufficient for our scale. Alternative: Qdrant if
+  we outgrow pgvector.
+- **One namespace per projectId.** Vectors never cross projects. Multitenancy
+  enforced at query time.
+- **Embeddings produced from:**
+  - traces (selected fields, redacted)
+  - prompts
+  - conversations (with consent — opt-in per-user, Art 21 friendly)
+  - project memory (always)
+- **Embedding model** is a per-deployment config, defaulting to a small
+  open-source model to avoid sending content to a paid provider just for
+  embeddings.
+- **Lifecycle:** when a record is deleted, its embedding is deleted in the
+  same transaction.
+
+### What this unlocks
+
+- True semantic similarity search on traces ("find traces like this one")
+- Episodic memory (L5) backed by retrieval over past conversations
+- Cross-project recommendations (with explicit consent)
+
+### Why NOT to ship in v2
+
+- Quality bar is high (a wrong vector match is a confidence trap)
+- Adds a new failure mode and infra concern
+- Most v2 use cases are served by structured tools + a curated project memory
+- Better to earn the right by getting v2 right first
+
+---
+
+## 12. Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-06 | Per-user L3 scoping in v2; no team-shared default | User explicitly chose to keep simple now, expand later |
+| 2026-05-06 | Opt-in "share this conversation with team" toggle | Best of both worlds — privacy default, sharing on demand |
+| 2026-05-06 | Auto-bootstrap project memory at project creation, silently | "Magic of being prepared" beats "let me learn" UI |
+| 2026-05-06 | User-initiated refresh streams; auto-bootstrap is silent | Streaming when user asks, silent when system acts |
+| 2026-05-06 | No vector store in v2; keep L7 design captured | Earn the right; revisit when conditions justify |
+| 2026-05-06 | Postgres only, no Redis or vector DB | Keep infra surface small |
+| 2026-05-06 | 90-day hard delete; 30-day backup retention | Industry-standard for SaaS; aligns with GDPR storage limitation |
+| 2026-05-06 | No LLM-provider restriction by data residency | Compliance handled at contract layer (DPA/SCC), not product layer; preserves "any model" flexibility |
+| 2026-05-06 | No memory opt-out flag | Memory is core to the product; Art 21 satisfied via deletion + right to stop using Langy |
+| 2026-05-06 | Audit log mutations + access events, not reads | Reads too noisy; mutations sufficient for incident response |
+
+---
+
+## 13. Open questions (deferred to implementation)
+
+1. **Conversation export format** — JSON is the primary format. Human-readable HTML/PDF nice-to-have, defer.
+2. **Sharing a conversation that contains another user's PII** — when Alice shares a conversation she had, and the conversation references Bob, do we redact Bob? Out of scope for v2 — share button has a "preview before sharing" step instead.


### PR DESCRIPTION
## Summary

Backend-only v2 of Langy per [`specs/assistant/PRD.md`](specs/assistant/PRD.md), [`memory-design.md`](specs/assistant/memory-design.md), [`architecture.md`](specs/assistant/architecture.md), and [`implementation-plan.md`](specs/assistant/implementation-plan.md) (Phase 2 + Phase 3 only). UI ships separately.

### Included

- **Schema** (`prisma/migrations/20260508153928_langy_memory/`): `LangyConversation`, `LangyMessage`, `LangyProjectMemory`, `LangyProjectMemoryHistory`, `LangyUserPreferences`. All project-scoped (multitenancy guard active).
- **Services** (`src/server/services/langy/`): conversation, message, project memory, project memory history, user preferences. Routes → services → repos; services use `getAll`/`getById`, repos use `findAll`/`findById`. Multitenancy + per-user authorization enforced at the service layer.
- **Hono routes** (`src/server/routes/langy.ts`):
  - `POST /api/langy/chat` — persists user + assistant messages, injects project memory + prefs into the system prompt, populates `tokenCount` via `TiktokenClient`. Returns `x-langy-conversation-id` header.
  - `GET/PATCH/DELETE /api/langy/conversations[/:id]`
  - `GET/PUT /api/langy/project-memory` + `POST /api/langy/project-memory/refresh` (Vercel AI SDK SSE)
  - `GET/PUT /api/langy/preferences`
  - `DELETE /api/langy/memory` (clear-all) and `GET /api/langy/memory/export` (GDPR Art 15/20 JSON archive)
- **Bootstrap worker** (`langyBootstrapQueue` + `langyBootstrapWorker.ts`): BullMQ, 3 attempts with exponential backoff, registered in `worker.ts`. Project create mutation enqueues `langyBootstrapQueue` inline; falls back to `gpt-5-mini` when no model is configured. Generates a starter memory if the LLM call fails.
- **L6 lazy retrieval tools**: `search_traces` (ES on `TRACE_INDEX.alias`), `search_prompts` (Postgres handle/name keyword match), `search_past_runs` (`BatchEvaluation`).
- **Rate limit** (`middleware/rate-limit-langy.ts`): 30 messages/min per `(userId, projectId)` via Redis; `stepCountIs(8)` retained for per-message tool-call cap.
- **Tool-output validator** (`services/langy/toolIdValidator.ts`): conversation-scoped `ConversationToolIdSet` records IDs returned from `list_*` tools and rejects propose-side IDs the agent didn't see.
- **Retention cron** (`langyRetentionQueue`): BullMQ repeatable, daily 03:00 UTC, hard-deletes soft-deleted conversations older than 90 days.
- **Audit log**: share/unshare, project-memory edit/refresh, clear-all-memory, GDPR export.
- **RBAC**: project memory edit/refresh and GDPR export gated on `project:manage` (closest existing capability — issue #3211).

### Deferred (per task brief)

- All UI (`langwatch/src/components/langy/*`, pages, `.tsx`)
- Self-tracer / dogfood project emit (Phase 1.3)
- Mastra migration (Phase 4)
- Inline post-turn suggestions (Phase 5)
- Replay harness (Phase 6)
- No feature flag — ships to all users.

### Verification

- `pnpm typecheck` — no new langy-related errors. (Pre-existing repo-wide errors for missing peer deps `liqe`, `better-auth`, `react-router`, `vite`, etc. are untouched.)
- `pnpm test:unit src/server/services/langy` — **10 tests pass** (cross-user/cross-project isolation, ownership checks, memory write+history, prefs upsert).

## Test plan

- [ ] Run integration suite locally with Postgres + Redis up.
- [ ] Create a project; verify a `LangyProjectMemory` row appears within ~30s.
- [ ] Send a chat message; verify `LangyConversation` + two `LangyMessage` rows (`role=user`/`assistant`) with non-null `tokenCount`.
- [ ] Verify cross-user read is blocked: user B `GET /api/langy/conversations/:id` for user A's unshared conversation returns 404.
- [ ] Verify share toggle: PATCH with `isShared: true`; user B in same project can read; audit log row written.
- [ ] Edit project memory as project admin; non-admin gets 403.
- [ ] `POST /api/langy/project-memory/refresh` streams content; new history row appended.
- [ ] `DELETE /api/langy/memory` soft-deletes user's conversations and resets prefs; audit log row written.
- [ ] `GET /api/langy/memory/export` returns user's conversations + messages + prefs as JSON.
- [ ] Flood `/api/langy/chat` past 30/min: receive 429 with `Retry-After`.
- [ ] Ask Langy to apply an evaluator with a fabricated slug → tool returns the validator error rather than crashing.
- [ ] Manually trigger `langyRetentionQueue` job; conversations soft-deleted >90 days are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)