### PR TITLE
fix(auth): enable accountLinking so orphan email-verified Users can sign in via SSO

### DIFF
--- a/langwatch/src/server/better-auth/__tests__/index.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/index.test.ts
@@ -17,6 +17,20 @@ describe("better-auth config", () => {
       expect(typeof (auth.api as any).signInEmail).toBe("function");
     });
 
+    it("enables account linking so orphan email-verified Users can sign in via OAuth", async () => {
+      // Regression: a User row with emailVerified=true but zero Account rows
+      // (pre-seeded invite, half-finished signup, or migration leftover)
+      // permanently blocks subsequent OAuth sign-ins for that email — error
+      // surfaces as "registered with another authentication method". On
+      // SSO-enforced orgs this locked users out even after successful IdP
+      // auth. Enabling accountLinking lets BetterAuth attach the new Account
+      // to the existing email-verified User. SSO-domain enforcement still
+      // runs in beforeAccountCreate, so wrong providers are rejected.
+      const { auth } = await import("../index");
+      const options = (auth as any).options;
+      expect(options?.account?.accountLinking?.enabled).toBe(true);
+    });
+
     it("forces sessions to be stored in the database (not Redis-only)", async () => {
       // Regression for iter-19 bug 15: with `secondaryStorage` set,
       // BetterAuth's `createSession` skips the main Prisma adapter unless

--- a/langwatch/src/server/better-auth/index.ts
+++ b/langwatch/src/server/better-auth/index.ts
@@ -330,6 +330,27 @@ export const auth = betterAuth({
       idToken: "id_token",
       scope: "scope",
     },
+    /**
+     * Allow an OAuth sign-in to link to an existing User row when the email
+     * matches AND that User's `emailVerified` is true. Without this, an
+     * orphan User (no `Account` rows — e.g. pre-seeded invite, half-finished
+     * legacy signup, or migration leftover) blocks every subsequent OAuth
+     * sign-in for that email with `account_already_linked_to_different_user`
+     * → surfaced to the UI as "registered with another authentication method".
+     *
+     * On SSO-enforced orgs this was especially broken: even though the user
+     * authenticated successfully through the org's IdP, BetterAuth refused to
+     * attach the new Account, leaving them permanently locked out.
+     *
+     * Security posture: linking requires the existing User to be
+     * `emailVerified=true` and the OAuth provider to return the same email
+     * (`allowDifferentEmails` defaults to false). SSO-domain enforcement
+     * still runs in `beforeAccountCreate` and rejects the wrong provider
+     * before any link happens.
+     */
+    accountLinking: {
+      enabled: true,
+    },
   },
   verification: {
     modelName: "VerificationToken",

--- a/specs/auth/sso-orphan-user-linking.feature
+++ b/specs/auth/sso-orphan-user-linking.feature
@@ -1,0 +1,25 @@
+Feature: SSO sign-in links to orphan email-verified User rows
+
+  Background:
+    Given an organization with SSO enforced for domain "example.com"
+    And the organization's SSO provider matches the OAuth provider configured for the deployment
+
+  Scenario: Orphan User row from a prior invite is auto-linked on first SSO sign-in
+    Given a User row exists for "alice@example.com" with emailVerified=true and zero linked Account rows
+    When Alice completes the SSO sign-in callback with the configured OAuth provider
+    Then a new Account row is created for that User
+    And Alice is signed in
+    And no "registered with another authentication method" error is shown
+
+  Scenario: Unverified orphan User cannot be hijacked via OAuth
+    Given a User row exists for "bob@example.com" with emailVerified=false and zero linked Account rows
+    When an OAuth sign-in callback returns email "bob@example.com"
+    Then linking is refused
+    And the OAuth callback redirects to the auth error page
+
+  Scenario: SSO-domain guard still blocks the wrong provider
+    Given a User row exists for "carol@example.com" with emailVerified=true and zero linked Account rows
+    And the organization's SSO provider is "waad|tenant" but the OAuth callback comes from a different provider
+    When the OAuth callback completes
+    Then sign-in is rejected with SSO_PROVIDER_NOT_ALLOWED
+    And no Account row is created


### PR DESCRIPTION
## Summary

- A `User` row with `emailVerified=true` but zero `Account` rows (pre-seeded invite, half-finished legacy signup, or migration leftover) silently blocked every subsequent OAuth sign-in for that email — surfaced in the UI as *"registered with another authentication method"*. On SSO-enforced orgs the user was permanently locked out after a successful IdP round-trip.
- Root cause: BetterAuth's default refuses to attach a new OAuth `Account` to an existing `User` unless `account.accountLinking` is enabled. The setting was missing.
- Fix: enable `account.accountLinking.enabled` in the BetterAuth config. Linking still requires `emailVerified=true` on the existing User and matching emails (`allowDifferentEmails` defaults to `false`). SSO-domain enforcement in `beforeAccountCreate` (`langwatch/src/server/better-auth/hooks.ts`) still rejects the wrong provider before any link.

## Repro

Surfaced by a customer report. Verified against prod:

- Orphan User row existed with `emailVerified=true`, `lastLoginAt=null`, zero `Account` rows.
- Org had SSO enforced (`ssoDomain` + `ssoProvider` set).
- Every OAuth callback returned `account_already_linked_to_different_user` → normalized to `OAuthAccountNotLinked` in `signin.tsx:31`.

Orphan row was cleaned up manually so the affected user can sign in again; this PR closes the gap for everyone else.

## Test plan

- [x] New BDD spec: `specs/auth/sso-orphan-user-linking.feature` covers happy path, unverified-email refusal, SSO wrong-provider rejection.
- [x] Regression test added in `langwatch/src/server/better-auth/__tests__/index.test.ts` locks `account.accountLinking.enabled=true` in.
- [x] `pnpm test:unit src/server/better-auth/__tests__/` — 93/93 passing.
- [ ] CI green.