### PR TITLE
feat(langy): refresh sidebar UI to Langy.html final design

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -314,18 +314,6 @@
     "vitest": "^4.1.4",
     "watch": "^1.0.2"
   },
-  "overrides": {
-    "braces": "^3.0.3",
-    "cross-spawn": "^7.0.6",
-    "exec-sh": "^0.4.0",
-    "glob": "^11.1.0",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
-    "react-is": "19.0.5",
-    "pino": "^10.3.1",
-    "pino-pretty": "^13.1.3",
-    "thread-stream": "^4.0.0"
-  },
   "pnpm": {
     "overrides": {
       "@aws-sdk/xml-builder>fast-xml-parser": "^5.7.0",
@@ -345,7 +333,17 @@
       "vite@>=8.0.0 <8.0.5": "8.0.10",
       "axios@>=1.0.0 <1.16.0": "1.16.0",
       "fast-xml-builder@<1.1.7": "1.1.7",
-      "fast-uri@<3.1.2": "3.1.2"
+      "fast-uri@<3.1.2": "3.1.2",
+      "braces": "^3.0.3",
+      "cross-spawn": "^7.0.6",
+      "exec-sh": "^0.4.0",
+      "glob": "^11.1.0",
+      "react": "^19.2.5",
+      "react-dom": "^19.2.5",
+      "react-is": "^19.2.5",
+      "pino": "^10.3.1",
+      "pino-pretty": "^13.1.3",
+      "thread-stream": "^4.0.0"
     }
   },
   "ct3aMetadata": {

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -23,6 +23,16 @@ overrides:
   axios@>=1.0.0 <1.16.0: 1.16.0
   fast-xml-builder@<1.1.7: 1.1.7
   fast-uri@<3.1.2: 3.1.2
+  braces: ^3.0.3
+  cross-spawn: ^7.0.6
+  exec-sh: ^0.4.0
+  glob: ^11.1.0
+  react: ^19.2.5
+  react-dom: ^19.2.5
+  react-is: ^19.2.5
+  pino: ^10.3.1
+  pino-pretty: ^13.1.3
+  thread-stream: ^4.0.0
 
 packageExtensionsChecksum: sha256-LBc1N1GezKyerwGBwpMHZPFoMYZTHjpxVKWJilBVvTU=
 
@@ -915,8 +925,8 @@ packages:
     resolution: {integrity: sha512-W21ELmhbniJQ2LMCytv5lwxz3FHpZp1iMp0Kvm9TXXxhldgDwMqVQa1uePeNBa068KIfXwnst0D2TGD8r0N/iA==}
     peerDependencies:
       '@ag-grid-community/core': 32.3.9
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@ag-grid-community/styles@32.3.9':
     resolution: {integrity: sha512-uPNR5EXeQqAIC0gohmY7CJ97cTIA/JtNSqAUzJ8AdVZcz4dbk9JJIl9DRFUYL+qWhMY+fUSTw2a+Yi6aOGSs8A==}
@@ -1017,7 +1027,7 @@ packages:
     resolution: {integrity: sha512-8CKMdSJDAHHUYEJSsI+HGanP/75dOYtnLWQ5WtQMvdmsA4PUVy8Hv6Bn1npoZBcTh250ESsuSptvctxFuIJrYw==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+      react: ^19.2.5
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -1077,8 +1087,8 @@ packages:
   '@ark-ui/react@5.36.2':
     resolution: {integrity: sha512-2lrZ7+Qtlj7hGx4qU2jZkE892JNrkULg/fUxqUuqmQfv9UGAXhdcw1Hr3N+zBgMDVz3aqip0Qa4v0Mox09MMvg==}
     peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1646,8 +1656,8 @@ packages:
     resolution: {integrity: sha512-qzfRNLwxKjxx2IXjBj6uz1nYI+pKsq6uwHxO619+hx1OzNNuwLIjEHJxnDfBzoynO7sPCBlubMwFWb1e1PrXzw==}
     peerDependencies:
       '@emotion/react': '>=11'
-      react: '>=18'
-      react-dom: '>=18'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@chevrotain/cst-dts-gen@12.0.0':
     resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
@@ -1674,23 +1684,23 @@ packages:
   '@copilotkit/react-core@1.8.14':
     resolution: {integrity: sha512-8/OXSaHoEzZHJSJcFxw3H2/laQ0g2nne14Flcc+Y2lxE3X+PaPiM4ajReNpEH6Bl3EO09jialmAkW78oWk3buQ==}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@copilotkit/react-ui@1.8.14':
     resolution: {integrity: sha512-e10Z2Ja+h1q7LsNrKl/NgJnUQ5qMofeGC6T5Xcn0SGVp0oEDF8K8VMDEdWeUq2sZJet1im9CVw1zPoHT9iMQUA==}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@copilotkit/runtime-client-gql@1.8.13':
     resolution: {integrity: sha512-LuYhCbno7aIcTV3bPuBJrJw6lIKQRhm4wGb83buxTGvuC42OOVvAZ4JIL9wQqnvoWl3QOgKQrJZB619Ww9YuuQ==}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@copilotkit/runtime-client-gql@1.8.14':
     resolution: {integrity: sha512-QYj3uvNfnATi+Xb2hv963gKxTuxo4hGLOx7Colxdpbqon0ji6sfhINBHIvtPoMstf0Z3V9bTj0vIme5BXVnN0Q==}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@copilotkit/runtime@1.8.14':
     resolution: {integrity: sha512-1u7rTs3v7DAeWN8ondZBg6snDyd0e6gQg8uRmbOQkweB4hkemXuDOfWafzI2e4YbStEhI+Ml8ZwDQmLkot2mBA==}
@@ -1748,24 +1758,24 @@ packages:
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^19.2.5
 
   '@dnd-kit/core@6.3.1':
     resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@dnd-kit/sortable@8.0.0':
     resolution: {integrity: sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==}
     peerDependencies:
       '@dnd-kit/core': ^6.1.0
-      react: '>=16.8.0'
+      react: ^19.2.5
 
   '@dnd-kit/utilities@3.2.2':
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^19.2.5
 
   '@elastic/elasticsearch@8.15.3':
     resolution: {integrity: sha512-T6NgSirgtlUC8GoPpstDt7dHu3Fxl7BxqcO8Fo+i9AoSNJRO+oRYzoSBD6kDRKCxm0BVsl424wDN5wglWJ+ofQ==}
@@ -1803,7 +1813,7 @@ packages:
     resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
     peerDependencies:
       '@types/react': '*'
-      react: '>=16.8.0'
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1819,7 +1829,7 @@ packages:
     peerDependencies:
       '@emotion/react': ^11.0.0-rc.0
       '@types/react': '*'
-      react: '>=16.8.0'
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1830,7 +1840,7 @@ packages:
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
     resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^19.2.5
 
   '@emotion/utils@1.4.2':
     resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
@@ -2378,14 +2388,14 @@ packages:
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@floating-ui/react@0.26.28':
     resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
@@ -2466,8 +2476,8 @@ packages:
     resolution: {integrity: sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@hono/node-server@1.19.10':
     resolution: {integrity: sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==}
@@ -2549,9 +2559,9 @@ packages:
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -3084,8 +3094,8 @@ packages:
     resolution: {integrity: sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==}
     peerDependencies:
       '@langchain/core': '>=0.2.31 <0.4.0'
-      react: ^18 || ^19
-      react-dom: ^18 || ^19
+      react: ^19.2.5
+      react-dom: ^19.2.5
     peerDependenciesMeta:
       '@langchain/core':
         optional: true
@@ -3098,7 +3108,7 @@ packages:
     resolution: {integrity: sha512-O8I12bfeMVz5fOrXnIcK4IdRf50IqyJTO458V56wAIHLNoi4H8/JHM+2M+Y4H2PtslXIGnvomWqlBd0eY5z/Og==}
     peerDependencies:
       '@langchain/core': '>=0.2.31 <0.4.0'
-      react: ^18 || ^19
+      react: ^19.2.5
     peerDependenciesMeta:
       '@langchain/core':
         optional: true
@@ -3173,8 +3183,8 @@ packages:
     resolution: {integrity: sha512-gNLkGvjFDeAqVGvK3H7lfoDqetn/9lW2ugiYiJhchc7jQU1ZaKsZnt97ANluXWFfd/wifoA9TrVOTsUXwXCJwA==}
     engines: {node: '>=17'}
     peerDependencies:
-      react: '>= 15'
-      react-dom: '>= 15'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@microsoft/fetch-event-source@2.0.1':
     resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
@@ -3206,8 +3216,8 @@ packages:
     resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
     peerDependencies:
       monaco-editor: '>= 0.25.0 < 1'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@monacopilot/core@1.2.12':
     resolution: {integrity: sha512-x+CNsZMGf/Wv5qekhQqeCBtLxB+XartKOcBPY9OIIGtDnkgGvu+K59IO7ux9cpQ/mW0seunZB2tcvvspgK7WOw==}
@@ -3251,7 +3261,7 @@ packages:
     peerDependencies:
       '@mui/material': ^7.3.10
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3264,8 +3274,8 @@ packages:
       '@emotion/styled': ^11.3.0
       '@mui/material-pigment-css': ^7.3.10
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
@@ -3281,7 +3291,7 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3292,7 +3302,7 @@ packages:
     peerDependencies:
       '@emotion/react': ^11.4.1
       '@emotion/styled': ^11.3.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
@@ -3306,7 +3316,7 @@ packages:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
@@ -3328,7 +3338,7 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4391,7 +4401,7 @@ packages:
     resolution: {integrity: sha512-uPJWrYRf6cJdO2H+fuXlahaqz0QjYglNAyUTaRfIInpzCa/d6guxBIK003soAZQFuQ035yg9FhtfFzKNWm+a5A==}
     peerDependencies:
       '@types/react': ^18 || ^19
-      react: ^18 || ^19
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4484,10 +4494,6 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
@@ -4566,14 +4572,14 @@ packages:
   '@react-aria/focus@3.22.0':
     resolution: {integrity: sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@react-aria/interactions@3.28.0':
     resolution: {integrity: sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@react-dnd/asap@5.0.2':
     resolution: {integrity: sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==}
@@ -4587,194 +4593,197 @@ packages:
   '@react-email/body@0.0.11':
     resolution: {integrity: sha512-ZSD2SxVSgUjHGrB0Wi+4tu3MEpB4fYSbezsFNEJk2xCWDBkFiOeEsjTmR5dvi+CxTK691hQTQlHv0XWuP7ENTg==}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/button@0.0.19':
     resolution: {integrity: sha512-HYHrhyVGt7rdM/ls6FuuD6XE7fa7bjZTJqB2byn6/oGsfiEZaogY77OtoLL/mrQHjHjZiJadtAMSik9XLcm7+A==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/button@0.2.1':
     resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
     engines: {node: '>=20.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/code-block@0.0.13':
     resolution: {integrity: sha512-4DE4yPSgKEOnZMzcrDvRuD6mxsNxOex0hCYEG9F9q23geYgb2WCCeGBvIUXVzK69l703Dg4Vzrd5qUjl+JfcwA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/code-inline@0.0.5':
     resolution: {integrity: sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/column@0.0.13':
     resolution: {integrity: sha512-Lqq17l7ShzJG/d3b1w/+lVO+gp2FM05ZUo/nW0rjxB8xBICXOVv6PqjDnn3FXKssvhO5qAV20lHM6S+spRhEwQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/components@0.0.42':
     resolution: {integrity: sha512-KZtf7RjCoLgEwa5swrsbEF/liGrmfMlZCDNDXqaAjlgF3iRq0h5KY/HNMs6LbLmW7fEneRhnynrwApwbkEwe+A==}
     engines: {node: '>=18.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/container@0.0.15':
     resolution: {integrity: sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/container@0.0.16':
     resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
     engines: {node: '>=20.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/font@0.0.9':
     resolution: {integrity: sha512-4zjq23oT9APXkerqeslPH3OZWuh5X4crHK6nx82mVHV2SrLba8+8dPEnWbaACWTNjOCbcLIzaC9unk7Wq2MIXw==}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/head@0.0.12':
     resolution: {integrity: sha512-X2Ii6dDFMF+D4niNwMAHbTkeCjlYYnMsd7edXOsi0JByxt9wNyZ9EnhFiBoQdqkE+SMDcu8TlNNttMrf5sJeMA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/heading@0.0.15':
     resolution: {integrity: sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==}
     engines: {node: '>=18.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/heading@0.0.16':
     resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
     engines: {node: '>=20.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/hr@0.0.11':
     resolution: {integrity: sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/html@0.0.11':
     resolution: {integrity: sha512-qJhbOQy5VW5qzU74AimjAR9FRFQfrMa7dn4gkEXKMB/S9xZN8e1yC1uA9C15jkXI/PzmJ0muDIWmFwatm5/+VA==}
     engines: {node: '>=18.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/html@0.0.12':
     resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
     engines: {node: '>=20.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/img@0.0.11':
     resolution: {integrity: sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/img@0.0.12':
     resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
     engines: {node: '>=20.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/link@0.0.12':
     resolution: {integrity: sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/markdown@0.0.15':
     resolution: {integrity: sha512-UQA9pVm5sbflgtg3EX3FquUP4aMBzmLReLbGJ6DZQZnAskBF36aI56cRykDq1o+1jT+CKIK1CducPYziaXliag==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/preview@0.0.13':
     resolution: {integrity: sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/render@1.1.2':
     resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@react-email/render@1.4.0':
     resolution: {integrity: sha512-ZtJ3noggIvW1ZAryoui95KJENKdCzLmN5F7hyZY1F/17B1vwzuxHB7YkuCg0QqHjDivc5axqYEYdIOw4JIQdUw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@react-email/row@0.0.12':
     resolution: {integrity: sha512-HkCdnEjvK3o+n0y0tZKXYhIXUNPDx+2vq1dJTmqappVHXS5tXS6W5JOPZr5j+eoZ8gY3PShI2LWj5rWF7ZEtIQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/section@0.0.16':
     resolution: {integrity: sha512-FjqF9xQ8FoeUZYKSdt8sMIKvoT9XF8BrzhT3xiFKdEMwYNbsDflcjfErJe3jb7Wj/es/lKTbV5QR1dnLzGpL3w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/section@0.0.17':
     resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/tailwind@1.0.5':
     resolution: {integrity: sha512-BH00cZSeFfP9HiDASl+sPHi7Hh77W5nzDgdnxtsVr/m3uQD9g180UwxcE3PhOfx0vRdLzQUU8PtmvvDfbztKQg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/text@0.1.5':
     resolution: {integrity: sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-email/text@0.1.6':
     resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^19.2.5
 
   '@react-types/shared@3.34.0':
     resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^19.2.5
 
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
-      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react: ^19.2.5
       react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
     peerDependenciesMeta:
       react:
@@ -5328,8 +5337,8 @@ packages:
   '@tanstack/react-query@4.44.0':
     resolution: {integrity: sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
       react-native: '*'
     peerDependenciesMeta:
       react-dom:
@@ -5340,20 +5349,20 @@ packages:
   '@tanstack/react-query@5.99.0':
     resolution: {integrity: sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==}
     peerDependencies:
-      react: ^18 || ^19
+      react: ^19.2.5
 
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@tanstack/react-virtual@3.13.24':
     resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
@@ -5383,8 +5392,8 @@ packages:
       '@testing-library/dom': ^10.0.0
       '@types/react': ^18.0.0 || ^19.0.0
       '@types/react-dom': ^18.0.0 || ^19.0.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5557,8 +5566,8 @@ packages:
       '@tiptap/pm': 3.22.5
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@tiptap/starter-kit@3.22.5':
     resolution: {integrity: sha512-LZ/LYbwH6rnDi5DnRyagkuNsYAVyhM+yJvvz+ZuYA0JkPiTXJV86J5PWSKew8M0gVfMHcNVtKjfQCvViFCeIgw==}
@@ -5583,8 +5592,8 @@ packages:
       '@tanstack/react-query': ^4.18.0
       '@trpc/client': 10.45.4
       '@trpc/server': 10.45.4
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@trpc/server@10.45.4':
     resolution: {integrity: sha512-5MuyK5sDuFVGHOT9EMVHgRjP5I5j3RqGymcb5D47UOp8tzn6LH0g1lEgYrAsOZ12vmk1gpxMw/v/y4xHHK/Qdg==}
@@ -6349,8 +6358,8 @@ packages:
   '@xyflow/react@12.10.2':
     resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
     peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@xyflow/system@0.0.76':
     resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
@@ -6520,8 +6529,8 @@ packages:
   '@zag-js/react@1.40.0':
     resolution: {integrity: sha512-2TFS1HYABYGc0lurC+4WEXvKkpxsVv6vKm+t8QAL7wfoeZnw6HDQWLc91kINp89vln+A2kwCfYqIq8HSm+9EeA==}
     peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   '@zag-js/rect-utils@1.40.0':
     resolution: {integrity: sha512-ikgLuE4rLlACm4mGLp6Ga8sJA44uFwohA1nVmb95sQ+VIyx2naf91CEF7SMrZVEwFKHaHpxdKVQSZLRjJqO/dw==}
@@ -6690,10 +6699,6 @@ packages:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -6701,10 +6706,6 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   ansis@3.17.0:
     resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
@@ -6916,8 +6917,8 @@ packages:
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
       pg: ^8.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
       solid-js: ^1.0.0
       svelte: ^4.0.0 || ^5.0.0
       vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
@@ -7139,7 +7140,7 @@ packages:
     peerDependencies:
       '@chakra-ui/react': 3.x
       next-themes: 0.x
-      react: 18.x || 19.x
+      react: ^19.2.5
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -7849,9 +7850,6 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -7874,13 +7872,10 @@ packages:
     resolution: {integrity: sha512-BmDdqInKFVYJpv7qS9WI6L9656cDAC+FkDvUjJds56nKHbaVTBNeDmLwKBytRnzu37zWHs9Isg7gt5PT43y6xA==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: '>=16'
+      react: ^19.2.5
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -8072,8 +8067,8 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  exec-sh@0.2.2:
-    resolution: {integrity: sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==}
+  exec-sh@0.4.0:
+    resolution: {integrity: sha512-BgAFra+J+hK/wquyWchMiqgaxSv1ec2c+//DRSePlF3NLx/tBOmkIkJEc1hWrX4Yis3tzxgv1+FiFs/mmucs/g==}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -8119,9 +8114,6 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  fast-copy@3.0.2:
-    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
   fast-copy@4.0.3:
     resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
@@ -8317,8 +8309,8 @@ packages:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -8345,9 +8337,6 @@ packages:
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -8428,18 +8417,11 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
-
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
@@ -8746,10 +8728,6 @@ packages:
     resolution: {integrity: sha512-+Bg3+kg+J6JUWn8J6bzFmOWkTQ6L/NHfDRSYU+EVvuKHDxUDHAXgqixHfVlzuBQaPOTac8hn43aPhMNk6rMe3g==}
     engines: {node: '>=18.0.0'}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -8961,8 +8939,9 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -9628,7 +9607,7 @@ packages:
   lucide-react@0.577.0:
     resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
@@ -9677,7 +9656,7 @@ packages:
   md-to-react-email@5.0.5:
     resolution: {integrity: sha512-OvAXqwq57uOk+WZqFFNCMZz8yDp8BD3WazW1wAKHUrPbbdr89K9DWS6JXY09vd9xNdPNeurI8DU/X4flcfaD8A==}
     peerDependencies:
-      react: ^18.0 || ^19.0
+      react: ^19.2.5
 
   mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
@@ -9762,9 +9741,6 @@ packages:
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-
-  merge@2.1.1:
-    resolution: {integrity: sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==}
 
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
@@ -9980,10 +9956,6 @@ packages:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -10045,8 +10017,8 @@ packages:
     resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -10124,8 +10096,8 @@ packages:
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   nice-grpc-client-middleware-retry@3.1.14:
     resolution: {integrity: sha512-n/E3n73R6N59Ef7YJ34NvCOQs45ZK4JhlKQn1uV5HuM2PktUoG2KKhoAaxn+7zdtV9dwstPLSv5IT/XxMle0og==}
@@ -10443,20 +10415,12 @@ packages:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -10513,20 +10477,13 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
-
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
   pino-opentelemetry-transport@2.0.0:
     resolution: {integrity: sha512-tWoq02WEtnCWfr63Co1n0sGlDpkBz2YUovSAsSBv/+jwKUIn/PjxwRileGViKrH/K3e+oc71nGl6yUdgQlrVkg==}
     peerDependencies:
-      pino: ^10.0.0
-
-  pino-pretty@11.3.0:
-    resolution: {integrity: sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==}
-    hasBin: true
+      pino: ^10.3.1
 
   pino-pretty@13.1.3:
     resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
@@ -10537,10 +10494,6 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
-    hasBin: true
-
-  pino@9.14.0:
-    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pirates@4.0.7:
@@ -10655,7 +10608,7 @@ packages:
   prism-react-renderer@2.4.1:
     resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
     peerDependencies:
-      react: '>=16.0.0'
+      react: ^19.2.5
 
   prisma@5.7.1:
     resolution: {integrity: sha512-ekho7ziH0WEJvC4AxuJz+ewRTMskrebPcrKuBwcNzVDniYxx+dXOGcorNeIb9VEMO5vrKzwNYvhD271Ui2jnNw==}
@@ -10806,8 +10759,8 @@ packages:
   ra-core@5.13.1:
     resolution: {integrity: sha512-7pjERvKNtFaeTg2OvZS2uKUQt3G4OnZFfZLKrGpc4dzLzWj7CRwG+7YCcc/Q69yw2fhA7eJCBJtTfJl+EEncCw==}
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
       react-hook-form: ^7.65.0
       react-router: ^6.28.1 || ^7.1.1
       react-router-dom: ^6.28.1 || ^7.1.1
@@ -10832,10 +10785,10 @@ packages:
       '@mui/utils': ^5.15.20 || ^6.0.0 || ^7.0.0
       csstype: ^3.1.3
       ra-core: 5.13.1
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
       react-hook-form: '*'
-      react-is: ^18.0.0 || ^19.0.0
+      react-is: ^19.2.5
       react-router: ^6.28.1 || ^7.1.1
       react-router-dom: ^6.28.1 || ^7.1.1
 
@@ -10871,14 +10824,14 @@ packages:
   react-admin@5.13.1:
     resolution: {integrity: sha512-osauKBeJ01KU6yUe5fpPngd1RwCk5THUt2IpZNicU5oNuwfoTygHY1M7ervX38TDMziW0juOmATR3FTeIuZIsA==}
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-aria@3.48.0:
     resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-base16-styling@0.10.0:
     resolution: {integrity: sha512-H1k2eFB6M45OaiRru3PBXkuCcn2qNmx+gzLb4a9IPMR7tMH8oBRXU5jGbPDYG1Hz+82d88ED0vjR8BmqU3pQdg==}
@@ -10886,14 +10839,14 @@ packages:
   react-collapsed@4.2.0:
     resolution: {integrity: sha512-8rQuV3wGTjBI4M1WzD5DpqCBRliHNDKEEFeC6tAQEVrRDic46xBOtySgMGjVVacIobEaMf7AiYlI5APCZIZtkg==}
     peerDependencies:
-      react: ^16.9.0 || ^17 || ^18 || ^19
-      react-dom: ^16.9.0 || ^17 || ^18 || ^19
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-contextual-analytics@1.1.2:
     resolution: {integrity: sha512-oJrQuEFsKLnIpO5z792vRdpyALtWRMmpgSLgEhs6iVFfOVuHTDUMqncchroyiEC8JJrJLgkdlfd/XIKnzf+CHA==}
     peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-dnd-html5-backend@16.0.1:
     resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
@@ -10904,7 +10857,7 @@ packages:
       '@types/hoist-non-react-statics': '>= 3.3.1'
       '@types/node': '>= 12'
       '@types/react': '>= 16'
-      react: '>= 16.14'
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/hoist-non-react-statics':
         optional: true
@@ -10922,17 +10875,17 @@ packages:
     resolution: {integrity: sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      react: '>= 16.8 || 18.0.0'
+      react: ^19.2.5
 
   react-error-boundary@4.1.2:
     resolution: {integrity: sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==}
     peerDependencies:
-      react: '>=16.13.1'
+      react: ^19.2.5
 
   react-error-boundary@6.1.1:
     resolution: {integrity: sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==}
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0
+      react: ^19.2.5
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -10940,43 +10893,34 @@ packages:
   react-feather@2.0.10:
     resolution: {integrity: sha512-BLhukwJ+Z92Nmdcs+EMw6dy1Z/VLiJTzEQACDUEnWMClhYnFykJCGWQx+NmwP/qQHGX/5CzQ+TGi8ofg2+HzVQ==}
     peerDependencies:
-      react: '>=16.8.6'
+      react: ^19.2.5
 
   react-helmet-async@3.0.0:
     resolution: {integrity: sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==}
     peerDependencies:
-      react: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
 
   react-hook-form@7.72.1:
     resolution: {integrity: sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18 || ^19
+      react: ^19.2.5
 
   react-hotkeys-hook@5.2.4:
     resolution: {integrity: sha512-BgKg+A1+TawkYluh5Bo4cTmcgMN5L29uhJbDUQdHwPX+qgXRjIPYU5kIDHyxnAwCkCBiu9V5OpB2mpyeluVF2A==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-icons@5.6.0:
     resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
     peerDependencies:
-      react: '*'
+      react: ^19.2.5
 
   react-international-phone@4.8.0:
     resolution: {integrity: sha512-PoyXx8t0OZNZXLupZN5UtmLb8nO6PQ6f6jQvYCAtg7VzxonuBcDs/4YA4+flqZZj5QOVqN4DLY1p39mEtJAwzw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
-  react-is@17.0.2:
-    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+      react: ^19.2.5
 
   react-is@19.2.5:
     resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
@@ -10988,19 +10932,19 @@ packages:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
-      react: '>=18'
+      react: ^19.2.5
 
   react-markdown@8.0.7:
     resolution: {integrity: sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==}
     peerDependencies:
       '@types/react': '>=16'
-      react: '>=16'
+      react: ^19.2.5
 
   react-markdown@9.1.0:
     resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
     peerDependencies:
       '@types/react': '>=18'
-      react: '>=18'
+      react: ^19.2.5
 
   react-papaparse@4.4.0:
     resolution: {integrity: sha512-xTEwHZYJ+1dh9mQDQjjwJXmWyX20DdZ52u+ddw75V+Xm5qsjXSvWmC7c8K82vRwMjKAOH2S9uFyGpHEyEztkUQ==}
@@ -11013,7 +10957,7 @@ packages:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
     peerDependencies:
       '@types/react': ^18.2.25 || ^19
-      react: ^18.0 || ^19
+      react: ^19.2.5
       redux: ^5.0.0
     peerDependenciesMeta:
       '@types/react':
@@ -11024,22 +10968,22 @@ packages:
   react-resizable-panels@2.1.9:
     resolution: {integrity: sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==}
     peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-router-dom@7.14.1:
     resolution: {integrity: sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-router@7.14.1:
     resolution: {integrity: sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: ^19.2.5
+      react-dom: ^19.2.5
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -11047,36 +10991,36 @@ packages:
   react-select@5.10.2:
     resolution: {integrity: sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-spinners@0.17.0:
     resolution: {integrity: sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==}
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react-stately@3.46.0:
     resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^19.2.5
 
   react-syntax-highlighter@15.6.6:
     resolution: {integrity: sha512-DgXrc+AZF47+HvAPEmn7Ua/1p10jNoVZVI/LoPiYdtY+OM+/nG5yefLHKJwdKqY1adMuHFbeyBaG9j64ML7vTw==}
     peerDependencies:
-      react: '>= 0.14.0'
+      react: ^19.2.5
 
   react-textarea-autosize@8.5.9:
     resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -11116,9 +11060,9 @@ packages:
     resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
+      react-dom: ^19.2.5
+      react-is: ^19.2.5
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -11272,7 +11216,7 @@ packages:
   rich-textarea@0.27.0:
     resolution: {integrity: sha512-u3vTbomrZtItGVLiOWJ4wbQq5IeY2jtykN543shn7NuIzjUqxucZHhG3HksMZKgaexRAYh0XZ6fmtUvfl0sHEA==}
     peerDependencies:
-      react: '>=16.14.0'
+      react: ^19.2.5
 
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
@@ -11608,10 +11552,6 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
   string-width@8.1.0:
     resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
     engines: {node: '>=20'}
@@ -11631,10 +11571,6 @@ packages:
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom@4.0.0:
@@ -11713,7 +11649,7 @@ packages:
   swr@2.4.1:
     resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
     peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -11785,9 +11721,6 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-
-  thread-stream@3.1.0:
-    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -12147,13 +12080,13 @@ packages:
     resolution: {integrity: sha512-3GgqNa6iF7bC4hY/ImJKN4REQILcSU9VKcKL8gfELZM8mM5BnLH1BsCc8kBdnVGD1LIFOs4W3O2idNHhON1r0w==}
     peerDependencies:
       '@urql/core': ^5.0.0
-      react: '>= 16.8.0'
+      react: ^19.2.5
 
   use-composed-ref@1.4.0:
     resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -12162,13 +12095,13 @@ packages:
     resolution: {integrity: sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
-      react: '*'
+      react: ^19.2.5
 
   use-isomorphic-layout-effect@1.2.1:
     resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -12177,7 +12110,7 @@ packages:
     resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -12185,13 +12118,13 @@ packages:
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.5
 
   usehooks-ts@2.16.0:
     resolution: {integrity: sha512-bez95WqYujxp6hFdM/CpRDiVPirZPxlMzOH2QB8yopoKQMXpscyZoxOjpEdaxvV+CAWUDSM62cWnqHE0E/MZ7w==}
     engines: {node: '>=16.15.0'}
     peerDependencies:
-      react: ^16.8.0  || ^17 || ^18
+      react: ^19.2.5
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -12497,10 +12430,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -12628,7 +12557,7 @@ packages:
     peerDependencies:
       '@types/react': '>=16.8'
       immer: '>=9.0.6'
-      react: '>=16.8'
+      react: ^19.2.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -14142,8 +14071,8 @@ snapshots:
       langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.216.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.20.0(bufferutil@4.1.0))(zod@3.25.76)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.216.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(axios@1.16.0(debug@4.4.3))(encoding@0.1.13)(handlebars@4.7.9)(openai@4.104.0(encoding@0.1.13)(ws@8.20.0(bufferutil@4.1.0))(zod@3.25.76))(ws@8.20.0(bufferutil@4.1.0))
       openai: 4.104.0(encoding@0.1.13)(ws@8.20.0(bufferutil@4.1.0))(zod@3.25.76)
       partial-json: 0.1.7
-      pino: 9.14.0
-      pino-pretty: 11.3.0
+      pino: 10.3.1
+      pino-pretty: 13.1.3
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       type-graphql: 2.0.0-rc.1(class-validator@0.14.4)(graphql-scalars@1.25.0(graphql@16.13.2))(graphql@16.13.2)
@@ -14986,14 +14915,7 @@ snapshots:
 
   '@ioredis/commands@1.5.1': {}
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
+  '@isaacs/cliui@9.0.0': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -15097,7 +15019,7 @@ snapshots:
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
-      glob: 7.2.3
+      glob: 11.1.0
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
@@ -17313,9 +17235,6 @@ snapshots:
     optional: true
 
   '@pinojs/redact@0.4.0': {}
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -20054,15 +19973,11 @@ snapshots:
 
   ansi-regex@6.1.0: {}
 
-  ansi-regex@6.2.2: {}
-
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
-
-  ansi-styles@6.2.3: {}
 
   ansis@3.17.0: {}
 
@@ -20075,7 +19990,7 @@ snapshots:
 
   archiver-utils@5.0.2:
     dependencies:
-      glob: 10.5.0
+      glob: 11.1.0
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
@@ -20469,7 +20384,7 @@ snapshots:
     dependencies:
       '@npmcli/fs': 5.0.0
       fs-minipass: 3.0.3
-      glob: 13.0.6
+      glob: 11.1.0
       lru-cache: 11.3.5
       minipass: 7.1.3
       minipass-collect: 2.0.1
@@ -21214,8 +21129,6 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
-  eastasianwidth@0.2.0: {}
-
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -21236,8 +21149,6 @@ snapshots:
       react: 19.2.5
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   emojis-list@3.0.0: {}
 
@@ -21490,9 +21401,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  exec-sh@0.2.2:
-    dependencies:
-      merge: 2.1.1
+  exec-sh@0.4.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -21605,8 +21514,6 @@ snapshots:
       - supports-color
 
   extend@3.0.2: {}
-
-  fast-copy@3.0.2: {}
 
   fast-copy@4.0.3: {}
 
@@ -21828,8 +21735,6 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.2:
     optional: true
 
@@ -21923,29 +21828,14 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.5.0:
+  glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
-  glob@13.0.6:
-    dependencies:
+      jackspeak: 4.2.3
       minimatch: 10.2.5
       minipass: 7.1.3
+      package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   google-auth-library@10.6.2:
     dependencies:
@@ -22191,7 +22081,7 @@ snapshots:
 
   hoist-non-react-statics@3.3.2:
     dependencies:
-      react-is: 16.13.1
+      react-is: 19.2.5
 
   hono-openapi@0.4.8(@hono/zod-validator@0.4.3(hono@4.12.16)(zod@3.25.76))(hono@4.12.16)(openapi-types@12.1.3)(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76):
     dependencies:
@@ -22359,11 +22249,6 @@ snapshots:
   indent-string@4.0.0: {}
 
   inflection@3.0.2: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -22568,11 +22453,9 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  jackspeak@3.4.3:
+  jackspeak@4.2.3:
     dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
+      '@isaacs/cliui': 9.0.0
 
   jake@10.9.4:
     dependencies:
@@ -22640,7 +22523,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
-      glob: 7.2.3
+      glob: 11.1.0
       graceful-fs: 4.2.11
       jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
       jest-environment-node: 29.7.0
@@ -22670,7 +22553,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
-      glob: 7.2.3
+      glob: 11.1.0
       graceful-fs: 4.2.11
       jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
       jest-environment-node: 29.7.0
@@ -22839,7 +22722,7 @@ snapshots:
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
-      glob: 7.2.3
+      glob: 11.1.0
       graceful-fs: 4.2.11
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
@@ -23764,8 +23647,6 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  merge@2.1.1: {}
-
   mermaid@11.14.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
@@ -24170,10 +24051,6 @@ snapshots:
       brace-expansion: 1.1.14
 
   minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.0
-
-  minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
 
@@ -24635,16 +24512,9 @@ snapshots:
 
   path-expression-matcher@1.5.0: {}
 
-  path-is-absolute@1.0.1: {}
-
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -24687,10 +24557,6 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pino-abstract-transport@2.0.0:
-    dependencies:
-      split2: 4.2.0
-
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
@@ -24702,23 +24568,6 @@ snapshots:
       pino-abstract-transport: 3.0.0
     transitivePeerDependencies:
       - '@opentelemetry/api'
-
-  pino-pretty@11.3.0:
-    dependencies:
-      colorette: 2.0.20
-      dateformat: 4.6.3
-      fast-copy: 3.0.2
-      fast-safe-stringify: 2.1.1
-      help-me: 5.0.0
-      joycon: 3.1.1
-      minimist: 1.2.8
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 2.0.0
-      pump: 3.0.4
-      readable-stream: 4.7.0
-      secure-json-parse: 2.7.0
-      sonic-boom: 4.2.1
-      strip-json-comments: 3.1.1
 
   pino-pretty@13.1.3:
     dependencies:
@@ -24751,20 +24600,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
-
-  pino@9.14.0:
-    dependencies:
-      '@pinojs/redact': 0.4.0
-      atomic-sleep: 1.0.0
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 2.0.0
-      pino-std-serializers: 7.1.0
-      process-warning: 5.0.0
-      quick-format-unescaped: 4.0.4
-      real-require: 0.2.0
-      safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.1
-      thread-stream: 3.1.0
 
   pirates@4.0.7: {}
 
@@ -24857,13 +24692,13 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
-      react-is: 17.0.2
+      react-is: 19.2.5
 
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
-      react-is: 18.3.1
+      react-is: 19.2.5
 
   prism-react-renderer@2.4.1(react@19.2.5):
     dependencies:
@@ -24899,7 +24734,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react-is: 16.13.1
+      react-is: 19.2.5
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -25310,12 +25145,6 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-is@16.13.1: {}
-
-  react-is@17.0.2: {}
-
-  react-is@18.3.1: {}
-
   react-is@19.2.5: {}
 
   react-lifecycles-compat@3.0.4: {}
@@ -25349,7 +25178,7 @@ snapshots:
       prop-types: 15.8.1
       property-information: 6.5.0
       react: 19.2.5
-      react-is: 18.3.1
+      react-is: 19.2.5
       remark-parse: 10.0.2
       remark-rehype: 10.1.0
       space-separated-tokens: 2.0.2
@@ -25721,7 +25550,7 @@ snapshots:
 
   rimraf@5.0.10:
     dependencies:
-      glob: 10.5.0
+      glob: 11.1.0
 
   robust-predicates@3.0.3: {}
 
@@ -25855,7 +25684,8 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
-  secure-json-parse@2.7.0: {}
+  secure-json-parse@2.7.0:
+    optional: true
 
   secure-json-parse@3.0.2: {}
 
@@ -26128,12 +25958,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
-
   string-width@8.1.0:
     dependencies:
       get-east-asian-width: 1.4.0
@@ -26159,10 +25983,6 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   strip-bom@4.0.0: {}
 
@@ -26324,7 +26144,7 @@ snapshots:
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.6
-      glob: 7.2.3
+      glob: 11.1.0
       minimatch: 3.1.5
 
   testcontainers@11.14.0:
@@ -26363,10 +26183,6 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
-
-  thread-stream@3.1.0:
-    dependencies:
-      real-require: 0.2.0
 
   thread-stream@4.0.0:
     dependencies:
@@ -27011,7 +26827,7 @@ snapshots:
 
   watch@1.0.2:
     dependencies:
-      exec-sh: 0.2.2
+      exec-sh: 0.4.0
       minimist: 1.2.8
 
   watchpack@2.5.1:
@@ -27126,12 +26942,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -14,6 +14,7 @@ import {
 } from "@chakra-ui/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
 import { MeshGradient } from "@paper-design/shaders-react";
+import { keyframes } from "@emotion/react";
 import {
   ArrowRight,
   Check,
@@ -24,10 +25,16 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Kbd } from "~/components/ops/shared/Kbd";
 import { Markdown } from "~/components/Markdown";
 import { toaster } from "~/components/ui/toaster";
+import { Tooltip } from "~/components/ui/tooltip";
 import { aiBrandPalette } from "~/features/traces-v2/components/ai/aiBrandPalette";
+import {
+  DEFAULT_THINKING_VERBS,
+  useCyclingVerb,
+} from "~/features/traces-v2/components/ai/useCyclingVerb";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
@@ -72,6 +79,141 @@ const SUGGESTION_CHIPS = [
   "Explain a low score",
 ];
 
+const COMPOSER_PLACEHOLDER_EXAMPLES = [
+  "Ask Langy or describe what you want…",
+  "Try: which evaluators are failing most?",
+  "Maybe: summarize today's runs",
+  "How about: suggest an evaluator for hallucinations",
+  "Like: compare last two experiment runs",
+];
+
+// Sweep the AI palette through the muted body colour for the "thinking"
+// shimmer. Lifted from AiPromptInput.tsx; the keyframes helper is the only
+// way to actually emit @keyframes from a CSS-in-JS object.
+const langyThinkingShimmer = keyframes`
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+`;
+const thinkingShimmerStyles = {
+  background: `linear-gradient(
+    90deg,
+    var(--chakra-colors-fg-muted) 0%,
+    var(--chakra-colors-fg-muted) 25%,
+    ${aiBrandPalette[0]} 42%,
+    ${aiBrandPalette[1]} 50%,
+    ${aiBrandPalette[2]} 58%,
+    var(--chakra-colors-fg-muted) 75%,
+    var(--chakra-colors-fg-muted) 100%
+  )`,
+  backgroundSize: "250% 100%",
+  WebkitBackgroundClip: "text",
+  backgroundClip: "text",
+  WebkitTextFillColor: "transparent",
+  animation: `${langyThinkingShimmer} 4.5s linear infinite`,
+} as const;
+
+const TYPEWRITER_TYPING_MS = 70;
+const TYPEWRITER_ERASING_MS = 40;
+const TYPEWRITER_HOLD_MS = 2600;
+
+/**
+ * Cycle through `examples`, typing each one, holding, then erasing — used
+ * as the composer placeholder when idle. Returns to the first example
+ * (no animation) under reduced-motion. Mirrors AiPromptInput's local
+ * implementation; copied inline to avoid forcing an export from a file
+ * that's otherwise unrelated to Langy.
+ */
+function useTypewriterPlaceholder(
+  active: boolean,
+  examples: readonly string[],
+): string {
+  const reduceMotion = useReducedMotion();
+  const [text, setText] = useState(examples[0] ?? "");
+
+  useEffect(() => {
+    if (!active || reduceMotion) {
+      setText(examples[0] ?? "");
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let index = 0;
+    let charIndex = (examples[0] ?? "").length;
+    let phase: "type" | "hold" | "erase" = "hold";
+
+    const tick = () => {
+      if (cancelled) return;
+      const word = examples[index] ?? "";
+      if (phase === "type") {
+        charIndex++;
+        setText(word.slice(0, charIndex));
+        if (charIndex >= word.length) {
+          phase = "hold";
+          timer = setTimeout(tick, TYPEWRITER_HOLD_MS);
+        } else {
+          timer = setTimeout(tick, TYPEWRITER_TYPING_MS);
+        }
+        return;
+      }
+      if (phase === "hold") {
+        phase = "erase";
+        timer = setTimeout(tick, TYPEWRITER_ERASING_MS);
+        return;
+      }
+      charIndex--;
+      setText(word.slice(0, Math.max(charIndex, 0)));
+      if (charIndex <= 0) {
+        index = (index + 1) % examples.length;
+        charIndex = 0;
+        phase = "type";
+      }
+      timer = setTimeout(tick, TYPEWRITER_ERASING_MS);
+    };
+
+    timer = setTimeout(tick, TYPEWRITER_HOLD_MS);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [active, reduceMotion, examples]);
+
+  return text;
+}
+
+/**
+ * `⌘L` / `Ctrl+L` toggles the Langy panel globally. Mirrors
+ * useGlobalAiShortcut from traces-v2. ⌘L is normally captured by the
+ * browser to focus the URL bar; preventDefault claims it for the page
+ * when keyboard focus is inside the document. If a text input is active
+ * with a non-empty selection we bail to avoid hijacking OS shortcuts
+ * users might be relying on (e.g. select-line).
+ */
+function useGlobalLangyShortcut(onTrigger: () => void): void {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const isAccel = event.metaKey || event.ctrlKey;
+      if (!isAccel) return;
+      if (event.key !== "l" && event.key !== "L") return;
+      if (event.altKey || event.shiftKey) return;
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        const isTextInput =
+          target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable;
+        if (isTextInput) {
+          const sel = window.getSelection?.();
+          if (sel && sel.toString().length > 0) return;
+        }
+      }
+      event.preventDefault();
+      onTrigger();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onTrigger]);
+}
+
 export interface LangyProposal {
   langyProposal: true;
   kind: string;
@@ -108,15 +250,20 @@ export function LangyDrawer({
   const isControlled = isOpenProp !== undefined;
   const [internalOpen, setInternalOpen] = useState(false);
   const isOpen = isControlled ? isOpenProp : internalOpen;
-  const setIsOpen = (next: boolean) => {
-    if (!isControlled) setInternalOpen(next);
-    onOpenChange?.(next);
-  };
+  const setIsOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+  const toggle = useCallback(() => setIsOpen(!isOpen), [isOpen, setIsOpen]);
+  useGlobalLangyShortcut(toggle);
 
   return (
     <>
       <SparkleGradientDefs />
-      <LangyHandle isOpen={isOpen} onToggle={() => setIsOpen(!isOpen)} />
+      <LangyHandle isOpen={isOpen} onToggle={toggle} />
       <LangyPanel
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
@@ -242,13 +389,14 @@ function LangyHandle({
   onToggle: () => void;
 }) {
   const [hover, setHover] = useState(false);
-  return (
+  const button = (
     <chakra.button
       type="button"
       onClick={onToggle}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       aria-label={isOpen ? "Close Langy" : "Open Langy assistant"}
+      aria-keyshortcuts="Meta+L Control+L"
       position="fixed"
       right={isOpen ? `${PANEL_WIDTH + PANEL_GUTTER + 4}px` : 0}
       top="50%"
@@ -292,6 +440,24 @@ function LangyHandle({
         </Text>
       </VStack>
     </chakra.button>
+  );
+
+  return (
+    <Tooltip
+      content={
+        <HStack gap={2}>
+          <Text>{isOpen ? "Close Langy" : "Open Langy"}</Text>
+          <HStack gap={1}>
+            <Kbd>⌘</Kbd>
+            <Kbd>L</Kbd>
+          </HStack>
+        </HStack>
+      }
+      positioning={{ placement: "left" }}
+      openDelay={200}
+    >
+      {button}
+    </Tooltip>
   );
 }
 
@@ -777,30 +943,39 @@ function Chip({
 }
 
 function ThinkingIndicator({ messages }: { messages: UIMessage[] }) {
+  const reduceMotion = useReducedMotion();
   const last = messages.at(-1);
   const activeTool =
     last?.role === "assistant"
       ? last.parts.findLast((part) => part.type?.startsWith("tool-"))
       : undefined;
-  const label = activeTool?.type
+  const toolLabel = activeTool?.type
     ? activeTool.type.replace(/^tool-/, "").replace(/_/g, " ")
-    : "thinking";
+    : null;
+
+  // While a tool is active, surface what it is — that's higher-signal
+  // than a generic verb. Otherwise cycle through the AI thinking verbs
+  // so the panel doesn't feel frozen during long generations.
+  const cyclingVerb = useCyclingVerb(!toolLabel, DEFAULT_THINKING_VERBS);
+  const text = toolLabel ? `Langy is ${toolLabel}…` : `${cyclingVerb}…`;
+
+  // Reduced-motion: drop the keyframes animation but keep the static
+  // gradient so the text still reads as "AI activity" without sweep.
+  const shimmerCss = reduceMotion
+    ? { ...thinkingShimmerStyles, animation: "none" }
+    : thinkingShimmerStyles;
 
   return (
-    <HStack gap={2} alignSelf="flex-start" color="fg.muted">
+    <HStack gap={2} alignSelf="flex-start">
       <SparkleTile size={24} sparkleSize={12} />
-      <HStack
-        gap={2}
-        paddingX={2.5}
-        paddingY={1.5}
-        borderRadius="md"
-        background="bg.subtle"
-        borderWidth="1px"
-        borderColor="border.muted"
+      <Box
+        textStyle="xs"
+        fontWeight="500"
+        letterSpacing="-0.005em"
+        css={shimmerCss}
       >
-        <Spinner size="xs" colorPalette="purple" />
-        <Text textStyle="xs">Langy is {label}…</Text>
-      </HStack>
+        {text}
+      </Box>
     </HStack>
   );
 }
@@ -823,6 +998,10 @@ function Composer({
   canSend: boolean;
 }) {
   const filled = input.trim().length > 0;
+  const typewriterPlaceholder = useTypewriterPlaceholder(
+    !filled && !isBusy && !disabled,
+    COMPOSER_PLACEHOLDER_EXAMPLES,
+  );
   return (
     <>
       <Separator />
@@ -857,7 +1036,7 @@ function Composer({
               }
             }}
             placeholder={
-              isBusy ? "Langy is working…" : "Ask Langy or describe what you want…"
+              isBusy ? "Langy is working…" : typewriterPlaceholder
             }
             disabled={disabled || isBusy}
             rows={1}

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -13,6 +13,7 @@ import {
   chakra,
 } from "@chakra-ui/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
+import { MeshGradient } from "@paper-design/shaders-react";
 import {
   ArrowRight,
   Check,
@@ -28,6 +29,7 @@ import { Markdown } from "~/components/Markdown";
 import { toaster } from "~/components/ui/toaster";
 import { aiBrandPalette } from "~/features/traces-v2/components/ai/aiBrandPalette";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
 import {
   useLangyConversations,
@@ -165,6 +167,48 @@ function GradientSparkle({ size = 16 }: { size?: number }) {
   );
 }
 
+/**
+ * Animated WebGL mesh of the AI brand colours, positioned absolute and
+ * sized to fill its parent. Drop into any AI affordance with
+ * `position: relative` and ensure the foreground content sits at
+ * `position: relative; zIndex: 1` so it stacks above the mesh. Mirrors
+ * the AskAiButton + AiShaderBackdrop usage from traces-v2.
+ *
+ * `active` lifts the swirl speed for the "thinking" state. Returns a
+ * static gradient when `prefers-reduced-motion: reduce` is set.
+ */
+function MeshGradientLayer({
+  active = false,
+  borderRadius,
+}: {
+  active?: boolean;
+  borderRadius?: string;
+}) {
+  const reduceMotion = useReducedMotion();
+  const speed = reduceMotion ? 0 : active ? 0.6 : 0.3;
+  return (
+    <Box
+      position="absolute"
+      inset={0}
+      pointerEvents="none"
+      overflow="hidden"
+      borderRadius={borderRadius}
+      _dark={{ opacity: 0.75 }}
+    >
+      <MeshGradient
+        colors={[...aiBrandPalette]}
+        distortion={0.5}
+        swirl={0.5}
+        grainMixer={0}
+        grainOverlay={0}
+        speed={speed}
+        scale={1.5}
+        style={{ width: "100%", height: "100%" }}
+      />
+    </Box>
+  );
+}
+
 function SparkleTile({
   size,
   sparkleSize,
@@ -214,7 +258,7 @@ function LangyHandle({
       cursor="pointer"
       borderTopLeftRadius="999px"
       borderBottomLeftRadius="999px"
-      background={AI_GRADIENT}
+      background="transparent"
       borderWidth="1px"
       borderStyle="solid"
       borderColor="rgba(255,255,255,0.18)"
@@ -223,8 +267,16 @@ function LangyHandle({
       boxShadow={hover ? AI_SHADOW : AI_SHADOW_SOFT}
       transform={hover ? "translate(-2px, -50%)" : "translateY(-50%)"}
       transition={`right ${LANGY_TRANSITION}, transform 180ms ease, box-shadow 180ms ease`}
+      overflow="hidden"
     >
-      <VStack gap={2} align="center" justify="center">
+      <MeshGradientLayer active={hover} />
+      <VStack
+        gap={2}
+        align="center"
+        justify="center"
+        position="relative"
+        zIndex={1}
+      >
         <Sparkles size={14} color="white" />
         <Text
           textStyle="2xs"
@@ -838,10 +890,11 @@ function Composer({
               aria-label="Send"
               onClick={onSend}
               disabled={!canSend}
-              background={canSend ? AI_GRADIENT : "#f5f5f4"}
+              background={canSend ? "transparent" : "#f5f5f4"}
               color={canSend ? "white" : "var(--chakra-colors-fg-muted)"}
               shadow={canSend}
               cursor={canSend ? "pointer" : "default"}
+              meshOverlay={canSend}
             >
               <Send size={14} />
             </SendButton>
@@ -867,6 +920,7 @@ function SendButton({
   color,
   shadow,
   cursor,
+  meshOverlay = false,
   ...rest
 }: {
   children: React.ReactNode;
@@ -874,13 +928,14 @@ function SendButton({
   color: string;
   shadow: boolean;
   cursor: string;
+  meshOverlay?: boolean;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <chakra.button
       type="button"
       width="32px"
       height="32px"
-      borderRadius="999px"
+      borderRadius="full"
       borderWidth={0}
       background={background}
       color={color}
@@ -890,9 +945,14 @@ function SendButton({
       flexShrink={0}
       boxShadow={shadow ? AI_SHADOW : undefined}
       transition="background 150ms ease, box-shadow 150ms ease"
+      position="relative"
+      overflow="hidden"
       {...rest}
     >
-      {children}
+      {meshOverlay && <MeshGradientLayer borderRadius="full" />}
+      <Box position="relative" zIndex={1} display="grid" placeItems="center">
+        {children}
+      </Box>
     </chakra.button>
   );
 }
@@ -1100,7 +1160,7 @@ function ProposalCard({
             borderRadius="md"
             borderWidth={0}
             background={
-              destructive ? "var(--chakra-colors-red-solid)" : AI_GRADIENT
+              destructive ? "var(--chakra-colors-red-solid)" : "transparent"
             }
             color="white"
             fontSize="12.5px"
@@ -1114,15 +1174,28 @@ function ProposalCard({
             boxShadow={destructive ? undefined : AI_SHADOW}
             onClick={onApply}
             disabled={isApplying}
+            position="relative"
+            overflow="hidden"
           >
-            <Check size={12} />
-            {isApplying
-              ? destructive
-                ? "Deleting…"
-                : "Applying…"
-              : destructive
-                ? "Delete"
-                : "Apply"}
+            {!destructive && (
+              <MeshGradientLayer borderRadius="md" active={isApplying} />
+            )}
+            <Box
+              position="relative"
+              zIndex={1}
+              display="flex"
+              alignItems="center"
+              gap={1.5}
+            >
+              <Check size={12} />
+              {isApplying
+                ? destructive
+                  ? "Deleting…"
+                  : "Applying…"
+                : destructive
+                  ? "Delete"
+                  : "Apply"}
+            </Box>
           </chakra.button>
           <Button
             size="xs"

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -4,10 +4,11 @@ import {
   Button,
   HStack,
   IconButton,
-  Input,
   Spinner,
   Text,
+  Textarea,
   VStack,
+  chakra,
 } from "@chakra-ui/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -16,7 +17,6 @@ import {
   LuCheck,
   LuPlus,
   LuSend,
-  LuSparkles,
   LuSquare,
   LuTrash2,
   LuX,
@@ -31,22 +31,32 @@ import {
   type LangyMessageRecord,
 } from "./useLangyConversations";
 
-const DRAWER_WIDTH = 420;
-const HANDLE_WIDTH = 26;
+const PANEL_WIDTH = 380;
 const PANEL_GUTTER = 16;
+const PILL_WIDTH = 30;
 
-/**
- * Total horizontal space the Langy panel occupies when docked open
- * (panel width + the right-side gutter). Page layouts can use this
- * to shift content out of the way with a matching transition.
- */
-export const LANGY_DOCKED_OFFSET = DRAWER_WIDTH + PANEL_GUTTER;
-export const LANGY_TRANSITION = "360ms cubic-bezier(0.32, 0.72, 0, 1)";
+export const LANGY_DOCKED_OFFSET = PANEL_WIDTH + PANEL_GUTTER;
+export const LANGY_TRANSITION = "240ms cubic-bezier(0.32, 0.72, 0, 1)";
 
-const SAMPLE_PROMPTS = [
-  "Summarize my current experiment",
-  "Which rows are failing and why?",
-  "Suggest an evaluator for measuring RAG hallucinations",
+const BRAND = {
+  primary: "#ea580c",
+  hover: "#c2410c",
+  bg50: "#fff7ed",
+  bg100: "#ffedd5",
+  border: "#fed7aa",
+  inverse: "#1c1917",
+  gradient: "linear-gradient(135deg, #fb923c 0%, #f97316 50%, #ea580c 100%)",
+  tileGradient: "linear-gradient(135deg, #fff7ed 0%, #ffedd5 100%)",
+  shadow: "0 6px 18px -4px rgba(234, 88, 12, 0.35)",
+  shadowSoft: "0 4px 12px -4px rgba(234, 88, 12, 0.25)",
+} as const;
+
+const SUGGESTION_CHIPS = [
+  "Summarize my experiment",
+  "Find failing traces",
+  "Suggest an evaluator",
+  "Compare two runs",
+  "Explain a low score",
 ];
 
 export interface LangyProposal {
@@ -59,11 +69,8 @@ export interface LangyProposal {
 }
 
 export type AppliedOutcome = {
-  /** Label for the "open" affordance. Defaults to "Open". */
   label?: string;
-  /** If provided, clicking the applied card triggers this (e.g. openDrawer). */
   onOpen?: () => void;
-  /** Fallback link target if no onOpen is provided. */
   href?: string;
 } | void;
 
@@ -75,11 +82,6 @@ export type ProposalHandlers = Record<
 interface LangyDrawerProps {
   proposalHandlers?: ProposalHandlers;
   experimentSlug?: string;
-  /**
-   * Controlled open state. When provided, the parent owns visibility —
-   * which is what enables the surrounding layout to shift in lockstep.
-   * If omitted, the drawer manages its own state (overlay-style).
-   */
   isOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -111,6 +113,57 @@ export function LangyDrawer({
   );
 }
 
+function GradientSparkle({ size = 16 }: { size?: number }) {
+  const id = `langy-sparkle-${size}`;
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden>
+      <defs>
+        <linearGradient id={id} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#fbbf24" />
+          <stop offset="60%" stopColor="#f97316" />
+          <stop offset="100%" stopColor="#c2410c" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M12 2.5l1.85 5.4 5.4 1.85-5.4 1.85L12 17l-1.85-5.4-5.4-1.85 5.4-1.85L12 2.5z"
+        fill={`url(#${id})`}
+      />
+      <path
+        d="M19 14l.85 2.15L22 17l-2.15.85L19 20l-.85-2.15L16 17l2.15-.85L19 14z"
+        fill={`url(#${id})`}
+        opacity={0.75}
+      />
+    </svg>
+  );
+}
+
+function SparkleTile({
+  size,
+  sparkleSize,
+}: {
+  size: number;
+  sparkleSize: number;
+}) {
+  return (
+    <Box
+      width={`${size}px`}
+      height={`${size}px`}
+      borderRadius={size >= 48 ? "18px" : "8px"}
+      background={BRAND.tileGradient}
+      borderWidth="1px"
+      borderColor={BRAND.border}
+      display="grid"
+      placeItems="center"
+      flexShrink={0}
+      boxShadow={
+        size >= 48 ? "0 6px 16px -8px rgba(234, 88, 12, 0.4)" : undefined
+      }
+    >
+      <GradientSparkle size={sparkleSize} />
+    </Box>
+  );
+}
+
 function LangyHandle({
   isOpen,
   onToggle,
@@ -118,51 +171,48 @@ function LangyHandle({
   isOpen: boolean;
   onToggle: () => void;
 }) {
+  const [hover, setHover] = useState(false);
   return (
-    <Box
-      as="button"
+    <chakra.button
+      type="button"
       onClick={onToggle}
-      aria-label={isOpen ? "Close Langy" : "Open Langy"}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      aria-label={isOpen ? "Close Langy" : "Open Langy assistant"}
       position="fixed"
-      right={isOpen ? `${DRAWER_WIDTH + PANEL_GUTTER / 2}px` : 0}
+      right={isOpen ? `${PANEL_WIDTH + PANEL_GUTTER + 4}px` : 0}
       top="50%"
-      transform="translateY(-50%)"
-      width={`${HANDLE_WIDTH}px`}
-      height="84px"
+      width={`${PILL_WIDTH}px`}
+      paddingY="14px"
       zIndex={1600}
       cursor="pointer"
-      borderTopLeftRadius="lg"
-      borderBottomLeftRadius="lg"
-      background="bg.surface/80"
-      backdropFilter="blur(25px)"
+      borderTopLeftRadius="999px"
+      borderBottomLeftRadius="999px"
+      background={BRAND.tileGradient}
       borderWidth="1px"
-      borderColor="border.emphasized"
+      borderColor={BRAND.border}
       borderRightWidth={0}
-      boxShadow="sm"
-      color={isOpen ? "blue.fg" : "fg.muted"}
-      transition={`right ${LANGY_TRANSITION}, transform 180ms ease, color 180ms ease, background 180ms ease`}
-      _hover={{
-        transform: "translate(-2px, -50%)",
-        color: "blue.fg",
-        background: "bg.panel/90",
-      }}
+      color={BRAND.primary}
+      boxShadow={hover ? BRAND.shadow : BRAND.shadowSoft}
+      transform={hover ? "translate(-2px, -50%)" : "translateY(-50%)"}
+      transition={`right ${LANGY_TRANSITION}, transform 180ms ease, box-shadow 180ms ease`}
     >
-      <VStack gap={1.5} height="full" justify="center">
-        <LuSparkles size={14} />
+      <VStack gap={2} align="center" justify="center">
+        <GradientSparkle size={14} />
         <Text
-          fontSize="10px"
+          fontSize="11px"
           fontWeight="600"
-          letterSpacing="0.12em"
+          letterSpacing="1.4px"
+          color={BRAND.primary}
           style={{
             writingMode: "vertical-rl",
             textOrientation: "mixed",
-            transform: "rotate(180deg)",
           }}
         >
           LANGY
         </Text>
       </VStack>
-    </Box>
+    </chakra.button>
   );
 }
 
@@ -182,10 +232,7 @@ function LangyPanel({
 
   const [input, setInput] = useState("");
   const [appliedOutcomes, setAppliedOutcomes] = useState<
-    Record<
-      string,
-      { href?: string; label?: string; onOpen?: () => void }
-    >
+    Record<string, { href?: string; label?: string; onOpen?: () => void }>
   >({});
   const [discardedProposals, setDiscardedProposals] = useState<Set<string>>(
     new Set(),
@@ -257,6 +304,7 @@ function LangyPanel({
   }, [messages, status]);
 
   const isBusy = status === "submitted" || status === "streaming";
+  const isEmpty = messages.length === 0;
 
   const send = async (text: string) => {
     if (!text.trim() || !projectId || isBusy) return;
@@ -265,6 +313,14 @@ function LangyPanel({
       { role: "user", parts: [{ type: "text", text }] },
       { body: { projectId, experimentSlug } },
     );
+  };
+
+  const handleNewChat = () => {
+    startNewConversation();
+  };
+
+  const handleSelectConversation = (id: string) => {
+    void selectConversation(id);
   };
 
   const applyProposal = async (
@@ -322,45 +378,62 @@ function LangyPanel({
     setDiscardedProposals((prev) => new Set(prev).add(proposalId));
   };
 
+  const subtitle = experimentSlug
+    ? `On: ${experimentSlug}`
+    : isEmpty
+      ? "Your AI copilot"
+      : "Working in this project";
+
   return (
     <Box
       position="fixed"
       top={2}
       right={2}
       bottom={2}
-      width={`${DRAWER_WIDTH}px`}
+      width={`${PANEL_WIDTH}px`}
       zIndex={1500}
-      borderRadius="lg"
-      background="bg.surface/85"
-      backdropFilter="blur(28px) saturate(140%)"
+      borderRadius="14px"
+      background="bg.surface"
       borderWidth="1px"
-      borderColor="border.emphasized"
-      boxShadow="0 24px 60px -20px rgba(15, 23, 42, 0.35), 0 8px 20px -8px rgba(15, 23, 42, 0.2)"
+      borderColor="border.muted"
+      boxShadow="0 24px 48px -16px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.06)"
+      overflow="hidden"
       transition={`transform ${LANGY_TRANSITION}, opacity 220ms ease`}
       transform={
         isOpen
           ? "translateX(0)"
-          : `translateX(calc(${DRAWER_WIDTH}px + ${PANEL_GUTTER}px))`
+          : `translateX(calc(${PANEL_WIDTH}px + ${PANEL_GUTTER}px))`
       }
       opacity={isOpen ? 1 : 0}
       pointerEvents={isOpen ? "auto" : "none"}
       aria-hidden={!isOpen}
+      role="complementary"
+      aria-label="Langy assistant"
     >
       <VStack gap={0} align="stretch" height="full">
-        <PanelHeader onClose={onClose} />
-        <LangyRecentList
+        <PanelHeader
+          subtitle={subtitle}
+          onNewChat={handleNewChat}
+          onClose={onClose}
+        />
+        <RecentList
           conversations={conversations}
           isLoading={isLoadingConversations}
           hasError={hasListError}
-          onSelect={(id) => void selectConversation(id)}
-          onStartNew={startNewConversation}
+          onSelect={handleSelectConversation}
           onDelete={(id) => void removeConversation(id)}
         />
-        <Box ref={scrollRef} flex={1} overflowY="auto" paddingX={4} paddingY={4}>
-          {messages.length === 0 ? (
+        <Box ref={scrollRef} flex={1} overflowY="auto" aria-live="polite">
+          {isEmpty ? (
             <EmptyState onPick={(prompt) => void send(prompt)} />
           ) : (
-            <VStack gap={3} align="stretch">
+            <VStack
+              gap="14px"
+              align="stretch"
+              paddingX="18px"
+              paddingTop="18px"
+              paddingBottom="12px"
+            >
               {messages.map((message) => (
                 <MessageContent
                   key={message.id}
@@ -390,103 +463,169 @@ function LangyPanel({
   );
 }
 
-function LangyRecentList({
+function PanelHeader({
+  subtitle,
+  onNewChat,
+  onClose,
+}: {
+  subtitle: string;
+  onNewChat: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <HStack
+      paddingY="14px"
+      paddingLeft="18px"
+      paddingRight="14px"
+      borderBottomWidth="1px"
+      borderColor="border.muted"
+      gap={2.5}
+      flexShrink={0}
+    >
+      <SparkleTile size={28} sparkleSize={15} />
+      <VStack align="start" gap={0} flex={1} minWidth={0}>
+        <Text fontSize="14px" fontWeight="600" lineHeight="1.2" color="fg">
+          Langy
+        </Text>
+        <Text
+          fontSize="11.5px"
+          color="fg.muted"
+          lineHeight="1.3"
+          marginTop="1px"
+          truncate
+        >
+          {subtitle}
+        </Text>
+      </VStack>
+      <HeaderIconButton aria-label="New chat" onClick={onNewChat}>
+        <LuPlus size={17} />
+      </HeaderIconButton>
+      <HeaderIconButton aria-label="Close Langy" onClick={onClose}>
+        <LuX size={17} />
+      </HeaderIconButton>
+    </HStack>
+  );
+}
+
+function HeaderIconButton({
+  children,
+  ...rest
+}: {
+  children: React.ReactNode;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <chakra.button
+      type="button"
+      width="30px"
+      height="30px"
+      borderRadius="8px"
+      borderWidth={0}
+      background="transparent"
+      color="fg.muted"
+      cursor="pointer"
+      display="grid"
+      placeItems="center"
+      transition="background 120ms ease, color 120ms ease"
+      _hover={{ background: "bg.subtle", color: "fg" }}
+      {...rest}
+    >
+      {children}
+    </chakra.button>
+  );
+}
+
+function RecentList({
   conversations,
   isLoading,
   hasError,
   onSelect,
-  onStartNew,
   onDelete,
 }: {
   conversations: LangyConversationSummary[];
   isLoading: boolean;
   hasError: boolean;
   onSelect: (id: string) => void;
-  onStartNew: () => void;
   onDelete: (id: string) => void;
 }) {
-  if (isLoading) {
-    return (
-      <HStack
-        paddingX={4}
-        paddingY={2}
-        borderBottomWidth="1px"
-        borderColor="border.muted"
-        gap={2}
-        aria-label="Loading recent conversations"
-      >
-        <Spinner size="xs" />
-        <Text fontSize="xs" color="fg.muted">
-          Loading recent…
-        </Text>
-      </HStack>
-    );
-  }
-
   if (hasError) return null;
+  // Keep the empty state pristine: hide the section entirely once we know
+  // there are no conversations to show. Still render while loading so the
+  // user sees their history is being fetched.
+  if (!isLoading && conversations.length === 0) return null;
 
   return (
     <VStack
       align="stretch"
       gap={1}
-      paddingX={3}
-      paddingY={2}
+      paddingX="14px"
+      paddingY="10px"
       borderBottomWidth="1px"
       borderColor="border.muted"
+      background="bg.subtle"
+      flexShrink={0}
+      maxHeight="220px"
+      overflowY="auto"
     >
-      <HStack justify="space-between" paddingX={1}>
-        <Text fontSize="2xs" fontWeight="600" color="fg.muted" letterSpacing="0.08em">
-          RECENT
-        </Text>
-        <Button
-          size="2xs"
-          variant="ghost"
-          onClick={onStartNew}
-          aria-label="New chat"
+      <Text
+        fontSize="10.5px"
+        fontWeight="600"
+        letterSpacing="0.5px"
+        color="fg.muted"
+        textTransform="uppercase"
+        paddingX="4px"
+        paddingBottom="4px"
+      >
+        Recent chats
+      </Text>
+      {isLoading ? (
+        <HStack
+          gap={2}
+          paddingX="4px"
+          paddingY="6px"
+          aria-label="Loading recent conversations"
         >
-          <LuPlus size={12} />
-          <Text fontSize="xs">New chat</Text>
-        </Button>
-      </HStack>
-      {conversations.length === 0 ? (
-        <Text fontSize="xs" color="fg.muted" paddingX={2} paddingY={1}>
-          No conversations yet.
-        </Text>
+          <Spinner size="xs" />
+          <Text fontSize="xs" color="fg.muted">
+            Loading…
+          </Text>
+        </HStack>
       ) : (
-        <Box as="ul" aria-label="Recent conversations" listStyleType="none" margin={0} padding={0}>
+        <Box
+          as="ul"
+          aria-label="Recent conversations"
+          listStyleType="none"
+          margin={0}
+          padding={0}
+        >
           {conversations.map((conv) => (
-            <Box
-              as="li"
-              key={conv.id}
-              display="flex"
-              alignItems="center"
-              gap={1}
-            >
-              <Box
-                as="button"
+            <HStack key={conv.id} as="li" gap={1}>
+              <chakra.button
                 type="button"
                 onClick={() => onSelect(conv.id)}
                 flex={1}
                 textAlign="left"
-                paddingX={2}
-                paddingY="6px"
-                borderRadius="md"
-                fontSize="xs"
+                paddingX="8px"
+                paddingY="7px"
+                borderRadius="6px"
+                fontSize="12.5px"
                 color="fg"
                 cursor="pointer"
-                _hover={{ background: "bg.subtle" }}
+                truncate
+                background="transparent"
+                borderWidth={0}
+                _hover={{ background: "bg.surface" }}
               >
                 {conv.title ?? "Untitled"}
-              </Box>
+              </chakra.button>
               <IconButton
                 size="2xs"
                 variant="ghost"
-                aria-label="Delete"
+                aria-label="Delete conversation"
                 onClick={() => onDelete(conv.id)}
               >
                 <LuTrash2 size={12} />
               </IconButton>
-            </Box>
+            </HStack>
           ))}
         </Box>
       )}
@@ -494,45 +633,80 @@ function LangyRecentList({
   );
 }
 
-function PanelHeader({ onClose }: { onClose: () => void }) {
+function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
   return (
-    <HStack
-      paddingX={4}
-      paddingY={3}
-      borderBottomWidth="1px"
-      borderColor="border.muted"
-      gap={3}
+    <VStack
+      gap={0}
+      align="center"
+      justify="center"
+      flex={1}
+      paddingX="24px"
+      paddingY="32px"
+      height="full"
     >
-      <Box
-        width="28px"
-        height="28px"
-        borderRadius="md"
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        background="blue.subtle"
-        color="blue.fg"
+      <SparkleTile size={60} sparkleSize={28} />
+      <Text
+        fontSize="20px"
+        fontWeight="600"
+        letterSpacing="-0.3px"
+        color="fg"
+        textAlign="center"
+        marginTop="18px"
       >
-        <LuSparkles size={14} />
-      </Box>
-      <VStack align="start" gap={0}>
-        <Text fontSize="sm" fontWeight="600" color="fg">
-          Langy
-        </Text>
-        <Text fontSize="xs" color="fg.muted">
-          Propose &amp; apply
-        </Text>
-      </VStack>
-      <Box flex={1} />
-      <IconButton
-        size="xs"
-        variant="ghost"
-        aria-label="Close Langy"
-        onClick={onClose}
+        How can I help?
+      </Text>
+      <Text
+        fontSize="13px"
+        color="fg.muted"
+        lineHeight="1.5"
+        textAlign="center"
+        maxWidth="280px"
+        marginTop="8px"
+        marginBottom="22px"
       >
-        <LuX size={14} />
-      </IconButton>
-    </HStack>
+        Ask in plain language. I&apos;ll read your traces and evals, then
+        propose changes you can apply.
+      </Text>
+      <HStack gap="6px" flexWrap="wrap" justify="center" maxWidth="320px">
+        {SUGGESTION_CHIPS.map((chip) => (
+          <Chip key={chip} onClick={() => onPick(chip)}>
+            {chip}
+          </Chip>
+        ))}
+      </HStack>
+    </VStack>
+  );
+}
+
+function Chip({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  const [hover, setHover] = useState(false);
+  return (
+    <chakra.button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      paddingX="12px"
+      paddingY="7px"
+      borderRadius="999px"
+      borderWidth="1px"
+      borderColor={hover ? BRAND.primary : "border.muted"}
+      background={hover ? BRAND.bg50 : "bg.surface"}
+      color={hover ? BRAND.primary : "fg.muted"}
+      fontSize="12.5px"
+      fontWeight={500}
+      cursor="pointer"
+      transition="all 120ms ease"
+      whiteSpace="nowrap"
+    >
+      {children}
+    </chakra.button>
   );
 }
 
@@ -547,19 +721,20 @@ function ThinkingIndicator({ messages }: { messages: UIMessage[] }) {
     : "thinking";
 
   return (
-    <HStack
-      color="fg.muted"
-      fontSize="xs"
-      paddingX={3}
-      paddingY={2}
-      borderRadius="md"
-      background="bg.subtle"
-      borderWidth="1px"
-      borderColor="border.muted"
-      alignSelf="flex-start"
-    >
-      <Spinner size="xs" colorPalette="blue" />
-      <Text>Langy is {label}…</Text>
+    <HStack gap={2} alignSelf="flex-start" color="fg.muted">
+      <SparkleTile size={24} sparkleSize={12} />
+      <HStack
+        gap={2}
+        paddingX="10px"
+        paddingY="6px"
+        borderRadius="10px"
+        background="bg.subtle"
+        borderWidth="1px"
+        borderColor="border.muted"
+      >
+        <Spinner size="xs" colorPalette="orange" />
+        <Text fontSize="12px">Langy is {label}…</Text>
+      </HStack>
     </HStack>
   );
 }
@@ -581,103 +756,128 @@ function Composer({
   disabled: boolean;
   canSend: boolean;
 }) {
+  const filled = input.trim().length > 0;
   return (
     <Box
-      paddingX={3}
-      paddingY={3}
+      paddingX="14px"
+      paddingTop="12px"
+      paddingBottom="14px"
       borderTopWidth="1px"
       borderColor="border.muted"
+      background="bg.surface"
+      flexShrink={0}
     >
-      <HStack gap={2}>
-        <Input
-          placeholder={
-            isBusy ? "Langy is working…" : "Ask Langy or describe what you want…"
-          }
+      <HStack
+        gap={2}
+        paddingY="6px"
+        paddingLeft="14px"
+        paddingRight="6px"
+        borderRadius="999px"
+        borderWidth="1px"
+        borderColor={filled ? BRAND.primary : "border.emphasized"}
+        background="bg.surface"
+        boxShadow={filled ? `0 0 0 3px ${BRAND.bg50}` : undefined}
+        transition="border-color 150ms ease, box-shadow 150ms ease"
+        align="center"
+      >
+        <Textarea
           value={input}
           onChange={(e) => onInputChange(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
-              if (!isBusy) onSend();
+              if (!isBusy && canSend) onSend();
             }
           }}
+          placeholder={
+            isBusy ? "Langy is working…" : "Ask Langy or describe what you want…"
+          }
           disabled={disabled || isBusy}
-          size="sm"
-          variant="outline"
-          borderColor="border.emphasized"
-          background="bg.panel"
+          rows={1}
+          autoresize
+          maxHeight="120px"
+          minHeight="22px"
+          padding={0}
+          border="none"
+          background="transparent"
+          fontSize="13.5px"
+          lineHeight="1.45"
+          color="fg"
+          resize="none"
+          _focus={{ outline: "none", boxShadow: "none" }}
+          _focusVisible={{ outline: "none", boxShadow: "none" }}
         />
         {isBusy ? (
-          <IconButton
-            size="sm"
-            colorPalette="red"
-            variant="outline"
+          <SendButton
             aria-label="Stop"
             onClick={onStop}
+            background="var(--chakra-colors-red-solid)"
+            color="white"
+            shadow={false}
+            cursor="pointer"
           >
             <LuSquare size={12} />
-          </IconButton>
+          </SendButton>
         ) : (
-          <IconButton
-            size="sm"
-            colorPalette="blue"
+          <SendButton
             aria-label="Send"
             onClick={onSend}
             disabled={!canSend}
+            background={canSend ? BRAND.gradient : "#f5f5f4"}
+            color={canSend ? "white" : "var(--chakra-colors-fg-muted)"}
+            shadow={canSend}
+            cursor={canSend ? "pointer" : "default"}
           >
             <LuSend size={14} />
-          </IconButton>
+          </SendButton>
         )}
       </HStack>
+      <Text
+        marginTop="8px"
+        fontSize="10.5px"
+        color="fg.muted"
+        textAlign="center"
+        letterSpacing="0.1px"
+      >
+        Langy proposes — you review and apply.
+      </Text>
     </Box>
   );
 }
 
-function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
+function SendButton({
+  children,
+  background,
+  color,
+  shadow,
+  cursor,
+  ...rest
+}: {
+  children: React.ReactNode;
+  background: string;
+  color: string;
+  shadow: boolean;
+  cursor: string;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
-    <VStack align="stretch" gap={3} paddingTop={2}>
-      <VStack align="start" gap={1}>
-        <Text fontSize="sm" fontWeight="600" color="fg">
-          Hey, I&apos;m Langy.
-        </Text>
-        <Text fontSize="xs" color="fg.muted" lineHeight="1.55">
-          I can propose evaluators, help you pick the right one for your
-          experiment, and (soon) touch prompts and datasets. Try:
-        </Text>
-      </VStack>
-      <VStack align="stretch" gap={2}>
-        {SAMPLE_PROMPTS.map((prompt) => (
-          <Box
-            key={prompt}
-            as="button"
-            textAlign="left"
-            paddingX={3}
-            paddingY="10px"
-            borderRadius="md"
-            cursor="pointer"
-            background="bg.panel"
-            borderWidth="1px"
-            borderColor="border.muted"
-            boxShadow="2xs"
-            transition="background 150ms ease, border-color 150ms ease"
-            _hover={{
-              background: "bg.subtle",
-              borderColor: "border.emphasized",
-            }}
-            onClick={() => onPick(prompt)}
-          >
-            <HStack gap={2} align="flex-start">
-              <Box color="blue.fg" paddingTop="2px">
-                <LuArrowRight size={12} />
-              </Box>
-              <Text fontSize="xs" color="fg" lineHeight="1.5">
-                {prompt}
-              </Text>
-            </HStack>
-          </Box>
-        ))}
-      </VStack>
-    </VStack>
+    <chakra.button
+      type="button"
+      width="32px"
+      height="32px"
+      borderRadius="999px"
+      borderWidth={0}
+      background={background}
+      color={color}
+      cursor={cursor}
+      display="grid"
+      placeItems="center"
+      flexShrink={0}
+      boxShadow={shadow ? BRAND.shadow : undefined}
+      transition="background 150ms ease, box-shadow 150ms ease"
+      {...rest}
+    >
+      {children}
+    </chakra.button>
   );
 }
 
@@ -700,74 +900,75 @@ function MessageContent({
   onDiscard: (proposalId: string) => void;
 }) {
   const isUser = message.role === "user";
-  const textParts = message.parts
-    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+  const text = message.parts
+    .filter(
+      (part): part is { type: "text"; text: string } => part.type === "text",
+    )
     .map((part) => part.text)
     .join("");
 
   const proposals = extractProposals(message);
+  if (!text && proposals.length === 0) return null;
 
-  if (!textParts && proposals.length === 0) return null;
+  if (isUser) {
+    return (
+      <Box alignSelf="flex-end" maxWidth="85%">
+        <Box
+          paddingX="13px"
+          paddingY="9px"
+          background={BRAND.inverse}
+          color="white"
+          borderRadius="14px"
+          borderBottomRightRadius="4px"
+          fontSize="13px"
+          lineHeight="1.45"
+          whiteSpace="pre-wrap"
+        >
+          {text}
+        </Box>
+      </Box>
+    );
+  }
 
   return (
-    <VStack align="stretch" gap={2} width="full">
-      {textParts && (
-        <Box
-          width="full"
-          display="flex"
-          justifyContent={isUser ? "flex-end" : "flex-start"}
-        >
+    <HStack gap="9px" align="flex-start" width="full">
+      <SparkleTile size={24} sparkleSize={12} />
+      <VStack align="stretch" gap="10px" flex={1} minWidth={0}>
+        {text && (
           <Box
-            maxWidth="88%"
-            paddingX={3}
-            paddingY={2}
-            borderRadius="md"
-            borderTopRightRadius={isUser ? "sm" : "md"}
-            borderTopLeftRadius={isUser ? "md" : "sm"}
-            background={isUser ? "blue.solid" : "bg.panel"}
-            color={isUser ? "white" : "fg"}
-            borderWidth={isUser ? 0 : "1px"}
-            borderColor="border.muted"
-            boxShadow="2xs"
+            fontSize="13px"
+            color="fg"
+            lineHeight="1.55"
+            css={{
+              "& p": { margin: 0 },
+              "& p + p": { marginTop: "6px" },
+              "& ul, & ol": { paddingLeft: "18px", margin: "4px 0" },
+              "& code": {
+                fontSize: "12px",
+                padding: "1px 5px",
+                borderRadius: "4px",
+                background: "var(--chakra-colors-bg-subtle)",
+                fontFamily:
+                  "ui-monospace, SFMono-Regular, Menlo, monospace",
+              },
+            }}
           >
-            {isUser ? (
-              <Text fontSize="sm" whiteSpace="pre-wrap" lineHeight="1.5">
-                {textParts}
-              </Text>
-            ) : (
-              <Box
-                fontSize="sm"
-                lineHeight="1.55"
-                css={{
-                  "& p": { margin: 0 },
-                  "& p + p": { marginTop: "6px" },
-                  "& ul, & ol": { paddingLeft: "18px", margin: "4px 0" },
-                  "& code": {
-                    fontSize: "12px",
-                    padding: "1px 5px",
-                    borderRadius: "4px",
-                    background: "bg.subtle",
-                  },
-                }}
-              >
-                <Markdown>{textParts}</Markdown>
-              </Box>
-            )}
+            <Markdown>{text}</Markdown>
           </Box>
-        </Box>
-      )}
-      {proposals.map(({ id, proposal }) => (
-        <ProposalCard
-          key={id}
-          proposal={proposal}
-          appliedOutcome={appliedOutcomes[id]}
-          isDiscarded={discardedProposals.has(id)}
-          isApplying={applyingProposals.has(id)}
-          onApply={() => void onApply(id, proposal)}
-          onDiscard={() => onDiscard(id)}
-        />
-      ))}
-    </VStack>
+        )}
+        {proposals.map(({ id, proposal }) => (
+          <ProposalCard
+            key={id}
+            proposal={proposal}
+            appliedOutcome={appliedOutcomes[id]}
+            isDiscarded={discardedProposals.has(id)}
+            isApplying={applyingProposals.has(id)}
+            onApply={() => void onApply(id, proposal)}
+            onDiscard={() => onDiscard(id)}
+          />
+        ))}
+      </VStack>
+    </HStack>
   );
 }
 
@@ -788,8 +989,12 @@ function ProposalCard({
 }) {
   const isApplied = !!appliedOutcome;
   const destructive = !!proposal.destructive;
-  const faded = isDiscarded;
-  const statusLabel = isApplied
+  const openHref = appliedOutcome?.href;
+  const onOpen = appliedOutcome?.onOpen;
+  const openLabel = appliedOutcome?.label ?? "Open";
+  const hasOpen = !!onOpen || !!openHref;
+
+  const overlineLabel = isApplied
     ? destructive
       ? "Done"
       : "Applied"
@@ -800,27 +1005,17 @@ function ProposalCard({
           ? "Deleting…"
           : "Applying…"
         : destructive
-          ? "Langy wants to delete"
-          : "Langy proposes";
-  const accentPalette = isApplied
-    ? destructive
-      ? "gray"
-      : "green"
-    : destructive
-      ? "red"
-      : "blue";
-  const borderTone = isApplied
-    ? destructive
-      ? "border.emphasized"
-      : "green.emphasized"
-    : destructive
-      ? "red.emphasized"
-      : "blue.emphasized";
-  const primaryButtonLabel = destructive ? "Delete" : "Apply";
-  const openHref = appliedOutcome?.href;
-  const onOpen = appliedOutcome?.onOpen;
-  const openLabel = appliedOutcome?.label ?? "Open";
-  const hasOpen = !!onOpen || !!openHref;
+          ? "Wants to delete"
+          : "Proposal";
+
+  const overlineColor =
+    destructive && !isApplied
+      ? "var(--chakra-colors-red-fg)"
+      : isApplied && !destructive
+        ? "var(--chakra-colors-green-fg)"
+        : isDiscarded
+          ? "var(--chakra-colors-fg-muted)"
+          : BRAND.primary;
 
   const triggerOpen = () => {
     if (onOpen) {
@@ -834,13 +1029,12 @@ function ProposalCard({
 
   return (
     <Box
-      padding={3}
-      borderRadius="lg"
-      background="bg.panel"
       borderWidth="1px"
-      borderColor={borderTone}
-      boxShadow="sm"
-      opacity={faded ? 0.75 : 1}
+      borderColor="border.muted"
+      borderRadius="12px"
+      padding="12px"
+      background="bg.subtle"
+      opacity={isDiscarded ? 0.65 : 1}
       cursor={hasOpen ? "pointer" : "default"}
       onClick={(e) => {
         if (!hasOpen) return;
@@ -849,89 +1043,103 @@ function ProposalCard({
         triggerOpen();
       }}
       transition="border-color 150ms ease, box-shadow 150ms ease"
-      _hover={
-        hasOpen
-          ? { borderColor: "green.fg", boxShadow: "md" }
-          : undefined
-      }
+      _hover={hasOpen ? { borderColor: "green.fg", boxShadow: "sm" } : undefined}
     >
-      <VStack align="stretch" gap={2}>
-        <HStack gap={2}>
-          <Box
-            width="20px"
-            height="20px"
-            borderRadius="sm"
+      <HStack
+        gap="6px"
+        marginBottom="8px"
+        fontSize="10.5px"
+        fontWeight="600"
+        letterSpacing="0.5px"
+        textTransform="uppercase"
+        color={overlineColor}
+      >
+        {isApplied && !destructive ? (
+          <LuCheck size={11} />
+        ) : (
+          <GradientSparkle size={11} />
+        )}
+        <Text>{overlineLabel}</Text>
+      </HStack>
+      <Text fontSize="13px" fontWeight="600" color="fg" marginBottom="2px">
+        {proposal.summary}
+      </Text>
+      {proposal.rationale && (
+        <Text
+          fontSize="12px"
+          color="fg.muted"
+          lineHeight="1.45"
+          marginBottom="12px"
+        >
+          {proposal.rationale}
+        </Text>
+      )}
+      {!isApplied && !isDiscarded && (
+        <HStack gap="6px" paddingTop={proposal.rationale ? "0px" : "10px"}>
+          <chakra.button
+            type="button"
+            flex={1}
+            paddingX="12px"
+            paddingY="8px"
+            borderRadius="8px"
+            borderWidth={0}
+            background={
+              destructive ? "var(--chakra-colors-red-solid)" : BRAND.gradient
+            }
+            color="white"
+            fontSize="12.5px"
+            fontWeight={500}
+            cursor={isApplying ? "default" : "pointer"}
+            opacity={isApplying ? 0.7 : 1}
             display="flex"
             alignItems="center"
             justifyContent="center"
-            background={`${accentPalette}.subtle`}
-            color={`${accentPalette}.fg`}
+            gap="5px"
+            boxShadow={destructive ? undefined : BRAND.shadow}
+            onClick={onApply}
+            disabled={isApplying}
           >
-            {isApplied ? <LuCheck size={12} /> : <LuSparkles size={12} />}
-          </Box>
-          <Text
-            fontSize="10px"
-            fontWeight="600"
-            letterSpacing="0.08em"
-            textTransform="uppercase"
-            color={`${accentPalette}.fg`}
+            <LuCheck size={12} />
+            {isApplying
+              ? destructive
+                ? "Deleting…"
+                : "Applying…"
+              : destructive
+                ? "Delete"
+                : "Apply"}
+          </chakra.button>
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={onDiscard}
+            disabled={isApplying}
           >
-            {statusLabel}
-          </Text>
+            {destructive ? "Cancel" : "Discard"}
+          </Button>
         </HStack>
-        <Text fontSize="sm" fontWeight="600" color="fg">
-          {proposal.summary}
-        </Text>
-        {proposal.rationale && (
-          <Text fontSize="xs" color="fg.muted" lineHeight="1.5">
-            {proposal.rationale}
-          </Text>
-        )}
-        {!isApplied && !isDiscarded && (
-          <HStack gap={2} paddingTop={1}>
+      )}
+      {isApplied && hasOpen && (
+        <HStack paddingTop="10px">
+          {onOpen ? (
             <Button
               size="xs"
-              colorPalette={destructive ? "red" : "blue"}
-              onClick={onApply}
-              disabled={isApplying}
-              loading={isApplying}
+              variant="outline"
+              colorPalette="green"
+              onClick={triggerOpen}
             >
-              <LuCheck size={12} />
-              {primaryButtonLabel}
+              {openLabel}
+              <LuArrowRight size={12} />
             </Button>
-            <Button
-              size="xs"
-              variant="ghost"
-              onClick={onDiscard}
-              disabled={isApplying}
-            >
-              {destructive ? "Cancel" : "Discard"}
-            </Button>
-          </HStack>
-        )}
-        {isApplied && hasOpen && (
-          <HStack gap={2} paddingTop={1}>
-            {onOpen ? (
-              <Button
-                size="xs"
-                variant="outline"
-                colorPalette="green"
-                onClick={triggerOpen}
-              >
+          ) : openHref ? (
+            <Button size="xs" variant="outline" colorPalette="green" asChild>
+              <a href={openHref}>
                 {openLabel}
                 <LuArrowRight size={12} />
-              </Button>
-            ) : openHref ? (
-              <Button size="xs" variant="outline" colorPalette="green" asChild>
-                <a href={openHref}>
-                  {openLabel}
-                  <LuArrowRight size={12} />
-                </a>
-              </Button>
-            ) : null}
-          </HStack>
-        )}
-      </VStack>
+              </a>
+            </Button>
+          ) : null}
+        </HStack>
+      )}
     </Box>
   );
 }

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -45,10 +45,13 @@ import {
 } from "./useLangyConversations";
 
 const PANEL_WIDTH = 380;
-const PANEL_GUTTER = 16;
+// The panel docks flush against the right edge of the viewport. Page
+// layouts coordinate via LANGY_DOCKED_OFFSET; we keep a small reserve so
+// content underneath still has breathing room when the panel is open.
+const PANEL_RESERVE = 0;
 const PILL_WIDTH = 30;
 
-export const LANGY_DOCKED_OFFSET = PANEL_WIDTH + PANEL_GUTTER;
+export const LANGY_DOCKED_OFFSET = PANEL_WIDTH + PANEL_RESERVE;
 export const LANGY_TRANSITION = "240ms cubic-bezier(0.32, 0.72, 0, 1)";
 
 // Single source of truth for the gradient id used by every gradient-stroke
@@ -398,7 +401,7 @@ function LangyHandle({
       aria-label={isOpen ? "Close Langy" : "Open Langy assistant"}
       aria-keyshortcuts="Meta+L Control+L"
       position="fixed"
-      right={isOpen ? `${PANEL_WIDTH + PANEL_GUTTER + 4}px` : 0}
+      right={isOpen ? `${PANEL_WIDTH}px` : 0}
       top="50%"
       width={`${PILL_WIDTH}px`}
       paddingY="14px"
@@ -632,23 +635,21 @@ function LangyPanel({
   return (
     <Box
       position="fixed"
-      top={2}
-      right={2}
-      bottom={2}
+      top={0}
+      right={0}
+      bottom={0}
       width={`${PANEL_WIDTH}px`}
       zIndex={1500}
-      borderRadius="14px"
       background="bg.surface"
-      borderWidth="1px"
-      borderStyle="solid"
-      borderColor="border.muted"
-      boxShadow="0 24px 48px -16px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.06)"
+      borderLeftWidth="1px"
+      borderLeftStyle="solid"
+      borderLeftColor="border.muted"
+      // No corner radius and no drop shadow — the panel reads as part of
+      // the page chrome (a docked drawer), not a floating popover.
       overflow="hidden"
       transition={`transform ${LANGY_TRANSITION}, opacity 220ms ease`}
       transform={
-        isOpen
-          ? "translateX(0)"
-          : `translateX(calc(${PANEL_WIDTH}px + ${PANEL_GUTTER}px))`
+        isOpen ? "translateX(0)" : `translateX(${PANEL_WIDTH}px)`
       }
       opacity={isOpen ? 1 : 0}
       pointerEvents={isOpen ? "auto" : "none"}

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -11,19 +11,21 @@ import {
   chakra,
 } from "@chakra-ui/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
-import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  LuArrowRight,
-  LuCheck,
-  LuPlus,
-  LuSend,
-  LuSquare,
-  LuTrash2,
-  LuX,
-} from "react-icons/lu";
-import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+  ArrowRight,
+  Check,
+  Plus,
+  Send,
+  Sparkles,
+  Square,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Markdown } from "~/components/Markdown";
 import { toaster } from "~/components/ui/toaster";
+import { aiBrandPalette } from "~/features/traces-v2/components/ai/aiBrandPalette";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
 import {
   useLangyConversations,
@@ -38,18 +40,25 @@ const PILL_WIDTH = 30;
 export const LANGY_DOCKED_OFFSET = PANEL_WIDTH + PANEL_GUTTER;
 export const LANGY_TRANSITION = "240ms cubic-bezier(0.32, 0.72, 0, 1)";
 
-const BRAND = {
-  primary: "#ea580c",
-  hover: "#c2410c",
-  bg50: "#fff7ed",
-  bg100: "#ffedd5",
-  border: "#fed7aa",
-  inverse: "#1c1917",
-  gradient: "linear-gradient(135deg, #fb923c 0%, #f97316 50%, #ea580c 100%)",
-  tileGradient: "linear-gradient(135deg, #fff7ed 0%, #ffedd5 100%)",
-  shadow: "0 6px 18px -4px rgba(234, 88, 12, 0.35)",
-  shadowSoft: "0 4px 12px -4px rgba(234, 88, 12, 0.25)",
-} as const;
+// Single source of truth for the gradient id used by every gradient-stroke
+// Sparkle in this component. Defined once in <SparkleGradientDefs /> and
+// referenced via `stroke="url(#langy-sparkle-grad)"`. Mirrors AiPromptInput.
+const SPARKLE_GRADIENT_ID = "langy-sparkle-grad";
+
+// Static three-stop AI brand gradient. Used for the LANGY pill, Send and
+// Apply buttons. Mirrors the colours of MeshGradient + AskAiButton so Langy
+// reads as the same AI surface as the rest of the product.
+const AI_GRADIENT = `linear-gradient(135deg, ${aiBrandPalette[0]} 0%, ${aiBrandPalette[1]} 50%, ${aiBrandPalette[2]} 100%)`;
+
+// AI accent shadows — purple-leaning so they feel cool, not warm.
+const AI_SHADOW = "0 6px 18px -4px rgba(168, 85, 247, 0.35)";
+const AI_SHADOW_SOFT = "0 4px 12px -4px rgba(168, 85, 247, 0.22)";
+
+// AI brand surface tones. Kept literal because we want the same exact tones
+// across light/dark; semantic purple.subtle from Chakra is too pale.
+const AI_BG_SUBTLE = "rgba(168, 85, 247, 0.06)";
+const AI_BG_HOVER = "rgba(168, 85, 247, 0.10)";
+const AI_BORDER = "rgba(168, 85, 247, 0.24)";
 
 const SUGGESTION_CHIPS = [
   "Summarize my experiment",
@@ -102,6 +111,7 @@ export function LangyDrawer({
 
   return (
     <>
+      <SparkleGradientDefs />
       <LangyHandle isOpen={isOpen} onToggle={() => setIsOpen(!isOpen)} />
       <LangyPanel
         isOpen={isOpen}
@@ -113,51 +123,68 @@ export function LangyDrawer({
   );
 }
 
-function GradientSparkle({ size = 16 }: { size?: number }) {
-  const id = `langy-sparkle-${size}`;
+/**
+ * Hidden SVG that defines the AI brand linear gradient. Every `<Sparkles>`
+ * (or other lucide icon) that wants the rainbow brand stroke references it
+ * via `stroke="url(#langy-sparkle-grad)"`. Defined once at the root so the
+ * gradient is available globally and the icons reuse the same paint server.
+ */
+function SparkleGradientDefs() {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden>
+    <svg
+      width="0"
+      height="0"
+      aria-hidden
+      style={{ position: "absolute", pointerEvents: "none" }}
+    >
       <defs>
-        <linearGradient id={id} x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0%" stopColor="#fbbf24" />
-          <stop offset="60%" stopColor="#f97316" />
-          <stop offset="100%" stopColor="#c2410c" />
+        <linearGradient id={SPARKLE_GRADIENT_ID} x1="0%" y1="0%" x2="100%" y2="100%">
+          {aiBrandPalette.map((color, i) => (
+            <stop
+              key={color}
+              offset={`${(i / (aiBrandPalette.length - 1)) * 100}%`}
+              stopColor={color}
+            />
+          ))}
         </linearGradient>
       </defs>
-      <path
-        d="M12 2.5l1.85 5.4 5.4 1.85-5.4 1.85L12 17l-1.85-5.4-5.4-1.85 5.4-1.85L12 2.5z"
-        fill={`url(#${id})`}
-      />
-      <path
-        d="M19 14l.85 2.15L22 17l-2.15.85L19 20l-.85-2.15L16 17l2.15-.85L19 14z"
-        fill={`url(#${id})`}
-        opacity={0.75}
-      />
     </svg>
+  );
+}
+
+/** AI-brand sparkle: outline-only icon with the rainbow gradient stroke. */
+function GradientSparkle({ size = 16 }: { size?: number }) {
+  return (
+    <Sparkles
+      size={size}
+      stroke={`url(#${SPARKLE_GRADIENT_ID})`}
+      strokeWidth={2}
+    />
   );
 }
 
 function SparkleTile({
   size,
   sparkleSize,
+  hero = false,
 }: {
   size: number;
   sparkleSize: number;
+  hero?: boolean;
 }) {
   return (
     <Box
       width={`${size}px`}
       height={`${size}px`}
-      borderRadius={size >= 48 ? "18px" : "8px"}
-      background={BRAND.tileGradient}
+      borderRadius={hero ? "full" : "8px"}
+      background={hero ? AI_BG_SUBTLE : AI_BG_SUBTLE}
       borderWidth="1px"
-      borderColor={BRAND.border}
+      borderStyle="solid"
+      borderColor={AI_BORDER}
       display="grid"
       placeItems="center"
       flexShrink={0}
-      boxShadow={
-        size >= 48 ? "0 6px 16px -8px rgba(234, 88, 12, 0.4)" : undefined
-      }
+      boxShadow={hero ? AI_SHADOW_SOFT : undefined}
     >
       <GradientSparkle size={sparkleSize} />
     </Box>
@@ -188,22 +215,23 @@ function LangyHandle({
       cursor="pointer"
       borderTopLeftRadius="999px"
       borderBottomLeftRadius="999px"
-      background={BRAND.tileGradient}
+      background={AI_GRADIENT}
       borderWidth="1px"
-      borderColor={BRAND.border}
+      borderStyle="solid"
+      borderColor="rgba(255,255,255,0.18)"
       borderRightWidth={0}
-      color={BRAND.primary}
-      boxShadow={hover ? BRAND.shadow : BRAND.shadowSoft}
+      color="white"
+      boxShadow={hover ? AI_SHADOW : AI_SHADOW_SOFT}
       transform={hover ? "translate(-2px, -50%)" : "translateY(-50%)"}
       transition={`right ${LANGY_TRANSITION}, transform 180ms ease, box-shadow 180ms ease`}
     >
       <VStack gap={2} align="center" justify="center">
-        <GradientSparkle size={14} />
+        <Sparkles size={14} color="white" />
         <Text
           fontSize="11px"
-          fontWeight="600"
+          fontWeight="700"
           letterSpacing="1.4px"
-          color={BRAND.primary}
+          color="white"
           style={{
             writingMode: "vertical-rl",
             textOrientation: "mixed",
@@ -395,6 +423,7 @@ function LangyPanel({
       borderRadius="14px"
       background="bg.surface"
       borderWidth="1px"
+      borderStyle="solid"
       borderColor="border.muted"
       boxShadow="0 24px 48px -16px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.06)"
       overflow="hidden"
@@ -498,10 +527,10 @@ function PanelHeader({
         </Text>
       </VStack>
       <HeaderIconButton aria-label="New chat" onClick={onNewChat}>
-        <LuPlus size={17} />
+        <Plus size={17} />
       </HeaderIconButton>
       <HeaderIconButton aria-label="Close Langy" onClick={onClose}>
-        <LuX size={17} />
+        <X size={17} />
       </HeaderIconButton>
     </HStack>
   );
@@ -548,9 +577,6 @@ function RecentList({
   onDelete: (id: string) => void;
 }) {
   if (hasError) return null;
-  // Keep the empty state pristine: hide the section entirely once we know
-  // there are no conversations to show. Still render while loading so the
-  // user sees their history is being fetched.
   if (!isLoading && conversations.length === 0) return null;
 
   return (
@@ -623,7 +649,7 @@ function RecentList({
                 aria-label="Delete conversation"
                 onClick={() => onDelete(conv.id)}
               >
-                <LuTrash2 size={12} />
+                <Trash2 size={12} />
               </IconButton>
             </HStack>
           ))}
@@ -644,7 +670,7 @@ function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
       paddingY="32px"
       height="full"
     >
-      <SparkleTile size={60} sparkleSize={28} />
+      <SparkleTile size={64} sparkleSize={28} hero />
       <Text
         fontSize="20px"
         fontWeight="600"
@@ -692,18 +718,22 @@ function Chip({
       onClick={onClick}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
+      appearance="none"
       paddingX="12px"
       paddingY="7px"
       borderRadius="999px"
       borderWidth="1px"
-      borderColor={hover ? BRAND.primary : "border.muted"}
-      background={hover ? BRAND.bg50 : "bg.surface"}
-      color={hover ? BRAND.primary : "fg.muted"}
+      borderStyle="solid"
+      borderColor={hover ? AI_BORDER : "border.emphasized"}
+      background={hover ? AI_BG_HOVER : "bg.subtle"}
+      color="fg"
       fontSize="12.5px"
       fontWeight={500}
+      lineHeight="1.2"
       cursor="pointer"
       transition="all 120ms ease"
       whiteSpace="nowrap"
+      boxShadow={hover ? "0 1px 2px rgba(168, 85, 247, 0.12)" : "none"}
     >
       {children}
     </chakra.button>
@@ -732,7 +762,7 @@ function ThinkingIndicator({ messages }: { messages: UIMessage[] }) {
         borderWidth="1px"
         borderColor="border.muted"
       >
-        <Spinner size="xs" colorPalette="orange" />
+        <Spinner size="xs" colorPalette="purple" />
         <Text fontSize="12px">Langy is {label}…</Text>
       </HStack>
     </HStack>
@@ -774,9 +804,10 @@ function Composer({
         paddingRight="6px"
         borderRadius="999px"
         borderWidth="1px"
-        borderColor={filled ? BRAND.primary : "border.emphasized"}
+        borderStyle="solid"
+        borderColor={filled ? AI_BORDER : "border.emphasized"}
         background="bg.surface"
-        boxShadow={filled ? `0 0 0 3px ${BRAND.bg50}` : undefined}
+        boxShadow={filled ? `0 0 0 3px ${AI_BG_SUBTLE}` : undefined}
         transition="border-color 150ms ease, box-shadow 150ms ease"
         align="center"
       >
@@ -816,19 +847,19 @@ function Composer({
             shadow={false}
             cursor="pointer"
           >
-            <LuSquare size={12} />
+            <Square size={12} />
           </SendButton>
         ) : (
           <SendButton
             aria-label="Send"
             onClick={onSend}
             disabled={!canSend}
-            background={canSend ? BRAND.gradient : "#f5f5f4"}
+            background={canSend ? AI_GRADIENT : "#f5f5f4"}
             color={canSend ? "white" : "var(--chakra-colors-fg-muted)"}
             shadow={canSend}
             cursor={canSend ? "pointer" : "default"}
           >
-            <LuSend size={14} />
+            <Send size={14} />
           </SendButton>
         )}
       </HStack>
@@ -872,7 +903,7 @@ function SendButton({
       display="grid"
       placeItems="center"
       flexShrink={0}
-      boxShadow={shadow ? BRAND.shadow : undefined}
+      boxShadow={shadow ? AI_SHADOW : undefined}
       transition="background 150ms ease, box-shadow 150ms ease"
       {...rest}
     >
@@ -916,7 +947,7 @@ function MessageContent({
         <Box
           paddingX="13px"
           paddingY="9px"
-          background={BRAND.inverse}
+          background="#1c1917"
           color="white"
           borderRadius="14px"
           borderBottomRightRadius="4px"
@@ -1015,7 +1046,7 @@ function ProposalCard({
         ? "var(--chakra-colors-green-fg)"
         : isDiscarded
           ? "var(--chakra-colors-fg-muted)"
-          : BRAND.primary;
+          : "var(--chakra-colors-purple-fg)";
 
   const triggerOpen = () => {
     if (onOpen) {
@@ -1055,7 +1086,7 @@ function ProposalCard({
         color={overlineColor}
       >
         {isApplied && !destructive ? (
-          <LuCheck size={11} />
+          <Check size={11} />
         ) : (
           <GradientSparkle size={11} />
         )}
@@ -1084,7 +1115,7 @@ function ProposalCard({
             borderRadius="8px"
             borderWidth={0}
             background={
-              destructive ? "var(--chakra-colors-red-solid)" : BRAND.gradient
+              destructive ? "var(--chakra-colors-red-solid)" : AI_GRADIENT
             }
             color="white"
             fontSize="12.5px"
@@ -1095,11 +1126,11 @@ function ProposalCard({
             alignItems="center"
             justifyContent="center"
             gap="5px"
-            boxShadow={destructive ? undefined : BRAND.shadow}
+            boxShadow={destructive ? undefined : AI_SHADOW}
             onClick={onApply}
             disabled={isApplying}
           >
-            <LuCheck size={12} />
+            <Check size={12} />
             {isApplying
               ? destructive
                 ? "Deleting…"
@@ -1128,13 +1159,13 @@ function ProposalCard({
               onClick={triggerOpen}
             >
               {openLabel}
-              <LuArrowRight size={12} />
+              <ArrowRight size={12} />
             </Button>
           ) : openHref ? (
             <Button size="xs" variant="outline" colorPalette="green" asChild>
               <a href={openHref}>
                 {openLabel}
-                <LuArrowRight size={12} />
+                <ArrowRight size={12} />
               </a>
             </Button>
           ) : null}

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -2,8 +2,10 @@ import { useChat } from "@ai-sdk/react";
 import {
   Box,
   Button,
+  Circle,
   HStack,
   IconButton,
+  Separator,
   Spinner,
   Text,
   Textarea,
@@ -166,25 +168,22 @@ function GradientSparkle({ size = 16 }: { size?: number }) {
 function SparkleTile({
   size,
   sparkleSize,
-  hero = false,
 }: {
   size: number;
   sparkleSize: number;
-  hero?: boolean;
 }) {
   return (
     <Box
       width={`${size}px`}
       height={`${size}px`}
-      borderRadius={hero ? "full" : "8px"}
-      background={hero ? AI_BG_SUBTLE : AI_BG_SUBTLE}
+      borderRadius="8px"
+      background={AI_BG_SUBTLE}
       borderWidth="1px"
       borderStyle="solid"
       borderColor={AI_BORDER}
       display="grid"
       placeItems="center"
       flexShrink={0}
-      boxShadow={hero ? AI_SHADOW_SOFT : undefined}
     >
       <GradientSparkle size={sparkleSize} />
     </Box>
@@ -228,9 +227,9 @@ function LangyHandle({
       <VStack gap={2} align="center" justify="center">
         <Sparkles size={14} color="white" />
         <Text
-          fontSize="11px"
+          textStyle="2xs"
           fontWeight="700"
-          letterSpacing="1.4px"
+          letterSpacing="0.12em"
           color="white"
           style={{
             writingMode: "vertical-rl",
@@ -502,64 +501,50 @@ function PanelHeader({
   onClose: () => void;
 }) {
   return (
-    <HStack
-      paddingY="14px"
-      paddingLeft="18px"
-      paddingRight="14px"
-      borderBottomWidth="1px"
-      borderColor="border.muted"
-      gap={2.5}
-      flexShrink={0}
-    >
-      <SparkleTile size={28} sparkleSize={15} />
-      <VStack align="start" gap={0} flex={1} minWidth={0}>
-        <Text fontSize="14px" fontWeight="600" lineHeight="1.2" color="fg">
-          Langy
-        </Text>
-        <Text
-          fontSize="11.5px"
+    <>
+      <HStack
+        paddingY={3}
+        paddingLeft={4}
+        paddingRight={3}
+        gap={2.5}
+        flexShrink={0}
+      >
+        <SparkleTile size={28} sparkleSize={15} />
+        <VStack align="start" gap={0} flex={1} minWidth={0}>
+          <Text textStyle="sm" fontWeight="600" lineHeight="1.2" color="fg">
+            Langy
+          </Text>
+          <Text
+            textStyle="2xs"
+            color="fg.muted"
+            lineHeight="1.3"
+            marginTop="1px"
+            truncate
+          >
+            {subtitle}
+          </Text>
+        </VStack>
+        <IconButton
+          size="xs"
+          variant="ghost"
+          aria-label="New chat"
           color="fg.muted"
-          lineHeight="1.3"
-          marginTop="1px"
-          truncate
+          onClick={onNewChat}
         >
-          {subtitle}
-        </Text>
-      </VStack>
-      <HeaderIconButton aria-label="New chat" onClick={onNewChat}>
-        <Plus size={17} />
-      </HeaderIconButton>
-      <HeaderIconButton aria-label="Close Langy" onClick={onClose}>
-        <X size={17} />
-      </HeaderIconButton>
-    </HStack>
-  );
-}
-
-function HeaderIconButton({
-  children,
-  ...rest
-}: {
-  children: React.ReactNode;
-} & React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <chakra.button
-      type="button"
-      width="30px"
-      height="30px"
-      borderRadius="8px"
-      borderWidth={0}
-      background="transparent"
-      color="fg.muted"
-      cursor="pointer"
-      display="grid"
-      placeItems="center"
-      transition="background 120ms ease, color 120ms ease"
-      _hover={{ background: "bg.subtle", color: "fg" }}
-      {...rest}
-    >
-      {children}
-    </chakra.button>
+          <Plus size={15} />
+        </IconButton>
+        <IconButton
+          size="xs"
+          variant="ghost"
+          aria-label="Close Langy"
+          color="fg.muted"
+          onClick={onClose}
+        >
+          <X size={15} />
+        </IconButton>
+      </HStack>
+      <Separator />
+    </>
   );
 }
 
@@ -580,82 +565,79 @@ function RecentList({
   if (!isLoading && conversations.length === 0) return null;
 
   return (
-    <VStack
-      align="stretch"
-      gap={1}
-      paddingX="14px"
-      paddingY="10px"
-      borderBottomWidth="1px"
-      borderColor="border.muted"
-      background="bg.subtle"
-      flexShrink={0}
-      maxHeight="220px"
-      overflowY="auto"
-    >
-      <Text
-        fontSize="10.5px"
-        fontWeight="600"
-        letterSpacing="0.5px"
-        color="fg.muted"
-        textTransform="uppercase"
-        paddingX="4px"
-        paddingBottom="4px"
+    <>
+      <VStack
+        align="stretch"
+        gap={1}
+        paddingX={3}
+        paddingY={2}
+        background="bg.subtle"
+        flexShrink={0}
+        maxHeight="220px"
+        overflowY="auto"
       >
-        Recent chats
-      </Text>
-      {isLoading ? (
-        <HStack
-          gap={2}
-          paddingX="4px"
-          paddingY="6px"
-          aria-label="Loading recent conversations"
+        <Text
+          textStyle="2xs"
+          fontWeight="600"
+          letterSpacing="0.08em"
+          color="fg.subtle"
+          textTransform="uppercase"
+          paddingX={1}
+          paddingBottom={1}
         >
-          <Spinner size="xs" />
-          <Text fontSize="xs" color="fg.muted">
-            Loading…
-          </Text>
-        </HStack>
-      ) : (
-        <Box
-          as="ul"
-          aria-label="Recent conversations"
-          listStyleType="none"
-          margin={0}
-          padding={0}
-        >
-          {conversations.map((conv) => (
-            <HStack key={conv.id} as="li" gap={1}>
-              <chakra.button
-                type="button"
-                onClick={() => onSelect(conv.id)}
-                flex={1}
-                textAlign="left"
-                paddingX="8px"
-                paddingY="7px"
-                borderRadius="6px"
-                fontSize="12.5px"
-                color="fg"
-                cursor="pointer"
-                truncate
-                background="transparent"
-                borderWidth={0}
-                _hover={{ background: "bg.surface" }}
-              >
-                {conv.title ?? "Untitled"}
-              </chakra.button>
-              <IconButton
-                size="2xs"
-                variant="ghost"
-                aria-label="Delete conversation"
-                onClick={() => onDelete(conv.id)}
-              >
-                <Trash2 size={12} />
-              </IconButton>
-            </HStack>
-          ))}
-        </Box>
-      )}
-    </VStack>
+          Recent chats
+        </Text>
+        {isLoading ? (
+          <HStack
+            gap={2}
+            paddingX={1}
+            paddingY={1.5}
+            aria-label="Loading recent conversations"
+          >
+            <Spinner size="xs" />
+            <Text textStyle="xs" color="fg.muted">
+              Loading…
+            </Text>
+          </HStack>
+        ) : (
+          <Box
+            as="ul"
+            aria-label="Recent conversations"
+            listStyleType="none"
+            margin={0}
+            padding={0}
+          >
+            {conversations.map((conv) => (
+              <HStack key={conv.id} as="li" gap={1}>
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  onClick={() => onSelect(conv.id)}
+                  flex={1}
+                  justifyContent="flex-start"
+                  fontWeight="normal"
+                  color="fg"
+                  paddingX={2}
+                  truncate
+                >
+                  {conv.title ?? "Untitled"}
+                </Button>
+                <IconButton
+                  size="2xs"
+                  variant="ghost"
+                  color="fg.subtle"
+                  aria-label="Delete conversation"
+                  onClick={() => onDelete(conv.id)}
+                >
+                  <Trash2 size={12} />
+                </IconButton>
+              </HStack>
+            ))}
+          </Box>
+        )}
+      </VStack>
+      <Separator />
+    </>
   );
 }
 
@@ -666,34 +648,43 @@ function EmptyState({ onPick }: { onPick: (prompt: string) => void }) {
       align="center"
       justify="center"
       flex={1}
-      paddingX="24px"
-      paddingY="32px"
+      paddingX={6}
+      paddingY={8}
       height="full"
     >
-      <SparkleTile size={64} sparkleSize={28} hero />
+      <Circle
+        size="64px"
+        bg={AI_BG_SUBTLE}
+        borderWidth="1px"
+        borderStyle="solid"
+        borderColor={AI_BORDER}
+        boxShadow={AI_SHADOW_SOFT}
+      >
+        <GradientSparkle size={28} />
+      </Circle>
       <Text
-        fontSize="20px"
+        textStyle="lg"
         fontWeight="600"
         letterSpacing="-0.3px"
         color="fg"
         textAlign="center"
-        marginTop="18px"
+        marginTop={4}
       >
         How can I help?
       </Text>
       <Text
-        fontSize="13px"
+        textStyle="sm"
         color="fg.muted"
         lineHeight="1.5"
         textAlign="center"
         maxWidth="280px"
-        marginTop="8px"
-        marginBottom="22px"
+        marginTop={2}
+        marginBottom={5}
       >
         Ask in plain language. I&apos;ll read your traces and evals, then
         propose changes you can apply.
       </Text>
-      <HStack gap="6px" flexWrap="wrap" justify="center" maxWidth="320px">
+      <HStack gap={1.5} flexWrap="wrap" justify="center" maxWidth="320px">
         {SUGGESTION_CHIPS.map((chip) => (
           <Chip key={chip} onClick={() => onPick(chip)}>
             {chip}
@@ -711,32 +702,25 @@ function Chip({
   children: React.ReactNode;
   onClick: () => void;
 }) {
-  const [hover, setHover] = useState(false);
   return (
-    <chakra.button
-      type="button"
+    <Button
+      size="xs"
+      variant="outline"
       onClick={onClick}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      appearance="none"
-      paddingX="12px"
-      paddingY="7px"
-      borderRadius="999px"
-      borderWidth="1px"
-      borderStyle="solid"
-      borderColor={hover ? AI_BORDER : "border.emphasized"}
-      background={hover ? AI_BG_HOVER : "bg.subtle"}
+      borderRadius="full"
+      fontWeight="500"
       color="fg"
-      fontSize="12.5px"
-      fontWeight={500}
-      lineHeight="1.2"
-      cursor="pointer"
-      transition="all 120ms ease"
+      borderColor="border.emphasized"
+      bg="bg.subtle"
+      _hover={{
+        bg: AI_BG_HOVER,
+        borderColor: AI_BORDER,
+        boxShadow: "0 1px 2px rgba(168, 85, 247, 0.12)",
+      }}
       whiteSpace="nowrap"
-      boxShadow={hover ? "0 1px 2px rgba(168, 85, 247, 0.12)" : "none"}
     >
       {children}
-    </chakra.button>
+    </Button>
   );
 }
 
@@ -755,15 +739,15 @@ function ThinkingIndicator({ messages }: { messages: UIMessage[] }) {
       <SparkleTile size={24} sparkleSize={12} />
       <HStack
         gap={2}
-        paddingX="10px"
-        paddingY="6px"
-        borderRadius="10px"
+        paddingX={2.5}
+        paddingY={1.5}
+        borderRadius="md"
         background="bg.subtle"
         borderWidth="1px"
         borderColor="border.muted"
       >
         <Spinner size="xs" colorPalette="purple" />
-        <Text fontSize="12px">Langy is {label}…</Text>
+        <Text textStyle="xs">Langy is {label}…</Text>
       </HStack>
     </HStack>
   );
@@ -788,91 +772,92 @@ function Composer({
 }) {
   const filled = input.trim().length > 0;
   return (
-    <Box
-      paddingX="14px"
-      paddingTop="12px"
-      paddingBottom="14px"
-      borderTopWidth="1px"
-      borderColor="border.muted"
-      background="bg.surface"
-      flexShrink={0}
-    >
-      <HStack
-        gap={2}
-        paddingY="6px"
-        paddingLeft="14px"
-        paddingRight="6px"
-        borderRadius="999px"
-        borderWidth="1px"
-        borderStyle="solid"
-        borderColor={filled ? AI_BORDER : "border.emphasized"}
+    <>
+      <Separator />
+      <Box
+        paddingX={3}
+        paddingTop={3}
+        paddingBottom={3}
         background="bg.surface"
-        boxShadow={filled ? `0 0 0 3px ${AI_BG_SUBTLE}` : undefined}
-        transition="border-color 150ms ease, box-shadow 150ms ease"
-        align="center"
+        flexShrink={0}
       >
-        <Textarea
-          value={input}
-          onChange={(e) => onInputChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault();
-              if (!isBusy && canSend) onSend();
+        <HStack
+          gap={2}
+          paddingY={1.5}
+          paddingLeft={3}
+          paddingRight={1.5}
+          borderRadius="full"
+          borderWidth="1px"
+          borderStyle="solid"
+          borderColor={filled ? AI_BORDER : "border.emphasized"}
+          background="bg.surface"
+          boxShadow={filled ? `0 0 0 3px ${AI_BG_SUBTLE}` : undefined}
+          transition="border-color 150ms ease, box-shadow 150ms ease"
+          align="center"
+        >
+          <Textarea
+            value={input}
+            onChange={(e) => onInputChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                if (!isBusy && canSend) onSend();
+              }
+            }}
+            placeholder={
+              isBusy ? "Langy is working…" : "Ask Langy or describe what you want…"
             }
-          }}
-          placeholder={
-            isBusy ? "Langy is working…" : "Ask Langy or describe what you want…"
-          }
-          disabled={disabled || isBusy}
-          rows={1}
-          autoresize
-          maxHeight="120px"
-          minHeight="22px"
-          padding={0}
-          border="none"
-          background="transparent"
-          fontSize="13.5px"
-          lineHeight="1.45"
-          color="fg"
-          resize="none"
-          _focus={{ outline: "none", boxShadow: "none" }}
-          _focusVisible={{ outline: "none", boxShadow: "none" }}
-        />
-        {isBusy ? (
-          <SendButton
-            aria-label="Stop"
-            onClick={onStop}
-            background="var(--chakra-colors-red-solid)"
-            color="white"
-            shadow={false}
-            cursor="pointer"
-          >
-            <Square size={12} />
-          </SendButton>
-        ) : (
-          <SendButton
-            aria-label="Send"
-            onClick={onSend}
-            disabled={!canSend}
-            background={canSend ? AI_GRADIENT : "#f5f5f4"}
-            color={canSend ? "white" : "var(--chakra-colors-fg-muted)"}
-            shadow={canSend}
-            cursor={canSend ? "pointer" : "default"}
-          >
-            <Send size={14} />
-          </SendButton>
-        )}
-      </HStack>
-      <Text
-        marginTop="8px"
-        fontSize="10.5px"
-        color="fg.muted"
-        textAlign="center"
-        letterSpacing="0.1px"
-      >
-        Langy proposes — you review and apply.
-      </Text>
-    </Box>
+            disabled={disabled || isBusy}
+            rows={1}
+            autoresize
+            maxHeight="120px"
+            minHeight="22px"
+            padding={0}
+            border="none"
+            background="transparent"
+            textStyle="sm"
+            lineHeight="1.45"
+            color="fg"
+            resize="none"
+            _focus={{ outline: "none", boxShadow: "none" }}
+            _focusVisible={{ outline: "none", boxShadow: "none" }}
+          />
+          {isBusy ? (
+            <SendButton
+              aria-label="Stop"
+              onClick={onStop}
+              background="var(--chakra-colors-red-solid)"
+              color="white"
+              shadow={false}
+              cursor="pointer"
+            >
+              <Square size={12} />
+            </SendButton>
+          ) : (
+            <SendButton
+              aria-label="Send"
+              onClick={onSend}
+              disabled={!canSend}
+              background={canSend ? AI_GRADIENT : "#f5f5f4"}
+              color={canSend ? "white" : "var(--chakra-colors-fg-muted)"}
+              shadow={canSend}
+              cursor={canSend ? "pointer" : "default"}
+            >
+              <Send size={14} />
+            </SendButton>
+          )}
+        </HStack>
+        <Text
+          marginTop={2}
+          textStyle="2xs"
+          color="fg.subtle"
+          textAlign="center"
+          letterSpacing="0.01em"
+        >
+          Langy proposes — you review and apply.
+        </Text>
+      </Box>
+    </>
   );
 }
 
@@ -945,13 +930,13 @@ function MessageContent({
     return (
       <Box alignSelf="flex-end" maxWidth="85%">
         <Box
-          paddingX="13px"
-          paddingY="9px"
+          paddingX={3}
+          paddingY={2}
           background="#1c1917"
           color="white"
-          borderRadius="14px"
-          borderBottomRightRadius="4px"
-          fontSize="13px"
+          borderRadius="lg"
+          borderBottomRightRadius="sm"
+          textStyle="sm"
           lineHeight="1.45"
           whiteSpace="pre-wrap"
         >
@@ -962,12 +947,12 @@ function MessageContent({
   }
 
   return (
-    <HStack gap="9px" align="flex-start" width="full">
+    <HStack gap={2} align="flex-start" width="full">
       <SparkleTile size={24} sparkleSize={12} />
-      <VStack align="stretch" gap="10px" flex={1} minWidth={0}>
+      <VStack align="stretch" gap={2.5} flex={1} minWidth={0}>
         {text && (
           <Box
-            fontSize="13px"
+            textStyle="sm"
             color="fg"
             lineHeight="1.55"
             css={{
@@ -1062,8 +1047,8 @@ function ProposalCard({
     <Box
       borderWidth="1px"
       borderColor="border.muted"
-      borderRadius="12px"
-      padding="12px"
+      borderRadius="md"
+      padding={3}
       background="bg.subtle"
       opacity={isDiscarded ? 0.65 : 1}
       cursor={hasOpen ? "pointer" : "default"}
@@ -1077,11 +1062,11 @@ function ProposalCard({
       _hover={hasOpen ? { borderColor: "green.fg", boxShadow: "sm" } : undefined}
     >
       <HStack
-        gap="6px"
-        marginBottom="8px"
-        fontSize="10.5px"
+        gap={1.5}
+        marginBottom={2}
+        textStyle="2xs"
         fontWeight="600"
-        letterSpacing="0.5px"
+        letterSpacing="0.08em"
         textTransform="uppercase"
         color={overlineColor}
       >
@@ -1092,27 +1077,27 @@ function ProposalCard({
         )}
         <Text>{overlineLabel}</Text>
       </HStack>
-      <Text fontSize="13px" fontWeight="600" color="fg" marginBottom="2px">
+      <Text textStyle="sm" fontWeight="600" color="fg" marginBottom={0.5}>
         {proposal.summary}
       </Text>
       {proposal.rationale && (
         <Text
-          fontSize="12px"
+          textStyle="xs"
           color="fg.muted"
           lineHeight="1.45"
-          marginBottom="12px"
+          marginBottom={3}
         >
           {proposal.rationale}
         </Text>
       )}
       {!isApplied && !isDiscarded && (
-        <HStack gap="6px" paddingTop={proposal.rationale ? "0px" : "10px"}>
+        <HStack gap={1.5} paddingTop={proposal.rationale ? 0 : 2.5}>
           <chakra.button
             type="button"
             flex={1}
-            paddingX="12px"
-            paddingY="8px"
-            borderRadius="8px"
+            paddingX={3}
+            paddingY={2}
+            borderRadius="md"
             borderWidth={0}
             background={
               destructive ? "var(--chakra-colors-red-solid)" : AI_GRADIENT
@@ -1125,7 +1110,7 @@ function ProposalCard({
             display="flex"
             alignItems="center"
             justifyContent="center"
-            gap="5px"
+            gap={1.5}
             boxShadow={destructive ? undefined : AI_SHADOW}
             onClick={onApply}
             disabled={isApplying}
@@ -1150,7 +1135,7 @@ function ProposalCard({
         </HStack>
       )}
       {isApplied && hasOpen && (
-        <HStack paddingTop="10px">
+        <HStack paddingTop={2.5}>
           {onOpen ? (
             <Button
               size="xs"

--- a/langwatch/src/components/langy/__tests__/LangyConversationHistory.integration.test.tsx
+++ b/langwatch/src/components/langy/__tests__/LangyConversationHistory.integration.test.tsx
@@ -80,6 +80,14 @@ vi.mock("ai", () => ({
   },
 }));
 
+// @paper-design/shaders-react requires WebGL, which jsdom does not provide.
+// MeshGradient is purely cosmetic — stub it out so Stage C's animated AI
+// cues don't spam the test output with unhandled "WebGL is not supported"
+// errors. Same pattern used in SearchBar.integration.test.tsx.
+vi.mock("@paper-design/shaders-react", () => ({
+  MeshGradient: () => null,
+}));
+
 import { LangyDrawer } from "../LangySidebar";
 import { toaster } from "~/components/ui/toaster";
 


### PR DESCRIPTION
## Summary

Stacks the Claude Design handoff for Langy on top of the v2 sidebar (#3971).
The handoff bundle picked **variant D** (centered/minimal) for the empty
state and **variant B** (gradient pill) for the collapsed handle. Public
API and chat plumbing are unchanged — only the visual layer is rewritten.

Base: \`langy-v2-integration\` (PR #3971). Merge after #3971.

## What changed

- Collapsed handle → orange gradient pill, vertical "LANGY" + sparkle, hover slides left
- Header → 28px gradient sparkle tile + "Langy" + dynamic subtitle ("Your AI copilot" empty / "Working in this project" once chatting / "On: <slug>" on experiment pages)
- Empty state → centered hero: 60px sparkle tile, "How can I help?", 5 chip prompts (flex-wrap, ≤280px column)
- Composer → pill-shaped input, circular gradient send button (gradient + shadow when filled, grey otherwise), footnote "Langy proposes — you review and apply."
- User message → near-black bubble (\`#1c1917\`), white text, asymmetric radius
- Langy message → 24px sparkle avatar + bare text, no bubble
- Proposal card → bg-subtle, "PROPOSAL" overline in brand orange + sparkle, gradient Apply (\`linear-gradient(135deg, #fb923c, #f97316, #ea580c)\`); preserves Discard / destructive Delete / Applied + Open states
- Recent list restyled; hidden cleanly when there are zero conversations so the empty hero stays pristine

## What did NOT change

- \`LangyDrawer\` public API (\`proposalHandlers\`, \`experimentSlug\`, controlled \`isOpen\`/\`onOpenChange\`)
- \`LANGY_DOCKED_OFFSET\`, \`LANGY_TRANSITION\` exports (page layouts that lockstep with the panel keep working)
- \`useChat\` transport (\`/api/langy/chat\`), \`useLangyConversations\` hook, applied/discarded/applying state machinery
- Toaster error semantics, \`isHandledByGlobalHandler\` integration
- Existing integration tests still pass (16/16 in \`LangyConversationHistory.integration.test.tsx\`)

## Design source

Bundle from claude.ai/design (Langy.html + langy-final.jsx). Design tokens live as a small \`BRAND\` constant at the top of \`LangySidebar.tsx\` for clarity; semantic Chakra tokens (\`bg.surface\`, \`fg.muted\`, \`border.muted\`) used everywhere they map cleanly so dark mode keeps working.

## Test plan

- [ ] Open Langy from any page — collapsed pill renders on right edge, slides on hover
- [ ] Click pill — panel slides in, empty state shows "How can I help?" + 5 chips
- [ ] Click a chip — sends as first message, conversation view replaces hero
- [ ] Type in composer — border + halo turn brand orange, send button goes gradient
- [ ] Enter sends, Shift+Enter newlines, busy state shows red Stop button
- [ ] Trigger a proposal from the experiments workbench — card renders with PROPOSAL overline + gradient Apply
- [ ] Apply succeeds → "Applied" + Open affordance; failure surfaces toast
- [ ] Destructive proposal still shows red Delete button
- [ ] Recent list appears once a conversation exists; New chat clears thread; delete removes from list
- [ ] Verify panel still stays in lockstep with experiments page layout (\`LANGY_DOCKED_OFFSET\` consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)