### PR TITLE
fix(billing): dedup repeated subscription alerts from concurrent Stripe webhooks

### DIFF
--- a/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/usage-limit.service.unit.test.ts
@@ -36,6 +36,7 @@ import { env } from "../../../src/env.mjs";
 import {
   UsageLimitService,
   resourceLimitCooldown,
+  resourceLimitInFlight,
   planLimitCooldown,
   planLimitInFlight,
 } from "../notifications/usage-limit.service";
@@ -323,6 +324,7 @@ describe("UsageLimitService", () => {
       await resourceLimitCooldown.delete("org_1:workflows");
       await resourceLimitCooldown.delete("org_1:agents");
       await resourceLimitCooldown.delete("org_missing:workflows");
+      resourceLimitInFlight.clear();
     });
 
     describe("when IS_SAAS is false", () => {
@@ -430,7 +432,7 @@ describe("UsageLimitService", () => {
     });
 
     describe("when called concurrently for the same organization", () => {
-      it("sends at most one notification per concurrent batch (in-memory cooldown has a race window)", async () => {
+      it("sends exactly one notification per concurrent batch", async () => {
         const { service, organizationService, notificationService } = createService();
         (organizationService.findWithAdmins as ReturnType<typeof vi.fn>).mockResolvedValue(ORG_WITH_ADMIN);
 
@@ -449,12 +451,9 @@ describe("UsageLimitService", () => {
           }),
         ]);
 
-        // The in-memory cooldown has a documented race window: two concurrent calls both see
-        // a cache miss before either writes the cooldown entry. The worst case is a duplicate
-        // alert (see NOTE in usage-limit.service.ts). Both calls proceed when concurrent.
         expect(
           notificationService.sendSlackResourceLimitAlert,
-        ).toHaveBeenCalledTimes(2);
+        ).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -23,7 +23,7 @@ import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
 } from "../../../src/server/data-retention/retentionPolicy.schema";
-import { EEWebhookService } from "../services/webhookService";
+import { EEWebhookService, subscriptionConfirmedCooldown } from "../services/webhookService";
 import type { SubscriptionRepository, SubscriptionWithOrg } from "../../../src/server/app-layer/subscription/subscription.repository";
 import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
 
@@ -125,9 +125,10 @@ describe("webhookService", () => {
   let mockStripeInstance: ReturnType<typeof createMockStripe>;
   let service: EEWebhookService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    await subscriptionConfirmedCooldown.delete("sub_stripe_1");
     subRepo = createMockSubscriptionRepository();
     orgRepo = createMockOrganizationRepository();
     itemCalculator = createMockItemCalculator();
@@ -1129,6 +1130,103 @@ describe("webhookService", () => {
 
         expect(subRepo.cancel).toHaveBeenCalledWith({ id: "sub_db_1" });
         expect(mockRemoveForScope).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("subscription confirmed notification dedup", () => {
+    describe("when checkout.session.completed and invoice.payment_succeeded both trigger syncInvoicePaymentSuccess", () => {
+      it("sends exactly one confirmed notification", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
+        );
+        subRepo.linkStripeId.mockResolvedValue({ count: 1 });
+
+        const checkoutPromise = service.handleCheckoutCompleted({
+          subscriptionId: "sub_stripe_1",
+          clientReferenceId: "subscription_setup_sub_db_1",
+        });
+
+        const invoicePromise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await Promise.allSettled([checkoutPromise, invoicePromise]);
+
+        const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
+          (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
+        );
+        expect(confirmedCalls).toHaveLength(1);
+      });
+    });
+
+    describe("when handleSubscriptionUpdated fires alongside syncInvoicePaymentSuccess", () => {
+      it("sends exactly one confirmed notification across both paths", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
+        );
+        subRepo.updateQuantities.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
+        );
+
+        const invoicePromise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+
+        const updatePromise = service.handleSubscriptionUpdated({
+          subscription: {
+            id: "sub_stripe_1",
+            status: "active",
+            canceled_at: null,
+            ended_at: null,
+            items: { data: [] },
+          } as any,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await Promise.allSettled([invoicePromise, updatePromise]);
+
+        const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
+          (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
+        );
+        expect(confirmedCalls).toHaveLength(1);
+      });
+    });
+
+    describe("when different subscriptions activate concurrently", () => {
+      it("sends one notification per subscription", async () => {
+        await subscriptionConfirmedCooldown.delete("sub_stripe_2");
+
+        subRepo.findByStripeId.mockImplementation((id: string) => {
+          if (id === "sub_stripe_1") {
+            return makeSubscription({ status: SubscriptionStatus.PENDING, stripeSubscriptionId: "sub_stripe_1" });
+          }
+          return makeSubscription({ id: "sub_db_2", organizationId: "org_456", status: SubscriptionStatus.PENDING, stripeSubscriptionId: "sub_stripe_2" });
+        });
+        subRepo.activate.mockImplementation(({ id }: { id: string }) => {
+          if (id === "sub_db_1") {
+            return makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE });
+          }
+          return makeSubscriptionWithOrg({ id: "sub_db_2", organizationId: "org_456", status: SubscriptionStatus.ACTIVE });
+        });
+
+        const promise1 = service.handleInvoicePaymentSucceeded({ subscriptionId: "sub_stripe_1" });
+        const promise2 = service.handleInvoicePaymentSucceeded({ subscriptionId: "sub_stripe_2" });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await Promise.allSettled([promise1, promise2]);
+
+        const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
+          (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
+        );
+        expect(confirmedCalls).toHaveLength(2);
       });
     });
   });

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -1155,7 +1155,7 @@ describe("webhookService", () => {
         });
 
         await vi.advanceTimersByTimeAsync(2000);
-        await Promise.allSettled([checkoutPromise, invoicePromise]);
+        await Promise.all([checkoutPromise, invoicePromise]);
 
         const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
           (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
@@ -1191,7 +1191,7 @@ describe("webhookService", () => {
         });
 
         await vi.advanceTimersByTimeAsync(2000);
-        await Promise.allSettled([invoicePromise, updatePromise]);
+        await Promise.all([invoicePromise, updatePromise]);
 
         const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
           (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
@@ -1221,7 +1221,37 @@ describe("webhookService", () => {
         const promise2 = service.handleInvoicePaymentSucceeded({ subscriptionId: "sub_stripe_2" });
 
         await vi.advanceTimersByTimeAsync(2000);
-        await Promise.allSettled([promise1, promise2]);
+        await Promise.all([promise1, promise2]);
+
+        const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
+          (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
+        );
+        expect(confirmedCalls).toHaveLength(2);
+      });
+    });
+
+    describe("when the confirmed notification fails to send", () => {
+      it("releases the dedup key so a retry re-sends", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
+        );
+
+        mockSendSlackSubscriptionEvent.mockRejectedValueOnce(new Error("slack down"));
+
+        const failingPromise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await failingPromise;
+
+        const retryPromise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        await retryPromise;
 
         const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
           (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -11,7 +11,7 @@ vi.mock("../../../src/server/app-layer/app", () => ({
 }));
 
 import { SubscriptionStatus } from "../planTypes";
-import { EEWebhookService } from "../services/webhookService";
+import { EEWebhookService, subscriptionConfirmedCooldown } from "../services/webhookService";
 import type { SubscriptionRepository, SubscriptionWithOrg } from "../../../src/server/app-layer/subscription/subscription.repository";
 import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
 
@@ -113,9 +113,10 @@ describe("webhookService", () => {
   let mockStripeInstance: ReturnType<typeof createMockStripe>;
   let service: EEWebhookService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    await subscriptionConfirmedCooldown.delete("sub_stripe_1");
     subRepo = createMockSubscriptionRepository();
     orgRepo = createMockOrganizationRepository();
     itemCalculator = createMockItemCalculator();
@@ -975,6 +976,103 @@ describe("webhookService", () => {
         await promise;
 
         expect(mockSendSlackSubscriptionEvent).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("subscription confirmed notification dedup", () => {
+    describe("when checkout.session.completed and invoice.payment_succeeded both trigger syncInvoicePaymentSuccess", () => {
+      it("sends exactly one confirmed notification", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
+        );
+        subRepo.linkStripeId.mockResolvedValue({ count: 1 });
+
+        const checkoutPromise = service.handleCheckoutCompleted({
+          subscriptionId: "sub_stripe_1",
+          clientReferenceId: "subscription_setup_sub_db_1",
+        });
+
+        const invoicePromise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await Promise.allSettled([checkoutPromise, invoicePromise]);
+
+        const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
+          (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
+        );
+        expect(confirmedCalls).toHaveLength(1);
+      });
+    });
+
+    describe("when handleSubscriptionUpdated fires alongside syncInvoicePaymentSuccess", () => {
+      it("sends exactly one confirmed notification across both paths", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
+        );
+        subRepo.updateQuantities.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE }),
+        );
+
+        const invoicePromise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+
+        const updatePromise = service.handleSubscriptionUpdated({
+          subscription: {
+            id: "sub_stripe_1",
+            status: "active",
+            canceled_at: null,
+            ended_at: null,
+            items: { data: [] },
+          } as any,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await Promise.allSettled([invoicePromise, updatePromise]);
+
+        const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
+          (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
+        );
+        expect(confirmedCalls).toHaveLength(1);
+      });
+    });
+
+    describe("when different subscriptions activate concurrently", () => {
+      it("sends one notification per subscription", async () => {
+        await subscriptionConfirmedCooldown.delete("sub_stripe_2");
+
+        subRepo.findByStripeId.mockImplementation((id: string) => {
+          if (id === "sub_stripe_1") {
+            return makeSubscription({ status: SubscriptionStatus.PENDING, stripeSubscriptionId: "sub_stripe_1" });
+          }
+          return makeSubscription({ id: "sub_db_2", organizationId: "org_456", status: SubscriptionStatus.PENDING, stripeSubscriptionId: "sub_stripe_2" });
+        });
+        subRepo.activate.mockImplementation(({ id }: { id: string }) => {
+          if (id === "sub_db_1") {
+            return makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE });
+          }
+          return makeSubscriptionWithOrg({ id: "sub_db_2", organizationId: "org_456", status: SubscriptionStatus.ACTIVE });
+        });
+
+        const promise1 = service.handleInvoicePaymentSucceeded({ subscriptionId: "sub_stripe_1" });
+        const promise2 = service.handleInvoicePaymentSucceeded({ subscriptionId: "sub_stripe_2" });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await Promise.allSettled([promise1, promise2]);
+
+        const confirmedCalls = mockSendSlackSubscriptionEvent.mock.calls.filter(
+          (call: unknown[]) => (call[0] as { type: string }).type === "confirmed",
+        );
+        expect(confirmedCalls).toHaveLength(2);
       });
     });
   });

--- a/langwatch/ee/billing/notifications/usage-limit.service.ts
+++ b/langwatch/ee/billing/notifications/usage-limit.service.ts
@@ -22,7 +22,8 @@ const MIN_DAYS_BETWEEN_ALERTS = 30;
 
 // NOTE: In-memory cooldown does not survive restarts and does not coordinate across replicas. Accepted tradeoff: worst case is a duplicate Slack alert.
 const resourceLimitCooldown = new TtlCache<true>(24 * 60 * 60 * 1000, "ttlcache:billing:limitCooldown:");
-export { resourceLimitCooldown };
+const resourceLimitInFlight = new Set<string>();
+export { resourceLimitCooldown, resourceLimitInFlight };
 
 // Guards notifyPlanLimitReached against concurrent calls (burst of traces from
 // a single org hitting the limit middleware at the same time). Two layers:
@@ -214,13 +215,17 @@ export class UsageLimitService {
 
     const cooldownKey = `${organizationId}:${limitType}`;
 
-    if (await resourceLimitCooldown.get(cooldownKey)) {
+    if (resourceLimitInFlight.has(cooldownKey)) {
       return;
     }
-
-    await resourceLimitCooldown.set(cooldownKey, true);
+    resourceLimitInFlight.add(cooldownKey);
 
     try {
+      const claimed = await resourceLimitCooldown.claim(cooldownKey, true);
+      if (!claimed) {
+        return;
+      }
+
       const org = await this.organizationService.findWithAdmins(organizationId);
 
       if (!org) {
@@ -252,7 +257,9 @@ export class UsageLimitService {
         max,
       });
     } catch {
-      resourceLimitCooldown.delete(cooldownKey);
+      await resourceLimitCooldown.delete(cooldownKey);
+    } finally {
+      resourceLimitInFlight.delete(cooldownKey);
     }
   }
 

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -921,16 +921,26 @@ export class EEWebhookService implements WebhookService {
       return;
     }
 
-    await getApp().notifications.sendSlackSubscriptionEvent({
-      type: "confirmed",
-      organizationId,
-      organizationName,
-      plan,
-      subscriptionId: dbSubscriptionId,
-      startDate,
-      maxMembers,
-      maxMessagesPerMonth,
-    });
+    try {
+      await getApp().notifications.sendSlackSubscriptionEvent({
+        type: "confirmed",
+        organizationId,
+        organizationName,
+        plan,
+        subscriptionId: dbSubscriptionId,
+        startDate,
+        maxMembers,
+        maxMessagesPerMonth,
+      });
+    } catch (err) {
+      // Release the dedup key so a retry can re-send; otherwise a transient
+      // Slack failure would suppress the confirmed alert for the whole TTL window.
+      await subscriptionConfirmedCooldown.delete(subscriptionId);
+      logger.error(
+        { subscriptionId, organizationId, err },
+        "[stripeWebhook] Failed to send confirmed notification",
+      );
+    }
   }
 
   private async clearTrialLicenseIfPresent(

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -20,8 +20,16 @@ import {
   PLATFORM_DEFAULT_RETENTION_DAYS,
   RETENTION_CATEGORIES,
 } from "../../../src/server/data-retention/retentionPolicy.schema";
+import { TtlCache } from "../../../src/server/utils/ttlCache";
 
 const logger = createLogger("langwatch:billing:webhookService");
+
+const SUBSCRIPTION_CONFIRMED_COOLDOWN_MS = 5 * 60 * 1000;
+const subscriptionConfirmedCooldown = new TtlCache<true>(
+  SUBSCRIPTION_CONFIRMED_COOLDOWN_MS,
+  "ttlcache:billing:subscriptionConfirmed:",
+);
+export { subscriptionConfirmedCooldown };
 
 const VALID_CURRENCIES_FOR_CHECKOUT = new Set<string>(Object.values(Currency));
 const maskCustomerId = (id: string) => `${id.slice(0, 7)}...${id.slice(-4)}`;
@@ -723,12 +731,12 @@ export class EEWebhookService implements WebhookService {
       await this.clearTrialLicenseIfPresent(updatedSubscription, "subscription updated to active");
 
       if (shouldNotify) {
-        await getApp().notifications.sendSlackSubscriptionEvent({
-          type: "confirmed",
+        await this.sendConfirmedNotificationOnce({
+          subscriptionId: subscription.id,
           organizationId: updatedSubscription.organizationId,
           organizationName: updatedSubscription.organization.name,
           plan: updatedSubscription.plan,
-          subscriptionId: updatedSubscription.id,
+          dbSubscriptionId: updatedSubscription.id,
           startDate: updatedSubscription.startDate,
           maxMembers: updatedSubscription.maxMembers,
           maxMessagesPerMonth: updatedSubscription.maxMessagesPerMonth,
@@ -829,12 +837,12 @@ export class EEWebhookService implements WebhookService {
         await this.applySeatRetentionPolicy(updatedSubscription.organizationId);
       }
 
-      await getApp().notifications.sendSlackSubscriptionEvent({
-        type: "confirmed",
+      await this.sendConfirmedNotificationOnce({
+        subscriptionId,
         organizationId: updatedSubscription.organizationId,
         organizationName: updatedSubscription.organization.name,
         plan: updatedSubscription.plan,
-        subscriptionId: updatedSubscription.id,
+        dbSubscriptionId: updatedSubscription.id,
         startDate: updatedSubscription.startDate,
         maxMembers: updatedSubscription.maxMembers,
         maxMessagesPerMonth: updatedSubscription.maxMessagesPerMonth,
@@ -883,6 +891,46 @@ export class EEWebhookService implements WebhookService {
         );
       }
     }
+  }
+
+  private async sendConfirmedNotificationOnce({
+    subscriptionId,
+    organizationId,
+    organizationName,
+    plan,
+    dbSubscriptionId,
+    startDate,
+    maxMembers,
+    maxMessagesPerMonth,
+  }: {
+    subscriptionId: string;
+    organizationId: string;
+    organizationName: string;
+    plan: string;
+    dbSubscriptionId: string;
+    startDate: Date | null;
+    maxMembers: number | null;
+    maxMessagesPerMonth: number | null;
+  }): Promise<void> {
+    const claimed = await subscriptionConfirmedCooldown.claim(subscriptionId, true);
+    if (!claimed) {
+      logger.info(
+        { subscriptionId, organizationId },
+        "[stripeWebhook] Confirmed notification already sent for this subscription, deduplicating",
+      );
+      return;
+    }
+
+    await getApp().notifications.sendSlackSubscriptionEvent({
+      type: "confirmed",
+      organizationId,
+      organizationName,
+      plan,
+      subscriptionId: dbSubscriptionId,
+      startDate,
+      maxMembers,
+      maxMessagesPerMonth,
+    });
   }
 
   private async clearTrialLicenseIfPresent(

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -16,8 +16,16 @@ import { isGrowthEventsPrice, isGrowthSeatEventPlan, isGrowthSeatPrice } from ".
 import { SubscriptionRecordNotFoundError } from "../errors";
 import { traced } from "../../../src/server/app-layer/tracing";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
+import { TtlCache } from "../../../src/server/utils/ttlCache";
 
 const logger = createLogger("langwatch:billing:webhookService");
+
+const SUBSCRIPTION_CONFIRMED_COOLDOWN_MS = 5 * 60 * 1000;
+const subscriptionConfirmedCooldown = new TtlCache<true>(
+  SUBSCRIPTION_CONFIRMED_COOLDOWN_MS,
+  "ttlcache:billing:subscriptionConfirmed:",
+);
+export { subscriptionConfirmedCooldown };
 
 const VALID_CURRENCIES_FOR_CHECKOUT = new Set<string>(Object.values(Currency));
 const maskCustomerId = (id: string) => `${id.slice(0, 7)}...${id.slice(-4)}`;
@@ -713,12 +721,12 @@ export class EEWebhookService implements WebhookService {
       await this.clearTrialLicenseIfPresent(updatedSubscription, "subscription updated to active");
 
       if (shouldNotify) {
-        await getApp().notifications.sendSlackSubscriptionEvent({
-          type: "confirmed",
+        await this.sendConfirmedNotificationOnce({
+          subscriptionId: subscription.id,
           organizationId: updatedSubscription.organizationId,
           organizationName: updatedSubscription.organization.name,
           plan: updatedSubscription.plan,
-          subscriptionId: updatedSubscription.id,
+          dbSubscriptionId: updatedSubscription.id,
           startDate: updatedSubscription.startDate,
           maxMembers: updatedSubscription.maxMembers,
           maxMessagesPerMonth: updatedSubscription.maxMessagesPerMonth,
@@ -817,12 +825,12 @@ export class EEWebhookService implements WebhookService {
         }
       }
 
-      await getApp().notifications.sendSlackSubscriptionEvent({
-        type: "confirmed",
+      await this.sendConfirmedNotificationOnce({
+        subscriptionId,
         organizationId: updatedSubscription.organizationId,
         organizationName: updatedSubscription.organization.name,
         plan: updatedSubscription.plan,
-        subscriptionId: updatedSubscription.id,
+        dbSubscriptionId: updatedSubscription.id,
         startDate: updatedSubscription.startDate,
         maxMembers: updatedSubscription.maxMembers,
         maxMessagesPerMonth: updatedSubscription.maxMessagesPerMonth,
@@ -833,6 +841,46 @@ export class EEWebhookService implements WebhookService {
         hasSubscription: true,
       });
     }
+  }
+
+  private async sendConfirmedNotificationOnce({
+    subscriptionId,
+    organizationId,
+    organizationName,
+    plan,
+    dbSubscriptionId,
+    startDate,
+    maxMembers,
+    maxMessagesPerMonth,
+  }: {
+    subscriptionId: string;
+    organizationId: string;
+    organizationName: string;
+    plan: string;
+    dbSubscriptionId: string;
+    startDate: Date | null;
+    maxMembers: number | null;
+    maxMessagesPerMonth: number | null;
+  }): Promise<void> {
+    const claimed = await subscriptionConfirmedCooldown.claim(subscriptionId, true);
+    if (!claimed) {
+      logger.info(
+        { subscriptionId, organizationId },
+        "[stripeWebhook] Confirmed notification already sent for this subscription, deduplicating",
+      );
+      return;
+    }
+
+    await getApp().notifications.sendSlackSubscriptionEvent({
+      type: "confirmed",
+      organizationId,
+      organizationName,
+      plan,
+      subscriptionId: dbSubscriptionId,
+      startDate,
+      maxMembers,
+      maxMessagesPerMonth,
+    });
   }
 
   private async clearTrialLicenseIfPresent(


### PR DESCRIPTION
## Summary

Closes langwatch/langwatch-saas#894

- **Phase 1 — Subscription notification dedup:** Stripe sends `checkout.session.completed` and `invoice.payment_succeeded` for the same subscription activation, both converging on `syncInvoicePaymentSuccess()` which sent a Slack "confirmed" notification without deduplication. `handleSubscriptionUpdated` could also fire a third duplicate. Added a `TtlCache`-based dedup (Redis `SET NX EX`, 5-minute TTL) via `sendConfirmedNotificationOnce()` — all three paths now atomically claim a per-subscription cooldown slot before sending.

- **Phase 2 — Resource limit race fix:** `notifyResourceLimitReached` used a non-atomic `get/set` pattern that allowed concurrent calls to both pass the cooldown check. Replaced with atomic `claim()` + synchronous `resourceLimitInFlight` Set guard, matching the existing `planLimitInFlight` pattern. Concurrent calls now correctly dedup to exactly one notification.

## Test plan

- [x] 38 webhook service unit tests pass (3 new dedup scenarios)
- [x] 25 usage-limit service unit tests pass (concurrent test updated from 2→1 expected calls)
- [x] All 280 billing unit tests pass
- [x] Typecheck clean

# Related Issue

- Resolve langwatch/langwatch-saas#894