### PR TITLE
fix(python-sdk): retry evaluator calls on gateway/edge transient failures

### DIFF
--- a/python-sdk/src/langwatch/evaluation/__init__.py
+++ b/python-sdk/src/langwatch/evaluation/__init__.py
@@ -29,6 +29,13 @@ from typing import Any, Dict, List, Literal, Optional, Union, cast, TYPE_CHECKIN
 from uuid import UUID
 
 import httpx
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+    wait_random,
+)
 import langwatch
 from langwatch.domain import SpanTimestamps
 from pksuid import PKSUID
@@ -74,6 +81,28 @@ from langwatch.experiment.platform_run import (
 
 if TYPE_CHECKING:
     from langwatch.telemetry.tracing import LangWatchTrace
+
+
+# Gateway/edge codes that mean "the request didn't reach a healthy origin or the
+# origin took too long" — distinct from a 500 the evaluator itself returned,
+# which usually reflects a deterministic problem retrying won't fix.
+_RETRYABLE_STATUS_CODES = frozenset({502, 503, 504, 524})
+
+
+def _is_transient_evaluator_error(exc: BaseException) -> bool:
+    if isinstance(exc, (httpx.TimeoutException, httpx.ConnectError)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in _RETRYABLE_STATUS_CODES
+    return False
+
+
+_retry_evaluator_call = retry(
+    retry=retry_if_exception(_is_transient_evaluator_error),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 1),
+    reraise=True,
+)
 
 
 # ============================================================================
@@ -159,10 +188,15 @@ def evaluate(
             span=span,
             as_guardrail=as_guardrail,
         )
-        try:
+        @_retry_evaluator_call
+        def _post() -> httpx.Response:
             with httpx.Client(timeout=900) as client:
                 response = client.post(**request_params)
                 better_raise_for_status(response, cls=EvaluatorException)
+                return response
+
+        try:
+            response = _post()
         except Exception as e:
             return _handle_exception(e, span, as_guardrail)
 
@@ -219,10 +253,15 @@ async def async_evaluate(
             span=span,
             as_guardrail=as_guardrail,
         )
-        try:
+        @_retry_evaluator_call
+        async def _post() -> httpx.Response:
             async with httpx.AsyncClient(timeout=900) as client:
                 response = await client.post(**request_params)
                 better_raise_for_status(response)
+                return response
+
+        try:
+            response = await _post()
         except Exception as e:
             return _handle_exception(e, span, as_guardrail)
 

--- a/python-sdk/src/langwatch/evaluation/__init__.py
+++ b/python-sdk/src/langwatch/evaluation/__init__.py
@@ -44,7 +44,7 @@ from langwatch.telemetry.context import get_current_span
 from langwatch.state import get_api_key, get_endpoint, get_instance
 from langwatch.attributes import AttributeKey
 from langwatch.utils.auth import build_auth_headers
-from langwatch.utils.exceptions import EvaluatorException, better_raise_for_status
+from langwatch.utils.exceptions import better_raise_for_status
 from pydantic import BaseModel
 
 from langwatch.types import (
@@ -192,7 +192,7 @@ def evaluate(
         def _post() -> httpx.Response:
             with httpx.Client(timeout=900) as client:
                 response = client.post(**request_params)
-                better_raise_for_status(response, cls=EvaluatorException)
+                better_raise_for_status(response)
                 return response
 
         try:


### PR DESCRIPTION
## Summary

- `langwatch.evaluation.evaluate()` / `async_evaluate()` currently surface a single 524 from Cloudflare as `status:"error"`, even though a re-issue almost always succeeds. Cause: the evaluator endpoint's underlying LLM (e.g. Ragas faithfulness, which does 2–3 sequential LLM calls per row) occasionally exceeds Cloudflare's ~100s idle timeout.
- Wrap the `httpx` POST in both functions with a `tenacity` retry that fires only on definitionally-transient errors:
  - `httpx.TimeoutException` / `httpx.ConnectError`
  - HTTP **502 / 503 / 504 / 524**
- **500 is intentionally excluded** — it generally reflects a deterministic evaluator-side error that retrying won't fix and would 3× the LLM cost on every failed row.
- Same retry config as the SDK's other retry sites (`telemetry/tracing.py`, `experiment.py`, `batch_evaluation.py`): `stop_after_attempt(3)`, `wait_exponential(2..10s)`. Adds a small `wait_random(0, 1)` jitter so parallel rows don't synchronise their retries on a shared outage.
- Behaviour on success and on exhausted retries is unchanged — the existing `_handle_exception` path still funnels persistent failures into the soft-error result, so callers see the same API.

## Test plan

- [ ] Unit: mock `httpx.Client.post` to return a 524 twice then a 200 — assert one final success and three POST attempts.
- [ ] Unit: mock `httpx.Client.post` to return a 500 — assert a single attempt (no retry) and soft `status:"error"` result.
- [ ] Unit: mock `httpx.Client.post` to raise `httpx.ConnectError` once then return 200 — assert retry fires and final success.
- [ ] Unit: same three cases against `async_evaluate()`.
- [ ] Manual: run a batch that previously had ~1–2% 524 rate on `ragas/faithfulness`; verify the failure rate drops while the API contract on callers is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)