### PR TITLE
fix(simulations): keep user in place after sidebar Quick Run (#3363)

### DIFF
--- a/langwatch/src/components/suites/SimulationsPage.tsx
+++ b/langwatch/src/components/suites/SimulationsPage.tsx
@@ -227,13 +227,8 @@ export default function SimulationsPage() {
   });
 
   const { requestRun, isPending: isRunPending, pendingBatchRunId, dialogProps: runDialogProps } = useRunSuite({
-    onRunScheduled: (suiteId) => {
+    onRunScheduled: () => {
       void utils.suites.getSummaries.invalidate();
-      // Navigate to the suite so the user sees the run starting
-      const suite = suites?.find((s) => s.id === suiteId);
-      if (suite && selectedSuiteSlug !== suite.slug) {
-        navigateToSuite(suite.slug);
-      }
     },
   });
 

--- a/langwatch/src/components/suites/SimulationsPage.tsx
+++ b/langwatch/src/components/suites/SimulationsPage.tsx
@@ -230,6 +230,12 @@ export default function SimulationsPage() {
     onRunScheduled: () => {
       void utils.suites.getSummaries.invalidate();
     },
+    // Quick Run stays in place (issue #3363); the success toast's "View run"
+    // action is the opt-in path to the run plan detail page.
+    onViewRun: (suiteId) => {
+      const suite = suites?.find((s) => s.id === suiteId);
+      if (suite) navigateToSuite(suite.slug);
+    },
   });
 
   // Handlers

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -281,6 +281,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
         capturedOnRunScheduled.current!("suite_target", "batch_002");
 
         expect(mockRouterPush).not.toHaveBeenCalled();
+        expect(mockGetSummariesInvalidate).toHaveBeenCalled();
       });
     });
 
@@ -296,6 +297,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
         capturedOnRunScheduled.current!("suite_target", "batch_003");
 
         expect(mockRouterPush).not.toHaveBeenCalled();
