### PR TITLE
feat(billing): stripe v22 upgrade + flexible billing with event overage thresholds

### DIFF
--- a/langwatch/ee/billing/__tests__/growthSeatEvent.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/growthSeatEvent.unit.test.ts
@@ -23,6 +23,7 @@ import {
   resolveGrowthSeatPriceId,
   resolveGrowthEventsPriceId,
   createCheckoutLineItems,
+  getEventsUsageThreshold,
 } from "../utils/growthSeatEvent";
 
 describe("growthSeatEvent", () => {
@@ -208,6 +209,12 @@ describe("growthSeatEvent", () => {
           { price: "price_events_eur_annual" },
         ]);
       });
+    });
+  });
+
+  describe("getEventsUsageThreshold()", () => {
+    it("returns the included events allowance", () => {
+      expect(getEventsUsageThreshold()).toBe(200_000);
     });
   });
 });

--- a/langwatch/ee/billing/__tests__/growthSeatEvent.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/growthSeatEvent.unit.test.ts
@@ -23,7 +23,6 @@ import {
   resolveGrowthSeatPriceId,
   resolveGrowthEventsPriceId,
   createCheckoutLineItems,
-  getEventsUsageThreshold,
 } from "../utils/growthSeatEvent";
 
 describe("growthSeatEvent", () => {
@@ -209,12 +208,6 @@ describe("growthSeatEvent", () => {
           { price: "price_events_eur_annual" },
         ]);
       });
-    });
-  });
-
-  describe("getEventsUsageThreshold()", () => {
-    it("returns the included events allowance", () => {
-      expect(getEventsUsageThreshold()).toBe(200_000);
     });
   });
 });

--- a/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/planLimits.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { PLAN_LIMITS } from "../planLimits";
+import { GROWTH_SEAT_INCLUDED_EVENTS, PLAN_LIMITS, UNLIMITED_MESSAGES } from "../planLimits";
 import { PlanTypes } from "../planTypes";
