### PR TITLE
fix(deps): consolidate pnpm overrides to fix Docker dev ERR_PNPM_LOCKFILE_CONFIG_MISMATCH

### DIFF
--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -314,38 +314,7 @@
     "vitest": "^4.1.4",
     "watch": "^1.0.2"
   },
-  "pnpm": {
-    "overrides": {
-      "@aws-sdk/xml-builder>fast-xml-parser": "^5.7.0",
-      "@langchain/community>fast-xml-parser": "^5.7.0",
-      "ra-core": "5.13.1",
-      "ra-i18n-polyglot": "5.13.1",
-      "ra-ui-materialui": "5.13.1",
-      "ra-language-english": "5.13.1",
-      "ai": "^6.0.161",
-      "liquidjs": ">=10.25.7",
-      "protobufjs": ">=7.5.5 <8.0.0 || >=8.0.1",
-      "postcss": "^8.5.13",
-      "lodash": "^4.18.1",
-      "merge": ">=2.1.1 <3.0.0",
-      "picomatch": ">=4.0.4",
-      "vite@<7.3.2": "8.0.10",
-      "vite@>=8.0.0 <8.0.5": "8.0.10",
-      "axios@>=1.0.0 <1.16.0": "1.16.0",
-      "fast-xml-builder@<1.1.7": "1.1.7",
-      "fast-uri@<3.1.2": "3.1.2",
-      "braces": "^3.0.3",
-      "cross-spawn": "^7.0.6",
-      "exec-sh": "^0.4.0",
-      "glob": "^11.1.0",
-      "react": "^19.2.5",
-      "react-dom": "^19.2.5",
-      "react-is": "^19.2.5",
-      "pino": "^10.3.1",
-      "pino-pretty": "^13.1.3",
-      "thread-stream": "^4.0.0"
-    }
-  },
+  "pnpm": {},
   "ct3aMetadata": {
     "initVersion": "7.19.0"
   },

--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -33,6 +33,20 @@ overrides:
   pino: ^10.3.1
   pino-pretty: ^13.1.3
   thread-stream: ^4.0.0
+  prettier: ^3.8.1
+  minimatch@<3.1.4: 3.1.4
+  minimatch@>=5.0.0 <5.1.8: 5.1.8
+  minimatch@>=9.0.0 <9.0.7: 9.0.7
+  fast-xml-parser@>=4.1.3 <4.5.4: 4.5.4
+  fast-xml-parser@>=5.0.0 <5.3.6: 5.3.6
+  '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
+  langchain@<0.3.37: 0.3.37
+  merge@<2.1.1: 2.1.1
+  validator@<13.15.22: 13.15.22
+  '@remix-run/router@<=1.23.1': 1.23.2
+  express-rate-limit@>=8.2.0 <8.2.2: 8.2.2
+  glob@>=10.2.0 <10.5.0: 10.5.0
+  next@>=13.0.0 <15.5.15: 15.5.15
 
 packageExtensionsChecksum: sha256-LBc1N1GezKyerwGBwpMHZPFoMYZTHjpxVKWJilBVvTU=
 
@@ -2559,6 +2573,10 @@ packages:
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
@@ -4493,6 +4511,10 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
@@ -6707,6 +6729,10 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@3.17.0:
     resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
     engines: {node: '>=14'}
@@ -6914,7 +6940,7 @@ packages:
       drizzle-orm: ^0.45.2
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
-      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      next: 15.5.15
       pg: ^8.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
       react: ^19.2.5
@@ -7850,6 +7876,9 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -7876,6 +7905,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -8092,14 +8124,8 @@ packages:
     peerDependencies:
       prom-client: '>=15.0.0'
 
