### PR TITLE
fix(test): correct Docker image for Redis testcontainer (boy-scout)

### DIFF
--- a/langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts
@@ -148,7 +148,7 @@ export async function setup(): Promise<void> {
     .start();
 
   // Start Redis container (reusable to speed up subsequent test runs)
-  redisContainer = await new RedisContainer("redis/redis:alpine")
+  redisContainer = await new RedisContainer("redis:alpine")
     .withLabels(CONTAINER_LABELS)
     .withReuse()
     .start();


### PR DESCRIPTION
## Summary

One-character fix: `new RedisContainer("redis/redis:alpine")` → `new RedisContainer("redis:alpine")`.

The official Redis image on Docker Hub is `redis` (no `redis/` namespace). `redis/redis` is not a real Docker Hub repository, so any local `pnpm test:integration` run fails at `globalSetup.ts:151` before any test file loads:

```
Error: (HTTP code 404) unexpected - pull access denied for redis/redis,
repository does not exist or may require 'docker login'
```

## Why this didn't catch fire in CI

CI sets `CI_REDIS_URL` and the early-return at `globalSetup.ts:128` skips the testcontainer branch entirely — CI uses an externally-provisioned Redis. Only local dev hits this code path.

## How I found it

Running the new Langy component integration tests from #3954 / Phase 1 locally hit the 404. Tracked back to the typo introduced in `5e9df24bae`.

## Test plan

- [x] On a clean local checkout, `pnpm test:integration <any-integration-test>` no longer errors at globalSetup; the testcontainer starts. **Verified locally on this branch:**
  ```
  [globalSetup] Starting testcontainers...
  [globalSetup] Redis URL: redis://localhost:32770
  [globalSetup] Testcontainers started successfully
  Test Files  1 passed (1)
  Tests  10 passed | 1 skipped (11)
  ```
  Confirmed via `docker ps` that the container uses the correct `redis:alpine` image.
- [x] CI integration job still passes (uses `CI_REDIS_URL`, never hits this line) — all `test-integration (1..4)` jobs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)