### PR TITLE
fix: guard Stripe meter event value limit

### DIFF
--- a/langwatch/ee/billing/__tests__/usageReportingService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/usageReportingService.unit.test.ts
@@ -95,6 +95,26 @@ describe("usageReportingService", () => {
       });
     });
 
+    describe("when value exceeds Stripe's 15 digit limit", () => {
+      it("returns reported: false without calling Stripe", async () => {
+        const results = await service.reportUsageDelta({
+          stripeCustomerId: "cus_abc123",
+          organizationId: "org_1",
+          events: [makeEvent({ value: 1_000_000_000_000_000 })],
+        });
+
+        expect(results).toEqual([
+          {
+            identifier: "org_1:langwatch_billable_events:2026-02-19:d100",
+            reported: false,
+            valueSent: 0,
+            error: "Stripe meter event values must not exceed 15 digits",
+          },
+        ]);
+        expect(stripe.billing.meterEvents.create).not.toHaveBeenCalled();
+      });
+    });
+
     describe("when batch has multiple events", () => {
       it("processes sequentially and returns ordered results", async () => {
         const callOrder: number[] = [];
@@ -457,6 +477,31 @@ describe("usageReportingService", () => {
             payload: expect.objectContaining({ value: "200" }),
           })
         );
+      });
+    });
+
+    describe("when computed delta exceeds Stripe's 15 digit limit", () => {
+      it("returns reported: false without calling Stripe", async () => {
+        const results = await service.reportUsageSet({
+          stripeCustomerId: "cus_abc123",
+          organizationId: "org_1",
+          events: [
+            {
+              ...makeEvent({ value: 1_000_000_000_000_000 }),
+              previouslyReportedValue: 0,
+            },
+          ],
+        });
+
+        expect(results).toEqual([
+          {
+            identifier: "org_1:langwatch_billable_events:2026-02-19:d100",
+            reported: false,
+            valueSent: 0,
+            error: "Stripe meter event values must not exceed 15 digits",
+          },
+        ]);
+        expect(stripe.billing.meterEvents.create).not.toHaveBeenCalled();
       });
     });
 

--- a/langwatch/ee/billing/services/usageReportingService.ts
+++ b/langwatch/ee/billing/services/usageReportingService.ts
@@ -4,6 +4,8 @@ import { createLogger } from "../../../src/utils/logger";
 
 const logger = createLogger("langwatch:billing:usageReportingService");
 
+const STRIPE_METER_EVENT_VALUE_MAX = 999_999_999_999_999;
+
 const meterEventSchema = z.object({
   eventName: z.string().min(1),
   value: z.number().int().nonnegative(),
@@ -89,6 +91,28 @@ export class StripeUsageReportingService implements UsageReportingService {
     timestamp: number;
     identifier: string;
   }): Promise<MeterEventResult> {
+    if (value > STRIPE_METER_EVENT_VALUE_MAX) {
+      const error = "Stripe meter event values must not exceed 15 digits";
+
+      logger.warn(
+        {
+          organizationId,
+          identifier,
+          valueSent: value,
+          reported: false,
+          error,
+        },
+        "[billing] Meter event value rejected before Stripe call"
+      );
+
+      return {
+        identifier,
+        reported: false,
+        valueSent: 0,
+        error,
+      };
+    }
+
     try {
       await this.stripe.billing.meterEvents.create({
         event_name: eventName,


### PR DESCRIPTION
## Summary
- Reject Stripe meter event payload values above the 15-digit limit before making the API call.
- Reuse the existing permanent rejection result shape so billing checkpoints are not advanced on invalid usage values.
- Add coverage for both direct delta reporting and set-to-delta reporting.

## Tests
- `NODE_ENV=test PINO_LOG_LEVEL=warn corepack pnpm --dir langwatch exec vitest run ee/billing/__tests__/usageReportingService.unit.test.ts`
