### PR TITLE
fix(docs): replace crashing "@langwatch/mcp-server" JSON snippets with prose (#3109)

### DIFF
--- a/docs/integration/mcp.mdx
+++ b/docs/integration/mcp.mdx
@@ -33,60 +33,37 @@ Run this command to add the MCP server:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey your-api-key-here
 ```
 
-Or add it manually to your `~/.claude.json`:
+Or add it manually to your `~/.claude.json`. Under the `mcpServers` object, add an entry named `langwatch` with these fields:
 
-```json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
+- `command`: `npx`
+- `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+- `env.LANGWATCH_API_KEY`: your LangWatch API key
 
 See the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp#plugin-provided-mcp-servers) for more details.
+
+<Info>
+This page intentionally describes the config in prose rather than as a JSON snippet. Some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` on multi-line JSON containing `"@langwatch/mcp-server"`. See [#3104](https://github.com/langwatch/langwatch/issues/3104) for details. The bash `claude mcp add` form above is safe — `@langwatch/mcp-server` is followed by a whitespace terminator.
+</Info>
 </Tab>
 
 <Tab title="Copilot">
-Add to `.vscode/mcp.json` in your project (or use **MCP: Add Server** from the Command Palette):
+Add to `.vscode/mcp.json` in your project (or use **MCP: Add Server** from the Command Palette).
 
-```json
-{
-  "servers": {
-    "langwatch": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": { "LANGWATCH_API_KEY": "your-api-key-here" }
-    }
-  }
-}
-```
+Under the `servers` object, add an entry named `langwatch` with these fields:
+
+- `type`: `stdio`
+- `command`: `npx`
+- `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+- `env.LANGWATCH_API_KEY`: your LangWatch API key
 </Tab>
 
 <Tab title="Cursor">
 1. Open Cursor Settings
 2. Navigate to the **Tools and MCP** section in the sidebar
-3. Add the LangWatch MCP server:
-
-```json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
+3. Add the LangWatch MCP server. Under the `mcpServers` object, add an entry named `langwatch` with these fields:
+   - `command`: `npx`
+   - `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+   - `env.LANGWATCH_API_KEY`: your LangWatch API key
 </Tab>
 
 <Tab title="ChatGPT">
@@ -119,21 +96,11 @@ The server supports OAuth Authorization Code + PKCE with Dynamic Client Registra
 </Tab>
 
 <Tab title="Other">
-For other MCP-compatible editors, add the following configuration to your MCP settings file:
+For other MCP-compatible editors, add an entry named `langwatch` under the `mcpServers` object of your editor's MCP settings file with these fields:
 
-```json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
+- `command`: `npx`
+- `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+- `env.LANGWATCH_API_KEY`: your LangWatch API key
 
 Refer to your editor's MCP documentation for the specific configuration file location.
 </Tab>

--- a/docs/integration/mcp.mdx
+++ b/docs/integration/mcp.mdx
@@ -42,7 +42,7 @@ Or add it manually to your `~/.claude.json`. Under the `mcpServers` object, add 
 See the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp#plugin-provided-mcp-servers) for more details.
 
 <Info>
-This page intentionally describes the config in prose rather than as a JSON snippet. Some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` on multi-line JSON containing `"@langwatch/mcp-server"`. See [#3104](https://github.com/langwatch/langwatch/issues/3104) for details. The bash `claude mcp add` form above is safe — `@langwatch/mcp-server` is followed by a whitespace terminator.
+This page intentionally describes the config in prose rather than as a JSON snippet. Some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` when a multi-line JSON snippet wraps the scoped package name in double quotes. See [#3104](https://github.com/langwatch/langwatch/issues/3104) for details. The bash `claude mcp add` form above is safe — the package name is followed by a whitespace terminator.
 </Info>
 </Tab>
 

--- a/docs/integration/quick-start.mdx
+++ b/docs/integration/quick-start.mdx
@@ -31,18 +31,12 @@ Let's get cracking.
   <Step title="Let LangWatch MCP do the rest for you (Optional)">
     Install the [LangWatch MCP Server](/integration/mcp) and ask your coding assistant (Cursor, Claude Code, Codex, etc.) to instrument your codebase with LangWatch, OR keep following the steps below to instrument your codebase manually.
 
-    Add the LangWatch MCP to your editor:
+    Add the LangWatch MCP to your editor. Under the `mcpServers` object of your editor's MCP settings file, add an entry named `langwatch` with these fields:
 
-    ```json
-    {
-      "mcpServers": {
-        "langwatch": {
-          "command": "npx",
-          "args": ["-y", "@langwatch/mcp-server"]
-        }
-      }
-    }
-    ```
+    - `command`: `npx`
+    - `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+
+    See [LangWatch MCP](/integration/mcp) for per-editor instructions and the API key field.
 
     Then ask your coding assistant to instrument your codebase with LangWatch:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -447,18 +447,12 @@ Let's get cracking.
   <Step title="Let LangWatch MCP do the rest for you (Optional)">
     Install the [LangWatch MCP Server](/integration/mcp) and ask your coding assistant (Cursor, Claude Code, Codex, etc.) to instrument your codebase with LangWatch, OR keep following the steps below to instrument your codebase manually.
 
-    Add the LangWatch MCP to your editor:
+    Add the LangWatch MCP to your editor. Under the `mcpServers` object of your editor's MCP settings file, add an entry named `langwatch` with these fields:
 
-    ```json
-    {
-      "mcpServers": {
-        "langwatch": {
-          "command": "npx",
-          "args": ["-y", "@langwatch/mcp-server"]
-        }
-      }
-    }
-    ```
+    - `command`: `npx`
+    - `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+
+    See [LangWatch MCP](/integration/mcp) for per-editor instructions and the API key field.
 
     Then ask your coding assistant to instrument your codebase with LangWatch:
 
@@ -11014,62 +11008,39 @@ Run this command to add the MCP server:
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey your-api-key-here
 ```
 
-Or add it manually to your `~/.claude.json`:
+Or add it manually to your `~/.claude.json`. Under the `mcpServers` object, add an entry named `langwatch` with these fields:
 
-```json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
+- `command`: `npx`
+- `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+- `env.LANGWATCH_API_KEY`: your LangWatch API key
 
 See the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp#plugin-provided-mcp-servers) for more details.
+
+<Info>
+This page intentionally describes the config in prose rather than as a JSON snippet. Some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` on multi-line JSON containing `"@langwatch/mcp-server"`. See [#3104](https://github.com/langwatch/langwatch/issues/3104) for details. The bash `claude mcp add` form above is safe — `@langwatch/mcp-server` is followed by a whitespace terminator.
+</Info>
 
 
 ### Copilot
 
-Add to `.vscode/mcp.json` in your project (or use **MCP: Add Server** from the Command Palette):
+Add to `.vscode/mcp.json` in your project (or use **MCP: Add Server** from the Command Palette).
 
-```json
-{
-  "servers": {
-    "langwatch": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": { "LANGWATCH_API_KEY": "your-api-key-here" }
-    }
-  }
-}
-```
+Under the `servers` object, add an entry named `langwatch` with these fields:
+
+- `type`: `stdio`
+- `command`: `npx`
+- `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+- `env.LANGWATCH_API_KEY`: your LangWatch API key
 
 
 ### Cursor
 
 1. Open Cursor Settings
 2. Navigate to the **Tools and MCP** section in the sidebar
-3. Add the LangWatch MCP server:
-
-```json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
+3. Add the LangWatch MCP server. Under the `mcpServers` object, add an entry named `langwatch` with these fields:
+   - `command`: `npx`
+   - `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+   - `env.LANGWATCH_API_KEY`: your LangWatch API key
 
 
 ### ChatGPT
@@ -11106,21 +11077,11 @@ The server supports OAuth Authorization Code + PKCE with Dynamic Client Registra
 
 ### Other
 
-For other MCP-compatible editors, add the following configuration to your MCP settings file:
+For other MCP-compatible editors, add an entry named `langwatch` under the `mcpServers` object of your editor's MCP settings file with these fields:
 
-```json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
+- `command`: `npx`
+- `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+- `env.LANGWATCH_API_KEY`: your LangWatch API key
 
 Refer to your editor's MCP documentation for the specific configuration file location.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -11017,7 +11017,7 @@ Or add it manually to your `~/.claude.json`. Under the `mcpServers` object, add 
 See the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp#plugin-provided-mcp-servers) for more details.
 
 <Info>
-This page intentionally describes the config in prose rather than as a JSON snippet. Some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` on multi-line JSON containing `"@langwatch/mcp-server"`. See [#3104](https://github.com/langwatch/langwatch/issues/3104) for details. The bash `claude mcp add` form above is safe — `@langwatch/mcp-server` is followed by a whitespace terminator.
+This page intentionally describes the config in prose rather than as a JSON snippet. Some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` when a multi-line JSON snippet wraps the scoped package name in double quotes. See [#3104](https://github.com/langwatch/langwatch/issues/3104) for details. The bash `claude mcp add` form above is safe — the package name is followed by a whitespace terminator.
 </Info>
 
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -4,29 +4,21 @@ MCP server that gives AI coding agents access to LangWatch observability data, p
 
 ## Quick Setup
 
-Add to your MCP client configuration (Claude Code, Cursor, etc.):
-
-```json
-{
-  "mcpServers": {
-    "langwatch": {
-      "command": "npx",
-      "args": ["-y", "@langwatch/mcp-server"],
-      "env": {
-        "LANGWATCH_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
-
-For Claude Code, you can also run:
+For Claude Code, run:
 
 ```bash
 claude mcp add langwatch -- npx -y @langwatch/mcp-server --apiKey your-api-key-here
 ```
 
+For Claude Code (manual) or other MCP clients (Cursor, Copilot, etc.), add an entry named `langwatch` under the `mcpServers` object of your client's MCP settings file with these fields:
+
+- `command`: `npx`
+- `args`: `-y`, then the package name `@langwatch/mcp-server` on a separate token
+- `env.LANGWATCH_API_KEY`: your LangWatch API key
+
 The API key is required for observability and prompt tools. Documentation tools work without it.
+
+> The config is described in prose rather than as a JSON snippet because some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` on multi-line JSON containing `"@langwatch/mcp-server"`. See [#3104](https://github.com/langwatch/langwatch/issues/3104). The bash form above is safe — the package name is followed by a whitespace terminator.
 
 ## Configuration
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -18,7 +18,7 @@ For Claude Code (manual) or other MCP clients (Cursor, Copilot, etc.), add an en
 
 The API key is required for observability and prompt tools. Documentation tools work without it.
 
-> The config is described in prose rather than as a JSON snippet because some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` on multi-line JSON containing `"@langwatch/mcp-server"`. See [#3104](https://github.com/langwatch/langwatch/issues/3104). The bash form above is safe — the package name is followed by a whitespace terminator.
+> The config is described in prose rather than as a JSON snippet because some CLI agents (notably Gemini CLI 0.36.0 and earlier) parse `@`-prefixed runs as file paths and can crash with `ENAMETOOLONG` when a multi-line JSON snippet wraps the scoped package name in double quotes. See [#3104](https://github.com/langwatch/langwatch/issues/3104). The bash form above is safe — the package name is followed by a whitespace terminator.
 
 ## Configuration
 


### PR DESCRIPTION
Closes #3109.

## Summary
- Follow-up to #3107. That PR neutralized the Gemini-CLI `ENAMETOOLONG` crash in `code-prompts.ts` and `skills/_shared/mcp-setup.md` by rewriting the JSON config block as a prose field list. The same crashing pattern still lived in the public docs surfaces enumerated in #3109.
- Reuse the exact prose-field-list shape from #3107 in: `docs/integration/mcp.mdx` (4 tabs), `docs/integration/quick-start.mdx`, and `mcp-server/README.md`.
- Regenerate `docs/llms-full.txt` via `docs/llms.txt.cjs` so the docs-CI diff check stays green.
- Add a brief `<Info>` callout on the primary `mcp.mdx` page (and a footnote on `mcp-server/README.md`) explaining **why** the config is shown in prose, linking to #3104. This keeps the rationale visible to future editors so the JSON doesn't quietly come back.

Net -86 lines across the 4 files — prose is more compact than the per-tab JSON blocks were.

## Root cause recap (from #3107's commit message)
Gemini CLI's chat-input `atCommandProcessor.AT_COMMAND_PATH_REGEX_SOURCE` extracts `@`-prefixed runs as candidate file paths and calls `fs.lstatSync()` on each. The regex includes a `"[^"]*"` alternative that matches across newlines, so the closing `"` of a JSON literal like `"@langwatch/mcp-server"` opens a quoted span that consumes the rest of the JSON block (>2KB), and `lstat()` throws `ENAMETOOLONG`. Reframing the snippet as prose makes `@langwatch/mcp-server` always followed by a whitespace terminator, capping every extracted run well under `NAME_MAX`.

## Out of scope
- `langwatch/src/features/onboarding/components/sections/shared/build-mcp-config.ts` still emits a JSON object for the in-app "Copy Config" button. PR #3107 already locked that path with regression tests over realistic API-key (54 bytes) and endpoint lengths — the longest extracted path component stays well under `NAME_MAX`.
- An upstream fix in Gemini CLI: still no merged fix as of 0.36.0 (https://github.com/google-gemini/gemini-cli/issues/22926). Once it ships, we can consider restoring the visual JSON form.

## Test plan
- [x] `grep -n '"@langwatch/mcp-server"' docs/ mcp-server/README.md` returns zero hits in any source file.
- [x] `grep -n '@langwatch/mcp-server' docs/llms-full.txt` returns only safe forms (bash with whitespace terminator, npmjs URL, backticked prose) — no JSON literal.
- [x] Existing regression suite in `langwatch/src/features/onboarding/components/sections/code-prompts.unit.test.ts` still passes locally — the assertions on PROMPT_* strings and `buildMcpJson` are unaffected by docs edits.
- [x] `node docs/llms.txt.cjs` re-runs cleanly and the generated `docs/llms-full.txt` matches the committed copy (docs-CI guardrail).
- [ ] CI green — running on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related Issue

- Resolve #3109