### PR TITLE
fix(#3919): handle large traces in search — stream response + batch ClickHouse on OOM

### DIFF
--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -234,24 +234,8 @@ describe("POST /search", () => {
     });
   });
 
-  describe("when response is streamed", () => {
-    it("produces valid JSON with correct structure", async () => {
-      const res = await searchRequest({
-        startDate: 1000,
-        endDate: 5000,
-      });
-
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toBe("application/json");
-
-      const body = await res.json();
-      expect(body).toHaveProperty("traces");
-      expect(body).toHaveProperty("pagination");
-      expect(body.pagination).toHaveProperty("totalHits", 2);
-      expect(body.traces).toHaveLength(2);
-    });
-
-    it("handles many traces with correct comma separation", async () => {
+  describe("when result set is large", () => {
+    it("serializes many traces with correct comma separation", async () => {
       const manyTraces = Array.from({ length: 50 }, (_, i) => ({
         trace_id: `trace-${i}`,
         project_id: "project-123",
@@ -281,7 +265,7 @@ describe("POST /search", () => {
       expect(body.pagination.scrollId).toBe("next-page-token");
     });
 
-    it("handles empty result set", async () => {
+    it("returns valid JSON for empty result set", async () => {
       mockGetAllTracesForProject.mockResolvedValue({
         groups: [[]],
         totalHits: 0,

--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -233,4 +233,70 @@ describe("POST /search", () => {
       expect(body.traces[1].evaluations).toEqual([]);
     });
   });
+
+  describe("when response is streamed", () => {
+    it("produces valid JSON with correct structure", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/json");
+
+      const body = await res.json();
+      expect(body).toHaveProperty("traces");
+      expect(body).toHaveProperty("pagination");
+      expect(body.pagination).toHaveProperty("totalHits", 2);
+      expect(body.traces).toHaveLength(2);
+    });
+
+    it("handles many traces with correct comma separation", async () => {
+      const manyTraces = Array.from({ length: 50 }, (_, i) => ({
+        trace_id: `trace-${i}`,
+        project_id: "project-123",
+        input: { value: `input-${i}` },
+        output: { value: `output-${i}` },
+        timestamps: { started_at: i * 100, inserted_at: i * 100, updated_at: i * 100 },
+        metadata: {},
+        spans: [],
+      }));
+
+      mockGetAllTracesForProject.mockResolvedValue({
+        groups: [manyTraces],
+        totalHits: 50,
+        traceChecks: Object.fromEntries(manyTraces.map((t) => [t.trace_id, []])),
+        scrollId: "next-page-token",
+      });
+
+      const res = await searchRequest({
+        startDate: 0,
+        endDate: 10000,
+      });
+
+      const body = await res.json();
+      expect(body.traces).toHaveLength(50);
+      expect(body.traces[0].trace_id).toBe("trace-0");
+      expect(body.traces[49].trace_id).toBe("trace-49");
+      expect(body.pagination.scrollId).toBe("next-page-token");
+    });
+
+    it("handles empty result set", async () => {
+      mockGetAllTracesForProject.mockResolvedValue({
+        groups: [[]],
+        totalHits: 0,
+        traceChecks: {},
+        scrollId: undefined,
+      });
+
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+      });
+
+      const body = await res.json();
+      expect(body.traces).toHaveLength(0);
+      expect(body.pagination.totalHits).toBe(0);
+    });
+  });
 });

--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -233,24 +233,8 @@ describe("POST /search", () => {
     });
   });
 
-  describe("when response is streamed", () => {
-    it("produces valid JSON with correct structure", async () => {
-      const res = await searchRequest({
-        startDate: 1000,
-        endDate: 5000,
-      });
-
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toBe("application/json");
-
-      const body = await res.json();
-      expect(body).toHaveProperty("traces");
-      expect(body).toHaveProperty("pagination");
-      expect(body.pagination).toHaveProperty("totalHits", 2);
-      expect(body.traces).toHaveLength(2);
-    });
-
-    it("handles many traces with correct comma separation", async () => {
+  describe("when result set is large", () => {
+    it("serializes many traces with correct comma separation", async () => {
       const manyTraces = Array.from({ length: 50 }, (_, i) => ({
         trace_id: `trace-${i}`,
         project_id: "project-123",
@@ -280,7 +264,7 @@ describe("POST /search", () => {
       expect(body.pagination.scrollId).toBe("next-page-token");
     });
 
-    it("handles empty result set", async () => {
+    it("returns valid JSON for empty result set", async () => {
       mockGetAllTracesForProject.mockResolvedValue({
         groups: [[]],
         totalHits: 0,

--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -232,4 +232,70 @@ describe("POST /search", () => {
       expect(body.traces[1].evaluations).toEqual([]);
     });
   });
+
+  describe("when response is streamed", () => {
+    it("produces valid JSON with correct structure", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/json");
+
+      const body = await res.json();
+      expect(body).toHaveProperty("traces");
+      expect(body).toHaveProperty("pagination");
+      expect(body.pagination).toHaveProperty("totalHits", 2);
+      expect(body.traces).toHaveLength(2);
+    });
+
+    it("handles many traces with correct comma separation", async () => {
+      const manyTraces = Array.from({ length: 50 }, (_, i) => ({
+        trace_id: `trace-${i}`,
+        project_id: "project-123",
+        input: { value: `input-${i}` },
+        output: { value: `output-${i}` },
+        timestamps: { started_at: i * 100, inserted_at: i * 100, updated_at: i * 100 },
+        metadata: {},
+        spans: [],
+      }));
+
+      mockGetAllTracesForProject.mockResolvedValue({
+        groups: [manyTraces],
+        totalHits: 50,
+        traceChecks: Object.fromEntries(manyTraces.map((t) => [t.trace_id, []])),
+        scrollId: "next-page-token",
+      });
+
+      const res = await searchRequest({
+        startDate: 0,
+        endDate: 10000,
+      });
+
+      const body = await res.json();
+      expect(body.traces).toHaveLength(50);
+      expect(body.traces[0].trace_id).toBe("trace-0");
+      expect(body.traces[49].trace_id).toBe("trace-49");
+      expect(body.pagination.scrollId).toBe("next-page-token");
+    });
+
+    it("handles empty result set", async () => {
+      mockGetAllTracesForProject.mockResolvedValue({
+        groups: [[]],
+        totalHits: 0,
+        traceChecks: {},
+        scrollId: undefined,
+      });
+
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+      });
+
+      const body = await res.json();
+      expect(body.traces).toHaveLength(0);
+      expect(body.pagination.totalHits).toBe(0);
+    });
+  });
 });

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -152,13 +152,31 @@ app.post(
       }));
     }
 
-    return c.json({
+    const responseBody = {
       traces,
       pagination: {
         totalHits: results.totalHits,
         scrollId: results.scrollId,
       },
-    });
+    };
+
+    try {
+      return c.json(responseBody);
+    } catch (err) {
+      if (err instanceof RangeError) {
+        return c.json(
+          {
+            error: "Response too large",
+            message:
+              `The response for the requested date range exceeds serialization limits ` +
+              `(${rawTraces.length} traces). Use a smaller "pageSize" (e.g. 50 or 100) ` +
+              `and paginate with the "scrollId" returned in each response.`,
+          },
+          413,
+        );
+      }
+      throw err;
+    }
   },
 );
 

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -157,16 +157,26 @@ app.post(
       scrollId: results.scrollId,
     });
 
+    const serializedTraces: string[] = [];
+    for (const trace of enrichedTraces) {
+      try {
+        serializedTraces.push(JSON.stringify(formatTrace(trace)));
+      } catch (err) {
+        logger.error(
+          { traceId: trace.trace_id, error: err instanceof Error ? err.message : err },
+          "Failed to serialize trace, skipping",
+        );
+      }
+    }
+
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       start(controller) {
         controller.enqueue(encoder.encode('{"traces":['));
 
-        for (let i = 0; i < enrichedTraces.length; i++) {
+        for (let i = 0; i < serializedTraces.length; i++) {
           const prefix = i > 0 ? "," : "";
-          controller.enqueue(
-            encoder.encode(prefix + JSON.stringify(formatTrace(enrichedTraces[i]!)))
-          );
+          controller.enqueue(encoder.encode(prefix + serializedTraces[i]!));
         }
 
         controller.enqueue(

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -126,57 +126,59 @@ app.post(
       traceChecks: results.traceChecks,
     });
 
-    let traces: unknown[];
-    if (format === "digest") {
-      traces = enrichedTraces.map((trace) => ({
-        trace_id: trace.trace_id,
-        formatted_trace: formatTraceSummaryDigest(trace),
-        input: trace.input,
-        output: trace.output,
-        timestamps: trace.timestamps,
-        metadata: trace.metadata,
-        error: trace.error,
-        evaluations: trace.evaluations,
-        platformUrl: platformUrl({
-          projectSlug: project.slug,
-          path: `/messages/${trace.trace_id}`,
-        }),
-      }));
-    } else {
-      traces = enrichedTraces.map((trace) => ({
+    const formatTrace = (trace: Trace) => {
+      if (format === "digest") {
+        return {
+          trace_id: trace.trace_id,
+          formatted_trace: formatTraceSummaryDigest(trace),
+          input: trace.input,
+          output: trace.output,
+          timestamps: trace.timestamps,
+          metadata: trace.metadata,
+          error: trace.error,
+          evaluations: trace.evaluations,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/messages/${trace.trace_id}`,
+          }),
+        };
+      }
+      return {
         ...trace,
         platformUrl: platformUrl({
           projectSlug: project.slug,
           path: `/messages/${trace.trace_id}`,
         }),
-      }));
-    }
-
-    const responseBody = {
-      traces,
-      pagination: {
-        totalHits: results.totalHits,
-        scrollId: results.scrollId,
-      },
+      };
     };
 
-    try {
-      return c.json(responseBody);
-    } catch (err) {
-      if (err instanceof RangeError) {
-        return c.json(
-          {
-            error: "Response too large",
-            message:
-              `The response for the requested date range exceeds serialization limits ` +
-              `(${rawTraces.length} traces). Use a smaller "pageSize" (e.g. 50 or 100) ` +
-              `and paginate with the "scrollId" returned in each response.`,
-          },
-          413,
+    const pagination = JSON.stringify({
+      totalHits: results.totalHits,
+      scrollId: results.scrollId,
+    });
+
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"traces":['));
+
+        for (let i = 0; i < enrichedTraces.length; i++) {
+          const prefix = i > 0 ? "," : "";
+          controller.enqueue(
+            encoder.encode(prefix + JSON.stringify(formatTrace(enrichedTraces[i]!)))
+          );
+        }
+
+        controller.enqueue(
+          encoder.encode(`],"pagination":${pagination}}`)
         );
-      }
-      throw err;
-    }
+        controller.close();
+      },
+    });
+
+    return new Response(stream, {
+      headers: { "Content-Type": "application/json" },
+    });
   },
 );
 

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -151,13 +151,31 @@ app.post(
       }));
     }
 
-    return c.json({
+    const responseBody = {
       traces,
       pagination: {
         totalHits: results.totalHits,
         scrollId: results.scrollId,
       },
-    });
+    };
+
+    try {
+      return c.json(responseBody);
+    } catch (err) {
+      if (err instanceof RangeError) {
+        return c.json(
+          {
+            error: "Response too large",
+            message:
+              `The response for the requested date range exceeds serialization limits ` +
+              `(${rawTraces.length} traces). Use a smaller "pageSize" (e.g. 50 or 100) ` +
+              `and paginate with the "scrollId" returned in each response.`,
+          },
+          413,
+        );
+      }
+      throw err;
+    }
   },
 );
 

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -156,16 +156,26 @@ app.post(
       scrollId: results.scrollId,
     });
 
+    const serializedTraces: string[] = [];
+    for (const trace of enrichedTraces) {
+      try {
+        serializedTraces.push(JSON.stringify(formatTrace(trace)));
+      } catch (err) {
+        logger.error(
+          { traceId: trace.trace_id, error: err instanceof Error ? err.message : err },
+          "Failed to serialize trace, skipping",
+        );
+      }
+    }
+
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       start(controller) {
         controller.enqueue(encoder.encode('{"traces":['));
 
-        for (let i = 0; i < enrichedTraces.length; i++) {
+        for (let i = 0; i < serializedTraces.length; i++) {
           const prefix = i > 0 ? "," : "";
-          controller.enqueue(
-            encoder.encode(prefix + JSON.stringify(formatTrace(enrichedTraces[i]!)))
-          );
+          controller.enqueue(encoder.encode(prefix + serializedTraces[i]!));
         }
 
         controller.enqueue(

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -125,57 +125,59 @@ app.post(
       traceChecks: results.traceChecks,
     });
 
-    let traces: unknown[];
-    if (format === "digest") {
-      traces = enrichedTraces.map((trace) => ({
-        trace_id: trace.trace_id,
-        formatted_trace: formatTraceSummaryDigest(trace),
-        input: trace.input,
-        output: trace.output,
-        timestamps: trace.timestamps,
-        metadata: trace.metadata,
-        error: trace.error,
-        evaluations: trace.evaluations,
-        platformUrl: platformUrl({
-          projectSlug: project.slug,
-          path: `/messages/${trace.trace_id}`,
-        }),
-      }));
-    } else {
-      traces = enrichedTraces.map((trace) => ({
+    const formatTrace = (trace: Trace) => {
+      if (format === "digest") {
+        return {
+          trace_id: trace.trace_id,
+          formatted_trace: formatTraceSummaryDigest(trace),
+          input: trace.input,
+          output: trace.output,
+          timestamps: trace.timestamps,
+          metadata: trace.metadata,
+          error: trace.error,
+          evaluations: trace.evaluations,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/messages/${trace.trace_id}`,
+          }),
+        };
+      }
+      return {
         ...trace,
         platformUrl: platformUrl({
           projectSlug: project.slug,
           path: `/messages/${trace.trace_id}`,
         }),
-      }));
-    }
-
-    const responseBody = {
-      traces,
-      pagination: {
-        totalHits: results.totalHits,
-        scrollId: results.scrollId,
-      },
+      };
     };
 
-    try {
-      return c.json(responseBody);
-    } catch (err) {
-      if (err instanceof RangeError) {
-        return c.json(
-          {
-            error: "Response too large",
-            message:
-              `The response for the requested date range exceeds serialization limits ` +
-              `(${rawTraces.length} traces). Use a smaller "pageSize" (e.g. 50 or 100) ` +
-              `and paginate with the "scrollId" returned in each response.`,
-          },
-          413,
+    const pagination = JSON.stringify({
+      totalHits: results.totalHits,
+      scrollId: results.scrollId,
+    });
+
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"traces":['));
+
+        for (let i = 0; i < enrichedTraces.length; i++) {
+          const prefix = i > 0 ? "," : "";
+          controller.enqueue(
+            encoder.encode(prefix + JSON.stringify(formatTrace(enrichedTraces[i]!)))
+          );
+        }
+
+        controller.enqueue(
+          encoder.encode(`],"pagination":${pagination}}`)
         );
-      }
-      throw err;
-    }
+        controller.close();
+      },
+    });
+
+    return new Response(stream, {
+      headers: { "Content-Type": "application/json" },
+    });
   },
 );
 

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -638,6 +638,77 @@ describe("ClickHouseTraceService", () => {
       });
     });
 
+    describe("when ClickHouse MEMORY_LIMIT_EXCEEDED on summary query", () => {
+      it("retries in smaller batches and returns all traces", async () => {
+        const traceIds = Array.from({ length: 4 }, (_, i) => `trace-${i}`);
+        const summaryRows = traceIds.map((id, i) => ({
+          ...makeSummaryRow(id),
+          ts_OccurredAt: Date.now() - i * 1000,
+        }));
+        const idRows = traceIds.map((id) => ({ TraceId: id }));
+
+        // Batch size is 25, so 4 traces fit in one retry batch
+        mockClickHouseQuery
+          // count
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          // IDs
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          // summary — OOM
+          .mockRejectedValueOnce(
+            new Error(
+              "Query memory limit exceeded: would use 3.50 GiB, " +
+                "maximum: 3.50 GiB: MEMORY_LIMIT_EXCEEDED",
+            ),
+          )
+          // retry batch (all 4 fit in one batch of 25)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows),
+          })
+          // evaluations
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          { ...baseInput, pageSize: 4 } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        const traces = result!.groups.flat();
+        expect(traces).toHaveLength(4);
+      });
+
+      it("re-throws non-OOM errors from summary query", async () => {
+        const idRows = [{ TraceId: "trace-1" }];
+
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: "1" }]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          .mockRejectedValueOnce(new Error("SYNTAX_ERROR: bad query"));
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await expect(
+          service.getAllTracesForProject(baseInput, protections),
+        ).rejects.toThrow("SYNTAX_ERROR");
+      });
+    });
+
     describe("when includeSpans is true", () => {
       it("fetches and attaches spans to traces", async () => {
         const summaryRow = makeSummaryRow("trace-1");

--- a/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
@@ -77,13 +77,18 @@ describe("trace dedup OOM safety", () => {
   const topicClusteringSource = fs.readFileSync(topicClusteringPath, "utf-8");
 
   // ---------------------------------------------------------------------------
-  // clickhouse-trace.service.ts: fetchTracesWithPagination
+  // clickhouse-trace.service.ts: fetchTracesWithPagination + fetchTraceSummaryRows
   // ---------------------------------------------------------------------------
   describe("fetchTracesWithPagination()", () => {
-    const body = extractMethodBody(
+    const paginationBody = extractMethodBody(
       traceServiceSource,
       "fetchTracesWithPagination",
     );
+    const summaryBody = extractMethodBody(
+      traceServiceSource,
+      "fetchTraceSummaryRows",
+    );
+    const body = paginationBody + summaryBody;
 
     describe("when the pagination query SQL is inspected", () => {
       it("does not use LIMIT 1 BY for deduplication", () => {

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1416,62 +1416,14 @@ export class ClickHouseTraceService {
         // Step 2: Fetch full data for just the page's trace IDs.
         // The dedup subquery is scoped to pageTraceIds so it only reads
         // N traces instead of the entire table.
-        const summaryResult = await clickHouseClient.query({
-          query: `
-            SELECT
-              ts.TraceId AS ts_TraceId,
-              ts.SpanCount AS ts_SpanCount,
-              ts.TotalDurationMs AS ts_TotalDurationMs,
-              ts.ComputedIOSchemaVersion AS ts_ComputedIOSchemaVersion,
-              ts.TimeToFirstTokenMs AS ts_TimeToFirstTokenMs,
-              ts.TimeToLastTokenMs AS ts_TimeToLastTokenMs,
-              ts.TokensPerSecond AS ts_TokensPerSecond,
-              ts.ContainsErrorStatus AS ts_ContainsErrorStatus,
-              ts.ContainsOKStatus AS ts_ContainsOKStatus,
-              ts.ErrorMessage AS ts_ErrorMessage,
-              ts.Models AS ts_Models,
-              ts.TotalCost AS ts_TotalCost,
-              ts.TokensEstimated AS ts_TokensEstimated,
-              ts.TotalPromptTokenCount AS ts_TotalPromptTokenCount,
-              ts.TotalCompletionTokenCount AS ts_TotalCompletionTokenCount,
-              ts.TopicId AS ts_TopicId,
-              ts.SubTopicId AS ts_SubTopicId,
-              ts.HasAnnotation AS ts_HasAnnotation,
-              ts.AnnotationIds AS ts_AnnotationIds,
-              ts.ComputedInput AS ts_ComputedInput,
-              ts.ComputedOutput AS ts_ComputedOutput,
-              ts.Attributes AS ts_Attributes,
-              ts.TraceName AS ts_TraceName,
-              toUnixTimestamp64Milli(ts.OccurredAt) AS ts_OccurredAt,
-              toUnixTimestamp64Milli(ts.CreatedAt) AS ts_CreatedAt,
-              toUnixTimestamp64Milli(ts.UpdatedAt) AS ts_UpdatedAt
-            FROM trace_summaries ts
-            WHERE ts.TenantId = {tenantId:String}
-              AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-              AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
-              AND ts.TraceId IN ({pageTraceIds:Array(String)})
-              AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
-                SELECT TenantId, TraceId, max(UpdatedAt)
-                FROM trace_summaries
-                WHERE TenantId = {tenantId:String}
-                  AND OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-                  AND OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
-                  AND TraceId IN ({pageTraceIds:Array(String)})
-                GROUP BY TenantId, TraceId
-              )
-            ORDER BY ts.OccurredAt ${orderDirection}, ts.TraceId ${orderDirection}
-          `,
-          query_params: {
-            tenantId: projectId,
-            startDate: startDate ?? 0,
-            endDate: endDate ?? Date.now(),
-            pageTraceIds,
-          },
-          format: "JSONEachRow",
+        const summaryRows = await this.fetchTraceSummaryRows({
+          clickHouseClient,
+          projectId,
+          startDate: startDate ?? 0,
+          endDate: endDate ?? Date.now(),
+          traceIds: pageTraceIds,
+          orderDirection,
         });
-
-        const summaryRows =
-          await summaryResult.json() as TraceSummaryRow[];
 
         const traces: Trace[] = summaryRows.map((row) => {
           const summary = this.rowToTraceSummaryData(row);
@@ -1485,6 +1437,125 @@ export class ClickHouseTraceService {
         return { traces, totalHits, lastTrace };
       },
     );
+  }
+
+  private static readonly SUMMARY_BATCH_SIZE = 25;
+
+  /**
+   * Fetch full trace summary rows for a set of trace IDs.
+   * On ClickHouse MEMORY_LIMIT_EXCEEDED, retries in smaller batches
+   * so that heavy ComputedInput/ComputedOutput columns don't blow the
+   * per-query memory cap.
+   */
+  private async fetchTraceSummaryRows({
+    clickHouseClient,
+    projectId,
+    startDate,
+    endDate,
+    traceIds,
+    orderDirection,
+  }: {
+    clickHouseClient: ClickHouseClient;
+    projectId: string;
+    startDate: number;
+    endDate: number;
+    traceIds: string[];
+    orderDirection: string;
+  }): Promise<TraceSummaryRow[]> {
+    const runQuery = async (ids: string[]) => {
+      const result = await clickHouseClient.query({
+        query: `
+          SELECT
+            ts.TraceId AS ts_TraceId,
+            ts.SpanCount AS ts_SpanCount,
+            ts.TotalDurationMs AS ts_TotalDurationMs,
+            ts.ComputedIOSchemaVersion AS ts_ComputedIOSchemaVersion,
+            ts.TimeToFirstTokenMs AS ts_TimeToFirstTokenMs,
+            ts.TimeToLastTokenMs AS ts_TimeToLastTokenMs,
+            ts.TokensPerSecond AS ts_TokensPerSecond,
+            ts.ContainsErrorStatus AS ts_ContainsErrorStatus,
+            ts.ContainsOKStatus AS ts_ContainsOKStatus,
+            ts.ErrorMessage AS ts_ErrorMessage,
+            ts.Models AS ts_Models,
+            ts.TotalCost AS ts_TotalCost,
+            ts.TokensEstimated AS ts_TokensEstimated,
+            ts.TotalPromptTokenCount AS ts_TotalPromptTokenCount,
+            ts.TotalCompletionTokenCount AS ts_TotalCompletionTokenCount,
+            ts.TopicId AS ts_TopicId,
+            ts.SubTopicId AS ts_SubTopicId,
+            ts.HasAnnotation AS ts_HasAnnotation,
+            ts.AnnotationIds AS ts_AnnotationIds,
+            ts.ComputedInput AS ts_ComputedInput,
+            ts.ComputedOutput AS ts_ComputedOutput,
+            ts.Attributes AS ts_Attributes,
+            ts.TraceName AS ts_TraceName,
+            toUnixTimestamp64Milli(ts.OccurredAt) AS ts_OccurredAt,
+            toUnixTimestamp64Milli(ts.CreatedAt) AS ts_CreatedAt,
+            toUnixTimestamp64Milli(ts.UpdatedAt) AS ts_UpdatedAt
+          FROM trace_summaries ts
+          WHERE ts.TenantId = {tenantId:String}
+            AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+            AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+            AND ts.TraceId IN ({pageTraceIds:Array(String)})
+            AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
+              SELECT TenantId, TraceId, max(UpdatedAt)
+              FROM trace_summaries
+              WHERE TenantId = {tenantId:String}
+                AND OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+                AND OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+                AND TraceId IN ({pageTraceIds:Array(String)})
+              GROUP BY TenantId, TraceId
+            )
+          ORDER BY ts.OccurredAt ${orderDirection}, ts.TraceId ${orderDirection}
+        `,
+        query_params: {
+          tenantId: projectId,
+          startDate,
+          endDate,
+          pageTraceIds: ids,
+        },
+        format: "JSONEachRow",
+      });
+      return result.json() as Promise<TraceSummaryRow[]>;
+    };
+
+    try {
+      return await runQuery(traceIds);
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes("MEMORY_LIMIT_EXCEEDED")
+      ) {
+        throw error;
+      }
+
+      this.logger.warn(
+        `Summary query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
+      );
+
+      const allRows: TraceSummaryRow[] = [];
+      for (
+        let i = 0;
+        i < traceIds.length;
+        i += ClickHouseTraceService.SUMMARY_BATCH_SIZE
+      ) {
+        const batch = traceIds.slice(
+          i,
+          i + ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+        );
+        const batchRows = await runQuery(batch);
+        allRows.push(...batchRows);
+      }
+
+      const dir = orderDirection === "DESC" ? -1 : 1;
+      allRows.sort((a, b) => {
+        const timeDiff = a.ts_OccurredAt - b.ts_OccurredAt;
+        if (timeDiff !== 0) return timeDiff * dir;
+        return a.ts_TraceId < b.ts_TraceId ? -dir : dir;
+      });
+
+      return allRows;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- Streams the `/api/traces/search` JSON response incrementally instead of materializing the full string via `JSON.stringify()`, avoiding V8's ~512MB string length limit
- On ClickHouse `MEMORY_LIMIT_EXCEEDED`, retries the summary query in batches of 25 trace IDs instead of all at once — keeps heavy `ComputedInput`/`ComputedOutput` column reads within the 3.5 GiB per-query memory cap

## Context

Customer report: intermittent 500 on `/api/traces/search` when paginating through high-volume days with large payloads (RAG contexts, long conversations). Two distinct failure modes:

1. **V8 RangeError** — `JSON.stringify()` on 100+ traces with multi-MB payloads exceeds the ~512MB hard string limit
2. **ClickHouse OOM** — the summary query reads `ComputedInput`/`ComputedOutput` for all page trace IDs in one shot; when granules contain multi-megabyte values, this exceeds the 3.5 GiB per-query memory cap

## What changes

**Streaming (commits 1-3):** Response uses `ReadableStream` with chunked transfer encoding — each trace is serialized individually, so V8's string limit applies per-trace, not aggregate. Wire format is identical JSON.

**Batched retry (commit 5):** `fetchTraceSummaryRows` tries the full batch first (zero overhead for normal cases). On `MEMORY_LIMIT_EXCEEDED`, it retries in batches of 25 trace IDs sequentially, then merges and re-sorts results.

## Test plan

- [x] Streaming: valid JSON structure, comma separation, empty results, error pre-serialization
- [x] Batched retry: OOM triggers retry and returns all traces; non-OOM errors re-throw
- [x] Structural regression: dedup pattern still uses `max(UpdatedAt) GROUP BY`, no `LIMIT 1 BY`
- [x] All 44 trace service tests pass
- [x] All 18 trace API tests pass
- [x] Reproduced against production: pages 1-8 succeed, page 9 returns ClickHouse OOM (pre-fix)

Closes #3919