### PR TITLE
fix(ui): set explicit white background on all Dialog/Drawer.Content

### DIFF
--- a/langwatch/src/components/AddAnnotationQueueDrawer.tsx
+++ b/langwatch/src/components/AddAnnotationQueueDrawer.tsx
@@ -232,7 +232,7 @@ export const AddAnnotationQueueDrawer = ({
           }
         }}
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.Header>
             <HStack>
               <Drawer.CloseTrigger onClick={() => closeAll()} />
@@ -457,7 +457,7 @@ export const AddAnnotationQueueDrawer = ({
         size="lg"
         onOpenChange={({ open }) => scoreTypeDrawerOpen.setOpen(open)}
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.Header>
             <HStack>
               <Drawer.CloseTrigger />

--- a/langwatch/src/components/AddAutomationDrawer.tsx
+++ b/langwatch/src/components/AddAutomationDrawer.tsx
@@ -321,7 +321,7 @@ export function AutomationDrawer() {
       onOpenChange={({ open }) => !open && closeDrawer()}
       placement="end"
     >
-      <Drawer.Content maxWidth="1200px">
+      <Drawer.Content bg="bg" maxWidth="1200px">
         <Drawer.Header>
           <Drawer.CloseTrigger />
           <Heading>Add Automation</Heading>

--- a/langwatch/src/components/AddDatasetRecordDrawer.tsx
+++ b/langwatch/src/components/AddDatasetRecordDrawer.tsx
@@ -256,7 +256,7 @@ export function AddDatasetRecordDrawerV2(props: AddDatasetDrawerProps) {
       }}
       preventScroll={true}
     >
-      <Drawer.Content
+      <Drawer.Content bg="bg"
         maxWidth="1400px"
         overflow="auto"
         ref={scrollRef}

--- a/langwatch/src/components/AddOrEditAnnotationScoreDrawer.tsx
+++ b/langwatch/src/components/AddOrEditAnnotationScoreDrawer.tsx
@@ -32,7 +32,7 @@ export const AddOrEditAnnotationScoreDrawer = ({
       }}
       onInteractOutside={handleClose}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <HStack>
             <Drawer.CloseTrigger />

--- a/langwatch/src/components/AddOrEditDatasetDrawer.tsx
+++ b/langwatch/src/components/AddOrEditDatasetDrawer.tsx
@@ -268,7 +268,7 @@ export function AddOrEditDatasetDrawer(props: AddDatasetDrawerProps) {
       onOpenChange={({ open }) => !open && onClose()}
       size="xl"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack>

--- a/langwatch/src/components/BatchEvaluationDrawer.tsx
+++ b/langwatch/src/components/BatchEvaluationDrawer.tsx
@@ -141,7 +141,7 @@ export function BatchEvaluationDrawer(props: BatchEvaluatioProps) {
         }
       }}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack>

--- a/langwatch/src/components/CascadeArchiveDialog.tsx
+++ b/langwatch/src/components/CascadeArchiveDialog.tsx
@@ -110,7 +110,7 @@ export function CascadeArchiveDialog({
       placement="center"
       initialFocusEl={() => inputRef.current}
     >
-      <Dialog.Content maxWidth="500px" onClick={(e) => e.stopPropagation()}>
+      <Dialog.Content bg="bg" maxWidth="500px" onClick={(e) => e.stopPropagation()}>
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title fontSize="md" fontWeight="500">

--- a/langwatch/src/components/EditAutomationFilterDrawer.tsx
+++ b/langwatch/src/components/EditAutomationFilterDrawer.tsx
@@ -294,7 +294,7 @@ export function EditAutomationFilterDrawer({ automationId }: { automationId?: st
       size="lg"
       onOpenChange={({ open }) => !open && closeDrawer()}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.CloseTrigger />
           <Heading>Edit Automation Filter</Heading>

--- a/langwatch/src/components/EditModelProviderDrawer.tsx
+++ b/langwatch/src/components/EditModelProviderDrawer.tsx
@@ -49,7 +49,7 @@ export const EditModelProviderDrawer = (
       }}
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <HStack>
             <Drawer.CloseTrigger />

--- a/langwatch/src/components/FeedbackLink.tsx
+++ b/langwatch/src/components/FeedbackLink.tsx
@@ -10,7 +10,7 @@ export function FeedbackLink() {
   return (
     <>
       <Dialog.Root open={open} onOpenChange={({ open }) => setOpen(open)}>
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>Feedback on LangWatch</Dialog.Title>
           </Dialog.Header>

--- a/langwatch/src/components/GenerateApiSnippetDialog.tsx
+++ b/langwatch/src/components/GenerateApiSnippetDialog.tsx
@@ -78,7 +78,7 @@ export function GenerateApiSnippetDialog({
         onOpenChange={({ open }) => (open ? onOpen() : onClose())}
         size="xl"
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.CloseTrigger />
           <Dialog.Header width="100%" marginTop={4}>
             <HStack

--- a/langwatch/src/components/HoverableBigText.tsx
+++ b/langwatch/src/components/HoverableBigText.tsx
@@ -24,7 +24,7 @@ export function ExpandedTextDialog({
       onOpenChange={({ open }) => onOpenChange(open)}
       size="5xl"
     >
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.Header
           background="bg.muted"
           padding={3}

--- a/langwatch/src/components/ScoreReasonModal.tsx
+++ b/langwatch/src/components/ScoreReasonModal.tsx
@@ -21,7 +21,7 @@ export function ScoreReasonModal({
 
   return (
     <Dialog.Root open={open} onOpenChange={onClose} placement="center">
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title fontSize="md" fontWeight="500">

--- a/langwatch/src/components/SeriesFilterDrawer.tsx
+++ b/langwatch/src/components/SeriesFilterDrawer.tsx
@@ -38,7 +38,7 @@ export function SeriesFiltersDrawer({
       size="lg"
       onOpenChange={() => closeDrawer()}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Heading>Edit Series Filter</Heading>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/TraceDetailsDrawer.tsx
+++ b/langwatch/src/components/TraceDetailsDrawer.tsx
@@ -32,7 +32,7 @@ export const TraceDetailsDrawer = (props: TraceDetailsDrawerProps) => {
         commentState.resetComment();
       }}
     >
-      <Drawer.Content
+      <Drawer.Content bg="bg"
         paddingX={0}
         maxWidth={traceView === "full" ? undefined : "70%"}
       >

--- a/langwatch/src/components/UpgradeModal.tsx
+++ b/langwatch/src/components/UpgradeModal.tsx
@@ -48,7 +48,7 @@ export function UpgradeModal({ open, onClose, variant }: UpgradeModalProps) {
   }>;
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.CloseTrigger />
         <Content variant={variant} onClose={onClose} open={open} />
       </Dialog.Content>

--- a/langwatch/src/components/agents/AgentCodeEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentCodeEditorDrawer.tsx
@@ -418,7 +418,7 @@ export function AgentCodeEditorDrawer(props: AgentCodeEditorDrawerProps) {
         modal={false}
         preventScroll={false}
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.CloseTrigger />
           <Drawer.Header>
             <HStack gap={2}>

--- a/langwatch/src/components/agents/AgentHistoryDrawer.tsx
+++ b/langwatch/src/components/agents/AgentHistoryDrawer.tsx
@@ -46,7 +46,7 @@ export function AgentHistoryDrawer({
 
   return (
     <Drawer.Root open={true} placement="end" size="md" onOpenChange={closeDrawer}>
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Text fontWeight="semibold" fontSize="lg">
             {`${agentName} history`}

--- a/langwatch/src/components/agents/AgentHttpEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentHttpEditorDrawer.tsx
@@ -477,7 +477,7 @@ export function AgentHttpEditorDrawer(props: AgentHttpEditorDrawerProps) {
         modal={false}
         preventScroll={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/agents/AgentListDrawer.tsx
+++ b/langwatch/src/components/agents/AgentListDrawer.tsx
@@ -183,7 +183,7 @@ export function AgentListDrawer(props: AgentListDrawerProps) {
         size="md"
         modal={false}
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.CloseTrigger />
           <Drawer.Header>
             <HStack gap={2} justify="space-between" width="full">

--- a/langwatch/src/components/agents/AgentTypeSelectorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentTypeSelectorDrawer.tsx
@@ -87,7 +87,7 @@ export function AgentTypeSelectorDrawer(props: AgentTypeSelectorDrawerProps) {
       size="md"
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/agents/AgentWorkflowEditorDrawer.tsx
+++ b/langwatch/src/components/agents/AgentWorkflowEditorDrawer.tsx
@@ -317,7 +317,7 @@ export function AgentWorkflowEditorDrawer(
       modal={false}
       preventScroll={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/agents/WorkflowSelectorDrawer.tsx
+++ b/langwatch/src/components/agents/WorkflowSelectorDrawer.tsx
@@ -191,7 +191,7 @@ export function WorkflowSelectorDrawer(props: WorkflowSelectorDrawerProps) {
         size="md"
         modal={false}
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.CloseTrigger />
           <Drawer.Header>
             <HStack gap={2}>

--- a/langwatch/src/components/analytics/AlertDrawer.tsx
+++ b/langwatch/src/components/analytics/AlertDrawer.tsx
@@ -345,7 +345,7 @@ export function AlertDrawer({ form: providedForm, graphId }: AlertDrawerProps) {
   if (graphQuery.isLoading) {
     return (
       <Drawer.Root open={true} placement="end" size="xl">
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.CloseTrigger />
           <Drawer.Header>
             <Heading>Configure Alert</Heading>
@@ -369,7 +369,7 @@ export function AlertDrawer({ form: providedForm, graphId }: AlertDrawerProps) {
       placement="end"
       size="xl"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <Heading>Configure Alert</Heading>

--- a/langwatch/src/components/analytics/DashboardNameDrawer.tsx
+++ b/langwatch/src/components/analytics/DashboardNameDrawer.tsx
@@ -89,7 +89,7 @@ export function DashboardNameDrawer({
         }
       }}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.CloseTrigger onClick={handleClose} />
           <Heading size="lg">Create Dashboard</Heading>

--- a/langwatch/src/components/annotations/DeleteConfirmationDialog.tsx
+++ b/langwatch/src/components/annotations/DeleteConfirmationDialog.tsx
@@ -38,7 +38,7 @@ export function DeleteConfirmationDialog({
       placement="center"
       initialFocusEl={() => inputRef.current}
     >
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title fontSize="md" fontWeight="500">

--- a/langwatch/src/components/datasets/AddRowsFromCSVModal.tsx
+++ b/langwatch/src/components/datasets/AddRowsFromCSVModal.tsx
@@ -218,7 +218,7 @@ export function AddRowsFromCSVModal({
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={({ open }) => !open && onClose()}>
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.Header>
           <Dialog.Title>Add rows from CSV</Dialog.Title>
           <Dialog.CloseTrigger />

--- a/langwatch/src/components/datasets/CopyDatasetDialog.tsx
+++ b/langwatch/src/components/datasets/CopyDatasetDialog.tsx
@@ -105,7 +105,7 @@ export const CopyDatasetDialog = ({
 
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content onClick={(e) => e.stopPropagation()}>
+      <Dialog.Content bg="bg" onClick={(e) => e.stopPropagation()}>
         <Dialog.Header>
           <Dialog.Title>Replicate Dataset</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/datasets/SelectDatasetDrawer.tsx
+++ b/langwatch/src/components/datasets/SelectDatasetDrawer.tsx
@@ -80,7 +80,7 @@ export function SelectDatasetDrawer(props: SelectDatasetDrawerProps) {
       onOpenChange={({ open }) => !open && onClose()}
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/datasets/UploadCSVModal.tsx
+++ b/langwatch/src/components/datasets/UploadCSVModal.tsx
@@ -76,7 +76,7 @@ export function UploadCSVModal({
         onOpenChange={({ open }) => !open && onClose()}
         closeOnInteractOutside={false}
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>Upload CSV</Dialog.Title>
             <Dialog.CloseTrigger />

--- a/langwatch/src/components/drawers/FeatureFlagsDrawer.tsx
+++ b/langwatch/src/components/drawers/FeatureFlagsDrawer.tsx
@@ -113,7 +113,7 @@ export function FeatureFlagsDrawer() {
       size="md"
       onOpenChange={() => closeDrawer()}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <HStack width="full">
             <Heading size="md">Feature Flags (Dev)</Heading>

--- a/langwatch/src/components/drawers/SdkRadarDrawer.tsx
+++ b/langwatch/src/components/drawers/SdkRadarDrawer.tsx
@@ -51,7 +51,7 @@ export function SdkRadarDrawer() {
       size="lg"
       onOpenChange={() => closeDrawer()}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <HStack width="full">
             <Heading size="md">SDK Radar</Heading>

--- a/langwatch/src/components/evaluations/AskIfUserWantsToContinueDraftDialog.tsx
+++ b/langwatch/src/components/evaluations/AskIfUserWantsToContinueDraftDialog.tsx
@@ -14,7 +14,7 @@ export function AskIfUserWantsToContinueDraftDialog({
 }: AskIfUserWantsToContinueDraftDialogProps) {
   return (
     <Dialog.Root {...dialogProps}>
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.Header>
           <Dialog.Title>Continue with Draft?</Dialog.Title>
           <Dialog.CloseTrigger />

--- a/langwatch/src/components/evaluations/CopyEvaluationDialog.tsx
+++ b/langwatch/src/components/evaluations/CopyEvaluationDialog.tsx
@@ -122,7 +122,7 @@ export const CopyEvaluationDialog = ({
 
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content onClick={(e) => e.stopPropagation()}>
+      <Dialog.Content bg="bg" onClick={(e) => e.stopPropagation()}>
         <Dialog.Header>
           <Dialog.Title>Replicate Evaluation</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/evaluations/GuardrailsDrawer.tsx
+++ b/langwatch/src/components/evaluations/GuardrailsDrawer.tsx
@@ -236,7 +236,7 @@ EOF
       onOpenChange={({ open }) => !open && handleClose()}
       size="lg"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <Heading size="md">New Guardrail</Heading>

--- a/langwatch/src/components/evaluations/OnlineEvaluationDrawer.tsx
+++ b/langwatch/src/components/evaluations/OnlineEvaluationDrawer.tsx
@@ -1052,7 +1052,7 @@ export function OnlineEvaluationDrawer(props: OnlineEvaluationDrawerProps) {
       onOpenChange={({ open }) => !open && handleClose()}
       size="lg"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/evaluations/wizard/EvaluationWizard.tsx
+++ b/langwatch/src/components/evaluations/wizard/EvaluationWizard.tsx
@@ -55,7 +55,7 @@ export function EvaluationWizard({ isLoading }: { isLoading: boolean }) {
     <ReactFlowProvider>
       <WizardProvider isInsideWizard={true}>
         <PostEventProvider>
-          <Dialog.Content width="full" height="full" minHeight="fit-content">
+          <Dialog.Content bg="bg" width="full" height="full" minHeight="fit-content">
             <Dialog.CloseTrigger />
             <Dialog.Header
               background="bg.surface"

--- a/langwatch/src/components/evaluators/EvaluatorCategorySelectorDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorCategorySelectorDrawer.tsx
@@ -211,7 +211,7 @@ export function EvaluatorCategorySelectorDrawer(
       size="lg"
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2} minH="32px">

--- a/langwatch/src/components/evaluators/EvaluatorEditorDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorEditorDrawer.tsx
@@ -30,7 +30,7 @@ export function EvaluatorEditorDrawer(props: EvaluatorEditorDrawerProps) {
       closeOnInteractOutside={false}
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/evaluators/EvaluatorHistoryDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorHistoryDrawer.tsx
@@ -46,7 +46,7 @@ export function EvaluatorHistoryDrawer({
 
   return (
     <Drawer.Root open={true} placement="end" size="md" onOpenChange={closeDrawer}>
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Text fontWeight="semibold" fontSize="lg">
             {`${evaluatorName} history`}

--- a/langwatch/src/components/evaluators/EvaluatorListDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorListDrawer.tsx
@@ -120,7 +120,7 @@ export function EvaluatorListDrawer(props: EvaluatorListDrawerProps) {
       size="md"
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2} justify="space-between" width="full">

--- a/langwatch/src/components/evaluators/EvaluatorTypeSelectorDrawer.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorTypeSelectorDrawer.tsx
@@ -44,7 +44,7 @@ export function EvaluatorTypeSelectorDrawer(
       size="md"
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/evaluators/WorkflowSelectorForEvaluatorDrawer.tsx
+++ b/langwatch/src/components/evaluators/WorkflowSelectorForEvaluatorDrawer.tsx
@@ -194,7 +194,7 @@ export function WorkflowSelectorForEvaluatorDrawer(
         size="md"
         modal={false}
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.CloseTrigger />
           <Drawer.Header>
             <HStack gap={2}>

--- a/langwatch/src/components/filters/SaveAsViewButton.tsx
+++ b/langwatch/src/components/filters/SaveAsViewButton.tsx
@@ -61,7 +61,7 @@ export function SaveAsViewButton() {
         onOpenChange={(e) => setIsOpen(e.open)}
         size="sm"
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>Save as view</Dialog.Title>
           </Dialog.Header>

--- a/langwatch/src/components/gateway/BudgetCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/BudgetCreateDrawer.tsx
@@ -125,7 +125,7 @@ export function BudgetCreateDrawer({
       placement="end"
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>New budget</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/gateway/BudgetEditDrawer.tsx
+++ b/langwatch/src/components/gateway/BudgetEditDrawer.tsx
@@ -107,7 +107,7 @@ export function BudgetEditDrawer({
       placement="end"
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>Edit budget</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/gateway/CacheRuleCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/CacheRuleCreateDrawer.tsx
@@ -66,7 +66,7 @@ export function CacheRuleCreateDrawer({ open, onOpenChange, onCreated }: Props) 
       placement="end"
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>New cache rule</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/gateway/CacheRuleEditDrawer.tsx
+++ b/langwatch/src/components/gateway/CacheRuleEditDrawer.tsx
@@ -97,7 +97,7 @@ export function CacheRuleEditDrawer({ rule, onOpenChange, onSaved }: Props) {
       placement="end"
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>Edit cache rule</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/gateway/ConfirmDialog.tsx
+++ b/langwatch/src/components/gateway/ConfirmDialog.tsx
@@ -35,7 +35,7 @@ export function ConfirmDialog({
       open={open}
       onOpenChange={(details) => onOpenChange(details.open)}
     >
-      <Dialog.Content maxWidth="480px">
+      <Dialog.Content bg="bg" maxWidth="480px">
         <Dialog.Header>
           <HStack gap={3} align="start">
             <AlertTriangle

--- a/langwatch/src/components/gateway/ProviderBindingCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/ProviderBindingCreateDrawer.tsx
@@ -148,7 +148,7 @@ export function ProviderBindingCreateDrawer({
       placement="end"
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>Bind provider to gateway</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/gateway/ProviderBindingEditDrawer.tsx
+++ b/langwatch/src/components/gateway/ProviderBindingEditDrawer.tsx
@@ -101,7 +101,7 @@ export function ProviderBindingEditDrawer({
       placement="end"
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>Edit provider binding</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/gateway/VirtualKeyCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyCreateDrawer.tsx
@@ -129,7 +129,7 @@ export function VirtualKeyCreateDrawer({
       placement="end"
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>New virtual key</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/gateway/VirtualKeyEditDrawer.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyEditDrawer.tsx
@@ -397,7 +397,7 @@ export function VirtualKeyEditDrawer({
       placement="end"
       size="md"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>Edit virtual key</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/gateway/VirtualKeySecretReveal.tsx
+++ b/langwatch/src/components/gateway/VirtualKeySecretReveal.tsx
@@ -68,7 +68,7 @@ export function VirtualKeySecretReveal({
       closeOnInteractOutside={false}
       closeOnEscape={false}
     >
-      <Dialog.Content maxWidth="560px">
+      <Dialog.Content bg="bg" maxWidth="560px">
           <Dialog.Header>
             <Dialog.Title>
               {kind === "rotate"

--- a/langwatch/src/components/license/LicenseGeneratorDrawer.tsx
+++ b/langwatch/src/components/license/LicenseGeneratorDrawer.tsx
@@ -36,7 +36,7 @@ export function LicenseGeneratorDrawer({
       closeOnInteractOutside={true}
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <Heading>Generate License</Heading>

--- a/langwatch/src/components/messages/ExportConfigDialog.tsx
+++ b/langwatch/src/components/messages/ExportConfigDialog.tsx
@@ -52,7 +52,7 @@ export function ExportConfigDialog({
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={({ open }) => !open && onClose()}>
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title>Export Traces</Dialog.Title>

--- a/langwatch/src/components/messages/MessagesTable.tsx
+++ b/langwatch/src/components/messages/MessagesTable.tsx
@@ -1380,7 +1380,7 @@ export function MessagesTable({
                   </Button>
                 </Dialog.Trigger>
                 <Portal>
-                  <Dialog.Content>
+                  <Dialog.Content bg="bg">
                     <Dialog.Header>
                       <Dialog.Title>Add to Queue</Dialog.Title>
                     </Dialog.Header>

--- a/langwatch/src/components/ops/foundry/FoundryDrawer.tsx
+++ b/langwatch/src/components/ops/foundry/FoundryDrawer.tsx
@@ -73,7 +73,7 @@ export function FoundryDrawer() {
 
   return (
     <Drawer.Root open={true} placement="end" size="md" onOpenChange={() => closeDrawer()}>
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <HStack width="full">
             <Heading size="md">The Foundry</Heading>

--- a/langwatch/src/components/ops/queues/GroupDetailDialog.tsx
+++ b/langwatch/src/components/ops/queues/GroupDetailDialog.tsx
@@ -33,7 +33,7 @@ export function GroupDetailDialog({
 
   return (
     <Dialog.Root open={!!group} onOpenChange={(e) => !e.open && onClose()} size="lg">
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.Header>
           <Dialog.Title>
             <Text textStyle="sm" fontFamily="mono" wordBreak="break-all">{group?.groupId}</Text>

--- a/langwatch/src/components/ops/shared/ConfirmDialog.tsx
+++ b/langwatch/src/components/ops/shared/ConfirmDialog.tsx
@@ -18,7 +18,7 @@ export function ConfirmDialog({
 }) {
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.Header>
           <Dialog.Title>{title}</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/projects/CreateProjectDrawer.tsx
+++ b/langwatch/src/components/projects/CreateProjectDrawer.tsx
@@ -123,7 +123,7 @@ export function CreateProjectDrawer({
         }
       }}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.CloseTrigger onClick={handleClose} />
           <Heading>Create New Project</Heading>

--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -1184,7 +1184,7 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
       size="sm"
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/prompts/PromptListDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptListDrawer.tsx
@@ -133,7 +133,7 @@ export function PromptListDrawer(props: PromptListDrawerProps) {
       size="md"
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2} justify="space-between" width="full">

--- a/langwatch/src/components/scenarios/ModelProviderRequiredModal.tsx
+++ b/langwatch/src/components/scenarios/ModelProviderRequiredModal.tsx
@@ -22,7 +22,7 @@ export function ModelProviderRequiredModal({
 }: ModelProviderRequiredModalProps) {
   return (
     <Dialog.Root open={open} onOpenChange={(d) => !d.open && onClose()}>
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title>Model provider not ready</Dialog.Title>

--- a/langwatch/src/components/scenarios/RunScenarioModal.tsx
+++ b/langwatch/src/components/scenarios/RunScenarioModal.tsx
@@ -35,7 +35,7 @@ export function RunScenarioModal({
 
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content overflow="visible">
+      <Dialog.Content bg="bg" overflow="visible">
         <Dialog.Header>
           <Dialog.Title>Run Scenario</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/scenarios/ScenarioArchiveDialog.tsx
+++ b/langwatch/src/components/scenarios/ScenarioArchiveDialog.tsx
@@ -36,7 +36,7 @@ export function ScenarioArchiveDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={onClose} placement="center">
-      <Dialog.Content maxWidth="500px" onClick={(e) => e.stopPropagation()}>
+      <Dialog.Content bg="bg" maxWidth="500px" onClick={(e) => e.stopPropagation()}>
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title fontSize="md" fontWeight="500">

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -346,7 +346,7 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
       onOpenChange={({ open }) => !open && onClose()}
       size="xl"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header borderBottomWidth="1px">
           <Heading size="md">

--- a/langwatch/src/components/scenarios/ScenarioWelcomeScreen.tsx
+++ b/langwatch/src/components/scenarios/ScenarioWelcomeScreen.tsx
@@ -104,7 +104,7 @@ export function ScenarioWelcomeModal({
 }) {
   return (
     <Dialog.Root open={open} onOpenChange={(e) => onOpenChange(e.open)} placement="center" size="lg">
-      <Dialog.Content maxWidth="640px">
+      <Dialog.Content bg="bg" maxWidth="640px">
         <Dialog.CloseTrigger />
         <Dialog.Body py={8} px={8}>
           <ScenarioWelcomeContent onProceed={onProceed} />

--- a/langwatch/src/components/settings/ChangePasswordDialog.tsx
+++ b/langwatch/src/components/settings/ChangePasswordDialog.tsx
@@ -84,7 +84,7 @@ export function ChangePasswordDialog({
       }}
       placement="center"
     >
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title fontSize="md" fontWeight="500">

--- a/langwatch/src/components/settings/CreateGroupDialog.tsx
+++ b/langwatch/src/components/settings/CreateGroupDialog.tsx
@@ -102,7 +102,7 @@ export function CreateGroupDialog({
       }}
       size="lg"
     >
-      <Dialog.Content maxHeight="90vh" overflowY="auto">
+      <Dialog.Content bg="bg" maxHeight="90vh" overflowY="auto">
         <Dialog.Header>
           <Dialog.Title>Create group</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/settings/CreateTeamDrawer.tsx
+++ b/langwatch/src/components/settings/CreateTeamDrawer.tsx
@@ -87,7 +87,7 @@ export function CreateTeamDrawer({ open = true }: { open?: boolean }): React.Rea
         if (!isOpen) closeDrawer();
       }}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.CloseTrigger onClick={closeDrawer} />
         </Drawer.Header>

--- a/langwatch/src/components/settings/GroupDetailDialog.tsx
+++ b/langwatch/src/components/settings/GroupDetailDialog.tsx
@@ -173,7 +173,7 @@ export function GroupDetailDialog({
       onOpenChange={(e) => { if (!e.open) { reset(); onClose(); } }}
       size="lg"
     >
-      <Dialog.Content maxHeight="90vh" overflowY="auto">
+      <Dialog.Content bg="bg" maxHeight="90vh" overflowY="auto">
         <Dialog.Header>
           <Dialog.Title>{group.name}</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/settings/LLMModelCostDrawer.tsx
+++ b/langwatch/src/components/settings/LLMModelCostDrawer.tsx
@@ -33,7 +33,7 @@ export function LLMModelCostDrawer({
       size={"xl"}
       onOpenChange={() => closeDrawer()}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Heading>{id ? "Edit LLM Model Cost" : "Add LLM Model Cost"}</Heading>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/settings/MemberDetailDialog.tsx
+++ b/langwatch/src/components/settings/MemberDetailDialog.tsx
@@ -152,7 +152,7 @@ export function MemberDetailDialog({
       }}
       size="lg"
     >
-      <Dialog.Content maxHeight="90vh" overflowY="auto">
+      <Dialog.Content bg="bg" maxHeight="90vh" overflowY="auto">
         <Dialog.Header>
           <Dialog.Title>{member.user.name ?? member.user.email}</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/settings/RegenerateApiKeyDialog.tsx
+++ b/langwatch/src/components/settings/RegenerateApiKeyDialog.tsx
@@ -21,7 +21,7 @@ export function RegenerateApiKeyDialog({
       placement="center"
     >
       {open && (
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.CloseTrigger />
           <Dialog.Header>
             <Dialog.Title>Regenerate API Key?</Dialog.Title>

--- a/langwatch/src/components/settings/RoleFormDialog.tsx
+++ b/langwatch/src/components/settings/RoleFormDialog.tsx
@@ -87,7 +87,7 @@ export function RoleFormDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={({ open }) => !open && onClose()}>
-      <Dialog.Content maxWidth="900px" maxHeight="90vh" overflowY="auto">
+      <Dialog.Content bg="bg" maxWidth="900px" maxHeight="90vh" overflowY="auto">
         <Dialog.Header>
           <Dialog.Title>{title}</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/shared/AICreateModal.tsx
+++ b/langwatch/src/components/shared/AICreateModal.tsx
@@ -155,7 +155,7 @@ export function AICreateModal({
 
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         {showCloseButton && <Dialog.CloseTrigger />}
         <Dialog.Header>
           <Dialog.Title>{title}</Dialog.Title>

--- a/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
+++ b/langwatch/src/components/simulations/ScenarioRunDetailDrawer.tsx
@@ -201,7 +201,7 @@ export function ScenarioRunDetailDrawer({
         placement="end"
         size="lg"
       >
-        <Drawer.Content paddingX={0} maxWidth="720px" overflow="hidden">
+        <Drawer.Content bg="bg" paddingX={0} maxWidth="720px" overflow="hidden">
           {!scenarioState && open && (
             <Drawer.Body>
               {runStateError ? (
@@ -457,7 +457,7 @@ export function ScenarioRunDetailDrawer({
         size="xl"
         modal={true}
       >
-        <Drawer.Content paddingX={0} maxWidth="70%">
+        <Drawer.Content bg="bg" paddingX={0} maxWidth="70%">
           <Drawer.CloseTrigger zIndex={10} />
           <Drawer.Body paddingY={0} paddingX={0} overflowY="auto">
             {traceDrawerTraceId && (

--- a/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
@@ -18,7 +18,7 @@ import { SimulationConsole } from "../simulation-console/SimulationConsole";
 const DrawerWrapper = ({ children }: { children: React.ReactNode }) => (
   <ChakraProvider value={defaultSystem}>
     <Drawer.Root open={true} placement="end">
-      <Drawer.Content>{children}</Drawer.Content>
+      <Drawer.Content bg="bg">{children}</Drawer.Content>
     </Drawer.Root>
   </ChakraProvider>
 );

--- a/langwatch/src/components/subscription/UserManagementDrawer.tsx
+++ b/langwatch/src/components/subscription/UserManagementDrawer.tsx
@@ -169,7 +169,7 @@ export function UserManagementDrawer({
         }
       }}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Heading size="md">Manage Seats</Heading>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/suites/RunRow.tsx
+++ b/langwatch/src/components/suites/RunRow.tsx
@@ -250,7 +250,7 @@ function RunRowData({
           open={isCancelAllDialogOpen}
           onOpenChange={({ open }) => setIsCancelAllDialogOpen(open)}
         >
-          <Dialog.Content maxWidth="sm">
+          <Dialog.Content bg="bg" maxWidth="sm">
             <Dialog.Header>
               <Dialog.Title>Cancel remaining jobs?</Dialog.Title>
             </Dialog.Header>

--- a/langwatch/src/components/suites/SuiteArchiveDialog.tsx
+++ b/langwatch/src/components/suites/SuiteArchiveDialog.tsx
@@ -25,7 +25,7 @@ export function SuiteArchiveDialog({
 }) {
   return (
     <Dialog.Root open={open} onOpenChange={onClose} placement="center">
-      <Dialog.Content maxWidth="500px" onClick={(e) => e.stopPropagation()}>
+      <Dialog.Content bg="bg" maxWidth="500px" onClick={(e) => e.stopPropagation()}>
         <Dialog.CloseTrigger />
         <Dialog.Header>
           <Dialog.Title fontSize="md" fontWeight="500">

--- a/langwatch/src/components/suites/SuiteFormDrawer.tsx
+++ b/langwatch/src/components/suites/SuiteFormDrawer.tsx
@@ -278,7 +278,7 @@ export function SuiteFormDrawer(_props: SuiteFormDrawerProps) {
       placement="end"
       size="lg"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>{title}</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/components/suites/SuiteRunConfirmationDialog.tsx
+++ b/langwatch/src/components/suites/SuiteRunConfirmationDialog.tsx
@@ -38,7 +38,7 @@ export function SuiteRunConfirmationDialog({
       }}
       placement="center"
     >
-      <Dialog.Content maxWidth="500px" onClick={(e) => e.stopPropagation()}>
+      <Dialog.Content bg="bg" maxWidth="500px" onClick={(e) => e.stopPropagation()}>
         {!isLoading && <Dialog.CloseTrigger />}
         <Dialog.Header>
           <Dialog.Title>{suiteName}</Dialog.Title>

--- a/langwatch/src/components/targets/TargetTypeSelectorDrawer.tsx
+++ b/langwatch/src/components/targets/TargetTypeSelectorDrawer.tsx
@@ -79,7 +79,7 @@ export function TargetTypeSelectorDrawer(props: TargetTypeSelectorDrawerProps) {
       size="md"
       modal={false}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.CloseTrigger />
         <Drawer.Header>
           <HStack gap={2}>

--- a/langwatch/src/components/ui/PushToCopiesDialog.tsx
+++ b/langwatch/src/components/ui/PushToCopiesDialog.tsx
@@ -81,7 +81,7 @@ export function PushToCopiesDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content onClick={(e) => e.stopPropagation()}>
+      <Dialog.Content bg="bg" onClick={(e) => e.stopPropagation()}>
         <Dialog.Header>
           <Dialog.Title>Push to Replicas</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/ui/ReplicateToProjectDialog.tsx
+++ b/langwatch/src/components/ui/ReplicateToProjectDialog.tsx
@@ -102,7 +102,7 @@ export function ReplicateToProjectDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content onClick={(e) => e.stopPropagation()}>
+      <Dialog.Content bg="bg" onClick={(e) => e.stopPropagation()}>
         <Dialog.Header>
           <Dialog.Title>{title}</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/components/ui/__tests__/drawer-backdrop.integration.test.tsx
+++ b/langwatch/src/components/ui/__tests__/drawer-backdrop.integration.test.tsx
@@ -17,7 +17,7 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 function renderDrawer() {
   render(
     <Drawer.Root open={true} placement="end">
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Body>Content</Drawer.Body>
       </Drawer.Content>
     </Drawer.Root>,

--- a/langwatch/src/components/ui/__tests__/overlay-z-index.integration.test.tsx
+++ b/langwatch/src/components/ui/__tests__/overlay-z-index.integration.test.tsx
@@ -46,7 +46,7 @@ describe("Overlay z-index stacking", () => {
     it("assigns incrementing z-indexes so the inner overlay is above the outer", () => {
       render(
         <Dialog.Root open={true}>
-          <Dialog.Content>
+          <Dialog.Content bg="bg">
             <Dialog.Body>
               <Popover.Root open={true}>
                 <Popover.Trigger>

--- a/langwatch/src/evaluations-v3/components/TableSettingsMenu.tsx
+++ b/langwatch/src/evaluations-v3/components/TableSettingsMenu.tsx
@@ -403,7 +403,7 @@ const CICDDialog = React.memo(function CICDDialog({
       onOpenChange={({ open: isOpen }) => !isOpen && onClose()}
       size="xl"
     >
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.CloseTrigger />
         <Dialog.Header width="100%" marginTop={4}>
           <VStack alignItems="flex-start" gap={2} width="100%">

--- a/langwatch/src/features/command-bar/CommandBar.tsx
+++ b/langwatch/src/features/command-bar/CommandBar.tsx
@@ -344,7 +344,7 @@ export function CommandBar() {
       placement="top"
       motionPreset="slide-in-top"
     >
-      <Dialog.Content
+      <Dialog.Content bg="bg"
         width={COMMAND_BAR_MAX_WIDTH}
         maxWidth="90vw"
         marginTop={COMMAND_BAR_TOP_MARGIN}

--- a/langwatch/src/features/traces-v2/components/SearchBar/SyntaxHelpDrawer.tsx
+++ b/langwatch/src/features/traces-v2/components/SearchBar/SyntaxHelpDrawer.tsx
@@ -171,7 +171,7 @@ export const SyntaxHelpDrawerHost: React.FC = () => {
       size="md"
       modal
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Drawer.Title>Query syntax</Drawer.Title>
           <Drawer.CloseTrigger />

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/KeyboardShortcutsHelp.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/KeyboardShortcutsHelp.tsx
@@ -77,7 +77,7 @@ export function KeyboardShortcutsHelp({
       }}
       size="lg"
     >
-      <Dialog.Content maxHeight="85vh" overflow="hidden">
+      <Dialog.Content bg="bg" maxHeight="85vh" overflow="hidden">
         <Dialog.Header
           paddingX={5}
           paddingY={4}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/RawJsonDialog.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/RawJsonDialog.tsx
@@ -46,7 +46,7 @@ export function RawJsonDialog({ open, onClose, trace }: RawJsonDialogProps) {
       size="xl"
       placement="center"
     >
-      <Dialog.Content maxHeight="85vh" display="flex" flexDirection="column">
+      <Dialog.Content bg="bg" maxHeight="85vh" display="flex" flexDirection="column">
         <Dialog.Header borderBottomWidth="1px" borderColor="border">
           <HStack gap={3} align="center">
             <Dialog.Title>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
@@ -100,7 +100,7 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
         size="lg"
         onOpenChange={() => handleClose()}
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.Body padding={0}>
             <TraceDrawerEmptyState
               error={headerQuery.error}
@@ -131,7 +131,7 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
       onOpenChange={() => handleClose()}
     >
       <CodeBlock.AdapterProvider value={shikiAdapter}>
-        <Drawer.Content
+        <Drawer.Content bg="bg"
           ref={drawerContentRef}
           paddingX={0}
           // Maximized state used to expand to a full 100vw, leaving no gap on

--- a/langwatch/src/features/traces-v2/onboarding/components/IntegrateDrawer.tsx
+++ b/langwatch/src/features/traces-v2/onboarding/components/IntegrateDrawer.tsx
@@ -134,7 +134,7 @@ export function IntegrateDrawer({
       size="xl"
       placement="end"
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <VStack align="stretch" gap={1}>
             <Drawer.Title>Send your own traces</Drawer.Title>

--- a/langwatch/src/optimization_studio/components/ChatWindow.tsx
+++ b/langwatch/src/optimization_studio/components/ChatWindow.tsx
@@ -88,7 +88,7 @@ export const ChatWindow = ({
       }}
       size="5xl"
     >
-      <Dialog.Content height="65vh" overflowY="auto">
+      <Dialog.Content bg="bg" height="65vh" overflowY="auto">
         <Dialog.Header>
           <Dialog.Title>Test Message</Dialog.Title>
           <Dialog.CloseTrigger />

--- a/langwatch/src/optimization_studio/components/DatasetModal.tsx
+++ b/langwatch/src/optimization_studio/components/DatasetModal.tsx
@@ -132,7 +132,7 @@ export function DatasetModal({
       onOpenChange={({ open }) => !open && onClose()}
       size="full"
     >
-      <Dialog.Content
+      <Dialog.Content bg="bg"
         css={{
           marginX: "32px",
           marginTop: "32px",

--- a/langwatch/src/optimization_studio/components/DemonstrationsModal.tsx
+++ b/langwatch/src/optimization_studio/components/DemonstrationsModal.tsx
@@ -77,7 +77,7 @@ export function DemonstrationsModal({
 
   return (
     <Dialog.Root open={open} onOpenChange={({ open }) => !open && onClose()}>
-      <Dialog.Content
+      <Dialog.Content bg="bg"
         marginX="32px"
         marginTop="32px"
         width="calc(100vw - 64px)"

--- a/langwatch/src/optimization_studio/components/Evaluate.tsx
+++ b/langwatch/src/optimization_studio/components/Evaluate.tsx
@@ -353,7 +353,7 @@ export function EvaluateModalContent({
 
   return (
     <FormProvider {...form}>
-    <Dialog.Content
+    <Dialog.Content bg="bg"
       as="form"
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onSubmit={form.handleSubmit(onSubmit)}

--- a/langwatch/src/optimization_studio/components/Optimize.tsx
+++ b/langwatch/src/optimization_studio/components/Optimize.tsx
@@ -341,7 +341,7 @@ export function OptimizeModalContent({
 
   if (!versions.data) {
     return (
-      <Dialog.Content borderTop="5px solid" borderColor="green.400">
+      <Dialog.Content bg="bg" borderTop="5px solid" borderColor="green.400">
         <Dialog.Header fontWeight={600}>Optimize Workflow</Dialog.Header>
         <Dialog.CloseTrigger />
         <Dialog.Body>
@@ -369,7 +369,7 @@ export function OptimizeModalContent({
 
   return (
     <FormProvider {...form}>
-    <Dialog.Content
+    <Dialog.Content bg="bg"
       as="form"
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onSubmit={form.handleSubmit(onSubmit)}

--- a/langwatch/src/optimization_studio/components/Publish.tsx
+++ b/langwatch/src/optimization_studio/components/Publish.tsx
@@ -587,7 +587,7 @@ function PublishModalContent({
 
   if (!versions.data) {
     return (
-      <Dialog.Content borderTop="5px solid" borderColor="green.400">
+      <Dialog.Content bg="bg" borderTop="5px solid" borderColor="green.400">
         <Dialog.Header>
           <Dialog.Title fontWeight={600}>Publish Workflow</Dialog.Title>
         </Dialog.Header>
@@ -609,7 +609,7 @@ function PublishModalContent({
 
   return (
     <FormProvider {...form}>
-    <Dialog.Content
+    <Dialog.Content bg="bg"
       as="form"
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onSubmit={form.handleSubmit(onSubmit)}
@@ -724,7 +724,7 @@ export const ApiModalContent = () => {
     2,
   );
   return (
-    <Dialog.Content>
+    <Dialog.Content bg="bg">
       <Dialog.Header>
         <Dialog.Title>Workflow API</Dialog.Title>
       </Dialog.Header>

--- a/langwatch/src/optimization_studio/components/code/CodeEditorModal.tsx
+++ b/langwatch/src/optimization_studio/components/code/CodeEditorModal.tsx
@@ -90,7 +90,7 @@ export function CodeEditorModal({
 
   return (
     <Dialog.Root open={open} onOpenChange={({ open }) => !open && onClose_()}>
-      <Dialog.Content
+      <Dialog.Content bg="bg"
         margin="64px"
         minWidth="calc(100vw - 128px)"
         height="calc(100vh - 128px)"

--- a/langwatch/src/optimization_studio/components/drawers/StudioDrawerWrapper.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/StudioDrawerWrapper.tsx
@@ -189,7 +189,7 @@ export function StudioDrawerWrapper({
         closeOnInteractOutside={false}
         modal={false}
       >
-        <Drawer.Content marginTop="56px">
+        <Drawer.Content bg="bg" marginTop="56px">
           {node && (
             <Drawer.Header
               paddingTop={4}

--- a/langwatch/src/optimization_studio/components/workflow/NewWorkflowModal.tsx
+++ b/langwatch/src/optimization_studio/components/workflow/NewWorkflowModal.tsx
@@ -144,7 +144,7 @@ export const NewWorkflowModal = ({
       onOpenChange={({ open }) => !open && onClose()}
       size="xl"
     >
-      <Dialog.Content paddingX={0}>
+      <Dialog.Content bg="bg" paddingX={0}>
         <Dialog.Header>
           <HStack gap={2}>
             {step.step === "create" && (

--- a/langwatch/src/pages/[project]/analytics/custom/index.tsx
+++ b/langwatch/src/pages/[project]/analytics/custom/index.tsx
@@ -461,7 +461,7 @@ function AnalyticsCustomGraphContent({
         onOpenChange={({ open }) => jsonModal.setOpen(open)}
         size="lg"
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>Graph JSON</Dialog.Title>
             <Dialog.CloseTrigger />
@@ -478,7 +478,7 @@ function AnalyticsCustomGraphContent({
         onOpenChange={({ open }) => apiModal.setOpen(open)}
         size="lg"
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>JSON API</Dialog.Title>
             <Dialog.CloseTrigger />

--- a/langwatch/src/pages/[project]/automations.tsx
+++ b/langwatch/src/pages/[project]/automations.tsx
@@ -443,7 +443,7 @@ function Automations() {
         onOpenChange={({ open }) => (open ? onOpen() : handleCloseModal())}
         size="lg"
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.Header>
             <Drawer.Title>Alert Message</Drawer.Title>
           </Drawer.Header>

--- a/langwatch/src/pages/dev/error-test.tsx
+++ b/langwatch/src/pages/dev/error-test.tsx
@@ -229,7 +229,7 @@ function InnerContent({
         open={dialogOpen}
         onOpenChange={({ open }) => setDialogOpen(open)}
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>Test Dialog</Dialog.Title>
             <Dialog.CloseTrigger />
@@ -247,7 +247,7 @@ function InnerContent({
         open={drawerOpen}
         onOpenChange={({ open }) => setDrawerOpen(open)}
       >
-        <Drawer.Content>
+        <Drawer.Content bg="bg">
           <Drawer.Header>
             <Drawer.Title>Test Drawer</Drawer.Title>
             <Drawer.CloseTrigger />

--- a/langwatch/src/pages/settings.tsx
+++ b/langwatch/src/pages/settings.tsx
@@ -899,7 +899,7 @@ function ProjectSettingsForm({ project }: { project: Project }) {
         open={showTraceSharingDialog}
         onOpenChange={({ open }) => setShowTraceSharingDialog(open)}
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>Disable Trace Sharing?</Dialog.Title>
           </Dialog.Header>

--- a/langwatch/src/pages/settings/api-keys/CreateApiKeyDrawer.tsx
+++ b/langwatch/src/pages/settings/api-keys/CreateApiKeyDrawer.tsx
@@ -195,7 +195,7 @@ export function CreateApiKeyDrawer({
         }
       }}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Heading size="md">Create new secret key</Heading>
           <Drawer.CloseTrigger />

--- a/langwatch/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
+++ b/langwatch/src/pages/settings/api-keys/EditApiKeyDrawer.tsx
@@ -131,7 +131,7 @@ export function EditApiKeyDrawer({
         if (!open) onClose();
       }}
     >
-      <Drawer.Content>
+      <Drawer.Content bg="bg">
         <Drawer.Header>
           <Heading size="md">Edit API key</Heading>
           <Drawer.CloseTrigger />

--- a/langwatch/src/pages/settings/api-keys/RevokeConfirmDialog.tsx
+++ b/langwatch/src/pages/settings/api-keys/RevokeConfirmDialog.tsx
@@ -24,7 +24,7 @@ export function RevokeConfirmDialog({
         if (!open) onCancel();
       }}
     >
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.Header>
           <Dialog.Title>Revoke API Key</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/pages/settings/groups.tsx
+++ b/langwatch/src/pages/settings/groups.tsx
@@ -239,7 +239,7 @@ function GroupsSettings() {
         open={!!groupToDelete}
         onOpenChange={(e) => { if (!e.open) setGroupToDelete(null); }}
       >
-        <Dialog.Content maxWidth="440px">
+        <Dialog.Content bg="bg" maxWidth="440px">
           <Dialog.Header>
             <Dialog.Title>Delete group</Dialog.Title>
           </Dialog.Header>

--- a/langwatch/src/pages/settings/members.tsx
+++ b/langwatch/src/pages/settings/members.tsx
@@ -420,7 +420,7 @@ function MembersList({
         open={isInviteLinkOpen}
         onOpenChange={({ open }) => (open ? undefined : onInviteModalClose())}
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>
               <Heading>Invite Link</Heading>
@@ -462,7 +462,7 @@ function MembersList({
           open ? onAddMembersOpen() : onAddMembersClose()
         }
       >
-        <Dialog.Content width="100%" maxWidth="1024px">
+        <Dialog.Content bg="bg" width="100%" maxWidth="1024px">
           <Dialog.Header>
             <Dialog.Title>
               <Heading>Add members</Heading>

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -299,7 +299,7 @@ export default function ModelsPage() {
             }
           }}
         >
-          <Dialog.Content>
+          <Dialog.Content bg="bg">
             <Dialog.Header>
               <Dialog.Title>Delete {providerToDisable?.name}?</Dialog.Title>
             </Dialog.Header>

--- a/langwatch/src/pages/settings/roles.tsx
+++ b/langwatch/src/pages/settings/roles.tsx
@@ -455,7 +455,7 @@ function RolesManagement({
         open={viewOpen}
         onOpenChange={({ open }) => !open && onViewClose()}
       >
-        <Dialog.Content maxWidth="600px" maxHeight="80vh" overflowY="auto">
+        <Dialog.Content bg="bg" maxWidth="600px" maxHeight="80vh" overflowY="auto">
           <Dialog.Header>
             <Dialog.Title>View Permissions - {viewingRole?.name}</Dialog.Title>
           </Dialog.Header>
@@ -494,7 +494,7 @@ function RolesManagement({
         open={defaultViewOpen}
         onOpenChange={({ open }) => !open && onDefaultViewClose()}
       >
-        <Dialog.Content maxWidth="600px" maxHeight="80vh" overflowY="auto">
+        <Dialog.Content bg="bg" maxWidth="600px" maxHeight="80vh" overflowY="auto">
           <Dialog.Header>
             <Dialog.Title>
               View Permissions - {viewingDefaultRole?.name}

--- a/langwatch/src/pages/settings/scim.tsx
+++ b/langwatch/src/pages/settings/scim.tsx
@@ -214,7 +214,7 @@ function ScimSettingsContent({
           }
         }}
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>
               <Heading size="md">Generate SCIM Token</Heading>
@@ -259,7 +259,7 @@ function ScimSettingsContent({
           }
         }}
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>
               <Heading size="md">Token Generated</Heading>
@@ -286,7 +286,7 @@ function ScimSettingsContent({
           if (!open) setTokenToRevoke(null);
         }}
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>
               <Heading size="md">Revoke Token</Heading>

--- a/langwatch/src/pages/settings/secrets.tsx
+++ b/langwatch/src/pages/settings/secrets.tsx
@@ -233,7 +233,7 @@ export default function SecretsPage() {
             }
           }}
         >
-          <Dialog.Content>
+          <Dialog.Content bg="bg">
             <Dialog.Header>
               <Dialog.Title>Add Secret</Dialog.Title>
             </Dialog.Header>
@@ -288,7 +288,7 @@ export default function SecretsPage() {
             }
           }}
         >
-          <Dialog.Content>
+          <Dialog.Content bg="bg">
             <Dialog.Header>
               <Dialog.Title>
                 Delete {secretToDelete?.name ?? ""}?
@@ -325,7 +325,7 @@ export default function SecretsPage() {
             }
           }}
         >
-          <Dialog.Content>
+          <Dialog.Content bg="bg">
             <Dialog.Header>
               <Dialog.Title>
                 Update Value for {secretToUpdate?.name ?? ""}

--- a/langwatch/src/pages/settings/teams.tsx
+++ b/langwatch/src/pages/settings/teams.tsx
@@ -161,7 +161,7 @@ function AddToTeamDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content maxWidth="440px">
+      <Dialog.Content bg="bg" maxWidth="440px">
         <Dialog.Header>
           <Dialog.Title>Add member to {teamName}</Dialog.Title>
         </Dialog.Header>
@@ -299,7 +299,7 @@ function AddToProjectDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()}>
-      <Dialog.Content maxWidth="440px">
+      <Dialog.Content bg="bg" maxWidth="440px">
         <Dialog.Header>
           <Dialog.Title>Add access to {projectName}</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/prompts/forms/ChangeHandleDialog.tsx
+++ b/langwatch/src/prompts/forms/ChangeHandleDialog.tsx
@@ -95,7 +95,7 @@ export function ChangeHandleDialog({
         }
       }}
     >
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/langwatch/src/prompts/forms/SaveVersionDialog.tsx
+++ b/langwatch/src/prompts/forms/SaveVersionDialog.tsx
@@ -66,7 +66,7 @@ export function SaveVersionDialog({
         }
       }}
     >
-      <Dialog.Content>
+      <Dialog.Content bg="bg">
         <Dialog.Header>
           <Dialog.Title>Save Version</Dialog.Title>
         </Dialog.Header>

--- a/langwatch/src/prompts/modals/DemonstrationsModal.tsx
+++ b/langwatch/src/prompts/modals/DemonstrationsModal.tsx
@@ -27,7 +27,7 @@ export function DemonstrationsModal({
 
   return (
     <Dialog.Root open={open} onOpenChange={({ open }) => !open && onClose()}>
-      <Dialog.Content
+      <Dialog.Content bg="bg"
         marginX="32px"
         marginTop="32px"
         maxWidth="calc(100vw - 64px)"

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/ExperimentFromPlaygroundButton.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/ExperimentFromPlaygroundButton.tsx
@@ -330,7 +330,7 @@ export function ExperimentFromPlaygroundButton({
         open={isDialogOpen}
         onOpenChange={({ open }) => setIsDialogOpen(open)}
       >
-        <Dialog.Content>
+        <Dialog.Content bg="bg">
           <Dialog.Header>
             <Dialog.Title>Create Experiment</Dialog.Title>
           </Dialog.Header>


### PR DESCRIPTION
## Summary
- Add `bg="bg"` to **76 `Dialog.Content`** and **63 `Drawer.Content`** instances across 123 files
- Modals/drawers inherited a grayish background instead of using explicit white — this fixes the visual inconsistency
- Excludes `OutputsSection.tsx` and `TypeSelector.tsx` which intentionally use dark `#272822` backgrounds for code editors

## Test plan
- [ ] Visual spot-check modals across settings, evaluations, datasets, scenarios, prompts, optimization studio, gateway, traces
- [ ] Verify dark-themed code editor modals (`OutputsSection`, `TypeSelector`) remain unchanged
- [ ] Confirm no layout/spacing regressions from the added prop

Closes #3998

# Related Issue

- Resolve #3998