### PR TITLE
feat(langy): defineLangyTool helper — runtime output validation (Phase 3)

### DIFF
--- a/langwatch/src/server/services/langy/__tests__/defineLangyTool.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/defineLangyTool.unit.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import {
-  defineLangyTool,
-  LANGY_TOOL_OUTPUT_INVALID_CODE,
-  langyToolErrorEnvelope,
-} from "../defineLangyTool";
+
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
 
 vi.mock("~/utils/logger/server", () => ({
   createLogger: () => ({
-    warn: vi.fn(),
+    warn: warnSpy,
     info: vi.fn(),
     error: vi.fn(),
     debug: vi.fn(),
   }),
 }));
+
+import {
+  defineLangyTool,
+  LANGY_TOOL_OUTPUT_INVALID_CODE,
+  langyToolErrorEnvelope,
+} from "../defineLangyTool";
 
 const inputSchema = z.object({ q: z.string() });
 const outputSchema = z.object({
@@ -101,6 +104,30 @@ describe("defineLangyTool", () => {
       };
       expect(Array.isArray(result.error.issues)).toBe(true);
       expect((result.error.issues ?? []).length).toBeGreaterThan(0);
+    });
+
+    it("logs a warning with the tool name and zod issues", async () => {
+      warnSpy.mockClear();
+      const tool = defineLangyTool({
+        name: "list_things_named",
+        description: "lists things",
+        inputSchema,
+        outputSchema,
+        execute: async () =>
+          null as unknown as { items: Array<{ id: string }> },
+      });
+
+      await invokeTool(tool, { q: "x" });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [meta, message] = warnSpy.mock.calls[0] ?? [];
+      expect(meta).toEqual(
+        expect.objectContaining({
+          tool: "list_things_named",
+          issues: expect.any(Array),
+        }),
+      );
+      expect(message).toContain("failed schema validation");
     });
   });
 

