### PR TITLE
fix(scenarios-ui): three P1 UI regressions from the Vite migration

### DIFF
--- a/langwatch/src/components/agents/__tests__/AgentEditorDrawersFromRegistry.integration.test.tsx
+++ b/langwatch/src/components/agents/__tests__/AgentEditorDrawersFromRegistry.integration.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression tests for #3193: Add New Agent flow from Edit Scenario
+ * navigates nowhere because the registry-mounted agent editor drawers
+ * never compute `open=true`.
+ *
+ * Repro: `CurrentDrawer` mounts a drawer with `{...queryDrawer}`, where
+ * `queryDrawer.open` is the drawer-name STRING parsed from the URL
+ * (e.g. `"agentHttpEditor"`), not a boolean. The drawer must treat the
+ * presence of any defined `open` prop as "open" so the registry-driven
+ * mount surface continues to function.
+ *
+ * The fix mirrors #1989's `ScenarioFormDrawerFromUrl` pattern — small
+ * `*FromUrl` wrappers that coerce the URL state into a boolean before
+ * delegating to the underlying drawer.
+ *
+ * @see specs/features/scenarios/scenarios-editor-ui-regressions.feature
+ */
+import type React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// -- Shared mocks (cover transitive deps across all three drawers) ----------
+
+const mockCloseDrawer = vi.fn();
+const mockGoBack = vi.fn();
+const mockOpenDrawer = vi.fn();
+const mockDrawerOpen = vi.fn((_drawer: string) => false as boolean);
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    query: { project: "test-project" },
+    asPath: "/test",
+    isReady: true,
+  }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { id: "test-user" } },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project", slug: "test-project" },
+    organization: { id: "test-org" },
+    team: null,
+  }),
+}));
+
+vi.mock("~/hooks/useLicenseEnforcement", () => ({
+  useLicenseEnforcement: () => ({
+    checkAndProceed: (callback: () => void) => callback(),
+    isLoading: false,
+    isAllowed: true,
+    limitInfo: { allowed: true, current: 0, max: 10 },
+  }),
+}));
+
+vi.mock("~/optimization_studio/components/code/CodeEditorModal", () => ({
+  CodeEditor: () => null,
+  CodeEditorModal: () => null,
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    closeDrawer: mockCloseDrawer,
+    openDrawer: mockOpenDrawer,
+    drawerOpen: mockDrawerOpen,
+    canGoBack: false,
+    goBack: mockGoBack,
+  }),
+  useDrawerParams: () => ({}),
+  getComplexProps: () => ({}),
+  getFlowCallbacks: () => ({}),
+  setFlowCallbacks: vi.fn(),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    agents: {
+      getById: {
+        useQuery: () => ({ data: null, isLoading: false, error: null }),
+      },
+      getAll: {
+        invalidate: vi.fn(),
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+      create: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+      update: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+    httpProxy: {
+      execute: {
+        useMutation: () => ({
+          mutateAsync: vi.fn().mockResolvedValue({ output: "test" }),
+          isPending: false,
+        }),
+      },
+    },
+    workflow: {
+      getAll: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+      create: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          mutateAsync: vi.fn(),
+          isPending: false,
+        }),
+      },
+    },
+    workflows: {
+      getAll: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+    },
+    useContext: () => ({
+      agents: {
+        getAll: { invalidate: vi.fn() },
+        getById: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+// Drawer registry imports the modules directly — pull them after mocks are set.
+import {
+  AgentHttpEditorDrawerFromUrl,
+  AgentCodeEditorDrawerFromUrl,
+  WorkflowSelectorDrawerFromUrl,
+} from "../drawerFromUrl";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("Agent editor drawer *FromUrl wrappers (regression #3193)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDrawerOpen.mockReset();
+  });
+  afterEach(cleanup);
+
+  describe("given CurrentDrawer mounts AgentHttpEditorDrawerFromUrl without an `open` prop", () => {
+    /** @scenario "Clicking HTTP Agent in the type selector opens the HTTP editor drawer" */
+    it("opens when the URL indicates agentHttpEditor is active", async () => {
+      mockDrawerOpen.mockImplementation(
+        (drawer: string) => drawer === "agentHttpEditor",
+      );
+
+      render(<AgentHttpEditorDrawerFromUrl />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("New HTTP Agent")).toBeInTheDocument();
+      });
+    });
+
+    it("stays closed when the URL does not indicate agentHttpEditor is active", () => {
+      mockDrawerOpen.mockReturnValue(false);
+
+      render(<AgentHttpEditorDrawerFromUrl />, { wrapper: Wrapper });
+
+      expect(screen.queryByText("New HTTP Agent")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given CurrentDrawer mounts AgentCodeEditorDrawerFromUrl without an `open` prop", () => {
+    /** @scenario "Clicking Code Agent in the type selector opens the code editor drawer" */
+    it("opens when the URL indicates agentCodeEditor is active", async () => {
+      mockDrawerOpen.mockImplementation(
+        (drawer: string) => drawer === "agentCodeEditor",
+      );
+
+      render(<AgentCodeEditorDrawerFromUrl />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        // AgentCodeEditorDrawer renders an "Agent name" label in its header
+        expect(screen.getByText(/Agent name/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given CurrentDrawer mounts WorkflowSelectorDrawerFromUrl without an `open` prop", () => {
+    /** @scenario "Clicking Workflow Agent in the type selector opens the workflow selector drawer" */
+    it("opens when the URL indicates workflowSelector is active", async () => {
+      mockDrawerOpen.mockImplementation(
+        (drawer: string) => drawer === "workflowSelector",
+      );
+
+      render(<WorkflowSelectorDrawerFromUrl />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /create workflow agent/i }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/agents/drawerFromUrl.tsx
+++ b/langwatch/src/components/agents/drawerFromUrl.tsx
@@ -1,0 +1,53 @@
+/**
+ * URL-state wrappers for the three agent editor drawers that the drawer
+ * registry mounts when `?drawer.open=agent{Http,Code}Editor` or
+ * `?drawer.open=workflowSelector` is present.
+ *
+ * Without these wrappers `CurrentDrawer` would spread the URL-parsed
+ * `drawer.*` object onto the drawer component, leaving `props.open` as
+ * the drawer-name STRING. Each underlying drawer treats any defined
+ * non-`false` `open` as "open", so the registry path technically works
+ * — but Chakra/Zag drawers only accept a boolean `open`. The wrappers
+ * coerce URL state into a proper boolean and pass it through.
+ *
+ * Mirrors the pre-existing `ScenarioFormDrawerFromUrl` pattern.
+ *
+ * @see specs/features/scenarios/scenarios-editor-ui-regressions.feature
+ */
+import { useDrawer } from "~/hooks/useDrawer";
+import {
+  AgentCodeEditorDrawer,
+  type AgentCodeEditorDrawerProps,
+} from "./AgentCodeEditorDrawer";
+import {
+  AgentHttpEditorDrawer,
+  type AgentHttpEditorDrawerProps,
+} from "./AgentHttpEditorDrawer";
+import {
+  WorkflowSelectorDrawer,
+  type WorkflowSelectorDrawerProps,
+} from "./WorkflowSelectorDrawer";
+
+export function AgentCodeEditorDrawerFromUrl(
+  props: Omit<AgentCodeEditorDrawerProps, "open"> & { open?: boolean },
+) {
+  const { drawerOpen } = useDrawer();
+  const open = props.open ?? drawerOpen("agentCodeEditor");
+  return <AgentCodeEditorDrawer {...props} open={open} />;
+}
+
+export function AgentHttpEditorDrawerFromUrl(
+  props: Omit<AgentHttpEditorDrawerProps, "open"> & { open?: boolean },
+) {
+  const { drawerOpen } = useDrawer();
+  const open = props.open ?? drawerOpen("agentHttpEditor");
+  return <AgentHttpEditorDrawer {...props} open={open} />;
+}
+
+export function WorkflowSelectorDrawerFromUrl(
+  props: Omit<WorkflowSelectorDrawerProps, "open"> & { open?: boolean },
+) {
+  const { drawerOpen } = useDrawer();
+  const open = props.open ?? drawerOpen("workflowSelector");
+  return <WorkflowSelectorDrawer {...props} open={open} />;
+}

--- a/langwatch/src/components/drawerRegistry.ts
+++ b/langwatch/src/components/drawerRegistry.ts
@@ -14,13 +14,15 @@ import { AddDatasetRecordDrawerV2 } from "./AddDatasetRecordDrawer";
 import { AddOrEditAnnotationScoreDrawer } from "./AddOrEditAnnotationScoreDrawer";
 import { AddOrEditDatasetDrawer } from "./AddOrEditDatasetDrawer";
 import { AutomationDrawer } from "./AddAutomationDrawer";
-import { AgentCodeEditorDrawer } from "./agents/AgentCodeEditorDrawer";
 import { AgentHistoryDrawer } from "./agents/AgentHistoryDrawer";
-import { AgentHttpEditorDrawer } from "./agents/AgentHttpEditorDrawer";
 import { AgentListDrawer } from "./agents/AgentListDrawer";
 import { AgentTypeSelectorDrawer } from "./agents/AgentTypeSelectorDrawer";
 import { AgentWorkflowEditorDrawer } from "./agents/AgentWorkflowEditorDrawer";
-import { WorkflowSelectorDrawer } from "./agents/WorkflowSelectorDrawer";
+import {
+  AgentCodeEditorDrawerFromUrl,
+  AgentHttpEditorDrawerFromUrl,
+  WorkflowSelectorDrawerFromUrl,
+} from "./agents/drawerFromUrl";
 import { AlertDrawer } from "./analytics/AlertDrawer";
 import { DashboardNameDrawer } from "./analytics/DashboardNameDrawer";
 import { BatchEvaluationDrawer } from "./BatchEvaluationDrawer";
@@ -87,10 +89,10 @@ export const drawers = {
   agentList: AgentListDrawer,
   agentHistory: AgentHistoryDrawer,
   agentTypeSelector: AgentTypeSelectorDrawer,
-  agentCodeEditor: AgentCodeEditorDrawer,
-  agentHttpEditor: AgentHttpEditorDrawer,
+  agentCodeEditor: AgentCodeEditorDrawerFromUrl,
+  agentHttpEditor: AgentHttpEditorDrawerFromUrl,
   agentWorkflowEditor: AgentWorkflowEditorDrawer,
-  workflowSelector: WorkflowSelectorDrawer,
+  workflowSelector: WorkflowSelectorDrawerFromUrl,
   evaluatorHistory: EvaluatorHistoryDrawer,
   evaluatorList: EvaluatorListDrawer,
   evaluatorCategorySelector: EvaluatorCategorySelectorDrawer,

--- a/langwatch/src/components/suites/ScenarioGridCard.tsx
+++ b/langwatch/src/components/suites/ScenarioGridCard.tsx
@@ -52,7 +52,8 @@ export function ScenarioGridCard({
       </Box>
       {onCancel && isCancellableStatus(scenarioRun.status) && (
         <HStack
-          as="button"
+          as="span"
+          role="button"
           tabIndex={isCancelling ? -1 : 0}
           gap={1}
           paddingX={2}

--- a/langwatch/src/components/suites/__tests__/CancelButtonNoNestedButton.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/CancelButtonNoNestedButton.integration.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Structural regression tests for the per-row Cancel button (#3192).
+ *
+ * Browsers parse nested <button> elements by closing the outer button
+ * prematurely. The visible cancel button — positioned `absolute` inside
+ * the card's clickable surface — then receives clicks that don't reach
+ * its handler, producing a no-op. The fix is to render the inner control
+ * as a non-button element (span/div) with role="button" so the outer
+ * card button remains the only real <button> in the tree.
+ *
+ * @see specs/features/scenarios/scenarios-editor-ui-regressions.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ScenarioRunStatus } from "~/server/scenarios/scenario-event.enums";
+import { ScenarioGridCard } from "../ScenarioGridCard";
+import { RunRow } from "../RunRow";
+import { makeScenarioRunData, makeBatchRun, makeSummary } from "./test-helpers";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+describe("<ScenarioGridCard/> per-row Cancel button structure (regression #3192)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("given an in-progress run with onCancel", () => {
+    /** @scenario "Per-row Cancel control is not a nested HTML button inside the card" */
+    it("does not nest a <button> element inside the outer card button", () => {
+      render(
+        <ScenarioGridCard
+          scenarioRun={makeScenarioRunData({
+            status: ScenarioRunStatus.IN_PROGRESS,
+            durationInMs: 0,
+          })}
+          targetName="Agent"
+          onClick={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      const cancelButton = screen.getByTestId("cancel-run-button");
+      // The cancel control must be an ARIA button on a non-button element so
+      // it can live inside the outer card <button> without invalid HTML
+      // nesting that browsers silently flatten.
+      expect(cancelButton.tagName.toLowerCase()).not.toBe("button");
+      expect(cancelButton.getAttribute("role")).toBe("button");
+
+      // Belt-and-suspenders: assert the parent chain to the outer card button
+      // contains no other <button> in between.
+      const outerCardButton = screen.getByLabelText(/View details for/);
+      expect(outerCardButton.tagName.toLowerCase()).toBe("button");
+      let node: HTMLElement | null = cancelButton;
+      while (node && node !== outerCardButton) {
+        if (node !== cancelButton && node.tagName.toLowerCase() === "button") {
+          throw new Error(
+            `Unexpected nested <button> found between cancel control and outer card button: ${node.outerHTML.slice(0, 200)}`,
+          );
+        }
+        node = node.parentElement;
+      }
+    });
+  });
+});
+
+describe("<RunRow/> per-row Cancel wiring in grid view (regression #3192)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("when the per-row Cancel button is clicked in grid view", () => {
+    /** @scenario "Per-row Cancel button on a grid card fires the cancel mutation" */
+    it("calls onCancelRun with the scenario run and does not open the detail drawer", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      const onCancelRun = vi.fn();
+      const onScenarioRunClick = vi.fn();
+      const scenarioRun = makeScenarioRunData({
+        scenarioRunId: "run_pending",
+        status: ScenarioRunStatus.IN_PROGRESS,
+        durationInMs: 0,
+      });
+
+      render(
+        <RunRow
+          batchRun={makeBatchRun({ scenarioRuns: [scenarioRun] })}
+          summary={makeSummary({ inProgressCount: 1, totalCount: 1, passedCount: 0, passRate: 0 })}
+          isExpanded={true}
+          onToggle={vi.fn()}
+          resolveTargetName={() => "Agent"}
+          onScenarioRunClick={onScenarioRunClick}
+          onCancelRun={onCancelRun}
+          viewMode="grid"
+        />,
+        { wrapper: Wrapper },
+      );
+
+      const cancelButton = screen.getByTestId("cancel-run-button");
+      await user.click(cancelButton);
+
+      expect(onCancelRun).toHaveBeenCalledOnce();
+      expect(onCancelRun).toHaveBeenCalledWith(scenarioRun);
+      expect(onScenarioRunClick).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/pages/[project]/simulations/scenarios/index.tsx
+++ b/langwatch/src/pages/[project]/simulations/scenarios/index.tsx
@@ -11,7 +11,6 @@ import { BatchActionBar } from "~/components/scenarios/BatchActionBar";
 import { ScenarioArchiveDialog } from "~/components/scenarios/ScenarioArchiveDialog";
 import { ScenarioCreateModal } from "~/components/scenarios/ScenarioCreateModal";
 import { ScenarioEmptyState } from "~/components/scenarios/ScenarioEmptyState";
-import { ScenarioFormDrawerFromUrl } from "~/components/scenarios/ScenarioFormDrawer";
 import { ScenarioTable } from "~/components/scenarios/ScenarioTable";
 import { ScenarioWelcomeModal, ScenarioWelcomeScreen } from "~/components/scenarios/ScenarioWelcomeScreen";
 import { PageLayout } from "~/components/ui/layouts/PageLayout";
@@ -26,7 +25,7 @@ import { api } from "~/utils/api";
 
 function ScenarioLibraryPage() {
   const { project } = useOrganizationTeamProject();
-  const { openDrawer, drawerOpen } = useDrawer();
+  const { openDrawer } = useDrawer();
   const {
     rowSelection,
     onRowSelectionChange,
@@ -219,7 +218,10 @@ function ScenarioLibraryPage() {
         )}
       </PageLayout.Container>
 
-      <ScenarioFormDrawerFromUrl open={drawerOpen("scenarioEditor")} />
+      {/* ScenarioFormDrawerFromUrl is mounted globally by CurrentDrawer via
+          the drawer registry (#3194). Rendering it explicitly here as well
+          duplicates the role="dialog" element in the DOM and breaks
+          accessible selectors / Playwright targeting. */}
       <ScenarioWelcomeModal
         open={showWelcomeModal}
         onOpenChange={handleWelcomeModalOpenChange}

--- a/langwatch/src/pages/__tests__/scenariosIndexNoDoubleDrawer.integration.test.tsx
+++ b/langwatch/src/pages/__tests__/scenariosIndexNoDoubleDrawer.integration.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression test for #3194: the Scenarios index page must NOT explicitly
+ * render `<ScenarioFormDrawerFromUrl>` — the drawer is mounted globally
+ * by `CurrentDrawer` via the drawer registry. Rendering it both ways
+ * puts two `role="dialog"` elements in the DOM and breaks accessible
+ * selectors / Playwright targeting.
+ *
+ * `CurrentDrawer.tsx` already emits a dev console warning when this
+ * happens; this test pins the page-side fix into CI so the regression
+ * cannot recur.
+ *
+ * @see specs/features/scenarios/scenarios-editor-ui-regressions.feature
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PAGE_PATH = join(
+  process.cwd(),
+  "src/pages/[project]/simulations/scenarios/index.tsx",
+);
+
+describe("Scenarios index page (regression #3194)", () => {
+  describe("given the page module source", () => {
+    /** @scenario "I'll write it myself" leaves exactly one Create Scenario drawer in the DOM */
+    it("does not import ScenarioFormDrawerFromUrl", () => {
+      const source = readFileSync(PAGE_PATH, "utf-8");
+      // The drawer should be mounted via CurrentDrawer/drawer registry only.
+      // An import here is a code smell — it likely means a duplicate render
+      // is being introduced (the bug pattern from #3194).
+      expect(source).not.toMatch(/^import .*ScenarioFormDrawerFromUrl/m);
+    });
+
+    /** @scenario ScenarioFormDrawerFromUrl is not rendered both explicitly and via the drawer registry */
+    it("does not render <ScenarioFormDrawerFromUrl> in JSX", () => {
+      const source = readFileSync(PAGE_PATH, "utf-8");
+      expect(source).not.toMatch(/<ScenarioFormDrawerFromUrl\b/);
+    });
+  });
+
+  describe("given the drawer registry", () => {
+    it("still registers ScenarioFormDrawerFromUrl as the scenarioEditor drawer", async () => {
+      const registry = await import("~/components/drawerRegistry");
+      expect(registry.drawers).toHaveProperty("scenarioEditor");
+      expect(registry.drawers.scenarioEditor.name).toBe(
+        "ScenarioFormDrawerFromUrl",
+      );
+    });
+  });
+});

--- a/specs/features/scenarios/scenarios-editor-ui-regressions.feature
+++ b/specs/features/scenarios/scenarios-editor-ui-regressions.feature
@@ -1,0 +1,70 @@
+Feature: Scenarios editor UI regressions from Vite migration
+  As a user running scenarios
+  I want the per-row Cancel, the Add New Agent flow, and the Create Scenario drawer
+  to behave correctly after the Vite + React Router migration (#3170)
+
+  # Three bugs surfaced during manual QA of Scenarios after #3170:
+  # - #3192: single-run Cancel button does nothing (no request fires)
+  # - #3193: Add New Agent from Edit Scenario closes both drawers and navigates nowhere
+  # - #3194: clicking "I'll write it myself" leaves two role=dialog drawer elements in the DOM
+
+  Background:
+    Given I am on the simulations runs page for my project
+
+  # ---------------------------------------------------------------------------
+  # #3192: per-row Cancel button on grid card must invoke the cancel mutation
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Per-row Cancel button on a grid card fires the cancel mutation
+    Given a batch run has an in-progress scenario run rendered in the grid view
+    When I click the per-row Stop button on that grid card
+    Then the cancel mutation is invoked with that scenario run's id
+    And the card's row-open click handler does not fire
+
+  @integration
+  Scenario: Per-row Cancel control is not a nested HTML button inside the card
+    Given a scenario grid card with a cancel button
+    Then the card's outer clickable element renders as a <button> element
+    But the cancel control inside it renders as a non-button element with role="button"
+
+  # ---------------------------------------------------------------------------
+  # #3193: Add New Agent flow from Edit Scenario must mount the chosen editor
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Clicking HTTP Agent in the type selector opens the HTTP editor drawer
+    Given the Edit Scenario drawer is open with the Agent Type Selector visible
+    When I click "HTTP Agent" in the type selector
+    Then the HTTP editor drawer is mounted with its form visible
+    And the URL reflects drawer.open=agentHttpEditor
+
+  @integration
+  Scenario: Clicking Code Agent in the type selector opens the code editor drawer
+    Given the Edit Scenario drawer is open with the Agent Type Selector visible
+    When I click "Code Agent" in the type selector
+    Then the code editor drawer is mounted with its form visible
+    And the URL reflects drawer.open=agentCodeEditor
+
+  @integration
+  Scenario: Clicking Workflow Agent in the type selector opens the workflow selector drawer
+    Given the Edit Scenario drawer is open with the Agent Type Selector visible
+    When I click "Workflow Agent" in the type selector
+    Then the workflow selector drawer is mounted with its content visible
+    And the URL reflects drawer.open=workflowSelector
+
+  # ---------------------------------------------------------------------------
+  # #3194: Create Scenario drawer must not coexist with its modal in the DOM
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: "I'll write it myself" leaves exactly one Create Scenario drawer in the DOM
+    Given the New Scenario modal is open
+    When I click "I'll write it myself"
+    Then exactly one role="dialog" Create Scenario drawer is rendered
+
+  @integration
+  Scenario: ScenarioFormDrawerFromUrl is not rendered both explicitly and via the drawer registry
+    Given the scenarios index page is mounted
+    Then ScenarioFormDrawerFromUrl is mounted only once in the page tree
+    And the drawer is sourced from CurrentDrawer via the drawer registry


### PR DESCRIPTION
## Summary

Three P1 UI regressions surfaced during manual QA of Scenarios after the Vite + Hono migration (#3170). All three live in the scenarios editor / runs surface and share the same theme (drawer + click wiring), so they ship as a single coherent fix.

- **#3192** — Per-row Cancel on a grid card was a nested HTML `<button>` inside the outer card `<button>`. Browsers close the outer button prematurely; clicks visually-on-cancel land on the card and only open the detail drawer (zero network requests, matches the Playwright observation in the issue). Aligned with `ScenarioTargetRow` (list view) which already uses `as=\"span\" role=\"button\"`.
- **#3193** — Add-New-Agent from Edit Scenario rendered nothing because `CurrentDrawer` spreads URL-parsed `drawer.*` onto the registered drawer, leaving `props.open` as the drawer-name *string*. Chakra/Zag Drawer expects a boolean. Added small `*FromUrl` wrappers for `AgentCodeEditorDrawer`, `AgentHttpEditorDrawer`, and `WorkflowSelectorDrawer` — mirrors the existing `ScenarioFormDrawerFromUrl` pattern from #1989.
- **#3194** — Two `role=\"dialog\"` Create-Scenario drawers in the DOM because `scenarios/index.tsx` rendered `<ScenarioFormDrawerFromUrl>` explicitly AND the drawer registry mounted the same component via `<CurrentDrawer/>`. CurrentDrawer's dev warning already flagged this; removed the explicit render and let the registry handle it.

## Test plan

- [x] `CancelButtonNoNestedButton.integration.test.tsx` — structural assertion (cancel control is not a nested `<button>`) + behavioural assertion (full `RunRow` → `ScenarioRunContent` → `ScenarioGridCard` cancel wiring fires `onCancelRun`).
- [x] `AgentEditorDrawersFromRegistry.integration.test.tsx` — each `*FromUrl` wrapper renders the underlying drawer open when `drawerOpen()` returns true for its key, and closed otherwise. Mirrors `NestedDrawerTyping.integration.test.tsx` (existing #1989 coverage).
- [x] `scenariosIndexNoDoubleDrawer.integration.test.tsx` — pins the page-side fix so a regression can't sneak the explicit `<ScenarioFormDrawerFromUrl>` back in.
- [x] BDD spec at `specs/features/scenarios/scenarios-editor-ui-regressions.feature` (parity-bound).
- [x] Full \`pnpm test:unit src/components/ src/evaluations-v3/ src/pages/__tests__/\` — 3050 passed / 0 failed.
- [x] \`pnpm typecheck\` — clean.
- [x] \`pnpm check:feature-parity\` — green.
- [ ] Manual QA against the real browser repros (the three issue bodies) once a maintainer can validate the staging build.

## Notes for reviewers

- `*FromUrl` wrappers are intentionally tiny — they only coerce URL state to a boolean and delegate. Same pattern as `ScenarioFormDrawerFromUrl` in #1989.
- Direct callsites of the underlying drawers (`SuiteFormDrawer` mounting `AgentHttpEditorDrawer`, `ScenarioFormDrawer` mounting `AgentTypeSelectorDrawer`) pass real booleans and are unaffected — verified in the existing test sweep.
- For #3192, the structural fix matches the working pattern in `ScenarioTargetRow` and the Cancel-All header button in `RunRow`. JSDOM doesn't faithfully reproduce the nested-button click-eating in real Chrome, so the behavioural test passes both before and after the fix — the structural test is the load-bearing regression guard.

Closes #3192
Closes #3193
Closes #3194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3192