+import { GROWTH_SEAT_PLAN_TYPES } from "../utils/growthSeatEvent";
 
 describe("PLAN_LIMITS", () => {
   describe("when checking critical plan-specific fields", () => {
@@ -14,6 +15,18 @@ describe("PLAN_LIMITS", () => {
 
     it("sets FREE maxProjects to 2", () => {
       expect(PLAN_LIMITS[PlanTypes.FREE].maxProjects).toBe(2);
+    });
+  });
+
+  describe("when checking GROWTH_SEAT plan limits", () => {
+    it("defines GROWTH_SEAT_INCLUDED_EVENTS as 200_000", () => {
+      expect(GROWTH_SEAT_INCLUDED_EVENTS).toBe(200_000);
+    });
+
+    it("keeps maxMessagesPerMonth as UNLIMITED for all GROWTH_SEAT plans", () => {
+      for (const type of GROWTH_SEAT_PLAN_TYPES) {
+        expect(PLAN_LIMITS[type].maxMessagesPerMonth).toBe(UNLIMITED_MESSAGES);
+      }
     });
   });
 });

--- a/langwatch/ee/billing/__tests__/seatEventSubscription.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/seatEventSubscription.unit.test.ts
@@ -37,7 +37,7 @@ const createMockStripe = () => ({
     },
   },
   invoices: {
-    retrieveUpcoming: vi.fn(),
+    createPreview: vi.fn(),
   },
   billingPortal: {
     sessions: {
@@ -119,20 +119,20 @@ describe("seatEventSubscription", () => {
 
       it("returns formatted proration amount and recurring total for USD", async () => {
         // "with change" invoice has $15 proration, "current" has $5 existing proration
-        stripe.invoices.retrieveUpcoming
+        stripe.invoices.createPreview
           .mockResolvedValueOnce({
             currency: "usd",
             lines: {
               data: [
-                { proration: true, amount: 1500 },
-                { proration: false, amount: 5000 },
+                { parent: { subscription_item_details: { proration: true } }, amount: 1500 },
+                { parent: { subscription_item_details: { proration: false } }, amount: 5000 },
               ],
             },
           })
           .mockResolvedValueOnce({
             currency: "usd",
             lines: {
-              data: [{ proration: true, amount: 500 }],
+              data: [{ parent: { subscription_item_details: { proration: true } }, amount: 500 }],
             },
           });
 
@@ -165,10 +165,10 @@ describe("seatEventSubscription", () => {
           },
         });
 
-        stripe.invoices.retrieveUpcoming
+        stripe.invoices.createPreview
           .mockResolvedValueOnce({
             currency: "eur",
-            lines: { data: [{ proration: true, amount: 2000 }] },
+            lines: { data: [{ parent: { subscription_item_details: { proration: true } }, amount: 2000 }] },
           })
           .mockResolvedValueOnce({
             currency: "eur",
@@ -186,10 +186,10 @@ describe("seatEventSubscription", () => {
       });
 
       it("formats whole-dollar amounts without decimals", async () => {
-        stripe.invoices.retrieveUpcoming
+        stripe.invoices.createPreview
           .mockResolvedValueOnce({
             currency: "usd",
-            lines: { data: [{ proration: true, amount: 5000 }] },
+            lines: { data: [{ parent: { subscription_item_details: { proration: true } }, amount: 5000 }] },
           })
           .mockResolvedValueOnce({
             currency: "usd",
@@ -208,14 +208,14 @@ describe("seatEventSubscription", () => {
       });
 
       it("formats fractional amounts with two decimal places", async () => {
-        stripe.invoices.retrieveUpcoming
+        stripe.invoices.createPreview
           .mockResolvedValueOnce({
             currency: "usd",
-            lines: { data: [{ proration: true, amount: 1550 }] },
+            lines: { data: [{ parent: { subscription_item_details: { proration: true } }, amount: 1550 }] },
           })
           .mockResolvedValueOnce({
             currency: "usd",
-            lines: { data: [{ proration: true, amount: 100 }] },
+            lines: { data: [{ parent: { subscription_item_details: { proration: true } }, amount: 100 }] },
           });
 
         const result = await service.previewProration({
@@ -228,20 +228,20 @@ describe("seatEventSubscription", () => {
       });
 
       it("subtracts existing prorations to isolate incremental cost", async () => {
-        stripe.invoices.retrieveUpcoming
+        stripe.invoices.createPreview
           .mockResolvedValueOnce({
             currency: "usd",
             lines: {
               data: [
-                { proration: true, amount: 3000 },
-                { proration: true, amount: 1000 },
+                { parent: { subscription_item_details: { proration: true } }, amount: 3000 },
+                { parent: { subscription_item_details: { proration: true } }, amount: 1000 },
               ],
             },
           })
           .mockResolvedValueOnce({
             currency: "usd",
             lines: {
-              data: [{ proration: true, amount: 2000 }],
+              data: [{ parent: { subscription_item_details: { proration: true } }, amount: 2000 }],
             },
           });
 
@@ -255,7 +255,7 @@ describe("seatEventSubscription", () => {
       });
 
       it("passes correct subscription_items to Stripe upstream invoice", async () => {
-        stripe.invoices.retrieveUpcoming
+        stripe.invoices.createPreview
           .mockResolvedValueOnce({
             currency: "usd",
             lines: { data: [] },
@@ -270,10 +270,12 @@ describe("seatEventSubscription", () => {
           newTotalSeats: 7,
         });
 
-        expect(stripe.invoices.retrieveUpcoming).toHaveBeenCalledWith({
+        expect(stripe.invoices.createPreview).toHaveBeenCalledWith({
           subscription: "sub_stripe_1",
-          subscription_items: [{ id: "si_seat", quantity: 7 }],
-          subscription_proration_behavior: "create_prorations",
+          subscription_details: {
+            items: [{ id: "si_seat", quantity: 7 }],
+            proration_behavior: "create_prorations",
+          },
         });
       });
     });

--- a/langwatch/ee/billing/__tests__/stripe.integration.test.ts
+++ b/langwatch/ee/billing/__tests__/stripe.integration.test.ts
@@ -22,7 +22,9 @@ if (STRIPE_SECRET_KEY && !STRIPE_SECRET_KEY.startsWith("sk_test_")) {
 const describeIfStripeKey = STRIPE_SECRET_KEY ? describe : describe.skip;
 
 describeIfStripeKey("Stripe billing integration", () => {
-  const stripe = new Stripe(STRIPE_SECRET_KEY!, { apiVersion: "2026-04-22.dahlia" });
+  const stripe = STRIPE_SECRET_KEY
+    ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2026-04-22.dahlia" })
+    : (undefined as unknown as Stripe);
 
   const createdCustomerIds: string[] = [];
   const createdSubscriptionIds: string[] = [];

--- a/langwatch/ee/billing/__tests__/stripe.integration.test.ts
+++ b/langwatch/ee/billing/__tests__/stripe.integration.test.ts
@@ -22,7 +22,7 @@ if (STRIPE_SECRET_KEY && !STRIPE_SECRET_KEY.startsWith("sk_test_")) {
 const describeIfStripeKey = STRIPE_SECRET_KEY ? describe : describe.skip;
 
 describeIfStripeKey("Stripe billing integration", () => {
-  const stripe = new Stripe(STRIPE_SECRET_KEY!, { apiVersion: "2024-04-10" });
+  const stripe = new Stripe(STRIPE_SECRET_KEY!, { apiVersion: "2026-04-22.dahlia" });
 
   const createdCustomerIds: string[] = [];
   const createdSubscriptionIds: string[] = [];

--- a/langwatch/ee/billing/__tests__/usageReportingService.integration.test.ts
+++ b/langwatch/ee/billing/__tests__/usageReportingService.integration.test.ts
@@ -21,7 +21,7 @@ if (STRIPE_SECRET_KEY && !STRIPE_SECRET_KEY.startsWith("sk_test_")) {
 const describeIfStripeKey = STRIPE_SECRET_KEY ? describe : describe.skip;
 
 describeIfStripeKey("Usage reporting integration", () => {
-  const stripe = new Stripe(STRIPE_SECRET_KEY!, { apiVersion: "2024-04-10" });
+  const stripe = new Stripe(STRIPE_SECRET_KEY!, { apiVersion: "2026-04-22.dahlia" });
   const service = new StripeUsageReportingService({
     stripe,
     meterId: meters.BILLABLE_EVENTS,

--- a/langwatch/ee/billing/__tests__/usageReportingService.integration.test.ts
+++ b/langwatch/ee/billing/__tests__/usageReportingService.integration.test.ts
@@ -21,7 +21,9 @@ if (STRIPE_SECRET_KEY && !STRIPE_SECRET_KEY.startsWith("sk_test_")) {
 const describeIfStripeKey = STRIPE_SECRET_KEY ? describe : describe.skip;
 
 describeIfStripeKey("Usage reporting integration", () => {
-  const stripe = new Stripe(STRIPE_SECRET_KEY!, { apiVersion: "2026-04-22.dahlia" });
+  const stripe = STRIPE_SECRET_KEY
+    ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2026-04-22.dahlia" })
+    : (undefined as unknown as Stripe);
   const service = new StripeUsageReportingService({
     stripe,
     meterId: meters.BILLABLE_EVENTS,

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -32,6 +32,40 @@ import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
 } from "../../../src/server/data-retention/retentionPolicy.schema";
+
+vi.mock("../stripe/stripePriceCatalog", () => ({
+  prices: {
+    PRO: "price_pro",
+    GROWTH: "price_growth",
+    LAUNCH: "price_launch",
+    LAUNCH_ANNUAL: "price_launch_annual",
+    ACCELERATE: "price_accelerate",
+    ACCELERATE_ANNUAL: "price_acc_annual",
+    LAUNCH_USERS: "price_launch_users",
+    ACCELERATE_USERS: "price_acc_users",
+    LAUNCH_ANNUAL_USERS: "price_launch_annual_users",
+    ACCELERATE_ANNUAL_USERS: "price_acc_annual_users",
+    LAUNCH_TRACES_10K: "price_launch_traces",
+    ACCELERATE_TRACES_100K: "price_acc_traces",
+    LAUNCH_ANNUAL_TRACES_10K: "price_launch_annual_traces",
+    ACCELERATE_ANNUAL_TRACES_100K: "price_acc_annual_traces",
+    GROWTH_SEAT_EUR_MONTHLY: "price_growth_seat_eur_monthly",
+    GROWTH_SEAT_EUR_ANNUAL: "price_growth_seat_eur_annual",
+    GROWTH_SEAT_USD_MONTHLY: "price_growth_seat_usd_monthly",
+    GROWTH_SEAT_USD_ANNUAL: "price_growth_seat_usd_annual",
+    GROWTH_EVENTS_EUR_MONTHLY: "price_growth_events_eur_monthly",
+    GROWTH_EVENTS_EUR_ANNUAL: "price_growth_events_eur_annual",
+    GROWTH_EVENTS_USD_MONTHLY: "price_growth_events_usd_monthly",
+    GROWTH_EVENTS_USD_ANNUAL: "price_growth_events_usd_annual",
+    GROWTH_EVENTS_EUR_MONTHLY_UNTIL_MAR_2026: "price_growth_events_eur_monthly_until_mar_2026",
+    GROWTH_EVENTS_EUR_ANNUAL_UNTIL_MAR_2026: "price_growth_events_eur_annual_until_mar_2026",
+    GROWTH_EVENTS_USD_MONTHLY_UNTIL_MAR_2026: "price_growth_events_usd_monthly_until_mar_2026",
+    GROWTH_EVENTS_USD_ANNUAL_UNTIL_MAR_2026: "price_growth_events_usd_annual_until_mar_2026",
+  },
+  isStripePriceName: (name: string) => name in { PRO: true, GROWTH: true, LAUNCH: true, ACCELERATE: true },
+  stripePricesFile: { prices: {} },
+}));
+
 import { SubscriptionStatus } from "../planTypes";
 import { EEWebhookService } from "../services/webhookService";
 
@@ -130,10 +164,15 @@ const makeSubscriptionWithOrg = (
 
 const createMockStripe = (overrides: Record<string, unknown> = {}) => ({
   subscriptions: {
-    retrieve: vi
-      .fn()
-      .mockResolvedValue({ id: "sub_stripe_1", status: "active" }),
+    retrieve: vi.fn().mockResolvedValue({
+      id: "sub_stripe_1",
+      status: "active",
+      items: { data: [] },
+    }),
     cancel: vi.fn().mockResolvedValue({}),
+  },
+  subscriptionItems: {
+    update: vi.fn().mockResolvedValue({}),
   },
   ...overrides,
 });
@@ -409,6 +448,16 @@ describe("webhookService", () => {
       /** @scenario Upgrade to a seat-event plan migrates old subscriptions */
       it("migrates tiered subscriptions and cancels old Stripe subs", async () => {
         const localStripe = createMockStripe();
+        localStripe.subscriptions.retrieve.mockResolvedValue({
+          id: "sub_stripe_1",
+          status: "active",
+          items: {
+            data: [
+              { id: "si_seat", price: { id: "price_growth_seat_eur_monthly" } },
+              { id: "si_events", price: { id: "price_growth_events_eur_monthly" } },
+            ],
+          },
+        });
         service = new EEWebhookService({
           subscriptionRepository: subRepo as unknown as SubscriptionRepository,
           organizationRepository: orgRepo as unknown as OrganizationRepository,
@@ -454,11 +503,91 @@ describe("webhookService", () => {
         );
       });
 
+      it("sets billing_thresholds on events subscription item after activation", async () => {
+        const localStripe = createMockStripe();
+        localStripe.subscriptions.retrieve.mockResolvedValue({
+          id: "sub_stripe_1",
+          status: "active",
+          items: {
+            data: [
+              { id: "si_seat", price: { id: "price_growth_seat_eur_monthly" } },
+              { id: "si_events", price: { id: "price_growth_events_eur_monthly" } },
+            ],
+          },
+        });
+        service = new EEWebhookService({
+          subscriptionRepository: subRepo as unknown as SubscriptionRepository,
+          organizationRepository: orgRepo as unknown as OrganizationRepository,
+          stripe: localStripe as any,
+          itemCalculator,
+        });
+
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.migrateToSeatEvent.mockResolvedValue([]);
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(localStripe.subscriptionItems.update).toHaveBeenCalledWith(
+          "si_events",
+          { billing_thresholds: { usage_gte: 200_000 } },
+        );
+      });
+
+      it("does not fail when billing_thresholds update fails", async () => {
+        const localStripe = createMockStripe();
+        localStripe.subscriptions.retrieve.mockResolvedValue({
+          id: "sub_stripe_1",
+          status: "active",
+          items: {
+            data: [
+              { id: "si_events", price: { id: "price_growth_events_eur_monthly" } },
+            ],
+          },
+        });
+        localStripe.subscriptionItems.update.mockRejectedValue(new Error("Stripe threshold error"));
+        service = new EEWebhookService({
+          subscriptionRepository: subRepo as unknown as SubscriptionRepository,
+          organizationRepository: orgRepo as unknown as OrganizationRepository,
+          stripe: localStripe as any,
+          itemCalculator,
+        });
+
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.migrateToSeatEvent.mockResolvedValue([]);
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalled();
+      });
+
       it("logs but does not fail when Stripe cancellation fails", async () => {
         const localStripe = createMockStripe();
         localStripe.subscriptions.cancel.mockRejectedValue(
           new Error("Stripe error"),
         );
+        localStripe.subscriptions.retrieve.mockResolvedValue({
+          id: "sub_stripe_1",
+          status: "active",
+          items: { data: [] },
+        });
         service = new EEWebhookService({
           subscriptionRepository: subRepo as unknown as SubscriptionRepository,
           organizationRepository: orgRepo as unknown as OrganizationRepository,

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -10,6 +10,39 @@ vi.mock("../../../src/server/app-layer/app", () => ({
   }),
 }));
 
+vi.mock("../stripe/stripePriceCatalog", () => ({
+  prices: {
+    PRO: "price_pro",
+    GROWTH: "price_growth",
+    LAUNCH: "price_launch",
+    LAUNCH_ANNUAL: "price_launch_annual",
+    ACCELERATE: "price_accelerate",
+    ACCELERATE_ANNUAL: "price_acc_annual",
+    LAUNCH_USERS: "price_launch_users",
+    ACCELERATE_USERS: "price_acc_users",
+    LAUNCH_ANNUAL_USERS: "price_launch_annual_users",
+    ACCELERATE_ANNUAL_USERS: "price_acc_annual_users",
+    LAUNCH_TRACES_10K: "price_launch_traces",
+    ACCELERATE_TRACES_100K: "price_acc_traces",
+    LAUNCH_ANNUAL_TRACES_10K: "price_launch_annual_traces",
+    ACCELERATE_ANNUAL_TRACES_100K: "price_acc_annual_traces",
+    GROWTH_SEAT_EUR_MONTHLY: "price_growth_seat_eur_monthly",
+    GROWTH_SEAT_EUR_ANNUAL: "price_growth_seat_eur_annual",
+    GROWTH_SEAT_USD_MONTHLY: "price_growth_seat_usd_monthly",
+    GROWTH_SEAT_USD_ANNUAL: "price_growth_seat_usd_annual",
+    GROWTH_EVENTS_EUR_MONTHLY: "price_growth_events_eur_monthly",
+    GROWTH_EVENTS_EUR_ANNUAL: "price_growth_events_eur_annual",
+    GROWTH_EVENTS_USD_MONTHLY: "price_growth_events_usd_monthly",
+    GROWTH_EVENTS_USD_ANNUAL: "price_growth_events_usd_annual",
+    GROWTH_EVENTS_EUR_MONTHLY_UNTIL_MAR_2026: "price_growth_events_eur_monthly_until_mar_2026",
+    GROWTH_EVENTS_EUR_ANNUAL_UNTIL_MAR_2026: "price_growth_events_eur_annual_until_mar_2026",
+    GROWTH_EVENTS_USD_MONTHLY_UNTIL_MAR_2026: "price_growth_events_usd_monthly_until_mar_2026",
+    GROWTH_EVENTS_USD_ANNUAL_UNTIL_MAR_2026: "price_growth_events_usd_annual_until_mar_2026",
+  },
+  isStripePriceName: (name: string) => name in { PRO: true, GROWTH: true, LAUNCH: true, ACCELERATE: true },
+  stripePricesFile: { prices: {} },
+}));
+
 import { SubscriptionStatus } from "../planTypes";
 import { EEWebhookService } from "../services/webhookService";
 import type { SubscriptionRepository, SubscriptionWithOrg } from "../../../src/server/app-layer/subscription/subscription.repository";
@@ -100,8 +133,11 @@ const makeSubscriptionWithOrg = (overrides: Record<string, unknown> = {}): Subsc
 
 const createMockStripe = (overrides: Record<string, unknown> = {}) => ({
   subscriptions: {
-    retrieve: vi.fn().mockResolvedValue({ id: "sub_stripe_1", status: "active" }),
+    retrieve: vi.fn().mockResolvedValue({ id: "sub_stripe_1", status: "active", items: { data: [] } }),
     cancel: vi.fn().mockResolvedValue({}),
+  },
+  subscriptionItems: {
+    update: vi.fn().mockResolvedValue({}),
   },
   ...overrides,
 });
@@ -369,6 +405,16 @@ describe("webhookService", () => {
       /** @scenario Upgrade to a seat-event plan migrates old subscriptions */
       it("migrates tiered subscriptions and cancels old Stripe subs", async () => {
         const localStripe = createMockStripe();
+        localStripe.subscriptions.retrieve.mockResolvedValue({
+          id: "sub_stripe_1",
+          status: "active",
+          items: {
+            data: [
+              { id: "si_seat", price: { id: "price_growth_seat_eur_monthly" } },
+              { id: "si_events", price: { id: "price_growth_events_eur_monthly" } },
+            ],
+          },
+        });
         service = new EEWebhookService({
           subscriptionRepository: subRepo as unknown as SubscriptionRepository,
           organizationRepository: orgRepo as unknown as OrganizationRepository,
@@ -402,9 +448,89 @@ describe("webhookService", () => {
         expect(localStripe.subscriptions.cancel).toHaveBeenCalledWith("sub_old_2", { prorate: true });
       });
 
+      it("sets billing_thresholds on events subscription item after activation", async () => {
+        const localStripe = createMockStripe();
+        localStripe.subscriptions.retrieve.mockResolvedValue({
+          id: "sub_stripe_1",
+          status: "active",
+          items: {
+            data: [
+              { id: "si_seat", price: { id: "price_growth_seat_eur_monthly" } },
+              { id: "si_events", price: { id: "price_growth_events_eur_monthly" } },
+            ],
+          },
+        });
+        service = new EEWebhookService({
+          subscriptionRepository: subRepo as unknown as SubscriptionRepository,
+          organizationRepository: orgRepo as unknown as OrganizationRepository,
+          stripe: localStripe as any,
+          itemCalculator,
+        });
+
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.migrateToSeatEvent.mockResolvedValue([]);
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(localStripe.subscriptionItems.update).toHaveBeenCalledWith(
+          "si_events",
+          { billing_thresholds: { usage_gte: 200_000 } },
+        );
+      });
+
+      it("does not fail when billing_thresholds update fails", async () => {
+        const localStripe = createMockStripe();
+        localStripe.subscriptions.retrieve.mockResolvedValue({
+          id: "sub_stripe_1",
+          status: "active",
+          items: {
+            data: [
+              { id: "si_events", price: { id: "price_growth_events_eur_monthly" } },
+            ],
+          },
+        });
+        localStripe.subscriptionItems.update.mockRejectedValue(new Error("Stripe threshold error"));
+        service = new EEWebhookService({
+          subscriptionRepository: subRepo as unknown as SubscriptionRepository,
+          organizationRepository: orgRepo as unknown as OrganizationRepository,
+          stripe: localStripe as any,
+          itemCalculator,
+        });
+
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.migrateToSeatEvent.mockResolvedValue([]);
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalled();
+      });
+
       it("logs but does not fail when Stripe cancellation fails", async () => {
         const localStripe = createMockStripe();
         localStripe.subscriptions.cancel.mockRejectedValue(new Error("Stripe error"));
+        localStripe.subscriptions.retrieve.mockResolvedValue({
+          id: "sub_stripe_1",
+          status: "active",
+          items: { data: [] },
+        });
         service = new EEWebhookService({
           subscriptionRepository: subRepo as unknown as SubscriptionRepository,
           organizationRepository: orgRepo as unknown as OrganizationRepository,

--- a/langwatch/ee/billing/planLimits.ts
+++ b/langwatch/ee/billing/planLimits.ts
@@ -9,6 +9,8 @@ import { GROWTH_SEAT_PLAN_TYPES } from "./utils/growthSeatEvent";
  */
 export const UNLIMITED_MESSAGES = 999_999_999;
 
+export { GROWTH_SEAT_INCLUDED_EVENTS } from "./utils/growthSeatConstants";
+
 const PAID_FEATURES = {
   maxWorkflows: 9999,
   maxPrompts: 9999,

--- a/langwatch/ee/billing/planLimits.ts
+++ b/langwatch/ee/billing/planLimits.ts
@@ -8,6 +8,8 @@ import { GROWTH_SEAT_PLAN_TYPES } from "./utils/growthSeatEvent";
  */
 export const UNLIMITED_MESSAGES = 999_999_999;
 
+export { GROWTH_SEAT_INCLUDED_EVENTS } from "./utils/growthSeatConstants";
+
 const PAID_FEATURES = {
   maxWorkflows: 9999,
   maxPrompts: 9999,

--- a/langwatch/ee/billing/services/seatEventSubscription.ts
+++ b/langwatch/ee/billing/services/seatEventSubscription.ts
@@ -149,14 +149,12 @@ export const createSeatEventSubscriptionFns = ({
     const billingCycleAnchor = new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1),
     );
-    const subscriptionData: Stripe.Checkout.SessionCreateParams["subscription_data"] =
-      {
+    const subscriptionData = {
         metadata: selectedOptionsMetadata,
         billing_cycle_anchor: Math.floor(
           billingCycleAnchor.getTime() / 1000,
         ),
-        proration_behavior:
-          "create_prorations" as Stripe.Checkout.SessionCreateParams.SubscriptionData.ProrationBehavior,
+        proration_behavior: "create_prorations" as const,
       };
 
     const session = await stripe.checkout.sessions.create({
@@ -283,17 +281,19 @@ export const createSeatEventSubscriptionFns = ({
     }
 
     // Fetch upcoming invoice WITH the proposed seat change
-    const upcomingWithChange = await stripe.invoices.retrieveUpcoming({
+    const upcomingWithChange = await stripe.invoices.createPreview({
       subscription: lastSubscription.stripeSubscriptionId,
-      subscription_items: [
-        { id: seatItem.id, quantity: newTotalSeats },
-      ],
-      subscription_proration_behavior: "create_prorations",
+      subscription_details: {
+        items: [
+          { id: seatItem.id, quantity: newTotalSeats },
+        ],
+        proration_behavior: "create_prorations",
+      },
     });
 
     // Fetch current upcoming invoice WITHOUT changes to isolate pre-existing
     // prorations (e.g. from mid-month signup with billing_cycle_anchor)
-    const upcomingCurrent = await stripe.invoices.retrieveUpcoming({
+    const upcomingCurrent = await stripe.invoices.createPreview({
       subscription: lastSubscription.stripeSubscriptionId,
     });
 
@@ -302,10 +302,18 @@ export const createSeatEventSubscriptionFns = ({
 
     // Subtract existing prorations from changed prorations to get ONLY
     // the incremental cost of adding/removing seats.
-    const sumProrations = (lines: { proration: boolean; amount: number }[]) => {
+    const isProration = (line: Stripe.InvoiceLineItem): boolean => {
+      const parent = line.parent;
+      if (!parent) return false;
+      return (
+        parent.invoice_item_details?.proration === true ||
+        parent.subscription_item_details?.proration === true
+      );
+    };
+    const sumProrations = (lines: Stripe.InvoiceLineItem[]) => {
       let total = 0;
       for (const line of lines) {
-        if (line.proration) total += line.amount;
+        if (isProration(line)) total += line.amount;
       }
       return total;
     };

--- a/langwatch/ee/billing/services/usageReportingService.ts
+++ b/langwatch/ee/billing/services/usageReportingService.ts
@@ -290,12 +290,12 @@ export class StripeUsageReportingService implements UsageReportingService {
 
 const isStripeInvalidRequestError = (
   error: unknown
-): error is Stripe.errors.StripeInvalidRequestError =>
+): error is InstanceType<typeof Stripe.errors.StripeInvalidRequestError> =>
   error instanceof Error &&
-  (error as Stripe.errors.StripeError).type === "StripeInvalidRequestError";
+  (error as InstanceType<typeof Stripe.errors.StripeError>).type === "StripeInvalidRequestError";
 
 const isStripeAuthenticationError = (
   error: unknown
-): error is Stripe.errors.StripeAuthenticationError =>
+): error is InstanceType<typeof Stripe.errors.StripeAuthenticationError> =>
   error instanceof Error &&
-  (error as Stripe.errors.StripeError).type === "StripeAuthenticationError";
+  (error as InstanceType<typeof Stripe.errors.StripeError>).type === "StripeAuthenticationError";

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -295,14 +295,21 @@ export class EEWebhookService implements WebhookService {
         | "invoice.payment_failed";
     },
   ): Promise<HandleEventResult> {
-    const paymentIntent = event.data.object as
-      | Stripe.Checkout.Session
-      | Stripe.Invoice;
+    const eventObject = event.data.object;
 
-    const subscriptionId =
-      typeof paymentIntent.subscription === "string"
-        ? paymentIntent.subscription
-        : paymentIntent.subscription?.id;
+    let subscriptionId: string | undefined;
+    if (event.type === "checkout.session.completed") {
+      const session = eventObject as Stripe.Checkout.Session;
+      subscriptionId =
+        typeof session.subscription === "string"
+          ? session.subscription
+          : session.subscription?.id ?? undefined;
+    } else {
+      const invoice = eventObject as Stripe.Invoice;
+      const subRef = invoice.parent?.subscription_details?.subscription;
+      subscriptionId =
+        typeof subRef === "string" ? subRef : subRef?.id ?? undefined;
+    }
 
     if (!subscriptionId) {
       logger.info(
@@ -316,10 +323,11 @@ export class EEWebhookService implements WebhookService {
     // Core handlers only need subscriptionId (+ client_reference_id for
     // checkout) — dropping the work here would ACK the event to Stripe
     // (no retry) while leaving the DB subscription PENDING.
+    const customerField = (eventObject as { customer?: string | { id: string } | null }).customer;
     const customerId =
-      typeof paymentIntent.customer === "string"
-        ? paymentIntent.customer
-        : paymentIntent.customer?.id;
+      typeof customerField === "string"
+        ? customerField
+        : customerField?.id;
 
     const organization = customerId
       ? await this.organizationRepository.findByStripeCustomerId(customerId)

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -18,7 +18,7 @@ import { SubscriptionRecordNotFoundError } from "../errors";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
 import { SubscriptionStatus } from "../planTypes";
 import {
-  getEventsUsageThreshold,
+  GROWTH_SEAT_INCLUDED_EVENTS,
   isGrowthEventsPrice,
   isGrowthSeatEventPlan,
   isGrowthSeatPrice,
@@ -996,7 +996,7 @@ export class EEWebhookService implements WebhookService {
     subscriptionItemId: string,
     stripeSubscriptionId: string,
   ): Promise<void> {
-    const threshold = getEventsUsageThreshold();
+    const threshold = GROWTH_SEAT_INCLUDED_EVENTS;
     try {
       await this.stripe.subscriptionItems.update(subscriptionItemId, {
         billing_thresholds: { usage_gte: threshold },

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -18,6 +18,7 @@ import { SubscriptionRecordNotFoundError } from "../errors";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
 import { SubscriptionStatus } from "../planTypes";
 import {
+  getEventsUsageThreshold,
   isGrowthEventsPrice,
   isGrowthSeatEventPlan,
   isGrowthSeatPrice,
@@ -689,7 +690,9 @@ export class EEWebhookService implements WebhookService {
         if (isGrowthSeatPrice(item.price.id)) {
           usersQuantity = item.quantity ?? 0;
         } else if (isGrowthEventsPrice(item.price.id)) {
-          // Events price exists on the subscription; traces limit comes from plan limits
+          if (!item.billing_thresholds) {
+            await this.applyEventsUsageThresholdToItem(item.id, subscription.id);
+          }
         } else if (
           item.price.id === this.itemCalculator.prices.LAUNCH_USERS ||
           item.price.id === this.itemCalculator.prices.ACCELERATE_USERS ||
@@ -849,6 +852,7 @@ export class EEWebhookService implements WebhookService {
         }
 
         await this.applySeatRetentionPolicy(updatedSubscription.organizationId);
+        await this.applyEventsUsageThreshold(subscriptionId);
       }
 
       await getApp().notifications.sendSlackSubscriptionEvent({
@@ -957,6 +961,56 @@ export class EEWebhookService implements WebhookService {
     await this.organizationRepository.clearTrialLicense(
       updatedSubscription.organizationId,
     );
+  }
+
+  private async applyEventsUsageThreshold(
+    stripeSubscriptionId: string,
+  ): Promise<void> {
+    try {
+      const stripeSubscription =
+        await this.stripe.subscriptions.retrieve(stripeSubscriptionId);
+      const eventsItem = stripeSubscription.items.data.find((item) =>
+        isGrowthEventsPrice(item.price.id),
+      );
+      if (eventsItem) {
+        await this.applyEventsUsageThresholdToItem(
+          eventsItem.id,
+          stripeSubscriptionId,
+        );
+      } else {
+        logger.warn(
+          { stripeSubscriptionId },
+          "[stripeWebhook] No events subscription item found to set billing_thresholds",
+        );
+      }
+    } catch (err) {
+      logger.error(
+        { stripeSubscriptionId, err },
+        "[stripeWebhook] Failed to apply billing_thresholds on events item. " +
+          "Usage will be billed at end-of-period rather than at threshold.",
+      );
+    }
+  }
+
+  private async applyEventsUsageThresholdToItem(
+    subscriptionItemId: string,
+    stripeSubscriptionId: string,
+  ): Promise<void> {
+    const threshold = getEventsUsageThreshold();
+    try {
+      await this.stripe.subscriptionItems.update(subscriptionItemId, {
+        billing_thresholds: { usage_gte: threshold },
+      });
+      logger.info(
+        { stripeSubscriptionId, subscriptionItemId, threshold },
+        "[stripeWebhook] Set billing_thresholds on events subscription item",
+      );
+    } catch (err) {
+      logger.warn(
+        { stripeSubscriptionId, subscriptionItemId, err },
+        "[stripeWebhook] Failed to set billing_thresholds on events item",
+      );
+    }
   }
 
   private normalizeSelectedCurrency(value?: string | null): Currency | null {

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -12,7 +12,7 @@ import { PrismaOrganizationRepository } from "../../../src/server/app-layer/orga
 import { PrismaSubscriptionRepository } from "./subscription.repository";
 import { SubscriptionStatus } from "../planTypes";
 import type { calculateQuantityForPrice, prices } from "./subscriptionItemCalculator";
-import { isGrowthEventsPrice, isGrowthSeatEventPlan, isGrowthSeatPrice } from "../utils/growthSeatEvent";
+import { getEventsUsageThreshold, isGrowthEventsPrice, isGrowthSeatEventPlan, isGrowthSeatPrice } from "../utils/growthSeatEvent";
 import { SubscriptionRecordNotFoundError } from "../errors";
 import { traced } from "../../../src/server/app-layer/tracing";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
@@ -674,7 +674,9 @@ export class EEWebhookService implements WebhookService {
         if (isGrowthSeatPrice(item.price.id)) {
           usersQuantity = item.quantity ?? 0;
         } else if (isGrowthEventsPrice(item.price.id)) {
-          // Events price exists on the subscription; traces limit comes from plan limits
+          if (!item.billing_thresholds) {
+            await this.applyEventsUsageThresholdToItem(item.id, subscription.id);
+          }
         } else if (
           item.price.id === this.itemCalculator.prices.LAUNCH_USERS ||
           item.price.id === this.itemCalculator.prices.ACCELERATE_USERS ||
@@ -823,6 +825,8 @@ export class EEWebhookService implements WebhookService {
             }
           }
         }
+
+        await this.applyEventsUsageThreshold(subscriptionId);
       }
 
       await getApp().notifications.sendSlackSubscriptionEvent({
@@ -855,6 +859,56 @@ export class EEWebhookService implements WebhookService {
     await this.organizationRepository.clearTrialLicense(
       updatedSubscription.organizationId,
     );
+  }
+
+  private async applyEventsUsageThreshold(
+    stripeSubscriptionId: string,
+  ): Promise<void> {
+    try {
+      const stripeSubscription =
+        await this.stripe.subscriptions.retrieve(stripeSubscriptionId);
+      const eventsItem = stripeSubscription.items.data.find((item) =>
+        isGrowthEventsPrice(item.price.id),
+      );
+      if (eventsItem) {
+        await this.applyEventsUsageThresholdToItem(
+          eventsItem.id,
+          stripeSubscriptionId,
+        );
+      } else {
+        logger.warn(
+          { stripeSubscriptionId },
+          "[stripeWebhook] No events subscription item found to set billing_thresholds",
+        );
+      }
+    } catch (err) {
+      logger.error(
+        { stripeSubscriptionId, err },
+        "[stripeWebhook] Failed to apply billing_thresholds on events item. " +
+          "Usage will be billed at end-of-period rather than at threshold.",
+      );
+    }
+  }
+
+  private async applyEventsUsageThresholdToItem(
+    subscriptionItemId: string,
+    stripeSubscriptionId: string,
+  ): Promise<void> {
+    const threshold = getEventsUsageThreshold();
+    try {
+      await this.stripe.subscriptionItems.update(subscriptionItemId, {
+        billing_thresholds: { usage_gte: threshold },
+      });
+      logger.info(
+        { stripeSubscriptionId, subscriptionItemId, threshold },
+        "[stripeWebhook] Set billing_thresholds on events subscription item",
+      );
+    } catch (err) {
+      logger.warn(
+        { stripeSubscriptionId, subscriptionItemId, err },
+        "[stripeWebhook] Failed to set billing_thresholds on events item",
+      );
+    }
   }
 
   private normalizeSelectedCurrency(value?: string | null): Currency | null {

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -284,14 +284,21 @@ export class EEWebhookService implements WebhookService {
         | "invoice.payment_failed";
     },
   ): Promise<HandleEventResult> {
-    const paymentIntent = event.data.object as
-      | Stripe.Checkout.Session
-      | Stripe.Invoice;
+    const eventObject = event.data.object;
 
-    const subscriptionId =
-      typeof paymentIntent.subscription === "string"
-        ? paymentIntent.subscription
-        : paymentIntent.subscription?.id;
+    let subscriptionId: string | undefined;
+    if (event.type === "checkout.session.completed") {
+      const session = eventObject as Stripe.Checkout.Session;
+      subscriptionId =
+        typeof session.subscription === "string"
+          ? session.subscription
+          : session.subscription?.id ?? undefined;
+    } else {
+      const invoice = eventObject as Stripe.Invoice;
+      const subRef = invoice.parent?.subscription_details?.subscription;
+      subscriptionId =
+        typeof subRef === "string" ? subRef : subRef?.id ?? undefined;
+    }
 
     if (!subscriptionId) {
       logger.info(
@@ -305,10 +312,11 @@ export class EEWebhookService implements WebhookService {
     // Core handlers only need subscriptionId (+ client_reference_id for
     // checkout) — dropping the work here would ACK the event to Stripe
     // (no retry) while leaving the DB subscription PENDING.
+    const customerField = (eventObject as { customer?: string | { id: string } | null }).customer;
     const customerId =
-      typeof paymentIntent.customer === "string"
-        ? paymentIntent.customer
-        : paymentIntent.customer?.id;
+      typeof customerField === "string"
+        ? customerField
+        : customerField?.id;
 
     const organization = customerId
       ? await this.organizationRepository.findByStripeCustomerId(customerId)

--- a/langwatch/ee/billing/stripe/stripeClient.ts
+++ b/langwatch/ee/billing/stripe/stripeClient.ts
@@ -8,6 +8,6 @@ export const createStripeClient = () => {
   }
 
   return new Stripe(secretKey, {
-    apiVersion: "2024-04-10",
+    apiVersion: "2026-04-22.dahlia",
   });
 };

--- a/langwatch/ee/billing/utils/growthSeatConstants.ts
+++ b/langwatch/ee/billing/utils/growthSeatConstants.ts
@@ -7,10 +7,3 @@
  * Traces continue flowing; only billing changes at the threshold.
  */
 export const GROWTH_SEAT_INCLUDED_EVENTS = 200_000;
-
-/**
- * Returns the billing_thresholds.usage_gte value for the events
- * subscription item on a Growth seat+event plan.
- */
-export const getEventsUsageThreshold = (): number =>
-  GROWTH_SEAT_INCLUDED_EVENTS;

--- a/langwatch/ee/billing/utils/growthSeatConstants.ts
+++ b/langwatch/ee/billing/utils/growthSeatConstants.ts
@@ -1,0 +1,16 @@
+/**
+ * Monthly events included in the Growth seat+event plan price.
+ * Usage beyond this threshold triggers immediate Stripe invoicing
+ * via billing_thresholds.usage_gte on the metered subscription item.
+ *
+ * This is NOT maxMessagesPerMonth (which controls trace blocking).
+ * Traces continue flowing; only billing changes at the threshold.
+ */
+export const GROWTH_SEAT_INCLUDED_EVENTS = 200_000;
+
+/**
+ * Returns the billing_thresholds.usage_gte value for the events
+ * subscription item on a Growth seat+event plan.
+ */
+export const getEventsUsageThreshold = (): number =>
+  GROWTH_SEAT_INCLUDED_EVENTS;

--- a/langwatch/ee/billing/utils/growthSeatEvent.ts
+++ b/langwatch/ee/billing/utils/growthSeatEvent.ts
@@ -136,11 +136,4 @@ export const createCheckoutLineItems = ({
   ];
 };
 
-/**
- * Returns the billing_thresholds.usage_gte value for the events
- * subscription item on a Growth seat+event plan.
- *
- * Stripe will generate an immediate invoice when metered usage
- * on the events line item reaches this number of units.
- */
-export { GROWTH_SEAT_INCLUDED_EVENTS, getEventsUsageThreshold } from "./growthSeatConstants";
+export { GROWTH_SEAT_INCLUDED_EVENTS } from "./growthSeatConstants";

--- a/langwatch/ee/billing/utils/growthSeatEvent.ts
+++ b/langwatch/ee/billing/utils/growthSeatEvent.ts
@@ -135,3 +135,12 @@ export const createCheckoutLineItems = ({
     },
   ];
 };
+
+/**
+ * Returns the billing_thresholds.usage_gte value for the events
+ * subscription item on a Growth seat+event plan.
+ *
+ * Stripe will generate an immediate invoice when metered usage
+ * on the events line item reaches this number of units.
+ */
+export { GROWTH_SEAT_INCLUDED_EVENTS, getEventsUsageThreshold } from "./growthSeatConstants";

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -240,7 +240,7 @@
     "semver": "^7.7.4",
     "shiki": "^3.23.0",
     "slugify": "^1.6.9",
-    "stripe": "^15.12.0",
+    "stripe": "^22.1.1",
     "superjson": "^1.13.3",
     "tiktoken": "^1.0.22",
     "ts-pattern": "^5.9.0",

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -241,7 +241,7 @@
     "semver": "^7.7.4",
     "shiki": "^3.23.0",
     "slugify": "^1.6.9",
-    "stripe": "^15.12.0",
+    "stripe": "^22.1.1",
     "superjson": "^1.13.3",
     "tiktoken": "^1.0.22",
     "ts-pattern": "^5.9.0",

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -597,8 +597,8 @@ importers:
         specifier: ^1.6.9
         version: 1.6.9
       stripe:
-        specifier: ^15.12.0
-        version: 15.12.0
+        specifier: ^22.1.1
+        version: 22.1.1(@types/node@18.19.130)
       superjson:
         specifier: ^1.13.3
         version: 1.13.3
@@ -1719,6 +1719,7 @@ packages:
 
   '@clickhouse/client-common@1.18.3':
     resolution: {integrity: sha512-3axzO3zvrsGT5PzDenxgWscltYCNRDbhaHWUgdsmcM9OnW/VnZn9EarOcZogr9P82Z0mQh+Jd2x+p2K4TFD2fA==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.18.3':
     resolution: {integrity: sha512-340ngdYktL8PLUBK2QKSwe0o02tYfZSz1mSn1uXCEU8TxHvwh9pnQxElf9YHumDGj5gX/IdgxPsJTGMs82Hgug==}
@@ -10581,9 +10582,14 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
-  stripe@15.12.0:
-    resolution: {integrity: sha512-slTbYS1WhRJXVB8YXU8fgHizkUrM9KJyrw4Dd8pLEwzKHYyQTIE46EePC2MVbSDZdE24o1GdNtzmJV4PrPpmJA==}
-    engines: {node: '>=12.*'}
+  stripe@22.1.1:
+    resolution: {integrity: sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -23695,10 +23701,9 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  stripe@15.12.0:
-    dependencies:
-      '@types/node': 20.19.39
-      qs: 6.15.2
+  stripe@22.1.1(@types/node@18.19.130):
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   strnum@2.2.3: {}
 

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -577,8 +577,8 @@ importers:
         specifier: ^1.6.9
         version: 1.6.9
       stripe:
-        specifier: ^15.12.0
-        version: 15.12.0
+        specifier: ^22.1.1
+        version: 22.1.1(@types/node@18.19.130)
       superjson:
         specifier: ^1.13.3
         version: 1.13.3
@@ -11676,9 +11676,14 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  stripe@15.12.0:
-    resolution: {integrity: sha512-slTbYS1WhRJXVB8YXU8fgHizkUrM9KJyrw4Dd8pLEwzKHYyQTIE46EePC2MVbSDZdE24o1GdNtzmJV4PrPpmJA==}
-    engines: {node: '>=12.*'}
+  stripe@22.1.1:
+    resolution: {integrity: sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -15024,7 +15029,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -15037,14 +15042,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -15069,7 +15074,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -15087,7 +15092,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -15109,7 +15114,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -15179,7 +15184,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -18710,7 +18715,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
 
   '@types/hast@2.3.10':
     dependencies:
@@ -22608,7 +22613,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
@@ -22677,6 +22682,36 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -22701,7 +22736,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -22711,7 +22746,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -22758,7 +22793,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -22793,7 +22828,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -22821,7 +22856,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -22867,7 +22902,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -22886,7 +22921,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -22895,13 +22930,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 25.6.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -26166,10 +26201,9 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stripe@15.12.0:
-    dependencies:
-      '@types/node': 20.19.39
-      qs: 6.15.1
+  stripe@22.1.1(@types/node@18.19.130):
+    optionalDependencies:
+      '@types/node': 18.19.130
 
   strnum@2.2.3: {}
 


### PR DESCRIPTION
## Summary

- Upgrades `stripe` SDK from `^15.12.0` to `^22.1.1` (API version `2026-04-22.dahlia`)
- Implements automatic overage invoicing for Growth seat+event plans via Stripe `billing_thresholds`
- When metered event usage exceeds 200K events/month, Stripe generates an immediate invoice

## Stripe Upgrade (commit 1)

| Breaking Change | File | Fix |
|--------|------|-----|
| `invoices.retrieveUpcoming()` removed | `seatEventSubscription.ts` | Migrated to `invoices.createPreview()` with `subscription_details` params |
| `Invoice.subscription` removed | `webhookService.ts` | Access via `Invoice.parent.subscription_details.subscription` |
| `InvoiceLineItem.proration` moved | `seatEventSubscription.ts` | Access via `parent.subscription_item_details.proration` |
| `Stripe.errors.*` types changed | `usageReportingService.ts` | Use `InstanceType<typeof Stripe.errors.*>` |
| API version `2024-04-10` → `2026-04-22.dahlia` | `stripeClient.ts`, test files | Updated all references |

## Flexible Billing (commit 2)

**Problem**: Growth seat+event plans have `maxMessagesPerMonth: UNLIMITED` and no overage billing — all events are metered at a flat per-event rate with no included allowance concept.

**Solution**: Apply `billing_thresholds.usage_gte: 200_000` on the metered events subscription item. When monthly usage hits 200K events, Stripe generates an immediate invoice for the overage.

**Key design decisions**:
- `maxMessagesPerMonth` stays `UNLIMITED_MESSAGES` — traces must NEVER be blocked (HTTP 429). Only billing changes at the threshold.
- `billing_thresholds` set post-checkout via webhook (Checkout Sessions don't support per-item thresholds)
- Existing subscriptions get thresholds backfilled via `handleSubscriptionUpdated` webhook
- New `GROWTH_SEAT_INCLUDED_EVENTS` constant (200K) in shared `growthSeatConstants.ts` to avoid circular dependency

**Files changed**:
- `ee/billing/utils/growthSeatConstants.ts` — new shared `GROWTH_SEAT_INCLUDED_EVENTS` constant
- `ee/billing/planLimits.ts` — re-exports `GROWTH_SEAT_INCLUDED_EVENTS`
- `ee/billing/utils/growthSeatEvent.ts` — re-exports `GROWTH_SEAT_INCLUDED_EVENTS`
- `ee/billing/services/webhookService.ts` — sets `billing_thresholds` on events item after activation + backfill on update
- Tests for all changes

**Files NOT changed (intentionally)**:
- `usageReportingService.ts` — already reports monthly deltas correctly
- `reportUsageForMonth.command.ts` — already runs monthly cycle
- `usage.service.ts` — must NOT change; `UNLIMITED_MESSAGES` short-circuit must remain
- Trace collector/middleware — traces must keep flowing

## Post-review cleanup (commit 3)

- CodeRabbit nitpick: dropped the redundant `getEventsUsageThreshold()` wrapper — it only returned `GROWTH_SEAT_INCLUDED_EVENTS` with no added logic. Call sites now use the constant directly.
- Rebased onto latest `main` (branch was ~2 months behind); resolved conflicts from the Stripe SDK lockfile bump and the concurrently-added seat retention policy call in `webhookService.ts` (both now run side by side on subscription activation).

## Test plan

- [x] 382 billing unit tests pass (26 test files) after rebase onto latest main
- [ ] Run Stripe integration tests with test-mode key
- [ ] Verify checkout flow creates subscription with threshold on events item (staging)
- [ ] Verify `handleSubscriptionUpdated` backfills thresholds on existing subs
- [ ] Verify overage invoice is generated when usage exceeds 200K in Stripe test mode
- [ ] Confirm traces continue flowing past 200K (no blocking)

Closes #3918