### PR TITLE
feat(langy): project memory settings page (L4 + privacy)

### DIFF
--- a/langwatch/src/components/SettingsLayout.tsx
+++ b/langwatch/src/components/SettingsLayout.tsx
@@ -160,7 +160,11 @@ export default function SettingsLayout({
 
           <NavSection
             label="Features"
-            paths={["/settings/annotation-scores", "/settings/topic-clustering"]}
+            paths={[
+              "/settings/annotation-scores",
+              "/settings/topic-clustering",
+              "/settings/langy-memory",
+            ]}
           >
             <MenuLink href="/settings/annotation-scores">Annotation Scores</MenuLink>
             {!isLiteMember && project?.slug && (
@@ -169,6 +173,7 @@ export default function SettingsLayout({
             {!isLiteMember && (
               <MenuLink href="/settings/topic-clustering">Topic Clustering</MenuLink>
             )}
+            <MenuLink href="/settings/langy-memory">Langy memory</MenuLink>
           </NavSection>
 
           {!isLiteMember && (

--- a/langwatch/src/components/langy/LangyMemorySettings.tsx
+++ b/langwatch/src/components/langy/LangyMemorySettings.tsx
@@ -1,0 +1,387 @@
+import {
+  Box,
+  Button,
+  HStack,
+  Heading,
+  IconButton,
+  Spinner,
+  Text,
+  Textarea,
+  VStack,
+} from "@chakra-ui/react";
+import { useCallback, useEffect, useState } from "react";
+import { LuDownload, LuRefreshCw, LuTrash2, LuTriangle } from "react-icons/lu";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { toaster } from "~/components/ui/toaster";
+
+const STALE_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface ProjectMemoryDTO {
+  id: string;
+  projectId: string;
+  content: string;
+  contentVersion: number;
+  refreshedAt: string;
+  updatedAt: string;
+}
+
+interface ConversationSummary {
+  id: string;
+  title: string | null;
+  lastActivityAt: string;
+}
+
+function isStale(memory: ProjectMemoryDTO | null): boolean {
+  if (!memory) return false;
+  const refreshed = new Date(memory.refreshedAt).getTime();
+  if (Number.isNaN(refreshed)) return false;
+  return Date.now() - refreshed > STALE_THRESHOLD_MS;
+}
+
+function reportError(message: string) {
+  toaster.create({
+    title: "Langy memory",
+    description: message,
+    type: "error",
+    duration: 5000,
+    meta: { closable: true },
+  });
+}
+
+function reportSuccess(message: string) {
+  toaster.create({
+    title: "Langy memory",
+    description: message,
+    type: "success",
+    duration: 3000,
+    meta: { closable: true },
+  });
+}
+
+export function LangyMemorySettings() {
+  const { project, hasPermission } = useOrganizationTeamProject();
+  const projectId = project?.id;
+  const isAdmin = hasPermission("project:manage");
+
+  const [memory, setMemory] = useState<ProjectMemoryDTO | null>(null);
+  const [draft, setDraft] = useState("");
+  const [isLoadingMemory, setIsLoadingMemory] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const loadMemory = useCallback(async () => {
+    if (!projectId) return;
+    setIsLoadingMemory(true);
+    try {
+      const res = await fetch(
+        `/api/langy/project-memory?projectId=${encodeURIComponent(projectId)}`,
+      );
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      const data = (await res.json()) as { memory: ProjectMemoryDTO | null };
+      setMemory(data.memory);
+      setDraft(data.memory?.content ?? "");
+    } catch {
+      reportError("Failed to load project memory.");
+    } finally {
+      setIsLoadingMemory(false);
+    }
+  }, [projectId]);
+
+  const loadConversations = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      const res = await fetch(
+        `/api/langy/conversations?projectId=${encodeURIComponent(projectId)}`,
+      );
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      const data = (await res.json()) as {
+        conversations: ConversationSummary[];
+      };
+      setConversations(data.conversations);
+    } catch {
+      reportError("Failed to load conversations.");
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void loadMemory();
+    void loadConversations();
+  }, [loadMemory, loadConversations]);
+
+  const save = async () => {
+    if (!projectId || !isAdmin) return;
+    setIsSaving(true);
+    try {
+      const res = await fetch("/api/langy/project-memory", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId, content: draft }),
+      });
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      const data = (await res.json()) as { memory: ProjectMemoryDTO };
+      setMemory(data.memory);
+      setDraft(data.memory.content);
+      reportSuccess("Project memory saved.");
+    } catch {
+      reportError("Failed to save project memory.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const refresh = async () => {
+    if (!projectId || !isAdmin) return;
+    setIsRefreshing(true);
+    try {
+      const res = await fetch("/api/langy/project-memory/refresh", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId }),
+      });
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      const data = (await res.json()) as { memory: ProjectMemoryDTO };
+      setMemory(data.memory);
+      setDraft(data.memory.content);
+      reportSuccess("Project memory refreshed.");
+    } catch {
+      reportError("Failed to refresh project memory.");
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const deleteConversation = async (id: string) => {
+    if (!projectId) return;
+    try {
+      const res = await fetch(
+        `/api/langy/conversations/${id}?projectId=${encodeURIComponent(projectId)}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      setConversations((prev) => prev.filter((c) => c.id !== id));
+    } catch {
+      reportError("Failed to delete conversation.");
+    }
+  };
+
+  const clearAll = async () => {
+    if (!projectId) return;
+    setIsClearing(true);
+    try {
+      const res = await fetch(
+        `/api/langy/memory?projectId=${encodeURIComponent(projectId)}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      setConversations([]);
+      reportSuccess("All Langy memory cleared for this project.");
+    } catch {
+      reportError("Failed to clear memory.");
+    } finally {
+      setIsClearing(false);
+      setConfirmingClear(false);
+    }
+  };
+
+  const exportData = async () => {
+    if (!projectId) return;
+    setIsExporting(true);
+    try {
+      const res = await fetch(
+        `/api/langy/memory/export?projectId=${encodeURIComponent(projectId)}`,
+      );
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      const data = await res.json();
+      // jsdom test env: just produce a Blob URL when supported; downstream
+      // wiring to <a download> is best-effort in tests.
+      if (typeof window !== "undefined" && typeof window.URL?.createObjectURL === "function") {
+        const blob = new Blob([JSON.stringify(data, null, 2)], {
+          type: "application/json",
+        });
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `langy-memory-${projectId}.json`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+      }
+      reportSuccess("Export downloaded.");
+    } catch {
+      reportError("Failed to export memory.");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  if (!projectId) return null;
+
+  return (
+    <VStack gap={6} width="full" align="stretch" paddingBottom={12}>
+      <VStack gap={1} align="start">
+        <Heading as="h2" size="lg">
+          Langy memory
+        </Heading>
+        <Text fontSize="sm" color="fg.muted">
+          Manage what Langy remembers about this project and your conversations.
+        </Text>
+      </VStack>
+
+      {/* Project memory editor */}
+      <VStack gap={3} align="stretch">
+        <HStack justify="space-between">
+          <Heading as="h3" size="md">
+            Project memory
+          </Heading>
+          {isLoadingMemory && <Spinner size="xs" />}
+        </HStack>
+
+        {isStale(memory) && (
+          <HStack
+            background="orange.subtle"
+            color="orange.fg"
+            paddingX={3}
+            paddingY={2}
+            borderRadius="md"
+            gap={2}
+          >
+            <LuTriangle size={14} />
+            <Text fontSize="sm">
+              This memory is over 30 days old. Consider refreshing it from the
+              current project state.
+            </Text>
+          </HStack>
+        )}
+
+        <Textarea
+          aria-label="Project memory"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          rows={10}
+          readOnly={!isAdmin}
+          placeholder={
+            memory ? undefined : "No project memory yet — refresh to generate it."
+          }
+        />
+        <HStack gap={2}>
+          <Button
+            colorPalette="blue"
+            onClick={() => void save()}
+            disabled={!isAdmin || isSaving}
+            loading={isSaving}
+          >
+            Save
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => void refresh()}
+            disabled={!isAdmin || isRefreshing}
+            loading={isRefreshing}
+          >
+            <LuRefreshCw size={14} />
+            Refresh from project
+          </Button>
+          {!isAdmin && (
+            <Text fontSize="xs" color="fg.muted">
+              Project admins can edit and refresh.
+            </Text>
+          )}
+        </HStack>
+      </VStack>
+
+      {/* Privacy controls */}
+      <VStack gap={3} align="stretch">
+        <Heading as="h3" size="md">
+          Your conversations
+        </Heading>
+        {conversations.length === 0 ? (
+          <Text fontSize="sm" color="fg.muted">
+            No Langy conversations yet in this project.
+          </Text>
+        ) : (
+          <Box
+            as="ul"
+            aria-label="Your conversations"
+            listStyleType="none"
+            margin={0}
+            padding={0}
+            borderWidth="1px"
+            borderColor="border.muted"
+            borderRadius="md"
+          >
+            {conversations.map((conv) => (
+              <Box
+                as="li"
+                key={conv.id}
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                paddingX={3}
+                paddingY={2}
+                borderBottomWidth="1px"
+                borderColor="border.muted"
+                _last={{ borderBottomWidth: 0 }}
+              >
+                <Text fontSize="sm">{conv.title ?? "Untitled"}</Text>
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  aria-label="Delete"
+                  onClick={() => void deleteConversation(conv.id)}
+                >
+                  <LuTrash2 size={12} />
+                </IconButton>
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        <HStack gap={2}>
+          {confirmingClear ? (
+            <>
+              <Button
+                colorPalette="red"
+                onClick={() => void clearAll()}
+                disabled={isClearing}
+                loading={isClearing}
+              >
+                Confirm clear
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => setConfirmingClear(false)}
+                disabled={isClearing}
+              >
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button
+              colorPalette="red"
+              variant="outline"
+              onClick={() => setConfirmingClear(true)}
+            >
+              <LuTrash2 size={14} />
+              Clear all my memory
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            onClick={() => void exportData()}
+            disabled={isExporting}
+            loading={isExporting}
+          >
+            <LuDownload size={14} />
+            Download my data
+          </Button>
+        </HStack>
+      </VStack>
+    </VStack>
+  );
+}

--- a/langwatch/src/components/langy/__tests__/LangyMemorySettings.integration.test.tsx
+++ b/langwatch/src/components/langy/__tests__/LangyMemorySettings.integration.test.tsx
@@ -1,0 +1,402 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for LangyMemorySettings (PR-2.5).
+ * Spec: specs/assistant/langy-memory.feature (L4 + privacy sections).
+ * Issue: #3955 (Phase 2). Epic: #3960.
+ *
+ * Boundary mocks: useOrganizationTeamProject (project + permissions),
+ * global.fetch (observable). No DB, no MSW.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const orgRef = {
+  current: {
+    project: { id: "project-demo", slug: "demo" },
+    hasPermission: (_p: string) => true,
+  },
+};
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => orgRef.current,
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("~/utils/trpcError", () => ({
+  isHandledByGlobalHandler: () => false,
+}));
+
+import { LangyMemorySettings } from "../LangyMemorySettings";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+interface FetchScenario {
+  memory: {
+    id: string;
+    projectId: string;
+    content: string;
+    contentVersion: number;
+    refreshedAt: string;
+    updatedAt: string;
+  } | null;
+  conversations: Array<{
+    id: string;
+    title: string | null;
+    lastActivityAt: string;
+  }>;
+  exportPayload?: unknown;
+  putShouldFail?: boolean;
+}
+
+function installFetchMock(scenario: FetchScenario): Mock {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url.startsWith("/api/langy/project-memory") && method === "GET") {
+      return new Response(JSON.stringify({ memory: scenario.memory }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.startsWith("/api/langy/project-memory") && method === "PUT") {
+      if (scenario.putShouldFail) {
+        return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+      }
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      return new Response(
+        JSON.stringify({
+          memory: {
+            ...(scenario.memory ?? {}),
+            content: body.content,
+            contentVersion: (scenario.memory?.contentVersion ?? 0) + 1,
+            updatedAt: new Date().toISOString(),
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.includes("/project-memory/refresh") && method === "POST") {
+      return new Response(
+        JSON.stringify({
+          memory: {
+            ...(scenario.memory ?? {}),
+            content: "refreshed content",
+            refreshedAt: new Date().toISOString(),
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.startsWith("/api/langy/conversations") && method === "GET") {
+      return new Response(
+        JSON.stringify({ conversations: scenario.conversations }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.startsWith("/api/langy/conversations/") && method === "DELETE") {
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    }
+    if (url.startsWith("/api/langy/memory/export") && method === "GET") {
+      return new Response(
+        JSON.stringify(scenario.exportPayload ?? { conversations: [] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.startsWith("/api/langy/memory") && method === "DELETE") {
+      return new Response(JSON.stringify({ deletedCount: 3 }), { status: 200 });
+    }
+    return new Response("not stubbed", { status: 501 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const baseMemory = {
+  id: "mem-1",
+  projectId: "project-demo",
+  content: "demo project memory content",
+  contentVersion: 1,
+  refreshedAt: "2026-05-01T10:00:00.000Z", // recent
+  updatedAt: "2026-05-01T10:00:00.000Z",
+};
+
+function renderSettings() {
+  return render(<LangyMemorySettings />, { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  orgRef.current = {
+    project: { id: "project-demo", slug: "demo" },
+    hasPermission: () => true,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LangyMemorySettings", () => {
+  describe("given a project with existing memory", () => {
+    describe("when the page mounts", () => {
+      it("fetches the project memory with the current projectId", async () => {
+        const fetchMock = installFetchMock({
+          memory: baseMemory,
+          conversations: [],
+        });
+        renderSettings();
+        await waitFor(() => {
+          const call = fetchMock.mock.calls.find(([url]) =>
+            String(url).startsWith("/api/langy/project-memory"),
+          );
+          expect(call).toBeTruthy();
+          expect(String(call![0])).toContain("projectId=project-demo");
+        });
+      });
+
+      it("renders the memory content in the editor", async () => {
+        installFetchMock({ memory: baseMemory, conversations: [] });
+        renderSettings();
+        const editor = await screen.findByRole("textbox", {
+          name: /project memory/i,
+        });
+        expect(editor).toHaveValue("demo project memory content");
+      });
+    });
+  });
+
+  describe("given the user is a project admin", () => {
+    beforeEach(() => {
+      orgRef.current = {
+        project: { id: "project-demo", slug: "demo" },
+        hasPermission: (p: string) => p === "project:manage",
+      };
+    });
+
+    describe("when the admin edits and saves", () => {
+      it("PUTs the updated content to /api/langy/project-memory", async () => {
+        const fetchMock = installFetchMock({
+          memory: baseMemory,
+          conversations: [],
+        });
+        renderSettings();
+        const editor = await screen.findByRole("textbox", {
+          name: /project memory/i,
+        });
+        await userEvent.clear(editor);
+        await userEvent.type(editor, "new content");
+        await userEvent.click(screen.getByRole("button", { name: /save/i }));
+        await waitFor(() => {
+          const put = fetchMock.mock.calls.find(
+            ([url, init]) =>
+              String(url).startsWith("/api/langy/project-memory") &&
+              (init?.method ?? "GET").toUpperCase() === "PUT",
+          );
+          expect(put).toBeTruthy();
+          const body = JSON.parse(String(put![1]!.body));
+          expect(body.content).toBe("new content");
+          expect(body.projectId).toBe("project-demo");
+        });
+      });
+    });
+
+    describe("when the admin clicks Refresh", () => {
+      it("POSTs to /api/langy/project-memory/refresh", async () => {
+        const fetchMock = installFetchMock({
+          memory: baseMemory,
+          conversations: [],
+        });
+        renderSettings();
+        await screen.findByRole("textbox", { name: /project memory/i });
+        await userEvent.click(
+          screen.getByRole("button", { name: /refresh from project/i }),
+        );
+        await waitFor(() => {
+          const post = fetchMock.mock.calls.find(
+            ([url, init]) =>
+              String(url).includes("/project-memory/refresh") &&
+              (init?.method ?? "GET").toUpperCase() === "POST",
+          );
+          expect(post).toBeTruthy();
+        });
+      });
+    });
+  });
+
+  describe("given the user is not a project admin", () => {
+    beforeEach(() => {
+      orgRef.current = {
+        project: { id: "project-demo", slug: "demo" },
+        hasPermission: () => false,
+      };
+    });
+
+    describe("when the page renders", () => {
+      it("disables the Save button", async () => {
+        installFetchMock({ memory: baseMemory, conversations: [] });
+        renderSettings();
+        const save = await screen.findByRole("button", { name: /save/i });
+        expect(save).toBeDisabled();
+      });
+
+      it("disables the Refresh button", async () => {
+        installFetchMock({ memory: baseMemory, conversations: [] });
+        renderSettings();
+        const refresh = await screen.findByRole("button", {
+          name: /refresh from project/i,
+        });
+        expect(refresh).toBeDisabled();
+      });
+    });
+  });
+
+  describe("given project memory is older than 30 days", () => {
+    describe("when the page mounts", () => {
+      it("shows a non-blocking stale banner", async () => {
+        const staleDate = new Date(
+          Date.now() - 31 * 24 * 60 * 60 * 1000,
+        ).toISOString();
+        installFetchMock({
+          memory: { ...baseMemory, refreshedAt: staleDate },
+          conversations: [],
+        });
+        renderSettings();
+        expect(
+          await screen.findByText(/memory is over 30 days old/i),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given the user has conversations in this project", () => {
+    const conversations = [
+      { id: "c1", title: "Chat A", lastActivityAt: "2026-05-10T10:00:00.000Z" },
+      { id: "c2", title: "Chat B", lastActivityAt: "2026-05-09T10:00:00.000Z" },
+    ];
+
+    describe("when the page mounts", () => {
+      it("lists the user's conversations under privacy controls", async () => {
+        installFetchMock({ memory: baseMemory, conversations });
+        renderSettings();
+        const list = await screen.findByRole("list", {
+          name: /your conversations/i,
+        });
+        const items = within(list).getAllByRole("listitem");
+        expect(items).toHaveLength(2);
+        expect(items[0]).toHaveTextContent(/Chat A/);
+      });
+    });
+
+    describe("when the user deletes a single conversation", () => {
+      it("calls DELETE /api/langy/conversations/:id", async () => {
+        const fetchMock = installFetchMock({
+          memory: baseMemory,
+          conversations,
+        });
+        renderSettings();
+        const list = await screen.findByRole("list", {
+          name: /your conversations/i,
+        });
+        const firstItem = within(list).getAllByRole("listitem")[0]!;
+        await userEvent.click(
+          within(firstItem).getByRole("button", { name: /delete/i }),
+        );
+        await waitFor(() => {
+          const del = fetchMock.mock.calls.find(
+            ([url, init]) =>
+              String(url).includes("/conversations/c1") &&
+              (init?.method ?? "GET").toUpperCase() === "DELETE",
+          );
+          expect(del).toBeTruthy();
+        });
+      });
+    });
+
+    describe("when the user clicks 'Clear all my memory' and confirms", () => {
+      it("calls DELETE /api/langy/memory with the projectId", async () => {
+        const fetchMock = installFetchMock({
+          memory: baseMemory,
+          conversations,
+        });
+        renderSettings();
+        await screen.findByRole("textbox", { name: /project memory/i });
+        await userEvent.click(
+          screen.getByRole("button", { name: /clear all my memory/i }),
+        );
+        // Confirm
+        await userEvent.click(
+          await screen.findByRole("button", { name: /^confirm clear$/i }),
+        );
+        await waitFor(() => {
+          const del = fetchMock.mock.calls.find(
+            ([url, init]) =>
+              String(url).startsWith("/api/langy/memory?") &&
+              !String(url).includes("/memory/export") &&
+              (init?.method ?? "GET").toUpperCase() === "DELETE",
+          );
+          expect(del).toBeTruthy();
+          expect(String(del![0])).toContain("projectId=project-demo");
+        });
+      });
+    });
+
+    describe("when the user clicks 'Download my data'", () => {
+      it("fetches /api/langy/memory/export with the projectId", async () => {
+        const fetchMock = installFetchMock({
+          memory: baseMemory,
+          conversations,
+          exportPayload: { conversations: ["sample"] },
+        });
+        // jsdom doesn't support real download anchor click; just verify the fetch fires.
+        renderSettings();
+        await screen.findByRole("textbox", { name: /project memory/i });
+        await userEvent.click(
+          screen.getByRole("button", { name: /download my data/i }),
+        );
+        await waitFor(() => {
+          const exp = fetchMock.mock.calls.find(([url]) =>
+            String(url).startsWith("/api/langy/memory/export"),
+          );
+          expect(exp).toBeTruthy();
+          expect(String(exp![0])).toContain("projectId=project-demo");
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/pages/settings/langy-memory.tsx
+++ b/langwatch/src/pages/settings/langy-memory.tsx
@@ -1,0 +1,20 @@
+import { withPermissionGuard } from "~/components/WithPermissionGuard";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import SettingsLayout from "../../components/SettingsLayout";
+import { LangyMemorySettings } from "../../components/langy/LangyMemorySettings";
+
+function LangyMemorySettingsPage() {
+  const { project } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+  });
+  if (!project) return null;
+  return (
+    <SettingsLayout>
+      <LangyMemorySettings />
+    </SettingsLayout>
+  );
+}
+
+export default withPermissionGuard("evaluations:view", {
+  layoutComponent: SettingsLayout,
+})(LangyMemorySettingsPage);


### PR DESCRIPTION
## Summary

Adds the `/settings/langy-memory` page that binds L4 + privacy backend endpoints from #3908. Project members see their privacy controls (conversations list, delete each, clear all, export); project admins additionally get edit + refresh on the project memory.

## Merge order (PR stack — DO NOT merge out of sequence)

This PR is the **top of a 5-PR stack**. Each is rebased onto its parent. Merge bottom-up:

```
main
 └── #3211  feat(sage→langy) — v1 baseline
      └── #3898  docs(langy) — v2 spec set
           └── #3908  feat(langy) — v2 backend (persistence, memory, L6, rate limit)
                └── #3961  feat(langy) — v2 UI binding (L3 conversation history)
                     └── #<this>  THIS PR — project memory settings (L4 + privacy)
```

After each parent lands on main, rebase the next PR before merging.

## Scope

Implements **PR-2.5** from `specs/assistant/implementation-plan.md` (Phase 2 — Memory). With this PR, Phase 2 is complete:

| Sub-PR | Status |
|---|---|
| PR-2.1 schema + migrations | ✅ in #3908 |
| PR-2.2 conv + msg services | ✅ in #3908 |
| PR-2.3 conv routes + UI | ✅ in #3961 |
| PR-2.4 project memory service + bootstrap | ✅ in #3908 |
| **PR-2.5 project memory edit + refresh + settings UI** | **✅ this PR** |
| PR-2.6 L6 lazy retrieval | ✅ in #3908 |

Covers these `langy-memory.feature` scenarios:
- Edit project memory (textarea + save, admin-gated)
- Stale project memory prompts a refresh (banner if `refreshedAt > 30 days`)
- View what Langy remembers about me in this project
- Clear all my memory in this project (two-step confirm)
- Download my data (GDPR export)

Out of scope (other phases):
- Mode toggle UI (Phase 3 / PR-3.1)
- Project memory injection into chat context (backend, in #3908)
- First-time bootstrap prompt (background worker, in #3908)

## Permission model

- Page guarded with `evaluations:view` → any project member can open it
- `Save` + `Refresh from project` buttons disabled unless `hasPermission("project:manage")` — matches backend's admin gate on `PUT/POST /langy/project-memory`
- Privacy actions (`Clear all my memory`, `Download my data`, per-conversation delete) available to all members — they only affect that user's own data per backend's `userId` scoping

## What changed

- **New** `src/components/langy/LangyMemorySettings.tsx` — the page body
- **New** `src/pages/settings/langy-memory.tsx` — Next.js route, `withPermissionGuard("evaluations:view")`
- **Modified** `src/components/SettingsLayout.tsx` — adds `Langy memory` entry under the Features section
- **New** `src/components/langy/__tests__/LangyMemorySettings.integration.test.tsx` — 11 integration tests

## Test plan

- [x] `pnpm vitest run src/components/langy/__tests__/LangyMemorySettings.integration.test.tsx` — 11/11 green
- [x] `pnpm vitest run src/components/langy/__tests__/` — 27/27 green (no regression to PR-2.3)
- [ ] Manual smoke once parent stack lands: open `/settings/langy-memory` as admin → edit + save → see version bump; switch to non-admin role → buttons disabled but list visible; clear-all → confirm → list empties

## Tracking

- Refs #3960 (Langy v2 epic)
- Completes **PR-2.5** in #3955 — Phase 2 is now fully covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related Issue

- Resolve #3955