+        expect(mockGetSummariesInvalidate).toHaveBeenCalled();
       });
     });
   });

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -47,6 +47,13 @@ const capturedFlowCallbacks = vi.hoisted(() => ({
 // Router mock — path is overridden per describe block via routerQueryPath
 const routerQueryPath = vi.hoisted(() => ({ current: undefined as string[] | undefined }));
 
+/**
+ * Hoisted spy on the suites.getSummaries cache invalidator. Pins AC4:
+ * onRunScheduled must keep firing the invalidation so the sidebar row
+ * refreshes after a quick run.
+ */
+const mockGetSummariesInvalidate = vi.hoisted(() => vi.fn());
+
 vi.mock("~/utils/compat/next-router", () => ({
   useRouter: () => ({
     push: mockRouterPush,
@@ -127,7 +134,7 @@ vi.mock("~/utils/api", () => ({
     useContext: () => ({
       suites: {
         getAll: { invalidate: vi.fn() },
-        getSummaries: { invalidate: vi.fn() },
+        getSummaries: { invalidate: mockGetSummariesInvalidate },
       },
       scenarios: {
         getSuiteRunData: { invalidate: vi.fn() },
@@ -248,6 +255,18 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
 
         expect(mockRouterPush).not.toHaveBeenCalled();
       });
+
+      it("still invalidates the suites.getSummaries cache so the sidebar row refreshes", async () => {
+        routerQueryPath.current = undefined;
+
+        await renderSimulationsPage();
+
+        expect(capturedOnRunScheduled.current).not.toBeNull();
+
+        capturedOnRunScheduled.current!("suite_target", "batch_004");
+
+        expect(mockGetSummariesInvalidate).toHaveBeenCalled();
+      });
     });
 
     describe("when the user is on a different suite's detail page", () => {
@@ -289,49 +308,51 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
    * no-nav invariant above: we are guarding against a future change that
    * accidentally widens the no-nav fix to cover this drawer flow too.
    */
-  describe("AC6 regression guard — Save and Run from suite editor drawer still navigates", () => {
-    it("calls router push toward the suite detail page when the run is requested from the editor", async () => {
-      const user = userEvent.setup();
-      routerQueryPath.current = undefined; // Start on All Runs
+  describe("given the suite editor drawer is open", () => {
+    describe("when Save and Run fires for a saved suite (AC6 regression guard)", () => {
+      it("calls router push toward the suite detail page", async () => {
+        const user = userEvent.setup();
+        routerQueryPath.current = undefined; // Start on All Runs
 
-      await renderSimulationsPage();
+        await renderSimulationsPage();
 
-      // Open the suite editor drawer — this causes SimulationsPage to call
-      // setFlowCallbacks("suiteEditor", { onSaved, onRunRequested }) which
-      // populates capturedFlowCallbacks.current.
-      const newSuiteButton = await screen.findByRole("button", {
-        name: /New Run Plan/i,
-      });
-      await user.click(newSuiteButton);
+        // Open the suite editor drawer — this causes SimulationsPage to call
+        // setFlowCallbacks("suiteEditor", { onSaved, onRunRequested }) which
+        // populates capturedFlowCallbacks.current.
+        const newSuiteButton = await screen.findByRole("button", {
+          name: /New Run Plan/i,
+        });
+        await user.click(newSuiteButton);
 
-      expect(capturedFlowCallbacks.current).not.toBeNull();
-      expect(capturedFlowCallbacks.current!.onRunRequested).toBeDefined();
+        expect(capturedFlowCallbacks.current).not.toBeNull();
+        expect(capturedFlowCallbacks.current!.onRunRequested).toBeDefined();
 
-      // Simulate the Save-and-Run callback firing with a newly saved suite
-      const testSuite = {
-        id: "suite_saved",
-        projectId: "project_1",
-        name: "Newly Saved Suite",
-        slug: "newly-saved-slug",
-        description: null,
-        scenarioIds: [],
-        targets: [],
-        repeatCount: 1,
-        labels: [],
-        archivedAt: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-      capturedFlowCallbacks.current!.onRunRequested!(testSuite);
+        // Simulate the Save-and-Run callback firing with a newly saved suite
+        const testSuite = {
+          id: "suite_saved",
+          projectId: "project_1",
+          name: "Newly Saved Suite",
+          slug: "newly-saved-slug",
+          description: null,
+          scenarioIds: [],
+          targets: [],
+          repeatCount: 1,
+          labels: [],
+          archivedAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        capturedFlowCallbacks.current!.onRunRequested!(testSuite);
 
-      // navigateToSuite must fire — router.push called with the run-plans path
-      expect(mockRouterPush).toHaveBeenCalled();
-      const pushCall = mockRouterPush.mock.calls[0]!;
-      const [routeArg] = pushCall;
-      expect(routeArg).toMatchObject({
-        query: expect.objectContaining({
-          path: expect.arrayContaining(["run-plans", "newly-saved-slug"]),
-        }),
+        // navigateToSuite must fire — router.push called with the run-plans path
+        expect(mockRouterPush).toHaveBeenCalled();
+        const pushCall = mockRouterPush.mock.calls[0]!;
+        const [routeArg] = pushCall;
+        expect(routeArg).toMatchObject({
+          query: expect.objectContaining({
+            path: expect.arrayContaining(["run-plans", "newly-saved-slug"]),
+          }),
+        });
       });
     });
   });

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -10,7 +10,8 @@
  * @see specs/features/suites/quick-run-stay-in-place.feature
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,17 @@ const capturedOnRunScheduled = vi.hoisted(
       current: null,
     }) as { current: ((suiteId: string, batchRunId: string) => void) | null },
 );
+
+/**
+ * Capture the flow callbacks registered by SimulationsPage via setFlowCallbacks("suiteEditor", …)
+ * so AC6 tests can directly invoke onRunRequested and assert navigation fires.
+ */
+const capturedFlowCallbacks = vi.hoisted(() => ({
+  current: null as {
+    onRunRequested?: (suite: any) => void;
+    onSaved?: (suite: any) => void;
+  } | null,
+}));
 
 // Router mock — path is overridden per describe block via routerQueryPath
 const routerQueryPath = vi.hoisted(() => ({ current: undefined as string[] | undefined }));
@@ -90,7 +102,9 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
 vi.mock("~/hooks/useDrawer", () => ({
   useDrawer: () => ({
     openDrawer: vi.fn(),
-    setFlowCallbacks: vi.fn(),
+    setFlowCallbacks: (_flow: string, callbacks: any) => {
+      capturedFlowCallbacks.current = callbacks;
+    },
   }),
 }));
 
@@ -215,6 +229,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
     cleanup();
     vi.clearAllMocks();
     capturedOnRunScheduled.current = null;
+    capturedFlowCallbacks.current = null;
     routerQueryPath.current = undefined;
   });
 
@@ -262,6 +277,61 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
         capturedOnRunScheduled.current!("suite_target", "batch_003");
 
         expect(mockRouterPush).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  /**
+   * AC6 regression guard — positive invariant.
+   *
+   * The Save-and-Run flow (handleRunRequested registered via setFlowCallbacks)
+   * MUST still navigate to the suite detail page. This is the OPPOSITE of the
+   * no-nav invariant above: we are guarding against a future change that
+   * accidentally widens the no-nav fix to cover this drawer flow too.
+   */
+  describe("AC6 regression guard — Save and Run from suite editor drawer still navigates", () => {
+    it("calls router push toward the suite detail page when the run is requested from the editor", async () => {
+      const user = userEvent.setup();
+      routerQueryPath.current = undefined; // Start on All Runs
+
+      await renderSimulationsPage();
+
+      // Open the suite editor drawer — this causes SimulationsPage to call
+      // setFlowCallbacks("suiteEditor", { onSaved, onRunRequested }) which
+      // populates capturedFlowCallbacks.current.
+      const newSuiteButton = await screen.findByRole("button", {
+        name: /New Run Plan/i,
+      });
+      await user.click(newSuiteButton);
+
+      expect(capturedFlowCallbacks.current).not.toBeNull();
+      expect(capturedFlowCallbacks.current!.onRunRequested).toBeDefined();
+
+      // Simulate the Save-and-Run callback firing with a newly saved suite
+      const testSuite = {
+        id: "suite_saved",
+        projectId: "project_1",
+        name: "Newly Saved Suite",
+        slug: "newly-saved-slug",
+        description: null,
+        scenarioIds: [],
+        targets: [],
+        repeatCount: 1,
+        labels: [],
+        archivedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      capturedFlowCallbacks.current!.onRunRequested!(testSuite);
+
+      // navigateToSuite must fire — router.push called with the run-plans path
+      expect(mockRouterPush).toHaveBeenCalled();
+      const pushCall = mockRouterPush.mock.calls[0]!;
+      const [routeArg] = pushCall;
+      expect(routeArg).toMatchObject({
+        query: expect.objectContaining({
+          path: expect.arrayContaining(["run-plans", "newly-saved-slug"]),
+        }),
       });
     });
   });

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration test for issue #3363: Quick Run no-navigation invariant.
+ *
+ * Pins that SimulationsPage's useRunSuite({ onRunScheduled }) callback does
+ * NOT navigate after a run is scheduled — the user stays wherever they were
+ * (All Runs, a different suite's detail, or the same suite's detail).
+ *
+ * @see specs/features/suites/quick-run-stay-in-place.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be declared before any import that touches the module
+// ---------------------------------------------------------------------------
+
+const mockRouterPush = vi.hoisted(() => vi.fn());
+const mockRouterReplace = vi.hoisted(() => vi.fn());
+
+/**
+ * Capture the onRunScheduled callback passed by SimulationsPage to useRunSuite
+ * so individual tests can trigger it directly without simulating a full
+ * API mutation cycle.
+ */
+const capturedOnRunScheduled = vi.hoisted(
+  () =>
+    ({
+      current: null,
+    }) as { current: ((suiteId: string, batchRunId: string) => void) | null },
+);
+
+// Router mock — path is overridden per describe block via routerQueryPath
+const routerQueryPath = vi.hoisted(() => ({ current: undefined as string[] | undefined }));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: mockRouterReplace,
+    query: {
+      project: "test-project",
+      ...(routerQueryPath.current !== undefined ? { path: routerQueryPath.current } : {}),
+    },
+    pathname: "/[project]/simulations/[[...path]]",
+    asPath: routerQueryPath.current?.length
+      ? `/test-project/simulations/${routerQueryPath.current.join("/")}`
+      : "/test-project/simulations",
+    isReady: true,
+    events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+  }),
+}));
+
+// Capture onRunScheduled from useRunSuite — do NOT mock useSuiteRouting so
+// navigateToSuite runs for real and calls router.push (that is what we observe).
+vi.mock("~/components/suites/useRunSuite", () => ({
+  useRunSuite: (opts: {
+    onRunScheduled?: (suiteId: string, batchRunId: string) => void;
+  }) => {
+    capturedOnRunScheduled.current = opts.onRunScheduled ?? null;
+    return {
+      requestRun: vi.fn(),
+      confirmRun: vi.fn(),
+      cancelRun: vi.fn(),
+      isPending: false,
+      pendingBatchRunId: null,
+      dialogProps: {
+        open: false,
+        onClose: vi.fn(),
+        onConfirm: vi.fn(),
+        suiteName: "",
+        scenarioCount: 0,
+        targetCount: 0,
+        repeatCount: 1,
+        isLoading: false,
+      },
+    };
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project_1", slug: "test-project" },
+    hasAnyPermission: () => true,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: vi.fn(),
+    setFlowCallbacks: vi.fn(),
+  }),
+}));
+
+vi.mock("~/hooks/useSimulationUpdateListener", () => ({
+  useSimulationUpdateListener: () => undefined,
+}));
+
+vi.mock("~/components/DashboardLayout", () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dashboard-layout">{children}</div>
+  ),
+}));
+
+vi.mock("~/components/suites/RunHistoryPanel", () => ({
+  RunHistoryPanel: () => <div data-testid="all-runs-panel">All Runs Panel</div>,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({
+      suites: {
+        getAll: { invalidate: vi.fn() },
+        getSummaries: { invalidate: vi.fn() },
+      },
+      scenarios: {
+        getSuiteRunData: { invalidate: vi.fn() },
+        getExternalSetSummaries: { invalidate: vi.fn() },
+      },
+    }),
+    suites: {
+      getAll: {
+        useQuery: () => ({
+          data: [
+            {
+              id: "suite_target",
+              projectId: "project_1",
+              name: "Target Suite",
+              slug: "target-suite-slug",
+              description: null,
+              scenarioIds: [],
+              targets: [],
+              repeatCount: 1,
+              labels: [],
+              archivedAt: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+          isLoading: false,
+          error: null,
+        }),
+      },
+      getSummaries: {
+        useQuery: () => ({ data: {}, isLoading: false }),
+      },
+      archive: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+      duplicate: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+      run: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+    scenarios: {
+      getSuiteRunData: {
+        useQuery: () => ({
+          data: { runs: [], scenarioSetIds: {}, hasMore: false },
+          isLoading: false,
+          error: null,
+        }),
+      },
+      getExternalSetSummaries: {
+        useQuery: () => ({ data: [], isLoading: false, error: null }),
+      },
+      getAll: {
+        useQuery: () => ({ data: [], isLoading: false, error: null }),
+      },
+      cancelJob: {
+        useMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+      },
+      cancelBatchRun: {
+        useMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+      },
+    },
+    agents: {
+      getAll: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+    prompts: {
+      getAllPromptsForProject: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+async function renderSimulationsPage() {
+  // Dynamic import ensures mocks are applied before the module is evaluated
+  const { default: SimulationsPage } = await import(
+    "~/components/suites/SimulationsPage"
+  );
+  render(<SimulationsPage />, { wrapper: Wrapper });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    capturedOnRunScheduled.current = null;
+    routerQueryPath.current = undefined;
+  });
+
+  describe("given a suite with id 'suite_target' and slug 'target-suite-slug'", () => {
+    describe("when the user is on All Runs", () => {
+      it("does not call the router push API when a run is scheduled", async () => {
+        // All Runs: no path segments
+        routerQueryPath.current = undefined;
+
+        await renderSimulationsPage();
+
+        expect(capturedOnRunScheduled.current).not.toBeNull();
+
+        // Simulate a run being scheduled for the target suite
+        capturedOnRunScheduled.current!("suite_target", "batch_001");
+
+        expect(mockRouterPush).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the user is on a different suite's detail page", () => {
+      it("does not call the router push API when a run is scheduled", async () => {
+        // Different suite detail page
+        routerQueryPath.current = ["run-plans", "other-suite-slug"];
+
+        await renderSimulationsPage();
+
+        expect(capturedOnRunScheduled.current).not.toBeNull();
+
+        capturedOnRunScheduled.current!("suite_target", "batch_002");
+
+        expect(mockRouterPush).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the user is on the same suite's detail page", () => {
+      it("does not call the router push API when a run is scheduled", async () => {
+        // Same suite detail page
+        routerQueryPath.current = ["run-plans", "target-suite-slug"];
+
+        await renderSimulationsPage();
+
+        expect(capturedOnRunScheduled.current).not.toBeNull();
+
+        capturedOnRunScheduled.current!("suite_target", "batch_003");
+
+        expect(mockRouterPush).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -34,6 +34,18 @@ const capturedOnRunScheduled = vi.hoisted(
 );
 
 /**
+ * Capture the onViewRun callback passed by SimulationsPage to useRunSuite.
+ * Pins AC8 page-wiring: invoking it must navigate to the run plan detail page
+ * (the opt-in counterpart to the no-auto-nav invariant).
+ */
+const capturedOnViewRun = vi.hoisted(
+  () =>
+    ({
+      current: null,
+    }) as { current: ((suiteId: string) => void) | null },
+);
+
+/**
  * Capture the flow callbacks registered by SimulationsPage via setFlowCallbacks("suiteEditor", …)
  * so AC6 tests can directly invoke onRunRequested and assert navigation fires.
  */
@@ -76,8 +88,10 @@ vi.mock("~/utils/compat/next-router", () => ({
 vi.mock("~/components/suites/useRunSuite", () => ({
   useRunSuite: (opts: {
     onRunScheduled?: (suiteId: string, batchRunId: string) => void;
+    onViewRun?: (suiteId: string) => void;
   }) => {
     capturedOnRunScheduled.current = opts.onRunScheduled ?? null;
+    capturedOnViewRun.current = opts.onViewRun ?? null;
     return {
       requestRun: vi.fn(),
       confirmRun: vi.fn(),
@@ -236,6 +250,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
     cleanup();
     vi.clearAllMocks();
     capturedOnRunScheduled.current = null;
+    capturedOnViewRun.current = null;
     capturedFlowCallbacks.current = null;
     routerQueryPath.current = undefined;
   });
@@ -354,6 +369,40 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
         expect(routeArg).toMatchObject({
           query: expect.objectContaining({
             path: expect.arrayContaining(["run-plans", "newly-saved-slug"]),
+          }),
+        });
+      });
+    });
+  });
+
+  /**
+   * AC8 — opt-in "View run" navigation.
+   *
+   * The page must wire useRunSuite's onViewRun option to navigation so the
+   * success toast's "View run" action lands the user on the run plan detail
+   * page. This is the explicit, user-initiated counterpart to the no-auto-nav
+   * invariant above: navigation only happens when onViewRun is invoked.
+   */
+  describe("given a suite with id 'suite_target' and slug 'target-suite-slug'", () => {
+    describe("when the View run toast action fires for a scheduled run", () => {
+      /** @scenario The run-scheduled success toast offers a View run action that navigates to the run plan detail page */
+      it("calls router push toward the run plan detail page", async () => {
+        routerQueryPath.current = undefined; // Start on All Runs
+
+        await renderSimulationsPage();
+
+        expect(capturedOnViewRun.current).not.toBeNull();
+
+        // Simulate the user clicking "View run" on the success toast for the
+        // suite that was just scheduled.
+        capturedOnViewRun.current!("suite_target");
+
+        expect(mockRouterPush).toHaveBeenCalled();
+        const pushCall = mockRouterPush.mock.calls[0]!;
+        const [routeArg] = pushCall;
+        expect(routeArg).toMatchObject({
+          query: expect.objectContaining({
+            path: expect.arrayContaining(["run-plans", "target-suite-slug"]),
           }),
         });
       });

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -310,6 +310,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
    */
   describe("given the suite editor drawer is open", () => {
     describe("when Save and Run fires for a saved suite (AC6 regression guard)", () => {
+      /** @scenario Save and Run from the suite editor drawer still navigates to the suite detail page */
       it("calls router push toward the suite detail page", async () => {
         const user = userEvent.setup();
         routerQueryPath.current = undefined; // Start on All Runs

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -57,7 +57,9 @@ const capturedFlowCallbacks = vi.hoisted(() => ({
 }));
 
 // Router mock — path is overridden per describe block via routerQueryPath
-const routerQueryPath = vi.hoisted(() => ({ current: undefined as string[] | undefined }));
+const routerQueryPath = vi.hoisted(() => ({
+  current: undefined as string[] | undefined,
+}));
 
 /**
  * Hoisted spy on the suites.getSummaries cache invalidator. Pins AC4:
@@ -72,7 +74,9 @@ vi.mock("~/utils/compat/next-router", () => ({
     replace: mockRouterReplace,
     query: {
       project: "test-project",
-      ...(routerQueryPath.current !== undefined ? { path: routerQueryPath.current } : {}),
+      ...(routerQueryPath.current !== undefined
+        ? { path: routerQueryPath.current }
+        : {}),
     },
     pathname: "/[project]/simulations/[[...path]]",
     asPath: routerQueryPath.current?.length

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -261,6 +261,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
 
   describe("given a suite with id 'suite_target' and slug 'target-suite-slug'", () => {
     describe("when the user is on All Runs", () => {
+      /** @scenario Quick run from the All Runs page keeps the user on All Runs */
       it("does not call the router push API when a run is scheduled", async () => {
         // All Runs: no path segments
         routerQueryPath.current = undefined;
@@ -289,6 +290,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
     });
 
     describe("when the user is on a different suite's detail page", () => {
+      /** @scenario Quick run on a different run plan from a run plan detail page keeps the user on the original detail page */
       it("does not call the router push API when a run is scheduled", async () => {
         // Different suite detail page
         routerQueryPath.current = ["run-plans", "other-suite-slug"];
@@ -305,6 +307,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
     });
 
     describe("when the user is on the same suite's detail page", () => {
+      /** @scenario Quick run on the same run plan the user is viewing keeps the user on that detail page */
       it("does not call the router push API when a run is scheduled", async () => {
         // Same suite detail page
         routerQueryPath.current = ["run-plans", "target-suite-slug"];

--- a/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx
@@ -13,6 +13,7 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UseRunSuiteOptions } from "~/components/suites/useRunSuite";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — must be declared before any import that touches the module
@@ -62,9 +63,12 @@ const routerQueryPath = vi.hoisted(() => ({
 }));
 
 /**
- * Hoisted spy on the suites.getSummaries cache invalidator. Pins AC4:
- * onRunScheduled must keep firing the invalidation so the sidebar row
- * refreshes after a quick run.
+ * Hoisted spy on the suites.getSummaries cache invalidator.
+ *
+ * Pins the *trigger* AC4 depends on: dropping the navigation must not also drop
+ * the invalidation, or the sidebar row would never refresh. AC4's rendered
+ * outcome (status icon + last-run timestamp) is not asserted here — the sidebar
+ * is not rendered from live summaries in this test. Tracked in #5602.
  */
 const mockGetSummariesInvalidate = vi.hoisted(() => vi.fn());
 
@@ -90,10 +94,7 @@ vi.mock("~/utils/compat/next-router", () => ({
 // Capture onRunScheduled from useRunSuite — do NOT mock useSuiteRouting so
 // navigateToSuite runs for real and calls router.push (that is what we observe).
 vi.mock("~/components/suites/useRunSuite", () => ({
-  useRunSuite: (opts: {
-    onRunScheduled?: (suiteId: string, batchRunId: string) => void;
-    onViewRun?: (suiteId: string) => void;
-  }) => {
+  useRunSuite: (opts: UseRunSuiteOptions) => {
     capturedOnRunScheduled.current = opts.onRunScheduled ?? null;
     capturedOnViewRun.current = opts.onViewRun ?? null;
     return {
@@ -302,6 +303,17 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
         capturedOnRunScheduled.current!("suite_target", "batch_002");
 
         expect(mockRouterPush).not.toHaveBeenCalled();
+      });
+
+      it("still invalidates the suites.getSummaries cache so the sidebar row refreshes", async () => {
+        routerQueryPath.current = ["run-plans", "other-suite-slug"];
+
+        await renderSimulationsPage();
+
+        expect(capturedOnRunScheduled.current).not.toBeNull();
+
+        capturedOnRunScheduled.current!("suite_target", "batch_002");
+
         expect(mockGetSummariesInvalidate).toHaveBeenCalled();
       });
     });
@@ -319,6 +331,17 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
         capturedOnRunScheduled.current!("suite_target", "batch_003");
 
         expect(mockRouterPush).not.toHaveBeenCalled();
+      });
+
+      it("still invalidates the suites.getSummaries cache so the sidebar row refreshes", async () => {
+        routerQueryPath.current = ["run-plans", "target-suite-slug"];
+
+        await renderSimulationsPage();
+
+        expect(capturedOnRunScheduled.current).not.toBeNull();
+
+        capturedOnRunScheduled.current!("suite_target", "batch_003");
+
         expect(mockGetSummariesInvalidate).toHaveBeenCalled();
       });
     });
@@ -390,7 +413,7 @@ describe("SimulationsPage quick-run no-navigation invariant (#3363)", () => {
    * page. This is the explicit, user-initiated counterpart to the no-auto-nav
    * invariant above: navigation only happens when onViewRun is invoked.
    */
-  describe("given a suite with id 'suite_target' and slug 'target-suite-slug'", () => {
+  describe("given a scheduled run for the suite with slug 'target-suite-slug'", () => {
     describe("when the View run toast action fires for a scheduled run", () => {
       /** @scenario The run-scheduled success toast offers a View run action that navigates to the run plan detail page */
       it("calls router push toward the run plan detail page", async () => {

--- a/langwatch/src/components/suites/__tests__/useRunSuite.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/useRunSuite.integration.test.tsx
@@ -32,7 +32,10 @@ const capturedRunOnSuccess = vi.hoisted(
       current: null,
     }) as {
       current:
-        | ((result: any, variables: { id: string; batchRunId?: string }) => void)
+        | ((
+            result: any,
+            variables: { id: string; batchRunId?: string },
+          ) => void)
         | null;
     },
 );

--- a/langwatch/src/components/suites/__tests__/useRunSuite.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/useRunSuite.integration.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration test for issue #3363 (founder follow-up on PR #3983).
+ *
+ * Pins the founder-requested compromise: after a successful quick-run with no
+ * skipped archived items, useRunSuite's success toast must carry an opt-in
+ * "View run" action whose onClick delegates to the onViewRun option (with the
+ * scheduled suite id). The hook itself does NOT navigate — it hands the suite
+ * id back to the consumer, preserving the no-auto-navigate thesis.
+ *
+ * The success path is driven by capturing api.suites.run.useMutation's
+ * onSuccess handler and invoking it with a fake successful result, rather than
+ * running a full tRPC mutation cycle.
+ *
+ * @see specs/features/suites/quick-run-stay-in-place.feature (AC8)
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted captures + spies — declared before any import touches the module
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture the onSuccess handler registered by useRunSuite on
+ * api.suites.run.useMutation so the test can invoke it with a fake result.
+ */
+const capturedRunOnSuccess = vi.hoisted(
+  () =>
+    ({
+      current: null,
+    }) as {
+      current:
+        | ((result: any, variables: { id: string; batchRunId?: string }) => void)
+        | null;
+    },
+);
+
+/** Spy on toaster.create so we can assert on the toast config (incl. action). */
+const mockToasterCreate = vi.hoisted(() => vi.fn());
+
+const mockOpenDrawer = vi.hoisted(() => vi.fn());
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useContext: () => ({
+      scenarios: {
+        getSuiteRunData: { invalidate: vi.fn() },
+      },
+    }),
+    suites: {
+      run: {
+        useMutation: (opts: {
+          onSuccess?: (result: any, variables: any) => void;
+          onError?: (err: any, variables: any) => void;
+        }) => {
+          capturedRunOnSuccess.current = opts.onSuccess ?? null;
+          return { mutate: vi.fn(), isPending: false };
+        },
+      },
+    },
+    scenarios: {
+      getAll: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+    },
+  },
+}));
+
+// The hook imports toaster from "../ui/toaster" -> ~/components/ui/toaster.
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: {
+    create: (args: unknown) => mockToasterCreate(args),
+  },
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: mockOpenDrawer,
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project_1", slug: "test-project" },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Mirrors the hook's success result shape (suite.router run -> service.run). */
+const successResult = {
+  scheduled: true,
+  jobCount: 1,
+  batchRunId: "batch_x",
+  skippedArchived: undefined,
+};
+
+async function renderUseRunSuite(options?: {
+  onViewRun?: (suiteId: string) => void;
+}) {
+  const { useRunSuite } = await import("~/components/suites/useRunSuite");
+  return renderHook(() => useRunSuite(options));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useRunSuite View run toast action (#3363 founder follow-up)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    capturedRunOnSuccess.current = null;
+  });
+
+  describe("given an onViewRun option is provided", () => {
+    describe("when a run is scheduled with no archived items skipped", () => {
+      it("shows a success toast carrying a View run action", async () => {
+        await renderUseRunSuite({ onViewRun: vi.fn() });
+
+        expect(capturedRunOnSuccess.current).not.toBeNull();
+        capturedRunOnSuccess.current!(successResult, { id: "suite_target" });
+
+        expect(mockToasterCreate).toHaveBeenCalled();
+        const [toastArg] = mockToasterCreate.mock.calls[0]!;
+        expect(toastArg).toMatchObject({
+          type: "success",
+          action: expect.objectContaining({ label: "View run" }),
+        });
+      });
+
+      it("delegates the View run action to onViewRun with the scheduled suite id", async () => {
+        const onViewRun = vi.fn();
+        await renderUseRunSuite({ onViewRun });
+
+        expect(capturedRunOnSuccess.current).not.toBeNull();
+        capturedRunOnSuccess.current!(successResult, { id: "suite_target" });
+
+        const [toastArg] = mockToasterCreate.mock.calls[0]!;
+        // Invoke the action wired onto the toast.
+        toastArg.action.onClick();
+
+        expect(onViewRun).toHaveBeenCalledWith("suite_target");
+      });
+    });
+  });
+
+  describe("given no onViewRun option is provided", () => {
+    describe("when a run is scheduled with no archived items skipped", () => {
+      it("shows a success toast with no action", async () => {
+        await renderUseRunSuite();
+
+        expect(capturedRunOnSuccess.current).not.toBeNull();
+        capturedRunOnSuccess.current!(successResult, { id: "suite_target" });
+
+        expect(mockToasterCreate).toHaveBeenCalled();
+        const [toastArg] = mockToasterCreate.mock.calls[0]!;
+        expect(toastArg.type).toBe("success");
+        expect(toastArg.action).toBeUndefined();
+      });
+    });
+  });
+});

--- a/langwatch/src/components/suites/useRunSuite.ts
+++ b/langwatch/src/components/suites/useRunSuite.ts
@@ -18,6 +18,13 @@ import { toaster } from "../ui/toaster";
 
 interface UseRunSuiteOptions {
   onRunScheduled?: (suiteId: string, batchRunId: string) => void;
+  /**
+   * Invoked when the user clicks the "View run" action on the run-scheduled
+   * success toast. The consumer decides where to navigate (e.g. the run plan
+   * detail page). When omitted, the success toast carries no action — the hook
+   * never navigates on its own.
+   */
+  onViewRun?: (suiteId: string) => void;
 }
 
 export function useRunSuite(options: UseRunSuiteOptions = {}) {
@@ -71,6 +78,12 @@ export function useRunSuite(options: UseRunSuiteOptions = {}) {
           title: `Run plan scheduled (${result.jobCount} jobs)`,
           type: "success",
           meta: { closable: true },
+          action: optionsRef.current.onViewRun
+            ? {
+                label: "View run",
+                onClick: () => optionsRef.current.onViewRun?.(variables.id),
+              }
+            : undefined,
         });
       }
 

--- a/langwatch/src/components/suites/useRunSuite.ts
+++ b/langwatch/src/components/suites/useRunSuite.ts
@@ -16,7 +16,7 @@ import { api } from "~/utils/api";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { toaster } from "../ui/toaster";
 
-interface UseRunSuiteOptions {
+export interface UseRunSuiteOptions {
   onRunScheduled?: (suiteId: string, batchRunId: string) => void;
   /**
    * Invoked when the user clicks the "View run" action on the run-scheduled

--- a/specs/features/suites/quick-run-stay-in-place.feature
+++ b/specs/features/suites/quick-run-stay-in-place.feature
@@ -86,6 +86,19 @@ Feature: Sidebar Quick Run keeps the user in place
     Then the router push API is not called toward /<projectSlug>/simulations/run-plans/<slug>
     And the run plan summaries query invalidation is still triggered
 
+  # --- AC8: the success toast offers an explicit, opt-in "View run" action ---
+  # Founder (Rogério) compromise: staying in place is kept, but the
+  # run-scheduled success toast carries a button so the user can jump to the
+  # run plan's detail page on demand instead of being auto-navigated.
+
+  @integration
+  Scenario: The run-scheduled success toast offers a View run action that navigates to the run plan detail page
+    Given the user is on the All Runs page at /<projectSlug>/simulations
+    When the user clicks the inline Run button on a run plan row in the sidebar
+    And the run is scheduled with no archived scenarios or targets skipped
+    Then a success toast is shown with a "View run" action
+    And clicking the "View run" action navigates to the run plan detail page at /<projectSlug>/simulations/run-plans/<slug>
+
   # --- AC Coverage Map ---
   # AC 1: "stays on All Runs after sidebar quick-run"
   #   -> Scenario: Quick run from the All Runs page keeps the user on All Runs
@@ -101,3 +114,5 @@ Feature: Sidebar Quick Run keeps the user in place
   #   -> Scenario: Save and Run from the suite editor drawer still navigates to the suite detail page
   # AC 7: "automated test covers the no-navigation regression"
   #   -> Scenario: useRunSuite onRunScheduled does not call the router push API
+  # AC 8: "success toast carries an opt-in View run action that navigates to the detail page"
+  #   -> Scenario: The run-scheduled success toast offers a View run action that navigates to the run plan detail page

--- a/specs/features/suites/quick-run-stay-in-place.feature
+++ b/specs/features/suites/quick-run-stay-in-place.feature
@@ -1,0 +1,103 @@
+Feature: Sidebar Quick Run keeps the user in place
+  As a user managing simulations
+  I want the sidebar's inline Run button to be a fire-and-forget action
+  So that I can launch a run plan without losing my current view or being pulled to the run plan's detail page
+
+  # Issue: https://github.com/langwatch/langwatch/issues/3363
+  # Investigation: clicking the inline Run button on a run plan row in
+  # SuiteSidebar fires useRunSuite's onRunScheduled callback. That callback
+  # lives in SimulationsPage.tsx and currently calls navigateToSuite(slug)
+  # whenever the user isn't already on that suite's detail page. The fix
+  # drops the navigation entirely — cache invalidation and existing SSE
+  # listeners surface the new run in-place without a route change.
+  #
+  # Out of scope: the "Save and Run" flow from the suite editor drawer
+  # (handleRunRequested) which deliberately navigates to the suite detail
+  # page so the editor lands on the page that shows the new run.
+
+  Background:
+    Given the user is in a project with at least one run plan in the simulations sidebar
+
+  # --- AC1: stays on All Runs after quick-run ---
+
+  @integration @unimplemented
+  Scenario: Quick run from the All Runs page keeps the user on All Runs
+    Given the user is on the All Runs page at /<projectSlug>/simulations
+    When the user clicks the inline Run button on a run plan row in the sidebar
+    And the run is scheduled
+    Then the URL stays at /<projectSlug>/simulations
+    And no navigation toward /<projectSlug>/simulations/run-plans/<slug> fires
+
+  # --- AC2: stays on the currently-viewed run plan detail when running a different plan ---
+
+  @integration @unimplemented
+  Scenario: Quick run on a different run plan from a run plan detail page keeps the user on the original detail page
+    Given the user is on the run plan detail page at /<projectSlug>/simulations/run-plans/<currentSlug>
+    When the user clicks the inline Run button on a different run plan row in the sidebar
+    And the run is scheduled
+    Then the URL stays at /<projectSlug>/simulations/run-plans/<currentSlug>
+    And no navigation toward the newly-run plan fires
+
+  # --- AC3: regression check — running the same plan the user is viewing also stays put ---
+
+  @integration @unimplemented
+  Scenario: Quick run on the same run plan the user is viewing keeps the user on that detail page
+    Given the user is on the run plan detail page at /<projectSlug>/simulations/run-plans/<slug>
+    When the user clicks the inline Run button for that same run plan in the sidebar
+    And the run is scheduled
+    Then the URL stays at /<projectSlug>/simulations/run-plans/<slug>
+    And no navigation call fires
+
+  # --- AC4: sidebar row reflects the new run after quick-run, via SSE/poll cadence ---
+
+  @integration @unimplemented
+  Scenario: Sidebar row updates after quick-run without manual refresh
+    Given the user is on any page in the simulations area
+    When the user clicks the inline Run button on a run plan row in the sidebar
+    And the run is scheduled
+    Then the run plan summaries query is invalidated
+    And the sidebar row for that run plan reflects the new pending run within the existing SSE/poll cadence
+
+  # --- AC5: All Runs main panel shows the new pending batch row without navigation ---
+
+  @integration @unimplemented
+  Scenario: All Runs main panel shows the new pending batch after quick-run without page navigation
+    Given the user is on the All Runs page at /<projectSlug>/simulations
+    When the user clicks the inline Run button on a run plan row in the sidebar
+    And the run is scheduled
+    Then the new pending batch row appears in the RunHistoryPanel in the main pane
+    And the URL stays at /<projectSlug>/simulations
+
+  # --- AC6: Save-and-Run from the editor drawer is untouched ---
+
+  @integration
+  Scenario: Save and Run from the suite editor drawer still navigates to the suite detail page
+    Given the user has the suite editor drawer open for a run plan
+    When the user clicks Save and Run
+    And the run is scheduled
+    Then the user is navigated to the suite detail page for the saved run plan
+
+  # --- AC7: automated regression test pins the no-navigation invariant ---
+
+  @integration @unimplemented
+  Scenario: useRunSuite onRunScheduled does not call the router push API
+    Given SimulationsPage is rendered with a spied router
+    When useRunSuite's onRunScheduled callback fires for a scheduled run
+    Then the router push API is not called toward /<projectSlug>/simulations/run-plans/<slug>
+    And the run plan summaries query invalidation is still triggered
+
+  # --- AC Coverage Map ---
+  # AC 1: "stays on All Runs after sidebar quick-run"
+  #   -> Scenario: Quick run from the All Runs page keeps the user on All Runs
+  # AC 2: "stays on currently-viewed run plan detail when running a different plan"
+  #   -> Scenario: Quick run on a different run plan from a run plan detail page keeps the user on the original detail page
+  # AC 3: "regression — same-plan quick-run still stays put"
+  #   -> Scenario: Quick run on the same run plan the user is viewing keeps the user on that detail page
+  # AC 4: "sidebar row reflects new run via SSE/poll cadence, no manual refresh"
+  #   -> Scenario: Sidebar row updates after quick-run without manual refresh
+  # AC 5: "All Runs main panel shows new pending batch without page navigation"
+  #   -> Scenario: All Runs main panel shows the new pending batch after quick-run without page navigation
+  # AC 6: "Save-and-Run drawer flow unchanged — still navigates to detail page"
+  #   -> Scenario: Save and Run from the suite editor drawer still navigates to the suite detail page
+  # AC 7: "automated test covers the no-navigation regression"
+  #   -> Scenario: useRunSuite onRunScheduled does not call the router push API

--- a/specs/features/suites/quick-run-stay-in-place.feature
+++ b/specs/features/suites/quick-run-stay-in-place.feature
@@ -20,7 +20,7 @@ Feature: Sidebar Quick Run keeps the user in place
 
   # --- AC1: stays on All Runs after quick-run ---
 
-  @integration @unimplemented
+  @integration
   Scenario: Quick run from the All Runs page keeps the user on All Runs
     Given the user is on the All Runs page at /<projectSlug>/simulations
     When the user clicks the inline Run button on a run plan row in the sidebar
@@ -30,7 +30,7 @@ Feature: Sidebar Quick Run keeps the user in place
 
   # --- AC2: stays on the currently-viewed run plan detail when running a different plan ---
 
-  @integration @unimplemented
+  @integration
   Scenario: Quick run on a different run plan from a run plan detail page keeps the user on the original detail page
     Given the user is on the run plan detail page at /<projectSlug>/simulations/run-plans/<currentSlug>
     When the user clicks the inline Run button on a different run plan row in the sidebar
@@ -40,7 +40,7 @@ Feature: Sidebar Quick Run keeps the user in place
 
   # --- AC3: regression check — running the same plan the user is viewing also stays put ---
 
-  @integration @unimplemented
+  @integration
   Scenario: Quick run on the same run plan the user is viewing keeps the user on that detail page
     Given the user is on the run plan detail page at /<projectSlug>/simulations/run-plans/<slug>
     When the user clicks the inline Run button for that same run plan in the sidebar
@@ -77,14 +77,10 @@ Feature: Sidebar Quick Run keeps the user in place
     And the run is scheduled
     Then the user is navigated to the suite detail page for the saved run plan
 
-  # --- AC7: automated regression test pins the no-navigation invariant ---
-
-  @integration @unimplemented
-  Scenario: useRunSuite onRunScheduled does not call the router push API
-    Given SimulationsPage is rendered with a spied router
-    When useRunSuite's onRunScheduled callback fires for a scheduled run
-    Then the router push API is not called toward /<projectSlug>/simulations/run-plans/<slug>
-    And the run plan summaries query invalidation is still triggered
+  # --- AC7 is a meta-criterion ("an automated test pins the regression") rather
+  # than a distinct user behaviour, so it has no scenario of its own: it is
+  # satisfied by the three @integration no-navigation scenarios above being
+  # bound to real tests. ---
 
   # --- AC8: the success toast offers an explicit, opt-in "View run" action ---
   # Founder (Rogério) compromise: staying in place is kept, but the
@@ -113,6 +109,6 @@ Feature: Sidebar Quick Run keeps the user in place
   # AC 6: "Save-and-Run drawer flow unchanged — still navigates to detail page"
   #   -> Scenario: Save and Run from the suite editor drawer still navigates to the suite detail page
   # AC 7: "automated test covers the no-navigation regression"
-  #   -> Scenario: useRunSuite onRunScheduled does not call the router push API
+  #   -> satisfied by the three bound @integration scenarios for AC 1-3 above
   # AC 8: "success toast carries an opt-in View run action that navigates to the detail page"
   #   -> Scenario: The run-scheduled success toast offers a View run action that navigates to the run plan detail page

--- a/specs/features/suites/quick-run-stay-in-place.feature
+++ b/specs/features/suites/quick-run-stay-in-place.feature
@@ -49,6 +49,8 @@ Feature: Sidebar Quick Run keeps the user in place
     And no navigation call fires
 
   # --- AC4: sidebar row reflects the new run after quick-run, via SSE/poll cadence ---
+  # @unimplemented: only the invalidation trigger is pinned by a test; the rendered
+  # status icon + timestamp are verified manually. Automated coverage tracked in #5602.
 
   @integration @unimplemented
   Scenario: Sidebar row updates after quick-run without manual refresh
@@ -59,6 +61,8 @@ Feature: Sidebar Quick Run keeps the user in place
     And the sidebar row for that run plan reflects the new pending run within the existing SSE/poll cadence
 
   # --- AC5: All Runs main panel shows the new pending batch row without navigation ---
+  # @unimplemented: RunHistoryPanel is stubbed in the page integration test, so the
+  # pending-row render is verified manually. Automated coverage tracked in #5602.
 
   @integration @unimplemented
   Scenario: All Runs main panel shows the new pending batch after quick-run without page navigation


### PR DESCRIPTION
**Low risk** — 11 lines of production change in one component + one hook, both frontend-only. The behavioural surface is a single navigation call that is deleted and re-offered behind an explicit button.

**Start here:** `langwatch/src/components/suites/useRunSuite.ts` — the `action:` block on the success toast. Everything else follows from whether that seam (`onViewRun`) is the right one.

## Why

Closes #3363

Clicking the inline **Run** button ("Quick Run") on a run plan row in the simulations sidebar unconditionally jumped the user to that run plan's detail page — even when they were on the All Runs view and just wanted to launch a run without losing context. The expected behaviour is fire-and-forget: schedule the run, surface it in-place via the existing SSE listeners, leave the user where they are.

## What changed

- **Delete the navigation from `onRunScheduled`, keep the cache invalidation** → alternative was keeping the existing `selectedSuiteSlug !== suite.slug` guard → that guard only suppressed the jump when you were *already* on the target plan's page, so every quick-run from All Runs still teleported you. Blast radius: if the SSE listeners ever stop surfacing new runs in-place, the user now has no automatic feedback — which is why AC4/AC5 matter (see proof below).

- **Re-offer navigation as an opt-in `View run` action on the success toast** (`aa2796d7a`, @rogeriochaves's requested compromise) → alternative was removing the affordance entirely → losing the "see the run" path outright was the objection to the original PR. `useRunSuite` gained an optional `onViewRun` callback; the hook still never navigates on its own, it hands the suite id back and `SimulationsPage` decides. When `onViewRun` is omitted the toast carries no action.

- **Preserve the Save-and-Run drawer navigation** → alternative was widening the no-nav fix to `handleRunRequested` too → landing on the plan you just created is the desired UX there. Pinned by a positive regression test so a future change cannot silently widen the fix.

## How it works

```
SimulationsPage.tsx
├─ onRunScheduled()  → invalidates suites.getSummaries   (no navigation)
└─ onViewRun(suiteId) → navigateToSuite(suite.slug)      (only on button click)

useRunSuite.ts
└─ runMutation.onSuccess
   └─ toaster.create({ ..., action: onViewRun ? { label: "View run", … } : undefined })
```

The hook owns the toast; the page owns navigation. That inversion is what keeps "the hook never navigates on its own" true and testable.

## Test plan

- **Failing regression test first** (`8f12345ce`): mocks `useRunSuite` to capture its `onRunScheduled` callback, spies the router via the next-router compat layer, and asserts `router.push` is NOT called toward `/<project>/simulations/run-plans/<slug>`. Three cases: user on All Runs (AC1), on a different plan's detail (AC2), on the same plan's detail (AC3 regression).
- **Fix** (`c8c74aeb7`): drops the `navigateToSuite` call.
- **AC6 regression guard** (`d174bb64a`): drives the New Run Plan drawer's `onRunRequested` flow callback and asserts `router.push` IS called toward `run-plans/<slug>`.
- **AC8** (`aa2796d7a`): hook-contract tests (toast carries the action; the action invokes `onViewRun`; no action when `onViewRun` is absent) plus a page-wiring test.
- **Spec bindings** (`d47b1ec0a`): AC1–AC3 were tagged `@unimplemented` despite having passing tests, so the feature-parity checker skipped them. Now bound via `@scenario`; the checker enforces 3 more scenarios (2405 → 2408).

## Human verification

1. Boot the app and open **Simulations** for a project with at least one run plan.
2. From the **All Runs** view (or a *different* run plan's detail page), click the inline **Run** (Quick Run) button on a run-plan row and confirm.
3. Confirm the URL **does not change** and a green **"Run plan scheduled"** toast appears with a **"View run"** button.
4. Click **"View run"** → confirm it navigates to that run plan's detail page.
5. Regression: the **Save & Run** drawer flow should STILL navigate.

## How I can prove I was successful

**AC1 / AC2 / AC3 — quick run does not navigate — `proven`.** The tests are falsifiable, re-verified this session at HEAD `b805c8e1a`: reverting the two production files (`SimulationsPage.tsx`, `useRunSuite.ts`) to `origin/main` turns **5 of the 11 tests red** (`Tests 5 failed | 6 passed (11)`); restoring them turns all 11 green (`11 passed (11)`).

```
$ pnpm test:integration run src/components/suites/__tests__/SimulationsPage-quick-run-no-nav.integration.test.tsx \
                            src/components/suites/__tests__/useRunSuite.integration.test.tsx
# with production code reverted to origin/main:
 Test Files  2 failed (2)
      Tests  5 failed | 6 passed (11)
      × does not call the router push API when a run is scheduled     (AC1)
      × does not call the router push API when a run is scheduled     (AC2)
      × calls router push toward the run plan detail page             (AC8 page-wiring)
      × shows a success toast carrying a View run action              (AC8 hook)
      × delegates the View run action to onViewRun ...                (AC8 hook)

# at HEAD:
 Test Files  2 passed (2)
      Tests  11 passed (11)
```

**AC1 + AC5 + AC8 — observed in the real app — `proven`.** Booted this branch on the golden VM, logged in, and drove the real UI with Playwright. Clicking the sidebar **Run** keeps the view on **All Runs** and shows a green *Run plan scheduled (1 jobs)* toast with a **View run** button. In the same frame, the main-pane run history shows the newly scheduled batch appearing in place — the `Starting…` spinner row and the `PR3983 Quick Run Plan · now` row — with no page navigation. That in-place appearance is **AC5**:

![Quick Run stays on All Runs; success toast carries a View run button; the new pending batch appears in the run history below without navigating](https://raw.githubusercontent.com/langwatch/langwatch/proof/3983-quickrun/proofs/3983-quickrun-stayinplace.png)

**AC8 — "View run" navigates on demand — `proven`.** Clicking the toast's button routes to `…/simulations/run-plans/pr3983-quick-run-plan`, where the run is visibly `Running`:

![Clicking View run navigates to the run-plan detail page, showing the run in a Running state](https://raw.githubusercontent.com/langwatch/langwatch/proof/3983-quickrun/proofs/3983-viewrun-navigates.png)

**AC6 — Save-and-Run still navigates — `proven`.** Pinned by a positive assertion (`router.push` IS called toward `run-plans/newly-saved-slug`), which fails if the no-nav fix is ever widened to that flow.

**AC4 — sidebar row reflects the new pending run — `claimed`.** What is proven is the *trigger*: a test asserts `suites.getSummaries.invalidate()` still fires on `onRunScheduled`, so removing the navigation did not remove the refresh. The rendered outcome AC4 describes (status icon + last-run timestamp on the sidebar row) is **not** asserted by any test — the sidebar is not rendered from live summaries in that harness — and it is not legible in the screenshots above. The rendering path is pre-existing infrastructure this PR does not touch. Automated coverage for AC4, and for AC5's pending-row render, is tracked in **#5602**; both scenarios stay `@unimplemented` in the feature file with that issue referenced inline, per `dev/docs/TESTING_PHILOSOPHY.md`.

Note on the screenshots: they were captured at `06cc28fd9`, before this branch was rebased onto current `main` (now at HEAD `b805c8e1a`). Every rebase since — including this one — preserved the PR's content diff byte-for-byte (only the base moved; the pre/post diffs were compared and are identical), and no commit since touches production behaviour beyond the no-nav fix and the `View run` toast affordance the screenshots already show. The runtime they depict is unchanged.

## Anything surprising?

- **`onViewRun` carries the suite id but not the `batchRunId`.** The routing model already supports `["run-plans", slug, batchId]` → scroll-to-and-highlight that batch, and the batch id is in hand at the call site. So a button labelled "View run" lands you on the plan's page rather than on *the run you just launched*. Deliberate: the founder's ask was a path to the run, and threading the id would require widening `navigateToSuite`'s signature. Flagged rather than fixed — say the word and it is a small follow-up.
- **The warning-variant toast (archived items skipped) has no "View run" action** — its single action slot is taken by "Edit Run Plan". Scoped out by AC8, which covers the no-archived-items case only.
- **`duplicateMutation.onSuccess` still auto-navigates** (`SimulationsPage.tsx:212`). Same shape as the original bug, but the user explicitly created a new resource and arguably wants to land on it. Out of scope for #3363; flag if product wants symmetry.
- **"Quick Run" does not appear in the code.** The issue's "Quick Run" is the sidebar list-item's inline `<Play /> Run` button.

# Related Issue

- Resolve #3363
- Follow-up: #5602 (automated AC4/AC5 coverage)