-  express-rate-limit@8.3.1:
-    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
-  express-rate-limit@8.3.2:
-    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+  express-rate-limit@8.2.2:
+    resolution: {integrity: sha512-Ybv7bqtOgA914MLwaHWVFXMpMYeR1MQu/D+z2MaLYteqBsTIp9sY3AU7mGNLMJv8eLg8uQMpE20I+L2Lv49nSg==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -8416,6 +8442,11 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
@@ -8939,6 +8970,9 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
@@ -9319,7 +9353,7 @@ packages:
       '@opentelemetry/context-zone': '>=1.19.0 <3.0.0'
       '@opentelemetry/sdk-node': '>=0.200.0 <1.0.0'
       '@opentelemetry/sdk-trace-web': '>=1.19.0 <3.0.0'
-      langchain: '>=0.3.0 <1.0.0'
+      langchain: 0.3.37
 
   langwatch@0.27.0:
     resolution: {integrity: sha512-J7NLn5QPvmSxUSs1S5MXwGVE60EXWA8zXdWhbcvhQ53gc5ikcil801SeNdqGY0nzABI3yXxxRefPEWwhwBDFaw==}
@@ -9335,7 +9369,7 @@ packages:
       '@opentelemetry/context-zone': '>=1.19.0 <3.0.0'
       '@opentelemetry/sdk-node': '>=0.200.0 <1.0.0'
       '@opentelemetry/sdk-trace-web': '>=1.19.0 <3.0.0'
-      langchain: '>=0.3.0 <2.0.0'
+      langchain: 0.3.37
     peerDependenciesMeta:
       '@ai-sdk/openai':
         optional: true
@@ -9949,12 +9983,16 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+  minimatch@3.1.4:
+    resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
 
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+  minimatch@5.1.8:
+    resolution: {integrity: sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==}
     engines: {node: '>=10'}
+
+  minimatch@9.0.7:
+    resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -10422,6 +10460,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -10586,11 +10628,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
@@ -11552,6 +11589,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@8.1.0:
     resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
     engines: {node: '>=20'}
@@ -12429,6 +12470,10 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -14915,6 +14960,15 @@ snapshots:
 
   '@ioredis/commands@1.5.1': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@isaacs/cliui@9.0.0': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
@@ -15487,6 +15541,31 @@ snapshots:
 
   '@microsoft/fetch-event-source@2.0.1': {}
 
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.10(hono@4.12.4)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.2(express@5.2.1)
+      hono: 4.12.4
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.10(hono@4.12.4)
@@ -15498,7 +15577,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.3.1(express@5.2.1)
+      express-rate-limit: 8.2.2(express@5.2.1)
       hono: 4.12.4
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -15522,7 +15601,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
+      express-rate-limit: 8.2.2(express@5.2.1)
       hono: 4.12.16
       jose: 6.2.2
       json-schema-typed: 8.0.2
@@ -15696,7 +15775,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       openai: 6.34.0(ws@8.20.0(bufferutil@4.1.0))(zod@3.25.76)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -17235,6 +17314,9 @@ snapshots:
     optional: true
 
   '@pinojs/redact@0.4.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -19979,6 +20061,8 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  ansi-styles@6.2.3: {}
+
   ansis@3.17.0: {}
 
   any-promise@1.3.0: {}
@@ -19990,7 +20074,7 @@ snapshots:
 
   archiver-utils@5.0.2:
     dependencies:
-      glob: 11.1.0
+      glob: 10.5.0
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
@@ -21129,6 +21213,8 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -21149,6 +21235,8 @@ snapshots:
       react: 19.2.5
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   emojis-list@3.0.0: {}
 
@@ -21434,12 +21522,7 @@ snapshots:
       prom-client: 15.1.3
       url-value-parser: 2.2.0
 
-  express-rate-limit@8.3.1(express@5.2.1):
-    dependencies:
-      express: 5.2.1
-      ip-address: 10.1.0
-
-  express-rate-limit@8.3.2(express@5.2.1):
+  express-rate-limit@8.2.2(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0
@@ -21607,7 +21690,7 @@ snapshots:
 
   filelist@1.0.6:
     dependencies:
-      minimatch: 5.1.9
+      minimatch: 5.1.8
 
   fill-range@7.1.1:
     dependencies:
@@ -21827,6 +21910,15 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.7
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@11.1.0:
     dependencies:
@@ -22452,6 +22544,12 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.2.3:
     dependencies:
@@ -24046,13 +24144,17 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@3.1.5:
+  minimatch@3.1.4:
     dependencies:
       brace-expansion: 1.1.14
 
-  minimatch@5.1.9:
+  minimatch@5.1.8:
     dependencies:
       brace-expansion: 2.1.0
+
+  minimatch@9.0.7:
+    dependencies:
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -24516,6 +24618,11 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.3.5
@@ -24683,8 +24790,6 @@ snapshots:
   preact@10.29.1: {}
 
   prelude-ls@1.2.1: {}
-
-  prettier@3.0.3: {}
 
   prettier@3.8.3: {}
 
@@ -25336,7 +25441,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 5.1.9
+      minimatch: 5.1.8
 
   readdirp@3.6.0:
     dependencies:
@@ -25550,7 +25655,7 @@ snapshots:
 
   rimraf@5.0.10:
     dependencies:
-      glob: 11.1.0
+      glob: 10.5.0
 
   robust-predicates@3.0.3: {}
 
@@ -25958,6 +26063,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
   string-width@8.1.0:
     dependencies:
       get-east-asian-width: 1.4.0
@@ -26145,7 +26256,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.6
       glob: 11.1.0
-      minimatch: 3.1.5
+      minimatch: 3.1.4
 
   testcontainers@11.14.0:
     dependencies:
@@ -26318,7 +26429,7 @@ snapshots:
       inquirer: 8.2.7(@types/node@18.19.130)
       lodash: 4.18.1
       ora: 5.4.1
-      prettier: 3.0.3
+      prettier: 3.8.3
       rxjs: 7.8.2
       slash: 3.0.0
       threads: 1.7.0
@@ -26943,6 +27054,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+
   wrappy@1.0.2: {}
 
   write-file-atomic@4.0.2:
@@ -27007,6 +27124,11 @@ snapshots:
   zod-openapi@4.2.4(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+    optional: true
 
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:

--- a/langwatch/pnpm-workspace.yaml
+++ b/langwatch/pnpm-workspace.yaml
@@ -4,43 +4,48 @@ packages:
   - "../mcp-server"
 
 overrides:
-  pino: ^10.3.0
-  pino-pretty: ^13.0.0
-  thread-stream: ^4.0.0
-  prettier: ^3.8.1
-  # Security: minimatch ReDoS (CVE #464/#476/#477/#478/#479)
+  "@aws-sdk/xml-builder>fast-xml-parser": "^5.7.0"
+  "@langchain/community>fast-xml-parser": "^5.7.0"
+  ra-core: "5.13.1"
+  ra-i18n-polyglot: "5.13.1"
+  ra-ui-materialui: "5.13.1"
+  ra-language-english: "5.13.1"
+  ai: "^6.0.161"
+  liquidjs: ">=10.25.7"
+  protobufjs: ">=7.5.5 <8.0.0 || >=8.0.1"
+  postcss: "^8.5.13"
+  lodash: "^4.18.1"
+  merge: ">=2.1.1 <3.0.0"
+  picomatch: ">=4.0.4"
+  "vite@<7.3.2": "8.0.10"
+  "vite@>=8.0.0 <8.0.5": "8.0.10"
+  "axios@>=1.0.0 <1.16.0": "1.16.0"
+  "fast-xml-builder@<1.1.7": "1.1.7"
+  "fast-uri@<3.1.2": "3.1.2"
+  braces: "^3.0.3"
+  cross-spawn: "^7.0.6"
+  exec-sh: "^0.4.0"
+  glob: "^11.1.0"
+  react: "^19.2.5"
+  react-dom: "^19.2.5"
+  react-is: "^19.2.5"
+  pino: "^10.3.1"
+  pino-pretty: "^13.1.3"
+  thread-stream: "^4.0.0"
+  prettier: "^3.8.1"
   "minimatch@<3.1.4": "3.1.4"
   "minimatch@>=5.0.0 <5.1.8": "5.1.8"
   "minimatch@>=9.0.0 <9.0.7": "9.0.7"
-  # Security: fast-xml-parser DoS (CVE #494/#495/#402)
   "fast-xml-parser@>=4.1.3 <4.5.4": "4.5.4"
   "fast-xml-parser@>=5.0.0 <5.3.6": "5.3.6"
-  # Security: @modelcontextprotocol/sdk cross-client data leak (#246)
   "@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3": "1.26.0"
-  # Security: langchain serialization injection (#223)
   "langchain@<0.3.37": "0.3.37"
-  # Security: merge prototype pollution (#194) via exec-sh
   "merge@<2.1.1": "2.1.1"
-  # Security: validator incomplete filtering (#216) via class-validator
   "validator@<13.15.22": "13.15.22"
-  # Security: @remix-run/router XSS via open redirects (#227) via react-admin
   "@remix-run/router@<=1.23.1": "1.23.2"
-  # Security: express-rate-limit DoS (from mcp-server)
   "express-rate-limit@>=8.2.0 <8.2.2": "8.2.2"
-  # Security: glob ReDoS (from mcp-server)
   "glob@>=10.2.0 <10.5.0": "10.5.0"
-  # Security: vite WebSocket file read + server.fs.deny bypass (#783/#784)
-  "vite@<7.3.2": "7.3.2"
-  "vite@>=8.0.0 <8.0.5": "8.0.5"
-  # Security: Next.js DoS with Server Components (#872)
-  # next is an unused optional peer dep of better-auth (this is a Vite app)
   "next@>=13.0.0 <15.5.15": "15.5.15"
-  # Security: axios prototype pollution gadgets, header injection, loopback bypass (#982/#984/#987/#988)
-  "axios@>=1.0.0 <1.16.0": "1.16.0"
-  # Security: fast-xml-builder attribute value quote bypass (#1028)
-  "fast-xml-builder@<1.1.7": "1.1.7"
-  # Security: fast-uri path traversal + host confusion (#1031-#1042)
-  "fast-uri@<3.1.2": "3.1.2"
 
 packageExtensions:
   bullmq-otel:
@@ -64,3 +69,21 @@ onlyBuiltDependencies:
   - protobufjs
   - sharp
   - ssh2
+
+allowBuilds:
+  '@anthropic-ai/claude-code': true
+  '@parcel/watcher': true
+  '@prisma/client': true
+  '@prisma/engines': true
+  '@scarf/scarf': true
+  bcrypt: true
+  bufferutil: true
+  core-js: true
+  cpu-features: true
+  esbuild: true
+  msgpackr-extract: true
+  node-pty: true
+  prisma: true
+  protobufjs: true
+  sharp: true
+  ssh2: true

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -76,10 +76,5 @@
   "bin": {
     "langwatch-mcp-server": "./dist/index.js"
   },
-  "pnpm": {
-    "overrides": {
-      "protobufjs": ">=7.5.5 <8.0.0 || >=8.0.1",
-      "fast-uri@<3.1.2": "3.1.2"
-    }
-  }
+  "pnpm": {}
 }

--- a/mcp-server/pnpm-workspace.yaml
+++ b/mcp-server/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+overrides:
+  protobufjs: ">=7.5.5 <8.0.0 || >=8.0.1"
+  "fast-uri@<3.1.2": "3.1.2"
+
 onlyBuiltDependencies:
   - node-pty


### PR DESCRIPTION
## Summary

- Fixes `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` in `make quickstart` / Docker init container
- **Root cause**: `node:24` ships pnpm 11 via corepack. pnpm 11 no longer reads `pnpm.overrides` from `package.json` — it only reads `overrides` from `pnpm-workspace.yaml`. The lockfiles were generated by pnpm 10 which recorded overrides from `package.json`, but pnpm 11 in Docker saw zero overrides → mismatch
- **Fix**: Moves all overrides from `package.json` `pnpm.overrides` to `pnpm-workspace.yaml` `overrides` (the location both pnpm 10 and 11 read). Applies to both langwatch and mcp-server. Regenerates both lockfiles. No version pinning needed
- All security overrides preserved with identical versions

## Test plan

- [x] pnpm 11.1.0 in Docker with `CI=true` (frozen lockfile): "Lockfile is up to date" for mcp-server
- [x] pnpm 11.1.0 in Docker with `CI=true` (frozen lockfile): "Lockfile is up to date" for langwatch
- [x] pnpm 10.24.0 locally: lockfiles regenerate cleanly
- [ ] `make quickstart` with profile 1 (dev) completes without errors