--- a/langwatch/src/server/services/langy/__tests__/defineLangyTool.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/defineLangyTool.unit.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  defineLangyTool,
+  LANGY_TOOL_OUTPUT_INVALID_CODE,
+  langyToolErrorEnvelope,
+} from "../defineLangyTool";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const inputSchema = z.object({ q: z.string() });
+const outputSchema = z.object({
+  items: z.array(z.object({ id: z.string() })),
+});
+
+function invokeTool(
+  toolDef: unknown,
+  input: unknown,
+): Promise<unknown> {
+  const exec = (toolDef as { execute: (i: unknown) => Promise<unknown> })
+    .execute;
+  return exec(input);
+}
+
+describe("defineLangyTool", () => {
+  describe("when execute returns data matching the output schema", () => {
+    it("returns the parsed data unchanged", async () => {
+      const tool = defineLangyTool({
+        name: "list_things",
+        description: "lists things",
+        inputSchema,
+        outputSchema,
+        execute: async ({ q }) => ({ items: [{ id: q }] }),
+      });
+
+      const result = await invokeTool(tool, { q: "hello" });
+      expect(result).toEqual({ items: [{ id: "hello" }] });
+    });
+
+    it("strips unknown fields from the result", async () => {
+      const tool = defineLangyTool({
+        name: "list_things",
+        description: "lists things",
+        inputSchema,
+        outputSchema,
+        execute: async ({ q }) =>
+          ({
+            items: [{ id: q, secret: "should_be_stripped" }],
+            extra: "also_stripped",
+          }) as unknown as { items: Array<{ id: string }> },
+      });
+
+      const result = (await invokeTool(tool, { q: "hello" })) as Record<
+        string,
+        unknown
+      >;
+      expect(result).toEqual({ items: [{ id: "hello" }] });
+      expect(result).not.toHaveProperty("extra");
+    });
+  });
+
+  describe("when execute returns data that does not match the output schema", () => {
+    it("returns a structured error envelope, never raw output", async () => {
+      const tool = defineLangyTool({
+        name: "list_things",
+        description: "lists things",
+        inputSchema,
+        outputSchema,
+        execute: async () =>
+          ({
+            items: [{ id: 42 as unknown as string }],
+          }) as unknown as { items: Array<{ id: string }> },
+      });
+
+      const result = await invokeTool(tool, { q: "hello" });
+      expect(langyToolErrorEnvelope.safeParse(result).success).toBe(true);
+      expect((result as { error: { code: string } }).error.code).toBe(
+        LANGY_TOOL_OUTPUT_INVALID_CODE,
+      );
+    });
+
+    it("includes the zod issues in the envelope for telemetry", async () => {
+      const tool = defineLangyTool({
+        name: "list_things",
+        description: "lists things",
+        inputSchema,
+        outputSchema,
+        execute: async () =>
+          null as unknown as { items: Array<{ id: string }> },
+      });
+
+      const result = (await invokeTool(tool, { q: "x" })) as {
+        error: { issues?: unknown[] };
+      };
+      expect(Array.isArray(result.error.issues)).toBe(true);
+      expect((result.error.issues ?? []).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("when execute itself throws", () => {
+    it("does not swallow the error — it propagates so the SDK can convert to tool-error", async () => {
+      const tool = defineLangyTool({
+        name: "list_things",
+        description: "lists things",
+        inputSchema,
+        outputSchema,
+        execute: async () => {
+          throw new Error("upstream failed");
+        },
+      });
+
+      await expect(invokeTool(tool, { q: "x" })).rejects.toThrow(
+        "upstream failed",
+      );
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/defineLangyTool.ts
+++ b/langwatch/src/server/services/langy/defineLangyTool.ts
@@ -16,43 +16,50 @@ export const langyToolErrorEnvelope = z.object({
 
 export type LangyToolErrorEnvelope = z.infer<typeof langyToolErrorEnvelope>;
 
-export function defineLangyTool<TInput, TOutput>({
-  name,
-  description,
-  inputSchema,
-  outputSchema,
-  execute,
-}: {
+// Two casts at the SDK boundary — one to make `tool()`'s overload set accept
+// our generic-typed object literal (it can't infer through our wrapper's
+// generics), one to preserve the precise `Tool<Input, Output>` shape on the
+// way back out. Both are local to this function: callers of defineLangyTool
+// see fully-typed inputs and outputs.
+export function defineLangyTool<
+  TInputSchema extends z.ZodType,
+  TOutput,
+>(args: {
   name: string;
   description: string;
-  inputSchema: z.ZodType<TInput>;
+  inputSchema: TInputSchema;
   outputSchema: z.ZodType<TOutput>;
-  execute: (input: TInput) => Promise<TOutput>;
-}) {
-  const execWithValidation = async (input: TInput) => {
-    const raw = await execute(input);
-    const parsed = outputSchema.safeParse(raw);
+  execute: (input: z.infer<TInputSchema>) => Promise<TOutput>;
+}): Tool<z.infer<TInputSchema>, TOutput> {
+  type Input = z.infer<TInputSchema>;
 
-    if (!parsed.success) {
-      logger.warn(
-        { tool: name, issues: parsed.error.issues },
-        "langy tool output failed schema validation",
-      );
-      return {
-        error: {
-          code: LANGY_TOOL_OUTPUT_INVALID_CODE,
-          message: "Tool returned data in an unexpected shape.",
-          issues: parsed.error.issues,
-        },
-      } as LangyToolErrorEnvelope;
-    }
+  const definition = {
+    description: args.description,
+    inputSchema: args.inputSchema,
+    execute: async (input: Input): Promise<TOutput> => {
+      const raw = await args.execute(input);
+      const parsed = args.outputSchema.safeParse(raw);
 
-    return parsed.data;
+      if (!parsed.success) {
+        logger.warn(
+          { tool: args.name, issues: parsed.error.issues },
+          "langy tool output failed schema validation",
+        );
+        const envelope: LangyToolErrorEnvelope = {
+          error: {
+            code: LANGY_TOOL_OUTPUT_INVALID_CODE,
+            message: "Tool returned data in an unexpected shape.",
+            issues: parsed.error.issues,
+          },
+        };
+        return envelope as unknown as TOutput;
+      }
+
+      return parsed.data;
+    },
   };
 
-  return tool({
-    description,
-    inputSchema: inputSchema as unknown as z.ZodType<TInput>,
-    execute: execWithValidation,
-  } as unknown as Parameters<typeof tool<TInput, TOutput | LangyToolErrorEnvelope>>[0]) as Tool<TInput, TOutput | LangyToolErrorEnvelope>;
+  return tool(
+    definition as unknown as Parameters<typeof tool<Input, TOutput>>[0],
+  ) as Tool<Input, TOutput>;
 }

--- a/langwatch/src/server/services/langy/defineLangyTool.ts
+++ b/langwatch/src/server/services/langy/defineLangyTool.ts
@@ -1,0 +1,58 @@
+import { tool, type Tool } from "ai";
+import { z } from "zod";
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:langy:tools:defineLangyTool");
+
+export const LANGY_TOOL_OUTPUT_INVALID_CODE = "tool_output_invalid" as const;
+
+export const langyToolErrorEnvelope = z.object({
+  error: z.object({
+    code: z.literal(LANGY_TOOL_OUTPUT_INVALID_CODE),
+    message: z.string(),
+    issues: z.array(z.unknown()).optional(),
+  }),
+});
+
+export type LangyToolErrorEnvelope = z.infer<typeof langyToolErrorEnvelope>;
+
+export function defineLangyTool<TInput, TOutput>({
+  name,
+  description,
+  inputSchema,
+  outputSchema,
+  execute,
+}: {
+  name: string;
+  description: string;
+  inputSchema: z.ZodType<TInput>;
+  outputSchema: z.ZodType<TOutput>;
+  execute: (input: TInput) => Promise<TOutput>;
+}) {
+  const execWithValidation = async (input: TInput) => {
+    const raw = await execute(input);
+    const parsed = outputSchema.safeParse(raw);
+
+    if (!parsed.success) {
+      logger.warn(
+        { tool: name, issues: parsed.error.issues },
+        "langy tool output failed schema validation",
+      );
+      return {
+        error: {
+          code: LANGY_TOOL_OUTPUT_INVALID_CODE,
+          message: "Tool returned data in an unexpected shape.",
+          issues: parsed.error.issues,
+        },
+      } as LangyToolErrorEnvelope;
+    }
+
+    return parsed.data;
+  };
+
+  return tool({
+    description,
+    inputSchema: inputSchema as unknown as z.ZodType<TInput>,
+    execute: execWithValidation,
+  } as unknown as Parameters<typeof tool<TInput, TOutput | LangyToolErrorEnvelope>>[0]) as Tool<TInput, TOutput | LangyToolErrorEnvelope>;
+}

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -164,6 +164,13 @@ Feature: Langy in-product AI assistant — baseline (v1)
     When Langy proposes updating that evaluator
     Then the proposal is accepted and presented to me as a card
 
+  Scenario: Malformed tool output never reaches the model raw
+    Given a Langy tool returns data that does not match its declared schema
+    When the tool result is sent back to the model
+    Then the model receives a "tool_output_invalid" error envelope
+    And the envelope does not include raw stack traces
+    And the failure is logged for telemetry with the tool name
+
   # ============================================================================
   # Read-only boundary (v1)
   # ============================================================================


### PR DESCRIPTION
## Why

Closes the last unchecked Phase 3 acceptance criterion (#3956):

> All tool outputs validated by Zod schema before reaching the model.

### The gap I found

AI SDK v6 exposes `outputSchema` on `tool()`, and I assumed adding it to each tool would satisfy the spec. After reading the SDK source (`ai/dist/index.mjs`), it turns out `outputSchema` is **only consulted by `validateUIMessages`** (UI message history restoration, line 9036+). The live tool execution path — `executeToolCall` at line 2775 — calls `tool.execute(input)` and passes the result **straight to the model with no validation**. Langy doesn't call `validateUIMessages`, so today nothing actually checks tool outputs at runtime.

`outputSchema` alone gives compile-time type-binding but **not** the runtime guarantee the spec asks for. This PR adds that runtime check.

## What this PR adds

A small helper `defineLangyTool({ name, description, inputSchema, outputSchema, execute })` that:

- **Compile-time:** is generic over input/output Zod schemas and constrains `execute` to return the declared shape (TS errors before deploy if a refactor breaks return types).
- **Runtime:** wraps `execute` with `outputSchema.safeParse(result)`. On failure, returns a structured error envelope `{ error: { code: "tool_output_invalid", message, issues } }` matching the existing envelope pattern (rate_limited, invalid_body, etc.) and logs the failure via `createLogger("langwatch:langy:tools:defineLangyTool")` for telemetry.
- **Bonus hardening:** returns Zod-parsed data on success, so unknown fields are stripped — if a downstream service starts returning extra fields one day, the model only sees the documented ones.
- **Errors:** thrown errors inside `execute` are intentionally NOT caught — they propagate so the AI SDK converts them into `tool-error` events as it already does.

## Why a helper instead of just `outputSchema`

| Approach | Compile-time safety | Runtime validation | Structured failure |
|---|---|---|---|
| Bare `outputSchema` on `tool()` | ✅ | ❌ (SDK doesn't check in execution path) | ❌ |
| Manual `parse()` inside each tool | ⚠️ (per-tool) | ✅ | ⚠️ (per-tool) |
| `defineLangyTool` helper | ✅ | ✅ | ✅ |

## Scope

This PR is **only** the helper + its unit tests. 5 tests cover:

- success path returns parsed data
- success path strips unknown fields
- validation failure returns the structured envelope (never raw output)
- envelope contains zod issues for telemetry
- thrown errors from `execute` propagate (not swallowed)

**Out of scope** (follow-up PRs):
- Migrating the 20 existing tools in `services/langy/tools/*.ts` to use the helper. Each migration will add BDD scenarios first per the spec-first convention in `CLAUDE.md`.
- Updating issue #3956 acceptance checkboxes (will happen after migrations).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `vitest run defineLangyTool.unit.test.ts` — 5/5 pass
- [ ] After migration PRs: `langy-baseline.feature` scenarios for tool-output-validation pass