### PR TITLE
refactor(langy): route tool handlers through service layer (PR-4.1)

### DIFF
--- a/langwatch/src/server/datasets/dataset-record.repository.ts
+++ b/langwatch/src/server/datasets/dataset-record.repository.ts
@@ -101,6 +101,27 @@ export class DatasetRecordRepository {
   }
 
   /**
+   * Returns the first N records of a dataset by createdAt ascending.
+   * Selects only id and entry — used for surfacing a sample to consumers
+   * (e.g. an AI assistant) without paying for full row data.
+   */
+  async findSample(input: {
+    datasetId: string;
+    projectId: string;
+    limit: number;
+  }): Promise<Array<Pick<DatasetRecord, "id" | "entry">>> {
+    return await this.prisma.datasetRecord.findMany({
+      where: {
+        datasetId: input.datasetId,
+        projectId: input.projectId,
+      },
+      orderBy: { createdAt: "asc" },
+      take: input.limit,
+      select: { id: true, entry: true },
+    });
+  }
+
+  /**
    * Finds a single record by id within a dataset and project.
    */
   async findOne(input: {

--- a/langwatch/src/server/datasets/dataset.repository.ts
+++ b/langwatch/src/server/datasets/dataset.repository.ts
@@ -193,4 +193,27 @@ export class DatasetRepository {
     return { datasets, total };
   }
 
+  async findAllNonArchivedWithCounts(input: {
+    projectId: string;
+  }): Promise<Array<Dataset & { _count: { datasetRecords: number } }>> {
+    return await this.prisma.dataset.findMany({
+      where: { projectId: input.projectId, archivedAt: null },
+      orderBy: { updatedAt: "desc" },
+      include: { _count: { select: { datasetRecords: true } } },
+    });
+  }
+
+  async findByIdNonArchivedWithCounts(input: {
+    id: string;
+    projectId: string;
+  }): Promise<(Dataset & { _count: { datasetRecords: number } }) | null> {
+    return await this.prisma.dataset.findFirst({
+      where: {
+        id: input.id,
+        projectId: input.projectId,
+        archivedAt: null,
+      },
+      include: { _count: { select: { datasetRecords: true } } },
+    });
+  }
 }

--- a/langwatch/src/server/datasets/dataset.service.ts
+++ b/langwatch/src/server/datasets/dataset.service.ts
@@ -458,6 +458,40 @@ export class DatasetService {
   }
 
   /**
+   * Lists every non-archived dataset for a project with record counts,
+   * ordered by most-recently-updated first. Unbounded — for callers that
+   * need the full surface (e.g. an AI assistant enumerating choices) rather
+   * than a paginated UI view.
+   */
+  async listAllNonArchivedWithCounts(params: { projectId: string }) {
+    return await this.repository.findAllNonArchivedWithCounts(params);
+  }
+
+  /**
+   * Resolves a non-archived dataset by id (id only — never slug) and
+   * returns it with its record count. Returns null when not found so the
+   * caller can map to a friendly error instead of a thrown exception.
+   */
+  async findByIdNonArchivedWithCounts(params: {
+    id: string;
+    projectId: string;
+  }) {
+    return await this.repository.findByIdNonArchivedWithCounts(params);
+  }
+
+  /**
+   * Returns the first N records of a dataset by createdAt ascending,
+   * containing only id and entry. For sample/preview use cases.
+   */
+  async listRecordsSample(params: {
+    datasetId: string;
+    projectId: string;
+    limit: number;
+  }) {
+    return await this.recordRepository.findSample(params);
+  }
+
+  /**
    * Lists non-archived datasets for a project with pagination and record counts.
    */
   async listDatasets(params: {

--- a/langwatch/src/server/evaluations/batch-evaluation.repository.ts
+++ b/langwatch/src/server/evaluations/batch-evaluation.repository.ts
@@ -1,0 +1,50 @@
+import type { BatchEvaluation, PrismaClient } from "@prisma/client";
+
+/**
+ * Repository for the legacy Postgres `BatchEvaluation` model.
+ *
+ * NOTE: this is the pre-evaluations-v3 batch-evaluation row stored in
+ * Postgres alongside `Experiment`. The v3 stack persists run records to
+ * Elasticsearch / ClickHouse via separate repositories; do not confuse
+ * the two.
+ */
+export class BatchEvaluationRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findRecentByExperiment(input: {
+    projectId: string;
+    experimentId?: string;
+    limit: number;
+  }): Promise<
+    Array<
+      Pick<
+        BatchEvaluation,
+        | "id"
+        | "experimentId"
+        | "createdAt"
+        | "status"
+        | "score"
+        | "passed"
+        | "evaluation"
+      >
+    >
+  > {
+    return await this.prisma.batchEvaluation.findMany({
+      where: {
+        projectId: input.projectId,
+        ...(input.experimentId ? { experimentId: input.experimentId } : {}),
+      },
+      orderBy: { createdAt: "desc" },
+      take: input.limit,
+      select: {
+        id: true,
+        experimentId: true,
+        createdAt: true,
+        status: true,
+        score: true,
+        passed: true,
+        evaluation: true,
+      },
+    });
+  }
+}

--- a/langwatch/src/server/evaluations/batch-evaluation.service.ts
+++ b/langwatch/src/server/evaluations/batch-evaluation.service.ts
@@ -1,0 +1,25 @@
+import type { PrismaClient } from "@prisma/client";
+import { BatchEvaluationRepository } from "./batch-evaluation.repository";
+
+/**
+ * Service for the legacy Postgres `BatchEvaluation` model. Currently only
+ * exposes recent-runs lookups; expand as more callers move off direct
+ * `prisma.batchEvaluation.*` access.
+ *
+ * See `batch-evaluation.repository.ts` for the v3 stack distinction.
+ */
+export class BatchEvaluationService {
+  constructor(private readonly repository: BatchEvaluationRepository) {}
+
+  static create(prisma: PrismaClient): BatchEvaluationService {
+    return new BatchEvaluationService(new BatchEvaluationRepository(prisma));
+  }
+
+  async getRecentByExperiment(params: {
+    projectId: string;
+    experimentId?: string;
+    limit: number;
+  }) {
+    return await this.repository.findRecentByExperiment(params);
+  }
+}

--- a/langwatch/src/server/experiments/experiment.service.ts
+++ b/langwatch/src/server/experiments/experiment.service.ts
@@ -35,6 +35,21 @@ export class ExperimentService {
     return experiment;
   }
 
+  /**
+   * Null-returning sibling of getBySlug for callers that prefer a missing
+   * experiment to be a value rather than a thrown exception (e.g. agent
+   * tools translating not-found into a friendly error message).
+   */
+  async findBySlug({
+    projectId,
+    slug,
+  }: {
+    projectId: string;
+    slug: string;
+  }): Promise<Experiment | null> {
+    return this.repository.findBySlug({ slug, projectId });
+  }
+
   async getById({
     projectId,
     id,

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -127,6 +127,19 @@ export class PromptService {
   }
 
   /**
+   * Lightweight keyword search over project-scoped prompts. Returns just
+   * id/handle/name for each match — meant for "did you mean" lookups by
+   * callers that don't need the full versioned prompt payload.
+   */
+  async searchByKeyword(params: {
+    projectId: string;
+    query: string;
+    limit: number;
+  }) {
+    return await this.repository.searchByKeyword(params);
+  }
+
+  /**
    * Get all prompts for a project
    */
   async getAllPrompts(params: {

--- a/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
@@ -807,6 +807,31 @@ export class LlmConfigRepository {
    * from the specified project or organization.
    * Returns the set of IDs that exist.
    */
+  /**
+   * Searches project-scoped prompt configs by case-insensitive substring
+   * match on handle or name. Used by lightweight lookup callers (e.g. an
+   * agent tool) that need a small "did you mean…" list — not a full
+   * prompts API view.
+   */
+  async searchByKeyword(params: {
+    projectId: string;
+    query: string;
+    limit: number;
+  }): Promise<Array<Pick<LlmPromptConfig, "id" | "handle" | "name">>> {
+    return await this.prisma.llmPromptConfig.findMany({
+      where: {
+        projectId: params.projectId,
+        OR: [
+          { handle: { contains: params.query, mode: "insensitive" } },
+          { name: { contains: params.query, mode: "insensitive" } },
+        ],
+      },
+      orderBy: { updatedAt: "desc" },
+      take: params.limit,
+      select: { id: true, handle: true, name: true },
+    });
+  }
+
   async findExistingIds(params: {
     ids: string[];
     projectId: string;

--- a/langwatch/src/server/routes/__tests__/langy.tool-surface.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy.tool-surface.unit.test.ts
@@ -12,10 +12,13 @@ const ALLOWED_PREFIXES = ["list_", "get_", "find_", "search_", "propose_"];
 const stubCtx = {
   projectId: "proj-test",
   experimentSlug: undefined,
+  batchEvaluationService: {} as never,
+  datasetService: {} as never,
   evaluatorService: {} as never,
+  experimentService: {} as never,
+  projectService: {} as never,
   promptService: {} as never,
   seenIds: new ConversationToolIdSet(),
-  prisma: {} as never,
 };
 
 const toolNames = Object.keys(buildLangyTools(stubCtx));

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -19,7 +19,12 @@ import { tracerMiddleware } from "~/app/api/middleware/tracer";
 import { hasProjectPermission } from "~/server/api/rbac";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
+import { ProjectService } from "~/server/app-layer/projects/project.service";
+import { PrismaProjectRepository } from "~/server/app-layer/projects/repositories/project.prisma.repository";
+import { DatasetService } from "~/server/datasets/dataset.service";
+import { BatchEvaluationService } from "~/server/evaluations/batch-evaluation.service";
 import { EvaluatorService } from "~/server/evaluators/evaluator.service";
+import { ExperimentService } from "~/server/experiments/experiment.service";
 import { getVercelAIModel } from "~/server/modelProviders/utils";
 import { PromptService } from "~/server/prompt-config/prompt.service";
 import { createLogger } from "~/utils/logger/server";
@@ -245,18 +250,27 @@ app.post("/langy/chat", async (c) => {
     });
   }
 
+  const batchEvaluationService = BatchEvaluationService.create(prisma);
+  const datasetService = DatasetService.create(prisma);
   const evaluatorService = EvaluatorService.create(prisma);
+  const experimentService = ExperimentService.create(prisma);
+  const projectService = new ProjectService(new PrismaProjectRepository(prisma));
   const promptService = new PromptService(prisma);
   const seenIds = new ConversationToolIdSet();
 
-  const tools = buildLangyTools({
+  const toolCtx = {
     projectId,
     experimentSlug,
+    batchEvaluationService,
+    datasetService,
     evaluatorService,
+    experimentService,
+    projectService,
     promptService,
     seenIds,
-    prisma,
-  });
+  };
+
+  const tools = buildLangyTools(toolCtx);
 
   const systemPrompt = buildSystemPrompt({
     projectMemory,
@@ -279,14 +293,7 @@ app.post("/langy/chat", async (c) => {
       "langy.chat: serving via Mastra path",
     );
     const mastraResponse = await streamLangyMastraResponse({
-      ctx: {
-        projectId,
-        experimentSlug,
-        evaluatorService,
-        promptService,
-        seenIds,
-        prisma,
-      },
+      ctx: toolCtx,
       model,
       systemPrompt,
       messages: modelMessages,

--- a/langwatch/src/server/services/langy/tools/datasets.ts
+++ b/langwatch/src/server/services/langy/tools/datasets.ts
@@ -8,10 +8,8 @@ export function makeListDatasets(ctx: LangyToolContext) {
       "Lists the datasets in the caller's project with their column schema and row count.",
     inputSchema: z.object({}),
     execute: async () => {
-      const datasets = await ctx.prisma.dataset.findMany({
-        where: { projectId: ctx.projectId, archivedAt: null },
-        orderBy: { updatedAt: "desc" },
-        include: { _count: { select: { datasetRecords: true } } },
+      const datasets = await ctx.datasetService.listAllNonArchivedWithCounts({
+        projectId: ctx.projectId,
       });
       for (const d of datasets) ctx.seenIds.record("dataset_id", d.id);
       return {
@@ -38,20 +36,19 @@ export function makeGetDatasetDetails(ctx: LangyToolContext) {
       sampleRowLimit: z.number().int().min(0).max(20).default(5),
     }),
     execute: async ({ datasetId, sampleRowLimit }) => {
-      const dataset = await ctx.prisma.dataset.findFirst({
-        where: { id: datasetId, projectId: ctx.projectId, archivedAt: null },
-        include: { _count: { select: { datasetRecords: true } } },
+      const dataset = await ctx.datasetService.findByIdNonArchivedWithCounts({
+        id: datasetId,
+        projectId: ctx.projectId,
       });
       if (!dataset) {
         return { error: `No dataset found with id '${datasetId}'.` };
       }
       const sampleRows =
         sampleRowLimit > 0
-          ? await ctx.prisma.datasetRecord.findMany({
-              where: { datasetId, projectId: ctx.projectId },
-              orderBy: { createdAt: "asc" },
-              take: sampleRowLimit,
-              select: { id: true, entry: true },
+          ? await ctx.datasetService.listRecordsSample({
+              datasetId,
+              projectId: ctx.projectId,
+              limit: sampleRowLimit,
             })
           : [];
       return {
@@ -133,9 +130,9 @@ export function makeProposeAddDatasetRows(ctx: LangyToolContext) {
           error: `Dataset '${datasetId}' was not surfaced by list_datasets in this conversation. Call list_datasets first and reference one of those ids.`,
         };
       }
-      const dataset = await ctx.prisma.dataset.findFirst({
-        where: { id: datasetId, projectId: ctx.projectId, archivedAt: null },
-        select: { id: true, name: true, slug: true },
+      const dataset = await ctx.datasetService.findByIdNonArchivedWithCounts({
+        id: datasetId,
+        projectId: ctx.projectId,
       });
       if (!dataset) {
         return { error: `No dataset found with id '${datasetId}'.` };

--- a/langwatch/src/server/services/langy/tools/evaluators.ts
+++ b/langwatch/src/server/services/langy/tools/evaluators.ts
@@ -175,10 +175,7 @@ export function makeProposeCreateEvaluator(ctx: LangyToolContext) {
           error: `No built-in evaluator with type '${evaluatorType}'. Use list_evaluators('built_in') first.`,
         };
       }
-      const project = await ctx.prisma.project.findUnique({
-        where: { id: ctx.projectId },
-        select: { defaultModel: true, embeddingsModel: true },
-      });
+      const project = await ctx.projectService.getById(ctx.projectId);
       const defaults = getEvaluatorDefaultSettings(
         getEvaluatorDefinitions(evaluatorType),
         project ?? undefined,

--- a/langwatch/src/server/services/langy/tools/prompts.ts
+++ b/langwatch/src/server/services/langy/tools/prompts.ts
@@ -72,16 +72,10 @@ export function makeSearchPrompts(ctx: LangyToolContext) {
       limit: z.number().int().min(1).max(20).default(10),
     }),
     execute: async ({ query, limit }) => {
-      const rows = await ctx.prisma.llmPromptConfig.findMany({
-        where: {
-          projectId: ctx.projectId,
-          OR: [
-            { handle: { contains: query, mode: "insensitive" } },
-            { name: { contains: query, mode: "insensitive" } },
-          ],
-        },
-        orderBy: { updatedAt: "desc" },
-        take: limit,
+      const rows = await ctx.promptService.searchByKeyword({
+        projectId: ctx.projectId,
+        query,
+        limit,
       });
       for (const r of rows) {
         ctx.seenIds.record("prompt_id", r.id);

--- a/langwatch/src/server/services/langy/tools/runs.ts
+++ b/langwatch/src/server/services/langy/tools/runs.ts
@@ -11,28 +11,19 @@ export function makeSearchPastRuns(ctx: LangyToolContext) {
       limit: z.number().int().min(1).max(20).default(10),
     }),
     execute: async ({ experimentSlug, limit }) => {
-      const where: Record<string, unknown> = { projectId: ctx.projectId };
+      let experimentId: string | undefined;
       if (experimentSlug) {
-        const exp = await ctx.prisma.experiment.findFirst({
-          where: { projectId: ctx.projectId, slug: experimentSlug },
-          select: { id: true },
+        const experiment = await ctx.experimentService.findBySlug({
+          projectId: ctx.projectId,
+          slug: experimentSlug,
         });
-        if (!exp) return { items: [], error: "experiment not found" };
-        where.experimentId = exp.id;
+        if (!experiment) return { items: [], error: "experiment not found" };
+        experimentId = experiment.id;
       }
-      const rows = await ctx.prisma.batchEvaluation.findMany({
-        where,
-        orderBy: { createdAt: "desc" },
-        take: limit,
-        select: {
-          id: true,
-          experimentId: true,
-          createdAt: true,
-          status: true,
-          score: true,
-          passed: true,
-          evaluation: true,
-        },
+      const rows = await ctx.batchEvaluationService.getRecentByExperiment({
+        projectId: ctx.projectId,
+        experimentId,
+        limit,
       });
       return {
         items: rows.map((r) => ({

--- a/langwatch/src/server/services/langy/tools/types.ts
+++ b/langwatch/src/server/services/langy/tools/types.ts
@@ -5,17 +5,26 @@
  * closures so the same definition can be threaded through the legacy
  * Vercel AI SDK runtime today and the Mastra runtime in Phase 4.3+
  * without reworking each tool.
+ *
+ * Tools must NOT receive a PrismaClient. All entity reads go through
+ * the service layer below — see PR-4.1.
  */
-import type { PrismaClient } from "@prisma/client";
+import type { DatasetService } from "~/server/datasets/dataset.service";
+import type { BatchEvaluationService } from "~/server/evaluations/batch-evaluation.service";
 import type { EvaluatorService } from "~/server/evaluators/evaluator.service";
+import type { ExperimentService } from "~/server/experiments/experiment.service";
+import type { ProjectService } from "~/server/app-layer/projects/project.service";
 import type { PromptService } from "~/server/prompt-config/prompt.service";
 import type { ConversationToolIdSet } from "../toolIdValidator";
 
 export interface LangyToolContext {
   projectId: string;
   experimentSlug?: string;
+  batchEvaluationService: BatchEvaluationService;
+  datasetService: DatasetService;
   evaluatorService: EvaluatorService;
+  experimentService: ExperimentService;
+  projectService: ProjectService;
   promptService: PromptService;
   seenIds: ConversationToolIdSet;
-  prisma: PrismaClient;
 }

--- a/langwatch/src/server/services/langy/tools/workbench.ts
+++ b/langwatch/src/server/services/langy/tools/workbench.ts
@@ -208,8 +208,9 @@ export function makeGetWorkbenchState(ctx: LangyToolContext) {
             "No experiment is currently open. The caller did not pass experimentSlug.",
         };
       }
-      const experiment = await ctx.prisma.experiment.findFirst({
-        where: { projectId: ctx.projectId, slug: ctx.experimentSlug },
+      const experiment = await ctx.experimentService.findBySlug({
+        projectId: ctx.projectId,
+        slug: ctx.experimentSlug,
       });
       if (!experiment) {
         return {
@@ -258,8 +259,9 @@ export function makeFindFailingRows(ctx: LangyToolContext) {
       if (!ctx.experimentSlug) {
         return { error: "No experiment is currently open." };
       }
-      const experiment = await ctx.prisma.experiment.findFirst({
-        where: { projectId: ctx.projectId, slug: ctx.experimentSlug },
+      const experiment = await ctx.experimentService.findBySlug({
+        projectId: ctx.projectId,
+        slug: ctx.experimentSlug,
       });
       if (!experiment?.workbenchState) {
         return {


### PR DESCRIPTION
Part of #3957 (Langy Phase 4 — Mastra migration). Closes the PR-4.1 checkbox.

## Summary

- Routes all 9 inline `ctx.prisma.*` calls in Langy tool handlers through services. Drops `prisma` from `LangyToolContext` entirely so there's no escape hatch.
- Closes the pre-existing CLAUDE.md "routes calling repositories directly" violation flagged by the Phase 3 audit.
- Pure refactor: same return shapes, same error messages, same query semantics. Unblocks PR-4.4 (Mastra memory adapter) by giving it clean service interfaces to wire into.

## What changed

**Tool handlers** (5 files) — each `ctx.prisma.*` call swapped for the matching service method:

| File | Was | Now |
|---|---|---|
| `tools/datasets.ts` | 4× `ctx.prisma.{dataset,datasetRecord}.*` | `ctx.datasetService.*` |
| `tools/evaluators.ts` | `ctx.prisma.project.findUnique` | `ctx.projectService.getById` |
| `tools/prompts.ts` | `ctx.prisma.llmPromptConfig.findMany` | `ctx.promptService.searchByKeyword` |
| `tools/runs.ts` | `ctx.prisma.{experiment,batchEvaluation}.*` | `ctx.experimentService.findBySlug` + `ctx.batchEvaluationService.getRecentByExperiment` |
| `tools/workbench.ts` | 2× `ctx.prisma.experiment.findFirst` | `ctx.experimentService.findBySlug` |

**New service surface** (small):

- `DatasetService.{listAllNonArchivedWithCounts, findByIdNonArchivedWithCounts, listRecordsSample}` (+ tiny repo helpers on `DatasetRepository` / `DatasetRecordRepository`)
- `ExperimentService.findBySlug` — null-returning sibling of the throwing `getBySlug`, since agent tools want a friendly error rather than an exception
- `PromptService.searchByKeyword` (+ helper on `LlmConfigRepository`) for the lightweight handle/name search
- **New** `BatchEvaluationService` — there was no service for the legacy Postgres `BatchEvaluation` model (the evaluations-v3 stack is ES/CH-backed and unrelated). One method, `getRecentByExperiment`.
- `ProjectService.getById` reused as-is for the evaluator default-model lookup.

**Wiring** (`routes/langy.ts`): per-request ctx now constructs all six services and threads them through both the legacy `streamText` path and the Mastra spike path; both share the same `toolCtx` value.

## Why this matters

1. **Multitenancy enforcement.** Every Langy query needs `projectId` in the WHERE clause. With one service method per access pattern, the type signature forces the caller to pass it — instead of 9 scattered prisma calls each with their own filter.
2. **Unblocks PR-4.4.** The Mastra memory adapter can wire into clean service interfaces instead of dragging a prisma escape hatch through the new agent runtime.
3. **Testability.** Tools now mock against typed service interfaces (`{ datasetService: { listAllNonArchivedWithCounts: vi.fn() } }`) instead of needing a partial prisma stub.

Removing `prisma` from the ctx type entirely (rather than just replacing the calls) is the part that matters: it makes the wrong thing impossible, not just discouraged.

## Test plan

- [x] `pnpm typecheck` — clean for every file touched (only pre-existing `saas-src/` and unrelated NODE_ENV errors remain)
- [x] Langy unit suite — 127/127 pass (12 test files: chat stream, guards, tool-surface, preferences, defineLangyTool, conversation/memory/preferences services, rate-limit, tracer, visibility, parseLangyErrorMessage)
- [x] Dataset/prompt service tests — 3/3 pass; no regressions on the modified service files
- [x] Tool-surface contract test updated with the new ctx fields (and `prisma` removed)
- [ ] Manual smoke after merge to `langy-v2-integration`: open Langy in dev, run through the 5 tool surfaces (list_datasets, get_dataset_details, search_prompts, search_past_runs, get_workbench_state) — confirm no behavior change vs current `langy-v2-integration`

## Phase 4 status after this PR

| | Status |
|---|---|
| PR-4.0 extract inline tools | ✅ Done |
| **PR-4.1 service-layer cleanup** | **This PR** |
| PR-4.2 LangyConversationContext rename | ⚠️ Mostly done by side-effect of 4.0/4.1 — left for a small follow-up |
| PR-4.3 Mastra spike behind flag | ✅ Done |
| PR-4.4 memory adapter on Mastra path | ❌ Next up — unblocked by this PR |
| PR-4.5 cutover + delete legacy | ❌ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)