### PR TITLE
fix(deps): align mastra protobufjs override to exclude 8.0.0-8.0.1

### DIFF
--- a/typescript-sdk/examples/mastra/package.json
+++ b/typescript-sdk/examples/mastra/package.json
@@ -33,6 +33,6 @@
   },
   "overrides": {
     "fast-uri": ">=3.1.2",
-    "protobufjs": ">=7.5.6"
+    "protobufjs": ">=7.5.6 <8.0.0 || >=8.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- Aligns `typescript-sdk/examples/mastra/package.json` protobufjs override from `>=7.5.6` to `>=7.5.6 <8.0.0 || >=8.0.2`
- Matches the pattern in `skills/package.json` to explicitly exclude vulnerable 8.0.0 and 8.0.1 versions
- Addresses CodeRabbit feedback from #4014

## Test plan
- [x] Lockfile unchanged (already resolves to 8.2.1)
- [ ] CI passes